### PR TITLE
Fix OptimisticTxPartitionAndMergeDuringCommitTest

### DIFF
--- a/core/src/test/java/org/infinispan/partitionhandling/BaseTxPartitionAndMergeTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/BaseTxPartitionAndMergeTest.java
@@ -34,8 +34,8 @@ import org.testng.AssertJUnit;
 public abstract class BaseTxPartitionAndMergeTest extends BasePartitionHandlingTest {
    private static final Log log = LogFactory.getLog(BaseTxPartitionAndMergeTest.class);
 
-   protected static final String INITIAL_VALUE = "init-value";
-   protected static final String FINAL_VALUE = "final-value";
+   static final String INITIAL_VALUE = "init-value";
+   static final String FINAL_VALUE = "final-value";
 
    private static NotifierFilter notifyCommandOn(Cache<?, ?> cache, Class<? extends CacheRpcCommand> blockClass) {
       NotifierFilter filter = new NotifierFilter(blockClass);
@@ -99,8 +99,8 @@ public abstract class BaseTxPartitionAndMergeTest extends BasePartitionHandlingT
       assertNoTransactionsInPartitionHandler(cacheName);
       assertNoLocks(cacheName);
 
-      assertValue(keyInfo.getKey1(), value, this.<Object, String>caches(cacheName));
-      assertValue(keyInfo.getKey2(), value, this.<Object, String>caches(cacheName));
+      assertValue(keyInfo.getKey1(), value, this.caches(cacheName));
+      assertValue(keyInfo.getKey2(), value, this.caches(cacheName));
    }
 
    protected void assertNoLocks(String cacheName) {
@@ -217,13 +217,16 @@ public abstract class BaseTxPartitionAndMergeTest extends BasePartitionHandlingT
 
       @Override
       public boolean before(CacheRpcCommand command, Reply reply, DeliverOrder order) {
+         log.tracef("[Blocking] Checking command %s.", command);
          if (aClass.isAssignableFrom(command.getClass())) {
+            log.tracef("[Blocking] Blocking command %s", command);
             notifier.open();
             try {
                blocker.await(30, TimeUnit.SECONDS);
             } catch (InterruptedException e) {
                Thread.currentThread().interrupt();
             }
+            log.tracef("[Blocking] Unblocking command %s", command);
          }
          return true;
       }
@@ -251,7 +254,9 @@ public abstract class BaseTxPartitionAndMergeTest extends BasePartitionHandlingT
 
       @Override
       public boolean before(CacheRpcCommand command, Reply reply, DeliverOrder order) {
+         log.tracef("[Notifier] Checking command %s.", command);
          if (aClass.isAssignableFrom(command.getClass())) {
+            log.tracef("[Notifier] Notifying command %s.", command);
             notifier.countDown();
          }
          return true;
@@ -281,7 +286,9 @@ public abstract class BaseTxPartitionAndMergeTest extends BasePartitionHandlingT
 
       @Override
       public boolean before(CacheRpcCommand command, Reply reply, DeliverOrder order) {
+         log.tracef("[Discard] Checking command %s.", command);
          if (!notifier.isOpened() && aClass.isAssignableFrom(command.getClass())) {
+            log.tracef("[Discard] Discarding command %s.", command);
             notifier.open();
             return false;
          }
@@ -304,12 +311,12 @@ public abstract class BaseTxPartitionAndMergeTest extends BasePartitionHandlingT
       private final Object key1;
       private final Object key2;
 
-      public KeyInfo(Object key1, Object key2) {
+      KeyInfo(Object key1, Object key2) {
          this.key1 = key1;
          this.key2 = key2;
       }
 
-      public void putFinalValue(Cache<Object, String> cache) {
+      void putFinalValue(Cache<Object, String> cache) {
          cache.put(key1, FINAL_VALUE);
          cache.put(key2, FINAL_VALUE);
       }
@@ -326,7 +333,7 @@ public abstract class BaseTxPartitionAndMergeTest extends BasePartitionHandlingT
    protected static class FilterCollection implements AwaitAndUnblock {
       private final Collection<AwaitAndUnblock> collection;
 
-      public FilterCollection(Collection<AwaitAndUnblock> collection) {
+      FilterCollection(Collection<AwaitAndUnblock> collection) {
          this.collection = collection;
       }
 

--- a/core/src/test/java/org/infinispan/partitionhandling/OptimisticTxPartitionAndMergeDuringCommitTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/OptimisticTxPartitionAndMergeDuringCommitTest.java
@@ -72,9 +72,20 @@ public class OptimisticTxPartitionAndMergeDuringCommitTest extends BaseOptimisti
 
    @Override
    protected void checkLocksDuringPartition(SplitMode splitMode, KeyInfo keyInfo, boolean discard) {
-      //on both caches, the key is locked and it is unlocked after the merge
-      assertLocked(cache(1, OPTIMISTIC_TX_CACHE_NAME), keyInfo.getKey1());
-      assertLocked(cache(2, OPTIMISTIC_TX_CACHE_NAME), keyInfo.getKey2());
+      if (splitMode == SplitMode.PRIMARY_OWNER_ISOLATED) {
+         //the majority partition, all the nodes involved commit the transaction
+         //the locks should be released (async) in all the nodes
+         assertEventuallyNotLocked(cache(0, OPTIMISTIC_TX_CACHE_NAME), keyInfo.getKey1());
+         assertEventuallyNotLocked(cache(0, OPTIMISTIC_TX_CACHE_NAME), keyInfo.getKey2());
+         assertEventuallyNotLocked(cache(1, OPTIMISTIC_TX_CACHE_NAME), keyInfo.getKey1());
+         assertEventuallyNotLocked(cache(1, OPTIMISTIC_TX_CACHE_NAME), keyInfo.getKey2());
+         assertEventuallyNotLocked(cache(3, OPTIMISTIC_TX_CACHE_NAME), keyInfo.getKey1());
+         assertEventuallyNotLocked(cache(3, OPTIMISTIC_TX_CACHE_NAME), keyInfo.getKey2());
+      } else {
+         //on both caches, the key is locked and it is unlocked after the merge
+         assertLocked(cache(1, OPTIMISTIC_TX_CACHE_NAME), keyInfo.getKey1());
+         assertLocked(cache(2, OPTIMISTIC_TX_CACHE_NAME), keyInfo.getKey2());
+      }
    }
 
    @Override


### PR DESCRIPTION
wrong assumption during when writing the test make it fail randomly.
the transaction is committed in the majority partition and checking and the locks are released. checking for locks during the split can fail depending if the locks are still acquired or not (locks are released asynchronously) 