### PR TITLE
ISPN-2082 JdbcStringBasedCacheStore: ORA-24816 when storing BLOB valu…

### DIFF
--- a/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/stringbased/JdbcStringBasedStore.java
+++ b/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/stringbased/JdbcStringBasedStore.java
@@ -2,7 +2,6 @@ package org.infinispan.persistence.jdbc.stringbased;
 
 import static org.infinispan.persistence.PersistenceUtil.getExpiryTime;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.sql.Connection;
@@ -595,9 +594,8 @@ public class JdbcStringBasedStore<K,V> implements AdvancedLoadWriteStore<K,V>, T
 
    private void prepareUpdateStatement(MarshalledEntry entry, String key, PreparedStatement ps) throws InterruptedException, SQLException {
       ByteBuffer byteBuffer = marshall(new KeyValuePair(entry.getValueBytes(), entry.getMetadataBytes()));
-      ps.setBinaryStream(1, new ByteArrayInputStream(byteBuffer.getBuf(), byteBuffer.getOffset(), byteBuffer.getLength()), byteBuffer.getLength());
-      ps.setLong(2, getExpiryTime(entry.getMetadata()));
-      ps.setString(3, key);
+      long expiryTime = getExpiryTime(entry.getMetadata());
+      tableManager.prepareUpdateStatement(ps, key, expiryTime, byteBuffer);
    }
 
    private String key2Str(Object key) throws PersistenceException {

--- a/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/table/management/AbstractTableManager.java
+++ b/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/table/management/AbstractTableManager.java
@@ -1,12 +1,15 @@
 package org.infinispan.persistence.jdbc.table.management;
 
+import java.io.ByteArrayInputStream;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Objects;
 
+import org.infinispan.commons.io.ByteBuffer;
 import org.infinispan.persistence.jdbc.JdbcUtil;
 import org.infinispan.persistence.jdbc.configuration.TableManipulationConfiguration;
 import org.infinispan.persistence.jdbc.connectionfactory.ConnectionFactory;
@@ -356,5 +359,12 @@ public abstract class AbstractTableManager implements TableManager {
    @Override
    public String encodeString(String string) {
       return string;
+   }
+
+   @Override
+   public void prepareUpdateStatement(PreparedStatement ps, String key, long timestamp, ByteBuffer byteBuffer) throws SQLException {
+      ps.setBinaryStream(1, new ByteArrayInputStream(byteBuffer.getBuf(), byteBuffer.getOffset(), byteBuffer.getLength()), byteBuffer.getLength());
+      ps.setLong(2, timestamp);
+      ps.setString(3, key);
    }
 }

--- a/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/table/management/TableManager.java
+++ b/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/table/management/TableManager.java
@@ -1,7 +1,10 @@
 package org.infinispan.persistence.jdbc.table.management;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
 
+import org.infinispan.commons.io.ByteBuffer;
 import org.infinispan.persistence.spi.PersistenceException;
 
 /**
@@ -64,4 +67,6 @@ public interface TableManager {
    boolean isStringEncodingRequired();
 
    String encodeString(String stringToEncode);
+
+   void prepareUpdateStatement(PreparedStatement ps, String key, long timestamp, ByteBuffer byteBuffer) throws SQLException;
 }


### PR DESCRIPTION
…es > 4000 bytes

-- PreparedStatements are now prepared in the TableManager
implementation to allow for greater flexibility for each database
vendor.

https://issues.jboss.org/browse/ISPN-2082