### PR TITLE
ISPN-8245 Make Hibernate Cache provider work with Hibernate 5.1

### DIFF
--- a/hibernate-cache/pom.xml
+++ b/hibernate-cache/pom.xml
@@ -15,6 +15,7 @@
 
    <properties>
       <module.skipComponentMetaDataProcessing>false</module.skipComponentMetaDataProcessing>
+      <version.hibernate.core>5.1.10.Final</version.hibernate.core>
    </properties>
 
    <dependencies>
@@ -25,6 +26,7 @@
       <dependency>
          <groupId>org.hibernate</groupId>
          <artifactId>hibernate-core</artifactId>
+         <version>${version.hibernate.core}</version>
       </dependency>
 
       <dependency>
@@ -36,6 +38,7 @@
       <dependency>
          <groupId>org.hibernate</groupId>
          <artifactId>hibernate-testing</artifactId>
+         <version>${version.hibernate.core}</version>
          <scope>test</scope>
          <exclusions>
             <exclusion>
@@ -43,6 +46,12 @@
                <artifactId>log4j</artifactId>
             </exclusion>
          </exclusions>
+      </dependency>
+      <dependency>
+         <groupId>org.hibernate</groupId>
+         <artifactId>hibernate-entitymanager</artifactId>
+         <version>${version.hibernate.core}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.mockito</groupId>

--- a/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/InfinispanRegionFactory.java
+++ b/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/InfinispanRegionFactory.java
@@ -303,7 +303,7 @@ public class InfinispanRegionFactory implements RegionFactory {
 	}
 
 	@Override
