### PR TITLE
[8.1.x] ISPN-7955 Make the Hot Rod client lazily resolve server addresses

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/ServerConfiguration.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/ServerConfiguration.java
@@ -23,4 +23,11 @@ public class ServerConfiguration {
       return port;
    }
 
+   @Override
+   public String toString() {
+      return "ServerConfiguration[" +
+            "host='" + host + '\'' +
+            ", port=" + port +
+            ']';
+   }
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/ConfigurationProperties.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/ConfigurationProperties.java
@@ -91,7 +91,7 @@ public class ConfigurationProperties {
          String host = components[0];
          int port = DEFAULT_HOTROD_PORT;
          if (components.length > 1) port = Integer.parseInt(components[1]);
-         addresses.add(new InetSocketAddress(host, port));
+         addresses.add(InetSocketAddress.createUnresolved(host, port));
       }
 
       if (addresses.isEmpty()) throw new IllegalStateException("No Hot Rod servers specified!");

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/RetryOnFailureOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/RetryOnFailureOperation.java
@@ -92,7 +92,7 @@ public abstract class RetryOnFailureOperation<T> extends HotRodOperation {
 
    private Set<SocketAddress> updateFailedServers(SocketAddress address, Set<SocketAddress> failedServers) {
       if (failedServers == null) {
-         failedServers = new HashSet<SocketAddress>();
+         failedServers = new HashSet<>();
       }
 
       if (trace)

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec10.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec10.java
@@ -265,7 +265,7 @@ public class Codec10 implements Codec {
          int port = transport.readUnsignedShort();
          int hashCode = transport.read4ByteInt();
          if (trace) localLog.tracef("Server read: %s:%d - hash code is %d", host, port, hashCode);
-         SocketAddress address = new InetSocketAddress(host, port);
+         SocketAddress address = InetSocketAddress.createUnresolved(host, port);
          Set<Integer> hashes = servers2Hash.get(address);
          if (hashes == null) {
             hashes = new HashSet<Integer>();

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec11.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec11.java
@@ -90,7 +90,7 @@ public class Codec11 extends Codec10 {
 
    private void cacheHashCode(Map<SocketAddress, Set<Integer>> servers2Hash,
             String host, int port, int hashCode) {
-      SocketAddress address = new InetSocketAddress(host, port);
+      SocketAddress address = InetSocketAddress.createUnresolved(host, port);
       Set<Integer> hashes = servers2Hash.get(address);
       if (hashes == null) {
          hashes = new HashSet<Integer>();

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec20.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec20.java
@@ -388,7 +388,7 @@ public class Codec20 implements Codec, HotRodConstants {
       for (int i = 0; i < clusterSize; i++) {
          String host = transport.readString();
          int port = transport.readUnsignedShort();
-         addresses[i] = new InetSocketAddress(host, port);
+         addresses[i] = InetSocketAddress.createUnresolved(host, port);
       }
 
       short hashFunctionVersion = transport.readByte();
@@ -432,5 +432,4 @@ public class Codec20 implements Codec, HotRodConstants {
                newTopologyId, topologyAge, addresses);
       }
    }
-
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/tcp/TcpTransportFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/tcp/TcpTransportFactory.java
@@ -5,7 +5,6 @@ import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -58,7 +57,7 @@ public class TcpTransportFactory implements TransportFactory {
 
    /**
     * We need synchronization as the thread that calls {@link TransportFactory#start(org.infinispan.client.hotrod.impl.protocol.Codec, org.infinispan.client.hotrod.configuration.Configuration, java.util.concurrent.atomic.AtomicInteger, org.infinispan.client.hotrod.event.ClientListenerNotifier)}
-    * might(and likely will) be different from the thread(s) that calls {@link TransportFactory#getTransport(byte[], java.util.Set, byte[])} or other methods
+    * might(and likely will) be different from the thread(s) that calls {@link TransportFactory#getTransport(Set, byte[])} or other methods
     */
    private final Object lock = new Object();
    // The connection pool implementation is assumed to be thread-safe, so we need to synchronize just the access to this field and not the method calls
@@ -98,15 +97,15 @@ public class TcpTransportFactory implements TransportFactory {
          boolean pingOnStartup = configuration.pingOnStartup();
          Collection<SocketAddress> servers = new ArrayList<>();
          initialServers = new ArrayList<>();
-         for(ServerConfiguration server : configuration.servers()) {
-            servers.add(new InetSocketAddress(server.host(), server.port()));
+         for (ServerConfiguration server : configuration.servers()) {
+            servers.add(InetSocketAddress.createUnresolved(server.host(), server.port()));
          }
          initialServers.addAll(servers);
          if (!configuration.clusters().isEmpty()) {
             configuration.clusters().stream().forEach(cluster -> {
                Collection<SocketAddress> clusterAddresses = cluster.getCluster().stream()
-                  .map(server -> new InetSocketAddress(server.host(), server.port()))
-                  .collect(Collectors.toList());
+                       .map(server -> InetSocketAddress.createUnresolved(server.host(), server.port()))
+                       .collect(Collectors.toList());
                ClusterInfo clusterInfo = new ClusterInfo(cluster.getClusterName(), clusterAddresses);
                log.debugf("Add secondary cluster: %s", clusterInfo);
                clusters.add(clusterInfo);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/CSAIntegrationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/CSAIntegrationTest.java
@@ -65,11 +65,11 @@ public class CSAIntegrationTest extends HitsAwareCacheManagersTest {
       addClusterEnabledCacheManager(builder);
 
       hotRodServer1 = HotRodClientTestingUtil.startHotRodServer(manager(0));
-      addr2hrServer.put(new InetSocketAddress(hotRodServer1.getHost(), hotRodServer1.getPort()), hotRodServer1);
+      addr2hrServer.put(InetSocketAddress.createUnresolved(hotRodServer1.getHost(), hotRodServer1.getPort()), hotRodServer1);
       hotRodServer2 = HotRodClientTestingUtil.startHotRodServer(manager(1));
-      addr2hrServer.put(new InetSocketAddress(hotRodServer2.getHost(), hotRodServer2.getPort()), hotRodServer2);
+      addr2hrServer.put(InetSocketAddress.createUnresolved(hotRodServer2.getHost(), hotRodServer2.getPort()), hotRodServer2);
       hotRodServer3 = HotRodClientTestingUtil.startHotRodServer(manager(2));
-      addr2hrServer.put(new InetSocketAddress(hotRodServer3.getHost(), hotRodServer3.getPort()), hotRodServer3);
+      addr2hrServer.put(InetSocketAddress.createUnresolved(hotRodServer3.getHost(), hotRodServer3.getPort()), hotRodServer3);
 
       assert manager(0).getCache() != null;
       assert manager(1).getCache() != null;

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ClientConnectionPoolingTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ClientConnectionPoolingTest.java
@@ -104,8 +104,8 @@ public class ClientConnectionPoolingTest extends MultipleCacheManagersTest {
       workerThread5 = new WorkerThread(remoteCache);
       workerThread6 = new WorkerThread(remoteCache);
 
-      hrServ1Addr = new InetSocketAddress("localhost", hotRodServer1.getPort());
-      hrServ2Addr = new InetSocketAddress("localhost", hotRodServer2.getPort());
+      hrServ1Addr = InetSocketAddress.createUnresolved("localhost", hotRodServer1.getPort());
+      hrServ2Addr = InetSocketAddress.createUnresolved("localhost", hotRodServer2.getPort());
    }
 
    @AfterMethod

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/DroppedConnectionsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/DroppedConnectionsTest.java
@@ -8,7 +8,6 @@ import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.server.hotrod.HotRodServer;
 import org.infinispan.test.SingleCacheManagerTest;
-import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/DroppedConnectionsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/DroppedConnectionsTest.java
@@ -58,7 +58,7 @@ public class DroppedConnectionsTest extends SingleCacheManagerTest {
       rc.put("k","v"); //make sure a connection is created
 
       GenericKeyedObjectPool keyedObjectPool = transportFactory.getConnectionPool();
-      InetSocketAddress address = new InetSocketAddress("127.0.0.1", hotRodServer.getPort());
+      InetSocketAddress address = InetSocketAddress.createUnresolved("127.0.0.1", hotRodServer.getPort());
 
       assertEquals(0, keyedObjectPool.getNumActive(address));
       assertEquals(1, keyedObjectPool.getNumIdle(address));

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HitsAwareCacheManagersTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HitsAwareCacheManagersTest.java
@@ -79,7 +79,7 @@ public abstract class HitsAwareCacheManagersTest extends MultipleCacheManagersTe
    protected HotRodServer addHotRodServer(ConfigurationBuilder builder) {
       EmbeddedCacheManager cm = addClusterEnabledCacheManager(builder);
       HotRodServer server = HotRodClientTestingUtil.startHotRodServer(cm);
-      InetSocketAddress addr = new InetSocketAddress(server.getHost(), server.getPort());
+      InetSocketAddress addr = InetSocketAddress.createUnresolved(server.getHost(), server.getPort());
       addr2hrServer.put(addr, server);
       return server;
    }
@@ -88,7 +88,7 @@ public abstract class HitsAwareCacheManagersTest extends MultipleCacheManagersTe
       EmbeddedCacheManager cm = addClusterEnabledCacheManager(builder);
       HotRodServer server = HotRodTestingUtil.startHotRodServer(
          cm, port, new HotRodServerConfigurationBuilder());
-      InetSocketAddress addr = new InetSocketAddress(server.getHost(), server.getPort());
+      InetSocketAddress addr = InetSocketAddress.createUnresolved(server.getHost(), server.getPort());
       addr2hrServer.put(addr, server);
       return server;
    }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HitsAwareCacheManagersTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HitsAwareCacheManagersTest.java
@@ -157,7 +157,7 @@ public abstract class HitsAwareCacheManagersTest extends MultipleCacheManagersTe
    }
 
    protected InetSocketAddress getAddress(HotRodServer hotRodServer) {
-      InetSocketAddress socketAddress = new InetSocketAddress(hotRodServer.getHost(), hotRodServer.getPort());
+      InetSocketAddress socketAddress = InetSocketAddress.createUnresolved(hotRodServer.getHost(), hotRodServer.getPort());
       addr2hrServer.put(socketAddress, hotRodServer);
       return socketAddress;
    }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ReplTopologyChangeTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ReplTopologyChangeTest.java
@@ -87,7 +87,7 @@ public class ReplTopologyChangeTest extends MultipleCacheManagersTest {
    }
 
    public void testTwoMembers() {
-      InetSocketAddress server1Address = new InetSocketAddress("localhost", hotRodServer1.getPort());
+      InetSocketAddress server1Address = InetSocketAddress.createUnresolved(hotRodServer1.getHost(), hotRodServer1.getPort());
       expectTopologyChange(server1Address, true);
       assertEquals(2, tcpTransportFactory.getServers().size());
    }
@@ -102,7 +102,7 @@ public class ReplTopologyChangeTest extends MultipleCacheManagersTest {
       waitForClusterToForm();
 
       try {
-         expectTopologyChange(new InetSocketAddress("localhost", hotRodServer3.getPort()), true);
+         expectTopologyChange(InetSocketAddress.createUnresolved(hotRodServer3.getHost(), hotRodServer3.getPort()), true);
          assertEquals(3, tcpTransportFactory.getServers().size());
       } finally {
          log.info("Members are: " + manager(0).getCache().getAdvancedCache().getRpcManager().getTransport().getMembers());
@@ -119,7 +119,7 @@ public class ReplTopologyChangeTest extends MultipleCacheManagersTest {
 
       waitForServerToDie(2);
 
-      InetSocketAddress server3Address = new InetSocketAddress("localhost", hotRodServer3.getPort());      
+      InetSocketAddress server3Address = InetSocketAddress.createUnresolved(hotRodServer3.getHost(), hotRodServer3.getPort());
 
       try {
          expectTopologyChange(server3Address, false);
@@ -136,13 +136,13 @@ public class ReplTopologyChangeTest extends MultipleCacheManagersTest {
 
    private void expectTopologyChange(InetSocketAddress server1Address, boolean added) {
       for (int i = 0; i < 10; i++) {
-         remoteCache.put("k" + i, "v" + i);         
+         remoteCache.put("k" + i, "v" + i);
          if (added == tcpTransportFactory.getServers().contains(server1Address)) break;
       }
       Collection<SocketAddress> addresses = tcpTransportFactory.getServers();
       assertEquals(server1Address + " not found in " + addresses, added, addresses.contains(server1Address));
    }
-   
+
    protected void waitForServerToDie(int memberCount) {
       TestingUtil.blockUntilViewReceived(manager(0).getCache(), memberCount, 30000, false);
    }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/RoundRobinBalancingIntegrationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/RoundRobinBalancingIntegrationTest.java
@@ -114,11 +114,11 @@ public class RoundRobinBalancingIntegrationTest extends MultipleCacheManagersTes
       hotRodServer4 = HotRodClientTestingUtil.startHotRodServer(c4.getCacheManager());
       registerCacheManager(c4.getCacheManager());
 
-      List<SocketAddress> serverAddresses = new ArrayList<SocketAddress>();
-      serverAddresses.add(new InetSocketAddress("localhost", hotRodServer1.getPort()));
-      serverAddresses.add(new InetSocketAddress("localhost", hotRodServer2.getPort()));
-      serverAddresses.add(new InetSocketAddress("localhost", hotRodServer3.getPort()));
-      serverAddresses.add(new InetSocketAddress("localhost", hotRodServer4.getPort()));
+      List<SocketAddress> serverAddresses = new ArrayList<>();
+      serverAddresses.add(InetSocketAddress.createUnresolved("localhost", hotRodServer1.getPort()));
+      serverAddresses.add(InetSocketAddress.createUnresolved("localhost", hotRodServer2.getPort()));
+      serverAddresses.add(InetSocketAddress.createUnresolved("localhost", hotRodServer3.getPort()));
+      serverAddresses.add(InetSocketAddress.createUnresolved("localhost", hotRodServer4.getPort()));
 
       RoundRobinBalancingStrategy balancer = getBalancer();
       balancer.setServers(serverAddresses);
@@ -184,9 +184,9 @@ public class RoundRobinBalancingIntegrationTest extends MultipleCacheManagersTes
 
    @Test(dependsOnMethods = "testStopServer")
    public void testRemoveServers() {
-      List<SocketAddress> serverAddresses = new ArrayList<SocketAddress>();
-      serverAddresses.add(new InetSocketAddress("localhost", hotRodServer1.getPort()));
-      serverAddresses.add(new InetSocketAddress("localhost", hotRodServer2.getPort()));
+      List<SocketAddress> serverAddresses = new ArrayList<>();
+      serverAddresses.add(InetSocketAddress.createUnresolved("localhost", hotRodServer1.getPort()));
+      serverAddresses.add(InetSocketAddress.createUnresolved("localhost", hotRodServer2.getPort()));
 
       RoundRobinBalancingStrategy balancer = getBalancer();
       balancer.setServers(serverAddresses);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ServerRestartTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ServerRestartTest.java
@@ -62,7 +62,7 @@ public class ServerRestartTest extends SingleCacheManagerTest {
       hotrodServer.stop();
 
       HotRodServerConfigurationBuilder builder = new HotRodServerConfigurationBuilder();
-      builder.host("127.0.0.1").port(port).workerThreads(2).idleTimeout(20000).tcpNoDelay(true).sendBufSize(15000).recvBufSize(25000);
+      builder  .host("127.0.0.1").port(port).workerThreads(2).idleTimeout(20000).tcpNoDelay(true).sendBufSize(15000).recvBufSize(25000);
       hotrodServer.start(builder.build(), cacheManager);
 
       Thread.sleep(3000);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientClusterEventsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientClusterEventsTest.java
@@ -1,8 +1,6 @@
 package org.infinispan.client.hotrod.event;
 
 import org.infinispan.client.hotrod.RemoteCache;
-import org.infinispan.client.hotrod.RemoteCacheManager;
-import org.infinispan.client.hotrod.annotation.ClientListener;
 import org.infinispan.client.hotrod.event.CustomEventLogListener.CustomEvent;
 import org.infinispan.client.hotrod.event.CustomEventLogListener.FilterConverterFactory;
 import org.infinispan.client.hotrod.event.CustomEventLogListener.FilterCustomEventLogListener;
@@ -17,7 +15,6 @@ import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.server.hotrod.HotRodServer;
-import org.infinispan.server.hotrod.configuration.HotRodServerConfigurationBuilder;
 import org.testng.annotations.Test;
 
 
@@ -42,8 +39,7 @@ public class ClientClusterEventsTest extends MultiHotRodServersTest {
 
    protected HotRodServer addHotRodServer(ConfigurationBuilder builder) {
       EmbeddedCacheManager cm = addClusterEnabledCacheManager(builder);
-      HotRodServerConfigurationBuilder serverBuilder = new HotRodServerConfigurationBuilder();
-      HotRodServer server = HotRodClientTestingUtil.startHotRodServer(cm, serverBuilder);
+      HotRodServer server = HotRodClientTestingUtil.startHotRodServer(cm);
       server.addCacheEventConverterFactory("static-converter-factory", new StaticConverterFactory());
       server.addCacheEventFilterConverterFactory("filter-converter-factory", new FilterConverterFactory());
       servers.add(server);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientCustomEventsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientCustomEventsTest.java
@@ -10,7 +10,6 @@ import org.infinispan.client.hotrod.test.RemoteCacheManagerCallable;
 import org.infinispan.client.hotrod.test.SingleHotRodServerTest;
 import org.infinispan.client.hotrod.exceptions.HotRodClientException;
 import org.infinispan.server.hotrod.HotRodServer;
-import org.infinispan.server.hotrod.configuration.HotRodServerConfigurationBuilder;
 import org.testng.annotations.Test;
 
 @Test(groups = "functional", testName = "client.hotrod.event.ClientCustomEventsTest")
@@ -18,8 +17,7 @@ public class ClientCustomEventsTest extends SingleHotRodServerTest {
 
    @Override
    protected HotRodServer createHotRodServer() {
-      HotRodServerConfigurationBuilder builder = new HotRodServerConfigurationBuilder();
-      HotRodServer server = HotRodClientTestingUtil.startHotRodServer(cacheManager, builder);
+      HotRodServer server = HotRodClientTestingUtil.startHotRodServer(cacheManager);
       server.addCacheEventConverterFactory("static-converter-factory", new StaticConverterFactory());
       server.addCacheEventConverterFactory("dynamic-converter-factory", new DynamicConverterFactory());
       server.addCacheEventConverterFactory("raw-static-converter-factory", new RawStaticConverterFactory());
@@ -42,7 +40,7 @@ public class ClientCustomEventsTest extends SingleHotRodServerTest {
          }
       });
    }
-   
+
    public void testTimeOrderedEvents() {
       final StaticCustomEventLogListener eventListener = new StaticCustomEventLogListener();
       withClientListener(eventListener, new RemoteCacheManagerCallable(remoteCacheManager) {

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientCustomFilterEventsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientCustomFilterEventsTest.java
@@ -12,7 +12,6 @@ import org.infinispan.notifications.cachelistener.filter.CacheEventConverterFact
 import org.infinispan.notifications.cachelistener.filter.CacheEventFilter;
 import org.infinispan.notifications.cachelistener.filter.CacheEventFilterFactory;
 import org.infinispan.server.hotrod.HotRodServer;
-import org.infinispan.server.hotrod.configuration.HotRodServerConfigurationBuilder;
 import org.testng.annotations.Test;
 
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.withClientListener;
@@ -22,8 +21,7 @@ public class ClientCustomFilterEventsTest extends SingleHotRodServerTest {
 
    @Override
    protected HotRodServer createHotRodServer() {
-      HotRodServerConfigurationBuilder builder = new HotRodServerConfigurationBuilder();
-      HotRodServer server = HotRodClientTestingUtil.startHotRodServer(cacheManager, builder);
+      HotRodServer server = HotRodClientTestingUtil.startHotRodServer(cacheManager);
       server.addCacheEventFilterConverterFactory("filter-converter-factory", new FilterConverterFactory());
       return server;
    }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientFilterEventsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientFilterEventsTest.java
@@ -15,7 +15,6 @@ import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
 import org.infinispan.client.hotrod.test.RemoteCacheManagerCallable;
 import org.infinispan.client.hotrod.test.SingleHotRodServerTest;
 import org.infinispan.server.hotrod.HotRodServer;
-import org.infinispan.server.hotrod.configuration.HotRodServerConfigurationBuilder;
 import org.testng.annotations.Test;
 
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.withClientListener;
@@ -25,8 +24,7 @@ public class ClientFilterEventsTest extends SingleHotRodServerTest {
 
    @Override
    protected HotRodServer createHotRodServer() {
-      HotRodServerConfigurationBuilder builder = new HotRodServerConfigurationBuilder();
-      HotRodServer server = HotRodClientTestingUtil.startHotRodServer(cacheManager, builder);
+      HotRodServer server = HotRodClientTestingUtil.startHotRodServer(cacheManager);
       server.addCacheEventFilterFactory("static-filter-factory", new StaticCacheEventFilterFactory(2));
       server.addCacheEventFilterFactory("dynamic-filter-factory", new DynamicCacheEventFilterFactory());
       server.addCacheEventFilterFactory("raw-static-filter-factory", new RawStaticCacheEventFilterFactory());

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/EventSocketTimeoutTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/EventSocketTimeoutTest.java
@@ -44,7 +44,7 @@ public class EventSocketTimeoutTest extends SingleHotRodServerTest {
    protected RemoteCacheManager getRemoteCacheManager() {
       org.infinispan.client.hotrod.configuration.ConfigurationBuilder builder =
          new org.infinispan.client.hotrod.configuration.ConfigurationBuilder();
-      builder.addServer().host("127.0.0.1").port(hotrodServer.getPort());
+      builder.addServer().host(hotrodServer.getHost()).port(hotrodServer.getPort());
       builder.socketTimeout(2000);
       builder.maxRetries(0);
       return new RemoteCacheManager(builder.build());

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/MultiServerDistRemoteIteratorTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/MultiServerDistRemoteIteratorTest.java
@@ -38,7 +38,7 @@ public class MultiServerDistRemoteIteratorTest extends BaseMultiServerRemoteIter
               .host("localhost")
               .port(serverPort)
               .maxRetries(maxRetries())
-              .balancingStrategy(new PreferredServerBalancingStrategy(new InetSocketAddress("localhost", serverPort)))
+              .balancingStrategy(new PreferredServerBalancingStrategy(InetSocketAddress.createUnresolved("localhost", serverPort)))
               .pingOnStartup(false);
       return clientBuilder;
    }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/DistributionRetryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/DistributionRetryTest.java
@@ -120,7 +120,7 @@ public class DistributionRetryTest extends AbstractRetryTest {
       Marshaller sm = new JBossMarshaller();
       TcpTransport transport = (TcpTransport) tcpTp.getTransport(sm.objectToByteBuffer(key, 64), null, RemoteCacheManager.cacheNameBytes());
       try {
-      assertEquals(transport.getServerAddress(), new InetSocketAddress("localhost", hotRodServer2.getPort()));
+      assertEquals(transport.getServerAddress(), InetSocketAddress.createUnresolved(hotRodServer2.getHost(), hotRodServer2.getPort()));
       } finally {
          tcpTp.releaseTransport(transport);
       }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/SecureServerFailureRetryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/SecureServerFailureRetryTest.java
@@ -8,7 +8,6 @@ import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.server.core.security.simple.SimpleServerAuthenticationProvider;
 import org.infinispan.server.hotrod.HotRodServer;
 import org.infinispan.server.hotrod.configuration.HotRodServerConfigurationBuilder;
-import org.infinispan.server.hotrod.test.HotRodTestingUtil;
 import org.infinispan.server.hotrod.test.TestCallbackHandler;
 import org.testng.annotations.Test;
 
@@ -20,7 +19,9 @@ public class SecureServerFailureRetryTest extends ServerFailureRetryTest {
       HotRodServerConfigurationBuilder serverBuilder = new HotRodServerConfigurationBuilder();
       SimpleServerAuthenticationProvider sap = new SimpleServerAuthenticationProvider();
       sap.addUser("user", "realm", "password".toCharArray(), null);
-      serverBuilder.authentication()
+      serverBuilder
+         .workerThreads(3)
+         .authentication()
          .enable()
          .serverName("localhost")
          .addAllowedMech("CRAM-MD5")

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/test/HotRodClientTestingUtil.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/test/HotRodClientTestingUtil.java
@@ -88,7 +88,7 @@ public class HotRodClientTestingUtil {
    }
 
    public static HotRodServer startHotRodServer(EmbeddedCacheManager cacheManager) {
-      return startHotRodServer(cacheManager, new HotRodServerConfigurationBuilder());
+      return startHotRodServer(cacheManager, new HotRodServerConfigurationBuilder().workerThreads(3));
    }
 
    /**

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/test/HotRodClientTestingUtil.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/test/HotRodClientTestingUtil.java
@@ -1,11 +1,18 @@
 package org.infinispan.client.hotrod.test;
 
-import io.netty.channel.ChannelException;
+import static org.infinispan.distribution.DistributionTestHelper.isFirstOwner;
+
+import java.io.IOException;
+import java.net.BindException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.util.Collection;
+import java.util.Random;
+
 import org.infinispan.Cache;
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
-import org.infinispan.client.hotrod.test.InternalRemoteCacheManager;
 import org.infinispan.client.hotrod.impl.protocol.HotRodConstants;
 import org.infinispan.client.hotrod.impl.transport.tcp.FailoverRequestBalancingStrategy;
 import org.infinispan.client.hotrod.impl.transport.tcp.TcpTransportFactory;
@@ -21,16 +28,6 @@ import org.infinispan.server.hotrod.test.HotRodTestingUtil;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.util.logging.LogFactory;
 
-import java.io.IOException;
-import java.net.BindException;
-import java.net.InetSocketAddress;
-import java.net.ServerSocket;
-import java.util.Collection;
-import java.util.Random;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import static org.infinispan.distribution.DistributionTestHelper.getFirstOwner;
-import static org.infinispan.distribution.DistributionTestHelper.isFirstOwner;
 
 /**
  * Utility methods for the Hot Rod client
@@ -42,39 +39,44 @@ public class HotRodClientTestingUtil {
 
    private static final Log log = LogFactory.getLog(HotRodClientTestingUtil.class, Log.class);
 
-   /**
-    * This needs to be different than the one used in the server tests in order to make sure that there's no clash.
-    */
-   private static final AtomicInteger uniquePort = new AtomicInteger(15232);
+   private static final int DEFAULT_PORT = 15232;
 
    public static HotRodServer startHotRodServer(EmbeddedCacheManager cacheManager, HotRodServerConfigurationBuilder builder) {
-      return startHotRodServer(cacheManager, uniquePort.incrementAndGet(), builder);
+      return startHotRodServer(cacheManager, findFreePort(), builder);
    }
 
-   public static HotRodServer startHotRodServer(EmbeddedCacheManager cacheManager, int startPort, HotRodServerConfigurationBuilder builder) {
-      // TODO: This is very rudimentary!! HotRodTestingUtil needs a more robust solution where ports are generated randomly and retries if already bound
+   private static boolean isBindException(Throwable e) {
+      if (e instanceof BindException)
+         return true;
+      return false;
+   }
+
+   private static int findFreePort() {
+      try {
+         try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+         }
+      } catch (IOException e) {
+         log.debug("Error finding free port, using default of " + DEFAULT_PORT);
+      }
+      return DEFAULT_PORT;
+   }
+
+   public static HotRodServer startHotRodServer(EmbeddedCacheManager cacheManager, int port, HotRodServerConfigurationBuilder builder) {
       HotRodServer server = null;
       int maxTries = 10;
       int currentTries = 0;
       Throwable lastError = null;
-      int port = startPort;
       while (server == null && currentTries < maxTries) {
          try {
-            server = HotRodTestingUtil.startHotRodServer(cacheManager, port++, builder);
-         } catch (ChannelException e) {
-            if (!(e.getCause() instanceof BindException)) {
-               throw e;
-            } else {
-               log.debug("Address already in use: [" + e.getMessage() + "], so let's try next port");
-               currentTries++;
-               lastError = e;
-            }
+            server = HotRodTestingUtil.startHotRodServer(cacheManager, port, builder);
          } catch (Throwable t) {
             if (!(t instanceof BindException)) {
                throw t;
             } else {
-               log.debug("Address already in use: [" + t.getMessage() + "], so let's try next port");
+               log.debug("Address already in use: [" + t.getMessage() + "], retrying");
                currentTries++;
+               port = findFreePort();
                lastError = t;
             }
          }
@@ -105,8 +107,7 @@ public class HotRodClientTestingUtil {
    /**
     * Kills a group of remote cache managers.
     *
-    * @param rcm
-    *           the remote cache manager instances to kill
+    * @param rcms the remote cache manager instances to kill
     */
    public static void killRemoteCacheManagers(RemoteCacheManager... rcms) {
       if (rcms != null) {
@@ -325,7 +326,7 @@ public class HotRodClientTestingUtil {
 
 
    public static void findServerAndKill(RemoteCacheManager client,
-         Collection<HotRodServer> servers, Collection<EmbeddedCacheManager> cacheManagers) {
+                                        Collection<HotRodServer> servers, Collection<EmbeddedCacheManager> cacheManagers) {
       InetSocketAddress addr = (InetSocketAddress) getLoadBalancer(client).nextServer(null);
       for (HotRodServer server : servers) {
          if (server.getPort() == addr.getPort()) {

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/test/MultiHotRodServersTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/test/MultiHotRodServersTest.java
@@ -93,8 +93,7 @@ public abstract class MultiHotRodServersTest extends MultipleCacheManagersTest {
 
    protected HotRodServer addHotRodServer(ConfigurationBuilder builder, int port) {
       EmbeddedCacheManager cm = addClusterEnabledCacheManager(builder);
-      HotRodServer server = HotRodTestingUtil.startHotRodServer(
-         cm, port, new HotRodServerConfigurationBuilder());
+      HotRodServer server = HotRodTestingUtil.startHotRodServer(cm, port);
       servers.add(server);
       return server;
    }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/xsite/AbstractHotRodSiteFailoverTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/xsite/AbstractHotRodSiteFailoverTest.java
@@ -101,7 +101,7 @@ abstract class AbstractHotRodSiteFailoverTest extends AbstractXSiteTest {
       TestSite site = createSite(siteName, NODES_PER_SITE, globalBuilder, builder);
       Collection<EmbeddedCacheManager> cacheManagers = site.cacheManagers();
       List<HotRodServer> servers = cacheManagers.stream().map(cm -> serverPort
-         .map(port -> HotRodClientTestingUtil.startHotRodServer(cm, port, new HotRodServerConfigurationBuilder()))
+         .map(port -> HotRodClientTestingUtil.startHotRodServer(cm, port, new HotRodServerConfigurationBuilder().workerThreads(3)))
          .orElseGet(() -> HotRodClientTestingUtil.startHotRodServer(cm))).collect(Collectors.toList());
       siteServers.put(siteName, servers);
 

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/configuration/HotRodServerConfigurationBuilder.java
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/configuration/HotRodServerConfigurationBuilder.java
@@ -1,10 +1,14 @@
 package org.infinispan.server.hotrod.configuration;
 
+import java.lang.invoke.MethodHandles;
+
 import org.infinispan.commons.configuration.Builder;
 import org.infinispan.configuration.cache.LockingConfigurationBuilder;
 import org.infinispan.configuration.cache.StateTransferConfigurationBuilder;
 import org.infinispan.configuration.cache.SyncConfigurationBuilder;
 import org.infinispan.server.core.configuration.ProtocolServerConfigurationBuilder;
+import org.infinispan.server.hotrod.logging.JavaLog;
+import org.infinispan.util.logging.LogFactory;
 
 /**
  * HotRodServerConfigurationBuilder.
@@ -14,6 +18,7 @@ import org.infinispan.server.core.configuration.ProtocolServerConfigurationBuild
  */
 public class HotRodServerConfigurationBuilder extends ProtocolServerConfigurationBuilder<HotRodServerConfiguration, HotRodServerConfigurationBuilder> implements
       Builder<HotRodServerConfiguration>, HotRodServerChildConfigurationBuilder {
+   private JavaLog log = LogFactory.getLog(MethodHandles.lookup().lookupClass(), JavaLog.class);
    private final AuthenticationConfigurationBuilder authentication = new AuthenticationConfigurationBuilder(this);
    private String proxyHost;
    private int proxyPort = -1;
@@ -112,6 +117,9 @@ public class HotRodServerConfigurationBuilder extends ProtocolServerConfiguratio
    @Override
    public void validate() {
       super.validate();
+      if (proxyHost == null && host == null) {
+         throw log.missingHostAddress();
+      }
       if (proxyHost == null) {
          proxyHost = host;
       }

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/logging/JavaLog.java
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/logging/JavaLog.java
@@ -84,4 +84,6 @@ public interface JavaLog extends org.infinispan.util.logging.Log {
    @Message(value = "Unauthorized operation", id = 6017)
    SecurityException unauthorizedOperation();
 
+   @Message(value = "A host or proxyHost address has not been specified", id = 6019)
+   CacheConfigurationException missingHostAddress();
 }

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/AbstractRemoteCacheManagerIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/AbstractRemoteCacheManagerIT.java
@@ -245,17 +245,17 @@ public abstract class AbstractRemoteCacheManagerIT {
 
         // perform first simulated operation
         tt = (TcpTransport) ttf.getTransport(null, rci.getName().getBytes());
-        sock_addr = (InetSocketAddress) tt.getServerAddress();
+        sock_addr = resolve((InetSocketAddress) tt.getServerAddress());
         ttf.releaseTransport(tt);
         serverAddrSequence.append(sock_addr.getAddress().getHostAddress() + ":" + sock_addr.getPort()).append(" ");
 
         tt = (TcpTransport) ttf.getTransport(null, rci.getName().getBytes());
-        sock_addr = (InetSocketAddress) tt.getServerAddress();
+        sock_addr = resolve((InetSocketAddress) tt.getServerAddress());
         ttf.releaseTransport(tt);
         serverAddrSequence.append(sock_addr.getAddress().getHostAddress() + ":" + sock_addr.getPort()).append(" ");
 
         tt = (TcpTransport) ttf.getTransport(null, rci.getName().getBytes());
-        sock_addr = (InetSocketAddress) tt.getServerAddress();
+        sock_addr = resolve((InetSocketAddress) tt.getServerAddress());
         ttf.releaseTransport(tt);
         serverAddrSequence.append(sock_addr.getAddress().getHostAddress() + ":" + sock_addr.getPort());
 
@@ -313,13 +313,13 @@ public abstract class AbstractRemoteCacheManagerIT {
         TcpTransportFactory ttf = (TcpTransportFactory) getTransportFactoryField(of);
         // perform first simulated operation
         tt = (TcpTransport) ttf.getTransport(null, rci.getName().getBytes());
-        sock_addr = (InetSocketAddress) tt.getServerAddress();
+        sock_addr = resolve((InetSocketAddress) tt.getServerAddress());
         ttf.releaseTransport(tt);
         assertEquals("load balancing first request: server address expected " + hostport0 + ", actual server address "
                 + sock_addr, sock_addr, hostport0);
 
         tt = (TcpTransport) ttf.getTransport(null, rci.getName().getBytes());
-        sock_addr = (InetSocketAddress) tt.getServerAddress();
+        sock_addr = resolve((InetSocketAddress) tt.getServerAddress());
         ttf.releaseTransport(tt);
         assertEquals("load balancing second request: server address expected " + hostport0 + ", actual server address"
                 + sock_addr, sock_addr, hostport0);
@@ -361,7 +361,7 @@ public abstract class AbstractRemoteCacheManagerIT {
                     found = true;
             }
             if (!found)
-                fail("The remote cache manager was configured to have server with an address " + scfg.host() + ":" + scfg.port() + ", but it doesn't.");
+                fail("The remote cache manager was configured to have server with an address " + scfg.host() + ":" + scfg.port() + ", but it doesn't (" + servers + ")");
         }
 
         assertEquals(config.forceReturnValues(), Boolean.parseBoolean(getForceReturnValueProperty(rc)));
@@ -412,12 +412,8 @@ public abstract class AbstractRemoteCacheManagerIT {
         int listSize = servers.size();
         int i = 0;
         for (Iterator iter = servers.iterator(); iter.hasNext(); i++) {
-            InetSocketAddress addr = (InetSocketAddress) iter.next();
+            InetSocketAddress addr = resolve((InetSocketAddress) iter.next());
             // take care to remove prepended backslash
-            String serverAddress = addr.getAddress().toString();
-//            if (serverAddress.startsWith("/"))
-//                serverAddress = serverAddress.substring(1);
-//            serverList.append(serverAddress);
             if (addr.getAddress() instanceof Inet6Address) {
                 serverList.append('[').append(addr.getHostName()).append(']');
             } else {
@@ -611,5 +607,12 @@ public abstract class AbstractRemoteCacheManagerIT {
             throw new Exception("Could not access transportFactory field", e);
         }
         return fieldValue;
+    }
+
+    private InetSocketAddress resolve(InetSocketAddress address) {
+        if (address.isUnresolved())
+            return new InetSocketAddress(address.getHostString(), address.getPort());
+        else
+            return address;
     }
 }

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/jmx/management/JmxManagementIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/jmx/management/JmxManagementIT.java
@@ -98,41 +98,52 @@ public class JmxManagementIT {
         invokeOperation(provider, memcachedCacheStatisticsMBean, "resetStatistics", null, null);
     }
 
+    private static int getNumberOfGlobalConnections(MBeanServerConnectionProvider provider, String mbean) throws Exception {
+        return Integer.parseInt(getAttribute(provider, mbean, "numberOfGlobalConnections"));
+    }
+
+    private static int getNumberOfLocalConnections(MBeanServerConnectionProvider provider, String mbean) throws Exception {
+        return Integer.parseInt(getAttribute(provider, mbean, "numberOfLocalConnections"));
+    }
+
     @Test
     public void testHotRodConnectionCount() throws Exception {
 
         // get number of current local/global connections
-        int initialLocal = Integer.parseInt(getAttribute(provider, hotRodServerMBean, "numberOfLocalConnections"));
-        int initialGlobal = Integer.parseInt(getAttribute(provider, hotRodServerMBean, "numberOfGlobalConnections"));
+        int initialLocal = getNumberOfLocalConnections(provider, hotRodServerMBean);
+        int initialGlobal = getNumberOfGlobalConnections(provider, hotRodServerMBean);
         assertEquals("Number of global connections obtained from node1 and node2 is not the same", initialGlobal,
-                Integer.parseInt(getAttribute(provider2, hotRodServerMBean, "numberOfGlobalConnections")));
+              getNumberOfGlobalConnections(provider2, hotRodServerMBean));
         // create another RCM and use it
-        Configuration conf = new ConfigurationBuilder().addServer().host(server1.getHotrodEndpoint().getInetAddress().getHostName()).port(server1
-                .getHotrodEndpoint().getPort()).build();
+        Configuration conf = new ConfigurationBuilder()
+              .addServer()
+                .host(server1.getHotrodEndpoint().getInetAddress().getHostAddress())
+                .port(server1.getHotrodEndpoint().getPort()).build();
         RemoteCacheManager manager2 = new RemoteCacheManager(conf);
+
         manager2.getCache().put("key", "value");
 
         // local connections increase by 1, global (in both nodes) by 2 (because we have distributed cache with 2 nodes, both nodes are accessed)
-        assertEquals(initialLocal + 1, Integer.parseInt(getAttribute(provider, hotRodServerMBean, "numberOfLocalConnections")));
-        assertEquals(initialGlobal + 2, Integer.parseInt(getAttribute(provider, hotRodServerMBean, "numberOfGlobalConnections")));
-        assertEquals(initialGlobal + 2, Integer.parseInt(getAttribute(provider2, hotRodServerMBean, "numberOfGlobalConnections")));
+        assertEquals(initialLocal + 1, getNumberOfLocalConnections(provider, hotRodServerMBean));
+        assertEquals(initialGlobal + 2, getNumberOfGlobalConnections(provider, hotRodServerMBean));
+        assertEquals(initialGlobal + 2, getNumberOfGlobalConnections(provider2, hotRodServerMBean));
     }
 
     @Test
     public void testMemCachedConnectionCount() throws Exception {
-        int initialLocal = Integer.parseInt(getAttribute(provider, memCachedServerMBean, "numberOfLocalConnections"));
-        int initialGlobal = Integer.parseInt(getAttribute(provider, memCachedServerMBean, "numberOfGlobalConnections"));
+        int initialLocal = getNumberOfLocalConnections(provider, memCachedServerMBean);
+        int initialGlobal = getNumberOfGlobalConnections(provider, memCachedServerMBean);
         assertEquals("Number of global connections obtained from node1 and node2 is not the same", initialGlobal,
-                Integer.parseInt(getAttribute(provider2, memCachedServerMBean, "numberOfGlobalConnections")));
+              getNumberOfGlobalConnections(provider2, memCachedServerMBean));
 
         MemcachedClient mc2 = new MemcachedClient("UTF-8", server1.getMemcachedEndpoint().getInetAddress()
                 .getHostName(), server1.getMemcachedEndpoint().getPort(), 10000);
         mc2.set("key", "value");
 
         // with the memcached endpoint, the connection is counted only once
-        assertEquals(initialLocal + 1, Integer.parseInt(getAttribute(provider, memCachedServerMBean, "numberOfLocalConnections")));
-        assertEquals(initialGlobal + 1, Integer.parseInt(getAttribute(provider, memCachedServerMBean, "numberOfGlobalConnections")));
-        assertEquals(initialGlobal + 1, Integer.parseInt(getAttribute(provider2, memCachedServerMBean, "numberOfGlobalConnections")));
+        assertEquals(initialLocal + 1, getNumberOfLocalConnections(provider, memCachedServerMBean));
+        assertEquals(initialGlobal + 1, getNumberOfGlobalConnections(provider, memCachedServerMBean));
+        assertEquals(initialGlobal + 1, getNumberOfGlobalConnections(provider2, memCachedServerMBean));
     }
 
     @Test

--- a/spring/spring4/spring4-remote/src/test/java/org/infinispan/spring/provider/sample/SampleHotrodServerLifecycleBean.java
+++ b/spring/spring4/spring4-remote/src/test/java/org/infinispan/spring/provider/sample/SampleHotrodServerLifecycleBean.java
@@ -46,8 +46,7 @@ public class SampleHotrodServerLifecycleBean implements InitializingBean, Dispos
       cacheManager.defineConfiguration(remoteBackupCacheName, HotRodTestingUtil.hotRodCacheConfiguration().build());
       cacheManager.defineConfiguration(customCacheName, HotRodTestingUtil.hotRodCacheConfiguration().build());
       HotRodServerConfigurationBuilder hcb = new HotRodServerConfigurationBuilder();
-      hcb.port(15233);
-      hotrodServer = HotRodClientTestingUtil.startHotRodServer(cacheManager, hcb);
+      hotrodServer = HotRodClientTestingUtil.startHotRodServer(cacheManager, 15233, hcb);
    }
 
    @Override


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-7955

Plus a partial backport of ISPN-7949 to clean up the client testsuite a bit