### PR TITLE
[EXP] testsuite tcp.xml experiments

### DIFF
--- a/core/src/test/resources/stacks/tcp.xml
+++ b/core/src/test/resources/stacks/tcp.xml
@@ -5,9 +5,11 @@
    <TCP_NIO2
          bind_addr="${jgroups.tcp.address:127.0.0.1}"
          bind_port="${jgroups.tcp.port:7800}"
-         port_range="30"
+         port_range="2"
+         sock_conn_timeout="300"
          recv_buf_size="20m"
          send_buf_size="640k"
+         max_send_buffers="100"
          enable_diagnostics="false"
          bundler_type="no-bundler"
 


### PR DESCRIPTION
* max_send_buffers=100
* port_range=2
* sock_conn_timeout=300

some changes to the jgroups configuration used in test suite.
I've run all day and I was unable to reproduce the failure (lucky day?). 
I'm opening this PR to run it a couple of times in CI