### PR TITLE
ISPN-8064 Clean up public API javadocs

### DIFF
--- a/cdi/common/src/main/java/org/infinispan/cdi/common/package-info.java
+++ b/cdi/common/src/main/java/org/infinispan/cdi/common/package-info.java
@@ -2,7 +2,5 @@
  * This is the Infinispan CDI module. This package contains the CDI extension implementation, the mechanism allowing
  * to inject and configure an Infinispan cache. For further details see the
  * <a href="https://docs.jboss.org/author/display/ISPN/CDI+Support">CDI Support</a> documentation.
- *
- * @public
  */
 package org.infinispan.cdi.common;

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/package-info.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/package-info.java
@@ -1,5 +1,5 @@
 /**
- * HotRod Client Configuration API
+ * Hot Rod client configuration API.
  *
  * @public
  */

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/exceptions/package-info.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/exceptions/package-info.java
@@ -1,5 +1,5 @@
 /**
- * HotRod Client Exceptions
+ * Hot Rod client exceptions.
  *
  * @public
  */

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/package-info.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/package-info.java
@@ -1,5 +1,5 @@
 /**
- * HotRod Client API
+ * Hot Rod client API.
  *
  * @public
  */

--- a/core/src/main/java/org/infinispan/distexec/package-info.java
+++ b/core/src/main/java/org/infinispan/distexec/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Distribute Executor APIs
+ * Distributed Executor APIs (deprecated)
  *
  * @public
  */

--- a/core/src/main/java/org/infinispan/expiration/package-info.java
+++ b/core/src/main/java/org/infinispan/expiration/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Classes related to entry expiration.
+ * Cache expiration.
  *
  * @public
  */

--- a/core/src/main/java/org/infinispan/manager/package-info.java
+++ b/core/src/main/java/org/infinispan/manager/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Cache manager package
+ * Cache manager API.
  *
  * @public
  */

--- a/core/src/main/java/org/infinispan/persistence/package-info.java
+++ b/core/src/main/java/org/infinispan/persistence/package-info.java
@@ -1,5 +1,5 @@
 /**
- * This package contains stores, which are used for overflow or persistence.
+ * Persistence API.
  *
  * @public
  */

--- a/core/src/main/java/org/infinispan/persistence/spi/package-info.java
+++ b/core/src/main/java/org/infinispan/persistence/spi/package-info.java
@@ -1,5 +1,5 @@
 /**
- * The Persistence SPI
+ * The Persistence SPI.
  *
  * @public
  */

--- a/core/src/main/java/org/infinispan/security/package-info.java
+++ b/core/src/main/java/org/infinispan/security/package-info.java
@@ -1,5 +1,5 @@
 /**
- * The Security API
+ * Security API.
  *
  * @public
  */

--- a/core/src/main/java/org/infinispan/stream/package-info.java
+++ b/core/src/main/java/org/infinispan/stream/package-info.java
@@ -1,6 +1,5 @@
 /**
- * This package contains various helper classes when using the {@link org.infinispan.CacheStream} or its various
- * classes.
+ * Cache stream processing.
  *
  * @public
  */

--- a/javadoc/javadoc-all/pom.xml
+++ b/javadoc/javadoc-all/pom.xml
@@ -79,12 +79,22 @@
 
       <dependency>
          <groupId>${project.groupId}</groupId>
+         <artifactId>infinispan-persistence-soft-index</artifactId>
+      </dependency>
+
+      <dependency>
+         <groupId>${project.groupId}</groupId>
          <artifactId>infinispan-cachestore-remote</artifactId>
       </dependency>
 
       <dependency>
          <groupId>${project.groupId}</groupId>
          <artifactId>infinispan-cachestore-rest</artifactId>
+      </dependency>
+
+      <dependency>
+         <groupId>${project.groupId}</groupId>
+         <artifactId>infinispan-cachestore-rocksdb</artifactId>
       </dependency>
 
       <dependency>
@@ -181,19 +191,19 @@
                         </group>
                         <group>
                            <title>Query API</title>
