### PR TITLE
Disable SiteConsumer/ProviderTopologyChangeTests

### DIFF
--- a/core/src/test/java/org/infinispan/xsite/statetransfer/failures/SiteConsumerTopologyChangeTest.java
+++ b/core/src/test/java/org/infinispan/xsite/statetransfer/failures/SiteConsumerTopologyChangeTest.java
@@ -31,7 +31,8 @@ import org.testng.annotations.Test;
  * @author Pedro Ruivo
  * @since 7.0
  */
-@Test(groups = "xsite", testName = "xsite.statetransfer.failures.SiteConsumerTopologyChangeTest")
+//unstable: it looks like not all cases are handled properly. Needs to be revisited! ISPN-6228
+@Test(groups = "unstable_xsite", testName = "xsite.statetransfer.failures.SiteConsumerTopologyChangeTest")
 public class SiteConsumerTopologyChangeTest extends AbstractTopologyChangeTest {
 
    public SiteConsumerTopologyChangeTest() {

--- a/core/src/test/java/org/infinispan/xsite/statetransfer/failures/SiteProviderTopologyChangeTest.java
+++ b/core/src/test/java/org/infinispan/xsite/statetransfer/failures/SiteProviderTopologyChangeTest.java
@@ -34,7 +34,8 @@ import org.testng.annotations.Test;
  * @author Pedro Ruivo
  * @since 7.0
  */
-@Test(groups = "xsite", testName = "xsite.statetransfer.failures.SiteProviderTopologyChangeTest")
+//unstable: it looks like not all cases are handled properly. Needs to be revisited! ISPN-6228
+@Test(groups = "unstable_xsite", testName = "xsite.statetransfer.failures.SiteProviderTopologyChangeTest")
 public class SiteProviderTopologyChangeTest extends AbstractTopologyChangeTest {
 
    public SiteProviderTopologyChangeTest() {


### PR DESCRIPTION
* The tests are unstable and they are tracked by ISPN-6228