### PR TITLE
ISPN-6245 Integration test and fix for deploying custom compat marshaller

### DIFF
--- a/documentation/src/main/asciidoc/server_guide/configuration.adoc
+++ b/documentation/src/main/asciidoc/server_guide/configuration.adoc
@@ -499,48 +499,44 @@ By default each protocol stores data in the cache in the most efficient format f
 
 ----
 
-To specify a custom server-side compatibility marshaller use the "marshaller" attribute:
+To specify a custom server-side compatibility marshaller use the "marshaller" attribute which can hold either an
+ordinary fully qualified class name or an 'extended' class name which is composed of a JBoss Modules module identifier,
+a slot name, and a fully qualified class name separated by the ':' character, (eg. "com.acme.my-module-name:my-slot:com.acme.CustomMarshaller").
+
+By using a plain fully qualified class name you will be able to reference only 'stock' marshallers provided by Infinispan,
+like "org.infinispan.query.remote.CompatibilityProtoStreamMarshaller". This option is provided for conciseness and backwards
+compatibility. The second option of using 'extended' class names is more generic and is preferred as it allows you to
+really add new marshallers from an external module of your choice.
+
+The module identifier and slot follow the rules imposed by JBoss Modules, and the designated module must be available to
+the server either in the 'modules' folder or be deployed through the deployer service in the 'deployments' folder. In
+the second case its module identifier will be of the form 'deployment.my-jar-name.jar' and the slot will be 'main'.
+
+NOTE: The referenced module will become an automatic dependency for the Cache referencing it, so in case the jar
+defining the module is redeployed, the Cache will be restarted.
 
 [source,xml]
 ----
+<!-- using an alternative, 'stock', marshaller -->
+<compatibility marshaller="org.infinispan.query.remote.CompatibilityProtoStreamMarshaller"/>
 
-<compatibility marshaller="com.acme.CustomMarshaller"/>
+or
 
-----
+<!-- using a marshaller deployed as a module -->
+<compatibility marshaller="com.acme.my-gadgets-module:main:com.acme.CustomCompatMarshaller"/>
 
-Your custom marshaller needs to be on the classpath of the Infinispan module. You can add it by either:
+or
 
-- copying your jar to
-+
-    modules/system/layers/base/org/infinispan/main
-+
-and editing the module definition to include the jar as resource-root:
-+
-[source,xml]
-.modules/system/layers/base/org/infinispan/main/modules.xml
-----
-
-<resources>
-    ...
-    <resource-root path="acme-custom-marshallers.jar"/>
-    ...
-</resources>
+<!-- using a marshaller deployed as a regular jar deployed by dropping it in the 'deployments' folder -->
+<compatibility marshaller="deployment.my-jar-with-gadgets.jar:main:com.acme.CustomCompatMarshaller"/>
 
 ----
 
-- or by creating a custom JBoss Module and adding it as a dependency to the Infinispan module:
-+
-[source,xml]
-.modules/system/layers/base/org/infinispan/main/modules.xml
-----
-
-<dependencies>
-    ...
-    <module name="com.acme.custom.marshallers"/>
-    ...
-</dependencies>
-
-----
+NOTE: Past versions of Infinispan (prior to 9.1.x) did not support the 'extended' class name format and were unable to
+refer to classes outside the Infinispan implementation and instead relied on the user to manually modify the
+'dependencies' or 'resources' element of the module.xml file of the "org.infinispan" module in order to 'inject' the
+user supplied jar containing the custom marshaller. This practice is suboptimal from the maintainability point of view
+and is now discouraged (but it still works) and you are urged to migrate to the new approach.
 
 ==== Custom Marshaller Bridges
 Infinispan provides two marshalling bridges for marshalling client/server requests using the Kryo and Protostuff libraries.

--- a/documentation/src/main/asciidoc/user_guide/query.adoc
+++ b/documentation/src/main/asciidoc/user_guide/query.adoc
@@ -288,7 +288,7 @@ public class Airplane {
 ====== Specifying indexed Entities
 
 Infinispan can automatically recognize and manage indexes for different entity types in a cache. Future versions of Infinispan will remove this capability so it's recommended to
-declare upfront which types are going to be indexed. This can be done via xml:
+declare upfront which types are going to be indexed (list them by their fully qualified class name). This can be done via xml:
 
 [source,xml]
 ----
@@ -297,8 +297,8 @@ declare upfront which types are going to be indexed. This can be done via xml:
       <replicated-cache name="default">
          <indexing index="ALL">
             <indexed-entities>
-                <indexed-entity>org.infinispan.query.test.Car</indexed-entity>
-                <indexed-entity>org.infinispan.query.test.Truck</indexed-entity>
+                <indexed-entity>com.acme.query.test.Car</indexed-entity>
+                <indexed-entity>com.acme.query.test.Truck</indexed-entity>
             </indexed-entities>
          </indexing>
       </replicated-cache>
@@ -317,6 +317,17 @@ or programmatically:
        .addIndexedEntity(Truck.class)
 
 ----
+
+In server mode, the class names listed under the 'indexed-entities' element must use the 'extended' class name format
+which is composed of a JBoss Modules module identifier, a slot name, and the fully qualified class name, these three
+components being separated by the ':' character, (eg. "com.acme.my-module-with-entity-classes:my-slot:com.acme.query.test.Car").
+The entity classes must be located in the referenced module, which can be either a user supplied module deployed in the
+'modules' folder of your server or a plain jar deployed in the 'deployments' folder. The module in question will become
+an automatic dependency of your Cache, so its eventual redeployment will cause the cache to be restarted.
+
+NOTE: Only for server, if you fail to follow the requirement of using 'extended' class names and use a plain class name
+its resolution will fail due to missing class because the wrong ClassLoader is being used (the Infinispan's internal
+class path is being used).
 
 
 ===== Index mode [[query.index-mode]]

--- a/query/src/main/java/org/infinispan/query/backend/QueryInterceptor.java
+++ b/query/src/main/java/org/infinispan/query/backend/QueryInterceptor.java
@@ -264,6 +264,15 @@ public final class QueryInterceptor extends DDAsyncInterceptor {
       }
    }
 
