### PR TITLE
ISPN-7911 Functional commands do not invalidate L1 cache

### DIFF
--- a/core/src/main/java/org/infinispan/distribution/L1Manager.java
+++ b/core/src/main/java/org/infinispan/distribution/L1Manager.java
@@ -1,7 +1,7 @@
 package org.infinispan.distribution;
 
 import java.util.Collection;
-import java.util.concurrent.Future;
+import java.util.concurrent.CompletableFuture;
 
 import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
@@ -24,7 +24,7 @@ public interface L1Manager {
     */
    void addRequestor(Object key, Address requestor);
 
-   Future<?> flushCache(Collection<Object> key, Address origin, boolean assumeOriginKeptEntryInL1);
+   CompletableFuture<?> flushCache(Collection<Object> key, Address origin, boolean assumeOriginKeptEntryInL1);
 
    /**
     * Registers the given write synchronizer to be notified whenever a remote value is looked up for the given key.

--- a/core/src/main/java/org/infinispan/distribution/impl/L1ManagerImpl.java
+++ b/core/src/main/java/org/infinispan/distribution/impl/L1ManagerImpl.java
@@ -135,7 +135,7 @@ public class L1ManagerImpl implements L1Manager, RemoteValueRetrievedListener {
    }
 
    @Override
-   public Future<?> flushCache(Collection<Object> keys, Address origin, boolean assumeOriginKeptEntryInL1) {
+   public CompletableFuture<?> flushCache(Collection<Object> keys, Address origin, boolean assumeOriginKeptEntryInL1) {
       final Collection<Address> invalidationAddresses = buildInvalidationAddressList(keys, origin, assumeOriginKeptEntryInL1);
 
       int nodes = invalidationAddresses.size();

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -550,7 +550,7 @@ public interface Log extends BasicLogger {
 
    @LogMessage(level = INFO)
    @Message(value = "Failed invalidating remote cache", id = 137)
-   void failedInvalidatingRemoteCache(@Cause Exception e);
+   void failedInvalidatingRemoteCache(@Cause Throwable e);
 
    @LogMessage(level = INFO)
    @Message(value = "Could not register object with name: %s", id = 138)

--- a/core/src/test/java/org/infinispan/functional/AbstractFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/functional/AbstractFunctionalTest.java
@@ -47,7 +47,7 @@ abstract class AbstractFunctionalTest extends MultipleCacheManagersTest {
       waitForClusterToForm(DIST, REPL);
    }
 
-   private void configureCache(ConfigurationBuilder builder) {
+   protected void configureCache(ConfigurationBuilder builder) {
       if (transactional != null) {
          builder.transaction().transactionMode(transactionMode());
          if (lockingMode != null) {

--- a/core/src/test/java/org/infinispan/functional/FunctionalL1Test.java
+++ b/core/src/test/java/org/infinispan/functional/FunctionalL1Test.java
@@ -1,0 +1,67 @@
+package org.infinispan.functional;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNotNull;
+
+import java.util.function.Function;
+
+import org.infinispan.Cache;
+import org.infinispan.functional.EntryView.ReadEntryView;
+import org.infinispan.marshall.core.MarshallableFunctions;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.container.entries.InternalCacheEntry;
+import org.infinispan.functional.impl.FunctionalMapImpl;
+import org.infinispan.functional.impl.ReadWriteMapImpl;
+import org.infinispan.functional.impl.WriteOnlyMapImpl;
+import org.testng.annotations.Test;
+
+@Test(groups = "functional", testName = "functional.FunctionalL1Test")
+public class FunctionalL1Test extends AbstractFunctionalOpTest {
+   @Override
+   protected void configureCache(ConfigurationBuilder builder) {
+      super.configureCache(builder);
+      if (builder.clustering().cacheMode().isDistributed()) {
+         builder.clustering().l1().enable();
+      }
+   }
+
+   @Test(dataProvider = "owningModeAndWriteMethod")
+   public void testEntryInvalidated(boolean isOwner, WriteMethod method) {
+      Cache<Object, String> primary = cache(isOwner ? 0 : 2, DIST);
+      Cache<Object, String> backup = cache(1, DIST);
+      Cache<Object, String> reader = cache(3, DIST);
+      Cache<Object, String> nonOwner = cache(isOwner ? 2 : 0, DIST);
+      Object KEY = getKeyForCache(primary, backup);
+      primary.put(KEY, "value");
+
+      assertNoEntry(reader, KEY);
+      assertEquals("value", reader.get(KEY));
+
+      assertEntry(primary, KEY, "value", false);
+      assertEntry(backup, KEY, "value", false);
+      assertEntry(reader, KEY, "value", true);
+      assertNoEntry(nonOwner, KEY);
+
+      FunctionalMapImpl<Object, String> functionalMap = FunctionalMapImpl.create(this.<Object, String>cache(0, DIST).getAdvancedCache());
+      FunctionalMap.WriteOnlyMap<Object, String> wo = WriteOnlyMapImpl.create(functionalMap);
+      FunctionalMap.ReadWriteMap<Object, String> rw = ReadWriteMapImpl.create(functionalMap);
+      Function<ReadEntryView<Object, String>, String> readFunc = MarshallableFunctions.returnReadOnlyFindOrNull();
+      method.eval(KEY, wo, rw, readFunc, (view, nil) -> view.set("value2"), FunctionalL1Test.class);
+
+      assertEntry(primary, KEY, "value2", false);
+      assertEntry(backup, KEY, "value2", false);
+      assertNoEntry(reader, KEY);
+      assertNoEntry(nonOwner, KEY);
+   }
+
+   private static void assertNoEntry(Cache<Object, String> cache, Object KEY) {
+      assertEquals(null, cache.getAdvancedCache().getDataContainer().get(KEY));
+   }
+
+   private static void assertEntry(Cache<Object, String> cache, Object KEY, String expectedValue, boolean isL1) {
+      InternalCacheEntry<Object, String> ice = cache.getAdvancedCache().getDataContainer().get(KEY);
+      assertNotNull(ice);
+      assertEquals(expectedValue, ice.getValue());
+      assertEquals(ice.toString(), isL1, ice.isL1Entry());
+   }
+}


### PR DESCRIPTION
* includes minor refactoring of L1-related interceptors to remove synchronous waiting

https://issues.jboss.org/browse/ISPN-7911