### PR TITLE
Fixing CacheStore / Lucene Directory integration

### DIFF
--- a/documentation/src/main/asciidoc/user_guide/integrations.adoc
+++ b/documentation/src/main/asciidoc/user_guide/integrations.adoc
@@ -157,11 +157,11 @@ Using a CacheLoader you can have the index content backed up to a permanent stor
 When using a CacheLoader to store a Lucene index, to get best write performance you would need to configure the CacheLoader with _async=true_ .
 
 ==== Storing the index in a database
-It might be useful to store the Lucene index in a relational database; this would be very slow but Infinispan can act as a cache between the application and the JDBC interface, making this configuration useful in both clustered and non-clustered configurations. When storing indexes in a JDBC database, it's suggested to use the _JdbcStringBasedCacheStore_ , which will need this attribute:
+It might be useful to store the Lucene index in a relational database; this would be very slow but Infinispan can act as a cache between the application and the JDBC interface, making this configuration useful in both clustered and non-clustered configurations. When storing indexes in a JDBC database, it's suggested to use the _JdbcStringBasedCacheStore_ , which will need the `key-to-string-mapper` attribute to be set to `org.infinispan.lucene.LuceneKey2StringMapper`:
 
 [source,xml]
 ----
-<property name="key2StringMapperClass" value="org.infinispan.lucene.LuceneKey2StringMapper" />
+<jdbc:string-keyed-jdbc-store preload="true" key-to-string-mapper="org.infinispan.lucene.LuceneKey2StringMapper">
 ----
 
 ==== Loading an existing Lucene Index

--- a/integrationtests/as-lucene-directory/src/test/resources/user-provided-infinispan-persistence.xml
+++ b/integrationtests/as-lucene-directory/src/test/resources/user-provided-infinispan-persistence.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<infinispan xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="urn:infinispan:config:9.0 http://www.infinispan.org/schemas/infinispan-config-9.0.xsd"
-            xmlns="urn:infinispan:config:9.0">
+<infinispan
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="urn:infinispan:config:9.0 http://www.infinispan.org/schemas/infinispan-config-9.0.xsd
+   urn:infinispan:config:store:jdbc:9.0 http://www.infinispan.org/schemas/infinispan-cachestore-jdbc-config-9.0.xsd"
+        xmlns="urn:infinispan:config:9.0"
+        xmlns:jdbc="urn:infinispan:config:store:jdbc:9.0">
 
     <jgroups>
         <stack-file name="default-jgroups-tcp" path="default-configs/default-jgroups-tcp.xml"/>
@@ -14,22 +17,33 @@
 
         <replicated-cache name="LuceneIndexesMetadata" mode="SYNC" remote-timeout="25000">
             <persistence passivation="false">
-                <file-store preload="true" purge="true" path="${jboss.server.temp.dir}/indexes"/>
+                <jdbc:string-keyed-jdbc-store preload="true" key-to-string-mapper="org.infinispan.lucene.LuceneKey2StringMapper">
+                    <jdbc:string-keyed-table prefix="IndexMeta">
+                        <jdbc:id-column name="K" type="VARCHAR(255)"/>
+                        <jdbc:data-column name="V" type="BLOB"/>
+                        <jdbc:timestamp-column name="T" type="BIGINT"/>
+                    </jdbc:string-keyed-table>
+                    <jdbc:data-source jndi-url="java:jboss/datasources/ExampleDS"/>
+                </jdbc:string-keyed-jdbc-store>
             </persistence>
             <indexing index="NONE"/>
         </replicated-cache>
 
         <distributed-cache name="LuceneIndexesData" mode="SYNC" remote-timeout="25000">
             <persistence passivation="false">
-                <file-store preload="true" purge="true" path="${jboss.server.temp.dir}/indexes"/>
+                <jdbc:string-keyed-jdbc-store key-to-string-mapper="org.infinispan.lucene.LuceneKey2StringMapper">
+                    <jdbc:string-keyed-table prefix="IndexData">
+                        <jdbc:id-column name="K" type="VARCHAR(255)"/>
+                        <jdbc:data-column name="V" type="BLOB"/>
+                        <jdbc:timestamp-column name="T" type="BIGINT"/>
+                    </jdbc:string-keyed-table>
+                    <jdbc:data-source jndi-url="java:jboss/datasources/ExampleDS"/>
+                </jdbc:string-keyed-jdbc-store>
             </persistence>
             <indexing index="NONE"/>
         </distributed-cache>
 
         <replicated-cache name="LuceneIndexesLocking" mode="SYNC" remote-timeout="25000">
-            <persistence passivation="false">
-                <file-store preload="true" purge="true" path="${jboss.server.temp.dir}/indexes"/>
-            </persistence>
             <indexing index="NONE"/>
         </replicated-cache>
     </cache-container>

