### PR TITLE
ISPN-7866 Remove metadata param from CacheEntry.commit()

### DIFF
--- a/core/src/main/java/org/infinispan/container/entries/AbstractInternalCacheEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/AbstractInternalCacheEntry.java
@@ -24,7 +24,7 @@ public abstract class AbstractInternalCacheEntry implements InternalCacheEntry {
    }
 
    @Override
-   public final void commit(DataContainer container, Metadata metadata) {
+   public final void commit(DataContainer container) {
       // no-op
    }
 

--- a/core/src/main/java/org/infinispan/container/entries/CacheEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/CacheEntry.java
@@ -112,8 +112,19 @@ public interface CacheEntry<K, V> extends Cloneable, Map.Entry<K, V>, MetadataAw
     * Commits changes
     *
     * @param container data container to commit to
+    * @deprecated since 9.1
     */
-   void commit(DataContainer<K, V> container, Metadata metadata);
+   @Deprecated
+   default void commit(DataContainer<K, V> container, Metadata metadata) {
+      commit(container);
+   }
+
+   /**
+    * Commits changes
+    *
+    * @param container data container to commit to
+    */
+   void commit(DataContainer<K, V> container);
 
    /**
     * Rolls back changes

--- a/core/src/main/java/org/infinispan/container/entries/ClearCacheEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/ClearCacheEntry.java
@@ -120,7 +120,7 @@ public class ClearCacheEntry<K, V> implements CacheEntry<K, V> {
    }
 
    @Override
-   public void commit(DataContainer<K, V> container, Metadata metadata) {
+   public void commit(DataContainer<K, V> container) {
       container.clear();
    }
 

--- a/core/src/main/java/org/infinispan/container/entries/ForwardingCacheEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/ForwardingCacheEntry.java
@@ -79,8 +79,8 @@ public abstract class ForwardingCacheEntry<K, V> implements CacheEntry<K, V> {
    }
 
    @Override
-   public void commit(DataContainer container, Metadata metadata) {
-      delegate().commit(container, metadata);
+   public void commit(DataContainer container) {
+      delegate().commit(container);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/container/entries/NullCacheEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/NullCacheEntry.java
@@ -80,7 +80,7 @@ public class NullCacheEntry<K, V> implements CacheEntry<K, V> {
    }
 
    @Override
-   public void commit(DataContainer container, Metadata metadata) {
+   public void commit(DataContainer container) {
       // No-op
    }
 

--- a/core/src/main/java/org/infinispan/container/entries/ReadCommittedEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/ReadCommittedEntry.java
@@ -115,14 +115,14 @@ public class ReadCommittedEntry implements MVCCEntry {
    }
 
    @Override
-   public final void commit(DataContainer container, Metadata providedMetadata) {
+   public final void commit(DataContainer container) {
       // TODO: No tombstones for now!!  I'll only need them for an eventually consistent cache
 
       // only do stuff if there are changes.
       if (isChanged()) {
          if (trace)
-            log.tracef("Updating entry (key=%s removed=%s valid=%s changed=%s created=%s value=%s metadata=%s, providedMetadata=%s)",
-                  toStr(getKey()), isRemoved(), isValid(), isChanged(), isCreated(), toStr(value), getMetadata(), providedMetadata);
+            log.tracef("Updating entry (key=%s removed=%s valid=%s changed=%s created=%s value=%s metadata=%s)",
+                  toStr(getKey()), isRemoved(), isValid(), isChanged(), isCreated(), toStr(value), getMetadata());
 
          // Ugh!
          if (value instanceof AtomicHashMap) {
@@ -143,7 +143,7 @@ public class ReadCommittedEntry implements MVCCEntry {
             // Can't just rely on the entry's metadata because it could have
             // been modified by the interceptor chain (i.e. new version
             // generated if none provided by the user)
-            container.put(key, value, providedMetadata == null ? metadata : providedMetadata);
+            container.put(key, value, metadata);
          }
       }
    }

--- a/core/src/main/java/org/infinispan/interceptors/impl/VersionedEntryWrappingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/VersionedEntryWrappingInterceptor.java
@@ -80,7 +80,7 @@ public class VersionedEntryWrappingInterceptor extends EntryWrappingInterceptor 
          }
 
          if (onePhaseCommit) {
-            commitContextEntries(txInvocationContext, null, null);
+            commitContextEntries(txInvocationContext, null);
          }
          return newVersionData;
       });
@@ -102,32 +102,31 @@ public class VersionedEntryWrappingInterceptor extends EntryWrappingInterceptor 
          ((TxInvocationContext<?>) rCtx).getCacheTransaction().setUpdatedEntryVersions(
                versionedCommitCommand.getUpdatedVersions());
       }
-      commitContextEntries(rCtx, null, null);
+      commitContextEntries(rCtx, null);
    }
 
    @Override
    protected void commitContextEntry(CacheEntry entry, InvocationContext ctx, FlagAffectedCommand command,
-                                     Metadata metadata, Flag stateTransferFlag, boolean l1Invalidation) {
+                                     Flag stateTransferFlag, boolean l1Invalidation) {
       if (ctx.isInTxScope() && stateTransferFlag == null) {
          EntryVersion updatedEntryVersion = ((TxInvocationContext) ctx)
                .getCacheTransaction().getUpdatedEntryVersions().get(entry.getKey());
          Metadata commitMetadata;
          if (updatedEntryVersion != null) {
-            if (metadata == null && entry.getMetadata() == null) {
+            if (entry.getMetadata() == null) {
                commitMetadata = new EmbeddedMetadata.Builder().version(updatedEntryVersion).build();
-            } else if (metadata != null) {
-               commitMetadata = metadata.builder().version(updatedEntryVersion).build();
             } else {
                commitMetadata = entry.getMetadata().builder().version(updatedEntryVersion).build();
             }
          } else {
-            commitMetadata = metadata != null ? metadata : entry.getMetadata();
+            commitMetadata = entry.getMetadata();
          }
 
-         cdl.commitEntry(entry, commitMetadata, command, ctx, null, l1Invalidation);
+         entry.setMetadata(commitMetadata);
+         cdl.commitEntry(entry, command, ctx, null, l1Invalidation);
       } else {
          // This could be a state transfer call!
-         cdl.commitEntry(entry, entry.getMetadata(), command, ctx, stateTransferFlag, l1Invalidation);
+         cdl.commitEntry(entry, command, ctx, stateTransferFlag, l1Invalidation);
       }
    }
 

--- a/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderVersionedEntryWrappingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderVersionedEntryWrappingInterceptor.java
@@ -18,7 +18,6 @@ import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.interceptors.InvocationSuccessFunction;
 import org.infinispan.interceptors.impl.VersionedEntryWrappingInterceptor;
 import org.infinispan.metadata.EmbeddedMetadata;
-import org.infinispan.metadata.Metadata;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -45,7 +44,7 @@ public class TotalOrderVersionedEntryWrappingInterceptor extends VersionedEntryW
          ctx.getCacheTransaction().setUpdatedEntryVersions(EMPTY_VERSION_MAP);
          return invokeNextThenAccept(ctx, command, (rCtx, rCommand, rv) -> {
             if (shouldCommitDuringPrepare((PrepareCommand) rCommand, ctx)) {
-               commitContextEntries(ctx, null, null);
+               commitContextEntries(ctx, null);
             }
          });
       }
@@ -66,7 +65,7 @@ public class TotalOrderVersionedEntryWrappingInterceptor extends VersionedEntryW
                   prepareCommand);
 
       if (prepareCommand.isOnePhaseCommit()) {
-         commitContextEntries(txInvocationContext, null, null);
+         commitContextEntries(txInvocationContext, null);
       } else {
          if (trace)
             log.tracef("Transaction %s will be committed in the 2nd phase",
@@ -78,14 +77,13 @@ public class TotalOrderVersionedEntryWrappingInterceptor extends VersionedEntryW
 
    @Override
    public Object visitCommitCommand(TxInvocationContext ctx, CommitCommand command) throws Throwable {
-      return invokeNextAndFinally(ctx, command, (rCtx, rCommand, rv, t) -> commitContextEntries(rCtx, null, null));
+      return invokeNextAndFinally(ctx, command, (rCtx, rCommand, rv, t) -> commitContextEntries(rCtx, null));
    }
 
    @Override
    protected void commitContextEntry(CacheEntry entry, InvocationContext ctx, FlagAffectedCommand command,
-                                     Metadata metadata, Flag stateTransferFlag, boolean l1Invalidation) {
+                                     Flag stateTransferFlag, boolean l1Invalidation) {
       if (ctx.isInTxScope() && stateTransferFlag == null) {
-         Metadata commitMetadata;
          // If user provided version, use it, otherwise generate/increment accordingly
          VersionedRepeatableReadEntry clusterMvccEntry = (VersionedRepeatableReadEntry) entry;
          EntryVersion existingVersion = clusterMvccEntry.getMetadata().version();
@@ -96,15 +94,11 @@ public class TotalOrderVersionedEntryWrappingInterceptor extends VersionedEntryW
             newVersion = versionGenerator.increment((IncrementableEntryVersion) existingVersion);
          }
 
-         if (metadata == null)
-            commitMetadata = new EmbeddedMetadata.Builder().version(newVersion).build();
-         else
-            commitMetadata = metadata.builder().version(newVersion).build();
-
-         cdl.commitEntry(entry, commitMetadata, command, ctx, null, l1Invalidation);
+         entry.setMetadata(new EmbeddedMetadata.Builder().version(newVersion).build());
+         cdl.commitEntry(entry, command, ctx, null, l1Invalidation);
       } else {
          // This could be a state transfer call!
-         cdl.commitEntry(entry, entry.getMetadata(), command, ctx, stateTransferFlag, l1Invalidation);
+         cdl.commitEntry(entry, command, ctx, stateTransferFlag, l1Invalidation);
       }
    }
 }

--- a/core/src/main/java/org/infinispan/statetransfer/CommitManager.java
+++ b/core/src/main/java/org/infinispan/statetransfer/CommitManager.java
@@ -11,7 +11,6 @@ import org.infinispan.container.DataContainer;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.context.Flag;
 import org.infinispan.factories.annotations.Inject;
-import org.infinispan.metadata.Metadata;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -73,13 +72,10 @@ public class CommitManager {
    /**
     * It tries to commit the cache entry. The entry is not committed if it is originated from state transfer and other
     * operation already has updated it.
-    *
-    * @param entry     the entry to commit
-    * @param metadata  the entry's metadata
+    *  @param entry     the entry to commit
     * @param operation if {@code null}, it identifies this commit as originated from a normal operation. Otherwise, it
-    *                  is originated from a state transfer (local or remote site)
     */
-   public final void commit(final CacheEntry entry, final Metadata metadata, final Flag operation,
+   public final void commit(final CacheEntry entry, final Flag operation,
                             boolean l1Invalidation) {
       if (trace) {
          log.tracef("Trying to commit. Key=%s. Operation Flag=%s, L1 invalidation=%s", toStr(entry.getKey()),
@@ -92,7 +88,7 @@ public class CommitManager {
             log.tracef("Committing key=%s. It is a L1 invalidation or a normal put and no tracking is enabled!",
                   toStr(entry.getKey()));
          }
-         entry.commit(dataContainer, metadata);
+         entry.commit(dataContainer);
          return;
       }
       if (isTrackDisabled(operation)) {
@@ -112,7 +108,7 @@ public class CommitManager {
             }
             return discardPolicy;
          }
-         entry.commit(dataContainer, metadata);
+         entry.commit(dataContainer);
          DiscardPolicy newDiscardPolicy = calculateDiscardPolicy();
          if (trace) {
             log.tracef("Committed key=%s. Old discard policy=%s. New discard policy=%s", toStr(entry.getKey()),

--- a/core/src/main/java/org/infinispan/util/CoreImmutables.java
+++ b/core/src/main/java/org/infinispan/util/CoreImmutables.java
@@ -56,7 +56,7 @@ public class CoreImmutables extends Immutables {
       }
 
       @Override
-      public void commit(DataContainer container, Metadata metadata) {
+      public void commit(DataContainer container) {
          throw new UnsupportedOperationException();
       }
 

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/OnlyPrimaryOwnerTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/OnlyPrimaryOwnerTest.java
@@ -32,7 +32,6 @@ import org.infinispan.distribution.ch.impl.DefaultConsistentHash;
 import org.infinispan.interceptors.impl.WrappedByteArrayConverter;
 import org.infinispan.interceptors.locking.ClusteringDependentLogic;
 import org.infinispan.lifecycle.ComponentStatus;
-import org.infinispan.metadata.Metadata;
 import org.infinispan.notifications.cachelistener.cluster.ClusterEventManager;
 import org.infinispan.notifications.cachelistener.event.CacheEntryCreatedEvent;
 import org.infinispan.notifications.cachelistener.event.Event;
@@ -87,7 +86,7 @@ public class OnlyPrimaryOwnerTest {
       }
 
       @Override
-      public void commitEntry(CacheEntry entry, Metadata metadata, FlagAffectedCommand command, InvocationContext ctx,
+      public void commitEntry(CacheEntry entry, FlagAffectedCommand command, InvocationContext ctx,
                               Flag trackFlag, boolean l1Invalidation) {
          throw new UnsupportedOperationException();
       }

--- a/core/src/test/java/org/infinispan/test/fwk/CacheEntryDelegator.java
+++ b/core/src/test/java/org/infinispan/test/fwk/CacheEntryDelegator.java
@@ -104,8 +104,8 @@ public class CacheEntryDelegator implements CacheEntry {
    }
 
    @Override
-   public void commit(DataContainer container, Metadata metadata) {
-      delegate.commit(container, metadata);
+   public void commit(DataContainer container) {
+      delegate.commit(container);
    }
 
    @Override

--- a/core/src/test/java/org/infinispan/test/fwk/ClusteringDependentLogicDelegator.java
+++ b/core/src/test/java/org/infinispan/test/fwk/ClusteringDependentLogicDelegator.java
@@ -10,7 +10,6 @@ import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.distribution.LocalizedCacheTopology;
 import org.infinispan.interceptors.locking.ClusteringDependentLogic;
-import org.infinispan.metadata.Metadata;
 import org.infinispan.remoting.transport.Address;
 
 /**
@@ -33,8 +32,8 @@ public class ClusteringDependentLogicDelegator implements ClusteringDependentLog
    }
 
    @Override
-   public void commitEntry(CacheEntry entry, Metadata metadata, FlagAffectedCommand command, InvocationContext ctx, Flag trackFlag, boolean l1Invalidation) {
-      clusteringDependentLogic.commitEntry(entry, metadata, command, ctx, trackFlag, l1Invalidation);
+   public void commitEntry(CacheEntry entry, FlagAffectedCommand command, InvocationContext ctx, Flag trackFlag, boolean l1Invalidation) {
+      clusteringDependentLogic.commitEntry(entry, command, ctx, trackFlag, l1Invalidation);
    }
 
    @Override


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-7866

Metadata should be simply updated using `setMetadata()` on the `CacheEntry` in context, instead of passing the instance down.