### PR TITLE
Create distribution stage to ensure that -Pdistribution builds pass.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,6 +50,22 @@ pipeline {
                 }
             }
         }
+
+        stage('distribution') {
+            when {
+                branch 'master'
+            }
+            steps {
+                configFileProvider([configFile(fileId: 'maven-settings-with-deploy-snapshot', variable: 'MAVEN_SETTINGS')]) {
+                    script {
+                        def mvnHome = tool 'Maven'
+                        sh "${mvnHome}/bin/mvn clean install -s $MAVEN_SETTINGS -Pdistribution -DskipTests"
+                        junit testDataPublishers: [[$class: 'ClaimTestDataPublisher']], testResults: '**/target/*-reports/*.xml'
+                        sh "${mvnHome}/bin/mvn clean -s $MAVEN_SETTINGS"
+                    }
+                }
+            }
+        }
         
         stage('Deploy SNAPSHOT') {
             when {


### PR DESCRIPTION
A test PR to see how much longer a -Pdistribution` build takes. Currently the distribution build is not tested, which resulted in a few issues with the build not being detected until the release process begain for 9.1.0.Alpha1