+   /**
+    * The set of known classes. Some might be indexable, some are not.
+    *
+    * @return an immutable set
+    */
+   public Set<Class<?>> getKnownClasses() {
+      return queryKnownClasses.keys();
+   }
+
    private Object extractValue(Object storedValue) {
       return fromStorage(storedValue, valueEncoder, valueWrapper);
    }

--- a/query/src/main/java/org/infinispan/query/backend/QueryInterceptor.java
+++ b/query/src/main/java/org/infinispan/query/backend/QueryInterceptor.java
@@ -31,7 +31,6 @@ import org.infinispan.commands.write.RemoveCommand;
 import org.infinispan.commands.write.ReplaceCommand;
 import org.infinispan.commands.write.WriteCommand;
 import org.infinispan.commons.dataconversion.Encoder;
-import org.infinispan.commons.dataconversion.EncodingUtils;
 import org.infinispan.commons.dataconversion.Wrapper;
 import org.infinispan.commons.util.EnumUtil;
 import org.infinispan.container.DataContainer;
@@ -263,10 +262,6 @@ public final class QueryInterceptor extends DDAsyncInterceptor {
       for (Work work : works) {
          worker.performWork(work, transactionContext);
       }
-   }
-
-   public boolean hasIndex(final Class<?> c) {
-      return searchFactoryHandler.hasIndex(c);
    }
 
    private Object extractValue(Object storedValue) {

--- a/query/src/main/java/org/infinispan/query/impl/LifecycleManager.java
+++ b/query/src/main/java/org/infinispan/query/impl/LifecycleManager.java
@@ -243,7 +243,7 @@ public class LifecycleManager extends AbstractModuleLifecycle {
    }
 
    /**
-    * Check that the classes declared by the user are really indexable.
+    * Check that the indexable classes declared by the user are really indexable.
     */
    private void checkIndexableClasses(SearchIntegrator searchFactory, Set<Class<?>> indexedEntities) {
       for (Class<?> c : indexedEntities) {

--- a/query/src/main/java/org/infinispan/query/impl/LifecycleManager.java
+++ b/query/src/main/java/org/infinispan/query/impl/LifecycleManager.java
@@ -18,6 +18,7 @@ import org.hibernate.search.cfg.SearchMapping;
 import org.hibernate.search.cfg.spi.SearchConfiguration;
 import org.hibernate.search.spi.SearchIntegrator;
 import org.hibernate.search.spi.SearchIntegratorBuilder;
+import org.hibernate.search.spi.impl.PojoIndexedTypeIdentifier;
 import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
 import org.infinispan.commons.CacheException;
@@ -246,7 +247,7 @@ public class LifecycleManager extends AbstractModuleLifecycle {
     */
    private void checkIndexableClasses(SearchIntegrator searchFactory, Set<Class<?>> indexedEntities) {
       for (Class<?> c : indexedEntities) {
-         if (searchFactory.getIndexBinding(c) == null) {
+         if (searchFactory.getIndexBinding(new PojoIndexedTypeIdentifier(c)) == null) {
             throw log.classNotIndexable(c.getName());
          }
       }

--- a/query/src/main/java/org/infinispan/query/spi/ProgrammaticSearchMappingProvider.java
+++ b/query/src/main/java/org/infinispan/query/spi/ProgrammaticSearchMappingProvider.java
@@ -4,10 +4,24 @@ import org.hibernate.search.cfg.SearchMapping;
 import org.infinispan.Cache;
 
 /**
+ * An advanced SPI to be implemented by Infinispan modules that want to customize the {@link SearchMapping} object
+ * before the bootstrap of the {@link org.hibernate.search.SearchFactory} belonging to an indexed {@link Cache}. The
+ * {@link SearchMapping} object provided via the "hibernate.search.model_mapping" config property is used as a starting
+ * point if it was present, otherwise an empty {@link SearchMapping} is used.
+ * <p>
+ * Please note that in case multiple providers are found the order of invocation is not predictable so implementations
+ * must be careful not to step on each others toes.
+ *
  * @author anistor@redhat.com
  * @since 6.0
  */
 public interface ProgrammaticSearchMappingProvider {
 
+   /**
+    * Supply some custom programmatic mappings.
+    *
+    * @param cache         the indexed cache
+    * @param searchMapping the mapping object to customize
+    */
    void defineMappings(Cache cache, SearchMapping searchMapping);
 }

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/impl/model/Employee.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/impl/model/Employee.java
@@ -6,7 +6,6 @@ import java.util.List;
 import org.hibernate.search.annotations.Analyze;
 import org.hibernate.search.annotations.DocumentId;
 import org.hibernate.search.annotations.Field;
-import org.hibernate.search.annotations.Fields;
 import org.hibernate.search.annotations.Indexed;
 import org.hibernate.search.annotations.IndexedEmbedded;
 

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/ProtobufMetadataManagerInterceptor.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/ProtobufMetadataManagerInterceptor.java
@@ -210,11 +210,11 @@ final class ProtobufMetadataManagerInterceptor extends BaseCustomAsyncIntercepto
 
       return invokeNextThenAccept(ctx, command, (rCtx, rCommand, rv) -> {
          PutKeyValueCommand putKeyValueCommand = (PutKeyValueCommand) rCommand;
-         long flagsBitSet = copyFlags(putKeyValueCommand);
          if (putKeyValueCommand.isSuccessful()) {
-            FileDescriptorSource source =
-                  new FileDescriptorSource().addProtoFile((String) key, (String) value);
+            FileDescriptorSource source = new FileDescriptorSource()
+                  .addProtoFile((String) key, (String) value);
 
+            long flagsBitSet = copyFlags(putKeyValueCommand);
             ProgressCallback progressCallback = null;
             if (rCtx.isOriginLocal() && !putKeyValueCommand.hasAnyFlag(FlagBitSets.PUT_FOR_STATE_TRANSFER)) {
                progressCallback = new ProgressCallback(rCtx, flagsBitSet);
@@ -366,9 +366,9 @@ final class ProtobufMetadataManagerInterceptor extends BaseCustomAsyncIntercepto
       invoker.invoke(ctx, cmd);
 
       return invokeNextThenAccept(ctx, command, (rCtx, rCommand, rv) -> {
-         if (((WriteCommand) rCommand).isSuccessful()) {
-            FileDescriptorSource source =
-                  new FileDescriptorSource().addProtoFile((String) key, (String) value);
+         if (rCommand.isSuccessful()) {
+            FileDescriptorSource source = new FileDescriptorSource()
+                        .addProtoFile((String) key, (String) value);
 
             long flagsBitSet = copyFlags(((WriteCommand) rCommand));
             ProgressCallback progressCallback = null;

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/indexing/IndexingMetadata.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/indexing/IndexingMetadata.java
@@ -12,12 +12,13 @@ import org.infinispan.protostream.descriptors.AnnotationElement;
 /**
  * All fields of Protobuf types are indexed and stored by default if no indexing annotations are present. This behaviour
  * exists only for compatibility with first release of remote query; it is deprecated and will be removed in Infinispan
- * 10.0 (the lack of annotations will imply no indexing support in this future release). Indexing all fields is
- * sometimes acceptable but it can become a performance problem if there are many or very large fields. To avoid such
- * problems Infinispan allows and encourages you to specify which fields to index and store by means of two annotations
- * ({@literal @}Indexed and {@literal @}Field) that behave very similarly to the identically named Hibernate Search
- * annotations and which can be directly added to your Protobuf schema files in the documentation comments of your
- * message type definitions as demonstrated in the example below:
+ * 10.0 (the lack of annotations on your message/field definition will imply no indexing support in this future release,
+ * but you will still be able to perform unindexed query). Indexing all fields is sometimes acceptable but it can become
+ * a performance problem if there are many or very large fields. To avoid such problems Infinispan allows and encourages
+ * you to specify which fields to index and store by means of two annotations ({@literal @}Indexed and
+ * {@literal @}Field) that behave very similarly to the identically named Hibernate Search annotations and which can be
+ * directly added to your Protobuf schema files in the documentation comments of your message type definitions as
+ * demonstrated in the example below:
  * <p/>
  * <b>Example:</b>
  * <p/>
@@ -49,8 +50,8 @@ import org.infinispan.protostream.descriptors.AnnotationElement;
  * }
  * </pre>
  * <p>
- * Documentation annotations can be added after the human-readable documentation text on the last lines of the
- * documentation comment that precedes the element to be annotated (a message type definition or a field definition).
+ * Documentation annotations can be added after the human-readable text on the last lines of the documentation comment
+ * that precedes the element to be annotated (a message type definition or a field definition).
  * The syntax for defining these pseudo-annotations is identical to the one use by the Java language.
  * <p>
  * The '{@literal @}Indexed' annotation applies to message types only, has a boolean value that defaults to 'true', so
@@ -71,6 +72,7 @@ import org.infinispan.protostream.descriptors.AnnotationElement;
  * The '{@literal @}Analyzer' annotation applies to messages and fields and allows you to specify which analyzer to use
  * if analysis was enabled. If has a single attribute name 'definition' which must contain a valid analyzer definition
  * name specified as a String.
+ * <p>
  * <b>NOTE:</b>
  * <ul>
  * <li>1. The {@literal @}Field and {@literal @}Analyzer annotations have effect only if the containing message

--- a/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/deployments/AbstractNamedFactoryExtensionProcessor.java
+++ b/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/deployments/AbstractNamedFactoryExtensionProcessor.java
@@ -45,9 +45,10 @@ public abstract class AbstractNamedFactoryExtensionProcessor<T> extends Abstract
                         String nameValue = annotation.value("name").asString();
                         AbstractExtensionManagerService<T> service = createService(nameValue, instance);
                         ServiceName extensionServiceName = Constants.DATAGRID.append(service.getServiceTypeName(), nameValue.replaceAll("\\.", "_"));
-                        ServiceBuilder<T> serviceBuilder = ctx.getServiceTarget().addService(extensionServiceName, service);
-                        serviceBuilder.setInitialMode(ServiceController.Mode.ACTIVE)
-                                .addDependency(extensionManagerServiceName, ExtensionManagerService.class, service.getExtensionManager());
+                        ServiceBuilder<T> serviceBuilder = ctx.getServiceTarget()
+                              .addService(extensionServiceName, service)
+                              .setInitialMode(ServiceController.Mode.ACTIVE)
+                              .addDependency(extensionManagerServiceName, ExtensionManagerService.class, service.getExtensionManager());
                         serviceBuilder.install();
                     }
                 }

--- a/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/deployments/ConverterFactoryExtensionProcessor.java
+++ b/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/deployments/ConverterFactoryExtensionProcessor.java
@@ -23,7 +23,8 @@ public final class ConverterFactoryExtensionProcessor extends AbstractNamedFacto
         return CacheEventConverterFactory.class;
     }
 
-    private static class ConverterFactoryService extends AbstractExtensionManagerService<CacheEventConverterFactory> {
+    private static final class ConverterFactoryService extends AbstractExtensionManagerService<CacheEventConverterFactory> {
+
         private ConverterFactoryService(String name, CacheEventConverterFactory converterFactory) {
             super(name, converterFactory);
         }

--- a/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/deployments/FilterConverterFactoryExtensionProcessor.java
+++ b/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/deployments/FilterConverterFactoryExtensionProcessor.java
@@ -23,7 +23,8 @@ public final class FilterConverterFactoryExtensionProcessor extends AbstractName
         return CacheEventFilterConverterFactory.class;
     }
 
-    private static class FilterConverterFactoryService extends AbstractExtensionManagerService<CacheEventFilterConverterFactory> {
+    private static final class FilterConverterFactoryService extends AbstractExtensionManagerService<CacheEventFilterConverterFactory> {
+
         private FilterConverterFactoryService(String name, CacheEventFilterConverterFactory converterFactory) {
             super(name, converterFactory);
         }

--- a/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/deployments/FilterFactoryExtensionProcessor.java
+++ b/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/deployments/FilterFactoryExtensionProcessor.java
@@ -23,8 +23,9 @@ public final class FilterFactoryExtensionProcessor extends AbstractNamedFactoryE
         return new FilterFactoryService(name, instance);
     }
 
-    private static class FilterFactoryService extends AbstractExtensionManagerService<CacheEventFilterFactory> {
-        public FilterFactoryService(String name, CacheEventFilterFactory filterFactory) {
+    private static final class FilterFactoryService extends AbstractExtensionManagerService<CacheEventFilterFactory> {
+
+        private FilterFactoryService(String name, CacheEventFilterFactory filterFactory) {
             super(name, filterFactory);
         }
 

--- a/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/deployments/KeyValueFilterConverterExtensionProcessor.java
+++ b/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/deployments/KeyValueFilterConverterExtensionProcessor.java
@@ -27,7 +27,8 @@ public class KeyValueFilterConverterExtensionProcessor extends AbstractNamedFact
       return KeyValueFilterConverterFactory.class;
    }
 
-   private static class KeyValueFilterConverterFactoryService extends AbstractExtensionManagerService<KeyValueFilterConverterFactory> {
+   private static final class KeyValueFilterConverterFactoryService extends AbstractExtensionManagerService<KeyValueFilterConverterFactory> {
+
       private KeyValueFilterConverterFactoryService(String name, KeyValueFilterConverterFactory converterFactory) {
          super(name, converterFactory);
       }

--- a/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/deployments/MarshallerExtensionProcessor.java
+++ b/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/deployments/MarshallerExtensionProcessor.java
@@ -32,8 +32,9 @@ public class MarshallerExtensionProcessor extends AbstractServerExtensionProcess
     public void installService(DeploymentPhaseContext ctx, String serviceName, Marshaller instance) {
         MarshallerService service = new MarshallerService(instance);
         ServiceName extensionServiceName = Constants.DATAGRID.append(service.getServiceTypeName());
-        ServiceBuilder<Marshaller> serviceBuilder = ctx.getServiceTarget().addService(extensionServiceName, service);
-        serviceBuilder.setInitialMode(ServiceController.Mode.ACTIVE)
+        ServiceBuilder<Marshaller> serviceBuilder = ctx.getServiceTarget()
+                .addService(extensionServiceName, service)
+                .setInitialMode(ServiceController.Mode.ACTIVE)
                 .addDependency(extensionManagerServiceName, ExtensionManagerService.class, service.getExtensionManager());
         try {
             serviceBuilder.install();
@@ -43,16 +44,17 @@ public class MarshallerExtensionProcessor extends AbstractServerExtensionProcess
         }
     }
 
-    static class MarshallerService implements Service<Marshaller> {
+    private static final class MarshallerService implements Service<Marshaller> {
+
         private final Marshaller marshaller;
         private final InjectedValue<ExtensionManagerService> extensionManager = new InjectedValue<>();
 
-        MarshallerService(Marshaller marshaller) {
+        private MarshallerService(Marshaller marshaller) {
             assert marshaller != null : ROOT_LOGGER.nullVar(getServiceTypeName());
             this.marshaller = marshaller;
         }
 
-        public InjectedValue<ExtensionManagerService> getExtensionManager() {
+        InjectedValue<ExtensionManagerService> getExtensionManager() {
             return extensionManager;
         }
 
@@ -73,7 +75,7 @@ public class MarshallerExtensionProcessor extends AbstractServerExtensionProcess
             return marshaller;
         }
 
-        public String getServiceTypeName() {
+        String getServiceTypeName() {
             return "remote-event-marshaller";
         }
     }

--- a/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/deployments/ServerExtensionDependenciesProcessor.java
+++ b/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/deployments/ServerExtensionDependenciesProcessor.java
@@ -25,16 +25,15 @@ public class ServerExtensionDependenciesProcessor implements DeploymentUnitProce
 
     @Override
     public void deploy(DeploymentPhaseContext ctx) throws DeploymentUnitProcessingException {
-        if (hasInfinispanExtensions(ctx)) {
-            DeploymentUnit deploymentUnit = ctx.getDeploymentUnit();
+        DeploymentUnit deploymentUnit = ctx.getDeploymentUnit();
+        if (hasInfinispanExtensions(deploymentUnit)) {
             ModuleSpecification moduleSpec = deploymentUnit.getAttachment(Attachments.MODULE_SPECIFICATION);
             ModuleLoader moduleLoader = Module.getBootModuleLoader();
             moduleSpec.addSystemDependency(new ModuleDependency(moduleLoader, API, false, false, false, false));
         }
     }
 
-    private boolean hasInfinispanExtensions(DeploymentPhaseContext ctx) {
-        DeploymentUnit deploymentUnit = ctx.getDeploymentUnit();
+    private boolean hasInfinispanExtensions(DeploymentUnit deploymentUnit) {
         ServicesAttachment servicesAttachment = deploymentUnit.getAttachment(Attachments.SERVICES);
         if (servicesAttachment != null) {
             List<String> filterFactories = servicesAttachment.getServiceImplementations(CacheEventFilterFactory.class.getName());
@@ -43,7 +42,7 @@ public class ServerExtensionDependenciesProcessor implements DeploymentUnitProce
             List<String> marshallers = servicesAttachment.getServiceImplementations(Marshaller.class.getName());
             List<String> keyValueFilterConverterFactories = servicesAttachment.getServiceImplementations(KeyValueFilterConverterFactory.class.getName());
             return !filterFactories.isEmpty() || !marshallers.isEmpty()
-                    || !converterFactories.isEmpty() || !filterConverterFactories.isEmpty() || !keyValueFilterConverterFactories.isEmpty();
+                  || !converterFactories.isEmpty() || !filterConverterFactories.isEmpty() || !keyValueFilterConverterFactories.isEmpty();
         }
         return false;
     }

--- a/server/integration/feature-pack/src/main/resources/modules/system/layers/base/org/infinispan/main/module.xml
+++ b/server/integration/feature-pack/src/main/resources/modules/system/layers/base/org/infinispan/main/module.xml
@@ -12,6 +12,7 @@
         <module name="org.infinispan.commons" export="true"/>
         <module name="org.infinispan.query" optional="true" services="import"/>
         <module name="org.infinispan.remote-query.server" optional="true"/>
+        <module name="org.infinispan.remote-query.client" optional="true"/>
         <module name="org.infinispan.lucene-directory" optional="true" export="true" services="export" />
         <module name="org.jboss.marshalling" services="import"/>
         <module name="org.jgroups"/>

--- a/server/integration/feature-pack/src/main/resources/modules/system/layers/base/org/infinispan/server/hotrod/main/module.xml
+++ b/server/integration/feature-pack/src/main/resources/modules/system/layers/base/org/infinispan/server/hotrod/main/module.xml
@@ -18,6 +18,7 @@
       <module name="org.infinispan.scripting" services="import"/>
       <module name="org.infinispan.tasks" services="import"/>
       <module name="org.infinispan.remote-query.server" services="import"/>
+      <module name="org.infinispan.remote-query.client"/>
       <module name="org.infinispan.objectfilter" />
       <module name="org.infinispan.query" />
       <module name="org.jboss.logging" />

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/cs/deployment/AbstractCacheStoreExtensionProcessor.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/cs/deployment/AbstractCacheStoreExtensionProcessor.java
@@ -74,7 +74,7 @@ public abstract class AbstractCacheStoreExtensionProcessor<T> implements Deploym
 
       protected final T extension;
       protected final String className;
-      protected InjectedValue<DeployedCacheStoreFactory> deployedCacheStoreFactory = new InjectedValue<>();
+      protected final InjectedValue<DeployedCacheStoreFactory> deployedCacheStoreFactory = new InjectedValue<>();
 
       protected AbstractExtensionManagerService(String className, T extension) {
          this.extension = extension;
@@ -93,7 +93,7 @@ public abstract class AbstractCacheStoreExtensionProcessor<T> implements Deploym
          deployedCacheStoreFactory.getValue().removeInstance(extension);
       }
 
-      public InjectedValue<DeployedCacheStoreFactory> getDeployedCacheStoreFactory() {
+      InjectedValue<DeployedCacheStoreFactory> getDeployedCacheStoreFactory() {
          return deployedCacheStoreFactory;
       }
 

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ClusteredCacheConfigurationAdd.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ClusteredCacheConfigurationAdd.java
@@ -38,7 +38,6 @@ import org.jboss.dmr.ModelNode;
  */
 public abstract class ClusteredCacheConfigurationAdd extends CacheConfigurationAdd {
 
-
     ClusteredCacheConfigurationAdd(CacheMode mode) {
         super(mode);
     }
@@ -63,7 +62,7 @@ public abstract class ClusteredCacheConfigurationAdd extends CacheConfigurationA
      */
     @Override
     void processModelNode(OperationContext context, String containerName, ModelNode cache, ConfigurationBuilder builder, List<Dependency<?>> dependencies)
-            throws OperationFailedException{
+            throws OperationFailedException {
 
         // process cache attributes and elements
         super.processModelNode(context, containerName, cache, builder, dependencies);

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/SharedStateCacheConfigurationAdd.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/SharedStateCacheConfigurationAdd.java
@@ -48,7 +48,7 @@ public abstract class SharedStateCacheConfigurationAdd extends ClusteredCacheCon
 
     @Override
     void processModelNode(OperationContext context, String containerName, ModelNode cache, ConfigurationBuilder builder, List<Dependency<?>> dependencies)
-            throws OperationFailedException{
+            throws OperationFailedException {
 
         // process the basic clustered configuration
         super.processModelNode(context, containerName, cache, builder, dependencies);

--- a/server/integration/testsuite/build-testsuite.xml
+++ b/server/integration/testsuite/build-testsuite.xml
@@ -236,6 +236,7 @@
         <transform in="standalone.xml" out="testsuite/standalone-eviction.xml" modifyInfinispan="${infinispan.parts}/eviction.xml"/>
         <transform in="standalone.xml" out="testsuite/standalone-customcs.xml" modifyInfinispan="${infinispan.parts}/customcs.xml" filtering="true"/>
         <transform in="standalone.xml" out="testsuite/standalone-customtask.xml" modifyInfinispan="${infinispan.parts}/customtask.xml" filtering="true"/>
+        <transform in="standalone.xml" out="testsuite/standalone-custom-compat-marshaller.xml" modifyInfinispan="${infinispan.parts}/custom-compat-marshaller.xml" filtering="true"/>
         <transform in="clustered.xml" out="testsuite/clustered-expiration.xml" modifyInfinispan="${infinispan.parts}/expiration.xml"/>
         <transform in="standalone.xml" out="testsuite/standalone-cachecontainer.xml"
                    modifyInfinispan="${infinispan.parts}/cachecontainer.xml"

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/HotRodCustomMarshallerEventIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/HotRodCustomMarshallerEventIT.java
@@ -81,7 +81,7 @@ public class HotRodCustomMarshallerEventIT {
                     .port(server.getHotrodEndpoint().getPort());
         }
 
-        config.marshaller("org.infinispan.server.test.client.hotrod.HotRodCustomMarshallerEventIT$IdMarshaller");
+        config.marshaller(IdMarshaller.class.getName());
         return config.build();
     }
 

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/HotRodCustomMarshallerIteratorIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/HotRodCustomMarshallerIteratorIT.java
@@ -99,15 +99,15 @@ public class HotRodCustomMarshallerIteratorIT {
             // Add custom marshaller classes
             .addClasses(CustomProtoStreamMarshaller.class, ProtoStreamMarshaller.class, BaseProtoStreamMarshaller.class)
             .addClasses(HotRodClientException.class, UserMarshaller.class, GenderMarshaller.class, User.class, Address.class)
-                  // Add marshaller dependencies
+            // Add marshaller dependencies
             .add(new StringAsset(protoFile), "/sample_bank_account/bank.proto")
             .add(new StringAsset("Dependencies: org.infinispan.protostream"), "META-INF/MANIFEST.MF")
-                  // Register marshaller
+            // Register marshaller
             .addAsServiceProvider(Marshaller.class, CustomProtoStreamMarshaller.class)
-                  // Add custom filterConverter classes
+            // Add custom filterConverter classes
             .addClasses(CustomFilterFactory.class, CustomFilterFactory.CustomFilter.class, ParamCustomFilterFactory.class,
-                    ParamCustomFilterFactory.ParamCustomFilter.class)
-                  // Register custom filterConverterFactories
+                  ParamCustomFilterFactory.ParamCustomFilter.class)
+            // Register custom filterConverterFactories
             .addAsServiceProviderAndClasses(KeyValueFilterConverterFactory.class, ParamCustomFilterFactory.class, CustomFilterFactory.class);
    }
 

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/cs/custom/CustomCacheStoreIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/cs/custom/CustomCacheStoreIT.java
@@ -37,7 +37,7 @@ import org.junit.runner.RunWith;
  * @author Sebastian Laskawiec
  */
 @RunWith(Arquillian.class)
-@Category({CacheStore.class})
+@Category(CacheStore.class)
 public class CustomCacheStoreIT {
    private static final Log log = LogFactory.getLog(CustomCacheStoreIT.class);
 

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/query/ManualIndexingIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/query/ManualIndexingIT.java
@@ -26,63 +26,59 @@ import org.junit.runner.RunWith;
  *
  * @author anistor@redhat.com
  * @author vchepeli@redhat.com
- *
  */
 @Category(Queries.class)
 @RunWith(Arquillian.class)
 public class ManualIndexingIT extends RemoteQueryBaseIT {
 
-    private static final String CACHE_CONTAINER_NAME = "clustered";
-    private static final String CACHE_NAME = "localtestcache_manual";
+   @InfinispanResource("remote-query-1")
+   protected RemoteInfinispanServer server;
 
-    @InfinispanResource("remote-query-1")
-    protected RemoteInfinispanServer server;
+   private MBeanServerConnectionProvider jmxConnectionProvider;
 
-    private MBeanServerConnectionProvider jmxConnectionProvider;
+   public ManualIndexingIT() {
+      super("clustered", "localtestcache_manual");
+   }
 
-    public ManualIndexingIT() {
-        super(CACHE_CONTAINER_NAME, CACHE_NAME);
-    }
+   @Override
+   public RemoteInfinispanServer getServer() {
+      return server;
+   }
 
-    @Override
-    public RemoteInfinispanServer getServer() {
-        return server;
-    }
+   @Before
+   @Override
+   public void setUp() throws Exception {
+      super.setUp();
+      jmxConnectionProvider = new MBeanServerConnectionProvider(getServer().getHotrodEndpoint().getInetAddress().getHostName(), SERVER1_MGMT_PORT);
+   }
 
-    @Before
-    @Override
-    public void setUp() throws Exception {
-        super.setUp();
-        jmxConnectionProvider = new MBeanServerConnectionProvider(getServer().getHotrodEndpoint().getInetAddress().getHostName(), SERVER1_MGMT_PORT);
-    }
+   @Test
+   public void testManualIndexing() throws Exception {
+      QueryBuilder qb = Search.getQueryFactory(remoteCache).from(User.class)
+            .having("name").eq("Tom");
 
-    @Test
-    public void testManualIndexing() throws Exception {
-        QueryBuilder qb = Search.getQueryFactory(remoteCache).from(User.class)
-                .having("name").eq("Tom");
+      User user = new User();
+      user.setId(1);
+      user.setName("Tom");
+      user.setSurname("Cat");
+      user.setGender(User.Gender.MALE);
+      remoteCache.put(1, user);
 
-        User user = new User();
-        user.setId(1);
-        user.setName("Tom");
-        user.setSurname("Cat");
-        user.setGender(User.Gender.MALE);
-        remoteCache.put(1, user);
+      assertEquals(0, qb.build().list().size());
 
-        assertEquals(0, qb.build().list().size());
+      //manual indexing
+      ObjectName massIndexerName = new ObjectName("jboss." + InfinispanSubsystem.SUBSYSTEM_NAME + ":type=Query,manager="
+            + ObjectName.quote(cacheContainerName)
+            + ",cache=" + ObjectName.quote(cacheName)
+            + ",component=MassIndexer");
+      jmxConnectionProvider.getConnection().invoke(massIndexerName, "start", null, null);
 
-        //manual indexing
-        ObjectName massIndexerName = new ObjectName("jboss." + InfinispanSubsystem.SUBSYSTEM_NAME + ":type=Query,manager="
-                + ObjectName.quote(CACHE_CONTAINER_NAME)
-                + ",cache=" + ObjectName.quote(CACHE_NAME)
-                + ",component=MassIndexer");
-        jmxConnectionProvider.getConnection().invoke(massIndexerName, "start", null, null);
-
-        List<User> list = qb.build().list();
-        assertEquals(1, list.size());
-        User foundUser = list.get(0);
-        assertEquals(1, foundUser.getId());
-        assertEquals("Tom", foundUser.getName());
-        assertEquals("Cat", foundUser.getSurname());
-        assertEquals(User.Gender.MALE, foundUser.getGender());
-    }
+      List<User> list = qb.build().list();
+      assertEquals(1, list.size());
+      User foundUser = list.get(0);
+      assertEquals(1, foundUser.getId());
+      assertEquals("Tom", foundUser.getName());
+      assertEquals("Cat", foundUser.getSurname());
+      assertEquals(User.Gender.MALE, foundUser.getGender());
+   }
 }

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/query/RemoteQueryCompatModeIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/query/RemoteQueryCompatModeIT.java
@@ -1,0 +1,104 @@
+package org.infinispan.server.test.query;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.util.List;
+
+import org.infinispan.arquillian.core.InfinispanResource;
+import org.infinispan.arquillian.core.RemoteInfinispanServer;
+import org.infinispan.arquillian.core.RunningServer;
+import org.infinispan.arquillian.core.WithRunningServer;
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.client.hotrod.Search;
+import org.infinispan.commons.marshall.Marshaller;
+import org.infinispan.commons.marshall.jboss.AbstractJBossMarshaller;
+import org.infinispan.commons.marshall.jboss.DefaultContextClassResolver;
+import org.infinispan.query.dsl.Query;
+import org.infinispan.query.dsl.QueryFactory;
+import org.infinispan.server.test.category.Queries;
+import org.infinispan.server.test.util.ITestUtils;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests for remote query using jboss marshalling and Hibernate Search annotated classes. Protobuf is not used!
+ *
+ * @author anistor@redhat.com
+ * @since 9.1
+ */
+@RunWith(Arquillian.class)
+@Category(Queries.class)
+public class RemoteQueryCompatModeIT {
+
+   private static RemoteCacheManager remoteCacheManager;
+
+   @InfinispanResource("standalone-custom-compat-marshaller")
+   RemoteInfinispanServer server1;
+
+   @BeforeClass
+   public static void before() throws Exception {
+      // We put the entity class in one jar and the marshaller in another jar, just to make things more interesting.
+      JavaArchive entityArchive = ShrinkWrap.create(JavaArchive.class)
+            .addClasses(TestEntity.class)
+            .add(new StringAsset("Dependencies: org.hibernate.search.engine"), "META-INF/MANIFEST.MF"); // we need the HS annotations
+
+      JavaArchive marshallerArchive = ShrinkWrap.create(JavaArchive.class)
+            .addClasses(CustomCompatModeMarshaller.class)
+            .add(new StringAsset("Dependencies: org.jboss.marshalling, " +
+                  "org.infinispan.commons, " +
+                  "org.infinispan.remote-query.client, " +
+                  "deployment.custom-test-entity.jar"),  // We depend on the jar containing the entity, so we can instantiate it.
+                  "META-INF/MANIFEST.MF")
+            .addAsServiceProvider(Marshaller.class, CustomCompatModeMarshaller.class);
+
+      String serverDir = System.getProperty("server1.dist");
+      entityArchive.as(ZipExporter.class).exportTo(new File(serverDir, "/standalone/deployments/custom-test-entity.jar"), true);
+      marshallerArchive.as(ZipExporter.class).exportTo(new File(serverDir, "/standalone/deployments/custom-compat-marshaller.jar"), true);
+   }
+
+   @AfterClass
+   public static void release() {
+      if (remoteCacheManager != null) {
+         remoteCacheManager.stop();
+      }
+   }
+
+   @Test
+   @WithRunningServer(@RunningServer(name = "standalone-custom-compat-marshaller"))
+   public void testCompatQuery() throws Exception {
+      remoteCacheManager = ITestUtils.createCacheManager(server1);
+      RemoteCache<Integer, TestEntity> remoteCache = remoteCacheManager.getCache();
+      remoteCache.clear();
+
+      for (int i = 0; i < 10; i++) {
+         TestEntity user = new TestEntity("name" + i);
+         remoteCache.put(i, user);
+      }
+
+      QueryFactory queryFactory = Search.getQueryFactory(remoteCache);
+
+      Query query = queryFactory.from(TestEntity.class).build();
+
+      List<?> list = query.list();
+      assertEquals(10, list.size());
+      assertTrue(list.get(0) instanceof TestEntity);
+   }
+
+   public static final class CustomCompatModeMarshaller extends AbstractJBossMarshaller {
+
+      public CustomCompatModeMarshaller() {
+         baseCfg.setClassResolver(new DefaultContextClassResolver(getClass().getClassLoader()));
+      }
+   }
+}

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/query/RemoteQueryDMRRegisterIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/query/RemoteQueryDMRRegisterIT.java
@@ -56,7 +56,7 @@ public class RemoteQueryDMRRegisterIT extends RemoteQueryIT {
       ModelControllerClient client = ModelControllerClient.Factory.create(
             getServer().getHotrodEndpoint().getInetAddress().getHostName(), SERVER1_MGMT_PORT);
 
-      ModelNode addProtobufFileOp = getOperation("clustered", "upload-proto-schemas", nameList, urlList);
+      ModelNode addProtobufFileOp = getOperation("upload-proto-schemas", nameList, urlList);
 
       ModelNode result = client.execute(addProtobufFileOp);
       assertEquals(SUCCESS, result.get(OUTCOME).asString());
@@ -70,10 +70,10 @@ public class RemoteQueryDMRRegisterIT extends RemoteQueryIT {
       MarshallerRegistration.registerMarshallers(ProtoStreamMarshaller.getSerializationContext(remoteCacheManager));
    }
 
-   private ModelNode getOperation(String containerName, String operationName, ModelNode nameList, ModelNode urlList) {
+   private ModelNode getOperation(String operationName, ModelNode nameList, ModelNode urlList) {
       PathAddress address = PathAddress.pathAddress(
             PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, InfinispanExtension.SUBSYSTEM_NAME))
-            .append("cache-container", containerName);
+            .append("cache-container", cacheContainerName);
       ModelNode op = new ModelNode();
       op.get(OP).set(operationName);
       op.get(OP_ADDR).set(address.toModelNode());

--- a/server/integration/testsuite/src/test/resources/arquillian.xml
+++ b/server/integration/testsuite/src/test/resources/arquillian.xml
@@ -1317,6 +1317,21 @@
                 <property name="jmxDomain">${server.jmx.domain}</property>
             </configuration>
         </container>
+        <container qualifier="standalone-custom-compat-marshaller" mode="manual">
+            <configuration>
+                <property name="javaHome">${server.jvm}</property>
+                <property name="jbossHome">${server1.dist}</property>
+                <property name="managementAddress">${node0.ip}</property>
+                <property name="serverConfig">testsuite/standalone-custom-compat-marshaller.xml</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Djboss.socket.binding.port-offset=300 -Djgroups.join_timeout=2000
+                </property>
+                <property name="managementPort">10290</property>
+                <property name="waitForPorts">11522 8380</property>
+                <property name="jmxDomain">${server.jmx.domain}</property>
+            </configuration>
+        </container>
     </group>
 
     <group qualifier="suite-client-local">

--- a/server/integration/testsuite/src/test/resources/config/infinispan/custom-compat-marshaller.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/custom-compat-marshaller.xml
@@ -1,0 +1,14 @@
+        <subsystem xmlns="urn:infinispan:server:core:9.0">
+            <cache-container name="local" default-cache="default">
+                <local-cache name="default">
+                    <compatibility enabled="true" marshaller="deployment.custom-compat-marshaller.jar:main:org.infinispan.server.test.query.RemoteQueryCompatModeIT$CustomCompatModeMarshaller"/>
+                    <indexing index="ALL">
+                        <indexed-entities>
+                            <indexed-entity>deployment.custom-test-entity.jar:main:org.infinispan.server.test.query.TestEntity</indexed-entity>
+                        </indexed-entities>
+                        <property name="default.directory_provider">ram</property>
+                    </indexing>
+                </local-cache>
+                <local-cache name="memcachedCache"/>
+            </cache-container>
+        </subsystem>

--- a/wildfly-modules/src/main/resources/org/infinispan/server/hotrod/main/module.xml
+++ b/wildfly-modules/src/main/resources/org/infinispan/server/hotrod/main/module.xml
@@ -19,6 +19,7 @@
       <module name="org.infinispan.tasks" services="import" slot="${slot}"/>
       <module name="org.infinispan.objectfilter" slot="${slot}"/>
       <module name="org.infinispan.query" slot="${slot}"/>
+      <module name="org.infinispan.query.remote.client" slot="${slot}"/>
       <module name="org.jboss.logging" />
       <module name="org.jboss.marshalling" slot="${slot}" services="import"/>
       <module name="org.jboss.sasl" services="import" />


### PR DESCRIPTION
Besides using a FQN to reference classes for compat marshaller and indexed entities (in server) we also accept an extended class name, composed of moduleName:slotName:fullyQualifiedClassName. See the updated docs for more info.

https://issues.jboss.org/browse/ISPN-6245
https://issues.jboss.org/browse/ISPN-6334
