### PR TITLE
ISPN-7998 Multi-key write commands don't work with union CHs

### DIFF
--- a/core/src/main/java/org/infinispan/distribution/ch/ConsistentHash.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/ConsistentHash.java
@@ -44,11 +44,11 @@ import org.infinispan.remoting.transport.Address;
  * @since 4.0
  */
 public interface ConsistentHash {
-
    /**
-    * @return The configured number of owners for each key. Note that {code @getOwners(key)} may return
-    *         a different number of owners.
+    * @return The configured number of owners. Note that the actual number of owners of each key may be different.
+    * @deprecated Since 9.1, it should not be used to obtain the number of owners of a particular key.
     */
+   @Deprecated
    int getNumOwners();
 
    /**

--- a/core/src/main/java/org/infinispan/interceptors/distribution/TriangleDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/TriangleDistributionInterceptor.java
@@ -39,7 +39,6 @@ import org.infinispan.context.impl.FlagBitSets;
 import org.infinispan.distribution.DistributionInfo;
 import org.infinispan.distribution.LocalizedCacheTopology;
 import org.infinispan.distribution.TriangleOrderManager;
-import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
 import org.infinispan.remoting.inboundhandler.DeliverOrder;
@@ -147,10 +146,9 @@ public class TriangleDistributionInterceptor extends NonTxDistributionIntercepto
 
    private Object handleRemotePutMapCommand(InvocationContext ctx, PutMapCommand command) {
       LocalizedCacheTopology cacheTopology = checkTopologyId(command);
-      final ConsistentHash ch = cacheTopology.getWriteConsistentHash();
       final VisitableCommand.LoadType loadType = command.loadType();
 
-      if (command.isForwarded() || ch.getNumOwners() == 1) {
+      if (command.isForwarded()) {
          //backup & remote || no backups
          return asyncInvokeNext(ctx, command,
                checkRemoteGetIfNeeded(ctx, command, command.getMap().keySet(), cacheTopology, loadType == OWNER));


### PR DESCRIPTION
The distribution interceptors assume all segments have
CH.getNumOwners() owners, but in a union CH that's not true.

https://issues.jboss.org/browse/ISPN-7998