### PR TITLE
[PRVIEW] regular reads

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -52,7 +52,7 @@
    </issueManagement>
 
    <properties>
-      <infinispan.codename>Ruppaner.1</infinispan.codename>
+      <infinispan.codename>Less Threads</infinispan.codename>
       <infinispan.core.schema.version>9.1</infinispan.core.schema.version>
 
       <version.java>1.8</version.java>

--- a/core/src/main/java/org/infinispan/interceptors/impl/BaseRpcInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/BaseRpcInterceptor.java
@@ -78,8 +78,8 @@ public abstract class BaseRpcInterceptor extends DDAsyncInterceptor {
    }
 
    private void initRpcOptions() {
-      singleTargetStaggeredOptions = rpcManager.getRpcOptionsBuilder(ResponseMode.SYNCHRONOUS_IGNORE_LEAVERS).build();
-      multiTargetStaggeredOptions = rpcManager.getRpcOptionsBuilder(ResponseMode.WAIT_FOR_VALID_RESPONSE)
+      singleTargetStaggeredOptions = rpcManager.getRpcOptionsBuilder(ResponseMode.SYNCHRONOUS_IGNORE_LEAVERS, DeliverOrder.PER_SENDER).build();
+      multiTargetStaggeredOptions = rpcManager.getRpcOptionsBuilder(ResponseMode.WAIT_FOR_VALID_RESPONSE, DeliverOrder.PER_SENDER)
             .responseFilter(SUCCESSFUL_OR_EXCEPTIONAL).build();
       defaultSyncOptions = rpcManager.getDefaultRpcOptions(true);
       syncIgnoreLeavers = rpcManager.getRpcOptionsBuilder(ResponseMode.SYNCHRONOUS_IGNORE_LEAVERS, DeliverOrder.NONE).build();

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/CommandAwareRpcDispatcher.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/CommandAwareRpcDispatcher.java
@@ -13,6 +13,7 @@ import java.util.concurrent.TimeUnit;
 import org.infinispan.IllegalLifecycleStateException;
 import org.infinispan.commands.FlagAffectedCommand;
 import org.infinispan.commands.ReplicableCommand;
+import org.infinispan.commands.remote.ClusteredGetCommand;
 import org.infinispan.commons.CacheException;
 import org.infinispan.commons.io.ByteBuffer;
 import org.infinispan.commons.marshall.StreamingMarshaller;
@@ -238,6 +239,9 @@ public class CommandAwareRpcDispatcher extends MessageDispatcher {
          // Always set the NO_FC flag
          short flags = (short) (req.getFlags() | REPLY_FLAGS_TO_SET & ~REPLY_FLAGS_TO_CLEAR);
          Message rsp = req.makeReply().setFlag(flags).setBuffer(rsp_buf);
+         if (command instanceof ClusteredGetCommand) {
+            rsp.clearFlag(Message.Flag.OOB);
+         }
 
          //exceptionThrown is always false because the exceptions are wrapped in an ExceptionResponse
          try {


### PR DESCRIPTION
It changes the reads requests and response from OOB messages to Regular messages.
IspnPerfTests shows slightly performance improvement and one order of magnitude lower thread pool usages (concrete number with 8 node, 150 -> 14 threads).