### PR TITLE
ISPN-8206 Update smoke test suite

### DIFF
--- a/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cache/DefaultCacheTest.java
+++ b/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cache/DefaultCacheTest.java
@@ -20,7 +20,7 @@ import org.testng.annotations.Test;
  * @author Pete Muir
  * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
  */
-@Test(groups = "functional", testName = "cdi.test.cache.embedded.DefaultCacheTest")
+@Test(groups = {"functional", "smoke"}, testName = "cdi.test.cache.embedded.DefaultCacheTest")
 public class DefaultCacheTest extends Arquillian {
 
    @Deployment

--- a/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cache/configured/ConfiguredCacheTest.java
+++ b/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cache/configured/ConfiguredCacheTest.java
@@ -19,7 +19,7 @@ import org.testng.annotations.Test;
  * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
  * @see Config
  */
-@Test(groups = "functional", testName = "cdi.test.cache.embedded.configured.ConfiguredCacheTest")
+@Test(groups = {"functional", "smoke"}, testName = "cdi.test.cache.embedded.configured.ConfiguredCacheTest")
 public class ConfiguredCacheTest extends Arquillian {
 
    @Deployment

--- a/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cachemanager/programmatic/ProgrammaticCacheContainerTest.java
+++ b/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cachemanager/programmatic/ProgrammaticCacheContainerTest.java
@@ -22,7 +22,7 @@ import org.testng.annotations.Test;
  * @see Config
  */
 @Listeners(TestResourceTrackingListener.class)
-@Test(groups = "functional", testName = "cdi.test.cachemanager.embedded.programmatic.ProgrammaticCacheContainerTest")
+@Test(groups = {"functional", "smoke"}, testName = "cdi.test.cachemanager.embedded.programmatic.ProgrammaticCacheContainerTest")
 public class ProgrammaticCacheContainerTest extends Arquillian {
 
    @Deployment

--- a/cdi/pom.xml
+++ b/cdi/pom.xml
@@ -33,7 +33,7 @@
         <profile>
             <id>smoke</id>
             <properties>
-                <defaultTestGroup>functional,unit,arquillian</defaultTestGroup>
+                <defaultTestGroup>smoke,arquillian</defaultTestGroup>
             </properties>
         </profile>
     </profiles>

--- a/cdi/remote/src/test/java/org/infinispan/cdi/embedded/test/cache/remote/NamedCacheTest.java
+++ b/cdi/remote/src/test/java/org/infinispan/cdi/embedded/test/cache/remote/NamedCacheTest.java
@@ -30,7 +30,7 @@ import org.testng.annotations.Test;
  * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
  */
 @Listeners(TestResourceTrackingListener.class)
-@Test(groups = "functional", testName = "cdi.test.cache.remote.NamedCacheTest")
+@Test(groups = {"functional", "smoke"}, testName = "cdi.test.cache.remote.NamedCacheTest")
 public class NamedCacheTest extends Arquillian {
 
    private static final String SERVER_LIST_KEY = "infinispan.client.hotrod.server_list";

--- a/client/hotrod-client/pom.xml
+++ b/client/hotrod-client/pom.xml
@@ -509,4 +509,24 @@
          </plugin>
       </plugins>
    </build>
+
+   <profiles>
+      <profile>
+         <id>smoke</id>
+         <build>
+            <plugins>
+               <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-surefire-plugin</artifactId>
+                  <configuration>
+                     <excludes>
+                        <exclude>**/*QueryDslConditions*.java</exclude>
+                        <exclude>**/*QueryString*.java</exclude>
+                     </excludes>
+                  </configuration>
+               </plugin>
+            </plugins>
+         </build>
+      </profile>
+   </profiles>
 </project>

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ExecTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ExecTest.java
@@ -36,7 +36,7 @@ import org.testng.annotations.Test;
  * @author Tristan Tarrant
  * @since 7.2
  */
-@Test(groups = "functional", testName = "client.hotrod.ExecTest")
+@Test(groups = {"functional", "smoke"}, testName = "client.hotrod.ExecTest")
 public class ExecTest extends MultiHotRodServersTest {
    private static final String SCRIPT_CACHE = "___script_cache";
    static final String REPL_CACHE = "R";

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HotRodIntegrationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HotRodIntegrationTest.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
  * @author mmarkus
  * @since 4.1
  */
-@Test (testName = "client.hotrod.HotRodIntegrationTest", groups = "functional" )
+@Test (testName = "client.hotrod.HotRodIntegrationTest", groups = {"functional", "smoke"} )
 public class HotRodIntegrationTest extends SingleCacheManagerTest {
 
    private static final Log log = LogFactory.getLog(HotRodIntegrationTest.class);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientEventsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientEventsTest.java
@@ -16,7 +16,7 @@ import org.testng.annotations.Test;
 /**
  * @author Galder Zamarreño
  */
-@Test(groups = "functional", testName = "client.hotrod.event.ClientEventsTest")
+@Test(groups = {"functional", "smoke"}, testName = "client.hotrod.event.ClientEventsTest")
 public class ClientEventsTest extends SingleHotRodServerTest {
 
    public void testCreatedEvent() {

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/InvalidatedNearCacheTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/InvalidatedNearCacheTest.java
@@ -12,7 +12,7 @@ import org.infinispan.client.hotrod.test.SingleHotRodServerTest;
 import org.infinispan.commons.CacheConfigurationException;
 import org.testng.annotations.Test;
 
-@Test(groups = "functional", testName = "client.hotrod.near.InvalidatedNearCacheTest")
+@Test(groups = {"functional", "smoke"}, testName = "client.hotrod.near.InvalidatedNearCacheTest")
 public class InvalidatedNearCacheTest extends SingleHotRodServerTest {
 
    AssertsNearCache<Integer, String> assertClient;

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/HotRodQueryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/HotRodQueryTest.java
@@ -44,7 +44,7 @@ import org.testng.annotations.Test;
  * @author anistor@redhat.com
  * @since 6.0
  */
-@Test(testName = "client.hotrod.query.HotRodQueryTest", groups = "functional")
+@Test(testName = "client.hotrod.query.HotRodQueryTest", groups = {"functional", "smoke"})
 public class HotRodQueryTest extends SingleCacheManagerTest {
 
    protected static final String TEST_CACHE_NAME = "userCache";

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -155,4 +155,24 @@
          </plugin>
       </plugins>
    </build>
+
+   <profiles>
+      <profile>
+         <id>smoke</id>
+         <build>
+            <plugins>
+               <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-surefire-plugin</artifactId>
+                  <executions>
+                     <execution>
+                        <id>default-test</id>
+                        <phase>none</phase>
+                     </execution>
+                  </executions>
+               </plugin>
+            </plugins>
+         </build>
+      </profile>
+   </profiles>
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -218,4 +218,30 @@
          </plugin>
       </plugins>
    </build>
+
+   <profiles>
+      <profile>
+         <id>smoke</id>
+         <build>
+            <plugins>
+               <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-surefire-plugin</artifactId>
+                  <configuration>
+                     <excludes>
+                        <!-- explicitly exclude some tests because of TestNG issue which ignores
+                             restricted groups in subclasses -->
+                        <exclude>**/*Async*.java</exclude>
+                        <exclude>**/ReplSyncDistributedExecutor*.java</exclude>
+                        <exclude>**/DistributedExecutorWith*.java</exclude>
+                        <exclude>**/DistAsync*.java</exclude>
+                        <exclude>**/DistSyncUnsafe*.java</exclude>
+                        <exclude>**/TopologyAwareDist*.java</exclude>
+                     </excludes>
+                  </configuration>
+               </plugin>
+            </plugins>
+         </build>
+      </profile>
+   </profiles>
 </project>

--- a/core/src/test/java/org/infinispan/distexec/ReplSyncDistributedExecutorTest.java
+++ b/core/src/test/java/org/infinispan/distexec/ReplSyncDistributedExecutorTest.java
@@ -8,7 +8,7 @@ import org.testng.annotations.Test;
  *
  * @author Vladimir Blagojevic
  */
-@Test(groups = {"functional", "smoke"}, testName = "distexec.ReplSyncDistributedExecutorTest")
+@Test(groups = {"functional"}, testName = "distexec.ReplSyncDistributedExecutorTest")
 public class ReplSyncDistributedExecutorTest extends DistributedExecutorTest {
 
    public ReplSyncDistributedExecutorTest() {

--- a/core/src/test/java/org/infinispan/distribution/DistAsyncFuncTest.java
+++ b/core/src/test/java/org/infinispan/distribution/DistAsyncFuncTest.java
@@ -11,7 +11,7 @@ import org.infinispan.test.ReplListener;
 import org.infinispan.test.TestingUtil;
 import org.testng.annotations.Test;
 
-@Test(groups = {"functional", "smoke"}, testName = "distribution.DistAsyncFuncTest")
+@Test(groups = {"functional"}, testName = "distribution.DistAsyncFuncTest")
 public class DistAsyncFuncTest extends DistSyncFuncTest {
 
    ReplListener r1, r2, r3, r4;

--- a/core/src/test/java/org/infinispan/invalidation/AsyncInvalidationTest.java
+++ b/core/src/test/java/org/infinispan/invalidation/AsyncInvalidationTest.java
@@ -2,7 +2,7 @@ package org.infinispan.invalidation;
 
 import org.testng.annotations.Test;
 
-@Test(groups = {"functional", "smoke"}, testName = "invalidation.AsyncInvalidationTest")
+@Test(groups = {"functional"}, testName = "invalidation.AsyncInvalidationTest")
 public class AsyncInvalidationTest extends BaseInvalidationTest {
    public AsyncInvalidationTest() {
       isSync = false;

--- a/core/src/test/java/org/infinispan/persistence/file/SingleFileStoreFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/persistence/file/SingleFileStoreFunctionalTest.java
@@ -34,6 +34,7 @@ public class SingleFileStoreFunctionalTest extends BaseStoreFunctionalTest {
    @BeforeClass
    protected void setUpTempDir() {
       tmpDirectory = TestingUtil.tmpDirectory(this.getClass());
+      Util.recursiveFileRemove(tmpDirectory);
    }
 
    @AfterClass

--- a/core/src/test/java/org/infinispan/replication/ReplicatedAPITest.java
+++ b/core/src/test/java/org/infinispan/replication/ReplicatedAPITest.java
@@ -12,7 +12,7 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.testng.annotations.Test;
 
-@Test(groups = "functional", testName = "replication.ReplicatedAPITest")
+@Test(groups = {"functional", "smoke"}, testName = "replication.ReplicatedAPITest")
 public class ReplicatedAPITest extends MultipleCacheManagersTest {
 
    protected void createCacheManagers() throws Throwable {

--- a/counter/src/test/java/org/infinispan/counter/AbstractCounterTest.java
+++ b/counter/src/test/java/org/infinispan/counter/AbstractCounterTest.java
@@ -18,7 +18,7 @@ import org.testng.annotations.Test;
  * @author Pedro Ruivo
  * @since 9.0
  */
-@Test(groups = "functional")
+@Test(groups = {"functional", "smoke"})
 public abstract class AbstractCounterTest<T extends TestCounter> extends BaseCounterTest {
 
    public void testDiffInitValues(Method method) throws ExecutionException, InterruptedException {

--- a/hibernate-cache/pom.xml
+++ b/hibernate-cache/pom.xml
@@ -105,4 +105,24 @@
          </plugin>
       </plugins>
    </build>
+
+   <profiles>
+      <profile>
+         <id>smoke</id>
+         <build>
+            <plugins>
+               <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-surefire-plugin</artifactId>
+                  <executions>
+                     <execution>
+                        <id>default-test</id>
+                        <phase>none</phase>
+                     </execution>
+                  </executions>
+               </plugin>
+            </plugins>
+         </build>
+      </profile>
+   </profiles>
 </project>

--- a/integrationtests/all-embedded-it/pom.xml
+++ b/integrationtests/all-embedded-it/pom.xml
@@ -84,5 +84,22 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>smoke</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-test</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>

--- a/integrationtests/all-embedded-query-it/pom.xml
+++ b/integrationtests/all-embedded-query-it/pom.xml
@@ -40,4 +40,24 @@
          <scope>test</scope>
       </dependency>
    </dependencies>
+
+   <profiles>
+      <profile>
+         <id>smoke</id>
+         <build>
+            <plugins>
+               <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-surefire-plugin</artifactId>
+                  <executions>
+                     <execution>
+                        <id>default-test</id>
+                        <phase>none</phase>
+                     </execution>
+                  </executions>
+               </plugin>
+            </plugins>
+         </build>
+      </profile>
+   </profiles>
 </project>

--- a/integrationtests/all-remote-it/pom.xml
+++ b/integrationtests/all-remote-it/pom.xml
@@ -139,4 +139,34 @@
          </plugin>
       </plugins>
    </build>
+
+   <profiles>
+      <profile>
+         <id>smoke</id>
+         <properties>
+            <skipTests>true</skipTests>
+         </properties>
+         <build>
+            <plugins>
+               <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-surefire-plugin</artifactId>
+                  <executions>
+                     <execution>
+                        <id>default-test</id>
+                        <phase>none</phase>
+                     </execution>
+                  </executions>
+               </plugin>
+               <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-failsafe-plugin</artifactId>
+                  <configuration>
+                     <skipITs>${skipTests}</skipITs>
+                  </configuration>
+               </plugin>
+            </plugins>
+         </build>
+      </profile>
+   </profiles>
 </project>

--- a/integrationtests/cdi-jcache-it/pom.xml
+++ b/integrationtests/cdi-jcache-it/pom.xml
@@ -124,6 +124,23 @@
             </dependency>
          </dependencies>
       </profile>
+      <profile>
+         <id>smoke</id>
+         <build>
+            <plugins>
+               <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-surefire-plugin</artifactId>
+                  <executions>
+                     <execution>
+                        <id>default-test</id>
+                        <phase>none</phase>
+                     </execution>
+                  </executions>
+               </plugin>
+            </plugins>
+         </build>
+      </profile>
    </profiles>
 
 </project>

--- a/integrationtests/elasticsearch-indexmanager-it/pom.xml
+++ b/integrationtests/elasticsearch-indexmanager-it/pom.xml
@@ -128,4 +128,23 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>smoke</id>
+            <properties>
+                <skipTests>true</skipTests>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <skipITs>${skipTests}</skipITs>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/integrationtests/wildfly-modules/pom.xml
+++ b/integrationtests/wildfly-modules/pom.xml
@@ -400,4 +400,24 @@
 
       </plugins>
    </build>
+
+   <profiles>
+      <profile>
+         <id>smoke</id>
+         <properties>
+            <skipTests>true</skipTests>
+         </properties>
+         <build>
+            <plugins>
+               <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-failsafe-plugin</artifactId>
+                  <configuration>
+                     <skipITs>${skipTests}</skipITs>
+                  </configuration>
+               </plugin>
+            </plugins>
+         </build>
+      </profile>
+   </profiles>
 </project>

--- a/jcache/commons/src/test/java/org/infinispan/jcache/AbstractTwoCachesBasicOpsTest.java
+++ b/jcache/commons/src/test/java/org/infinispan/jcache/AbstractTwoCachesBasicOpsTest.java
@@ -41,7 +41,7 @@ import org.testng.annotations.Test;
  *
  * @author Matej Cimbora
  */
-@Test(testName = "org.infinispan.jcache.AbstractTwoCachesBasicOpsTest", groups = "functional")
+@Test(testName = "org.infinispan.jcache.AbstractTwoCachesBasicOpsTest", groups = {"functional", "smoke"})
 public abstract class AbstractTwoCachesBasicOpsTest extends MultipleCacheManagersTest {
 
    @Test

--- a/jcache/tck-runner/pom.xml
+++ b/jcache/tck-runner/pom.xml
@@ -354,6 +354,9 @@
 
       <profile>
          <id>smoke</id>
+         <properties>
+            <skipTests>true</skipTests>
+         </properties>
          <build>
             <plugins>
                <plugin>
@@ -365,6 +368,13 @@
                         <phase>none</phase>
                      </execution>
                   </executions>
+               </plugin>
+               <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-failsafe-plugin</artifactId>
+                  <configuration>
+                     <skipITs>${skipTests}</skipITs>
+                  </configuration>
                </plugin>
             </plugins>
          </build>

--- a/object-filter/pom.xml
+++ b/object-filter/pom.xml
@@ -153,4 +153,24 @@
          </plugin>
       </plugins>
    </build>
+
+   <profiles>
+      <profile>
+         <id>smoke</id>
+         <build>
+            <plugins>
+               <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-surefire-plugin</artifactId>
+                  <executions>
+                     <execution>
+                        <id>default-test</id>
+                        <phase>none</phase>
+                     </execution>
+                  </executions>
+               </plugin>
+            </plugins>
+         </build>
+      </profile>
+   </profiles>
 </project>

--- a/persistence/rocksdb/src/test/java/org/infinispan/persistence/rocksdb/RocksDBParallelIterationTest.java
+++ b/persistence/rocksdb/src/test/java/org/infinispan/persistence/rocksdb/RocksDBParallelIterationTest.java
@@ -9,7 +9,7 @@ import org.infinispan.persistence.rocksdb.configuration.RocksDBStoreConfiguratio
 import org.infinispan.test.TestingUtil;
 import org.testng.annotations.Test;
 
-@Test (groups = "functional", testName = "persistence.rocksdb.RocksDBParallelIterationTest")
+@Test (groups = {"functional", "smoke"}, testName = "persistence.rocksdb.RocksDBParallelIterationTest")
 public class RocksDBParallelIterationTest extends ParallelIterationTest {
 
    private String tmpDirectory;

--- a/query-dsl/pom.xml
+++ b/query-dsl/pom.xml
@@ -64,4 +64,24 @@
          </plugin>
       </plugins>
    </build>
+
+   <profiles>
+      <profile>
+         <id>smoke</id>
+         <build>
+            <plugins>
+               <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-surefire-plugin</artifactId>
+                  <executions>
+                     <execution>
+                        <id>default-test</id>
+                        <phase>none</phase>
+                     </execution>
+                  </executions>
+               </plugin>
+            </plugins>
+         </build>
+      </profile>
+   </profiles>
 </project>

--- a/query/pom.xml
+++ b/query/pom.xml
@@ -234,4 +234,27 @@
          </plugin>
       </plugins>
    </build>
+
+   <profiles>
+      <profile>
+         <id>smoke</id>
+         <build>
+            <plugins>
+               <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-surefire-plugin</artifactId>
+                  <configuration>
+                     <!-- explicitly exclude some tests because of TestNG issue which ignores
+                          restricted groups in subclasses -->
+                     <includes>
+                        <include>**/LocalCacheTest.java</include>
+                        <include>**/QueryDslConditionsTest.java</include>
+                        <include>**/QueryStringTest.java</include>
+                     </includes>
+                  </configuration>
+               </plugin>
+            </plugins>
+         </build>
+      </profile>
+   </profiles>
 </project>

--- a/query/src/test/java/org/infinispan/query/blackbox/ClusteredCacheTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/ClusteredCacheTest.java
@@ -57,7 +57,7 @@ import org.testng.annotations.Test;
  * @author Navin Surtani
  * @author Sanne Grinovero
  */
-@Test(groups = {"functional", "smoke"}, testName = "query.blackbox.ClusteredCacheTest")
+@Test(groups = {"functional"}, testName = "query.blackbox.ClusteredCacheTest")
 public class ClusteredCacheTest extends MultipleCacheManagersTest {
 
    protected Cache<Object, Person> cache1;

--- a/query/src/test/java/org/infinispan/query/queries/faceting/SimpleFacetingTest.java
+++ b/query/src/test/java/org/infinispan/query/queries/faceting/SimpleFacetingTest.java
@@ -24,7 +24,7 @@ import org.testng.annotations.Test;
  * @author Sanne Grinovero <sanne@hibernate.org> (C) 2011 Red Hat Inc.
  * @author Hardy Ferentschik
  */
-@Test(groups = {"functional", "smoke"}, testName = "query.queries.faceting.SimpleFacetingTest")
+@Test(groups = {"functional"}, testName = "query.queries.faceting.SimpleFacetingTest")
 public class SimpleFacetingTest extends SingleCacheManagerTest {
 
    private static final String indexFieldName = "cubicCapacity";

--- a/query/src/test/java/org/infinispan/query/queries/phrases/QueryPhrasesTest.java
+++ b/query/src/test/java/org/infinispan/query/queries/phrases/QueryPhrasesTest.java
@@ -26,7 +26,7 @@ import org.testng.annotations.Test;
  *
  * @author Anna Manukyan
  */
-@Test(groups = {"functional", "smoke"}, testName = "query.queries.phrases.QueryPhrasesTest")
+@Test(groups = {"functional"}, testName = "query.queries.phrases.QueryPhrasesTest")
 public class QueryPhrasesTest extends SingleCacheManagerTest {
    private Person person1;
    private Person person2;

--- a/query/src/test/java/org/infinispan/query/queries/ranges/QueryRangesTest.java
+++ b/query/src/test/java/org/infinispan/query/queries/ranges/QueryRangesTest.java
@@ -26,7 +26,7 @@ import org.testng.annotations.Test;
  *
  * @author Anna Manukyan
  */
-@Test(groups = {"functional", "smoke"}, testName = "query.queries.ranges.QueryRangesTest")
+@Test(groups = {"functional"}, testName = "query.queries.ranges.QueryRangesTest")
 public class QueryRangesTest extends SingleCacheManagerTest {
 
    private final static TimeZone GMT = TimeZone.getTimeZone("GMT");

--- a/query/src/test/java/org/infinispan/query/queries/spatial/QuerySpatialTest.java
+++ b/query/src/test/java/org/infinispan/query/queries/spatial/QuerySpatialTest.java
@@ -28,7 +28,7 @@ import org.testng.annotations.Test;
  *
  * @author Anna Manukyan
  */
-@Test(groups = {"functional", "smoke"}, testName = "query.queries.spatial.QuerySpatialTest")
+@Test(groups = {"functional"}, testName = "query.queries.spatial.QuerySpatialTest")
 public class QuerySpatialTest extends SingleCacheManagerTest {
 
    public QuerySpatialTest() {

--- a/server/integration/endpoint/pom.xml
+++ b/server/integration/endpoint/pom.xml
@@ -215,4 +215,24 @@
       </dependency>
 
    </dependencies>
+
+   <profiles>
+      <profile>
+         <id>smoke</id>
+         <build>
+            <plugins>
+               <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-surefire-plugin</artifactId>
+                  <executions>
+                     <execution>
+                        <id>default-test</id>
+                        <phase>none</phase>
+                     </execution>
+                  </executions>
+               </plugin>
+            </plugins>
+         </build>
+      </profile>
+   </profiles>
 </project>

--- a/server/integration/jgroups/pom.xml
+++ b/server/integration/jgroups/pom.xml
@@ -128,4 +128,24 @@
         </plugins>
     </build>
     <description>Infinispan Server - JGroups Subsystem</description>
+
+    <profiles>
+        <profile>
+            <id>smoke</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-test</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/server/integration/testsuite/pom.xml
+++ b/server/integration/testsuite/pom.xml
@@ -347,7 +347,7 @@
         <suite.client.repl.phase>integration-test</suite.client.repl.phase>
         <suite.client.repl.domain.phase>none</suite.client.repl.domain.phase>
         <suite.security.phase>none</suite.security.phase>
-        <suite.client.smoke.phase>none</suite.client.smoke.phase>
+        <suite.smoke.phase>none</suite.smoke.phase>
 
         <suite.manual.include>**/*.java</suite.manual.include>
         <suite.manual.exclude.groups>
@@ -1046,13 +1046,13 @@
                     </execution>
                     <execution>
                         <id>suite-smoke</id>
-                        <phase>${suite.client.smoke.phase}</phase>
+                        <phase>${suite.smoke.phase}</phase>
                         <goals>
                             <goal>integration-test</goal>
                         </goals>
                         <configuration>
                             <groups>org.infinispan.server.test.category.Smoke</groups>
-                            <excludedGroups>${groups.unstable}</excludedGroups>
+                            <excludedGroups>${groups.unstable}, org.infinispan.server.test.category.MemcachedClustered</excludedGroups>
                             <systemPropertyVariables>
                                 <arquillian.launch>suite-client-dist</arquillian.launch>
                             </systemPropertyVariables>
@@ -1172,6 +1172,7 @@
         <profile>
             <id>smoke</id>
             <properties>
+                <suite.smoke.phase>integration-test</suite.smoke.phase>
                 <suite.manual.phase>none</suite.manual.phase>
                 <suite.manual.include.groups>org.infinispan.server.test.category.Smoke</suite.manual.include.groups>
                 <suite.queries.phase>none</suite.queries.phase>

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/HotRodRemoteCacheDomainIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/HotRodRemoteCacheDomainIT.java
@@ -10,7 +10,6 @@ import java.util.List;
 import org.infinispan.arquillian.core.InfinispanResource;
 import org.infinispan.arquillian.core.RemoteInfinispanServer;
 import org.infinispan.server.test.category.HotRodClusteredDomain;
-import org.infinispan.server.test.category.Smoke;
 import org.infinispan.server.test.util.ManagementClient;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
@@ -30,7 +29,7 @@ import org.junit.runner.RunWith;
  * @author Martin Gencur
  */
 @RunWith(Arquillian.class)
-@Category({HotRodClusteredDomain.class, Smoke.class})
+@Category(HotRodClusteredDomain.class)
 public class HotRodRemoteCacheDomainIT extends AbstractRemoteCacheIT {
 
     @InfinispanResource(value = "master:server-one", jmxPort = 4447)

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/HotRodRemoteCacheManagerDomainIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/HotRodRemoteCacheManagerDomainIT.java
@@ -10,7 +10,6 @@ import java.util.List;
 import org.infinispan.arquillian.core.InfinispanResource;
 import org.infinispan.arquillian.core.RemoteInfinispanServer;
 import org.infinispan.server.test.category.HotRodClusteredDomain;
-import org.infinispan.server.test.category.Smoke;
 import org.infinispan.server.test.util.ManagementClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.junit.AfterClass;
@@ -24,7 +23,7 @@ import org.junit.runner.RunWith;
  * @author Vitalii Chepeliuk
  */
 @RunWith(Arquillian.class)
-@Category({ HotRodClusteredDomain.class, Smoke.class })
+@Category(HotRodClusteredDomain.class)
 public class HotRodRemoteCacheManagerDomainIT extends AbstractRemoteCacheManagerIT {
 
     @InfinispanResource(value = "master:server-one", jmxPort = 4447)

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/memcached/MemcachedClusteredDomainIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/memcached/MemcachedClusteredDomainIT.java
@@ -24,7 +24,7 @@ import org.junit.runner.RunWith;
  * @author Martin Gencur
  */
 @RunWith(Arquillian.class)
-@Category({ MemcachedClusteredDomain.class, Smoke.class })
+@Category(MemcachedClusteredDomain.class)
 public class MemcachedClusteredDomainIT extends AbstractMemcachedClusteredIT {
 
     private static final int MEMCACHED_PORT1 = 11213;

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/rest/RESTClusteredDomainIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/rest/RESTClusteredDomainIT.java
@@ -9,7 +9,6 @@ import java.util.List;
 import org.infinispan.arquillian.core.InfinispanResource;
 import org.infinispan.arquillian.core.RemoteInfinispanServer;
 import org.infinispan.server.test.category.RESTClusteredDomain;
-import org.infinispan.server.test.category.Smoke;
 import org.infinispan.server.test.util.ManagementClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.junit.AfterClass;
@@ -25,7 +24,7 @@ import org.junit.runner.RunWith;
  * @version August 2011
  */
 @RunWith(Arquillian.class)
-@Category({ RESTClusteredDomain.class, Smoke.class })
+@Category(RESTClusteredDomain.class)
 public class RESTClusteredDomainIT extends AbstractRESTClusteredIT {
 
     private static final int REST_PORT1 = 8081;

--- a/server/router/pom.xml
+++ b/server/router/pom.xml
@@ -225,4 +225,24 @@
 
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>smoke</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-test</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/spring/spring4/spring4-embedded/src/test/java/org/infinispan/spring/config/InfinispanEmbeddedCacheManagerDefinitionTest.java
+++ b/spring/spring4/spring4-embedded/src/test/java/org/infinispan/spring/config/InfinispanEmbeddedCacheManagerDefinitionTest.java
@@ -13,7 +13,7 @@ import org.testng.annotations.Test;
  * @author Marius Bogoevici
  */
 
-@Test(groups = "functional", testName = "spring.config.InfinispanEmbeddedCacheManagerDefinitionTest")
+@Test(groups = {"functional", "smoke"}, testName = "spring.config.InfinispanEmbeddedCacheManagerDefinitionTest")
 @ContextConfiguration
 public class InfinispanEmbeddedCacheManagerDefinitionTest extends AbstractTestNGSpringContextTests {
 

--- a/spring/spring4/spring4-embedded/src/test/java/org/infinispan/spring/config/NonTransactionalCacheTest.java
+++ b/spring/spring4/spring4-embedded/src/test/java/org/infinispan/spring/config/NonTransactionalCacheTest.java
@@ -15,7 +15,7 @@ import org.testng.annotations.Test;
  * @author Galder Zamarreño
  * @since 5.1
  */
-@Test(groups = "functional", testName = "spring.config.NonTransactionalCacheTest")
+@Test(groups = {"functional", "smoke"}, testName = "spring.config.NonTransactionalCacheTest")
 @ContextConfiguration
 public class NonTransactionalCacheTest extends AbstractTestNGSpringContextTests {
 

--- a/spring/spring4/spring4-embedded/src/test/java/org/infinispan/spring/provider/SpringCacheCacheTest.java
+++ b/spring/spring4/spring4-embedded/src/test/java/org/infinispan/spring/provider/SpringCacheCacheTest.java
@@ -30,7 +30,7 @@ import org.testng.annotations.Test;
  * @author Marius Bogoevici
  *
  */
-@Test(testName = "spring.provider.SpringCacheCacheTest", groups = "unit")
+@Test(testName = "spring.provider.SpringCacheCacheTest", groups = {"unit", "smoke"})
 public class SpringCacheCacheTest extends SingleCacheManagerTest {
 
    protected final static String CACHE_NAME = "testCache";

--- a/spring/spring4/spring4-remote/src/test/java/org/infinispan/spring/config/InfinispanRemoteCacheManagerDefinitionTest.java
+++ b/spring/spring4/spring4-remote/src/test/java/org/infinispan/spring/config/InfinispanRemoteCacheManagerDefinitionTest.java
@@ -13,7 +13,7 @@ import org.testng.annotations.Test;
  * @author Marius Bogoevici
  */
 
-@Test(groups = "functional", testName = "spring.config.InfinispanRemoteCacheManagerDefinitionTest")
+@Test(groups = {"functional", "smoke"}, testName = "spring.config.InfinispanRemoteCacheManagerDefinitionTest")
 @ContextConfiguration
 public class InfinispanRemoteCacheManagerDefinitionTest extends AbstractTestNGSpringContextTests {
 

--- a/spring/spring4/spring4-remote/src/test/java/org/infinispan/spring/provider/SpringRemoteCacheManagerTest.java
+++ b/spring/spring4/spring4-remote/src/test/java/org/infinispan/spring/provider/SpringRemoteCacheManagerTest.java
@@ -30,7 +30,7 @@ import org.testng.annotations.Test;
  * @author Marius Bogoevici
  *
  */
-@Test(testName = "spring.provider.SpringRemoteCacheManagerTest", groups = "functional")
+@Test(testName = "spring.provider.SpringRemoteCacheManagerTest", groups = {"functional", "smoke"})
 public class SpringRemoteCacheManagerTest extends SingleCacheManagerTest {
 
    private static final String TEST_CACHE_NAME = "spring.remote.cache.manager.Test";


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-8206

Smoke tests are run for majority of Infinispan modules. When there are no smoke tests in the module it means that the functionality is covered by other modules (e.g. query-dsl is covered by query tests) or they are not part of the product. The smoke test suite will be run for the product on some less frequently used platforms. I'm going to create another PR for the product when this PR is integrated.