### PR TITLE
ISPN-8189 Use IdentityEncoder in SizeCommand to avoid unmarshalling keys

### DIFF
--- a/core/src/main/java/org/infinispan/commands/read/SizeCommand.java
+++ b/core/src/main/java/org/infinispan/commands/read/SizeCommand.java
@@ -1,8 +1,10 @@
 package org.infinispan.commands.read;
 
+import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
 import org.infinispan.commands.VisitableCommand;
 import org.infinispan.commands.Visitor;
+import org.infinispan.commons.dataconversion.IdentityEncoder;
 import org.infinispan.commons.util.EnumUtil;
 import org.infinispan.context.Flag;
 import org.infinispan.context.InvocationContext;
@@ -16,15 +18,15 @@ import org.infinispan.context.InvocationContext;
  * @since 4.0
  */
 public class SizeCommand extends AbstractLocalCommand implements VisitableCommand {
-   private final Cache<Object, ?> cache;
+   private final AdvancedCache<?, ?> cache;
 
    public SizeCommand(Cache<Object, ?> cache, long flags) {
       setFlagsBitSet(flags);
+      AdvancedCache<Object, ?> advancedCache = cache.getAdvancedCache();
       if (flags != EnumUtil.EMPTY_BIT_SET) {
-         this.cache = cache.getAdvancedCache().withFlags(EnumUtil.enumArrayOf(flags, Flag.class));
-      } else {
-         this.cache = cache;
+         advancedCache = advancedCache.withFlags(EnumUtil.enumArrayOf(flags, Flag.class));
       }
+      this.cache = advancedCache.withEncoding(IdentityEncoder.class);
    }
 
    @Override

--- a/core/src/test/java/org/infinispan/eviction/impl/MarshalledValuesEvictionTest.java
+++ b/core/src/test/java/org/infinispan/eviction/impl/MarshalledValuesEvictionTest.java
@@ -2,63 +2,80 @@ package org.infinispan.eviction.impl;
 
 import static org.testng.AssertJUnit.assertEquals;
 
-import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import org.infinispan.commons.marshall.SerializeWith;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
-import org.infinispan.eviction.EvictionStrategy;
+import org.infinispan.configuration.cache.StorageType;
+import org.infinispan.eviction.EvictionType;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.jgroups.util.Util;
 import org.testng.annotations.Test;
 
-@Test(groups = "unstable", testName = "eviction.MarshalledValuesEvictionTest",
-      description = "See ISPN-4042. Is this test even valid?  Evictions don't go thru the " +
-            "marshalled value interceptor when initiated form the data container! " +
-            "-- original group: functional")
+@Test(groups = "functional", testName = "eviction.MarshalledValuesEvictionTest")
 public class MarshalledValuesEvictionTest extends SingleCacheManagerTest {
 
-   private static final int CACHE_SIZE=128;
+   private static final int CACHE_SIZE = 128;
 
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       ConfigurationBuilder cfg = new ConfigurationBuilder();
-      cfg.eviction().strategy(EvictionStrategy.LRU).maxEntries(CACHE_SIZE) // CACHE_SIZE max entries
-         .expiration().wakeUpInterval(100L)
-         .locking().useLockStriping(false) // to minimise chances of deadlock in the unit test
-         .storeAsBinary().enable()
-         .build();
+      cfg.memory().size(CACHE_SIZE).evictionType(EvictionType.COUNT).storageType(StorageType.BINARY)
+            .expiration().wakeUpInterval(100L)
+            .locking().useLockStriping(false) // to minimise chances of deadlock in the unit test
+            .build();
       cacheManager = TestCacheManagerFactory.createCacheManager(cfg);
       cache = cacheManager.getCache();
       return cacheManager;
    }
 
    public void testEvictCustomKeyValue() {
-      for (int i = 0; i<CACHE_SIZE*2;i++) {
+      EvictionPojo.Externalizer.resetStats();
+      int expectedWrites = 0;
+      int expectedReads = 0;
+      for (int i = 0; i < CACHE_SIZE * 2; i++) {
          EvictionPojo p1 = new EvictionPojo();
-         p1.i = (int)Util.random(2000);
+         p1.i = (int) Util.random(2000);
          EvictionPojo p2 = new EvictionPojo();
          p2.i = 24;
-         cache.put(p1, p2);
+         Object old = cache.put(p1, p2);
+         if (old != null)
+            expectedReads++; // unmarshall old value if overwritten
+         expectedWrites += 2; // key and value
       }
 
       assertEquals(CACHE_SIZE, cache.getAdvancedCache().getDataContainer().size());
+      assertEquals(expectedWrites, EvictionPojo.Externalizer.writes.get());
+      assertEquals(expectedReads, EvictionPojo.Externalizer.reads.get());
    }
 
    public void testEvictPrimitiveKeyCustomValue() {
-      for (int i = 0; i<CACHE_SIZE*2;i++) {
+      EvictionPojo.Externalizer.resetStats();
+      int expectedWrites = 0;
+      int expectedReads = 0;
+      for (int i = 0; i < CACHE_SIZE * 2; i++) {
          EvictionPojo p1 = new EvictionPojo();
-         p1.i = (int)Util.random(2000);
-         cache.put(i, p1);
+         p1.i = (int) Util.random(2000);
+         Object old = cache.put(i, p1);
+         if (old != null)
+            expectedReads++; // unmarshall old value if overwritten
+         expectedWrites++; // just the value
       }
+      assertEquals(expectedWrites, EvictionPojo.Externalizer.writes.get());
+      assertEquals(expectedReads, EvictionPojo.Externalizer.reads.get());
    }
 
-   public static class EvictionPojo implements Externalizable {
+   @SerializeWith(EvictionPojo.Externalizer.class)
+   public static class EvictionPojo {
       int i;
+
+
 
       @Override
       public boolean equals(Object o) {
@@ -75,14 +92,28 @@ public class MarshalledValuesEvictionTest extends SingleCacheManagerTest {
          return result;
       }
 
-      @Override
-      public void writeExternal(ObjectOutput out) throws IOException {
-         out.writeInt(i);
-      }
+      public static class Externalizer implements org.infinispan.commons.marshall.Externalizer<EvictionPojo> {
+         static AtomicInteger writes = new AtomicInteger();
+         static AtomicInteger reads = new AtomicInteger();
 
-      @Override
-      public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
-         i = in.readInt();
+         public static void resetStats() {
+            reads.set(0);
+            writes.set(0);
+         }
+
+         @Override
+         public void writeObject(ObjectOutput out, EvictionPojo pojo) throws IOException {
+            out.writeInt(pojo.i);
+            writes.incrementAndGet();
+         }
+
+         @Override
+         public EvictionPojo readObject(ObjectInput in) throws IOException, ClassNotFoundException {
+            EvictionPojo pojo = new EvictionPojo();
+            pojo.i = in.readInt();
+            reads.incrementAndGet();
+            return pojo;
+         }
       }
 
    }

--- a/core/src/test/java/org/infinispan/eviction/impl/MarshalledValuesManualEvictionTest.java
+++ b/core/src/test/java/org/infinispan/eviction/impl/MarshalledValuesManualEvictionTest.java
@@ -4,8 +4,10 @@ import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.cache.StorageType;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.marshall.core.ExternalPojo;
 import org.infinispan.test.SingleCacheManagerTest;
@@ -20,13 +22,14 @@ public class MarshalledValuesManualEvictionTest extends SingleCacheManagerTest {
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       ConfigurationBuilder cfg = new ConfigurationBuilder();
-      cfg.storeAsBinary().enable();
+      cfg.memory().storageType(StorageType.BINARY);
       EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(cfg);
       cache = cm.getCache();
       return cm;
    }
 
    public void testManualEvictCustomKeyValue() {
+      ManualEvictionPojo.resetStats();
       ManualEvictionPojo p1 = new ManualEvictionPojo();
       p1.i = 64;
       ManualEvictionPojo p2 = new ManualEvictionPojo();
@@ -36,30 +39,42 @@ public class MarshalledValuesManualEvictionTest extends SingleCacheManagerTest {
       ManualEvictionPojo p4 = new ManualEvictionPojo();
       p4.i = 35;
 
-      cache.put(p1, p2);
-      cache.put(p3, p4);
+      cache.put(p1, p2); // 2 writes, key & value
+      cache.put(p3, p4); // 2 writes, key & value
       assertEquals(2, cache.size());
-      cache.evict(p1);
+      cache.evict(p1); // 1 write
       assertEquals(1, cache.size());
-      assertEquals(p4, cache.get(p3));
+      assertEquals(p4, cache.get(p3)); // 1 write, 1 read
+      assertEquals(6, ManualEvictionPojo.writes.get());
+      assertEquals(1, ManualEvictionPojo.reads.get());
    }
 
    public void testEvictPrimitiveKeyCustomValue() {
+      ManualEvictionPojo.resetStats();
       ManualEvictionPojo p1 = new ManualEvictionPojo();
       p1.i = 51;
       ManualEvictionPojo p2 = new ManualEvictionPojo();
       p2.i = 78;
 
-      cache.put("key-isoprene", p1);
-      cache.put("key-hexastyle", p2);
+      cache.put("key-isoprene", p1); // 1 write
+      cache.put("key-hexastyle", p2); // 1 write
       assertEquals(2, cache.size());
       cache.evict("key-isoprene");
       assertEquals(1, cache.size());
-      assertEquals(p2, cache.get("key-hexastyle"));
+      assertEquals(p2, cache.get("key-hexastyle")); // 1 read
+      assertEquals(2, ManualEvictionPojo.writes.get());
+      assertEquals(1, ManualEvictionPojo.reads.get());
    }
 
    public static class ManualEvictionPojo implements Externalizable, ExternalPojo {
+      static AtomicInteger writes = new AtomicInteger();
+      static AtomicInteger reads = new AtomicInteger();
       int i;
+
+      public static void resetStats() {
+         reads.set(0);
+         writes.set(0);
+      }
 
       @Override
       public boolean equals(Object o) {
@@ -80,11 +95,13 @@ public class MarshalledValuesManualEvictionTest extends SingleCacheManagerTest {
       @Override
       public void writeExternal(ObjectOutput out) throws IOException {
          out.writeInt(i);
+         writes.incrementAndGet();
       }
 
       @Override
       public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
          i = in.readInt();
+         reads.incrementAndGet();
       }
    }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-8189
https://issues.jboss.org/browse/ISPN-4042

Also resurrects the MarshalledValuesEvictionTest to count marshalls/unmarshalls (to ensure we don't get spurious/unexpected ones).
