### PR TITLE
JGRP-2167 workaround

### DIFF
--- a/core/src/test/resources/stacks/tcp.xml
+++ b/core/src/test/resources/stacks/tcp.xml
@@ -43,12 +43,14 @@
    <FD_ALL interval="1000" timeout="4000" timeout_check_interval="1000"/>
    <VERIFY_SUSPECT timeout="1000"/>
 
+   <!-- resend_last_seqno_max_times=10000 is a workaround for JGRP-2167  -->
    <pbcast.NAKACK2
    					use_mcast_xmit="false"
                     xmit_interval="100"
                     xmit_table_num_rows="50"
                     xmit_table_msgs_per_row="1024"
-                    xmit_table_max_compaction_time="30000"/>
+                    xmit_table_max_compaction_time="30000"
+                    resend_last_seqno_max_times="10000"/>
    <UNICAST3
               xmit_interval="100"
               xmit_table_num_rows="50"


### PR DESCRIPTION
See https://issues.jboss.org/browse/JGRP-2167 (ping @belaban)

This issue is causing an often failure in `GetAllCommandStressTest`, where the `getAll()` fails with `TimeoutException` instead of being properly retried, because the originator node does not get the new view (without stopped member).