### PR TITLE
ISPN-7116 Test methods that use a TestNg dataProvider are duplicated in

### DIFF
--- a/commons-test/src/main/java/org/infinispan/commons/test/PolarionJUnitXMLReporter.java
+++ b/commons-test/src/main/java/org/infinispan/commons/test/PolarionJUnitXMLReporter.java
@@ -189,7 +189,7 @@ public class PolarionJUnitXMLReporter implements IResultListener2, ISuiteListene
       document.pop();
 
       // Reset output directory
-      Utils.writeUtf8File(suite.getOutputDirectory().replaceAll("/Surefire suite", ""),
+      Utils.writeUtf8File(suite.getOutputDirectory().replaceAll(".Surefire suite", ""),
             generateFileName(suite) + ".xml", document.toXML());
    }
 


### PR DESCRIPTION
JUnit reports

https://issues.jboss.org/browse/ISPN-7116

Fix hard coded path separator