### PR TITLE
ISPN-7670 Upgrade to Hibernate Search 5.8.0.Beta1

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -68,7 +68,7 @@
       <version.gnu.getopt>1.0.13</version.gnu.getopt>
       <version.hibernate.javax.persistence>1.0.0.Final</version.hibernate.javax.persistence>
       <version.hibernate.core>5.2.7.Final</version.hibernate.core>
-      <version.hibernate.search>5.7.0.Final</version.hibernate.search>
+      <version.hibernate.search>5.8.0.Beta1</version.hibernate.search>
       <version.hikaricp>2.4.6</version.hikaricp>
       <version.javax.cache>1.0.0</version.javax.cache>
       <version.cdi>1.2</version.cdi>

--- a/integrationtests/elasticsearch-indexmanager-it/README-tests.txt
+++ b/integrationtests/elasticsearch-indexmanager-it/README-tests.txt
@@ -1,5 +1,7 @@
-Tests require a running elasticsearch instance, which is started and stopped by maven.
+Tests require a running Elasticsearch instance, which is downloaded, started and stopped automatically by Maven plugins.
 
-To manually start Elasticsearch and thus run tests from the IDE, run `mvn elasticsearch:run`
+To manually start Elasticsearch and thus run tests from the IDE, run the ./start-elastic.sh script that uses docker.
 
-or alternatively the ./start-elastic.sh script that uses docker.
+Alternatively, after having built it at least once via Maven, you can launch the downloaded version from
+ > cd target/elasticsearch0/bin
+ > ./elasticsearch

--- a/integrationtests/elasticsearch-indexmanager-it/pom.xml
+++ b/integrationtests/elasticsearch-indexmanager-it/pom.xml
@@ -98,39 +98,12 @@
                 </executions>
             </plugin>
             <plugin>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>unpack-es-plugins</id>
-                        <phase>pre-integration-test</phase>
-                        <goals>
-                            <goal>unpack</goal>
-                        </goals>
-                        <configuration>
-                            <skip>${skipTests}</skip>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>org.elasticsearch.plugin</groupId>
-                                    <artifactId>delete-by-query</artifactId>
-                                    <version>${version.elasticsearch}</version>
-                                    <type>zip</type>
-                                    <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/plugins/delete-by-query
-                                    </outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>com.github.alexcojocaru</groupId>
                 <artifactId>elasticsearch-maven-plugin</artifactId>
-                <version>2.3</version>
                 <configuration>
+                    <version>${version.elasticsearch}</version>
                     <skip>${skipTests}</skip>
-                    <clusterName>test</clusterName>
-                    <pluginsPath>${project.build.directory}/plugins/</pluginsPath>
+                    <clusterName>elasticTestCluster</clusterName>
                     <tcpPort>9300</tcpPort>
                     <httpPort>9200</httpPort>
                 </configuration>
@@ -139,7 +112,7 @@
                         <id>start-elasticsearch</id>
                         <phase>pre-integration-test</phase>
                         <goals>
-                            <goal>start</goal>
+                            <goal>runforked</goal>
                         </goals>
                     </execution>
                     <execution>
@@ -150,13 +123,6 @@
                         </goals>
                     </execution>
                 </executions>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.elasticsearch</groupId>
-                        <artifactId>elasticsearch</artifactId>
-                        <version>${version.elasticsearch}</version>
-                    </dependency>
-                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/integrationtests/elasticsearch-indexmanager-it/pom.xml
+++ b/integrationtests/elasticsearch-indexmanager-it/pom.xml
@@ -75,10 +75,10 @@
                     <useFile>false</useFile>
                     <skip>${skipTests}</skip>
                     <properties>
-		                <property>
-		                   <name>usedefaultlisteners</name>
-		                   <value>false</value>
-		                </property>
+                        <property>
+                            <name>usedefaultlisteners</name>
+                            <value>false</value>
+                        </property>
                         <property>
                             <name>listener</name>
                             <value>${testNGListeners}</value>

