### PR TITLE
ISPN-7717 ClusteredGetAllCommand should be invoked with SYNCHRONOUS_IGNORE_LEAVERS

### DIFF
--- a/core/src/main/java/org/infinispan/interceptors/impl/BaseRpcInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/BaseRpcInterceptor.java
@@ -56,7 +56,8 @@ public abstract class BaseRpcInterceptor extends DDAsyncInterceptor {
    protected boolean defaultSynchronous;
    protected volatile RpcOptions singleTargetStaggeredOptions;
    protected volatile RpcOptions multiTargetStaggeredOptions;
-   protected RpcOptions defaultSyncOptions;
+   protected volatile RpcOptions defaultSyncOptions;
+   protected volatile RpcOptions syncIgnoreLeavers;
    protected RpcOptions defaultAsyncOptions;
 
    protected abstract Log getLog();
@@ -81,6 +82,7 @@ public abstract class BaseRpcInterceptor extends DDAsyncInterceptor {
       multiTargetStaggeredOptions = rpcManager.getRpcOptionsBuilder(ResponseMode.WAIT_FOR_VALID_RESPONSE)
             .responseFilter(SUCCESSFUL_OR_EXCEPTIONAL).build();
       defaultSyncOptions = rpcManager.getDefaultRpcOptions(true);
+      syncIgnoreLeavers = rpcManager.getRpcOptionsBuilder(ResponseMode.SYNCHRONOUS_IGNORE_LEAVERS, DeliverOrder.NONE).build();
    }
 
    protected RpcOptions getStaggeredOptions(int numTargets) {

--- a/core/src/main/java/org/infinispan/interceptors/impl/BaseStateTransferInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/BaseStateTransferInterceptor.java
@@ -214,7 +214,6 @@ public abstract class BaseStateTransferInterceptor extends DDAsyncInterceptor {
          // An example of this situation is when a node sends leave - topology can be installed before the new view.
          // To prevent suspect exceptions use SYNCHRONOUS_IGNORE_LEAVERS response mode.
          if (currentTopologyId == cmd.getTopologyId() && !cacheTopology.getActualMembers().contains(((SuspectException) ce).getSuspect())) {
-            // TODO: provide a test case
             throw new IllegalStateException("Command was not sent with SYNCHRONOUS_IGNORE_LEAVERS?");
          }
       } else if (ce instanceof OutdatedTopologyException) {

--- a/core/src/test/java/org/infinispan/commands/GetAllCommandNodeCrashTest.java
+++ b/core/src/test/java/org/infinispan/commands/GetAllCommandNodeCrashTest.java
@@ -1,0 +1,78 @@
+package org.infinispan.commands;
+
+import static org.infinispan.test.TestingUtil.extractComponent;
+import static org.infinispan.test.TestingUtil.replaceComponent;
+import static org.infinispan.test.TestingUtil.wrapComponent;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertTrue;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.infinispan.commands.remote.ClusteredGetAllCommand;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.distribution.MagicKey;
+import org.infinispan.remoting.rpc.RpcManager;
+import org.infinispan.statetransfer.StateConsumer;
+import org.infinispan.statetransfer.StateTransferLock;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.tx.dld.ControlledRpcManager;
+import org.testng.annotations.Test;
+
+@Test(groups = "functional", testName = "commands.GetAllCommandNodeCrashTest")
+public class GetAllCommandNodeCrashTest extends MultipleCacheManagersTest {
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      createClusteredCaches(3, getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC));
+   }
+
+   public void test() throws Exception {
+      MagicKey key = new MagicKey(cache(0), cache(1));
+      cache(2).put(key, "value");
+
+      ControlledRpcManager rpcManager = wrapComponent(cache(2), RpcManager.class, ControlledRpcManager::new);
+      rpcManager.blockBefore(ClusteredGetAllCommand.class);
+
+      CountDownLatch blockTopologyUpdate = new CountDownLatch(1);
+      StateConsumer stateConsumerMock = spy(extractComponent(cache(2), StateConsumer.class));
+      doAnswer(invocation -> {
+         assertTrue(blockTopologyUpdate.await(10, TimeUnit.SECONDS));
+         return invocation.callRealMethod();
+      }).when(stateConsumerMock).onTopologyUpdate(any(), anyBoolean());
+      replaceComponent(cache(2), StateConsumer.class, stateConsumerMock, true);
+
+      StateTransferLock stateTransferLockMock = spy(extractComponent(cache(2), StateTransferLock.class));
+      doAnswer(invocation -> {
+         blockTopologyUpdate.countDown();
+         return invocation.callRealMethod();
+      }).when(stateTransferLockMock).topologyFuture(anyInt());
+      replaceComponent(cache(2), StateTransferLock.class, stateTransferLockMock, true);
+
+      Future<Map<Object, Object>> f = fork(() -> cache(2).getAdvancedCache().getAll(Collections.singleton(key)));
+
+      rpcManager.waitForCommandToBlock();
+      // it's necessary to stop whole cache manager, not just cache, because otherwise the exception would have
+      // suspect node defined
+      cacheManagers.get(0).stop();
+      rpcManager.stopBlocking();
+
+      try {
+         Map<Object, Object> map = f.get(10, TimeUnit.SECONDS);
+         assertNotNull(map);
+         assertFalse(map.isEmpty());
+         assertEquals("value", map.get(key));
+      } finally {
+         blockTopologyUpdate.countDown();
+      }
+   }
+}

--- a/core/src/test/java/org/infinispan/test/TestingUtil.java
+++ b/core/src/test/java/org/infinispan/test/TestingUtil.java
@@ -1532,6 +1532,13 @@ public class TestingUtil {
       return wrap;
    }
 
+   public static <T, W extends T> W wrapComponent(Cache<?, ?> cache, Class<T> tClass, Function<T, W> ctor) {
+      T current = extractComponent(cache, tClass);
+      W wrap = ctor.apply(current);
+      replaceComponent(cache, tClass, wrap, true);
+      return wrap;
+   }
+
    public static <T extends PerCacheInboundInvocationHandler> T wrapInboundInvocationHandler(Cache cache, Function<PerCacheInboundInvocationHandler, T> ctor) {
       PerCacheInboundInvocationHandler current = extractComponent(cache, PerCacheInboundInvocationHandler.class);
       T wrap = ctor.apply(current);


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-7717

I am actually not sure if throwing the IllegalStateException is entirely necessary, I vaguely recall Dan asking me to add it there, but I am fine with leaving it out. IIRC, upon suspect exception the retry should have been executed immediately, without waiting for the next topology.