### PR TITLE
ISPN-7743

### DIFF
--- a/core/src/test/java/org/infinispan/stream/DistributedStreamIteratorTest.java
+++ b/core/src/test/java/org/infinispan/stream/DistributedStreamIteratorTest.java
@@ -243,7 +243,7 @@ public class DistributedStreamIteratorTest extends BaseClusteredStreamIteratorTe
       checkPoint.awaitStrict("pre_iterator_invoked", 10, TimeUnit.SECONDS);
 
       // Now kill the cache - we should recover and get appropriate values
-      killMember(1, CACHE_NAME);
+      killMember(1, CACHE_NAME, false);
 
       // Now let them process the results
       checkPoint.triggerForever("pre_iterator_released");


### PR DESCRIPTION
DistributedStreamIteratorTest.testNodeLeavesWhileIteratingOverContainerCausingRehashToLoseValues
fails randomly

* Don't force mainline to wait for rehash - stream does this

Not waiting for rehash allows the remote thread to return earlier which in turn causes less issues with rehash.