### PR TITLE
[8.1.x][ISPN-7535] Cache creation requires specific permissions when using s…

### DIFF
--- a/commons/src/main/java/org/infinispan/commons/util/ReflectionUtil.java
+++ b/commons/src/main/java/org/infinispan/commons/util/ReflectionUtil.java
@@ -6,7 +6,6 @@ import org.infinispan.commons.logging.LogFactory;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -163,17 +162,7 @@ public class ReflectionUtil {
     * @param parameters parameters
     */
    public static Object invokeAccessibly(Object instance, Method method, Object[] parameters) {
-      try {
-         method.setAccessible(true);
-         return method.invoke(instance, parameters);
-      } catch (InvocationTargetException e) {
-         Throwable cause = e.getCause() != null ? e.getCause() : e;
-         throw new CacheException("Unable to invoke method " + method + " on object of type " + (instance == null ? "null" : instance.getClass().getSimpleName()) +
-                                        (parameters != null ? " with parameters " + Arrays.asList(parameters) : ""), cause);
-      } catch (Exception e) {
-         throw new CacheException("Unable to invoke method " + method + " on object of type " + (instance == null ? "null" : instance.getClass().getSimpleName()) +
-               (parameters != null ? " with parameters " + Arrays.asList(parameters) : ""), e);
-      }
+      return SecurityActions.invokeAccessibly(instance, method, parameters);
    }
 
    public static Method findGetterForField(Class<?> c, String fieldName) {

--- a/commons/src/main/java/org/infinispan/commons/util/SecurityActions.java
+++ b/commons/src/main/java/org/infinispan/commons/util/SecurityActions.java
@@ -1,7 +1,12 @@
 package org.infinispan.commons.util;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.Arrays;
+
+import org.infinispan.commons.CacheException;
 
 /**
  * Privileged actions for the package
@@ -69,5 +74,63 @@ final class SecurityActions {
          return SysProps.NON_PRIVILEGED.getProperty(name);
 
       return SysProps.PRIVILEGED.getProperty(name);
+   }
+
+   private static <T> T doPrivileged(PrivilegedAction<T> action) {
+      if (System.getSecurityManager() != null) {
+         return AccessController.doPrivileged(action);
+      } else {
+         return action.run();
+      }
+   }
+
+   static Object invokeAccessibly(Object instance, Method method, Object[] parameters) {
+       return doPrivileged((PrivilegedAction<Object>) () -> {
+          try {
+             method.setAccessible(true);
+             return method.invoke(instance, parameters);
+          } catch (InvocationTargetException e) {
+             Throwable cause = e.getCause() != null ? e.getCause() : e;
+             throw new CacheException("Unable to invoke method " + method + " on object of type " + (instance == null ? "null" : instance.getClass().getSimpleName()) +
+                                            (parameters != null ? " with parameters " + Arrays.asList(parameters) : ""), cause);
+          } catch (Exception e) {
+             throw new CacheException("Unable to invoke method " + method + " on object of type " + (instance == null ? "null" : instance.getClass().getSimpleName()) +
+                   (parameters != null ? " with parameters " + Arrays.asList(parameters) : ""), e);
+          }
+       });
+   }
+
+   static ClassLoader[] getClassLoaders(ClassLoader appClassLoader) {
+      return doPrivileged((PrivilegedAction<ClassLoader[]>) () -> {
+         return new ClassLoader[] { appClassLoader,   // User defined classes
+               Util.class.getClassLoader(),           // Infinispan classes (not always on TCCL [modular env])
+               ClassLoader.getSystemClassLoader(),    // Used when load time instrumentation is in effect
+               Thread.currentThread().getContextClassLoader() //Used by jboss-as stuff
+         };
+      });
+   }
+
+   private static ClassLoader getOSGiClassLoader() {
+       // Make loading class optional
+       try {
+           Class<?> osgiClassLoader = Class.forName("org.infinispan.commons.util.OsgiClassLoader");
+           return (ClassLoader) osgiClassLoader.getMethod("getInstance", null).invoke(null);
+       } catch (ClassNotFoundException e) {
+           // fall back option - it can't hurt if we scan ctx class loader 2 times.
+           return Thread.currentThread().getContextClassLoader();
+       } catch (Exception e) {
+           throw new RuntimeException("Unable to call getInstance on OsgiClassLoader", e);
+       }
+   }
+
+   static ClassLoader[] getOSGIContextClassLoaders(ClassLoader appClassLoader) {
+      return doPrivileged((PrivilegedAction<ClassLoader[]>) () -> {
+         return new ClassLoader[] { appClassLoader,   // User defined classes
+               getOSGiClassLoader(), // OSGi bundle context needs to be on top of TCCL, system CL, etc.
+               Util.class.getClassLoader(),           // Infinispan classes (not always on TCCL [modular env])
+               ClassLoader.getSystemClassLoader(),    // Used when load time instrumentation is in effect
+               Thread.currentThread().getContextClassLoader() //Used by jboss-as stuff
+         };
+      });
    }
 }

--- a/commons/src/main/java/org/infinispan/commons/util/Util.java
+++ b/commons/src/main/java/org/infinispan/commons/util/Util.java
@@ -115,18 +115,9 @@ public final class Util {
 
    public static ClassLoader[] getClassLoaders(ClassLoader appClassLoader) {
       if (isOSGiContext()) {
-         return new ClassLoader[] { appClassLoader,   // User defined classes
-               OsgiClassLoader.getInstance(),         // OSGi bundle context needs to be on top of TCCL, system CL, etc.
-               Util.class.getClassLoader(),           // Infinispan classes (not always on TCCL [modular env])
-               ClassLoader.getSystemClassLoader(),    // Used when load time instrumentation is in effect
-               Thread.currentThread().getContextClassLoader() //Used by jboss-as stuff
-         };
+         return SecurityActions.getOSGIContextClassLoaders(appClassLoader);
       } else {
-         return new ClassLoader[] { appClassLoader,   // User defined classes
-               Util.class.getClassLoader(),           // Infinispan classes (not always on TCCL [modular env])
-               ClassLoader.getSystemClassLoader(),    // Used when load time instrumentation is in effect
-               Thread.currentThread().getContextClassLoader() //Used by jboss-as stuff
-         };
+         return SecurityActions.getClassLoaders(appClassLoader);
       }
    }
 


### PR DESCRIPTION
…ecurity manager

Move Util.getClassLoaders() and ReflectionUtil.invokeAccessibly() to doPrivileged() when security manager is enabled

Jira: https://issues.jboss.org/browse/ISPN-7535

PR to 8.2.x branch: https://github.com/infinispan/infinispan/pull/4918