### PR TITLE
ISPN-7400 Fix the the non-owner cache selection in BaseUtilGroupTest

### DIFF
--- a/core/src/test/java/org/infinispan/distribution/groups/BaseUtilGroupTest.java
+++ b/core/src/test/java/org/infinispan/distribution/groups/BaseUtilGroupTest.java
@@ -123,7 +123,7 @@ public abstract class BaseUtilGroupTest extends MultipleCacheManagersTest {
                DistributionInfo distributionInfo = distributionManager.getCacheTopology().getDistribution(groupName);
                if (primaryOwner == null && distributionInfo.isPrimary()) {
                   primaryOwner = cache;
-               } else if (nonOwner == null && distributionInfo.isWriteOwner()) {
+               } else if (nonOwner == null && !distributionInfo.isWriteOwner()) {
                   nonOwner = cache.getAdvancedCache();
                }
                if (primaryOwner != null && nonOwner != null) {


### PR DESCRIPTION
Radim noticed a mistake introduced by my ISPN-7400 fix, which means the originator cache is sometimes a backup owner instead of a non-owner. The tests probably pass because the replication is about the same either way :)