### PR TITLE
Some fixes for IBM JDK

### DIFF
--- a/server/integration/feature-pack/src/main/resources/modules/system/layers/base/org/infinispan/protostream/main/module.xml
+++ b/server/integration/feature-pack/src/main/resources/modules/system/layers/base/org/infinispan/protostream/main/module.xml
@@ -7,5 +7,6 @@
 
     <dependencies>
         <module name="org.jboss.logging"/>
+        <module name="sun.jdk"/>
     </dependencies>
 </module>

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/security/HotRodKrbAuthIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/security/HotRodKrbAuthIT.java
@@ -48,7 +48,8 @@ public class HotRodKrbAuthIT extends HotRodSaslAuthTestBase {
    }
 
    protected Subject getSubject(String login, String password) throws LoginException {
-      System.setProperty("java.security.auth.login.config", HotRodKrbAuthIT.class.getResource("/jaas_krb_login.conf")
+      String krbLogin = System.getProperty("java.vendor").contains("IBM") ? "/ibm_jaas_krb_login.conf" : "/jaas_krb_login.conf";
+      System.setProperty("java.security.auth.login.config", HotRodKrbAuthIT.class.getResource(krbLogin)
             .getPath());
       System.setProperty("java.security.krb5.conf", HotRodKrbAuthIT.class.getResource("/krb5.conf").getPath());
       LoginContext lc = new LoginContext("HotRodKrbClient", new SimpleLoginHandler(login + "@" + KRB_REALM, password));

--- a/server/integration/testsuite/src/test/resources/ibm_jaas_krb_login.conf
+++ b/server/integration/testsuite/src/test/resources/ibm_jaas_krb_login.conf
@@ -1,0 +1,3 @@
+HotRodKrbClient {
+    com.ibm.security.auth.module.Krb5LoginModule required refreshKrb5Config=true client=TRUE;
+};

--- a/wildfly-modules/src/main/resources/org/infinispan/protostream/main/module.xml
+++ b/wildfly-modules/src/main/resources/org/infinispan/protostream/main/module.xml
@@ -6,5 +6,6 @@
 
     <dependencies>
         <module name="org.jboss.logging"/>
+        <module name="sun.jdk"/>
     </dependencies>
 </module>


### PR DESCRIPTION
ISPN-7675 Use a special JAAS login configuration file for Kerberos tests
ISPN-7676 Add sun.jdk dependency to Protostream server module

https://issues.jboss.org/browse/ISPN-7675
https://issues.jboss.org/browse/ISPN-7676