### PR TITLE
ISPN-8036 TestResourceTracker keeps cache managers alive

### DIFF
--- a/core/src/test/java/org/infinispan/test/MultipleCacheManagersTest.java
+++ b/core/src/test/java/org/infinispan/test/MultipleCacheManagersTest.java
@@ -39,6 +39,7 @@ import org.infinispan.remoting.transport.Address;
 import org.infinispan.test.fwk.InCacheMode;
 import org.infinispan.test.fwk.InTransactionMode;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.test.fwk.TestResourceTracker;
 import org.infinispan.test.fwk.TestSelector;
 import org.infinispan.test.fwk.TransportFlags;
 import org.infinispan.transaction.LockingMode;
@@ -141,6 +142,7 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
       } else {
          TestingUtil.clearContent(cacheManagers);
          TestingUtil.killCacheManagers(cacheManagers);
+         TestResourceTracker.cleanUpResources(getTestName());
          cacheManagers.clear();
       }
    }

--- a/core/src/test/java/org/infinispan/test/fwk/TestResourceTracker.java
+++ b/core/src/test/java/org/infinispan/test/fwk/TestResourceTracker.java
@@ -44,7 +44,7 @@ public class TestResourceTracker {
       addResource(testName, cleaner);
    }
 
-   protected static void cleanUpResources(String testName) {
+   public static void cleanUpResources(String testName) {
       TestResources resources = testResources.remove(testName);
       if (resources != null) {
          for (Cleaner<?> cleaner : resources.getCleaners()) {


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-8036

May fix the random distexec failures in CI.