### PR TITLE
ISPN-7599 Jolokia support

### DIFF
--- a/documentation/src/main/asciidoc/server_guide/management.adoc
+++ b/documentation/src/main/asciidoc/server_guide/management.adoc
@@ -65,3 +65,10 @@ In domain mode the port will be the port of the Remoting connector for the Serve
 </subsystem>
 
 ----
+
+=== Jolokia
+
+You can also expose JMX beans using link:https://jolokia.org/[Jolokia]. In order to do this, just run the server with
+additional parameter `--jmx`, for example: `./standalone.xml -c cloud.xml --jmx`. Jolokia configuration is stored in
+`agent.conf` file. It is possible to override this file by specifying it after `--jmx` parameter. For example:
+`./standalone.sh -c cloud.xml --jmx my-config.properties`.

--- a/server/integration/feature-pack/pom.xml
+++ b/server/integration/feature-pack/pom.xml
@@ -629,6 +629,17 @@
             <artifactId>oauth</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>agent-bond-agent</artifactId>
+            <version>${version.agent-bond}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>

--- a/server/integration/feature-pack/src/main/resources/content/bin/agent.conf
+++ b/server/integration/feature-pack/src/main/resources/content/bin/agent.conf
@@ -1,0 +1,1 @@
+jolokia=port=8778

--- a/server/integration/feature-pack/src/main/resources/content/bin/jolokia.bat
+++ b/server/integration/feature-pack/src/main/resources/content/bin/jolokia.bat
@@ -1,0 +1,5 @@
+set AGENT_BOND_JAR=
+for /r %JBOSS_HOME%\modules\system\layers\base\io\fabric8\agent-bond\main %%X in (*.jar) do (
+  set AGENT_BOND_JAR=%%X
+)
+set JAVA_OPTS=%JAVA_OPTS% -javaagent:%AGENT_BOND_JAR%=%1

--- a/server/integration/feature-pack/src/main/resources/content/bin/jolokia.sh
+++ b/server/integration/feature-pack/src/main/resources/content/bin/jolokia.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+function getfiles {
+  FILES=$(ls $1*.jar)
+  echo ${FILES} | sed -e "s| |:|g"
+}
+
+AGENT_BOND_JAR=$(getfiles $JBOSS_HOME/modules/system/layers/base/io/fabric8/agent-bond/main/)
+JAVA_OPTS="$JAVA_OPTS -javaagent:$AGENT_BOND_JAR=$1"

--- a/server/integration/feature-pack/src/main/resources/content/bin/standalone.conf
+++ b/server/integration/feature-pack/src/main/resources/content/bin/standalone.conf
@@ -35,7 +35,7 @@
 #JAVA=""
 
 if [ "x$JBOSS_MODULES_SYSTEM_PKGS" = "x" ]; then
-   JBOSS_MODULES_SYSTEM_PKGS="org.jboss.byteman"
+   JBOSS_MODULES_SYSTEM_PKGS="org.jboss.byteman,org.jboss.logmanager.LogManager"
 fi
 
 # Uncomment the following line to prevent manipulation of JVM options

--- a/server/integration/feature-pack/src/main/resources/content/bin/standalone.sh
+++ b/server/integration/feature-pack/src/main/resources/content/bin/standalone.sh
@@ -8,6 +8,8 @@
 DEBUG_MODE=false
 DEBUG_PORT="8787"
 SERVER_OPTS=""
+USE_JMX_COLLECTORS=""
+JMX_CONF=""
 while [ "$#" -gt 0 ]
 do
     case "$1" in
@@ -15,6 +17,13 @@ do
           DEBUG_MODE=true
           if [ -n "$2" ] && [ "$2" = `echo "$2" | sed 's/-//'` ]; then
               DEBUG_PORT=$2
+              shift
+          fi
+          ;;
+      --jmx)
+          USE_JMX_COLLECTORS=true
+          if [ -n "$2" ] && [ "$2" = `echo "$2" | sed 's/-//'` ]; then
+              JMX_CONF=$2
               shift
           fi
           ;;
@@ -105,6 +114,10 @@ if [ "x$RUN_CONF" = "x" ]; then
 fi
 if [ -r "$RUN_CONF" ]; then
     . "$RUN_CONF"
+fi
+
+if [ "x$JMX_CONF" = "x" ]; then
+    JMX_CONF="$DIRNAME/agent.conf"
 fi
 
 # Set debug settings if not already set
@@ -318,6 +331,11 @@ MODULE_OPTS=""
 if [ "$SECMGR" = "true" ]; then
     MODULE_OPTS="$MODULE_OPTS -secmgr";
 fi
