### PR TITLE
ISPN-7929 Introduce a test for Async indexing on Infinispan DirectoryProvider with Exclusive locks

### DIFF
--- a/lucene/directory-provider/src/test/java/org/infinispan/hibernate/search/AsyncLiveRunningTest.java
+++ b/lucene/directory-provider/src/test/java/org/infinispan/hibernate/search/AsyncLiveRunningTest.java
@@ -1,0 +1,166 @@
+package org.infinispan.hibernate.search;
+
+import static org.infinispan.hibernate.search.ClusterTestHelper.clusterSize;
+import static org.infinispan.hibernate.search.ClusterTestHelper.createClusterNode;
+import static org.infinispan.hibernate.search.ClusterTestHelper.waitMembersCount;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.hibernate.Transaction;
+import org.hibernate.search.FullTextQuery;
+import org.hibernate.search.FullTextSession;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
+import org.hibernate.search.spi.IndexedTypeSet;
+import org.hibernate.search.spi.impl.PojoIndexedTypeIdentifier;
+import org.hibernate.search.test.util.FullTextSessionBuilder;
+import org.infinispan.hibernate.search.ClusterTestHelper.ExclusiveIndexUse;
+import org.infinispan.hibernate.search.ClusterTestHelper.IndexingFlushMode;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * In this test we initially start a master node which will stay alive for the full test duration and constantly
+ * indexing new entities, focusing on the configurtion using async indexing and exclusive lock ownership on the primary
+ * node.
+ * <p/>
+ * After that we add and remove additional new nodes, still making more index changes checking that each node is always
+ * able to see changes - although the purpose here is to test async indexing so the visibility on these changes might
+ * be slightly delayed.
+ * This results in a very stressfull test as the cluster topology is changed frequently, but since it uses replication
+ * it doesn't need to perform rehashing.
+ *
+ * @author Sanne Grinovero <sanne@hibernate.org> (C) 2017 Red Hat Inc.
+ */
+public class AsyncLiveRunningTest {
+
+   // Raise the following constants to run it as a stress test:
+
+   private static final int TEST_RUNS = 17;
+   private static final int CLUSTER_RESIZE_EVERY_N_OPERATIONS = 3;
+   private static final int MAX_SLAVES = 3;
+   private static final boolean VERBOSE = false;
+   private static final IndexingFlushMode flushMode = IndexingFlushMode.ASYNC;
+
+   private static final IndexedTypeIdentifier EMAIL_TYPE = new PojoIndexedTypeIdentifier(SimpleEmail.class);
+   private static final IndexedTypeSet TEST_TYPES = EMAIL_TYPE.asTypeSet();
+   private static final long TIMEOUT_ASYNCINDEX_WAIT_MS = 2000;
+
+   private final FullTextSessionBuilder master = createClusterNode(TEST_TYPES, ExclusiveIndexUse.EXCLUSIVE, flushMode);
+   private final List<FullTextSessionBuilder> slaves = new LinkedList<>();
+
+   private boolean growCluster = true;
+
+   private int storedEmailsCount = 0;
+
+   @Test
+   public void liveRun() {
+      try {
+         for (int i = 0; i < TEST_RUNS; i++) {
+            writeOnMaster();
+            adjustSlavesNumber(i);
+            assertViews();
+            printout("Cicle passed: " + i);
+         }
+      } finally {
+         master.close();
+         for (FullTextSessionBuilder slave : slaves) {
+            slave.close();
+         }
+      }
+   }
+
+   private void assertViews() {
+      final long failTime = System.currentTimeMillis() + TIMEOUT_ASYNCINDEX_WAIT_MS;
+      assertView(master, failTime);
+      for (FullTextSessionBuilder slave : slaves) {
+         assertView(slave, failTime);
+      }
+   }
+
+   private void assertView(FullTextSessionBuilder node, final long failTime) {
+      assertEquals(slaves.size() + 1, clusterSize(node, EMAIL_TYPE));
+      while (true) {
+         long remainingTime = failTime - System.currentTimeMillis();
+         if (remainingTime < 0) {
+            org.junit.Assert.fail("Timeout excedded, index state still not consistent across nodes");
+         }
+         FullTextSession session = node.openFullTextSession();
+         try {
+            FullTextQuery fullTextQuery = session.createFullTextQuery(new MatchAllDocsQuery());
+            int resultSize = fullTextQuery.getResultSize();
+            if (resultSize == storedEmailsCount) {
+               printout("Matching data found in less than ms: " + remainingTime);
+               return; //All good
+            }
+         } finally {
+            session.close();
+         }
+      }
+   }
+
+   private void adjustSlavesNumber(int i) {
+      if (i % CLUSTER_RESIZE_EVERY_N_OPERATIONS != 0) {
+         return;
+      }
+      if (growCluster) {
+         if (slaves.size() >= MAX_SLAVES) {
+            growCluster = false;
+         } else {
+            slaves.add(createClusterNode(TEST_TYPES, ExclusiveIndexUse.SHARED, flushMode));
+         }
+      } else {
+         if (slaves.size() == 0) {
+            growCluster = true;
+         } else {
+            FullTextSessionBuilder sessionBuilder = slaves.remove(0);
+            sessionBuilder.close();
+         }
+      }
+      waitForAllJoinsCompleted();
+   }
+
+   private void writeOnMaster() {
+      FullTextSession fullTextSession = master.openFullTextSession();
+      try {
+         Transaction transaction = fullTextSession.beginTransaction();
+         SimpleEmail simpleEmail = new SimpleEmail();
+         simpleEmail.to = "outher space";
+         simpleEmail.message = "anybody out there?";
+         fullTextSession.save(simpleEmail);
+         transaction.commit();
+         storedEmailsCount++;
+      } finally {
+         fullTextSession.close();
+      }
+   }
+
+   private void waitForAllJoinsCompleted() {
+      int expectedSize = slaves.size() + 1;
+      waitMembersCount(master, EMAIL_TYPE, expectedSize);
+      for (FullTextSessionBuilder slave : slaves) {
+         waitMembersCount(slave, EMAIL_TYPE, expectedSize);
+      }
+   }
+
+   private void printout(String message) {
+      if (VERBOSE) {
+         System.out.println(message);
+      }
+   }
+
+   @BeforeClass
+   public static void prepareConnectionPool() {
+      ClusterSharedConnectionProvider.realStart();
+   }
+
+   @AfterClass
+   public static void shutdownConnectionPool() {
+      ClusterSharedConnectionProvider.realStop();
+   }
+
+}

