### PR TITLE
ISPN-7070

### DIFF
--- a/core/src/test/java/org/infinispan/notifications/cachelistener/CacheNotifierImplInitialTransferDistTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/CacheNotifierImplInitialTransferDistTest.java
@@ -13,6 +13,7 @@ import static org.testng.Assert.fail;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -583,9 +584,9 @@ public class CacheNotifierImplInitialTransferDistTest extends MultipleCacheManag
             assertEquals(event.getValue(), value);
          }
       } finally {
+         cache.removeListener(listener);
          TestingUtil.replaceComponent(cache, CacheNotifier.class, notifier, true);
          TestingUtil.replaceComponent(cache, ClusterCacheNotifier.class, notifier, true);
-         cache.removeListener(listener);
       }
    }
 
@@ -660,12 +661,12 @@ public class CacheNotifierImplInitialTransferDistTest extends MultipleCacheManag
    }
 
    protected static abstract class StateListener<K, V> {
-      final List<CacheEntryEvent<K, V>> events = new ArrayList<>();
+      final List<CacheEntryEvent<K, V>> events = Collections.synchronizedList(new ArrayList<>());
 
       @CacheEntryCreated
       @CacheEntryModified
       @CacheEntryRemoved
-      public synchronized void onCacheNotification(CacheEntryEvent<K, V> event) {
+      public void onCacheNotification(CacheEntryEvent<K, V> event) {
          events.add(event);
       }
    }


### PR DESCRIPTION
CacheNotifierImplInitialTransferDistTest.testIterationBeganAndSegmentNotComplete
random failures

* Make sure reads into listener collection are also synchronized
* Remove listener before replacing notifier that it registered with

https://issues.jboss.org/browse/ISPN-7070