-                           <packages>org.infinispan.query*</packages>
+                           <packages>org.infinispan.query*:org.infinispan.objectfilter*</packages>
                         </group>
                         <group>
-                           <title>Distributed Executors and Map/Reduce API</title>
+                           <title>Distributed Executors (deprecated)</title>
                            <packages>org.infinispan.distexec*</packages>
                         </group>
                         <group>
                            <title>Hot Rod Client API</title>
-                           <packages>org.infinispan.client.hotrod*</packages>
+                           <packages>org.infinispan.client.hotrod*:org.infinispan.query.remote.client*</packages>
                         </group>
                         <group>
                            <title>Server Connectors API</title>
-                           <packages>org.infinispan.server*</packages>
+                           <packages>org.infinispan.server*:org.infinispan.rest*</packages>
                         </group>
                         <group>
                            <title>Tree API</title>
@@ -207,14 +217,14 @@
                      </dependencySourceIncludes>
                      <javadocDirectory>${basedir}/src/main/javadoc</javadocDirectory>
                      <links>
-                        <link>http://docs.oracle.com/javase/7/docs/api/</link>
-                        <link>http://docs.oracle.com/javaee/5/api/</link>
+                        <link>http://docs.oracle.com/javase/8/docs/api/</link>
+                        <link>http://docs.oracle.com/javaee/7/api/</link>
                         <link>http://docs.jboss.org/jbossmarshalling/1.3/</link>
                         <link>http://docs.jboss.org/jbosslogging/latest/</link>
                         <link>http://www.osgi.org/javadoc/r4v43/core/</link>
                         <link>http://jgroups.org/javadoc/</link>
-                        <link>http://lucene.apache.org/core/4_0_0/core/</link>
-                        <link>http://docs.jboss.org/hibernate/search/4.5/api/</link>
+                        <link>http://lucene.apache.org/core/5_5_4/core/</link>
+                        <link>http://docs.jboss.org/hibernate/search/5.8/api/</link>
                      </links>
                      <quiet>true</quiet>
                      <stylesheetfile>${basedir}/src/main/javadoc/stylesheet.css</stylesheetfile>
@@ -257,7 +267,7 @@
                         <additionalDependency>
                            <groupId>org.hibernate</groupId>
                            <artifactId>hibernate-core</artifactId>
-                           <version>4.3.8.Final</version>
+                           <version>${version.hibernate.core}</version>
                         </additionalDependency>
                         <additionalDependency>
                            <groupId>com.mchange</groupId>

--- a/javadoc/javadoc-embedded/pom.xml
+++ b/javadoc/javadoc-embedded/pom.xml
@@ -85,6 +85,16 @@
       </dependency>
 
       <dependency>
+         <groupId>${project.groupId}</groupId>
+         <artifactId>infinispan-cachestore-rocksdb</artifactId>
+      </dependency>
+
+      <dependency>
+         <groupId>${project.groupId}</groupId>
+         <artifactId>infinispan-persistence-soft-index</artifactId>
+      </dependency>
+
+      <dependency>
          <groupId>org.infinispan</groupId>
          <artifactId>infinispan-lucene-directory</artifactId>
       </dependency>
@@ -160,7 +170,7 @@
                         <artifactId>infinispan-tools</artifactId>
                         <version>${project.version}</version>
                      </docletArtifact>
-                     <doctitle>Infinispan ${project.version} API</doctitle>
+                     <doctitle>Infinispan ${project.version} Embedded API</doctitle>
 
                      <docfilessubdirs>true</docfilessubdirs>
                      <detectLinks>false</detectLinks>
@@ -176,15 +186,15 @@
                         </group>
                         <group>
                            <title>Query API</title>
-                           <packages>org.infinispan.query*</packages>
+                           <packages>org.infinispan.query*:org.infinispan.objectfilter*</packages>
                         </group>
                         <group>
