### PR TITLE
ISPN-7710 Remote query server module dependency

### DIFF
--- a/server/integration/feature-pack/src/main/resources/modules/system/layers/base/org/infinispan/main/module.xml
+++ b/server/integration/feature-pack/src/main/resources/modules/system/layers/base/org/infinispan/main/module.xml
@@ -11,6 +11,7 @@
         <module name="org.jboss.logging"/>
         <module name="org.infinispan.commons" export="true"/>
         <module name="org.infinispan.query" optional="true" services="import"/>
+        <module name="org.infinispan.remote-query.server" optional="true"/>
         <module name="org.infinispan.lucene-directory" optional="true" export="true" services="export" />
         <module name="org.jboss.marshalling" services="import"/>
         <module name="org.jgroups"/>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-7710

* Add remote query server dependency to org.infinispan module in server
  as optional dependency so that CompatibilityProtoStreamMarshaller can
  easily be set in configuration.