### PR TITLE
ISPN-7913 Unify logger outputs

### DIFF
--- a/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/EndpointLogger.java
+++ b/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/EndpointLogger.java
@@ -80,8 +80,8 @@ public interface EndpointLogger extends BasicLogger {
     *           the port on which the protocol is listening
     */
    @LogMessage(level = INFO)
-   @Message(id = 10002, value = "%s listening on %s (mapped to %s/%s)")
-   void httpEndpointStarted(String protocolName, String listenAddress, String contextPath, String servletPath);
+   @Message(id = 10002, value = "%s listening on %s (mapped to %s)")
+   void httpEndpointStarted(String protocolName, String listenAddress, String contextPath);
 
    @Message(id = 10003, value = "No connector is defined in the endpoint subsystem")
    StartException noConnectorDefined();

--- a/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/subsystem/ProtocolServerService.java
+++ b/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/subsystem/ProtocolServerService.java
@@ -130,7 +130,7 @@ class ProtocolServerService implements Service<ProtocolServer>, EncryptableServi
          final String qual;
          if (encryptionRealm != null) {
             EncryptableServiceHelper.fillSecurityConfiguration(this, configurationBuilder.ssl());
-            qual = isSniEnabled() ? " (SSL+SNI)" : " (SSL)";
+            qual = isSniEnabled() ? " (TLS+SNI)" : " (TLS)";
          } else {
             qual = "";
          }

--- a/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/subsystem/RestService.java
+++ b/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/subsystem/RestService.java
@@ -85,7 +85,7 @@ public class RestService implements Service<RestServer>, EncryptableService {
 
       String protocolName = getProtocolName();
 
-      ROOT_LOGGER.endpointStarting(protocolName);
+      ROOT_LOGGER.endpointStarting(serverName);
       try {
          SocketBinding socketBinding = getSocketBinding().getOptionalValue();
          if(socketBinding == null) {
@@ -128,7 +128,7 @@ public class RestService implements Service<RestServer>, EncryptableService {
 
       try {
          restServer.start(builder.build(), cacheManagerInjector.getValue());
-         ROOT_LOGGER.httpEndpointStarted(protocolName, restServer.getHost() + ":" + restServer.getPort(), contextPath, "rest");
+         ROOT_LOGGER.httpEndpointStarted(protocolName, restServer.getHost() + ":" + restServer.getPort(), contextPath);
       } catch (Exception e) {
          throw ROOT_LOGGER.restContextStartFailed(e);
       }
@@ -136,7 +136,7 @@ public class RestService implements Service<RestServer>, EncryptableService {
 
    private String getProtocolName() {
       return EncryptableServiceHelper.isSecurityEnabled(this) ?
-            (EncryptableServiceHelper.isSniEnabled(this) ? serverName + "+SNI" : serverName + "+SSL") : serverName;
+            (EncryptableServiceHelper.isSniEnabled(this) ? serverName + " (TLS/SNI)" : serverName + " (TLS)") : serverName;
    }
 
    /** {@inheritDoc} */


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-7913

The loggers output looks like this now:

```
14:57:43,579 INFO  [org.infinispan.server.endpoint] (MSC service thread 1-8) DGENDPT10000: HotRodServer starting
14:57:43,583 INFO  [org.infinispan.server.endpoint] (MSC service thread 1-8) DGENDPT10001: HotRodServer (TLS) listening on 127.0.0.1:11222
14:57:43,586 INFO  [org.infinispan.server.endpoint] (MSC service thread 1-5) DGENDPT10000: REST starting
14:57:43,717 INFO  [org.infinispan.server.endpoint] (MSC service thread 1-5) DGENDPT10002: REST (TLS) listening on 127.0.0.1:11222 (mapped to rest)
```