--- a/integrationtests/elasticsearch-indexmanager-it/src/test/java/org/infinispan/query/it/ClusteredCacheWithElasticsearchIndexManagerIT.java
+++ b/integrationtests/elasticsearch-indexmanager-it/src/test/java/org/infinispan/query/it/ClusteredCacheWithElasticsearchIndexManagerIT.java
@@ -1,6 +1,5 @@
 package org.infinispan.query.it;
 
-import org.hibernate.search.elasticsearch.impl.ElasticsearchIndexManager;
 import org.infinispan.Cache;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
@@ -35,10 +34,8 @@ public class ClusteredCacheWithElasticsearchIndexManagerIT extends ClusteredCach
         cacheCfg.clustering().hash().keyPartitioner(new AffinityPartitioner());
         cacheCfg.indexing()
                 .index(Index.LOCAL)
-                .addIndexedEntity(Person.class)
-                .addProperty("default.indexmanager", ElasticsearchIndexManager.class.getName())
-                .addProperty("default.elasticsearch.refresh_after_write", "true")
-                .addProperty("error_handler", "org.infinispan.query.helper.StaticTestingErrorHandler");
+                .addIndexedEntity(Person.class);
+        ElasticsearchTesting.applyTestProperties(cacheCfg.indexing());
         List<Cache<String, Person>> caches = createClusteredCaches(2, cacheCfg);
         cache1 = caches.get(0);
         cache2 = caches.get(1);

