### PR TITLE
ISPN-8106 Upgrade checkstyle and enable the unused imports check

### DIFF
--- a/checkstyle/pom.xml
+++ b/checkstyle/pom.xml
@@ -20,7 +20,7 @@
       <dependency>
          <groupId>com.puppycrawl.tools</groupId>
          <artifactId>checkstyle</artifactId>
-         <version>6.11.2</version>
+         <version>8.1</version>
          <exclusions>
             <exclusion>
                <groupId>com.sun</groupId>

--- a/checkstyle/src/main/java/org/infinispan/checkstyle/checks/interceptors/AbstractInterceptorCheck.java
+++ b/checkstyle/src/main/java/org/infinispan/checkstyle/checks/interceptors/AbstractInterceptorCheck.java
@@ -11,13 +11,13 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import com.puppycrawl.tools.checkstyle.api.Check;
+import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 
 /**
  * Checks that if the interceptor handles one command it handles all conceptually similar ones.
  */
-public abstract class AbstractInterceptorCheck extends Check {
+public abstract class AbstractInterceptorCheck extends AbstractCheck {
    protected static Stream<DetailAST> stream(DetailAST ast, int type) {
       Stream.Builder<DetailAST> builder = Stream.builder();
       for (DetailAST child = ast.getFirstChild(); child != null; child = child.getNextSibling()) {
@@ -61,7 +61,7 @@ public abstract class AbstractInterceptorCheck extends Check {
             })) {
                // Don't report deprecated classes
                return;
-            };
+            }
          }
 
          Set<String> missingMethods = new HashSet<>(methods());

--- a/checkstyle/src/main/java/org/infinispan/checkstyle/checks/regexp/IllegalImport.java
+++ b/checkstyle/src/main/java/org/infinispan/checkstyle/checks/regexp/IllegalImport.java
@@ -1,8 +1,9 @@
 package org.infinispan.checkstyle.checks.regexp;
 
+import java.util.Arrays;
 import java.util.HashSet;
 
-import com.puppycrawl.tools.checkstyle.api.Check;
+import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -12,9 +13,9 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *
  * @author Sanne Grinovero
  */
