### PR TITLE
Support and document the new `local_heap` configuration property for Query configuration

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientListenerWithIndexingAndProtobufTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientListenerWithIndexingAndProtobufTest.java
@@ -42,7 +42,7 @@ public class ClientListenerWithIndexingAndProtobufTest extends MultiHotRodServer
    protected void createCacheManagers() throws Throwable {
       ConfigurationBuilder cfgBuilder = hotRodCacheConfiguration(getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false));
       cfgBuilder.indexing().index(Index.ALL)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
 
       createHotRodServers(NUM_NODES, cfgBuilder);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/EmbeddedCompatClientListenerWithDslFilterTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/EmbeddedCompatClientListenerWithDslFilterTest.java
@@ -96,7 +96,7 @@ public class EmbeddedCompatClientListenerWithDslFilterTest extends MultiHotRodSe
       ConfigurationBuilder cfgBuilder = hotRodCacheConfiguration(getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false));
       cfgBuilder.compatibility().enable().marshaller(new CompatibilityProtoStreamMarshaller());
       cfgBuilder.indexing().index(Index.ALL)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       return cfgBuilder;
    }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/EmbeddedCompatContinuousQueryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/EmbeddedCompatContinuousQueryTest.java
@@ -99,7 +99,7 @@ public class EmbeddedCompatContinuousQueryTest extends MultiHotRodServersTest {
       ConfigurationBuilder cfgBuilder = hotRodCacheConfiguration(getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false));
       cfgBuilder.compatibility().enable().marshaller(new CompatibilityProtoStreamMarshaller());
       cfgBuilder.indexing().index(Index.ALL)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       cfgBuilder.expiration().disableReaper();
       return cfgBuilder;

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/RemoteContinuousQueryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/RemoteContinuousQueryTest.java
@@ -88,7 +88,7 @@ public class RemoteContinuousQueryTest extends MultiHotRodServersTest {
    protected ConfigurationBuilder getConfigurationBuilder() {
       ConfigurationBuilder cfgBuilder = hotRodCacheConfiguration(getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false));
       cfgBuilder.indexing().index(Index.ALL)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       cfgBuilder.expiration().disableReaper();
       return cfgBuilder;

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/RemoteListenerWithDslFilterTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/RemoteListenerWithDslFilterTest.java
@@ -87,7 +87,7 @@ public class RemoteListenerWithDslFilterTest extends MultiHotRodServersTest {
    protected ConfigurationBuilder getConfigurationBuilder() {
       ConfigurationBuilder cfgBuilder = hotRodCacheConfiguration(getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false));
       cfgBuilder.indexing().index(Index.ALL)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       return cfgBuilder;
    }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/ProtobufRemoteIteratorIndexingTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/ProtobufRemoteIteratorIndexingTest.java
@@ -36,7 +36,7 @@ public class ProtobufRemoteIteratorIndexingTest extends MultiHotRodServersTest i
    @Override
    protected void createCacheManagers() throws Throwable {
       ConfigurationBuilder cfg = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, false);
-      cfg.indexing().index(Index.ALL).indexing().addProperty("default.directory_provider", "ram");
+      cfg.indexing().index(Index.ALL).indexing().addProperty("default.directory_provider", "local-heap");
       createHotRodServers(NUM_NODES, hotRodCacheConfiguration(cfg));
 
       waitForClusterToForm();

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/EmbeddedCompatTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/EmbeddedCompatTest.java
@@ -122,7 +122,7 @@ public class EmbeddedCompatTest extends SingleCacheManagerTest {
       org.infinispan.configuration.cache.ConfigurationBuilder builder = hotRodCacheConfiguration();
       builder.compatibility().enable().marshaller(new CompatibilityProtoStreamMarshaller());
       builder.indexing().index(Index.ALL)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       return builder;
    }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/HotRodQueryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/HotRodQueryTest.java
@@ -91,7 +91,7 @@ public class HotRodQueryTest extends SingleCacheManagerTest {
    protected ConfigurationBuilder getConfigurationBuilder() {
       ConfigurationBuilder builder = new ConfigurationBuilder();
       builder.indexing().index(Index.ALL)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       return builder;
    }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/JBMARRemoteQueryDslConditionsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/JBMARRemoteQueryDslConditionsTest.java
@@ -76,7 +76,7 @@ public class JBMARRemoteQueryDslConditionsTest extends QueryDslConditionsTest {
             .enable()
             .marshaller(new GenericJBossMarshaller());
       builder.indexing().index(Index.ALL)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       return builder;
    }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/MultiHotRodServerQueryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/MultiHotRodServerQueryTest.java
@@ -49,7 +49,7 @@ public class MultiHotRodServerQueryTest extends MultiHotRodServersTest {
    protected void createCacheManagers() throws Throwable {
       ConfigurationBuilder builder = hotRodCacheConfiguration(getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, false));
       builder.indexing().index(Index.ALL)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
 
       createHotRodServers(3, builder);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryDslConditionsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryDslConditionsTest.java
@@ -144,7 +144,7 @@ public class RemoteQueryDslConditionsTest extends QueryDslConditionsTest {
    protected ConfigurationBuilder getConfigurationBuilder() {
       ConfigurationBuilder builder = hotRodCacheConfiguration();
       builder.indexing().index(Index.ALL)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       return builder;
    }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryJmxTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryJmxTest.java
@@ -76,7 +76,7 @@ public class RemoteQueryJmxTest extends SingleCacheManagerTest {
 
       ConfigurationBuilder builder = new ConfigurationBuilder();
       builder.indexing().index(Index.ALL)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
 
       cacheManager = TestCacheManagerFactory.createCacheManager(gcb, builder, true);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryStringTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryStringTest.java
@@ -107,7 +107,7 @@ public class RemoteQueryStringTest extends QueryStringTest {
    protected ConfigurationBuilder getConfigurationBuilder() {
       ConfigurationBuilder builder = hotRodCacheConfiguration();
       builder.indexing().index(Index.ALL)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       return builder;
    }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryWithProtostreamAnnotationsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryWithProtostreamAnnotationsTest.java
@@ -114,7 +114,7 @@ public class RemoteQueryWithProtostreamAnnotationsTest extends SingleHotRodServe
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       org.infinispan.configuration.cache.ConfigurationBuilder builder = new org.infinispan.configuration.cache.ConfigurationBuilder();
       builder.indexing().index(Index.ALL)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
 
       return TestCacheManagerFactory.createCacheManager(builder);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/stress/RemoteQueryDslPerfTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/stress/RemoteQueryDslPerfTest.java
@@ -62,7 +62,7 @@ public class RemoteQueryDslPerfTest extends MultipleCacheManagersTest {
       ConfigurationBuilder builder = hotRodCacheConfiguration();
       builder.compatibility().enable().marshaller(new CompatibilityProtoStreamMarshaller());
       builder.indexing().index(Index.ALL)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       createClusteredCaches(1, builder);
 

--- a/core/src/main/java/org/infinispan/configuration/cache/IndexingConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/IndexingConfiguration.java
@@ -31,7 +31,14 @@ public class IndexingConfiguration extends AbstractTypedPropertiesConfiguration 
    }
 
    private static final String DIRECTORY_PROVIDER_KEY = "directory_provider";
+
+   /**
+    * Legacy name "ram" was replaced by "local-heap"
+    */
+   @Deprecated
    private static final String RAM_DIRECTORY_PROVIDER = "ram";
+   private static final String LOCAL_HEAP_DIRECTORY_PROVIDER = "local-heap";
+   private static final String LOCAL_HEAP_DIRECTORY_PROVIDER_FQN = "org.hibernate.search.store.impl.RAMDirectoryProvider";
 
    private final Attribute<Index> index;
    private final Attribute<Boolean> autoConfig;
@@ -116,7 +123,10 @@ public class IndexingConfiguration extends AbstractTypedPropertiesConfiguration 
       for (Object objKey : properties.keySet()) {
          String key = (String) objKey;
          if (key.endsWith(DIRECTORY_PROVIDER_KEY)) {
-            if (properties.get(key).equals(RAM_DIRECTORY_PROVIDER)) {
+            String directoryImplementationName = String.valueOf(properties.get(key)).trim();
+            if (LOCAL_HEAP_DIRECTORY_PROVIDER.equalsIgnoreCase(directoryImplementationName)
+                  || RAM_DIRECTORY_PROVIDER.equalsIgnoreCase(directoryImplementationName)
+                  || LOCAL_HEAP_DIRECTORY_PROVIDER_FQN.equals(directoryImplementationName)) {
                hasRamDirectoryProvider = true;
             } else {
                return true;

--- a/documentation/src/main/asciidoc/upgrading/upgrading.asciidoc
+++ b/documentation/src/main/asciidoc/upgrading/upgrading.asciidoc
@@ -48,6 +48,17 @@ Interfaces `DeltaAware`, `Delta` and `CopyableDeltaAware` have been deprecated. 
 
 Any partial updates to an entry should be replaced using the link:../user_guide/user_guide.html#functional_map_api[Functional API].
 
+=== Infinispan Query Configuration
+
+The configuration property `directory_provider` now accepts a new value `local-heap`.
+This value replaces the now deprecated `ram`, and as its predecessor will cause the index to be stored in a `org.apache.lucene.store.RAMDirectory`.
+
+The configuration value `ram` is still accepted and will have the same effect, but failing to replace `ram` with `local-heap` will cause a warning to be logged.
+We suggest to perform this replacement, as the `ram` value will no longer be recognised by Infinispan in a future version.
+
+This change was made as the team believes the `local-heap` name better expresses the storage model, especially as this storage method will not allow real-time replication of the index across multiple nodes.
+This index storage option is mostly useful for single node integration testing of the query functionality.
+
 == Upgrading from 8.x to 9.0
 
 === Default transaction mode changed

--- a/documentation/src/main/asciidoc/user_guide/query.adoc
+++ b/documentation/src/main/asciidoc/user_guide/query.adoc
@@ -226,13 +226,13 @@ cacheCfg.indexing().index(Index.ALL)
 
 ====== Index names
 
-Each property inside the `index` element is prefixed with the index name, for the index named `org.infinispan.sample.Car` the `directory_provider` is `ram`:
+Each property inside the `index` element is prefixed with the index name, for the index named `org.infinispan.sample.Car` the `directory_provider` is `local-heap`:
 
 [source,xml]
 ----
     ...
     <indexing index="ALL">
-        <property name="org.infinispan.sample.Car.directory_provider">ram</property>
+        <property name="org.infinispan.sample.Car.directory_provider">local-heap</property>
     </indexing>
     ...
 </infinispan>
@@ -243,7 +243,7 @@ Each property inside the `index` element is prefixed with the index name, for th
 ----
 cacheCfg.indexing()
    .index(Index.ALL)
-      .addProperty("org.infinispan.sample.Car.directory_provider", "ram")
+      .addProperty("org.infinispan.sample.Car.directory_provider", "local-heap")
 
 ----
 
@@ -251,8 +251,8 @@ Infinispan creates an index for each entity existent in a cache, and it allows t
 For a class annotated with `@Indexed`, the index name is the fully qualified class name, unless overridden with the
 `name` argument in the annotation.
 
-In the snippet below, the default storage for all entities is `infinispan`, but `Boat` instances will be stored on `ram` in an index named
-`boatIndex`. `Airplane` entities will also be stored in `ram`. Any other entity's index will be configured with the property prefixed by `default`.
+In the snippet below, the default storage for all entities is `infinispan`, but `Boat` instances will be stored on `local-heap` in an index named
+`boatIndex`. `Airplane` entities will also be stored in `local-heap`. Any other entity's index will be configured with the property prefixed by `default`.
 
 [source,java]
 ----
@@ -274,7 +274,7 @@ public class Airplane {
     ...
     <indexing index="ALL">
         <property name="default.directory_provider">infinispan</property>
-        <property name="boatIndex.directory_provider">ram</property>
+        <property name="boatIndex.directory_provider">local-heap</property>
         <property name="org.infinispan.sample.Airplane.directory_provider">
             ram
         </property>
@@ -530,7 +530,7 @@ is needed. Configuration:
 ----
 <replicated-cache name="myCache">
    <indexing index="ALL">
-      <property name="default.directory_provider">ram</property>
+      <property name="default.directory_provider">local-heap</property>
    </indexing>
 </replicated-cache>
 ----
@@ -569,7 +569,7 @@ In order to use Infinispan storage with a non-shared index, it's necessary to us
 
 Similar to the `directory-based` index manager but takes advantage of the Near-Real-Time features of Lucene. It has better write performance than
 the `directory-based` because it flushes the index to the underlying store less often. The drawback is that unflushed index changes can be lost in case
-of a non-clean shutdown. Can be used in conjunction with `ram`, `filesystem` and local infinispan storage. Configuration for each different storage
+of a non-clean shutdown. Can be used in conjunction with `local-heap`, `filesystem` and local infinispan storage. Configuration for each different storage
 type is the same as the <<query.directory-based>> index manager.
 
 Example with ram:
@@ -579,7 +579,7 @@ Example with ram:
 <replicated-cache name="default">
     <indexing index="ALL">
         <property name="default.indexmanager">near-real-time</property>
-        <property name="default.directory_provider">ram</property>
+        <property name="default.directory_provider">local-heap</property>
     </indexing>
 </replicated-cache>
 ----

--- a/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/AbstractQueryTest.java
+++ b/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/AbstractQueryTest.java
@@ -50,7 +50,7 @@ public abstract class AbstractQueryTest {
           .addIndexedEntity(NumericType.class)
           .addIndexedEntity(Person.class)
           .addIndexedEntity(Car.class)
-          .addProperty("default.directory_provider", "ram")
+          .addProperty("default.directory_provider", "local-heap")
           .addProperty("error_handler", "org.infinispan.all.embeddedquery.testdomain.StaticTestingErrorHandler")
           .addProperty("lucene_version", "LUCENE_CURRENT");
 

--- a/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/IndexedEntityAutodetectTest.java
+++ b/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/IndexedEntityAutodetectTest.java
@@ -28,7 +28,7 @@ public class IndexedEntityAutodetectTest extends LocalCacheTest {
             .transactionMode(TransactionMode.TRANSACTIONAL)
             .indexing()
             .index(Index.ALL)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("error_handler", "org.infinispan.all.embeddedquery.testdomain.StaticTestingErrorHandler")
             .addProperty("lucene_version", "LUCENE_CURRENT");
 

--- a/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/QueryDslConditionsTest.java
+++ b/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/QueryDslConditionsTest.java
@@ -82,7 +82,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
             .addIndexedEntity(getModelFactory().getUserImplClass())
             .addIndexedEntity(getModelFactory().getAccountImplClass())
             .addIndexedEntity(getModelFactory().getTransactionImplClass())
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("error_handler", "org.infinispan.all.embeddedquery.testdomain.StaticTestingErrorHandler")
             .addProperty("lucene_version", "LUCENE_CURRENT");
 

--- a/integrationtests/security-manager-it/src/test/java/org/infinispan/security/QueryAuthorizationTest.java
+++ b/integrationtests/security-manager-it/src/test/java/org/infinispan/security/QueryAuthorizationTest.java
@@ -42,7 +42,7 @@ public class QueryAuthorizationTest extends SingleCacheManagerTest {
          .indexing()
             .index(Index.LOCAL)
             .addIndexedEntity(TestEntity.class)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT")
          .security()
             .authorization().enable().role("admin").role("query").role("noquery");

--- a/query/src/test/java/org/infinispan/query/analysis/AnalyzerTest.java
+++ b/query/src/test/java/org/infinispan/query/analysis/AnalyzerTest.java
@@ -38,7 +38,7 @@ public class AnalyzerTest extends SingleCacheManagerTest {
          .indexing()
             .index(Index.ALL)
             .addIndexedEntity(Team.class)
-            .addProperty("hibernate.search.default.directory_provider", "ram")
+            .addProperty("hibernate.search.default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       return TestCacheManagerFactory.createCacheManager(cfg);
    }

--- a/query/src/test/java/org/infinispan/query/api/NonIndexedValuesTest.java
+++ b/query/src/test/java/org/infinispan/query/api/NonIndexedValuesTest.java
@@ -22,7 +22,7 @@ public class NonIndexedValuesTest extends SingleCacheManagerTest {
          .index(Index.ALL)
          .addIndexedEntity(TestEntity.class)
          .addIndexedEntity(AnotherTestEntity.class)
-         .addProperty("default.directory_provider", "ram")
+         .addProperty("default.directory_provider", "local-heap")
          .addProperty("error_handler", "org.infinispan.query.helper.StaticTestingErrorHandler")
          .addProperty("lucene_version", "LUCENE_CURRENT");
       return TestCacheManagerFactory.createCacheManager(c);

--- a/query/src/test/java/org/infinispan/query/api/PutAllTest.java
+++ b/query/src/test/java/org/infinispan/query/api/PutAllTest.java
@@ -49,7 +49,7 @@ public class PutAllTest extends SingleCacheManagerTest {
             .index(Index.ALL)
             .addIndexedEntity(TestEntity.class)
             .addIndexedEntity(AnotherTestEntity.class)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("error_handler", "org.infinispan.query.helper.StaticTestingErrorHandler")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       cfg.memory()

--- a/query/src/test/java/org/infinispan/query/api/ReplaceTest.java
+++ b/query/src/test/java/org/infinispan/query/api/ReplaceTest.java
@@ -22,7 +22,7 @@ public class ReplaceTest extends SingleCacheManagerTest {
          .indexing()
             .index(Index.ALL)
             .addIndexedEntity(TestEntity.class)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("error_handler", "org.infinispan.query.helper.StaticTestingErrorHandler")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       return TestCacheManagerFactory.createCacheManager(cfg);

--- a/query/src/test/java/org/infinispan/query/backend/CustomSearchWorkCreatorTest.java
+++ b/query/src/test/java/org/infinispan/query/backend/CustomSearchWorkCreatorTest.java
@@ -41,7 +41,7 @@ public class CustomSearchWorkCreatorTest extends SingleCacheManagerTest {
       ConfigurationBuilder cfg = getDefaultStandaloneCacheConfig(false);
       cfg.indexing().index(Index.ALL)
               .addIndexedEntity(Person.class)
-              .addProperty("default.directory_provider", "ram")
+              .addProperty("default.directory_provider", "local-heap")
               .addProperty("lucene_version", "LUCENE_CURRENT");
       return TestCacheManagerFactory.createCacheManager(cfg);
    }

--- a/query/src/test/java/org/infinispan/query/backend/ExtendedSearchWorkCreatorTest.java
+++ b/query/src/test/java/org/infinispan/query/backend/ExtendedSearchWorkCreatorTest.java
@@ -99,7 +99,7 @@ public class ExtendedSearchWorkCreatorTest extends SingleCacheManagerTest {
       ConfigurationBuilder cfg = getDefaultStandaloneCacheConfig(false);
       cfg.indexing().index(Index.ALL)
               .addIndexedEntity(Entity.class)
-              .addProperty("default.directory_provider", "ram")
+              .addProperty("default.directory_provider", "local-heap")
               .addProperty("lucene_version", "LUCENE_CURRENT");
       return TestCacheManagerFactory.createCacheManager(cfg);
    }

--- a/query/src/test/java/org/infinispan/query/backend/MultipleEntitiesTest.java
+++ b/query/src/test/java/org/infinispan/query/backend/MultipleEntitiesTest.java
@@ -41,7 +41,7 @@ public class MultipleEntitiesTest extends SingleCacheManagerTest {
       cfg.indexing().index(Index.ALL)
             .addIndexedEntity(Bond.class)
             .addIndexedEntity(Debenture.class)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("error_handler", "org.infinispan.query.helper.StaticTestingErrorHandler")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       return TestCacheManagerFactory.createCacheManager(cfg);

--- a/query/src/test/java/org/infinispan/query/blackbox/ClusteredCacheTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/ClusteredCacheTest.java
@@ -102,7 +102,7 @@ public class ClusteredCacheTest extends MultipleCacheManagersTest {
       cacheCfg.indexing()
             .index(Index.ALL)
             .addIndexedEntity(Person.class)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("error_handler", "org.infinispan.query.helper.StaticTestingErrorHandler")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       cacheCfg.memory()

--- a/query/src/test/java/org/infinispan/query/blackbox/ClusteredCacheWithLongIndexNameTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/ClusteredCacheWithLongIndexNameTest.java
@@ -49,7 +49,7 @@ public class ClusteredCacheWithLongIndexNameTest extends MultipleCacheManagersTe
             .indexing()
             .index(Index.ALL)
             .addIndexedEntity(VeryLongIndexNamedClass.class)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
 
       return cacheCfg;

--- a/query/src/test/java/org/infinispan/query/blackbox/ClusteredPessimisticLockingCacheTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/ClusteredPessimisticLockingCacheTest.java
@@ -25,7 +25,7 @@ public class ClusteredPessimisticLockingCacheTest extends ClusteredCacheTest {
       cacheCfg.indexing()
             .index(Index.ALL)
             .addIndexedEntity(Person.class)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("error_handler", "org.infinispan.query.helper.StaticTestingErrorHandler")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       enhanceConfig(cacheCfg);

--- a/query/src/test/java/org/infinispan/query/blackbox/ClusteredQueryMultipleCachesTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/ClusteredQueryMultipleCachesTest.java
@@ -25,7 +25,7 @@ public class ClusteredQueryMultipleCachesTest extends ClusteredQueryTest {
       ConfigurationBuilder cacheCfg = getDefaultClusteredCacheConfig(getCacheMode(), false);
       cacheCfg.indexing().index(Index.LOCAL)
             .addIndexedEntity(Person.class)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("error_handler", "org.infinispan.query.helper.StaticTestingErrorHandler")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       enhanceConfig(cacheCfg);

--- a/query/src/test/java/org/infinispan/query/blackbox/ClusteredQueryTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/ClusteredQueryTest.java
@@ -62,7 +62,7 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
             .indexing()
             .index(Index.LOCAL)
             .addIndexedEntity(Person.class)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("error_handler", "org.infinispan.query.helper.StaticTestingErrorHandler")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       enhanceConfig(cacheCfg);

--- a/query/src/test/java/org/infinispan/query/blackbox/CompatModeClusteredCacheTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/CompatModeClusteredCacheTest.java
@@ -26,7 +26,7 @@ public class CompatModeClusteredCacheTest extends ClusteredCacheTest {
             .indexing()
             .index(Index.ALL)
             .addIndexedEntity(Person.class)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("error_handler", "org.infinispan.query.helper.StaticTestingErrorHandler")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       enhanceConfig(cacheCfg);

--- a/query/src/test/java/org/infinispan/query/blackbox/CompatModeLocalCacheTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/CompatModeLocalCacheTest.java
@@ -26,7 +26,7 @@ public class CompatModeLocalCacheTest extends LocalCacheTest {
             .index(Index.ALL)
             .addIndexedEntity(Person.class)
             .addIndexedEntity(AnotherGrassEater.class)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("error_handler", "org.infinispan.query.helper.StaticTestingErrorHandler")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       enhanceConfig(cfg);

--- a/query/src/test/java/org/infinispan/query/blackbox/IndexedEntityAutodetectTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/IndexedEntityAutodetectTest.java
@@ -40,7 +40,7 @@ public class IndexedEntityAutodetectTest extends LocalCacheTest {
       cfg
             .indexing()
             .index(Index.ALL)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("error_handler", "org.infinispan.query.helper.StaticTestingErrorHandler")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       enhanceConfig(cfg);

--- a/query/src/test/java/org/infinispan/query/blackbox/KeyTypeTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/KeyTypeTest.java
@@ -40,7 +40,7 @@ public class KeyTypeTest extends SingleCacheManagerTest {
          .indexing()
             .index(Index.ALL)
             .addIndexedEntity(Person.class)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       cacheManager = TestCacheManagerFactory.createCacheManager(cfg);
 

--- a/query/src/test/java/org/infinispan/query/blackbox/LocalCacheTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/LocalCacheTest.java
@@ -663,7 +663,7 @@ public class LocalCacheTest extends SingleCacheManagerTest {
             .index(Index.ALL)
             .addIndexedEntity(Person.class)
             .addIndexedEntity(AnotherGrassEater.class)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("error_handler", "org.infinispan.query.helper.StaticTestingErrorHandler")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       enhanceConfig(cfg);

--- a/query/src/test/java/org/infinispan/query/blackbox/QueryCacheRestartTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/QueryCacheRestartTest.java
@@ -46,7 +46,7 @@ public class QueryCacheRestartTest extends AbstractInfinispanTest {
       ConfigurationBuilder builder = new ConfigurationBuilder();
       builder.indexing().index(localOnly ? Index.LOCAL : Index.ALL)
             .addIndexedEntity(Book.class)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       final NoOpInterceptor noOpInterceptor = new NoOpInterceptor();
       builder.customInterceptors().addInterceptor().interceptor(noOpInterceptor).position(Position.FIRST);

--- a/query/src/test/java/org/infinispan/query/blackbox/SearchFactoryShutdownTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/SearchFactoryShutdownTest.java
@@ -32,7 +32,7 @@ public class SearchFactoryShutdownTest extends AbstractInfinispanTest {
             .indexing()
                .index(Index.ALL)
                .addIndexedEntity(Person.class)
-               .addProperty("default.directory_provider", "ram")
+               .addProperty("default.directory_provider", "local-heap")
                .addProperty("lucene_version", "LUCENE_CURRENT");
          cc = TestCacheManagerFactory.createCacheManager(cfg);
          Cache<?, ?> cache = cc.getCache();

--- a/query/src/test/java/org/infinispan/query/config/DeclarativeConfigTest.java
+++ b/query/src/test/java/org/infinispan/query/config/DeclarativeConfigTest.java
@@ -32,7 +32,7 @@ public class DeclarativeConfigTest extends SingleCacheManagerTest {
             "<cache-container default-cache=\"default\">" +
             "   <local-cache name=\"default\">\n" +
             "      <indexing index=\"LOCAL\">\n" +
-            "            <property name=\"default.directory_provider\">ram</property>\n" +
+            "            <property name=\"default.directory_provider\">local-heap</property>\n" +
             "            <property name=\"lucene_version\">LUCENE_CURRENT</property>\n" +
             "      </indexing>\n" +
             "   </local-cache>\n" +

--- a/query/src/test/java/org/infinispan/query/config/MultipleCachesTest.java
+++ b/query/src/test/java/org/infinispan/query/config/MultipleCachesTest.java
@@ -39,7 +39,7 @@ public class MultipleCachesTest extends SingleCacheManagerTest {
             "   </local-cache>\n" +
             "   <local-cache name=\"indexingenabled\">\n" +
             "      <indexing index=\"LOCAL\" >\n" +
-            "            <property name=\"default.directory_provider\">ram</property>\n" +
+            "            <property name=\"default.directory_provider\">local-heap</property>\n" +
             "            <property name=\"lucene_version\">LUCENE_CURRENT</property>\n" +
             "      </indexing>\n" +
             "   </local-cache>\n" +

--- a/query/src/test/java/org/infinispan/query/config/QueryParsingTest.java
+++ b/query/src/test/java/org/infinispan/query/config/QueryParsingTest.java
@@ -34,7 +34,7 @@ public class QueryParsingTest extends AbstractInfinispanTest {
       Configuration memoryCfg = namedConfigurations.get("memory-searchable").build();
       assertTrue(memoryCfg.indexing().index().isEnabled());
       assertEquals(2, memoryCfg.indexing().properties().size());
-      assertEquals(memoryCfg.indexing().properties().getProperty("default.directory_provider"), "ram");
+      assertEquals(memoryCfg.indexing().properties().getProperty("default.directory_provider"), "local-heap");
 
       Configuration diskCfg = namedConfigurations.get("disk-searchable").build();
       assertTrue(diskCfg.indexing().index().isEnabled());
@@ -73,7 +73,7 @@ public class QueryParsingTest extends AbstractInfinispanTest {
       assertTrue(memoryCfg.indexing().index().isEnabled());
       assertFalse(memoryCfg.indexing().index().isLocalOnly());
       assertEquals(memoryCfg.indexing().properties().size(), 2);
-      assertEquals(memoryCfg.indexing().properties().getProperty("hibernate.search.default.directory_provider"), "ram");
+      assertEquals(memoryCfg.indexing().properties().getProperty("hibernate.search.default.directory_provider"), "local-heap");
 
       Configuration diskCfg = namedConfigurations.get("disk-searchable").build();
       assertTrue(diskCfg.indexing().index().isEnabled());

--- a/query/src/test/java/org/infinispan/query/directoryinteraction/IndexStoredIndexedCacheTest.java
+++ b/query/src/test/java/org/infinispan/query/directoryinteraction/IndexStoredIndexedCacheTest.java
@@ -54,7 +54,7 @@ public class IndexStoredIndexedCacheTest extends MultipleCacheManagersTest {
       .indexing()
          .index(Index.ALL)
             .addIndexedEntity(Person.class)
-            .addProperty("hibernate.search.default.directory_provider", "ram")
+            .addProperty("hibernate.search.default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       createClusteredCaches(2, "lucene", configurationBuilder);
    }

--- a/query/src/test/java/org/infinispan/query/distributed/AsyncMassIndexPerfTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/AsyncMassIndexPerfTest.java
@@ -140,7 +140,7 @@ public class AsyncMassIndexPerfTest extends MultipleCacheManagersTest {
    }
 
    private enum Provider {
-      RAM("ram"),
+      RAM("local-heap"),
       FILESYSTEM("filesystem"),
       INFINISPAN("infinispan");
       private final String cfg;

--- a/query/src/test/java/org/infinispan/query/distributed/DegeneratedClusterMassIndexingTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/DegeneratedClusterMassIndexingTest.java
@@ -27,7 +27,7 @@ public class DegeneratedClusterMassIndexingTest extends MultipleCacheManagersTes
       cfg.indexing()
             .index(Index.ALL)
             .addIndexedEntity(Car.class)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
 
       addClusterEnabledCacheManager(cfg);

--- a/query/src/test/java/org/infinispan/query/distributed/LocalCacheMassIndexerTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/LocalCacheMassIndexerTest.java
@@ -36,7 +36,7 @@ public class LocalCacheMassIndexerTest extends SingleCacheManagerTest {
       ConfigurationBuilder cfg = getDefaultStandaloneCacheConfig(false);
       cfg.indexing().index(Index.ALL)
             .addIndexedEntity(Person.class)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       return TestCacheManagerFactory.createCacheManager(cfg);
    }

--- a/query/src/test/java/org/infinispan/query/distributed/MultipleEntitiesMassIndexTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/MultipleEntitiesMassIndexTest.java
@@ -41,7 +41,7 @@ public class MultipleEntitiesMassIndexTest extends DistributedMassIndexingTest {
             .index(Index.ALL)
             .addIndexedEntity(Car.class)
             .addIndexedEntity(Person.class)
-            .addProperty("hibernate.search.person.directory_provider", "ram")
+            .addProperty("hibernate.search.person.directory_provider", "local-heap")
             .addProperty("hibernate.search.car.indexmanager", "org.infinispan.query.indexmanager.InfinispanIndexManager")
             .addProperty("error_handler", "org.infinispan.query.helper.StaticTestingErrorHandler")
             .addProperty("lucene_version", "LUCENE_CURRENT");

--- a/query/src/test/java/org/infinispan/query/distributed/OverlappingIndexMassIndexTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/OverlappingIndexMassIndexTest.java
@@ -38,7 +38,7 @@ public class OverlappingIndexMassIndexTest extends MultipleCacheManagersTest {
             .index(Index.ALL)
             .addIndexedEntity(Transaction.class)
             .addIndexedEntity(Block.class)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("error_handler", "org.infinispan.query.helper.StaticTestingErrorHandler")
             .addProperty("lucene_version", "LUCENE_CURRENT");
 

--- a/query/src/test/java/org/infinispan/query/distributed/ReplRamMassIndexingTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/ReplRamMassIndexingTest.java
@@ -26,7 +26,7 @@ public class ReplRamMassIndexingTest extends DistributedMassIndexingTest {
             .indexing()
             .index(Index.ALL)
             .addIndexedEntity(Car.class)
-            .addProperty("hibernate.search.default.directory_provider", "ram")
+            .addProperty("hibernate.search.default.directory_provider", "local-heap")
             .addProperty("hibernate.search.default.exclusive_index_use", "true")
             .addProperty("error_handler", "org.infinispan.query.helper.StaticTestingErrorHandler")
             .addProperty("lucene_version", "LUCENE_CURRENT")

--- a/query/src/test/java/org/infinispan/query/distributed/ShardingMassIndexTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/ShardingMassIndexTest.java
@@ -40,7 +40,7 @@ public class ShardingMassIndexTest extends MultipleCacheManagersTest {
             .index(Index.ALL)
             .addIndexedEntity(Car.class)
             .addProperty("hibernate.search.car.sharding_strategy.nbr_of_shards", "2")
-            .addProperty("hibernate.search.car.1.directory_provider", "ram")
+            .addProperty("hibernate.search.car.1.directory_provider", "local-heap")
             .addProperty("hibernate.search.car.0.indexmanager", "org.infinispan.query.indexmanager.InfinispanIndexManager")
             .addProperty("error_handler", "org.infinispan.query.helper.StaticTestingErrorHandler")
             .addProperty("lucene_version", "LUCENE_CURRENT");

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/AbstractQueryDslTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/AbstractQueryDslTest.java
@@ -76,7 +76,7 @@ public abstract class AbstractQueryDslTest extends MultipleCacheManagersTest {
             .addIndexedEntity(getModelFactory().getUserImplClass())
             .addIndexedEntity(getModelFactory().getAccountImplClass())
             .addIndexedEntity(getModelFactory().getTransactionImplClass())
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       createClusteredCaches(1, cfg);
    }

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/CompatModeQueryDslConditionsTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/CompatModeQueryDslConditionsTest.java
@@ -23,7 +23,7 @@ public class CompatModeQueryDslConditionsTest extends QueryDslConditionsTest {
             .addIndexedEntity(getModelFactory().getUserImplClass())
             .addIndexedEntity(getModelFactory().getAccountImplClass())
             .addIndexedEntity(getModelFactory().getTransactionImplClass())
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       createClusteredCaches(1, cfg);
    }

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/ListenerWithDslFilterTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/ListenerWithDslFilterTest.java
@@ -44,7 +44,7 @@ public class ListenerWithDslFilterTest extends SingleCacheManagerTest {
       ConfigurationBuilder cfgBuilder = new ConfigurationBuilder();
       cfgBuilder.indexing().index(Index.ALL)
             .addIndexedEntity(Person.class)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       return cfgBuilder;
    }

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/NamedParamsPerfTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/NamedParamsPerfTest.java
@@ -66,7 +66,7 @@ public class NamedParamsPerfTest extends AbstractQueryDslTest {
             .transactionMode(TransactionMode.TRANSACTIONAL)
             .indexing().index(Index.ALL)
             .addIndexedEntity(Person.class)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       createClusteredCaches(1, cfg);
    }

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/QueryDslConditionsTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/QueryDslConditionsTest.java
@@ -68,7 +68,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
             .addIndexedEntity(getModelFactory().getUserImplClass())
             .addIndexedEntity(getModelFactory().getAccountImplClass())
             .addIndexedEntity(getModelFactory().getTransactionImplClass())
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       createClusteredCaches(1, cfg);
    }

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/QueryStringTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/QueryStringTest.java
@@ -39,7 +39,7 @@ public class QueryStringTest extends AbstractQueryDslTest {
             .addIndexedEntity(getModelFactory().getUserImplClass())
             .addIndexedEntity(getModelFactory().getAccountImplClass())
             .addIndexedEntity(getModelFactory().getTransactionImplClass())
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       createClusteredCaches(1, cfg);
    }

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/SingleClassDSLQueryTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/SingleClassDSLQueryTest.java
@@ -40,7 +40,7 @@ public class SingleClassDSLQueryTest extends SingleCacheManagerTest {
    protected void configureCache(ConfigurationBuilder builder) {
       builder.indexing().index(Index.ALL)
             .addIndexedEntity(Person.class)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
    }
 

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/impl/EmbeddedQueryEngineTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/impl/EmbeddedQueryEngineTest.java
@@ -70,7 +70,7 @@ public class EmbeddedQueryEngineTest extends MultipleCacheManagersTest {
             .addIndexedEntity(TransactionHS.class)
             .addIndexedEntity(TheEntity.class)
             .addIndexedEntity(Book.class)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       createClusteredCaches(1, cfg);
    }

--- a/query/src/test/java/org/infinispan/query/dynamicexample/DynamicPropertiesTest.java
+++ b/query/src/test/java/org/infinispan/query/dynamicexample/DynamicPropertiesTest.java
@@ -29,7 +29,7 @@ public class DynamicPropertiesTest extends SingleCacheManagerTest {
          .indexing()
             .index(Index.ALL)
             .addIndexedEntity(DynamicPropertiesEntity.class)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       return TestCacheManagerFactory.createCacheManager(cfg);
    }

--- a/query/src/test/java/org/infinispan/query/helper/TestQueryHelperFactory.java
+++ b/query/src/test/java/org/infinispan/query/helper/TestQueryHelperFactory.java
@@ -79,7 +79,7 @@ public class TestQueryHelperFactory {
 
       if (isRamDirectoryProvider) {
          builder.indexing()
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT")
             .addProperty("error_handler", "org.infinispan.query.helper.StaticTestingErrorHandler");
       } else {

--- a/query/src/test/java/org/infinispan/query/impl/QueryCacheEmbeddedTest.java
+++ b/query/src/test/java/org/infinispan/query/impl/QueryCacheEmbeddedTest.java
@@ -40,7 +40,7 @@ public class QueryCacheEmbeddedTest extends SingleCacheManagerTest {
             .transactionMode(TransactionMode.TRANSACTIONAL)
             .indexing().index(Index.ALL)
             .addIndexedEntity(UserHS.class)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
 
       return TestCacheManagerFactory.createCacheManager(cfg);

--- a/query/src/test/java/org/infinispan/query/indexedembedded/BooksExampleTest.java
+++ b/query/src/test/java/org/infinispan/query/indexedembedded/BooksExampleTest.java
@@ -27,7 +27,7 @@ public class BooksExampleTest extends SingleCacheManagerTest {
          .indexing()
             .index(Index.ALL)
             .addIndexedEntity(Book.class)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       return TestCacheManagerFactory.createCacheManager(cfg);
    }

--- a/query/src/test/java/org/infinispan/query/indexedembedded/CollectionsIndexingTest.java
+++ b/query/src/test/java/org/infinispan/query/indexedembedded/CollectionsIndexingTest.java
@@ -35,7 +35,7 @@ public class CollectionsIndexingTest extends SingleCacheManagerTest {
          .indexing()
             .index(Index.ALL)
             .addIndexedEntity(Country.class)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       return TestCacheManagerFactory.createCacheManager(cfg);
    }

--- a/query/src/test/java/org/infinispan/query/jmx/QueryMBeanTest.java
+++ b/query/src/test/java/org/infinispan/query/jmx/QueryMBeanTest.java
@@ -53,7 +53,7 @@ public class QueryMBeanTest extends SingleCacheManagerTest {
 
       ConfigurationBuilder builder = getDefaultStandaloneCacheConfig(true);
       builder.indexing().index(Index.ALL)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("error_handler", "org.infinispan.query.helper.StaticTestingErrorHandler")
             .addProperty("lucene_version", "LUCENE_CURRENT");
 
@@ -184,7 +184,7 @@ public class QueryMBeanTest extends SingleCacheManagerTest {
          ConfigurationBuilder defaultCacheConfig2 = new ConfigurationBuilder();
          defaultCacheConfig2
                .indexing().index(Index.ALL)
-               .addProperty("default.directory_provider", "ram")
+               .addProperty("default.directory_provider", "local-heap")
                .addProperty("lucene_version", "LUCENE_CURRENT")
                .jmxStatistics().enable();
 

--- a/query/src/test/java/org/infinispan/query/nulls/NullCollectionElementsClusteredTest.java
+++ b/query/src/test/java/org/infinispan/query/nulls/NullCollectionElementsClusteredTest.java
@@ -193,7 +193,7 @@ public class NullCollectionElementsClusteredTest extends MultipleCacheManagersTe
             .indexing()
             .index(Index.LOCAL)
             .addIndexedEntity(Foo.class)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       createClusteredCaches(2, cfg);
 

--- a/query/src/test/java/org/infinispan/query/nulls/NullCollectionElementsTest.java
+++ b/query/src/test/java/org/infinispan/query/nulls/NullCollectionElementsTest.java
@@ -47,7 +47,7 @@ public class NullCollectionElementsTest extends SingleCacheManagerTest {
          .indexing()
             .index(Index.LOCAL)
              .addIndexedEntity(Foo.class)
-             .addProperty("default.directory_provider", "ram")
+             .addProperty("default.directory_provider", "local-heap")
              .addProperty("lucene_version", "LUCENE_CURRENT");
       return TestCacheManagerFactory.createCacheManager(cfg);
    }

--- a/query/src/test/java/org/infinispan/query/persistence/EntryActivatingTest.java
+++ b/query/src/test/java/org/infinispan/query/persistence/EntryActivatingTest.java
@@ -101,7 +101,7 @@ public class EntryActivatingTest extends AbstractInfinispanTest {
          .indexing()
             .index(Index.ALL)
             .addIndexedEntity(Country.class)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT")
          ;
       cm = TestCacheManagerFactory.createCacheManager(cfg);

--- a/query/src/test/java/org/infinispan/query/programmaticmapping/SearchMappingTest.java
+++ b/query/src/test/java/org/infinispan/query/programmaticmapping/SearchMappingTest.java
@@ -47,7 +47,7 @@ public class SearchMappingTest extends AbstractInfinispanTest {
             .property("isin", ElementType.METHOD).field();
 
       final Properties properties = new Properties();
-      properties.put("default.directory_provider", "ram");
+      properties.put("default.directory_provider", "local-heap");
       properties.put("lucene_version", "LUCENE_CURRENT");
       properties.put(Environment.MODEL_MAPPING, mapping);
 
@@ -117,7 +117,7 @@ public class SearchMappingTest extends AbstractInfinispanTest {
    @Test
    public void testWithoutSearchMapping() {
       final Properties properties = new Properties();
-      properties.put("default.directory_provider", "ram");
+      properties.put("default.directory_provider", "local-heap");
       properties.put("lucene_version", "LUCENE_CURRENT");
 
       ConfigurationBuilder builder = new ConfigurationBuilder();

--- a/query/src/test/java/org/infinispan/query/projection/ProjectionTest.java
+++ b/query/src/test/java/org/infinispan/query/projection/ProjectionTest.java
@@ -34,7 +34,7 @@ public class ProjectionTest extends SingleCacheManagerTest {
       ConfigurationBuilder cfg = getDefaultStandaloneCacheConfig(true);
       cfg.indexing().index(Index.ALL)
             .addIndexedEntity(Foo.class)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       EmbeddedCacheManager cacheManager = TestCacheManagerFactory.createCacheManager(cfg);
       Cache<Object, Object> cache = cacheManager.getCache();

--- a/query/src/test/java/org/infinispan/query/queries/faceting/SimpleFacetingTest.java
+++ b/query/src/test/java/org/infinispan/query/queries/faceting/SimpleFacetingTest.java
@@ -38,7 +38,7 @@ public class SimpleFacetingTest extends SingleCacheManagerTest {
          .indexing()
             .index(Index.ALL)
             .addIndexedEntity(Car.class)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       return TestCacheManagerFactory.createCacheManager(cfg);
    }

--- a/query/src/test/java/org/infinispan/query/queries/phrases/QueryPhrasesTest.java
+++ b/query/src/test/java/org/infinispan/query/queries/phrases/QueryPhrasesTest.java
@@ -53,7 +53,7 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
             .addIndexedEntity(NumericType.class)
             .addIndexedEntity(Person.class)
             .addIndexedEntity(AnotherGrassEater.class)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       return TestCacheManagerFactory.createCacheManager(cfg);
    }

--- a/query/src/test/java/org/infinispan/query/queries/ranges/QueryRangesTest.java
+++ b/query/src/test/java/org/infinispan/query/queries/ranges/QueryRangesTest.java
@@ -52,7 +52,7 @@ public class QueryRangesTest extends SingleCacheManagerTest {
             .indexing()
             .index(Index.ALL)
             .addIndexedEntity(Person.class)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       return TestCacheManagerFactory.createCacheManager(cfg);
    }

--- a/query/src/test/java/org/infinispan/query/queries/spatial/QuerySpatialTest.java
+++ b/query/src/test/java/org/infinispan/query/queries/spatial/QuerySpatialTest.java
@@ -41,7 +41,7 @@ public class QuerySpatialTest extends SingleCacheManagerTest {
       cfg.indexing()
             .index(Index.ALL)
             .addIndexedEntity(CitySpatial.class)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       return TestCacheManagerFactory.createCacheManager(cfg);
    }

--- a/query/src/test/java/org/infinispan/query/searchmanager/ClusteredCacheQueryTimeoutTest.java
+++ b/query/src/test/java/org/infinispan/query/searchmanager/ClusteredCacheQueryTimeoutTest.java
@@ -35,7 +35,7 @@ public class ClusteredCacheQueryTimeoutTest extends MultipleCacheManagersTest {
       cacheCfg.indexing()
             .index(Index.LOCAL)
             .addIndexedEntity(Foo.class)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       List<Cache<String, Person>> caches = createClusteredCaches(2, cacheCfg);
       cache1 = caches.get(0);

--- a/query/src/test/java/org/infinispan/query/searchmanager/TimeoutTest.java
+++ b/query/src/test/java/org/infinispan/query/searchmanager/TimeoutTest.java
@@ -31,7 +31,7 @@ public class TimeoutTest extends SingleCacheManagerTest {
          .indexing()
             .index(Index.ALL)
             .addIndexedEntity(Foo.class)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       return TestCacheManagerFactory.createCacheManager(cfg);
    }

--- a/query/src/test/java/org/infinispan/query/statetransfer/BaseReIndexingTest.java
+++ b/query/src/test/java/org/infinispan/query/statetransfer/BaseReIndexingTest.java
@@ -38,7 +38,7 @@ public abstract class BaseReIndexingTest extends MultipleCacheManagersTest {
 
       builder.indexing().index(Index.ALL)
             .addIndexedEntity(Person.class)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
 
       configureCache(builder);

--- a/query/src/test/java/org/infinispan/query/tx/NonLocalIndexingTest.java
+++ b/query/src/test/java/org/infinispan/query/tx/NonLocalIndexingTest.java
@@ -36,7 +36,7 @@ public class NonLocalIndexingTest extends MultipleCacheManagersTest {
       builder.indexing().index(Index.ALL)
             .addIndexedEntity(Person.class)
             .addIndexedEntity(AnotherGrassEater.class)
-            .addProperty("hibernate.search.default.directory_provider", "ram")
+            .addProperty("hibernate.search.default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       createClusteredCaches(2, builder);
    }

--- a/query/src/test/java/org/infinispan/query/tx/TransactionalQueryTest.java
+++ b/query/src/test/java/org/infinispan/query/tx/TransactionalQueryTest.java
@@ -25,7 +25,7 @@ public class TransactionalQueryTest extends SingleCacheManagerTest {
          .indexing()
             .index(Index.ALL)
             .addIndexedEntity(Session.class)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       return TestCacheManagerFactory.createCacheManager(cfg);
    }

--- a/query/src/test/java/org/infinispan/query/tx/TwoPhaseCommitIndexingTest.java
+++ b/query/src/test/java/org/infinispan/query/tx/TwoPhaseCommitIndexingTest.java
@@ -45,7 +45,7 @@ public class TwoPhaseCommitIndexingTest extends SingleCacheManagerTest {
          .indexing()
             .index(Index.ALL)
             .addIndexedEntity(Person.class)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT")
          .locking().isolationLevel(IsolationLevel.READ_COMMITTED);
       return TestCacheManagerFactory.createCacheManager(cfg);

--- a/query/src/test/resources/configuration-inheritance-parsing-test.xml
+++ b/query/src/test/resources/configuration-inheritance-parsing-test.xml
@@ -10,7 +10,7 @@
             <indexed-entities>
                <indexed-entity>org.infinispan.query.indexedembedded.Book</indexed-entity>
             </indexed-entities>
-            <property name="default.directory_provider">ram</property>
+            <property name="default.directory_provider">local-heap</property>
          </indexing>
       </local-cache-configuration>
       <local-cache name="default" configuration="template" />

--- a/query/src/test/resources/configuration-parsing-test-enbledInDefault.xml
+++ b/query/src/test/resources/configuration-parsing-test-enbledInDefault.xml
@@ -19,7 +19,7 @@
       </local-cache>
       <local-cache name="memory-searchable" configuration="base">
          <indexing index="ALL">
-            <property name="hibernate.search.default.directory_provider">ram</property>
+            <property name="hibernate.search.default.directory_provider">local-heap</property>
             <property name="lucene_version">LUCENE_48</property>
          </indexing>
       </local-cache>

--- a/query/src/test/resources/configuration-parsing-test.xml
+++ b/query/src/test/resources/configuration-parsing-test.xml
@@ -16,7 +16,7 @@
       <local-cache name="simple" />
       <local-cache name="memory-searchable">
          <indexing index="ALL">
-            <property name="default.directory_provider">ram</property>
+            <property name="default.directory_provider">local-heap</property>
             <property name="lucene_version">LUCENE_48</property>
          </indexing>
       </local-cache>

--- a/remote-query/remote-query-server/src/test/java/org/infinispan/query/remote/impl/ProtobufFieldIndexingMetadataTest.java
+++ b/remote-query/remote-query-server/src/test/java/org/infinispan/query/remote/impl/ProtobufFieldIndexingMetadataTest.java
@@ -46,7 +46,7 @@ public class ProtobufFieldIndexingMetadataTest extends SingleCacheManagerTest {
       ConfigurationBuilder cfg = getDefaultStandaloneCacheConfig(true);
       cfg.transaction().transactionMode(TransactionMode.TRANSACTIONAL)
             .indexing().index(Index.ALL)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       return TestCacheManagerFactory.createCacheManager(cfg);
    }

--- a/remote-query/remote-query-server/src/test/java/org/infinispan/query/remote/impl/indexing/ProtobufWrapperIndexingTest.java
+++ b/remote-query/remote-query-server/src/test/java/org/infinispan/query/remote/impl/indexing/ProtobufWrapperIndexingTest.java
@@ -37,7 +37,7 @@ public class ProtobufWrapperIndexingTest extends SingleCacheManagerTest {
       ConfigurationBuilder cfg = getDefaultStandaloneCacheConfig(true);
       cfg.transaction().transactionMode(TransactionMode.TRANSACTIONAL)
             .indexing().index(Index.ALL)
-            .addProperty("default.directory_provider", "ram")
+            .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       return TestCacheManagerFactory.createCacheManager(cfg);
    }

--- a/server/integration/infinispan/src/main/resources/subsystem-templates/infinispan-core.xml
+++ b/server/integration/infinispan/src/main/resources/subsystem-templates/infinispan-core.xml
@@ -309,7 +309,7 @@
             <!-- Indexes are local to each node, stored in memory -->
             <replicated-cache name="InMemoryNonSharedIndex">
                <indexing index="ALL">
-                  <property name="default.directory_provider">ram</property>
+                  <property name="default.directory_provider">local-heap</property>
                </indexing>
             </replicated-cache>
             <!-- Indexes are local to each node, stored on infinispan itself on configured caches -->

--- a/server/integration/infinispan/src/test/java/org/jboss/as/clustering/infinispan/subsystem/IndexedOperationsTestCase.java
+++ b/server/integration/infinispan/src/test/java/org/jboss/as/clustering/infinispan/subsystem/IndexedOperationsTestCase.java
@@ -69,7 +69,7 @@ public class IndexedOperationsTestCase extends OperationTestCaseBase {
       PathAddress indexingAddress = PathAddress.pathAddress(configAddOp.get(ClientConstants.OP_ADDR)).append(ModelKeys.INDEXING, ModelKeys.INDEXING_NAME);
       ModelNode indexingAdd = Util.createAddOperation(indexingAddress);
       indexingAdd.get(ModelKeys.INDEXING).set("LOCAL");
-      indexingAdd.get(ModelKeys.INDEXING_PROPERTIES).get("default.directory_provider").set("ram");
+      indexingAdd.get(ModelKeys.INDEXING_PROPERTIES).get("default.directory_provider").set("local-heap");
       indexingAdd.get(ModelKeys.INDEXING_PROPERTIES).get("hibernate.search.jmx_enabled").set("true");
       indexingAdd.get(ModelKeys.INDEXING_PROPERTIES).get("lucene_version").set("LUCENE_CURRENT");
       indexingAdd.get(ModelKeys.INDEXING_PROPERTIES).get("hibernate.search.indexing_strategy").set("manual");

--- a/server/integration/testsuite/src/test/resources/config/infinispan/custom-compat-marshaller.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/custom-compat-marshaller.xml
@@ -6,7 +6,7 @@
                         <indexed-entities>
                             <indexed-entity>deployment.custom-test-entity.jar:main:org.infinispan.server.test.query.TestEntity</indexed-entity>
                         </indexed-entities>
-                        <property name="default.directory_provider">ram</property>
+                        <property name="default.directory_provider">local-heap</property>
                     </indexing>
                 </local-cache>
                 <local-cache name="memcachedCache"/>

--- a/server/integration/testsuite/src/test/resources/config/infinispan/indexing-secured.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/indexing-secured.xml
@@ -15,7 +15,7 @@
 
                 <distributed-cache name="test_cache_indexed">
                     <indexing index="ALL">
-                        <property name="default.directory_provider">ram</property>
+                        <property name="default.directory_provider">local-heap</property>
                     </indexing>
                     <security>
                         <authorization roles="admin reader writer supervisor" enabled="true"/>

--- a/server/integration/testsuite/src/test/resources/config/infinispan/indexing.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/indexing.xml
@@ -15,20 +15,20 @@
 
                 <distributed-cache name="disttestcache">
                     <indexing index="ALL">
-                        <property name="default.directory_provider">ram</property>
+                        <property name="default.directory_provider">local-heap</property>
                     </indexing>
                 </distributed-cache>
 
                 <local-cache name="localtestcache">
                     <indexing index="ALL">
-                        <property name="default.directory_provider">ram</property>
+                        <property name="default.directory_provider">local-heap</property>
                         <property name="lucene_version">LUCENE_CURRENT</property>
                     </indexing>
                 </local-cache>
 
                 <local-cache name="localtestcache_manual">
                     <indexing index="ALL">
-                        <property name="default.directory_provider">ram</property>
+                        <property name="default.directory_provider">local-heap</property>
                         <property name="lucene_version">LUCENE_CURRENT</property>
                         <property name="hibernate.search.indexing_strategy">manual</property>
                         <property name="hibernate.search.jmx_enabled">true</property>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-8034

The "ram" short name to use Lucene's RAMDirectory implementation was renamed to "local_heap" in Hibernate Search to make its function clearer in the context of Infinispan as there are many kinds of ram.

The "ram" keyword was hardcoded into the Infinispan project though, so this needs to be updated and documented.
