### PR TITLE
DMR operation register-proto-schemas fails with NPE if the proto file has syntax errors

### DIFF
--- a/core/src/main/java/org/infinispan/interceptors/distribution/TxDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/TxDistributionInterceptor.java
@@ -62,6 +62,7 @@ import org.infinispan.remoting.responses.UnsureResponse;
 import org.infinispan.remoting.rpc.ResponseMode;
 import org.infinispan.remoting.rpc.RpcOptions;
 import org.infinispan.remoting.transport.Address;
+import org.infinispan.remoting.transport.jgroups.SuspectException;
 import org.infinispan.statetransfer.OutdatedTopologyException;
 import org.infinispan.topology.CacheTopology;
 import org.infinispan.transaction.impl.LocalTransaction;

--- a/remote-query/remote-query-server/src/test/java/org/infinispan/query/remote/impl/ProtobufMetadataCachePreserveStateAcrossRestartsTest.java
+++ b/remote-query/remote-query-server/src/test/java/org/infinispan/query/remote/impl/ProtobufMetadataCachePreserveStateAcrossRestartsTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.query.remote.impl;
 
+import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertTrue;
 
 import org.infinispan.Cache;
@@ -9,7 +10,7 @@ import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.query.remote.client.ProtobufMetadataManagerConstants;
 import org.infinispan.test.AbstractInfinispanTest;
-import org.infinispan.test.CacheManagerCallable;
+import org.infinispan.test.MultiCacheManagerCallable;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.testng.annotations.Test;
@@ -18,9 +19,9 @@ import org.testng.annotations.Test;
 public class ProtobufMetadataCachePreserveStateAcrossRestartsTest extends AbstractInfinispanTest {
 
    protected EmbeddedCacheManager createCacheManager(String persistentStateLocation) throws Exception {
-      GlobalConfigurationBuilder global = new GlobalConfigurationBuilder();
+      GlobalConfigurationBuilder global = new GlobalConfigurationBuilder().clusteredDefault();
       global.globalState().enable().persistentLocation(persistentStateLocation);
-      EmbeddedCacheManager cacheManager = TestCacheManagerFactory.createCacheManager(global, new ConfigurationBuilder());
+      EmbeddedCacheManager cacheManager = TestCacheManagerFactory.createClusteredCacheManager(global, new ConfigurationBuilder());
       cacheManager.getCache();
       return cacheManager;
    }
@@ -29,19 +30,24 @@ public class ProtobufMetadataCachePreserveStateAcrossRestartsTest extends Abstra
       String persistentStateLocation = TestingUtil.tmpDirectory(this.getClass());
       Util.recursiveFileRemove(persistentStateLocation);
 
-      TestingUtil.withCacheManager(new CacheManagerCallable(createCacheManager(persistentStateLocation)) {
+      final String persistentStateLocation1 = persistentStateLocation + "/1";
+      final String persistentStateLocation2 = persistentStateLocation + "/2";
+      TestingUtil.withCacheManagers(new MultiCacheManagerCallable(createCacheManager(persistentStateLocation1),
+                                                                  createCacheManager(persistentStateLocation2)) {
          @Override
          public void call() throws Exception {
-            Cache<String, String> protobufMetadaCache = cm.getCache(ProtobufMetadataManagerConstants.PROTOBUF_METADATA_CACHE_NAME);
-            protobufMetadaCache.put("test.proto", "package X;");
+            Cache<String, String> protobufMetadaCache = cms[0].getCache(ProtobufMetadataManagerConstants.PROTOBUF_METADATA_CACHE_NAME);
+            protobufMetadaCache.put("testA.proto", "package A;");
+            protobufMetadaCache.put("testB.proto", "import \"testB.proto\";\npackage B;");
          }
       });
 
-      TestingUtil.withCacheManager(new CacheManagerCallable(createCacheManager(persistentStateLocation)) {
+      TestingUtil.withCacheManagers(new MultiCacheManagerCallable(createCacheManager(persistentStateLocation1),
+                                                                  createCacheManager(persistentStateLocation2)) {
          @Override
          public void call() throws Exception {
-            Cache<String, String> protobufMetadaCache = cm.getCache(ProtobufMetadataManagerConstants.PROTOBUF_METADATA_CACHE_NAME);
-            assertTrue(protobufMetadaCache.containsKey("test.proto"));
+            Cache<String, String> protobufMetadaCache = cms[0].getCache(ProtobufMetadataManagerConstants.PROTOBUF_METADATA_CACHE_NAME);
+            assertTrue(protobufMetadaCache.containsKey("testA.proto"));
          }
       });
    }

--- a/remote-query/remote-query-server/src/test/java/org/infinispan/query/remote/impl/ProtobufMetadataCachePreserveStateAcrossRestartsTest.java
+++ b/remote-query/remote-query-server/src/test/java/org/infinispan/query/remote/impl/ProtobufMetadataCachePreserveStateAcrossRestartsTest.java
@@ -1,6 +1,5 @@
 package org.infinispan.query.remote.impl;
 
-import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertTrue;
 
 import org.infinispan.Cache;
@@ -48,6 +47,8 @@ public class ProtobufMetadataCachePreserveStateAcrossRestartsTest extends Abstra
          public void call() throws Exception {
             Cache<String, String> protobufMetadaCache = cms[0].getCache(ProtobufMetadataManagerConstants.PROTOBUF_METADATA_CACHE_NAME);
             assertTrue(protobufMetadaCache.containsKey("testA.proto"));
+            assertTrue(protobufMetadaCache.containsKey("testB.proto"));
+            assertTrue(protobufMetadaCache.containsKey("testB.proto.errors"));
          }
       });
    }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-7405

Preload is also problematic, both when the file has syntax/semantic errors and when it doesn't (because the {{.errors}} file is locked either way).
