### PR TITLE
ISPN-7659 Infinispan doesn't build with the latest OpenJDK 9 early ac…

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -57,7 +57,7 @@
 
       <version.java>1.8</version.java>
 
-      <version.maven-compiler-plugin>3.5.1</version.maven-compiler-plugin>
+      <version.maven-compiler-plugin>3.6.1</version.maven-compiler-plugin>
 
       <version.caffeine>2.4.0</version.caffeine>
       <version.protostream>4.0.0.Alpha9</version.protostream>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1220,7 +1220,6 @@
                 <artifactId>maven-scala-plugin</artifactId>
                 <version>${version.maven.scala}</version>
                 <executions>
-
                    <execution>
                       <id>compile</id>
                       <phase>none</phase>
@@ -1616,7 +1615,7 @@
       <profile>
          <id>jigsaw</id>
          <activation>
-            <jdk>[1.9,)</jdk>
+            <jdk>[9,)</jdk>
          </activation>
          <build>
             <pluginManagement>
@@ -1628,8 +1627,8 @@
                         <!-- fork is needed so compiler args can be used -->
                         <fork>true</fork>
                         <compilerArgs>
-                           <arg>-J-addmods</arg>
-                           <arg>-Jjava.annotations.common</arg>
+                           <arg>-J--add-modules</arg>
+                           <arg>-Jjava.xml.ws.annotation</arg>
                         </compilerArgs>
                      </configuration>
                   </plugin>


### PR DESCRIPTION
…cess builds
https://issues.jboss.org/browse/ISPN-7659

* Upgrade maven-compiler-plugin to version 3.6.1
* Change -addmods to --add-modules
* Add explicit cast for map() lambda in QueryCacheEmbeddedTest

Please keep the JIRA issue open, the HotRod server module still isn't compiling.