### PR TITLE
Ispn 7865 Distributed Iterator Reactive Streams

### DIFF
--- a/commons/src/main/java/org/infinispan/commons/marshall/Ids.java
+++ b/commons/src/main/java/org/infinispan/commons/marshall/Ids.java
@@ -157,9 +157,10 @@ public interface Ids {
 
    int IMMUTABLE_SET = 110;
 
-   int CONVERTER_KEY_MAPPER = 111;
-   int CONVERTER_VALUE_MAPPER = 112;
-   int CONVERTER_ENTRY_MAPPER = 113;
+   int STREAM_ITERATOR_RESPONSE = 111;
+   int END_ITERATOR = 112;
+
+   int STREAM_MAP_OPS = 113;
 
    int TRIANGLE_ACK_EXTERNALIZER = 114;
 
@@ -184,6 +185,8 @@ public interface Ids {
    int SCATTERED_CONSISTENT_HASH_FACTORY = 127;
    int SCATTERED_CONSISTENT_HASH = 128;
    int METADATA_REMOTE = 129;
+
+   int INT_SET = 130;
 
    int COUNTER_CONFIGURATION = 2000; //from counter
    int COUNTER_STATE = 2001; //from counter

--- a/commons/src/main/java/org/infinispan/commons/util/AbstractIterator.java
+++ b/commons/src/main/java/org/infinispan/commons/util/AbstractIterator.java
@@ -1,0 +1,49 @@
+package org.infinispan.commons.util;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.function.Consumer;
+
+/**
+ * Abstract iterator that allows overriding just the {@link AbstractIterator#getNext()} method to implement it.
+ * This iterator works on the premise that a null value returned from {@link AbstractIterator#getNext()} means
+ * that this iterator is complete.
+ * Note this iterator does not implement {@link Iterator#remove()} and is up to implementors to do so.
+ * @author wburns
+ * @since 9.2
+ */
+public abstract class AbstractIterator<E> implements Iterator<E> {
+   E next;
+
+   /**
+    * Method to implement to provide an iterator implementation. When this method returns null, the iterator is complete.
+    * @return the next value for the iterator to return or null for it to be complete.
+    */
+   protected abstract E getNext();
+
+   @Override
+   public boolean hasNext() {
+      return next != null || (next = getNext()) != null;
+   }
+
+   @Override
+   public E next() {
+      if (hasNext()) {
+         E returnValue = next;
+         next = null;
+         return returnValue;
+      }
+      throw new NoSuchElementException();
+   }
+
+   @Override
+   public void forEachRemaining(Consumer<? super E> action) {
+      if (next != null) {
+         action.accept(next);
+      }
+      E next;
+      while ((next = getNext()) != null) {
+         action.accept(next);
+      }
+   }
+}

--- a/commons/src/main/java/org/infinispan/commons/util/Closeables.java
+++ b/commons/src/main/java/org/infinispan/commons/util/Closeables.java
@@ -4,6 +4,7 @@ import java.util.Iterator;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.function.Consumer;
+import java.util.stream.BaseStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -46,7 +47,7 @@ public class Closeables {
     * @param <R> The type of the stream
     * @return A spliterator that when closed will also close the underlying stream
     */
-   public static <R> CloseableSpliterator<R> spliterator(Stream<R> stream) {
+   public static <R> CloseableSpliterator<R> spliterator(BaseStream<R, Stream<R>> stream) {
       return new StreamToCloseableSpliterator<>(stream);
    }
 
@@ -56,7 +57,7 @@ public class Closeables {
     * @param <R> The type of the stream
     * @return An iterator that when closed will also close the underlying stream
     */
-   public static <R> CloseableIterator<R> iterator(Stream<? extends R> stream) {
+   public static <R> CloseableIterator<R> iterator(BaseStream<R, Stream<R>> stream) {
       return new StreamToCloseableIterator<>(stream);
    }
 
@@ -174,9 +175,9 @@ public class Closeables {
    }
 
    private static class StreamToCloseableIterator<E> extends IteratorAsCloseableIterator<E> {
-      private final Stream<? extends E> stream;
+      private final BaseStream<E, Stream<E>> stream;
 
-      public StreamToCloseableIterator(Stream<? extends E> stream) {
+      public StreamToCloseableIterator(BaseStream<E, Stream<E>> stream) {
          super(stream.iterator());
          this.stream = stream;
       }
@@ -188,9 +189,9 @@ public class Closeables {
    }
 
    private static class StreamToCloseableSpliterator<T> extends SpliteratorAsCloseableSpliterator<T> {
-      private final Stream<T> stream;
+      private final BaseStream<T, Stream<T>> stream;
 
-      public StreamToCloseableSpliterator(Stream<T> stream) {
+      public StreamToCloseableSpliterator(BaseStream<T, Stream<T>> stream) {
          super(stream.spliterator());
          this.stream = stream;
       }

--- a/commons/src/main/java/org/infinispan/commons/util/IntSet.java
+++ b/commons/src/main/java/org/infinispan/commons/util/IntSet.java
@@ -1,0 +1,68 @@
+package org.infinispan.commons.util;
+
+import java.util.PrimitiveIterator;
+import java.util.Set;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+/**
+ * A set that represents primitive ints. This interface describes methods that can be used without having to box an int.
+ * @author wburns
+ * @since 9.0
+ */
+public interface IntSet extends Set<Integer> {
+
+   /**
+    * Adds the given int to this set and returns whether the int was present before
+    * @param i the int value to add
+    * @return whether this int was already present
+    */
+   boolean add(int i);
+
+   /**
+    * Adds or sets the int without returning whether it was previously set
+    * @param i the value to make sure is in the set
+    */
+   void set(int i);
+
+   /**
+    * Removes, if present, the int from the set and returns if it was present or not
+    * @param i the int to remove
+    * @return whether the int was present in the set before it was removed
+    */
+   boolean remove(int i);
+
+   /**
+    * Whether this set contains the given int
+    * @param i the int to check
+    * @return if the set contains the int
+    */
+   boolean contains(int i);
+
+   /**
+    * Whether this set contains all ints in the given IntSet
+    * @param set the set to check if all are present
+    * @return if the set contains all the ints
+    */
+   boolean containsAll(IntSet set);
+
+   /**
+    * Modifies this set to only remove all ints that are not present in the provided IntSet
+    * @param c the ints this set should kep
+    * @return if this set removed any ints
+    */
+   boolean retainAll(IntSet c);
+
+   /**
+    * A primtive iterator that allows iteration over the int values. This iterator supports removal if the set is
+    * modifiable.
+    * @return the iterator
+    */
+   PrimitiveIterator.OfInt iterator();
+
+   /**
+    * A stream of ints representing the data in this set
+    * @return the stream
+    */
+   IntStream intStream();
+}

--- a/commons/src/main/java/org/infinispan/commons/util/SmallIntSet.java
+++ b/commons/src/main/java/org/infinispan/commons/util/SmallIntSet.java
@@ -3,10 +3,14 @@ package org.infinispan.commons.util;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.io.Serializable;
 import java.util.BitSet;
 import java.util.Collection;
+import java.util.NoSuchElementException;
 import java.util.PrimitiveIterator;
 import java.util.Set;
+import java.util.function.IntConsumer;
+import java.util.stream.IntStream;
 
 import org.infinispan.commons.io.UnsignedNumeric;
 
@@ -19,7 +23,7 @@ import org.infinispan.commons.io.UnsignedNumeric;
  * @author Dan Berindei
  * @since 9.0
  */
-public class SmallIntSet implements Set<Integer> {
+public class SmallIntSet implements IntSet {
    private final BitSet bitSet;
 
    public static SmallIntSet of(int i1) {
@@ -51,6 +55,25 @@ public class SmallIntSet implements Set<Integer> {
       return set;
    }
 
+   public static SmallIntSet of(PrimitiveIterator.OfInt iterator) {
+      SmallIntSet set = new SmallIntSet();
+      iterator.forEachRemaining((IntConsumer) set::set);
+      return set;
+   }
+
+   /**
+    * Either converts the given set to an IntSet if it is one or creates a new IntSet and copies the contents
+    * @param set
+    * @return
+    */
+   public static SmallIntSet from(Set<Integer> set) {
+      if (set instanceof SmallIntSet) {
+         return (SmallIntSet) set;
+      } else {
+         return new SmallIntSet(set);
+      }
+   }
+
    public SmallIntSet() {
       bitSet = new BitSet();
    }
@@ -70,6 +93,17 @@ public class SmallIntSet implements Set<Integer> {
    public SmallIntSet(Set<Integer> set) {
       bitSet = new BitSet();
       set.forEach(bitSet::set);
+   }
+
+   public SmallIntSet(IntSet set) {
+      if (set instanceof SmallIntSet) {
+         BitSet bitSet = ((SmallIntSet) set).bitSet;
+         this.bitSet = new BitSet(bitSet.size());
+         this.bitSet.or(bitSet);
+      } else {
+         this.bitSet = new BitSet();
+         set.iterator().forEachRemaining((IntConsumer) bitSet::set);
+      }
    }
 
    @Override
@@ -104,7 +138,43 @@ public class SmallIntSet implements Set<Integer> {
 
    @Override
    public PrimitiveIterator.OfInt iterator() {
-      return bitSet.stream().iterator();
+      return new BitSetIntIterator(bitSet);
+   }
+
+   static class BitSetIntIterator implements PrimitiveIterator.OfInt {
+      private final BitSet bitSet;
+      private int offset;
+      private int prev;
+
+      BitSetIntIterator(BitSet bitSet) {
+         this.bitSet = bitSet;
+         this.offset = bitSet.nextSetBit(0);
+         this.prev = -1;
+      }
+
+      @Override
+      public int nextInt() {
+         if (offset < 0) {
+            throw new NoSuchElementException();
+         }
+         prev = offset;
+         offset = bitSet.nextSetBit(offset + 1);
+         return prev;
+      }
+
+      @Override
+      public boolean hasNext() {
+         return offset >= 0;
+      }
+
+      @Override
+      public void remove() {
+         if (prev < 0) {
+            throw new IllegalStateException();
+         }
+         bitSet.clear(prev);
+         prev = -1;
+      }
    }
 
    @Override
@@ -191,7 +261,18 @@ public class SmallIntSet implements Set<Integer> {
    }
 
    @Override
+   public boolean containsAll(IntSet set) {
+      if (set instanceof SmallIntSet) {
+         return bitSet.equals(((SmallIntSet) set).bitSet);
+      }
+      return bitSet.stream().allMatch(set::contains);
+   }
+
+   @Override
    public boolean addAll(Collection<? extends Integer> c) {
+      if (c instanceof IntSet) {
+         return containsAll((IntSet) c);
+      }
       boolean modified = false;
       for (Integer integer : c) {
          modified |= add(integer);
@@ -210,6 +291,21 @@ public class SmallIntSet implements Set<Integer> {
 
    @Override
    public boolean retainAll(Collection<?> c) {
+      if (c instanceof IntSet) {
+         return retainAll((IntSet) c);
+      }
+      boolean modified = false;
+      for (int i = bitSet.nextSetBit(0); i >= 0; i = bitSet.nextSetBit(i + 1)) {
+         if (!c.contains(i)) {
+            bitSet.clear(i);
+            modified = true;
+         }
+      }
+      return modified;
+   }
+
+   @Override
+   public boolean retainAll(IntSet c) {
       boolean modified = false;
       for (int i = bitSet.nextSetBit(0); i >= 0; i = bitSet.nextSetBit(i + 1)) {
          if (!c.contains(i)) {
@@ -223,6 +319,11 @@ public class SmallIntSet implements Set<Integer> {
    @Override
    public void clear() {
       bitSet.clear();
+   }
+
+   @Override
+   public IntStream intStream() {
+      return bitSet.stream();
    }
 
    @Override

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -51,6 +51,11 @@
       </dependency>
 
       <dependency>
+         <groupId>io.reactivex.rxjava2</groupId>
+         <artifactId>rxjava</artifactId>
+      </dependency>
+
+      <dependency>
          <groupId>${project.groupId}</groupId>
          <artifactId>infinispan-commons-test</artifactId>
          <scope>test</scope>

--- a/core/src/main/java/org/infinispan/BaseCacheStream.java
+++ b/core/src/main/java/org/infinispan/BaseCacheStream.java
@@ -2,12 +2,17 @@ package org.infinispan;
 
 import java.util.Comparator;
 import java.util.Iterator;
+import java.util.PrimitiveIterator;
 import java.util.Set;
 import java.util.Spliterator;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.BaseStream;
+
+import org.infinispan.commons.util.IntSet;
+import org.infinispan.commons.util.SmallIntSet;
 
 /**
  * Interface that defines the base methods of all streams returned from a {@link Cache}.  This interface
@@ -78,6 +83,8 @@ public interface BaseCacheStream<T, S extends BaseStream<T, S>> extends BaseStre
     * is not specified.  Please see {@link CacheStream#iterator()} for more information.</p>
     * <p>Multiple listeners may be registered upon multiple invocations of this method.  The ordering of notified
     * listeners is not specified.</p>
+    * <p>This is only used if this stream did not invoke {@link BaseCacheStream#disableRehashAware()} and has no
+    * flat map based operations. If this is done no segments will be notified.</p>
     * @param listener The listener that will be called back as segments are completed.
     * @return a stream with the listener registered.
     */
@@ -113,11 +120,22 @@ public interface BaseCacheStream<T, S extends BaseStream<T, S>> extends BaseStre
     * @since 9.0
     */
    @FunctionalInterface
-   interface SegmentCompletionListener {
+   interface SegmentCompletionListener extends Consumer<Supplier<PrimitiveIterator.OfInt>> {
       /**
        * Method invoked when the segment has been found to be consumed properly by the terminal operation.
        * @param segments The segments that were completed
+       * @deprecated This method requires boxing for each segment. Please use {@link SegmentCompletionListener#accept(Supplier)} instead
        */
+      @Deprecated
       void segmentCompleted(Set<Integer> segments);
+
+      /**
+       * Invoked each time a given number of segments have completed and the terminal opearation has consumed all
+       * entries in the given segment
+       * @param segments The segments that were completed
+       */
+      default void accept(Supplier<PrimitiveIterator.OfInt> segments) {
+         segmentCompleted(SmallIntSet.of(segments.get()));
+      }
    }
 }

--- a/core/src/main/java/org/infinispan/commands/CommandsFactory.java
+++ b/core/src/main/java/org/infinispan/commands/CommandsFactory.java
@@ -67,6 +67,7 @@ import org.infinispan.commands.write.RemoveCommand;
 import org.infinispan.commands.write.RemoveExpiredCommand;
 import org.infinispan.commands.write.ReplaceCommand;
 import org.infinispan.commands.write.WriteCommand;
+import org.infinispan.commons.util.IntSet;
 import org.infinispan.functional.EntryView.ReadEntryView;
 import org.infinispan.functional.EntryView.ReadWriteEntryView;
 import org.infinispan.functional.EntryView.WriteEntryView;
@@ -78,8 +79,12 @@ import org.infinispan.remoting.transport.Address;
 import org.infinispan.statetransfer.StateChunk;
 import org.infinispan.statetransfer.StateRequestCommand;
 import org.infinispan.statetransfer.StateResponseCommand;
+import org.infinispan.stream.impl.StreamIteratorCloseCommand;
+import org.infinispan.stream.impl.StreamIteratorNextCommand;
+import org.infinispan.stream.impl.StreamIteratorRequestCommand;
 import org.infinispan.stream.impl.StreamRequestCommand;
 import org.infinispan.stream.impl.StreamResponseCommand;
+import org.infinispan.stream.impl.intops.IntermediateOperation;
 import org.infinispan.transaction.xa.GlobalTransaction;
 import org.infinispan.xsite.SingleXSiteRpcCommand;
 import org.infinispan.xsite.XSiteAdminCommand;
@@ -498,6 +503,14 @@ public interface CommandsFactory {
     */
    <R> StreamResponseCommand<R> buildStreamResponseCommand(Object identifier, boolean complete, Set<Integer> lostSegments,
            R response);
+
+   <K> StreamIteratorRequestCommand<K> buildStreamIteratorRequestCommand(Object id, boolean parallelStream,
+         IntSet segments, Set<K> keys, Set<K> excludedKeys, boolean includeLoader,
+         Iterable<IntermediateOperation> intOps, long batchSize);
+
+   StreamIteratorNextCommand buildStreamIteratorNextCommand(Object id, long batchSize);
+
+   StreamIteratorCloseCommand buildStreamIteratorCloseCommand(Object id);
 
    <K, V, R> ReadOnlyKeyCommand<K, V, R> buildReadOnlyKeyCommand(K key, Function<ReadEntryView<K, V>, R> f, Params params);
 

--- a/core/src/main/java/org/infinispan/commands/CommandsFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/commands/CommandsFactoryImpl.java
@@ -74,6 +74,7 @@ import org.infinispan.commands.write.RemoveExpiredCommand;
 import org.infinispan.commands.write.ReplaceCommand;
 import org.infinispan.commands.write.ValueMatcher;
 import org.infinispan.commands.write.WriteCommand;
+import org.infinispan.commons.util.IntSet;
 import org.infinispan.functional.EntryView.ReadEntryView;
 import org.infinispan.functional.EntryView.ReadWriteEntryView;
 import org.infinispan.functional.EntryView.WriteEntryView;
@@ -110,10 +111,15 @@ import org.infinispan.statetransfer.StateRequestCommand;
 import org.infinispan.statetransfer.StateResponseCommand;
 import org.infinispan.statetransfer.StateTransferManager;
 import org.infinispan.stream.impl.ClusterStreamManager;
+import org.infinispan.stream.impl.IteratorHandler;
 import org.infinispan.stream.impl.LocalStreamManager;
+import org.infinispan.stream.impl.StreamIteratorCloseCommand;
+import org.infinispan.stream.impl.StreamIteratorNextCommand;
+import org.infinispan.stream.impl.StreamIteratorRequestCommand;
 import org.infinispan.stream.impl.StreamRequestCommand;
 import org.infinispan.stream.impl.StreamResponseCommand;
 import org.infinispan.stream.impl.StreamSegmentResponseCommand;
+import org.infinispan.stream.impl.intops.IntermediateOperation;
 import org.infinispan.transaction.impl.TransactionTable;
 import org.infinispan.transaction.xa.GlobalTransaction;
 import org.infinispan.transaction.xa.recovery.RecoveryManager;
@@ -169,6 +175,7 @@ public class CommandsFactoryImpl implements CommandsFactory {
    private XSiteStateTransferManager xSiteStateTransferManager;
    private GroupManager groupManager;
    private LocalStreamManager localStreamManager;
+   private IteratorHandler iteratorHandler;
    private ClusterStreamManager clusterStreamManager;
    private ClusteringDependentLogic clusteringDependentLogic;
    private CommandAckCollector commandAckCollector;
@@ -195,7 +202,7 @@ public class CommandsFactoryImpl implements CommandsFactory {
                                  CommandAckCollector commandAckCollector,
                                  StateReceiver stateReceiver,
                                  ComponentRegistry componentRegistry,
-                                 OrderedUpdatesManager orderedUpdatesManager) {
+                                 OrderedUpdatesManager orderedUpdatesManager, IteratorHandler iteratorHandler) {
       this.dataContainer = container;
       this.notifier = notifier;
       this.cache = cache;
@@ -218,6 +225,7 @@ public class CommandsFactoryImpl implements CommandsFactory {
       this.xSiteStateTransferManager = xSiteStateTransferManager;
       this.groupManager = groupManager;
       this.localStreamManager = localStreamManager;
+      this.iteratorHandler = iteratorHandler;
       this.clusterStreamManager = clusterStreamManager;
       this.clusteringDependentLogic = clusteringDependentLogic;
       this.marshaller = marshaller;
@@ -516,6 +524,18 @@ public class CommandsFactoryImpl implements CommandsFactory {
             StreamSegmentResponseCommand streamSegmentResponseCommand = (StreamSegmentResponseCommand) c;
             streamSegmentResponseCommand.inject(clusterStreamManager);
             break;
+         case StreamIteratorRequestCommand.COMMAND_ID:
+            StreamIteratorRequestCommand streamIteratorRequestCommand = (StreamIteratorRequestCommand) c;
+            streamIteratorRequestCommand.inject(localStreamManager);
+            break;
+         case StreamIteratorNextCommand.COMMAND_ID:
+            StreamIteratorNextCommand streamIteratorNextCommand = (StreamIteratorNextCommand) c;
+            streamIteratorNextCommand.inject(localStreamManager);
+            break;
+         case StreamIteratorCloseCommand.COMMAND_ID:
+            StreamIteratorCloseCommand streamIteratorCloseCommand = (StreamIteratorCloseCommand) c;
+            streamIteratorCloseCommand.inject(iteratorHandler);
+            break;
          case RemoveExpiredCommand.COMMAND_ID:
             RemoveExpiredCommand removeExpiredCommand = (RemoveExpiredCommand) c;
             removeExpiredCommand.init(notifier);
@@ -671,6 +691,24 @@ public class CommandsFactoryImpl implements CommandsFactory {
          return new StreamSegmentResponseCommand<>(cacheName, cache.getCacheManager().getAddress(), identifier,
                  complete, response, lostSegments);
       }
+   }
+
+   @Override
+   public <K> StreamIteratorRequestCommand<K> buildStreamIteratorRequestCommand(Object id, boolean parallelStream,
+         IntSet segments, Set<K> keys, Set<K> excludedKeys, boolean includeLoader,
+         Iterable<IntermediateOperation> intOps, long batchSize) {
+      return new StreamIteratorRequestCommand<>(cacheName, cache.getCacheManager().getAddress(), id, parallelStream,
+            segments, keys, excludedKeys, includeLoader, intOps, batchSize);
+   }
+
+   @Override
+   public StreamIteratorNextCommand buildStreamIteratorNextCommand(Object id, long batchSize) {
+      return new StreamIteratorNextCommand(cacheName, id, batchSize);
+   }
+
+   @Override
+   public StreamIteratorCloseCommand buildStreamIteratorCloseCommand(Object id) {
+      return new StreamIteratorCloseCommand(cacheName, cache.getCacheManager().getAddress(), id);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/commands/RemoteCommandsFactory.java
+++ b/core/src/main/java/org/infinispan/commands/RemoteCommandsFactory.java
@@ -62,6 +62,9 @@ import org.infinispan.manager.impl.ReplicableCommandManagerFunction;
 import org.infinispan.manager.impl.ReplicableCommandRunnable;
 import org.infinispan.statetransfer.StateRequestCommand;
 import org.infinispan.statetransfer.StateResponseCommand;
+import org.infinispan.stream.impl.StreamIteratorCloseCommand;
+import org.infinispan.stream.impl.StreamIteratorNextCommand;
+import org.infinispan.stream.impl.StreamIteratorRequestCommand;
 import org.infinispan.stream.impl.StreamRequestCommand;
 import org.infinispan.stream.impl.StreamResponseCommand;
 import org.infinispan.stream.impl.StreamSegmentResponseCommand;
@@ -314,6 +317,15 @@ public class RemoteCommandsFactory {
                break;
             case StreamResponseCommand.COMMAND_ID:
                command = new StreamResponseCommand(cacheName);
+               break;
+            case StreamIteratorRequestCommand.COMMAND_ID:
+               command = new StreamIteratorRequestCommand<>(cacheName);
+               break;
+            case StreamIteratorNextCommand.COMMAND_ID:
+               command = new StreamIteratorNextCommand(cacheName);
+               break;
+            case StreamIteratorCloseCommand.COMMAND_ID:
+               command = new StreamIteratorCloseCommand(cacheName);
                break;
             case BackupWriteRpcCommand.COMMAND_ID:
                command = new BackupWriteRpcCommand(cacheName);

--- a/core/src/main/java/org/infinispan/commands/read/EntrySetCommand.java
+++ b/core/src/main/java/org/infinispan/commands/read/EntrySetCommand.java
@@ -4,6 +4,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.Spliterator;
+import java.util.function.ToIntFunction;
 
 import org.infinispan.Cache;
 import org.infinispan.CacheSet;
@@ -22,6 +23,7 @@ import org.infinispan.context.Flag;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.distribution.ch.ConsistentHash;
+import org.infinispan.distribution.ch.KeyPartitioner;
 import org.infinispan.stream.impl.local.EntryStreamSupplier;
 import org.infinispan.stream.impl.local.LocalCacheStream;
 import org.infinispan.util.DataContainerRemoveIterator;
@@ -131,23 +133,23 @@ public class EntrySetCommand<K, V> extends AbstractLocalCommand implements Visit
          }
       }
 
-      private ConsistentHash getConsistentHash(Cache<K, V> cache) {
+      private ToIntFunction<Object> getSegmentMapper(Cache<K, V> cache) {
          DistributionManager dm = cache.getAdvancedCache().getDistributionManager();
          if (dm != null) {
-            return dm.getReadConsistentHash();
+            return dm.getCacheTopology()::getSegment;
          }
          return null;
       }
 
       @Override
       public CacheStream<CacheEntry<K, V>> stream() {
-         return new LocalCacheStream<>(new EntryStreamSupplier<>(cache, getConsistentHash(cache),
+         return new LocalCacheStream<>(new EntryStreamSupplier<>(cache, getSegmentMapper(cache),
                  () -> super.stream()), false, cache.getAdvancedCache().getComponentRegistry());
       }
 
       @Override
       public CacheStream<CacheEntry<K, V>> parallelStream() {
-         return new LocalCacheStream<>(new EntryStreamSupplier<>(cache, getConsistentHash(cache),
+         return new LocalCacheStream<>(new EntryStreamSupplier<>(cache, getSegmentMapper(cache),
                  () -> super.stream()), true, cache.getAdvancedCache().getComponentRegistry());
       }
    }

--- a/core/src/main/java/org/infinispan/commands/read/KeySetCommand.java
+++ b/core/src/main/java/org/infinispan/commands/read/KeySetCommand.java
@@ -101,7 +101,7 @@ public class KeySetCommand<K, V> extends AbstractLocalCommand implements Visitab
       @Override
       public CacheStream<K> stream() {
          DistributionManager dm = cache.getAdvancedCache().getDistributionManager();
-         return new LocalCacheStream<>(new KeyStreamSupplier<>(cache, dm != null ? dm.getWriteConsistentHash() : null,
+         return new LocalCacheStream<>(new KeyStreamSupplier<>(cache, dm != null ? dm.getCacheTopology()::getSegment : null,
                  () -> StreamSupport.stream(spliterator(), false)), false,
                  cache.getAdvancedCache().getComponentRegistry());
       }
@@ -109,7 +109,7 @@ public class KeySetCommand<K, V> extends AbstractLocalCommand implements Visitab
       @Override
       public CacheStream<K> parallelStream() {
          DistributionManager dm = cache.getAdvancedCache().getDistributionManager();
-         return new LocalCacheStream<>(new KeyStreamSupplier<>(cache, dm != null ? dm.getWriteConsistentHash() : null,
+         return new LocalCacheStream<>(new KeyStreamSupplier<>(cache, dm != null ? dm.getCacheTopology()::getSegment : null,
                  () -> StreamSupport.stream(spliterator(), false)), true,
                  cache.getAdvancedCache().getComponentRegistry());
       }

--- a/core/src/main/java/org/infinispan/distribution/ch/impl/ScatteredConsistentHash.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/impl/ScatteredConsistentHash.java
@@ -4,6 +4,7 @@ import net.jcip.annotations.Immutable;
 import org.infinispan.commons.hash.Hash;
 import org.infinispan.commons.marshall.Ids;
 import org.infinispan.commons.marshall.InstanceReusingAdvancedExternalizer;
+import org.infinispan.commons.util.SmallIntSet;
 import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.globalstate.ScopedPersistentState;
 import org.infinispan.remoting.transport.Address;
@@ -112,7 +113,7 @@ public class ScatteredConsistentHash extends AbstractConsistentHash {
          throw new IllegalArgumentException("Node " + owner + " is not a member");
       }
 
-      Set<Integer> segments = new HashSet<Integer>();
+      SmallIntSet segments = new SmallIntSet();
       for (int segment = 0; segment < segmentOwners.length; segment++) {
          if (Objects.equals(segmentOwners[segment], owner)) {
             segments.add(segment);

--- a/core/src/main/java/org/infinispan/factories/EmptyConstructorFactory.java
+++ b/core/src/main/java/org/infinispan/factories/EmptyConstructorFactory.java
@@ -13,6 +13,7 @@ import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
 import org.infinispan.remoting.inboundhandler.GlobalInboundInvocationHandler;
 import org.infinispan.remoting.inboundhandler.InboundInvocationHandler;
+import org.infinispan.stream.impl.IteratorHandler;
 import org.infinispan.topology.PersistentUUIDManager;
 import org.infinispan.topology.PersistentUUIDManagerImpl;
 import org.infinispan.util.DefaultTimeService;
@@ -33,7 +34,7 @@ import org.infinispan.xsite.BackupReceiverRepositoryImpl;
 @DefaultFactoryFor(classes = {BackupReceiverRepository.class, CancellationService.class, EventLogManager.class,
                               InboundInvocationHandler.class, PersistentUUIDManager.class,
                               RemoteCommandsFactory.class, TimeService.class, OffHeapEntryFactory.class,
-                              OffHeapMemoryAllocator.class})
+                              OffHeapMemoryAllocator.class, IteratorHandler.class})
 @Scope(Scopes.GLOBAL)
 public class EmptyConstructorFactory extends AbstractComponentFactory implements AutoInstantiableFactory {
 
@@ -58,6 +59,8 @@ public class EmptyConstructorFactory extends AbstractComponentFactory implements
          return componentType.cast(new OffHeapEntryFactoryImpl());
       else if (componentType.equals(OffHeapMemoryAllocator.class))
          return componentType.cast(new UnpooledOffHeapMemoryAllocator());
+      else if (componentType.equals(IteratorHandler.class))
+         return componentType.cast(new IteratorHandler());
 
       throw new CacheConfigurationException("Don't know how to create a " + componentType.getName());
    }

--- a/core/src/main/java/org/infinispan/interceptors/distribution/DistributionBulkInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/DistributionBulkInterceptor.java
@@ -198,7 +198,8 @@ public class DistributionBulkInterceptor<K, V> extends DDAsyncInterceptor {
          ComponentRegistry registry = advancedCache.getComponentRegistry();
          ClusterStreamManager<K> realManager = registry.getComponent(ClusterStreamManager.class);
          LocalizedCacheTopology cacheTopology = dm.getCacheTopology();
-         TxClusterStreamManager<K> txManager = new TxClusterStreamManager<>(realManager, ctx, cacheTopology::getSegment);
+         TxClusterStreamManager<K> txManager = new TxClusterStreamManager<>(realManager, ctx,
+               cacheTopology.getCurrentCH().getNumSegments(), cacheTopology::getSegment);
 
          CacheStream<CacheEntry<K, V>> cacheStream = new TxDistributedCacheStream<>(cache.getCacheManager().getAddress(),
                  false, dm, entrySet::stream, txManager, !command.hasAnyFlag(FlagBitSets.SKIP_CACHE_LOAD),
@@ -214,7 +215,8 @@ public class DistributionBulkInterceptor<K, V> extends DDAsyncInterceptor {
          ComponentRegistry registry = advancedCache.getComponentRegistry();
          ClusterStreamManager<K> realManager = registry.getComponent(ClusterStreamManager.class);
          LocalizedCacheTopology cacheTopology = dm.getCacheTopology();
-         TxClusterStreamManager<K> txManager = new TxClusterStreamManager<>(realManager, ctx, cacheTopology::getSegment);
+         TxClusterStreamManager<K> txManager = new TxClusterStreamManager<>(realManager, ctx,
+               cacheTopology.getCurrentCH().getNumSegments(), cacheTopology::getSegment);
 
          CacheStream<CacheEntry<K, V>> cacheStream = new TxDistributedCacheStream<>(cache.getCacheManager().getAddress(),
                  true, dm, entrySet::parallelStream, txManager, !command.hasAnyFlag(FlagBitSets.SKIP_CACHE_LOAD),
@@ -341,7 +343,8 @@ public class DistributionBulkInterceptor<K, V> extends DDAsyncInterceptor {
          ComponentRegistry registry = advancedCache.getComponentRegistry();
          ClusterStreamManager<K> realManager = registry.getComponent(ClusterStreamManager.class);
          LocalizedCacheTopology cacheTopology = dm.getCacheTopology();
-         TxClusterStreamManager<K> txManager = new TxClusterStreamManager<>(realManager, ctx, cacheTopology::getSegment);
+         TxClusterStreamManager<K> txManager = new TxClusterStreamManager<>(realManager, ctx,
+               cacheTopology.getCurrentCH().getNumSegments(), cacheTopology::getSegment);
 
          return new TxDistributedCacheStream<>(cache.getCacheManager().getAddress(), false,
                  dm, entrySet::stream, txManager, !command.hasAnyFlag(FlagBitSets.SKIP_CACHE_LOAD),
@@ -357,7 +360,8 @@ public class DistributionBulkInterceptor<K, V> extends DDAsyncInterceptor {
          ComponentRegistry registry = advancedCache.getComponentRegistry();
          ClusterStreamManager<K> realManager = registry.getComponent(ClusterStreamManager.class);
          LocalizedCacheTopology cacheTopology = dm.getCacheTopology();
-         TxClusterStreamManager<K> txManager = new TxClusterStreamManager<>(realManager, ctx, cacheTopology::getSegment);
+         TxClusterStreamManager<K> txManager = new TxClusterStreamManager<>(realManager, ctx,
+               cacheTopology.getCurrentCH().getNumSegments(), cacheTopology::getSegment);
 
          return new TxDistributedCacheStream<>(cache.getCacheManager().getAddress(), true,
                  dm, entrySet::parallelStream, txManager, !command.hasAnyFlag(FlagBitSets.SKIP_CACHE_LOAD),

--- a/core/src/main/java/org/infinispan/interceptors/distribution/DistributionBulkInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/DistributionBulkInterceptor.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import java.util.Spliterator;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.infinispan.AdvancedCache;
@@ -31,6 +30,7 @@ import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.FlagBitSets;
 import org.infinispan.context.impl.LocalTxInvocationContext;
 import org.infinispan.distribution.DistributionManager;
+import org.infinispan.distribution.LocalizedCacheTopology;
 import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.interceptors.DDAsyncInterceptor;
@@ -197,7 +197,8 @@ public class DistributionBulkInterceptor<K, V> extends DDAsyncInterceptor {
          DistributionManager dm = advancedCache.getDistributionManager();
          ComponentRegistry registry = advancedCache.getComponentRegistry();
          ClusterStreamManager<K> realManager = registry.getComponent(ClusterStreamManager.class);
-         TxClusterStreamManager<K> txManager = new TxClusterStreamManager<>(realManager, ctx, dm.getWriteConsistentHash());
+         LocalizedCacheTopology cacheTopology = dm.getCacheTopology();
+         TxClusterStreamManager<K> txManager = new TxClusterStreamManager<>(realManager, ctx, cacheTopology::getSegment);
 
          CacheStream<CacheEntry<K, V>> cacheStream = new TxDistributedCacheStream<>(cache.getCacheManager().getAddress(),
                  false, dm, entrySet::stream, txManager, !command.hasAnyFlag(FlagBitSets.SKIP_CACHE_LOAD),
@@ -212,7 +213,8 @@ public class DistributionBulkInterceptor<K, V> extends DDAsyncInterceptor {
          DistributionManager dm = advancedCache.getDistributionManager();
          ComponentRegistry registry = advancedCache.getComponentRegistry();
          ClusterStreamManager<K> realManager = registry.getComponent(ClusterStreamManager.class);
-         TxClusterStreamManager<K> txManager = new TxClusterStreamManager<>(realManager, ctx, dm.getWriteConsistentHash());
+         LocalizedCacheTopology cacheTopology = dm.getCacheTopology();
+         TxClusterStreamManager<K> txManager = new TxClusterStreamManager<>(realManager, ctx, cacheTopology::getSegment);
 
          CacheStream<CacheEntry<K, V>> cacheStream = new TxDistributedCacheStream<>(cache.getCacheManager().getAddress(),
                  true, dm, entrySet::parallelStream, txManager, !command.hasAnyFlag(FlagBitSets.SKIP_CACHE_LOAD),
@@ -338,7 +340,8 @@ public class DistributionBulkInterceptor<K, V> extends DDAsyncInterceptor {
          DistributionManager dm = advancedCache.getDistributionManager();
          ComponentRegistry registry = advancedCache.getComponentRegistry();
          ClusterStreamManager<K> realManager = registry.getComponent(ClusterStreamManager.class);
-         TxClusterStreamManager<K> txManager = new TxClusterStreamManager<>(realManager, ctx, dm.getWriteConsistentHash());
+         LocalizedCacheTopology cacheTopology = dm.getCacheTopology();
+         TxClusterStreamManager<K> txManager = new TxClusterStreamManager<>(realManager, ctx, cacheTopology::getSegment);
 
          return new TxDistributedCacheStream<>(cache.getCacheManager().getAddress(), false,
                  dm, entrySet::stream, txManager, !command.hasAnyFlag(FlagBitSets.SKIP_CACHE_LOAD),
@@ -353,7 +356,8 @@ public class DistributionBulkInterceptor<K, V> extends DDAsyncInterceptor {
          DistributionManager dm = advancedCache.getDistributionManager();
          ComponentRegistry registry = advancedCache.getComponentRegistry();
          ClusterStreamManager<K> realManager = registry.getComponent(ClusterStreamManager.class);
-         TxClusterStreamManager<K> txManager = new TxClusterStreamManager<>(realManager, ctx, dm.getWriteConsistentHash());
+         LocalizedCacheTopology cacheTopology = dm.getCacheTopology();
+         TxClusterStreamManager<K> txManager = new TxClusterStreamManager<>(realManager, ctx, cacheTopology::getSegment);
 
          return new TxDistributedCacheStream<>(cache.getCacheManager().getAddress(), true,
                  dm, entrySet::parallelStream, txManager, !command.hasAnyFlag(FlagBitSets.SKIP_CACHE_LOAD),

--- a/core/src/main/java/org/infinispan/interceptors/impl/PrefetchInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/PrefetchInterceptor.java
@@ -529,13 +529,13 @@ public class PrefetchInterceptor extends DDAsyncInterceptor {
 
       @Override
       public CacheStream<CacheEntry<K, V>> stream() {
-         return new LocalCacheStream<>(new EntryStreamSupplier<>(cache, dm.getReadConsistentHash(),
+         return new LocalCacheStream<>(new EntryStreamSupplier<>(cache, dm.getCacheTopology()::getSegment,
             () -> super.stream()), false, cache.getAdvancedCache().getComponentRegistry());
       }
 
       @Override
       public CacheStream<CacheEntry<K, V>> parallelStream() {
-         return new LocalCacheStream<>(new EntryStreamSupplier<>(cache, dm.getReadConsistentHash(),
+         return new LocalCacheStream<>(new EntryStreamSupplier<>(cache, dm.getCacheTopology()::getSegment,
             () -> super.stream()), true, cache.getAdvancedCache().getComponentRegistry());
       }
    }
@@ -723,14 +723,14 @@ public class PrefetchInterceptor extends DDAsyncInterceptor {
 
       @Override
       public CacheStream<K> stream() {
-         return new LocalCacheStream<>(new KeyStreamSupplier<>(cache, dm.getReadConsistentHash(),
+         return new LocalCacheStream<>(new KeyStreamSupplier<>(cache, dm.getCacheTopology()::getSegment,
             () -> StreamSupport.stream(spliterator(), false)), false,
             cache.getAdvancedCache().getComponentRegistry());
       }
 
       @Override
       public CacheStream<K> parallelStream() {
-         return new LocalCacheStream<>(new KeyStreamSupplier<>(cache, dm.getReadConsistentHash(),
+         return new LocalCacheStream<>(new KeyStreamSupplier<>(cache, dm.getCacheTopology()::getSegment,
             () -> StreamSupport.stream(spliterator(), false)), true,
             cache.getAdvancedCache().getComponentRegistry());
       }

--- a/core/src/main/java/org/infinispan/marshall/core/InternalExternalizers.java
+++ b/core/src/main/java/org/infinispan/marshall/core/InternalExternalizers.java
@@ -97,6 +97,9 @@ import org.infinispan.remoting.transport.jgroups.JGroupsTopologyAwareAddress;
 import org.infinispan.statetransfer.StateChunk;
 import org.infinispan.statetransfer.TransactionInfo;
 import org.infinispan.stream.StreamMarshalling;
+import org.infinispan.stream.impl.AbstractCacheStream;
+import org.infinispan.stream.impl.EndIterator;
+import org.infinispan.stream.impl.IteratorResponses;
 import org.infinispan.stream.impl.intops.IntermediateOperationExternalizer;
 import org.infinispan.stream.impl.termop.TerminalOperationExternalizer;
 import org.infinispan.topology.CacheJoinInfo;
@@ -110,6 +113,7 @@ import org.infinispan.transaction.xa.recovery.InDoubtTxInfoImpl;
 import org.infinispan.transaction.xa.recovery.RecoveryAwareDldGlobalTransaction;
 import org.infinispan.transaction.xa.recovery.RecoveryAwareGlobalTransaction;
 import org.infinispan.transaction.xa.recovery.SerializableXid;
+import org.infinispan.util.IntSetExternalizer;
 import org.infinispan.util.KeyValuePair;
 import org.infinispan.xsite.statetransfer.XSiteState;
 
@@ -240,10 +244,14 @@ final class InternalExternalizers {
       addInternalExternalizer(new WrappedByteArray.Externalizer(), exts);
       addInternalExternalizer(new XSiteState.XSiteStateExternalizer(), exts);
       addInternalExternalizer(new TriangleAckExternalizer(), exts);
+      addInternalExternalizer(new IteratorResponses.IteratorResponsesExternalizer(), exts);
+      addInternalExternalizer(new EndIterator.EndIteratorExternalizer(), exts);
       addInternalExternalizer(XidImpl.EXTERNALIZER, exts);
       addInternalExternalizer(new EncoderKeyMapper.Externalizer(), exts);
       addInternalExternalizer(new EncoderValueMapper.Externalizer(), exts);
       addInternalExternalizer(new EncoderEntryMapper.Externalizer(), exts);
+      addInternalExternalizer(new IntSetExternalizer(), exts);
+      addInternalExternalizer(new AbstractCacheStream.MapOpsExternalizer(), exts);
 
       return exts;
    }

--- a/core/src/main/java/org/infinispan/marshall/exts/CacheRpcCommandExternalizer.java
+++ b/core/src/main/java/org/infinispan/marshall/exts/CacheRpcCommandExternalizer.java
@@ -37,6 +37,9 @@ import org.infinispan.factories.GlobalComponentRegistry;
 import org.infinispan.marshall.core.Ids;
 import org.infinispan.statetransfer.StateRequestCommand;
 import org.infinispan.statetransfer.StateResponseCommand;
+import org.infinispan.stream.impl.StreamIteratorCloseCommand;
+import org.infinispan.stream.impl.StreamIteratorNextCommand;
+import org.infinispan.stream.impl.StreamIteratorRequestCommand;
 import org.infinispan.stream.impl.StreamRequestCommand;
 import org.infinispan.stream.impl.StreamResponseCommand;
 import org.infinispan.stream.impl.StreamSegmentResponseCommand;
@@ -81,7 +84,8 @@ public final class CacheRpcCommandExternalizer extends AbstractExternalizer<Cach
                ClusteredGetAllCommand.class,
                StreamRequestCommand.class, StreamSegmentResponseCommand.class, StreamResponseCommand.class,
                BackupWriteRpcCommand.class, BackupPutMapRpcCommand.class,
-               InvalidateVersionsCommand.class);
+               InvalidateVersionsCommand.class, StreamIteratorRequestCommand.class,
+               StreamIteratorNextCommand.class, StreamIteratorCloseCommand.class);
       // Only interested in cache specific replicable commands
       coreCommands.addAll(gcr.getModuleProperties().moduleCacheRpcCommands());
       return coreCommands;

--- a/core/src/main/java/org/infinispan/marshall/exts/CollectionExternalizer.java
+++ b/core/src/main/java/org/infinispan/marshall/exts/CollectionExternalizer.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
@@ -74,6 +75,8 @@ public class CollectionExternalizer implements AdvancedExternalizer<Collection> 
             MarshallUtil.marshallCollection(collection, output);
             break;
          case SINGLETON_LIST:
+            output.writeObject(((List) collection).get(0));
+            break;
          case SINGLETON_SET:
             output.writeObject(collection.iterator().next());
             break;

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/CacheNotifierImpl.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/CacheNotifierImpl.java
@@ -61,6 +61,7 @@ import org.infinispan.distexec.DistributedCallable;
 import org.infinispan.distexec.DistributedExecutionCompletionService;
 import org.infinispan.distexec.DistributedExecutorService;
 import org.infinispan.distribution.DistributionManager;
+import org.infinispan.distribution.LocalizedCacheTopology;
 import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.factories.annotations.Inject;
@@ -1372,7 +1373,9 @@ public final class CacheNotifierImpl<K, V> extends AbstractListenerImpl<Event<K,
                QueueingSegmentListener handler = segmentHandler.get(identifier);
                if (handler == null) {
                   if (config.clustering().cacheMode().isDistributed()) {
-                     handler = new DistributedQueueingSegmentListener(entryFactory, distributionManager);
+                     LocalizedCacheTopology cacheTopology = distributionManager.getCacheTopology();
+                     handler = new DistributedQueueingSegmentListener(entryFactory,
+                           cacheTopology.getCurrentCH().getNumSegments(), cacheTopology::getSegment);
                   } else {
                      handler = new QueueingAllSegmentListener(entryFactory);
                   }

--- a/core/src/main/java/org/infinispan/stream/impl/ClusterStreamManager.java
+++ b/core/src/main/java/org/infinispan/stream/impl/ClusterStreamManager.java
@@ -2,13 +2,20 @@ package org.infinispan.stream.impl;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.PrimitiveIterator;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import java.util.function.IntFunction;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 import org.infinispan.CacheStream;
+import org.infinispan.commons.util.IntSet;
 import org.infinispan.remoting.transport.Address;
+import org.infinispan.stream.impl.intops.IntermediateOperation;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
 
 /**
  * Manages distribution of various stream operations that are sent to remote nodes.  Note usage of any operations
@@ -28,9 +35,8 @@ public interface ClusterStreamManager<K> {
        * {@link CacheStream#forEach(Consumer)} and {@link CacheStream#toArray()}.
        * @param address Which node this data came from
        * @param results The results obtained so far.
-       * @return the segments that completed with some value
        */
-      Set<Integer> onIntermediateResult(Address address, R results);
+      void onIntermediateResult(Address address, R results);
 
       /**
        * Essentially the same as {@link ClusterStreamManager.ResultsCallback#onIntermediateResult(Address address, Object)}
@@ -156,4 +162,50 @@ public interface ClusterStreamManager<K> {
     * @return Whether or not the operation should continue operating, only valid if complete was false
     */
    <R1> boolean receiveResponse(Object id, Address origin, boolean complete, Set<Integer> segments, R1 response);
+
+   /**
+    *
+    * @param parallelStream
+    * @param segments
+    * @param keysToInclude
+    * @param keysToExclude
+    * @param includeLoader
+    * @param intermediateOperations
+    * @param <E>
+    * @return
+    */
+   <E> RemoteIteratorPublisher<E> remoteIterationPublisher(boolean parallelStream,
+         Supplier<Map.Entry<Address, IntSet>> segments, Set<K> keysToInclude, IntFunction<Set<K>> keysToExclude,
+         boolean includeLoader, Iterable<IntermediateOperation> intermediateOperations);
+
+   /**
+    * {@inheritDoc}
+    * <p>
+    * This producer is used to allow for it to provide additional signals to the subscribing caller. Callers may want
+    * to use the producer as a standard producer but also listen for the additional lost segment signal. This can
+    * be accomplished by doing the following:
+    * <pre>{@code Publisher<K> publisher = s -> remoteIteratorPublisher.subscribe(s, segments -> { // Do something};}</pre>
+    */
+   interface RemoteIteratorPublisher<K> extends Publisher<K> {
+      /**
+       * Essentially the same as {@link Publisher#subscribe(Subscriber)} except that a {@link Consumer} is provided
+       * that will be invoked when a segment for a given request has been lost. This is to notify the subscribing
+       * code that they may have to rerequest such data.
+       * <p>
+       * This publisher guarantees it will call the {@link Consumer}s before {@link Subscriber#onComplete()} and it will
+       * not call them concurrently. The provided segments will always be non null, however it could be empty. However
+       * it is possible that a key returned could be mapped to a segment that was found to be suspected or completed.
+       * @see Publisher#subscribe(Subscriber)
+       * @param s the subscriber to subscribe
+       * @param lostSegments the consumer to be notified of lost segments
+       * @param completedSegments the consumer to  be notified of completed segments
+       */
+      void subscribe(Subscriber<? super K> s, Consumer<? super Supplier<PrimitiveIterator.OfInt>> lostSegments,
+            Consumer<? super Supplier<PrimitiveIterator.OfInt>> completedSegments);
+
+      @Override
+      default void subscribe(Subscriber<? super K> s) {
+         subscribe(s, lostSegments -> { }, completedSegments -> { });
+      }
+   }
 }

--- a/core/src/main/java/org/infinispan/stream/impl/ClusterStreamManagerImpl.java
+++ b/core/src/main/java/org/infinispan/stream/impl/ClusterStreamManagerImpl.java
@@ -5,35 +5,55 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
+import java.util.PrimitiveIterator;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.IntFunction;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.infinispan.commands.CommandsFactory;
+import org.infinispan.commands.ReplicableCommand;
 import org.infinispan.commons.CacheException;
+import org.infinispan.commons.util.IntSet;
 import org.infinispan.commons.util.SmallIntSet;
+import org.infinispan.commons.util.concurrent.ConcurrentHashSet;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.distribution.LocalizedCacheTopology;
 import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
+import org.infinispan.remoting.responses.ExceptionResponse;
 import org.infinispan.remoting.responses.Response;
+import org.infinispan.remoting.responses.SuccessfulResponse;
+import org.infinispan.remoting.rpc.ResponseMode;
 import org.infinispan.remoting.rpc.RpcManager;
+import org.infinispan.remoting.rpc.RpcOptions;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.remoting.transport.jgroups.SuspectException;
 import org.infinispan.statetransfer.StateTransferLock;
+import org.infinispan.stream.impl.intops.IntermediateOperation;
 import org.infinispan.util.RangeSet;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import io.reactivex.internal.subscriptions.EmptySubscription;
 
 /**
  * Cluster stream manager that sends all requests using the {@link RpcManager} to do the underlying communications.
@@ -41,6 +61,7 @@ import org.infinispan.util.logging.LogFactory;
  */
 public class ClusterStreamManagerImpl<K> implements ClusterStreamManager<K> {
    protected final Map<String, RequestTracker> currentlyRunning = new ConcurrentHashMap<>();
+   protected final Set<Subscriber> iteratorsRunning = new ConcurrentHashSet<>();
    protected final AtomicInteger requestId = new AtomicInteger();
    protected RpcManager rpc;
    protected CommandsFactory factory;
@@ -48,9 +69,12 @@ public class ClusterStreamManagerImpl<K> implements ClusterStreamManager<K> {
    protected StateTransferLock stateTransferLock;
    protected Configuration configuration;
 
+   protected RpcOptions rpcOptions;
+
    protected Address localAddress;
 
    protected final static Log log = LogFactory.getLog(ClusterStreamManagerImpl.class);
+   protected final static boolean trace = log.isTraceEnabled();
 
    @Inject
    public void inject(RpcManager rpc, CommandsFactory factory, DistributionManager dm,
@@ -65,6 +89,7 @@ public class ClusterStreamManagerImpl<K> implements ClusterStreamManager<K> {
    @Start
    public void start() {
       localAddress = rpc.getAddress();
+      rpcOptions = rpc.getRpcOptionsBuilder(ResponseMode.SYNCHRONOUS).timeout(Long.MAX_VALUE, TimeUnit.DAYS).build();
    }
 
    @Override
@@ -265,6 +290,22 @@ public class ClusterStreamManagerImpl<K> implements ClusterStreamManager<K> {
       }).collect(Collectors.toSet());
    }
 
+   // TODO: we could have this method return a Stream etc. so it doesn't have to iterate upon keys multiple times (helps rehash and tx)
+   private Set<K> determineExcludedKeys(IntFunction<Set<K>> keysToExclude, IntSet segmentsToUse) {
+      if (keysToExclude == null) {
+         return Collections.emptySet();
+      }
+
+      // Special map only supports get operations
+      return segmentsToUse.intStream().mapToObj(s -> {
+         Set<K> keysForSegment = keysToExclude.apply(s);
+         if (keysForSegment != null) {
+            return keysForSegment.stream();
+         }
+         return null;
+      }).flatMap(Function.identity()).collect(Collectors.toSet());
+   }
+
    private Map<Address, Set<Integer>> determineTargets(Set<Integer> segments) {
       LocalizedCacheTopology cacheTopology = dm.getCacheTopology();
       ConsistentHash ch = cacheTopology.getReadConsistentHash();
@@ -407,6 +448,244 @@ public class ClusterStreamManagerImpl<K> implements ClusterStreamManager<K> {
       } else {
          log.tracef("Ignoring response as we already received a completed response for %s from %s", id, origin);
          return false;
+      }
+   }
+
+   @Override
+   public <E> RemoteIteratorPublisher<E> remoteIterationPublisher(boolean parallelStream,
+         Supplier<Map.Entry<Address, IntSet>> targets, Set<K> keysToInclude, IntFunction<Set<K>> keysToExclude,
+         boolean includeLoader, Iterable<IntermediateOperation> intermediateOperations) {
+
+      return new RemoteIteratorPublisherImpl<>(parallelStream, targets, keysToInclude, keysToExclude, includeLoader,
+            intermediateOperations);
+   }
+
+   private class RemoteIteratorPublisherImpl<V> implements RemoteIteratorPublisher<V> {
+      private final boolean parallelStream;
+      private final Supplier<Map.Entry<Address, IntSet>> targets;
+      private final Set<K> keysToInclude;
+      private final IntFunction<Set<K>> keysToExclude;
+      private final boolean includeLoader;
+      private final Iterable<IntermediateOperation> intermediateOperations;
+
+      RemoteIteratorPublisherImpl(boolean parallelStream, Supplier<Map.Entry<Address, IntSet>> targets,
+            Set<K> keysToInclude, IntFunction<Set<K>> keysToExclude, boolean includeLoader,
+            Iterable<IntermediateOperation> intermediateOperations) {
+         this.parallelStream = parallelStream;
+         this.targets = targets;
+         this.keysToInclude = keysToInclude;
+         this.keysToExclude = keysToExclude;
+         this.includeLoader = includeLoader;
+         this.intermediateOperations = intermediateOperations;
+      }
+
+      @Override
+      public void subscribe(Subscriber<? super V> s, Consumer<? super Supplier<PrimitiveIterator.OfInt>> onLostSegments,
+            Consumer<? super Supplier<PrimitiveIterator.OfInt>> onSegmentsComplete) {
+         Map.Entry<Address, IntSet> target = targets.get();
+         if (target == null) {
+            EmptySubscription.complete(s);
+         } else {
+            String id = localAddress.toString() + "-" + requestId.getAndIncrement();
+            if (trace) {
+               log.tracef("Starting request: %s", id);
+            }
+            iteratorsRunning.add(s);
+            s.onSubscribe(new ClusterStreamSubscription<V>(s, this, onLostSegments, onSegmentsComplete, id, target));
+         }
+      }
+   }
+
+   private class ClusterStreamSubscription<V> implements Subscription {
+
+      private final Subscriber<? super V> s;
+      private final RemoteIteratorPublisherImpl<V> publisher;
+      private final Consumer<? super Supplier<PrimitiveIterator.OfInt>> onSegmentsComplete;
+      private final Consumer<? super Supplier<PrimitiveIterator.OfInt>> onSegmentsLost;
+      private final String id;
+
+      private final AtomicLong requestedAmount = new AtomicLong();
+      private final AtomicBoolean pendingRequest = new AtomicBoolean();
+
+      private volatile AtomicReference<Map.Entry<Address, IntSet>> currentTarget;
+      private volatile boolean alreadyCreated;
+
+      ClusterStreamSubscription(Subscriber<? super V> s, RemoteIteratorPublisherImpl<V> publisher,
+            Consumer<? super Supplier<PrimitiveIterator.OfInt>> onSegmentsComplete,
+            Consumer<? super Supplier<PrimitiveIterator.OfInt>> onSegmentsLost,
+            String id, Map.Entry<Address, IntSet> currentTarget) {
+         this.s = s;
+         this.publisher = publisher;
+         this.onSegmentsComplete = onSegmentsComplete;
+         this.onSegmentsLost = onSegmentsLost;
+         this.id = id;
+         // We assume the map has at least one otherwise this subscription wouldn't be created
+         this.currentTarget = new AtomicReference<>(currentTarget);
+      }
+
+      @Override
+      public void request(long n) {
+         // If current target is null it means we completed
+         if (currentTarget == null) {
+            return;
+         }
+         if (n <= 0) {
+            throw new IllegalArgumentException("request amount must be greater than 0");
+         }
+         long batchAmount = requestedAmount.addAndGet(n);
+         // If there is no pending request we can submit a new one
+         if (!pendingRequest.getAndSet(true)) {
+            sendRequest(batchAmount);
+         }
+      }
+
+      ReplicableCommand getCommand(IntSet segments, long batchAmount) {
+         if (alreadyCreated) {
+            return factory.buildStreamIteratorNextCommand(id, batchAmount);
+         } else {
+            alreadyCreated = true;
+            return factory.buildStreamIteratorRequestCommand(id,
+                  publisher.parallelStream, segments, publisher.keysToInclude,
+                  determineExcludedKeys(publisher.keysToExclude, segments), publisher.includeLoader,
+                  publisher.intermediateOperations, batchAmount);
+         }
+      }
+
+      private void sendRequest(long batchAmount) {
+         // Copy the variable in case if we are closed concurrently - also this double check works for resubmission
+         Map.Entry<Address, IntSet> target = currentTarget.get();
+         if (target != null) {
+            IntSet segments = target.getValue();
+            if (trace) {
+               log.tracef("Request: %s is requesting %d more entries from %s in segments %s", id, batchAmount, target, segments);
+            }
+            Address sendee = target.getKey();
+            CompletableFuture<Map<Address, Response>> completableFuture = rpc.invokeRemotelyAsync(
+                  Collections.singleton(sendee), getCommand(segments, batchAmount), rpcOptions);
+            completableFuture.whenComplete((r, t) -> {
+               if (t != null) {
+                  handleThrowable(t, target);
+               } else {
+                  try {
+                     Response response = r.values().iterator().next();
+                     if (response instanceof SuccessfulResponse) {
+                        IteratorResponse<V> iteratorResponse = (IteratorResponse) ((SuccessfulResponse) response).getResponseValue();
+                        if (trace) {
+                           log.tracef("Received valid response %s for id %s from node %s", iteratorResponse, id, target.getKey());
+                        }
+                        long returnedAmount = 0;
+                        Iterator<V> iter = iteratorResponse.getIterator();
+                        while (iter.hasNext()) {
+                           returnedAmount++;
+                           s.onNext(iter.next());
+                        }
+                        log.tracef("Received %d entries for id %s from %s", returnedAmount, id, sendee);
+
+                        if (iteratorResponse.isComplete()) {
+                           Set<Integer> lostSegments = iteratorResponse.getSuspectedSegments();
+                           if (lostSegments.isEmpty()) {
+                              onSegmentsComplete.accept((Supplier<PrimitiveIterator.OfInt>) segments::iterator);
+                           } else {
+                              onSegmentsLost.accept((Supplier<PrimitiveIterator.OfInt>)
+                                    () -> lostSegments.stream().mapToInt(Integer::intValue).iterator());
+
+                              if (lostSegments.size() != segments.size()) {
+                                 // TODO: need to convert response to return IntSet
+                                 onSegmentsComplete.accept((Supplier<PrimitiveIterator.OfInt>)
+                                       () -> segments.intStream()
+                                             .filter(s -> !lostSegments.contains(s))
+                                             .iterator());
+                              }
+                           }
+
+                           Map.Entry<Address, IntSet> nextTarget = publisher.targets.get();
+
+                           if (nextTarget != null) {
+                              alreadyCreated = false;
+                              // Only set if target is still the same
+                              // No other thread can be here (see pendingRequest)
+                              // so if it fails it means it must be closed (ie. null)
+                              currentTarget.compareAndSet(target, nextTarget);
+                           } else {
+                              currentTarget.set(null);
+                              // No more targets means this subscription is done
+                              completed();
+                              return;
+                           }
+                        }
+
+                        long remaining = requestedAmount.addAndGet(-returnedAmount);
+                        if (remaining > 0) {
+                           // Either more was requested while we were processing or we didn't return enough, so
+                           // try again
+                           sendRequest(remaining);
+                        } else {
+                           pendingRequest.set(false);
+                           // We have to recheck just in case if there was another thread that added to request amount
+                           // but was unable to acquire pending request (otherwise no pending request will be sent)
+                           remaining = requestedAmount.get();
+                           if (remaining > 0 && !pendingRequest.getAndSet(true)) {
+                              sendRequest(remaining);
+                           }
+                        }
+                     } else if (response instanceof ExceptionResponse) {
+                        handleThrowable(((ExceptionResponse) response).getException(), target);
+                     } else {
+                        handleThrowable(new IllegalArgumentException("Unsupported response received: " + response), target);
+                     }
+                  } catch (Throwable throwable) {
+                     // This block is for general programming issues to notify directly to user thread
+                     cancel();
+                     s.onError(throwable);
+                  }
+               }
+            });
+         }
+      }
+
+      private void handleThrowable(Throwable t, Map.Entry<Address, IntSet> target) {
+         cancel();
+         // Most likely SuspectException will be wrapped in CompletionException
+         if (t instanceof SuspectException || t.getCause() instanceof SuspectException) {
+            if (trace) {
+               log.tracef("Received suspect exception for id %s from node %s when requesting segments %s", id,
+                     target.getKey(), target.getValue());
+            }
+            onSegmentsLost.accept((Supplier<PrimitiveIterator.OfInt>) () -> target.getValue().iterator());
+            // We then have to tell the subscriber we completed - even though we lost segments
+            s.onComplete();
+         } else {
+            if (trace) {
+               log.tracef(t, "Received exception for id %s from node %s when requesting segments %s", id, target.getKey(),
+                     target.getValue());
+            }
+            s.onError(t);
+         }
+      }
+
+      @Override
+      public void cancel() {
+         Map.Entry<Address, IntSet> target = currentTarget.getAndSet(null);
+         if (target != null && alreadyCreated) {
+            Address targetNode = target.getKey();
+            rpc.invokeRemotelyAsync(Collections.singleton(targetNode),
+                  factory.buildStreamIteratorCloseCommand(id), rpcOptions).whenComplete((v, t) -> {
+               if (t != null) {
+                  if (trace) {
+                     log.tracef(t, "Unable to close iterator on %s for requestId %s", targetNode, requestId);
+                  }
+               }
+            });
+         }
+         iteratorsRunning.remove(s);
+      }
+
+      private void completed() {
+         if (trace) {
+            log.tracef("Processor completed for request: %s", id);
+         }
+         cancel();
+         s.onComplete();
       }
    }
 

--- a/core/src/main/java/org/infinispan/stream/impl/DistributedCacheStream.java
+++ b/core/src/main/java/org/infinispan/stream/impl/DistributedCacheStream.java
@@ -3,28 +3,27 @@ package org.infinispan.stream.impl;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.lang.invoke.MethodHandles;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.HashSet;
-import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.PrimitiveIterator;
 import java.util.Set;
 import java.util.Spliterator;
 import java.util.Spliterators;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.locks.Condition;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicReferenceArray;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.BinaryOperator;
@@ -36,27 +35,35 @@ import java.util.function.Supplier;
 import java.util.function.ToDoubleFunction;
 import java.util.function.ToIntFunction;
 import java.util.function.ToLongFunction;
+import java.util.stream.BaseStream;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import org.infinispan.Cache;
 import org.infinispan.CacheStream;
 import org.infinispan.DoubleCacheStream;
 import org.infinispan.IntCacheStream;
 import org.infinispan.LongCacheStream;
-import org.infinispan.commons.CacheException;
 import org.infinispan.commons.marshall.Externalizer;
 import org.infinispan.commons.marshall.SerializeWith;
+import org.infinispan.commons.util.AbstractIterator;
+import org.infinispan.commons.util.ByRef;
 import org.infinispan.commons.util.CloseableIterator;
+import org.infinispan.commons.util.Closeables;
+import org.infinispan.commons.util.IntSet;
+import org.infinispan.commons.util.IteratorMapper;
+import org.infinispan.commons.util.SmallIntSet;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.remoting.transport.Address;
+import org.infinispan.stream.impl.intops.IntermediateOperation;
 import org.infinispan.stream.impl.intops.object.DistinctOperation;
 import org.infinispan.stream.impl.intops.object.FilterOperation;
 import org.infinispan.stream.impl.intops.object.FlatMapOperation;
@@ -71,11 +78,7 @@ import org.infinispan.stream.impl.intops.object.MapToLongOperation;
 import org.infinispan.stream.impl.intops.object.PeekOperation;
 import org.infinispan.stream.impl.termop.object.ForEachBiOperation;
 import org.infinispan.stream.impl.termop.object.ForEachOperation;
-import org.infinispan.stream.impl.termop.object.NoMapIteratorOperation;
-import org.infinispan.util.CloseableSuppliedIterator;
 import org.infinispan.util.RangeSet;
-import org.infinispan.util.concurrent.TimeoutException;
-import org.infinispan.util.function.CloseableSupplier;
 import org.infinispan.util.function.SerializableBiConsumer;
 import org.infinispan.util.function.SerializableBiFunction;
 import org.infinispan.util.function.SerializableBinaryOperator;
@@ -88,6 +91,11 @@ import org.infinispan.util.function.SerializableSupplier;
 import org.infinispan.util.function.SerializableToDoubleFunction;
 import org.infinispan.util.function.SerializableToIntFunction;
 import org.infinispan.util.function.SerializableToLongFunction;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+import org.reactivestreams.Publisher;
+
+import io.reactivex.Flowable;
 
 /**
  * Implementation of {@link CacheStream} that provides support for lazily distributing stream methods to appropriate
@@ -96,6 +104,8 @@ import org.infinispan.util.function.SerializableToLongFunction;
  */
 public class DistributedCacheStream<R> extends AbstractCacheStream<R, Stream<R>, CacheStream<R>>
         implements CacheStream<R> {
+
+   private static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
 
    // This is a hack to allow for cast to work properly, since Java doesn't work as well with nested generics
    protected static Supplier<CacheStream<CacheEntry>> supplierStreamCast(Supplier supplier) {
@@ -151,6 +161,11 @@ public class DistributedCacheStream<R> extends AbstractCacheStream<R, Stream<R>,
     */
    protected DistributedCacheStream(AbstractCacheStream other) {
       super(other);
+   }
+
+   @Override
+   protected Log getLog() {
+      return log;
    }
 
    @Override
@@ -550,382 +565,414 @@ public class DistributedCacheStream<R> extends AbstractCacheStream<R, Stream<R>,
 
    @Override
    public Iterator<R> iterator() {
-      return remoteIterator();
+      log.tracef("Distributed iterator invoked with rehash: %s", rehashAware);
+      if (!rehashAware) {
+         // Non rehash doesn't care about lost segments or completed ones
+         CloseableIterator<R> closeableIterator = nonRehashRemoteIterator(segmentsToFilter, null,
+               IdentityPublisherDecorator.getInstance(), intermediateOperations);
+         onClose(closeableIterator::close);
+         return closeableIterator;
+      } else {
+         Iterable<IntermediateOperation> ops = iteratorOperation.prepareForIteration(intermediateOperations);
+         CloseableIterator<R> closeableIterator;
+         if (segmentCompletionListener != null && iteratorOperation != IteratorOperation.FLAT_MAP) {
+            closeableIterator = new CompletionListenerRehashIterator<>(ops, segmentCompletionListener);
+         } else {
+            closeableIterator = new RehashIterator<>(ops);
+         }
+         onClose(closeableIterator::close);
+         // This cast messes up generic checking, but that is okay
+         Function<R, R> function = iteratorOperation.getFunction();
+         if (function != null) {
+            return new IteratorMapper<>(closeableIterator, function);
+         } else {
+            return closeableIterator;
+         }
+      }
    }
 
-   Iterator<R> remoteIterator() {
-      BlockingQueue<R> queue = new ArrayBlockingQueue<>(distributedBatchSize);
+   interface PublisherDecorator<S> {
+      Publisher<S> decorateRemote(ClusterStreamManager.RemoteIteratorPublisher<S> remotePublisher);
+      Publisher<S> decorateLocal(ConsistentHash beginningCh, boolean onlyLocal, IntSet segmentsToFilter,
+            Publisher<S> localPublisher);
+   }
 
-      final AtomicBoolean complete = new AtomicBoolean();
+   private static class IdentityPublisherDecorator<S, R> implements PublisherDecorator<S> {
+      private static final IdentityPublisherDecorator decorator = new IdentityPublisherDecorator();
+      private IdentityPublisherDecorator() { }
 
-      Lock nextLock = new ReentrantLock();
-      Condition nextCondition = nextLock.newCondition();
-
-      Consumer<R> consumer = new HandOffConsumer<>(queue, complete, nextLock, nextCondition);
-
-      IteratorSupplier<R> supplier = new IteratorSupplier<>(queue, complete, nextLock, nextCondition, csm);
-
-      boolean iteratorParallelDistribute = parallelDistribution == null ? false : parallelDistribution;
-
-      if (rehashAware) {
-         rehashAwareIteration(complete, consumer, supplier, iteratorParallelDistribute);
-      } else {
-         ignoreRehashIteration(consumer, supplier, iteratorParallelDistribute);
+      static <S, R> IdentityPublisherDecorator<S, R> getInstance() {
+         return decorator;
       }
 
-      CloseableIterator<R> closeableIterator = new CloseableSuppliedIterator<>(supplier);
-      onClose(supplier::close);
-      return closeableIterator;
+      @Override
+      public Publisher<S> decorateRemote(ClusterStreamManager.RemoteIteratorPublisher<S> remotePublisher) {
+         return remotePublisher;
+      }
+
+      @Override
+      public Publisher<S> decorateLocal(ConsistentHash beginningCh, boolean onlyLocal, IntSet segmentsToFilter,
+            Publisher<S> localPublisher) {
+         return localPublisher;
+      }
    }
 
-   private void ignoreRehashIteration(Consumer<R> consumer, IteratorSupplier<R> supplier, boolean iteratorParallelDistribute) {
-      CollectionConsumer<R> remoteResults = new CollectionConsumer<>(consumer);
-      ConsistentHash ch = dm.getWriteConsistentHash();
+   private class RehashPublisherDecorator<S> implements PublisherDecorator<S> {
+      private final Consumer<? super Supplier<PrimitiveIterator.OfInt>> completedSegments;
+      private final Consumer<? super Supplier<PrimitiveIterator.OfInt>> lostSegments;
+      private final Consumer<Object> keyConsumer;
 
-      boolean runLocal = ch.getMembers().contains(localAddress);
-      boolean stayLocal = runLocal && segmentsToFilter != null
-              && ch.getSegmentsForOwner(localAddress).containsAll(segmentsToFilter);
+      RehashPublisherDecorator(Consumer<? super Supplier<PrimitiveIterator.OfInt>> completedSegments,
+            Consumer<? super Supplier<PrimitiveIterator.OfInt>> lostSegments, Consumer<Object> keyConsumer) {
+         this.completedSegments = completedSegments;
+         this.lostSegments = lostSegments;
+         this.keyConsumer = keyConsumer;
+      }
 
-      NoMapIteratorOperation<?, R> op = new NoMapIteratorOperation<>(intermediateOperations, supplierForSegments(ch,
-              segmentsToFilter, null, !stayLocal), distributedBatchSize);
+      @Override
+      public Publisher<S> decorateRemote(ClusterStreamManager.RemoteIteratorPublisher<S> remotePublisher) {
+         Publisher<S> convertedPublisher = s -> remotePublisher.subscribe(s, completedSegments, lostSegments);
+         return decorateBeforeReturn(convertedPublisher);
+      }
 
-      Thread thread = Thread.currentThread();
-      executor.execute(() -> {
-         try {
-            log.tracef("Thread %s submitted iterator request for stream", thread);
-
-            if (!stayLocal) {
-               Object id = csm.remoteStreamOperation(iteratorParallelDistribute, parallel, segmentsToFilter,
-                       keysToFilter, Collections.<Object, Set<R>>emptyMap(), includeLoader, op, remoteResults);
-               // Make sure to run this after we submit to the manager so it can process the other nodes
-               // asynchronously with the local operation
-               Collection<R> localValue = op.performOperation(remoteResults);
-               remoteResults.onCompletion(null, Collections.emptySet(), localValue);
-               if (id != null) {
-                  supplier.pending = id;
-                  try {
-                     try {
-                        if (!csm.awaitCompletion(id, timeout, timeoutUnit)) {
-                           throw new TimeoutException();
-                        }
-                     } catch (InterruptedException e) {
-                        throw new CacheException(e);
-                     }
-
-                  } finally {
-                     csm.forgetOperation(id);
-                  }
-               }
+      @Override
+      public Publisher<S> decorateLocal(ConsistentHash beginningCh, boolean onlyLocal, IntSet segmentsToFilter,
+            Publisher<S> localPublisher) {
+         Publisher<S> convertedPublisher = Flowable.fromPublisher(localPublisher).doOnComplete(() -> {
+            IntSet ourSegments;
+            if (onlyLocal) {
+               ourSegments = SmallIntSet.from(beginningCh.getSegmentsForOwner(localAddress));
             } else {
-               Collection<R> localValue = op.performOperation(remoteResults);
-               remoteResults.onCompletion(null, Collections.emptySet(), localValue);
+               ourSegments = SmallIntSet.from(beginningCh.getPrimarySegmentsForOwner(localAddress));
             }
-            supplier.close();
-         } catch (CacheException e) {
-            log.trace("Encountered local cache exception for stream", e);
-            supplier.close(e);
-         } catch (Throwable t) {
-            log.trace("Encountered local throwable for stream", t);
-            supplier.close(new CacheException(t));
-         }
-      });
+            ourSegments.retainAll(segmentsToFilter);
+            // This will notify both completed and suspect of segments that may not even exist or were completed before
+            // on a rehash
+            if (dm.getReadConsistentHash().equals(beginningCh)) {
+               log.tracef("Local iterator has completed segments %s", ourSegments);
+               completedSegments.accept((Supplier<PrimitiveIterator.OfInt>) ourSegments::iterator);
+            } else {
+               log.tracef("Local iterator segments %s are all suspect as consistent hash has changed", ourSegments);
+               lostSegments.accept((Supplier<PrimitiveIterator.OfInt>) ourSegments::iterator);
+            }
+         });
+         return decorateBeforeReturn(convertedPublisher);
+      }
+
+      protected Publisher<S> decorateBeforeReturn(Publisher<S> publisher) {
+         return iteratorOperation.handlePublisher(publisher, keyConsumer);
+      }
    }
 
-   private void rehashAwareIteration(AtomicBoolean complete, Consumer<R> consumer, IteratorSupplier<R> supplier, boolean iteratorParallelDistribute) {
-      ConsistentHash segmentInfoCH = dm.getReadConsistentHash();
-      SegmentListenerNotifier<R> listenerNotifier;
-      if (segmentCompletionListener != null) {
-         listenerNotifier = new SegmentListenerNotifier<>(
-                 segmentCompletionListener);
-         supplier.setConsumer(listenerNotifier);
-      } else {
-         listenerNotifier = null;
-      }
-      KeyTrackingConsumer<Object, R> results = new KeyTrackingConsumer<>(keyPartitioner, segmentInfoCH,
-                                                                         iteratorOperation.wrapConsumer(consumer), iteratorOperation.getFunction(),
-                                                                         listenerNotifier);
-      Thread thread = Thread.currentThread();
-      executor.execute(() -> {
-         try {
-            log.tracef("Thread %s submitted iterator request for stream", thread);
-            Set<Integer> segmentsToProcess = segmentsToFilter == null ?
-                                             new RangeSet(segmentInfoCH.getNumSegments()) : segmentsToFilter;
-            do {
-               ConsistentHash ch = dm.getReadConsistentHash();
-               boolean runLocal = ch.getMembers().contains(localAddress);
-               Set<Integer> segments;
-               Set<Object> excludedKeys;
-               boolean stayLocal = false;
-               if (runLocal) {
-                  Set<Integer> segmentsForOwner = ch.getSegmentsForOwner(localAddress);
-                  // If we own all of the segments locally, even as backup, we don't want the iterator to go remotely
-                  stayLocal = segmentsForOwner.containsAll(segmentsToProcess);
-                  if (stayLocal) {
-                     segments = segmentsToProcess;
-                  } else {
-                     segments = ch.getPrimarySegmentsForOwner(localAddress).stream()
-                             .filter(segmentsToProcess::contains).collect(Collectors.toSet());
-                  }
+   private class RehashIterator<S> extends AbstractIterator<S> implements CloseableIterator<S> {
+      private final AtomicReferenceArray<Set<Object>> receivedKeys;
+      private final Iterable<IntermediateOperation> intermediateOperations;
+      private final IntSet segmentsToUse;
+      private final Consumer<? super Supplier<PrimitiveIterator.OfInt>> completedHandler;
 
-                  excludedKeys = segments.stream().flatMap(s -> results.referenceArray.get(s).stream())
-                          .collect(Collectors.toSet());
-               } else {
-                  segments = null;
-                  excludedKeys = Collections.emptySet();
+      private CloseableIterator<S> currentIterator;
+
+      private RehashIterator(Iterable<IntermediateOperation> intermediateOperations) {
+         this.intermediateOperations = intermediateOperations;
+         int maxSegment = dm.getCacheTopology().getCurrentCH().getNumSegments();
+         if (segmentsToFilter == null) {
+            // We can't use RangeSet as we have to modify this IntSet
+            segmentsToUse = new SmallIntSet(maxSegment);
+            for (int i = 0; i < maxSegment; ++i) {
+               segmentsToUse.set(i);
+            }
+         } else {
+            // Need to make copy as we will modify this below
+            segmentsToUse = new SmallIntSet(segmentsToFilter);
+         }
+
+         // TODO: we could optimize this array (make smaller) if we don't require all segments
+         receivedKeys = new AtomicReferenceArray<>(maxSegment);
+         for (int i = 0; i < receivedKeys.length(); ++i) {
+            // Only 1 thread would be adding to a given set a time (a thread will only touch a subset of segments)
+            receivedKeys.set(i, new HashSet<>());
+         }
+
+         completedHandler = completed -> {
+            IntSet intSet;
+            if (log.isTraceEnabled()) {
+               intSet = new SmallIntSet();
+            } else {
+               intSet = null;
+            }
+            // For each completed segment we remove that segment and decrement our counter
+            completed.get().forEachRemaining((int i) -> {
+               // This way keys are able to be GC'd
+               receivedKeys.set(i, null);
+               if (intSet != null) {
+                  intSet.set(i);
                }
-               KeyTrackingTerminalOperation<Object, R, Object> op = iteratorOperation.getOperation(
-                       intermediateOperations, supplierForSegments(ch, segmentsToProcess, excludedKeys, !stayLocal),
-                       distributedBatchSize);
-               if (!stayLocal) {
-                  Object id = csm.remoteStreamOperationRehashAware(iteratorParallelDistribute, parallel,
-                        segmentsToProcess, keysToFilter, new AtomicReferenceArrayToMap<>(results.referenceArray),
-                          includeLoader, op, results);
-                  if (id != null) {
-                     supplier.pending = id;
-                  }
-                  try {
-                     if (runLocal) {
-                        performLocalRehashAwareOperation(results, segmentsToProcess, ch, segments, op,
-                                () -> ch.getPrimarySegmentsForOwner(localAddress), id);
-                     }
-                     if (id != null) {
-                        try {
-                           if (!csm.awaitCompletion(id, timeout, timeoutUnit)) {
-                              throw new TimeoutException();
-                           }
-                        } catch (InterruptedException e) {
-                           throw new CacheException(e);
+               // in case if multiple responses occur (IntSet impl are not concurrent)
+               synchronized (segmentsToUse) {
+                  segmentsToUse.remove(i);
+               }
+            });
+
+            if (intSet != null) {
+               log.tracef("Remote rehash iterator completed segments %s", intSet);
+            }
+         };
+      }
+
+      @Override
+      protected S getNext() {
+         do {
+            if (currentIterator == null) {
+               log.tracef("Creating rehash iterator for segments %s", segmentsToUse);
+               currentIterator = nonRehashRemoteIterator(segmentsToUse, receivedKeys::get,
+                     publisherDecorator(completedHandler, lostSegments -> {
+                     }, k -> {
+                        // Every time a key is retrieved from iterator we add it to the keys received
+                        // Then when we retry we exclude those keys to keep out duplicates
+                        Set<Object> set = receivedKeys.get(keyPartitioner.getSegment(k));
+                        if (set != null) {
+                           set.add(k);
                         }
-                     }
-                     segmentsToProcess = segmentsToProcess(supplier, results, segmentsToProcess, id);
-                  } finally {
-                     csm.forgetOperation(id);
-                  }
-               } else {
-                  performLocalRehashAwareOperation(results, segmentsToProcess, ch, segments, op,
-                          () -> ch.getSegmentsForOwner(localAddress), null);
-                  segmentsToProcess = segmentsToProcess(supplier, results, segmentsToProcess, null);
-               }
-            } while (!complete.get());
-         } catch (CacheException e) {
-            log.trace("Encountered local cache exception for stream", e);
-            supplier.close(e);
-         } catch (Throwable t) {
-            log.trace("Encountered local throwable for stream", t);
-            supplier.close(new CacheException(t));
-         }
-      });
-   }
+                     }), intermediateOperations);
 
-   private Set<Integer> segmentsToProcess(IteratorSupplier<R> supplier, KeyTrackingConsumer<Object, R> results,
-                                          Set<Integer> segmentsToProcess, Object id) {
-      String strId = id == null ? "local" : id.toString();
-      if (!results.lostSegments.isEmpty()) {
-         segmentsToProcess = new HashSet<>(results.lostSegments);
-         results.lostSegments.clear();
-         log.tracef("Found %s lost segments for %s", segmentsToProcess, strId);
-      } else {
-         supplier.close();
-         log.tracef("Finished rehash aware operation for %s", strId);
-      }
-      return segmentsToProcess;
-   }
-
-   private void performLocalRehashAwareOperation(KeyTrackingConsumer<Object, R> results,
-                                                 Set<Integer> segmentsToProcess,
-                                                 ConsistentHash ch,
-                                                 Set<Integer> segments,
-                                                 KeyTrackingTerminalOperation<Object, R, Object> op,
-                                                 Supplier<Set<Integer>> ownedSegmentsSupplier,
-                                                 Object id) {
-      Collection<CacheEntry<Object, Object>> localValue = op.performOperationRehashAware(results);
-      // TODO: we can do this more efficiently - this hampers performance during rehash
-      if (dm.getReadConsistentHash().equals(ch)) {
-         log.tracef("Found local values %s for id %s", localValue.size(), id);
-         results.onCompletion(null, segments, localValue);
-      } else {
-         Set<Integer> ourSegments = ownedSegmentsSupplier.get();
-         Set<Integer> lostSegments = ourSegments.stream().filter(segmentsToProcess::contains).collect(Collectors.toSet());
-         log.tracef("CH changed - making %s segments suspect for identifier %s", lostSegments, id);
-         results.onSegmentsLost(lostSegments);
-      }
-   }
-
-   static class HandOffConsumer<R> implements Consumer<R> {
-      private final BlockingQueue<R> queue;
-      private final AtomicBoolean completed;
-      private final Lock nextLock;
-      private final Condition nextCondition;
-
-      HandOffConsumer(BlockingQueue<R> queue, AtomicBoolean completed, Lock nextLock, Condition nextCondition) {
-         this.queue = queue;
-         this.completed = completed;
-         this.nextLock = nextLock;
-         this.nextCondition = nextCondition;
-      }
-
-      @Override
-      public void accept(R rs) {
-         // TODO: we don't awake people if they are waiting until we fill up the queue or process retrieves all values
-         // is this the reason for slowdown?
-         if (!queue.offer(rs)) {
-            if (!completed.get()) {
-               // Signal anyone waiting for values to consume from the queue
-               nextLock.lock();
-               try {
-                  nextCondition.signalAll();
-               } finally {
-                  nextLock.unlock();
-               }
-               while (!completed.get()) {
-                  // We keep trying to offer the value until it takes it.  In this case we check the completed after
-                  // each time to make sure the iterator wasn't closed early
-                  try {
-                     if (queue.offer(rs, 100, TimeUnit.MILLISECONDS)) {
-                        break;
-                     }
-                  } catch (InterruptedException e) {
-                     throw new CacheException(e);
-                  }
-               }
             }
-         }
-      }
-   }
+            if (currentIterator.hasNext()) {
+               return currentIterator.next();
+            } else {
+               // Force new iterator once we have exhausted this one (if we have segments left)
+               currentIterator = null;
+            }
+         } while (!segmentsToUse.isEmpty());
 
-   static class SegmentListenerNotifier<T> implements Consumer<T> {
-      private final SegmentCompletionListener listener;
-      // we know the objects will always be ==
-      private final Map<T, Set<Integer>> segmentsByObject = new IdentityHashMap<>();
-
-      SegmentListenerNotifier(SegmentCompletionListener listener) {
-         this.listener = listener;
+         return null;
       }
 
-      @Override
-      public void accept(T t) {
-         Set<Integer> segments = segmentsByObject.remove(t);
-         if (segments != null) {
-            listener.segmentCompleted(segments);
-         }
-      }
-
-      public void addSegmentsForObject(T object, Set<Integer> segments) {
-         segmentsByObject.put(object, segments);
-      }
-
-      public void completeSegmentsNoResults(Set<Integer> segments) {
-         listener.segmentCompleted(segments);
-      }
-   }
-
-   static class IteratorSupplier<R> implements CloseableSupplier<R> {
-      private final BlockingQueue<R> queue;
-      private final AtomicBoolean completed;
-      private final Lock nextLock;
-      private final Condition nextCondition;
-      private final ClusterStreamManager<?> clusterStreamManager;
-
-      CacheException exception;
-      volatile Object pending;
-
-      private Consumer<R> consumer;
-
-      IteratorSupplier(BlockingQueue<R> queue, AtomicBoolean completed, Lock nextLock, Condition nextCondition,
-              ClusterStreamManager<?> clusterStreamManager) {
-         this.queue = queue;
-         this.completed = completed;
-         this.nextLock = nextLock;
-         this.nextCondition = nextCondition;
-         this.clusterStreamManager = clusterStreamManager;
+      PublisherDecorator<S> publisherDecorator(Consumer<? super Supplier<PrimitiveIterator.OfInt>> completedSegments,
+            Consumer<? super Supplier<PrimitiveIterator.OfInt>> lostSegments, Consumer<Object> keyConsumer) {
+         return new RehashPublisherDecorator<>(completedSegments, lostSegments, keyConsumer);
       }
 
       @Override
       public void close() {
-         close(null);
-      }
-
-      public void close(CacheException e) {
-         nextLock.lock();
-         try {
-            if (!completed.getAndSet(true)) {
-               if (e != null) {
-                  exception = e;
-               }
-            }
-            if (pending != null) {
-               clusterStreamManager.forgetOperation(pending);
-               pending = null;
-            }
-            nextCondition.signalAll();
-         } finally {
-            nextLock.unlock();
+         if (currentIterator != null) {
+            currentIterator.close();
          }
+      }
+   }
+
+   /**
+    * Rehash Iterator which also has a completion listener. We cannot allow a segment to complete
+    * until we are now releasing the last entry for a given set of segments
+    * @param <S>
+    */
+   private class CompletionListenerRehashIterator<S> extends RehashIterator<S> {
+      private final KeyWatchingCompletionListener completionListener;
+
+      private CompletionListenerRehashIterator(Iterable<IntermediateOperation> intermediateOperations,
+            Consumer<? super Supplier<PrimitiveIterator.OfInt>> completionListener) {
+         super(intermediateOperations);
+         this.completionListener = new KeyWatchingCompletionListener(completionListener);
       }
 
       @Override
-      public R get() {
-         R entry = queue.poll();
-         if (entry == null) {
-            if (completed.get()) {
-               if (exception != null) {
-                  throw exception;
-               } else if ((entry = queue.poll()) != null) {
-                  // We check the queue one last time to make sure we didn't have a concurrent queue addition and
-                  // completed iterator
-                  if (consumer != null) {
-                     consumer.accept(entry);
-                  }
-                  return entry;
-               }
-               return null;
-            }
-            nextLock.lock();
-            try {
-               boolean interrupted = false;
-               while (!completed.get()) {
-                  // We should check to make sure nothing was added to the queue as well before sleeping
-                  if ((entry = queue.poll()) != null) {
-                     break;
-                  }
-                  try {
-                     nextCondition.await(100, TimeUnit.MILLISECONDS);
-                  } catch (InterruptedException e) {
-                     // If interrupted, we just loop back around
-                     interrupted = true;
-                  }
-               }
-               if (entry == null) {
-                  // If there is no entry and we are completed check one last time if there are entries in the queue
-                  // It is possible for entries to be added to the queue and the iterator completed at the same time.
-                  // Completed is a sign of either 3 things: all entries have been retrieved (what this case is for),
-                  // an exception has been found in processing, or the user has manually closed the iterator.  In the
-                  // latter 2 cases no additional entries are added to the queue since processing is stopped, therefore
-                  // we can just process the rest of the elements in the queue with no worry.
-                  entry = queue.poll();
-                  if (entry == null) {
-                     if (exception != null) {
-                        throw exception;
-                     }
-                     return null;
-                  }
-               } else if (interrupted) {
-                  // Now reset the interrupt state before returning
-                  Thread.currentThread().interrupt();
-               }
-            } finally {
-               nextLock.unlock();
-            }
+      protected S getNext() {
+         S next = super.getNext();
+         if (next != null) {
+            completionListener.valueIterated(next);
+         } else {
+            completionListener.completed();
          }
-         if (consumer != null) {
-            consumer.accept(entry);
-         }
-         return entry;
+         return next;
       }
 
-      public void setConsumer(Consumer<R> consumer) {
-         this.consumer = consumer;
+      @Override
+      PublisherDecorator<S> publisherDecorator(Consumer<? super Supplier<PrimitiveIterator.OfInt>> completedSegments,
+            Consumer<? super Supplier<PrimitiveIterator.OfInt>> lostSegments, Consumer<Object> keyConsumer) {
+         Consumer<? super Supplier<PrimitiveIterator.OfInt>> ourCompleted = i -> {
+            completionListener.segmentsEncountered(i);
+            completedSegments.accept(i);
+         };
+         return new RehashPublisherDecorator<S>(ourCompleted, lostSegments, keyConsumer) {
+            @Override
+            protected Publisher<S> decorateBeforeReturn(Publisher<S> publisher) {
+               return Flowable.fromPublisher(super.decorateBeforeReturn(publisher)).doOnNext(
+                     completionListener::valueAdded);
+            }
+         };
       }
+   }
+
+   /**
+    * Only notifies a completion listener when the last key for a segment has been found. The last key for a segment
+    * is assumed to be the last key seen {@link KeyWatchingCompletionListener#valueAdded(Object)} before segments
+    * are encountered {@link KeyWatchingCompletionListener#segmentsEncountered(Supplier)}.
+    */
+   private class KeyWatchingCompletionListener {
+      private final AtomicReference<Object> currentKey = new AtomicReference<>();
+      private final Map<Object, Supplier<PrimitiveIterator.OfInt>> pendingSegments = new ConcurrentHashMap<>();
+      private final Consumer<? super Supplier<PrimitiveIterator.OfInt>> completionListener;
+      // The next 2 variables are possible assuming that the iterator is not used concurrently. This way we don't
+      // have to allocate them on every entry iterated
+      private final ByRef<Supplier<PrimitiveIterator.OfInt>> ref = new ByRef<>(null);
+      private final BiFunction<Object, Supplier<PrimitiveIterator.OfInt>, Supplier<PrimitiveIterator.OfInt>> iteratorMapping;
+
+      private KeyWatchingCompletionListener(Consumer<? super Supplier<PrimitiveIterator.OfInt>> completionListener) {
+         this.completionListener = completionListener;
+         this.iteratorMapping = (k, v) -> {
+            if (v != null) {
+               ref.set(v);
+            }
+            currentKey.compareAndSet(k, null);
+            return null;
+         };
+      }
+
+      public void valueAdded(Object key) {
+         currentKey.set(key);
+      }
+
+      public void valueIterated(Object key) {
+         pendingSegments.compute(key, iteratorMapping);
+         if (ref.get() != null) {
+            completionListener.accept(ref.get());
+         }
+      }
+
+      private IntStream toStream(PrimitiveIterator.OfInt iter) {
+         return StreamSupport.intStream(Spliterators.spliteratorUnknownSize(iter,
+               Spliterator.DISTINCT | Spliterator.NONNULL), false);
+      }
+
+      public void segmentsEncountered(Supplier<PrimitiveIterator.OfInt> segments) {
+         // This code assumes that valueAdded and segmentsEncountered are not invoked concurrently and that all values
+         // added for a response before the segments are completed.
+         // The valueIterated method can be invoked at any point however.
+         // See ClusterStreamManagerImpl$ClusterStreamSubscription.sendRequest where the added and segments are called into
+         AtomicBoolean shouldNotify = new AtomicBoolean(true);
+         Object key = currentKey.get();
+         if (key != null) {
+            pendingSegments.compute(key, (k, v) -> {
+               // This check is if iterator caught up to us
+               if (currentKey.get() == null) {
+                  return null;
+               }
+               shouldNotify.set(false);
+               if (v == null) {
+                  return segments;
+               } else {
+                  // This is ugly, but we shouldn't hit this often (need a response with no entries and completed
+                  // segments and iterator that hasn't caught up)
+                  return () -> Stream.of(segments, v).flatMapToInt(s -> toStream(s.get())).iterator();
+               }
+            });
+         }
+         if (shouldNotify.get()) {
+            completionListener.accept(segments);
+         }
+      }
+
+      public void completed() {
+         pendingSegments.forEach((k, v) -> completionListener.accept(v));
+      }
+   }
+
+   <S> Publisher<S> localPublisher(IntSet segmentsToFilter, ConsistentHash ch, Set<Object> excludedKeys,
+         Iterable<IntermediateOperation> intermediateOperations, boolean stayLocal) {
+      Supplier<Stream<CacheEntry>> supplier = supplierForSegments(ch, segmentsToFilter, excludedKeys, stayLocal);
+      BaseStream stream = supplier.get();
+      for (IntermediateOperation intermediateOperation : intermediateOperations) {
+         stream = intermediateOperation.perform(stream);
+      }
+      BaseStream innerStream = stream;
+      return Flowable.fromIterable(() -> innerStream.iterator());
+   }
+
+   <S> CloseableIterator<S> nonRehashRemoteIterator(IntSet segmentsToFilter, IntFunction<Set<Object>> keysToExclude,
+         PublisherDecorator<S> publisherFunction, Iterable<IntermediateOperation> intermediateOperations) {
+      ConsistentHash ch = dm.getReadConsistentHash();
+
+      boolean stayLocal;
+
+      Publisher<S> localPublisher;
+
+      if (ch.getMembers().contains(localAddress)) {
+         Set<Integer> ownedSegments = ch.getSegmentsForOwner(localAddress);
+         if (segmentsToFilter == null) {
+            stayLocal = ownedSegments.size() == ch.getNumSegments();
+         } else {
+            stayLocal = ownedSegments.containsAll(segmentsToFilter);
+         }
+
+         Publisher<S> innerPublisher = localPublisher(segmentsToFilter, ch,
+               keysToExclude == null ? Collections.emptySet() :
+                     (segmentsToFilter == null ? IntStream.range(0, ch.getNumSegments()) : segmentsToFilter.intStream())
+                           .mapToObj(i -> keysToExclude.apply(i).stream()).flatMap(Function.identity()).collect(Collectors.toSet()),
+               intermediateOperations, !stayLocal);
+
+         localPublisher = publisherFunction.decorateLocal(ch, stayLocal, segmentsToFilter, innerPublisher);
+      } else {
+         stayLocal = false;
+         localPublisher = Flowable.empty();
+      }
+
+      if (stayLocal) {
+         return Closeables.iterator(Flowable.fromPublisher(localPublisher).blockingIterable().iterator());
+      } else {
+         Map<Address, IntSet> targets = determineTargets(ch, segmentsToFilter);
+         Iterator<Map.Entry<Address, IntSet>> targetIter = targets.entrySet().iterator();
+
+         // Parallel distribution is enabled by default, so it is only false if explicitly disabled
+         if (parallelDistribution == Boolean.FALSE) {
+            Supplier<Map.Entry<Address, IntSet>> supplier = () -> targetIter.hasNext() ? targetIter.next() : null;
+            ClusterStreamManager.RemoteIteratorPublisher<S> remotePublisher = csm.remoteIterationPublisher(false,
+                  supplier, keysToFilter, keysToExclude, includeLoader, intermediateOperations);
+            Publisher<S> publisher = publisherFunction.decorateRemote(remotePublisher);
+
+            // Local publisher is always last
+            return PriorityMergingProcessor.build(publisher, distributedBatchSize, localPublisher, 64).iterator();
+         } else {
+            // Have to synchronize supplier retrieval as it could be called from 2 threads at once
+            Supplier<Map.Entry<Address, IntSet>> supplier = () -> {
+               synchronized (this) {
+                  return targetIter.hasNext() ? targetIter.next() : null;
+               }
+            };
+            PriorityMergingProcessor.Builder<S> builder = PriorityMergingProcessor.builder();
+            // TODO: do we want to cap number of parallel distributions like this?
+            for (int i = 0; i < 4 && i < targets.size(); ++i) {
+               ClusterStreamManager.RemoteIteratorPublisher<S> remotePublisher = csm.remoteIterationPublisher(false,
+                     supplier, keysToFilter, keysToExclude, includeLoader, intermediateOperations);
+               Publisher<S> publisher = publisherFunction.decorateRemote(remotePublisher);
+
+               builder.addPublisher(publisher, distributedBatchSize);
+            }
+
+            // Local publisher is always last
+            return builder.addPublisher(localPublisher, 64).build().iterator();
+         }
+      }
+   }
+
+   private Map<Address, IntSet> determineTargets(ConsistentHash ch, IntSet segments) {
+      if (segments == null) {
+         segments = new RangeSet(ch.getNumSegments());
+      }
+      Map<Address, IntSet> targets = new HashMap<>();
+      PrimitiveIterator.OfInt segmentIterator = segments.iterator();
+      while (segmentIterator.hasNext()) {
+         int segment = segmentIterator.nextInt();
+         Address owner = ch.locatePrimaryOwnerForSegment(segment);
+         if (owner.equals(localAddress)) {
+            continue;
+         }
+         IntSet targetSegments = targets.get(owner);
+         if (targetSegments == null) {
+            targetSegments = new SmallIntSet();
+            targets.put(owner, targetSegments);
+         }
+         targetSegments.set(segment);
+      }
+      return targets;
    }
 
    @Override
@@ -1010,9 +1057,8 @@ public class DistributedCacheStream<R> extends AbstractCacheStream<R, Stream<R>,
    }
 
    @Override
-   public CacheStream<R>
-   filterKeySegments(Set<Integer> segments) {
-      segmentsToFilter = segments;
+   public CacheStream<R> filterKeySegments(Set<Integer> segments) {
+      segmentsToFilter = SmallIntSet.from(segments);
       return this;
    }
 

--- a/core/src/main/java/org/infinispan/stream/impl/EndIterator.java
+++ b/core/src/main/java/org/infinispan/stream/impl/EndIterator.java
@@ -1,0 +1,49 @@
+package org.infinispan.stream.impl;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.Collections;
+import java.util.Set;
+
+import org.infinispan.commons.marshall.AbstractExternalizer;
+import org.infinispan.commons.marshall.Ids;
+
+/**
+ * Singleton object with no state that is used to signal that an iterator has reached the end. This is useful for
+ * serialization/deserialization so you don't have to query the total number of elements.
+ * @author wburns
+ * @since 9.0
+ */
+public class EndIterator {
+   private EndIterator() { }
+
+   private static EndIterator INSTANCE = new EndIterator();
+
+   public static EndIterator getInstance() {
+      return INSTANCE;
+   }
+
+   public static class EndIteratorExternalizer extends AbstractExternalizer<EndIterator> {
+
+      @Override
+      public Integer getId() {
+         return Ids.END_ITERATOR;
+      }
+
+      @Override
+      public Set<Class<? extends EndIterator>> getTypeClasses() {
+         return Collections.singleton(EndIterator.class);
+      }
+
+      @Override
+      public void writeObject(ObjectOutput output, EndIterator object) throws IOException {
+
+      }
+
+      @Override
+      public EndIterator readObject(ObjectInput input) throws IOException, ClassNotFoundException {
+         return EndIterator.getInstance();
+      }
+   }
+}

--- a/core/src/main/java/org/infinispan/stream/impl/IteratorHandler.java
+++ b/core/src/main/java/org/infinispan/stream/impl/IteratorHandler.java
@@ -1,0 +1,244 @@
+package org.infinispan.stream.impl;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.stream.BaseStream;
+import java.util.stream.Stream;
+
+import org.infinispan.commons.util.CloseableIterator;
+import org.infinispan.commons.util.Closeables;
+import org.infinispan.commons.util.concurrent.ConcurrentHashSet;
+import org.infinispan.container.entries.CacheEntry;
+import org.infinispan.factories.annotations.Inject;
+import org.infinispan.factories.annotations.Start;
+import org.infinispan.factories.annotations.Stop;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.notifications.Listener;
+import org.infinispan.notifications.cachemanagerlistener.annotation.ViewChanged;
+import org.infinispan.notifications.cachemanagerlistener.event.ViewChangedEvent;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.stream.impl.intops.IntermediateOperation;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
+/**
+ * Handler for storing iterators between invocations so that remote node can request data in chunks.
+ * @author wburns
+ * @since 9.1
+ */
+@Listener(observation = Listener.Observation.POST)
+public class IteratorHandler {
+   private static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
+   private static final boolean trace = log.isTraceEnabled();
+
+   private final Map<Object, CloseableIterator<?>> currentRequests = new ConcurrentHashMap<>();
+   private final Map<Address, Set<Object>> ownerRequests = new ConcurrentHashMap<>();
+
+   private EmbeddedCacheManager manager;
+
+   /**
+    * A {@link CloseableIterator} that also allows callers to attach {@link Runnable} instances to it, so that when
+    * this iterator is closed, those <b>Runnable</b>s are also invoked.
+    * @param <E>
+    */
+   public interface OnCloseIterator<E> extends CloseableIterator<E> {
+      /**
+       * Register a runnable to be invoked when this iterator is closed
+       * @param runnable the runnable to run
+       * @return this iterator again
+       */
+      OnCloseIterator<E> onClose(Runnable runnable);
+   }
+
+   @ViewChanged
+   public void viewChange(ViewChangedEvent event) {
+      List<Address> newMembers = event.getNewMembers();
+      Iterator<Map.Entry<Address, Set<Object>>> iter = ownerRequests.entrySet().iterator();
+      while (iter.hasNext()) {
+         Map.Entry<Address, Set<Object>> entry = iter.next();
+         Address owner = entry.getKey();
+         // If an originating node is no longer here then we have to close their iterators
+         if (!newMembers.contains(owner)) {
+            Set<Object> ids = entry.getValue();
+            if (!ids.isEmpty()) {
+               log.tracef("View changed and no longer contains %s, closing %s iterators", owner, ids);
+               ids.forEach(this::closeIterator);
+            }
+            iter.remove();
+         }
+      }
+   }
+
+   @Inject
+   public void inject(EmbeddedCacheManager manager) {
+      this.manager = manager;
+   }
+
+   @Start
+   public void start() {
+      manager.addListener(this);
+   }
+
+   @Stop
+   public void stop() {
+      // If our cache is stopped we should remove our listener, since this doesn't mean the cache manager is stopped
+      manager.removeListener(this);
+   }
+
+   /**
+    * Starts an iteration process from the given stream that converts the stream to a subsequent stream using the given
+    * intermediate operations and then creates a managed iterator for the caller to subsequently retrieve.
+    * @param streamSupplier the supplied stream
+    * @param intOps the intermediate operations to perform on the stream
+    * @param <E>
+    * @return the id of the managed iterator
+    */
+   public <K, V, E> OnCloseIterator<E> start(Address origin, Supplier<Stream<CacheEntry<K, V>>> streamSupplier,
+         Iterable<IntermediateOperation> intOps, Object requestId) {
+      if (trace) {
+         log.tracef("Iterator requested from %s using requestId %s", origin, requestId);
+      }
+      BaseStream stream = streamSupplier.get();
+      for (IntermediateOperation intOp : intOps) {
+         stream = intOp.perform(stream);
+      }
+
+      OnCloseIterator<E> iter = new IteratorCloser<>((CloseableIterator<E>) Closeables.iterator(stream));
+      // When the iterator is closed make sure to clean up
+      iter.onClose(() -> closeIterator(origin, requestId));
+      currentRequests.put(requestId, iter);
+      // This will be null if there have been no iterators for this node.
+      // If the originating node died before we start this iterator this could be null as well. In this case the
+      // iterator will be closed on the next view change.
+      Set<Object> ids = ownerRequests.computeIfAbsent(origin, k -> new ConcurrentHashSet<>());
+      ids.add(requestId);
+      return iter;
+   }
+
+   public <E> CloseableIterator<E> getIterator(Object requestId) {
+      CloseableIterator<E> closeableIterator = (CloseableIterator<E>) currentRequests.get(requestId);
+      if (closeableIterator == null) {
+         throw new IllegalStateException("Iterator for requestId " + requestId + " doesn't exist!");
+      }
+      if (trace) {
+         log.tracef("Iterator retrieved using requestId %s", requestId);
+      }
+      return closeableIterator;
+   }
+
+   /**
+    * Returns how many iterators are currently open
+    * @return how many iterators are currently open
+    */
+   public int openIterators() {
+      return currentRequests.size();
+   }
+
+   /**
+    * Invoked to have handler forget about given iterator they requested. This should be invoked when an
+    * {@link Iterator} has been found to have completed {@link Iterator#hasNext()} is false or if the caller
+    * wishes to stop a given iteration early. If an iterator is fully iterated upon (ie. {@link Iterator#hasNext()}
+    * returns false, that invocation will also close resources related to the iterator.
+    * @param requestId the id of the iterator
+    */
+   public void closeIterator(Address origin, Object requestId) {
+      Set<Object> ids = ownerRequests.get(origin);
+      if (ids != null) {
+         ids.remove(requestId);
+      }
+      closeIterator(requestId);
+   }
+
+   private void closeIterator(Object requestId) {
+      CloseableIterator<?> closeableIterator = currentRequests.remove(requestId);
+      if (closeableIterator != null) {
+         if (trace) {
+            log.tracef("Closing iterator using requestId %s", requestId);
+         }
+         closeableIterator.close();
+      }
+   }
+
+   private class IteratorCloser<E> implements OnCloseIterator<E> {
+      private final CloseableIterator<E> closeableIterator;
+      private volatile Runnable closeRunnable;
+
+      IteratorCloser(CloseableIterator<E> closeableIterator) {
+         this.closeableIterator = closeableIterator;
+      }
+
+      @Override
+      public boolean hasNext() {
+         boolean hasNext = closeableIterator.hasNext();
+         if (!hasNext) {
+            close();
+         }
+         return hasNext;
+      }
+
+      @Override
+      public E next() {
+         // Make sure to double check hasNext in case if user didn't call it before next.
+         hasNext();
+         return closeableIterator.next();
+      }
+
+      @Override
+      public void forEachRemaining(Consumer<? super E> action) {
+         closeableIterator.forEachRemaining(action);
+         close();
+      }
+
+      @Override
+      public void close() {
+         closeableIterator.close();
+         // We only want to run the runnable once, in case if we end up closing twice
+         Runnable onClose = closeRunnable;
+         if (onClose != null) {
+            closeRunnable = null;
+            onClose.run();
+         }
+      }
+
+      @Override
+      public IteratorCloser<E> onClose(Runnable closeHandler) {
+         if (this.closeRunnable == null) {
+            this.closeRunnable = closeHandler;
+         } else {
+            this.closeRunnable = composeWithExceptions(this.closeRunnable, closeHandler);
+         }
+         return this;
+      }
+   }
+
+   /**
+    * Given two Runnables, return a Runnable that executes both in sequence,
+    * even if the first throws an exception, and if both throw exceptions, add
+    * any exceptions thrown by the second as suppressed exceptions of the first.
+    */
+   private static Runnable composeWithExceptions(Runnable a, Runnable b) {
+      return () -> {
+         try {
+            a.run();
+         }
+         catch (Throwable e1) {
+            try {
+               b.run();
+            }
+            catch (Throwable e2) {
+               try {
+                  e1.addSuppressed(e2);
+               } catch (Throwable ignore) {}
+            }
+            throw e1;
+         }
+         b.run();
+      };
+   }
+}

--- a/core/src/main/java/org/infinispan/stream/impl/IteratorResponse.java
+++ b/core/src/main/java/org/infinispan/stream/impl/IteratorResponse.java
@@ -1,0 +1,30 @@
+package org.infinispan.stream.impl;
+
+import java.util.Iterator;
+import java.util.Set;
+
+/**
+ * Iterator response returned when an iterator batch is sent back which contains the iterator, if any segments
+ * were suspected and if the iterator has returned all values (complete).
+ * @author wburns
+ * @since 9.0
+ */
+public interface IteratorResponse<V> {
+   /**
+    * The iterator containing the elements from the response
+    * @return the iterator
+    */
+   Iterator<V> getIterator();
+
+   /**
+    * Whether the iterator is the end or if more requests are needed
+    * @return if no more elements are available
+    */
+   boolean isComplete();
+
+   /**
+    * The segments that were lost during the iteration process
+    * @return the segments that need to be re-queried
+    */
+   Set<Integer> getSuspectedSegments();
+}

--- a/core/src/main/java/org/infinispan/stream/impl/IteratorResponses.java
+++ b/core/src/main/java/org/infinispan/stream/impl/IteratorResponses.java
@@ -1,0 +1,173 @@
+package org.infinispan.stream.impl;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.lang.invoke.MethodHandles;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.infinispan.commons.marshall.AbstractExternalizer;
+import org.infinispan.commons.marshall.Ids;
+import org.infinispan.commons.marshall.MarshallUtil;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
+/**
+ * Response object used when an iterator is the response value and it is unknown if the iterator has enough entries
+ * for the given batch size. The {@link RemoteResponse} is used by a remote node to return and this will be
+ * externalized into a {@link BatchResponse} or {@link LastResponse} on the requesting node depending on if the iterator
+ * has seen all entries.
+ * @author wburns
+ * @since 9.0
+ */
+public abstract class IteratorResponses implements IteratorResponse {
+   private final static Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
+
+   private final Iterator<Object> iterator;
+
+   IteratorResponses(Iterator<Object> iterator) {
+      this.iterator = iterator;
+   }
+
+   @Override
+   public Iterator<Object> getIterator() {
+      return iterator;
+   }
+
+   /**
+    * This response is used by remote nodes only - it is magically serialized into the below classes when deserialized
+    * based on if the iterator is exhausted (see {@link IteratorResponsesExternalizer}
+    */
+   static class RemoteResponse extends IteratorResponses {
+      private final Set<Integer> suspectedSegments;
+      private final long batchSize;
+
+      RemoteResponse(Iterator<Object> iterator, Set<Integer> suspectedSegments, long batchSize) {
+         super(iterator);
+         this.suspectedSegments = suspectedSegments;
+         this.batchSize = batchSize;
+      }
+
+      @Override
+      public Set<Integer> getSuspectedSegments() {
+         return suspectedSegments;
+      }
+   }
+
+   private static class BatchResponse extends IteratorResponses {
+
+      BatchResponse(Iterator<Object> iterator) {
+         super(iterator);
+      }
+
+      @Override
+      public Set<Integer> getSuspectedSegments() {
+         return Collections.emptySet();
+      }
+
+      @Override
+      public String toString() {
+         return "BatchResponse - more values required";
+      }
+   }
+
+   private static class LastResponse extends IteratorResponses {
+      private final Set<Integer> suspectedSegments;
+
+      LastResponse(Iterator<Object> iterator, Set<Integer> suspectedSegments) {
+         super(iterator);
+         this.suspectedSegments = suspectedSegments;
+      }
+
+      @Override
+      public boolean isComplete() {
+         return true;
+      }
+
+      @Override
+      public Set<Integer> getSuspectedSegments() {
+         return suspectedSegments;
+      }
+
+      @Override
+      public String toString() {
+         return "LastResponse {suspectedSegments=" + suspectedSegments + "}";
+      }
+   }
+
+   @Override
+   public boolean isComplete() {
+      return false;
+   }
+
+   /**
+    * This externalizer is a special breed that converts a given response into others, based on whether or not
+    * an iterator has completed or not. This allows the originator to not have to create an intermediate collection
+    * to store the batched iterator and then the originator only has to create an object that requires given values.
+    */
+   public static class IteratorResponsesExternalizer extends AbstractExternalizer<IteratorResponses> {
+
+      @Override
+      public Integer getId() {
+         return Ids.STREAM_ITERATOR_RESPONSE;
+      }
+
+      @Override
+      public Set<Class<? extends IteratorResponses>> getTypeClasses() {
+         // We only support
+         return Collections.singleton(RemoteResponse.class);
+      }
+
+      @Override
+      public void writeObject(ObjectOutput output, IteratorResponses object) throws IOException {
+         // This special handling is because we don't know if we are done with the iterator until we have iterated
+         // upon it
+         RemoteResponse resp = (RemoteResponse) object;
+         Iterator<Object> iter = resp.getIterator();
+         long i = 0;
+         for (; i < resp.batchSize && iter.hasNext(); ++i) {
+            output.writeObject(iter.next());
+         }
+         output.writeObject(EndIterator.getInstance());
+         // If there are no more entries that mean we are completed.
+         boolean completed = !iter.hasNext();
+         log.tracef("Sending %s entries to requestor and was complete? %s", String.valueOf(i), completed);
+         output.writeBoolean(completed);
+         if (completed) {
+            // The final response will show all of the suspected segments if there are any
+            Set<Integer> segments = resp.getSuspectedSegments();
+            // This set is written to from other threads - so we have to synchronize to guarantee read visibility
+            // The hasNext call above should have unregistered LocalStreamManagerImpl.SegmentListener
+            synchronized (segments) {
+               output.writeObject(segments);
+            }
+         }
+      }
+
+      @Override
+      public IteratorResponses readObject(ObjectInput input) throws IOException, ClassNotFoundException {
+         Object object = input.readObject();
+         Iterator<Object> iterator;
+         if (object != EndIterator.getInstance()) {
+            Stream.Builder<Object> builder = Stream.builder();
+            builder.accept(object);
+            while ((object = input.readObject()) != EndIterator.getInstance()) {
+               builder.accept(object);
+            }
+            iterator = builder.build().iterator();
+         } else {
+            iterator = Collections.emptyIterator();
+         }
+         boolean complete = input.readBoolean();
+         if (complete) {
+            return new LastResponse(iterator, (Set<Integer>) input.readObject());
+         } else {
+            return new BatchResponse(iterator);
+         }
+      }
+   }
+}

--- a/core/src/main/java/org/infinispan/stream/impl/LocalStreamManager.java
+++ b/core/src/main/java/org/infinispan/stream/impl/LocalStreamManager.java
@@ -1,8 +1,11 @@
 package org.infinispan.stream.impl;
 
+import java.util.Iterator;
 import java.util.Set;
 
+import org.infinispan.commons.util.IntSet;
 import org.infinispan.remoting.transport.Address;
+import org.infinispan.stream.impl.intops.IntermediateOperation;
 
 /**
  * Stream manager that is invoked on a local node.  This is normally called due to a {@link ClusterStreamManager} from
@@ -71,4 +74,28 @@ public interface LocalStreamManager<K> {
    <R2> void streamOperationRehashAware(Object requestId, Address origin, boolean parallelStream, Set<Integer> segments,
            Set<K> keysToInclude, Set<K> keysToExclude, boolean includeLoader,
            KeyTrackingTerminalOperation<K, ?, R2> operation);
+
+   /**
+    * Signals that a new iterator is created using the given arguments. Returns a response which only returns the given
+    * <b>batchSize</b> worth of elements.
+    * @param requestId the originating request id
+    * @param origin the node this request came from
+    * @param segments the segments to include in this operation
+    * @param keysToInclude which keys to include
+    * @param keysToExclude which keys to exclude
+    * @param includeLoader whether or not a cache loader should be utilized
+    * @param intermediateOperations the operations to apply to the underlying data
+    * @param batchSize how many elements to return
+    * @return the response containing iterator
+    */
+   IteratorResponse startIterator(Object requestId, Address origin, IntSet segments, Set<K> keysToInclude,
+         Set<K> keysToExclude, boolean includeLoader, Iterable<IntermediateOperation> intermediateOperations, long batchSize);
+
+   /**
+    * Continues an existing iterator by retrieving the next <b>batchSize</b> of elements
+    * @param requestId the originating request id
+    * @param batchSize how many elements to return
+    * @return the response containing iterator
+    */
+   IteratorResponse continueIterator(Object requestId, long batchSize);
 }

--- a/core/src/main/java/org/infinispan/stream/impl/LocalStreamManagerImpl.java
+++ b/core/src/main/java/org/infinispan/stream/impl/LocalStreamManagerImpl.java
@@ -16,7 +16,9 @@ import org.infinispan.CacheSet;
 import org.infinispan.cache.impl.AbstractDelegatingCache;
 import org.infinispan.commands.CommandsFactory;
 import org.infinispan.commons.CacheException;
+import org.infinispan.commons.util.CloseableIterator;
 import org.infinispan.commons.util.CollectionFactory;
+import org.infinispan.commons.util.IntSet;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.container.entries.CacheEntry;
@@ -32,6 +34,7 @@ import org.infinispan.notifications.cachelistener.event.DataRehashedEvent;
 import org.infinispan.remoting.rpc.RpcManager;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.statetransfer.StateTransferManager;
+import org.infinispan.stream.impl.intops.IntermediateOperation;
 import org.infinispan.topology.CacheTopology;
 import org.infinispan.util.ByteString;
 import org.infinispan.util.logging.Log;
@@ -54,6 +57,7 @@ public class LocalStreamManagerImpl<K, V> implements LocalStreamManager<K> {
    private RpcManager rpc;
    private CommandsFactory factory;
    private boolean hasLoader;
+   private IteratorHandler iteratorHandler;
 
    private Address localAddress;
    private CacheMode cacheMode;
@@ -69,7 +73,7 @@ public class LocalStreamManagerImpl<K, V> implements LocalStreamManager<K> {
       SegmentListener(Set<Integer> segments, SegmentAwareOperation op) {
          this.segments = new HashSet<>(segments);
          this.op = op;
-         this.segmentsLost = new HashSet<>();
+         this.segmentsLost = Collections.synchronizedSet(new HashSet<>());
       }
 
       public void localSegments(Set<Integer> localSegments) {
@@ -104,7 +108,7 @@ public class LocalStreamManagerImpl<K, V> implements LocalStreamManager<K> {
 
    @Inject
    public void inject(Cache<K, V> cache, ComponentRegistry registry, StateTransferManager stm, RpcManager rpc,
-           Configuration configuration, CommandsFactory factory) {
+           Configuration configuration, CommandsFactory factory, IteratorHandler iterationHandler) {
       // We need to unwrap the cache as a local stream should only deal with BOXED values and obviously only
       // with local entries.  Any mappings will be provided by the originator node in their intermediate operation
       // stack in the operation itself.
@@ -115,6 +119,7 @@ public class LocalStreamManagerImpl<K, V> implements LocalStreamManager<K> {
       this.rpc = rpc;
       this.factory = factory;
       this.hasLoader = configuration.persistence().usingStores();
+      this.iteratorHandler = iterationHandler;
    }
 
    @Start
@@ -186,6 +191,7 @@ public class LocalStreamManagerImpl<K, V> implements LocalStreamManager<K> {
          stream = stream.filter(entry -> entry.getValue() != null);
       }
       if (!keysToExclude.isEmpty()) {
+         log.warn("Added exclude filter");
          return stream.filter(e -> !keysToExclude.contains(e.getKey()));
       }
       return stream;
@@ -361,6 +367,47 @@ public class LocalStreamManagerImpl<K, V> implements LocalStreamManager<K> {
 
       rpc.invokeRemotely(Collections.singleton(origin), factory.buildStreamResponseCommand(requestId, true,
               listener.segmentsLost, results), rpc.getDefaultRpcOptions(true));
+   }
+
+   @Override
+   public IteratorResponse startIterator(Object requestId, Address origin, IntSet segments, Set<K> keysToInclude,
+         Set<K> keysToExclude, boolean includeLoader, Iterable<IntermediateOperation> intermediateOperations, long batchSize) {
+      if (trace) {
+         log.tracef("Received rehash aware operation request to start iterator for id %s from %s for segments %s",
+               requestId, origin, segments);
+      }
+      CacheSet<CacheEntry<K, V>> cacheEntrySet = getCacheRespectingLoader(includeLoader).cacheEntrySet();
+      SegmentListener listener = new SegmentListener(segments, i -> true);
+
+      if (changeListener.putIfAbsent(requestId, listener) != null) {
+         throw new IllegalStateException("Iterator was already created for id " + requestId);
+      }
+
+      if (trace) {
+         log.tracef("Registered change listener for %s", requestId);
+      }
+      IteratorHandler.OnCloseIterator<Object> iterator = iteratorHandler.start(origin, () -> getRehashStream(cacheEntrySet,
+            requestId, listener, false, segments,
+            keysToInclude, keysToExclude), intermediateOperations, requestId);
+      // Have to clear out our change listener when the iterator is closed
+      iterator.onClose(() -> {
+         changeListener.remove(requestId);
+         // If the cache is no longer running, all segments have to be suspect
+         if (cache.getStatus() != ComponentStatus.RUNNING) {
+            if (trace) {
+               log.tracef("Cache status is no longer running after completing iterator, all segments are now suspect for %s", requestId);
+            }
+            listener.segmentsLost.addAll(segments);
+         }
+      });
+
+      return new IteratorResponses.RemoteResponse(iterator, listener.segmentsLost, batchSize);
+   }
+
+   @Override
+   public IteratorResponse continueIterator(Object requestId, long batchSize) {
+      CloseableIterator<Object> iterator = iteratorHandler.getIterator(requestId);
+      return new IteratorResponses.RemoteResponse(iterator, changeListener.get(requestId).segmentsLost, batchSize);
    }
 
    class NonRehashIntermediateCollector<R> implements KeyTrackingTerminalOperation.IntermediateCollector<R> {

--- a/core/src/main/java/org/infinispan/stream/impl/PartitionAwareClusterStreamManager.java
+++ b/core/src/main/java/org/infinispan/stream/impl/PartitionAwareClusterStreamManager.java
@@ -4,9 +4,12 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.function.IntFunction;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 import org.infinispan.Cache;
+import org.infinispan.commons.util.IntSet;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
@@ -16,6 +19,8 @@ import org.infinispan.notifications.cachelistener.event.PartitionStatusChangedEv
 import org.infinispan.partitionhandling.AvailabilityException;
 import org.infinispan.partitionhandling.AvailabilityMode;
 import org.infinispan.partitionhandling.PartitionHandling;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.stream.impl.intops.IntermediateOperation;
 
 /**
  * Cluster stream manager that also pays attention to partition status and properly closes iterators and throws
@@ -105,6 +110,14 @@ public class PartitionAwareClusterStreamManager<K> extends ClusterStreamManagerI
       checkPartitionStatus();
       return super.remoteStreamOperationRehashAware(parallelDistribution, parallelStream, segments, keysToInclude,
               keysToExclude, includeLoader, operation, callback);
+   }
+
+   @Override
+   public <E> RemoteIteratorPublisher<E> remoteIterationPublisher(boolean parallelStream,
+         Supplier<Map.Entry<Address, IntSet>> targets, Set<K> keysToInclude, IntFunction<Set<K>> keysToExclude,
+         boolean includeLoader, Iterable<IntermediateOperation> intermediateOperations) {
+      checkPartitionStatus();
+      return super.remoteIterationPublisher(parallelStream, targets, keysToInclude, keysToExclude, includeLoader, intermediateOperations);
    }
 
    private void checkPartitionStatus() {

--- a/core/src/main/java/org/infinispan/stream/impl/PriorityMergingProcessor.java
+++ b/core/src/main/java/org/infinispan/stream/impl/PriorityMergingProcessor.java
@@ -1,0 +1,304 @@
+package org.infinispan.stream.impl;
+
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.infinispan.commons.CacheException;
+import org.infinispan.commons.util.AbstractIterator;
+import org.infinispan.commons.util.CloseableIterable;
+import org.infinispan.commons.util.CloseableIterator;
+import org.infinispan.util.concurrent.TimeoutException;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import io.reactivex.exceptions.MissingBackpressureException;
+import io.reactivex.internal.queue.SpscArrayQueue;
+import io.reactivex.internal.subscriptions.SubscriptionHelper;
+
+/**
+ * An iterable that will automatically poll entries from the given publishers. Entries are first attempted to be
+ * returned from the first publisher and so forth. If no publisher has recently published an entry the iterator
+ * will block until one does so or all are known to have completed.
+ * <p>
+ * The iterator returned should be closed by the user when they are done to ensure resources are freed properly.
+ * @author wburns
+ * @since 9.0
+ */
+public class PriorityMergingProcessor<T> implements CloseableIterable<T> {
+   private final static Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
+
+   private final Collection<PublisherIntPair<T>> pairs;
+
+   public static <T> PriorityMergingProcessor<T> build(Publisher<T> publisher, int firstbatchSize, Publisher<T> secondPublisher,
+         int secondBatchSize) {
+      return new PriorityMergingProcessor<>(publisher, firstbatchSize, secondPublisher, secondBatchSize);
+   }
+
+   public static <T> Builder<T> builder() {
+      return new Builder<>();
+   }
+
+   private static class PublisherIntPair<T> {
+      private final Publisher<T> publisher;
+      private final int batchSize;
+
+      private PublisherIntPair(Publisher<T> publisher, int batchSize) {
+         this.publisher = Objects.requireNonNull(publisher);
+         if (batchSize <= 0) {
+            throw new IllegalArgumentException("batchSize must be greater than 0");
+         }
+         this.batchSize = batchSize;
+      }
+   }
+
+   public static class Builder<T> {
+      Stream.Builder<PublisherIntPair<T>> current = Stream.builder();
+
+      Builder<T> addPublisher(Publisher<T> publisher, int batchSize) {
+         current.accept(new PublisherIntPair<T>(publisher, batchSize));
+         return this;
+      }
+
+      PriorityMergingProcessor<T> build() {
+         return new PriorityMergingProcessor<>(current.build().collect(Collectors.toList()));
+      }
+   }
+
+   private PriorityMergingProcessor(Publisher<T> publisher, int firstbatchSize, Publisher<T> secondPublisher,
+         int secondBatchSize) {
+      this.pairs = Arrays.asList(new PublisherIntPair<T>(publisher, firstbatchSize),
+            new PublisherIntPair<T>(secondPublisher, secondBatchSize));
+   }
+
+   private PriorityMergingProcessor(Collection<PublisherIntPair<T>> pairs) {
+      this.pairs = pairs;
+   }
+
+   @Override
+   public void close() {
+      // This does nothing, the iterators need to be closed individually
+   }
+
+   @Override
+   public CloseableIterator<T> iterator() {
+      MultiSubscriberIterator<T> iterator = new MultiSubscriberIterator<>(pairs);
+      iterator.start();
+      return iterator;
+   }
+
+
+   private static final class MultiSubscriberIterator<T> extends AbstractIterator<T> implements CloseableIterator<T> {
+
+      private final QueueSubscriber<T>[] queueSubscribers;
+
+      private final Lock lock;
+
+      private final Condition condition;
+
+      private final AtomicBoolean signalled;
+
+      volatile Throwable error;
+
+      MultiSubscriberIterator(Collection<PublisherIntPair<T>> pairs) {
+         this.queueSubscribers = new QueueSubscriber[pairs.size()];
+
+         this.signalled = new AtomicBoolean();
+         this.lock = new ReentrantLock();
+         this.condition = lock.newCondition();
+
+         int offset = 0;
+         for (PublisherIntPair<T> pair : pairs) {
+            QueueSubscriber<T> actualSubscriber = new QueueSubscriber<>(pair.publisher, pair.batchSize, this);
+            queueSubscribers[offset++] = actualSubscriber;
+         }
+      }
+
+      /**
+       * Actually starts each subscriber - needed because otherwise subscriber could call back while in constructor
+       */
+      public void start() {
+         for (QueueSubscriber<T> queueSubscriber : queueSubscribers) {
+            queueSubscriber.start();
+         }
+      }
+
+      static RuntimeException wrapOrThrow(Throwable error) {
+         if (!(error instanceof CacheException)) {
+            return new CacheException(error);
+         }
+         return (CacheException) error;
+      }
+
+      @Override
+      public void close() {
+         for (QueueSubscriber<T> queueSubscriber : queueSubscribers) {
+            queueSubscriber.close();
+         }
+         signalConsumer();
+      }
+
+      @Override
+      protected T getNext() {
+         do {
+            boolean allDone = true;
+            // Set this to false just in case we get a signal while iterating
+            signalled.set(false);
+
+            if (error != null) {
+               throw wrapOrThrow(error);
+            }
+            for (QueueSubscriber<T> t : queueSubscribers) {
+               T nextValue = t.poll();
+               if (nextValue != null) {
+                  return nextValue;
+               }
+               allDone &= t.isDone();
+            }
+            if (allDone) {
+               return null;
+            }
+            lock.lock();
+            try {
+               while (!signalled.get()) {
+                  try {
+                     if (!condition.await(30, TimeUnit.SECONDS)) {
+                        log.debugf("Timeout encountered: signaled %s, error %s, queues %s", signalled.get(), error,
+                              Arrays.toString(queueSubscribers));
+                        throw new TimeoutException();
+                     }
+                  } catch (InterruptedException e) {
+                     throw wrapOrThrow(e);
+                  }
+               }
+            } finally {
+               lock.unlock();
+            }
+         }
+         while (true);
+      }
+
+      void onError(Throwable t) {
+         error = t;
+         signalConsumer();
+      }
+
+      void signalConsumer() {
+         lock.lock();
+         try {
+            signalled.set(true);
+            condition.signalAll();
+         } finally {
+            lock.unlock();
+         }
+      }
+   }
+
+   static final class QueueSubscriber<T> extends AtomicReference<Subscription> implements Subscriber<T>, AutoCloseable {
+      private final Publisher<T> publisher;
+      private final SpscArrayQueue<T> queue;
+      private final long batchSize;
+      private final long limit;
+      private MultiSubscriberIterator notifier;
+
+      private long produced;
+
+      private volatile boolean done;
+
+      QueueSubscriber(Publisher<T> publisher, int batchSize, MultiSubscriberIterator subscriber) {
+         this.publisher = publisher;
+         this.queue = new SpscArrayQueue<T>(batchSize);
+         this.batchSize = batchSize;
+         this.notifier = subscriber;
+         this.limit = batchSize - (batchSize >> 2);
+      }
+
+      void start() {
+         publisher.subscribe(this);
+      }
+
+      /**
+       * Returns value if available as well as requesting more from producer as needed.
+       */
+      public T poll() {
+         T returned = queue.poll();
+         if (returned != null) {
+            long p = produced + 1;
+            if (p == limit) {
+               produced = 0;
+               get().request(p);
+            } else {
+               produced = p;
+            }
+         }
+         return returned;
+      }
+
+      @Override
+      public void onSubscribe(Subscription s) {
+         if (SubscriptionHelper.setOnce(this, s)) {
+            s.request(batchSize);
+         }
+      }
+
+      @Override
+      public void onNext(T t) {
+         if (!queue.offer(t)) {
+            SubscriptionHelper.cancel(this);
+
+            onError(new IllegalStateException("Too many items requested, this is a bug!"));
+         } else {
+            // This is just to wake them up - in case if they are waiting for an item
+            notifier.signalConsumer();
+         }
+      }
+
+      @Override
+      public void onError(Throwable t) {
+         done = true;
+         notifier.onError(t);
+      }
+
+      @Override
+      public void onComplete() {
+         done = true;
+         // We have to signal consumer, just in case if they were waiting on us to return, but we ended up completing
+         // instead.
+         notifier.signalConsumer();
+      }
+
+      @Override
+      public void close() {
+         SubscriptionHelper.cancel(this);
+      }
+
+      public boolean isDone() {
+         return done;
+      }
+
+      @Override
+      public String toString() {
+         return "QueueSubscriber{" +
+               "queue.empty = " + queue.isEmpty() + ", " +
+               "done = " + done +
+               "}";
+      }
+   }
+}

--- a/core/src/main/java/org/infinispan/stream/impl/StreamIteratorCloseCommand.java
+++ b/core/src/main/java/org/infinispan/stream/impl/StreamIteratorCloseCommand.java
@@ -1,0 +1,78 @@
+package org.infinispan.stream.impl;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.concurrent.CompletableFuture;
+
+import org.infinispan.commands.TopologyAffectedCommand;
+import org.infinispan.commands.remote.BaseRpcCommand;
+import org.infinispan.commons.io.UnsignedNumeric;
+import org.infinispan.factories.annotations.Inject;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.util.ByteString;
+import org.infinispan.util.concurrent.CompletableFutures;
+
+/**
+ * Stream iterator command that unregisters an iterator so it doesn't consume memory unnecessarily
+ */
+public class StreamIteratorCloseCommand extends BaseRpcCommand {
+   public static final byte COMMAND_ID = 72;
+
+   protected IteratorHandler handler;
+
+   protected Object id;
+
+   public Object getId() {
+      return id;
+   }
+
+   // Only here for CommandIdUniquenessTest
+   private StreamIteratorCloseCommand() { super(null); }
+
+   public StreamIteratorCloseCommand(ByteString cacheName) {
+      super(cacheName);
+   }
+
+   public StreamIteratorCloseCommand(ByteString cacheName, Address origin, Object id) {
+      super(cacheName);
+      setOrigin(origin);
+      this.id = id;
+   }
+
+   @Inject
+   public void inject(IteratorHandler handler) {
+      this.handler = handler;
+   }
+
+   @Override
+   public CompletableFuture<Object> invokeAsync() throws Throwable {
+      handler.closeIterator(getOrigin(), id);
+      return CompletableFutures.completedNull();
+   }
+
+   @Override
+   public byte getCommandId() {
+      return COMMAND_ID;
+   }
+
+   @Override
+   public void writeTo(ObjectOutput output) throws IOException {
+      output.writeObject(id);
+   }
+
+   @Override
+   public void readFrom(ObjectInput input) throws IOException, ClassNotFoundException {
+      id = input.readObject();
+   }
+
+   @Override
+   public boolean isReturnValueExpected() {
+      return false;
+   }
+
+   @Override
+   public boolean canBlock() {
+      return false;
+   }
+}

--- a/core/src/main/java/org/infinispan/stream/impl/StreamIteratorNextCommand.java
+++ b/core/src/main/java/org/infinispan/stream/impl/StreamIteratorNextCommand.java
@@ -1,0 +1,89 @@
+package org.infinispan.stream.impl;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.concurrent.CompletableFuture;
+
+import org.infinispan.commands.TopologyAffectedCommand;
+import org.infinispan.commands.remote.BaseRpcCommand;
+import org.infinispan.commons.io.UnsignedNumeric;
+import org.infinispan.factories.annotations.Inject;
+import org.infinispan.util.ByteString;
+
+/**
+ * Stream request command that is sent to remote nodes handle execution of remote intermediate and terminal operations.
+ */
+public class StreamIteratorNextCommand extends BaseRpcCommand implements TopologyAffectedCommand {
+   public static final byte COMMAND_ID = 71;
+
+   protected LocalStreamManager lsm;
+
+   protected Object id;
+   protected long batchSize;
+   protected int topologyId = -1;
+
+   @Override
+   public int getTopologyId() {
+      return topologyId;
+   }
+
+   @Override
+   public void setTopologyId(int topologyId) {
+      this.topologyId = topologyId;
+   }
+
+   public Object getId() {
+      return id;
+   }
+
+   // Only here for CommandIdUniquenessTest
+   private StreamIteratorNextCommand() { super(null); }
+
+   public StreamIteratorNextCommand(ByteString cacheName) {
+      super(cacheName);
+   }
+
+   public StreamIteratorNextCommand(ByteString cacheName, Object id, long batchSize) {
+      super(cacheName);
+      this.id = id;
+      this.batchSize = batchSize;
+   }
+
+   @Inject
+   public void inject(LocalStreamManager lsm) {
+      this.lsm = lsm;
+   }
+
+   @Override
+   public CompletableFuture<Object> invokeAsync() throws Throwable {
+      return CompletableFuture.completedFuture(lsm.continueIterator(id, batchSize));
+   }
+
+   @Override
+   public byte getCommandId() {
+      return COMMAND_ID;
+   }
+
+   @Override
+   public void writeTo(ObjectOutput output) throws IOException {
+      output.writeObject(id);
+      UnsignedNumeric.writeUnsignedLong(output, batchSize);
+   }
+
+   @Override
+   public void readFrom(ObjectInput input) throws IOException, ClassNotFoundException {
+      id = input.readObject();
+      batchSize = UnsignedNumeric.readUnsignedLong(input);
+   }
+
+   @Override
+   public boolean isReturnValueExpected() {
+      return true;
+   }
+
+   @Override
+   public boolean canBlock() {
+      return true;
+   }
+}

--- a/core/src/main/java/org/infinispan/stream/impl/StreamIteratorRequestCommand.java
+++ b/core/src/main/java/org/infinispan/stream/impl/StreamIteratorRequestCommand.java
@@ -1,0 +1,95 @@
+package org.infinispan.stream.impl;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import org.infinispan.commons.marshall.MarshallUtil;
+import org.infinispan.commons.util.IntSet;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.stream.impl.intops.IntermediateOperation;
+import org.infinispan.util.ByteString;
+
+/**
+ * Stream request command that is sent to remote nodes handle execution of remote intermediate and terminal operations.
+ * @param <K> the key type
+ */
+public class StreamIteratorRequestCommand<K> extends StreamIteratorNextCommand {
+   public static final byte COMMAND_ID = 70;
+
+   private boolean parallelStream;
+   private IntSet segments;
+   private Set<K> keys;
+   private Set<K> excludedKeys;
+   private boolean includeLoader;
+   private Iterable<IntermediateOperation> intOps;
+
+   // Only here for CommandIdUniquenessTest
+   private StreamIteratorRequestCommand() { super(null); }
+
+   public StreamIteratorRequestCommand(ByteString cacheName) {
+      super(cacheName);
+   }
+
+   public StreamIteratorRequestCommand(ByteString cacheName, Address origin, Object id, boolean parallelStream,
+         IntSet segments, Set<K> keys, Set<K> excludedKeys, boolean includeLoader,
+                               Iterable<IntermediateOperation> intOps, long batchSize) {
+      super(cacheName, id, batchSize);
+      setOrigin(origin);
+      this.parallelStream = parallelStream;
+      this.segments = segments;
+      this.keys = keys;
+      this.excludedKeys = excludedKeys;
+      this.includeLoader = includeLoader;
+      this.intOps = intOps;
+   }
+
+   @Override
+   public CompletableFuture<Object> invokeAsync() throws Throwable {
+      return CompletableFuture.completedFuture(lsm.startIterator(id, getOrigin(), segments, keys, excludedKeys,
+            includeLoader, intOps, batchSize));
+   }
+
+   @Override
+   public byte getCommandId() {
+      return COMMAND_ID;
+   }
+
+   @Override
+   public void writeTo(ObjectOutput output) throws IOException {
+      super.writeTo(output);
+      output.writeObject(getOrigin());
+      output.writeBoolean(parallelStream);
+      output.writeObject(segments);
+      MarshallUtil.marshallCollection(keys, output);
+      MarshallUtil.marshallCollection(excludedKeys, output);
+      output.writeBoolean(includeLoader);
+      output.writeObject(intOps);
+
+   }
+
+   @Override
+   public void readFrom(ObjectInput input) throws IOException, ClassNotFoundException {
+      super.readFrom(input);
+      setOrigin((Address) input.readObject());
+      parallelStream = input.readBoolean();
+      segments = (IntSet) input.readObject();
+      keys = MarshallUtil.unmarshallCollectionUnbounded(input, HashSet::new);
+      excludedKeys = MarshallUtil.unmarshallCollectionUnbounded(input, HashSet::new);
+      includeLoader = input.readBoolean();
+      intOps = (Iterable<IntermediateOperation>) input.readObject();
+   }
+
+   @Override
+   public boolean isReturnValueExpected() {
+      return true;
+   }
+
+   @Override
+   public boolean canBlock() {
+      return true;
+   }
+}

--- a/core/src/main/java/org/infinispan/stream/impl/interceptor/AbstractDelegatingEntryCacheSet.java
+++ b/core/src/main/java/org/infinispan/stream/impl/interceptor/AbstractDelegatingEntryCacheSet.java
@@ -45,7 +45,7 @@ public abstract class AbstractDelegatingEntryCacheSet<K, V> extends AbstractDele
       DistributionManager dm = cache.getAdvancedCache().getDistributionManager();
       CloseableSpliterator<CacheEntry<K, V>> closeableSpliterator = spliterator();
       CacheStream<CacheEntry<K, V>> stream = new LocalCacheStream<>(new EntryStreamSupplier<>(cache, dm != null ?
-              dm.getWriteConsistentHash() : null, () -> StreamSupport.stream(closeableSpliterator, false)), parallel,
+              dm.getCacheTopology()::getSegment : null, () -> StreamSupport.stream(closeableSpliterator, false)), parallel,
               cache.getAdvancedCache().getComponentRegistry());
       // We rely on the fact that on close returns the same instance
       stream.onClose(closeableSpliterator::close);

--- a/core/src/main/java/org/infinispan/stream/impl/interceptor/AbstractDelegatingKeyCacheSet.java
+++ b/core/src/main/java/org/infinispan/stream/impl/interceptor/AbstractDelegatingKeyCacheSet.java
@@ -43,7 +43,7 @@ public abstract class AbstractDelegatingKeyCacheSet<K, V> extends AbstractDelega
    protected CacheStream<K> getStream(boolean parallel) {
       DistributionManager dm = cache.getAdvancedCache().getDistributionManager();
       CloseableSpliterator<K> closeableSpliterator = spliterator();
-      CacheStream<K> stream = new LocalCacheStream<>(new KeyStreamSupplier<>(cache, dm != null ? dm.getWriteConsistentHash() : null,
+      CacheStream<K> stream = new LocalCacheStream<>(new KeyStreamSupplier<>(cache, dm != null ? dm.getCacheTopology()::getSegment : null,
               () -> StreamSupport.stream(closeableSpliterator, false)), parallel, cache.getAdvancedCache().getComponentRegistry());
       // We rely on the fact that on close returns the same instance
       stream.onClose(closeableSpliterator::close);

--- a/core/src/main/java/org/infinispan/stream/impl/intops/FlatMappingOperation.java
+++ b/core/src/main/java/org/infinispan/stream/impl/intops/FlatMappingOperation.java
@@ -1,0 +1,23 @@
+package org.infinispan.stream.impl.intops;
+
+import java.util.function.Function;
+import java.util.stream.BaseStream;
+import java.util.stream.Stream;
+
+/**
+ * Interface to signify that an {@link IntermediateOperation} is a flat map operation. This also provides proper
+ * generics for converting a flat map as a map operation resulting in a Stream containing the proper stream
+ * @author wburns
+ * @since 9.0
+ */
+public interface FlatMappingOperation<InputType, InputStream extends BaseStream<InputType, InputStream>,
+      OutputType, OutputStream extends BaseStream<OutputType, OutputStream>>
+      extends MappingOperation<InputType, InputStream, OutputType, OutputStream> {
+
+   /**
+    * Instead of flat mapping this returns a stream of {@link OutputStream}.
+    * @param inputStream the stream to convert
+    * @return the stream of streams
+    */
+   Stream<OutputStream> map(InputStream inputStream);
+}

--- a/core/src/main/java/org/infinispan/stream/impl/intops/MappingOperation.java
+++ b/core/src/main/java/org/infinispan/stream/impl/intops/MappingOperation.java
@@ -1,0 +1,13 @@
+package org.infinispan.stream.impl.intops;
+
+import java.util.stream.BaseStream;
+
+/**
+ * Marker interface to signify that an {@link IntermediateOperation} is a map operation.
+ * @author wburns
+ * @since 9.0
+ */
+public interface MappingOperation<InputType, InputStream extends BaseStream<InputType, InputStream>,
+      OutputType, OutputStream extends BaseStream<OutputType, OutputStream>>
+      extends IntermediateOperation<InputType, InputStream, OutputType, OutputStream> {
+}

--- a/core/src/main/java/org/infinispan/stream/impl/intops/object/FlatMapOperation.java
+++ b/core/src/main/java/org/infinispan/stream/impl/intops/object/FlatMapOperation.java
@@ -3,14 +3,14 @@ package org.infinispan.stream.impl.intops.object;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import org.infinispan.stream.impl.intops.IntermediateOperation;
+import org.infinispan.stream.impl.intops.FlatMappingOperation;
 
 /**
  * Performs flat map operation on a regular {@link Stream}
  * @param <I> the type of the input stream
  * @param <O> the type of the output stream
  */
-public class FlatMapOperation<I, O> implements IntermediateOperation<I, Stream<I>, O, Stream<O>> {
+public class FlatMapOperation<I, O> implements FlatMappingOperation<I, Stream<I>, O, Stream<O>> {
    private final Function<? super I, ? extends Stream<? extends O>> function;
 
    public FlatMapOperation(Function<? super I, ? extends Stream<? extends O>> function) {
@@ -24,5 +24,11 @@ public class FlatMapOperation<I, O> implements IntermediateOperation<I, Stream<I
 
    public Function<? super I, ? extends Stream<? extends O>> getFunction() {
       return function;
+   }
+
+   @Override
+   public Stream<Stream<O>> map(Stream<I> iStream) {
+      // Have to cast to make generics happy
+      return iStream.map((Function<I, Stream<O>>) function);
    }
 }

--- a/core/src/main/java/org/infinispan/stream/impl/intops/object/FlatMapToDoubleOperation.java
+++ b/core/src/main/java/org/infinispan/stream/impl/intops/object/FlatMapToDoubleOperation.java
@@ -4,13 +4,13 @@ import java.util.function.Function;
 import java.util.stream.DoubleStream;
 import java.util.stream.Stream;
 
-import org.infinispan.stream.impl.intops.IntermediateOperation;
+import org.infinispan.stream.impl.intops.FlatMappingOperation;
 
 /**
  * Performs flat map to double operation on a regular {@link Stream}
  * @param <I> the type of the input stream
  */
-public class FlatMapToDoubleOperation<I> implements IntermediateOperation<I, Stream<I>, Double, DoubleStream> {
+public class FlatMapToDoubleOperation<I> implements FlatMappingOperation<I, Stream<I>, Double, DoubleStream> {
    private final Function<? super I, ? extends DoubleStream> function;
 
    public FlatMapToDoubleOperation(Function<? super I, ? extends DoubleStream> function) {
@@ -24,5 +24,10 @@ public class FlatMapToDoubleOperation<I> implements IntermediateOperation<I, Str
 
    public Function<? super I, ? extends DoubleStream> getFunction() {
       return function;
+   }
+
+   @Override
+   public Stream<DoubleStream> map(Stream<I> iStream) {
+      return iStream.map(function);
    }
 }

--- a/core/src/main/java/org/infinispan/stream/impl/intops/object/FlatMapToIntOperation.java
+++ b/core/src/main/java/org/infinispan/stream/impl/intops/object/FlatMapToIntOperation.java
@@ -4,13 +4,13 @@ import java.util.function.Function;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import org.infinispan.stream.impl.intops.IntermediateOperation;
+import org.infinispan.stream.impl.intops.FlatMappingOperation;
 
 /**
  * Performs flat map to int operation on a regular {@link Stream}
  * @param <I> the type of the input stream
  */
-public class FlatMapToIntOperation<I> implements IntermediateOperation<I, Stream<I>, Integer, IntStream> {
+public class FlatMapToIntOperation<I> implements FlatMappingOperation<I, Stream<I>, Integer, IntStream> {
    private final Function<? super I, ? extends IntStream> function;
 
    public FlatMapToIntOperation(Function<? super I, ? extends IntStream> function) {
@@ -24,5 +24,10 @@ public class FlatMapToIntOperation<I> implements IntermediateOperation<I, Stream
 
    public Function<? super I, ? extends IntStream> getFunction() {
       return function;
+   }
+
+   @Override
+   public Stream<IntStream> map(Stream<I> iStream) {
+      return iStream.map(function);
    }
 }

--- a/core/src/main/java/org/infinispan/stream/impl/intops/object/FlatMapToLongOperation.java
+++ b/core/src/main/java/org/infinispan/stream/impl/intops/object/FlatMapToLongOperation.java
@@ -4,13 +4,13 @@ import java.util.function.Function;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
-import org.infinispan.stream.impl.intops.IntermediateOperation;
+import org.infinispan.stream.impl.intops.FlatMappingOperation;
 
 /**
  * Performs flat map to long operation on a regular {@link Stream}
  * @param <I> the type of the input stream
  */
-public class FlatMapToLongOperation<I> implements IntermediateOperation<I, Stream<I>, Long, LongStream> {
+public class FlatMapToLongOperation<I> implements FlatMappingOperation<I, Stream<I>, Long, LongStream> {
    private final Function<? super I, ? extends LongStream> function;
 
    public FlatMapToLongOperation(Function<? super I, ? extends LongStream> function) {
@@ -24,5 +24,10 @@ public class FlatMapToLongOperation<I> implements IntermediateOperation<I, Strea
 
    public Function<? super I, ? extends LongStream> getFunction() {
       return function;
+   }
+
+   @Override
+   public Stream<LongStream> map(Stream<I> iStream) {
+      return iStream.map(function);
    }
 }

--- a/core/src/main/java/org/infinispan/stream/impl/intops/object/MapOperation.java
+++ b/core/src/main/java/org/infinispan/stream/impl/intops/object/MapOperation.java
@@ -5,17 +5,23 @@ import java.util.stream.Stream;
 
 import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.stream.impl.intops.IntermediateOperation;
+import org.infinispan.stream.impl.intops.MappingOperation;
+import org.infinispan.util.function.SerializableFunction;
 
 /**
  * Performs map to operation on a regular {@link Stream}
  * @param <I> the type of the input stream
  * @param <O> the type of the output stream
  */
-public class MapOperation<I, O> implements IntermediateOperation<I, Stream<I>, O, Stream<O>> {
+public class MapOperation<I, O> implements MappingOperation<I, Stream<I>, O, Stream<O>> {
    private final Function<? super I, ? extends O> function;
 
    public MapOperation(Function<? super I, ? extends O> function) {
       this.function = function;
+   }
+
+   public MapOperation(SerializableFunction<? super I, ? extends O> function) {
+      this((Function<? super I, ? extends O>) function);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/stream/impl/intops/object/MapToDoubleOperation.java
+++ b/core/src/main/java/org/infinispan/stream/impl/intops/object/MapToDoubleOperation.java
@@ -1,16 +1,18 @@
 package org.infinispan.stream.impl.intops.object;
 
 import java.util.function.ToDoubleFunction;
+import java.util.stream.BaseStream;
 import java.util.stream.DoubleStream;
 import java.util.stream.Stream;
 
 import org.infinispan.stream.impl.intops.IntermediateOperation;
+import org.infinispan.stream.impl.intops.MappingOperation;
 
 /**
  * Performs map to double operation on a regular {@link Stream}
  * @param <I> the type of the input stream
  */
-public class MapToDoubleOperation<I> implements IntermediateOperation<I, Stream<I>, Double, DoubleStream> {
+public class MapToDoubleOperation<I> implements MappingOperation<I, Stream<I>, Double, DoubleStream> {
    private final ToDoubleFunction<? super I> function;
 
    public MapToDoubleOperation(ToDoubleFunction<? super I> function) {

--- a/core/src/main/java/org/infinispan/stream/impl/intops/object/MapToIntOperation.java
+++ b/core/src/main/java/org/infinispan/stream/impl/intops/object/MapToIntOperation.java
@@ -5,12 +5,13 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import org.infinispan.stream.impl.intops.IntermediateOperation;
+import org.infinispan.stream.impl.intops.MappingOperation;
 
 /**
  * Performs map to int operation on a regular {@link Stream}
  * @param <I> the type of the input stream
  */
-public class MapToIntOperation<I> implements IntermediateOperation<I, Stream<I>, Integer, IntStream> {
+public class MapToIntOperation<I> implements MappingOperation<I, Stream<I>, Integer, IntStream> {
    private final ToIntFunction<? super I> function;
 
    public MapToIntOperation(ToIntFunction<? super I> function) {

--- a/core/src/main/java/org/infinispan/stream/impl/intops/object/MapToLongOperation.java
+++ b/core/src/main/java/org/infinispan/stream/impl/intops/object/MapToLongOperation.java
@@ -5,12 +5,13 @@ import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
 import org.infinispan.stream.impl.intops.IntermediateOperation;
+import org.infinispan.stream.impl.intops.MappingOperation;
 
 /**
  * Performs map to long operation on a regular {@link Stream}
  * @param <I> the type of the input stream
  */
-public class MapToLongOperation<I> implements IntermediateOperation<I, Stream<I>, Long, LongStream> {
+public class MapToLongOperation<I> implements MappingOperation<I, Stream<I>, Long, LongStream> {
    private final ToLongFunction<? super I> function;
 
    public MapToLongOperation(ToLongFunction<? super I> function) {

--- a/core/src/main/java/org/infinispan/stream/impl/intops/primitive/d/FlatMapDoubleOperation.java
+++ b/core/src/main/java/org/infinispan/stream/impl/intops/primitive/d/FlatMapDoubleOperation.java
@@ -1,14 +1,16 @@
 package org.infinispan.stream.impl.intops.primitive.d;
 
 import java.util.function.DoubleFunction;
+import java.util.function.Function;
 import java.util.stream.DoubleStream;
+import java.util.stream.Stream;
 
-import org.infinispan.stream.impl.intops.IntermediateOperation;
+import org.infinispan.stream.impl.intops.FlatMappingOperation;
 
 /**
  * Performs flat map operation on a {@link DoubleStream}
  */
-public class FlatMapDoubleOperation implements IntermediateOperation<Double, DoubleStream, Double, DoubleStream> {
+public class FlatMapDoubleOperation implements FlatMappingOperation<Double, DoubleStream, Double, DoubleStream> {
    private final DoubleFunction<? extends DoubleStream> function;
 
    public FlatMapDoubleOperation(DoubleFunction<? extends DoubleStream> function) {
@@ -22,5 +24,10 @@ public class FlatMapDoubleOperation implements IntermediateOperation<Double, Dou
 
    public DoubleFunction<? extends DoubleStream> getFunction() {
       return function;
+   }
+
+   @Override
+   public Stream<DoubleStream> map(DoubleStream doubleStream) {
+      return doubleStream.mapToObj(function);
    }
 }

--- a/core/src/main/java/org/infinispan/stream/impl/intops/primitive/i/FlatMapIntOperation.java
+++ b/core/src/main/java/org/infinispan/stream/impl/intops/primitive/i/FlatMapIntOperation.java
@@ -1,14 +1,16 @@
 package org.infinispan.stream.impl.intops.primitive.i;
 
+import java.util.function.Function;
 import java.util.function.IntFunction;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
-import org.infinispan.stream.impl.intops.IntermediateOperation;
+import org.infinispan.stream.impl.intops.FlatMappingOperation;
 
 /**
  * Performs flat map operation on a {@link IntStream}
  */
-public class FlatMapIntOperation implements IntermediateOperation<Integer, IntStream, Integer, IntStream> {
+public class FlatMapIntOperation implements FlatMappingOperation<Integer, IntStream, Integer, IntStream> {
    private final IntFunction<? extends IntStream> function;
 
    public FlatMapIntOperation(IntFunction<? extends IntStream> function) {
@@ -22,5 +24,10 @@ public class FlatMapIntOperation implements IntermediateOperation<Integer, IntSt
 
    public IntFunction<? extends IntStream> getFunction() {
       return function;
+   }
+
+   @Override
+   public Stream<IntStream> map(IntStream intStream) {
+      return intStream.mapToObj(function);
    }
 }

--- a/core/src/main/java/org/infinispan/stream/impl/intops/primitive/l/FlatMapLongOperation.java
+++ b/core/src/main/java/org/infinispan/stream/impl/intops/primitive/l/FlatMapLongOperation.java
@@ -1,14 +1,16 @@
 package org.infinispan.stream.impl.intops.primitive.l;
 
+import java.util.function.Function;
 import java.util.function.LongFunction;
 import java.util.stream.LongStream;
+import java.util.stream.Stream;
 
-import org.infinispan.stream.impl.intops.IntermediateOperation;
+import org.infinispan.stream.impl.intops.FlatMappingOperation;
 
 /**
  * Performs flat map operation on a {@link LongStream}
  */
-public class FlatMapLongOperation implements IntermediateOperation<Long, LongStream, Long, LongStream> {
+public class FlatMapLongOperation implements FlatMappingOperation<Long, LongStream, Long, LongStream> {
    private final LongFunction<? extends LongStream> function;
 
    public FlatMapLongOperation(LongFunction<? extends LongStream> function) {
@@ -22,5 +24,10 @@ public class FlatMapLongOperation implements IntermediateOperation<Long, LongStr
 
    public LongFunction<? extends LongStream> getFunction() {
       return function;
+   }
+
+   @Override
+   public Stream<LongStream> map(LongStream longStream) {
+      return longStream.mapToObj(function);
    }
 }

--- a/core/src/main/java/org/infinispan/stream/impl/local/EntryStreamSupplier.java
+++ b/core/src/main/java/org/infinispan/stream/impl/local/EntryStreamSupplier.java
@@ -19,6 +19,7 @@ import org.infinispan.commons.util.RemovableCloseableIterator;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.context.Flag;
 import org.infinispan.distribution.ch.ConsistentHash;
+import org.infinispan.distribution.ch.KeyPartitioner;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -72,7 +73,8 @@ public class EntryStreamSupplier<K, V> implements AbstractLocalCacheStream.Strea
          }
          BitSet bitSet = new BitSet(hash.getNumSegments());
          segmentsToFilter.forEach(bitSet::set);
-         stream = stream.filter(k -> bitSet.get(hash.getSegment(k.getKey())));
+         KeyPartitioner partitioner = cache.getAdvancedCache().getComponentRegistry().getComponent(KeyPartitioner.class);
+         stream = stream.filter(k -> bitSet.get(partitioner.getSegment(k.getKey())));
       }
       return stream;
    }

--- a/core/src/main/java/org/infinispan/stream/impl/local/EntryStreamSupplier.java
+++ b/core/src/main/java/org/infinispan/stream/impl/local/EntryStreamSupplier.java
@@ -2,10 +2,10 @@ package org.infinispan.stream.impl.local;
 
 import static org.infinispan.commons.dataconversion.EncodingUtils.toStorage;
 
-import java.util.BitSet;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
+import java.util.function.ToIntFunction;
 import java.util.stream.Stream;
 
 import org.infinispan.AdvancedCache;
@@ -15,11 +15,11 @@ import org.infinispan.commons.dataconversion.ByteArrayWrapper;
 import org.infinispan.commons.dataconversion.Encoder;
 import org.infinispan.commons.dataconversion.Wrapper;
 import org.infinispan.commons.util.CloseableIterator;
+import org.infinispan.commons.util.IntSet;
 import org.infinispan.commons.util.RemovableCloseableIterator;
+import org.infinispan.commons.util.SmallIntSet;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.context.Flag;
-import org.infinispan.distribution.ch.ConsistentHash;
-import org.infinispan.distribution.ch.KeyPartitioner;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -32,13 +32,13 @@ public class EntryStreamSupplier<K, V> implements AbstractLocalCacheStream.Strea
    private static final boolean trace = log.isTraceEnabled();
 
    private final Cache<K, V> cache;
-   private final ConsistentHash hash;
+   private final ToIntFunction<Object> toIntFunction;
    private final Supplier<Stream<CacheEntry<K, V>>> supplier;
    private final Wrapper wrapper = new ByteArrayWrapper();
 
-   public EntryStreamSupplier(Cache<K, V> cache, ConsistentHash hash, Supplier<Stream<CacheEntry<K, V>>> supplier) {
+   public EntryStreamSupplier(Cache<K, V> cache, ToIntFunction<Object> toIntFunction, Supplier<Stream<CacheEntry<K, V>>> supplier) {
       this.cache = cache;
-      this.hash = hash;
+      this.toIntFunction = toIntFunction;
       this.supplier = supplier;
    }
 
@@ -67,14 +67,12 @@ public class EntryStreamSupplier<K, V> implements AbstractLocalCacheStream.Strea
       } else {
          stream = supplier.get();
       }
-      if (segmentsToFilter != null && hash != null) {
+      if (segmentsToFilter != null && toIntFunction != null) {
          if (trace) {
             log.tracef("Applying segment filter %s", segmentsToFilter);
          }
-         BitSet bitSet = new BitSet(hash.getNumSegments());
-         segmentsToFilter.forEach(bitSet::set);
-         KeyPartitioner partitioner = cache.getAdvancedCache().getComponentRegistry().getComponent(KeyPartitioner.class);
-         stream = stream.filter(k -> bitSet.get(partitioner.getSegment(k.getKey())));
+         IntSet intSet = SmallIntSet.from(segmentsToFilter);
+         stream = stream.filter(k -> intSet.contains(toIntFunction.applyAsInt(k.getKey())));
       }
       return stream;
    }

--- a/core/src/main/java/org/infinispan/stream/impl/local/KeyStreamSupplier.java
+++ b/core/src/main/java/org/infinispan/stream/impl/local/KeyStreamSupplier.java
@@ -13,6 +13,7 @@ import org.infinispan.commons.util.CloseableIterator;
 import org.infinispan.commons.util.RemovableCloseableIterator;
 import org.infinispan.context.Flag;
 import org.infinispan.distribution.ch.ConsistentHash;
+import org.infinispan.distribution.ch.KeyPartitioner;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -58,7 +59,8 @@ public class KeyStreamSupplier<K, V> implements AbstractLocalCacheStream.StreamS
          }
          BitSet bitSet = new BitSet(hash.getNumSegments());
          segmentsToFilter.forEach(bitSet::set);
-         stream = stream.filter(k -> bitSet.get(hash.getSegment(k)));
+         KeyPartitioner partitioner = cache.getAdvancedCache().getComponentRegistry().getComponent(KeyPartitioner.class);
+         stream = stream.filter(k -> bitSet.get(partitioner.getSegment(k)));
       }
       return stream;
    }

--- a/core/src/main/java/org/infinispan/stream/impl/local/KeyStreamSupplier.java
+++ b/core/src/main/java/org/infinispan/stream/impl/local/KeyStreamSupplier.java
@@ -1,8 +1,8 @@
 package org.infinispan.stream.impl.local;
 
-import java.util.BitSet;
 import java.util.Set;
 import java.util.function.Supplier;
+import java.util.function.ToIntFunction;
 import java.util.stream.Stream;
 
 import org.infinispan.AdvancedCache;
@@ -10,10 +10,10 @@ import org.infinispan.Cache;
 import org.infinispan.cache.impl.AbstractDelegatingCache;
 import org.infinispan.cache.impl.EncoderCache;
 import org.infinispan.commons.util.CloseableIterator;
+import org.infinispan.commons.util.IntSet;
 import org.infinispan.commons.util.RemovableCloseableIterator;
+import org.infinispan.commons.util.SmallIntSet;
 import org.infinispan.context.Flag;
-import org.infinispan.distribution.ch.ConsistentHash;
-import org.infinispan.distribution.ch.KeyPartitioner;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -26,12 +26,12 @@ public class KeyStreamSupplier<K, V> implements AbstractLocalCacheStream.StreamS
    private static final boolean trace = log.isTraceEnabled();
 
    private final Cache<K, V> cache;
-   private final ConsistentHash hash;
+   private final ToIntFunction<Object> toIntFunction;
    private final Supplier<Stream<K>> supplier;
 
-   public KeyStreamSupplier(Cache<K, V> cache, ConsistentHash hash, Supplier<Stream<K>> supplier) {
+   public KeyStreamSupplier(Cache<K, V> cache, ToIntFunction<Object> toIntFunction, Supplier<Stream<K>> supplier) {
       this.cache = cache;
-      this.hash = hash;
+      this.toIntFunction = toIntFunction;
       this.supplier = supplier;
    }
 
@@ -53,14 +53,12 @@ public class KeyStreamSupplier<K, V> implements AbstractLocalCacheStream.StreamS
       } else {
          stream = supplier.get();
       }
-      if (segmentsToFilter != null && hash != null) {
+      if (segmentsToFilter != null && toIntFunction != null) {
          if (trace) {
             log.tracef("Applying segment filter %s", segmentsToFilter);
          }
-         BitSet bitSet = new BitSet(hash.getNumSegments());
-         segmentsToFilter.forEach(bitSet::set);
-         KeyPartitioner partitioner = cache.getAdvancedCache().getComponentRegistry().getComponent(KeyPartitioner.class);
-         stream = stream.filter(k -> bitSet.get(partitioner.getSegment(k)));
+         IntSet intSet = SmallIntSet.from(segmentsToFilter);
+         stream = stream.filter(k -> intSet.contains(toIntFunction.applyAsInt(k)));
       }
       return stream;
    }

--- a/core/src/main/java/org/infinispan/stream/impl/tx/TxClusterStreamManager.java
+++ b/core/src/main/java/org/infinispan/stream/impl/tx/TxClusterStreamManager.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
+import java.util.function.ToIntFunction;
 
 import org.infinispan.context.impl.LocalTxInvocationContext;
 import org.infinispan.distribution.ch.ConsistentHash;
@@ -25,19 +26,20 @@ import org.infinispan.util.AbstractDelegatingMap;
 public class TxClusterStreamManager<K> implements ClusterStreamManager<K> {
    private final ClusterStreamManager<K> manager;
    private final LocalTxInvocationContext ctx;
-   private final ConsistentHash hash;
+   private final ToIntFunction<Object> intFunction;
 
-   public TxClusterStreamManager(ClusterStreamManager<K> manager, LocalTxInvocationContext ctx, ConsistentHash hash) {
+   public TxClusterStreamManager(ClusterStreamManager<K> manager, LocalTxInvocationContext ctx,
+         ToIntFunction<Object> intFunction) {
       this.manager = manager;
       this.ctx = ctx;
-      this.hash = hash;
+      this.intFunction = intFunction;
    }
 
    @Override
    public <R> Object remoteStreamOperation(boolean parallelDistribution, boolean parallelStream,
                                            Set<Integer> segments, Set<K> keysToInclude, Map<Integer, Set<K>> keysToExclude, boolean includeLoader,
                                            TerminalOperation<R> operation, ResultsCallback<R> callback, Predicate<? super R> earlyTerminatePredicate) {
-      TxExcludedKeys<K> txExcludedKeys = new TxExcludedKeys<>(keysToExclude, ctx, hash);
+      TxExcludedKeys<K> txExcludedKeys = new TxExcludedKeys<>(keysToExclude, ctx, intFunction);
       return manager.remoteStreamOperation(parallelDistribution, parallelStream, segments, keysToInclude,
               txExcludedKeys, includeLoader, operation, callback, earlyTerminatePredicate);
    }
@@ -47,7 +49,7 @@ public class TxClusterStreamManager<K> implements ClusterStreamManager<K> {
                                                       Set<Integer> segments, Set<K> keysToInclude, Map<Integer, Set<K>> keysToExclude,
                                                       boolean includeLoader, TerminalOperation<R> operation, ResultsCallback<R> callback,
                                                       Predicate<? super R> earlyTerminatePredicate) {
-      TxExcludedKeys<K> txExcludedKeys = new TxExcludedKeys<>(keysToExclude, ctx, hash);
+      TxExcludedKeys<K> txExcludedKeys = new TxExcludedKeys<>(keysToExclude, ctx, intFunction);
       return manager.remoteStreamOperationRehashAware(parallelDistribution, parallelStream, segments, keysToInclude,
               txExcludedKeys, includeLoader, operation, callback, earlyTerminatePredicate);
    }
@@ -56,7 +58,7 @@ public class TxClusterStreamManager<K> implements ClusterStreamManager<K> {
    public <R> Object remoteStreamOperation(boolean parallelDistribution, boolean parallelStream,
                                            Set<Integer> segments, Set<K> keysToInclude, Map<Integer, Set<K>> keysToExclude, boolean includeLoader,
                                            KeyTrackingTerminalOperation<K, R, ?> operation, ResultsCallback<Collection<R>> callback) {
-      TxExcludedKeys<K> txExcludedKeys = new TxExcludedKeys<>(keysToExclude, ctx, hash);
+      TxExcludedKeys<K> txExcludedKeys = new TxExcludedKeys<>(keysToExclude, ctx, intFunction);
       return manager.remoteStreamOperation(parallelDistribution, parallelStream, segments, keysToInclude,
               txExcludedKeys, includeLoader, operation, callback);
    }
@@ -65,7 +67,7 @@ public class TxClusterStreamManager<K> implements ClusterStreamManager<K> {
    public <R2> Object remoteStreamOperationRehashAware(boolean parallelDistribution, boolean parallelStream,
                                                        Set<Integer> segments, Set<K> keysToInclude, Map<Integer, Set<K>> keysToExclude,
                                                        boolean includeLoader, KeyTrackingTerminalOperation<K, ?, R2> operation, ResultsCallback<Map<K, R2>> callback) {
-      TxExcludedKeys<K> txExcludedKeys = new TxExcludedKeys<>(keysToExclude, ctx, hash);
+      TxExcludedKeys<K> txExcludedKeys = new TxExcludedKeys<>(keysToExclude, ctx, intFunction);
       return manager.remoteStreamOperationRehashAware(parallelDistribution, parallelStream, segments, keysToInclude,
               txExcludedKeys, includeLoader, operation, callback);
    }
@@ -94,15 +96,15 @@ public class TxClusterStreamManager<K> implements ClusterStreamManager<K> {
       private final Map<Integer, Set<K>> map;
       private final Map<Integer, Set<K>> ctxMap;
 
-      private TxExcludedKeys(Map<Integer, Set<K>> map, LocalTxInvocationContext ctx, ConsistentHash hash) {
+      private TxExcludedKeys(Map<Integer, Set<K>> map, LocalTxInvocationContext ctx, ToIntFunction<Object> intFunction) {
          this.map = map;
-         this.ctxMap = contextToMap(ctx, hash);
+         this.ctxMap = contextToMap(ctx, intFunction);
       }
 
-      Map<Integer, Set<K>> contextToMap(LocalTxInvocationContext ctx, ConsistentHash hash) {
+      Map<Integer, Set<K>> contextToMap(LocalTxInvocationContext ctx, ToIntFunction<Object> intFunction) {
          Map<Integer, Set<K>> contextMap = new HashMap<>();
          ctx.getLookedUpEntries().forEach((k, v) -> {
-            Integer segment = hash.getSegment(k);
+            Integer segment = intFunction.applyAsInt(k);
             Set<K> innerSet = contextMap.get(segment);
             if (innerSet == null) {
                innerSet = new HashSet<K>();

--- a/core/src/main/java/org/infinispan/stream/impl/tx/TxClusterStreamManager.java
+++ b/core/src/main/java/org/infinispan/stream/impl/tx/TxClusterStreamManager.java
@@ -6,15 +6,18 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.function.IntFunction;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.function.ToIntFunction;
 
+import org.infinispan.commons.util.IntSet;
 import org.infinispan.context.impl.LocalTxInvocationContext;
-import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.stream.impl.ClusterStreamManager;
 import org.infinispan.stream.impl.KeyTrackingTerminalOperation;
 import org.infinispan.stream.impl.TerminalOperation;
+import org.infinispan.stream.impl.intops.IntermediateOperation;
 import org.infinispan.util.AbstractDelegatingMap;
 
 /**
@@ -26,12 +29,14 @@ import org.infinispan.util.AbstractDelegatingMap;
 public class TxClusterStreamManager<K> implements ClusterStreamManager<K> {
    private final ClusterStreamManager<K> manager;
    private final LocalTxInvocationContext ctx;
+   private final int maxSegments;
    private final ToIntFunction<Object> intFunction;
 
-   public TxClusterStreamManager(ClusterStreamManager<K> manager, LocalTxInvocationContext ctx,
+   public TxClusterStreamManager(ClusterStreamManager<K> manager, LocalTxInvocationContext ctx, int maxSegments,
          ToIntFunction<Object> intFunction) {
       this.manager = manager;
       this.ctx = ctx;
+      this.maxSegments = maxSegments;
       this.intFunction = intFunction;
    }
 
@@ -90,6 +95,47 @@ public class TxClusterStreamManager<K> implements ClusterStreamManager<K> {
    @Override
    public <R1> boolean receiveResponse(Object id, Address origin, boolean complete, Set<Integer> segments, R1 response) {
       return manager.receiveResponse(id, origin, complete, segments, response);
+   }
+
+   @Override
+   public <E> RemoteIteratorPublisher<E> remoteIterationPublisher(boolean parallelStream,
+         Supplier<Map.Entry<Address, IntSet>> segments, Set<K> keysToInclude, IntFunction<Set<K>> keysToExclude,
+         boolean includeLoader, Iterable<IntermediateOperation> intermediateOperations) {
+
+      if (ctx.getLookedUpEntries().isEmpty()) {
+         return manager.remoteIterationPublisher(parallelStream, segments, keysToInclude, keysToExclude, includeLoader,
+               intermediateOperations);
+      } else {
+         Set<K>[] contextSet = generateContextSet(ctx);
+         if (keysToExclude == null) {
+            return manager.remoteIterationPublisher(parallelStream, segments, keysToInclude, i -> contextSet[i], includeLoader,
+                  intermediateOperations);
+         } else {
+            return manager.remoteIterationPublisher(parallelStream, segments, keysToInclude, i -> {
+               Set<K> set = contextSet[i];
+               if (set != null) {
+                  set.addAll(keysToExclude.apply(i));
+                  return set;
+               } else {
+                  return keysToExclude.apply(i);
+               }
+            }, includeLoader, intermediateOperations);
+         }
+      }
+   }
+
+   Set<K>[] generateContextSet(LocalTxInvocationContext ctx) {
+      Set<K>[] set = new Set[maxSegments];
+      ctx.getLookedUpEntries().forEach((k, v) -> {
+         int segment = intFunction.applyAsInt(k);
+         Set<K> innerSet = set[segment];
+         if (innerSet == null) {
+            innerSet = new HashSet<>();
+            set[segment] = innerSet;
+         }
+         innerSet.add((K) k);
+      });
+      return set;
    }
 
    private static class TxExcludedKeys<K> extends AbstractDelegatingMap<Integer, Set<K>> {

--- a/core/src/main/java/org/infinispan/stream/impl/tx/TxDistributedCacheStream.java
+++ b/core/src/main/java/org/infinispan/stream/impl/tx/TxDistributedCacheStream.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.infinispan.CacheStream;
+import org.infinispan.commons.util.IntSet;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.context.impl.LocalTxInvocationContext;
 import org.infinispan.distribution.DistributionManager;
@@ -60,7 +61,7 @@ public class TxDistributedCacheStream<R> extends DistributedCacheStream<R> {
    }
 
    @Override
-   protected Supplier<Stream<CacheEntry>> supplierForSegments(ConsistentHash ch, Set<Integer> targetSegments,
+   protected Supplier<Stream<CacheEntry>> supplierForSegments(ConsistentHash ch, IntSet targetSegments,
            Set<Object> excludedKeys, boolean primaryOnly) {
       return () -> {
          Supplier<Stream<CacheEntry>> supplier = super.supplierForSegments(ch, targetSegments, excludedKeys, primaryOnly);

--- a/core/src/main/java/org/infinispan/stream/impl/tx/TxDistributedDoubleCacheStream.java
+++ b/core/src/main/java/org/infinispan/stream/impl/tx/TxDistributedDoubleCacheStream.java
@@ -5,6 +5,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.infinispan.commons.util.IntSet;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.context.impl.LocalTxInvocationContext;
 import org.infinispan.distribution.ch.ConsistentHash;
@@ -33,7 +34,7 @@ public class TxDistributedDoubleCacheStream extends DistributedDoubleCacheStream
    }
 
    @Override
-   protected Supplier<Stream<CacheEntry>> supplierForSegments(ConsistentHash ch, Set<Integer> targetSegments,
+   protected Supplier<Stream<CacheEntry>> supplierForSegments(ConsistentHash ch, IntSet targetSegments,
            Set<Object> excludedKeys, boolean primaryOnly) {
       return () -> {
          Supplier<Stream<CacheEntry>> supplier = super.supplierForSegments(ch, targetSegments, excludedKeys, primaryOnly);

--- a/core/src/main/java/org/infinispan/stream/impl/tx/TxDistributedIntCacheStream.java
+++ b/core/src/main/java/org/infinispan/stream/impl/tx/TxDistributedIntCacheStream.java
@@ -5,6 +5,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.infinispan.commons.util.IntSet;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.context.impl.LocalTxInvocationContext;
 import org.infinispan.distribution.ch.ConsistentHash;
@@ -31,7 +32,7 @@ public class TxDistributedIntCacheStream extends DistributedIntCacheStream {
    }
 
    @Override
-   protected Supplier<Stream<CacheEntry>> supplierForSegments(ConsistentHash ch, Set<Integer> targetSegments,
+   protected Supplier<Stream<CacheEntry>> supplierForSegments(ConsistentHash ch, IntSet targetSegments,
            Set<Object> excludedKeys, boolean primaryOnly) {
       return () -> {
          Supplier<Stream<CacheEntry>> supplier = super.supplierForSegments(ch, targetSegments, excludedKeys, primaryOnly);

--- a/core/src/main/java/org/infinispan/stream/impl/tx/TxDistributedLongCacheStream.java
+++ b/core/src/main/java/org/infinispan/stream/impl/tx/TxDistributedLongCacheStream.java
@@ -5,6 +5,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.infinispan.commons.util.IntSet;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.context.impl.LocalTxInvocationContext;
 import org.infinispan.distribution.ch.ConsistentHash;
@@ -33,7 +34,7 @@ public class TxDistributedLongCacheStream extends DistributedLongCacheStream {
    }
 
    @Override
-   protected Supplier<Stream<CacheEntry>> supplierForSegments(ConsistentHash ch, Set<Integer> targetSegments,
+   protected Supplier<Stream<CacheEntry>> supplierForSegments(ConsistentHash ch, IntSet targetSegments,
            Set<Object> excludedKeys, boolean primaryOnly) {
       return () -> {
          Supplier<Stream<CacheEntry>> supplier = super.supplierForSegments(ch, targetSegments, excludedKeys, primaryOnly);

--- a/core/src/main/java/org/infinispan/transaction/xa/recovery/InDoubtTxInfoImpl.java
+++ b/core/src/main/java/org/infinispan/transaction/xa/recovery/InDoubtTxInfoImpl.java
@@ -36,7 +36,7 @@ public class InDoubtTxInfoImpl implements RecoveryManager.InDoubtTxInfo {
    public InDoubtTxInfoImpl(Xid xid, long internalId, Set<Integer> status) {
       this.xid = xid;
       this.internalId = internalId;
-      this.status = new SmallIntSet(status);
+      this.status = SmallIntSet.from(status);
    }
 
    public InDoubtTxInfoImpl(Xid xid, long internalId) {

--- a/core/src/main/java/org/infinispan/util/IntSetExternalizer.java
+++ b/core/src/main/java/org/infinispan/util/IntSetExternalizer.java
@@ -1,0 +1,70 @@
+package org.infinispan.util;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.Set;
+
+import org.infinispan.commons.io.UnsignedNumeric;
+import org.infinispan.commons.marshall.AbstractExternalizer;
+import org.infinispan.commons.marshall.Ids;
+import org.infinispan.commons.util.IntSet;
+import org.infinispan.commons.util.SmallIntSet;
+import org.infinispan.commons.util.Util;
+import org.jboss.marshalling.util.IdentityIntMap;
+
+/**
+ * Externalizer to be used for IntSet implementations
+ * @author wburns
+ * @since 9.0
+ */
+public class IntSetExternalizer extends AbstractExternalizer<IntSet> {
+   private static final int RANGESET = 0;
+   private static final int SMALLINTSET = 1;
+
+   private final IdentityIntMap<Class<?>> numbers = new IdentityIntMap<Class<?>>(2);
+
+   public IntSetExternalizer() {
+      numbers.put(RangeSet.class, RANGESET);
+      numbers.put(SmallIntSet.class, SMALLINTSET);
+   }
+
+   @Override
+   public Integer getId() {
+      return Ids.INT_SET;
+   }
+
+   @Override
+   public Set<Class<? extends IntSet>> getTypeClasses() {
+      return Util.asSet(SmallIntSet.class, RangeSet.class);
+   }
+
+   @Override
+   public void writeObject(ObjectOutput output, IntSet object) throws IOException {
+      int number = numbers.get(object.getClass(), -1);
+      output.write(number);
+      switch (number) {
+         case RANGESET:
+            UnsignedNumeric.writeUnsignedInt(output, ((RangeSet) object).size);
+            break;
+         case SMALLINTSET:
+            SmallIntSet.writeTo(output, (SmallIntSet) object);
+            break;
+         default:
+            throw new UnsupportedOperationException("Unsupported number: " + number);
+      }
+   }
+
+   @Override
+   public IntSet readObject(ObjectInput input) throws IOException, ClassNotFoundException {
+      int magicNumber = input.readUnsignedByte();
+      switch (magicNumber) {
+         case RANGESET:
+            return new RangeSet(UnsignedNumeric.readUnsignedInt(input));
+         case SMALLINTSET:
+            return SmallIntSet.readFrom(input);
+         default:
+            throw new UnsupportedOperationException("Unsupported number: " + magicNumber);
+      }
+   }
+}

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/CacheNotifierImplInitialTransferDistTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/CacheNotifierImplInitialTransferDistTest.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.PrimitiveIterator;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.BrokenBarrierException;
@@ -29,6 +30,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import org.infinispan.Cache;
@@ -693,13 +695,16 @@ public class CacheNotifierImplInitialTransferDistTest extends MultipleCacheManag
                                                        withSettings().defaultAnswer(listenerAnswer));
 
             doAnswer(i -> {
-               Set<Integer> segments = i.getArgument(0);
-               log.tracef("Completed segments %s", segments);
-               if (segments.contains(segment)) {
-                  wasLastSegment.set(true);
+               Supplier<PrimitiveIterator.OfInt> segments = i.getArgument(0);
+               log.tracef("Completed segments %s", segments.get());
+               PrimitiveIterator.OfInt iter = segments.get();
+               while (iter.hasNext()) {
+                  if (iter.nextInt() == segment) {
+                     wasLastSegment.set(true);
+                  }
                }
                return listenerAnswer.answer(i);
-            }).when(mockListener).segmentCompleted(Mockito.anySet());
+            }).when(mockListener).accept(Mockito.any(Supplier.class));
 
             doAnswer(i -> {
                Object k = i.getArgument(0);

--- a/core/src/test/java/org/infinispan/partitionhandling/StreamDistPartitionHandlingTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/StreamDistPartitionHandlingTest.java
@@ -1,21 +1,21 @@
 package org.infinispan.partitionhandling;
 
-import static org.infinispan.test.Mocks.invokeAndReturnMock;
-import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.withSettings;
+import static org.mockito.Mockito.spy;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertTrue;
 import static org.testng.AssertJUnit.fail;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.infinispan.Cache;
 import org.infinispan.commons.util.CloseableIterator;
@@ -23,8 +23,9 @@ import org.infinispan.commons.util.Closeables;
 import org.infinispan.context.Flag;
 import org.infinispan.distribution.MagicKey;
 import org.infinispan.notifications.cachelistener.CacheNotifier;
-import org.infinispan.remoting.transport.Address;
-import org.infinispan.stream.impl.ClusterStreamManager;
+import org.infinispan.remoting.rpc.RpcManager;
+import org.infinispan.stream.impl.StreamIteratorRequestCommand;
+import org.infinispan.test.Mocks;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.CheckPoint;
 import org.testng.annotations.Test;
@@ -73,33 +74,33 @@ public class StreamDistPartitionHandlingTest extends BasePartitionHandlingTest {
 
    public void testUsingIteratorButPartitionOccursBeforeRetrievingRemoteValues() throws InterruptedException {
       Cache<MagicKey, String> cache0 = cache(0);
+      // Make sure we have 1 entry in each - since onEach will then be invoked once on each node
       cache0.put(new MagicKey(cache(1), cache(2)), "not-local");
       cache0.put(new MagicKey(cache(0), cache(1)), "local");
 
-      CheckPoint cp = new CheckPoint();
+      CheckPoint iteratorCP = new CheckPoint();
       // This must be before the stream is generated or else it won't see the update
-      blockStreamResponse(cp, cache0);
-      // we have to enable parallel distribution since single distribution uses the async thread to send requests and
-      // it can't complete since we are blocking the response
-      try (CloseableIterator<?> iterator = Closeables.iterator(cache0.entrySet().stream().parallelDistribution())) {
+      blockUntilRemoteNodesRespond(iteratorCP, cache0);
+      try (CloseableIterator<?> iterator = Closeables.iterator(cache0.entrySet().stream())) {
 
+         CheckPoint partitionCP = new CheckPoint();
          // Now we replace the notifier so we know when the notifier was told of the partition change so we know
          // our iterator should have been notified
-         blockNotifierPartitionStatusChanged(cp, cache0);
+         blockNotifierPartitionStatusChanged(partitionCP, cache0);
 
          // We don't want to block the notifier
-         cp.triggerForever("pre_notify_partition_released");
-         cp.triggerForever("post_notify_partition_released");
+         partitionCP.triggerForever(Mocks.BEFORE_RELEASE);
+         partitionCP.triggerForever(Mocks.AFTER_RELEASE);
 
          // Now split the cluster
          splitCluster(new int[]{0, 1}, new int[]{2, 3});
 
          // Wait until we have been notified before letting remote responses to arrive
-         assertTrue(cp.await("post_notify_partition_invoked", 10, TimeUnit.SECONDS));
+         assertTrue(partitionCP.await(Mocks.AFTER_INVOCATION, 10, TimeUnit.SECONDS));
 
          // Afterwards let all the responses come in
-         cp.triggerForever("pre_receive_response_released");
-         cp.triggerForever("post_receive_response_released");
+         iteratorCP.triggerForever(Mocks.BEFORE_RELEASE);
+         iteratorCP.triggerForever(Mocks.AFTER_RELEASE);
 
          try {
             while (iterator.hasNext()) {
@@ -112,87 +113,69 @@ public class StreamDistPartitionHandlingTest extends BasePartitionHandlingTest {
       }
    }
 
-   public void testUsingIteratorButPartitionOccursAfterRetrievingRemoteValues() throws InterruptedException {
+   public void testUsingIteratorButPartitionOccursAfterRetrievingRemoteValues() throws InterruptedException, TimeoutException, ExecutionException {
       Cache<MagicKey, String> cache0 = cache(0);
+      // Make sure we have 1 entry in each - since onEach will then be invoked once on each node
       cache0.put(new MagicKey(cache(1), cache(2)), "not-local");
       cache0.put(new MagicKey(cache(0), cache(1)), "local");
 
-      CheckPoint cp = new CheckPoint();
-      // This must be before the stream is generated or else it won't see the update
-      blockStreamResponse(cp, cache0);
-      // we have to enable parallel distribution since single distribution uses the async thread to send requests and
-      // it can't complete since we are blocking the response
-      try (CloseableIterator<?> iterator = Closeables.iterator(cache0.entrySet().stream().parallelDistribution())) {
+      CheckPoint iteratorCP = new CheckPoint();
+      // This must be before the iterator is generated or else it won't see the update
+      blockUntilRemoteNodesRespond(iteratorCP, cache0);
+      try (CloseableIterator<?> iterator = Closeables.iterator(cache0.entrySet().stream())) {
 
          // Let all the responses go first
-         cp.triggerForever("pre_receive_response_released");
-         cp.triggerForever("post_receive_response_released");
+         iteratorCP.triggerForever(Mocks.BEFORE_RELEASE);
+         iteratorCP.triggerForever(Mocks.AFTER_RELEASE);
+
+         // We have to iterate in another thread as stream iterator is requested on same thread and we would deadlock
+         Future<?> future = fork(() -> {
+            // This should complete without issue now
+            while (iterator.hasNext()) {
+               iterator.next();
+            }
+         });
 
          // Wait for all the responses to come back - we have to do this before splitting
-         assertTrue(cp.await("post_receive_response_invoked", numMembersInCluster - 1, 10, TimeUnit.SECONDS));
+         assertTrue(iteratorCP.await(Mocks.AFTER_INVOCATION, numMembersInCluster - 1, 10, TimeUnit.SECONDS));
 
+         CheckPoint partitionCP = new CheckPoint();
          // Now we replace the notifier so we know when the notifier was told of the partition change so we know
          // our iterator should have been notified
-         blockNotifierPartitionStatusChanged(cp, cache0);
+         blockNotifierPartitionStatusChanged(partitionCP, cache0);
 
          // Now split the cluster
          splitCluster(new int[]{0, 1}, new int[]{2, 3});
 
          // Now let the notification occur after all the responses are done
-         cp.triggerForever("pre_notify_partition_released");
-         cp.triggerForever("post_notify_partition_released");
+         partitionCP.triggerForever(Mocks.BEFORE_RELEASE);
+         partitionCP.triggerForever(Mocks.AFTER_RELEASE);
 
-         // This should complete without issue now
-         while (iterator.hasNext()) {
-            iterator.next();
-         }
+         future.get(10, TimeUnit.SECONDS);
       }
    }
 
    private static <K, V> CacheNotifier<K, V> blockNotifierPartitionStatusChanged(final CheckPoint checkPoint,
                                                                                  Cache<K, V> cache) {
-      CacheNotifier<K, V> notifier = TestingUtil.extractComponent(cache, CacheNotifier.class);
-      CacheNotifier mockNotifier =
-            mock(CacheNotifier.class, withSettings().defaultAnswer(i -> invokeAndReturnMock(i, notifier)));
-
-      doAnswer(invocation -> {
-         checkPoint.trigger("pre_notify_partition_invoked");
-         assertTrue(checkPoint.await("pre_notify_partition_released", 20, TimeUnit.SECONDS));
-         try {
-            return invokeAndReturnMock(invocation, notifier);
-         } finally {
-            checkPoint.trigger("post_notify_partition_invoked");
-            assertTrue(checkPoint.await("post_notify_partition_released", 20, TimeUnit.SECONDS));
-         }
-      }).when(mockNotifier).notifyPartitionStatusChanged(eq(AvailabilityMode.DEGRADED_MODE), eq(false));
-      TestingUtil.replaceComponent(cache, CacheNotifier.class, mockNotifier, true);
-      return notifier;
+      return Mocks.blockingMock(checkPoint, CacheNotifier.class, cache, (stub, m) ->
+            stub.when(m).notifyPartitionStatusChanged(eq(AvailabilityMode.DEGRADED_MODE), eq(false)));
    }
 
-   private static <K> ClusterStreamManager<K> blockStreamResponse(final CheckPoint checkPoint, Cache<K, ?> cache) {
-      ClusterStreamManager<K> manager = TestingUtil.extractComponent(cache, ClusterStreamManager.class);
-      ClusterStreamManager mockManager = mock(ClusterStreamManager.class, withSettings().defaultAnswer(i -> {
-         try {
-            return invokeAndReturnMock(i, manager);
-         } catch (InvocationTargetException e) {
-            Throwable cause = e.getCause();
-            if (cause instanceof AvailabilityException) {
-               throw cause;
-            }
-            throw e;
-         }
-      }));
-      doAnswer(invocation -> {
-         checkPoint.trigger("pre_receive_response_invoked");
-         assertTrue(checkPoint.await("pre_receive_response_released", 20, TimeUnit.SECONDS));
-         try {
-            return invokeAndReturnMock(invocation, manager);
-         } finally {
-            checkPoint.trigger("post_receive_response_invoked");
-            assertTrue(checkPoint.await("post_receive_response_released", 20, TimeUnit.SECONDS));
-         }
-      }).when(mockManager).receiveResponse(any(String.class), any(Address.class), anyBoolean(), anySet(), any());
-      TestingUtil.replaceComponent(cache, ClusterStreamManager.class, mockManager, true);
-      return manager;
+   private static RpcManager blockUntilRemoteNodesRespond(final CheckPoint checkPoint, Cache<?, ?> cache) {
+      RpcManager realManager = TestingUtil.extractComponent(cache, RpcManager.class);
+      RpcManager spy = spy(realManager);
+
+      doAnswer(invocation -> Mocks.blockingCompletableFuture(() -> {
+               try {
+                  return (CompletableFuture) invocation.callRealMethod();
+               } catch (Throwable throwable) {
+                  throw new AssertionError(throwable);
+               }
+            }, checkPoint).call()
+      ).when(spy).invokeRemotelyAsync(anyCollection(), any(StreamIteratorRequestCommand.class), any());
+
+      TestingUtil.replaceComponent(cache, RpcManager.class, spy, true);
+
+      return realManager;
    }
 }

--- a/core/src/test/java/org/infinispan/stream/DistributedStreamIteratorTest.java
+++ b/core/src/test/java/org/infinispan/stream/DistributedStreamIteratorTest.java
@@ -1,8 +1,5 @@
 package org.infinispan.stream;
 
-import static org.mockito.ArgumentMatchers.anyCollection;
-import static org.mockito.ArgumentMatchers.anySet;
-import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyLong;
@@ -32,21 +29,22 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import org.infinispan.Cache;
 import org.infinispan.CacheStream;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.container.DataContainer;
+import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.container.entries.ImmortalCacheEntry;
 import org.infinispan.context.Flag;
 import org.infinispan.distribution.MagicKey;
 import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.distribution.ch.KeyPartitioner;
-import org.infinispan.remoting.rpc.RpcManager;
-import org.infinispan.remoting.rpc.RpcOptions;
-import org.infinispan.remoting.transport.Address;
 import org.infinispan.stream.impl.ClusterStreamManager;
-import org.infinispan.stream.impl.StreamResponseCommand;
+import org.infinispan.stream.impl.IteratorHandler;
+import org.infinispan.stream.impl.LocalStreamManager;
+import org.infinispan.test.Mocks;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.CheckPoint;
 import org.mockito.AdditionalAnswers;
@@ -75,7 +73,6 @@ public class DistributedStreamIteratorTest extends BaseClusteredStreamIteratorTe
       return new MagicKey(cache);
    }
 
-   @Test
    public void verifyNodeLeavesBeforeGettingData() throws TimeoutException, InterruptedException, ExecutionException {
       Map<Object, String> values = putValueInEachCache(3);
 
@@ -83,7 +80,7 @@ public class DistributedStreamIteratorTest extends BaseClusteredStreamIteratorTe
       Cache<Object, String> cache1 = cache(1, CACHE_NAME);
 
       CheckPoint checkPoint = new CheckPoint();
-      checkPoint.triggerForever("post_send_response_released");
+      checkPoint.triggerForever(Mocks.AFTER_RELEASE);
       waitUntilSendingResponse(cache1, checkPoint);
 
       final BlockingQueue<String> returnQueue = new ArrayBlockingQueue<>(10);
@@ -97,12 +94,12 @@ public class DistributedStreamIteratorTest extends BaseClusteredStreamIteratorTe
       });
 
       // Make sure the thread is waiting for the response
-      checkPoint.awaitStrict("pre_send_response_invoked", 10, TimeUnit.SECONDS);
+      checkPoint.awaitStrict(Mocks.BEFORE_INVOCATION, 10, TimeUnit.SECONDS);
 
       // Now kill the cache - we should recover
       killMember(1, CACHE_NAME);
 
-      checkPoint.trigger("pre_send_response_released");
+      checkPoint.trigger(Mocks.BEFORE_RELEASE);
 
       future.get(10, TimeUnit.SECONDS);
 
@@ -114,7 +111,6 @@ public class DistributedStreamIteratorTest extends BaseClusteredStreamIteratorTe
    /**
     * This test is to verify proper behavior when a node dies after sending a batch to the requestor
     */
-   @Test
    public void verifyNodeLeavesAfterSendingBackSomeData() throws TimeoutException, InterruptedException, ExecutionException {
       Cache<Object, String> cache0 = cache(0, CACHE_NAME);
       Cache<Object, String> cache1 = cache(1, CACHE_NAME);
@@ -130,7 +126,7 @@ public class DistributedStreamIteratorTest extends BaseClusteredStreamIteratorTe
 
       CheckPoint checkPoint = new CheckPoint();
       // Let the first request come through fine
-      checkPoint.trigger("pre_send_response_released");
+      checkPoint.trigger(Mocks.BEFORE_RELEASE);
       waitUntilSendingResponse(cache1, checkPoint);
 
       final BlockingQueue<Map.Entry<Object, String>> returnQueue = new LinkedBlockingQueue<>();
@@ -144,7 +140,8 @@ public class DistributedStreamIteratorTest extends BaseClusteredStreamIteratorTe
       });
 
       // Now wait for them to send back first results
-      checkPoint.awaitStrict("post_send_response_invoked", 10, TimeUnit.SECONDS);
+      checkPoint.awaitStrict(Mocks.AFTER_INVOCATION, 10, TimeUnit.SECONDS);
+      checkPoint.trigger(Mocks.AFTER_RELEASE);
 
       // We should get a value now, note all values are currently residing on cache1 as primary
       Map.Entry<Object, String> value = returnQueue.poll(10, TimeUnit.SECONDS);
@@ -159,7 +156,6 @@ public class DistributedStreamIteratorTest extends BaseClusteredStreamIteratorTe
       }
    }
 
-   @Test
    public void waitUntilProcessingResults() throws TimeoutException, InterruptedException, ExecutionException {
       Cache<Object, String> cache0 = cache(0, CACHE_NAME);
       Cache<Object, String> cache1 = cache(1, CACHE_NAME);
@@ -172,8 +168,10 @@ public class DistributedStreamIteratorTest extends BaseClusteredStreamIteratorTe
       }
 
       CheckPoint checkPoint = new CheckPoint();
-      checkPoint.triggerForever("post_receive_response_released");
-      waitUntilStartOfProcessingResult(cache0, checkPoint);
+      checkPoint.triggerForever(Mocks.AFTER_RELEASE);
+
+      Mocks.blockingMock(checkPoint, ClusterStreamManager.class, cache0,
+            (stub, m) -> stub.when(m).remoteIterationPublisher(anyBoolean(), any(), any(), any(), anyBoolean(), any()));
 
       final BlockingQueue<Map.Entry<Object, String>> returnQueue = new LinkedBlockingQueue<>();
       Future<Void> future = fork(() -> {
@@ -186,10 +184,10 @@ public class DistributedStreamIteratorTest extends BaseClusteredStreamIteratorTe
       });
 
       // Now wait for them to send back first results but don't let them process
-      checkPoint.awaitStrict("pre_receive_response_invoked", 10, TimeUnit.SECONDS);
+      checkPoint.awaitStrict(Mocks.BEFORE_INVOCATION, 10, TimeUnit.SECONDS);
 
       // Now let them process the results
-      checkPoint.triggerForever("pre_receive_response_released");
+      checkPoint.triggerForever(Mocks.BEFORE_RELEASE);
 
       // Now kill the cache - we should recover and get appropriate values
       killMember(1, CACHE_NAME);
@@ -320,6 +318,54 @@ public class DistributedStreamIteratorTest extends BaseClusteredStreamIteratorTe
       assertEquals(values.size(), count);
    }
 
+   public void testIteratorClosedProperlyOnClose() {
+      Cache<Object, String> cache0 = cache(0, CACHE_NAME);
+      Cache<Object, String> cache1 = cache(1, CACHE_NAME);
+      Cache<Object, String> cache2 = cache(2, CACHE_NAME);
+
+      // We insert 2 values into caches where we aren't the owner (they have to be in same node or else iterator
+      // will finish early)
+      cache0.put(magicKey(cache1, cache2), "not-local");
+      cache0.put(magicKey(cache1, cache2), "not-local");
+      cache0.put(magicKey(cache1, cache2), "not-local");
+
+      IteratorHandler handler = TestingUtil.extractComponent(cache1, IteratorHandler.class);
+      assertEquals(0, handler.openIterators());
+
+      try (CacheStream<Map.Entry<Object, String>> stream = cache0.entrySet().stream()) {
+         Iterator<Map.Entry<Object, String>> iter = stream.distributedBatchSize(1).iterator();
+         assertTrue(iter.hasNext());
+         assertEquals(1, handler.openIterators());
+      }
+
+      // The close is done asynchronously
+      eventually(() -> 0 == handler.openIterators());
+   }
+
+   public void testIteratorClosedWhenIteratedFully() {
+      Cache<Object, String> cache0 = cache(0, CACHE_NAME);
+      Cache<Object, String> cache1 = cache(1, CACHE_NAME);
+      Cache<Object, String> cache2 = cache(2, CACHE_NAME);
+
+      // We insert 2 values into caches where we aren't the owner (they have to be in same node or else iterator
+      // will finish early)
+      cache0.put(magicKey(cache1, cache2), "not-local");
+      cache0.put(magicKey(cache1, cache2), "not-local");
+      cache0.put(magicKey(cache1, cache2), "not-local");
+
+      IteratorHandler handler = TestingUtil.extractComponent(cache1, IteratorHandler.class);
+      assertEquals(0, handler.openIterators());
+
+      Iterator<Map.Entry<Object, String>> iter = cache0.entrySet().stream().distributedBatchSize(1).iterator();
+      assertTrue(iter.hasNext());
+      assertEquals(1, handler.openIterators());
+
+      iter.forEachRemaining(ignore -> {});
+
+      // The close is done asynchronously
+      eventually(() -> 0 == handler.openIterators());
+   }
+
    protected MagicKey magicKey(Cache<Object, String> cache1, Cache<Object, String> cache2) {
       if (cache1.getCacheConfiguration().clustering().hash().numOwners() < 2) {
          return new MagicKey(cache1);
@@ -380,51 +426,9 @@ public class DistributedStreamIteratorTest extends BaseClusteredStreamIteratorTe
       return returnMap;
    }
 
-   protected RpcManager waitUntilSendingResponse(final Cache<?, ?> cache, final CheckPoint checkPoint) {
-      RpcManager rpc = TestingUtil.extractComponent(cache, RpcManager.class);
-      final Answer<Object> forwardedAnswer = AdditionalAnswers.delegatesTo(rpc);
-      RpcManager mockManager = mock(RpcManager.class, withSettings().defaultAnswer(forwardedAnswer));
-      doAnswer(invocation -> {
-         // Wait for main thread to sync up
-         checkPoint.trigger("pre_send_response_invoked");
-         // Now wait until main thread lets us through
-         checkPoint.awaitStrict("pre_send_response_released", 10, TimeUnit.SECONDS);
-
-         try {
-            return forwardedAnswer.answer(invocation);
-         } finally {
-            // Wait for main thread to sync up
-            checkPoint.trigger("post_send_response_invoked");
-            // Now wait until main thread lets us through
-            checkPoint.awaitStrict("post_send_response_released", 10, TimeUnit.SECONDS);
-         }
-      }).when(mockManager).invokeRemotely(anyCollection(), any(StreamResponseCommand.class), nullable(RpcOptions.class));
-      TestingUtil.replaceComponent(cache, RpcManager.class, mockManager, true);
-      return rpc;
-   }
-
-   protected ClusterStreamManager waitUntilStartOfProcessingResult(final Cache<?, ?> cache, final CheckPoint checkPoint) {
-      ClusterStreamManager rpc = TestingUtil.extractComponent(cache, ClusterStreamManager.class);
-      final Answer<Object> forwardedAnswer = AdditionalAnswers.delegatesTo(rpc);
-      ClusterStreamManager mockRetriever = mock(ClusterStreamManager.class, withSettings().defaultAnswer(forwardedAnswer));
-      doAnswer(invocation -> {
-         // Wait for main thread to sync up
-         checkPoint.trigger("pre_receive_response_invoked");
-         // Now wait until main thread lets us through
-         checkPoint.awaitStrict("pre_receive_response_released", 10, TimeUnit.SECONDS);
-
-         try {
-            return forwardedAnswer.answer(invocation);
-         } finally {
-            // Wait for main thread to sync up
-            checkPoint.trigger("post_receive_response_invoked");
-            // Now wait until main thread lets us through
-            checkPoint.awaitStrict("post_receive_response_released", 10, TimeUnit.SECONDS);
-         }
-      }).when(mockRetriever).receiveResponse(any(String.class), any(Address.class), anyBoolean(), anySet(),
-              any());
-      TestingUtil.replaceComponent(cache, ClusterStreamManager.class, mockRetriever, true);
-      return rpc;
+   protected <K> LocalStreamManager<K> waitUntilSendingResponse(final Cache<?, ?> cache, final CheckPoint checkPoint) {
+      return Mocks.blockingMock(checkPoint, LocalStreamManager.class, cache,
+            (stub, m) -> stub.when(m).startIterator(any(), any(), any(), any(), any(), anyBoolean(), any(), anyLong()));
    }
 
    protected DataContainer waitUntilDataContainerWillBeIteratedOn(final Cache<?, ?> cache, final CheckPoint checkPoint) {

--- a/core/src/test/java/org/infinispan/test/Mocks.java
+++ b/core/src/test/java/org/infinispan/test/Mocks.java
@@ -1,8 +1,25 @@
 package org.infinispan.test;
 
-import java.lang.reflect.InvocationTargetException;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
+import static org.testng.AssertJUnit.assertTrue;
 
+import java.lang.reflect.InvocationTargetException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.infinispan.Cache;
+import org.infinispan.test.fwk.CheckPoint;
+import org.mockito.AdditionalAnswers;
 import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.mockito.stubbing.Stubber;
 
 /**
  * Utility methods for dealing with Mockito mocks.
@@ -11,15 +28,144 @@ import org.mockito.invocation.InvocationOnMock;
  * @since 9.0
  */
 public class Mocks {
+   private Mocks() { }
    /**
     * Delegates a Mockito invocation to a target object, and returns the mock instead of the target object.
     *
     * Useful when {@code Mockito.spy(object)} doesn't work and the mocked class has a fluent interface.
     */
-   public static <T> Object invokeAndReturnMock(InvocationOnMock i, T target)
+   public static <T, R> R invokeAndReturnMock(InvocationOnMock i, T target)
          throws IllegalAccessException, InvocationTargetException {
       Object returnValue = i.getMethod().invoke(target, i.getArguments());
       // If necessary, replace the return value with the mock
-      return (returnValue == target) ? i.getMock() : returnValue;
+      return (returnValue == target) ? (R) i.getMock() : (R) returnValue;
+   }
+
+   /**
+    * Checkpoint name that is triggered to tell the test that the code has reached a spot just before invocation. This
+    * thread will not proceed with the invocation until {@link Mocks#BEFORE_RELEASE} is released.
+    */
+   public static final String BEFORE_INVOCATION = "pre_invoked";
+
+   /**
+    * Checkpoint name that this code waits on before the invocation until the test triggers it. This will require
+    * triggering per invocation if there are more than one.
+    */
+   public static final String BEFORE_RELEASE = "pre_released";
+
+   /**
+    * Checkpoint name that is triggered to tell the test that the code has reached a spot just after invocation. This
+    * thread will not proceed after the invocation until {@link Mocks#AFTER_RELEASE} is released.
+    */
+   public static final String AFTER_INVOCATION = "post_invoked";
+
+   /**
+    * Checkpoint name that this code waits on after the invocation until the test triggers it. This will require
+    * triggering per invocation if there are more than one.
+    */
+   public static final String AFTER_RELEASE = "post_released";
+
+   /**
+    * Helper that provides the ability to replace a component from the cache and automatically mocks around it, returning
+    * the same results as the original object. The provided stub will provide blocking when the mock uses this
+    * <pre>
+    *    {@code (stubber, mock) -> stubber.when(mock).methodToBlock(); }
+    * </pre>The caller can then
+    * control how the blocking occurs as the mock will do the following
+    *
+    * <pre> {@code
+    * checkpoint.trigger(BEFORE_INVOCATION);
+    * checkpoint.await(BEFORE_RELEASE);
+    *  ... do actual invocation ...
+    * checkpoint.trigger(AFTER_INVOCATION);
+    * checkpoint.await(AFTER_RELEASE);
+    * return result;
+    * }
+    * </pre>
+    *
+    * The user must release the BEFORE_RELEASE and AFTER_RELEASE checkpoints or else these will timeout and cause
+    * test instabilities.
+    * @param checkPoint the check point to use to control blocking
+    * @param classToMock the actual class from the component registry to mock
+    * @param cache the cache to replace the object on
+    * @param mockStubConsumer the consumer to invoke the method on the stubber and the actual mock
+    * @param <Mock> the class of objec to replace
+    * @return the original object to put back into the cache
+    */
+   public static <Mock> Mock blockingMock(final CheckPoint checkPoint, Class<? extends Mock> classToMock,
+         Cache<?, ?> cache, BiConsumer<? super Stubber, ? super Mock> mockStubConsumer) {
+      return blockingMock(checkPoint, classToMock, cache, AdditionalAnswers::delegatesTo, mockStubConsumer);
+   }
+
+   /**
+    * The same as {@link Mocks#blockingMock(CheckPoint, Class, Cache, BiConsumer)} except the user can also modify
+    * how the default answers are produced.
+    * @param checkPoint the check point to use to control blocking
+    * @param classToMock the actual class from the component registry to mock
+    * @param cache the cache to replace the object on
+    * @param answerFunction the function to map the real object to an answer
+    * @param mockStubConsumer the consumer to invoke the method on the stubber and the actual mock
+    * @param <Mock> the class of objec to replace
+    * @return the original object to put back into the cache
+    */
+   public static <Mock> Mock blockingMock(final CheckPoint checkPoint, Class<? extends Mock> classToMock,
+         Cache<?, ?> cache, Function<? super Mock, Answer> answerFunction, BiConsumer<? super Stubber, ? super Mock> mockStubConsumer) {
+      Mock realObject = TestingUtil.extractComponent(cache, classToMock);
+      Answer forwardedAnswer = answerFunction.apply(realObject);
+      Mock mock = mock(classToMock, forwardedAnswer);
+      mockStubConsumer.accept(doAnswer(blockingAnswer(forwardedAnswer, checkPoint)), mock);
+      TestingUtil.replaceComponent(cache, classToMock, mock, true);
+      return realObject;
+   }
+
+   /**
+    * Allows for decorating an existing answer to apply before and after invocation and release checkpoints as
+    * described in {@link Mocks#blockingMock(CheckPoint, Class, Cache, BiConsumer)}.
+    * @param answer the answer to decorate with a blocking one
+    * @param checkPoint the checkpoint to register with
+    * @param <T> the result type of the answer
+    * @return the new blocking answer
+    */
+   public static <T> Answer<T> blockingAnswer(Answer<T> answer, CheckPoint checkPoint) {
+      return invocation -> {
+         checkPoint.trigger(BEFORE_INVOCATION);
+         assertTrue(checkPoint.await(BEFORE_RELEASE, 20, TimeUnit.SECONDS));
+         try {
+            return answer.answer(invocation);
+         } finally {
+            checkPoint.trigger(AFTER_INVOCATION);
+            assertTrue(checkPoint.await(AFTER_RELEASE, 20, TimeUnit.SECONDS));
+         }
+      };
+   }
+
+   /**
+    * Blocks before creation of the completable future and then subsequently blocks after the completable future
+    * is completed. Uses the same checkpoint names as {@link Mocks#blockingMock(CheckPoint, Class, Cache, BiConsumer)}.
+    * Note this method returns another Callable as we may not want to always block the invoking thread.
+    * @param completableFutureCallable callable to invoke between blocking
+    * @param checkPoint the checkpoint to use
+    * @param <V> the answer from the future
+    * @return a callable that will block
+    */
+   public static <V> Callable<CompletableFuture<V>> blockingCompletableFuture(Callable<CompletableFuture<V>> completableFutureCallable,
+         CheckPoint checkPoint) {
+      return () -> {
+         checkPoint.trigger(BEFORE_INVOCATION);
+         try {
+            assertTrue(checkPoint.await(BEFORE_RELEASE, 20, TimeUnit.SECONDS));
+         } catch (InterruptedException e) {
+            throw new AssertionError(e);
+         }
+         CompletableFuture<V> completableFuture = completableFutureCallable.call();
+         return completableFuture.whenComplete((v, t) -> {
+            checkPoint.trigger(AFTER_INVOCATION);
+            try {
+               assertTrue(checkPoint.await(AFTER_RELEASE, 20, TimeUnit.SECONDS));
+            } catch (InterruptedException e) {
+               throw new AssertionError(e);
+            }
+         });
+      };
    }
 }

--- a/core/src/test/java/org/infinispan/test/TestingUtil.java
+++ b/core/src/test/java/org/infinispan/test/TestingUtil.java
@@ -1142,7 +1142,7 @@ public class TestingUtil {
     *
     * @return the original component that was replaced
     */
-   public static <T> T replaceComponent(Cache<?, ?> cache, Class<T> componentType, T replacementComponent, boolean rewire) {
+   public static <T> T replaceComponent(Cache<?, ?> cache, Class<? extends T> componentType, T replacementComponent, boolean rewire) {
       ComponentRegistry cr = extractComponentRegistry(cache);
       T old = cr.getComponent(componentType);
       cr.registerComponent(replacementComponent, componentType);
@@ -1160,7 +1160,7 @@ public class TestingUtil {
     *
     * @return the original component that was replaced
     */
-   public static <T> T replaceComponent(CacheContainer cacheContainer, Class<T> componentType, T replacementComponent, boolean rewire) {
+   public static <T> T replaceComponent(CacheContainer cacheContainer, Class<? extends T> componentType, T replacementComponent, boolean rewire) {
       GlobalComponentRegistry cr = extractGlobalComponentRegistry(cacheContainer);
       T old = cr.getComponent(componentType);
       cr.registerComponent(replacementComponent, componentType);

--- a/core/src/test/java/org/infinispan/util/mocks/ControlledCommandFactory.java
+++ b/core/src/test/java/org/infinispan/util/mocks/ControlledCommandFactory.java
@@ -74,6 +74,7 @@ import org.infinispan.commands.write.RemoveCommand;
 import org.infinispan.commands.write.RemoveExpiredCommand;
 import org.infinispan.commands.write.ReplaceCommand;
 import org.infinispan.commands.write.WriteCommand;
+import org.infinispan.commons.util.IntSet;
 import org.infinispan.functional.EntryView;
 import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.functional.impl.Params;
@@ -83,8 +84,12 @@ import org.infinispan.remoting.transport.Address;
 import org.infinispan.statetransfer.StateChunk;
 import org.infinispan.statetransfer.StateRequestCommand;
 import org.infinispan.statetransfer.StateResponseCommand;
+import org.infinispan.stream.impl.StreamIteratorCloseCommand;
+import org.infinispan.stream.impl.StreamIteratorNextCommand;
+import org.infinispan.stream.impl.StreamIteratorRequestCommand;
 import org.infinispan.stream.impl.StreamRequestCommand;
 import org.infinispan.stream.impl.StreamResponseCommand;
+import org.infinispan.stream.impl.intops.IntermediateOperation;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.transaction.xa.GlobalTransaction;
 import org.infinispan.util.concurrent.ReclosableLatch;
@@ -396,6 +401,24 @@ public class ControlledCommandFactory implements CommandsFactory {
    public <R> StreamResponseCommand<R> buildStreamResponseCommand(Object identifier, boolean complete,
                                                                   Set<Integer> lostSegments, R response) {
       return actual.buildStreamResponseCommand(identifier, complete, lostSegments, response);
+   }
+
+   @Override
+   public <K> StreamIteratorRequestCommand<K> buildStreamIteratorRequestCommand(Object id, boolean parallelStream,
+         IntSet segments, Set<K> keys, Set<K> excludedKeys, boolean includeLoader,
+         Iterable<IntermediateOperation> intOps, long batchSize) {
+      return actual.buildStreamIteratorRequestCommand(id, parallelStream, segments, keys, excludedKeys, includeLoader,
+            intOps, batchSize);
+   }
+
+   @Override
+   public StreamIteratorNextCommand buildStreamIteratorNextCommand(Object id, long batchSize) {
+      return actual.buildStreamIteratorNextCommand(id, batchSize);
+   }
+
+   @Override
+   public StreamIteratorCloseCommand buildStreamIteratorCloseCommand(Object id) {
+      return actual.buildStreamIteratorCloseCommand(id);
    }
 
    @Override

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -173,6 +173,7 @@
         <version.org.jboss.naming>5.0.6.CR1</version.org.jboss.naming>
         <version.org.picketbox>4.0.20.Final</version.org.picketbox>
         <version.postgresql.driver>9.3-1101-jdbc41</version.postgresql.driver>
+        <version.rxjava>2.1.1</version.rxjava>
         <version.shrinkwrapResolver>2.2.4</version.shrinkwrapResolver>
         <version.slf4j-jboss-logging>1.1.0.Final</version.slf4j-jboss-logging>
         <version.snappy>1.0.5</version.snappy>
@@ -494,6 +495,11 @@
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-core</artifactId>
                 <version>${version.hibernate.core}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.reactivex.rxjava2</groupId>
+                <artifactId>rxjava</artifactId>
+                <version>${version.rxjava}</version>
             </dependency>
             <dependency>
                 <groupId>org.jboss.shrinkwrap.resolver</groupId>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-7865

The big new change is in ClusterStreamManager which now exposes a Publisher that will go through all available node targets one by one.

I also refactored a lot of code to utilize IntSet instead of Set<Integer> to avoid boxing if possible (this still needs work after this PR).