-                           <title>Distributed Executors and Map/Reduce API</title>
+                           <title>Distributed Executors (deprecated)</title>
                            <packages>org.infinispan.distexec*</packages>
                         </group>
                         <group>
                            <title>Server Connectors API</title>
-                           <packages>org.infinispan.server*</packages>
+                           <packages>org.infinispan.server*:org.infinispan.rest*</packages>
                         </group>
                         <group>
                            <title>Tree API</title>
@@ -198,14 +208,14 @@
                      </dependencySourceIncludes>
                      <javadocDirectory>${basedir}/src/main/javadoc</javadocDirectory>
                      <links>
-                        <link>http://docs.oracle.com/javase/7/docs/api/</link>
-                        <link>http://docs.oracle.com/javaee/5/api/</link>
+                        <link>http://docs.oracle.com/javase/8/docs/api/</link>
+                        <link>http://docs.oracle.com/javaee/7/api/</link>
                         <link>http://docs.jboss.org/jbossmarshalling/1.3/</link>
                         <link>http://docs.jboss.org/jbosslogging/latest/</link>
                         <link>http://www.osgi.org/javadoc/r4v43/core/</link>
                         <link>http://jgroups.org/javadoc/</link>
-                        <link>http://lucene.apache.org/core/5_5_0/core/</link>
-                        <link>http://docs.jboss.org/hibernate/search/5.7/api/</link>
+                        <link>http://lucene.apache.org/core/5_5_4/core/</link>
+                        <link>http://docs.jboss.org/hibernate/search/5.8/api/</link>
                      </links>
                      <quiet>true</quiet>
                      <stylesheetfile>${basedir}/src/main/javadoc/stylesheet.css</stylesheetfile>
@@ -248,7 +258,7 @@
                         <additionalDependency>
                            <groupId>org.hibernate</groupId>
                            <artifactId>hibernate-core</artifactId>
-                           <version>4.3.8.Final</version>
+                           <version>${version.hibernate.core}</version>
                         </additionalDependency>
                         <additionalDependency>
                            <groupId>com.mchange</groupId>

--- a/javadoc/javadoc-remote/pom.xml
+++ b/javadoc/javadoc-remote/pom.xml
@@ -59,7 +59,7 @@
                         <artifactId>infinispan-tools</artifactId>
                         <version>${project.version}</version>
                      </docletArtifact>
-                     <doctitle>Infinispan ${project.version} API</doctitle>
+                     <doctitle>Infinispan ${project.version} Remote API</doctitle>
 
                      <docfilessubdirs>true</docfilessubdirs>
                      <detectLinks>false</detectLinks>
@@ -81,8 +81,8 @@
                      </dependencySourceIncludes>
                      <javadocDirectory>${basedir}/src/main/javadoc</javadocDirectory>
                      <links>
-                        <link>http://docs.oracle.com/javase/7/docs/api/</link>
-                        <link>http://docs.oracle.com/javaee/5/api/</link>
+                        <link>http://docs.oracle.com/javase/8/docs/api/</link>
+                        <link>http://docs.oracle.com/javaee/7/api/</link>
                         <link>http://docs.jboss.org/jbossmarshalling/1.3/</link>
                         <link>http://docs.jboss.org/jbosslogging/latest/</link>
                         <link>http://www.osgi.org/javadoc/r4v43/core/</link>

--- a/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/configuration/package-info.java
+++ b/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/configuration/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Configuration for {@link org.infinispan.persistence.jdbc.stringbased.JdbcStringBasedStore}, {@link org.infinispan.persistence.jdbc.binary.JdbcBinaryStore} and {@link org.infinispan.persistence.jdbc.mixed.JdbcMixedStore}
+ * Configuration for the JDBC CacheStore.
  *
  * @public
  */

