### PR TITLE
ISPN-6039 NonTxBackupOwnerBecomingPrimaryOwnerTest.testPrimaryOwnerCh…

### DIFF
--- a/core/src/test/java/org/infinispan/distribution/BaseDistSyncL1Test.java
+++ b/core/src/test/java/org/infinispan/distribution/BaseDistSyncL1Test.java
@@ -76,7 +76,7 @@ public abstract class BaseDistSyncL1Test extends BaseDistFunctionalTest<Object, 
                                          Class<? extends VisitableCommand> commandClass,
          Class<? extends AsyncInterceptor> interceptorPosition,
                                          boolean blockAfterCommand) {
-      BlockingInterceptor bi = new BlockingInterceptor(barrier, commandClass, blockAfterCommand, false);
+      BlockingInterceptor bi = new BlockingInterceptor<>(barrier, commandClass, blockAfterCommand, false);
       AsyncInterceptorChain interceptorChain = cache.getAdvancedCache().getAsyncInterceptorChain();
       assertTrue(interceptorChain.addInterceptorBefore(bi, interceptorPosition));
       return bi;

--- a/core/src/test/java/org/infinispan/distribution/rehash/BaseTxStateTransferOverwriteTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/BaseTxStateTransferOverwriteTest.java
@@ -239,7 +239,7 @@ public abstract class BaseTxStateTransferOverwriteTest extends BaseDistFunctiona
                   log.tracef("Adding additional value on nonOwner value inserted: %s = %s", mk, value);
                }
                primaryOwnerCache.getAdvancedCache().getAsyncInterceptorChain().addInterceptorBefore(
-                     new BlockingInterceptor(cyclicBarrier, getVisitableCommand(op), true, false),
+                     new BlockingInterceptor<>(cyclicBarrier, getVisitableCommand(op), true, false),
                      StateTransferInterceptor.class);
                return op.perform(primaryOwnerCache, key);
             }
@@ -355,7 +355,7 @@ public abstract class BaseTxStateTransferOverwriteTest extends BaseDistFunctiona
 
       // Every PutKeyValueCommand will be blocked before committing the entry on cache1
       CyclicBarrier beforeCommitCache1Barrier = new CyclicBarrier(2);