--- a/lucene/directory-provider/src/test/java/org/infinispan/hibernate/search/LiveRunningTest.java
+++ b/lucene/directory-provider/src/test/java/org/infinispan/hibernate/search/LiveRunningTest.java
@@ -17,6 +17,8 @@ import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.spi.IndexedTypeSet;
 import org.hibernate.search.spi.impl.PojoIndexedTypeIdentifier;
 import org.hibernate.search.test.util.FullTextSessionBuilder;
+import org.infinispan.hibernate.search.ClusterTestHelper.ExclusiveIndexUse;
+import org.infinispan.hibernate.search.ClusterTestHelper.IndexingFlushMode;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -34,12 +36,12 @@ import org.junit.Test;
 public class LiveRunningTest {
 
    private static final int TEST_RUNS = 17;
-   private static final int MAX_SLAVES = 5;
+   private static final int MAX_SLAVES = 7;
 
    private static final IndexedTypeIdentifier EMAIL_TYPE = new PojoIndexedTypeIdentifier(SimpleEmail.class);
    private static final IndexedTypeSet TEST_TYPES = EMAIL_TYPE.asTypeSet();
 
-   private final FullTextSessionBuilder master = createClusterNode(TEST_TYPES, true);
+   private final FullTextSessionBuilder master = createClusterNode(TEST_TYPES, ExclusiveIndexUse.EXCLUSIVE, IndexingFlushMode.SYNC);
    private final List<FullTextSessionBuilder> slaves = new LinkedList<>();
 
    private boolean growCluster = true;
@@ -86,7 +88,7 @@ public class LiveRunningTest {
          if (slaves.size() >= MAX_SLAVES) {
             growCluster = false;
          } else {
-            slaves.add(createClusterNode(TEST_TYPES, false));
+            slaves.add(createClusterNode(TEST_TYPES, ExclusiveIndexUse.SHARED, IndexingFlushMode.SYNC));
          }
       } else {
          if (slaves.size() == 0) {

--- a/lucene/directory-provider/src/test/java/org/infinispan/hibernate/search/TwoNodesTest.java
+++ b/lucene/directory-provider/src/test/java/org/infinispan/hibernate/search/TwoNodesTest.java
@@ -1,7 +1,6 @@
 package org.infinispan.hibernate.search;
 
 import static org.infinispan.hibernate.search.ClusterTestHelper.clusterSize;
-import static org.infinispan.hibernate.search.ClusterTestHelper.createClusterNode;
 import static org.infinispan.hibernate.search.ClusterTestHelper.waitMembersCount;
 
 import static org.junit.Assert.assertEquals;
@@ -17,6 +16,8 @@ import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.spi.IndexedTypeSet;
 import org.hibernate.search.spi.impl.PojoIndexedTypeIdentifier;
 import org.hibernate.search.test.util.FullTextSessionBuilder;
+import org.infinispan.hibernate.search.ClusterTestHelper.ExclusiveIndexUse;
+import org.infinispan.hibernate.search.ClusterTestHelper.IndexingFlushMode;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -60,7 +61,7 @@ public class TwoNodesTest {
       // verify nodeb is able to find it:
       verifyNodeSeesUpdatedIndex(nodeb);
       // now start a new node, it will join the cluster and receive the current index state:
-      FullTextSessionBuilder nodeC = createClusterNode(TEST_TYPES, true);
+      FullTextSessionBuilder nodeC = createClusterNode();
       assertEquals(3, clusterSize(nodea, EMAIL_TYPE));
       try {
          // verify the new node is able to perform the same searches:
@@ -100,9 +101,13 @@ public class TwoNodesTest {
    public void setUp() throws Exception {
       entityTypes = new HashSet<Class<?>>();
       entityTypes.add(SimpleEmail.class);
-      nodea = createClusterNode(TEST_TYPES, true);
-      nodeb = createClusterNode(TEST_TYPES, true);
+      nodea = createClusterNode();
+      nodeb = createClusterNode();
       waitMembersCount(nodea, EMAIL_TYPE, 2);
+   }
+
+   private FullTextSessionBuilder createClusterNode() {
+      return ClusterTestHelper.createClusterNode(TEST_TYPES, ExclusiveIndexUse.EXCLUSIVE, IndexingFlushMode.SYNC);
    }
 
    @After

--- a/lucene/directory-provider/src/test/java/org/infinispan/hibernate/search/sharedIndex/SharedIndexTest.java
+++ b/lucene/directory-provider/src/test/java/org/infinispan/hibernate/search/sharedIndex/SharedIndexTest.java
@@ -20,7 +20,10 @@ import org.hibernate.search.spi.impl.IndexedTypeSets;
 import org.hibernate.search.spi.impl.PojoIndexedTypeIdentifier;
 import org.hibernate.search.test.util.FullTextSessionBuilder;
 import org.infinispan.hibernate.search.ClusterSharedConnectionProvider;
+import org.infinispan.hibernate.search.ClusterTestHelper;
 import org.infinispan.hibernate.search.SimpleEmail;
+import org.infinispan.hibernate.search.ClusterTestHelper.ExclusiveIndexUse;
+import org.infinispan.hibernate.search.ClusterTestHelper.IndexingFlushMode;
 import org.infinispan.hibernate.search.spi.InfinispanDirectoryProvider;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.remoting.transport.Address;
@@ -77,7 +80,7 @@ public class SharedIndexTest {
 
    @Before
    public void setUp() throws Exception {
-      node = createClusterNode(TEST_TYPES, true);
+      node = createClusterNode(TEST_TYPES, ExclusiveIndexUse.EXCLUSIVE, IndexingFlushMode.SYNC);
       waitMembersCount(node, TOASTER_TYPE, 1);
    }
 


### PR DESCRIPTION
I'm introducing a new functional test combining async indexing, exclusive locking and replicated Lucene Directory.

Some users claimed this wasn't working, but I couldn't manage to see it failing; possibly a configuration issue.

You see anything wrong with the new test?
See also: https://hibernate.atlassian.net/browse/HSEARCH-2022

 - https://issues.jboss.org/browse/ISPN-7929