### PR TITLE
ISPN-7539 Do not configure data container key/value equivalence in tests

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/SizeTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/SizeTest.java
@@ -3,7 +3,6 @@ package org.infinispan.client.hotrod;
 import static org.testng.AssertJUnit.assertEquals;
 
 import org.infinispan.client.hotrod.test.MultiHotRodServersTest;
-import org.infinispan.commons.equivalence.ByteArrayEquivalence;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.persistence.dummy.DummyInMemoryStoreConfigurationBuilder;
@@ -48,7 +47,6 @@ public class SizeTest extends MultiHotRodServersTest {
       String cacheName = "persistent-distributed-size";
       ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false);
       builder.eviction().size(1);
-      builder.dataContainer().keyEquivalence(ByteArrayEquivalence.INSTANCE);
       builder.persistence()
             .passivation(true)
             .addStore(DummyInMemoryStoreConfigurationBuilder.class)

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/SingleServerCompatibilityRemoteIteratorTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/SingleServerCompatibilityRemoteIteratorTest.java
@@ -1,7 +1,6 @@
 package org.infinispan.client.hotrod.impl.iteration;
 
 
-import org.infinispan.commons.equivalence.AnyEquivalence;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.server.hotrod.test.HotRodTestingUtil;
@@ -21,7 +20,6 @@ public class SingleServerCompatibilityRemoteIteratorTest extends SingleServerRem
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       ConfigurationBuilder cb = HotRodTestingUtil.hotRodCacheConfiguration();
-      cb.dataContainer().keyEquivalence(AnyEquivalence.INT).valueEquivalence(AnyEquivalence.STRING); //reset default byte array equivalence
       cb.compatibility().enable();
       return TestCacheManagerFactory.createCacheManager(cb);
    }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/HotRodNonIndexedQueryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/HotRodNonIndexedQueryTest.java
@@ -1,6 +1,5 @@
 package org.infinispan.client.hotrod.query;
 
-import org.infinispan.commons.equivalence.ByteArrayEquivalence;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.testng.annotations.Test;
 
@@ -13,8 +12,6 @@ public class HotRodNonIndexedQueryTest extends HotRodQueryTest {
 
    @Override
    protected ConfigurationBuilder getConfigurationBuilder() {
-      ConfigurationBuilder builder = new ConfigurationBuilder();
-      builder.dataContainer().keyEquivalence(ByteArrayEquivalence.INSTANCE);
-      return builder;
+      return new ConfigurationBuilder();
    }
 }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/HotRodNonIndexedSingleFileStoreQueryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/HotRodNonIndexedSingleFileStoreQueryTest.java
@@ -1,6 +1,5 @@
 package org.infinispan.client.hotrod.query;
 
-import org.infinispan.commons.equivalence.ByteArrayEquivalence;
 import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.SingleFileStoreConfigurationBuilder;
