### PR TITLE
ISPN-5218 Add batching to the CacheWriter Interface

### DIFF
--- a/core/src/main/java/org/infinispan/interceptors/impl/CacheWriterInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/CacheWriterInterceptor.java
@@ -5,18 +5,16 @@ import static org.infinispan.persistence.manager.PersistenceManager.AccessMode.B
 import static org.infinispan.persistence.manager.PersistenceManager.AccessMode.PRIVATE;
 
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Predicate;
 
 import javax.transaction.InvalidTransactionException;
 import javax.transaction.SystemException;
 import javax.transaction.Transaction;
 import javax.transaction.TransactionManager;
 
-import org.infinispan.commands.AbstractVisitor;
 import org.infinispan.commands.FlagAffectedCommand;
 import org.infinispan.commands.VisitableCommand;
-import org.infinispan.commands.functional.AbstractWriteManyCommand;
 import org.infinispan.commands.functional.FunctionalCommand;
 import org.infinispan.commands.functional.ReadWriteKeyCommand;
 import org.infinispan.commands.functional.ReadWriteKeyValueCommand;
@@ -28,7 +26,6 @@ import org.infinispan.commands.functional.WriteOnlyManyCommand;
 import org.infinispan.commands.functional.WriteOnlyManyEntriesCommand;
 import org.infinispan.commands.tx.CommitCommand;
 import org.infinispan.commands.tx.PrepareCommand;
-import org.infinispan.commands.write.ApplyDeltaCommand;
 import org.infinispan.commands.write.ClearCommand;
 import org.infinispan.commands.write.DataWriteCommand;
 import org.infinispan.commands.write.PutKeyValueCommand;
@@ -42,23 +39,21 @@ import org.infinispan.commons.marshall.StreamingMarshaller;
 import org.infinispan.configuration.cache.PersistenceConfiguration;
 import org.infinispan.container.InternalEntryFactory;
 import org.infinispan.container.entries.CacheEntry;
-import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.container.entries.InternalCacheValue;
-import org.infinispan.container.versioning.EntryVersion;
-import org.infinispan.container.versioning.EntryVersionsMap;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.FlagBitSets;
 import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
+import org.infinispan.interceptors.InvocationSuccessAction;
 import org.infinispan.jmx.annotations.MBean;
 import org.infinispan.jmx.annotations.ManagedAttribute;
 import org.infinispan.jmx.annotations.ManagedOperation;
 import org.infinispan.jmx.annotations.MeasurementType;
+import org.infinispan.marshall.core.MarshalledEntry;
 import org.infinispan.marshall.core.MarshalledEntryImpl;
-import org.infinispan.metadata.EmbeddedMetadata;
-import org.infinispan.metadata.Metadata;
 import org.infinispan.persistence.manager.PersistenceManager;