--- a/integrationtests/elasticsearch-indexmanager-it/src/test/java/org/infinispan/query/it/ClusteredCacheWithElasticsearchIndexManagerIT.java
+++ b/integrationtests/elasticsearch-indexmanager-it/src/test/java/org/infinispan/query/it/ClusteredCacheWithElasticsearchIndexManagerIT.java
@@ -17,7 +17,6 @@ import java.util.List;
 @Test(groups = "functional", testName = "query.blackbox.ClusteredCacheWithElasticsearchIndexManagerIT")
 public class ClusteredCacheWithElasticsearchIndexManagerIT extends ClusteredCacheTest {
 
-
     @Override
     public void testCombinationOfFilters() throws Exception {
         // Not supported by hibernate search
@@ -26,6 +25,11 @@ public class ClusteredCacheWithElasticsearchIndexManagerIT extends ClusteredCach
     @Override
     public void testFullTextFilterOnOff() throws Exception {
         // Not supported by hibernate search
+    }
+
+    @Override
+    public void testSearchKeyTransformer() throws Exception {
+        // Will be fixed in Hibernate Search v. 5.8.0.Beta2 : see HSEARCH-2688
     }
 
     @Override

--- a/integrationtests/elasticsearch-indexmanager-it/src/test/java/org/infinispan/query/it/ElasticSearchMassIndexingIT.java
+++ b/integrationtests/elasticsearch-indexmanager-it/src/test/java/org/infinispan/query/it/ElasticSearchMassIndexingIT.java
@@ -20,11 +20,8 @@ public class ElasticSearchMassIndexingIT extends DistributedMassIndexingTest {
     protected void createCacheManagers() throws Throwable {
         ConfigurationBuilder cacheCfg = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, false);
         cacheCfg.indexing().index(Index.LOCAL)
-                .addIndexedEntity(Car.class)
-                .addProperty("default.indexmanager", "elasticsearch")
-                .addProperty("default.elasticsearch.refresh_after_write", "true")
-                .addProperty("error_handler", "org.infinispan.query.helper.StaticTestingErrorHandler")
-                .addProperty("lucene_version", "LUCENE_CURRENT");
+                .addIndexedEntity(Car.class);
+        ElasticsearchTesting.applyTestProperties(cacheCfg.indexing());
         List<Cache<Object, Object>> cacheList = createClusteredCaches(NUM_NODES, cacheCfg);
         defineConfigurationOnAllManagers("default", cacheCfg);
         ConfigurationBuilder indexCache = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, false);

--- a/integrationtests/elasticsearch-indexmanager-it/src/test/java/org/infinispan/query/it/ElasticSearchNonIndexedValuesIT.java
+++ b/integrationtests/elasticsearch-indexmanager-it/src/test/java/org/infinispan/query/it/ElasticSearchNonIndexedValuesIT.java
@@ -1,7 +1,6 @@
 package org.infinispan.query.it;
 
 
-import org.hibernate.search.elasticsearch.impl.ElasticsearchIndexManager;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.Index;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -19,16 +18,13 @@ public class ElasticSearchNonIndexedValuesIT extends NonIndexedValuesTest {
 
     @Override
     protected EmbeddedCacheManager createCacheManager() throws Exception {
-        ConfigurationBuilder c = getDefaultStandaloneCacheConfig(isTransactional());
-        c.indexing()
+        ConfigurationBuilder cacheCfg = getDefaultStandaloneCacheConfig(isTransactional());
+        cacheCfg.indexing()
                 .index(Index.LOCAL)
                 .addIndexedEntity(TestEntity.class)
-                .addIndexedEntity(AnotherTestEntity.class)
-                .addProperty("default.indexmanager", ElasticsearchIndexManager.class.getName())
-                .addProperty("default.elasticsearch.refresh_after_write", "true")
-                .addProperty("error_handler", "org.infinispan.query.helper.StaticTestingErrorHandler")
-                .addProperty("lucene_version", "LUCENE_CURRENT");
-        return TestCacheManagerFactory.createCacheManager(c);
+                .addIndexedEntity(AnotherTestEntity.class);
+        ElasticsearchTesting.applyTestProperties(cacheCfg.indexing());
+        return TestCacheManagerFactory.createCacheManager(cacheCfg);
     }
 
     protected boolean isTransactional() {

--- a/integrationtests/elasticsearch-indexmanager-it/src/test/java/org/infinispan/query/it/ElasticsearchDSLConditionsIT.java
+++ b/integrationtests/elasticsearch-indexmanager-it/src/test/java/org/infinispan/query/it/ElasticsearchDSLConditionsIT.java
@@ -3,7 +3,6 @@ package org.infinispan.query.it;
 import org.infinispan.query.dsl.embedded.ClusteredQueryDslConditionsTest;
 import org.testng.annotations.Test;
 
-import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -20,10 +19,7 @@ public class ElasticsearchDSLConditionsIT extends ClusteredQueryDslConditionsTes
 
     @Override
     protected Map<String, String> getIndexConfig() {
-        Map<String, String> indexConfig = new HashMap<>();
-        indexConfig.put("default.indexmanager", "elasticsearch");
-        indexConfig.put("default.elasticsearch.refresh_after_write", "true");
-        indexConfig.put("lucene_version", "LUCENE_CURRENT");
-        return indexConfig;
+        return ElasticsearchTesting.getConfigProperties();
     }
+
 }

--- a/integrationtests/elasticsearch-indexmanager-it/src/test/java/org/infinispan/query/it/ElasticsearchTesting.java
+++ b/integrationtests/elasticsearch-indexmanager-it/src/test/java/org/infinispan/query/it/ElasticsearchTesting.java
@@ -1,0 +1,29 @@
+package org.infinispan.query.it;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.infinispan.configuration.cache.IndexingConfigurationBuilder;
+
+/**
+ * Recommended configuration properties to run integration tests
+ * with the Hibernate Search / Elasticsearch indexing option.
+ */
+public class ElasticsearchTesting {
+
+   public static Map<String, String> getConfigProperties() {
+      Map<String, String> indexConfig = new HashMap<>();
+      indexConfig.put("default.indexmanager", "elasticsearch");
+      indexConfig.put("default.elasticsearch.required_index_status", "yellow");
+      indexConfig.put("default.elasticsearch.index_schema_management_strategy", "drop-and-create-and-drop");
+      indexConfig.put("default.elasticsearch.refresh_after_write", "true");
+      indexConfig.put("lucene_version", "LUCENE_CURRENT");
+      indexConfig.put("error_handler", "org.infinispan.query.helper.StaticTestingErrorHandler");
+      return indexConfig;
+   }
+
+   public static void applyTestProperties(IndexingConfigurationBuilder indexing) {
+      getConfigProperties().forEach( (k,v) -> indexing.addProperty(k, v));
+   }
+
+}

--- a/integrationtests/elasticsearch-indexmanager-it/start-elastic.sh
+++ b/integrationtests/elasticsearch-indexmanager-it/start-elastic.sh
@@ -13,11 +13,6 @@ function startElastic()
   waitForElastic
 }
 
-function installPlugins()
-{
-  docker exec elastic bin/plugin install delete-by-query
-}
-
 function restartElastic()
 {
   docker restart elastic
@@ -25,5 +20,4 @@ function restartElastic()
 }
 
 startElastic
-installPlugins
 restartElastic

--- a/integrationtests/wildfly-modules/pom.xml
+++ b/integrationtests/wildfly-modules/pom.xml
@@ -141,12 +141,6 @@
       </dependency>
 
       <dependency>
-         <groupId>org.elasticsearch.plugin</groupId>
-         <artifactId>delete-by-query</artifactId>
-         <scope>test</scope>
-      </dependency>
-
-      <dependency>
          <groupId>org.elasticsearch</groupId>
          <artifactId>elasticsearch</artifactId>
          <scope>test</scope>

--- a/integrationtests/wildfly-modules/pom.xml
+++ b/integrationtests/wildfly-modules/pom.xml
@@ -262,37 +262,15 @@
                      </artifactItems>
                   </configuration>
                </execution>
-               <execution>
-                  <id>unpack-es-plugins</id>
-                  <phase>pre-integration-test</phase>
-                  <goals>
-                     <goal>unpack</goal>
-                  </goals>
-                  <configuration>
-                     <skip>${skipTests}</skip>
-                     <artifactItems>
-                        <artifactItem>
-                           <groupId>org.elasticsearch.plugin</groupId>
-                           <artifactId>delete-by-query</artifactId>
-                           <version>${version.elasticsearch}</version>
-                           <type>zip</type>
-                           <overWrite>true</overWrite>
-                           <outputDirectory>${project.build.directory}/plugins/delete-by-query
-                           </outputDirectory>
-                        </artifactItem>
-                     </artifactItems>
-                  </configuration>
-               </execution>
             </executions>
          </plugin>
          <plugin>
             <groupId>com.github.alexcojocaru</groupId>
             <artifactId>elasticsearch-maven-plugin</artifactId>
-            <version>2.3</version>
             <configuration>
+               <version>${version.elasticsearch}</version>
                <skip>${skipTests}</skip>
-               <clusterName>test</clusterName>
-               <pluginsPath>${project.build.directory}/plugins/</pluginsPath>
+               <clusterName>elasticTestCluster</clusterName>
                <tcpPort>9300</tcpPort>
                <httpPort>9200</httpPort>
             </configuration>
@@ -301,7 +279,7 @@
                   <id>start-elasticsearch</id>
                   <phase>pre-integration-test</phase>
                   <goals>
-                     <goal>start</goal>
+                     <goal>runforked</goal>
                   </goals>
                </execution>
                <execution>
@@ -312,13 +290,6 @@
                   </goals>
                </execution>
             </executions>
-            <dependencies>
-               <dependency>
-                  <groupId>org.elasticsearch</groupId>
-                  <artifactId>elasticsearch</artifactId>
-                  <version>${version.elasticsearch}</version>
-               </dependency>
-            </dependencies>
          </plugin>
 
          <plugin>

--- a/integrationtests/wildfly-modules/src/test/resources/elasticsearch-indexing.xml
+++ b/integrationtests/wildfly-modules/src/test/resources/elasticsearch-indexing.xml
@@ -16,6 +16,8 @@
             <indexing index="LOCAL">
                 <property name="default.indexmanager">elasticsearch</property>
                 <property name="default.elasticsearch.refresh_after_write">true</property>
+                <property name="default.elasticsearch.required_index_status">yellow</property>
+                <property name="default.elasticsearch.index_schema_management_strategy">drop-and-create-and-drop</property>
             </indexing>
         </distributed-cache>
     </cache-container>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -114,7 +114,7 @@
       <version.commons.io>2.5</version.commons.io>
       <version.commons.logging>1.2</version.commons.logging>
       <version.commons.math>2.2</version.commons.math>
-      <version.elasticsearch>2.4.4</version.elasticsearch>
+      <version.elasticsearch>5.3.0</version.elasticsearch>
       <version.geronimo.tm>3.1.1</version.geronimo.tm>
       <version.h2.driver>1.4.180</version.h2.driver>
       <version.h2.driver-within-wildfly>1.3.173</version.h2.driver-within-wildfly>
@@ -994,12 +994,6 @@
          <dependency>
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>
-            <version>${version.elasticsearch}</version>
-            <scope>test</scope>
-         </dependency>
-         <dependency>
-            <groupId>org.elasticsearch.plugin</groupId>
-            <artifactId>delete-by-query</artifactId>
             <version>${version.elasticsearch}</version>
             <scope>test</scope>
          </dependency>

--- a/query/src/main/java/org/infinispan/query/impl/LifecycleManager.java
+++ b/query/src/main/java/org/infinispan/query/impl/LifecycleManager.java
@@ -315,12 +315,25 @@ public class LifecycleManager extends AbstractModuleLifecycle {
                indexedEntities = new Class[0];
             }
          }
+         allowDynamicSortingByDefault(indexingProperties);
          // Set up the search factory for Hibernate Search first.
          SearchConfiguration config = new SearchableCacheConfiguration(indexedEntities, indexingProperties, uninitializedCacheManager, cr);
          searchFactory = new SearchIntegratorBuilder().configuration(config).buildSearchIntegrator();
          cr.registerComponent(searchFactory, SearchIntegrator.class);
       }
       return searchFactory;
