### PR TITLE
ISPN-7759 Shaded version of Infinispan Query Embedded should not inco…

### DIFF
--- a/integrationtests/all-embedded-query-it/pom.xml
+++ b/integrationtests/all-embedded-query-it/pom.xml
@@ -18,6 +18,10 @@
          <artifactId>infinispan-embedded-query</artifactId>
       </dependency>
       <dependency>
+         <groupId>org.hibernate</groupId>
+         <artifactId>hibernate-search-elasticsearch</artifactId>
+      </dependency>
+      <dependency>
          <groupId>javax.transaction</groupId>
          <artifactId>transaction-api</artifactId>
          <version>1.1</version>

--- a/query/pom.xml
+++ b/query/pom.xml
@@ -61,6 +61,7 @@
       <dependency>
          <groupId>org.hibernate</groupId>
          <artifactId>hibernate-search-elasticsearch</artifactId>
+         <optional>true</optional>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
…rporate the Elasticsearch components

 - https://issues.jboss.org/browse/ISPN-7759


This one-lines will change the shaded artifact of ` infinispan-embedded-query` from this:

[INFO] --- maven-shade-plugin:2.4.3:shade (default) @ infinispan-embedded-query ---
[INFO] Excluding org.infinispan:infinispan-embedded:jar:9.1.0-SNAPSHOT from the shaded jar.
[INFO] Excluding org.jboss.spec.javax.transaction:jboss-transaction-api_1.1_spec:jar:1.0.1.Final from the shaded jar.
[INFO] Including org.infinispan:infinispan-query:jar:9.1.0-SNAPSHOT in the shaded jar.
[INFO] Excluding org.infinispan:infinispan-core:jar:9.1.0-SNAPSHOT from the shaded jar.
[INFO] Excluding org.infinispan:infinispan-commons:jar:9.1.0-SNAPSHOT from the shaded jar.
[INFO] Excluding org.jgroups:jgroups:jar:4.0.1.Final from the shaded jar.
[INFO] Including com.github.ben-manes.caffeine:caffeine:jar:2.4.0 in the shaded jar.
[INFO] Excluding org.jboss.marshalling:jboss-marshalling-osgi:jar:2.0.0.Beta3 from the shaded jar.
[INFO] Including org.jboss.logging:jboss-logging:jar:3.3.0.Final in the shaded jar.
[INFO] Including org.infinispan:infinispan-query-dsl:jar:9.1.0-SNAPSHOT in the shaded jar.
[INFO] Including org.infinispan:infinispan-objectfilter:jar:9.1.0-SNAPSHOT in the shaded jar.
[INFO] Including org.antlr:antlr-runtime:jar:3.4 in the shaded jar.
[INFO] Including org.antlr:stringtemplate:jar:3.2.1 in the shaded jar.
[INFO] Including antlr:antlr:jar:2.7.7 in the shaded jar.
[INFO] Including org.hibernate:hibernate-search-engine:jar:5.8.0.Beta1 in the shaded jar.
[INFO] Including org.hibernate.common:hibernate-commons-annotations:jar:5.0.1.Final in the shaded jar.
[INFO] Including org.apache.lucene:lucene-core:jar:5.5.4 in the shaded jar.
[INFO] Including org.apache.lucene:lucene-misc:jar:5.5.4 in the shaded jar.
[INFO] Including org.apache.lucene:lucene-analyzers-common:jar:5.5.4 in the shaded jar.
[INFO] Including org.apache.lucene:lucene-facet:jar:5.5.4 in the shaded jar.
[INFO] Including org.apache.lucene:lucene-queries:jar:5.5.4 in the shaded jar.
[INFO] Including org.apache.lucene:lucene-queryparser:jar:5.5.4 in the shaded jar.
[INFO] Including org.infinispan:infinispan-directory-provider:jar:9.1.0-SNAPSHOT in the shaded jar.
[INFO] Including org.hibernate:hibernate-search-serialization-avro:jar:5.8.0.Beta1 in the shaded jar.
[INFO] Including org.apache.avro:avro:jar:1.7.6 in the shaded jar.
[INFO] Including org.codehaus.jackson:jackson-core-asl:jar:1.9.13 in the shaded jar.
[INFO] Including org.codehaus.jackson:jackson-mapper-asl:jar:1.9.13 in the shaded jar.
[INFO] Including com.thoughtworks.paranamer:paranamer:jar:2.3 in the shaded jar.
[INFO] Including org.apache.commons:commons-compress:jar:1.4 in the shaded jar.
[INFO] Including org.slf4j:slf4j-api:jar:1.7.7.jbossorg-1 in the shaded jar.
[INFO] Including org.hibernate:hibernate-search-elasticsearch:jar:5.8.0.Beta1 in the shaded jar.
[INFO] Including org.elasticsearch.client:rest:jar:5.3.0 in the shaded jar.
[INFO] Including org.apache.httpcomponents:httpclient:jar:4.5 in the shaded jar.
[INFO] Including org.apache.httpcomponents:httpcore:jar:4.4.1 in the shaded jar.
[INFO] Including org.apache.httpcomponents:httpasyncclient:jar:4.1.2 in the shaded jar.
[INFO] Including org.apache.httpcomponents:httpcore-nio:jar:4.4.1 in the shaded jar.
[INFO] Including commons-codec:commons-codec:jar:1.4 in the shaded jar.
[INFO] Including commons-logging:commons-logging:jar:1.2 in the shaded jar.
[INFO] Including org.elasticsearch.client:sniffer:jar:5.3.0 in the shaded jar.
[INFO] Including com.fasterxml.jackson.core:jackson-core:jar:2.8.6 in the shaded jar.
[INFO] Including com.google.code.gson:gson:jar:2.8.0 in the shaded jar.
[INFO] Including org.infinispan:infinispan-lucene-directory:jar:9.1.0-SNAPSHOT in the shaded jar.
[INFO] Excluding net.jcip:jcip-annotations:jar:1.0 from the shaded jar.


