### PR TITLE
ISPN-7922 OffHeap stream causes too many entries in memory at once

### DIFF
--- a/core/src/test/java/org/infinispan/container/offheap/OffHeapSingleNodeTest.java
+++ b/core/src/test/java/org/infinispan/container/offheap/OffHeapSingleNodeTest.java
@@ -84,7 +84,7 @@ public class OffHeapSingleNodeTest extends OffHeapMultiNodeTest {
    public void testLotsOfWrites() {
       Cache<String, String> cache = cache(0);
 
-      for (int i = 0; i < 100000; ++i) {
+      for (int i = 0; i < 5_000; ++i) {
          cache.put("key" + i, "value" + i);
       }
 


### PR DESCRIPTION
* Make sure that we only have 1 flatMap

https://issues.jboss.org/browse/ISPN-7922