### PR TITLE
Ispn 7924/upgrade kube ping

### DIFF
--- a/all/embedded/pom.xml
+++ b/all/embedded/pom.xml
@@ -140,18 +140,8 @@
       </dependency>
 
       <dependency>
-         <groupId>org.jboss</groupId>
-         <artifactId>jboss-dmr</artifactId>
-         <optional>${uberjar.deps.optional}</optional>
-      </dependency>
-      <dependency>
          <groupId>org.jgroups.kubernetes</groupId>
-         <artifactId>dns</artifactId>
-         <optional>${uberjar.deps.optional}</optional>
-      </dependency>
-      <dependency>
-         <groupId>org.jgroups.kubernetes</groupId>
-         <artifactId>kubernetes</artifactId>
+         <artifactId>jgroups-kubernetes</artifactId>
          <optional>${uberjar.deps.optional}</optional>
       </dependency>
    </dependencies>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -75,7 +75,7 @@
       <version.cdi>1.2</version.cdi>
       <version.jboss.marshalling>2.0.0.Beta3</version.jboss.marshalling>
       <version.jboss.logging>3.3.0.Final</version.jboss.logging>
-      <version.jgroups>4.0.1.Final</version.jgroups>
+      <version.jgroups>4.0.3.Final</version.jgroups>
       <version.jta>1.0.1.Final</version.jta>
       <version.netty>4.1.9.Final</version.netty>
       <version.osgi>4.3.1</version.osgi>

--- a/cloud/pom.xml
+++ b/cloud/pom.xml
@@ -21,7 +21,7 @@
 
       <dependency>
          <groupId>org.jgroups.kubernetes</groupId>
-         <artifactId>kubernetes</artifactId>
+         <artifactId>jgroups-kubernetes</artifactId>
       </dependency>
    </dependencies>
 

--- a/documentation/src/main/asciidoc/upgrading/upgrading.asciidoc
+++ b/documentation/src/main/asciidoc/upgrading/upgrading.asciidoc
@@ -9,6 +9,12 @@ This guide walks you through the process of upgrading Infinispan.
 
 == Upgrading from 9.0 to 9.1
 
+=== Kubernetes Ping changes
+
+The latest version of Kubernetes Ping uses unified environmental variables for both Kubernetes and OpenShift.
+Some of them were shortened for example `OPENSHIFT_KUBE_PING_NAMESPACE` was changed to `KUBERNETES_NAMESPACE`.
+Please refer to link:https://github.com/jgroups-extras/jgroups-kubernetes/blob/master/README.adoc[Kubernetes Ping documentation].
+
 === Stat Changes
 Average values for read, write and removals are now returned in Nanoseconds, opposed to Milliseconds.
 

--- a/documentation/src/main/asciidoc/user_guide/cloud.adoc
+++ b/documentation/src/main/asciidoc/user_guide/cloud.adoc
@@ -95,7 +95,7 @@ Since OpenShift uses Kubernetes underneath both of them can use the same discove
 
 The most important thing is to bind JGroups to `eth0` interface, which is link:https://docs.docker.com/engine/userguide/networking/dockernetworks/[used by Docker containers for network communication].
 
-KUBE_PING protocol is configured by environmental variables (which should be available inside a container). The most important thing is to set `OPENSHIFT_KUBE_PING_NAMESPACE` to proper namespace. It might be either hardcoded or populated via link:https://github.com/kubernetes/kubernetes/tree/release-1.0/docs/user-guide/downward-api[Kubernetes' Downward API].
+KUBE_PING protocol is configured by environmental variables (which should be available inside a container). The most important thing is to set `KUBERNETES_NAMESPACE` to proper namespace. It might be either hardcoded or populated via link:https://github.com/kubernetes/kubernetes/tree/release-1.0/docs/user-guide/downward-api[Kubernetes' Downward API].
 
 Since KUBE_PING uses Kubernetes API for obtaining available Pods, OpenShift requires adding additional privileges. Assuming that `oc project -q` returns current namespace and `default` is the service account name, one needs to run:
 
