### PR TITLE
ISPN-8177 OSGi testsuite improvements

### DIFF
--- a/integrationtests/osgi/pom.xml
+++ b/integrationtests/osgi/pom.xml
@@ -21,17 +21,6 @@
             <skipOSGiTests>true</skipOSGiTests>
          </properties>
       </profile>
-      <profile>
-         <id>jigsaw</id>
-         <activation>
-            <jdk>[9,)</jdk>
-         </activation>
-         <properties>
-            <!-- TODO Upgrade to pax-exam 4.11.0 and remove this profile -->
-            <!-- 4.10.0 doesn't work with the latest JDK9 builds, see https://ops4j1.jira.com/browse/PAXEXAM-810 -->
-            <skipOSGiTests>true</skipOSGiTests>
-         </properties>
-      </profile>
    </profiles>
 
    <dependencies>
@@ -269,6 +258,7 @@
                <skipTests>${skipOSGiTests}</skipTests>
                <testNGArtifactName>none:none</testNGArtifactName>
                <disableXmlReport>false</disableXmlReport>
+               <runOrder>alphabetical</runOrder>
                <properties>
                   <property>
                      <name>listener</name>

--- a/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/BasicInfinispanOSGiTest.java
+++ b/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/BasicInfinispanOSGiTest.java
@@ -7,6 +7,7 @@ import java.net.URL;
 
 import org.infinispan.Cache;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.it.osgi.util.SuiteCategory;
 import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.TestingUtil;
