### PR TITLE
fix to be able to search for numeric fields with Ickle full text range query

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteNonIndexedQueryStringTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteNonIndexedQueryStringTest.java
@@ -69,6 +69,12 @@ public class RemoteNonIndexedQueryStringTest extends RemoteQueryStringTest {
 
    @Test(expectedExceptions = HotRodClientException.class, expectedExceptionsMessageRegExp = "java.lang.IllegalStateException: The cache must be indexed in order to use full-text queries.")
    @Override
+   public void testFullTextRangeWildcard() throws Exception {
+      super.testFullTextRangeWildcard();
+   }
+
+   @Test(expectedExceptions = HotRodClientException.class, expectedExceptionsMessageRegExp = "java.lang.IllegalStateException: The cache must be indexed in order to use full-text queries.")
+   @Override
    public void testFullTextRange() throws Exception {
       super.testFullTextRange();
    }

--- a/object-filter/src/main/antlr3/org/infinispan/objectfilter/impl/ql/parse/QueryRenderer.g
+++ b/object-filter/src/main/antlr3/org/infinispan/objectfilter/impl/ql/parse/QueryRenderer.g
@@ -361,8 +361,8 @@ ftClause
          { delegate.predicateFullTextRegexp($REGEXP_LITERAL.text); }
    |  ^(FT_RANGE startRange=(LSQUARE | LCURLY) lower=ftRangeBound upper=ftRangeBound endRange=(RSQUARE | RCURLY))
          { delegate.predicateFullTextRange($startRange.type == LSQUARE,
-                                     $lower.tree.getType() == ASTERISK ? null : $lower.text,
-                                     $upper.tree.getType() == ASTERISK ? null : $upper.text,
+                                     $lower.start.getType() == ASTERISK ? null : $lower.text,
+                                     $upper.start.getType() == ASTERISK ? null : $upper.text,
                                      $endRange.type == RSQUARE); }
    |  ^(OR { delegate.activateOR(); } ftClause ftClause { delegate.deactivateBoolean(); })
    |  ^(AND { delegate.activateAND(); } ftClause ftClause { delegate.deactivateBoolean(); })

--- a/object-filter/src/main/java/org/infinispan/objectfilter/impl/logging/Log.java
+++ b/object-filter/src/main/java/org/infinispan/objectfilter/impl/logging/Log.java
@@ -96,4 +96,11 @@ public interface Log extends BasicLogger {
 
    @Message(id = 28526, value = "Invalid query: %s; Parser error messages: %s.")
    ParsingException getQuerySyntaxException(String query, List<?> parserErrorMessages);
+
+   @Message(id = 28527, value = "No relational queries can be applied to property '%2$s' in type %1$s since the property is indexed.")
+   ParsingException getQueryOnIndexedPropertyNotSupportedException(String typeName, String propertyName);
+
+   @Message(id = 28528, value = "Full-text queries cannot be applied to property '%2$s' in type %1$s unless the property is indexed.")
+   ParsingException getFullTextQueryOnNotIndexedPropertyNotSupportedException(String typeName, String propertyName);
+
 }

--- a/object-filter/src/main/java/org/infinispan/objectfilter/impl/syntax/FullTextRangeExpr.java
+++ b/object-filter/src/main/java/org/infinispan/objectfilter/impl/syntax/FullTextRangeExpr.java
@@ -10,13 +10,13 @@ public final class FullTextRangeExpr implements PrimaryPredicateExpr {
 
    private final boolean includeLower;
 
-   private final String lower;
+   private final Object lower;
 
    private final boolean includeUpper;
 
-   private final String upper;
+   private final Object upper;
 
-   public FullTextRangeExpr(ValueExpr leftChild, boolean includeLower, String lower, String upper, boolean includeUpper) {
+   public FullTextRangeExpr(ValueExpr leftChild, boolean includeLower, Object lower, Object upper, boolean includeUpper) {
       this.leftChild = leftChild;
       this.includeLower = includeLower;
       this.lower = lower;
@@ -32,11 +32,11 @@ public final class FullTextRangeExpr implements PrimaryPredicateExpr {
       return includeUpper;
    }
 
-   public String getLower() {
+   public Object getLower() {
       return lower;
    }
 
-   public String getUpper() {
+   public Object getUpper() {
       return upper;
    }
 

--- a/object-filter/src/main/java/org/infinispan/objectfilter/impl/syntax/parser/ExpressionBuilder.java
+++ b/object-filter/src/main/java/org/infinispan/objectfilter/impl/syntax/parser/ExpressionBuilder.java
@@ -67,7 +67,7 @@ final class ExpressionBuilder<TypeMetadata> {
       push(new FullTextRegexpExpr(makePropertyValueExpr(propertyPath), regexp));
    }
 
-   public void addFullTextRange(PropertyPath<?> propertyPath, boolean includeLower, String lower, String upper, boolean includeUpper) {
+   public void addFullTextRange(PropertyPath<?> propertyPath, boolean includeLower, Object lower, Object upper, boolean includeUpper) {
       push(new FullTextRangeExpr(makePropertyValueExpr(propertyPath), includeLower, lower, upper, includeUpper));
    }
 

--- a/object-filter/src/main/java/org/infinispan/objectfilter/impl/syntax/parser/QueryRendererDelegateImpl.java
+++ b/object-filter/src/main/java/org/infinispan/objectfilter/impl/syntax/parser/QueryRendererDelegateImpl.java
@@ -384,9 +384,9 @@ final class QueryRendererDelegateImpl<TypeMetadata> implements QueryRendererDele
          if (property.isEmpty()) {
             throw log.getPredicatesOnEntityAliasNotAllowedException(propertyPath.asStringPath());
          }
-         String from = lower != null ? (String) parameterValue(lower) : null;
-         String to = upper != null ? (String) parameterValue(upper) : null;
-         checkAnalyzed(property, true);
+         Object from = lower != null ? parameterValue(lower) : null;
+         Object to = upper != null ? parameterValue(upper) : null;
+         checkIndexed(property, true);
          whereBuilder.addFullTextRange(property, includeLower, from, to, includeUpper);
       } else if (phase == Phase.HAVING) {
          throw log.getFullTextQueriesNotAllowedInHavingClauseException();
@@ -403,6 +403,18 @@ final class QueryRendererDelegateImpl<TypeMetadata> implements QueryRendererDele
       } else {
          if (expectAnalyzed) {
             throw log.getFullTextQueryOnNotAalyzedPropertyNotSupportedException(targetTypeName, propertyPath.asStringPath());
+         }
+      }
+   }
+
+   private void checkIndexed(PropertyPath<?> propertyPath, boolean expectIndexed) {
+      if (fieldIndexingMetadata.isIndexed(propertyPath.asArrayPath())) {
+         if (!expectIndexed) {
+            throw log.getQueryOnIndexedPropertyNotSupportedException(targetTypeName, propertyPath.asStringPath());
+         }
+      } else {
+         if (expectIndexed) {
+            throw log.getFullTextQueryOnNotIndexedPropertyNotSupportedException(targetTypeName, propertyPath.asStringPath());
          }
       }
    }

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/NonIndexedQueryStringTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/NonIndexedQueryStringTest.java
@@ -70,7 +70,13 @@ public class NonIndexedQueryStringTest extends QueryStringTest {
       super.testFullTextTermDoesntOccur();
    }
 
-   @Test(expectedExceptions = ParsingException.class, expectedExceptionsMessageRegExp = "ISPN028521: Full-text queries cannot be applied to property 'longDescription' in type org.infinispan.query.dsl.embedded.testdomain.hsearch.TransactionHS unless the property is indexed and analyzed.")
+   @Test(expectedExceptions = ParsingException.class, expectedExceptionsMessageRegExp = "ISPN028528: Full-text queries cannot be applied to property 'longDescription' in type org.infinispan.query.dsl.embedded.testdomain.hsearch.TransactionHS unless the property is indexed.")
+   @Override
+   public void testFullTextRangeWildcard() throws Exception {
+      super.testFullTextRangeWildcard();
+   }
+
+   @Test(expectedExceptions = ParsingException.class, expectedExceptionsMessageRegExp = "ISPN028528: Full-text queries cannot be applied to property 'amount' in type org.infinispan.query.dsl.embedded.testdomain.hsearch.TransactionHS unless the property is indexed.")
    @Override
    public void testFullTextRange() throws Exception {
       super.testFullTextRange();

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/QueryStringTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/QueryStringTest.java
@@ -285,13 +285,22 @@ public class QueryStringTest extends AbstractQueryDslTest {
       assertEquals(6, list.size());
    }
 
-   public void testFullTextRange() throws Exception {
+   public void testFullTextRangeWildcard() throws Exception {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.create("from " + getModelFactory().getTransactionTypeName() + " t where t.longDescription : [* to *]");
 
       List<Transaction> list = q.list();
       assertEquals(54, list.size());
+   }
+
+   public void testFullTextRange() throws Exception {
+      QueryFactory qf = getQueryFactory();
+
+      Query q = qf.create("from " + getModelFactory().getTransactionTypeName() + " t where t.amount : [23 to 45]");
+
+      List<Transaction> list = q.list();
+      assertEquals(2, list.size());
    }
 
    public void testFullTextPrefix() throws Exception {


### PR DESCRIPTION
In current Ickle, full text range query like [this blog entry](http://blog.infinispan.org/2016/12/meet-ickle.html) does not work.
```
from com.acme.Transaction where amount : [40 to 90}
```
I think that the cause is as follows.
- QueryRenderer class can not get value of condition of range query
- [QueryRendererDelegateImpl class expects the search condition to be a string](https://github.com/infinispan/infinispan/blob/9.0.0.Final/object-filter/src/main/java/org/infinispan/objectfilter/impl/syntax/parser/QueryRendererDelegateImpl.java#L387-L388)
- [QueryRendererDelegateImpl class expects an analyzed field, but the numeric field is not analyzed](https://github.com/infinispan/infinispan/blob/9.0.0.Final/object-filter/src/main/java/org/infinispan/objectfilter/impl/syntax/parser/QueryRendererDelegateImpl.java#L389)

It behaves differently for other Query APIs.

For example, the following code created based on [QueryStringTest](https://github.com/infinispan/infinispan/blob/9.0.0.Final/query/src/test/java/org/infinispan/query/dsl/embedded/QueryStringTest.java) will work
```java
   public void testFullTextRangeAsDsl() throws Exception {
      QueryFactory qf = getQueryFactory();
      Query q =
              qf.from(getModelFactory().getTransactionImplClass())
                      .having("amount")
                      .between(23, 45)
                      .build();
      List<Transaction> list = q.list();
      assertEquals(2, list.size());
   }

   public void testFullTextRangeHs() throws Exception {
      SearchManager searchManager = Search.getSearchManager((Cache) getCacheForQuery());
      org.apache.lucene.search.Query luceneQuery =
              searchManager
                      .buildQueryBuilderForClass(getModelFactory().getTransactionImplClass())
                      .get()
                      .range()
                      .onField("amount")
                      .from(23.0).to(45.0)
                      .createQuery();
      CacheQuery q = searchManager.getQuery(luceneQuery, getModelFactory().getTransactionImplClass());

      List<Transaction> list = q.list();
      assertEquals(2, list.size());
   }
```

The following code does not work.(A NullPointerException is thrown.)
```java
   public void testFullTextRangeIckle() throws Exception {
      QueryFactory qf = getQueryFactory();

      Query q = qf.create("from " + getModelFactory().getTransactionTypeName() + " t where t.amount : [23 to 45]");

      List<Transaction> list = q.list();
      assertEquals(2, list.size());
   }
```

I think like this, but how is it?