### PR TITLE
ISPN-7618 Bounded Off Heap can crash when a single entry size is larger

### DIFF
--- a/core/src/main/java/org/infinispan/container/offheap/BoundedOffHeapDataContainer.java
+++ b/core/src/main/java/org/infinispan/container/offheap/BoundedOffHeapDataContainer.java
@@ -106,6 +106,7 @@ public class BoundedOffHeapDataContainer extends OffHeapDataContainer {
       try {
          // Current size has to be updated in the lock
          currentSize -=  removedSize;
+         boolean middleNode = true;
          if (lruNode == lastAddress) {
             if (trace) {
                log.tracef("Removing last LRU node at %d", lruNode);
@@ -115,7 +116,9 @@ public class BoundedOffHeapDataContainer extends OffHeapDataContainer {
                UNSAFE.putLong(previousLRUNode + 16, 0);
             }
             lastAddress = previousLRUNode;
-         } else if (lruNode == firstAddress) {
+            middleNode = false;
+         }
+         if (lruNode == firstAddress) {
             if (trace) {
                log.tracef("Removing first LRU node at %d", lruNode);
             }
@@ -124,7 +127,9 @@ public class BoundedOffHeapDataContainer extends OffHeapDataContainer {
                UNSAFE.putLong(nextLRUNode + 8, 0);
             }
             firstAddress = nextLRUNode;
-         } else {
+            middleNode = false;
+         }
+         if (middleNode) {
             if (trace) {
                log.tracef("Removing middle LRU node at %d", lruNode);
             }

--- a/core/src/test/java/org/infinispan/container/offheap/OffHeapBoundedMemoryTest.java
+++ b/core/src/test/java/org/infinispan/container/offheap/OffHeapBoundedMemoryTest.java
@@ -1,0 +1,34 @@
+package org.infinispan.container.offheap;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNull;
+
+import org.infinispan.Cache;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.cache.StorageType;
+import org.infinispan.eviction.EvictionType;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.test.AbstractInfinispanTest;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.Test;
+
+/**
+ * @author wburns
+ * @since 9.0
+ */
+@Test(groups = "functional", testName = "container.offheap.OffHeapBoundedMemoryTest")
+public class OffHeapBoundedMemoryTest extends AbstractInfinispanTest {
+   public void testTooSmallToInsert() {
+      ConfigurationBuilder builder = new ConfigurationBuilder();
+      builder.memory()
+            .size(10)
+            .evictionType(EvictionType.MEMORY)
+            .storageType(StorageType.OFF_HEAP);
+      EmbeddedCacheManager manager = TestCacheManagerFactory.createCacheManager(builder);
+      Cache<Object, Object> smallHeapCache = manager.getCache();
+      assertEquals(0, smallHeapCache.size());
+      // Put something larger than size
+      assertNull(smallHeapCache.put(1, 3));
+      assertEquals(0, smallHeapCache.size());
+   }
+}


### PR DESCRIPTION
than total size

* Make sure to handle eviction when entry is both head and tail

https://issues.jboss.org/browse/ISPN-7618