### PR TITLE
ISPN-7523 Update cached RpcOptions when timeout changes

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/cache/ClusteringConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/ClusteringConfiguration.java
@@ -19,7 +19,7 @@ public class ClusteringConfiguration {
          AttributeDefinition.builder("remoteTimeout", TimeUnit.SECONDS.toMillis(15)).build();
 
    static AttributeSet attributeDefinitionSet() {
-      return new AttributeSet(ClusteringConfiguration.class, CACHE_MODE);
+      return new AttributeSet(ClusteringConfiguration.class, CACHE_MODE, REMOTE_TIMEOUT);
    }
 
    private final Attribute<CacheMode> cacheMode;


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-7523

Not sure if the `volatile` is really needed - we could probably live a moment before the update is propagated to the other threads. But volatile reads should be cheap.