### PR TITLE
Upgrade JGroups to 4.0.4.Final

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -75,7 +75,7 @@
       <version.cdi>1.2</version.cdi>
       <version.jboss.marshalling>2.0.0.Beta3</version.jboss.marshalling>
       <version.jboss.logging>3.3.0.Final</version.jboss.logging>
-      <version.jgroups>4.0.3.Final</version.jgroups>
+      <version.jgroups>4.0.4.Final</version.jgroups>
       <version.jta>1.0.1.Final</version.jta>
       <version.netty>4.1.9.Final</version.netty>
       <version.osgi>4.3.1</version.osgi>


### PR DESCRIPTION
Contains fix which is causing noise in our logs https://github.com/belaban/JGroups/commit/48d0b8c12c5ae491f81811f5e7c7b0065ebeedb4