-public class IllegalImport extends Check {
+public class IllegalImport extends AbstractCheck {
 
-   private final HashSet<String> notAllowedImports = new HashSet<String>();
+   private final HashSet<String> notAllowedImports = new HashSet<>();
    private String message = "";
 
    /**
@@ -24,9 +25,7 @@ public class IllegalImport extends Check {
     *           array of illegal packages
     */
    public void setIllegalClassnames(String[] importStatements) {
-      for (String impo : importStatements) {
-         notAllowedImports.add(impo);
-      }
+      notAllowedImports.addAll(Arrays.asList(importStatements));
    }
 
    public void setMessage(String message) {
@@ -38,6 +37,16 @@ public class IllegalImport extends Check {
    @Override
    public int[] getDefaultTokens() {
       return new int[] { TokenTypes.IMPORT, TokenTypes.STATIC_IMPORT };
+   }
+
+   @Override
+   public int[] getAcceptableTokens() {
+      return getDefaultTokens();
+   }
+
+   @Override
+   public int[] getRequiredTokens() {
+      return getDefaultTokens();
    }
 
    @Override

--- a/checkstyle/src/main/java/org/infinispan/checkstyle/filters/HeadersNoCopyrightCheck.java
+++ b/checkstyle/src/main/java/org/infinispan/checkstyle/filters/HeadersNoCopyrightCheck.java
@@ -4,6 +4,8 @@ import java.io.File;
 import java.util.List;
 
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
+import com.puppycrawl.tools.checkstyle.api.FileText;
 
 /**
  * Use a simple CheckStyle rule to make sure no copyright templates are being used:
@@ -14,8 +16,8 @@ import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
 public class HeadersNoCopyrightCheck extends AbstractFileSetCheck {
 
    @Override
-   protected void processFiltered(File aFile, List<String> aLines) {
-      final String fileName = aFile.getName();
+   protected void processFiltered(File file, FileText fileText) {
+      final String fileName = file.getName();
       if (fileName != null && !fileName.endsWith(".java")) {
          //Not a Java source file, skip it.
          return;
@@ -24,8 +26,8 @@ public class HeadersNoCopyrightCheck extends AbstractFileSetCheck {
          //package-info files don't necessarily start with "package"
          return;
       }
-      else if (!aLines.isEmpty()) {
-         final String firstLine = aLines.get(0);
+      else if (fileText.size() != 0) {
+         final String firstLine = fileText.get(0);
          if (firstLine!=null && !firstLine.startsWith("package ")) {
             log(1, "Java files should start with \''package \''. Infinispan doesn\''t use bulky copyright headers!");
          }

--- a/checkstyle/src/main/resources/checkstyle.xml
+++ b/checkstyle/src/main/resources/checkstyle.xml
@@ -17,8 +17,7 @@
         <!-- Checks for imports -->
         <module name="AvoidStarImport" />
         <module name="RedundantImport" />
-        <!-- Unfortunately unused import plugin is too buggy to be used https://github.com/checkstyle/checkstyle/issues/1004 -->
-        <!--<module name="UnusedImports" />-->
+        <module name="UnusedImports" />
 
         <!-- Checks for common coding problems -->
         <!--<module name="EqualsHashCode" />-->

--- a/cli/cli-interpreter/src/main/java/org/infinispan/cli/interpreter/statement/StatsStatement.java
+++ b/cli/cli-interpreter/src/main/java/org/infinispan/cli/interpreter/statement/StatsStatement.java
@@ -16,7 +16,6 @@ import org.infinispan.factories.components.ComponentMetadataRepo;
 import org.infinispan.factories.components.JmxAttributeMetadata;
 import org.infinispan.factories.components.ManageableComponentMetadata;
 import org.infinispan.interceptors.AsyncInterceptor;
-import org.infinispan.interceptors.base.CommandInterceptor;
 import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.util.logging.LogFactory;
 

--- a/cli/cli-interpreter/src/test/java/org/infinispan/cli/interpreter/InterpreterTest.java
+++ b/cli/cli-interpreter/src/test/java/org/infinispan/cli/interpreter/InterpreterTest.java
@@ -13,7 +13,6 @@ import org.infinispan.Cache;
 import org.infinispan.cli.interpreter.logging.Log;
 import org.infinispan.cli.interpreter.result.ResultKeys;
 import org.infinispan.cli.interpreter.statement.CacheStatement;
-import org.infinispan.commons.api.BasicCacheContainer;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.factories.GlobalComponentRegistry;

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCache.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCache.java
@@ -1,7 +1,5 @@
 package org.infinispan.client.hotrod;
 
-import java.util.Collection;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/ConfigurationChildBuilder.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/ConfigurationChildBuilder.java
@@ -1,6 +1,5 @@
 package org.infinispan.client.hotrod.configuration;
 
-import java.util.List;
 import java.util.Properties;
 
 import org.infinispan.client.hotrod.ProtocolVersion;

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/RemoteCacheImpl.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/RemoteCacheImpl.java
@@ -10,7 +10,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -19,7 +18,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 import java.util.stream.Stream;
 
 import org.infinispan.client.hotrod.CacheTopologyInfo;

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/RemoteCacheSupport.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/RemoteCacheSupport.java
@@ -2,9 +2,7 @@ package org.infinispan.client.hotrod.impl;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
-import java.util.Collection;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/GetOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/GetOperation.java
@@ -1,9 +1,7 @@
 package org.infinispan.client.hotrod.impl.operations;
 
-import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.infinispan.client.hotrod.configuration.ClientIntelligence;
 import org.infinispan.client.hotrod.configuration.Configuration;
 import org.infinispan.client.hotrod.impl.protocol.Codec;
 import org.infinispan.client.hotrod.impl.protocol.HotRodConstants;

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/GetWithVersionOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/GetWithVersionOperation.java
@@ -1,10 +1,8 @@
 package org.infinispan.client.hotrod.impl.operations;
 
-import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.infinispan.client.hotrod.VersionedValue;
-import org.infinispan.client.hotrod.configuration.ClientIntelligence;
 import org.infinispan.client.hotrod.configuration.Configuration;
 import org.infinispan.client.hotrod.impl.VersionedValueImpl;
 import org.infinispan.client.hotrod.impl.protocol.Codec;

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/ParallelHotRodOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/ParallelHotRodOperation.java
@@ -10,7 +10,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.infinispan.client.hotrod.configuration.ClientIntelligence;
 import org.infinispan.client.hotrod.configuration.Configuration;
 import org.infinispan.client.hotrod.exceptions.ParallelOperationException;
 import org.infinispan.client.hotrod.impl.protocol.Codec;

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/PutOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/PutOperation.java
@@ -3,7 +3,6 @@ package org.infinispan.client.hotrod.impl.operations;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.infinispan.client.hotrod.configuration.ClientIntelligence;
 import org.infinispan.client.hotrod.configuration.Configuration;
 import org.infinispan.client.hotrod.exceptions.InvalidResponseException;
 import org.infinispan.client.hotrod.impl.protocol.Codec;

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/RemoveIfUnmodifiedOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/RemoveIfUnmodifiedOperation.java
@@ -2,7 +2,6 @@ package org.infinispan.client.hotrod.impl.operations;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.infinispan.client.hotrod.configuration.ClientIntelligence;
 import org.infinispan.client.hotrod.configuration.Configuration;
 import org.infinispan.client.hotrod.impl.VersionedOperationResponse;
 import org.infinispan.client.hotrod.impl.protocol.Codec;

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/ReplaceIfUnmodifiedOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/ReplaceIfUnmodifiedOperation.java
@@ -3,7 +3,6 @@ package org.infinispan.client.hotrod.impl.operations;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.infinispan.client.hotrod.configuration.ClientIntelligence;
 import org.infinispan.client.hotrod.configuration.Configuration;
 import org.infinispan.client.hotrod.impl.VersionedOperationResponse;
 import org.infinispan.client.hotrod.impl.protocol.Codec;

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/RetryOnFailureOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/RetryOnFailureOperation.java
@@ -5,7 +5,6 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.infinispan.client.hotrod.configuration.ClientIntelligence;
 import org.infinispan.client.hotrod.configuration.Configuration;
 import org.infinispan.client.hotrod.exceptions.HotRodClientException;
 import org.infinispan.client.hotrod.exceptions.RemoteIllegalLifecycleStateException;

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/StatsOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/StatsOperation.java
@@ -6,7 +6,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.infinispan.client.hotrod.configuration.ClientIntelligence;
 import org.infinispan.client.hotrod.configuration.Configuration;
 import org.infinispan.client.hotrod.impl.protocol.Codec;
 import org.infinispan.client.hotrod.impl.protocol.HeaderParams;

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/logging/Log.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/logging/Log.java
@@ -7,7 +7,6 @@ import static org.jboss.logging.Logger.Level.TRACE;
 import static org.jboss.logging.Logger.Level.WARN;
 
 import java.io.IOException;
-import java.io.InvalidClassException;
 import java.lang.reflect.Method;
 import java.net.SocketAddress;
 import java.util.Collection;

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/marshall/MarshallerUtil.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/marshall/MarshallerUtil.java
@@ -3,7 +3,6 @@ package org.infinispan.client.hotrod.marshall;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InvalidClassException;
 import java.io.ObjectInputStream;
 import java.io.ObjectStreamClass;
 import java.io.ObjectStreamConstants;
@@ -11,7 +10,6 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.infinispan.client.hotrod.configuration.Configuration;
 import org.infinispan.client.hotrod.exceptions.HotRodClientException;
 import org.infinispan.client.hotrod.impl.protocol.HotRodConstants;
 import org.infinispan.client.hotrod.logging.Log;

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/configuration/ConfigurationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/configuration/ConfigurationTest.java
@@ -36,7 +36,6 @@ import static org.testng.AssertJUnit.assertTrue;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.NoSuchAlgorithmException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/EmbeddedCompatTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/EmbeddedCompatTest.java
@@ -30,7 +30,6 @@ import org.infinispan.commons.dataconversion.IdentityEncoder;
 import org.infinispan.commons.util.CloseableIterator;
 import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.Index;
-import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.filter.AbstractKeyValueFilterConverter;
 import org.infinispan.filter.KeyValueFilterConverterFactory;
 import org.infinispan.manager.EmbeddedCacheManager;

--- a/commons/src/main/java/org/infinispan/commons/util/RemovableCloseableIterator.java
+++ b/commons/src/main/java/org/infinispan/commons/util/RemovableCloseableIterator.java
@@ -1,9 +1,6 @@
 package org.infinispan.commons.util;
 
 import java.util.function.Consumer;
-import java.util.function.Function;
-
-import org.infinispan.commons.api.BasicCache;
 
 /**
  * A CloseableIterator implementation that allows for a CloseableIterator that doesn't allow remove operations to

--- a/commons/src/main/java/org/infinispan/commons/util/RemovableIterator.java
+++ b/commons/src/main/java/org/infinispan/commons/util/RemovableIterator.java
@@ -3,9 +3,6 @@ package org.infinispan.commons.util;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.function.Consumer;
-import java.util.function.Function;
-
-import org.infinispan.commons.api.BasicCache;
 
 /**
  * An Iterator implementation that allows for a Iterator that doesn't allow remove operations to

--- a/core/src/main/java/org/infinispan/Cache.java
+++ b/core/src/main/java/org/infinispan/Cache.java
@@ -1,7 +1,6 @@
 package org.infinispan;
 
 import java.util.Collection;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
@@ -315,7 +314,7 @@ public interface Cache<K, V> extends BasicCache<K, V>, BatchingCache, FilteringL
     * mentioned {@link org.infinispan.context.Flag#SKIP_CACHE_LOAD} is also configured.
     * <p/>
     * <h3>Modifying or Adding Entries</h3>
-    * An entry's value is supported to be modified by using the {@link Map.Entry#setValue(Object)} and it will update
+    * An entry's value is supported to be modified by using the {@link java.util.Map.Entry#setValue(Object)} and it will update
     * the cache as well.  Also this backing set does allow addition of a new Map.Entry(s) via the
     * {@link Set#add(Object)} or {@link Set#addAll(java.util.Collection)} methods.
     * <h3>Iterator Use</h3>

--- a/core/src/main/java/org/infinispan/cache/impl/AbstractDelegatingAdvancedCache.java
+++ b/core/src/main/java/org/infinispan/cache/impl/AbstractDelegatingAdvancedCache.java
@@ -42,7 +42,6 @@ import org.infinispan.security.AuthorizationManager;
 import org.infinispan.stats.Stats;
 import org.infinispan.topology.LocalTopologyManager;
 import org.infinispan.util.concurrent.locks.LockManager;
-import org.infinispan.util.function.SerializableBiFunction;
 
 /**
  * Similar to {@link org.infinispan.cache.impl.AbstractDelegatingCache}, but for {@link AdvancedCache}.

--- a/core/src/main/java/org/infinispan/cache/impl/CacheImpl.java
+++ b/core/src/main/java/org/infinispan/cache/impl/CacheImpl.java
@@ -9,7 +9,6 @@ import static org.infinispan.context.Flag.PUT_FOR_EXTERNAL_READ;
 import static org.infinispan.context.Flag.ZERO_LOCK_ACQUISITION_TIMEOUT;
 import static org.infinispan.context.InvocationContextFactory.UNBOUNDED;
 
-import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -94,7 +93,6 @@ import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.SurvivesRestarts;
 import org.infinispan.filter.KeyFilter;
-import org.infinispan.functional.EntryView;
 import org.infinispan.functional.impl.Params;
 import org.infinispan.interceptors.AsyncInterceptor;
 import org.infinispan.interceptors.AsyncInterceptorChain;

--- a/core/src/main/java/org/infinispan/cache/impl/DecoratedCache.java
+++ b/core/src/main/java/org/infinispan/cache/impl/DecoratedCache.java
@@ -25,7 +25,6 @@ import org.infinispan.metadata.EmbeddedMetadata;
 import org.infinispan.metadata.Metadata;
 import org.infinispan.stream.StreamMarshalling;
 import org.infinispan.stream.impl.local.ValueCacheCollection;
-import org.infinispan.util.function.SerializableBiFunction;
 
 /**
  * A decorator to a cache, which can be built with a specific set of {@link Flag}s.  This

--- a/core/src/main/java/org/infinispan/cache/impl/EncoderEntryMapper.java
+++ b/core/src/main/java/org/infinispan/cache/impl/EncoderEntryMapper.java
@@ -7,7 +7,6 @@ import java.util.Collections;
 import java.util.Set;
 
 import org.infinispan.commons.dataconversion.Encoder;
-import org.infinispan.commons.dataconversion.EncodingUtils;
 import org.infinispan.commons.dataconversion.Wrapper;
 import org.infinispan.commons.marshall.AdvancedExternalizer;
 import org.infinispan.commons.marshall.Ids;

--- a/core/src/main/java/org/infinispan/cache/impl/EncoderValueMapper.java
+++ b/core/src/main/java/org/infinispan/cache/impl/EncoderValueMapper.java
@@ -9,7 +9,6 @@ import java.util.Collections;
 import java.util.Set;
 
 import org.infinispan.commons.dataconversion.Encoder;
-import org.infinispan.commons.dataconversion.EncodingUtils;
 import org.infinispan.commons.dataconversion.Wrapper;
 import org.infinispan.commons.marshall.AdvancedExternalizer;
 import org.infinispan.commons.marshall.Ids;

--- a/core/src/main/java/org/infinispan/commands/tx/totalorder/TotalOrderCommitCommand.java
+++ b/core/src/main/java/org/infinispan/commands/tx/totalorder/TotalOrderCommitCommand.java
@@ -1,7 +1,6 @@
 package org.infinispan.commands.tx.totalorder;
 
 import org.infinispan.commands.tx.CommitCommand;
-import org.infinispan.transaction.impl.RemoteTransaction;
 import org.infinispan.transaction.xa.GlobalTransaction;
 import org.infinispan.util.ByteString;
 import org.infinispan.util.logging.Log;

--- a/core/src/main/java/org/infinispan/commands/tx/totalorder/TotalOrderRollbackCommand.java
+++ b/core/src/main/java/org/infinispan/commands/tx/totalorder/TotalOrderRollbackCommand.java
@@ -1,7 +1,6 @@
 package org.infinispan.commands.tx.totalorder;
 
 import org.infinispan.commands.tx.RollbackCommand;
-import org.infinispan.transaction.impl.RemoteTransaction;
 import org.infinispan.transaction.xa.GlobalTransaction;
 import org.infinispan.util.ByteString;
 import org.infinispan.util.logging.Log;

--- a/core/src/main/java/org/infinispan/commands/tx/totalorder/TotalOrderVersionedCommitCommand.java
+++ b/core/src/main/java/org/infinispan/commands/tx/totalorder/TotalOrderVersionedCommitCommand.java
@@ -1,7 +1,6 @@
 package org.infinispan.commands.tx.totalorder;
 
 import org.infinispan.commands.tx.VersionedCommitCommand;
-import org.infinispan.transaction.impl.RemoteTransaction;
 import org.infinispan.transaction.xa.GlobalTransaction;
 import org.infinispan.util.ByteString;
 import org.infinispan.util.logging.Log;

--- a/core/src/main/java/org/infinispan/distribution/impl/L1ManagerImpl.java
+++ b/core/src/main/java/org/infinispan/distribution/impl/L1ManagerImpl.java
@@ -6,7 +6,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;

--- a/core/src/main/java/org/infinispan/interceptors/distribution/DistributionBulkInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/DistributionBulkInterceptor.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import java.util.Spliterator;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.infinispan.AdvancedCache;

--- a/core/src/main/java/org/infinispan/interceptors/distribution/TxDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/TxDistributionInterceptor.java
@@ -1,7 +1,5 @@
 package org.infinispan.interceptors.distribution;
 
-import static java.lang.String.format;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;

--- a/core/src/main/java/org/infinispan/interceptors/impl/TxInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/TxInterceptor.java
@@ -69,7 +69,6 @@ import org.infinispan.jmx.annotations.ManagedOperation;
 import org.infinispan.jmx.annotations.MeasurementType;
 import org.infinispan.partitionhandling.impl.PartitionHandlingManager;
 import org.infinispan.remoting.rpc.RpcManager;
-import org.infinispan.remoting.transport.Address;
 import org.infinispan.statetransfer.OutdatedTopologyException;
 import org.infinispan.stream.impl.interceptor.AbstractDelegatingEntryCacheSet;
 import org.infinispan.stream.impl.interceptor.AbstractDelegatingKeyCacheSet;

--- a/core/src/main/java/org/infinispan/persistence/manager/OrderedUpdatesManagerImpl.java
+++ b/core/src/main/java/org/infinispan/persistence/manager/OrderedUpdatesManagerImpl.java
@@ -16,8 +16,6 @@ import org.infinispan.distribution.DistributionManager;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.metadata.Metadata;
 import org.infinispan.util.concurrent.CompletableFutures;
-import org.infinispan.util.logging.Log;
-import org.infinispan.util.logging.LogFactory;
 
 public class OrderedUpdatesManagerImpl implements OrderedUpdatesManager {
    private DataContainer<Object, Object> dataContainer;

--- a/core/src/main/java/org/infinispan/stream/impl/RemovableIterator.java
+++ b/core/src/main/java/org/infinispan/stream/impl/RemovableIterator.java
@@ -1,7 +1,6 @@
 package org.infinispan.stream.impl;
 
 import java.util.Iterator;
-import java.util.NoSuchElementException;
 import java.util.function.Function;
 
 import org.infinispan.Cache;

--- a/core/src/test/java/org/infinispan/commands/GetAllCacheNotFoundResponseTest.java
+++ b/core/src/test/java/org/infinispan/commands/GetAllCacheNotFoundResponseTest.java
@@ -17,7 +17,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import org.infinispan.commands.remote.ClusteredGetAllCommand;
-import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.container.entries.ImmortalCacheValue;

--- a/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/InfinispanRegionFactory.java
+++ b/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/InfinispanRegionFactory.java
@@ -17,7 +17,6 @@ import java.util.Properties;
 import java.util.function.Consumer;
 
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
-import org.hibernate.MultiTenancyStrategy;
 import org.hibernate.boot.registry.selector.spi.StrategySelector;
 import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.cache.CacheException;

--- a/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/access/NonStrictAccessDelegate.java
+++ b/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/access/NonStrictAccessDelegate.java
@@ -7,7 +7,6 @@
 package org.infinispan.hibernate.cache.access;
 
 import java.util.Comparator;
-import java.util.concurrent.TimeUnit;
 
 import org.hibernate.cache.CacheException;
 import org.infinispan.hibernate.cache.impl.BaseTransactionalDataRegion;

--- a/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/access/NonTxInvalidationInterceptor.java
+++ b/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/access/NonTxInvalidationInterceptor.java
@@ -27,8 +27,6 @@ import org.infinispan.util.concurrent.locks.RemoteLockCommand;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
-import java.util.Collections;
-
 /**
  * This interceptor should completely replace default InvalidationInterceptor.
  * We need to send custom invalidation commands with transaction identifier (as the invalidation)

--- a/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/access/NonTxPutFromLoadInterceptor.java
+++ b/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/access/NonTxPutFromLoadInterceptor.java
@@ -11,16 +11,11 @@ import org.infinispan.hibernate.cache.util.CacheCommandInitializer;
 import org.infinispan.hibernate.cache.util.EndInvalidationCommand;
 
 import org.infinispan.hibernate.cache.util.InfinispanMessageLogger;
-import org.infinispan.commands.CommandsFactory;
 import org.infinispan.commands.write.InvalidateCommand;
-import org.infinispan.commands.write.PutKeyValueCommand;
-import org.infinispan.commands.write.RemoveCommand;
-import org.infinispan.context.Flag;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
 import org.infinispan.interceptors.BaseCustomAsyncInterceptor;
-import org.infinispan.interceptors.base.BaseCustomInterceptor;
 import org.infinispan.remoting.inboundhandler.DeliverOrder;
 import org.infinispan.remoting.rpc.ResponseMode;
 import org.infinispan.remoting.rpc.RpcManager;

--- a/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/access/PutFromLoadValidator.java
+++ b/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/access/PutFromLoadValidator.java
@@ -13,7 +13,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -31,7 +30,6 @@ import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.interceptors.AsyncInterceptor;
 import org.infinispan.interceptors.AsyncInterceptorChain;
-import org.infinispan.interceptors.base.CommandInterceptor;
 import org.infinispan.interceptors.impl.EntryWrappingInterceptor;
 import org.infinispan.interceptors.impl.InvalidationInterceptor;
 import org.infinispan.manager.EmbeddedCacheManager;

--- a/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/access/TombstoneCallInterceptor.java
+++ b/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/access/TombstoneCallInterceptor.java
@@ -16,7 +16,6 @@ import org.infinispan.commands.write.PutKeyValueCommand;
 import org.infinispan.commands.write.ValueMatcher;
 import org.infinispan.commons.logging.Log;
 import org.infinispan.commons.logging.LogFactory;
-import org.infinispan.commons.util.CloseableIterable;
 import org.infinispan.commons.util.CloseableIterator;
 import org.infinispan.commons.util.Closeables;
 import org.infinispan.container.entries.CacheEntry;
@@ -30,7 +29,6 @@ import org.infinispan.interceptors.DDAsyncInterceptor;
 import org.infinispan.metadata.EmbeddedMetadata;
 import org.infinispan.metadata.Metadata;
 
-import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;

--- a/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/access/TxPutFromLoadInterceptor.java
+++ b/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/access/TxPutFromLoadInterceptor.java
@@ -8,9 +8,7 @@ package org.infinispan.hibernate.cache.access;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import org.infinispan.hibernate.cache.util.CacheCommandInitializer;
 import org.infinispan.hibernate.cache.util.EndInvalidationCommand;

--- a/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/impl/BaseTransactionalDataRegion.java
+++ b/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/impl/BaseTransactionalDataRegion.java
@@ -40,7 +40,6 @@ import org.infinispan.expiration.impl.ExpirationManagerImpl;
 import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.filter.KeyValueFilter;
 import org.infinispan.interceptors.AsyncInterceptorChain;
-import org.infinispan.interceptors.base.CommandInterceptor;
 import org.infinispan.interceptors.distribution.NonTxDistributionInterceptor;
 import org.infinispan.interceptors.distribution.TriangleDistributionInterceptor;
 import org.infinispan.interceptors.impl.CallInterceptor;
@@ -49,8 +48,6 @@ import org.infinispan.interceptors.locking.NonTransactionalLockingInterceptor;
 
 import javax.transaction.TransactionManager;
 
-import java.lang.reflect.Field;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 

--- a/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/util/BeginInvalidationCommand.java
+++ b/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/util/BeginInvalidationCommand.java
@@ -8,7 +8,6 @@ package org.infinispan.hibernate.cache.util;
 
 import org.infinispan.commands.CommandInvocationId;
 import org.infinispan.commands.write.InvalidateCommand;
-import org.infinispan.context.Flag;
 import org.infinispan.notifications.cachelistener.CacheNotifier;
 
 import java.io.IOException;
@@ -16,7 +15,6 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Arrays;
 import java.util.Objects;
-import java.util.Set;
 
 /**
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;

--- a/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/util/CacheCommandInitializer.java
+++ b/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/util/CacheCommandInitializer.java
@@ -11,13 +11,11 @@ import org.infinispan.commands.CommandInvocationId;
 import org.infinispan.commands.ReplicableCommand;
 import org.infinispan.commands.module.ModuleCommandInitializer;
 import org.infinispan.configuration.cache.Configuration;
-import org.infinispan.context.Flag;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.interceptors.locking.ClusteringDependentLogic;
 import org.infinispan.notifications.cachelistener.CacheNotifier;
 import org.infinispan.util.ByteString;
 
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**

--- a/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/collection/CollectionRegionAccessExtraAPITest.java
+++ b/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/collection/CollectionRegionAccessExtraAPITest.java
@@ -8,10 +8,6 @@ package org.infinispan.test.hibernate.cache.collection;
 
 import org.hibernate.cache.spi.access.CollectionRegionAccessStrategy;
 import org.infinispan.test.hibernate.cache.AbstractExtraAPITest;
-import org.infinispan.test.hibernate.cache.util.TestInfinispanRegionFactory;
-
-import static org.junit.Assert.assertNull;
-import static org.mockito.Mockito.mock;
 
 /**
  * @author Galder Zamarreño

--- a/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/functional/NoTenancyTest.java
+++ b/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/functional/NoTenancyTest.java
@@ -1,7 +1,6 @@
 package org.infinispan.test.hibernate.cache.functional;
 
 import org.infinispan.hibernate.cache.entity.EntityRegionImpl;
-import org.infinispan.hibernate.cache.util.Caches;
 import org.infinispan.test.hibernate.cache.functional.entities.Item;
 import org.infinispan.AdvancedCache;
 import org.infinispan.commons.util.CloseableIterator;

--- a/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/functional/SingleNodeTest.java
+++ b/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/functional/SingleNodeTest.java
@@ -13,7 +13,6 @@ import java.util.concurrent.Callable;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 
 /**
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;

--- a/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/util/IspnKarafOptions.java
+++ b/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/util/IspnKarafOptions.java
@@ -32,7 +32,6 @@ import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.karaf.options.KarafDistributionConfigurationConsoleOption;
 import org.ops4j.pax.exam.karaf.options.LogLevelOption.LogLevel;
 import org.ops4j.pax.exam.options.AbstractUrlProvisionOption;
-import org.ops4j.pax.exam.options.MavenUrlReference;
 import org.ops4j.pax.exam.options.UrlProvisionOption;
 import org.ops4j.pax.exam.options.WrappedUrlProvisionOption;
 

--- a/integrationtests/wildfly-modules/src/test/java/org/infinispan/test/integration/as/InfinispanModulesStoreJdbcIT.java
+++ b/integrationtests/wildfly-modules/src/test/java/org/infinispan/test/integration/as/InfinispanModulesStoreJdbcIT.java
@@ -7,11 +7,8 @@ import org.junit.runner.RunWith;
 
 import org.infinispan.Cache;
 import org.infinispan.Version;
-import org.infinispan.configuration.cache.ConfigurationBuilder;
-import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.manager.EmbeddedCacheManager;
-import org.infinispan.persistence.jdbc.configuration.JdbcStringBasedStoreConfigurationBuilder;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;

--- a/integrationtests/wildfly-modules/src/test/java/org/infinispan/test/integration/as/cdi/DuplicatedDomainsCdiIT.java
+++ b/integrationtests/wildfly-modules/src/test/java/org/infinispan/test/integration/as/cdi/DuplicatedDomainsCdiIT.java
@@ -14,7 +14,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 import org.jboss.shrinkwrap.resolver.api.maven.PomEquippedResolveStage;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 

--- a/jcache/remote/src/main/java/org/infinispan/jcache/remote/RemoteCacheWrapper.java
+++ b/jcache/remote/src/main/java/org/infinispan/jcache/remote/RemoteCacheWrapper.java
@@ -1,8 +1,5 @@
 package org.infinispan.jcache.remote;
 
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;

--- a/lucene/directory-provider/src/main/java/org/infinispan/hibernate/search/impl/DefaultCacheManagerService.java
+++ b/lucene/directory-provider/src/main/java/org/infinispan/hibernate/search/impl/DefaultCacheManagerService.java
@@ -14,7 +14,6 @@ import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.spi.BuildContext;
 import org.hibernate.search.util.configuration.impl.ConfigurationParseHelper;
 
-import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.configuration.global.SerializationConfigurationBuilder;
 import org.infinispan.configuration.parsing.ConfigurationBuilderHolder;
 import org.infinispan.hibernate.search.logging.Log;

--- a/lucene/directory-provider/src/test/java/org/infinispan/hibernate/search/sharedIndex/SharedIndexTest.java
+++ b/lucene/directory-provider/src/test/java/org/infinispan/hibernate/search/sharedIndex/SharedIndexTest.java
@@ -4,7 +4,6 @@ import static org.infinispan.hibernate.search.ClusterTestHelper.createClusterNod
 import static org.infinispan.hibernate.search.ClusterTestHelper.waitMembersCount;
 import static org.junit.Assert.assertEquals;
 
-import java.util.HashSet;
 import java.util.List;
 
 import org.apache.lucene.search.Query;
@@ -20,8 +19,6 @@ import org.hibernate.search.spi.impl.IndexedTypeSets;
 import org.hibernate.search.spi.impl.PojoIndexedTypeIdentifier;
 import org.hibernate.search.test.util.FullTextSessionBuilder;
 import org.infinispan.hibernate.search.ClusterSharedConnectionProvider;
-import org.infinispan.hibernate.search.ClusterTestHelper;
-import org.infinispan.hibernate.search.SimpleEmail;
 import org.infinispan.hibernate.search.ClusterTestHelper.ExclusiveIndexUse;
 import org.infinispan.hibernate.search.ClusterTestHelper.IndexingFlushMode;
 import org.infinispan.hibernate.search.spi.InfinispanDirectoryProvider;

--- a/lucene/lucene-directory/src/test/java/org/infinispan/lucene/DirectoryOnMultipleCachesTest.java
+++ b/lucene/lucene-directory/src/test/java/org/infinispan/lucene/DirectoryOnMultipleCachesTest.java
@@ -14,7 +14,6 @@ import org.infinispan.Cache;
 import org.infinispan.lucene.directory.DirectoryBuilder;
 import org.infinispan.lucene.impl.FileListCacheValue;
 import org.infinispan.lucene.testutils.TestSegmentReadLocker;
-import org.infinispan.manager.CacheContainer;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.test.TestingUtil;

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -114,6 +114,8 @@
         <version.avro>1.7.6</version.avro>
         <version.c3p0>0.9.5-pre8</version.c3p0>
         <version.c3p0_dep.mchange-commons-java>0.2.7</version.c3p0_dep.mchange-commons-java>
+        <version.checkstyle>8.1</version.checkstyle>
+        <version.checkstyle.maven-plugin>2.17</version.checkstyle.maven-plugin>
         <version.com.intellij.forms_rt>6.0.5</version.com.intellij.forms_rt>
         <version.commons.compress>1.4</version.commons.compress>
         <version.commons.codec>1.4</version.commons.codec>
@@ -1234,8 +1236,13 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>2.17</version>
+                    <version>${version.checkstyle.maven-plugin}</version>
                     <dependencies>
+                        <dependency>
+                            <groupId>com.puppycrawl.tools</groupId>
+                            <artifactId>checkstyle</artifactId>
+                            <version>${version.checkstyle}</version>
+                        </dependency>
                         <dependency>
                             <groupId>org.infinispan</groupId>
                             <artifactId>infinispan-checkstyle</artifactId>

--- a/persistence/jdbc/src/test/java/org/infinispan/persistence/jdbc/stringbased/JdbcStringBasedStoreTest.java
+++ b/persistence/jdbc/src/test/java/org/infinispan/persistence/jdbc/stringbased/JdbcStringBasedStoreTest.java
@@ -4,17 +4,13 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.testng.AssertJUnit.assertNull;
 
-import java.io.IOException;
-
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.persistence.BaseStoreTest;
 import org.infinispan.persistence.jdbc.DatabaseType;
 import org.infinispan.persistence.jdbc.configuration.JdbcStringBasedStoreConfigurationBuilder;
 import org.infinispan.persistence.jdbc.connectionfactory.ConnectionFactory;
 import org.infinispan.persistence.jdbc.table.management.TableManager;
-import org.infinispan.persistence.keymappers.UnsupportedKeyTypeException;
 import org.infinispan.persistence.spi.AdvancedLoadWriteStore;
-import org.infinispan.persistence.spi.PersistenceException;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.test.fwk.UnitTestDatabaseManager;
 import org.testng.annotations.Test;

--- a/persistence/jdbc/src/test/java/org/infinispan/persistence/jdbc/stringbased/StringStoreWithManagedConnectionTest.java
+++ b/persistence/jdbc/src/test/java/org/infinispan/persistence/jdbc/stringbased/StringStoreWithManagedConnectionTest.java
@@ -3,8 +3,6 @@ package org.infinispan.persistence.jdbc.stringbased;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertTrue;
 
-import java.io.IOException;
-
 import org.infinispan.Cache;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.StoreConfiguration;
@@ -12,9 +10,7 @@ import org.infinispan.persistence.jdbc.ManagedConnectionFactoryTest;
 import org.infinispan.persistence.jdbc.configuration.JdbcStringBasedStoreConfiguration;
 import org.infinispan.persistence.jdbc.configuration.JdbcStringBasedStoreConfigurationBuilder;
 import org.infinispan.persistence.jdbc.connectionfactory.ManagedConnectionFactory;
-import org.infinispan.persistence.keymappers.UnsupportedKeyTypeException;
 import org.infinispan.persistence.spi.AdvancedLoadWriteStore;
-import org.infinispan.persistence.spi.PersistenceException;
 import org.infinispan.test.CacheManagerCallable;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;

--- a/persistence/jpa/src/test/java/org/infinispan/persistence/jpa/AbstractJpaStoreTest.java
+++ b/persistence/jpa/src/test/java/org/infinispan/persistence/jpa/AbstractJpaStoreTest.java
@@ -3,7 +3,6 @@ package org.infinispan.persistence.jpa;
 import static org.testng.Assert.assertTrue;
 import static org.testng.AssertJUnit.assertNotNull;
 
-import org.hibernate.ejb.HibernateEntityManagerFactory;
 import org.infinispan.commons.marshall.StreamingMarshaller;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.container.entries.InternalCacheEntry;

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/ExecutorFactoryConfiguration.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/ExecutorFactoryConfiguration.java
@@ -2,7 +2,6 @@ package org.infinispan.persistence.remote.configuration;
 
 import org.infinispan.commons.configuration.AbstractTypedPropertiesConfiguration;
 import org.infinispan.commons.configuration.attributes.AttributeDefinition;
-import org.infinispan.commons.configuration.attributes.AttributeInitializer;
 import org.infinispan.commons.configuration.attributes.AttributeSet;
 import org.infinispan.commons.executors.ExecutorFactory;
 import org.infinispan.executors.DefaultExecutorFactory;

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/upgrade/HotRodMigratorHelper.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/upgrade/HotRodMigratorHelper.java
@@ -6,7 +6,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import org.infinispan.client.hotrod.impl.protocol.VersionUtils;
-import org.infinispan.commons.CacheException;
 import org.infinispan.persistence.remote.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 

--- a/persistence/rest/src/main/java/org/infinispan/persistence/rest/configuration/ConnectionPoolConfiguration.java
+++ b/persistence/rest/src/main/java/org/infinispan/persistence/rest/configuration/ConnectionPoolConfiguration.java
@@ -1,11 +1,8 @@
 package org.infinispan.persistence.rest.configuration;
 
 import org.infinispan.commons.configuration.BuiltBy;
-import org.infinispan.commons.configuration.ConfigurationFor;
-import org.infinispan.commons.configuration.attributes.Attribute;
 import org.infinispan.commons.configuration.attributes.AttributeDefinition;
 import org.infinispan.commons.configuration.attributes.AttributeSet;
-import org.infinispan.configuration.serializing.SerializedWith;
 
 /**
  * ConnectionPoolConfiguration.

--- a/query/src/main/java/org/infinispan/query/backend/QueryInterceptor.java
+++ b/query/src/main/java/org/infinispan/query/backend/QueryInterceptor.java
@@ -38,7 +38,6 @@ import org.infinispan.commons.dataconversion.Encoder;
 import org.infinispan.commons.dataconversion.Wrapper;
 import org.infinispan.commons.util.EnumUtil;
 import org.infinispan.container.DataContainer;
-import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.FlagBitSets;

--- a/query/src/main/java/org/infinispan/query/dsl/embedded/impl/QueryCache.java
+++ b/query/src/main/java/org/infinispan/query/dsl/embedded/impl/QueryCache.java
@@ -7,7 +7,6 @@ import java.util.concurrent.TimeUnit;
 import org.infinispan.Cache;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
-import org.infinispan.eviction.EvictionStrategy;
 import org.infinispan.eviction.EvictionType;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.manager.EmbeddedCacheManager;

--- a/query/src/main/java/org/infinispan/query/impl/massindex/IndexWorker.java
+++ b/query/src/main/java/org/infinispan/query/impl/massindex/IndexWorker.java
@@ -15,7 +15,6 @@ import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.spi.impl.PojoIndexedTypeIdentifier;
 import org.infinispan.Cache;
 import org.infinispan.commons.dataconversion.Encoder;
-import org.infinispan.commons.dataconversion.EncodingUtils;
 import org.infinispan.commons.dataconversion.Wrapper;
 import org.infinispan.commons.marshall.AbstractExternalizer;
 import org.infinispan.container.entries.CacheEntry;

--- a/query/src/test/java/org/infinispan/query/affinity/BaseAffinityTest.java
+++ b/query/src/test/java/org/infinispan/query/affinity/BaseAffinityTest.java
@@ -22,7 +22,6 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.LockSupport;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.HdrHistogram.Histogram;

--- a/query/src/test/java/org/infinispan/query/analysis/Team.java
+++ b/query/src/test/java/org/infinispan/query/analysis/Team.java
@@ -16,7 +16,6 @@ import org.apache.lucene.analysis.standard.StandardTokenizerFactory;
 import org.apache.lucene.analysis.synonym.SynonymFilterFactory;
 import org.hibernate.search.annotations.Analyzer;
 import org.hibernate.search.annotations.AnalyzerDef;
-import org.hibernate.search.annotations.AnalyzerDefs;
 import org.hibernate.search.annotations.CharFilterDef;
 import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.Indexed;

--- a/query/src/test/java/org/infinispan/query/backend/QueryInterceptorTest.java
+++ b/query/src/test/java/org/infinispan/query/backend/QueryInterceptorTest.java
@@ -16,7 +16,6 @@ import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.Index;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
-import org.infinispan.eviction.EvictionStrategy;
 import org.infinispan.eviction.EvictionType;
 import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.manager.EmbeddedCacheManager;

--- a/query/src/test/java/org/infinispan/query/blackbox/ClusteredCachePerfIspnTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/ClusteredCachePerfIspnTest.java
@@ -1,8 +1,5 @@
 package org.infinispan.query.blackbox;
 
-import java.util.List;
-
-import org.infinispan.Cache;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.Index;

--- a/query/src/test/java/org/infinispan/query/blackbox/ClusteredCacheTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/ClusteredCacheTest.java
@@ -51,7 +51,6 @@ import org.infinispan.query.test.CustomKey3Transformer;
 import org.infinispan.query.test.Person;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
-import org.infinispan.util.function.SerializableBiFunction;
 import org.testng.annotations.Test;
 
 /**

--- a/query/src/test/java/org/infinispan/query/distributed/DistProgrammaticMassIndexTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/DistProgrammaticMassIndexTest.java
@@ -3,8 +3,6 @@ package org.infinispan.query.distributed;
 import static org.infinispan.query.helper.TestQueryHelperFactory.createQueryParser;
 import static org.testng.AssertJUnit.assertEquals;
 
-import java.util.List;
-
 import org.apache.lucene.queryparser.classic.QueryParser;
 import org.apache.lucene.search.Query;
 import org.infinispan.Cache;

--- a/query/src/test/java/org/infinispan/query/distributed/MultipleEntitiesMassIndexTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/MultipleEntitiesMassIndexTest.java
@@ -11,7 +11,6 @@ import org.apache.lucene.queryparser.classic.QueryParser;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.infinispan.Cache;
-import org.infinispan.commons.api.BasicCacheContainer;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.Index;

--- a/query/src/test/java/org/infinispan/query/helper/TestQueryHelperFactory.java
+++ b/query/src/test/java/org/infinispan/query/helper/TestQueryHelperFactory.java
@@ -24,8 +24,6 @@ import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.query.CacheQuery;
 import org.infinispan.query.Search;
 import org.infinispan.query.SearchManager;
-import org.infinispan.query.queries.faceting.Car;
-import org.infinispan.query.test.Person;
 import org.infinispan.test.AbstractCacheTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 

--- a/query/src/test/java/org/infinispan/query/impl/EagerIteratorTest.java
+++ b/query/src/test/java/org/infinispan/query/impl/EagerIteratorTest.java
@@ -15,8 +15,6 @@ import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.infinispan.AdvancedCache;
 import org.infinispan.query.ResultIterator;
 import org.infinispan.query.backend.KeyTransformationHandler;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;

--- a/query/src/test/java/org/infinispan/query/jmx/DistributedMassIndexingViaJmxTest.java
+++ b/query/src/test/java/org/infinispan/query/jmx/DistributedMassIndexingViaJmxTest.java
@@ -8,7 +8,6 @@ import javax.management.ObjectName;
 
 import org.infinispan.Cache;
 import org.infinispan.commons.CacheException;
-import org.infinispan.commons.api.BasicCacheContainer;
 import org.infinispan.commons.util.FileLookupFactory;
 import org.infinispan.configuration.parsing.ConfigurationBuilderHolder;
 import org.infinispan.configuration.parsing.ParserRegistry;

--- a/server/core/src/main/java/io/netty/handler/ssl/ALPNHackSSLEngine.java
+++ b/server/core/src/main/java/io/netty/handler/ssl/ALPNHackSSLEngine.java
@@ -33,7 +33,6 @@ import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLSession;
 
 import org.infinispan.commons.logging.LogFactory;
-import org.infinispan.server.core.logging.Log;
 
 /**
  * SSLEngine wrapper that provides some super hacky ALPN support on JDK8.

--- a/server/core/src/test/java/org/infinispan/server/core/AbstractProtocolServerTest.java
+++ b/server/core/src/test/java/org/infinispan/server/core/AbstractProtocolServerTest.java
@@ -1,6 +1,5 @@
 package org.infinispan.server.core;
 
-import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.server.core.configuration.MockServerConfigurationBuilder;

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/CacheDecodeContext.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/CacheDecodeContext.java
@@ -14,7 +14,6 @@ import org.infinispan.container.versioning.SimpleClusteredVersion;
 import org.infinispan.container.versioning.VersionGenerator;
 import org.infinispan.context.Flag;
 import org.infinispan.factories.ComponentRegistry;
-import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.metadata.EmbeddedMetadata;
 import org.infinispan.metadata.Metadata;

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/ErrorResponse.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/ErrorResponse.java
@@ -1,9 +1,5 @@
 package org.infinispan.server.hotrod;
 
-import org.infinispan.server.hotrod.transport.ExtendedByteBuf;
-
-import io.netty.buffer.ByteBuf;
-
 /**
  * @author wburns
  * @since 9.0

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/HotRodDecoder.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/HotRodDecoder.java
@@ -1,6 +1,5 @@
 package org.infinispan.server.hotrod;
 
-import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.function.Predicate;
 

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/LocalContextHandler.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/LocalContextHandler.java
@@ -2,11 +2,6 @@ package org.infinispan.server.hotrod;
 
 import static org.infinispan.server.hotrod.ResponseWriting.writeResponse;
 
-import java.security.PrivilegedExceptionAction;
-
-import javax.security.auth.Subject;
-
-import org.infinispan.security.Security;
 import org.infinispan.server.core.transport.NettyTransport;
 
 import io.netty.channel.ChannelHandlerContext;

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodMultiNodeTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodMultiNodeTest.java
@@ -21,7 +21,6 @@ import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
 
 /**
  * Base test class for multi node or clustered Hot Rod tests.

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodSingleClusteredNonLoopbackTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodSingleClusteredNonLoopbackTest.java
@@ -1,7 +1,6 @@
 package org.infinispan.server.hotrod;
 
 import static org.infinispan.server.core.test.ServerTestingUtil.killServer;
-import static org.infinispan.server.hotrod.OperationStatus.ParseError;
 import static org.infinispan.server.hotrod.OperationStatus.Success;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.findNetworkInterfaces;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.getDefaultHotRodConfiguration;
@@ -12,7 +11,6 @@ import static org.infinispan.server.hotrod.test.HotRodTestingUtil.serverPort;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.startHotRodServer;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.v;
 import static org.testng.Assert.assertEquals;
-import static org.testng.AssertJUnit.assertTrue;
 
 import java.lang.reflect.Method;
 import java.net.NetworkInterface;
@@ -23,7 +21,6 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.registry.InternalCacheRegistry;
 import org.infinispan.server.hotrod.test.HotRodClient;
-import org.infinispan.server.hotrod.test.TestErrorResponse;
 import org.infinispan.server.hotrod.test.TestResponse;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/test/HotRodSingleNodeTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/test/HotRodSingleNodeTest.java
@@ -12,7 +12,6 @@ import org.infinispan.server.hotrod.HotRodServer;
 import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.testng.annotations.AfterClass;
-import org.testng.annotations.Test;
 
 import io.netty.util.concurrent.Future;
 

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerMetricsHandler.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerMetricsHandler.java
@@ -40,7 +40,6 @@ import org.infinispan.server.infinispan.SecurityActions;
 import org.infinispan.server.infinispan.spi.service.CacheContainerServiceName;
 import org.infinispan.stats.CacheContainerStats;
 import org.infinispan.stats.ClusterContainerStats;
-import org.infinispan.stats.impl.AbstractClusterStats;
 import org.infinispan.xsite.GlobalXSiteAdminOperations;
 import org.infinispan.xsite.status.SiteStatus;
 import org.jboss.as.clustering.infinispan.DefaultCacheContainer;

--- a/server/integration/jgroups/src/main/java/org/infinispan/server/jgroups/ForkChannelFactory.java
+++ b/server/integration/jgroups/src/main/java/org/infinispan/server/jgroups/ForkChannelFactory.java
@@ -23,7 +23,6 @@ package org.infinispan.server.jgroups;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 

--- a/server/integration/jgroups/src/main/java/org/infinispan/server/jgroups/security/RealmAuthorizationCallbackHandler.java
+++ b/server/integration/jgroups/src/main/java/org/infinispan/server/jgroups/security/RealmAuthorizationCallbackHandler.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.security.Principal;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 

--- a/server/integration/jgroups/src/main/java/org/infinispan/server/jgroups/subsystem/ChannelAddHandler.java
+++ b/server/integration/jgroups/src/main/java/org/infinispan/server/jgroups/subsystem/ChannelAddHandler.java
@@ -38,7 +38,6 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.RunningMode;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.dmr.ModelNode;
-import org.jboss.modules.ModuleIdentifier;
 import org.jboss.msc.service.ServiceTarget;
 import org.jgroups.JChannel;
 

--- a/server/integration/jgroups/src/main/java/org/infinispan/server/jgroups/subsystem/ChannelMetric.java
+++ b/server/integration/jgroups/src/main/java/org/infinispan/server/jgroups/subsystem/ChannelMetric.java
@@ -27,7 +27,6 @@ import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.jgroups.JChannel;
-import org.jgroups.protocols.TP;
 
 /**
  * Enumerates management metrics for a channel.

--- a/server/integration/jgroups/src/main/java/org/infinispan/server/jgroups/subsystem/JGroupsSubsystemRemoveHandler.java
+++ b/server/integration/jgroups/src/main/java/org/infinispan/server/jgroups/subsystem/JGroupsSubsystemRemoveHandler.java
@@ -24,7 +24,6 @@ package org.infinispan.server.jgroups.subsystem;
 import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
-import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.dmr.ModelNode;

--- a/server/integration/jgroups/src/main/java/org/infinispan/server/jgroups/subsystem/ThreadsAttributesWriteHandler.java
+++ b/server/integration/jgroups/src/main/java/org/infinispan/server/jgroups/subsystem/ThreadsAttributesWriteHandler.java
@@ -26,7 +26,6 @@ import org.infinispan.server.jgroups.logging.JGroupsLogger;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
-import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.controller.registry.Resource;

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/rollingupgrades/HotRodRollingUpgradesDistIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/rollingupgrades/HotRodRollingUpgradesDistIT.java
@@ -5,23 +5,15 @@ import static org.junit.Assert.assertEquals;
 
 import javax.management.ObjectName;
 
-import org.infinispan.arquillian.core.InfinispanResource;
-import org.infinispan.arquillian.core.RemoteInfinispanServers;
 import org.infinispan.arquillian.utils.MBeanServerConnectionProvider;
 import org.infinispan.client.hotrod.ProtocolVersion;
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
-import org.infinispan.client.hotrod.impl.ConfigurationProperties;
 import org.infinispan.server.infinispan.spi.InfinispanSubsystem;
 import org.infinispan.server.test.category.RollingUpgradesDist;
-import org.infinispan.server.test.util.RemoteCacheManagerFactory;
 import org.infinispan.server.test.util.RemoteInfinispanMBeans;
-import org.jboss.arquillian.container.test.api.ContainerController;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.test.api.ArquillianResource;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/rollingupgrades/HotRodRollingUpgradesIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/rollingupgrades/HotRodRollingUpgradesIT.java
@@ -5,23 +5,15 @@ import static org.junit.Assert.assertEquals;
 
 import javax.management.ObjectName;
 
-import org.infinispan.arquillian.core.InfinispanResource;
-import org.infinispan.arquillian.core.RemoteInfinispanServers;
 import org.infinispan.arquillian.utils.MBeanServerConnectionProvider;
 import org.infinispan.client.hotrod.ProtocolVersion;
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
-import org.infinispan.client.hotrod.impl.ConfigurationProperties;
 import org.infinispan.server.infinispan.spi.InfinispanSubsystem;
 import org.infinispan.server.test.category.RollingUpgrades;
-import org.infinispan.server.test.util.RemoteCacheManagerFactory;
 import org.infinispan.server.test.util.RemoteInfinispanMBeans;
-import org.jboss.arquillian.container.test.api.ContainerController;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.test.api.ArquillianResource;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/util/ITestUtils.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/util/ITestUtils.java
@@ -15,7 +15,6 @@ import org.infinispan.client.hotrod.ProtocolVersion;
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
-import org.infinispan.client.hotrod.impl.ConfigurationProperties;
 import org.infinispan.client.hotrod.impl.RemoteCacheImpl;
 import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.server.test.client.memcached.MemcachedClient;

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/util/RemoteCacheManagerFactory.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/util/RemoteCacheManagerFactory.java
@@ -8,7 +8,6 @@ import org.infinispan.client.hotrod.ProtocolVersion;
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
-import org.infinispan.client.hotrod.impl.ConfigurationProperties;
 
 /**
  * Keeps collection of {@link RemoteCacheManager} objects, to be able to stop all of them when needed.

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/util/jdbc/DBServer.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/util/jdbc/DBServer.java
@@ -9,10 +9,7 @@ import java.sql.ResultSet;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.Callable;
-
-import org.infinispan.commons.equivalence.ByteArrayEquivalence;
 
 /**
  * @author <a href="mailto:mgencur@redhat.com">Martin Gencur</a>

--- a/server/rest/src/main/java/org/infinispan/rest/InfinispanRequest.java
+++ b/server/rest/src/main/java/org/infinispan/rest/InfinispanRequest.java
@@ -2,7 +2,6 @@ package org.infinispan.rest;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.Scanner;
 import java.util.StringTokenizer;
 
 import io.netty.buffer.ByteBuf;

--- a/server/rest/src/test/java/org/infinispan/rest/http2/Http2Client.java
+++ b/server/rest/src/test/java/org/infinispan/rest/http2/Http2Client.java
@@ -1,7 +1,5 @@
 package org.infinispan.rest.http2;
 
-import static io.netty.buffer.Unpooled.wrappedBuffer;
-
 import java.io.FileInputStream;
 import java.security.KeyStore;
 import java.util.Queue;

--- a/server/websocket/src/main/java/org/infinispan/server/websocket/WebSocketServer.java
+++ b/server/websocket/src/main/java/org/infinispan/server/websocket/WebSocketServer.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.StringWriter;
 import java.lang.invoke.MethodHandles;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/spring/spring4/spring4-embedded/src/main/java/org/infinispan/spring/support/embedded/InfinispanNamedEmbeddedCacheFactoryBean.java
+++ b/spring/spring4/spring4-embedded/src/main/java/org/infinispan/spring/support/embedded/InfinispanNamedEmbeddedCacheFactoryBean.java
@@ -1,7 +1,6 @@
 package org.infinispan.spring.support.embedded;
 
 import org.infinispan.Cache;
-import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.util.logging.Log;

--- a/spring/spring4/spring4-embedded/src/test/java/org/infinispan/spring/provider/SpringEmbeddedCacheManagerFactoryBeanTest.java
+++ b/spring/spring4/spring4-embedded/src/test/java/org/infinispan/spring/provider/SpringEmbeddedCacheManagerFactoryBeanTest.java
@@ -7,7 +7,6 @@ import static org.testng.AssertJUnit.assertTrue;
 import org.infinispan.Cache;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
-import org.infinispan.configuration.global.GlobalJmxStatisticsConfigurationBuilder;
 import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.spring.builders.SpringEmbeddedCacheManagerFactoryBeanBuilder;

--- a/tasks/manager/src/main/java/org/infinispan/tasks/impl/TaskManagerImpl.java
+++ b/tasks/manager/src/main/java/org/infinispan/tasks/impl/TaskManagerImpl.java
@@ -3,7 +3,6 @@ package org.infinispan.tasks.impl;
 import static org.infinispan.tasks.logging.Messages.MESSAGES;
 
 import java.lang.invoke.MethodHandles;
-import java.security.Principal;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -11,7 +10,6 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 
 import javax.security.auth.Subject;

--- a/tools/src/main/java/org/infinispan/tools/jdbc/migrator/marshaller/ExternalizerTable.java
+++ b/tools/src/main/java/org/infinispan/tools/jdbc/migrator/marshaller/ExternalizerTable.java
@@ -10,7 +10,6 @@ import org.infinispan.commons.io.ByteBufferImpl;
 import org.infinispan.commons.io.UnsignedNumeric;
 import org.infinispan.commons.marshall.AdvancedExternalizer;
 import org.infinispan.commons.marshall.StreamingMarshaller;
-import org.infinispan.commons.util.ImmutableListCopy;
 import org.infinispan.commons.util.Immutables;
 import org.infinispan.container.entries.ImmortalCacheEntry;
 import org.infinispan.container.entries.ImmortalCacheValue;

--- a/tools/src/main/java/org/infinispan/tools/jdbc/migrator/marshaller/externalizers/ArrayExternalizers.java
+++ b/tools/src/main/java/org/infinispan/tools/jdbc/migrator/marshaller/externalizers/ArrayExternalizers.java
@@ -9,7 +9,6 @@ import java.util.Set;
 import org.infinispan.commons.io.UnsignedNumeric;
 import org.infinispan.commons.marshall.AdvancedExternalizer;
 import org.infinispan.commons.util.Util;
-import org.infinispan.marshall.core.Ids;
 
 /**
  * Externalizers for diverse array types.

--- a/tools/src/main/java/org/infinispan/tools/jdbc/migrator/marshaller/externalizers/ListExternalizer.java
+++ b/tools/src/main/java/org/infinispan/tools/jdbc/migrator/marshaller/externalizers/ListExternalizer.java
@@ -11,7 +11,6 @@ import java.util.Set;
 import org.infinispan.commons.marshall.AbstractExternalizer;
 import org.infinispan.commons.marshall.MarshallUtil;
 import org.infinispan.commons.util.Util;
-import org.infinispan.marshall.core.Ids;
 import org.jboss.marshalling.util.IdentityIntMap;
 
 import net.jcip.annotations.Immutable;

--- a/tree/src/test/java/org/infinispan/api/tree/TreeStructureHashCodeTest.java
+++ b/tree/src/test/java/org/infinispan/api/tree/TreeStructureHashCodeTest.java
@@ -5,7 +5,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.infinispan.commons.equivalence.AnyEquivalence;
 import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.tree.Fqn;
 import org.infinispan.tree.impl.NodeKey;


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-8106

Checkstyle 8.1 is much better at recognizing imports needed by javadoc. The only problem I found so far is that `Map.Entry#setValue(Object)` is not recognized as a reference to `java.util.Map`.