--- a/integrationtests/wildfly-modules/src/test/java/org/infinispan/test/integration/as/InfinispanModulesStoreJdbcIT.java
+++ b/integrationtests/wildfly-modules/src/test/java/org/infinispan/test/integration/as/InfinispanModulesStoreJdbcIT.java
@@ -1,0 +1,70 @@
+package org.infinispan.test.integration.as;
+
+import java.io.IOException;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.infinispan.Cache;
+import org.infinispan.Version;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.manager.DefaultCacheManager;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.persistence.jdbc.configuration.JdbcStringBasedStoreConfigurationBuilder;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+import org.jboss.shrinkwrap.descriptor.api.spec.se.manifest.ManifestDescriptor;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test the Infinispan JDBC CacheStore AS module integration.
+ * N.B. the Module of the JDBC CacheStore is intentionally
+ * NOT available to the deployment: it needs to be able to
+ * initialize it via the dependency from the org.infinispan
+ * main module.
+ *
+ * @author Tristan Tarrant
+ * @author Sanne Grinovero
+ * @since 9.0
+ */
+@RunWith(Arquillian.class)
+public class InfinispanModulesStoreJdbcIT {
+
+   @Deployment
+   public static Archive<?> deployment() {
+      return ShrinkWrap.create(WebArchive.class, "jdbc.war")
+            .addClass(InfinispanModulesStoreJdbcIT.class)
+            .addAsResource("jdbc-config.xml")
+            .add(manifest(), "META-INF/MANIFEST.MF");
+   }
+
+   private static Asset manifest() {
+      String manifest = Descriptors.create(ManifestDescriptor.class)
+            .attribute("Dependencies", "org.infinispan:" + Version.getModuleSlot() + " services").exportAsString();
+      return new StringAsset(manifest);
+   }
+
+   @Test
+   public void testXmlConfig() throws IOException {
+      EmbeddedCacheManager cm = null;
+      try {
+         cm = new DefaultCacheManager("jdbc-config.xml");
+         Cache<String, String> cache = cm.getCache("anotherCache");
+         cache.put("a", "a");
+         assertEquals("a", cache.get("a"));
+      } finally {
+         if (cm != null)
+            cm.stop();
+      }
+   }
+
+}

