### PR TITLE
ISPN-7572 Correct the testing configuration for index storage in H2

### DIFF
--- a/integrationtests/as-lucene-directory/src/test/java/org/infinispan/test/integration/as/wildfly/InfinispanModuleMemberRegistrationIT.java
+++ b/integrationtests/as-lucene-directory/src/test/java/org/infinispan/test/integration/as/wildfly/InfinispanModuleMemberRegistrationIT.java
@@ -56,7 +56,7 @@ public class InfinispanModuleMemberRegistrationIT extends MemberRegistrationBase
               .version("2.0")
               .createPersistenceUnit()
               .name("primary")
-              .jtaDataSource("java:jboss/datasources/ExampleDS")
+              .jtaDataSource("java:jboss/datasources/HibernateTestingDS")
               .getOrCreateProperties()
               .createProperty()
               .name("hibernate.hbm2ddl.auto")

--- a/integrationtests/as-lucene-directory/src/test/resources/user-provided-infinispan-persistence.xml
+++ b/integrationtests/as-lucene-directory/src/test/resources/user-provided-infinispan-persistence.xml
@@ -10,8 +10,12 @@
         <jmx duplicate-domains="true"/>
 
         <replicated-cache name="LuceneIndexesMetadata" mode="SYNC" remote-timeout="25000">
+            <transaction mode="NONE" />
             <persistence passivation="false">
-                <string-keyed-jdbc-store preload="true" key-to-string-mapper="org.infinispan.lucene.LuceneKey2StringMapper" shared="true">
+                <!-- N.B. "shared" is false which is unusual for a JDBC CacheStore,
+                 but for testing purposes we use an in-memory H2 so each WildFly node
+                 will have an independent CacheStore instance -->
+                <string-keyed-jdbc-store preload="true" key-to-string-mapper="org.infinispan.lucene.LuceneKey2StringMapper" shared="false">
                     <string-keyed-table prefix="IndexMeta">
                         <id-column name="K" type="VARCHAR(255)"/>
                         <data-column name="V" type="BLOB"/>
@@ -24,8 +28,10 @@
         </replicated-cache>
 
         <distributed-cache name="LuceneIndexesData" mode="SYNC" remote-timeout="25000">
+            <transaction mode="NONE" />
             <persistence passivation="false">
-                <string-keyed-jdbc-store key-to-string-mapper="org.infinispan.lucene.LuceneKey2StringMapper" shared="true">
+                <!-- N.B. "shared" is false: see comment in LuceneIndexesMetadata cache -->
+                <string-keyed-jdbc-store key-to-string-mapper="org.infinispan.lucene.LuceneKey2StringMapper" shared="false">
                     <string-keyed-table prefix="IndexData">
                         <id-column name="K" type="VARCHAR(255)"/>
                         <data-column name="V" type="BLOB"/>


### PR DESCRIPTION
A follow up on the already-merged ISPN-7572 to fix the regression spotted by the testsuite.

The important bit is setting the caches to `non-transactional` as otherwise the concurrent writes on H2 end up in transaction locks, caused e.g. by the Lucene merger thread and our async deletions of index data.

While at it, I also spotted two configuration inconsistencies.