To this:

[INFO] --- maven-shade-plugin:2.4.3:shade (default) @ infinispan-embedded-query ---
[INFO] Excluding org.infinispan:infinispan-embedded:jar:9.1.0-SNAPSHOT from the shaded jar.
[INFO] Excluding org.jboss.spec.javax.transaction:jboss-transaction-api_1.1_spec:jar:1.0.1.Final from the shaded jar.
[INFO] Including org.infinispan:infinispan-query:jar:9.1.0-SNAPSHOT in the shaded jar.
[INFO] Excluding org.infinispan:infinispan-core:jar:9.1.0-SNAPSHOT from the shaded jar.
[INFO] Excluding org.infinispan:infinispan-commons:jar:9.1.0-SNAPSHOT from the shaded jar.
[INFO] Excluding org.jgroups:jgroups:jar:4.0.1.Final from the shaded jar.
[INFO] Including com.github.ben-manes.caffeine:caffeine:jar:2.4.0 in the shaded jar.
[INFO] Excluding org.jboss.marshalling:jboss-marshalling-osgi:jar:2.0.0.Beta3 from the shaded jar.
[INFO] Including org.jboss.logging:jboss-logging:jar:3.3.0.Final in the shaded jar.
[INFO] Including org.infinispan:infinispan-query-dsl:jar:9.1.0-SNAPSHOT in the shaded jar.
[INFO] Including org.infinispan:infinispan-objectfilter:jar:9.1.0-SNAPSHOT in the shaded jar.
[INFO] Including org.antlr:antlr-runtime:jar:3.4 in the shaded jar.
[INFO] Including org.antlr:stringtemplate:jar:3.2.1 in the shaded jar.
[INFO] Including antlr:antlr:jar:2.7.7 in the shaded jar.
[INFO] Including org.hibernate:hibernate-search-engine:jar:5.8.0.Beta1 in the shaded jar.
[INFO] Including org.hibernate.common:hibernate-commons-annotations:jar:5.0.1.Final in the shaded jar.
[INFO] Including org.apache.lucene:lucene-core:jar:5.5.4 in the shaded jar.
[INFO] Including org.apache.lucene:lucene-misc:jar:5.5.4 in the shaded jar.
[INFO] Including org.apache.lucene:lucene-analyzers-common:jar:5.5.4 in the shaded jar.
[INFO] Including org.apache.lucene:lucene-facet:jar:5.5.4 in the shaded jar.
[INFO] Including org.apache.lucene:lucene-queries:jar:5.5.4 in the shaded jar.
[INFO] Including org.apache.lucene:lucene-queryparser:jar:5.5.4 in the shaded jar.
[INFO] Including org.infinispan:infinispan-directory-provider:jar:9.1.0-SNAPSHOT in the shaded jar.
[INFO] Including org.hibernate:hibernate-search-serialization-avro:jar:5.8.0.Beta1 in the shaded jar.
[INFO] Including org.apache.avro:avro:jar:1.7.6 in the shaded jar.
[INFO] Including org.codehaus.jackson:jackson-core-asl:jar:1.9.13 in the shaded jar.
[INFO] Including org.codehaus.jackson:jackson-mapper-asl:jar:1.9.13 in the shaded jar.
[INFO] Including com.thoughtworks.paranamer:paranamer:jar:2.3 in the shaded jar.
[INFO] Including org.apache.commons:commons-compress:jar:1.4 in the shaded jar.
[INFO] Including org.slf4j:slf4j-api:jar:1.7.7.jbossorg-1 in the shaded jar.
[INFO] Including org.infinispan:infinispan-lucene-directory:jar:9.1.0-SNAPSHOT in the shaded jar.
[INFO] Excluding net.jcip:jcip-annotations:jar:1.0 from the shaded jar.
[INFO] Replacing original artifact with shaded artifact.
