### PR TITLE
added support for named parameter to the like operator of Ickle Query

### DIFF
--- a/object-filter/src/main/java/org/infinispan/objectfilter/impl/predicateindex/be/BETreeMaker.java
+++ b/object-filter/src/main/java/org/infinispan/objectfilter/impl/predicateindex/be/BETreeMaker.java
@@ -129,7 +129,7 @@ public final class BETreeMaker<AttributeId extends Comparable<AttributeId>> {
          addPredicateNode(parent, nodes, treeCounters, isNegated, path, new Predicate<>(isRepeated, IsNullCondition.INSTANCE));
       } else if (condition instanceof LikeExpr) {
          LikeExpr likeExpr = (LikeExpr) condition;
-         addPredicateNode(parent, nodes, treeCounters, isNegated, path, new Predicate<>(isRepeated, new LikeCondition(likeExpr.getPattern(), likeExpr.getEscapeChar())));
+         addPredicateNode(parent, nodes, treeCounters, isNegated, path, new Predicate<>(isRepeated, new LikeCondition(likeExpr.getPatternAs(namedParameters), likeExpr.getEscapeChar())));
       } else {
          throw new IllegalStateException("Unexpected condition type (" + condition.getClass().getSimpleName() + "): " + condition);
       }

--- a/object-filter/src/main/java/org/infinispan/objectfilter/impl/syntax/LikeExpr.java
+++ b/object-filter/src/main/java/org/infinispan/objectfilter/impl/syntax/LikeExpr.java
@@ -1,5 +1,7 @@
 package org.infinispan.objectfilter.impl.syntax;
 