+
+if [ "x$USE_JMX_COLLECTORS" != "x" ]; then
+    . $DIRNAME/jolokia.sh $JMX_CONF
+fi
+
 
 # Display our environment
 echo "========================================================================="

--- a/server/integration/feature-pack/src/main/resources/modules/system/layers/base/io/fabric8/agent-bond/main/module.xml
+++ b/server/integration/feature-pack/src/main/resources/modules/system/layers/base/io/fabric8/agent-bond/main/module.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<module xmlns="urn:jboss:module:1.3" name="io.fabric8.agent-bond">
+    <resources>
+        <artifact name="${io.fabric8:agent-bond-agent}" />
+    </resources>
+
+    <dependencies>
+        <module name="javax.api"/>
+        <module name="sun.jdk"/>
+    </dependencies>
+</module>

--- a/server/integration/versions/pom.xml
+++ b/server/integration/versions/pom.xml
@@ -78,6 +78,8 @@
       <version.commonslang3>3.4</version.commonslang3>
       <checkstyle.config.location>${session.executionRootDirectory}/checkstyle/src/main/resources/checkstyle.xml</checkstyle.config.location>
       <version.jboss.aesh>0.66.13</version.jboss.aesh>
+      <!-- Jolokia and Prometheus support -->
+      <version.agent-bond>1.0.2</version.agent-bond>
    </properties>
 
    <dependencyManagement>
@@ -118,13 +120,13 @@
             <artifactId>wildfly-security</artifactId>
             <version>${version.org.wildfly}</version>
          </dependency>
-         
+
          <dependency>
             <groupId>org.wildfly</groupId>
             <artifactId>wildfly-transactions</artifactId>
             <version>${version.org.wildfly}</version>
          </dependency>
-         
+
          <dependency>
             <groupId>org.wildfly</groupId>
             <artifactId>wildfly-dist</artifactId>
@@ -237,7 +239,7 @@
             <artifactId>infinispan-server-commons</artifactId>
             <version>${project.version}</version>
          </dependency>
-         
+
          <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>infinispan-server-commons</artifactId>
@@ -294,7 +296,7 @@
             <artifactId>infinispan-server-endpoints</artifactId>
             <version>${project.version}</version>
          </dependency>
-         
+
          <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>infinispan-server-feature-pack</artifactId>
@@ -319,7 +321,7 @@
             <artifactId>jboss-logmanager-log4j</artifactId>
             <version>${version.org.jboss.logmanager.jboss-logmanager-log4j}</version>
          </dependency>
-         
+
          <dependency>
             <groupId>org.jboss.modules</groupId>
             <artifactId>jboss-modules</artifactId>
@@ -431,7 +433,7 @@
             <artifactId>infinispan-cli-interpreter</artifactId>
             <version>${version.org.infinispan}</version>
          </dependency>
-         
+
          <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-management-console</artifactId>
@@ -612,7 +614,7 @@
             <scope>test</scope>
             <version>${version.h2.database}</version>
          </dependency>
-         
+
          <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-security-integrationtests</artifactId>
@@ -696,6 +698,12 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>${version.commonslang3}</version>
+         </dependency>
+
+         <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>agent-bond-agent</artifactId>
+            <version>${version.agent-bond}</version>
          </dependency>
 
       </dependencies>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-7599

This PR is a proposed approach for enabling Jolokia in the server. It uses Agent Bond, which provides a single Java agent for Jolokia (OpenShift) and Prometheus (Kubernetes). 

Highlights:

* Agent Bond was put into the modules (it would look weird it had been placed elsewhere).
* Jolokia bootstrap script is placed in a separate file. It may be also reused in domain mode.
* The agent is turned off by default and in order to enable it, one needs to supply `--jmx` parameter.

Questions and open issues:

* [x] Shall we use it in domain mode? Or are we good with DMR?
* [x] Do we want to bootstrap it with additional parameter? Or should we leave it enabled by default (allocates yet another port in the host).
* [x] Windows script needs to be ironed out (but probably *after* we agree whether this approach is something that we want or not).
* [x] In Docker bootstrap script there is a clash with `--jmx` parameter. It just needs to be debugged and fixed.
* [ ] `agent.conf` needs to be altered for Kubernetes/OpenShift. It needs to have the following content: `jolokia=port=8778,protocol=https,caCert=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt,clientPrincipal=cn=system:master-proxy,useSslClientAuthentication=true,extraClientCheck=true,host=0.0.0.0,discoveryEnabled=false`. The question where do we want to do the substitution? In a separate conf file? In Docker image? Or maybe put this on users (they can use ConfigMap to override this file on their own).
* [ ] With the above point in mind, the Management Console should operate also on https.

//cc @vblagoje @ryanemerson @tristantarrant @gustavonalle @galderz 