### PR TITLE
ISPN-7513 AbstractClusteredWriteSkewTest can fail randomly still

### DIFF
--- a/core/src/test/java/org/infinispan/container/versioning/AbstractClusteredWriteSkewTest.java
+++ b/core/src/test/java/org/infinispan/container/versioning/AbstractClusteredWriteSkewTest.java
@@ -301,19 +301,22 @@ public abstract class AbstractClusteredWriteSkewTest extends MultipleCacheManage
       }
 
       DataContainer dataContainer = TestingUtil.extractComponent(primaryOwner, DataContainer.class);
-      MagicKey[] keys = new MagicKey[MAX_ENTRIES];
+      int retryCount = 5;
       int insertCount = 10;
-      for (int i = 0; i < insertCount; ++i) {
-         for (int j = 0; j < MAX_ENTRIES; ++j) {
-            MagicKey tempKey = keys[j];
-            if (tempKey == null) {
-               tempKey = new MagicKey("other-key-" + j, primaryOwner);
-               keys[j] = tempKey;
+      for (int retry = 0; retry < 5; ++retry) {
+         MagicKey[] keys = new MagicKey[MAX_ENTRIES];
+         for (int i = 0; i < insertCount; ++i) {
+            for (int j = 0; j < MAX_ENTRIES; ++j) {
+               MagicKey tempKey = keys[j];
+               if (tempKey == null) {
+                  tempKey = new MagicKey("other-key-" + j, primaryOwner);
+                  keys[j] = tempKey;
+               }
+               primaryOwner.put(tempKey, "value");
             }
-            primaryOwner.put(tempKey, "value");
          }
       }
-      assertTrue("The key was not evicted after " + insertCount + " inserts", dataContainer.peek(key) == null);
+      assertTrue("The key was not evicted after " + insertCount + " inserts - retried " + retryCount, dataContainer.peek(key) == null);
 
       log.debugf("It is going to try to commit the suspended transaction");
       try {


### PR DESCRIPTION
* Tries inserting different keys if first set fails

https://issues.jboss.org/browse/ISPN-7513