@@ -22,7 +23,7 @@ import org.ops4j.pax.exam.spi.reactors.PerSuite;
  */
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerSuite.class)
-@Category(PerSuite.class)
+@Category(SuiteCategory.FeaturesSuite.class)
 public class BasicInfinispanOSGiTest extends BaseInfinispanCoreOSGiTest {
 
    @Test

--- a/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/features/OSGiKarafFeaturesTest.java
+++ b/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/features/OSGiKarafFeaturesTest.java
@@ -11,6 +11,7 @@ import org.infinispan.commons.test.skip.SkipOnOs;
 import org.infinispan.commons.test.skip.SkipOnOsRule;
 import org.infinispan.it.osgi.util.MavenUtils;
 import org.infinispan.it.osgi.util.PaxExamUtils;
+import org.infinispan.it.osgi.util.SuiteCategory;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -34,7 +35,7 @@ import org.osgi.framework.ServiceReference;
  */
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerClass.class)
-@Category(PerClass.class)
+@Category(SuiteCategory.FeaturesSuite.class)
 public class OSGiKarafFeaturesTest {
 
    @Rule

--- a/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/file/SingleFileStoreFunctionalTest.java
+++ b/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/file/SingleFileStoreFunctionalTest.java
@@ -5,6 +5,7 @@ import static org.ops4j.pax.exam.CoreOptions.options;
 
 import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.PersistenceConfigurationBuilder;
+import org.infinispan.it.osgi.util.SuiteCategory;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestResourceTracker;
 import org.junit.After;
@@ -25,7 +26,7 @@ import org.ops4j.pax.exam.spi.reactors.PerSuite;
  */
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerSuite.class)
-@Category(PerSuite.class)
+@Category(SuiteCategory.PersistenceSuite.class)
 public class SingleFileStoreFunctionalTest extends org.infinispan.persistence.file.SingleFileStoreFunctionalTest {
    private static String tmpDirectory;
 

--- a/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/jdbc/configuration/XmlFileParsingTest.java
+++ b/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/jdbc/configuration/XmlFileParsingTest.java
@@ -3,6 +3,7 @@ package org.infinispan.it.osgi.persistence.jdbc.configuration;
 import static org.infinispan.it.osgi.util.IspnKarafOptions.perSuiteOptions;
 import static org.ops4j.pax.exam.CoreOptions.options;
 
+import org.infinispan.it.osgi.util.SuiteCategory;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestResourceTracker;
 import org.junit.After;
@@ -20,7 +21,7 @@ import org.ops4j.pax.exam.spi.reactors.PerSuite;
  */
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerSuite.class)
-@Category(PerSuite.class)
+@Category(SuiteCategory.PersistenceSuite.class)
 public class XmlFileParsingTest extends org.infinispan.persistence.jdbc.configuration.XmlFileParsingTest {
    @Configuration
    public Option[] config() throws Exception {

--- a/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/jdbc/stringbased/JdbcStringBasedStoreFunctionalTest.java
+++ b/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/jdbc/stringbased/JdbcStringBasedStoreFunctionalTest.java
@@ -5,6 +5,7 @@ import static org.ops4j.pax.exam.CoreOptions.options;
 
 import org.infinispan.configuration.cache.PersistenceConfigurationBuilder;
 import org.infinispan.it.osgi.persistence.jdbc.UnitTestDatabaseManager;
+import org.infinispan.it.osgi.util.SuiteCategory;
 import org.infinispan.persistence.BaseStoreFunctionalTest;
 import org.infinispan.persistence.jdbc.configuration.JdbcStringBasedStoreConfigurationBuilder;
 import org.infinispan.test.fwk.TestResourceTracker;
@@ -26,7 +27,7 @@ import org.ops4j.pax.exam.spi.reactors.PerSuite;
  */
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerSuite.class)
-@Category(PerSuite.class)
+@Category(SuiteCategory.PersistenceSuite.class)
 public class JdbcStringBasedStoreFunctionalTest extends BaseStoreFunctionalTest {
    @Configuration
    public Option[] config() throws Exception {

--- a/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/jdbc/stringbased/JdbcStringBasedStoreManagedFactoryFunctionalTest.java
+++ b/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/jdbc/stringbased/JdbcStringBasedStoreManagedFactoryFunctionalTest.java
@@ -5,6 +5,7 @@ import static org.ops4j.pax.exam.CoreOptions.options;
 
 import org.infinispan.configuration.cache.PersistenceConfigurationBuilder;
 import org.infinispan.it.osgi.persistence.jdbc.UnitTestDatabaseManager;
+import org.infinispan.it.osgi.util.SuiteCategory;
 import org.infinispan.persistence.jdbc.configuration.JdbcStringBasedStoreConfigurationBuilder;
 import org.junit.Before;
 import org.junit.experimental.categories.Category;
@@ -23,7 +24,7 @@ import org.osgi.framework.FrameworkUtil;
  */
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerSuite.class)
-@Category(PerSuite.class)
+@Category(SuiteCategory.PersistenceSuite.class)
 public class JdbcStringBasedStoreManagedFactoryFunctionalTest extends JdbcStringBasedStoreFunctionalTest {
    @Configuration
    public Option[] config() throws Exception {

--- a/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/jpa/JpaConfigurationTest.java
+++ b/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/jpa/JpaConfigurationTest.java
@@ -5,6 +5,7 @@ import static org.ops4j.pax.exam.CoreOptions.options;
 
 import java.io.IOException;
 
+import org.infinispan.it.osgi.util.SuiteCategory;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -16,7 +17,7 @@ import org.ops4j.pax.exam.spi.reactors.PerSuite;
 
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerSuite.class)
-@Category(PerSuite.class)
+@Category(SuiteCategory.PersistenceSuite.class)
 public class JpaConfigurationTest extends org.infinispan.persistence.jpa.configuration.JpaConfigurationTest {
    @Configuration
    public Option[] config() throws Exception {

--- a/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/jpa/JpaStoreFunctionalTest.java
+++ b/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/jpa/JpaStoreFunctionalTest.java
@@ -3,6 +3,7 @@ package org.infinispan.it.osgi.persistence.jpa;
 import static org.infinispan.it.osgi.util.IspnKarafOptions.perSuiteOptions;
 import static org.ops4j.pax.exam.CoreOptions.options;
 
+import org.infinispan.it.osgi.util.SuiteCategory;
 import org.infinispan.test.fwk.TestResourceTracker;
 import org.junit.After;
 import org.junit.Before;
@@ -17,7 +18,7 @@ import org.ops4j.pax.exam.spi.reactors.PerSuite;
 
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerSuite.class)
-@Category(PerSuite.class)
+@Category(SuiteCategory.PersistenceSuite.class)
 public class JpaStoreFunctionalTest extends org.infinispan.persistence.jpa.JpaStoreFunctionalTest {
    @Configuration
    public Option[] config() throws Exception {

--- a/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/jpa/JpaStorePersonEntityTest.java
+++ b/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/jpa/JpaStorePersonEntityTest.java
@@ -3,6 +3,7 @@ package org.infinispan.it.osgi.persistence.jpa;
 import static org.infinispan.it.osgi.util.IspnKarafOptions.perSuiteOptions;
 import static org.ops4j.pax.exam.CoreOptions.options;
 
+import org.infinispan.it.osgi.util.SuiteCategory;
 import org.infinispan.persistence.spi.PersistenceException;
 import org.infinispan.test.fwk.TestResourceTracker;
 import org.junit.After;
@@ -18,7 +19,7 @@ import org.ops4j.pax.exam.spi.reactors.PerSuite;
 
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerSuite.class)
-@Category(PerSuite.class)
+@Category(SuiteCategory.PersistenceSuite.class)
 public class JpaStorePersonEntityTest extends org.infinispan.persistence.jpa.JpaStorePersonEntityTest {
    @Configuration
    public Option[] config() throws Exception {

--- a/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/jpa/JpaStoreTest.java
+++ b/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/jpa/JpaStoreTest.java
@@ -3,6 +3,7 @@ package org.infinispan.it.osgi.persistence.jpa;
 import static org.infinispan.it.osgi.util.IspnKarafOptions.perSuiteOptions;
 import static org.ops4j.pax.exam.CoreOptions.options;
 
+import org.infinispan.it.osgi.util.SuiteCategory;
 import org.infinispan.persistence.spi.PersistenceException;
 import org.infinispan.test.fwk.TestResourceTracker;
 import org.junit.After;
@@ -18,7 +19,7 @@ import org.ops4j.pax.exam.spi.reactors.PerSuite;
 
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerSuite.class)
-@Category(PerSuite.class)
+@Category(SuiteCategory.PersistenceSuite.class)
 public class JpaStoreTest extends org.infinispan.persistence.jpa.JpaStoreTest {
    @Configuration
    public Option[] config() throws Exception {

--- a/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/jpa/JpaStoreUserEntityTest.java
+++ b/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/jpa/JpaStoreUserEntityTest.java
@@ -3,6 +3,7 @@ package org.infinispan.it.osgi.persistence.jpa;
 import static org.infinispan.it.osgi.util.IspnKarafOptions.perSuiteOptions;
 import static org.ops4j.pax.exam.CoreOptions.options;
 
+import org.infinispan.it.osgi.util.SuiteCategory;
 import org.infinispan.persistence.spi.PersistenceException;
 import org.infinispan.test.fwk.TestResourceTracker;
 import org.junit.After;
@@ -18,7 +19,7 @@ import org.ops4j.pax.exam.spi.reactors.PerSuite;
 
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerSuite.class)
-@Category(PerSuite.class)
+@Category(SuiteCategory.PersistenceSuite.class)
 public class JpaStoreUserEntityTest extends org.infinispan.persistence.jpa.JpaStoreUserEntityTest {
    @Configuration
    public Option[] config() throws Exception {

--- a/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/jpa/JpaStoreVehicleEntityTest.java
+++ b/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/jpa/JpaStoreVehicleEntityTest.java
@@ -3,6 +3,7 @@ package org.infinispan.it.osgi.persistence.jpa;
 import static org.infinispan.it.osgi.util.IspnKarafOptions.perSuiteOptions;
 import static org.ops4j.pax.exam.CoreOptions.options;
 
+import org.infinispan.it.osgi.util.SuiteCategory;
 import org.infinispan.persistence.spi.PersistenceException;
 import org.infinispan.test.fwk.TestResourceTracker;
 import org.junit.After;
@@ -18,7 +19,7 @@ import org.ops4j.pax.exam.spi.reactors.PerSuite;
 
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerSuite.class)
-@Category(PerSuite.class)
+@Category(SuiteCategory.PersistenceSuite.class)
 public class JpaStoreVehicleEntityTest extends org.infinispan.persistence.jpa.JpaStoreVehicleEntityTest {
    @Configuration
    public Option[] config() throws Exception {

--- a/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/remote/RemoteStoreFunctionalTest.java
+++ b/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/remote/RemoteStoreFunctionalTest.java
@@ -4,6 +4,7 @@ import static org.infinispan.it.osgi.util.IspnKarafOptions.perSuiteOptions;
 import static org.ops4j.pax.exam.CoreOptions.options;
 
 import org.infinispan.configuration.cache.PersistenceConfigurationBuilder;
+import org.infinispan.it.osgi.util.SuiteCategory;
 import org.infinispan.persistence.BaseStoreFunctionalTest;
 import org.infinispan.persistence.remote.configuration.RemoteStoreConfigurationBuilder;
 import org.junit.Ignore;
@@ -30,7 +31,7 @@ import org.ops4j.pax.exam.spi.reactors.PerSuite;
  */
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerSuite.class)
-@Category(PerSuite.class)
+@Category(SuiteCategory.PersistenceSuite.class)
 @Ignore
 public class RemoteStoreFunctionalTest extends BaseStoreFunctionalTest {
 

--- a/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/rocksdb/RocksDBStoreFunctionalTest.java
+++ b/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/rocksdb/RocksDBStoreFunctionalTest.java
@@ -5,6 +5,7 @@ import static org.ops4j.pax.exam.CoreOptions.options;
 
 import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.PersistenceConfigurationBuilder;
+import org.infinispan.it.osgi.util.SuiteCategory;
 import org.infinispan.persistence.BaseStoreFunctionalTest;
 import org.infinispan.persistence.rocksdb.configuration.RocksDBStoreConfigurationBuilder;
 import org.infinispan.test.TestingUtil;
@@ -27,7 +28,7 @@ import org.ops4j.pax.exam.spi.reactors.PerSuite;
  */
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerSuite.class)
-@Category(PerSuite.class)
+@Category(SuiteCategory.PersistenceSuite.class)
 public class RocksDBStoreFunctionalTest extends BaseStoreFunctionalTest {
 
    private static String tmpDirectory;

--- a/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/tx/CustomObjectsReplicatedCacheTest.java
+++ b/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/tx/CustomObjectsReplicatedCacheTest.java
@@ -9,6 +9,7 @@ import java.io.Serializable;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.it.osgi.util.PaxExamUtils;
+import org.infinispan.it.osgi.util.SuiteCategory;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestResourceTracker;
@@ -30,7 +31,7 @@ import org.ops4j.pax.exam.spi.reactors.PerSuite;
  */
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerSuite.class)
-@Category(PerSuite.class)
+@Category(SuiteCategory.TransactionalSuite.class)
 public class CustomObjectsReplicatedCacheTest extends MultipleCacheManagersTest {
 
    @Override

--- a/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/tx/TransactionsSpanningReplicatedCachesTest.java
+++ b/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/tx/TransactionsSpanningReplicatedCachesTest.java
@@ -4,6 +4,7 @@ import static org.infinispan.it.osgi.util.IspnKarafOptions.perSuiteOptions;
 import static org.ops4j.pax.exam.CoreOptions.options;
 
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.it.osgi.util.SuiteCategory;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestResourceTracker;
 import org.junit.After;
@@ -22,7 +23,7 @@ import org.ops4j.pax.exam.spi.reactors.PerSuite;
  */
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerSuite.class)
-@Category(PerSuite.class)
+@Category(SuiteCategory.TransactionalSuite.class)
 public class TransactionsSpanningReplicatedCachesTest extends org.infinispan.tx.TransactionsSpanningReplicatedCachesTest {
    @Override
    protected void createCacheManagers() {

--- a/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/util/SuiteCategory.java
+++ b/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/util/SuiteCategory.java
@@ -1,0 +1,14 @@
+package org.infinispan.it.osgi.util;
+
+/**
+ * // TODO: Document this
+ *
+ * @author Tristan Tarrant
+ * @since 9.2
+ */
+
+public final class SuiteCategory {
+   public static final class PersistenceSuite {}
+   public static final class FeaturesSuite {}
+   public static final class TransactionalSuite {}
+}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -211,7 +211,7 @@
         <version.jacoco>0.7.5.201505241946</version.jacoco>
         <version.pax.url>2.5.2</version.pax.url>
         <version.karaf>3.0.8</version.karaf>
-        <version.pax.exam>4.10.0</version.pax.exam>
+        <version.pax.exam>4.11.0</version.pax.exam>
         <version.ant-contrib>1.0b3</version.ant-contrib>
         <dir.ispn>../</dir.ispn>
         <dir.jacoco>${session.executionRootDirectory}/jacoco/</dir.jacoco>

--- a/server/integration/versions/pom.xml
+++ b/server/integration/versions/pom.xml
@@ -69,7 +69,7 @@
       <version.xpp3>1.1.4c</version.xpp3>
       <version.pax.url>2.5.2</version.pax.url>
       <version.karaf>4.1.1</version.karaf>
-      <version.pax.exam>4.10.0</version.pax.exam>
+      <version.pax.exam>4.11.0</version.pax.exam>
       <version.h2.database>1.3.173</version.h2.database>
       <version.resteasy>3.1.0.Final</version.resteasy>
       <version.lucene>5.5.4</version.lucene>
@@ -118,13 +118,13 @@
             <artifactId>wildfly-security</artifactId>
             <version>${version.org.wildfly}</version>
          </dependency>
-         
+
          <dependency>
             <groupId>org.wildfly</groupId>
             <artifactId>wildfly-transactions</artifactId>
             <version>${version.org.wildfly}</version>
          </dependency>
-         
+
          <dependency>
             <groupId>org.wildfly</groupId>
             <artifactId>wildfly-dist</artifactId>
@@ -237,7 +237,7 @@
             <artifactId>infinispan-server-commons</artifactId>
             <version>${project.version}</version>
          </dependency>
-         
+
          <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>infinispan-server-commons</artifactId>
@@ -294,7 +294,7 @@
             <artifactId>infinispan-server-endpoints</artifactId>
             <version>${project.version}</version>
          </dependency>
-         
+
          <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>infinispan-server-feature-pack</artifactId>
@@ -319,7 +319,7 @@
             <artifactId>jboss-logmanager-log4j</artifactId>
             <version>${version.org.jboss.logmanager.jboss-logmanager-log4j}</version>
          </dependency>
-         
+
          <dependency>
             <groupId>org.jboss.modules</groupId>
             <artifactId>jboss-modules</artifactId>
@@ -431,7 +431,7 @@
             <artifactId>infinispan-cli-interpreter</artifactId>
             <version>${version.org.infinispan}</version>
          </dependency>
-         
+
          <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-management-console</artifactId>
@@ -612,7 +612,7 @@
             <scope>test</scope>
             <version>${version.h2.database}</version>
          </dependency>
-         
+
          <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-security-integrationtests</artifactId>


### PR DESCRIPTION
- Upgrade to Pax Exam 4.11
- Split testsuite into 3 minisuites to avoid the surefire container dying

NB. This doesn't fix the OSGi test issues completely but at least it makes it run completely

https://issues.jboss.org/browse/ISPN-8177