### PR TITLE
ISPN-7838 Fix JBoss Modules NPE in Domain mode

### DIFF
--- a/server/integration/feature-pack/pom.xml
+++ b/server/integration/feature-pack/pom.xml
@@ -566,6 +566,18 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jboss.marshalling</groupId>
+            <artifactId>jboss-marshalling-river</artifactId>
+            <version>${version.org.jboss.marshalling.jboss-marshalling}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.marshalling</groupId>
+                    <artifactId>jboss-marshalling</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-netty4</artifactId>
             <exclusions>

--- a/server/integration/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/marshalling/river/main/module.xml
+++ b/server/integration/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/marshalling/river/main/module.xml
@@ -2,7 +2,7 @@
 
 <module xmlns="urn:jboss:module:1.3" name="org.jboss.marshalling.river">
     <resources>
-       <!-- empty placeholder module -->
+        <artifact name="${org.jboss.marshalling:jboss-marshalling-river}"/>
     </resources>
 
     <dependencies>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-7838

I think we will need this for 9.0.x and probably 8.2.x.

@galderz @tristantarrant For ISPN-7652 it wasn't sufficient to simply ignore the river marshaller because wildfly-core depends on the river marshaller [upon domain startup](https://github.com/wildfly/wildfly-core/blob/master/server/src/main/java/org/jboss/as/server/DomainServerMain.java#L116), hence the NPE we encounter. So instead, we now explicitly depend on the version we need (2.0.0.Beta3), whilst excluding jboss-marshalling from this jar. This resolves the NPE and prevents `rg.infinispan.server.test.client.hotrod.HotRodRemoteCacheIT` from failing (as discussed [here](https://github.com/infinispan/infinispan/pull/4709))