### PR TITLE
ISPN-8218 ScatteredStreamIteratorTest.waitUntilProcessingResults random failure

### DIFF
--- a/core/src/main/java/org/infinispan/stream/impl/PartitionAwareClusterStreamManager.java
+++ b/core/src/main/java/org/infinispan/stream/impl/PartitionAwareClusterStreamManager.java
@@ -8,6 +8,7 @@ import java.util.function.Predicate;
 
 import org.infinispan.Cache;
 import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
 import org.infinispan.notifications.Listener;
@@ -70,40 +71,40 @@ public class PartitionAwareClusterStreamManager<K> extends ClusterStreamManagerI
    }
 
    @Override
-   public <R> Object remoteStreamOperation(boolean parallelDistribution, boolean parallelStream,
-                                           Set<Integer> segments, Set<K> keysToInclude, Map<Integer, Set<K>> keysToExclude, boolean includeLoader,
-                                           TerminalOperation<R> operation, ResultsCallback<R> callback, Predicate<? super R> earlyTerminatePredicate) {
+   public <R> Object remoteStreamOperation(boolean parallelDistribution, boolean parallelStream, ConsistentHash ch,
+           Set<Integer> segments, Set<K> keysToInclude, Map<Integer, Set<K>> keysToExclude, boolean includeLoader,
+           TerminalOperation<R> operation, ResultsCallback<R> callback, Predicate<? super R> earlyTerminatePredicate) {
       checkPartitionStatus();
-      return super.remoteStreamOperation(parallelDistribution, parallelStream, segments, keysToInclude,
+      return super.remoteStreamOperation(parallelDistribution, parallelStream, ch, segments, keysToInclude,
               keysToExclude, includeLoader, operation, callback, earlyTerminatePredicate);
    }
 
    @Override
-   public <R> Object remoteStreamOperation(boolean parallelDistribution, boolean parallelStream,
-                                           Set<Integer> segments, Set<K> keysToInclude, Map<Integer, Set<K>> keysToExclude, boolean includeLoader,
-                                           KeyTrackingTerminalOperation<K, R, ?> operation, ResultsCallback<Collection<R>> callback) {
+   public <R> Object remoteStreamOperation(boolean parallelDistribution, boolean parallelStream, ConsistentHash ch,
+           Set<Integer> segments, Set<K> keysToInclude, Map<Integer, Set<K>> keysToExclude, boolean includeLoader,
+           KeyTrackingTerminalOperation<K, R, ?> operation, ResultsCallback<Collection<R>> callback) {
       checkPartitionStatus();
-      return super.remoteStreamOperation(parallelDistribution, parallelStream, segments, keysToInclude,
+      return super.remoteStreamOperation(parallelDistribution, parallelStream, ch, segments, keysToInclude,
               keysToExclude, includeLoader, operation, callback);
    }
 
    @Override
    public <R> Object remoteStreamOperationRehashAware(boolean parallelDistribution, boolean parallelStream,
-                                                      Set<Integer> segments, Set<K> keysToInclude, Map<Integer, Set<K>> keysToExclude,
-                                                      boolean includeLoader, TerminalOperation<R> operation, ResultsCallback<R> callback,
-                                                      Predicate<? super R> earlyTerminatePredicate) {
+           ConsistentHash ch, Set<Integer> segments, Set<K> keysToInclude, Map<Integer, Set<K>> keysToExclude,
+           boolean includeLoader, TerminalOperation<R> operation, ResultsCallback<R> callback,
+           Predicate<? super R> earlyTerminatePredicate) {
       checkPartitionStatus();
-      return super.remoteStreamOperationRehashAware(parallelDistribution, parallelStream, segments, keysToInclude,
+      return super.remoteStreamOperationRehashAware(parallelDistribution, parallelStream, ch, segments, keysToInclude,
               keysToExclude, includeLoader, operation, callback, earlyTerminatePredicate);
    }
 
    @Override
    public <R2> Object remoteStreamOperationRehashAware(boolean parallelDistribution, boolean parallelStream,
-                                                       Set<Integer> segments, Set<K> keysToInclude, Map<Integer, Set<K>> keysToExclude,
-                                                       boolean includeLoader, KeyTrackingTerminalOperation<K, ?, R2> operation,
-                                                       ResultsCallback<Map<K, R2>> callback) {
+           ConsistentHash ch, Set<Integer> segments, Set<K> keysToInclude, Map<Integer, Set<K>> keysToExclude,
+           boolean includeLoader, KeyTrackingTerminalOperation<K, ?, R2> operation,
+           ResultsCallback<Map<K, R2>> callback) {
       checkPartitionStatus();
-      return super.remoteStreamOperationRehashAware(parallelDistribution, parallelStream, segments, keysToInclude,
+      return super.remoteStreamOperationRehashAware(parallelDistribution, parallelStream, ch, segments, keysToInclude,
               keysToExclude, includeLoader, operation, callback);
    }
 

--- a/core/src/main/java/org/infinispan/stream/impl/tx/TxClusterStreamManager.java
+++ b/core/src/main/java/org/infinispan/stream/impl/tx/TxClusterStreamManager.java
@@ -34,39 +34,39 @@ public class TxClusterStreamManager<K> implements ClusterStreamManager<K> {
    }
 
    @Override
-   public <R> Object remoteStreamOperation(boolean parallelDistribution, boolean parallelStream,
-                                           Set<Integer> segments, Set<K> keysToInclude, Map<Integer, Set<K>> keysToExclude, boolean includeLoader,
-                                           TerminalOperation<R> operation, ResultsCallback<R> callback, Predicate<? super R> earlyTerminatePredicate) {
+   public <R> Object remoteStreamOperation(boolean parallelDistribution, boolean parallelStream, ConsistentHash ch,
+           Set<Integer> segments, Set<K> keysToInclude, Map<Integer, Set<K>> keysToExclude, boolean includeLoader,
+           TerminalOperation<R> operation, ResultsCallback<R> callback, Predicate<? super R> earlyTerminatePredicate) {
       TxExcludedKeys<K> txExcludedKeys = new TxExcludedKeys<>(keysToExclude, ctx, hash);
-      return manager.remoteStreamOperation(parallelDistribution, parallelStream, segments, keysToInclude,
+      return manager.remoteStreamOperation(parallelDistribution, parallelStream, ch, segments, keysToInclude,
               txExcludedKeys, includeLoader, operation, callback, earlyTerminatePredicate);
    }
 
    @Override
    public <R> Object remoteStreamOperationRehashAware(boolean parallelDistribution, boolean parallelStream,
-                                                      Set<Integer> segments, Set<K> keysToInclude, Map<Integer, Set<K>> keysToExclude,
-                                                      boolean includeLoader, TerminalOperation<R> operation, ResultsCallback<R> callback,
-                                                      Predicate<? super R> earlyTerminatePredicate) {
+           ConsistentHash ch, Set<Integer> segments, Set<K> keysToInclude, Map<Integer, Set<K>> keysToExclude,
+           boolean includeLoader, TerminalOperation<R> operation, ResultsCallback<R> callback,
+           Predicate<? super R> earlyTerminatePredicate) {
       TxExcludedKeys<K> txExcludedKeys = new TxExcludedKeys<>(keysToExclude, ctx, hash);
-      return manager.remoteStreamOperationRehashAware(parallelDistribution, parallelStream, segments, keysToInclude,
+      return manager.remoteStreamOperationRehashAware(parallelDistribution, parallelStream, ch, segments, keysToInclude,
               txExcludedKeys, includeLoader, operation, callback, earlyTerminatePredicate);
    }
 
    @Override
-   public <R> Object remoteStreamOperation(boolean parallelDistribution, boolean parallelStream,
-                                           Set<Integer> segments, Set<K> keysToInclude, Map<Integer, Set<K>> keysToExclude, boolean includeLoader,
-                                           KeyTrackingTerminalOperation<K, R, ?> operation, ResultsCallback<Collection<R>> callback) {
+   public <R> Object remoteStreamOperation(boolean parallelDistribution, boolean parallelStream, ConsistentHash ch,
+           Set<Integer> segments, Set<K> keysToInclude, Map<Integer, Set<K>> keysToExclude, boolean includeLoader,
+           KeyTrackingTerminalOperation<K, R, ?> operation, ResultsCallback<Collection<R>> callback) {
       TxExcludedKeys<K> txExcludedKeys = new TxExcludedKeys<>(keysToExclude, ctx, hash);
-      return manager.remoteStreamOperation(parallelDistribution, parallelStream, segments, keysToInclude,
+      return manager.remoteStreamOperation(parallelDistribution, parallelStream, ch, segments, keysToInclude,
               txExcludedKeys, includeLoader, operation, callback);
    }
 
    @Override
    public <R2> Object remoteStreamOperationRehashAware(boolean parallelDistribution, boolean parallelStream,
-                                                       Set<Integer> segments, Set<K> keysToInclude, Map<Integer, Set<K>> keysToExclude,
-                                                       boolean includeLoader, KeyTrackingTerminalOperation<K, ?, R2> operation, ResultsCallback<Map<K, R2>> callback) {
+           ConsistentHash ch, Set<Integer> segments, Set<K> keysToInclude, Map<Integer, Set<K>> keysToExclude,
+           boolean includeLoader, KeyTrackingTerminalOperation<K, ?, R2> operation, ResultsCallback<Map<K, R2>> callback) {
       TxExcludedKeys<K> txExcludedKeys = new TxExcludedKeys<>(keysToExclude, ctx, hash);
-      return manager.remoteStreamOperationRehashAware(parallelDistribution, parallelStream, segments, keysToInclude,
+      return manager.remoteStreamOperationRehashAware(parallelDistribution, parallelStream, ch, segments, keysToInclude,
               txExcludedKeys, includeLoader, operation, callback);
    }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-8218

Reverts most of the stream related changes from ISPN-6645, fixing the
consistent hash instance used for both remote and local iteration. The
retry with newer topology is moved to xCacheStream instead.
Non-rehash-aware iteration through scattered cache may miss segments
that don't have owner during rehash.