### PR TITLE
ISPN-6997 PessimisticTxPartitionAndMergeDuringRuntimeTest.testOriginatorIsolatedPartition random failures

### DIFF
--- a/core/src/main/java/org/infinispan/commands/tx/AbstractTransactionBoundaryCommand.java
+++ b/core/src/main/java/org/infinispan/commands/tx/AbstractTransactionBoundaryCommand.java
@@ -92,7 +92,7 @@ public abstract class AbstractTransactionBoundaryCommand implements TransactionB
    @Override
    public CompletableFuture<Object> invokeAsync() throws Throwable {
       markGtxAsRemote();
-      RemoteTransaction transaction = getRemoteTransaction();
+      RemoteTransaction transaction = txTable.getRemoteTransaction(globalTx);
       if (transaction == null) {
          if (trace) log.tracef("Did not find a RemoteTransaction for %s", globalTx);
          return CompletableFuture.completedFuture(invalidRemoteTxReturnValue());
@@ -106,10 +106,6 @@ public abstract class AbstractTransactionBoundaryCommand implements TransactionB
 
    protected void visitRemoteTransaction(RemoteTransaction tx) {
       // to be overridden
-   }
-
-   protected RemoteTransaction getRemoteTransaction() {
-      return txTable.getRemoteTransaction(globalTx);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/commands/tx/PrepareCommand.java
+++ b/core/src/main/java/org/infinispan/commands/tx/PrepareCommand.java
@@ -118,7 +118,7 @@ public class PrepareCommand extends AbstractTransactionBoundaryCommand implement
       }
 
       // 1. first create a remote transaction (or get the existing one)
-      RemoteTransaction remoteTransaction = getRemoteTransaction();
+      RemoteTransaction remoteTransaction = txTable.getOrCreateRemoteTransaction(globalTx, modifications);
       //set the list of modifications anyway, as the transaction might have already been created by a previous
       //LockControlCommand with null modifications.
       if (hasModifications()) {
@@ -184,11 +184,6 @@ public class PrepareCommand extends AbstractTransactionBoundaryCommand implement
    @Override
    public boolean hasSkipLocking() {
       return false;
-   }
-
-   @Override
-   protected RemoteTransaction getRemoteTransaction() {
-      return txTable.getOrCreateRemoteTransaction(globalTx, modifications);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/commands/tx/totalorder/TotalOrderCommitCommand.java
+++ b/core/src/main/java/org/infinispan/commands/tx/totalorder/TotalOrderCommitCommand.java
@@ -34,9 +34,4 @@ public class TotalOrderCommitCommand extends CommitCommand {
    public byte getCommandId() {
       return COMMAND_ID;
    }
-
-   @Override
-   protected RemoteTransaction getRemoteTransaction() {
-      return txTable.getOrCreateRemoteTransaction(globalTx, null);
-   }
 }

--- a/core/src/main/java/org/infinispan/commands/tx/totalorder/TotalOrderNonVersionedPrepareCommand.java
+++ b/core/src/main/java/org/infinispan/commands/tx/totalorder/TotalOrderNonVersionedPrepareCommand.java
@@ -57,7 +57,7 @@ public class TotalOrderNonVersionedPrepareCommand extends PrepareCommand impleme
 
    @Override
    public TotalOrderRemoteTransactionState getOrCreateState() {
-      return getRemoteTransaction().getTransactionState();
+      return txTable.getOrCreateRemoteTransaction(globalTx, modifications).getTransactionState();
    }
 
 }

--- a/core/src/main/java/org/infinispan/commands/tx/totalorder/TotalOrderRollbackCommand.java
+++ b/core/src/main/java/org/infinispan/commands/tx/totalorder/TotalOrderRollbackCommand.java
@@ -35,9 +35,4 @@ public class TotalOrderRollbackCommand extends RollbackCommand {
    public byte getCommandId() {
       return COMMAND_ID;
    }
-
-   @Override
-   protected RemoteTransaction getRemoteTransaction() {
-      return txTable.getOrCreateRemoteTransaction(globalTx, null);
-   }
 }

--- a/core/src/main/java/org/infinispan/commands/tx/totalorder/TotalOrderVersionedCommitCommand.java
+++ b/core/src/main/java/org/infinispan/commands/tx/totalorder/TotalOrderVersionedCommitCommand.java
@@ -34,9 +34,4 @@ public class TotalOrderVersionedCommitCommand extends VersionedCommitCommand {
    public byte getCommandId() {
       return COMMAND_ID;
    }
-
-   @Override
-   protected RemoteTransaction getRemoteTransaction() {
-      return txTable.getOrCreateRemoteTransaction(globalTx, null);
-   }
 }

--- a/core/src/main/java/org/infinispan/commands/tx/totalorder/TotalOrderVersionedPrepareCommand.java
+++ b/core/src/main/java/org/infinispan/commands/tx/totalorder/TotalOrderVersionedPrepareCommand.java
@@ -54,7 +54,7 @@ public class TotalOrderVersionedPrepareCommand extends VersionedPrepareCommand i
 
    @Override
    public TotalOrderRemoteTransactionState getOrCreateState() {
-      return getRemoteTransaction().getTransactionState();
+      return txTable.getOrCreateRemoteTransaction(globalTx, modifications).getTransactionState();
    }
 
 }

--- a/core/src/main/java/org/infinispan/interceptors/impl/TxInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/TxInterceptor.java
@@ -604,6 +604,8 @@ public class TxInterceptor<K, V> extends DDAsyncInterceptor implements JmxStatis
             log.tracef("Rolling back remote transaction %s because either already completed (%s) or originator no longer in the cluster (%s).",
                        globalTransaction, alreadyCompleted, originatorMissing);
          }
+         // The rollback command only marks the transaction as completed in invokeAsync()
+         txTable.markTransactionCompleted(globalTransaction, false);
          RollbackCommand rollback = commandsFactory.buildRollbackCommand(command.getGlobalTransaction());
          return invokeNextAndFinally(ctx, rollback, (rCtx, rCommand, rv1, throwable1) -> {
             RemoteTransaction remoteTx = ((TxInvocationContext<RemoteTransaction>) rCtx).getCacheTransaction();

--- a/core/src/main/java/org/infinispan/interceptors/locking/PessimisticLockingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/locking/PessimisticLockingInterceptor.java
@@ -9,7 +9,6 @@ import org.infinispan.commands.CommandsFactory;
 import org.infinispan.commands.DataCommand;
 import org.infinispan.commands.FlagAffectedCommand;
 import org.infinispan.commands.control.LockControlCommand;
-import org.infinispan.commands.remote.recovery.TxCompletionNotificationCommand;
 import org.infinispan.commands.tx.PrepareCommand;
 import org.infinispan.commands.write.ApplyDeltaCommand;
 import org.infinispan.commands.write.DataWriteCommand;
@@ -18,8 +17,7 @@ import org.infinispan.context.impl.FlagBitSets;
 import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.distribution.DistributionInfo;
 import org.infinispan.factories.annotations.Inject;
-import org.infinispan.remoting.inboundhandler.DeliverOrder;
-import org.infinispan.statetransfer.OutdatedTopologyException;
+import org.infinispan.interceptors.InvocationSuccessFunction;
 import org.infinispan.statetransfer.StateTransferManager;
 import org.infinispan.transaction.impl.LocalTransaction;
 import org.infinispan.util.concurrent.locks.LockUtil;
@@ -45,6 +43,9 @@ public class PessimisticLockingInterceptor extends AbstractTxLockingInterceptor 
    private static final Log log = LogFactory.getLog(PessimisticLockingInterceptor.class);
    public static final boolean trace = log.isTraceEnabled();
 
+   private final InvocationSuccessFunction localLockCommandWork =
+         (rCtx, rCommand, rv) -> localLockCommandWork(rCtx, (LockControlCommand) rCommand);
+
    private CommandsFactory cf;
    private StateTransferManager stateTransferManager;
 
@@ -66,32 +67,23 @@ public class PessimisticLockingInterceptor extends AbstractTxLockingInterceptor 
          return invokeNext(ctx, command);
       }
 
-      try {
-         if (!readNeedsLock(ctx, command)) {
-            return invokeNext(ctx, command);
-         }
-
-         Object key = command.getKey();
-         if (!needRemoteLocks(ctx, key, command)) {
-            acquireLocalLock(ctx, command);
-            return invokeNext(ctx, command);
-         }
-
-         TxInvocationContext txContext = (TxInvocationContext) ctx;
-         LockControlCommand lcc = cf.buildLockControlCommand(key, command.getFlagsBitSet(),
-               txContext.getGlobalTransaction());
-         Object result = invokeNextThenApply(ctx, lcc, (rCtx, rCommand, rv) -> invokeNext(rCtx, command));
-         return makeStage(result).andFinally(ctx, command, (rCtx, rCommand, rv, t) -> {
-            if (t != null) {
-               rethrowAndReleaseLocksIfNeeded(rCtx, t);
-            } else {
-               acquireLocalLock(rCtx, (DataCommand) rCommand);
-            }
-         });
-      } catch (Throwable t) {
-         rethrowAndReleaseLocksIfNeeded(ctx, t);
-         throw t;
+      if (!readNeedsLock(ctx, command)) {
+         return invokeNext(ctx, command);
       }
+
+      Object key = command.getKey();
+      if (!needRemoteLocks(ctx, key, command)) {
+         acquireLocalLock(ctx, command);
+         return invokeNext(ctx, command);
+      }
+
+      TxInvocationContext txContext = (TxInvocationContext) ctx;
+      LockControlCommand lcc = cf.buildLockControlCommand(key, command.getFlagsBitSet(),
+            txContext.getGlobalTransaction());
+      return invokeNextThenApply(ctx, lcc, (rCtx, rCommand, rv) -> {
+         acquireLocalLock(rCtx, command);
+         return invokeNext(rCtx, command);
+      });
 
    }
 
@@ -110,33 +102,25 @@ public class PessimisticLockingInterceptor extends AbstractTxLockingInterceptor 
 
    @Override
    protected Object handleReadManyCommand(InvocationContext ctx, FlagAffectedCommand command, Collection<?> keys) throws Throwable {
-      try {
-         Object stage;
-         if (!readNeedsLock(ctx, command)) {
-            stage = invokeNext(ctx, command);
+      Object maybeStage;
+      if (!readNeedsLock(ctx, command)) {
+         maybeStage = invokeNext(ctx, command);
+      } else {
+         if (!needRemoteLocks(ctx, keys, command)) {
+            acquireLocalLocks(ctx, command, keys);
+            maybeStage = invokeNext(ctx, command);
          } else {
-            if (!needRemoteLocks(ctx, keys, command)) {
-               acquireLocalLocks(ctx, command, keys);
-               stage = invokeNext(ctx, command);
-            } else {
-               // Acquire the remote locks first, then the local locks
-               final TxInvocationContext txContext = (TxInvocationContext) ctx;
-               LockControlCommand lcc = cf.buildLockControlCommand(keys, command.getFlagsBitSet(),
-                     txContext.getGlobalTransaction());
-               stage = invokeNextThenApply(ctx, lcc, (rCtx, rLockCommand, rv) -> {
-                  acquireLocalLocks(rCtx, command, keys);
-                  return invokeNext(rCtx, command);
-               });
-            }
+            // Acquire the remote locks first, then the local locks
+            final TxInvocationContext txContext = (TxInvocationContext) ctx;
+            LockControlCommand lcc = cf.buildLockControlCommand(keys, command.getFlagsBitSet(),
+                  txContext.getGlobalTransaction());
+            maybeStage = invokeNextThenApply(ctx, lcc, (rCtx, rLockCommand, rv) -> {
+               acquireLocalLocks(rCtx, command, keys);
+               return invokeNext(rCtx, command);
+            });
          }
-         return makeStage(stage).andExceptionally(ctx, command, (rCtx, rCommand, t) -> {
-            releaseLocksOnFailureBeforePrepare(rCtx);
-            throw t;
-         });
-      } catch (Throwable t) {
-         releaseLocksOnFailureBeforePrepare(ctx);
-         throw t;
       }
+      return maybeStage;
    }
 
    private void acquireLocalLocks(InvocationContext ctx, FlagAffectedCommand command, Collection<?> keys)
@@ -157,101 +141,81 @@ public class PessimisticLockingInterceptor extends AbstractTxLockingInterceptor 
 
    @Override
    protected <K> Object handleWriteManyCommand(InvocationContext ctx, FlagAffectedCommand command, Collection<K> keys, boolean forwarded) throws Throwable {
-      try {
-         Object stage;
-         if (hasSkipLocking(command)) {
-            stage = invokeNext(ctx, command);
+      Object maybeStage;
+      if (hasSkipLocking(command)) {
+         maybeStage = invokeNext(ctx, command);
+      } else {
+         if (!needRemoteLocks(ctx, keys, command)) {
+            acquireLocalLocks(ctx, command, keys);
+            maybeStage = invokeNext(ctx, command);
          } else {
-            if (!needRemoteLocks(ctx, keys, command)) {
-               acquireLocalLocks(ctx, command, keys);
-               stage = invokeNext(ctx, command);
-            } else {
-               final TxInvocationContext txContext = (TxInvocationContext) ctx;
-               LockControlCommand lcc = cf.buildLockControlCommand(keys, command.getFlagsBitSet(),
-                     txContext.getGlobalTransaction());
-               stage = invokeNextThenApply(ctx, lcc, (rCtx, rCommand, rv) -> {
-                  acquireLocalLocks(rCtx, command, keys);
-                  return invokeNext(rCtx, command);
-               });
-            }
+            final TxInvocationContext txContext = (TxInvocationContext) ctx;
+            LockControlCommand lcc = cf.buildLockControlCommand(keys, command.getFlagsBitSet(),
+                  txContext.getGlobalTransaction());
+            maybeStage = invokeNextThenApply(ctx, lcc, (rCtx, rCommand, rv) -> {
+               acquireLocalLocks(rCtx, command, keys);
+               return invokeNext(rCtx, command);
+            });
          }
-         return makeStage(stage).andExceptionally(ctx, command, (rCtx, rCommand, t) -> {
-            rethrowAndReleaseLocksIfNeeded(rCtx, t);
-            throw t;
-         });
-      } catch (Throwable t) {
-         rethrowAndReleaseLocksIfNeeded(ctx, t);
-         throw t;
       }
+      return maybeStage;
    }
 
    @Override
    protected Object visitDataWriteCommand(InvocationContext ctx, DataWriteCommand command)
          throws Throwable {
-      try {
-         Object stage;
-         Object key = command.getKey();
-         if (hasSkipLocking(command)) {
-            // Non-modifying functional write commands are executed in non-transactional context on non-originators
-            if (ctx.isInTxScope()) {
-               // Mark the key as affected even with SKIP_LOCKING
-               ((TxInvocationContext<?>) ctx).addAffectedKey(key);
-            }
-            stage = invokeNext(ctx, command);
-         } else {
-            if (!needRemoteLocks(ctx, key, command)) {
-               acquireLocalLock(ctx, command);
-               stage = invokeNext(ctx, command);
-            } else {
-               final TxInvocationContext txContext = (TxInvocationContext) ctx;
-               LockControlCommand lcc = cf.buildLockControlCommand(key, command.getFlagsBitSet(),
-                     txContext.getGlobalTransaction());
-               return invokeNextAndHandle(ctx, lcc, (rCtx, rCommand, rv, t) -> {
-                  rethrowAndReleaseLocksIfNeeded(rCtx, t);
-                  acquireLocalLock(rCtx, command);
-                  return invokeNext(rCtx, command);
-               });
-            }
+      Object maybeStage;
+      Object key = command.getKey();
+      if (hasSkipLocking(command)) {
+         // Non-modifying functional write commands are executed in non-transactional context on non-originators
+         if (ctx.isInTxScope()) {
+            // Mark the key as affected even with SKIP_LOCKING
+            ((TxInvocationContext<?>) ctx).addAffectedKey(key);
          }
-         return makeStage(stage).andExceptionally(ctx, command, (rCtx, rCommand, t) -> {
-            rethrowAndReleaseLocksIfNeeded(rCtx, t);
-            throw t;
-         });
-      } catch (Throwable t) {
-         releaseLocksOnFailureBeforePrepare(ctx);
-         throw t;
+         maybeStage = invokeNext(ctx, command);
+      } else {
+         if (!needRemoteLocks(ctx, key, command)) {
+            acquireLocalLock(ctx, command);
+            maybeStage = invokeNext(ctx, command);
+         } else {
+            final TxInvocationContext txContext = (TxInvocationContext) ctx;
+            LockControlCommand lcc = cf.buildLockControlCommand(key, command.getFlagsBitSet(),
+                  txContext.getGlobalTransaction());
+            return invokeNextThenApply(ctx, lcc, (rCtx, rCommand, rv) -> {
+               acquireLocalLock(rCtx, command);
+               return invokeNext(rCtx, command);
+            });
+         }
       }
+      return maybeStage;
    }
 
    @Override
    public Object visitApplyDeltaCommand(InvocationContext ctx, ApplyDeltaCommand command)
          throws Throwable {
       try {
-         Object stage;
+         Object maybeStage;
          if (hasSkipLocking(command)) {
-            stage = invokeNext(ctx, command);
+            maybeStage = invokeNext(ctx, command);
          } else {
             Object[] compositeKeys = command.getCompositeKeys();
             Set<Object> keysToLock = new HashSet<>(Arrays.asList(compositeKeys));
             if (!needRemoteLocks(ctx, keysToLock, command)) {
                ((TxInvocationContext<?>) ctx).addAllAffectedKeys(keysToLock);
                acquireLocalCompositeLocks(command, keysToLock, ctx);
-               stage = invokeNext(ctx, command);
+               maybeStage = invokeNext(ctx, command);
             } else {
                final TxInvocationContext txContext = (TxInvocationContext) ctx;
                LockControlCommand lcc = cf.buildLockControlCommand(keysToLock, command.getFlagsBitSet(),
                      txContext.getGlobalTransaction());
-               stage = invokeNextThenApply(ctx, lcc, (rCtx, rCommand, rv) -> {
+               maybeStage = invokeNextThenApply(ctx, lcc, (rCtx, rCommand, rv) -> {
                   ((TxInvocationContext<?>) rCtx).addAllAffectedKeys(keysToLock);
                   acquireLocalCompositeLocks(command, keysToLock, rCtx);
                   return invokeNext(rCtx, command);
                });
             }
          }
-         return makeStage(stage).andExceptionally(ctx, command, (rCtx, rCommand, t) -> {
-            lockManager.unlockAll(rCtx);
-            throw t;
-         });
+         return maybeStage;
       } catch (Throwable t) {
          lockManager.unlockAll(ctx);
          throw t;
@@ -302,10 +266,7 @@ public class PessimisticLockingInterceptor extends AbstractTxLockingInterceptor 
          }
       }
 
-      return invokeNextAndHandle(ctx, command, (rCtx, rCommand, rv, t) -> {
-         rethrowAndReleaseLocksIfNeeded(rCtx, t);
-         return localLockCommandWork(rCtx, (LockControlCommand) rCommand);
-      });
+      return invokeNextThenApply(ctx, command, localLockCommandWork);
    }
 
    private boolean localLockCommandWork(InvocationContext ctx, LockControlCommand command)
@@ -318,28 +279,11 @@ public class PessimisticLockingInterceptor extends AbstractTxLockingInterceptor 
       if (command.isUnlock()) {
          if (ctx.isOriginLocal()) throw new AssertionError(
                "There's no advancedCache.unlock so this must have originated remotely.");
-         releaseLocksOnFailureBeforePrepare(ctx);
          return false;
       }
 
-      try {
-         lockAllOrRegisterBackupLock(txInvocationContext, command.getKeys(), getLockTimeoutMillis(command));
-      } catch (Throwable t) {
-         releaseLocksOnFailureBeforePrepare(ctx);
-         throw t;
-      }
+      lockAllOrRegisterBackupLock(txInvocationContext, command.getKeys(), getLockTimeoutMillis(command));
       return true;
-   }
-
-   private void rethrowAndReleaseLocksIfNeeded(InvocationContext ctx, Throwable throwable)
-         throws Throwable {
-      if (throwable != null) {
-         // If the command will be retried, there is no need to release this or other locks
-         if (!(throwable instanceof OutdatedTopologyException)) {
-            releaseLocksOnFailureBeforePrepare(ctx);
-         }
-         throw throwable;
-      }
    }
 
    private boolean needRemoteLocks(InvocationContext ctx, Collection<?> keys,
@@ -392,26 +336,4 @@ public class PessimisticLockingInterceptor extends AbstractTxLockingInterceptor 
    private boolean isStateTransferInProgress() {
       return stateTransferManager != null && stateTransferManager.isStateTransferInProgress();
    }
-
-   private void releaseLocksOnFailureBeforePrepare(InvocationContext ctx) {
-      if (!ctx.isInTxScope()) {
-         return;
-      }
-      TxInvocationContext txContext = (TxInvocationContext) ctx;
-      try {
-         lockManager.unlockAll(ctx);
-         if (ctx.isOriginLocal() && ctx.isInTxScope() && rpcManager != null) {
-            TxCompletionNotificationCommand command =
-                  cf.buildTxCompletionNotificationCommand(null, txContext.getGlobalTransaction());
-            final LocalTransaction cacheTransaction = (LocalTransaction) txContext.getCacheTransaction();
-            if (!cacheTransaction.getRemoteLocksAcquired().isEmpty()) {
-               rpcManager.invokeRemotely(cacheTransaction.getRemoteLocksAcquired(), command,
-                                         rpcManager.getDefaultRpcOptions(false, DeliverOrder.NONE));
-            }
-         }
-      } catch (Throwable t) {
-         log.debugf(t, "Error releasing locks for failure before prepare for transaction %s", txContext.getCacheTransaction());
-      }
-   }
-
 }

--- a/core/src/main/java/org/infinispan/statetransfer/OutdatedTopologyException.java
+++ b/core/src/main/java/org/infinispan/statetransfer/OutdatedTopologyException.java
@@ -22,8 +22,6 @@ public class OutdatedTopologyException extends CacheException {
     * handle a command.
     * <p>
     * It avoids the cost associated to create and collect the stack when it isn't needed.
-    *
-    * @return a cached instance of {@link OutdatedTopologyException}.
     */
    @SuppressWarnings("ThrowableInstanceNeverThrown")
    public static final OutdatedTopologyException INSTANCE = new OutdatedTopologyException();
@@ -40,7 +38,6 @@ public class OutdatedTopologyException extends CacheException {
 
    /**
     * Request retrying the command in explicitly set topology (or later one).
-    * @param requestedTopologyId
     */
    public OutdatedTopologyException(int requestedTopologyId) {
       super(null, null, false, false);

--- a/core/src/main/java/org/infinispan/transaction/impl/LocalTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/impl/LocalTransaction.java
@@ -212,12 +212,12 @@ public abstract class LocalTransaction extends AbstractCacheTransaction {
       if (recipients == null) {
          return null;
       }
-      if (getTopologyId() == currentTopologyId) {
-         return recipients;
-      }
+      // Include all the nodes we sent a LockControlCommand to and are not in the recipients list now
+      // either because the topology changed, or because the lock failed.
+      // Also include nodes that are no longer in the cluster, so if JGroups retransmits a lock/prepare command
+      // after a merge, it also retransmits the commit/rollback.
       Set<Address> allRecipients = new HashSet<>(getRemoteLocksAcquired());
       allRecipients.addAll(recipients);
-      allRecipients.retainAll(members);
       if (trace) log.tracef("The merged list of nodes to send commit/rollback is %s", allRecipients);
       return allRecipients;
    }

--- a/core/src/test/java/org/infinispan/partitionhandling/BaseTxPartitionAndMergeTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/BaseTxPartitionAndMergeTest.java
@@ -22,6 +22,7 @@ import org.infinispan.util.concurrent.ReclosableLatch;
 import org.infinispan.util.concurrent.TimeoutException;
 import org.infinispan.util.concurrent.locks.LockManager;
 import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
 import org.testng.AssertJUnit;
 
 /**
@@ -31,6 +32,7 @@ import org.testng.AssertJUnit;
  * @since 8.0
  */
 public abstract class BaseTxPartitionAndMergeTest extends BasePartitionHandlingTest {
+   private static final Log log = LogFactory.getLog(BaseTxPartitionAndMergeTest.class);
 
    protected static final String INITIAL_VALUE = "init-value";
    protected static final String FINAL_VALUE = "final-value";
@@ -195,6 +197,8 @@ public abstract class BaseTxPartitionAndMergeTest extends BasePartitionHandlingT
          final Filter currentFilter = filter;
          if (currentFilter != null && currentFilter.before(command, reply, order)) {
             delegate.handle(command, reply, order);
+         } else {
+            log.debugf("Ignoring command %s", command);
          }
       }
    }

--- a/core/src/test/java/org/infinispan/tx/exception/TxAndTimeoutExceptionTest.java
+++ b/core/src/test/java/org/infinispan/tx/exception/TxAndTimeoutExceptionTest.java
@@ -76,14 +76,14 @@ public class TxAndTimeoutExceptionTest extends SingleCacheManagerTest {
       assertTrue(lm.isLocked("k2"));
       assertEquals(2, txTable.getLocalTxCount());
       assertNotNull(tm.getTransaction());
-      expectException(TimeoutException.class, () -> op.execute());
+      expectException(TimeoutException.class, op::execute);
 
       //make sure that locks acquired by that tx were released even before the transaction is rolled back, the tx object
       //was marked for rollback
       Transaction transaction = tm.getTransaction();
       assertNotNull(transaction);
       assertEquals(Status.STATUS_MARKED_ROLLBACK, transaction.getStatus());
-      assertFalse(lm.isLocked("k2"));
+      assertTrue(lm.isLocked("k2"));
       assertTrue(lm.isLocked("k1"));
       expectException(CacheException.class, IllegalStateException.class, () -> cache.put("k3", "v3"));
       assertEquals(2, txTable.getLocalTxCount());
@@ -99,6 +99,7 @@ public class TxAndTimeoutExceptionTest extends SingleCacheManagerTest {
       assertEquals(0, txTable.getLocalTxCount());
       assertEquals("v1", cache.get("k1"));
       assertFalse(lm.isLocked("k1"));
+      assertFalse(lm.isLocked("k2"));
       assertEquals(0, txTable.getLocalTxCount());
    }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6997
https://issues.jboss.org/browse/ISPN-7960

* Handle lock failures with a regular rollback command.
* Don't send TxCompletionNotificationCommands from
  PessimisticLockingInterceptor.
* Add lock recipients to the affected nodes even in case of failure.
* Send commit/rollback to all affected nodes, even if the cache
  topology did not change.
* Do not change protocols when the cluster changes size 
* Do not create a remote transaction when the originator is not a
  cluster member.
* Remove the originator check in TxInterceptor.