### PR TITLE
ISPN-7678 Endpoints should not depend on the default cache

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/cache/Configurations.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/Configurations.java
@@ -70,4 +70,8 @@ public class Configurations {
       PrivateGlobalConfiguration config = globalConfiguration.module(PrivateGlobalConfiguration.class);
       return config == null || !config.isServerMode();
    }
+
+   public static boolean isClustered(GlobalConfiguration globalConfiguration) {
+      return globalConfiguration.transport().transport() != null;
+   }
 }

--- a/core/src/main/java/org/infinispan/registry/InternalCacheRegistry.java
+++ b/core/src/main/java/org/infinispan/registry/InternalCacheRegistry.java
@@ -62,6 +62,12 @@ public interface InternalCacheRegistry {
    void registerInternalCache(String name, Configuration configuration, EnumSet<Flag> flags);
 
    /**
+    * Unregisters  an internal cache
+    * @param name The name of the cache
+    */
+   void unregisterInternalCache(String name);
+
+   /**
     * Returns whether the cache is internal, i.e. it has been registered using the
     * {@link #registerInternalCache(String, Configuration)} method
     */

--- a/core/src/main/java/org/infinispan/registry/impl/InternalCacheRegistryImpl.java
+++ b/core/src/main/java/org/infinispan/registry/impl/InternalCacheRegistryImpl.java
@@ -75,6 +75,18 @@ public class InternalCacheRegistryImpl implements InternalCacheRegistry {
    }
 
    @Override
+   public synchronized void unregisterInternalCache(String name) {
+      if (isInternalCache(name)) {
+         Cache<Object, Object> cache = cacheManager.getCache(name, false);
+         if (cache != null)
+            cache.stop();
+         internalCaches.remove(name);
+         privateCaches.remove(name);
+         SecurityActions.undefineConfiguration(cacheManager, name);
+      }
+   }
+
+   @Override
    public boolean isInternalCache(String name) {
       return internalCaches.containsKey(name);
    }

--- a/core/src/main/java/org/infinispan/registry/impl/SecurityActions.java
+++ b/core/src/main/java/org/infinispan/registry/impl/SecurityActions.java
@@ -6,6 +6,7 @@ import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.security.Security;
 import org.infinispan.security.actions.DefineConfigurationAction;
+import org.infinispan.security.actions.UndefineConfigurationAction;
 
 /**
  * SecurityActions for the org.infinispan.registry.impl package.
@@ -23,6 +24,15 @@ final class SecurityActions {
 
    static void defineConfiguration(final EmbeddedCacheManager cacheManager, final String cacheName, final Configuration configurationOverride) {
       DefineConfigurationAction action = new DefineConfigurationAction(cacheManager, cacheName, configurationOverride);
+      if (System.getSecurityManager() != null) {
+         AccessController.doPrivileged(action);
+      } else {
+         Security.doPrivileged(action);
+      }
+   }
+
+   static void undefineConfiguration(EmbeddedCacheManager cacheManager, String name) {
+      UndefineConfigurationAction action = new UndefineConfigurationAction(cacheManager, name);
       if (System.getSecurityManager() != null) {
          AccessController.doPrivileged(action);
       } else {

--- a/core/src/main/java/org/infinispan/security/actions/UndefineConfigurationAction.java
+++ b/core/src/main/java/org/infinispan/security/actions/UndefineConfigurationAction.java
@@ -1,0 +1,29 @@
+package org.infinispan.security.actions;
+
+import java.security.PrivilegedAction;
+
+import org.infinispan.manager.EmbeddedCacheManager;
+
+/**
+ * UndefineConfigurationAction.
+ *
+ * @author Tristan Tarrant
+ * @since 9.0
+ */
+public final class UndefineConfigurationAction implements PrivilegedAction<Void> {
+
+   private final EmbeddedCacheManager cacheManager;
+   private final String cacheName;
+
+   public UndefineConfigurationAction(EmbeddedCacheManager cacheManager, String cacheName) {
+      this.cacheManager = cacheManager;
+      this.cacheName = cacheName;
+   }
+
+   @Override
+   public Void run() {
+      cacheManager.undefineConfiguration(cacheName);
+      return null;
+   }
+
+}

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/HotRodServer.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/HotRodServer.java
@@ -33,7 +33,7 @@ import org.infinispan.commons.util.ServiceFinder;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
-import org.infinispan.configuration.global.GlobalConfiguration;
+import org.infinispan.configuration.cache.Configurations;
 import org.infinispan.context.Flag;
 import org.infinispan.distexec.DefaultExecutorService;
 import org.infinispan.distexec.DistributedCallable;
@@ -157,9 +157,7 @@ public class HotRodServer extends AbstractProtocolServer<HotRodServerConfigurati
 
 
       // Add self to topology cache last, after everything is initialized
-      GlobalConfiguration globalConfig = cacheManager.getCacheManagerConfiguration();
-      isClustered = globalConfig.transport().transport() != null;
-      if (isClustered) {
+      if (Configurations.isClustered(cacheManager.getCacheManagerConfiguration())) {
          defineTopologyCacheConfig(cacheManager);
          if (log.isDebugEnabled())
             log.debugf("Externally facing address is %s:%d", configuration.proxyHost(), configuration.proxyPort());
@@ -409,6 +407,11 @@ public class HotRodServer extends AbstractProtocolServer<HotRodServerConfigurati
       }
       if (topologyChangeListener != null) {
          SecurityActions.removeListener(addressCache, topologyChangeListener);
+      }
+      if (Configurations.isClustered(cacheManager.getCacheManagerConfiguration())) {
+         InternalCacheRegistry internalCacheRegistry = cacheManager.getGlobalComponentRegistry().getComponent(InternalCacheRegistry.class);
+         if (internalCacheRegistry != null)
+            internalCacheRegistry.unregisterInternalCache(configuration.topologyCacheName());
       }
       if (distributedExecutorService != null) {
          distributedExecutorService.shutdownNow();

--- a/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/subsystem/HotRodSubsystemAdd.java
+++ b/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/subsystem/HotRodSubsystemAdd.java
@@ -77,7 +77,6 @@ class HotRodSubsystemAdd extends ProtocolServiceSubsystemAdd {
       String cacheContainerName = getCacheContainerName(operation);
       EndpointUtils.addCacheContainerConfigurationDependency(builder, cacheContainerName, service.getCacheManagerConfiguration());
       EndpointUtils.addCacheContainerDependency(builder, cacheContainerName, service.getCacheManager());
-      EndpointUtils.addCacheDependency(builder, cacheContainerName, null);
       EndpointUtils.addSocketBindingDependency(context, builder, getSocketBindingName(operation), service.getSocketBinding());
 
       EncryptableSubsystemHelper.processEncryption(context, config, service, builder);

--- a/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/subsystem/MemcachedSubsystemAdd.java
+++ b/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/subsystem/MemcachedSubsystemAdd.java
@@ -68,7 +68,6 @@ class MemcachedSubsystemAdd extends ProtocolServiceSubsystemAdd {
       String cacheContainerName = getCacheContainerName(operation);
       EndpointUtils.addCacheContainerDependency(builder, cacheContainerName, service.getCacheManager());
       EndpointUtils.addCacheDependency(builder, cacheContainerName, cacheName);
-      EndpointUtils.addCacheDependency(builder, cacheContainerName, null);
       EndpointUtils.addSocketBindingDependency(context, builder, getSocketBindingName(operation), service.getSocketBinding());
 
       builder.install();

--- a/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/subsystem/RestSubsystemAdd.java
+++ b/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/subsystem/RestSubsystemAdd.java
@@ -71,7 +71,6 @@ class RestSubsystemAdd extends AbstractAddStepHandler {
       ServiceBuilder<?> builder = context.getServiceTarget().addService(EndpointUtils.getServiceName(operation, "rest"), service);
       String cacheContainerName = config.hasDefined(ModelKeys.CACHE_CONTAINER) ? config.get(ModelKeys.CACHE_CONTAINER).asString() : null;
       EndpointUtils.addCacheContainerDependency(builder, cacheContainerName, service.getCacheManager());
-      EndpointUtils.addCacheDependency(builder, cacheContainerName, null);
       EndpointUtils.addSocketBindingDependency(context, builder, getSocketBindingName(operation), service.getSocketBinding());
 
       builder.addDependency(PathManagerService.SERVICE_NAME, PathManager.class, service.getPathManagerInjector());

--- a/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/subsystem/WebSocketSubsystemAdd.java
+++ b/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/subsystem/WebSocketSubsystemAdd.java
@@ -65,7 +65,6 @@ class WebSocketSubsystemAdd extends ProtocolServiceSubsystemAdd {
       String cacheContainerName = getCacheContainerName(operation);
       EndpointUtils.addCacheContainerDependency(builder, cacheContainerName, service.getCacheManager());
       EndpointUtils.addSocketBindingDependency(context, builder, getSocketBindingName(operation), service.getSocketBinding());
-      EndpointUtils.addCacheDependency(builder, cacheContainerName, null);
       builder.install();
    }
 


### PR DESCRIPTION
- Prevents endpoint restart on default cache reconfiguration

ISPN-7683 Unregisters the internal topology cache on server stop

https://issues.jboss.org/browse/ISPN-7678
https://issues.jboss.org/browse/ISPN-7683