+import org.infinispan.persistence.support.BatchModification;
 import org.infinispan.transaction.xa.GlobalTransaction;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -83,6 +78,8 @@ public class CacheWriterInterceptor extends JmxStatsCommandInterceptor {
    private InternalEntryFactory entryFactory;
    private TransactionManager transactionManager;
    private StreamingMarshaller marshaller;
+
+   protected InvocationSuccessAction handlePutMapCommandReturn = this::handlePutMapCommandReturn;
 
    private static final Log log = LogFactory.getLog(CacheWriterInterceptor.class);
 
@@ -209,20 +206,27 @@ public class CacheWriterInterceptor extends JmxStatsCommandInterceptor {
 
    @Override
    public Object visitPutMapCommand(InvocationContext ctx, PutMapCommand command) throws Throwable {
-      return invokeNextThenAccept(ctx, command, (rCtx, rCommand, rv) -> {
-         PutMapCommand putMapCommand = (PutMapCommand) rCommand;
-         if (!isStoreEnabled(putMapCommand) || rCtx.isInTxScope())
-            return;
+      return invokeNextThenAccept(ctx, command, handlePutMapCommandReturn);
+   }
 
-         Map<Object, Object> map = putMapCommand.getMap();
-         for (Object key : map.keySet()) {
-            if (isProperWriter(rCtx, putMapCommand, key)) {
-               storeEntry(rCtx, key, putMapCommand);
-            }
-         }
-         if (getStatisticsEnabled())
-            cacheStores.getAndAdd(map.size());
-      });
+   protected void handlePutMapCommandReturn(InvocationContext rCtx, VisitableCommand rCommand, Object rv) {
+      PutMapCommand putMapCommand = (PutMapCommand) rCommand;
+      if (!isStoreEnabled(putMapCommand) || rCtx.isInTxScope())
+         return;
+
+      processIterableBatch(rCtx, putMapCommand, BOTH, key -> !skipSharedStores(rCtx, key, putMapCommand));
+      processIterableBatch(rCtx, putMapCommand, PRIVATE, key -> skipSharedStores(rCtx, key, putMapCommand));
+   }
+
+   protected void processIterableBatch(InvocationContext ctx, PutMapCommand cmd, PersistenceManager.AccessMode mode, Predicate<Object> filter) {
+      if (getStatisticsEnabled())
+         cacheStores.addAndGet(cmd.getMap().size());
+
+      Iterable<MarshalledEntry> iterable = () -> cmd.getMap().keySet().stream()
+            .filter(filter)
+            .map(key -> createMarshalledEntry(ctx, key))
+            .iterator();
+      persistenceManager.writeBatchToAllNonTxStores(iterable, mode, cmd.getFlagsBitSet());
    }
 
    @Override
@@ -350,14 +354,27 @@ public class CacheWriterInterceptor extends JmxStatsCommandInterceptor {
       if (trace) getLog().tracef("Cache loader modification list: %s", modifications);
 
 
-      Updater modsBuilder = new Updater(getStatisticsEnabled());
+      TxBatchUpdater modsBuilder = TxBatchUpdater.createNonTxStoreUpdater(this, persistenceManager, entryFactory, marshaller);
       for (WriteCommand cacheCommand : modifications) {
          if (isStoreEnabled(cacheCommand)) {
             cacheCommand.acceptVisitor(ctx, modsBuilder);
          }
       }
-      if (getStatisticsEnabled() && modsBuilder.putCount > 0) {
-         cacheStores.getAndAdd(modsBuilder.putCount);
+      BatchModification sharedMods = modsBuilder.getModifications();
+      BatchModification nonSharedMods = modsBuilder.getNonSharedModifications();
+
+      persistenceManager.writeBatchToAllNonTxStores(sharedMods.getMarshalledEntries(), BOTH, 0);
+      persistenceManager.writeBatchToAllNonTxStores(nonSharedMods.getMarshalledEntries(), PRIVATE, 0);
+      persistenceManager.deleteBatchFromAllNonTxStores(sharedMods.getKeysToRemove(), BOTH, 0);
+      persistenceManager.deleteBatchFromAllNonTxStores(nonSharedMods.getKeysToRemove(), PRIVATE, 0);
+
+      if (trace) {
+         getLog().tracef("Writing shared batch with #entries=%d and non-shared batch with #entries=%d", sharedMods.getMarshalledEntries().size(), nonSharedMods.getMarshalledEntries().size());
+         getLog().tracef("Deleting shared batch with #entries=%d and non-shared batch with #entries=%d", sharedMods.getKeysToRemove().size(), nonSharedMods.getKeysToRemove().size());
+      }
+
+      if (getStatisticsEnabled() && modsBuilder.getPutCount() > 0) {
+         cacheStores.getAndAdd(modsBuilder.getPutCount());
       }
    }
 
@@ -371,150 +388,6 @@ public class CacheWriterInterceptor extends JmxStatsCommandInterceptor {
 
    protected boolean isProperWriter(InvocationContext ctx, FlagAffectedCommand command, Object key) {
       return true;
-   }
-
-   public class Updater extends AbstractVisitor {
-
-      protected final boolean generateStatistics;
-      int putCount;
-
-      public Updater(boolean generateStatistics) {
-         this.generateStatistics = generateStatistics;
-      }
-
-      @Override
-      public Object visitPutKeyValueCommand(InvocationContext ctx, PutKeyValueCommand command) throws Throwable {
-         return visitSingleStore(ctx, command, command.getKey());
-      }
-
-      @Override
-      public Object visitApplyDeltaCommand(InvocationContext ctx, ApplyDeltaCommand command) throws Throwable {
-         if (isProperWriter(ctx, command, command.getKey())) {
-            if (generateStatistics) putCount++;
-            CacheEntry entry = ctx.lookupEntry(command.getKey());
-            // If the value is null, there is a subsequent remove operation in the transaction and we can ignore
-            // this modification.
-            if (entry.getValue() == null) {
-               return null;
-            }
-            InternalCacheEntry ice;
-            if (entry instanceof InternalCacheEntry) {
-               ice = (InternalCacheEntry) entry;
-            } else {
-               ice = entryFactory.create(entry);
-            }
-            MarshalledEntryImpl marshalledEntry = new MarshalledEntryImpl(ice.getKey(), ice.getValue(), internalMetadata(ice), marshaller);
-            persistenceManager.writeToAllNonTxStores(marshalledEntry, skipSharedStores(ctx, command.getKey(), command) ? PRIVATE : BOTH);
-         }
-         return null;
-      }
-
-      @Override
-      public Object visitReplaceCommand(InvocationContext ctx, ReplaceCommand command) throws Throwable {
-         return visitSingleStore(ctx, command, command.getKey());
-      }
-
-      @Override
-      public Object visitPutMapCommand(InvocationContext ctx, PutMapCommand command) throws Throwable {
-         Map<Object, Object> map = command.getMap();
-         for (Object key : map.keySet())
-            visitSingleStore(ctx, command, key);
-         return null;
-      }
-
-      @Override
-      public Object visitWriteOnlyKeyCommand(InvocationContext ctx, WriteOnlyKeyCommand command) throws Throwable {
-         return visitModify(ctx, command, command.getKey());
-      }
-
-      @Override
-      public Object visitReadWriteKeyValueCommand(InvocationContext ctx, ReadWriteKeyValueCommand command) throws Throwable {
-         return visitModify(ctx, command, command.getKey());
-      }
-
-      @Override
-      public Object visitReadWriteKeyCommand(InvocationContext ctx, ReadWriteKeyCommand command) throws Throwable {
-         return visitModify(ctx, command, command.getKey());
-      }
-
-      @Override
-      public Object visitWriteOnlyManyEntriesCommand(InvocationContext ctx, WriteOnlyManyEntriesCommand command) throws Throwable {
-         return visitManyModify(ctx, command);
-      }
-
-      @Override
-      public Object visitWriteOnlyKeyValueCommand(InvocationContext ctx, WriteOnlyKeyValueCommand command) throws Throwable {
-         return visitModify(ctx, command, command.getKey());
-      }
-
-      @Override
-      public Object visitWriteOnlyManyCommand(InvocationContext ctx, WriteOnlyManyCommand command) throws Throwable {
-         return visitManyModify(ctx, command);
-      }
-
-      @Override
-      public Object visitReadWriteManyCommand(InvocationContext ctx, ReadWriteManyCommand command) throws Throwable {
-         return visitManyModify(ctx, command);
-      }
-
-      @Override
-      public Object visitReadWriteManyEntriesCommand(InvocationContext ctx, ReadWriteManyEntriesCommand command) throws Throwable {
-         return visitManyModify(ctx, command);
-      }
-
-      @Override
-      public Object visitRemoveCommand(InvocationContext ctx, RemoveCommand command) throws Throwable {
-         Object key = command.getKey();
-         if (isProperWriter(ctx, command, key)) {
-            persistenceManager.deleteFromAllStores(key, skipSharedStores(ctx, key, command) ? PRIVATE : BOTH);
-         }
-         return null;
-      }
-
-      @Override
-      public Object visitClearCommand(InvocationContext ctx, ClearCommand command) throws Throwable {
-         persistenceManager.clearAllStores(ctx.isOriginLocal() ? PRIVATE : BOTH);
-         return null;
-      }
-
-      protected Object visitSingleStore(InvocationContext ctx, FlagAffectedCommand command, Object key) throws Throwable {
-         if (isProperWriter(ctx, command, key)) {
-            if (generateStatistics) putCount++;
-            InternalCacheValue sv = entryFactory.getValueFromCtxOrCreateNew(key, ctx);
-            // TODO: we should merge all modifications and write each key only once
-            // If the value in context is null, the transaction contains a subsequent remove,
-            // so we'll ignore this modification
-            if (sv.getValue() != null) {
-               MarshalledEntryImpl me = new MarshalledEntryImpl(key, sv.getValue(), internalMetadata(sv), marshaller);
-               persistenceManager.writeToAllNonTxStores(me, skipSharedStores(ctx, key, command) ? PRIVATE : BOTH);
-            }
-         }
-         return null;
-      }
-
-      protected Object visitModify(InvocationContext ctx, FlagAffectedCommand command, Object key) throws Throwable {
-         if (isProperWriter(ctx, command, key)) {
-            CacheEntry entry = ctx.lookupEntry(key);
-            if (!entry.isChanged()) {
-               return null;
-            } else if (entry.getValue() == null) {
-               persistenceManager.deleteFromAllStores(key, skipSharedStores(ctx, key, command) ? PRIVATE : BOTH);
-            } else {
-               if (generateStatistics) putCount++;
-               InternalCacheValue sv = entryFactory.getValueFromCtxOrCreateNew(key, ctx);
-               MarshalledEntryImpl me = new MarshalledEntryImpl(key, sv.getValue(), internalMetadata(sv), marshaller);
-               persistenceManager.writeToAllNonTxStores(me, skipSharedStores(ctx, key, command) ? PRIVATE : BOTH);
-            }
-         }
-         return null;
-      }
-
-      protected Object visitManyModify(InvocationContext ctx, AbstractWriteManyCommand command) throws Throwable {
-         for (Object key : command.getAffectedKeys()) {
-            visitModify(ctx, command, key);
-         }
-         return null;
-      }
    }
 
    @Override
@@ -536,43 +409,18 @@ public class CacheWriterInterceptor extends JmxStatsCommandInterceptor {
    }
 
    void storeEntry(InvocationContext ctx, Object key, FlagAffectedCommand command) {
-      InternalCacheValue sv = getStoredValue(key, ctx);
-      persistenceManager.writeToAllNonTxStores(new MarshalledEntryImpl(key, sv.getValue(), internalMetadata(sv), marshaller),
-                                               skipSharedStores(ctx, key, command) ? PRIVATE : BOTH, command.getFlagsBitSet());
-      if (trace) getLog().tracef("Stored entry %s under key %s", sv, key);
+      MarshalledEntry entry = createMarshalledEntry(ctx, key);
+      persistenceManager.writeToAllNonTxStores(entry, skipSharedStores(ctx, key, command) ? PRIVATE : BOTH, command.getFlagsBitSet());
+      if (trace) getLog().tracef("Stored entry %s under key %s", entry.getValue(), key);
+   }
+
+   MarshalledEntry createMarshalledEntry(InvocationContext ctx, Object key) {
+      InternalCacheValue sv = entryFactory.getValueFromCtxOrCreateNew(key, ctx);
+      return new MarshalledEntryImpl(key, sv.getValue(), internalMetadata(sv), marshaller);
    }
 
    protected boolean skipSharedStores(InvocationContext ctx, Object key, FlagAffectedCommand command) {
       return !ctx.isOriginLocal() ||
             command.hasAnyFlag(FlagBitSets.SKIP_SHARED_CACHE_STORE);
-   }
-
-   InternalCacheValue getStoredValue(Object key, InvocationContext ctx) {
-      CacheEntry entry = ctx.lookupEntry(key);
-      if (entry instanceof InternalCacheEntry) {
-         return ((InternalCacheEntry) entry).toInternalCacheValue();
-      } else {
-         if (ctx.isInTxScope()) {
-            EntryVersionsMap updatedVersions =
-                  ((TxInvocationContext) ctx).getCacheTransaction().getUpdatedEntryVersions();
-            if (updatedVersions != null) {
-               EntryVersion version = updatedVersions.get(entry.getKey());
-               if (version != null) {
-                  Metadata metadata = entry.getMetadata();
-                  if (metadata == null) {
-                     // If no metadata passed, assumed embedded metadata
-                     metadata = new EmbeddedMetadata.Builder().lifespan(entry.getLifespan()).maxIdle(entry.getMaxIdle())
-                                                              .version(version).build();
-                     return entryFactory.create(entry.getKey(), entry.getValue(), metadata).toInternalCacheValue();
-                  } else {
-                     metadata = metadata.builder().version(version).build();
-                     return entryFactory.create(entry.getKey(), entry.getValue(), metadata).toInternalCacheValue();
-                  }
-               }
-            }
-         }
-
-         return entryFactory.create(entry).toInternalCacheValue();
-      }
    }
 }

--- a/core/src/main/java/org/infinispan/interceptors/impl/TransactionalStoreInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/TransactionalStoreInterceptor.java
@@ -3,35 +3,19 @@ package org.infinispan.interceptors.impl;
 import static org.infinispan.persistence.manager.PersistenceManager.AccessMode.SHARED;
 
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 import javax.transaction.Transaction;
 
-import org.infinispan.commands.AbstractVisitor;
 import org.infinispan.commands.tx.CommitCommand;
 import org.infinispan.commands.tx.PrepareCommand;
 import org.infinispan.commands.tx.RollbackCommand;
-import org.infinispan.commands.write.ApplyDeltaCommand;
-import org.infinispan.commands.write.ClearCommand;
-import org.infinispan.commands.write.PutKeyValueCommand;
-import org.infinispan.commands.write.PutMapCommand;
-import org.infinispan.commands.write.RemoveCommand;
-import org.infinispan.commands.write.ReplaceCommand;
 import org.infinispan.commands.write.WriteCommand;
 import org.infinispan.commons.marshall.StreamingMarshaller;
 import org.infinispan.container.InternalEntryFactory;
-import org.infinispan.container.entries.CacheEntry;
-import org.infinispan.container.entries.InternalCacheEntry;
-import org.infinispan.container.entries.InternalCacheValue;
-import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.interceptors.DDAsyncInterceptor;
-import org.infinispan.marshall.core.MarshalledEntryImpl;
-import org.infinispan.persistence.PersistenceUtil;
 import org.infinispan.persistence.manager.PersistenceManager;
-import org.infinispan.persistence.support.BatchModification;
 
 /**
  * An interceptor which ensures that writes to an underlying transactional store are prepared->committed/rolledback as part
@@ -58,12 +42,14 @@ public class TransactionalStoreInterceptor extends DDAsyncInterceptor {
    public Object visitPrepareCommand(TxInvocationContext ctx, PrepareCommand command) throws Throwable {
       if (ctx.isOriginLocal()) {
          Transaction tx = ctx.getTransaction();
-         Updater modBuilder = new Updater(ctx.getCacheTransaction().getAffectedKeys());
+         TxBatchUpdater modBuilder = TxBatchUpdater.createTxStoreUpdater(
+               persistenceManager, entryFactory, marshaller, ctx.getCacheTransaction().getAffectedKeys());
+
          List<WriteCommand> modifications = ctx.getCacheTransaction().getAllModifications();
          for (WriteCommand writeCommand : modifications) {
             writeCommand.acceptVisitor(ctx, modBuilder);
          }
-         persistenceManager.prepareAllTxStores(tx, modBuilder.modifications, SHARED);
+         persistenceManager.prepareAllTxStores(tx, modBuilder.getModifications(), SHARED);
       }
       return invokeNext(ctx, command);
    }
@@ -82,63 +68,5 @@ public class TransactionalStoreInterceptor extends DDAsyncInterceptor {
          persistenceManager.rollbackAllTxStores(ctx.getTransaction(), SHARED);
       }
       return invokeNext(ctx, command);
-   }
-
-   private class Updater extends AbstractVisitor {
-      private final BatchModification modifications;
-
-      Updater(Set<Object> affectedKeys) {
-         modifications = new BatchModification(affectedKeys);
-      }
-
-      @Override
-      public Object visitPutKeyValueCommand(InvocationContext ctx, PutKeyValueCommand command) throws Throwable {
-         return visitSingleStore(ctx, command.getKey());
-      }
-
-      @Override
-      public Object visitApplyDeltaCommand(InvocationContext ctx, ApplyDeltaCommand command) throws Throwable {
-         CacheEntry entry = ctx.lookupEntry(command.getKey());
-         InternalCacheEntry ice;
-         if (entry instanceof InternalCacheEntry) {
-            ice = (InternalCacheEntry) entry;
-         } else {
-            ice = entryFactory.create(entry);
-         }
-         MarshalledEntryImpl marshalledEntry = new MarshalledEntryImpl(ice.getKey(), ice.getValue(), PersistenceUtil.internalMetadata(ice), marshaller);
-         modifications.addMarshalledEntry(ice.getKey(), marshalledEntry);
-         return null;
-      }
-
-      @Override
-      public Object visitReplaceCommand(InvocationContext ctx, ReplaceCommand command) throws Throwable {
-         return visitSingleStore(ctx, command.getKey());
-      }
-
-      @Override
-      public Object visitPutMapCommand(InvocationContext ctx, PutMapCommand command) throws Throwable {
-         Map<Object, Object> map = command.getMap();
-         for (Object key : map.keySet())
-            visitSingleStore(ctx, key);
-         return null;
-      }
-
-      @Override
-      public Object visitRemoveCommand(InvocationContext ctx, RemoveCommand command) throws Throwable {
-         modifications.removeEntry(command.getKey());
-         return null;
-      }
-
-      @Override
-      public Object visitClearCommand(InvocationContext ctx, ClearCommand command) throws Throwable {
-         // This should never happen as the ClearCommand should never be included in a Tx's modification list
-         throw new UnsupportedOperationException("Clear command not supported inside a transaction");
-      }
-
-      private Object visitSingleStore(InvocationContext ctx, Object key) throws Throwable {
-         InternalCacheValue icv = entryFactory.getValueFromCtxOrCreateNew(key, ctx);
-         modifications.addMarshalledEntry(key, new MarshalledEntryImpl(key, icv.getValue(), PersistenceUtil.internalMetadata(icv), marshaller));
-         return null;
-      }
    }
 }

--- a/core/src/main/java/org/infinispan/interceptors/impl/TxBatchUpdater.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/TxBatchUpdater.java
@@ -1,0 +1,226 @@
+package org.infinispan.interceptors.impl;
+
+import static org.infinispan.persistence.PersistenceUtil.internalMetadata;
+import static org.infinispan.persistence.manager.PersistenceManager.AccessMode.BOTH;
+import static org.infinispan.persistence.manager.PersistenceManager.AccessMode.PRIVATE;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.infinispan.commands.AbstractVisitor;
+import org.infinispan.commands.FlagAffectedCommand;
+import org.infinispan.commands.functional.AbstractWriteManyCommand;
+import org.infinispan.commands.functional.ReadWriteKeyCommand;
+import org.infinispan.commands.functional.ReadWriteKeyValueCommand;
+import org.infinispan.commands.functional.ReadWriteManyCommand;
+import org.infinispan.commands.functional.ReadWriteManyEntriesCommand;
+import org.infinispan.commands.functional.WriteOnlyKeyCommand;
+import org.infinispan.commands.functional.WriteOnlyKeyValueCommand;
+import org.infinispan.commands.functional.WriteOnlyManyCommand;
+import org.infinispan.commands.functional.WriteOnlyManyEntriesCommand;
+import org.infinispan.commands.write.ApplyDeltaCommand;
+import org.infinispan.commands.write.ClearCommand;
+import org.infinispan.commands.write.PutKeyValueCommand;
+import org.infinispan.commands.write.PutMapCommand;
+import org.infinispan.commands.write.RemoveCommand;
+import org.infinispan.commands.write.ReplaceCommand;
+import org.infinispan.commons.marshall.StreamingMarshaller;
+import org.infinispan.container.InternalEntryFactory;
+import org.infinispan.container.entries.CacheEntry;
+import org.infinispan.container.entries.InternalCacheEntry;
+import org.infinispan.container.entries.InternalCacheValue;
+import org.infinispan.context.InvocationContext;
+import org.infinispan.marshall.core.MarshalledEntryImpl;
+import org.infinispan.persistence.manager.PersistenceManager;
+import org.infinispan.persistence.support.BatchModification;
+
+/**
+ * @author Ryan Emerson
+ * @since 9.1
+ */
+public class TxBatchUpdater extends AbstractVisitor {
+   private final CacheWriterInterceptor cwi;
+   private final PersistenceManager persistenceManager;
+   private final InternalEntryFactory entryFactory;
+   private final StreamingMarshaller marshaller;
+   private final BatchModification modifications;
+   private final BatchModification nonSharedModifications;
+   private final boolean generateStatistics;
+   private int putCount;
+
+   static TxBatchUpdater createNonTxStoreUpdater(CacheWriterInterceptor interceptor, PersistenceManager persistenceManager,
+                                                 InternalEntryFactory entryFactory, StreamingMarshaller marshaller) {
+      return new TxBatchUpdater(interceptor, persistenceManager, entryFactory, marshaller,
+            new BatchModification(null), new BatchModification(null));
+   }
+
+   static TxBatchUpdater createTxStoreUpdater(PersistenceManager persistenceManager, InternalEntryFactory entryFactory,
+                                              StreamingMarshaller marshaller, Set<Object> affectedKeys) {
+      return new TxBatchUpdater(null, persistenceManager, entryFactory, marshaller, new BatchModification(affectedKeys), null);
+   }
+
+   private TxBatchUpdater(CacheWriterInterceptor cwi, PersistenceManager persistenceManager, InternalEntryFactory entryFactory,
+                          StreamingMarshaller marshaller, BatchModification modifications, BatchModification nonSharedModifications) {
+      this.cwi = cwi;
+      this.persistenceManager = persistenceManager;
+      this.entryFactory = entryFactory;
+      this.marshaller = marshaller;
+      this.modifications = modifications;
+      this.nonSharedModifications = nonSharedModifications;
+      this.generateStatistics = cwi != null && cwi.getStatisticsEnabled();
+   }
+
+   @Override
+   public Object visitPutKeyValueCommand(InvocationContext ctx, PutKeyValueCommand command) throws Throwable {
+      return visitSingleStore(ctx, command, command.getKey());
+   }
+
+   @Override
+   public Object visitApplyDeltaCommand(InvocationContext ctx, ApplyDeltaCommand command) throws Throwable {
+      Object key = command.getKey();
+      if (isProperWriter(ctx, command, key)) {
+         if (generateStatistics) putCount++;
+         CacheEntry entry = ctx.lookupEntry(key);
+         // If the value is null, there is a subsequent remove operation in the transaction and we can ignore
+         // this modification.
+         if (entry.getValue() == null) {
+            return null;
+         }
+         InternalCacheEntry ice;
+         if (entry instanceof InternalCacheEntry) {
+            ice = (InternalCacheEntry) entry;
+         } else {
+            ice = entryFactory.create(entry);
+         }
+         MarshalledEntryImpl marshalledEntry = new MarshalledEntryImpl(ice.getKey(), ice.getValue(), internalMetadata(ice), marshaller);
+         getModifications(ctx, key, command).addMarshalledEntry(marshalledEntry.getKey(), marshalledEntry);
+      }
+      return null;
+   }
+
+   @Override
+   public Object visitReplaceCommand(InvocationContext ctx, ReplaceCommand command) throws Throwable {
+      return visitSingleStore(ctx, command, command.getKey());
+   }
+
+   @Override
+   public Object visitPutMapCommand(InvocationContext ctx, PutMapCommand command) throws Throwable {
+      Map<Object, Object> map = command.getMap();
+      for (Object key : map.keySet())
+         visitSingleStore(ctx, command, key);
+      return null;
+   }
+
+   @Override
+   public Object visitWriteOnlyKeyCommand(InvocationContext ctx, WriteOnlyKeyCommand command) throws Throwable {
+      return visitModify(ctx, command, command.getKey());
+   }
+
+   @Override
+   public Object visitReadWriteKeyValueCommand(InvocationContext ctx, ReadWriteKeyValueCommand command) throws Throwable {
+      return visitModify(ctx, command, command.getKey());
+   }
+
+   @Override
+   public Object visitReadWriteKeyCommand(InvocationContext ctx, ReadWriteKeyCommand command) throws Throwable {
+      return visitModify(ctx, command, command.getKey());
+   }
+
+   @Override
+   public Object visitWriteOnlyManyEntriesCommand(InvocationContext ctx, WriteOnlyManyEntriesCommand command) throws Throwable {
+      return visitManyModify(ctx, command);
+   }
+
+   @Override
+   public Object visitWriteOnlyKeyValueCommand(InvocationContext ctx, WriteOnlyKeyValueCommand command) throws Throwable {
+      return visitModify(ctx, command, command.getKey());
+   }
+
+   @Override
+   public Object visitWriteOnlyManyCommand(InvocationContext ctx, WriteOnlyManyCommand command) throws Throwable {
+      return visitManyModify(ctx, command);
+   }
+
+   @Override
+   public Object visitReadWriteManyCommand(InvocationContext ctx, ReadWriteManyCommand command) throws Throwable {
+      return visitManyModify(ctx, command);
+   }
+
+   @Override
+   public Object visitReadWriteManyEntriesCommand(InvocationContext ctx, ReadWriteManyEntriesCommand command) throws Throwable {
+      return visitManyModify(ctx, command);
+   }
+
+   @Override
+   public Object visitRemoveCommand(InvocationContext ctx, RemoveCommand command) throws Throwable {
+      Object key = command.getKey();
+      if (isProperWriter(ctx, command, key)) {
+         getModifications(ctx, key, command).removeEntry(key);
+      }
+      return null;
+   }
+
+   @Override
+   public Object visitClearCommand(InvocationContext ctx, ClearCommand command) throws Throwable {
+      persistenceManager.clearAllStores(ctx.isOriginLocal() ? PRIVATE : BOTH);
+      return null;
+   }
+
+   private Object visitSingleStore(InvocationContext ctx, FlagAffectedCommand command, Object key) throws Throwable {
+      if (isProperWriter(ctx, command, key)) {
+         if (generateStatistics) putCount++;
+         InternalCacheValue sv = entryFactory.getValueFromCtxOrCreateNew(key, ctx);
+         if (sv.getValue() != null) {
+            MarshalledEntryImpl me = new MarshalledEntryImpl(key, sv.getValue(), internalMetadata(sv), marshaller);
+            getModifications(ctx, key, command).addMarshalledEntry(key, me);
+         }
+      }
+      return null;
+   }
+
+   private Object visitModify(InvocationContext ctx, FlagAffectedCommand command, Object key) throws Throwable {
+      if (isProperWriter(ctx, command, key)) {
+         CacheEntry entry = ctx.lookupEntry(key);
+         if (!entry.isChanged()) {
+            return null;
+         } else if (entry.getValue() == null) {
+            getModifications(ctx, key, command).removeEntry(key);
+         } else {
+            if (generateStatistics) putCount++;
+            InternalCacheValue sv = entryFactory.getValueFromCtxOrCreateNew(key, ctx);
+            MarshalledEntryImpl me = new MarshalledEntryImpl(key, sv.getValue(), internalMetadata(sv), marshaller);
+            getModifications(ctx, key, command).addMarshalledEntry(key, me);
+         }
+      }
+      return null;
+   }
+
+   private Object visitManyModify(InvocationContext ctx, AbstractWriteManyCommand command) throws Throwable {
+      for (Object key : command.getAffectedKeys()) {
+         visitModify(ctx, command, key);
+      }
+      return null;
+   }
+
+   private BatchModification getModifications(InvocationContext ctx, Object key, FlagAffectedCommand command) {
+      if (cwi != null && cwi.skipSharedStores(ctx, key, command))
+         return nonSharedModifications;
+      return modifications;
+   }
+
+   private boolean isProperWriter(InvocationContext ctx, FlagAffectedCommand command, Object key) {
+      return cwi == null || cwi.isProperWriter(ctx, command, key);
+   }
+
+   BatchModification getModifications() {
+      return modifications;
+   }
+
+   BatchModification getNonSharedModifications() {
+      return nonSharedModifications;
+   }
+
+   int getPutCount() {
+      return putCount;
+   }
+}

--- a/core/src/main/java/org/infinispan/persistence/manager/PersistenceManager.java
+++ b/core/src/main/java/org/infinispan/persistence/manager/PersistenceManager.java
@@ -27,7 +27,7 @@ public interface PersistenceManager extends Lifecycle {
    /**
     * Loads the data from the external store into memory during cache startup.
     */
-   public void preload();
+   void preload();
 
    /**
     * Marks the given storage as disabled.
@@ -67,7 +67,7 @@ public interface PersistenceManager extends Lifecycle {
 
    int size();
 
-   public static enum AccessMode {
+   enum AccessMode {
       /**
        * The operation is performed in all {@link org.infinispan.persistence.spi.CacheWriter} or {@link
        * org.infinispan.persistence.spi.CacheLoader}
@@ -158,4 +158,22 @@ public interface PersistenceManager extends Lifecycle {
     * @param accessMode the type of access to the underlying store.
     */
    void rollbackAllTxStores(Transaction transaction, AccessMode accessMode);
+
+   /**
+    * Write all entries to the underlying non-transactional stores as a single batch.
+    *
+    * @param entries a List of MarshalledEntry to be written to the store.
+    * @param accessMode the type of access to the underlying store.
+    * @param flags Flags used during command invocation
+    */
+   void writeBatchToAllNonTxStores(Iterable<MarshalledEntry> entries, AccessMode accessMode, long flags);
+
+   /**
+    * Remove all entries from the underlying non-transactional stores as a single batch.
+    *
+    * @param entries a List of Keys to be removed from the store.
+    * @param accessMode the type of access to the underlying store.
+    * @param flags Flags used during command invocation
+    */
+   void deleteBatchFromAllNonTxStores(Iterable<Object> keys, AccessMode accessMode, long flags);
 }

--- a/core/src/main/java/org/infinispan/persistence/manager/PersistenceManagerStub.java
+++ b/core/src/main/java/org/infinispan/persistence/manager/PersistenceManagerStub.java
@@ -113,4 +113,12 @@ public class PersistenceManagerStub implements PersistenceManager {
    @Override
    public void rollbackAllTxStores(Transaction transaction, AccessMode accessMode) {
    }
+
+   @Override
+   public void writeBatchToAllNonTxStores(Iterable<MarshalledEntry> entries, AccessMode accessMode, long flags) {
+   }
+
+   @Override
+   public void deleteBatchFromAllNonTxStores(Iterable<Object> keys, AccessMode accessMode, long flags) {
+   }
 }

--- a/core/src/main/java/org/infinispan/persistence/modifications/Modification.java
+++ b/core/src/main/java/org/infinispan/persistence/modifications/Modification.java
@@ -7,7 +7,7 @@ package org.infinispan.persistence.modifications;
  * @since 4.0
  */
 public interface Modification {
-   static enum Type {
+   enum Type {
       STORE, REMOVE, CLEAR, LIST
    }
 

--- a/core/src/main/java/org/infinispan/persistence/spi/AdvancedCacheWriter.java
+++ b/core/src/main/java/org/infinispan/persistence/spi/AdvancedCacheWriter.java
@@ -35,7 +35,7 @@ public interface AdvancedCacheWriter<K, V> extends CacheWriter<K, V> {
     * Callback to be notified when an entry is removed by the {@link #purge(java.util.concurrent.Executor,
     * org.infinispan.persistence.spi.AdvancedCacheWriter.PurgeListener)} method.
     */
-   public interface PurgeListener<K> {
+   interface PurgeListener<K> {
 
       /**
        * Optional. If possible, {@link AdvancedCacheWriter} implementors should invoke this method for every entry that

--- a/core/src/main/java/org/infinispan/persistence/spi/CacheWriter.java
+++ b/core/src/main/java/org/infinispan/persistence/spi/CacheWriter.java
@@ -35,4 +35,30 @@ public interface CacheWriter<K, V> extends Lifecycle {
     * @throws PersistenceException in case of an error, e.g. communicating with the external storage
     */
    boolean delete(Object key);
+
+   /**
+    * Persist all provided entries to the store in a single batch update. If this is not supported by the
+    * underlying store, then entries are written to the store individually via {@link #write(MarshalledEntry)}.
+    * As the execution order of MarshalledEntries is not guaranteed, you should ensure that only a single entry exists
+    * in the Collection for a given key.
+    *
+    * @param entries a Collection of MarshalledEntry to be written to the store.
+    * @throws NullPointerException if entries is null.
+    */
+   default void writeBatch(Iterable<MarshalledEntry<? extends K, ? extends V>> entries) {
+      entries.forEach(this::write);
+   }
+
+   /**
+    * Remove all provided keys from the store in a single batch operation. If this is not supported by the
+    * underlying store, then keys are removed from the store individually via {@link #delete(Object)}.
+    * As the execution order of MarshalledEntries is not guaranteed, you should ensure that only a single entry exists
+    * in the Collection for a given key.
+    *
+    * @param keys a Collection of MarshalledEntry to be removed from the store.
+    * @throws NullPointerException if keys is null.
+    */
+   default void deleteBatch(Iterable<Object> keys) {
+      keys.forEach(this::delete);
+   }
 }

--- a/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/logging/Log.java
+++ b/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/logging/Log.java
@@ -161,4 +161,10 @@ public interface Log extends org.infinispan.util.logging.Log {
    @Message(value = "Unable to notify the PurgeListener of expired cache entries as the configured key2StringMapper " +
          "does not implement %s", id = 8036)
    void twoWayKey2StringMapperIsMissing(String className);
+
+   @Message(value = "Error while writing entries in batch to the database:", id = 8037)
+   PersistenceException sqlFailureWritingBatch(@Cause Exception e);
+
+   @Message(value = "Error whilst removing keys in batch from the database. Keys: %s", id = 8038)
+   PersistenceException sqlFailureDeletingBatch(Iterable<Object> keys, @Cause Exception e);
 }

--- a/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/stringbased/JdbcStringBasedStore.java
+++ b/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/stringbased/JdbcStringBasedStore.java
@@ -257,6 +257,52 @@ public class JdbcStringBasedStore<K,V> implements AdvancedLoadWriteStore<K,V>, T
    }
 
    @Override
+   public void writeBatch(Iterable<MarshalledEntry<? extends K, ? extends V>> marshalledEntries) {
+      // If upsert is not supported, then we must execute the legacy write for each entry; i.e. read then update/insert
+      if (!tableManager.isUpsertSupported()) {
+         marshalledEntries.forEach(this::write);
+         return;
+      }
+
+      Connection connection = null;
+      try {
+         connection = connectionFactory.getConnection();
+         try (PreparedStatement upsertBatch = connection.prepareStatement(tableManager.getUpsertRowSql())) {
+            for (MarshalledEntry entry : marshalledEntries) {
+               String keyStr = key2Str(entry.getKey());
+               prepareUpdateStatement(entry, keyStr, upsertBatch);
+               upsertBatch.addBatch();
+            }
+            upsertBatch.executeBatch();
+         }
+      } catch (SQLException | InterruptedException e) {
+         throw log.sqlFailureWritingBatch(e);
+      } finally {
+         connectionFactory.releaseConnection(connection);
+      }
+   }
+
+   @Override
+   public void deleteBatch(Iterable<Object> keys) {
+      Connection connection = null;
+      try {
+         connection = connectionFactory.getConnection();
+         try (PreparedStatement deleteBatch = connection.prepareStatement(tableManager.getDeleteRowSql())) {
+            for (Object key : keys) {
+               String keyStr = key2Str(key);
+               deleteBatch.setString(1, keyStr);
+               deleteBatch.addBatch();
+            }
+            deleteBatch.executeBatch();
+         }
+      } catch (SQLException e) {
+         throw log.sqlFailureDeletingBatch(keys, e);
+      } finally {
+         connectionFactory.releaseConnection(connection);
+      }
+   }
+
+   @Override
    public MarshalledEntry load(Object key) {
       String lockingKey = key2Str(key);
       Connection conn = null;

--- a/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/table/management/PostgresTableManager.java
+++ b/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/table/management/PostgresTableManager.java
@@ -1,8 +1,11 @@
 package org.infinispan.persistence.jdbc.table.management;
 
+import java.sql.Connection;
+
 import org.infinispan.persistence.jdbc.configuration.TableManipulationConfiguration;
 import org.infinispan.persistence.jdbc.connectionfactory.ConnectionFactory;
 import org.infinispan.persistence.jdbc.logging.Log;
+import org.infinispan.persistence.spi.PersistenceException;
 import org.infinispan.util.logging.LogFactory;
 
 /**
@@ -14,6 +17,12 @@ class PostgresTableManager extends AbstractTableManager {
 
    PostgresTableManager(ConnectionFactory connectionFactory, TableManipulationConfiguration config, DbMetaData metaData) {
       super(connectionFactory, config, metaData, LOG);
+   }
+
+   @Override
+   protected void dropTimestampIndex(Connection conn) throws PersistenceException {
+      String dropIndexDdl = String.format("DROP INDEX IF EXISTS  %s", getIndexName(true));
+      executeUpdateSql(conn, dropIndexDdl);
    }
 
    @Override

--- a/persistence/jpa/src/main/java/org/infinispan/persistence/jpa/impl/Stats.java
+++ b/persistence/jpa/src/main/java/org/infinispan/persistence/jpa/impl/Stats.java
@@ -33,9 +33,13 @@ public class Stats {
    private final Operation txReadCommitted = new Operation();
    private final Operation txWriteCommitted = new Operation();
    private final Operation txRemoveCommitted = new Operation();
+   private final Operation txBatchWriteCommitted = new Operation();
+   private final Operation txBatchRemoveCommitted = new Operation();
    private final Operation txReadFailed = new Operation();
    private final Operation txWriteFailed = new Operation();
    private final Operation txRemoveFailed = new Operation();
+   private final Operation txBatchWriteFailed = new Operation();
+   private final Operation txBatchRemoveFailed = new Operation();
 
 
    public void addEntityMerge(long duration) {
@@ -86,6 +90,22 @@ public class Stats {
       txRemoveFailed.add(duration);
    }
 
+   public void addBatchWriteTxCommitted(long duration) {
+      txBatchWriteCommitted.add(duration);
+   }
+
+   public void addBatchWriteTxFailed(long duration) {
+      txBatchWriteFailed.add(duration);
+   }
+
+   public void addBatchRemoveTxCommitted(long duration) {
+      txBatchRemoveCommitted.add(duration);
+   }
+
+   public void addBatchRemoveTxFailed(long duration) {
+      txBatchRemoveFailed.add(duration);
+   }
+
    @Override
    public String toString() {
       return "Stats{" +
@@ -96,11 +116,15 @@ public class Stats {
             "\nmetadataMerge=" + metadataMerge +
             "\nmetadataRemove=" + metadataRemove +
             "\ntxReadCommitted=" + txReadCommitted +
-            "\ntxReadFailed=" + txReadFailed +
             "\ntxWriteCommitted=" + txWriteCommitted +
-            "\ntxWriteFailed=" + txWriteFailed +
             "\ntxRemoveCommitted=" + txRemoveCommitted +
+            "\ntxBatchWriteCommitted=" + txBatchWriteCommitted +
+            "\ntxBatchRemoveCommitted=" + txBatchRemoveCommitted +
+            "\ntxReadFailed=" + txReadFailed +
+            "\ntxWriteFailed=" + txWriteFailed +
             "\ntxRemoveFailed=" + txRemoveFailed +
+            "\ntxBatchWriteFailed=" + txBatchWriteFailed +
+            "\ntxBatchRemoveFailed=" + txBatchRemoveFailed +
             '}';
    }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5218
https://issues.jboss.org/browse/ISPN-7901

I have added the `writeBatch` and `deleteBatch` methods to the `CacheWriter` interface opposed to the `AdvancedCacheWriter` as the `DelegatingCacheWriter` implements the former. Both of these are implemented as default methods in the interface, which fall back to sequentially calling write/delete if a store is unable to perform batch write and/or delete operations. 