-	public CollectionRegion buildCollectionRegion(String regionName, Map<String, Object> configValues, CacheDataDescription metadata) {
+	public CollectionRegion buildCollectionRegion(String regionName, Properties properties, CacheDataDescription metadata) {
 		if ( log.isDebugEnabled() ) {
 			log.debug( "Building collection cache region [" + regionName + "]" );
 		}
@@ -314,16 +314,7 @@ public class InfinispanRegionFactory implements RegionFactory {
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
-	public CollectionRegion buildCollectionRegion(
-			String regionName,
-			Properties properties,
-			CacheDataDescription metadata) throws CacheException {
-		return buildCollectionRegion( regionName, (Map) properties, metadata );
-	}
-
-	@Override
-	public EntityRegion buildEntityRegion(String regionName, Map<String, Object> configValues, CacheDataDescription metadata) {
+	public EntityRegion buildEntityRegion(String regionName, Properties properties, CacheDataDescription metadata) {
 		if ( log.isDebugEnabled() ) {
 			log.debugf(
 					"Building entity cache region [%s] (mutable=%s, versioned=%s)",
@@ -339,13 +330,7 @@ public class InfinispanRegionFactory implements RegionFactory {
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
-	public EntityRegion buildEntityRegion(String regionName, Properties properties, CacheDataDescription metadata) {
-		return buildEntityRegion( regionName, (Map) properties, metadata );
-	}
-
-	@Override
-	public NaturalIdRegion buildNaturalIdRegion(String regionName, Map<String, Object> configValues, CacheDataDescription metadata) {
+	public NaturalIdRegion buildNaturalIdRegion(String regionName, Properties properties, CacheDataDescription metadata) {
 		if ( log.isDebugEnabled() ) {
 			log.debug("Building natural id cache region [" + regionName + "]");
 		}
@@ -356,13 +341,7 @@ public class InfinispanRegionFactory implements RegionFactory {
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
-	public NaturalIdRegion buildNaturalIdRegion(String regionName, Properties properties, CacheDataDescription metadata) {
-		return buildNaturalIdRegion( regionName, (Map) properties, metadata );
-	}
-
-	@Override
-	public QueryResultsRegion buildQueryResultsRegion(String regionName, Map<String, Object> configValues) {
+	public QueryResultsRegion buildQueryResultsRegion(String regionName, Properties properties) {
 		if ( log.isDebugEnabled() ) {
 			log.debug( "Building query results cache region [" + regionName + "]" );
 		}
@@ -374,13 +353,7 @@ public class InfinispanRegionFactory implements RegionFactory {
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
-	public QueryResultsRegion buildQueryResultsRegion(String regionName, Properties properties) {
-		return buildQueryResultsRegion( regionName, (Map) properties );
-	}
-
-	@Override
-	public TimestampsRegion buildTimestampsRegion(String regionName, Map<String, Object> configValues) {
+	public TimestampsRegion buildTimestampsRegion(String regionName, Properties properties) {
 		if ( log.isDebugEnabled() ) {
 			log.debug( "Building timestamps cache region [" + regionName + "]" );
 		}
@@ -388,12 +361,6 @@ public class InfinispanRegionFactory implements RegionFactory {
 		final TimestampsRegionImpl region = createTimestampsRegion( cache, regionName );
 		startRegion( region );
 		return region;
-	}
-
-	@Override
-	@SuppressWarnings("unchecked")
-	public TimestampsRegion buildTimestampsRegion(String regionName, Properties properties) {
-		return buildTimestampsRegion( regionName, (Map) properties );
 	}
 
 	protected TimestampsRegionImpl createTimestampsRegion(

--- a/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/access/AccessDelegate.java
+++ b/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/access/AccessDelegate.java
@@ -8,7 +8,7 @@ package org.infinispan.hibernate.cache.access;
 
 import org.hibernate.cache.CacheException;
 import org.hibernate.cache.spi.access.SoftLock;
-import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
 
 /**
  * Defines the strategy for access to entity or collection data in a Infinispan instance.
@@ -20,7 +20,7 @@ import org.hibernate.engine.spi.SharedSessionContractImplementor;
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
 public interface AccessDelegate {
-	Object get(SharedSessionContractImplementor session, Object key, long txTimestamp) throws CacheException;
+	Object get(SessionImplementor session, Object key, long txTimestamp) throws CacheException;
 
 	/**
 	 * Attempt to cache an object, after loading from the database.
@@ -32,7 +32,7 @@ public interface AccessDelegate {
 	 * @param version the item version number
 	 * @return <tt>true</tt> if the object was successfully cached
 	 */
-	boolean putFromLoad(SharedSessionContractImplementor session, Object key, Object value, long txTimestamp, Object version);
+	boolean putFromLoad(SessionImplementor session, Object key, Object value, long txTimestamp, Object version);
 
 	/**
 	 * Attempt to cache an object, after loading from the database, explicitly
@@ -47,7 +47,7 @@ public interface AccessDelegate {
 	 * @return <tt>true</tt> if the object was successfully cached
 	 * @throws org.hibernate.cache.CacheException Propogated from underlying {@link org.hibernate.cache.spi.Region}
 	 */
-	boolean putFromLoad(SharedSessionContractImplementor session, Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
+	boolean putFromLoad(SessionImplementor session, Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
 			throws CacheException;
 
 	/**
@@ -61,7 +61,7 @@ public interface AccessDelegate {
 	 * @return Were the contents of the cache actual changed by this operation?
 	 * @throws CacheException if the insert fails
 	 */
-	boolean insert(SharedSessionContractImplementor session, Object key, Object value, Object version) throws CacheException;
+	boolean insert(SessionImplementor session, Object key, Object value, Object version) throws CacheException;
 
 	/**
 	 * Called after an item has been updated (before the transaction completes),
@@ -75,7 +75,7 @@ public interface AccessDelegate {
 	 * @return Whether the contents of the cache actual changed by this operation
 	 * @throws CacheException if the update fails
 	 */
-	boolean update(SharedSessionContractImplementor session, Object key, Object value, Object currentVersion, Object previousVersion)
+	boolean update(SessionImplementor session, Object key, Object value, Object currentVersion, Object previousVersion)
 			throws CacheException;
 
 	/**
@@ -85,7 +85,7 @@ public interface AccessDelegate {
 	 * @param key The key of the item to remove
 	 * @throws CacheException if removing the cached item fails
 	 */
-	void remove(SharedSessionContractImplementor session, Object key) throws CacheException;
+	void remove(SessionImplementor session, Object key) throws CacheException;
 
 	/**
 	 * Called to evict data from the entire region
@@ -121,7 +121,7 @@ public interface AccessDelegate {
 	 * @param key The item key
 	 * @throws org.hibernate.cache.CacheException Propogated from underlying {@link org.hibernate.cache.spi.Region}
 	 */
-	void unlockItem(SharedSessionContractImplementor session, Object key) throws CacheException;
+	void unlockItem(SessionImplementor session, Object key) throws CacheException;
 
 	/**
 	 * Called after an item has been inserted (after the transaction completes),
@@ -136,7 +136,7 @@ public interface AccessDelegate {
 	 * @return Were the contents of the cache actual changed by this operation?
 	 * @throws CacheException Propagated from underlying {@link org.hibernate.cache.spi.Region}
 	 */
-	boolean afterInsert(SharedSessionContractImplementor session, Object key, Object value, Object version);
+	boolean afterInsert(SessionImplementor session, Object key, Object value, Object version);
 
 	/**
 	 * Called after an item has been updated (after the transaction completes),
@@ -153,5 +153,5 @@ public interface AccessDelegate {
 	 * @return Were the contents of the cache actual changed by this operation?
 	 * @throws CacheException Propagated from underlying {@link org.hibernate.cache.spi.Region}
 	 */
-	boolean afterUpdate(SharedSessionContractImplementor session, Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock);
+	boolean afterUpdate(SessionImplementor session, Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock);
 }

--- a/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/access/FutureUpdateSynchronization.java
+++ b/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/access/FutureUpdateSynchronization.java
@@ -12,7 +12,7 @@ import org.infinispan.hibernate.cache.impl.BaseTransactionalDataRegion;
 import org.infinispan.hibernate.cache.util.FutureUpdate;
 import org.infinispan.hibernate.cache.util.InfinispanMessageLogger;
 import org.infinispan.hibernate.cache.util.InvocationAfterCompletion;
-import org.hibernate.resource.transaction.spi.TransactionCoordinator;
+import org.hibernate.resource.transaction.TransactionCoordinator;
 
 import org.infinispan.AdvancedCache;
 

--- a/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/access/InvalidationCacheAccessDelegate.java
+++ b/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/access/InvalidationCacheAccessDelegate.java
@@ -10,7 +10,7 @@ import org.hibernate.cache.CacheException;
 import org.infinispan.hibernate.cache.impl.BaseRegion;
 import org.infinispan.hibernate.cache.util.Caches;
 import org.infinispan.hibernate.cache.util.InfinispanMessageLogger;
-import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
 
 import org.infinispan.AdvancedCache;
 
@@ -54,7 +54,7 @@ public abstract class InvalidationCacheAccessDelegate implements AccessDelegate 
     */
 	@Override
 	@SuppressWarnings("UnusedParameters")
-	public Object get(SharedSessionContractImplementor session, Object key, long txTimestamp) throws CacheException {
+	public Object get(SessionImplementor session, Object key, long txTimestamp) throws CacheException {
 		if ( !region.checkValid() ) {
 			return null;
 		}
@@ -66,7 +66,7 @@ public abstract class InvalidationCacheAccessDelegate implements AccessDelegate 
 	}
 
 	@Override
-	public boolean putFromLoad(SharedSessionContractImplementor session, Object key, Object value, long txTimestamp, Object version) {
+	public boolean putFromLoad(SessionImplementor session, Object key, Object value, long txTimestamp, Object version) {
 		return putFromLoad(session, key, value, txTimestamp, version, false );
 	}
 
@@ -85,7 +85,7 @@ public abstract class InvalidationCacheAccessDelegate implements AccessDelegate 
     */
 	@Override
 	@SuppressWarnings("UnusedParameters")
-	public boolean putFromLoad(SharedSessionContractImplementor session, Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
+	public boolean putFromLoad(SessionImplementor session, Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
 			throws CacheException {
 		if ( !region.checkValid() ) {
 			if ( TRACE_ENABLED ) {
@@ -122,7 +122,7 @@ public abstract class InvalidationCacheAccessDelegate implements AccessDelegate 
 	}
 
 	@Override
-	public void remove(SharedSessionContractImplementor session, Object key) throws CacheException {
+	public void remove(SessionImplementor session, Object key) throws CacheException {
 		putValidator.setCurrentSession(session);
 		try {
 			// We update whether or not the region is valid. Other nodes
@@ -170,6 +170,6 @@ public abstract class InvalidationCacheAccessDelegate implements AccessDelegate 
 	}
 
 	@Override
-	public void unlockItem(SharedSessionContractImplementor session, Object key) throws CacheException {
+	public void unlockItem(SessionImplementor session, Object key) throws CacheException {
 	}
 }

--- a/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/access/NonTxInvalidationCacheAccessDelegate.java
+++ b/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/access/NonTxInvalidationCacheAccessDelegate.java
@@ -9,7 +9,7 @@ package org.infinispan.hibernate.cache.access;
 import org.hibernate.cache.CacheException;
 import org.infinispan.hibernate.cache.impl.BaseRegion;
 import org.hibernate.cache.spi.access.SoftLock;
-import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
 
 /**
  * Delegate for non-transactional caches
@@ -23,7 +23,7 @@ public class NonTxInvalidationCacheAccessDelegate extends InvalidationCacheAcces
 
 	@Override
 	@SuppressWarnings("UnusedParameters")
-	public boolean insert(SharedSessionContractImplementor session, Object key, Object value, Object version) throws CacheException {
+	public boolean insert(SessionImplementor session, Object key, Object value, Object version) throws CacheException {
 		if ( !region.checkValid() ) {
 			return false;
 		}
@@ -45,7 +45,7 @@ public class NonTxInvalidationCacheAccessDelegate extends InvalidationCacheAcces
 
 	@Override
 	@SuppressWarnings("UnusedParameters")
-	public boolean update(SharedSessionContractImplementor session, Object key, Object value, Object currentVersion, Object previousVersion)
+	public boolean update(SessionImplementor session, Object key, Object value, Object currentVersion, Object previousVersion)
 			throws CacheException {
 		// We update whether or not the region is valid. Other nodes
 		// may have already restored the region so they need to
@@ -67,13 +67,13 @@ public class NonTxInvalidationCacheAccessDelegate extends InvalidationCacheAcces
 	}
 
 	@Override
-	public boolean afterInsert(SharedSessionContractImplementor session, Object key, Object value, Object version) {
+	public boolean afterInsert(SessionImplementor session, Object key, Object value, Object version) {
 		// endInvalidatingKeys is called from NonTxInvalidationInterceptor, from the synchronization callback
 		return false;
 	}
 
 	@Override
-	public boolean afterUpdate(SharedSessionContractImplementor session, Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock) {
+	public boolean afterUpdate(SessionImplementor session, Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock) {
 		// endInvalidatingKeys is called from NonTxInvalidationInterceptor, from the synchronization callback
 		return false;
 	}

--- a/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/access/PutFromLoadValidator.java
+++ b/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/access/PutFromLoadValidator.java
@@ -16,12 +16,12 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.resource.transaction.TransactionCoordinator;
 import org.infinispan.hibernate.cache.InfinispanRegionFactory;
 import org.infinispan.hibernate.cache.util.CacheCommandInitializer;
 import org.infinispan.hibernate.cache.util.InfinispanMessageLogger;
 import org.hibernate.cache.spi.RegionFactory;
-import org.hibernate.engine.spi.SharedSessionContractImplementor;
-import org.hibernate.resource.transaction.spi.TransactionCoordinator;
 
 import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
@@ -37,7 +37,7 @@ import org.infinispan.util.ByteString;
 
 /**
  * Encapsulates logic to allow a {@link InvalidationCacheAccessDelegate} to determine
- * whether a {@link InvalidationCacheAccessDelegate#putFromLoad(org.hibernate.engine.spi.SharedSessionContractImplementor, Object, Object, long, Object, boolean)}
+ * whether a {@link InvalidationCacheAccessDelegate#putFromLoad(org.hibernate.engine.spi.SessionImplementor, Object, Object, long, Object, boolean)}
  * call should be allowed to update the cache. A <code>putFromLoad</code> has
  * the potential to store stale data, since the data may have been removed from the
  * database and the cache between the time when the data was read from the database
@@ -47,9 +47,9 @@ import org.infinispan.util.ByteString;
  * not find data is:
  * <p/>
  * <ol>
- * <li> Call {@link #registerPendingPut(SharedSessionContractImplementor, Object, long)}</li>
+ * <li> Call {@link #registerPendingPut(SessionImplementor, Object, long)}</li>
  * <li> Read the database</li>
- * <li> Call {@link #acquirePutFromLoadLock(SharedSessionContractImplementor, Object, long)}
+ * <li> Call {@link #acquirePutFromLoadLock(SessionImplementor, Object, long)}
  * <li> if above returns <code>null</code>, the thread should not cache the data;
  * only if above returns instance of <code>AcquiredLock</code>, put data in the cache and...</li>
  * <li> then call {@link #releasePutFromLoadLock(Object, Lock)}</li>
@@ -72,8 +72,8 @@ import org.infinispan.util.ByteString;
  * <p/>
  * <p>
  * This class also supports the concept of "naked puts", which are calls to
- * {@link #acquirePutFromLoadLock(SharedSessionContractImplementor, Object, long)} without a preceding {@link #registerPendingPut(SharedSessionContractImplementor, Object, long)}.
- * Besides not acquiring lock in {@link #registerPendingPut(SharedSessionContractImplementor, Object, long)} this can happen when collection
+ * {@link #acquirePutFromLoadLock(SessionImplementor, Object, long)} without a preceding {@link #registerPendingPut(SessionImplementor, Object, long)}.
+ * Besides not acquiring lock in {@link #registerPendingPut(SessionImplementor, Object, long)} this can happen when collection
  * elements are loaded after the collection has not been found in the cache, where the elements
  * don't have their own table but can be listed as 'select ... from Element where collection_id = ...'.
  * Naked puts are handled according to txTimestamp obtained by calling {@link RegionFactory#nextTimestamp()}
@@ -125,7 +125,7 @@ public class PutFromLoadValidator {
 	/**
 	 * Allows propagation of current Session to callbacks invoked from interceptors
 	 */
-	private final ThreadLocal<SharedSessionContractImplementor> currentSession = new ThreadLocal<SharedSessionContractImplementor>();
+	private final ThreadLocal<SessionImplementor> currentSession = new ThreadLocal<SessionImplementor>();
 
 	/**
 	 * Creates a new put from load validator instance.
@@ -260,7 +260,7 @@ public class PutFromLoadValidator {
 		return cci.removePutFromLoadValidator(cache.getName());
 	}
 
-	public void setCurrentSession(SharedSessionContractImplementor session) {
+	public void setCurrentSession(SessionImplementor session) {
 		currentSession.set(session);
 	}
 
@@ -274,7 +274,7 @@ public class PutFromLoadValidator {
    }
 
 	/**
-	 * Marker for lock acquired in {@link #acquirePutFromLoadLock(SharedSessionContractImplementor, Object, long)}
+	 * Marker for lock acquired in {@link #acquirePutFromLoadLock(SessionImplementor, Object, long)}
 	 */
 	public static abstract class Lock {
 		private Lock() {}
@@ -295,7 +295,7 @@ public class PutFromLoadValidator {
 	 * @return <code>AcquiredLock</code> if the lock is acquired and the cache put
 	 *         can proceed; <code>null</code> if the data should not be cached
 	 */
-	public Lock acquirePutFromLoadLock(SharedSessionContractImplementor session, Object key, long txTimestamp) {
+	public Lock acquirePutFromLoadLock(SessionImplementor session, Object key, long txTimestamp) {
 		if (trace) {
 			log.tracef("acquirePutFromLoadLock(%s#%s, %d)", cache.getName(), key, txTimestamp);
 		}
@@ -403,7 +403,7 @@ public class PutFromLoadValidator {
 
 	/**
 	 * Releases the lock previously obtained by a call to
-	 * {@link #acquirePutFromLoadLock(SharedSessionContractImplementor, Object, long)}.
+	 * {@link #acquirePutFromLoadLock(SessionImplementor, Object, long)}.
 	 *
 	 * @param key the key
 	 */
@@ -422,9 +422,9 @@ public class PutFromLoadValidator {
 	}
 
 	/**
-	 * Invalidates all {@link #registerPendingPut(SharedSessionContractImplementor, Object, long) previously registered pending puts} ensuring a subsequent call to
-	 * {@link #acquirePutFromLoadLock(SharedSessionContractImplementor, Object, long)} will return <code>false</code>. <p> This method will block until any
-	 * concurrent thread that has {@link #acquirePutFromLoadLock(SharedSessionContractImplementor, Object, long) acquired the putFromLoad lock} for the any key has
+	 * Invalidates all {@link #registerPendingPut(SessionImplementor, Object, long) previously registered pending puts} ensuring a subsequent call to
+	 * {@link #acquirePutFromLoadLock(SessionImplementor, Object, long)} will return <code>false</code>. <p> This method will block until any
+	 * concurrent thread that has {@link #acquirePutFromLoadLock(SessionImplementor, Object, long) acquired the putFromLoad lock} for the any key has
 	 * released the lock. This allows the caller to be certain the putFromLoad will not execute after this method returns,
 	 * possibly caching stale data. </p>
 	 *
@@ -492,7 +492,7 @@ public class PutFromLoadValidator {
 
 	/**
 	 * Notifies this validator that it is expected that a database read followed by a subsequent {@link
-	 * #acquirePutFromLoadLock(SharedSessionContractImplementor, Object, long)} call will occur. The intent is this method would be called following a cache miss
+	 * #acquirePutFromLoadLock(SessionImplementor, Object, long)} call will occur. The intent is this method would be called following a cache miss
 	 * wherein it is expected that a database read plus cache put will occur. Calling this method allows the validator to
 	 * treat the subsequent <code>acquirePutFromLoadLock</code> as if the database read occurred when this method was
 	 * invoked. This allows the validator to compare the timestamp of this call against the timestamp of subsequent removal
@@ -502,7 +502,7 @@ public class PutFromLoadValidator {
 	 * @param key key that will be used for subsequent cache put
 	 * @param txTimestamp
 	 */
-	public void registerPendingPut(SharedSessionContractImplementor session, Object key, long txTimestamp) {
+	public void registerPendingPut(SessionImplementor session, Object key, long txTimestamp) {
 		long invalidationTimestamp = this.regionInvalidationTimestamp;
 		if (txTimestamp <= invalidationTimestamp) {
 			if (trace) {
@@ -553,10 +553,10 @@ public class PutFromLoadValidator {
 	}
 
 	/**
-	 * Invalidates any {@link #registerPendingPut(SharedSessionContractImplementor, Object, long) previously registered pending puts}
-	 * and disables further registrations ensuring a subsequent call to {@link #acquirePutFromLoadLock(SharedSessionContractImplementor, Object, long)}
+	 * Invalidates any {@link #registerPendingPut(SessionImplementor, Object, long) previously registered pending puts}
+	 * and disables further registrations ensuring a subsequent call to {@link #acquirePutFromLoadLock(SessionImplementor, Object, long)}
 	 * will return <code>false</code>. <p> This method will block until any concurrent thread that has
-	 * {@link #acquirePutFromLoadLock(SharedSessionContractImplementor, Object, long) acquired the putFromLoad lock} for the given key
+	 * {@link #acquirePutFromLoadLock(SessionImplementor, Object, long) acquired the putFromLoad lock} for the given key
 	 * has released the lock. This allows the caller to be certain the putFromLoad will not execute after this method
 	 * returns, possibly caching stale data. </p>
 	 * After this transaction completes, {@link #endInvalidatingKey(Object, Object)} needs to be called }
@@ -651,7 +651,7 @@ public class PutFromLoadValidator {
 	}
 
 	public boolean registerRemoteInvalidation(Object key, Object lockOwner) {
-		SharedSessionContractImplementor session = currentSession.get();
+		SessionImplementor session = currentSession.get();
 		TransactionCoordinator transactionCoordinator = session == null ? null : session.getTransactionCoordinator();
 		if (transactionCoordinator != null) {
 			if (trace) {
@@ -669,7 +669,7 @@ public class PutFromLoadValidator {
 
 	// we can't use SessionImpl.toString() concurrently
 	private static String lockOwnerToString(Object lockOwner) {
-		return lockOwner instanceof SharedSessionContractImplementor ? "Session#" + lockOwner.hashCode() : lockOwner.toString();
+		return lockOwner instanceof SessionImplementor ? "Session#" + lockOwner.hashCode() : lockOwner.toString();
 	}
 
 	public void removePendingPutsCache() {

--- a/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/access/RemovalSynchronization.java
+++ b/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/access/RemovalSynchronization.java
@@ -11,7 +11,7 @@ import java.util.concurrent.TimeUnit;
 import org.infinispan.hibernate.cache.impl.BaseTransactionalDataRegion;
 import org.infinispan.hibernate.cache.util.InvocationAfterCompletion;
 import org.infinispan.hibernate.cache.util.VersionedEntry;
-import org.hibernate.resource.transaction.spi.TransactionCoordinator;
+import org.hibernate.resource.transaction.TransactionCoordinator;
 
 import org.infinispan.AdvancedCache;
 

--- a/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/access/TombstoneAccessDelegate.java
+++ b/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/access/TombstoneAccessDelegate.java
@@ -14,8 +14,8 @@ import org.infinispan.hibernate.cache.util.InfinispanMessageLogger;
 import org.infinispan.hibernate.cache.util.Tombstone;
 import org.infinispan.hibernate.cache.util.TombstoneUpdate;
 import org.hibernate.cache.spi.access.SoftLock;
-import org.hibernate.engine.spi.SharedSessionContractImplementor;
-import org.hibernate.resource.transaction.spi.TransactionCoordinator;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.resource.transaction.TransactionCoordinator;
 
 import org.infinispan.AdvancedCache;
 import org.infinispan.configuration.cache.Configuration;
@@ -53,7 +53,7 @@ public class TombstoneAccessDelegate implements AccessDelegate {
 	}
 
 	@Override
-	public Object get(SharedSessionContractImplementor session, Object key, long txTimestamp) throws CacheException {
+	public Object get(SessionImplementor session, Object key, long txTimestamp) throws CacheException {
 		if (txTimestamp < region.getLastRegionInvalidation() ) {
 			return null;
 		}
@@ -70,12 +70,12 @@ public class TombstoneAccessDelegate implements AccessDelegate {
 	}
 
 	@Override
-	public boolean putFromLoad(SharedSessionContractImplementor session, Object key, Object value, long txTimestamp, Object version) {
+	public boolean putFromLoad(SessionImplementor session, Object key, Object value, long txTimestamp, Object version) {
 		return putFromLoad(session, key, value, txTimestamp, version, false);
 	}
 
 	@Override
-	public boolean putFromLoad(SharedSessionContractImplementor session, Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride) throws CacheException {
+	public boolean putFromLoad(SessionImplementor session, Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride) throws CacheException {
 		long lastRegionInvalidation = region.getLastRegionInvalidation();
 		if (txTimestamp < lastRegionInvalidation) {
 			log.tracef("putFromLoad not executed since tx started at %d, before last region invalidation finished = %d", txTimestamp, lastRegionInvalidation);
@@ -103,23 +103,23 @@ public class TombstoneAccessDelegate implements AccessDelegate {
 	}
 
 	@Override
-	public boolean insert(SharedSessionContractImplementor session, Object key, Object value, Object version) throws CacheException {
+	public boolean insert(SessionImplementor session, Object key, Object value, Object version) throws CacheException {
 		write(session, key, value);
 		return true;
 	}
 
 	@Override
-	public boolean update(SharedSessionContractImplementor session, Object key, Object value, Object currentVersion, Object previousVersion) throws CacheException {
+	public boolean update(SessionImplementor session, Object key, Object value, Object currentVersion, Object previousVersion) throws CacheException {
 		write(session, key, value);
 		return true;
 	}
 
 	@Override
-	public void remove(SharedSessionContractImplementor session, Object key) throws CacheException {
+	public void remove(SessionImplementor session, Object key) throws CacheException {
 		write(session, key, null);
 	}
 
-	protected void write(SharedSessionContractImplementor session, Object key, Object value) {
+	protected void write(SessionImplementor session, Object key, Object value) {
 		TransactionCoordinator tc = session.getTransactionCoordinator();
 		FutureUpdateSynchronization sync = new FutureUpdateSynchronization(tc, asyncWriteCache, requiresTransaction, key, value, region, session.getTimestamp());
 		// The update will be invalidating all putFromLoads for the duration of expiration or until removed by the synchronization
@@ -158,16 +158,16 @@ public class TombstoneAccessDelegate implements AccessDelegate {
 	}
 
 	@Override
-	public void unlockItem(SharedSessionContractImplementor session, Object key) throws CacheException {
+	public void unlockItem(SessionImplementor session, Object key) throws CacheException {
 	}
 
 	@Override
-	public boolean afterInsert(SharedSessionContractImplementor session, Object key, Object value, Object version) {
+	public boolean afterInsert(SessionImplementor session, Object key, Object value, Object version) {
 		return false;
 	}
 
 	@Override
-	public boolean afterUpdate(SharedSessionContractImplementor session, Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock) {
+	public boolean afterUpdate(SessionImplementor session, Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock) {
 		return false;
 	}
 }

--- a/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/access/TxInvalidationCacheAccessDelegate.java
+++ b/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/access/TxInvalidationCacheAccessDelegate.java
@@ -9,7 +9,7 @@ package org.infinispan.hibernate.cache.access;
 import org.hibernate.cache.CacheException;
 import org.infinispan.hibernate.cache.impl.BaseRegion;
 import org.hibernate.cache.spi.access.SoftLock;
-import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
 
 /**
  * Delegate for transactional caches
@@ -23,7 +23,7 @@ public class TxInvalidationCacheAccessDelegate extends InvalidationCacheAccessDe
 
 	@Override
 	@SuppressWarnings("UnusedParameters")
-	public boolean insert(SharedSessionContractImplementor session, Object key, Object value, Object version) throws CacheException {
+	public boolean insert(SessionImplementor session, Object key, Object value, Object version) throws CacheException {
 		if ( !region.checkValid() ) {
 			return false;
 		}
@@ -39,7 +39,7 @@ public class TxInvalidationCacheAccessDelegate extends InvalidationCacheAccessDe
 
 	@Override
 	@SuppressWarnings("UnusedParameters")
-	public boolean update(SharedSessionContractImplementor session, Object key, Object value, Object currentVersion, Object previousVersion)
+	public boolean update(SessionImplementor session, Object key, Object value, Object currentVersion, Object previousVersion)
 			throws CacheException {
 		// We update whether or not the region is valid. Other nodes
 		// may have already restored the region so they need to
@@ -55,13 +55,13 @@ public class TxInvalidationCacheAccessDelegate extends InvalidationCacheAccessDe
 	}
 
 	@Override
-	public boolean afterInsert(SharedSessionContractImplementor session, Object key, Object value, Object version) {
+	public boolean afterInsert(SessionImplementor session, Object key, Object value, Object version) {
 		// The endInvalidatingKey(...) is called from TxPutFromLoadInterceptor because we need the global transaction id.
 		return false;
 	}
 
 	@Override
-	public boolean afterUpdate(SharedSessionContractImplementor session, Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock) {
+	public boolean afterUpdate(SessionImplementor session, Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock) {
 		// The endInvalidatingKey(...) is called from TxPutFromLoadInterceptor because we need the global transaction id.
 		return false;
 	}

--- a/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/collection/CollectionAccess.java
+++ b/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/collection/CollectionAccess.java
@@ -12,7 +12,7 @@ import org.hibernate.cache.spi.CollectionRegion;
 import org.hibernate.cache.spi.access.CollectionRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.persister.collection.CollectionPersister;
 
 /**
@@ -39,20 +39,20 @@ class CollectionAccess implements CollectionRegionAccessStrategy {
 		delegate.evictAll();
 	}
 
-	public Object get(SharedSessionContractImplementor session, Object key, long txTimestamp) throws CacheException {
+	public Object get(SessionImplementor session, Object key, long txTimestamp) throws CacheException {
 		return delegate.get( session, key, txTimestamp );
 	}
 
-	public boolean putFromLoad(SharedSessionContractImplementor session, Object key, Object value, long txTimestamp, Object version) throws CacheException {
+	public boolean putFromLoad(SessionImplementor session, Object key, Object value, long txTimestamp, Object version) throws CacheException {
 		return delegate.putFromLoad( session, key, value, txTimestamp, version );
 	}
 
-	public boolean putFromLoad(SharedSessionContractImplementor session, Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
+	public boolean putFromLoad(SessionImplementor session, Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
 			throws CacheException {
 		return delegate.putFromLoad( session, key, value, txTimestamp, version, minimalPutOverride );
 	}
 
-	public void remove(SharedSessionContractImplementor session, Object key) throws CacheException {
+	public void remove(SessionImplementor session, Object key) throws CacheException {
 		delegate.remove( session, key );
 	}
 
@@ -64,7 +64,7 @@ class CollectionAccess implements CollectionRegionAccessStrategy {
 		return region;
 	}
 
-	public SoftLock lockItem(SharedSessionContractImplementor session, Object key, Object version) throws CacheException {
+	public SoftLock lockItem(SessionImplementor session, Object key, Object version) throws CacheException {
 		return null;
 	}
 
@@ -72,7 +72,7 @@ class CollectionAccess implements CollectionRegionAccessStrategy {
 		return null;
 	}
 
-	public void unlockItem(SharedSessionContractImplementor session, Object key, SoftLock lock) throws CacheException {
+	public void unlockItem(SessionImplementor session, Object key, SoftLock lock) throws CacheException {
 		delegate.unlockItem( session, key);
 	}
 

--- a/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/entity/ReadOnlyAccess.java
+++ b/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/entity/ReadOnlyAccess.java
@@ -12,7 +12,7 @@ import org.hibernate.cache.spi.EntityRegion;
 import org.hibernate.cache.spi.access.EntityRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.persister.entity.EntityPersister;
 
 /**
@@ -40,7 +40,7 @@ class ReadOnlyAccess implements EntityRegionAccessStrategy {
 		delegate.evictAll();
 	}
 
-	public Object get(SharedSessionContractImplementor session, Object key, long txTimestamp) throws CacheException {
+	public Object get(SessionImplementor session, Object key, long txTimestamp) throws CacheException {
 		return delegate.get( session, key, txTimestamp );
 	}
 
@@ -48,16 +48,16 @@ class ReadOnlyAccess implements EntityRegionAccessStrategy {
 		return this.region;
 	}
 
-	public boolean putFromLoad(SharedSessionContractImplementor session, Object key, Object value, long txTimestamp, Object version) throws CacheException {
+	public boolean putFromLoad(SessionImplementor session, Object key, Object value, long txTimestamp, Object version) throws CacheException {
 		return delegate.putFromLoad( session, key, value, txTimestamp, version );
 	}
 
-	public boolean putFromLoad(SharedSessionContractImplementor session, Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
+	public boolean putFromLoad(SessionImplementor session, Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
 			throws CacheException {
 		return delegate.putFromLoad( session, key, value, txTimestamp, version, minimalPutOverride );
 	}
 
-	public void remove(SharedSessionContractImplementor session, Object key) throws CacheException {
+	public void remove(SessionImplementor session, Object key) throws CacheException {
 		delegate.remove ( session, key );
 	}
 
@@ -65,18 +65,18 @@ class ReadOnlyAccess implements EntityRegionAccessStrategy {
 		delegate.removeAll();
 	}
 
-	public boolean insert(SharedSessionContractImplementor session, Object key, Object value, Object version) throws CacheException {
+	public boolean insert(SessionImplementor session, Object key, Object value, Object version) throws CacheException {
 		return delegate.insert( session, key, value, version );
 	}
 
 	@Override
 	public boolean update(
-			SharedSessionContractImplementor session, Object key, Object value, Object currentVersion,
+			SessionImplementor session, Object key, Object value, Object currentVersion,
 			Object previousVersion) throws CacheException {
 		throw new UnsupportedOperationException( "Illegal attempt to edit read only item" );
 	}
 
-	public SoftLock lockItem(SharedSessionContractImplementor session, Object key, Object version) throws CacheException {
+	public SoftLock lockItem(SessionImplementor session, Object key, Object version) throws CacheException {
 		return null;
 	}
 
@@ -84,20 +84,20 @@ class ReadOnlyAccess implements EntityRegionAccessStrategy {
 		return null;
 	}
 
-	public void unlockItem(SharedSessionContractImplementor session, Object key, SoftLock lock) throws CacheException {
+	public void unlockItem(SessionImplementor session, Object key, SoftLock lock) throws CacheException {
 		delegate.unlockItem( session, key );
 	}
 
 	public void unlockRegion(SoftLock lock) throws CacheException {
 	}
 
-	public boolean afterInsert(SharedSessionContractImplementor session, Object key, Object value, Object version) throws CacheException {
+	public boolean afterInsert(SessionImplementor session, Object key, Object value, Object version) throws CacheException {
 		return delegate.afterInsert( session, key, value, version );
 	}
 
 	@Override
 	public boolean afterUpdate(
-			SharedSessionContractImplementor session, Object key, Object value, Object currentVersion,
+			SessionImplementor session, Object key, Object value, Object currentVersion,
 			Object previousVersion, SoftLock lock) throws CacheException {
 		throw new UnsupportedOperationException( "Illegal attempt to edit read only item" );
 	}

--- a/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/entity/ReadWriteAccess.java
+++ b/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/entity/ReadWriteAccess.java
@@ -9,7 +9,7 @@ package org.infinispan.hibernate.cache.entity;
 import org.hibernate.cache.CacheException;
 import org.infinispan.hibernate.cache.access.AccessDelegate;
 import org.hibernate.cache.spi.access.SoftLock;
-import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
 
 /**
  * Read-write or transactional entity region access for Infinispan.
@@ -24,12 +24,12 @@ class ReadWriteAccess extends ReadOnlyAccess {
 		super(region, delegate);
 	}
 
-	public boolean update(SharedSessionContractImplementor session, Object key, Object value, Object currentVersion, Object previousVersion)
+	public boolean update(SessionImplementor session, Object key, Object value, Object currentVersion, Object previousVersion)
 			throws CacheException {
 		return delegate.update( session, key, value, currentVersion, previousVersion );
 	}
 
-	public boolean afterUpdate(SharedSessionContractImplementor session, Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock)
+	public boolean afterUpdate(SessionImplementor session, Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock)
 			throws CacheException {
 		return delegate.afterUpdate( session, key, value, currentVersion, previousVersion, lock );
 	}

--- a/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/impl/BaseGeneralDataRegion.java
+++ b/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/impl/BaseGeneralDataRegion.java
@@ -10,7 +10,7 @@ import org.hibernate.cache.CacheException;
 import org.infinispan.hibernate.cache.InfinispanRegionFactory;
 import org.infinispan.hibernate.cache.util.Caches;
 import org.hibernate.cache.spi.GeneralDataRegion;
-import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
 
 import org.infinispan.AdvancedCache;
 
@@ -50,13 +50,13 @@ public abstract class BaseGeneralDataRegion extends BaseRegion implements Genera
 	}
 
 	@Override
-	public Object get(SharedSessionContractImplementor session, Object key) throws CacheException {
+	public Object get(SessionImplementor session, Object key) throws CacheException {
 		return cache.get( key );
 	}
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void put(SharedSessionContractImplementor session, Object key, Object value) throws CacheException {
+	public void put(SessionImplementor session, Object key, Object value) throws CacheException {
 		putCache.put( key, value );
 	}
 

--- a/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/naturalid/ReadOnlyAccess.java
+++ b/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/naturalid/ReadOnlyAccess.java
@@ -11,7 +11,7 @@ import org.infinispan.hibernate.cache.access.AccessDelegate;
 import org.hibernate.cache.spi.NaturalIdRegion;
 import org.hibernate.cache.spi.access.NaturalIdRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
-import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.persister.entity.EntityPersister;
 
 /**
@@ -28,12 +28,12 @@ class ReadOnlyAccess implements NaturalIdRegionAccessStrategy {
 	}
 
 	@Override
-	public boolean insert(SharedSessionContractImplementor session, Object key, Object value) throws CacheException {
+	public boolean insert(SessionImplementor session, Object key, Object value) throws CacheException {
 		return delegate.insert( session, key, value, null );
 	}
 
 	@Override
-	public boolean update(SharedSessionContractImplementor session, Object key, Object value) throws CacheException {
+	public boolean update(SessionImplementor session, Object key, Object value) throws CacheException {
 		throw new UnsupportedOperationException( "Illegal attempt to edit read only item" );
 	}
 
@@ -53,23 +53,23 @@ class ReadOnlyAccess implements NaturalIdRegionAccessStrategy {
 	}
 
 	@Override
-	public Object get(SharedSessionContractImplementor session, Object key, long txTimestamp) throws CacheException {
+	public Object get(SessionImplementor session, Object key, long txTimestamp) throws CacheException {
 		return delegate.get( session, key, txTimestamp );
 	}
 
 	@Override
-	public boolean putFromLoad(SharedSessionContractImplementor session, Object key, Object value, long txTimestamp, Object version) throws CacheException {
+	public boolean putFromLoad(SessionImplementor session, Object key, Object value, long txTimestamp, Object version) throws CacheException {
 		return delegate.putFromLoad( session, key, value, txTimestamp, version );
 	}
 
 	@Override
-	public boolean putFromLoad(SharedSessionContractImplementor session, Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
+	public boolean putFromLoad(SessionImplementor session, Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
 			throws CacheException {
 		return delegate.putFromLoad( session, key, value, txTimestamp, version, minimalPutOverride );
 	}
 
 	@Override
-	public void remove(SharedSessionContractImplementor session, Object key) throws CacheException {
+	public void remove(SessionImplementor session, Object key) throws CacheException {
 		delegate.remove( session, key );
 	}
 
@@ -79,7 +79,7 @@ class ReadOnlyAccess implements NaturalIdRegionAccessStrategy {
 	}
 
 	@Override
-	public SoftLock lockItem(SharedSessionContractImplementor session, Object key, Object version) throws CacheException {
+	public SoftLock lockItem(SessionImplementor session, Object key, Object version) throws CacheException {
 		return null;
 	}
 
@@ -89,7 +89,7 @@ class ReadOnlyAccess implements NaturalIdRegionAccessStrategy {
 	}
 
 	@Override
-	public void unlockItem(SharedSessionContractImplementor session, Object key, SoftLock lock) throws CacheException {
+	public void unlockItem(SessionImplementor session, Object key, SoftLock lock) throws CacheException {
 		delegate.unlockItem( session, key );
 	}
 
@@ -98,17 +98,17 @@ class ReadOnlyAccess implements NaturalIdRegionAccessStrategy {
 	}
 
 	@Override
-	public boolean afterInsert(SharedSessionContractImplementor session, Object key, Object value) throws CacheException {
+	public boolean afterInsert(SessionImplementor session, Object key, Object value) throws CacheException {
 		return delegate.afterInsert( session, key, value, null );
 	}
 
 	@Override
-	public boolean afterUpdate(SharedSessionContractImplementor session, Object key, Object value, SoftLock lock) throws CacheException {
+	public boolean afterUpdate(SessionImplementor session, Object key, Object value, SoftLock lock) throws CacheException {
 		throw new UnsupportedOperationException( "Illegal attempt to edit read only item" );
 	}
 
 	@Override
-	public Object generateCacheKey(Object[] naturalIdValues, EntityPersister persister, SharedSessionContractImplementor session) {
+	public Object generateCacheKey(Object[] naturalIdValues, EntityPersister persister, SessionImplementor session) {
 		return region.getCacheKeysFactory().createNaturalIdKey(naturalIdValues, persister, session);
 	}
 

--- a/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/naturalid/ReadWriteAccess.java
+++ b/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/naturalid/ReadWriteAccess.java
@@ -9,7 +9,7 @@ package org.infinispan.hibernate.cache.naturalid;
 import org.hibernate.cache.CacheException;
 import org.infinispan.hibernate.cache.access.AccessDelegate;
 import org.hibernate.cache.spi.access.SoftLock;
-import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
 
 /**
  * @author Strong Liu <stliu@hibernate.org>
@@ -21,12 +21,12 @@ class ReadWriteAccess extends ReadOnlyAccess {
 	}
 
 	@Override
-	public boolean update(SharedSessionContractImplementor session, Object key, Object value) throws CacheException {
+	public boolean update(SessionImplementor session, Object key, Object value) throws CacheException {
 		return delegate.update( session, key, value, null, null );
 	}
 
 	@Override
-	public boolean afterUpdate(SharedSessionContractImplementor session, Object key, Object value, SoftLock lock) throws CacheException {
+	public boolean afterUpdate(SessionImplementor session, Object key, Object value, SoftLock lock) throws CacheException {
 		return delegate.afterUpdate( session, key, value, null, null, lock );
 	}
 

--- a/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/query/QueryResultsRegionImpl.java
+++ b/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/query/QueryResultsRegionImpl.java
@@ -14,14 +14,14 @@ import javax.transaction.Transaction;
 import javax.transaction.TransactionManager;
 
 import org.hibernate.cache.CacheException;
+import org.hibernate.resource.transaction.TransactionCoordinator;
 import org.infinispan.hibernate.cache.InfinispanRegionFactory;
 import org.infinispan.hibernate.cache.impl.BaseTransactionalDataRegion;
 import org.infinispan.hibernate.cache.util.Caches;
 import org.infinispan.hibernate.cache.util.InfinispanMessageLogger;
 import org.infinispan.hibernate.cache.util.InvocationAfterCompletion;
 import org.hibernate.cache.spi.QueryResultsRegion;
-import org.hibernate.engine.spi.SharedSessionContractImplementor;
-import org.hibernate.resource.transaction.spi.TransactionCoordinator;
+import org.hibernate.engine.spi.SessionImplementor;
 
 import org.infinispan.AdvancedCache;
 import org.infinispan.configuration.cache.TransactionConfiguration;
@@ -41,7 +41,7 @@ public class QueryResultsRegionImpl extends BaseTransactionalDataRegion implemen
 	private final AdvancedCache evictCache;
 	private final AdvancedCache putCache;
 	private final AdvancedCache getCache;
-	private final ConcurrentMap<SharedSessionContractImplementor, Map> transactionContext = new ConcurrentHashMap<SharedSessionContractImplementor, Map>();
+	private final ConcurrentMap<SessionImplementor, Map> transactionContext = new ConcurrentHashMap<SessionImplementor, Map>();
 	private final boolean putCacheRequiresTransaction;
 
 	/**
@@ -103,7 +103,7 @@ public class QueryResultsRegionImpl extends BaseTransactionalDataRegion implemen
 	}
 
 	@Override
-	public Object get(SharedSessionContractImplementor session, Object key) throws CacheException {
+	public Object get(SessionImplementor session, Object key) throws CacheException {
 		if ( !checkValid() ) {
 			return null;
 		}
@@ -126,7 +126,7 @@ public class QueryResultsRegionImpl extends BaseTransactionalDataRegion implemen
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void put(SharedSessionContractImplementor session, Object key, Object value) throws CacheException {
+	public void put(SessionImplementor session, Object key, Object value) throws CacheException {
 		if ( checkValid() ) {
 			// See HHH-7898: Even with FAIL_SILENTLY flag, failure to write in transaction
 			// fails the whole transaction. It is an Infinispan quirk that cannot be fixed
@@ -164,11 +164,11 @@ public class QueryResultsRegionImpl extends BaseTransactionalDataRegion implemen
 	}
 
 	private class PostTransactionQueryUpdate extends InvocationAfterCompletion {
-		private final SharedSessionContractImplementor session;
+		private final SessionImplementor session;
 		private final Object key;
 		private final Object value;
 
-		public PostTransactionQueryUpdate(TransactionCoordinator tc, SharedSessionContractImplementor session, Object key, Object value) {
+		public PostTransactionQueryUpdate(TransactionCoordinator tc, SessionImplementor session, Object key, Object value) {
 			super(tc, putCacheRequiresTransaction);
 			this.session = session;
 			this.key = key;

--- a/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/timestamp/ClusteredTimestampsRegionImpl.java
+++ b/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/timestamp/ClusteredTimestampsRegionImpl.java
@@ -13,7 +13,7 @@ import javax.transaction.Transaction;
 import org.hibernate.cache.CacheException;
 import org.infinispan.hibernate.cache.InfinispanRegionFactory;
 import org.infinispan.hibernate.cache.util.Caches;
-import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
 
 import org.infinispan.AdvancedCache;
 import org.infinispan.commons.util.CloseableIterator;
@@ -63,7 +63,7 @@ public class ClusteredTimestampsRegionImpl extends TimestampsRegionImpl {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public Object get(SharedSessionContractImplementor session, Object key) throws CacheException {
+	public Object get(SessionImplementor session, Object key) throws CacheException {
 		Object value = localCache.get( key );
 
 		if ( value == null && checkValid() ) {

--- a/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/timestamp/TimestampsRegionImpl.java
+++ b/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/timestamp/TimestampsRegionImpl.java
@@ -13,7 +13,7 @@ import org.infinispan.hibernate.cache.InfinispanRegionFactory;
 import org.infinispan.hibernate.cache.impl.BaseGeneralDataRegion;
 import org.infinispan.hibernate.cache.util.Caches;
 import org.hibernate.cache.spi.TimestampsRegion;
-import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
 
 import org.infinispan.AdvancedCache;
 import org.infinispan.context.Flag;
@@ -81,7 +81,7 @@ public class TimestampsRegionImpl extends BaseGeneralDataRegion implements Times
 
 
 	@Override
-	public Object get(SharedSessionContractImplementor session, Object key) throws CacheException {
+	public Object get(SessionImplementor session, Object key) throws CacheException {
 		if ( checkValid() ) {
 			return cache.get( key );
 		}
@@ -91,7 +91,7 @@ public class TimestampsRegionImpl extends BaseGeneralDataRegion implements Times
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void put(SharedSessionContractImplementor session, final Object key, final Object value) throws CacheException {
+	public void put(SessionImplementor session, final Object key, final Object value) throws CacheException {
 		try {
 			// We ensure ASYNC semantics (JBCACHE-1175) and make sure previous
 			// value is not loaded from cache store cos it's not needed.

--- a/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/util/InvocationAfterCompletion.java
+++ b/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/util/InvocationAfterCompletion.java
@@ -14,7 +14,7 @@ import javax.transaction.Synchronization;
 import org.hibernate.HibernateException;
 import org.hibernate.jdbc.WorkExecutor;
 import org.hibernate.jdbc.WorkExecutorVisitable;
-import org.hibernate.resource.transaction.spi.TransactionCoordinator;
+import org.hibernate.resource.transaction.TransactionCoordinator;
 
 /**
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;

--- a/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/AbstractExtraAPITest.java
+++ b/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/AbstractExtraAPITest.java
@@ -4,7 +4,7 @@ import org.hibernate.cache.internal.CacheDataDescriptionImpl;
 import org.hibernate.cache.spi.CacheDataDescription;
 import org.hibernate.cache.spi.access.RegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
-import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.internal.util.compare.ComparableComparator;
 
 import org.infinispan.test.hibernate.cache.util.TestingKeyFactory;
@@ -25,7 +25,7 @@ public abstract class AbstractExtraAPITest<S extends RegionAccessStrategy> exten
 	public static final Object KEY = TestingKeyFactory.generateCollectionCacheKey( "KEY" );
 	public static final CacheDataDescription CACHE_DATA_DESCRIPTION
 			= new CacheDataDescriptionImpl(true, true, ComparableComparator.INSTANCE, null);
-	protected static final SharedSessionContractImplementor SESSION = mock(SharedSessionContractImplementor.class);
+	protected static final SessionImplementor SESSION = mock(SessionImplementor.class);
 
 	protected S accessStrategy;
 	protected NodeEnvironment environment;

--- a/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/AbstractNonFunctionalTest.java
+++ b/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/AbstractNonFunctionalTest.java
@@ -18,7 +18,7 @@ import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.infinispan.hibernate.cache.util.Caches;
 import org.hibernate.cache.spi.RegionFactory;
 import org.hibernate.cache.spi.access.AccessType;
-import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.engine.transaction.jta.platform.spi.JtaPlatform;
 import org.hibernate.resource.transaction.spi.TransactionStatus;
 
@@ -140,7 +140,7 @@ public abstract class AbstractNonFunctionalTest extends org.hibernate.testing.ju
 		return true;
 	}
 
-	protected <T> T withTx(NodeEnvironment environment, SharedSessionContractImplementor session, Callable<T> callable) throws Exception {
+	protected <T> T withTx(NodeEnvironment environment, SessionImplementor session, Callable<T> callable) throws Exception {
 		if (jtaPlatform != null) {
 			TransactionManager tm = environment.getServiceRegistry().getService(JtaPlatform.class).retrieveTransactionManager();
 			return Caches.withinTx(tm, callable);

--- a/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/CacheKeysFactoryTest.java
+++ b/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/CacheKeysFactoryTest.java
@@ -6,6 +6,7 @@ import org.hibernate.cache.internal.SimpleCacheKeysFactory;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.Environment;
 import org.hibernate.engine.spi.CacheImplementor;
+import org.hibernate.jpa.AvailableSettings;
 import org.infinispan.test.hibernate.cache.functional.entities.Name;
 import org.infinispan.test.hibernate.cache.functional.entities.Person;
 import org.infinispan.test.hibernate.cache.util.InfinispanTestingSetup;
@@ -30,7 +31,7 @@ public class CacheKeysFactoryTest extends BaseUnitTestCase {
          .setProperty(Environment.USE_SECOND_LEVEL_CACHE, "true")
          .setProperty(Environment.CACHE_REGION_FACTORY, TestInfinispanRegionFactory.class.getName())
          .setProperty(Environment.DEFAULT_CACHE_CONCURRENCY_STRATEGY, "transactional")
-         .setProperty(Environment.JPA_SHARED_CACHE_MODE, "ALL")
+         .setProperty(AvailableSettings.SHARED_CACHE_MODE, "ALL")
          .setProperty(Environment.HBM2DDL_AUTO, "create-drop");
       if (cacheKeysFactory != null) {
          configuration.setProperty(Environment.CACHE_KEYS_FACTORY, cacheKeysFactory);

--- a/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/access/PutFromLoadValidatorUnitTest.java
+++ b/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/access/PutFromLoadValidatorUnitTest.java
@@ -25,7 +25,7 @@ import javax.transaction.TransactionManager;
 import org.infinispan.hibernate.cache.InfinispanRegionFactory;
 import org.infinispan.hibernate.cache.access.PutFromLoadValidator;
 import org.infinispan.hibernate.cache.util.InfinispanMessageLogger;
-import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
 
 import org.infinispan.test.hibernate.cache.util.TestInfinispanRegionFactory;
 import org.infinispan.test.hibernate.cache.util.TestTimeService;
@@ -222,8 +222,8 @@ public class PutFromLoadValidatorUnitTest {
 			if (transactional) {
 				tm.begin();
 			}
-			SharedSessionContractImplementor session1 = mock(SharedSessionContractImplementor.class);
-			SharedSessionContractImplementor session2 = mock(SharedSessionContractImplementor.class);
+			SessionImplementor session1 = mock(SessionImplementor.class);
+			SessionImplementor session2 = mock(SessionImplementor.class);
 			testee.registerPendingPut(session1, KEY1, txTimestamp);
 			if (removeRegion) {
 				testee.beginInvalidatingRegion();
@@ -273,7 +273,7 @@ public class PutFromLoadValidatorUnitTest {
 				if (transactional) {
 					tm.begin();
 				}
-				SharedSessionContractImplementor session = mock (SharedSessionContractImplementor.class);
+				SessionImplementor session = mock(SessionImplementor.class);
 				testee.registerPendingPut(session, KEY1, txTimestamp);
 				registeredLatch.countDown();
 				registeredLatch.await(5, TimeUnit.SECONDS);
@@ -332,7 +332,7 @@ public class PutFromLoadValidatorUnitTest {
 
 		Callable<Boolean> pferCallable = () -> {
 			long txTimestamp = TIME_SERVICE.wallClockTime();
-			SharedSessionContractImplementor session = mock (SharedSessionContractImplementor.class);
+			SessionImplementor session = mock (SessionImplementor.class);
 			testee.registerPendingPut(session, KEY1, txTimestamp);
 			PutFromLoadValidator.Lock lock = testee.acquirePutFromLoadLock(session, KEY1, txTimestamp);
 			if (lock != null) {
@@ -352,7 +352,7 @@ public class PutFromLoadValidatorUnitTest {
 		Callable<Void> invalidateCallable = () -> {
          removeLatch.await();
          if (keyOnly) {
-            SharedSessionContractImplementor session = mock (SharedSessionContractImplementor.class);
+            SessionImplementor session = mock (SessionImplementor.class);
             testee.beginInvalidatingKey(session, KEY1);
          } else {
             testee.beginInvalidatingRegion();
@@ -410,7 +410,7 @@ public class PutFromLoadValidatorUnitTest {
 				assertTrue(success);
 				putFromLoadValidator.endInvalidatingRegion();
 			} else {
-				SharedSessionContractImplementor session = mock (SharedSessionContractImplementor.class);
+				SessionImplementor session = mock (SessionImplementor.class);
 				boolean success = putFromLoadValidator.beginInvalidatingKey(session, KEY1);
 				assertTrue(success);
 				success = putFromLoadValidator.endInvalidatingKey(session, KEY1);
@@ -434,7 +434,7 @@ public class PutFromLoadValidatorUnitTest {
 		public Void call() throws Exception {
 			try {
 				long txTimestamp = TIME_SERVICE.wallClockTime(); // this should be acquired before UserTransaction.begin()
-				SharedSessionContractImplementor session = mock (SharedSessionContractImplementor.class);
+				SessionImplementor session = mock (SessionImplementor.class);
 				putFromLoadValidator.registerPendingPut(session, KEY1, txTimestamp);
 
 				PutFromLoadValidator.Lock lock = putFromLoadValidator.acquirePutFromLoadLock(session, KEY1, txTimestamp);
@@ -465,7 +465,7 @@ public class PutFromLoadValidatorUnitTest {
 		public Void call() throws Exception {
 			try {
 				long txTimestamp = TIME_SERVICE.wallClockTime(); // this should be acquired before UserTransaction.begin()
-				SharedSessionContractImplementor session = mock (SharedSessionContractImplementor.class);
+				SessionImplementor session = mock (SessionImplementor.class);
 				PutFromLoadValidator.Lock lock = testee.acquirePutFromLoadLock(session, KEY1, txTimestamp);
 				try {
 					if (expectSuccess) {
@@ -502,7 +502,7 @@ public class PutFromLoadValidatorUnitTest {
 		for (int i = 0; i < 100; ++i) {
 			try {
 				withTx(tm, () -> {
-					SharedSessionContractImplementor session = mock (SharedSessionContractImplementor.class);
+					SessionImplementor session = mock (SessionImplementor.class);
 					testee.registerPendingPut(session, KEY1, 0);
 					return null;
 				});

--- a/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/collection/CollectionRegionAccessStrategyTest.java
+++ b/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/collection/CollectionRegionAccessStrategyTest.java
@@ -19,7 +19,7 @@ import org.infinispan.hibernate.cache.access.TxInvalidationCacheAccessDelegate;
 import org.infinispan.hibernate.cache.collection.CollectionRegionImpl;
 import org.hibernate.cache.spi.access.CollectionRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
-import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
 
 import org.infinispan.test.hibernate.cache.AbstractRegionAccessStrategyTest;
 import org.infinispan.test.hibernate.cache.NodeEnvironment;
@@ -109,14 +109,14 @@ public class CollectionRegionAccessStrategyTest extends
 
 		final String KEY = "k1";
 		Future<Void> pferFuture = executorService.submit(() -> {
-			SharedSessionContractImplementor session = mockedSession();
+			SessionImplementor session = mockedSession();
 			delegate.putFromLoad(session, KEY, "v1", session.getTimestamp(), null);
 			return null;
 		});
 
 		Future<Void> removeFuture = executorService.submit(() -> {
 			removeLatch.await();
-			SharedSessionContractImplementor session = mockedSession();
+			SessionImplementor session = mockedSession();
 			withTx(localEnvironment, session, () -> {
 				delegate.remove(session, KEY);
 				return null;
@@ -143,7 +143,7 @@ public class CollectionRegionAccessStrategyTest extends
 	}
 
 	@Override
-	protected void doUpdate(CollectionRegionAccessStrategy strategy, SharedSessionContractImplementor session, Object key, Object value, Object version) throws javax.transaction.RollbackException, javax.transaction.SystemException {
+	protected void doUpdate(CollectionRegionAccessStrategy strategy, SessionImplementor session, Object key, Object value, Object version) throws javax.transaction.RollbackException, javax.transaction.SystemException {
 		SoftLock softLock = strategy.lockItem(session, key, version);
 		strategy.remove(session, key);
 		session.getTransactionCoordinator().getLocalSynchronizations().registerSynchronization(

--- a/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/functional/AbstractFunctionalTest.java
+++ b/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/functional/AbstractFunctionalTest.java
@@ -36,7 +36,7 @@ import org.hibernate.mapping.RootClass;
 import org.hibernate.mapping.SimpleValue;
 import org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorBuilderImpl;
 import org.hibernate.resource.transaction.backend.jta.internal.JtaTransactionCoordinatorBuilderImpl;
-import org.hibernate.resource.transaction.spi.TransactionCoordinatorBuilder;
+import org.hibernate.resource.transaction.TransactionCoordinatorBuilder;
 
 import org.infinispan.remoting.inboundhandler.DeliverOrder;
 import org.infinispan.remoting.inboundhandler.PerCacheInboundInvocationHandler;

--- a/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/functional/AbstractNonInvalidationTest.java
+++ b/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/functional/AbstractNonInvalidationTest.java
@@ -16,6 +16,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.persistence.OptimisticLockException;
 import javax.persistence.PessimisticLockException;
+
+import org.hibernate.StaleStateException;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.infinispan.hibernate.cache.InfinispanRegionFactory;
 import org.infinispan.hibernate.cache.entity.EntityRegionImpl;
@@ -128,11 +130,11 @@ public abstract class AbstractNonInvalidationTest extends SingleNodeTest {
                awaitOrThrow(preFlushLatch);
             }
             s.flush();
-         } catch (OptimisticLockException e) {
+         } catch (StaleStateException e) {
             log.info("Exception thrown: ", e);
             markRollbackOnly(s);
             return false;
-         } catch (PessimisticLockException e) {
+         } catch (PessimisticLockException | org.hibernate.PessimisticLockException e) {
             log.info("Exception thrown: ", e);
             markRollbackOnly(s);
             return false;
@@ -160,7 +162,7 @@ public abstract class AbstractNonInvalidationTest extends SingleNodeTest {
                awaitOrThrow(preFlushLatch);
             }
             s.flush();
-         } catch (OptimisticLockException e) {
+         } catch (StaleStateException e) {
             log.info("Exception thrown: ", e);
             markRollbackOnly(s);
             return false;

--- a/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/functional/InvalidationTest.java
+++ b/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/functional/InvalidationTest.java
@@ -151,8 +151,7 @@ public class InvalidationTest extends SingleNodeTest {
    }
 
    protected AdvancedCache getPendingPutsCache(Class<Item> entityClazz) {
-      EntityRegionImpl region = (EntityRegionImpl) sessionFactory().getCache()
-         .getEntityRegionAccess(entityClazz.getName()).getRegion();
+      EntityRegionImpl region = (EntityRegionImpl) sessionFactory().getSecondLevelCacheRegion( entityClazz.getName() );
       AdvancedCache entityCache = region.getCache();
       return (AdvancedCache) entityCache.getCacheManager().getCache(
             entityCache.getName() + "-" + InfinispanRegionFactory.DEF_PENDING_PUTS_RESOURCE).getAdvancedCache();
@@ -171,7 +170,7 @@ public class InvalidationTest extends SingleNodeTest {
          Item i = new Item("inserted", "bar");
          s.persist(i);
          s.flush();
-         s.getTransaction().setRollbackOnly();
+         s.getTransaction().markRollbackOnly();
       });
       assertNoInvalidators(pendingPutsCache);
    }
@@ -191,14 +190,14 @@ public class InvalidationTest extends SingleNodeTest {
          s.persist(item2);
          s.flush();
          s.flush(); // workaround for HHH-11312
-         s.getTransaction().setRollbackOnly();
+         s.getTransaction().markRollbackOnly();
       });
       assertNoInvalidators(pendingPutsCache);
 
       withTxSession(s -> {
          Item item3 = s.load(Item.class, item.getId());
          assertEquals("before-update", item3.getName());
-         s.remove(item3);
+         s.delete(item3);
       });
       assertNoInvalidators(pendingPutsCache);
    }
@@ -214,16 +213,16 @@ public class InvalidationTest extends SingleNodeTest {
       withTxSession(s -> {
          Item item2 = s.load(Item.class, item.getId());
          assertEquals("before-remove", item2.getName());
-         s.remove(item2);
+         s.delete(item2);
          s.flush();
-         s.getTransaction().setRollbackOnly();
+         s.getTransaction().markRollbackOnly();
       });
       assertNoInvalidators(pendingPutsCache);
 
       withTxSession(s -> {
          Item item3 = s.load(Item.class, item.getId());
          assertEquals("before-remove", item3.getName());
-         s.remove(item3);
+         s.delete(item3);
       });
       assertNoInvalidators(pendingPutsCache);
    }

--- a/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/functional/VersionedTest.java
+++ b/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/functional/VersionedTest.java
@@ -20,7 +20,7 @@ import org.infinispan.hibernate.cache.access.VersionedCallInterceptor;
 import org.infinispan.hibernate.cache.impl.BaseTransactionalDataRegion;
 import org.infinispan.hibernate.cache.util.Caches;
 import org.infinispan.hibernate.cache.util.VersionedEntry;
-import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
 
 import org.infinispan.test.hibernate.cache.functional.entities.Item;
 import org.infinispan.test.hibernate.cache.functional.entities.OtherItem;
@@ -144,7 +144,7 @@ public class VersionedTest extends AbstractNonInvalidationTest {
 
       Future<Boolean> action = executor.submit(() -> withTxSessionApply(s -> {
          try {
-            ((SharedSessionContractImplementor) s).getTransactionCoordinator().getLocalSynchronizations().registerSynchronization(new Synchronization() {
+            ((SessionImplementor) s).getTransactionCoordinator().getLocalSynchronizations().registerSynchronization(new Synchronization() {
                @Override
                public void beforeCompletion() {
                }

--- a/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/functional/cluster/DualNodeTest.java
+++ b/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/functional/cluster/DualNodeTest.java
@@ -19,7 +19,7 @@ import org.infinispan.hibernate.cache.util.InfinispanMessageLogger;
 import org.hibernate.cfg.Environment;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.resource.transaction.backend.jta.internal.JtaTransactionCoordinatorBuilderImpl;
-import org.hibernate.resource.transaction.spi.TransactionCoordinatorBuilder;
+import org.hibernate.resource.transaction.TransactionCoordinatorBuilder;
 
 import org.infinispan.test.hibernate.cache.functional.AbstractFunctionalTest;
 import org.infinispan.test.hibernate.cache.util.InfinispanTestingSetup;

--- a/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/query/QueryRegionImplTest.java
+++ b/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/query/QueryRegionImplTest.java
@@ -24,7 +24,7 @@ import org.hibernate.cache.internal.StandardQueryCache;
 import org.hibernate.cache.spi.CacheDataDescription;
 import org.hibernate.cache.spi.QueryResultsRegion;
 import org.hibernate.cache.spi.Region;
-import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
 
 import org.hibernate.testing.TestForIssue;
 import org.infinispan.test.hibernate.cache.AbstractGeneralDataRegionTest;
@@ -228,11 +228,11 @@ public class QueryRegionImplTest extends AbstractGeneralDataRegionTest {
 	}
 
 	protected interface SessionConsumer {
-		void accept(SharedSessionContractImplementor session) throws Exception;
+		void accept(SessionImplementor session) throws Exception;
 	}
 
 	protected interface SessionCallable<T> {
-		T call(SharedSessionContractImplementor session) throws Exception;
+		T call(SessionImplementor session) throws Exception;
 	}
 
 	protected <T> T callWithSession(SessionFactory sessionFactory, SessionCallable<T> callable) throws Exception {
@@ -240,7 +240,7 @@ public class QueryRegionImplTest extends AbstractGeneralDataRegionTest {
 		Transaction tx = session.getTransaction();
 		tx.begin();
 		try {
-			T retval = callable.call((SharedSessionContractImplementor) session);
+			T retval = callable.call((SessionImplementor) session);
 			tx.commit();
 			return retval;
 		} catch (Exception e) {

--- a/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/stress/CorrectnessTestCase.java
+++ b/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/stress/CorrectnessTestCase.java
@@ -478,7 +478,7 @@ public abstract class CorrectnessTestCase {
       List<DelayedInvalidators> delayed = new LinkedList<>();
       for (int i = 0; i < sessionFactories.length; i++) {
          SessionFactoryImplementor sfi = (SessionFactoryImplementor) sessionFactories[i];
-         for (Object regionName : sfi.getCache().getSecondLevelCacheRegionNames()) {
+         for (Object regionName : sfi.getAllSecondLevelCacheRegions().keySet()) {
             PutFromLoadValidator validator = getPutFromLoadValidator(sfi, (String) regionName);
             if (validator == null) {
                log.warn("No validator for " + regionName);

--- a/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/tm/JBossStandaloneJtaExampleTest.java
+++ b/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/tm/JBossStandaloneJtaExampleTest.java
@@ -22,6 +22,7 @@ import org.hibernate.boot.Metadata;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.resource.transaction.spi.TransactionStatus;
 import org.infinispan.hibernate.cache.util.InfinispanMessageLogger;
 import org.hibernate.cfg.Environment;
 import org.hibernate.engine.transaction.jta.platform.internal.JBossStandAloneJtaPlatform;
@@ -108,7 +109,7 @@ public class JBossStandaloneJtaExampleTest {
 			ut.begin();
 			try {
 				Session session = sessionFactory.openSession();
-				assertTrue(session.getTransaction().isActive());
+            assertEquals(TransactionStatus.ACTIVE, session.getTransaction().getStatus());
 				item = new Item("anItem", "An item owned by someone");
 				session.persist(item);
 				// IMO the flush should not be necessary, but session.close() does not flush
@@ -129,7 +130,7 @@ public class JBossStandaloneJtaExampleTest {
 			ut.begin();
 			try {
 				Session session = sessionFactory.openSession();
-				assertTrue(session.getTransaction().isActive());
+            assertEquals(TransactionStatus.ACTIVE, session.getTransaction().getStatus());
 				Item found = (Item) session.load(Item.class, item.getId());
 				Statistics stats = session.getSessionFactory().getStatistics();
 				log.info(stats.toString());
@@ -155,7 +156,7 @@ public class JBossStandaloneJtaExampleTest {
 			ut.begin();
 			try {
 				Session session = sessionFactory.openSession();
-				assertTrue(session.getTransaction().isActive());
+            assertEquals(TransactionStatus.ACTIVE, session.getTransaction().getStatus());
 				assertNull(session.get(Item.class, item.getId()));
 				session.close();
 			} catch(Exception e) {

--- a/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/util/BatchModeTransactionCoordinator.java
+++ b/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/util/BatchModeTransactionCoordinator.java
@@ -15,9 +15,9 @@ import org.hibernate.engine.transaction.spi.IsolationDelegate;
 import org.hibernate.engine.transaction.spi.TransactionObserver;
 import org.hibernate.resource.transaction.backend.jta.internal.JtaIsolationDelegate;
 import org.hibernate.resource.transaction.backend.jta.internal.StatusTranslator;
-import org.hibernate.resource.transaction.spi.SynchronizationRegistry;
-import org.hibernate.resource.transaction.spi.TransactionCoordinator;
-import org.hibernate.resource.transaction.spi.TransactionCoordinatorBuilder;
+import org.hibernate.resource.transaction.SynchronizationRegistry;
+import org.hibernate.resource.transaction.TransactionCoordinator;
+import org.hibernate.resource.transaction.TransactionCoordinatorBuilder;
 import org.hibernate.resource.transaction.spi.TransactionStatus;
 
 import org.infinispan.transaction.tm.BatchModeTransactionManager;
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * Mocks transaction coordinator when {@link org.hibernate.engine.spi.SharedSessionContractImplementor} is only mocked
+ * Mocks transaction coordinator when {@link org.hibernate.engine.spi.SessionImplementor} is only mocked
  * and {@link org.infinispan.transaction.tm.BatchModeTransactionManager} is used.
  *
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
@@ -176,22 +176,6 @@ public class BatchModeTransactionCoordinator implements TransactionCoordinator {
 			transactionDriver.rollback();
 		}
 
-		@Override
-		public void setRollbackOnly() {
-
-		}
-
-		@Override
-		public boolean getRollbackOnly() {
-			return false;
-		}
-
-		@Override
-		public boolean isActive() {
-			return false;
-		}
-
-		@Override
 		public TransactionStatus getStatus() {
 			return transactionDriver.getStatus();
 		}

--- a/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/util/TestSynchronization.java
+++ b/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/util/TestSynchronization.java
@@ -3,18 +3,18 @@ package org.infinispan.test.hibernate.cache.util;
 import org.hibernate.cache.spi.access.EntityRegionAccessStrategy;
 import org.hibernate.cache.spi.access.RegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
-import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
 
 /**
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
 public abstract class TestSynchronization implements javax.transaction.Synchronization {
-	protected final SharedSessionContractImplementor session;
+	protected final SessionImplementor session;
 	protected final Object key;
 	protected final Object value;
 	protected final Object version;
 
-	public TestSynchronization(SharedSessionContractImplementor session, Object key, Object value, Object version) {
+	public TestSynchronization(SessionImplementor session, Object key, Object value, Object version) {
 		this.session = session;
 		this.key = key;
 		this.value = value;
@@ -29,7 +29,7 @@ public abstract class TestSynchronization implements javax.transaction.Synchroni
 	public static class AfterInsert extends TestSynchronization {
 		private final EntityRegionAccessStrategy strategy;
 
-		public AfterInsert(EntityRegionAccessStrategy strategy, SharedSessionContractImplementor session, Object key, Object value, Object version) {
+		public AfterInsert(EntityRegionAccessStrategy strategy, SessionImplementor session, Object key, Object value, Object version) {
 			super(session, key, value, version);
 			this.strategy = strategy;
 		}
@@ -44,7 +44,7 @@ public abstract class TestSynchronization implements javax.transaction.Synchroni
 		private final EntityRegionAccessStrategy strategy;
 		private final SoftLock lock;
 
-		public AfterUpdate(EntityRegionAccessStrategy strategy, SharedSessionContractImplementor session, Object key, Object value, Object version, SoftLock lock) {
+		public AfterUpdate(EntityRegionAccessStrategy strategy, SessionImplementor session, Object key, Object value, Object version, SoftLock lock) {
 			super(session, key, value, version);
 			this.strategy = strategy;
 			this.lock = lock;
@@ -60,7 +60,7 @@ public abstract class TestSynchronization implements javax.transaction.Synchroni
 		private final RegionAccessStrategy strategy;
 		private final SoftLock lock;
 
-		public UnlockItem(RegionAccessStrategy strategy, SharedSessionContractImplementor session, Object key, SoftLock lock) {
+		public UnlockItem(RegionAccessStrategy strategy, SessionImplementor session, Object key, SoftLock lock) {
 			super(session, key, null, null);
 			this.strategy = strategy;
 			this.lock = lock;


### PR DESCRIPTION
We need to get this into Infinispan 9.1.1 so that Wildfly can consume it.