@@ -144,8 +144,6 @@ An example Deployment Configuration (Kubernetes uses very similar concept called
           ports:
           - containerPort: 8181
             protocol: TCP
-          - containerPort: 8888
-            protocol: TCP
           - containerPort: 9990
             protocol: TCP
           - containerPort: 11211
@@ -159,7 +157,7 @@ An example Deployment Configuration (Kubernetes uses very similar concept called
           - containerPort: 8080
             protocol: TCP
           env:
-          - name: OPENSHIFT_KUBE_PING_NAMESPACE
+          - name: KUBERNETES_NAMESPACE
             valueFrom: {fieldRef: {apiVersion: v1, fieldPath: metadata.namespace}}
           terminationMessagePath: /dev/termination-log
           terminationGracePeriodSeconds: 90
@@ -203,7 +201,6 @@ A typical example is migrating from one version to another.
 For both Kubernetes and OpenShift, the Rolling Upgrade procedure is almost the same. It is based on a standard <<_Rolling_chapter,Rolling Upgrade procedure>> with small changes.
 
 .Key differences when upgrading using OpenShift/Kubernetes are:
-* When forming a new cluster, make sure you use labels. Labels can be used by link:$$https://github.com/jgroups-extras/jgroups-kubernetes$$[Kubernetes PING Protocol] (see `OPENSHIFT_KUBE_PING_LABELS` environment variable) and they allow controlling which nodes are assigned to which clusters.
 * Depending on configuration, it is a good practice to use link:$$https://docs.openshift.org/latest/architecture/core_concepts/routes.html$$[OpenShift Routes] or link:$$http://kubernetes.io/docs/user-guide/ingress$$[Kubernetes Ingress API] to expose services to the clients. During the upgrade the Route (or Ingress) used by the clients can be altered to point to the new cluster.
 * Invoking CLI commands can be done by using Kubernetes (`kubectl exec`) or OpenShift clients (`oc exec`). Here is an example: `oc exec <POD_NAME> -- '/opt/jboss/infinispan-server/bin/ispn-cli.sh' '-c' '--controller=$(hostname -i):9990' '/subsystem=datagrid-infinispan/cache-container=clustered/distributed-cache=default:disconnect-source(migrator-name=hotrod)'`
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -178,7 +178,7 @@
       <version.webdav.servlet>2.0.1</version.webdav.servlet>
       <version.weld>2.3.4.Final</version.weld>
       <version.weld-se>2.3.4.Final</version.weld-se>
-      <version.jgroups.kubernetes>0.9.1</version.jgroups.kubernetes>
+      <version.jgroups.kubernetes>1.0.0.Beta1</version.jgroups.kubernetes>
       <version.jmh>1.12</version.jmh>
       <version.oauth.core>20090531</version.oauth.core>
 
@@ -965,23 +965,7 @@
          </dependency>
          <dependency>
             <groupId>org.jgroups.kubernetes</groupId>
-            <artifactId>kubernetes</artifactId>
-            <version>${version.jgroups.kubernetes}</version>
-         </dependency>
-         <dependency>
-            <groupId>org.jgroups.kubernetes</groupId>
-            <artifactId>common</artifactId>
-            <version>${version.jgroups.kubernetes}</version>
-            <exclusions>
-               <exclusion>
-                  <groupId>io.undertow</groupId>
-                  <artifactId>undertow-core</artifactId>
-               </exclusion>
-            </exclusions>
-         </dependency>
-         <dependency>
-            <groupId>org.jgroups.kubernetes</groupId>
-            <artifactId>dns</artifactId>
+            <artifactId>jgroups-kubernetes</artifactId>
             <version>${version.jgroups.kubernetes}</version>
          </dependency>
          <dependency>

--- a/server/integration/feature-pack/pom.xml
+++ b/server/integration/feature-pack/pom.xml
@@ -616,27 +616,7 @@
 
         <dependency>
             <groupId>org.jgroups.kubernetes</groupId>
-            <artifactId>kubernetes</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.jgroups.kubernetes</groupId>
-            <artifactId>common</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.jgroups.kubernetes</groupId>
-            <artifactId>dns</artifactId>
+            <artifactId>jgroups-kubernetes</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/server/integration/feature-pack/src/main/resources/modules/system/layers/base/org/jgroups/kubernetes/kubernetes/main/module.xml
+++ b/server/integration/feature-pack/src/main/resources/modules/system/layers/base/org/jgroups/kubernetes/kubernetes/main/module.xml
@@ -6,16 +6,12 @@
     </properties>
 
     <resources>
-        <artifact name="${org.jgroups.kubernetes:kubernetes}"/>
-        <artifact name="${org.jgroups.kubernetes:common}"/>
-        <artifact name="${org.jgroups.kubernetes:dns}"/>
+        <artifact name="${org.jgroups.kubernetes:jgroups-kubernetes}"/>
         <artifact name="${net.oauth.core:oauth}"/>
     </resources>
 
     <dependencies>
         <module name="javax.api"/>
-        <module name="io.undertow.core"/>
-        <module name="org.jboss.dmr"/>
         <module name="org.jgroups"/>
     </dependencies>
 </module>

--- a/wildfly-modules/build.xml
+++ b/wildfly-modules/build.xml
@@ -148,7 +148,7 @@
         <module-def name="org.infinispan.jcache" slot="${infinispan.slot}">
             <maven-resource group="org.infinispan" artifact="infinispan-jcache" />
         </module-def>
-        
+
         <module-def name="org.infinispan.jcache.commons" slot="${infinispan.slot}">
             <maven-resource group="org.infinispan" artifact="infinispan-jcache-commons" />
         </module-def>
@@ -182,9 +182,7 @@
         </module-def>
 
         <module-def name="org.jgroups.kubernetes.kubernetes" slot="${infinispan.slot}">
-            <maven-resource group="org.jgroups.kubernetes" artifact="kubernetes" />
-            <maven-resource group="org.jgroups.kubernetes" artifact="common" />
-            <maven-resource group="org.jgroups.kubernetes" artifact="dns" />
+            <maven-resource group="org.jgroups.kubernetes" artifact="jgroups-kubernetes" />
             <maven-resource group="net.oauth.core" artifact="oauth" />
         </module-def>
 

--- a/wildfly-modules/pom.xml
+++ b/wildfly-modules/pom.xml
@@ -243,15 +243,7 @@
 
       <dependency>
          <groupId>org.jgroups.kubernetes</groupId>
-         <artifactId>kubernetes</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>org.jgroups.kubernetes</groupId>
-         <artifactId>common</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>org.jgroups.kubernetes</groupId>
-         <artifactId>dns</artifactId>
+         <artifactId>jgroups-kubernetes</artifactId>
       </dependency>
       <dependency>
          <groupId>net.oauth.core</groupId>

--- a/wildfly-modules/src/main/resources/org/jgroups/kubernetes/kubernetes/main/module.xml
+++ b/wildfly-modules/src/main/resources/org/jgroups/kubernetes/kubernetes/main/module.xml
@@ -11,8 +11,6 @@
 
     <dependencies>
         <module name="javax.api"/>
-        <module name="io.undertow.core"/>
-        <module name="org.jboss.dmr"/>
         <module name="org.jgroups" slot="${slot}"/>
     </dependencies>
 </module>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-7924
https://issues.jboss.org/browse/ISPN-7928

This PR integrates the latest `KUBE_PING` into Infinispan. You may want to read [Bela's blog](http://belaban.blogspot.ch/2017/05/running-infinispan-cluster-with.html) to get the full spectrum of changes. The important from Infinispan perspective are:

* `KUBE_PING` has only 2 explicit dependencies now - JGroups and OAuth library.
* There is no need to use separate port for discovery (previously `KUBE_PING` used embedded HTTP for this).
* We don't need DMR (!!) dependency
* The new version of `KUBE_PING` uses only `KUBERNETES` prefixes for environmental variables. Previously it was possible to use either `KUBERNETES` or `OPENSHIFT`. This potentially impacts user apps deployed on *OpenShift* (apps deployed on Kubernetes won't get hurt). However it's just a matter of updating configuration.