### PR TITLE
ISPN-7784 BytesObjectInput doesn't implement ObjectInput properly

### DIFF
--- a/core/src/main/java/org/infinispan/marshall/core/ExternalJBossMarshaller.java
+++ b/core/src/main/java/org/infinispan/marshall/core/ExternalJBossMarshaller.java
@@ -146,17 +146,13 @@ final class ExternalJBossMarshaller implements StreamingMarshaller {
 
       @Override
       public int read() throws IOException {
-         try {
-            return in.readUnsignedByte();
-         } catch (ArrayIndexOutOfBoundsException e) {
-            // When JBoss Marshalling starts reading a stream, it buffers
-            // the contents, so it'll try as read as much as it can, so it
-            // can end up reading too far, in which case return -1 to signal
-            // that the end of the stream has been reached
-            return -1;
-         }
+         return in.read();
       }
 
+      @Override
+      public int read(byte[] b, int off, int len) throws IOException {
+         return in.read(b, off, len);
+      }
    }
 
 }

--- a/core/src/main/java/org/infinispan/marshall/core/Primitives.java
+++ b/core/src/main/java/org/infinispan/marshall/core/Primitives.java
@@ -1,5 +1,6 @@
 package org.infinispan.marshall.core;
 
+import java.io.EOFException;
 import java.io.IOException;
 
 import org.jboss.marshalling.util.IdentityIntMap;
@@ -398,7 +399,7 @@ final class Primitives {
       return new boolean[len];
    }
 
-   private static boolean[] readBooleans(boolean[] arr, BytesObjectInput in) {
+   private static boolean[] readBooleans(boolean[] arr, BytesObjectInput in) throws EOFException {
       final int len = arr.length;
       int v;
       int bc = len & ~7;


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-7784

Return -1 instead of throwing an exception at the end of the buffer.