--- a/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/stringbased/package-info.java
+++ b/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/stringbased/package-info.java
@@ -1,6 +1,6 @@
 /**
- * This JDBC CacheStore implementation is optimized for storing String
- * keys in the cache.  If you can guarantee that your application would only use
+ * JDBC CacheStore implementation which maps keys to strings.
+   If you can guarantee that your application would only use
  * Strings as keys, then this implementation will perform better than binary or mixed
  * implementations.
  *

--- a/persistence/jpa/src/main/java/org/infinispan/persistence/jpa/configuration/package-info.java
+++ b/persistence/jpa/src/main/java/org/infinispan/persistence/jpa/configuration/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Configuration for {@link org.infinispan.persistence.jpa.JpaStore}
+ * Configuration for {@link org.infinispan.persistence.jpa.JpaStore}.
  *
  * @public
  */

--- a/persistence/jpa/src/main/java/org/infinispan/persistence/jpa/package-info.java
+++ b/persistence/jpa/src/main/java/org/infinispan/persistence/jpa/package-info.java
@@ -1,5 +1,5 @@
 /**
- * JPA-based {@link org.infinispan.persistence.spi.AdvancedLoadWriteStore}
+ * JPA-based {@link org.infinispan.persistence.spi.AdvancedLoadWriteStore}.
  *
  * @public
  */

--- a/persistence/leveldb/src/main/java/org/infinispan/persistence/leveldb/configuration/package-info.java
+++ b/persistence/leveldb/src/main/java/org/infinispan/persistence/leveldb/configuration/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Configuration for {@link org.infinispan.persistence.leveldb.LevelDBStore}
+ * Configuration for {@link org.infinispan.persistence.leveldb.LevelDBStore}.
  *
  * @public
  */

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/package-info.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Configuration for {@link org.infinispan.persistence.remote.RemoteStore}
+ * Configuration for {@link org.infinispan.persistence.remote.RemoteStore}.
  *
  * @public
  */

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/package-info.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/package-info.java
@@ -1,5 +1,5 @@
 /**
- * HotRod-based {@link org.infinispan.persistence.spi.AdvancedLoadWriteStore}
+ * Hot Rod-based {@link org.infinispan.persistence.spi.AdvancedLoadWriteStore}.
  *
  * @public
  */

--- a/persistence/rest/src/main/java/org/infinispan/persistence/rest/configuration/package-info.java
+++ b/persistence/rest/src/main/java/org/infinispan/persistence/rest/configuration/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Configuration for {@link org.infinispan.persistence.rest.RestStore}
+ * Configuration for {@link org.infinispan.persistence.rest.RestStore}.
  *
  * @public
  */

--- a/persistence/rest/src/main/java/org/infinispan/persistence/rest/package-info.java
+++ b/persistence/rest/src/main/java/org/infinispan/persistence/rest/package-info.java
@@ -1,5 +1,5 @@
 /**
- * RESTful {@link org.infinispan.persistence.spi.AdvancedLoadWriteStore}
+ * RESTful {@link org.infinispan.persistence.spi.AdvancedLoadWriteStore}.
  *
  * @public
  */

--- a/persistence/rocksdb/src/main/java/org/infinispan/persistence/rocksdb/configuration/package-info.java
+++ b/persistence/rocksdb/src/main/java/org/infinispan/persistence/rocksdb/configuration/package-info.java
@@ -1,6 +1,6 @@
 /**
- * Configuration for {@link org.infinispan.persistence.leveldb.RocksDBStore}
+ * Configuration for {@link org.infinispan.persistence.rocksdb.RocksDBStore}.
  *
  * @public
  */
-package org.infinispan.persistence.leveldb.configuration;
+package org.infinispan.persistence.rocksdb.configuration;

--- a/persistence/rocksdb/src/main/java/org/infinispan/persistence/rocksdb/package-info.java
+++ b/persistence/rocksdb/src/main/java/org/infinispan/persistence/rocksdb/package-info.java
@@ -1,6 +1,6 @@
 /**
- * LevelDB-based {@link org.infinispan.persistence.spi.AdvancedLoadWriteStore}
+ * RocksDB-based {@link org.infinispan.persistence.spi.AdvancedLoadWriteStore}.
  *
  * @public
  */
-package org.infinispan.persistence.leveldb;
+package org.infinispan.persistence.rocksdb;

