### PR TITLE
[testsuite] Minor convenience changes

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ExpiryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ExpiryTest.java
@@ -34,7 +34,7 @@ public class ExpiryTest extends MultiHotRodServersTest {
       ConfigurationBuilder builder = hotRodCacheConfiguration(getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, false));
       builder.expiration().lifespan(EXPIRATION_TIMEOUT);
       createHotRodServers(1, builder);
-      timeService = new ControlledTimeService(0);
+      timeService = new ControlledTimeService();
       TestingUtil.replaceComponent(cacheManagers.get(0), TimeService.class, timeService, true);
    }
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientClusterExpirationEventsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientClusterExpirationEventsTest.java
@@ -58,9 +58,10 @@ public class ClientClusterExpirationEventsTest extends MultiHotRodServersTest {
    }
 
    private void injectTimeServices() {
-      ts0 = new ControlledTimeService(0);
+      long now = System.currentTimeMillis();
+      ts0 = new ControlledTimeService(now);
       TestingUtil.replaceComponent(server(0).getCacheManager(), TimeService.class, ts0, true);
-      ts1 = new ControlledTimeService(0);
+      ts1 = new ControlledTimeService(now);
       TestingUtil.replaceComponent(server(1).getCacheManager(), TimeService.class, ts1, true);
    }
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientClusterFailoverEventsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientClusterFailoverEventsTest.java
@@ -31,9 +31,10 @@ public class ClientClusterFailoverEventsTest extends MultiHotRodServersTest {
    }
 
    private void injectTimeServices() {
-      ts0 = new ControlledTimeService(0);
+      long now = System.currentTimeMillis();
+      ts0 = new ControlledTimeService(now);
       TestingUtil.replaceComponent(server(0).getCacheManager(), TimeService.class, ts0, true);
-      ts1 = new ControlledTimeService(0);
+      ts1 = new ControlledTimeService(now);
       TestingUtil.replaceComponent(server(1).getCacheManager(), TimeService.class, ts1, true);
    }
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/EmbeddedCompatContinuousQueryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/EmbeddedCompatContinuousQueryTest.java
@@ -61,7 +61,7 @@ public class EmbeddedCompatContinuousQueryTest extends MultiHotRodServersTest {
 
    private RemoteCache<String, User> remoteCache;
 
-   private ControlledTimeService timeService = new ControlledTimeService(0);
+   private ControlledTimeService timeService = new ControlledTimeService();
 
    @Override
    protected void createCacheManagers() throws Throwable {

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/RemoteContinuousQueryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/RemoteContinuousQueryTest.java
@@ -57,7 +57,7 @@ public class RemoteContinuousQueryTest extends MultiHotRodServersTest {
 
    private RemoteCache<String, User> remoteCache;
 
-   private ControlledTimeService timeService = new ControlledTimeService(0);
+   private ControlledTimeService timeService = new ControlledTimeService();
 
    @Override
    protected void createCacheManagers() throws Throwable {

--- a/core/src/test/java/org/infinispan/api/ConditionalOperationPrimaryOwnerFailTest.java
+++ b/core/src/test/java/org/infinispan/api/ConditionalOperationPrimaryOwnerFailTest.java
@@ -1,7 +1,7 @@
 package org.infinispan.api;
 
 import static org.infinispan.test.TestingUtil.extractComponent;
-import static org.infinispan.test.TestingUtil.replaceField;
+import static org.infinispan.test.TestingUtil.wrapInboundInvocationHandler;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyObject;
@@ -20,7 +20,6 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.container.EntryFactory;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.distribution.MagicKey;
-import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.remoting.inboundhandler.DeliverOrder;
 import org.infinispan.remoting.inboundhandler.PerCacheInboundInvocationHandler;
 import org.infinispan.remoting.inboundhandler.Reply;
@@ -102,10 +101,6 @@ public class ConditionalOperationPrimaryOwnerFailTest extends MultipleCacheManag
    }
 
    private PerCacheInboundInvocationHandler spyInvocationHandler(Cache cache) {
-      PerCacheInboundInvocationHandler spy = Mockito.spy(extractComponent(cache, PerCacheInboundInvocationHandler.class));
-      TestingUtil.replaceComponent(cache, PerCacheInboundInvocationHandler.class, spy, true);
-      replaceField(spy, "inboundInvocationHandler", cache.getAdvancedCache().getComponentRegistry(), ComponentRegistry.class);
-      return spy;
+      return wrapInboundInvocationHandler(cache, Mockito::spy);
    }
-
 }

--- a/core/src/test/java/org/infinispan/api/MetadataAPIDefaultExpiryTest.java
+++ b/core/src/test/java/org/infinispan/api/MetadataAPIDefaultExpiryTest.java
@@ -21,7 +21,7 @@ public class MetadataAPIDefaultExpiryTest extends SingleCacheManagerTest {
 
    public static final int EXPIRATION_TIMEOUT = 1000;
 
-   private final ControlledTimeService controlledTimeService = new ControlledTimeService(0);
+   private final ControlledTimeService controlledTimeService = new ControlledTimeService();
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {

--- a/core/src/test/java/org/infinispan/container/SimpleDataContainerTest.java
+++ b/core/src/test/java/org/infinispan/container/SimpleDataContainerTest.java
@@ -49,7 +49,7 @@ public class SimpleDataContainerTest extends AbstractInfinispanTest {
    protected DataContainer<String, String> createContainer() {
       DefaultDataContainer<String, String> dc = new DefaultDataContainer<>(16);
       InternalEntryFactoryImpl internalEntryFactory = new InternalEntryFactoryImpl();
-      timeService = new ControlledTimeService(0);
+      timeService = new ControlledTimeService();
       internalEntryFactory.injectTimeService(timeService);
       ActivationManager activationManager = mock(ActivationManager.class);
       doNothing().when(activationManager).onUpdate(Mockito.anyObject(), Mockito.anyBoolean());

--- a/core/src/test/java/org/infinispan/expiration/impl/ClusterExpirationFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/expiration/impl/ClusterExpirationFunctionalTest.java
@@ -52,11 +52,12 @@ public class ClusterExpirationFunctionalTest extends MultipleCacheManagersTest {
    }
 
    protected void injectTimeServices() {
-      ts0 = new ControlledTimeService(0);
+      long now = System.currentTimeMillis();
+      ts0 = new ControlledTimeService(now);
       TestingUtil.replaceComponent(manager(0), TimeService.class, ts0, true);
-      ts1 = new ControlledTimeService(0);
+      ts1 = new ControlledTimeService(now);
       TestingUtil.replaceComponent(manager(1), TimeService.class, ts1, true);
-      ts2 = new ControlledTimeService(0);
+      ts2 = new ControlledTimeService(now);
       TestingUtil.replaceComponent(manager(2), TimeService.class, ts2, true);
    }
 

--- a/core/src/test/java/org/infinispan/expiration/impl/ExpirationFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/expiration/impl/ExpirationFunctionalTest.java
@@ -17,7 +17,7 @@ import org.testng.annotations.Test;
 public class ExpirationFunctionalTest extends SingleCacheManagerTest {
 
    protected final int SIZE = 10;
-   protected ControlledTimeService timeService = new ControlledTimeService(0);
+   protected ControlledTimeService timeService = new ControlledTimeService();
 
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       ConfigurationBuilder builder = TestCacheManagerFactory.getDefaultCacheConfiguration(false);

--- a/core/src/test/java/org/infinispan/expiry/AutoCommitExpiryTest.java
+++ b/core/src/test/java/org/infinispan/expiry/AutoCommitExpiryTest.java
@@ -80,7 +80,7 @@ public abstract class AutoCommitExpiryTest extends SingleCacheManagerTest {
             .locking().isolationLevel(IsolationLevel.READ_COMMITTED);
       EmbeddedCacheManager cm = TestCacheManagerFactory.createClusteredCacheManager(builder);
 
-      timeService = new ControlledTimeService(0);
+      timeService = new ControlledTimeService();
       TestingUtil.replaceComponent(cm, TimeService.class, timeService, true);
       return cm;
    }

--- a/core/src/test/java/org/infinispan/expiry/ExpiryTest.java
+++ b/core/src/test/java/org/infinispan/expiry/ExpiryTest.java
@@ -43,7 +43,7 @@ public class ExpiryTest extends AbstractInfinispanTest {
    @BeforeMethod
    public void setUp() {
       cm = TestCacheManagerFactory.createCacheManager(false);
-      timeService = new ControlledTimeService(0);
+      timeService = new ControlledTimeService();
       TestingUtil.replaceComponent(cm, TimeService.class, timeService, true);
    }
 

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/AbstractClusterListenerUtilTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/AbstractClusterListenerUtilTest.java
@@ -97,11 +97,12 @@ public abstract class AbstractClusterListenerUtilTest extends MultipleCacheManag
    }
 
    protected void injectTimeServices() {
-      ts0 = new ControlledTimeService(0);
+      long now = System.currentTimeMillis();
+      ts0 = new ControlledTimeService(now);
       TestingUtil.replaceComponent(manager(0), TimeService.class, ts0, true);
-      ts1 = new ControlledTimeService(0);
+      ts1 = new ControlledTimeService(now);
       TestingUtil.replaceComponent(manager(1), TimeService.class, ts1, true);
-      ts2 = new ControlledTimeService(0);
+      ts2 = new ControlledTimeService(now);
       TestingUtil.replaceComponent(manager(2), TimeService.class, ts2, true);
    }
 

--- a/core/src/test/java/org/infinispan/partitionhandling/BaseTxPartitionAndMergeTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/BaseTxPartitionAndMergeTest.java
@@ -2,8 +2,8 @@ package org.infinispan.partitionhandling;
 
 import static org.infinispan.test.TestingUtil.extractComponent;
 import static org.infinispan.test.TestingUtil.extractLockManager;
+import static org.infinispan.test.TestingUtil.wrapInboundInvocationHandler;
 import static org.infinispan.test.TestingUtil.waitForRehashToComplete;
-import static org.infinispan.test.TestingUtil.wrapPerCacheInboundInvocationHandler;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -54,7 +54,7 @@ public abstract class BaseTxPartitionAndMergeTest extends BasePartitionHandlingT
    }
 
    private static void wrapAndApplyFilter(Cache<?, ?> cache, Filter filter) {
-      ControlledInboundHandler controlledInboundHandler = wrapPerCacheInboundInvocationHandler(cache, (wrapOn, current) -> new ControlledInboundHandler(current), true);
+      ControlledInboundHandler controlledInboundHandler = wrapInboundInvocationHandler(cache, ControlledInboundHandler::new);
       controlledInboundHandler.filter = filter;
    }
 

--- a/core/src/test/java/org/infinispan/persistence/BaseStoreTest.java
+++ b/core/src/test/java/org/infinispan/persistence/BaseStoreTest.java
@@ -105,7 +105,7 @@ public abstract class BaseStoreTest extends AbstractInfinispanTest {
     * To be overridden if the store requires special time handling
     */
    protected ControlledTimeService getTimeService() {
-      return new ControlledTimeService(0);
+      return new ControlledTimeService();
    }
 
    /**

--- a/core/src/test/java/org/infinispan/statetransfer/TxReplay3Test.java
+++ b/core/src/test/java/org/infinispan/statetransfer/TxReplay3Test.java
@@ -1,7 +1,7 @@
 package org.infinispan.statetransfer;
 
+import static org.infinispan.test.TestingUtil.wrapInboundInvocationHandler;
 import static org.infinispan.test.TestingUtil.wrapComponent;
-import static org.infinispan.test.TestingUtil.wrapPerCacheInboundInvocationHandler;
 import static org.testng.AssertJUnit.assertEquals;
 
 import java.util.Map;
@@ -64,8 +64,7 @@ public class TxReplay3Test extends MultipleCacheManagersTest {
 
       wrapComponent(cache(1), RpcManager.class,
                     (wrapOn, current) -> new UnsureResponseRpcManager(current, sequencer), true);
-      Handler handler = wrapPerCacheInboundInvocationHandler(cache(0),
-                                                             (wrapOn, current) -> new Handler(current, sequencer), true);
+      Handler handler = wrapInboundInvocationHandler(cache(0), current -> new Handler(current, sequencer));
       handler.setOrigin(address(cache(2)));
 
       Future<Void> tx1 = fork(() -> {

--- a/core/src/test/java/org/infinispan/test/TestingUtil.java
+++ b/core/src/test/java/org/infinispan/test/TestingUtil.java
@@ -36,6 +36,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.LockSupport;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -1560,11 +1561,10 @@ public class TestingUtil {
       return wrap;
    }
 
-   public static <T extends PerCacheInboundInvocationHandler> T wrapPerCacheInboundInvocationHandler(
-         Cache<?, ?> cache, WrapFactory<PerCacheInboundInvocationHandler, T, Cache<?, ?>> factory, boolean rewire) {
+   public static <T extends PerCacheInboundInvocationHandler> T wrapInboundInvocationHandler(Cache cache, Function<PerCacheInboundInvocationHandler, T> ctor) {
       PerCacheInboundInvocationHandler current = extractComponent(cache, PerCacheInboundInvocationHandler.class);
-      T wrap = factory.wrap(cache, current);
-      replaceComponent(cache, PerCacheInboundInvocationHandler.class, wrap, rewire);
+      T wrap = ctor.apply(current);
+      replaceComponent(cache, PerCacheInboundInvocationHandler.class, wrap, true);
       replaceField(wrap, "inboundInvocationHandler", cache.getAdvancedCache().getComponentRegistry(), ComponentRegistry.class);
       return wrap;
    }

--- a/core/src/test/java/org/infinispan/test/concurrent/InboundRpcSequencerAction.java
+++ b/core/src/test/java/org/infinispan/test/concurrent/InboundRpcSequencerAction.java
@@ -1,15 +1,12 @@
 package org.infinispan.test.concurrent;
 
-import static org.infinispan.test.TestingUtil.extractComponent;
-import static org.infinispan.test.TestingUtil.replaceComponent;
-import static org.infinispan.test.TestingUtil.replaceField;
+import static org.infinispan.test.TestingUtil.wrapInboundInvocationHandler;
 
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 
 import org.infinispan.Cache;
 import org.infinispan.commands.remote.CacheRpcCommand;
-import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.remoting.inboundhandler.DeliverOrder;
 import org.infinispan.remoting.inboundhandler.PerCacheInboundInvocationHandler;
 import org.infinispan.remoting.inboundhandler.Reply;
@@ -47,10 +44,8 @@ public class InboundRpcSequencerAction {
 
    private void replaceInboundInvocationHandler() {
       if (ourHandler == null) {
-         PerCacheInboundInvocationHandler handler = extractComponent(cache, PerCacheInboundInvocationHandler.class);
-         ourHandler = new SequencerPerCacheInboundInvocationHandler(handler, stateSequencer, matcher);
-         replaceComponent(cache, PerCacheInboundInvocationHandler.class, ourHandler, true);
-         replaceField(ourHandler, "inboundInvocationHandler", cache.getAdvancedCache().getComponentRegistry(), ComponentRegistry.class);
+         ourHandler = wrapInboundInvocationHandler(cache, handler ->
+               new SequencerPerCacheInboundInvocationHandler(handler, stateSequencer, matcher));
       }
    }
 

--- a/core/src/test/java/org/infinispan/util/ControlledTimeService.java
+++ b/core/src/test/java/org/infinispan/util/ControlledTimeService.java
@@ -8,6 +8,10 @@ import java.time.Instant;
 public class ControlledTimeService extends DefaultTimeService {
    protected long currentMillis;
 
+   public ControlledTimeService() {
+      this(System.currentTimeMillis());
+   }
+
    public ControlledTimeService(long currentMillis) {
       this.currentMillis = currentMillis;
    }

--- a/core/src/test/java/org/infinispan/xsite/offline/OfflineStatusTest.java
+++ b/core/src/test/java/org/infinispan/xsite/offline/OfflineStatusTest.java
@@ -182,7 +182,7 @@ public class OfflineStatusTest extends AbstractInfinispanTest {
    }
 
    private static TestContext createNew(long minWait, int afterFailures) {
-      ControlledTimeService t = new ControlledTimeService(0);
+      ControlledTimeService t = new ControlledTimeService();
       ListenerImpl l = new ListenerImpl();
       TakeOfflineConfiguration c = new TakeOfflineConfigurationBuilder(null, null)
             .afterFailures(afterFailures)

--- a/core/src/test/java/org/infinispan/xsite/statetransfer/failures/RetryMechanismTest.java
+++ b/core/src/test/java/org/infinispan/xsite/statetransfer/failures/RetryMechanismTest.java
@@ -3,8 +3,8 @@ package org.infinispan.xsite.statetransfer.failures;
 import static org.infinispan.test.TestingUtil.WrapFactory;
 import static org.infinispan.test.TestingUtil.extractGlobalComponent;
 import static org.infinispan.test.TestingUtil.replaceComponent;
+import static org.infinispan.test.TestingUtil.wrapInboundInvocationHandler;
 import static org.infinispan.test.TestingUtil.wrapComponent;
-import static org.infinispan.test.TestingUtil.wrapPerCacheInboundInvocationHandler;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -351,12 +351,7 @@ public class RetryMechanismTest extends AbstractTopologyChangeTest {
       }
 
       public static DiscardHandler replaceOn(Cache<?, ?> cache) {
-         return wrapPerCacheInboundInvocationHandler(cache, new WrapFactory<PerCacheInboundInvocationHandler, DiscardHandler, Cache<?, ?>>() {
-            @Override
-            public DiscardHandler wrap(Cache<?, ?> wrapOn, PerCacheInboundInvocationHandler current) {
-               return new DiscardHandler(current);
-            }
-         }, true);
+         return wrapInboundInvocationHandler(cache, DiscardHandler::new);
       }
 
       @Override
@@ -401,12 +396,7 @@ public class RetryMechanismTest extends AbstractTopologyChangeTest {
       }
 
       public static FailureHandler replaceOn(Cache<?, ?> cache) {
-         return wrapPerCacheInboundInvocationHandler(cache, new WrapFactory<PerCacheInboundInvocationHandler, FailureHandler, Cache<?, ?>>() {
-            @Override
-            public FailureHandler wrap(Cache<?, ?> wrapOn, PerCacheInboundInvocationHandler current) {
-               return new FailureHandler(current);
-            }
-         }, true);
+         return wrapInboundInvocationHandler(cache, FailureHandler::new);
       }
 
       @Override

--- a/extended-statistics/src/test/java/org/infinispan/stats/BaseClusteredExtendedStatisticTest.java
+++ b/extended-statistics/src/test/java/org/infinispan/stats/BaseClusteredExtendedStatisticTest.java
@@ -1,9 +1,7 @@
 package org.infinispan.stats;
 
-import static org.infinispan.test.TestingUtil.extractComponent;
 import static org.infinispan.test.TestingUtil.k;
-import static org.infinispan.test.TestingUtil.replaceComponent;
-import static org.infinispan.test.TestingUtil.replaceField;
+import static org.infinispan.test.TestingUtil.wrapInboundInvocationHandler;
 import static org.testng.AssertJUnit.assertNull;
 
 import java.lang.reflect.Method;
@@ -35,7 +33,6 @@ import org.infinispan.commands.write.WriteCommand;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.InterceptorConfiguration;
-import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.remoting.inboundhandler.DeliverOrder;
 import org.infinispan.remoting.inboundhandler.PerCacheInboundInvocationHandler;
@@ -398,16 +395,8 @@ public abstract class BaseClusteredExtendedStatisticTest extends MultipleCacheMa
 
    private void replaceAllPerCacheInboundInvocationHandler() {
       for (Cache<?, ?> cache : caches()) {
-         inboundHandlerList.add(replacePerCacheInboundInvocationHandler(cache));
+         inboundHandlerList.add(wrapInboundInvocationHandler(cache, ControlledPerCacheInboundInvocationHandler::new));
       }
-   }
-
-   private ControlledPerCacheInboundInvocationHandler replacePerCacheInboundInvocationHandler(Cache<?, ?> cache) {
-      ControlledPerCacheInboundInvocationHandler handler = new ControlledPerCacheInboundInvocationHandler(
-            extractComponent(cache, PerCacheInboundInvocationHandler.class));
-      replaceComponent(cache, PerCacheInboundInvocationHandler.class, handler, true);
-      replaceField(handler, "inboundInvocationHandler", cache.getAdvancedCache().getComponentRegistry(), ComponentRegistry.class);
-      return handler;
    }
 
    protected enum Operation {

--- a/jcache/commons/src/test/java/org/infinispan/jcache/AbstractTwoCachesExpirationTest.java
+++ b/jcache/commons/src/test/java/org/infinispan/jcache/AbstractTwoCachesExpirationTest.java
@@ -26,7 +26,7 @@ import org.testng.annotations.Test;
 @Test(testName = "org.infinispan.jcache.AbstractTwoCachesExpirationTest", groups = "functional")
 public abstract class AbstractTwoCachesExpirationTest extends MultipleCacheManagersTest {
 
-   protected final ControlledTimeService controlledTimeService = new ControlledTimeService(0);
+   protected final ControlledTimeService controlledTimeService = new ControlledTimeService();
    protected static final int EXPIRATION_TIMEOUT = 1000;
 
    @Test

--- a/jcache/embedded/src/test/java/org/infinispan/jcache/JCacheLoaderTest.java
+++ b/jcache/embedded/src/test/java/org/infinispan/jcache/JCacheLoaderTest.java
@@ -119,7 +119,7 @@ public class JCacheLoaderTest extends AbstractInfinispanTest {
          TestCacheManagerFactory.createCacheManager(false)) {
          @Override
          public void call() {
-            ControlledTimeService timeService = new ControlledTimeService(0);
+            ControlledTimeService timeService = new ControlledTimeService();
             TestingUtil.replaceComponent(cm, TimeService.class, timeService, true);
             JCacheManager jCacheManager = createJCacheManager(cm, this);
 

--- a/lucene/lucene-directory/src/test/java/org/infinispan/lucene/impl/DeltaReplicationTest.java
+++ b/lucene/lucene-directory/src/test/java/org/infinispan/lucene/impl/DeltaReplicationTest.java
@@ -1,8 +1,7 @@
 package org.infinispan.lucene.impl;
 
 import static org.infinispan.test.TestingUtil.extractComponent;
-import static org.infinispan.test.TestingUtil.replaceComponent;
-import static org.infinispan.test.TestingUtil.replaceField;
+import static org.infinispan.test.TestingUtil.wrapInboundInvocationHandler;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertTrue;
 
@@ -26,7 +25,6 @@ import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.container.DataContainer;
 import org.infinispan.container.entries.InternalCacheEntry;
-import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.lucene.FileListCacheKey;
 import org.infinispan.lucene.directory.DirectoryBuilder;
 import org.infinispan.lucene.testutils.LuceneSettings;
@@ -93,12 +91,8 @@ public class DeltaReplicationTest extends MultipleCacheManagersTest {
       waitForClusterToForm();
    }
 
-   private InboundInvocationHandlerDecorator replaceOn(Cache cache) {
-      InboundInvocationHandlerDecorator decorator = new InboundInvocationHandlerDecorator(
-            extractComponent(cache, PerCacheInboundInvocationHandler.class));
-      replaceComponent(cache, PerCacheInboundInvocationHandler.class, decorator, true);
-      replaceField(decorator, "inboundInvocationHandler", cache.getAdvancedCache().getComponentRegistry(), ComponentRegistry.class);
-      return decorator;
+   private InboundInvocationHandlerDecorator replaceOn(Cache cache0) {
+      return wrapInboundInvocationHandler(cache0, InboundInvocationHandlerDecorator::new);
    }
 
    private void writeSingleDocument(Directory dir) throws IOException {

--- a/query/src/test/java/org/infinispan/query/continuous/ContinuousQueryTest.java
+++ b/query/src/test/java/org/infinispan/query/continuous/ContinuousQueryTest.java
@@ -29,7 +29,7 @@ import org.testng.annotations.Test;
 @Test(groups = "functional", testName = "query.continuous.ContinuousQueryTest")
 public class ContinuousQueryTest extends SingleCacheManagerTest {
 
-   protected ControlledTimeService timeService = new ControlledTimeService(0);
+   protected ControlledTimeService timeService = new ControlledTimeService();
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {


### PR DESCRIPTION
Offloading independent changes handy in other (future) PRs.

My motivation for using real time as start offset of the TimeService mock was that I wanted to place `assert timestamp != 0` at certain places.