### PR TITLE
ISPN-7699 Upgrade to protostream-4.0.0.Final

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -60,7 +60,7 @@
       <version.maven-compiler-plugin>3.6.1</version.maven-compiler-plugin>
 
       <version.caffeine>2.4.0</version.caffeine>
-      <version.protostream>4.0.0.CR3</version.protostream>
+      <version.protostream>4.0.0.Final</version.protostream>
       <version.aesh>0.66.13</version.aesh>
       <version.antlr>3.5.2</version.antlr>
       <version.c3p0>0.9.5</version.c3p0>

--- a/server/integration/versions/pom.xml
+++ b/server/integration/versions/pom.xml
@@ -52,7 +52,7 @@
       <version.org.xerial.snappy>1.0.5</version.org.xerial.snappy>
       <version.antrun.maven.plugin>1.8</version.antrun.maven.plugin>
       <version.xml.maven.plugin>1.0</version.xml.maven.plugin>
-      <version.org.infinispan.protostream>4.0.0.CR3</version.org.infinispan.protostream>
+      <version.org.infinispan.protostream>4.0.0.Final</version.org.infinispan.protostream>
       <version.http.core>4.4</version.http.core>
       <version.http.client>4.5</version.http.client>
       <version.org.picketbox>4.0.17.SP2</version.org.picketbox>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-7699

Infinispan 9.0.0.Final uses protostream-4.0.0.CR3 which is identical to 4.0.0.Final, so this upgrade is safe both for infinispan 9.1.x and 9.0.1.