### PR TITLE
ISPN-6176 Rename DummyTransactionManager to EmbeddedTransactionManager

### DIFF
--- a/core/src/main/java/org/infinispan/transaction/lookup/DummyTransactionManagerLookup.java
+++ b/core/src/main/java/org/infinispan/transaction/lookup/DummyTransactionManagerLookup.java
@@ -12,7 +12,9 @@ import org.infinispan.transaction.tm.DummyTransactionManager;
  *
  * @author Bela Ban Sept 5 2003
  * @since 4.0
+ * @deprecated use {@link EmbeddedTransactionManagerLookup}
  */
+@Deprecated
 public class DummyTransactionManagerLookup implements TransactionManagerLookup {
 
    @Override

--- a/core/src/main/java/org/infinispan/transaction/lookup/EmbeddedTransactionManagerLookup.java
+++ b/core/src/main/java/org/infinispan/transaction/lookup/EmbeddedTransactionManagerLookup.java
@@ -1,0 +1,36 @@
+package org.infinispan.transaction.lookup;
+
+
+import javax.transaction.TransactionManager;
+import javax.transaction.UserTransaction;
+
+import org.infinispan.transaction.tm.EmbeddedTransactionManager;
+
+
+/**
+ * Returns an instance of {@link org.infinispan.transaction.tm.EmbeddedTransactionManager}.
+ *
+ * @author Bela Ban
+ * @author Pedro Ruivo
+ * @since 9.0
+ */
+public class EmbeddedTransactionManagerLookup implements TransactionManagerLookup {
+
+   public static UserTransaction getUserTransaction() {
+      return EmbeddedTransactionManager.getUserTransaction();
+   }
+
+   public static void cleanup() {
+      EmbeddedTransactionManager.destroy();
+   }
+
+   @Override
+   public TransactionManager getTransactionManager() throws Exception {
+      return EmbeddedTransactionManager.getInstance();
+   }
+
+   @Override
+   public String toString() {
+      return "EmbeddedTransactionManagerLookup";
+   }
+}

--- a/core/src/main/java/org/infinispan/transaction/lookup/GenericTransactionManagerLookup.java
+++ b/core/src/main/java/org/infinispan/transaction/lookup/GenericTransactionManagerLookup.java
@@ -9,15 +9,15 @@ import javax.transaction.TransactionManager;
 import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.factories.annotations.Inject;
-import org.infinispan.transaction.tm.DummyTransactionManager;
+import org.infinispan.transaction.tm.EmbeddedTransactionManager;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
 /**
  * A transaction manager lookup class that attempts to locate a TransactionManager. A variety of different classes and
  * JNDI locations are tried, for servers such as: <ul> <li> JBoss <li> JRun4 <li> Resin <li> Orion <li> JOnAS <li> BEA
- * Weblogic <li> Websphere 4.0, 5.0, 5.1, 6.0 <li> Sun, Glassfish </ul> If a transaction manager is not found, returns a
- * {@link org.infinispan.transaction.tm.DummyTransactionManager}.
+ * Weblogic <li> Websphere 4.0, 5.0, 5.1, 6.0 <li> Sun, Glassfish </ul> If a transaction manager is not found, returns
+ * an {@link org.infinispan.transaction.tm.EmbeddedTransactionManager}.
  *
  * @author Markus Plesser
  * @since 4.0
@@ -86,7 +86,7 @@ public class GenericTransactionManagerLookup implements TransactionManagerLookup
    }
 
    /**
-    * Get the systemwide used TransactionManager
+    * Get the system-wide used TransactionManager
     *
     * @return TransactionManager
     */
@@ -112,8 +112,8 @@ public class GenericTransactionManagerLookup implements TransactionManagerLookup
    }
 
    private void useDummyTM() {
-      tm = DummyTransactionManager.getInstance();
-      log.fallingBackToDummyTm();
+      tm = EmbeddedTransactionManager.getInstance();
+      log.fallingBackToEmbeddedTm();
    }
 
    private void tryEmbeddedJBossTM() {
@@ -132,14 +132,13 @@ public class GenericTransactionManagerLookup implements TransactionManagerLookup
    private void doLookups(ClassLoader cl) {
       if (lookupFailed)
          return;
-      InitialContext ctx = null;
+      InitialContext ctx;
       try {
          ctx = new InitialContext();
       }
       catch (NamingException e) {
          log.failedToCreateInitialCtx(e);
          lookupFailed = true;
-         Util.close(ctx);
          return;
       }
 

--- a/core/src/main/java/org/infinispan/transaction/tm/BatchModeTransactionManager.java
+++ b/core/src/main/java/org/infinispan/transaction/tm/BatchModeTransactionManager.java
@@ -7,23 +7,26 @@ package org.infinispan.transaction.tm;
  * @author bela
  * @since 4.0
  */
-public class BatchModeTransactionManager extends DummyBaseTransactionManager {
+public class BatchModeTransactionManager extends EmbeddedBaseTransactionManager {
 
-   private static final long serialVersionUID = 5656602677430350961L;
+   private static BatchModeTransactionManager INSTANCE = null;
 
-   static BatchModeTransactionManager instance = null;
+   private BatchModeTransactionManager() {
+   }
 
    public static BatchModeTransactionManager getInstance() {
-      if (instance == null) {
-         instance = new BatchModeTransactionManager();
+      if (INSTANCE == null) {
+         INSTANCE = new BatchModeTransactionManager();
       }
-      return instance;
+      return INSTANCE;
    }
 
    public static void destroy() {
-      if (instance == null) return;
-      instance.setTransaction(null);
-      instance = null;
+      if (INSTANCE == null) {
+         return;
+      }
+      dissociateTransaction();
+      INSTANCE = null;
    }
 
 }

--- a/core/src/main/java/org/infinispan/transaction/tm/DummyBaseTransactionManager.java
+++ b/core/src/main/java/org/infinispan/transaction/tm/DummyBaseTransactionManager.java
@@ -20,10 +20,12 @@ import org.infinispan.util.logging.LogFactory;
 /**
  * @author bela
  * @since 4.0
+ * @deprecated use {@link EmbeddedBaseTransactionManager}
  */
+@Deprecated
 public class DummyBaseTransactionManager implements TransactionManager, Serializable {
-   static ThreadLocal<DummyTransaction> thread_local = new ThreadLocal<DummyTransaction>();
-   private static final long serialVersionUID = -6716097342564237376l;
+   static ThreadLocal<DummyTransaction> thread_local = new ThreadLocal<>();
+   private static final long serialVersionUID = -6716097342564237376L;
    private static final Log log = LogFactory.getLog(DummyBaseTransactionManager.class);
    private static final boolean trace = log.isTraceEnabled();
    final UUID transactionManagerId = UUID.randomUUID();

--- a/core/src/main/java/org/infinispan/transaction/tm/DummyNoXaXid.java
+++ b/core/src/main/java/org/infinispan/transaction/tm/DummyNoXaXid.java
@@ -10,7 +10,9 @@ import javax.transaction.xa.Xid;
  *
  * @author Mircea Markus <mircea.markus@jboss.com> (C) 2011 Red Hat Inc.
  * @since 5.1
+ * @deprecated it will be removed and {@link EmbeddedXid} would be used instead.
  */
+@Deprecated
 public final class DummyNoXaXid implements Xid {
 
    private static final AtomicInteger txIdCounter = new AtomicInteger(0);

--- a/core/src/main/java/org/infinispan/transaction/tm/DummyTransactionManager.java
+++ b/core/src/main/java/org/infinispan/transaction/tm/DummyTransactionManager.java
@@ -12,7 +12,9 @@ import org.infinispan.util.logging.LogFactory;
  *         <p/>
  *         Date: May 15, 2003 Time: 4:11:37 PM
  * @since 4.0
+ * @deprecated use {@link EmbeddedTransactionManager}
  */
+@Deprecated
 public class DummyTransactionManager extends DummyBaseTransactionManager {
 
    protected static final Log log = LogFactory.getLog(DummyTransactionManager.class);

--- a/core/src/main/java/org/infinispan/transaction/tm/DummyUserTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/tm/DummyUserTransaction.java
@@ -14,7 +14,9 @@ import javax.transaction.UserTransaction;
  *         <p/>
  *         Date: May 15, 2003 Time: 4:20:17 PM
  * @since 4.0
+ * @deprecated use {@link EmbeddedUserTransaction}
  */
+@Deprecated
 public class DummyUserTransaction implements UserTransaction, java.io.Serializable {
    DummyTransactionManager tm;
    private static final long serialVersionUID = -6568400755677046127L;

--- a/core/src/main/java/org/infinispan/transaction/tm/DummyXid.java
+++ b/core/src/main/java/org/infinispan/transaction/tm/DummyXid.java
@@ -13,7 +13,9 @@ import org.infinispan.commons.util.Util;
  * Implementation of Xid.
  * @author Mircea.Markus@jboss.com
  * @since 4.0
+ * @deprecated use {@link EmbeddedXid}.
  */
+@Deprecated
 public final class DummyXid implements Xid {
 
    private static final AtomicLong GLOBAL_ID_GENERATOR = new AtomicLong(1);

--- a/core/src/main/java/org/infinispan/transaction/tm/EmbeddedBaseTransactionManager.java
+++ b/core/src/main/java/org/infinispan/transaction/tm/EmbeddedBaseTransactionManager.java
@@ -1,0 +1,133 @@
+package org.infinispan.transaction.tm;
+
+
+import java.util.UUID;
+
+import javax.transaction.HeuristicMixedException;
+import javax.transaction.HeuristicRollbackException;
+import javax.transaction.InvalidTransactionException;
+import javax.transaction.NotSupportedException;
+import javax.transaction.RollbackException;
+import javax.transaction.Status;
+import javax.transaction.SystemException;
+import javax.transaction.Transaction;
+import javax.transaction.TransactionManager;
+
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
+/**
+ * A simple {@link TransactionManager} implementation.
+ * <p>
+ * It provides the basic to handle {@link Transaction}s and supports any {@link javax.transaction.xa.XAResource}.
+ * <p>
+ * Implementation notes: <ul> <li>The state is kept in memory only.</li> <li>Does not support recover.</li> <li>Does not
+ * support multi-thread transactions. Although it is possible to execute the transactions in multiple threads, this
+ * transaction manager does not wait for them to complete. It is the application responsibility to wait before invoking
+ * {@link #commit()} or {@link #rollback()}</li> <li>The transaction should not block. It is no possible to {@link
+ * #setTransactionTimeout(int)} and this transaction manager won't rollback the transaction if it takes too long.</li>
+ * </ul>
+ * <p>
+ * If you need any of the requirements above, please consider use another implementation.
+ * <p>
+ * Also, it does not implement any 1-phase-commit optimization.
+ *
+ * @author Bela Ban
+ * @author Pedro Ruivo
+ * @since 9.0
+ */
+public class EmbeddedBaseTransactionManager implements TransactionManager {
+   private static final Log log = LogFactory.getLog(EmbeddedBaseTransactionManager.class);
+   private static final boolean trace = log.isTraceEnabled();
+   private static ThreadLocal<EmbeddedTransaction> CURRENT_TRANSACTION = new ThreadLocal<>();
+   final UUID transactionManagerId = UUID.randomUUID();
+
+   /**
+    * Associate the transaction {@code tx} to the current thread.
+    */
+   static void associateTransaction(Transaction tx) {
+      CURRENT_TRANSACTION.set((EmbeddedTransaction) tx);
+   }
+
+   /**
+    * Dissociate transaction from current thread.
+    */
+   static void dissociateTransaction() {
+      CURRENT_TRANSACTION.remove();
+   }
+
+   @Override
+   public void begin() throws NotSupportedException, SystemException {
+      Transaction currentTx = getTransaction();
+      if (currentTx != null) {
+         throw new NotSupportedException(
+               Thread.currentThread() + " is already associated with a transaction (" + currentTx + ")");
+      }
+      associateTransaction(new EmbeddedTransaction(this));
+   }
+
+   @Override
+   public void commit() throws RollbackException, HeuristicMixedException,
+         HeuristicRollbackException, SecurityException,
+         IllegalStateException, SystemException {
+      getTransactionAndFailIfNone().commit();
+      dissociateTransaction();
+   }
+
+   @Override
+   public void rollback() throws IllegalStateException, SecurityException,
+         SystemException {
+      getTransactionAndFailIfNone().rollback();
+      dissociateTransaction();
+   }
+
+   @Override
+   public void setRollbackOnly() throws IllegalStateException, SystemException {
+      getTransactionAndFailIfNone().setRollbackOnly();
+   }
+
+   @Override
+   public int getStatus() throws SystemException {
+      Transaction tx = getTransaction();
+      return tx != null ? tx.getStatus() : Status.STATUS_NO_TRANSACTION;
+   }
+
+   @Override
+   public EmbeddedTransaction getTransaction() {
+      return CURRENT_TRANSACTION.get();
+   }
+
+   @Override
+   public void setTransactionTimeout(int seconds) throws SystemException {
+      throw new SystemException("not supported");
+   }
+
+   @Override
+   public Transaction suspend() throws SystemException {
+      Transaction tx = getTransaction();
+      dissociateTransaction();
+      if (trace) {
+         log.tracef("Suspending tx %s", tx);
+      }
+      return tx;
+   }
+
+   @Override
+   public void resume(Transaction tx) throws InvalidTransactionException, IllegalStateException, SystemException {
+      if (trace) {
+         log.tracef("Resuming tx %s", tx);
+      }
+      associateTransaction(tx);
+   }
+
+   /**
+    * @return the current transaction (not null!)
+    */
+   private EmbeddedTransaction getTransactionAndFailIfNone() {
+      EmbeddedTransaction transaction = CURRENT_TRANSACTION.get();
+      if (transaction == null) {
+         throw new IllegalStateException("no transaction associated with calling thread");
+      }
+      return transaction;
+   }
+}

--- a/core/src/main/java/org/infinispan/transaction/tm/EmbeddedTransactionManager.java
+++ b/core/src/main/java/org/infinispan/transaction/tm/EmbeddedTransactionManager.java
@@ -1,0 +1,45 @@
+package org.infinispan.transaction.tm;
+
+import javax.transaction.xa.XAResource;
+
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
+/**
+ * Simple transaction manager implementation that maintains transaction state in memory only.
+ * <p>
+ * See {@link EmbeddedBaseTransactionManager} for details about which features are supported.
+ *
+ * @author bela
+ * @author Pedro Ruivo
+ * @see EmbeddedBaseTransactionManager
+ * @since 9.0
+ */
+public class EmbeddedTransactionManager extends EmbeddedBaseTransactionManager {
+
+   protected static final Log log = LogFactory.getLog(EmbeddedTransactionManager.class);
+
+   private EmbeddedTransactionManager() {
+   }
+
+   public static EmbeddedTransactionManager getInstance() {
+      return LazyInitializeHolder.TM_INSTANCE;
+   }
+
+   public static EmbeddedUserTransaction getUserTransaction() {
+      return LazyInitializeHolder.USER_TX_INSTANCE;
+   }
+
+   public static void destroy() {
+      dissociateTransaction();
+   }
+
+   public XAResource firstEnlistedResource() {
+      return getTransaction().firstEnlistedResource();
+   }
+
+   private static class LazyInitializeHolder {
+      static final EmbeddedTransactionManager TM_INSTANCE = new EmbeddedTransactionManager();
+      static final EmbeddedUserTransaction USER_TX_INSTANCE = new EmbeddedUserTransaction(TM_INSTANCE);
+   }
+}

--- a/core/src/main/java/org/infinispan/transaction/tm/EmbeddedUserTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/tm/EmbeddedUserTransaction.java
@@ -1,0 +1,62 @@
+package org.infinispan.transaction.tm;
+
+
+import javax.transaction.HeuristicMixedException;
+import javax.transaction.HeuristicRollbackException;
+import javax.transaction.NotSupportedException;
+import javax.transaction.RollbackException;
+import javax.transaction.SystemException;
+import javax.transaction.UserTransaction;
+
+/**
+ * A {@link UserTransaction} implementation that uses {@link EmbeddedTransactionManager}.
+ * <p>
+ * This implementation does not support transaction timeout and it does not cancel long running transactions.
+ * <p>
+ * See {@link EmbeddedBaseTransactionManager} for more details about its implementation.
+ *
+ * @author Bela Ban
+ * @author Pedro Ruivo
+ * @see EmbeddedBaseTransactionManager
+ * @since 9.0
+ */
+public class EmbeddedUserTransaction implements UserTransaction {
+   private final EmbeddedTransactionManager tm;
+
+   EmbeddedUserTransaction(EmbeddedTransactionManager tm) {
+      this.tm = tm;
+   }
+
+   @Override
+   public void begin() throws NotSupportedException, SystemException {
+      tm.begin();
+   }
+
+   @Override
+   public void commit()
+         throws RollbackException, HeuristicMixedException, HeuristicRollbackException, SecurityException,
+         SystemException {
+      tm.commit();
+   }
+
+   @Override
+   public void rollback() throws IllegalStateException, SystemException {
+      tm.rollback();
+   }
+
+   @Override
+   public void setRollbackOnly() throws IllegalStateException, SystemException {
+      tm.setRollbackOnly();
+   }
+
+   @Override
+   public int getStatus() throws SystemException {
+      return tm.getStatus();
+   }
+
+   @Override
+   public void setTransactionTimeout(int seconds) throws SystemException {
+      throw new SystemException("not supported");
+   }
+
+}

--- a/core/src/main/java/org/infinispan/transaction/tm/EmbeddedXid.java
+++ b/core/src/main/java/org/infinispan/transaction/tm/EmbeddedXid.java
@@ -1,0 +1,100 @@
+package org.infinispan.transaction.tm;
+
+import java.util.Arrays;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+
+import javax.transaction.xa.Xid;
+
+import org.infinispan.commons.io.UnsignedNumeric;
+import org.infinispan.commons.util.Util;
+
+/**
+ * Implementation of {@link Xid} used by {@link EmbeddedTransactionManager}.
+ *
+ * @author Mircea.Markus@jboss.com
+ * @author Pedro Ruivo
+ * @since 9.0
+ */
+public final class EmbeddedXid implements Xid {
+
+   //format can be anything except:
+   //-1: means a null Xid
+   // 0: means OSI CCR format
+   //I would like ot use 0x4953504E (ISPN in hex) for the format, but keep it to 1 to be consistent with DummyXid.
+   private static final int FORMAT = 1;
+   private static final AtomicLong GLOBAL_ID_GENERATOR = new AtomicLong(1);
+   private static final AtomicLong BRANCH_QUALIFIER_GENERATOR = new AtomicLong(1);
+   private final int cachedHashcode;
+   //note: AFAIK, the max size is 64 but it can be smaller. keep it until the DummyXid is removed.
+   private byte[] globalTransactionId = new byte[64];
+   private byte[] branchQualifier = new byte[64];
+
+   public EmbeddedXid(UUID transactionManagerId) {
+      cachedHashcode = initializeAndCalculateHash(transactionManagerId);
+   }
+
+   @Override
+   public int getFormatId() {
+      return FORMAT;
+   }
+
+   //the getter is not safe. we should clone it to prevent any modification
+   @Override
+   public byte[] getGlobalTransactionId() {
+      return globalTransactionId;
+   }
+
+   @Override
+   public byte[] getBranchQualifier() {
+      return branchQualifier;
+   }
+
+   @Override
+   public String toString() {
+      return "EmbeddedXid{" +
+            ", globalTransactionId = " + Util.printArray(globalTransactionId, false) +
+            ", branchQualifier = " + Util.printArray(branchQualifier, false) +
+            '}';
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if (this == o) {
+         return true;
+      }
+      if (o == null || !(o instanceof Xid)) {
+         return false;
+      }
+
+      Xid other = (Xid) o;
+
+      return other.getFormatId() == FORMAT &&
+            Arrays.equals(branchQualifier, other.getBranchQualifier()) &&
+            Arrays.equals(globalTransactionId, other.getGlobalTransactionId());
+   }
+
+   @Override
+   public int hashCode() {
+      return cachedHashcode;
+   }
+
+   private int initializeAndCalculateHash(UUID transactionManagerId) {
+      int hc1 = initialize(transactionManagerId, GLOBAL_ID_GENERATOR, globalTransactionId);
+      return 37 * hc1 + initialize(transactionManagerId, BRANCH_QUALIFIER_GENERATOR, branchQualifier);
+   }
+
+   private int initialize(UUID transactionManagerId, AtomicLong generator, byte[] field) {
+      long lsb = transactionManagerId.getLeastSignificantBits();
+      long msb = transactionManagerId.getMostSignificantBits();
+      long id = generator.getAndIncrement();
+      Arrays.fill(field, (byte) 0);
+      UnsignedNumeric.writeUnsignedLong(field, 0, lsb);
+      UnsignedNumeric.writeUnsignedLong(field, 10, msb);
+      UnsignedNumeric.writeUnsignedLong(field, 20, id);
+      int hash = (int) (lsb ^ lsb >>> 32);
+      hash = 37 * hash + (int) (msb ^ msb >>> 32);
+      hash = 37 * hash + (int) (id ^ id >>> 32);
+      return hash;
+   }
+}

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -409,8 +409,8 @@ public interface Log extends BasicLogger {
 //   void remoteTxAlreadyRegistered();
 
    @LogMessage(level = WARN)
-   @Message(value = "Falling back to DummyTransactionManager from Infinispan", id = 104)
-   void fallingBackToDummyTm();
+   @Message(value = "Falling back to EmbeddedTransactionManager from Infinispan", id = 104)
+   void fallingBackToEmbeddedTm();
 
    @LogMessage(level = ERROR)
    @Message(value = "Failed creating initial JNDI context", id = 105)

--- a/core/src/test/java/org/infinispan/api/ClearTest.java
+++ b/core/src/test/java/org/infinispan/api/ClearTest.java
@@ -11,7 +11,7 @@ import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.transaction.LockingMode;
 import org.infinispan.transaction.TransactionMode;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 import org.testng.annotations.Test;
@@ -50,7 +50,7 @@ public class ClearTest extends MultipleCacheManagersTest {
 
       if (transactional) {
          builder.transaction().transactionMode(TransactionMode.TRANSACTIONAL)
-            .transactionManagerLookup(new DummyTransactionManagerLookup())
+            .transactionManagerLookup(new EmbeddedTransactionManagerLookup())
             .syncCommitPhase(true).syncRollbackPhase(true)
             .lockingMode(lockingMode);
       }

--- a/core/src/test/java/org/infinispan/api/batch/BatchWithCustomTMTest.java
+++ b/core/src/test/java/org/infinispan/api/batch/BatchWithCustomTMTest.java
@@ -11,8 +11,8 @@ import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.transaction.TransactionMode;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
-import org.infinispan.transaction.tm.DummyTransactionManager;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
+import org.infinispan.transaction.tm.EmbeddedBaseTransactionManager;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -21,7 +21,7 @@ import org.testng.annotations.Test;
 @Test(groups = {"functional", "transaction"}, testName = "api.batch.BatchWithCustomTMTest")
 public class BatchWithCustomTMTest extends AbstractBatchTest {
 
-   EmbeddedCacheManager cm;
+   private EmbeddedCacheManager cm;
 
    @BeforeClass
    public void createCacheManager() {
@@ -35,8 +35,7 @@ public class BatchWithCustomTMTest extends AbstractBatchTest {
    }
 
    public void testBatchWithOngoingTM() throws Exception {
-      Cache<String, String> cache = null;
-      cache = createCache("testBatchWithOngoingTM");
+      Cache<String, String> cache =createCache("testBatchWithOngoingTM");
       TransactionManager tm = TestingUtil.getTransactionManager(cache);
       assertEquals(MyDummyTransactionManager.class, tm.getClass());
       tm.begin();
@@ -109,7 +108,7 @@ public class BatchWithCustomTMTest extends AbstractBatchTest {
       return cm.getCache(name);
    }
 
-   static class MyDummyTransactionManagerLookup extends DummyTransactionManagerLookup {
+   static class MyDummyTransactionManagerLookup extends EmbeddedTransactionManagerLookup {
       MyDummyTransactionManager tm = new MyDummyTransactionManager();
 
       @Override
@@ -118,7 +117,7 @@ public class BatchWithCustomTMTest extends AbstractBatchTest {
       }
    }
 
-   static class MyDummyTransactionManager extends DummyTransactionManager {
+   static class MyDummyTransactionManager extends EmbeddedBaseTransactionManager {
 
    }
 }

--- a/core/src/test/java/org/infinispan/api/mvcc/repeatable_read/RepeatableReadLockTest.java
+++ b/core/src/test/java/org/infinispan/api/mvcc/repeatable_read/RepeatableReadLockTest.java
@@ -9,7 +9,7 @@ import javax.transaction.TransactionManager;
 
 import org.infinispan.Cache;
 import org.infinispan.api.mvcc.LockTestBase;
-import org.infinispan.transaction.tm.DummyTransactionManager;
+import org.infinispan.transaction.tm.EmbeddedTransactionManager;
 import org.testng.annotations.Test;
 
 @Test(groups = "functional", testName = "api.mvcc.repeatable_read.RepeatableReadLockTest")
@@ -126,7 +126,7 @@ public class RepeatableReadLockTest extends LockTestBase {
    public void testLocksOnPutKeyVal() throws Exception {
       LockTestData tl = lockTestData;
       Cache<String, String> cache = tl.cache;
-      DummyTransactionManager tm = (DummyTransactionManager) tl.tm;
+      EmbeddedTransactionManager tm = tl.tm;
       tm.begin();
       cache.put("k", "v");
       tm.getTransaction().runPrepare();

--- a/core/src/test/java/org/infinispan/configuration/ConfigurationUnitTest.java
+++ b/core/src/test/java/org/infinispan/configuration/ConfigurationUnitTest.java
@@ -35,7 +35,7 @@ import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.test.fwk.TransportFlags;
 import org.infinispan.transaction.TransactionMode;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
 import org.infinispan.util.concurrent.IsolationLevel;
 import org.testng.Assert;
 import org.testng.AssertJUnit;
@@ -78,7 +78,7 @@ public class ConfigurationUnitTest extends AbstractInfinispanTest {
    public void testDummyTMGetCache() throws Exception {
       ConfigurationBuilder cb = new ConfigurationBuilder();
       cb.transaction().use1PcForAutoCommitTransactions(true)
-            .transactionManagerLookup(new DummyTransactionManagerLookup());
+            .transactionManagerLookup(new EmbeddedTransactionManagerLookup());
       withCacheManager(new CacheManagerCallable(createCacheManager()) {
          @Override
          public void call() {

--- a/core/src/test/java/org/infinispan/configuration/TransactionalCacheConfigTest.java
+++ b/core/src/test/java/org/infinispan/configuration/TransactionalCacheConfigTest.java
@@ -12,7 +12,7 @@ import org.infinispan.test.CacheManagerCallable;
 import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.transaction.TransactionMode;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
 import org.testng.annotations.Test;
 
 /**
@@ -66,7 +66,7 @@ public class TransactionalCacheConfigTest extends SingleCacheManagerTest {
       Configuration c = cb.build();
       assert !c.transaction().transactionMode().isTransactional();
 
-      c = cb.transaction().transactionManagerLookup(new DummyTransactionManagerLookup()).build();
+      c = cb.transaction().transactionManagerLookup(new EmbeddedTransactionManagerLookup()).build();
       assert c.transaction().transactionMode().isTransactional();
 
       cb = new ConfigurationBuilder();
@@ -89,7 +89,7 @@ public class TransactionalCacheConfigTest extends SingleCacheManagerTest {
    public void testOverride() {
       final ConfigurationBuilder c = new ConfigurationBuilder();
       c.transaction().transactionMode(TransactionMode.TRANSACTIONAL)
-            .transactionManagerLookup(new DummyTransactionManagerLookup());
+            .transactionManagerLookup(new EmbeddedTransactionManagerLookup());
 
       withCacheManager(new CacheManagerCallable(TestCacheManagerFactory.createCacheManager()){
          @Override
@@ -121,9 +121,5 @@ public class TransactionalCacheConfigTest extends SingleCacheManagerTest {
             assert a.getCacheConfiguration().transaction().transactionMode().isTransactional();
          }
       });
-   }
-
-   private void assertTmLookupSet(Configuration c, boolean b) {
-      assert b == (c.transaction().transactionManagerLookup() != null);
    }
 }

--- a/core/src/test/java/org/infinispan/configuration/TxManagerLookupConfigTest.java
+++ b/core/src/test/java/org/infinispan/configuration/TxManagerLookupConfigTest.java
@@ -12,7 +12,7 @@ import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.test.CacheManagerCallable;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.transaction.lookup.TransactionManagerLookup;
-import org.infinispan.transaction.tm.DummyTransactionManager;
+import org.infinispan.transaction.tm.EmbeddedBaseTransactionManager;
 import org.testng.annotations.Test;
 
 /**
@@ -43,9 +43,9 @@ public class TxManagerLookupConfigTest extends AbstractInfinispanTest {
       });
    }
 
-   public static class TmA extends DummyTransactionManager {}
+   private static class TmA extends EmbeddedBaseTransactionManager {}
 
-   public static class TmB extends DummyTransactionManager {}
+   private static class TmB extends EmbeddedBaseTransactionManager {}
 
    public static class TxManagerLookupA implements TransactionManagerLookup {
 

--- a/core/src/test/java/org/infinispan/container/versioning/TransactionalLocalWriteSkewTest.java
+++ b/core/src/test/java/org/infinispan/container/versioning/TransactionalLocalWriteSkewTest.java
@@ -18,7 +18,7 @@ import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.transaction.LockingMode;
 import org.infinispan.transaction.TransactionMode;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
 import org.infinispan.util.concurrent.IsolationLevel;
 import org.testng.annotations.Test;
 
@@ -30,7 +30,7 @@ public class TransactionalLocalWriteSkewTest extends SingleCacheManagerTest {
       ConfigurationBuilder builder = new ConfigurationBuilder();
       builder
             .transaction()
-            .transactionManagerLookup(new DummyTransactionManagerLookup())
+            .transactionManagerLookup(new EmbeddedTransactionManagerLookup())
             .transactionMode(TransactionMode.TRANSACTIONAL)
             .lockingMode(LockingMode.OPTIMISTIC).syncCommitPhase(true)
             .locking().lockAcquisitionTimeout(TestingUtil.shortTimeoutMillis())
@@ -56,7 +56,7 @@ public class TransactionalLocalWriteSkewTest extends SingleCacheManagerTest {
       // this will keep the values put by both threads. any duplicate value
       // will be detected because of the
       // return value of add() method
-      ConcurrentSkipListSet<Integer> uniqueValuesIncremented = new ConcurrentSkipListSet<Integer>();
+      ConcurrentSkipListSet<Integer> uniqueValuesIncremented = new ConcurrentSkipListSet<>();
 
       // create both threads (simulate a node)
       Future<Void> ict1 = fork(new IncrementCounterTask(c1, uniqueValuesIncremented, counterMaxValue), null);

--- a/core/src/test/java/org/infinispan/distribution/rehash/ConsistencyStressTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/ConsistencyStressTest.java
@@ -32,7 +32,7 @@ import org.infinispan.remoting.transport.Address;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.transaction.LockingMode;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
 import org.infinispan.util.concurrent.IsolationLevel;
 import org.infinispan.util.concurrent.TimeoutException;
 import org.infinispan.util.logging.Log;
@@ -64,7 +64,7 @@ public class ConsistencyStressTest extends MultipleCacheManagersTest {
                .replTimeout(30000)
          .transaction()
             .lockingMode(LockingMode.PESSIMISTIC)
-            .transactionManagerLookup(new DummyTransactionManagerLookup())
+            .transactionManagerLookup(new EmbeddedTransactionManagerLookup())
             .syncCommitPhase(true)
             .syncRollbackPhase(true);
 
@@ -79,7 +79,7 @@ public class ConsistencyStressTest extends MultipleCacheManagersTest {
       registerCacheManager(cacheManagers.toArray(new EmbeddedCacheManager[NUM_NODES]));
    }
 
-   public void testConsistency() throws Throwable, InterruptedException {
+   public void testConsistency() throws Throwable {
       Set<Future<Void>> futures = new HashSet<Future<Void>>(NUM_NODES * WORKERS_PER_NODE);
       Set<String> keysToIgnore = new HashSet<String>();
 

--- a/core/src/test/java/org/infinispan/distribution/rehash/OptimisticPrimaryOwnerCrashDuringPrepareTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/OptimisticPrimaryOwnerCrashDuringPrepareTest.java
@@ -14,8 +14,8 @@ import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.concurrent.StateSequencer;
 import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.infinispan.transaction.LockingMode;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
-import org.infinispan.transaction.tm.DummyTransaction;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
+import org.infinispan.transaction.tm.EmbeddedTransaction;
 import org.infinispan.util.ControlledConsistentHashFactory;
 import org.testng.annotations.Test;
 
@@ -37,16 +37,16 @@ public class OptimisticPrimaryOwnerCrashDuringPrepareTest extends MultipleCacheM
 
       tm(0).begin();
       cache(0).put("k", "v1");
-      DummyTransaction tx1 = (DummyTransaction) tm(0).suspend();
+      EmbeddedTransaction tx1 = (EmbeddedTransaction) tm(0).suspend();
       tx1.runPrepare();
 
       advanceOnInboundRpc(ss, cache(1), matchCommand(PrepareCommand.class).build())
             .before("block_prepare", "resume_prepare");
 
-      Future<DummyTransaction> tx2Future = fork(() -> {
+      Future<EmbeddedTransaction> tx2Future = fork(() -> {
          tm(0).begin();
          cache(0).put("k", "v2");
-         DummyTransaction tx2 = (DummyTransaction) tm(0).suspend();
+         EmbeddedTransaction tx2 = (EmbeddedTransaction) tm(0).suspend();
          tx2.runPrepare();
          return tx2;
       });
@@ -55,7 +55,7 @@ public class OptimisticPrimaryOwnerCrashDuringPrepareTest extends MultipleCacheM
       killMember(1);
       ss.exit("crash_primary");
 
-      DummyTransaction tx2 = tx2Future.get(10, SECONDS);
+      EmbeddedTransaction tx2 = tx2Future.get(10, SECONDS);
       try {
          tx2.runCommit(false);
          fail("tx2 should not be able to commit");
@@ -73,7 +73,7 @@ public class OptimisticPrimaryOwnerCrashDuringPrepareTest extends MultipleCacheM
       config.transaction().lockingMode(LockingMode.OPTIMISTIC);
       config.clustering().hash().numSegments(1)
             .consistentHashFactory(new ControlledConsistentHashFactory(1, 0));
-      config.transaction().transactionManagerLookup(new DummyTransactionManagerLookup())
+      config.transaction().transactionManagerLookup(new EmbeddedTransactionManagerLookup())
             .cacheStopTimeout(1, SECONDS);
       createCluster(config, 2);
       waitForClusterToForm();

--- a/core/src/test/java/org/infinispan/expiry/AutoCommitExpiryTest.java
+++ b/core/src/test/java/org/infinispan/expiry/AutoCommitExpiryTest.java
@@ -22,12 +22,10 @@ import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.transaction.TransactionMode;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
 import org.infinispan.util.ControlledTimeService;
 import org.infinispan.util.TimeService;
 import org.testng.annotations.Test;
-
-import static org.testng.AssertJUnit.assertEquals;
 
 @Test(groups = "functional", testName = "expiry.AutoCommitExpiryTest")
 public abstract class AutoCommitExpiryTest extends SingleCacheManagerTest {
@@ -76,7 +74,7 @@ public abstract class AutoCommitExpiryTest extends SingleCacheManagerTest {
             .jmxStatistics().enable()
             .transaction()
             .transactionMode(TransactionMode.TRANSACTIONAL)
-            .transactionManagerLookup(new DummyTransactionManagerLookup())
+            .transactionManagerLookup(new EmbeddedTransactionManagerLookup())
             .autoCommit(autoCommit);
       EmbeddedCacheManager cm = TestCacheManagerFactory.createClusteredCacheManager(builder);
 

--- a/core/src/test/java/org/infinispan/jmx/MvccLockManagerMBeanTest.java
+++ b/core/src/test/java/org/infinispan/jmx/MvccLockManagerMBeanTest.java
@@ -12,8 +12,8 @@ import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
-import org.infinispan.transaction.tm.DummyTransactionManager;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
+import org.infinispan.transaction.tm.EmbeddedTransactionManager;
 import org.testng.annotations.Test;
 
 /**
@@ -24,7 +24,7 @@ import org.testng.annotations.Test;
  */
 @Test(groups = "functional", testName = "jmx.MvccLockManagerMBeanTest")
 public class MvccLockManagerMBeanTest extends SingleCacheManagerTest {
-   public static final int CONCURRENCY_LEVEL = 129;
+   private static final int CONCURRENCY_LEVEL = 129;
 
    private ObjectName lockManagerObjName;
    private MBeanServer threadMBeanServer;
@@ -42,7 +42,7 @@ public class MvccLockManagerMBeanTest extends SingleCacheManagerTest {
                .concurrencyLevel(CONCURRENCY_LEVEL)
                .useLockStriping(true)
             .transaction()
-               .transactionManagerLookup(new DummyTransactionManagerLookup());
+               .transactionManagerLookup(new EmbeddedTransactionManagerLookup());
 
       cacheManager.defineConfiguration("test", configuration.build());
       cache = cacheManager.getCache("test");
@@ -61,7 +61,7 @@ public class MvccLockManagerMBeanTest extends SingleCacheManagerTest {
    }
 
    public void testNumberOfLocksHeld() throws Exception {
-      DummyTransactionManager tm = (DummyTransactionManager) TestingUtil.extractComponent(cache, TransactionManager.class);
+      EmbeddedTransactionManager tm = (EmbeddedTransactionManager) TestingUtil.extractComponent(cache, TransactionManager.class);
       tm.begin();
       cache.put("key", "value");
       tm.getTransaction().runPrepare();
@@ -71,7 +71,7 @@ public class MvccLockManagerMBeanTest extends SingleCacheManagerTest {
    }
 
    public void testNumberOfLocksAvailable() throws Exception {
-      DummyTransactionManager tm = (DummyTransactionManager) TestingUtil.extractComponent(cache, TransactionManager.class);
+      EmbeddedTransactionManager tm = (EmbeddedTransactionManager) TestingUtil.extractComponent(cache, TransactionManager.class);
       int initialAvailable = getAttrValue("NumberOfLocksAvailable");
       tm.begin();
       cache.put("key", "value");

--- a/core/src/test/java/org/infinispan/lock/L1LockTest.java
+++ b/core/src/test/java/org/infinispan/lock/L1LockTest.java
@@ -5,7 +5,7 @@ import static org.testng.AssertJUnit.assertEquals;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.test.MultipleCacheManagersTest;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
 import org.testng.annotations.Test;
 
 /**
@@ -17,7 +17,7 @@ public class L1LockTest extends MultipleCacheManagersTest {
    @Override
    protected void createCacheManagers() throws Throwable {
       ConfigurationBuilder config = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, true);
-      config.clustering().hash().numOwners(1).transaction().transactionManagerLookup(new DummyTransactionManagerLookup());
+      config.clustering().hash().numOwners(1).transaction().transactionManagerLookup(new EmbeddedTransactionManagerLookup());
       createCluster(config, 2);
       waitForClusterToForm();
    }

--- a/core/src/test/java/org/infinispan/lock/singlelock/AbstractInitiatorCrashTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/AbstractInitiatorCrashTest.java
@@ -4,7 +4,7 @@ import java.util.concurrent.CountDownLatch;
 
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.transaction.LockingMode;
-import org.infinispan.transaction.tm.DummyTransaction;
+import org.infinispan.transaction.tm.EmbeddedTransaction;
 import org.testng.annotations.Test;
 
 /**
@@ -37,12 +37,7 @@ public abstract class AbstractInitiatorCrashTest extends AbstractCrashTest {
 
       killMember(1);
 
-      eventually(new Condition() {
-         @Override
-         public boolean isSatisfied() throws Exception {
-            return checkTxCount(0, 0, 0) && checkTxCount(1, 0, 0);
-         }
-      });
+      eventually(() -> checkTxCount(0, 0, 0) && checkTxCount(1, 0, 0));
       assertNotLocked(k);
    }
 
@@ -52,7 +47,7 @@ public abstract class AbstractInitiatorCrashTest extends AbstractCrashTest {
 
       tm(1).begin();
       cache(1).put(k,"v");
-      final DummyTransaction transaction = (DummyTransaction) tm(1).getTransaction();
+      final EmbeddedTransaction transaction = (EmbeddedTransaction) tm(1).getTransaction();
       transaction.runPrepare();
       tm(1).suspend();
 
@@ -67,11 +62,6 @@ public abstract class AbstractInitiatorCrashTest extends AbstractCrashTest {
       killMember(1);
 
       assertNotLocked(k);
-      eventually(new Condition() {
-         @Override
-         public boolean isSatisfied() throws Exception {
-            return checkTxCount(0, 0, 0) && checkTxCount(1, 0, 0);
-         }
-      });
+      eventually(() -> checkTxCount(0, 0, 0) && checkTxCount(1, 0, 0));
    }
 }

--- a/core/src/test/java/org/infinispan/lock/singlelock/MainOwnerChangesPessimisticLockTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/MainOwnerChangesPessimisticLockTest.java
@@ -15,8 +15,8 @@ import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.infinispan.transaction.LockingMode;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
-import org.infinispan.transaction.tm.DummyTransaction;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
+import org.infinispan.transaction.tm.EmbeddedTransaction;
 import org.testng.annotations.Test;
 
 /**
@@ -35,7 +35,7 @@ public class MainOwnerChangesPessimisticLockTest extends MultipleCacheManagersTe
    protected void createCacheManagers() throws Throwable {
       dccc = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, true, true);
       dccc.transaction()
-            .transactionManagerLookup(new DummyTransactionManagerLookup())
+            .transactionManagerLookup(new EmbeddedTransactionManagerLookup())
             .lockingMode(LockingMode.PESSIMISTIC)
             .syncCommitPhase(true)
             .syncRollbackPhase(true)
@@ -97,7 +97,7 @@ public class MainOwnerChangesPessimisticLockTest extends MultipleCacheManagersTe
             migratedKey = key;
             migratedTransaction = key2Tx.get(key);
             log.trace("Migrated key = " + migratedKey);
-            log.trace("Migrated transaction = " + ((DummyTransaction) migratedTransaction).getEnlistedResources());
+            log.trace("Migrated transaction = " + ((EmbeddedTransaction) migratedTransaction).getEnlistedResources());
             break;
          }
       }

--- a/core/src/test/java/org/infinispan/lock/singlelock/optimistic/BasicSingleLockOptimisticTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/optimistic/BasicSingleLockOptimisticTest.java
@@ -5,7 +5,7 @@ import static org.testng.Assert.assertEquals;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.lock.singlelock.AbstractNoCrashTest;
 import org.infinispan.transaction.LockingMode;
-import org.infinispan.transaction.tm.DummyTransaction;
+import org.infinispan.transaction.tm.EmbeddedTransaction;
 import org.testng.annotations.Test;
 
 /**
@@ -29,7 +29,7 @@ public class BasicSingleLockOptimisticTest extends AbstractNoCrashTest {
 
       tm(0).begin();
       operation.perform(k, 0);
-      DummyTransaction dtm = (DummyTransaction) tm(0).getTransaction();
+       EmbeddedTransaction dtm = (EmbeddedTransaction) tm(0).getTransaction();
       dtm.runPrepare();
 
       assert !lockManager(0).isLocked(k);
@@ -53,7 +53,7 @@ public class BasicSingleLockOptimisticTest extends AbstractNoCrashTest {
       tm(0).begin();
       cache(0).put(k1, "v");
       cache(0).put(k2, "v");
-      DummyTransaction dtm = (DummyTransaction) tm(0).getTransaction();
+      EmbeddedTransaction dtm = (EmbeddedTransaction) tm(0).getTransaction();
       dtm.runPrepare();
 
       assert !lockManager(0).isLocked(k1);
@@ -76,7 +76,7 @@ public class BasicSingleLockOptimisticTest extends AbstractNoCrashTest {
 
       tm(0).begin();
       cache(0).put(k, "v");
-      DummyTransaction dtm = (DummyTransaction) tm(0).getTransaction();
+      EmbeddedTransaction dtm = (EmbeddedTransaction) tm(0).getTransaction();
       dtm.runPrepare();
       tm(0).suspend();
 
@@ -93,12 +93,7 @@ public class BasicSingleLockOptimisticTest extends AbstractNoCrashTest {
          //ignore
       }
 
-      eventually(new Condition() {
-         @Override
-         public boolean isSatisfied() throws Exception {
-            return checkTxCount(0, 1, 0) && checkTxCount(1, 0, 1) && checkTxCount(2, 0, 1);
-         }
-      });
+      eventually(() -> checkTxCount(0, 1, 0) && checkTxCount(1, 0, 1) && checkTxCount(2, 0, 1));
 
 
       log.info("Before second failure");
@@ -111,12 +106,7 @@ public class BasicSingleLockOptimisticTest extends AbstractNoCrashTest {
          //expected
       }
 
-      eventually(new Condition() {
-         @Override
-         public boolean isSatisfied() throws Exception {
-            return checkTxCount(0, 1, 0) && checkTxCount(1, 0, 1) && checkTxCount(2, 0, 1);
-         }
-      });
+      eventually(() -> checkTxCount(0, 1, 0) && checkTxCount(1, 0, 1) && checkTxCount(2, 0, 1));
 
 
       tm(0).resume(dtm);
@@ -124,11 +114,6 @@ public class BasicSingleLockOptimisticTest extends AbstractNoCrashTest {
 
       assertValue(k, false);
 
-      eventually(new Condition() {
-         @Override
-         public boolean isSatisfied() throws Exception {
-            return noPendingTransactions(0) && noPendingTransactions(1) && noPendingTransactions(2);
-         }
-      });
+      eventually(() -> noPendingTransactions(0) && noPendingTransactions(1) && noPendingTransactions(2));
    }
 }

--- a/core/src/test/java/org/infinispan/lock/singlelock/optimistic/LockOwnerCrashOptimisticTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/optimistic/LockOwnerCrashOptimisticTest.java
@@ -7,7 +7,7 @@ import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.lock.singlelock.AbstractLockOwnerCrashTest;
 import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.infinispan.transaction.LockingMode;
-import org.infinispan.transaction.tm.DummyTransaction;
+import org.infinispan.transaction.tm.EmbeddedTransaction;
 import org.testng.annotations.Test;
 
 
@@ -23,29 +23,21 @@ public class LockOwnerCrashOptimisticTest extends AbstractLockOwnerCrashTest {
       super(CacheMode.DIST_SYNC, LockingMode.OPTIMISTIC, false);
    }
 
-   private DummyTransaction transaction;
+   private EmbeddedTransaction transaction;
 
    public void testLockOwnerCrashesBeforePrepare() throws Exception {
       final Object k = getKeyForCache(2);
-      inNewThread(new Runnable() {
-         @Override
-         public void run() {
-            try {
-               tm(1).begin();
-               cache(1).put(k, "v");
-               transaction = (DummyTransaction) tm(1).getTransaction();
-            } catch (Throwable e) {
-               log.errorf(e, "Error starting transaction for key %s", k);
-            }
+      inNewThread(() -> {
+         try {
+            tm(1).begin();
+            cache(1).put(k, "v");
+            transaction = (EmbeddedTransaction) tm(1).getTransaction();
+         } catch (Throwable e) {
+            log.errorf(e, "Error starting transaction for key %s", k);
          }
       });
 
-      eventually(new Condition() {
-         @Override
-         public boolean isSatisfied() throws Exception {
-            return checkTxCount(0, 0, 0) && checkTxCount(1, 1, 0)&& checkTxCount(2, 0, 0);
-         }
-      });
+      eventually(() -> checkTxCount(0, 0, 0) && checkTxCount(1, 1, 0)&& checkTxCount(2, 0, 0));
 
       killMember(2);
       assert caches().size() == 2;
@@ -57,37 +49,24 @@ public class LockOwnerCrashOptimisticTest extends AbstractLockOwnerCrashTest {
       assertEquals("v", cache(1).get(k));
 
       assertNotLocked(k);
-      eventually(new Condition() {
-         @Override
-         public boolean isSatisfied() throws Exception {
-            return checkTxCount(0, 0, 0) && checkTxCount(1, 0, 0);
-         }
-      });
+      eventually(() -> checkTxCount(0, 0, 0) && checkTxCount(1, 0, 0));
    }
 
    public void lockOwnerCrasherBetweenPrepareAndCommit() throws Exception {
       final Object k = getKeyForCache(2);
-      inNewThread(new Runnable() {
-         @Override
-         public void run() {
-            try {
-               tm(1).begin();
-               cache(1).put(k, "v");
-               transaction = (DummyTransaction) tm(1).getTransaction();
-               transaction.runPrepare();
-            } catch (Throwable e) {
-               log.errorf(e, "Error preparing transaction for key %s", k);
-            }
+      inNewThread(() -> {
+         try {
+            tm(1).begin();
+            cache(1).put(k, "v");
+            transaction = (EmbeddedTransaction) tm(1).getTransaction();
+            transaction.runPrepare();
+         } catch (Throwable e) {
+            log.errorf(e, "Error preparing transaction for key %s", k);
          }
       });
 
 
-      eventually(new Condition() {
-         @Override
-         public boolean isSatisfied() throws Exception {
-            return checkTxCount(0, 0, 1) &&  checkTxCount(1, 1, 0) &&  checkTxCount(2, 0, 1);
-         }
-      });
+      eventually(() -> checkTxCount(0, 0, 1) &&  checkTxCount(1, 1, 0) &&  checkTxCount(2, 0, 1));
 
       killMember(2);
       assert caches().size() == 2;

--- a/core/src/test/java/org/infinispan/lock/singlelock/pessimistic/BasicSingleLockPessimisticTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/pessimistic/BasicSingleLockPessimisticTest.java
@@ -4,9 +4,8 @@ import static org.testng.Assert.assertEquals;
 
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.lock.singlelock.AbstractNoCrashTest;
-import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.transaction.LockingMode;
-import org.infinispan.transaction.tm.DummyTransaction;
+import org.infinispan.transaction.tm.EmbeddedTransaction;
 import org.testng.annotations.Test;
 
 /**
@@ -74,7 +73,7 @@ public class BasicSingleLockPessimisticTest extends AbstractNoCrashTest {
 
       tm(0).begin();
       cache(0).put(k, "v");
-      DummyTransaction dtm = (DummyTransaction) tm(0).getTransaction();
+      EmbeddedTransaction dtm = (EmbeddedTransaction) tm(0).getTransaction();
       tm(0).suspend();
 
       assert checkTxCount(0, 1, 0);
@@ -92,12 +91,7 @@ public class BasicSingleLockPessimisticTest extends AbstractNoCrashTest {
       }
 
       assertNotLocked(k1);
-      eventually(new AbstractInfinispanTest.Condition() {
-         @Override
-         public boolean isSatisfied() throws Exception {
-            return checkTxCount(0, 1, 0) && checkTxCount(1, 0, 0) && checkTxCount(2, 0, 0);
-         }
-      });
+      eventually(() -> checkTxCount(0, 1, 0) && checkTxCount(1, 0, 0) && checkTxCount(2, 0, 0));
 
 
       log.info("Before second failure");
@@ -113,12 +107,7 @@ public class BasicSingleLockPessimisticTest extends AbstractNoCrashTest {
       }
       assertNotLocked(k1);
 
-      eventually(new AbstractInfinispanTest.Condition() {
-         @Override
-         public boolean isSatisfied() throws Exception {
-            return checkTxCount(0, 1, 0) && checkTxCount(1, 0, 0) && checkTxCount(1, 0, 0);
-         }
-      });
+      eventually(() -> checkTxCount(0, 1, 0) && checkTxCount(1, 0, 0) && checkTxCount(1, 0, 0));
 
 
       log.trace("about to commit transaction.");
@@ -127,11 +116,6 @@ public class BasicSingleLockPessimisticTest extends AbstractNoCrashTest {
 
       assertValue(k, false);
 
-      eventually(new AbstractInfinispanTest.Condition() {
-         @Override
-         public boolean isSatisfied() throws Exception {
-            return noPendingTransactions(0) && noPendingTransactions(1) && noPendingTransactions(2);
-         }
-      });
+      eventually(() -> noPendingTransactions(0) && noPendingTransactions(1) && noPendingTransactions(2));
    }
 }

--- a/core/src/test/java/org/infinispan/lock/singlelock/replicated/optimistic/BasicSingleLockReplOptTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/replicated/optimistic/BasicSingleLockReplOptTest.java
@@ -4,7 +4,7 @@ import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.distribution.MagicKey;
 import org.infinispan.lock.singlelock.AbstractNoCrashTest;
 import org.infinispan.transaction.LockingMode;
-import org.infinispan.transaction.tm.DummyTransaction;
+import org.infinispan.transaction.tm.EmbeddedTransaction;
 import org.testng.annotations.Test;
 
 /**
@@ -27,7 +27,7 @@ public class BasicSingleLockReplOptTest extends AbstractNoCrashTest {
 
       tm(0).begin();
       operation.perform(k, 0);
-      DummyTransaction dtm = (DummyTransaction) tm(0).getTransaction();
+      EmbeddedTransaction dtm = (EmbeddedTransaction) tm(0).getTransaction();
       dtm.runPrepare();
 
       assert lockManager(0).isLocked(k);
@@ -48,7 +48,7 @@ public class BasicSingleLockReplOptTest extends AbstractNoCrashTest {
       tm(0).begin();
       cache(0).put(k1, "v");
       cache(0).put(k2, "v");
-      DummyTransaction dtm = (DummyTransaction) tm(0).getTransaction();
+      EmbeddedTransaction dtm = (EmbeddedTransaction) tm(0).getTransaction();
       dtm.runPrepare();
 
       assert lockManager(0).isLocked(k1);
@@ -71,7 +71,7 @@ public class BasicSingleLockReplOptTest extends AbstractNoCrashTest {
 
       tm(0).begin();
       cache(0).put(k0, "v");
-      DummyTransaction dtm = (DummyTransaction) tm(0).getTransaction();
+      EmbeddedTransaction dtm = (EmbeddedTransaction) tm(0).getTransaction();
 
       dtm.runPrepare();
 
@@ -90,7 +90,7 @@ public class BasicSingleLockReplOptTest extends AbstractNoCrashTest {
 
       tm(0).begin();
       cache(0).put(k0, "v");
-      DummyTransaction dtm = (DummyTransaction) tm(0).getTransaction();
+      EmbeddedTransaction dtm = (EmbeddedTransaction) tm(0).getTransaction();
       dtm.runPrepare();
       tm(0).suspend();
 
@@ -107,12 +107,7 @@ public class BasicSingleLockReplOptTest extends AbstractNoCrashTest {
          //ignore
       }
 
-      eventually(new Condition() {
-         @Override
-         public boolean isSatisfied() throws Exception {
-            return checkTxCount(0, 1, 0) && checkTxCount(1, 0, 1) && checkTxCount(2, 0, 1);
-         }
-      });
+      eventually(() -> checkTxCount(0, 1, 0) && checkTxCount(1, 0, 1) && checkTxCount(2, 0, 1));
 
 
       tm(1).begin();
@@ -124,12 +119,7 @@ public class BasicSingleLockReplOptTest extends AbstractNoCrashTest {
          //expected
       }
 
-      eventually(new Condition() {
-         @Override
-         public boolean isSatisfied() throws Exception {
-            return checkTxCount(0, 1, 0) && checkTxCount(1, 0, 1) && checkTxCount(2, 0, 1);
-         }
-      });
+      eventually(() -> checkTxCount(0, 1, 0) && checkTxCount(1, 0, 1) && checkTxCount(2, 0, 1));
 
 
       tm(0).resume(dtm);
@@ -137,11 +127,6 @@ public class BasicSingleLockReplOptTest extends AbstractNoCrashTest {
 
       assertValue(k0, false);
 
-      eventually(new Condition() {
-         @Override
-         public boolean isSatisfied() throws Exception {
-            return noPendingTransactions(0) && noPendingTransactions(1) && noPendingTransactions(2);
-         }
-      });
+      eventually(() -> noPendingTransactions(0) && noPendingTransactions(1) && noPendingTransactions(2));
    }
 }

--- a/core/src/test/java/org/infinispan/lock/singlelock/replicated/pessimistic/BasicSingleLockRepPessimisticTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/replicated/pessimistic/BasicSingleLockRepPessimisticTest.java
@@ -3,9 +3,8 @@ package org.infinispan.lock.singlelock.replicated.pessimistic;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.distribution.MagicKey;
 import org.infinispan.lock.singlelock.AbstractNoCrashTest;
-import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.transaction.LockingMode;
-import org.infinispan.transaction.tm.DummyTransaction;
+import org.infinispan.transaction.tm.EmbeddedTransaction;
 import org.testng.annotations.Test;
 
 /**
@@ -79,7 +78,7 @@ public class BasicSingleLockRepPessimisticTest extends AbstractNoCrashTest {
       Object k0 = new MagicKey("k0", cache(0));
       tm(0).begin();
       cache(0).put(k0, "v");
-      DummyTransaction dtm = (DummyTransaction) tm(0).suspend();
+      EmbeddedTransaction dtm = (EmbeddedTransaction) tm(0).suspend();
 
       assert checkTxCount(0, 1, 0);
       assert checkTxCount(1, 0, 0);
@@ -93,12 +92,7 @@ public class BasicSingleLockRepPessimisticTest extends AbstractNoCrashTest {
          tm(0).rollback();
       }
 
-      eventually(new AbstractInfinispanTest.Condition() {
-         @Override
-         public boolean isSatisfied() throws Exception {
-            return checkTxCount(0, 1, 0) && checkTxCount(1, 0, 0) && checkTxCount(2, 0, 0);
-         }
-      });
+      eventually(() -> checkTxCount(0, 1, 0) && checkTxCount(1, 0, 0) && checkTxCount(2, 0, 0));
 
 
       tm(1).begin();
@@ -109,12 +103,7 @@ public class BasicSingleLockRepPessimisticTest extends AbstractNoCrashTest {
          tm(0).rollback();
       }
 
-      eventually(new AbstractInfinispanTest.Condition() {
-         @Override
-         public boolean isSatisfied() throws Exception {
-            return checkTxCount(0, 1, 0) && checkTxCount(1, 0, 0) && checkTxCount(2, 0, 0);
-         }
-      });
+      eventually(() -> checkTxCount(0, 1, 0) && checkTxCount(1, 0, 0) && checkTxCount(2, 0, 0));
 
 
       tm(0).resume(dtm);
@@ -122,19 +111,14 @@ public class BasicSingleLockRepPessimisticTest extends AbstractNoCrashTest {
 
       assertValue(k0, false);
 
-      eventually(new AbstractInfinispanTest.Condition() {
-         @Override
-         public boolean isSatisfied() throws Exception {
-            return noPendingTransactions(0) && noPendingTransactions(1) && noPendingTransactions(2);
-         }
-      });
+      eventually(() -> noPendingTransactions(0) && noPendingTransactions(1) && noPendingTransactions(2));
    }
 
    public void testSecondTxCannotPrepare2() throws Exception {
       Object k0 = new MagicKey("k0", cache(0));
       tm(1).begin();
       cache(1).put(k0, "v");
-      DummyTransaction dtm = (DummyTransaction) tm(1).suspend();
+      EmbeddedTransaction dtm = (EmbeddedTransaction) tm(1).suspend();
 
       assert checkTxCount(0, 0, 1);
       assert checkTxCount(1, 1, 0);
@@ -148,12 +132,7 @@ public class BasicSingleLockRepPessimisticTest extends AbstractNoCrashTest {
          tm(0).rollback();
       }
 
-      eventually(new AbstractInfinispanTest.Condition() {
-         @Override
-         public boolean isSatisfied() throws Exception {
-            return checkTxCount(0, 0, 1) && checkTxCount(1, 1, 0) && checkTxCount(2, 0, 1);
-         }
-      });
+      eventually(() -> checkTxCount(0, 0, 1) && checkTxCount(1, 1, 0) && checkTxCount(2, 0, 1));
 
 
       tm(1).begin();
@@ -164,12 +143,7 @@ public class BasicSingleLockRepPessimisticTest extends AbstractNoCrashTest {
          tm(0).rollback();
       }
 
-      eventually(new AbstractInfinispanTest.Condition() {
-         @Override
-         public boolean isSatisfied() throws Exception {
-            return checkTxCount(0, 0, 1) && checkTxCount(1, 1, 0) && checkTxCount(2, 0, 1);
-         }
-      });
+      eventually(() -> checkTxCount(0, 0, 1) && checkTxCount(1, 1, 0) && checkTxCount(2, 0, 1));
 
 
       tm(0).resume(dtm);
@@ -177,11 +151,6 @@ public class BasicSingleLockRepPessimisticTest extends AbstractNoCrashTest {
 
       assertValue(k0, false);
 
-      eventually(new AbstractInfinispanTest.Condition() {
-         @Override
-         public boolean isSatisfied() throws Exception {
-            return noPendingTransactions(0) && noPendingTransactions(1) && noPendingTransactions(2);
-         }
-      });
+      eventually(() -> noPendingTransactions(0) && noPendingTransactions(1) && noPendingTransactions(2));
    }
 }

--- a/core/src/test/java/org/infinispan/manager/CacheManagerComponentRegistryTest.java
+++ b/core/src/test/java/org/infinispan/manager/CacheManagerComponentRegistryTest.java
@@ -14,8 +14,8 @@ import org.infinispan.test.AbstractCacheTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.transaction.TransactionMode;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
-import org.infinispan.transaction.tm.DummyTransactionManager;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
+import org.infinispan.transaction.tm.EmbeddedTransactionManager;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
@@ -25,7 +25,7 @@ import org.testng.annotations.Test;
  */
 @Test(groups = "functional", testName = "manager.CacheManagerComponentRegistryTest")
 public class CacheManagerComponentRegistryTest extends AbstractCacheTest {
-   EmbeddedCacheManager cm;
+   private EmbeddedCacheManager cm;
 
    @AfterMethod
    public void tearDown() {
@@ -49,13 +49,13 @@ public class CacheManagerComponentRegistryTest extends AbstractCacheTest {
       Cache c = cm.getCache();
 
       ConfigurationBuilder overrides = TestCacheManagerFactory.getDefaultCacheConfiguration(true);
-      overrides.transaction().transactionManagerLookup(new DummyTransactionManagerLookup());
+      overrides.transaction().transactionManagerLookup(new EmbeddedTransactionManagerLookup());
       cm.defineConfiguration("transactional", overrides.build());
       Cache transactional = cm.getCache("transactional");
 
       // assert components.
       assert TestingUtil.extractComponent(c, TransactionManager.class) == null;
-      assert TestingUtil.extractComponent(transactional, TransactionManager.class) instanceof DummyTransactionManager;
+      assert TestingUtil.extractComponent(transactional, TransactionManager.class) instanceof EmbeddedTransactionManager;
 
       // assert force-shared components
       assert TestingUtil.extractComponent(c, Transport.class) != null;
@@ -78,7 +78,7 @@ public class CacheManagerComponentRegistryTest extends AbstractCacheTest {
       Cache c = cm.getCache();
 
       ConfigurationBuilder overrides = TestCacheManagerFactory.getDefaultCacheConfiguration(true);
-      overrides.transaction().transactionManagerLookup(new DummyTransactionManagerLookup());
+      overrides.transaction().transactionManagerLookup(new EmbeddedTransactionManagerLookup());
       cm.defineConfiguration("transactional", overrides.build());
       Cache transactional = cm.getCache("transactional");
 

--- a/core/src/test/java/org/infinispan/partitionhandling/BaseOptimisticTxPartitionAndMergeTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/BaseOptimisticTxPartitionAndMergeTest.java
@@ -15,9 +15,9 @@ import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.transaction.LockingMode;
 import org.infinispan.transaction.TransactionMode;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
-import org.infinispan.transaction.tm.DummyTransaction;
-import org.infinispan.transaction.tm.DummyTransactionManager;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
+import org.infinispan.transaction.tm.EmbeddedTransaction;
+import org.infinispan.transaction.tm.EmbeddedTransactionManager;
 
 /**
  * It tests multiple scenarios where a split can happen during a transaction.
@@ -27,14 +27,14 @@ import org.infinispan.transaction.tm.DummyTransactionManager;
  */
 public abstract class BaseOptimisticTxPartitionAndMergeTest extends BaseTxPartitionAndMergeTest {
 
-   protected static final String OPTIMISTIC_TX_CACHE_NAME = "opt-cache";
+   static final String OPTIMISTIC_TX_CACHE_NAME = "opt-cache";
 
    @Override
    protected void createCacheManagers() throws Throwable {
       super.createCacheManagers();
       ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC);
       builder.clustering().partitionHandling().enabled(true);
-      builder.transaction().lockingMode(LockingMode.OPTIMISTIC).transactionMode(TransactionMode.TRANSACTIONAL).transactionManagerLookup(new DummyTransactionManagerLookup());
+      builder.transaction().lockingMode(LockingMode.OPTIMISTIC).transactionMode(TransactionMode.TRANSACTIONAL).transactionManagerLookup(new EmbeddedTransactionManagerLookup());
       defineConfigurationOnAllManagers(OPTIMISTIC_TX_CACHE_NAME, builder);
    }
 
@@ -52,10 +52,10 @@ public abstract class BaseOptimisticTxPartitionAndMergeTest extends BaseTxPartit
       final FilterCollection filterCollection = createFilters(OPTIMISTIC_TX_CACHE_NAME, discard, getCommandClass(), splitMode);
 
       Future<Integer> put = fork(() -> {
-         final DummyTransactionManager transactionManager = (DummyTransactionManager) originator.getAdvancedCache().getTransactionManager();
+         final EmbeddedTransactionManager transactionManager = (EmbeddedTransactionManager) originator.getAdvancedCache().getTransactionManager();
          transactionManager.begin();
          keyInfo.putFinalValue(originator);
-         final DummyTransaction transaction = transactionManager.getTransaction();
+         final EmbeddedTransaction transaction = transactionManager.getTransaction();
          transaction.runPrepare();
          transaction.runCommit(forceRollback());
          return transaction.getStatus();

--- a/core/src/test/java/org/infinispan/partitionhandling/BasePessimisticTxPartitionAndMergeTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/BasePessimisticTxPartitionAndMergeTest.java
@@ -16,7 +16,7 @@ import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.transaction.LockingMode;
 import org.infinispan.transaction.TransactionMode;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
 
 /**
  * It tests multiple scenarios where a split can happen during a transaction.
@@ -33,7 +33,7 @@ public abstract class BasePessimisticTxPartitionAndMergeTest extends BaseTxParti
       super.createCacheManagers();
       ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC);
       builder.clustering().partitionHandling().enabled(true);
-      builder.transaction().lockingMode(LockingMode.PESSIMISTIC).transactionMode(TransactionMode.TRANSACTIONAL).transactionManagerLookup(new DummyTransactionManagerLookup());
+      builder.transaction().lockingMode(LockingMode.PESSIMISTIC).transactionMode(TransactionMode.TRANSACTIONAL).transactionManagerLookup(new EmbeddedTransactionManagerLookup());
       defineConfigurationOnAllManagers(PESSIMISTIC_TX_CACHE_NAME, builder);
    }
 

--- a/core/src/test/java/org/infinispan/partitionhandling/OptimisticTxPartitionAndMergeDuringCommitTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/OptimisticTxPartitionAndMergeDuringCommitTest.java
@@ -3,8 +3,8 @@ package org.infinispan.partitionhandling;
 import org.infinispan.Cache;
 import org.infinispan.commands.tx.CommitCommand;
 import org.infinispan.commands.tx.TransactionBoundaryCommand;
-import org.infinispan.transaction.tm.DummyTransaction;
-import org.infinispan.transaction.tm.DummyTransactionManager;
+import org.infinispan.transaction.tm.EmbeddedTransaction;
+import org.infinispan.transaction.tm.EmbeddedTransactionManager;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 import org.testng.AssertJUnit;
@@ -51,9 +51,9 @@ public class OptimisticTxPartitionAndMergeDuringCommitTest extends BaseOptimisti
       final KeyInfo keyInfo = createKeys(OPTIMISTIC_TX_CACHE_NAME);
       final Cache<Object, String> originator = cache(0, OPTIMISTIC_TX_CACHE_NAME);
 
-      final DummyTransactionManager transactionManager = (DummyTransactionManager) originator.getAdvancedCache().getTransactionManager();
+      final EmbeddedTransactionManager transactionManager = (EmbeddedTransactionManager) originator.getAdvancedCache().getTransactionManager();
       transactionManager.begin();
-      final DummyTransaction transaction = transactionManager.getTransaction();
+      final EmbeddedTransaction transaction = transactionManager.getTransaction();
       keyInfo.putFinalValue(originator);
       AssertJUnit.assertTrue(transaction.runPrepare());
       transactionManager.suspend();

--- a/core/src/test/java/org/infinispan/partitionhandling/OptimisticTxPartitionAndMergeDuringRollbackTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/OptimisticTxPartitionAndMergeDuringRollbackTest.java
@@ -3,8 +3,8 @@ package org.infinispan.partitionhandling;
 import org.infinispan.Cache;
 import org.infinispan.commands.tx.RollbackCommand;
 import org.infinispan.commands.tx.TransactionBoundaryCommand;
-import org.infinispan.transaction.tm.DummyTransaction;
-import org.infinispan.transaction.tm.DummyTransactionManager;
+import org.infinispan.transaction.tm.EmbeddedTransaction;
+import org.infinispan.transaction.tm.EmbeddedTransactionManager;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 import org.testng.AssertJUnit;
@@ -51,9 +51,9 @@ public class OptimisticTxPartitionAndMergeDuringRollbackTest extends BaseOptimis
       final KeyInfo keyInfo = createKeys(OPTIMISTIC_TX_CACHE_NAME);
       final Cache<Object, String> originator = cache(0, OPTIMISTIC_TX_CACHE_NAME);
 
-      final DummyTransactionManager transactionManager = (DummyTransactionManager) originator.getAdvancedCache().getTransactionManager();
+      final EmbeddedTransactionManager transactionManager = (EmbeddedTransactionManager) originator.getAdvancedCache().getTransactionManager();
       transactionManager.begin();
-      final DummyTransaction transaction = transactionManager.getTransaction();
+      final EmbeddedTransaction transaction = transactionManager.getTransaction();
       keyInfo.putFinalValue(originator);
       AssertJUnit.assertTrue(transaction.runPrepare());
       transactionManager.suspend();

--- a/core/src/test/java/org/infinispan/persistence/LocalModePassivationTest.java
+++ b/core/src/test/java/org/infinispan/persistence/LocalModePassivationTest.java
@@ -26,7 +26,7 @@ import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.transaction.LockingMode;
 import org.infinispan.transaction.TransactionMode;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
 import org.infinispan.util.concurrent.IsolationLevel;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
@@ -64,7 +64,7 @@ public class LocalModePassivationTest extends SingleCacheManagerTest {
 
       ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.LOCAL, true, true);
       builder.transaction().transactionMode(TransactionMode.TRANSACTIONAL).lockingMode(LockingMode.PESSIMISTIC)
-            .transactionManagerLookup(new DummyTransactionManagerLookup())
+            .transactionManagerLookup(new EmbeddedTransactionManagerLookup())
             .eviction().maxEntries(150).strategy(EvictionStrategy.LIRS)
             .locking().useLockStriping(false).writeSkewCheck(false).isolationLevel(IsolationLevel.READ_COMMITTED)
             .dataContainer().storeAsBinary()

--- a/core/src/test/java/org/infinispan/profiling/DeadlockDetectionPerformanceTest.java
+++ b/core/src/test/java/org/infinispan/profiling/DeadlockDetectionPerformanceTest.java
@@ -18,7 +18,7 @@ import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 import org.testng.annotations.BeforeTest;
@@ -189,7 +189,7 @@ public class DeadlockDetectionPerformanceTest extends AbstractInfinispanTest {
 
    private ConfigurationBuilder getConfiguration() {
       ConfigurationBuilder configuration = new ConfigurationBuilder();
-      configuration.transaction().transactionManagerLookup(new DummyTransactionManagerLookup()).deadlockDetection().enabled(USE_DLD).locking().useLockStriping(false);
+      configuration.transaction().transactionManagerLookup(new EmbeddedTransactionManagerLookup()).deadlockDetection().enabled(USE_DLD).locking().useLockStriping(false);
       return configuration;
    }
 

--- a/core/src/test/java/org/infinispan/replication/ReplicationExceptionTest.java
+++ b/core/src/test/java/org/infinispan/replication/ReplicationExceptionTest.java
@@ -1,6 +1,7 @@
 package org.infinispan.replication;
 
 import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertTrue;
 import static org.testng.AssertJUnit.fail;
 
 import java.io.Serializable;
@@ -21,8 +22,8 @@ import org.infinispan.interceptors.base.CommandInterceptor;
 import org.infinispan.marshall.core.ExternalPojo;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
-import org.infinispan.transaction.tm.DummyTransactionManager;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
+import org.infinispan.transaction.tm.EmbeddedTransactionManager;
 import org.infinispan.util.concurrent.IsolationLevel;
 import org.testng.annotations.Test;
 
@@ -35,7 +36,7 @@ public class ReplicationExceptionTest extends MultipleCacheManagersTest {
       configuration.locking()
             .isolationLevel(IsolationLevel.REPEATABLE_READ)
             .lockAcquisitionTimeout(60000l)
-            .transaction().transactionManagerLookup(new DummyTransactionManagerLookup());
+            .transaction().transactionManagerLookup(new EmbeddedTransactionManagerLookup());
       createClusteredCaches(2, "syncReplCache", configuration);
       waitForClusterToForm("syncReplCache");
 
@@ -137,10 +138,10 @@ public class ReplicationExceptionTest extends MultipleCacheManagersTest {
       TestingUtil.blockUntilViewsReceived(10000, cache1, cache2);
 
       // get a lock on cache 2 and hold on to it.
-      DummyTransactionManager tm = (DummyTransactionManager) TestingUtil.getTransactionManager(cache2);
+      EmbeddedTransactionManager tm = (EmbeddedTransactionManager) TestingUtil.getTransactionManager(cache2);
       tm.begin();
       cache2.put("block", "block");
-      assert tm.getTransaction().runPrepare();
+      assertTrue(tm.getTransaction().runPrepare());
       tm.suspend();
       cache1.put("block", "v");
    }

--- a/core/src/test/java/org/infinispan/replication/SyncLockingTest.java
+++ b/core/src/test/java/org/infinispan/replication/SyncLockingTest.java
@@ -15,8 +15,8 @@ import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.InCacheMode;
 import org.infinispan.transaction.LockingMode;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
-import org.infinispan.transaction.tm.DummyTransactionManager;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
+import org.infinispan.transaction.tm.EmbeddedTransactionManager;
 import org.testng.annotations.Test;
 
 /**
@@ -40,7 +40,7 @@ public class SyncLockingTest extends MultipleCacheManagersTest {
    @Override
    protected void createCacheManagers() throws Throwable {
       ConfigurationBuilder cfg = getDefaultClusteredCacheConfig(cacheMode, true);
-      cfg.transaction().transactionManagerLookup(new DummyTransactionManagerLookup())
+      cfg.transaction().transactionManagerLookup(new EmbeddedTransactionManagerLookup())
             .lockingMode(LockingMode.PESSIMISTIC)
             .locking().lockAcquisitionTimeout(TestingUtil.shortTimeoutMillis());
       createClusteredCaches(2, "testcache", cfg);
@@ -135,10 +135,10 @@ public class SyncLockingTest extends MultipleCacheManagersTest {
          public void run() {
             log.info("Concurrent " + (useTx ? "tx" : "non-tx") + " write started "
                   + (sameNode ? "on same node..." : "on a different node..."));
-            DummyTransactionManager mgr = null;
+            EmbeddedTransactionManager mgr = null;
             try {
                if (useTx) {
-                  mgr = (DummyTransactionManager) TestingUtil.getTransactionManager(sameNode ? cache1 : cache2);
+                  mgr = (EmbeddedTransactionManager) TestingUtil.getTransactionManager(sameNode ? cache1 : cache2);
                   mgr.begin();
                }
                if (sameNode) {

--- a/core/src/test/java/org/infinispan/replication/SyncPessimisticLockingTest.java
+++ b/core/src/test/java/org/infinispan/replication/SyncPessimisticLockingTest.java
@@ -22,7 +22,7 @@ import org.infinispan.test.fwk.InCacheMode;
 import org.infinispan.transaction.LockingMode;
 import org.infinispan.transaction.impl.LocalTransaction;
 import org.infinispan.transaction.impl.RemoteTransaction;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
 import org.testng.annotations.Test;
 
 /**
@@ -44,7 +44,7 @@ public class SyncPessimisticLockingTest extends MultipleCacheManagersTest {
 
    protected void createCacheManagers() throws Throwable {
       ConfigurationBuilder cfg = getDefaultClusteredCacheConfig(cacheMode, true);
-      cfg.transaction().transactionManagerLookup(new DummyTransactionManagerLookup())
+      cfg.transaction().transactionManagerLookup(new EmbeddedTransactionManagerLookup())
             .lockingMode(LockingMode.PESSIMISTIC)
             .locking().lockAcquisitionTimeout(TestingUtil.shortTimeoutMillis());
       createClusteredCaches(2, "testcache", cfg);

--- a/core/src/test/java/org/infinispan/statetransfer/DistStateTransferOnJoinConsistencyTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/DistStateTransferOnJoinConsistencyTest.java
@@ -27,7 +27,7 @@ import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.infinispan.transaction.LockingMode;
 import org.infinispan.transaction.TransactionMode;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
 import org.infinispan.util.concurrent.IsolationLevel;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -60,7 +60,7 @@ public class DistStateTransferOnJoinConsistencyTest extends MultipleCacheManager
       ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, true, true);
       builder.clustering().hash().numOwners(3).numSegments(2);
       builder.transaction().transactionMode(TransactionMode.TRANSACTIONAL)
-            .transactionManagerLookup(new DummyTransactionManagerLookup())
+            .transactionManagerLookup(new EmbeddedTransactionManagerLookup())
             .syncCommitPhase(true).syncRollbackPhase(true);
 
       if (isOptimistic) {

--- a/core/src/test/java/org/infinispan/statetransfer/DistStateTransferOnLeaveConsistencyTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/DistStateTransferOnLeaveConsistencyTest.java
@@ -25,7 +25,7 @@ import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.infinispan.transaction.LockingMode;
 import org.infinispan.transaction.TransactionMode;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
 import org.infinispan.util.ControlledConsistentHashFactory;
 import org.infinispan.util.concurrent.IsolationLevel;
 import org.infinispan.util.logging.Log;
@@ -59,7 +59,7 @@ public class DistStateTransferOnLeaveConsistencyTest extends MultipleCacheManage
    protected ConfigurationBuilder createConfigurationBuilder(boolean isOptimistic) {
       ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, true, true);
       builder.transaction().transactionMode(TransactionMode.TRANSACTIONAL)
-            .transactionManagerLookup(new DummyTransactionManagerLookup())
+            .transactionManagerLookup(new EmbeddedTransactionManagerLookup())
             .syncCommitPhase(true).syncRollbackPhase(true);
 
       if (isOptimistic) {

--- a/core/src/test/java/org/infinispan/statetransfer/InitialStateTransferCompletionTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/InitialStateTransferCompletionTest.java
@@ -25,7 +25,7 @@ import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.infinispan.topology.CacheTopology;
 import org.infinispan.transaction.LockingMode;
 import org.infinispan.transaction.TransactionMode;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
 import org.testng.annotations.Test;
 
 /**
@@ -44,7 +44,7 @@ public class InitialStateTransferCompletionTest extends MultipleCacheManagersTes
    protected void createCacheManagers() throws Throwable {
       cacheConfigBuilder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, true, true);
       cacheConfigBuilder.transaction().transactionMode(TransactionMode.TRANSACTIONAL)
-            .transactionManagerLookup(new DummyTransactionManagerLookup())
+            .transactionManagerLookup(new EmbeddedTransactionManagerLookup())
             .syncCommitPhase(true).syncRollbackPhase(true)
             .lockingMode(LockingMode.PESSIMISTIC)
             .clustering().hash().numOwners(10)  // a number bigger than actual number of nodes will make this distributed cluster behave as if fully replicated

--- a/core/src/test/java/org/infinispan/statetransfer/OperationsDuringStateTransferTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/OperationsDuringStateTransferTest.java
@@ -35,7 +35,7 @@ import org.infinispan.topology.CacheTopology;
 import org.infinispan.topology.ClusterTopologyManager;
 import org.infinispan.transaction.LockingMode;
 import org.infinispan.transaction.TransactionMode;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
 import org.infinispan.util.concurrent.IsolationLevel;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -70,7 +70,7 @@ public class OperationsDuringStateTransferTest extends MultipleCacheManagersTest
       cacheConfigBuilder = getDefaultClusteredCacheConfig(cacheMode, transactional, true);
       if (transactional) {
          cacheConfigBuilder.transaction().transactionMode(TransactionMode.TRANSACTIONAL)
-               .transactionManagerLookup(new DummyTransactionManagerLookup())
+               .transactionManagerLookup(new EmbeddedTransactionManagerLookup())
                .syncCommitPhase(true).syncRollbackPhase(true);
 
          cacheConfigBuilder.transaction().lockingMode(lockingMode);

--- a/core/src/test/java/org/infinispan/statetransfer/ReplStateTransferCacheLoaderTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/ReplStateTransferCacheLoaderTest.java
@@ -13,7 +13,7 @@ import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.infinispan.transaction.LockingMode;
 import org.infinispan.transaction.TransactionMode;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
 import org.infinispan.util.concurrent.IsolationLevel;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -45,7 +45,7 @@ public class ReplStateTransferCacheLoaderTest extends MultipleCacheManagersTest 
       // reproduce the MODE-1754 config as closely as possible
       builder = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, true, true);
       builder.transaction().transactionMode(TransactionMode.TRANSACTIONAL).lockingMode(LockingMode.PESSIMISTIC)
-            .transactionManagerLookup(new DummyTransactionManagerLookup())
+            .transactionManagerLookup(new EmbeddedTransactionManagerLookup())
             .eviction().maxEntries(1000).strategy(EvictionStrategy.LIRS)
             .locking().lockAcquisitionTimeout(20000)
             .concurrencyLevel(5000) // lowering this to 50 makes the test pass also on 5.2 but it's just a temporary workaround

--- a/core/src/test/java/org/infinispan/statetransfer/ReplStateTransferOnJoinConsistencyTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/ReplStateTransferOnJoinConsistencyTest.java
@@ -7,7 +7,7 @@ import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.infinispan.transaction.LockingMode;
 import org.infinispan.transaction.TransactionMode;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
 import org.infinispan.util.concurrent.IsolationLevel;
 import org.testng.annotations.Test;
 
@@ -27,7 +27,7 @@ public class ReplStateTransferOnJoinConsistencyTest extends DistStateTransferOnJ
    protected ConfigurationBuilder createConfigurationBuilder(boolean isOptimistic) {
       ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, true, true);
       builder.transaction().transactionMode(TransactionMode.TRANSACTIONAL)
-            .transactionManagerLookup(new DummyTransactionManagerLookup())
+            .transactionManagerLookup(new EmbeddedTransactionManagerLookup())
             .syncCommitPhase(true).syncRollbackPhase(true);
 
       if (isOptimistic) {

--- a/core/src/test/java/org/infinispan/statetransfer/StateTransferPessimisticTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateTransferPessimisticTest.java
@@ -13,7 +13,7 @@ import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.infinispan.transaction.LockingMode;
 import org.infinispan.transaction.TransactionMode;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
 import org.testng.annotations.Test;
 
 /**
@@ -34,7 +34,7 @@ public class StateTransferPessimisticTest extends MultipleCacheManagersTest {
       dccc = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, true, true);
       dccc.transaction()
             .transactionMode(TransactionMode.TRANSACTIONAL)
-            .transactionManagerLookup(new DummyTransactionManagerLookup())
+            .transactionManagerLookup(new EmbeddedTransactionManagerLookup())
             .lockingMode(LockingMode.PESSIMISTIC)
             .syncCommitPhase(true)
             .syncRollbackPhase(true);

--- a/core/src/test/java/org/infinispan/statetransfer/StateTransferRestart2Test.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateTransferRestart2Test.java
@@ -22,7 +22,7 @@ import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.infinispan.test.fwk.TransportFlags;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
 import org.jgroups.protocols.DISCARD;
 import org.testng.annotations.Test;
 
@@ -47,7 +47,7 @@ public class StateTransferRestart2Test extends MultipleCacheManagersTest {
    @Override
    protected void createCacheManagers() throws Throwable {
       cfgBuilder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, true);
-      cfgBuilder.transaction().transactionManagerLookup(new DummyTransactionManagerLookup());
+      cfgBuilder.transaction().transactionManagerLookup(new EmbeddedTransactionManagerLookup());
       cfgBuilder.clustering().hash().numOwners(2);
       cfgBuilder.clustering().stateTransfer().fetchInMemoryState(true);
       cfgBuilder.clustering().stateTransfer().timeout(20000);

--- a/core/src/test/java/org/infinispan/statetransfer/StateTransferRestartTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateTransferRestartTest.java
@@ -23,7 +23,7 @@ import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.infinispan.test.fwk.TransportFlags;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
 import org.jgroups.protocols.DISCARD;
 import org.testng.annotations.Test;
 
@@ -73,7 +73,7 @@ public class StateTransferRestartTest extends MultipleCacheManagersTest {
    @Override
    protected void createCacheManagers() throws Throwable {
       cfgBuilder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, true);
-      cfgBuilder.transaction().transactionManagerLookup(new DummyTransactionManagerLookup());
+      cfgBuilder.transaction().transactionManagerLookup(new EmbeddedTransactionManagerLookup());
       cfgBuilder.clustering().hash().numOwners(2);
       cfgBuilder.clustering().stateTransfer().fetchInMemoryState(true);
       cfgBuilder.clustering().stateTransfer().timeout(20000);

--- a/core/src/test/java/org/infinispan/statetransfer/TxDuringStateTransferTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/TxDuringStateTransferTest.java
@@ -15,9 +15,9 @@ import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.distribution.MagicKey;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.fwk.CleanupAfterMethod;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
-import org.infinispan.transaction.tm.DummyTransaction;
-import org.infinispan.transaction.tm.DummyTransactionManager;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
+import org.infinispan.transaction.tm.EmbeddedTransaction;
+import org.infinispan.transaction.tm.EmbeddedTransactionManager;
 import org.testng.annotations.Test;
 
 /**
@@ -61,7 +61,7 @@ public class TxDuringStateTransferTest extends MultipleCacheManagersTest {
    protected void createCacheManagers() throws Throwable {
       ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, true);
       builder.transaction()
-            .transactionManagerLookup(new DummyTransactionManagerLookup())
+            .transactionManagerLookup(new EmbeddedTransactionManagerLookup())
             .useSynchronization(false)
             .recovery().disable();
       builder.clustering()
@@ -76,10 +76,10 @@ public class TxDuringStateTransferTest extends MultipleCacheManagersTest {
       //init
       operation.init(cache(0), key);
 
-      final DummyTransactionManager transactionManager = (DummyTransactionManager) tm(0);
+      final EmbeddedTransactionManager transactionManager = (EmbeddedTransactionManager) tm(0);
       transactionManager.begin();
       operation.perform(cache(0), key);
-      final DummyTransaction transaction = transactionManager.getTransaction();
+      final EmbeddedTransaction transaction = transactionManager.getTransaction();
       transaction.runPrepare();
       assertEquals("Wrong transaction status before killing backup owner.",
                    Status.STATUS_PREPARED, transaction.getStatus());

--- a/core/src/test/java/org/infinispan/statetransfer/TxReplay2Test.java
+++ b/core/src/test/java/org/infinispan/statetransfer/TxReplay2Test.java
@@ -34,9 +34,9 @@ import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.concurrent.StateSequencer;
 import org.infinispan.transaction.impl.TransactionTable;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
-import org.infinispan.transaction.tm.DummyTransaction;
-import org.infinispan.transaction.tm.DummyTransactionManager;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
+import org.infinispan.transaction.tm.EmbeddedTransaction;
+import org.infinispan.transaction.tm.EmbeddedTransactionManager;
 import org.infinispan.transaction.xa.GlobalTransaction;
 import org.infinispan.util.ByteString;
 import org.infinispan.util.ControlledConsistentHashFactory;
@@ -81,11 +81,11 @@ public class TxReplay2Test extends MultipleCacheManagersTest {
       advanceOnInboundRpc(sequencer, newBackupOwnerCache, matchCommand(TxCompletionNotificationCommand.class).build())
             .before("tx:mark_tx_completed");
 
-      final DummyTransactionManager transactionManager = (DummyTransactionManager) tm(0);
+      final EmbeddedTransactionManager transactionManager = (EmbeddedTransactionManager) tm(0);
       transactionManager.begin();
       primaryOwnerCache.put(key, VALUE);
 
-      final DummyTransaction transaction = transactionManager.getTransaction();
+      final EmbeddedTransaction transaction = transactionManager.getTransaction();
       TransactionTable transactionTable0 = TestingUtil.getTransactionTable(primaryOwnerCache);
       final GlobalTransaction gtx = transactionTable0.getLocalTransaction(transaction).getGlobalTransaction();
       transaction.runPrepare();
@@ -147,7 +147,7 @@ public class TxReplay2Test extends MultipleCacheManagersTest {
       ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, true);
       builder.transaction()
             .useSynchronization(false)
-            .transactionManagerLookup(new DummyTransactionManagerLookup())
+            .transactionManagerLookup(new EmbeddedTransactionManagerLookup())
             .recovery().disable();
       builder.clustering()
             .hash().numOwners(3).numSegments(1).consistentHashFactory(consistentHashFactory)

--- a/core/src/test/java/org/infinispan/statetransfer/TxReplay3Test.java
+++ b/core/src/test/java/org/infinispan/statetransfer/TxReplay3Test.java
@@ -26,7 +26,7 @@ import org.infinispan.remoting.rpc.RpcManager;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.concurrent.StateSequencer;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
 import org.infinispan.util.AbstractControlledRpcManager;
 import org.infinispan.util.ControlledConsistentHashFactory;
 import org.infinispan.util.logging.Log;
@@ -100,7 +100,7 @@ public class TxReplay3Test extends MultipleCacheManagersTest {
       ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, true);
       builder.transaction()
             .useSynchronization(false)
-            .transactionManagerLookup(new DummyTransactionManagerLookup())
+            .transactionManagerLookup(new EmbeddedTransactionManagerLookup())
             .recovery().disable();
       builder.locking().lockAcquisitionTimeout(1, TimeUnit.MINUTES);
       builder.clustering()

--- a/core/src/test/java/org/infinispan/statetransfer/TxReplayTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/TxReplayTest.java
@@ -24,9 +24,9 @@ import org.infinispan.interceptors.impl.CallInterceptor;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.transaction.impl.TransactionTable;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
-import org.infinispan.transaction.tm.DummyTransaction;
-import org.infinispan.transaction.tm.DummyTransactionManager;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
+import org.infinispan.transaction.tm.EmbeddedTransaction;
+import org.infinispan.transaction.tm.EmbeddedTransactionManager;
 import org.testng.annotations.Test;
 
 /**
@@ -46,10 +46,10 @@ public class TxReplayTest extends MultipleCacheManagersTest {
       final Cache<Object, Object> newBackupOwnerCache = cache(2);
       final TxCommandInterceptor interceptor = TxCommandInterceptor.inject(newBackupOwnerCache);
 
-      DummyTransactionManager transactionManager = (DummyTransactionManager) tm(0);
+      EmbeddedTransactionManager transactionManager = (EmbeddedTransactionManager) tm(0);
       transactionManager.begin();
       cache(0).put(key, VALUE);
-      final DummyTransaction transaction = transactionManager.getTransaction();
+      final EmbeddedTransaction transaction = transactionManager.getTransaction();
       transaction.runPrepare();
       assertEquals("Wrong transaction status before killing backup owner.",
                    Status.STATUS_PREPARED, transaction.getStatus());
@@ -76,7 +76,7 @@ public class TxReplayTest extends MultipleCacheManagersTest {
       ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, true);
       builder.transaction()
             .useSynchronization(false)
-            .transactionManagerLookup(new DummyTransactionManagerLookup())
+            .transactionManagerLookup(new EmbeddedTransactionManagerLookup())
             .recovery().disable();
       builder.clustering()
             .hash().numOwners(2)

--- a/core/src/test/java/org/infinispan/test/fwk/TransactionSetup.java
+++ b/core/src/test/java/org/infinispan/test/fwk/TransactionSetup.java
@@ -4,7 +4,7 @@ import javax.transaction.TransactionManager;
 import javax.transaction.UserTransaction;
 
 import org.infinispan.commons.util.LegacyKeySupportSystemProperties;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
 import org.infinispan.transaction.lookup.JBossStandaloneJTAManagerLookup;
 import org.infinispan.transaction.lookup.TransactionManagerLookup;
 import org.infinispan.util.tx.lookup.GeronimoTransactionManagerLookup;
@@ -49,17 +49,17 @@ public class TransactionSetup {
       String property = JTA;
        if (DUMMY_TM.equalsIgnoreCase(property)) {
          System.out.println("Transaction manager used: Dummy");
-         final String lookup = DummyTransactionManagerLookup.class.getName();
-         final DummyTransactionManagerLookup instance = new DummyTransactionManagerLookup();
+         final String lookup = EmbeddedTransactionManagerLookup.class.getName();
+         final EmbeddedTransactionManagerLookup instance = new EmbeddedTransactionManagerLookup();
          operations = new Operations() {
             @Override
             public UserTransaction getUserTransaction() {
-               return instance.getUserTransaction();
+               return EmbeddedTransactionManagerLookup.getUserTransaction();
             }
 
             @Override
             public void cleanup() {
-               instance.cleanup();
+               EmbeddedTransactionManagerLookup.cleanup();
             }
 
             @Override

--- a/core/src/test/java/org/infinispan/tx/BatchingAndEnlistmentTest.java
+++ b/core/src/test/java/org/infinispan/tx/BatchingAndEnlistmentTest.java
@@ -12,7 +12,7 @@ import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.transaction.impl.TransactionTable;
 import org.infinispan.transaction.tm.BatchModeTransactionManager;
-import org.infinispan.transaction.tm.DummyTransaction;
+import org.infinispan.transaction.tm.EmbeddedTransaction;
 import org.testng.annotations.Test;
 
 /**
@@ -45,7 +45,7 @@ public class BatchingAndEnlistmentTest extends SingleCacheManagerTest {
       assert getBatchTx(bc) == null;
    }
 
-   private DummyTransaction getBatchTx(BatchContainer bc) {
-      return (DummyTransaction) bc.getBatchTransaction();
+   private EmbeddedTransaction getBatchTx(BatchContainer bc) {
+      return (EmbeddedTransaction) bc.getBatchTransaction();
    }
 }

--- a/core/src/test/java/org/infinispan/tx/EmbeddedTransactionTest.java
+++ b/core/src/test/java/org/infinispan/tx/EmbeddedTransactionTest.java
@@ -20,8 +20,8 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
-import org.infinispan.transaction.tm.DummyTransactionManager;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
+import org.infinispan.transaction.tm.EmbeddedTransactionManager;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
 
@@ -31,8 +31,8 @@ import org.testng.annotations.Test;
  * @author Pedro Ruivo
  * @since 7.2
  */
-@Test(groups = "functional", testName = "tx.DummyTransactionTest")
-public class DummyTransactionTest extends SingleCacheManagerTest {
+@Test(groups = "functional", testName = "tx.EmbeddedTransactionTest")
+public class EmbeddedTransactionTest extends SingleCacheManagerTest {
 
    private static final String SYNC_CACHE_NAME = "sync-cache";
    private static final String XA_CACHE_NAME = "xa-cache";
@@ -43,95 +43,95 @@ public class DummyTransactionTest extends SingleCacheManagerTest {
    public void testFailBeforeWithMarkRollbackFirstSync() throws Exception {
       doCommitWithRollbackExceptionTest(Arrays.asList(
             new RegisterFailSynchronization(FailMode.BEFORE_MARK_ROLLBACK),
-            new RegisterCacheTransaction(cacheManager.<String, String>getCache(SYNC_CACHE_NAME)),
-            new RegisterCacheTransaction(cacheManager.<String, String>getCache(XA_CACHE_NAME))
+            new RegisterCacheTransaction(cacheManager.getCache(SYNC_CACHE_NAME)),
+            new RegisterCacheTransaction(cacheManager.getCache(XA_CACHE_NAME))
       ));
    }
 
    public void testFailBeforeWithExceptionFirstSync() throws Exception {
       doCommitWithRollbackExceptionTest(Arrays.asList(
             new RegisterFailSynchronization(FailMode.BEFORE_THROW_EXCEPTION),
-            new RegisterCacheTransaction(cacheManager.<String, String>getCache(SYNC_CACHE_NAME)),
-            new RegisterCacheTransaction(cacheManager.<String, String>getCache(XA_CACHE_NAME))
+            new RegisterCacheTransaction(cacheManager.getCache(SYNC_CACHE_NAME)),
+            new RegisterCacheTransaction(cacheManager.getCache(XA_CACHE_NAME))
       ));
    }
 
    public void testFailBeforeWithMarkRollbackSecondSync() throws Exception {
       doCommitWithRollbackExceptionTest(Arrays.asList(
-            new RegisterCacheTransaction(cacheManager.<String, String>getCache(SYNC_CACHE_NAME)),
+            new RegisterCacheTransaction(cacheManager.getCache(SYNC_CACHE_NAME)),
             new RegisterFailSynchronization(FailMode.BEFORE_MARK_ROLLBACK),
-            new RegisterCacheTransaction(cacheManager.<String, String>getCache(XA_CACHE_NAME))
+            new RegisterCacheTransaction(cacheManager.getCache(XA_CACHE_NAME))
       ));
    }
 
    public void testFailBeforeWithExceptionSecondSync() throws Exception {
       doCommitWithRollbackExceptionTest(Arrays.asList(
-            new RegisterCacheTransaction(cacheManager.<String, String>getCache(SYNC_CACHE_NAME)),
+            new RegisterCacheTransaction(cacheManager.getCache(SYNC_CACHE_NAME)),
             new RegisterFailSynchronization(FailMode.BEFORE_THROW_EXCEPTION),
-            new RegisterCacheTransaction(cacheManager.<String, String>getCache(XA_CACHE_NAME))
+            new RegisterCacheTransaction(cacheManager.getCache(XA_CACHE_NAME))
       ));
    }
 
    public void testEndFailFirstXa() throws Exception {
       doCommitWithRollbackExceptionTest(Arrays.asList(
-            new RegisterCacheTransaction(cacheManager.<String, String>getCache(SYNC_CACHE_NAME)),
+            new RegisterCacheTransaction(cacheManager.getCache(SYNC_CACHE_NAME)),
             new RegisterFailXaResource(FailMode.XA_END),
-            new RegisterCacheTransaction(cacheManager.<String, String>getCache(XA_CACHE_NAME))
+            new RegisterCacheTransaction(cacheManager.getCache(XA_CACHE_NAME))
       ));
    }
 
    public void testEndFailSecondXa() throws Exception {
       doCommitWithRollbackExceptionTest(Arrays.asList(
-            new RegisterCacheTransaction(cacheManager.<String, String>getCache(SYNC_CACHE_NAME)),
-            new RegisterCacheTransaction(cacheManager.<String, String>getCache(XA_CACHE_NAME)),
+            new RegisterCacheTransaction(cacheManager.getCache(SYNC_CACHE_NAME)),
+            new RegisterCacheTransaction(cacheManager.getCache(XA_CACHE_NAME)),
             new RegisterFailXaResource(FailMode.XA_END)
       ));
    }
 
    public void testPrepareFailFirstXa() throws Exception {
       doCommitWithRollbackExceptionTest(Arrays.asList(
-            new RegisterCacheTransaction(cacheManager.<String, String>getCache(SYNC_CACHE_NAME)),
+            new RegisterCacheTransaction(cacheManager.getCache(SYNC_CACHE_NAME)),
             new RegisterFailXaResource(FailMode.XA_PREPARE),
-            new RegisterCacheTransaction(cacheManager.<String, String>getCache(XA_CACHE_NAME))
+            new RegisterCacheTransaction(cacheManager.getCache(XA_CACHE_NAME))
       ));
    }
 
    public void testPrepareFailSecondXa() throws Exception {
       doCommitWithRollbackExceptionTest(Arrays.asList(
-            new RegisterCacheTransaction(cacheManager.<String, String>getCache(SYNC_CACHE_NAME)),
-            new RegisterCacheTransaction(cacheManager.<String, String>getCache(XA_CACHE_NAME)),
+            new RegisterCacheTransaction(cacheManager.getCache(SYNC_CACHE_NAME)),
+            new RegisterCacheTransaction(cacheManager.getCache(XA_CACHE_NAME)),
             new RegisterFailXaResource(FailMode.XA_PREPARE)
       ));
    }
 
    public void testCommitFailFirstXa() throws Exception {
       doCommitWithHeuristicExceptionTest(Arrays.asList(
-            new RegisterCacheTransaction(cacheManager.<String, String>getCache(SYNC_CACHE_NAME)),
+            new RegisterCacheTransaction(cacheManager.getCache(SYNC_CACHE_NAME)),
             new RegisterFailXaResource(FailMode.XA_COMMIT),
-            new RegisterCacheTransaction(cacheManager.<String, String>getCache(XA_CACHE_NAME))
+            new RegisterCacheTransaction(cacheManager.getCache(XA_CACHE_NAME))
       ));
    }
 
    public void testCommitFailSecondXa() throws Exception {
       doCommitWithHeuristicExceptionTest(Arrays.asList(
-            new RegisterCacheTransaction(cacheManager.<String, String>getCache(SYNC_CACHE_NAME)),
-            new RegisterCacheTransaction(cacheManager.<String, String>getCache(XA_CACHE_NAME)),
+            new RegisterCacheTransaction(cacheManager.getCache(SYNC_CACHE_NAME)),
+            new RegisterCacheTransaction(cacheManager.getCache(XA_CACHE_NAME)),
             new RegisterFailXaResource(FailMode.XA_COMMIT)
       ));
    }
 
    public void testRollbackFailFirstXa() throws Exception {
       doRollbackWithHeuristicExceptionTest(Arrays.asList(
-            new RegisterCacheTransaction(cacheManager.<String, String>getCache(SYNC_CACHE_NAME)),
+            new RegisterCacheTransaction(cacheManager.getCache(SYNC_CACHE_NAME)),
             new RegisterFailXaResource(FailMode.XA_ROLLBACK),
-            new RegisterCacheTransaction(cacheManager.<String, String>getCache(XA_CACHE_NAME))
+            new RegisterCacheTransaction(cacheManager.getCache(XA_CACHE_NAME))
       ));
    }
 
    public void testRollbackFailSecondXa() throws Exception {
       doRollbackWithHeuristicExceptionTest(Arrays.asList(
-            new RegisterCacheTransaction(cacheManager.<String, String>getCache(SYNC_CACHE_NAME)),
-            new RegisterCacheTransaction(cacheManager.<String, String>getCache(XA_CACHE_NAME)),
+            new RegisterCacheTransaction(cacheManager.getCache(SYNC_CACHE_NAME)),
+            new RegisterCacheTransaction(cacheManager.getCache(XA_CACHE_NAME)),
             new RegisterFailXaResource(FailMode.XA_ROLLBACK)
       ));
    }
@@ -139,22 +139,22 @@ public class DummyTransactionTest extends SingleCacheManagerTest {
    public void testFailAfterFirstSync() throws Exception {
       doAfterCompletionFailTest(Arrays.asList(
             new RegisterFailSynchronization(FailMode.AFTER_THROW_EXCEPTION),
-            new RegisterCacheTransaction(cacheManager.<String, String>getCache(SYNC_CACHE_NAME)),
-            new RegisterCacheTransaction(cacheManager.<String, String>getCache(XA_CACHE_NAME))
+            new RegisterCacheTransaction(cacheManager.getCache(SYNC_CACHE_NAME)),
+            new RegisterCacheTransaction(cacheManager.getCache(XA_CACHE_NAME))
       ));
    }
 
    public void testFailAfterSecondSync() throws Exception {
       doAfterCompletionFailTest(Arrays.asList(
-            new RegisterCacheTransaction(cacheManager.<String, String>getCache(SYNC_CACHE_NAME)),
+            new RegisterCacheTransaction(cacheManager.getCache(SYNC_CACHE_NAME)),
             new RegisterFailSynchronization(FailMode.AFTER_THROW_EXCEPTION),
-            new RegisterCacheTransaction(cacheManager.<String, String>getCache(XA_CACHE_NAME))
+            new RegisterCacheTransaction(cacheManager.getCache(XA_CACHE_NAME))
       ));
    }
 
    public void testReadOnlyResource() throws Exception {
       //test for ISPN-2813
-      DummyTransactionManager transactionManager = DummyTransactionManager.getInstance();
+      EmbeddedTransactionManager transactionManager = EmbeddedTransactionManager.getInstance();
       transactionManager.begin();
       cacheManager.<String, String>getCache(SYNC_CACHE_NAME).put(KEY, VALUE);
       cacheManager.<String, String>getCache(XA_CACHE_NAME).put(KEY, VALUE);
@@ -172,18 +172,18 @@ public class DummyTransactionTest extends SingleCacheManagerTest {
 
       ConfigurationBuilder builder = getDefaultStandaloneCacheConfig(true);
       builder.transaction().useSynchronization(true);
-      builder.transaction().transactionManagerLookup(new DummyTransactionManagerLookup());
+      builder.transaction().transactionManagerLookup(new EmbeddedTransactionManagerLookup());
       cacheManager.defineConfiguration(SYNC_CACHE_NAME, builder.build());
 
       builder = getDefaultStandaloneCacheConfig(true);
       builder.transaction().useSynchronization(false);
-      builder.transaction().transactionManagerLookup(new DummyTransactionManagerLookup());
+      builder.transaction().transactionManagerLookup(new EmbeddedTransactionManagerLookup());
       cacheManager.defineConfiguration(XA_CACHE_NAME, builder.build());
       return cacheManager;
    }
 
    private void doCommitWithRollbackExceptionTest(Collection<RegisterTransaction> registerTransactionCollection) throws Exception {
-      DummyTransactionManager transactionManager = DummyTransactionManager.getInstance();
+      EmbeddedTransactionManager transactionManager = EmbeddedTransactionManager.getInstance();
       transactionManager.begin();
       for (RegisterTransaction registerTransaction : registerTransactionCollection) {
          registerTransaction.register(transactionManager);
@@ -201,7 +201,7 @@ public class DummyTransactionTest extends SingleCacheManagerTest {
    }
 
    private void doCommitWithHeuristicExceptionTest(Collection<RegisterTransaction> registerTransactionCollection) throws Exception {
-      DummyTransactionManager transactionManager = DummyTransactionManager.getInstance();
+      EmbeddedTransactionManager transactionManager = EmbeddedTransactionManager.getInstance();
       transactionManager.begin();
       for (RegisterTransaction registerTransaction : registerTransactionCollection) {
          registerTransaction.register(transactionManager);
@@ -219,7 +219,7 @@ public class DummyTransactionTest extends SingleCacheManagerTest {
    }
 
    private void doRollbackWithHeuristicExceptionTest(Collection<RegisterTransaction> registerTransactionCollection) throws Exception {
-      DummyTransactionManager transactionManager = DummyTransactionManager.getInstance();
+      EmbeddedTransactionManager transactionManager = EmbeddedTransactionManager.getInstance();
       transactionManager.begin();
       for (RegisterTransaction registerTransaction : registerTransactionCollection) {
          registerTransaction.register(transactionManager);
@@ -237,7 +237,7 @@ public class DummyTransactionTest extends SingleCacheManagerTest {
    }
 
    private void doAfterCompletionFailTest(Collection<RegisterTransaction> registerTransactionCollection) throws Exception {
-      DummyTransactionManager transactionManager = DummyTransactionManager.getInstance();
+      EmbeddedTransactionManager transactionManager = EmbeddedTransactionManager.getInstance();
       transactionManager.begin();
       for (RegisterTransaction registerTransaction : registerTransactionCollection) {
          registerTransaction.register(transactionManager);

--- a/core/src/test/java/org/infinispan/tx/InfinispanNodeFailureTest.java
+++ b/core/src/test/java/org/infinispan/tx/InfinispanNodeFailureTest.java
@@ -18,7 +18,7 @@ import org.infinispan.interceptors.BaseCustomAsyncInterceptor;
 import org.infinispan.remoting.transport.jgroups.JGroupsTransport;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.transaction.LockingMode;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
 import org.infinispan.util.concurrent.IsolationLevel;
 import org.jgroups.View;
 import org.testng.annotations.Test;
@@ -143,7 +143,7 @@ public class InfinispanNodeFailureTest extends MultipleCacheManagersTest {
             .isolationLevel(IsolationLevel.READ_COMMITTED)
             .lockAcquisitionTimeout(20000);
       configuration.transaction()
-            .transactionManagerLookup(new DummyTransactionManagerLookup())
+            .transactionManagerLookup(new EmbeddedTransactionManagerLookup())
             .lockingMode(LockingMode.PESSIMISTIC)
             .useSynchronization(false)
             .syncCommitPhase(true)

--- a/core/src/test/java/org/infinispan/tx/LockCleanupStateTransferTest.java
+++ b/core/src/test/java/org/infinispan/tx/LockCleanupStateTransferTest.java
@@ -22,7 +22,7 @@ import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.infinispan.transaction.impl.TransactionTable;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
 import org.infinispan.util.mocks.ControlledCommandFactory;
 import org.testng.annotations.Test;
 
@@ -46,7 +46,7 @@ public class LockCleanupStateTransferTest extends MultipleCacheManagersTest {
    @Override
    protected void createCacheManagers() throws Throwable {
       dcc = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, true);
-      dcc.transaction().transactionManagerLookup(new DummyTransactionManagerLookup());
+      dcc.transaction().transactionManagerLookup(new EmbeddedTransactionManagerLookup());
       dcc.clustering().hash().numOwners(1);
       dcc.clustering().stateTransfer().fetchInMemoryState(true);
       createCluster(dcc, 2);

--- a/core/src/test/java/org/infinispan/tx/ParticipantFailsAfterPrepareTest.java
+++ b/core/src/test/java/org/infinispan/tx/ParticipantFailsAfterPrepareTest.java
@@ -14,8 +14,8 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
-import org.infinispan.transaction.tm.DummyTransaction;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
+import org.infinispan.transaction.tm.EmbeddedTransaction;
 import org.testng.annotations.Test;
 
 /**
@@ -31,7 +31,7 @@ public class ParticipantFailsAfterPrepareTest extends MultipleCacheManagersTest 
          .locking()
             .useLockStriping(false)
          .transaction()
-            .transactionManagerLookup(new DummyTransactionManagerLookup())
+            .transactionManagerLookup(new EmbeddedTransactionManagerLookup())
             .useSynchronization(false)
             .recovery()
                .disable()
@@ -46,7 +46,7 @@ public class ParticipantFailsAfterPrepareTest extends MultipleCacheManagersTest 
 
    public void testNonOriginatorFailsAfterPrepare() throws Exception {
       final Object key = getKeyForCache(0);
-      DummyTransaction dummyTransaction = beginAndSuspendTx(cache(0), key);
+      EmbeddedTransaction dummyTransaction = beginAndSuspendTx(cache(0), key);
       prepareTransaction(dummyTransaction);
 
       int indexToKill = -1;
@@ -92,7 +92,7 @@ public class ParticipantFailsAfterPrepareTest extends MultipleCacheManagersTest 
    }
 
    private List<Cache> getAliveParticipants(int indexToKill) {
-      List<Cache> participants = new ArrayList<Cache>();
+      List<Cache> participants = new ArrayList<>();
       for (int i = 0; i < 4; i++) {
          if (i == indexToKill) continue;
          participants.add(cache(i));

--- a/core/src/test/java/org/infinispan/tx/RollbackBeforePrepareTest.java
+++ b/core/src/test/java/org/infinispan/tx/RollbackBeforePrepareTest.java
@@ -13,7 +13,7 @@ import org.infinispan.interceptors.base.CommandInterceptor;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.InCacheMode;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
 import org.infinispan.util.concurrent.TimeoutException;
 import org.infinispan.util.mocks.ControlledCommandFactory;
 import org.testng.annotations.Test;
@@ -34,7 +34,7 @@ public class RollbackBeforePrepareTest extends MultipleCacheManagersTest {
             .locking().lockAcquisitionTimeout(LOCK_TIMEOUT)
             .clustering().remoteTimeout(REPL_TIMEOUT)
             .clustering().hash().numOwners(numOwners)
-            .transaction().transactionManagerLookup(new DummyTransactionManagerLookup())
+            .transaction().transactionManagerLookup(new EmbeddedTransactionManagerLookup())
             .transaction().completedTxTimeout(3600000);
 
       createCluster(config, 3);

--- a/core/src/test/java/org/infinispan/tx/StaleLockAfterTxAbortTest.java
+++ b/core/src/test/java/org/infinispan/tx/StaleLockAfterTxAbortTest.java
@@ -10,9 +10,9 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
-import org.infinispan.transaction.tm.DummyTransaction;
-import org.infinispan.transaction.tm.DummyTransactionManager;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
+import org.infinispan.transaction.tm.EmbeddedTransaction;
+import org.infinispan.transaction.tm.EmbeddedTransactionManager;
 import org.testng.annotations.Test;
 
 /**
@@ -31,7 +31,7 @@ public class StaleLockAfterTxAbortTest extends SingleCacheManagerTest {
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       ConfigurationBuilder c = getDefaultStandaloneCacheConfig(true);
-      c.transaction().transactionManagerLookup(new DummyTransactionManagerLookup()).useSynchronization(false).recovery().disable();
+      c.transaction().transactionManagerLookup(new EmbeddedTransactionManagerLookup()).useSynchronization(false).recovery().disable();
       return TestCacheManagerFactory.createCacheManager(c);
    }
 
@@ -46,10 +46,10 @@ public class StaleLockAfterTxAbortTest extends SingleCacheManagerTest {
 //      lockManager.lockAndRecord(k, ctx);
 //      ctx.putLookedUpEntry(k, null);
 
-      DummyTransactionManager dtm = (DummyTransactionManager) tm();
+      EmbeddedTransactionManager dtm = (EmbeddedTransactionManager) tm();
       tm().begin();
       cache.put(k, "some");
-      final DummyTransaction transaction = dtm.getTransaction();
+      final EmbeddedTransaction transaction = dtm.getTransaction();
       transaction.runPrepare();
       tm().suspend();
 

--- a/core/src/test/java/org/infinispan/tx/TransactionCleanupWithRecoveryTest.java
+++ b/core/src/test/java/org/infinispan/tx/TransactionCleanupWithRecoveryTest.java
@@ -12,7 +12,7 @@ import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.transaction.LockingMode;
 import org.infinispan.transaction.TransactionMode;
 import org.infinispan.transaction.impl.TransactionTable;
-import org.infinispan.tx.recovery.RecoveryDummyTransactionManagerLookup;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
 import org.infinispan.util.concurrent.IsolationLevel;
 import org.testng.annotations.Test;
 
@@ -32,7 +32,7 @@ public class TransactionCleanupWithRecoveryTest extends MultipleCacheManagersTes
             .transaction()
             .transactionMode(TransactionMode.TRANSACTIONAL)
             .lockingMode(LockingMode.PESSIMISTIC)
-            .transactionManagerLookup(new RecoveryDummyTransactionManagerLookup())
+            .transactionManagerLookup(new EmbeddedTransactionManagerLookup())
             .recovery().enable();
 
       registerCacheManager(TestCacheManagerFactory.createClusteredCacheManager(cfg),

--- a/core/src/test/java/org/infinispan/tx/TransactionManagerLookupTest.java
+++ b/core/src/test/java/org/infinispan/tx/TransactionManagerLookupTest.java
@@ -5,7 +5,7 @@ import javax.transaction.TransactionManager;
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.test.AbstractInfinispanTest;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
 import org.infinispan.transaction.lookup.GenericTransactionManagerLookup;
 import org.infinispan.transaction.lookup.JBossStandaloneJTAManagerLookup;
 import org.infinispan.transaction.lookup.TransactionManagerLookup;
@@ -29,7 +29,7 @@ public class TransactionManagerLookupTest extends AbstractInfinispanTest {
    }
 
    public void testDummyTransactionManagerLookup() throws Exception {
-      doTest(new DummyTransactionManagerLookup());
+      doTest(new EmbeddedTransactionManagerLookup());
    }
 
    public void testJBossStandaloneJTAManagerLookup() throws Exception {

--- a/core/src/test/java/org/infinispan/tx/TransactionXaAdapterTmIntegrationTest.java
+++ b/core/src/test/java/org/infinispan/tx/TransactionXaAdapterTmIntegrationTest.java
@@ -17,9 +17,9 @@ import org.infinispan.context.InvocationContextFactory;
 import org.infinispan.context.TransactionalInvocationContextFactory;
 import org.infinispan.interceptors.InterceptorChain;
 import org.infinispan.transaction.impl.TransactionCoordinator;
-import org.infinispan.transaction.tm.DummyBaseTransactionManager;
-import org.infinispan.transaction.tm.DummyTransaction;
-import org.infinispan.transaction.tm.DummyXid;
+import org.infinispan.transaction.tm.EmbeddedBaseTransactionManager;
+import org.infinispan.transaction.tm.EmbeddedTransaction;
+import org.infinispan.transaction.tm.EmbeddedXid;
 import org.infinispan.transaction.xa.GlobalTransaction;
 import org.infinispan.transaction.xa.LocalXaTransaction;
 import org.infinispan.transaction.xa.TransactionFactory;
@@ -36,7 +36,7 @@ import org.testng.annotations.Test;
 public class TransactionXaAdapterTmIntegrationTest {
    private LocalXaTransaction localTx;
    private TransactionXaAdapter xaAdapter;
-   private DummyXid xid;
+   private EmbeddedXid xid;
    private UUID uuid = UUID.randomUUID();
    private TransactionCoordinator txCoordinator;
 
@@ -52,9 +52,9 @@ public class TransactionXaAdapterTmIntegrationTest {
       TransactionFactory gtf = new TransactionFactory();
       gtf.init(false, false, true, false);
       GlobalTransaction globalTransaction = gtf.newGlobalTransaction(null, false);
-      DummyBaseTransactionManager tm = new DummyBaseTransactionManager();
-      localTx = new LocalXaTransaction(new DummyTransaction(tm), globalTransaction, false, 1, 0);
-      xid = new DummyXid(uuid);
+      EmbeddedBaseTransactionManager tm = new EmbeddedBaseTransactionManager();
+      localTx = new LocalXaTransaction(new EmbeddedTransaction(tm), globalTransaction, false, 1, 0);
+      xid = new EmbeddedXid(uuid);
 
       InvocationContextFactory icf = new TransactionalInvocationContextFactory();
       CommandsFactory commandsFactory = mock(CommandsFactory.class);
@@ -67,7 +67,7 @@ public class TransactionXaAdapterTmIntegrationTest {
    }
 
    public void testPrepareOnNonexistentXid() {
-      DummyXid xid = new DummyXid(uuid);
+      EmbeddedXid xid = new EmbeddedXid(uuid);
       try {
          xaAdapter.prepare(xid);
          assert false;
@@ -77,7 +77,7 @@ public class TransactionXaAdapterTmIntegrationTest {
    }
 
    public void testCommitOnNonexistentXid() {
-      DummyXid xid = new DummyXid(uuid);
+      EmbeddedXid xid = new EmbeddedXid(uuid);
       try {
          xaAdapter.commit(xid, false);
          assert false;
@@ -87,7 +87,7 @@ public class TransactionXaAdapterTmIntegrationTest {
    }
 
    public void testRollabckOnNonexistentXid() {
-      DummyXid xid = new DummyXid(uuid);
+      EmbeddedXid xid = new EmbeddedXid(uuid);
       try {
          xaAdapter.rollback(xid);
          assert false;
@@ -116,7 +116,7 @@ public class TransactionXaAdapterTmIntegrationTest {
       Configuration configuration = new ConfigurationBuilder().clustering().cacheMode(CacheMode.INVALIDATION_ASYNC).build();
       txCoordinator.init(null, null, null, null, null, configuration);
       try {
-         DummyXid doesNotExists = new DummyXid(uuid);
+         EmbeddedXid doesNotExists = new EmbeddedXid(uuid);
          xaAdapter.commit(doesNotExists, false);
          assert false;
       } catch (XAException e) {
@@ -128,7 +128,7 @@ public class TransactionXaAdapterTmIntegrationTest {
       Configuration configuration = new ConfigurationBuilder().clustering().cacheMode(CacheMode.DIST_SYNC).build();
       txCoordinator.init(null, null, null, null, null, configuration);
       try {
-         DummyXid doesNotExists = new DummyXid(uuid);
+         EmbeddedXid doesNotExists = new EmbeddedXid(uuid);
          xaAdapter.commit(doesNotExists, true);
          assert false;
       } catch (XAException e) {

--- a/core/src/test/java/org/infinispan/tx/TxCleanupServiceTest.java
+++ b/core/src/test/java/org/infinispan/tx/TxCleanupServiceTest.java
@@ -5,7 +5,6 @@ import static org.testng.AssertJUnit.assertEquals;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
@@ -17,9 +16,9 @@ import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.infinispan.transaction.impl.TransactionTable;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
-import org.infinispan.transaction.tm.DummyTransaction;
-import org.infinispan.transaction.tm.DummyTransactionManager;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
+import org.infinispan.transaction.tm.EmbeddedTransaction;
+import org.infinispan.transaction.tm.EmbeddedTransactionManager;
 import org.infinispan.util.ControlledConsistentHashFactory;
 import org.infinispan.util.mocks.ControlledCommandFactory;
 import org.testng.annotations.Test;
@@ -37,7 +36,7 @@ public class TxCleanupServiceTest extends MultipleCacheManagersTest {
    @Override
    protected void createCacheManagers() throws Throwable {
       dcc = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, true);
-      dcc.transaction().transactionManagerLookup(new DummyTransactionManagerLookup());
+      dcc.transaction().transactionManagerLookup(new EmbeddedTransactionManagerLookup());
       consistentHashFactory = new ControlledConsistentHashFactory(1);
       dcc.clustering().hash().numOwners(1).numSegments(1).consistentHashFactory(consistentHashFactory);
       createCluster(dcc, 2);
@@ -48,35 +47,27 @@ public class TxCleanupServiceTest extends MultipleCacheManagersTest {
       final ControlledCommandFactory ccf = ControlledCommandFactory.registerControlledCommandFactory(cache(1), CommitCommand.class);
       ccf.gate.close();
 
-      final Map<Object, DummyTransaction> keys2Tx = new HashMap<Object, DummyTransaction>(TX_COUNT);
+      final Map<Object, EmbeddedTransaction> keys2Tx = new HashMap<>(TX_COUNT);
 
       int viewId = advancedCache(0).getRpcManager().getTransport().getViewId();
 
       log.tracef("ViewId before %s", viewId);
 
       //fork it into another thread as this is going to block in commit
-      Future<Object> future = fork(new Callable<Object>() {
-         @Override
-         public Object call() throws Exception {
-            for (int i = 0; i < TX_COUNT; i++) {
-               Object k = getKeyForCache(1);
-               tm(0).begin();
-               cache(0).put(k, k);
-               DummyTransaction transaction = ((DummyTransactionManager) tm(0)).getTransaction();
-               keys2Tx.put(k, transaction);
-               tm(0).commit();
-            }
-            return null;
+      Future<Object> future = fork(() -> {
+         for (int i = 0; i < TX_COUNT; i++) {
+            Object k = getKeyForCache(1);
+            tm(0).begin();
+            cache(0).put(k, k);
+            EmbeddedTransaction transaction = ((EmbeddedTransactionManager) tm(0)).getTransaction();
+            keys2Tx.put(k, transaction);
+            tm(0).commit();
          }
+         return null;
       });
 
       //now wait for all the commits to block
-      eventually(new Condition() {
-         @Override
-         public boolean isSatisfied() throws Exception {
-            return ccf.blockTypeCommandsReceived.get() == TX_COUNT;
-         }
-      });
+      eventually(() -> ccf.blockTypeCommandsReceived.get() == TX_COUNT);
 
       log.tracef("Viewid middle %s", viewId);
 
@@ -92,7 +83,7 @@ public class TxCleanupServiceTest extends MultipleCacheManagersTest {
       log.tracef("Viewid after before %s", viewId);
 
 
-      final Map<Object, DummyTransaction> migratedTx = new HashMap<Object, DummyTransaction>(TX_COUNT);
+      final Map<Object, EmbeddedTransaction> migratedTx = new HashMap<>(TX_COUNT);
       for (Object key : keys2Tx.keySet()) {
          if (keyMapsToNode(key, 2)) {
             migratedTx.put(key, keys2Tx.get(key));
@@ -102,43 +93,30 @@ public class TxCleanupServiceTest extends MultipleCacheManagersTest {
       log.tracef("Number of migrated tx is %s", migratedTx.size());
       assertEquals(TX_COUNT, migratedTx.size());
 
-      eventually(new Condition() {
-         @Override
-         public boolean isSatisfied() throws Exception {
-            return TestingUtil.getTransactionTable(cache(2)).getRemoteTxCount() == migratedTx.size();
-         }
-      });
+      eventually(() -> TestingUtil.getTransactionTable(cache(2)).getRemoteTxCount() == migratedTx.size());
 
       log.trace("Releasing the gate");
       ccf.gate.open();
 
       future.get(10, TimeUnit.SECONDS);
 
-      eventually(new Condition() {
-         @Override
-         public boolean isSatisfied() throws Exception {
-            return TestingUtil.getTransactionTable(cache(2)).getRemoteTxCount() == 0;
-         }
-      });
+      eventually(() -> TestingUtil.getTransactionTable(cache(2)).getRemoteTxCount() == 0);
 
 
-      eventually(new Condition() {
-         @Override
-         public boolean isSatisfied() throws Exception {
-            boolean allZero = true;
-            for (int i = 0; i < 3; i++) {
-               TransactionTable tt = TestingUtil.getTransactionTable(cache(i));
+      eventually(() -> {
+         boolean allZero = true;
+         for (int i = 0; i < 3; i++) {
+            TransactionTable tt = TestingUtil.getTransactionTable(cache(i));
 //               assertEquals("For cache " + i, 0, tt.getLocalTxCount());
 //               assertEquals("For cache " + i, 0, tt.getRemoteTxCount());
-               int local = tt.getLocalTxCount();
-               int remote = tt.getRemoteTxCount();
-               log.tracef("For cache %d, localTxCount=%s, remoteTxCount=%s", i, local, remote);
-               log.tracef(String.format("For cache %s , localTxCount=%s, remoteTxCount=%s", i, local, remote));
-               allZero = allZero && (local == 0);
-               allZero = allZero && (remote == 0);
-            }
-            return allZero;
+            int local = tt.getLocalTxCount();
+            int remote = tt.getRemoteTxCount();
+            log.tracef("For cache %d, localTxCount=%s, remoteTxCount=%s", i, local, remote);
+            log.tracef(String.format("For cache %s , localTxCount=%s, remoteTxCount=%s", i, local, remote));
+            allZero = allZero && (local == 0);
+            allZero = allZero && (remote == 0);
          }
+         return allZero;
       });
 
       for (Object key : keys2Tx.keySet()) {

--- a/core/src/test/java/org/infinispan/tx/locking/AbstractClusteredTxTest.java
+++ b/core/src/test/java/org/infinispan/tx/locking/AbstractClusteredTxTest.java
@@ -11,7 +11,7 @@ import javax.transaction.RollbackException;
 import javax.transaction.SystemException;
 
 import org.infinispan.test.MultipleCacheManagersTest;
-import org.infinispan.transaction.tm.DummyTransactionManager;
+import org.infinispan.transaction.tm.EmbeddedTransactionManager;
 import org.testng.annotations.Test;
 
 /**
@@ -73,7 +73,7 @@ public abstract class AbstractClusteredTxTest extends MultipleCacheManagersTest 
    }
 
    protected void commit() {
-      DummyTransactionManager dtm = (DummyTransactionManager) tm(0);
+      EmbeddedTransactionManager dtm = (EmbeddedTransactionManager) tm(0);
       try {
          dtm.getTransaction().runCommit(false);
       } catch (HeuristicMixedException | HeuristicRollbackException | RollbackException e) {
@@ -82,12 +82,12 @@ public abstract class AbstractClusteredTxTest extends MultipleCacheManagersTest 
    }
 
    protected void prepare() {
-      DummyTransactionManager dtm = (DummyTransactionManager) tm(0);
+      EmbeddedTransactionManager dtm = (EmbeddedTransactionManager) tm(0);
       dtm.getTransaction().runPrepare();
    }
 
    protected void rollback() {
-      DummyTransactionManager dtm = (DummyTransactionManager) tm(0);
+      EmbeddedTransactionManager dtm = (EmbeddedTransactionManager) tm(0);
       try {
          dtm.getTransaction().rollback();
       } catch (SystemException e) {

--- a/core/src/test/java/org/infinispan/tx/locking/AbstractLocalTest.java
+++ b/core/src/test/java/org/infinispan/tx/locking/AbstractLocalTest.java
@@ -12,8 +12,8 @@ import javax.transaction.xa.Xid;
 
 import org.infinispan.context.Flag;
 import org.infinispan.test.SingleCacheManagerTest;
-import org.infinispan.transaction.tm.DummyTransaction;
-import org.infinispan.transaction.tm.DummyTransactionManager;
+import org.infinispan.transaction.tm.EmbeddedTransaction;
+import org.infinispan.transaction.tm.EmbeddedTransactionManager;
 import org.testng.annotations.Test;
 
 /**
@@ -61,7 +61,7 @@ public abstract class AbstractLocalTest extends SingleCacheManagerTest {
    protected abstract void assertLocking();
 
    protected void commit() {
-      DummyTransactionManager dtm = (DummyTransactionManager) tm();
+      EmbeddedTransactionManager dtm = (EmbeddedTransactionManager) tm();
       try {
          dtm.firstEnlistedResource().commit(getXid(), true);
       } catch (Throwable e) {
@@ -70,7 +70,7 @@ public abstract class AbstractLocalTest extends SingleCacheManagerTest {
    }
 
    protected void prepare() {
-      DummyTransactionManager dtm = (DummyTransactionManager) tm();
+      EmbeddedTransactionManager dtm = (EmbeddedTransactionManager) tm();
       try {
          dtm.firstEnlistedResource().prepare(getXid());
       } catch (Throwable e) {
@@ -79,7 +79,7 @@ public abstract class AbstractLocalTest extends SingleCacheManagerTest {
    }
 
    protected void rollback() {
-      DummyTransactionManager dtm = (DummyTransactionManager) tm();
+      EmbeddedTransactionManager dtm = (EmbeddedTransactionManager) tm();
       try {
          dtm.getTransaction().rollback();
       } catch (SystemException e) {
@@ -88,7 +88,8 @@ public abstract class AbstractLocalTest extends SingleCacheManagerTest {
    }
 
    private Xid getXid() throws SystemException {
-      Xid xid;DummyTransaction dummyTransaction = (DummyTransaction) tm().getTransaction();
+      Xid xid;
+      EmbeddedTransaction dummyTransaction = (EmbeddedTransaction) tm().getTransaction();
       xid = dummyTransaction.getXid();
       return xid;
    }

--- a/core/src/test/java/org/infinispan/tx/locking/LocalOptimisticTxTest.java
+++ b/core/src/test/java/org/infinispan/tx/locking/LocalOptimisticTxTest.java
@@ -7,7 +7,7 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.transaction.LockingMode;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
 import org.testng.annotations.Test;
 
 /**
@@ -23,7 +23,7 @@ public class LocalOptimisticTxTest extends AbstractLocalTest {
       config
          .transaction()
             .lockingMode(LockingMode.OPTIMISTIC)
-            .transactionManagerLookup(new DummyTransactionManagerLookup())
+            .transactionManagerLookup(new EmbeddedTransactionManagerLookup())
             .useSynchronization(false)
             .recovery()
                .disable();

--- a/core/src/test/java/org/infinispan/tx/locking/LocalPessimisticTxTest.java
+++ b/core/src/test/java/org/infinispan/tx/locking/LocalPessimisticTxTest.java
@@ -8,7 +8,7 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.transaction.LockingMode;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
 import org.testng.annotations.Test;
 
 /**
@@ -35,7 +35,7 @@ public class LocalPessimisticTxTest extends AbstractLocalTest {
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       final ConfigurationBuilder config = getDefaultStandaloneCacheConfig(true);
       config.transaction().lockingMode(LockingMode.PESSIMISTIC)
-            .transactionManagerLookup(new DummyTransactionManagerLookup())
+            .transactionManagerLookup(new EmbeddedTransactionManagerLookup())
             .useSynchronization(false)
             .recovery().disable();
       return TestCacheManagerFactory.createCacheManager(config);

--- a/core/src/test/java/org/infinispan/tx/locking/OptimisticReplTxTest.java
+++ b/core/src/test/java/org/infinispan/tx/locking/OptimisticReplTxTest.java
@@ -8,7 +8,7 @@ import javax.transaction.Transaction;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.transaction.LockingMode;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
 import org.testng.annotations.Test;
 
 /**
@@ -49,7 +49,7 @@ public class OptimisticReplTxTest extends AbstractClusteredTxTest {
       final ConfigurationBuilder conf = getDefaultClusteredCacheConfig(cacheMode, true);
       conf.transaction()
             .lockingMode(LockingMode.OPTIMISTIC)
-            .transactionManagerLookup(new DummyTransactionManagerLookup());
+            .transactionManagerLookup(new EmbeddedTransactionManagerLookup());
       createCluster(conf, 2);
       waitForClusterToForm();
       k = getKeyForCache(0);

--- a/core/src/test/java/org/infinispan/tx/locking/PessimisticReplTxTest.java
+++ b/core/src/test/java/org/infinispan/tx/locking/PessimisticReplTxTest.java
@@ -13,7 +13,7 @@ import org.infinispan.distribution.MagicKey;
 import org.infinispan.remoting.RemoteException;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.transaction.LockingMode;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
 import org.infinispan.util.concurrent.TimeoutException;
 import org.testng.annotations.Test;
 
@@ -37,7 +37,7 @@ public class PessimisticReplTxTest extends AbstractClusteredTxTest {
       final ConfigurationBuilder conf = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, true);
       conf.transaction()
             .lockingMode(LockingMode.PESSIMISTIC)
-            .transactionManagerLookup(new DummyTransactionManagerLookup())
+            .transactionManagerLookup(new EmbeddedTransactionManagerLookup())
          .locking().lockAcquisitionTimeout(TestingUtil.shortTimeoutMillis());
       return conf;
    }

--- a/core/src/test/java/org/infinispan/tx/locking/SizeDistTxRepeatableReadTest.java
+++ b/core/src/test/java/org/infinispan/tx/locking/SizeDistTxRepeatableReadTest.java
@@ -9,7 +9,7 @@ import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.transaction.LockingMode;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
 import org.infinispan.util.concurrent.IsolationLevel;
 import org.testng.annotations.Test;
 
@@ -35,7 +35,7 @@ public class SizeDistTxRepeatableReadTest extends MultipleCacheManagersTest {
             .locking().isolationLevel(isolation)
             .transaction()
             .lockingMode(LockingMode.OPTIMISTIC)
-            .transactionManagerLookup(new DummyTransactionManagerLookup());
+            .transactionManagerLookup(new EmbeddedTransactionManagerLookup());
       createCluster(conf, 2);
       waitForClusterToForm();
       k0 = getKeyForCache(0);

--- a/core/src/test/java/org/infinispan/tx/recovery/PostCommitRecoveryStateTest.java
+++ b/core/src/test/java/org/infinispan/tx/recovery/PostCommitRecoveryStateTest.java
@@ -18,7 +18,8 @@ import org.infinispan.remoting.transport.Address;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.transaction.impl.TransactionTable;
-import org.infinispan.transaction.tm.DummyTransaction;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
+import org.infinispan.transaction.tm.EmbeddedTransaction;
 import org.infinispan.transaction.xa.GlobalTransaction;
 import org.infinispan.transaction.xa.XaTransactionTable;
 import org.infinispan.transaction.xa.recovery.RecoveryAwareRemoteTransaction;
@@ -45,7 +46,7 @@ public class PostCommitRecoveryStateTest extends MultipleCacheManagersTest {
       configuration
          .locking().useLockStriping(false)
          .transaction()
-            .transactionManagerLookup(new RecoveryDummyTransactionManagerLookup())
+            .transactionManagerLookup(new EmbeddedTransactionManagerLookup())
             .useSynchronization(false)
             .recovery().enable()
          .clustering().stateTransfer().fetchInMemoryState(false);
@@ -66,7 +67,7 @@ public class PostCommitRecoveryStateTest extends MultipleCacheManagersTest {
       assertEquals(rm1.getInDoubtTransactionsMap().size(), 0);
       assertEquals(tt1.getRemoteTxCount(), 0);
 
-      DummyTransaction t0 = beginAndSuspendTx(cache(0));
+      EmbeddedTransaction t0 = beginAndSuspendTx(cache(0));
       assertEquals(rm1.getInDoubtTransactionsMap().size(),0);
       assertEquals(tt1.getRemoteTxCount(), 0);
 

--- a/core/src/test/java/org/infinispan/tx/recovery/RecoveryDummyTransactionManagerLookup.java
+++ b/core/src/test/java/org/infinispan/tx/recovery/RecoveryDummyTransactionManagerLookup.java
@@ -2,13 +2,16 @@ package org.infinispan.tx.recovery;
 
 import javax.transaction.TransactionManager;
 
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
 import org.infinispan.transaction.lookup.TransactionManagerLookup;
 import org.infinispan.transaction.tm.DummyTransactionManager;
 
 /**
  * @author Mircea Markus <mircea.markus@jboss.com> (C) 2011 Red Hat Inc.
  * @since 5.1
+ * @deprecated use {@link EmbeddedTransactionManagerLookup}
  */
+@Deprecated
 public class RecoveryDummyTransactionManagerLookup implements TransactionManagerLookup {
 
    @Override

--- a/core/src/test/java/org/infinispan/tx/recovery/RecoveryTestUtil.java
+++ b/core/src/test/java/org/infinispan/tx/recovery/RecoveryTestUtil.java
@@ -7,8 +7,8 @@ import javax.transaction.xa.XAResource;
 
 import org.infinispan.Cache;
 import org.infinispan.test.TestingUtil;
-import org.infinispan.transaction.tm.DummyTransaction;
-import org.infinispan.transaction.tm.DummyTransactionManager;
+import org.infinispan.transaction.tm.EmbeddedTransaction;
+import org.infinispan.transaction.tm.EmbeddedTransactionManager;
 import org.infinispan.transaction.xa.TransactionXaAdapter;
 import org.infinispan.transaction.xa.recovery.RecoveryManager;
 import org.infinispan.transaction.xa.recovery.RecoveryManagerImpl;
@@ -17,17 +17,17 @@ public class RecoveryTestUtil {
 
    public static int count = 0;
 
-   public static void commitTransaction(DummyTransaction dtx) throws XAException {
+   public static void commitTransaction(EmbeddedTransaction dtx) throws XAException {
       TransactionXaAdapter xaResource = (TransactionXaAdapter) dtx.firstEnlistedResource();
       xaResource.commit(xaResource.getLocalTransaction().getXid(), false);
    }
 
-   public static void rollbackTransaction(DummyTransaction dtx) throws XAException {
+   public static void rollbackTransaction(EmbeddedTransaction dtx) throws XAException {
       TransactionXaAdapter xaResource = (TransactionXaAdapter) dtx.firstEnlistedResource();
       xaResource.commit(xaResource.getLocalTransaction().getXid(), false);
    }
 
-   public static void prepareTransaction(DummyTransaction suspend1) {
+   public static void prepareTransaction(EmbeddedTransaction suspend1) {
       TransactionXaAdapter xaResource = (TransactionXaAdapter) suspend1.firstEnlistedResource();
       try {
          xaResource.prepare(xaResource.getLocalTransaction().getXid());
@@ -36,8 +36,8 @@ public class RecoveryTestUtil {
       }
    }
 
-   public static void assertPrepared(int count, DummyTransaction...tx) throws XAException {
-      for (DummyTransaction dt : tx) {
+   static void assertPrepared(int count, EmbeddedTransaction... tx) throws XAException {
+      for (EmbeddedTransaction dt : tx) {
          TransactionXaAdapter xaRes = (TransactionXaAdapter) dt.firstEnlistedResource();
          assertEquals(count, xaRes.recover(XAResource.TMSTARTRSCAN | XAResource.TMENDRSCAN).length);
       }
@@ -47,16 +47,16 @@ public class RecoveryTestUtil {
       return (RecoveryManagerImpl) TestingUtil.extractComponentRegistry(cache).getComponent(RecoveryManager.class);
    }
 
-   public static DummyTransaction beginAndSuspendTx(Cache cache) {
+   public static EmbeddedTransaction beginAndSuspendTx(Cache cache) {
       return beginAndSuspendTx(cache, "k" + count++);
    }
 
-   public static DummyTransaction beginAndSuspendTx(Cache cache, Object key) {
-      DummyTransactionManager dummyTm = (DummyTransactionManager) TestingUtil.getTransactionManager(cache);
+   public static EmbeddedTransaction beginAndSuspendTx(Cache cache, Object key) {
+      EmbeddedTransactionManager dummyTm = (EmbeddedTransactionManager) TestingUtil.getTransactionManager(cache);
       try {
          dummyTm.begin();
          cache.put(key, "v");
-         return (DummyTransaction) dummyTm.suspend();
+         return (EmbeddedTransaction) dummyTm.suspend();
       } catch (Exception e) {
          throw new RuntimeException(e);
       }

--- a/core/src/test/java/org/infinispan/tx/recovery/RecoveryWithDefaultCacheReplTest.java
+++ b/core/src/test/java/org/infinispan/tx/recovery/RecoveryWithDefaultCacheReplTest.java
@@ -3,6 +3,7 @@ package org.infinispan.tx.recovery;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.test.fwk.CleanupAfterMethod;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
 import org.testng.annotations.Test;
 
 /**
@@ -15,7 +16,7 @@ public class RecoveryWithDefaultCacheReplTest extends RecoveryWithDefaultCacheDi
    @Override
    protected ConfigurationBuilder configure() {
       ConfigurationBuilder config = super.configure();
-      config.transaction().transactionManagerLookup(new RecoveryDummyTransactionManagerLookup())
+      config.transaction().transactionManagerLookup(new EmbeddedTransactionManagerLookup())
             .clustering().cacheMode(CacheMode.REPL_SYNC);
       return config;
    }

--- a/core/src/test/java/org/infinispan/tx/recovery/admin/AbstractRecoveryTest.java
+++ b/core/src/test/java/org/infinispan/tx/recovery/admin/AbstractRecoveryTest.java
@@ -10,10 +10,10 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.transaction.impl.TransactionTable;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
 import org.infinispan.transaction.xa.recovery.RecoveryAdminOperations;
 import org.infinispan.transaction.xa.recovery.RecoveryAwareTransactionTable;
 import org.infinispan.transaction.xa.recovery.RecoveryManager;
-import org.infinispan.tx.recovery.RecoveryDummyTransactionManagerLookup;
 import org.testng.annotations.Test;
 
 /**
@@ -25,7 +25,7 @@ public abstract class AbstractRecoveryTest extends MultipleCacheManagersTest {
 
    protected ConfigurationBuilder defaultRecoveryConfig() {
       ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, true);
-      builder.transaction().transactionManagerLookup(new RecoveryDummyTransactionManagerLookup())
+      builder.transaction().transactionManagerLookup(new EmbeddedTransactionManagerLookup())
             .useSynchronization(false)
             .recovery().enable()
             .locking().useLockStriping(false)

--- a/core/src/test/java/org/infinispan/tx/recovery/admin/CommitFailsTest.java
+++ b/core/src/test/java/org/infinispan/tx/recovery/admin/CommitFailsTest.java
@@ -13,7 +13,7 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.distribution.MagicKey;
 import org.infinispan.interceptors.impl.InvocationContextInterceptor;
 import org.infinispan.test.TestingUtil;
-import org.infinispan.transaction.tm.DummyTransaction;
+import org.infinispan.transaction.tm.EmbeddedTransaction;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -52,7 +52,7 @@ public class CommitFailsTest extends AbstractRecoveryTest {
 
       tm(2).begin();
       cache(2).put(this.key, "newValue");
-      DummyTransaction tx = (DummyTransaction) tm(2).suspend();
+      EmbeddedTransaction tx = (EmbeddedTransaction) tm(2).suspend();
       prepareTransaction(tx);
       try {
          commitTransaction(tx);

--- a/core/src/test/java/org/infinispan/tx/recovery/admin/ForgetTest.java
+++ b/core/src/test/java/org/infinispan/tx/recovery/admin/ForgetTest.java
@@ -11,7 +11,7 @@ import javax.transaction.xa.Xid;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.transaction.impl.RemoteTransaction;
-import org.infinispan.transaction.tm.DummyTransaction;
+import org.infinispan.transaction.tm.EmbeddedTransaction;
 import org.infinispan.transaction.xa.XaTransactionTable;
 import org.infinispan.transaction.xa.recovery.RecoverableTransactionIdentifier;
 import org.infinispan.transaction.xa.recovery.RecoveryManager;
@@ -27,7 +27,7 @@ import org.testng.annotations.Test;
 public class ForgetTest extends AbstractRecoveryTest {
 
    private PostCommitRecoveryStateTest.RecoveryManagerDelegate recoveryManager;
-   private DummyTransaction tx;
+   private EmbeddedTransaction tx;
 
    @Override
    protected void createCacheManagers() throws Throwable {

--- a/core/src/test/java/org/infinispan/tx/recovery/admin/InDoubtWithCommitFailsTest.java
+++ b/core/src/test/java/org/infinispan/tx/recovery/admin/InDoubtWithCommitFailsTest.java
@@ -16,8 +16,8 @@ import org.infinispan.interceptors.base.CommandInterceptor;
 import org.infinispan.interceptors.impl.InvocationContextInterceptor;
 import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.infinispan.transaction.impl.TransactionTable;
-import org.infinispan.transaction.tm.DummyTransaction;
-import org.infinispan.tx.recovery.RecoveryDummyTransactionManagerLookup;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
+import org.infinispan.transaction.tm.EmbeddedTransaction;
 import org.testng.annotations.Test;
 
 /**
@@ -33,7 +33,7 @@ public class InDoubtWithCommitFailsTest extends AbstractRecoveryTest {
    @Override
    protected void createCacheManagers() throws Throwable {
       ConfigurationBuilder configuration = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, true);
-      configuration.transaction().transactionManagerLookup(new RecoveryDummyTransactionManagerLookup())
+      configuration.transaction().transactionManagerLookup(new EmbeddedTransactionManagerLookup())
             .useSynchronization(false)
             .recovery().enable()
             .locking().useLockStriping(false)
@@ -56,7 +56,7 @@ public class InDoubtWithCommitFailsTest extends AbstractRecoveryTest {
       assert recoveryOps(0).showInDoubtTransactions().isEmpty();
       TransactionTable tt0 = cache(0).getAdvancedCache().getComponentRegistry().getComponent(TransactionTable.class);
 
-      DummyTransaction dummyTransaction = beginAndSuspendTx(cache(0));
+      EmbeddedTransaction dummyTransaction = beginAndSuspendTx(cache(0));
       prepareTransaction(dummyTransaction);
       assert tt0.getLocalTxCount() == 1;
 

--- a/core/src/test/java/org/infinispan/tx/recovery/admin/OriginatorAndOwnerFailureTest.java
+++ b/core/src/test/java/org/infinispan/tx/recovery/admin/OriginatorAndOwnerFailureTest.java
@@ -8,7 +8,7 @@ import java.util.List;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.distribution.MagicKey;
 import org.infinispan.test.fwk.CleanupAfterMethod;
-import org.infinispan.transaction.tm.DummyTransaction;
+import org.infinispan.transaction.tm.EmbeddedTransaction;
 import org.testng.annotations.Test;
 
 /**
@@ -34,7 +34,7 @@ public class OriginatorAndOwnerFailureTest extends AbstractRecoveryTest {
 
       tm(2).begin();
       cache(2).put(this.key, "newValue");
-      DummyTransaction tx = (DummyTransaction) tm(2).suspend();
+      EmbeddedTransaction tx = (EmbeddedTransaction) tm(2).suspend();
       prepareTransaction(tx);
 
       killMember(2);

--- a/core/src/test/java/org/infinispan/tx/synchronisation/LocalModeWithSyncTxTest.java
+++ b/core/src/test/java/org/infinispan/tx/synchronisation/LocalModeWithSyncTxTest.java
@@ -8,8 +8,8 @@ import javax.transaction.SystemException;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
-import org.infinispan.transaction.tm.DummyTransaction;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
+import org.infinispan.transaction.tm.EmbeddedTransaction;
 import org.infinispan.tx.LocalModeTxTest;
 import org.testng.annotations.Test;
 
@@ -23,12 +23,12 @@ public class LocalModeWithSyncTxTest extends LocalModeTxTest {
    @Override
    protected EmbeddedCacheManager createCacheManager() {
       ConfigurationBuilder config = getDefaultStandaloneCacheConfig(true);
-      config.transaction().transactionManagerLookup(new DummyTransactionManagerLookup()).useSynchronization(true);
+      config.transaction().transactionManagerLookup(new EmbeddedTransactionManagerLookup()).useSynchronization(true);
       return TestCacheManagerFactory.createCacheManager(config);
    }
 
    public void testSyncRegisteredWithCommit() throws Exception {
-      DummyTransaction dt = startTx();
+      EmbeddedTransaction dt = startTx();
       tm().commit();
       assertEquals(0, dt.getEnlistedResources().size());
       assertEquals(0, dt.getEnlistedSynchronization().size());
@@ -36,17 +36,17 @@ public class LocalModeWithSyncTxTest extends LocalModeTxTest {
    }
 
    public void testSyncRegisteredWithRollback() throws Exception {
-      DummyTransaction dt = startTx();
+      EmbeddedTransaction dt = startTx();
       tm().rollback();
       assertEquals(null, cache.get("k"));
       assertEquals(0, dt.getEnlistedResources().size());
       assertEquals(0, dt.getEnlistedSynchronization().size());
    }
 
-   private DummyTransaction startTx() throws NotSupportedException, SystemException {
+   private EmbeddedTransaction startTx() throws NotSupportedException, SystemException {
       tm().begin();
       cache.put("k","v");
-      DummyTransaction dt = (DummyTransaction) tm().getTransaction();
+      EmbeddedTransaction dt = (EmbeddedTransaction) tm().getTransaction();
       assertEquals(0, dt.getEnlistedResources().size());
       assertEquals(1, dt.getEnlistedSynchronization().size());
       cache.put("k2","v2");

--- a/core/src/test/resources/configs/batching.xml
+++ b/core/src/test/resources/configs/batching.xml
@@ -9,7 +9,7 @@
          <transaction mode="BATCH" stop-timeout="2"/>
       </local-cache>
       <local-cache name="tml">
-         <transaction mode="NON_XA" transaction-manager-lookup="org.infinispan.transaction.lookup.DummyTransactionManagerLookup" stop-timeout="2"/>
+         <transaction mode="NON_XA" transaction-manager-lookup="org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup" stop-timeout="2"/>
       </local-cache>
    </cache-container>
 

--- a/documentation/src/main/asciidoc/contributing/building.adoc
+++ b/documentation/src/main/asciidoc/contributing/building.adoc
@@ -207,7 +207,7 @@ The profiles available in the generated sample project are:
 
 * udp: use UDP for network communications rather than TCP
 * tcp: use TCP for network communications rather than UDP
-* jbosstm: Use the embedded link:http://www.jboss.org/jbosstm[JBoss Transaction Manager] rather than Infinispan's dummy test transaction manager 
+* jbosstm: Use the embedded link:http://www.jboss.org/jbosstm[JBoss Transaction Manager] rather than Infinispan's embedded transaction manager
 
 ===== Contributing tests back to Infinispan
 If you have written a functional, unit or stress test for Infinispan and want to contribute this back to Infinispan, your best bet is to link:https://github.com/infinispan/infinispan[fork the Infinispan sources on GitHub].

--- a/documentation/src/main/asciidoc/contributing/tests.adoc
+++ b/documentation/src/main/asciidoc/contributing/tests.adoc
@@ -118,10 +118,10 @@ Note that due to the way Maven operates, only one permutation can be executed pe
 So automating multiple runs requires shell scripting, or some other execution framework to make multiple calls to Maven.
 
 ==== Running permutations manually or in an IDE
-Sometimes you want to run a test using settings other than the defaults (such as UDP for `jgroups` group tests or the DummyTransactionManager for `transaction` group tests).
+Sometimes you want to run a test using settings other than the defaults (such as UDP for `jgroups` group tests or the EmbeddedTransactionManager for `transaction` group tests).
 This can be achieved by referring to the Maven POM file to figure out which system properties are passed in to the test when doing something different.
 For example to run a `jgroups` group test in your IDE using TCP instead of the default UDP, set `-Dinfinispan.test.jgroups.protocol=tcp`.
-Or, to use JBoss JTA (Arjuna TM) instead of the DummyTransactionManager in a `transaction` group test, set `-Dinfinispan.test.jta.tm=jbosstm`.
+Or, to use JBoss JTA (Arjuna TM) instead of the EmbeddedTransactionManager in a `transaction` group test, set `-Dinfinispan.test.jta.tm=jbosstm`.
 Please refer to the POM file for more properties and permutations. 
 
 === The Parallel Test Suite

--- a/documentation/src/main/asciidoc/getting_started/create_project.adoc
+++ b/documentation/src/main/asciidoc/getting_started/create_project.adoc
@@ -67,7 +67,7 @@ The profiles available in the generated sample project are:
 
 * udp: use UDP for network communications rather than TCP
 * tcp: use TCP for network communications rather than UDP
-*  jbosstm: Use the embedded link:http://www.jboss.org/jbosstm[JBoss Transaction Manager] rather than Infinispan's dummy test transaction manager 
+* jbosstm: Use the embedded link:http://www.jboss.org/jbosstm[JBoss Transaction Manager] rather than Infinispan's embedded transaction manager
 
 
 ===== Contributing tests back to Infinispan

--- a/documentation/src/main/asciidoc/getting_started/example_with_groovy.adoc
+++ b/documentation/src/main/asciidoc/getting_started/example_with_groovy.adoc
@@ -222,7 +222,7 @@ Thats all related to the use of the Infinispan API, now lets check some differen
 You are able to specify the cache to use a transaction manager, and even explicitly control the transactions. Start by configuring the cache to use a specific TransactionManagerLookup class. Infinispan implements a couple TransactionManagerLookup classes.
 
 
-*  link:{javadocroot}/org/infinispan/transaction/lookup/DummyTransactionManagerLookup.html[org.infinispan.transaction.lookup.DummyTransactionManagerLookup]
+*  link:{javadocroot}/org/infinispan/transaction/lookup/EmbeddedTransactionManager.html[org.infinispan.transaction.lookup.EmbeddedTransactionManager]
 
 
 *  link:{javadocroot}/org/infinispan/transaction/lookup/GenericTransactionManagerLookup.html[org.infinispan.transaction.lookup.GenericTransactionManagerLookup]
@@ -237,7 +237,7 @@ For the tutorial its enough to use:
 [source,xml]
 ----
 <namedCache name="LocalTX">
-    <transaction transactionManagerLookupClass="org.infinispan.transaction.lookup.DummyTransactionManagerLookup"/>
+    <transaction transactionManagerLookupClass="org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup"/>
 </namedCache>
 
 ----
@@ -255,7 +255,7 @@ groovy:000> cr = localTxCache.getComponentRegistry()
 === > org.infinispan.factories.ComponentRegistry@87e9bf
 //GET A REFERENCE TO THE TRANSACTION MANAGER
 groovy:000> tm = cr.getComponent(TransactionManager.class)
-=== > org.infinispan.transaction.tm.DummyTransactionManager@b5d05b
+=== > org.infinispan.transaction.tm.EmbeddedTransactionManager@b5d05b
 //STARTING A NEW TRANSACTION
 groovy:000> tm.begin()
 === > null

--- a/documentation/src/main/asciidoc/getting_started/example_with_scala.adoc
+++ b/documentation/src/main/asciidoc/getting_started/example_with_scala.adoc
@@ -28,7 +28,7 @@ where infinispan-embedded-{infinispanversion}.0.Final.jar, jboss-transaction-api
    <cache-container default-cache="default">
       <transport stack="tcpStack" cluster="sampleCluster"/>
       <local-cache name="LocalTX">
-         <transaction transaction-manager-lookup="org.infinispan.transaction.lookup.DummyTransactionManagerLookup" />
+         <transaction transaction-manager-lookup="org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup" />
       </local-cache>
       <local-cache name="CacheStore">
          <persistence>
@@ -199,7 +199,7 @@ scala> val localTxCache = manager.getCache[String, String]("LocalTX")
 localTxCache: org.infinispan.Cache[String,String] = Cache 'LocalTX'@955386212
 
 scala> val tm = localTxCache.getAdvancedCache().getTransactionManager()
-tm: javax.transaction.TransactionManager = org.infinispan.transaction.tm.DummyTransactionManager@81ee8c1
+tm: javax.transaction.TransactionManager = org.infinispan.transaction.tm.EmbeddedTransactionManager@81ee8c1
 
 scala> tm.begin
 
@@ -210,7 +210,7 @@ scala> localTxCache.size
 res2: Int = 1
 
 scala> val tx = tm.suspend
-res3: javax.transaction.Transaction = DummyTransaction{xid=DummyXid{id=1}, status=0}
+res3: javax.transaction.Transaction = EmbeddedTransaction{xid=DummyXid{id=1}, status=0}
 
 scala> localTxCache.size
 res4: Int = 0

--- a/documentation/src/main/asciidoc/upgrading/upgrading.asciidoc
+++ b/documentation/src/main/asciidoc/upgrading/upgrading.asciidoc
@@ -9,6 +9,16 @@ This guide walks you through the process of upgrading Infinispan.
 
 == Upgrading from 8.x to 9.0
 
+=== Deprecated all the dummy related transaction classes.
+The following classes has been deprecated and they will be removed in the future:
+
+* `DummyBaseTransactionManager`: replaced by `EmbeddedBasedTransactionManager`;
+* `DummyNoXaXid` and `DummyXid`: replaced by `EmbeddedXid`;
+* `DummyTransaction`: replaced by `EmbeddedTransaction`;
+* `DummyTransactionManager`: replaced by `EmbeddedTransactionManager`;
+* `DummyTransactionManagerLookup` and `RecoveryDummyTransactionManagerLookup`: replaced by `EmbeddedTransactionManagerLookup`;
+* `DummyUserTransaction`: replaced by `EmbeddedUserTransaction`;
+
 === Clustering configuration changes
 The `mode` attribute in the XML declaration of clustered caches is no longer mandatory. It defaults to SYNC.
 

--- a/documentation/src/main/asciidoc/user_guide/transactions.adoc
+++ b/documentation/src/main/asciidoc/user_guide/transactions.adoc
@@ -14,17 +14,20 @@ When the cache starts, it will create an instance of this class and invoke its `
 Infinispan ships with several transaction manager lookup classes:
 
 .Transaction manager lookup implementations
-*  link:{javadocroot}/org/infinispan/transaction/lookup/DummyTransactionManagerLookup.html[DummyTransactionManagerLookup]:
-This provides with a dummy transaction manager which should only be used for testing.
-Being a dummy, this is not recommended for production use a it has some severe limitations to do with concurrent transactions and recovery.
+*  link:{javadocroot}/org/infinispan/transaction/lookup/EmbeddedTransactionManagerLookup.html[EmbeddedTransactionManagerLookup]:
+This provides with a basic transaction manager which should only be used for embedded mode when no other implementation is available.
+This implementation has some severe limitations to do with concurrent transactions and recovery.
 
 *  link:{javadocroot}/org/infinispan/transaction/lookup/JBossStandaloneJTAManagerLookup.html[JBossStandaloneJTAManagerLookup]:
 If you're running Infinispan in a standalone environment, this should be your default choice for transaction manager.
-It's a fully fledged transaction manager based on link:http://narayana.io/[JBoss Transactions] which overcomes all the deficiencies of the dummy transaction manager.
+It's a fully fledged transaction manager based on link:http://narayana.io/[JBoss Transactions] which overcomes all the deficiencies of the `EmbeddedTransactionManager`.
 
 *  link:{javadocroot}/org/infinispan/transaction/lookup/GenericTransactionManagerLookup.html[GenericTransactionManagerLookup]:
 This is a lookup class that locate transaction managers in the most popular Java EE application servers.
-If no transaction manager can be found, it defaults on the dummy transaction manager.
+If no transaction manager can be found, it defaults on the `EmbeddedTransactionManager`.
+
+WARN: `DummyTransactionManagerLookup` has been deprecated in 9.0 and it will be removed in the future.
+Use `EmbeddedTransactionManagerLookup` instead.
 
 Once initialized, the `TransactionManager` can also be obtained from the `Cache` itself:
 

--- a/server/rest/src/test/java/org/infinispan/rest/TwoServerTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/TwoServerTest.java
@@ -20,7 +20,7 @@ import org.infinispan.rest.configuration.RestServerConfigurationBuilder;
 import org.infinispan.test.AbstractCacheTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -42,7 +42,7 @@ public class TwoServerTest extends RestServerTestBase {
    @BeforeClass
    private void setUp() throws Exception {
       ConfigurationBuilder cfgBuilder = AbstractCacheTest.getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, true);
-      cfgBuilder.transaction().transactionManagerLookup(new DummyTransactionManagerLookup());
+      cfgBuilder.transaction().transactionManagerLookup(new EmbeddedTransactionManagerLookup());
       cfgBuilder.clustering().hash().numOwners(2);
       cfgBuilder.clustering().stateTransfer().fetchInMemoryState(true);
       cfgBuilder.clustering().stateTransfer().timeout(20000);

--- a/tools/src/main/java/org/infinispan/tools/jdbc/migrator/MigratorConfiguration.java
+++ b/tools/src/main/java/org/infinispan/tools/jdbc/migrator/MigratorConfiguration.java
@@ -41,7 +41,7 @@ import org.infinispan.persistence.jdbc.table.management.DbMetaData;
 import org.infinispan.persistence.keymappers.DefaultTwoWayKey2StringMapper;
 import org.infinispan.persistence.keymappers.TwoWayKey2StringMapper;
 import org.infinispan.transaction.TransactionMode;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
 
 /**
  * @author Ryan Emerson
@@ -97,7 +97,7 @@ class MigratorConfiguration {
          stringTable = createTableConfig(STRING, builder);
          builder.transaction()
                .transactionMode(TransactionMode.TRANSACTIONAL)
-               .transactionManagerLookup(new DummyTransactionManagerLookup());
+               .transactionManagerLookup(new EmbeddedTransactionManagerLookup());
       }
       builder.validate();
       jdbcConfigBuilder = builder;


### PR DESCRIPTION
* All dummy* related classes deprecated
* New embedded* related classes added
* Testsuite is using the new classes

https://issues.jboss.org/browse/ISPN-6176

I would like an opinion on
* ```DummyXid``` and ```DummyNoXaXid``` has been kept. should it be changed to a new name?
* There is a ```useXaXid``` boolean that is set when recovery is in use. this boolean choose between the creation of ```DummyNoXaXid```  or ```DummyXid```. IMO, the field should be removed and we should create only ```DummyXid```. Also, I can remove ```RecoveryEmbeddedTransactionManagerLookup```.