### PR TITLE
ISPN-8085 Deprecate CacheEntry.isValid/setValid

### DIFF
--- a/core/src/main/java/org/infinispan/container/entries/AbstractInternalCacheEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/AbstractInternalCacheEntry.java
@@ -49,16 +49,6 @@ public abstract class AbstractInternalCacheEntry implements InternalCacheEntry {
    }
 
    @Override
-   public final void setValid(boolean valid) {
-      // no-op
-   }
-
-   @Override
-   public void setLoaded(boolean loaded) {
-      // no-op
-   }
-
-   @Override
    public void setSkipLookup(boolean skipLookup) {
       //no-op
    }
@@ -86,16 +76,6 @@ public abstract class AbstractInternalCacheEntry implements InternalCacheEntry {
    @Override
    public final boolean isEvicted() {
       return true;
-   }
-
-   @Override
-   public final boolean isValid() {
-      return true;
-   }
-
-   @Override
-   public boolean isLoaded() {
-      return false;
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/container/entries/CacheEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/CacheEntry.java
@@ -44,15 +44,20 @@ public interface CacheEntry<K, V> extends Cloneable, Map.Entry<K, V>, MetadataAw
    boolean isEvicted();
 
    /**
-    * @return true if this entry is still valid, false otherwise.
-    */
-   boolean isValid();
-
-   /**
-    * @deprecated Always returns false.
+    * @deprecated since 9.2
     */
    @Deprecated
-   boolean isLoaded();
+   default boolean isValid() {
+      throw new UnsupportedOperationException();
+   }
+
+   /**
+    * @deprecated since 8.1
+    */
+   @Deprecated
+   default boolean isLoaded() {
+      throw new UnsupportedOperationException();
+   }
 
    /**
     * Retrieves the key to this entry
@@ -142,13 +147,19 @@ public interface CacheEntry<K, V> extends Cloneable, Map.Entry<K, V>, MetadataAw
 
    void setEvicted(boolean evicted);
 
-   void setValid(boolean valid);
-
    /**
-    * @deprecated Does nothing.
+    * @deprecated since 9.2
     */
    @Deprecated
-   void setLoaded(boolean loaded);
+   default void setValid(boolean valid) {
+   }
+
+   /**
+    * @deprecated since 8.1
+    */
+   @Deprecated
+   default void setLoaded(boolean loaded) {
+   }
 
    /**
     * See {@link #skipLookup()}.

--- a/core/src/main/java/org/infinispan/container/entries/ClearCacheEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/ClearCacheEntry.java
@@ -69,26 +69,6 @@ public class ClearCacheEntry<K, V> implements CacheEntry<K, V> {
    }
 
    @Override
-   public boolean isValid() {
-      return true;
-   }
-
-   @Override
-   public void setValid(boolean valid) {
-      /*no-op*/
-   }
-
-   @Override
-   public boolean isLoaded() {
-      return false;
-   }
-
-   @Override
-   public void setLoaded(boolean loaded) {
-      /*no-op*/
-   }
-
-   @Override
    public K getKey() {
       return null;
    }

--- a/core/src/main/java/org/infinispan/container/entries/ForwardingCacheEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/ForwardingCacheEntry.java
@@ -39,16 +39,6 @@ public abstract class ForwardingCacheEntry<K, V> implements CacheEntry<K, V> {
    }
 
    @Override
-   public boolean isValid() {
-      return delegate().isValid();
-   }
-
-   @Override
-   public boolean isLoaded() {
-      return delegate().isLoaded();
-   }
-
-   @Override
    public K getKey() {
       return delegate().getKey();
    }
@@ -101,16 +91,6 @@ public abstract class ForwardingCacheEntry<K, V> implements CacheEntry<K, V> {
    @Override
    public void setEvicted(boolean evicted) {
       delegate().setEvicted(evicted);
-   }
-
-   @Override
-   public void setValid(boolean valid) {
-      delegate().setValid(valid);
-   }
-
-   @Override
-   public void setLoaded(boolean loaded) {
-      delegate().setLoaded(loaded);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/container/entries/NullCacheEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/NullCacheEntry.java
@@ -40,16 +40,6 @@ public class NullCacheEntry<K, V> implements CacheEntry<K, V> {
    }
 
    @Override
-   public boolean isValid() {
-      return false;
-   }
-
-   @Override
-   public boolean isLoaded() {
-      return false;
-   }
-
-   @Override
    public K getKey() {
       return null;
    }
@@ -101,16 +91,6 @@ public class NullCacheEntry<K, V> implements CacheEntry<K, V> {
 
    @Override
    public void setEvicted(boolean evicted) {
-      // No-op
-   }
-
-   @Override
-   public void setValid(boolean valid) {
-      // No-op
-   }
-
-   @Override
-   public void setLoaded(boolean loaded) {
       // No-op
    }
 

--- a/core/src/main/java/org/infinispan/container/entries/ReadCommittedEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/ReadCommittedEntry.java
@@ -6,7 +6,6 @@ import static org.infinispan.container.entries.ReadCommittedEntry.Flags.CREATED;
 import static org.infinispan.container.entries.ReadCommittedEntry.Flags.EVICTED;
 import static org.infinispan.container.entries.ReadCommittedEntry.Flags.EXPIRED;
 import static org.infinispan.container.entries.ReadCommittedEntry.Flags.REMOVED;
-import static org.infinispan.container.entries.ReadCommittedEntry.Flags.VALID;
 
 import org.infinispan.commons.util.Util;
 import org.infinispan.container.DataContainer;
@@ -45,7 +44,7 @@ public class ReadCommittedEntry implements MVCCEntry {
       CHANGED(1),
       CREATED(1 << 1),
       REMOVED(1 << 2),
-      VALID(1 << 3),
+      // 1 << 3 no longer used (was: VALID)
       EVICTED(1 << 4),
       EXPIRED(1 << 5),
       SKIP_LOOKUP(1 << 6),
@@ -120,8 +119,8 @@ public class ReadCommittedEntry implements MVCCEntry {
       // only do stuff if there are changes.
       if (isChanged()) {
          if (trace)
-            log.tracef("Updating entry (key=%s removed=%s valid=%s changed=%s created=%s value=%s metadata=%s)",
-                  toStr(getKey()), isRemoved(), isValid(), isChanged(), isCreated(), toStr(value), getMetadata());
+            log.tracef("Updating entry (key=%s removed=%s changed=%s created=%s value=%s metadata=%s)",
+                  toStr(getKey()), isRemoved(), isChanged(), isCreated(), toStr(value), getMetadata());
 
          if (isEvicted()) {
             container.evict(key);
@@ -172,16 +171,6 @@ public class ReadCommittedEntry implements MVCCEntry {
       Object prev = this.value;
       this.value = value;
       return prev;
-   }
-
-   @Override
-   public boolean isValid() {
-      return isFlagSet(VALID);
-   }
-
-   @Override
-   public final void setValid(boolean valid) {
-      setFlag(valid, VALID);
    }
 
    @Override
@@ -244,17 +233,6 @@ public class ReadCommittedEntry implements MVCCEntry {
       setFlag(expired, EXPIRED);
    }
 
-   @Override
-   @Deprecated
-   public boolean isLoaded() {
-      return false;
-   }
-
-   @Override
-   @Deprecated
-   public void setLoaded(boolean loaded) {
-   }
-
    final void setFlag(boolean enable, Flags flag) {
       if (enable)
          setFlag(flag);
@@ -289,7 +267,6 @@ public class ReadCommittedEntry implements MVCCEntry {
             ", isCreated=" + isCreated() +
             ", isChanged=" + isChanged() +
             ", isRemoved=" + isRemoved() +
-            ", isValid=" + isValid() +
             ", isExpired=" + isExpired() +
             ", skipLookup=" + skipLookup() +
             ", metadata=" + metadata +

--- a/core/src/main/java/org/infinispan/util/CoreImmutables.java
+++ b/core/src/main/java/org/infinispan/util/CoreImmutables.java
@@ -186,16 +186,6 @@ public class CoreImmutables extends Immutables {
       }
 
       @Override
-      public boolean isValid() {
-         return entry.isValid();
-      }
-
-      @Override
-      public boolean isLoaded() {
-         return entry.isLoaded();
-      }
-
-      @Override
       public void setCreated(boolean created) {
          throw new UnsupportedOperationException();
       }
@@ -213,16 +203,6 @@ public class CoreImmutables extends Immutables {
       @Override
       public void setEvicted(boolean evicted) {
          entry.setEvicted(evicted);
-      }
-
-      @Override
-      public void setValid(boolean valid) {
-         throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public void setLoaded(boolean loaded) {
-         throw new UnsupportedOperationException();
       }
 
       @Override

--- a/core/src/test/java/org/infinispan/test/fwk/CacheEntryDelegator.java
+++ b/core/src/test/java/org/infinispan/test/fwk/CacheEntryDelegator.java
@@ -54,16 +54,6 @@ public class CacheEntryDelegator implements CacheEntry {
    }
 
    @Override
-   public boolean isValid() {
-      return delegate.isValid();
-   }
-
-   @Override
-   public boolean isLoaded() {
-      return delegate.isLoaded();
-   }
-
-   @Override
    public Object getKey() {
       return delegate.getKey();
    }
@@ -126,16 +116,6 @@ public class CacheEntryDelegator implements CacheEntry {
    @Override
    public void setEvicted(boolean evicted) {
       delegate.setEvicted(evicted);
-   }
-
-   @Override
-   public void setValid(boolean valid) {
-      delegate.setValid(valid);
-   }
-
-   @Override
-   public void setLoaded(boolean loaded) {
-      delegate.setLoaded(loaded);
    }
 
    @Override


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-8085

* Add default implementations to isLoaded/setLoaded and removing
  existing stubs, too.