--- a/lucene/directory-provider/src/main/java/org/infinispan/hibernate/search/impl/InfinispanConfigurationParser.java
+++ b/lucene/directory-provider/src/main/java/org/infinispan/hibernate/search/impl/InfinispanConfigurationParser.java
@@ -22,7 +22,8 @@ public class InfinispanConfigurationParser {
    private final ClassLoader ispnClassLoadr;
 
    public InfinispanConfigurationParser() {
-      ispnClassLoadr = ParserRegistry.class.getClassLoader();
+      //This class instance will have visibility on the components we need
+      ispnClassLoadr = InfinispanConfigurationParser.class.getClassLoader();
       configurationParser = new ParserRegistry(ispnClassLoadr);
    }
 

--- a/lucene/lucene-directory/pom.xml
+++ b/lucene/lucene-directory/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-cachestore-jdbc</artifactId>
-            <optional>true</optional>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.infinispan</groupId>

--- a/lucene/lucene-directory/src/main/java/org/infinispan/lucene/LifecycleCallbacks.java
+++ b/lucene/lucene-directory/src/main/java/org/infinispan/lucene/LifecycleCallbacks.java
@@ -1,5 +1,6 @@
 package org.infinispan.lucene;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.infinispan.commons.marshall.AdvancedExternalizer;
@@ -24,6 +25,16 @@ public class LifecycleCallbacks extends AbstractModuleLifecycle {
    @Override
    public void cacheManagerStarting(GlobalComponentRegistry gcr, GlobalConfiguration globalCfg) {
       Map<Integer,AdvancedExternalizer<?>> externalizerMap = globalCfg.serialization().advancedExternalizers();
+      externalizerMap.putAll( moduleExternalizers() );
+   }
+
+   /**
+    * Static helper to allow for explicit registration of Externalizers:
+    * service discovery is not always an option.
+    * @return the map of Id and Externalizer implementations for this module
+    */
+   public static Map<Integer,AdvancedExternalizer<?>> moduleExternalizers() {
+      Map<Integer,AdvancedExternalizer<?>> externalizerMap = new HashMap<>();
       externalizerMap.put(ExternalizerIds.CHUNK_CACHE_KEY, new ChunkCacheKey.Externalizer());
       externalizerMap.put(ExternalizerIds.FILE_CACHE_KEY, new FileCacheKey.Externalizer());
       externalizerMap.put(ExternalizerIds.FILE_LIST_CACHE_KEY, new FileListCacheKey.Externalizer());
@@ -33,6 +44,7 @@ public class LifecycleCallbacks extends AbstractModuleLifecycle {
       externalizerMap.put(ExternalizerIds.FILE_LIST_VALUE_DELTA, new FileListCacheValueDelta.Externalizer());
       externalizerMap.put(ExternalizerIds.FILE_LIST_DELTA_ADD, new AddOperation.AddOperationExternalizer());
       externalizerMap.put(ExternalizerIds.FILE_LIST_DELTA_DEL, new DeleteOperation.DeleteElementOperationExternalizer());
+      return externalizerMap;
    }
 
 }

--- a/wildfly-modules/build.xml
+++ b/wildfly-modules/build.xml
@@ -57,9 +57,7 @@
                 <filter token="override.hibernate-search-directory-wildfly-ref" value="@{slot}" />
             </filterset>
             <module-def name="org.infinispan.hibernate-search.directory-provider" slot="@{slot}" module.src="org.infinispan.for-hibernatesearch-wildfly">
-                <maven-resource group="org.infinispan" artifact="infinispan-core"/>
                 <maven-resource group="org.infinispan" artifact="infinispan-lucene-directory"/>
-                <maven-resource group="org.infinispan" artifact="infinispan-commons"/>
                 <maven-resource group="org.infinispan" artifact="infinispan-directory-provider" />
             </module-def>
         </sequential>

--- a/wildfly-modules/src/main/resources/org/infinispan/core/main/module.xml
+++ b/wildfly-modules/src/main/resources/org/infinispan/core/main/module.xml
@@ -13,8 +13,6 @@
         <module name="org.apache.xerces" services="import"/>
         <module name="org.infinispan.commons" slot="${slot}" />
         <module name="com.github.ben-manes.caffeine" slot="${slot}"/>
-        <module name="org.infinispan.query" slot="${slot}" services="import" />
-        <module name="org.infinispan.lucene-directory" slot="${slot}" services="import" />
         <module name="org.jboss.jandex"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.marshalling" slot="${slot}" services="import"/>

--- a/wildfly-modules/src/main/resources/org/infinispan/core/main/module.xml
+++ b/wildfly-modules/src/main/resources/org/infinispan/core/main/module.xml
@@ -20,5 +20,12 @@
         <module name="org.jboss.marshalling" slot="${slot}" services="import"/>
         <module name="org.jgroups" slot="${slot}"/>
         <module name="sun.jdk"/>
+        <!-- The CacheStore modules are listed as dependencies so that people can use them even
+          when they aren't directly exposed to the deployment !-->
+        <module name="org.infinispan.persistence.jdbc" slot="${slot}" services="import" optional="true"/>
+        <module name="org.infinispan.persistence.jpa" slot="${slot}" services="import" optional="true"/>
+        <module name="org.infinispan.persistence.remote" slot="${slot}" services="import" optional="true"/>
+        <module name="org.infinispan.persistence.rest" slot="${slot}" services="import" optional="true"/>
+        <module name="org.infinispan.persistence.rocksdb" slot="${slot}" services="import" optional="true"/>
     </dependencies>
 </module>

--- a/wildfly-modules/src/main/resources/org/infinispan/for-hibernatesearch-wildfly/main/module.xml
+++ b/wildfly-modules/src/main/resources/org/infinispan/for-hibernatesearch-wildfly/main/module.xml
@@ -25,16 +25,9 @@ and obviously needs to avoid dependencies to different versions of Hibernate Sea
     <dependencies>
         <module name="org.apache.lucene" slot="${override.lucene.slot}" />
         <module name="org.hibernate.search.engine" slot="${override.hibernate-search.slot}" />
-        <!-- Next dependencies are essentially a copy of those from module org.infinispan,
-             but filtering out the ones related to Apache Lucene, Infinispan Query and Hibernate Search. -->
         <module name="javax.api"/>
-        <module name="javax.transaction.api"/>
-        <module name="org.apache.xerces" services="import"/>
-        <module name="org.jboss.jandex"/>
+        <module name="org.infinispan.commons" slot="${infinispan.slot}" export="true"/>
+        <module name="org.infinispan.core" slot="${infinispan.slot}" export="true" services="export" />
         <module name="org.jboss.logging"/>
-        <module name="org.jboss.marshalling" slot="${infinispan.slot}" services="import"/>
-        <module name="org.jgroups" slot="${infinispan.slot}"/>
-        <module name="com.github.ben-manes.caffeine" slot="${infinispan.slot}"/>
-        <module name="sun.jdk"/>
     </dependencies>
 </module>


### PR DESCRIPTION

This was a bit more complex than expected, as the Lucene Directory Provider component for Hibernate Search used to have its own copy of Infinispan-core.

Because of this copy, the CacheStore implementations would also depend on the wrong infinispan-core module instance, so I finally pulled off the full cleanup and we no longer need the Infinispan-core copies in the custom modules.

To achieve this removal, I had to fallback to an "explicit registration" of the custom Externalizers of the Lucene Directory module, as infinispan-core can no longer depend directly on Infinispan Query, or it would introduce the wrong Hibernate Search module on classpath.. 

Finally it feels much cleaner, I guess the mistake was trying hard to make service discovery work.

https://issues.jboss.org/browse/ISPN-7572