@@ -34,8 +33,7 @@ public class HotRodNonIndexedSingleFileStoreQueryTest extends HotRodNonIndexedQu
    @Override
    protected ConfigurationBuilder getConfigurationBuilder() {
       ConfigurationBuilder builder = new ConfigurationBuilder();
-      builder.dataContainer().keyEquivalence(ByteArrayEquivalence.INSTANCE)
-            .persistence()
+      builder.persistence()
             .addStore(SingleFileStoreConfigurationBuilder.class)
             .location(tmpDirectory);
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/HotRodQueryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/HotRodQueryTest.java
@@ -20,7 +20,6 @@ import org.infinispan.client.hotrod.query.testdomain.protobuf.AddressPB;
 import org.infinispan.client.hotrod.query.testdomain.protobuf.UserPB;
 import org.infinispan.client.hotrod.query.testdomain.protobuf.marshallers.MarshallerRegistration;
 import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
-import org.infinispan.commons.equivalence.ByteArrayEquivalence;
 import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.Index;
@@ -91,9 +90,7 @@ public class HotRodQueryTest extends SingleCacheManagerTest {
 
    protected ConfigurationBuilder getConfigurationBuilder() {
       ConfigurationBuilder builder = new ConfigurationBuilder();
-      builder.dataContainer()
-            .keyEquivalence(ByteArrayEquivalence.INSTANCE)
-            .indexing().index(Index.ALL)
+      builder.indexing().index(Index.ALL)
             .addProperty("default.directory_provider", "ram")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       return builder;

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryDslConditionsTunedTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryDslConditionsTunedTest.java
@@ -4,7 +4,6 @@ import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertTrue;
 
 import org.hibernate.search.spi.SearchIntegrator;
-import org.infinispan.commons.equivalence.ByteArrayEquivalence;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.Index;
 import org.infinispan.query.Search;
@@ -24,10 +23,7 @@ public class RemoteQueryDslConditionsTunedTest extends RemoteQueryDslConditionsF
    @Override
    protected ConfigurationBuilder getConfigurationBuilder() {
       ConfigurationBuilder builder = new ConfigurationBuilder();
-      builder.dataContainer()
-            .keyEquivalence(ByteArrayEquivalence.INSTANCE)
-            .valueEquivalence(ByteArrayEquivalence.INSTANCE)
-            .indexing().index(Index.ALL)
+      builder.indexing().index(Index.ALL)
             .addProperty("default.indexmanager", "near-real-time")
             .addProperty("default.indexBase", indexDirectory)
             .addProperty("default.exclusive_index_use", "true")

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryJmxTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryJmxTest.java
@@ -28,7 +28,6 @@ import org.infinispan.client.hotrod.query.testdomain.protobuf.AddressPB;
 import org.infinispan.client.hotrod.query.testdomain.protobuf.UserPB;
 import org.infinispan.client.hotrod.query.testdomain.protobuf.marshallers.MarshallerRegistration;
 import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
-import org.infinispan.commons.equivalence.ByteArrayEquivalence;
 import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.Index;
@@ -76,10 +75,7 @@ public class RemoteQueryJmxTest extends SingleCacheManagerTest {
             .mBeanServerLookup(new PerThreadMBeanServerLookup());
 
       ConfigurationBuilder builder = new ConfigurationBuilder();
-      builder.dataContainer()
-            .keyEquivalence(ByteArrayEquivalence.INSTANCE)
-            .valueEquivalence(ByteArrayEquivalence.INSTANCE)
-            .indexing().index(Index.ALL)
+      builder.indexing().index(Index.ALL)
             .addProperty("default.directory_provider", "ram")
             .addProperty("lucene_version", "LUCENE_CURRENT");
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryWithProtostreamAnnotationsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryWithProtostreamAnnotationsTest.java
@@ -12,7 +12,6 @@ import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.Search;
 import org.infinispan.client.hotrod.marshall.ProtoStreamMarshaller;
 import org.infinispan.client.hotrod.test.SingleHotRodServerTest;
-import org.infinispan.commons.equivalence.ByteArrayEquivalence;
 import org.infinispan.configuration.cache.Index;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.protostream.FileDescriptorSource;
@@ -113,10 +112,7 @@ public class RemoteQueryWithProtostreamAnnotationsTest extends SingleHotRodServe
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       org.infinispan.configuration.cache.ConfigurationBuilder builder = new org.infinispan.configuration.cache.ConfigurationBuilder();
-      builder.dataContainer()
-            .keyEquivalence(ByteArrayEquivalence.INSTANCE)
-            .valueEquivalence(ByteArrayEquivalence.INSTANCE)
-            .indexing().index(Index.ALL)
+      builder.indexing().index(Index.ALL)
             .addProperty("default.directory_provider", "ram")
             .addProperty("lucene_version", "LUCENE_CURRENT");
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/TwoCachesSharedIndexTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/TwoCachesSharedIndexTest.java
@@ -15,7 +15,6 @@ import org.infinispan.client.hotrod.query.testdomain.protobuf.AccountPB;
 import org.infinispan.client.hotrod.query.testdomain.protobuf.UserPB;
 import org.infinispan.client.hotrod.query.testdomain.protobuf.marshallers.MarshallerRegistration;
 import org.infinispan.client.hotrod.test.MultiHotRodServersTest;
-import org.infinispan.commons.equivalence.ByteArrayEquivalence;
 import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.Configuration;
@@ -49,10 +48,7 @@ public class TwoCachesSharedIndexTest extends MultiHotRodServersTest {
 
    public Configuration buildIndexedConfig(String lockCache, String dataCache, String metadataCache) {
       ConfigurationBuilder builder = hotRodCacheConfiguration(getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false));
-      builder.dataContainer()
-              .keyEquivalence(ByteArrayEquivalence.INSTANCE)
-              .valueEquivalence(ByteArrayEquivalence.INSTANCE)
-              .indexing().index(Index.LOCAL)
+      builder.indexing().index(Index.LOCAL)
               .addProperty("default.indexmanager", InfinispanIndexManager.class.getName())
               .addProperty("default.metadata_cachename", metadataCache)
               .addProperty("default.data_cachename", dataCache)

--- a/core/src/test/java/org/infinispan/api/ByteArrayCacheTest.java
+++ b/core/src/test/java/org/infinispan/api/ByteArrayCacheTest.java
@@ -1,15 +1,12 @@
 package org.infinispan.api;
 
 import static org.infinispan.test.TestingUtil.withCacheManager;
-import static org.testng.AssertJUnit.assertFalse;
-import static org.testng.AssertJUnit.assertNull;
 import static org.testng.AssertJUnit.assertTrue;
 
 import java.util.Arrays;
 import java.util.Map;
 
 import org.infinispan.Cache;
-import org.infinispan.commons.equivalence.ByteArrayEquivalence;
 import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -36,14 +33,11 @@ public class ByteArrayCacheTest extends SingleCacheManagerTest {
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       ConfigurationBuilder builder = new ConfigurationBuilder();
-      // If key equivalence is set, it will also be used for value
-      builder.dataContainer().keyEquivalence(ByteArrayEquivalence.INSTANCE);
       return TestCacheManagerFactory.createCacheManager(builder);
    }
 
    public void testByteArrayValueOnlyReplace() {
       ConfigurationBuilder builder = new ConfigurationBuilder();
-      builder.dataContainer().valueEquivalence(ByteArrayEquivalence.INSTANCE);
       withCacheManager(new CacheManagerCallable(
             TestCacheManagerFactory.createCacheManager(builder)) {
          @Override

--- a/core/src/test/java/org/infinispan/api/MetadataAPIDistTest.java
+++ b/core/src/test/java/org/infinispan/api/MetadataAPIDistTest.java
@@ -6,8 +6,6 @@ import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.internal.junit.ArrayAsserts.assertArrayEquals;
 
 import org.infinispan.Cache;
-import org.infinispan.commons.equivalence.ByteArrayEquivalence;
-import org.infinispan.commons.equivalence.Equivalence;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.container.entries.CacheEntry;
@@ -20,9 +18,7 @@ public class MetadataAPIDistTest extends MultipleCacheManagersTest {
    @Override
    protected void createCacheManagers() throws Throwable {
       ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC);
-      Equivalence<byte[]> eq = ByteArrayEquivalence.INSTANCE;
-      builder.dataContainer().keyEquivalence(eq).valueEquivalence(eq)
-             .clustering().hash().numOwners(1);
+      builder.clustering().hash().numOwners(1);
       createCluster(builder, 2);
       waitForClusterToForm();
    }

--- a/core/src/test/java/org/infinispan/lock/KeyLockTest.java
+++ b/core/src/test/java/org/infinispan/lock/KeyLockTest.java
@@ -2,7 +2,6 @@ package org.infinispan.lock;
 
 import java.util.concurrent.TimeUnit;
 
-import org.infinispan.commons.equivalence.ByteArrayEquivalence;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -49,7 +48,6 @@ public class KeyLockTest extends SingleCacheManagerTest {
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.LOCAL);
       builder.locking().lockAcquisitionTimeout(100, TimeUnit.MILLISECONDS);
-      builder.dataContainer().keyEquivalence(ByteArrayEquivalence.INSTANCE);
       EmbeddedCacheManager cacheManager = TestCacheManagerFactory.createCacheManager(builder);
       for (CacheName cacheName : CacheName.values()) {
          cacheName.configure(builder);

--- a/core/src/test/java/org/infinispan/persistence/BaseStoreFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/persistence/BaseStoreFunctionalTest.java
@@ -16,7 +16,6 @@ import javax.transaction.TransactionManager;
 import org.infinispan.Cache;
 import org.infinispan.atomic.AtomicMap;
 import org.infinispan.atomic.AtomicMapLookup;
-import org.infinispan.commons.equivalence.ByteArrayEquivalence;
 import org.infinispan.commons.util.ByRef;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
@@ -203,7 +202,6 @@ public abstract class BaseStoreFunctionalTest extends SingleCacheManagerTest {
 
    public void testStoreByteArrays(final Method m) throws PersistenceException {
       ConfigurationBuilder base = new ConfigurationBuilder();
-      base.dataContainer().keyEquivalence(ByteArrayEquivalence.INSTANCE);
       // we need to purge the container when loading, because we could try to compare
       // some old entry using ByteArrayEquivalence and this throws ClassCastException
       // for non-byte[] arguments

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/test/HotRodTestingUtils.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/test/HotRodTestingUtils.java
@@ -28,7 +28,6 @@ import java.util.stream.Collectors;
 import org.infinispan.Cache;
 import org.infinispan.commons.CacheException;
 import org.infinispan.commons.api.BasicCacheContainer;
-import org.infinispan.commons.equivalence.ByteArrayEquivalence;
 import org.infinispan.commons.logging.LogFactory;
 import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
@@ -448,14 +447,7 @@ public class HotRodTestingUtils {
    }
 
    public static ConfigurationBuilder hotRodCacheConfiguration() {
-      return hotRodCacheConfiguration(new ConfigurationBuilder());
-   }
-
-   public static ConfigurationBuilder hotRodCacheConfiguration(ConfigurationBuilder base) {
-      base.dataContainer()
-            .keyEquivalence(ByteArrayEquivalence.INSTANCE)
-            .valueEquivalence(ByteArrayEquivalence.INSTANCE);
-      return base;
+      return new ConfigurationBuilder();
    }
 
    public static InternalCacheEntry assertHotRodEquals(EmbeddedCacheManager cm, byte[] key, byte[] expectedValue) {

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/test/HotRodTestingUtil.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/test/HotRodTestingUtil.scala
@@ -1,20 +1,18 @@
 package org.infinispan.server.hotrod.test
 
 import java.lang.reflect.Method
-import java.net.{InetAddress, NetworkInterface}
+import java.net.NetworkInterface
 import java.util.{Arrays, Collections, Optional, List => JList, Map => JMap}
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicInteger
 
 import io.netty.channel.{Channel, ChannelFuture, ChannelInitializer}
 import org.infinispan.commons.api.BasicCacheContainer
-import org.infinispan.commons.equivalence.ByteArrayEquivalence
-import org.infinispan.commons.hash.MurmurHash3
 import org.infinispan.commons.logging.LogFactory
 import org.infinispan.commons.marshall.WrappedByteArray
 import org.infinispan.commons.util.Util
 import org.infinispan.configuration.cache.ConfigurationBuilder
-import org.infinispan.configuration.global.{GlobalAuthorizationConfigurationBuilder, GlobalConfigurationBuilder}
+import org.infinispan.configuration.global.GlobalConfigurationBuilder
 import org.infinispan.manager.{DefaultCacheManager, EmbeddedCacheManager}
 import org.infinispan.marshall.core.JBossMarshaller
 import org.infinispan.notifications.Listener
@@ -401,9 +399,6 @@ object HotRodTestingUtil {
       hotRodCacheConfiguration(new ConfigurationBuilder())
 
    def hotRodCacheConfiguration(base: ConfigurationBuilder): ConfigurationBuilder = {
-      base.dataContainer()
-              .keyEquivalence(ByteArrayEquivalence.INSTANCE)
-              .valueEquivalence(ByteArrayEquivalence.INSTANCE)
       base
    }
 


### PR DESCRIPTION
* this is deprecated and a no-op anyway

https://issues.jboss.org/browse/ISPN-7539