-      BlockingInterceptor blockingInterceptor1 = new BlockingInterceptor(beforeCommitCache1Barrier,
+      BlockingInterceptor blockingInterceptor1 = new BlockingInterceptor<>(beforeCommitCache1Barrier,
                                                                          op.getCommandClass(), true, false);
       nonOwnerCache.getAsyncInterceptorChain().addInterceptorAfter(blockingInterceptor1, EntryWrappingInterceptor.class);
 
@@ -437,7 +437,7 @@ public abstract class BaseTxStateTransferOverwriteTest extends BaseDistFunctiona
 
       // Block on the interceptor right after ST which should now have the soon to be old topology id
       CyclicBarrier beforeCommitCache1Barrier = new CyclicBarrier(2);
-      BlockingInterceptor blockingInterceptor1 = new BlockingInterceptor(beforeCommitCache1Barrier,
+      BlockingInterceptor blockingInterceptor1 = new BlockingInterceptor<>(beforeCommitCache1Barrier,
                                                                          getVisitableCommand(op), false, false);
       primaryOwnerCache.getAsyncInterceptorChain().addInterceptorAfter(blockingInterceptor1, StateTransferInterceptor.class);
 

--- a/core/src/test/java/org/infinispan/distribution/rehash/L1StateTransferRemovesValueTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/L1StateTransferRemovesValueTest.java
@@ -139,7 +139,7 @@ public class L1StateTransferRemovesValueTest extends BaseDistFunctionalTest<Stri
 
       CyclicBarrier barrier = new CyclicBarrier(2);
       c3.getAdvancedCache().getAsyncInterceptorChain()
-            .addInterceptorAfter(new BlockingInterceptor(barrier, InvalidateL1Command.class, true, false),
+            .addInterceptorAfter(new BlockingInterceptor<>(barrier, InvalidateL1Command.class, true, false),
                   EntryWrappingInterceptor.class);
 
       Future<String> future = c1.putAsync(key, newValue);

--- a/core/src/test/java/org/infinispan/distribution/rehash/NonTxOriginatorBecomingPrimaryOwnerTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/NonTxOriginatorBecomingPrimaryOwnerTest.java
@@ -59,7 +59,7 @@ public class NonTxOriginatorBecomingPrimaryOwnerTest extends MultipleCacheManage
 
       // Every PutKeyValueCommand will be blocked before reaching the distribution interceptor
       CyclicBarrier distInterceptorBarrier = new CyclicBarrier(2);
-      BlockingInterceptor blockingInterceptor = new BlockingInterceptor(distInterceptorBarrier, PutKeyValueCommand.class, false, false);
+      BlockingInterceptor blockingInterceptor = new BlockingInterceptor<>(distInterceptorBarrier, PutKeyValueCommand.class, false, false);
       cache0.getAsyncInterceptorChain().addInterceptorBefore(blockingInterceptor, TriangleDistributionInterceptor.class);
 
       for (int i = 0; i < NUM_KEYS; i++) {

--- a/core/src/test/java/org/infinispan/distribution/rehash/NonTxPrimaryOwnerBecomingNonOwnerTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/NonTxPrimaryOwnerBecomingNonOwnerTest.java
@@ -141,7 +141,7 @@ public class NonTxPrimaryOwnerBecomingNonOwnerTest extends MultipleCacheManagers
 
       // Every operation command will be blocked before reaching the distribution interceptor on cache0 (the originator)
       CyclicBarrier beforeCache0Barrier = new CyclicBarrier(2);
-      BlockingInterceptor blockingInterceptor0 = new BlockingInterceptor(beforeCache0Barrier,
+      BlockingInterceptor blockingInterceptor0 = new BlockingInterceptor<>(beforeCache0Barrier,
             op.getCommandClass(), false, true);
       cache0.getAsyncInterceptorChain().addInterceptorBefore(blockingInterceptor0, EntryWrappingInterceptor.class);
 

--- a/core/src/test/java/org/infinispan/distribution/rehash/StateTransferOverwritingValueTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/StateTransferOverwritingValueTest.java
@@ -147,7 +147,7 @@ public class StateTransferOverwritingValueTest extends MultipleCacheManagersTest
 
       // Every PutKeyValueCommand will be blocked before committing the entry on cache1
       CyclicBarrier beforeCommitCache1Barrier = new CyclicBarrier(2);
-      BlockingInterceptor blockingInterceptor1 = new BlockingInterceptor(beforeCommitCache1Barrier,
+      BlockingInterceptor blockingInterceptor1 = new BlockingInterceptor<>(beforeCommitCache1Barrier,
             op.getCommandClass(), true, false);
       cache1.getAsyncInterceptorChain().addInterceptorAfter(blockingInterceptor1, EntryWrappingInterceptor.class);
 

--- a/core/src/test/java/org/infinispan/functional/distribution/rehash/FunctionalNonTxBackupOwnerBecomingPrimaryOwnerTest.java
+++ b/core/src/test/java/org/infinispan/functional/distribution/rehash/FunctionalNonTxBackupOwnerBecomingPrimaryOwnerTest.java
@@ -100,8 +100,7 @@ public class FunctionalNonTxBackupOwnerBecomingPrimaryOwnerTest extends NonTxBac
 
    @Override
    public void testPrimaryOwnerChangingDuringRemove() throws Exception {
-      // To be fixed in ISPN-6040
-      // doTest(TestWriteOperation.REMOVE_FUNCTIONAL);
+      doTest(TestWriteOperation.REMOVE_FUNCTIONAL);
    }
 
    @Override

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/ClusterListenerDistTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/ClusterListenerDistTest.java
@@ -47,7 +47,7 @@ public class ClusterListenerDistTest extends AbstractClusterListenerNonTxTest {
       cache0.addListener(clusterListener);
 
       CyclicBarrier barrier = new CyclicBarrier(2);
-      BlockingInterceptor blockingInterceptor = new BlockingInterceptor(barrier, PutKeyValueCommand.class, true, false);
+      BlockingInterceptor blockingInterceptor = new BlockingInterceptor<>(barrier, PutKeyValueCommand.class, true, false);
       cache1.getAdvancedCache().getAsyncInterceptorChain().addInterceptorBefore(blockingInterceptor, TriangleDistributionInterceptor.class);
 
       final MagicKey key = new MagicKey(cache1, cache2);

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/ClusterListenerReplTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/ClusterListenerReplTest.java
@@ -83,10 +83,10 @@ public class ClusterListenerReplTest extends AbstractClusterListenerNonTxTest {
       cache0.addListener(clusterListener);
 
       CyclicBarrier barrier = new CyclicBarrier(3);
-      BlockingInterceptor blockingInterceptor0 = new BlockingInterceptor(barrier, PutKeyValueCommand.class,
+      BlockingInterceptor blockingInterceptor0 = new BlockingInterceptor<>(barrier, PutKeyValueCommand.class,
             true, false);
       cache0.getAdvancedCache().getAsyncInterceptorChain().addInterceptorBefore(blockingInterceptor0, EntryWrappingInterceptor.class);
-      BlockingInterceptor blockingInterceptor2 = new BlockingInterceptor(barrier, PutKeyValueCommand.class,
+      BlockingInterceptor blockingInterceptor2 = new BlockingInterceptor<>(barrier, PutKeyValueCommand.class,
             true, false);
       cache2.getAdvancedCache().getAsyncInterceptorChain().addInterceptorBefore(blockingInterceptor2, EntryWrappingInterceptor.class);
 


### PR DESCRIPTION
…angingDuringPutOverwrite random failures

https://issues.jboss.org/browse/ISPN-6039

basically, don't block the put for state transfer :)

ps. I've enabled FunctionalNonTxBackupOwnerBecomingPrimaryOwnerTest.testPrimaryOwnerChangingDuringRemove again (see comment https://issues.jboss.org/browse/ISPN-6040)