### PR TITLE
ISPN-7587 DefaultCacheManager.defineConfiguration(String, String,

### DIFF
--- a/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
@@ -349,7 +349,7 @@ public class DefaultCacheManager implements EmbeddedCacheManager {
          if (c == null) {
             throw log.undeclaredConfiguration(template, name);
          } else {
-            return doDefineConfiguration(name, configurationOverride, c);
+            return doDefineConfiguration(name, c, configurationOverride);
          }
       }
       return doDefineConfiguration(name, configurationOverride);


### PR DESCRIPTION
Configuration) applies the configurations in the wrong order

* Changed order so template applies first

https://issues.jboss.org/browse/ISPN-7587