+   }
+
+   /**
+    * Dynamic index uninverting is deprecated: using it will cause warnings to be logged,
+    * to encourage people to use the annotation org.hibernate.search.annotations.SortableField.
+    * The default in Hibernate Search is to throw an exception rather than logging a warning;
+    * we opt to be more lenient by default in the Infinispan use case, matching the behaviour
+    * of previous versions of Hibernate Search.
+    * @param indexingProperties
+    */
+   private void allowDynamicSortingByDefault(Properties indexingProperties) {
+      indexingProperties.putIfAbsent( Environment.INDEX_UNINVERTING_ALLOWED, Boolean.TRUE.toString() );
    }
 
    private Properties addProgrammaticMappings(Properties indexingProperties, ComponentRegistry cr) {

--- a/query/src/test/java/org/infinispan/query/blackbox/TopologyAwareClusteredCacheTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/TopologyAwareClusteredCacheTest.java
@@ -19,7 +19,7 @@ public class TopologyAwareClusteredCacheTest extends ClusteredCacheTest {
    @Override
    protected void createCacheManagers() throws Throwable {
       List caches = TestQueryHelperFactory.createTopologyAwareCacheNodes(
-               2, getCacheMode(), transactionEnabled(), isIndexLocalOnly(), isRamDirectory(), "default");
+               2, getCacheMode(), transactionEnabled(), isIndexLocalOnly(), isRamDirectory(), "default", Person.class);
 
       for (Object cache : caches) {
          cacheManagers.add(((Cache) cache).getCacheManager());

--- a/query/src/test/java/org/infinispan/query/blackbox/TopologyAwareClusteredQueryTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/TopologyAwareClusteredQueryTest.java
@@ -19,7 +19,7 @@ public class TopologyAwareClusteredQueryTest extends ClusteredQueryTest {
    @Override
    protected void createCacheManagers() throws Throwable {
       List caches = TestQueryHelperFactory.createTopologyAwareCacheNodes(2, getCacheMode(), transactionEnabled(),
-                                                                         isIndexLocalOnly(), isRamDirectory(), "default");
+                                                                         isIndexLocalOnly(), isRamDirectory(), "default", Person.class);
 
       for(Object cache : caches) {
          cacheManagers.add(((Cache) cache).getCacheManager());

--- a/query/src/test/java/org/infinispan/query/distributed/TopologyAwareDistMassIndexingTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/TopologyAwareDistMassIndexingTest.java
@@ -3,10 +3,9 @@ package org.infinispan.query.distributed;
 import org.infinispan.Cache;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.Configuration;
-import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.hibernate.search.spi.InfinispanIntegration;
-import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.query.helper.TestQueryHelperFactory;
+import org.infinispan.query.queries.faceting.Car;
 import org.testng.annotations.Test;
 
 /**
@@ -23,7 +22,8 @@ public class TopologyAwareDistMassIndexingTest extends DistributedMassIndexingTe
                      .clustering().stateTransfer().fetchInMemoryState(true).build();
                holder.newConfigurationBuilder(InfinispanIntegration.DEFAULT_INDEXESDATA_CACHENAME).read(cacheCfg1);
                holder.newConfigurationBuilder(InfinispanIntegration.DEFAULT_LOCKING_CACHENAME).read(cacheCfg1);
-            });
+            },
+            Car.class);
 
       for(Object cache : caches) {
          Cache cacheObj = (Cache) cache;

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/impl/model/TheEntity.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/impl/model/TheEntity.java
@@ -4,6 +4,7 @@ import org.hibernate.search.annotations.Analyze;
 import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.Indexed;
 import org.hibernate.search.annotations.IndexedEmbedded;
+import org.hibernate.search.annotations.SortableField;
 import org.hibernate.search.annotations.Store;
 
 /**
@@ -17,6 +18,7 @@ public class TheEntity {
     * Set a different name to demonstrate field mapping.
     */
    @Field(name = "theField", store = Store.YES, analyze = Analyze.NO)
+   @SortableField(forField="theField")
    private String fieldX;
 
    @IndexedEmbedded(indexNullAs = Field.DEFAULT_NULL_TOKEN)

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/testdomain/hsearch/AccountHS.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/testdomain/hsearch/AccountHS.java
@@ -31,6 +31,7 @@ public class AccountHS implements Account, Serializable, ExternalPojo {
 
    @Field(store = Store.YES, analyze = Analyze.NO)
    @DateBridge(encoding=EncodingType.STRING, resolution=Resolution.MILLISECOND)
+   @SortableField
    private Date creationDate;
 
    public int getId() {

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/testdomain/hsearch/TransactionHS.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/testdomain/hsearch/TransactionHS.java
@@ -49,6 +49,7 @@ public class TransactionHS implements Transaction, Serializable, ExternalPojo {
 
    @Field(store = Store.YES, analyze = Analyze.NO)
    @NumericField
+   @SortableField
    private double amount;
 
    @Field(store = Store.YES, analyze = Analyze.NO)

--- a/query/src/test/java/org/infinispan/query/helper/TestQueryHelperFactory.java
+++ b/query/src/test/java/org/infinispan/query/helper/TestQueryHelperFactory.java
@@ -63,14 +63,14 @@ public class TestQueryHelperFactory {
    }
 
    public static List createTopologyAwareCacheNodes(int numberOfNodes, CacheMode cacheMode, boolean transactional,
-         boolean indexLocalOnly, boolean isRamDirectoryProvider, String defaultCacheName) {
+         boolean indexLocalOnly, boolean isRamDirectoryProvider, String defaultCacheName, Class... indexedTypes) {
       return createTopologyAwareCacheNodes(numberOfNodes, cacheMode, transactional, indexLocalOnly,
-            isRamDirectoryProvider, defaultCacheName, f -> {});
+            isRamDirectoryProvider, defaultCacheName, f -> {}, indexedTypes);
    }
 
    public static List createTopologyAwareCacheNodes(int numberOfNodes, CacheMode cacheMode, boolean transactional,
          boolean indexLocalOnly, boolean isRamDirectoryProvider, String defaultCacheName,
-         Consumer<ConfigurationBuilderHolder> holderConsumer) {
+         Consumer<ConfigurationBuilderHolder> holderConsumer, Class... indexedTypes) {
       List caches = new ArrayList();
 
       ConfigurationBuilder builder = AbstractCacheTest.getDefaultClusteredCacheConfig(cacheMode, transactional);
@@ -79,21 +79,20 @@ public class TestQueryHelperFactory {
 
       if (isRamDirectoryProvider) {
          builder.indexing()
-            .addIndexedEntity(Person.class)
-            .addIndexedEntity(Car.class)
             .addProperty("default.directory_provider", "ram")
             .addProperty("lucene_version", "LUCENE_CURRENT")
             .addProperty("error_handler", "org.infinispan.query.helper.StaticTestingErrorHandler");
       } else {
          builder.indexing()
-            .addIndexedEntity(Person.class)
-            .addIndexedEntity(Car.class)
             .addProperty("default.indexmanager", "org.infinispan.query.indexmanager.InfinispanIndexManager")
             .addProperty("lucene_version", "LUCENE_CURRENT")
             .addProperty("error_handler", "org.infinispan.query.helper.StaticTestingErrorHandler");
          if (cacheMode.isClustered()) {
             builder.clustering().stateTransfer().fetchInMemoryState(true);
          }
+      }
+      for (Class indexedType : indexedTypes) {
+         builder.indexing().addIndexedEntity(indexedType);
       }
 
       for (int i = 0; i < numberOfNodes; i++) {

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/indexing/IndexingTagHandler.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/indexing/IndexingTagHandler.java
@@ -29,13 +29,13 @@ final class IndexingTagHandler implements TagHandler {
    private static final NullMarkerCodec NULL_TOKEN_CODEC = new LuceneStringNullMarkerCodec(new ToStringNullMarker(IndexingMetadata.DEFAULT_NULL_TOKEN));
 
    private static final LuceneOptions NOT_STORED_NOT_ANALYZED = new LuceneOptionsImpl(
-         new DocumentFieldMetadata.Builder(new BackReference<>(), new BackReference<>(), null, Store.NO, Field.Index.NOT_ANALYZED, Field.TermVector.NO)
+         new DocumentFieldMetadata.Builder(BackReference.empty(), BackReference.empty(), null, null, Store.NO, Field.Index.NOT_ANALYZED, Field.TermVector.NO)
                .indexNullAs(NULL_TOKEN_CODEC)
                .boost(1.0F)
                .build(), 1.0F, 1.0F);
 
    private static final LuceneOptions STORED_NOT_ANALYZED = new LuceneOptionsImpl(
-         new DocumentFieldMetadata.Builder(new BackReference<>(), new BackReference<>(), null, Store.YES, Field.Index.NOT_ANALYZED, Field.TermVector.NO)
+         new DocumentFieldMetadata.Builder(BackReference.empty(), BackReference.empty(), null, null, Store.YES, Field.Index.NOT_ANALYZED, Field.TermVector.NO)
                .indexNullAs(NULL_TOKEN_CODEC)
                .boost(1.0F)
                .build(), 1.0F, 1.0F);

--- a/wildfly-modules/build.xml
+++ b/wildfly-modules/build.xml
@@ -209,7 +209,7 @@
 
         <!-- Infinispan/Lucene targeting the latest community release of Hibernate Search which we support -->
         <hibernatesearch-directoryprovide-module
-            slot="for-hibernatesearch-5.7" hibernatesearch.slot="5.7" lucene.slot="5.5" />
+            slot="for-hibernatesearch-5.8" hibernatesearch.slot="5.8" lucene.slot="5.5" />
 
         <!-- Infinispan/Lucene targeting the version of Hibernate Search included in WildFly -->
         <hibernatesearch-directoryprovide-module


### PR DESCRIPTION
Upgrading Hibernate Search to the latest.

Headlines are here, essentially it now supports Elasticsearch 5 and the client is much improved:
 - http://in.relation.to/2017/04/15/HibernateSearchNowSpeakingEs5/

Relevant for Infinispan: several internal bugfixes, some small performance improvements and most notably we flipped the default value for this configuration property:
 - https://docs.jboss.org/hibernate/search/5.8/api/org/hibernate/search/cfg/Environment.html#INDEX_UNINVERTING_ALLOWED

This PR includes a "flip back" of the defaults for Infinispan, as I believe Infinispan Server is not ready to handle that yet.

 - https://issues.jboss.org/browse/ISPN-7670
