### PR TITLE
updated the schema version of clustered counter to 9.1

### DIFF
--- a/counter/src/main/java/org/infinispan/counter/configuration/CounterConfigurationParser.java
+++ b/counter/src/main/java/org/infinispan/counter/configuration/CounterConfigurationParser.java
@@ -27,6 +27,7 @@ import org.kohsuke.MetaInfServices;
 @MetaInfServices
 @Namespaces({
       @Namespace(root = "counters"),
+      @Namespace(uri = "urn:infinispan:config:counters:9.1", root = "counters"),
       @Namespace(uri = "urn:infinispan:config:counters:9.0", root = "counters")
 })
 public class CounterConfigurationParser implements ConfigurationParser {

--- a/counter/src/main/resources/schema/infinispan-counters-config-9.1.xsd
+++ b/counter/src/main/resources/schema/infinispan-counters-config-9.1.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" version="1.0"
-           targetNamespace="urn:infinispan:config:counters:9.0"
-           xmlns:tns="urn:infinispan:config:counters:9.0"
+           targetNamespace="urn:infinispan:config:counters:9.1"
+           xmlns:tns="urn:infinispan:config:counters:9.1"
            xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
     <xs:element name="counters" type="tns:counters"/>

--- a/counter/src/test/resources/config/counters.xml
+++ b/counter/src/test/resources/config/counters.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <infinispan
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:infinispan:config:9.0 http://www.infinispan.org/schemas/infinispan-config-9.0.xsd
-   urn:infinispan:config:counters:9.0 infinispan-counters-config-9.0.xsd"
-        xmlns="urn:infinispan:config:9.0">
+        xsi:schemaLocation="urn:infinispan:config:9.1 http://www.infinispan.org/schemas/infinispan-config-9.1.xsd
+   urn:infinispan:config:counters:9.1 infinispan-counters-config-9.1.xsd"
+        xmlns="urn:infinispan:config:9.1">
 
     <cache-container default-cache="default">
         <transport/>
@@ -13,7 +13,7 @@
         <local-cache name="default">
             <locking concurrency-level="100" acquire-timeout="1000"/>
         </local-cache>
-        <counters xmlns="urn:infinispan:config:counters:9.0" num-owners="3" reliability="CONSISTENT">
+        <counters xmlns="urn:infinispan:config:counters:9.1" num-owners="3" reliability="CONSISTENT">
             <strong-counter name="c1" initial-value="1" storage="PERSISTENT"/>
             <strong-counter name="c2" initial-value="2" storage="VOLATILE">
                 <lower-bound value="0"/>

--- a/counter/src/test/resources/config/invalid.xml
+++ b/counter/src/test/resources/config/invalid.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <infinispan
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:infinispan:config:9.0 http://www.infinispan.org/schemas/infinispan-config-9.0.xsd
-   urn:infinispan:config:counters:9.0 infinispan-counters-config-9.0.xsd"
-        xmlns="urn:infinispan:config:9.0">
+        xsi:schemaLocation="urn:infinispan:config:9.1 http://www.infinispan.org/schemas/infinispan-config-9.1.xsd
+   urn:infinispan:config:counters:9.1 infinispan-counters-config-9.1.xsd"
+        xmlns="urn:infinispan:config:9.1">
 
     <cache-container default-cache="default">
         <transport/>
@@ -12,7 +12,7 @@
         </global-state>
         <local-cache name="default">
             <locking concurrency-level="100" acquire-timeout="1000"/>
-            <counters xmlns="urn:infinispan:config:counters:9.0" num-owners="3" reliability="CONSISTENT">
+            <counters xmlns="urn:infinispan:config:counters:9.1" num-owners="3" reliability="CONSISTENT">
                 <strong-counter name="c1" initial-value="1" storage="PERSISTENT"/>
                 <strong-counter name="c2" initial-value="2" storage="VOLATILE">
                     <lower-bound value="0"/>


### PR DESCRIPTION
The schema version of clustered counter remained at 9.0, so I updated it to 9.1.
https://github.com/infinispan/infinispan/blob/9.1.0.Final/counter/src/main/resources/schema/infinispan-counters-config-9.0.xsd