### PR TITLE
ISPN-6456 OptimisticTxPartitionAndMergeDuringPrepareTest.testOriginat…

### DIFF
--- a/core/src/main/java/org/infinispan/transaction/impl/TransactionTable.java
+++ b/core/src/main/java/org/infinispan/transaction/impl/TransactionTable.java
@@ -390,7 +390,12 @@ public class TransactionTable implements org.infinispan.transaction.TransactionT
             if (topologyId < minTxTopologyId) {
                if (trace)
                   log.tracef("Changing minimum topology ID from %d to %d", minTxTopologyId, topologyId);
-               minTxTopologyId = topologyId;
+               minTopologyRecalculationLock.lock();
+               try {
+                  minTxTopologyId = topologyId;
+               } finally {
+                  minTopologyRecalculationLock.unlock();
+               }
             }
             return newTransaction;
          }


### PR DESCRIPTION
…orIsolatedPartition fails randomly

https://issues.jboss.org/browse/ISPN-6456

I believe this should also fix the `PessimisticTxPartiionAndMergeDuringPrepareTest# testPrimaryOwnerIsolatedPartition` failures.

From the logs, I can see that in the failure cases node C (the pirmary owner of key 2) never updates its TransactionTable minTopology to the topology established after a merge, therefore it never removes the old transaction from its records. 