### PR TITLE
ISPN-7930 Avoid provided deps unless necessary

### DIFF
--- a/jcache/commons/pom.xml
+++ b/jcache/commons/pom.xml
@@ -16,7 +16,6 @@
       <dependency>
          <groupId>${project.groupId}</groupId>
          <artifactId>infinispan-commons</artifactId>
-         <scope>provided</scope>
       </dependency>
 
       <dependency>

--- a/jcache/embedded/pom.xml
+++ b/jcache/embedded/pom.xml
@@ -22,7 +22,6 @@
       <dependency>
          <groupId>${project.groupId}</groupId>
          <artifactId>infinispan-core</artifactId>
-         <scope>provided</scope>
       </dependency>
 
       <dependency>
@@ -53,7 +52,7 @@
       <dependency>
          <groupId>${project.groupId}</groupId>
          <artifactId>infinispan-cdi-embedded</artifactId>
-         <scope>provided</scope>
+         <optional>true</optional>
       </dependency>
 
       <dependency>

--- a/jcache/remote/pom.xml
+++ b/jcache/remote/pom.xml
@@ -21,13 +21,12 @@
       <dependency>
          <groupId>${project.groupId}</groupId>
          <artifactId>infinispan-query-dsl</artifactId>
-         <scope>provided</scope>
+         <optional>true</optional>
       </dependency>
 
       <dependency>
          <groupId>${project.groupId}</groupId>
          <artifactId>infinispan-client-hotrod</artifactId>
-         <scope>provided</scope>
       </dependency>
 
       <dependency>

--- a/spring/spring4/spring4-common/pom.xml
+++ b/spring/spring4/spring4-common/pom.xml
@@ -26,7 +26,6 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>infinispan-commons</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/spring/spring4/spring4-embedded/pom.xml
+++ b/spring/spring4/spring4-embedded/pom.xml
@@ -32,7 +32,6 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>infinispan-core</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/spring/spring4/spring4-remote/pom.xml
+++ b/spring/spring4/spring4-remote/pom.xml
@@ -32,7 +32,6 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>infinispan-client-hotrod</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-7930

* Some of the provided dependencies were added to avoid issues with uber
  jars, but these uber jars are not really designed for Maven-like envs.
* Having these provided dependencies forces users to define the provided
  dependencies on top which is a usability issue.
* So this JIRA reverts these provided dependencies since users should
  not be relying on uber jars as dependencies.