+import java.util.Map;
+
 /**
  * @author anistor@redhat.com
  * @since 7.0
@@ -13,10 +15,10 @@ public final class LikeExpr implements PrimaryPredicateExpr {
    public static final char DEFAULT_ESCAPE_CHARACTER = '\\';
 
    private final ValueExpr child;
-   private final String pattern;
+   private final Object pattern;
    private final char escapeChar = DEFAULT_ESCAPE_CHARACTER;
 
-   public LikeExpr(ValueExpr child, String pattern) {
+   public LikeExpr(ValueExpr child, Object pattern) {
       this.child = child;
       this.pattern = pattern;
    }
@@ -26,8 +28,25 @@ public final class LikeExpr implements PrimaryPredicateExpr {
       return child;
    }
 
-   public String getPattern() {
+   public Object getPattern() {
       return pattern;
+   }
+
+   public String getPatternAs(Map<String, Object> namedParameters) {
+      if (pattern instanceof ConstantValueExpr.ParamPlaceholder) {
+         String paramName = ((ConstantValueExpr.ParamPlaceholder) pattern).getName();
+         if (namedParameters == null) {
+            throw new IllegalStateException("Missing value for parameter " + paramName);
+         }
+         String p = (String) namedParameters.get(paramName);
+         if (p == null) {
+            throw new IllegalStateException("Missing value for parameter " + paramName);
+         }
+
+         return p;
+      } else {
+         return (String) pattern;
+      }
    }
 
    public char getEscapeChar() {

--- a/object-filter/src/main/java/org/infinispan/objectfilter/impl/syntax/parser/ExpressionBuilder.java
+++ b/object-filter/src/main/java/org/infinispan/objectfilter/impl/syntax/parser/ExpressionBuilder.java
@@ -93,7 +93,7 @@ final class ExpressionBuilder<TypeMetadata> {
       push(new OrExpr(children));
    }
 
-   public void addLike(PropertyPath<?> propertyPath, String patternValue, Character escapeCharacter) {
+   public void addLike(PropertyPath<?> propertyPath, Object patternValue, Character escapeCharacter) {
       // TODO [anistor] escapeCharacter is ignored for now
       push(new LikeExpr(makePropertyValueExpr(propertyPath), patternValue));
    }

--- a/object-filter/src/main/java/org/infinispan/objectfilter/impl/syntax/parser/QueryRendererDelegateImpl.java
+++ b/object-filter/src/main/java/org/infinispan/objectfilter/impl/syntax/parser/QueryRendererDelegateImpl.java
@@ -305,9 +305,9 @@ final class QueryRendererDelegateImpl<TypeMetadata> implements QueryRendererDele
       }
       checkAnalyzed(property, false);
       if (phase == Phase.WHERE) {
-         whereBuilder.addLike(property, (String) pattern, escapeCharacter);
+         whereBuilder.addLike(property, pattern, escapeCharacter);
       } else if (phase == Phase.HAVING) {
-         havingBuilder.addLike(property, (String) pattern, escapeCharacter);
+         havingBuilder.addLike(property, pattern, escapeCharacter);
       } else {
          throw new IllegalStateException();
       }

--- a/query/src/main/java/org/infinispan/query/dsl/embedded/impl/LuceneQueryMaker.java
+++ b/query/src/main/java/org/infinispan/query/dsl/embedded/impl/LuceneQueryMaker.java
@@ -425,7 +425,7 @@ public final class LuceneQueryMaker<TypeMetadata> implements Visitor<Query, Quer
    @Override
    public Query visit(LikeExpr likeExpr) {
       PropertyValueExpr propertyValueExpr = (PropertyValueExpr) likeExpr.getChild();
-      StringBuilder lucenePattern = new StringBuilder(likeExpr.getPattern());
+      StringBuilder lucenePattern = new StringBuilder(likeExpr.getPatternAs(namedParameters));
       // transform 'Like' pattern into Lucene wildcard pattern
       boolean isEscaped = false;
       for (int i = 0; i < lucenePattern.length(); i++) {

--- a/query/src/main/java/org/infinispan/query/dsl/embedded/impl/QueryEngine.java
+++ b/query/src/main/java/org/infinispan/query/dsl/embedded/impl/QueryEngine.java
@@ -208,7 +208,8 @@ public class QueryEngine<TypeMetadata> {
             return new EmptyResultQuery(queryFactory, cache, queryString, namedParameters, startOffset, maxResults);
          }
          if (normalizedHavingClause != ConstantBooleanExpr.TRUE) {
-            havingClause = SyntaxTreePrinter.printTree(swapVariables(normalizedHavingClause, parsingResult.getTargetEntityMetadata(), columns, propertyHelper));
+            havingClause = SyntaxTreePrinter.printTree(swapVariables(normalizedHavingClause, parsingResult.getTargetEntityMetadata(),
+                    columns, namedParameters, propertyHelper));
          }
       }
 
@@ -312,7 +313,7 @@ public class QueryEngine<TypeMetadata> {
     */
    private BooleanExpr swapVariables(BooleanExpr expr, TypeMetadata targetEntityMetadata,
                                      LinkedHashMap<PropertyPath, RowPropertyHelper.ColumnMetadata> columns,
-                                     ObjectPropertyHelper<TypeMetadata> propertyHelper) {
+                                     Map<String, Object> namedParameters, ObjectPropertyHelper<TypeMetadata> propertyHelper) {
       class PropertyReplacer extends ExprVisitor {
 
          @Override
@@ -355,7 +356,7 @@ public class QueryEngine<TypeMetadata> {
 
          @Override
          public BooleanExpr visit(LikeExpr likeExpr) {
-            return new LikeExpr(likeExpr.getChild().acceptVisitor(this), likeExpr.getPattern());
+            return new LikeExpr(likeExpr.getChild().acceptVisitor(this), likeExpr.getPatternAs(namedParameters));
          }
 
          @Override


### PR DESCRIPTION
Using the named parameter for the like operator of the current Ickle Query throws an exception.

For example, if you run the following code
```java
   @Test
   public void testParamLike() throws Exception {
      QueryFactory qf = getQueryFactory();

      Query q = qf.create("from " + getModelFactory().getTransactionTypeName() + " where description like :descriptionParam");

      q.setParameter("descriptionParam", "%january%");

      List<Transaction> list = q.list();

      assertEquals(1, list.size());
   }
```

A ClassCastException is thrown.
```
java.lang.ClassCastException: org.infinispan.objectfilter.impl.syntax.ConstantValueExpr$ParamPlaceholder cannot be cast to java.lang.String
	at org.infinispan.objectfilter.impl.syntax.parser.QueryRendererDelegateImpl.predicateLike(QueryRendererDelegateImpl.java:308)
	at org.infinispan.objectfilter.impl.ql.parse.QueryRenderer.predicate(QueryRenderer.java:3714)
	at org.infinispan.objectfilter.impl.ql.parse.QueryRenderer.searchCondition(QueryRenderer.java:3007)
	at org.infinispan.objectfilter.impl.ql.parse.QueryRenderer.whereClause(QueryRenderer.java:657)
	at org.infinispan.objectfilter.impl.ql.parse.QueryRenderer.querySpec(QueryRenderer.java:510)
	at org.infinispan.objectfilter.impl.ql.parse.QueryRenderer.queryStatement(QueryRenderer.java:379)
	at org.infinispan.objectfilter.impl.ql.parse.QueryRenderer.queryStatementSet(QueryRenderer.java:292)
	at org.infinispan.objectfilter.impl.ql.parse.QueryRenderer.statement(QueryRenderer.java:220)
	at org.infinispan.objectfilter.impl.ql.QueryParser.render(QueryParser.java:88
```

In the QueryRendererDelegateImpl class, the value of the like operator can only handle String.
https://github.com/infinispan/infinispan/blob/9.0.0.Final/object-filter/src/main/java/org/infinispan/objectfilter/impl/syntax/parser/QueryRendererDelegateImpl.java#L307-L310

Also, I think that the reason is that the LikeExpr class can not handle the ConstantValueExpr.ParamPlaceholder class.

I think like this, but how is it?