### PR TITLE
ISPN-7540 Calling getCache(String, String) - template overrides cache

### DIFF
--- a/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
@@ -339,7 +339,7 @@ public class DefaultCacheManager implements EmbeddedCacheManager {
 
    @Override
    public Configuration defineConfiguration(String name, Configuration configuration) {
-      return actualDefineConfiguration(name, configuration);
+      return doDefineConfiguration(name, configuration);
    }
 
    @Override
@@ -349,13 +349,13 @@ public class DefaultCacheManager implements EmbeddedCacheManager {
          if (c == null) {
             throw log.undeclaredConfiguration(template, name);
          } else {
-            return actualDefineConfiguration(name, configurationOverride, c);
+            return doDefineConfiguration(name, configurationOverride, c);
          }
       }
-      return actualDefineConfiguration(name, configurationOverride);
+      return doDefineConfiguration(name, configurationOverride);
    }
 
-   private Configuration actualDefineConfiguration(String name, Configuration... configurations) {
+   private Configuration doDefineConfiguration(String name, Configuration... configurations) {
       authzHelper.checkPermission(AuthorizationPermission.ADMIN);
       assertIsNotTerminated();
       if (name == null || configurations == null)

--- a/core/src/main/java/org/infinispan/manager/EmbeddedCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/EmbeddedCacheManager.java
@@ -232,7 +232,7 @@ public interface EmbeddedCacheManager extends CacheContainer, Listenable {
     * @param configurationName name of the configuration template to use
     * @return null if no configuration exists as per rules set above, otherwise
     *         returns a cache instance identified by cacheName
-    * @deprecated Use {@link EmbeddedCacheManager#defineConfiguration(String, String, Configuration)} and
+    * @deprecated as of 9.0. Use {@link EmbeddedCacheManager#defineConfiguration(String, String, Configuration)} and
     * {@link EmbeddedCacheManager#getCache(String)} instead
     */
    <K, V> Cache<K, V> getCache(String cacheName, String configurationName);
@@ -253,7 +253,7 @@ public interface EmbeddedCacheManager extends CacheContainer, Listenable {
     *        #getCache(String, String)}
     * @return null if no configuration exists as per rules set above, otherwise
     *         returns a cache instance identified by cacheName
-    * @deprecated Use {@link EmbeddedCacheManager#defineConfiguration(String, String, Configuration)} and
+    * @deprecated as of 9.0. Use {@link EmbeddedCacheManager#defineConfiguration(String, String, Configuration)} and
     * {@link EmbeddedCacheManager#getCache(String, boolean)} instead
     */
    <K, V> Cache<K, V> getCache(String cacheName, String configurationTemplate, boolean createIfAbsent);


### PR DESCRIPTION
* Added version for deprecation
* Changed internal method name

https://issues.jboss.org/browse/ISPN-7540