--- a/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/configuration/package-info.java
+++ b/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/configuration/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Configuration for {@link org.infinispan.persistence.sifs.SoftIndexFileStore}.
+ *
+ * @public
+ */
+package org.infinispan.persistence.sifs.configuration;

--- a/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/package-info.java
+++ b/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Soft Index {@link org.infinispan.persistence.spi.AdvancedLoadWriteStore}.
+ *
+ * @public
+ */
+package org.infinispan.persistence.sifs;

--- a/query-dsl/src/main/java/org/infinispan/query/api/continuous/package-info.java
+++ b/query-dsl/src/main/java/org/infinispan/query/api/continuous/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Continuous querying API for Infinispan.
+ * Continuous querying API.
  *
  * @author anistor@redhat.com
  * @since 8.2

--- a/query-dsl/src/main/java/org/infinispan/query/dsl/package-info.java
+++ b/query-dsl/src/main/java/org/infinispan/query/dsl/package-info.java
@@ -1,5 +1,5 @@
 /**
- * A DSL for querying an Infinispan Cache.
+ * Query DSL API.
  *
  * @author anistor@redhat.com
  * @since 6.0

--- a/query/src/main/java/org/infinispan/query/package-info.java
+++ b/query/src/main/java/org/infinispan/query/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Query API
+ * Query API.
  *
  * @public
  */

--- a/remote-query/remote-query-client/src/main/java/org/infinispan/query/remote/client/package-info.java
+++ b/remote-query/remote-query-client/src/main/java/org/infinispan/query/remote/client/package-info.java
@@ -1,4 +1,5 @@
 /**
+ * Hot Rod query API
  * @public
  */
 package org.infinispan.query.remote.client;

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/package-info.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/package-info.java
@@ -1,4 +1,6 @@
 /**
+ * Server-side remote query components.
+ *
  * @public
  */
 package org.infinispan.query.remote;

--- a/server/rest/src/main/java/org/infinispan/rest/cachemanager/package-info.java
+++ b/server/rest/src/main/java/org/infinispan/rest/cachemanager/package-info.java
@@ -1,6 +1,6 @@
 /**
  * Cache manager wrapper for REST interface.
  *
- * @public
+ * @private
  */
 package org.infinispan.rest.cachemanager;

--- a/server/rest/src/main/java/org/infinispan/rest/context/package-info.java
+++ b/server/rest/src/main/java/org/infinispan/rest/context/package-info.java
@@ -1,6 +1,6 @@
 /**
  * REST Context checker classes.
  *
- * @public
+ * @private
  */
 package org.infinispan.rest.context;

--- a/server/rest/src/main/java/org/infinispan/rest/operations/package-info.java
+++ b/server/rest/src/main/java/org/infinispan/rest/operations/package-info.java
@@ -1,6 +1,6 @@
 /**
  * REST Server Operations classes.
  *
- * @public
+ * @private
  */
 package org.infinispan.rest.operations;

--- a/tasks/scripting/src/main/java/org/infinispan/scripting/package-info.java
+++ b/tasks/scripting/src/main/java/org/infinispan/scripting/package-info.java
@@ -1,5 +1,1 @@
-/**
- * Scripting APIs
- * @public
- */
 package org.infinispan.scripting;

--- a/tree/src/main/java/org/infinispan/tree/package-info.java
+++ b/tree/src/main/java/org/infinispan/tree/package-info.java
@@ -1,5 +1,5 @@
 /**
- * This package contains the TreeCache.  For usage, see the TreeCache and
+ * TreeCache API.  For usage, see the TreeCache and
  * TreeCacheFactory classes and their javadocs.
  * <p />
  * This package is intended as a compatibility layer between JBoss Cache and Infinispan, and also


### PR DESCRIPTION
- remove @public doclet from scripting, cdi commons, rest internals, etc
- include rocskdb and soft-index in javadocs
- consistent naming of Hot Rod
- better grouping of correlated javadocs
- minor cleanups

https://issues.jboss.org/browse/ISPN-8064