### PR TITLE
ISPN-7002 Early detection of improper query module usage in wildfly

### DIFF
--- a/query/src/main/java/org/infinispan/query/Search.java
+++ b/query/src/main/java/org/infinispan/query/Search.java
@@ -17,8 +17,10 @@ import org.infinispan.query.dsl.embedded.impl.JPACacheEventFilterConverter;
 import org.infinispan.query.dsl.embedded.impl.JPAFilterAndConverter;
 import org.infinispan.query.dsl.impl.BaseQuery;
 import org.infinispan.query.impl.SearchManagerImpl;
+import org.infinispan.query.logging.Log;
 import org.infinispan.security.AuthorizationManager;
 import org.infinispan.security.AuthorizationPermission;
+import org.infinispan.util.logging.LogFactory;
 
 /**
  * Helper class to get a SearchManager out of an indexing enabled cache.
@@ -27,6 +29,8 @@ import org.infinispan.security.AuthorizationPermission;
  * @author anistor@redhat.com
  */
 public final class Search {
+
+   private static final Log log = LogFactory.getLog(Search.class, Log.class);
 
    private Search() {
    }
@@ -52,6 +56,9 @@ public final class Search {
       AdvancedCache<?, ?> advancedCache = cache.getAdvancedCache();
       ensureAccessPermissions(advancedCache);
       EmbeddedQueryEngine queryEngine = SecurityActions.getCacheComponentRegistry(advancedCache).getComponent(EmbeddedQueryEngine.class);
+      if (queryEngine == null) {
+         throw log.queryModuleNotInitialised();
+      }
       return new EmbeddedQueryFactory(queryEngine);
    }
 

--- a/query/src/main/java/org/infinispan/query/logging/Log.java
+++ b/query/src/main/java/org/infinispan/query/logging/Log.java
@@ -155,4 +155,7 @@ public interface Log extends org.infinispan.util.logging.Log {
 
    @Message(value = "Invalid boolean literal '%s'", id = 14037)
    ParsingException getInvalidBooleanLiteralException(String value);
+
+   @Message(value = "infinispan-query.jar module is in the classpath but has not been properly initialised!", id = 14038)
+   CacheException queryModuleNotInitialised();
 }


### PR DESCRIPTION
Add early detection of the case when the query jar is added just as a pom dependency but not as a proper wildfly module dependency. This allows the application classloading to apparently work but the query module never gets initialised and leads to further failures.

PLEASE do not close the Jira yet.
https://issues.jboss.org/browse/ISPN-7002
