### PR TITLE
ISPN-8248 Missing timeout exceptions in distributed executor tests

### DIFF
--- a/core/src/test/java/org/infinispan/distexec/DistributedExecutorTest.java
+++ b/core/src/test/java/org/infinispan/distexec/DistributedExecutorTest.java
@@ -67,11 +67,13 @@ public class DistributedExecutorTest extends LocalDistributedExecutorTest {
       DistributedExecutorService des = createDES(cache1);
       Address target = address(0);
 
-      DistributedTaskBuilder builder = des.createDistributedTaskBuilder(new SleepingSimpleCallable());
-      builder.timeout(1000, TimeUnit.MILLISECONDS);
+      latchHolder.get().close();
+      DistributedTaskBuilder builder = des.createDistributedTaskBuilder(new SleepingSimpleCallable(latchHolder));
+      builder.timeout(100, TimeUnit.MILLISECONDS);
 
       Future<Integer> future = des.submit(target, builder.build());
       expectException(ExecutionException.class, () -> future.get());
+      latchHolder.get().open();
    }
 
    public void testBasicTargetRemoteDistributedCallableWithException() throws Exception {
@@ -96,12 +98,14 @@ public class DistributedExecutorTest extends LocalDistributedExecutorTest {
       DistributedExecutorService des = createDES(cache1);
       Address target = cache1.getAdvancedCache().getRpcManager().getAddress();
 
+      latchHolder.get().close();
       DistributedTaskBuilder builder = des
-            .createDistributedTaskBuilder(new SleepingSimpleCallable());
-      builder.timeout(1000, TimeUnit.MILLISECONDS);
+            .createDistributedTaskBuilder(new SleepingSimpleCallable(latchHolder));
+      builder.timeout(100, TimeUnit.MILLISECONDS);
 
       Future<Integer> future = des.submit(target, builder.build());
       expectException(TimeoutException.class, () -> future.get(10000, TimeUnit.MILLISECONDS));
+      latchHolder.get().open();
    }
 
    public void testBasicTargetLocalDistributedCallableWithLowFutureAndHighTaskTimeout() throws Exception {
@@ -111,12 +115,14 @@ public class DistributedExecutorTest extends LocalDistributedExecutorTest {
       DistributedExecutorService des = createDES(cache1);
       Address target = cache1.getAdvancedCache().getRpcManager().getAddress();
 
+      latchHolder.get().close();
       DistributedTaskBuilder builder = des
-            .createDistributedTaskBuilder(new SleepingSimpleCallable());
+            .createDistributedTaskBuilder(new SleepingSimpleCallable(latchHolder));
       builder.timeout(10000, TimeUnit.MILLISECONDS);
 
       Future<Integer> future = des.submit(target, builder.build());
-      expectException(TimeoutException.class, () -> future.get(1000, TimeUnit.MILLISECONDS));
+      expectException(TimeoutException.class, () -> future.get(100, TimeUnit.MILLISECONDS));
+      latchHolder.get().open();
    }
 
    public void testBasicTargetRemoteDistributedCallableWithHighFutureAndLowTaskTimeout() throws Exception {
@@ -127,12 +133,14 @@ public class DistributedExecutorTest extends LocalDistributedExecutorTest {
       DistributedExecutorService des = createDES(cache1);
       Address target = cache2.getAdvancedCache().getRpcManager().getAddress();
 
+      latchHolder.get().close();
       DistributedTaskBuilder builder = des
-            .createDistributedTaskBuilder(new SleepingSimpleCallable());
-      builder.timeout(1000, TimeUnit.MILLISECONDS);
+            .createDistributedTaskBuilder(new SleepingSimpleCallable(latchHolder));
+      builder.timeout(100, TimeUnit.MILLISECONDS);
 
       Future<Integer> future = des.submit(target, builder.build());
       expectException(TimeoutException.class, () -> future.get(10000, TimeUnit.MILLISECONDS));
+      latchHolder.get().open();
    }
 
    public void testBasicTargetRemoteDistributedCallableWithLowFutureAndHighTaskTimeout() throws Exception {
@@ -143,12 +151,14 @@ public class DistributedExecutorTest extends LocalDistributedExecutorTest {
       DistributedExecutorService des = createDES(cache1);
       Address target = cache2.getAdvancedCache().getRpcManager().getAddress();
 
+      latchHolder.get().close();
       DistributedTaskBuilder builder = des
-            .createDistributedTaskBuilder(new SleepingSimpleCallable());
+            .createDistributedTaskBuilder(new SleepingSimpleCallable(latchHolder));
       builder.timeout(10000, TimeUnit.MILLISECONDS);
 
       Future<Integer> future = des.submit(target, builder.build());
-      expectException(TimeoutException.class, () -> future.get(1000, TimeUnit.MILLISECONDS));
+      expectException(TimeoutException.class, () -> future.get(100, TimeUnit.MILLISECONDS));
+      latchHolder.get().open();
    }
 
    public void testBasicTargetLocalDistributedCallableWithoutSpecTimeout() throws Exception {
@@ -159,7 +169,7 @@ public class DistributedExecutorTest extends LocalDistributedExecutorTest {
       Address target = cache1.getAdvancedCache().getRpcManager().getAddress();
 
       DistributedTaskBuilder builder = des
-            .createDistributedTaskBuilder(new SleepingSimpleCallable());
+            .createDistributedTaskBuilder(new SleepingSimpleCallable(latchHolder));
 
       Future<Integer> future = des.submit(target, builder.build());
 
@@ -203,7 +213,7 @@ public class DistributedExecutorTest extends LocalDistributedExecutorTest {
       assertEquals(caches(cacheName()).size(), members.size());
       members.remove(getCache().getAdvancedCache().getRpcManager().getAddress());
 
-      DistributedTaskBuilder<Integer> tb = des.createDistributedTaskBuilder(new SleepingSimpleCallable());
+      DistributedTaskBuilder<Integer> tb = des.createDistributedTaskBuilder(new SleepingSimpleCallable(latchHolder));
       final Future<Integer> future = des.submit(members.get(0),tb.build());
 
       future.cancel(true);
@@ -213,8 +223,10 @@ public class DistributedExecutorTest extends LocalDistributedExecutorTest {
    public void testTimeoutOnLocalNode() throws Exception {
       AdvancedCache<Object, Object> localCache = getCache().getAdvancedCache();
       DistributedExecutorService des = createDES(localCache);
-      Future<Integer> future = des.submit(localCache.getRpcManager().getAddress(), new SleepingSimpleCallable());
-      expectException(TimeoutException.class, () -> future.get(1000, TimeUnit.MILLISECONDS));
+      latchHolder.get().close();
+      Future<Integer> future = des.submit(localCache.getRpcManager().getAddress(), new SleepingSimpleCallable(latchHolder));
+      expectException(TimeoutException.class, () -> future.get(100, TimeUnit.MILLISECONDS));
+      latchHolder.get().open();
    }
 
    public void testBasicTargetDistributedCallableTargetSameNode() throws Exception {
@@ -262,7 +274,7 @@ public class DistributedExecutorTest extends LocalDistributedExecutorTest {
       DistributedExecutorService des = createDES(cache1);
       Address target = cache1.getAdvancedCache().getRpcManager().getAddress();
 
-      DistributedTaskBuilder<Integer> builder = des.createDistributedTaskBuilder(new SleepingSimpleCallable());
+      DistributedTaskBuilder<Integer> builder = des.createDistributedTaskBuilder(new SleepingSimpleCallable(latchHolder));
       builder.timeout(10, TimeUnit.MILLISECONDS);
 
       Future<Integer> future = des.submit(target, builder.build());

--- a/core/src/test/java/org/infinispan/test/fwk/TestClassLocal.java
+++ b/core/src/test/java/org/infinispan/test/fwk/TestClassLocal.java
@@ -1,0 +1,79 @@
+package org.infinispan.test.fwk;
+
+import java.io.ObjectStreamException;
+import java.io.Serializable;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.infinispan.test.AbstractInfinispanTest;
+
+/**
+ * @author Dan Berindei
+ * @since 9.1
+ */
+public class TestClassLocal<T> implements Serializable {
+   private static final Map<String, TestClassLocal> values = new ConcurrentHashMap<>();
+
+   private final String name;
+   private final AbstractInfinispanTest test;
+   private final Supplier<T> supplier;
+   private final Consumer<T> destroyer;
+   private Object value;
+
+   public TestClassLocal(String name, AbstractInfinispanTest test, Supplier<T> supplier, Consumer<T> destroyer) {
+      this.name = name;
+      this.test = test;
+      this.supplier = supplier;
+      this.destroyer = destroyer;
+      values.put(id(), this);
+   }
+
+   @SuppressWarnings("unchecked")
+   public T get() {
+      synchronized (this) {
+         if (value == null) {
+            value = supplier.get();
+            TestResourceTracker.addResource(test, new TestResourceTracker.Cleaner<TestClassLocal<T>>(this) {
+               @Override
+               public void close() {
+                  ref.destroyer.accept(ref.get());
+               }
+            });
+         }
+         return (T) value;
+      }
+   }
+
+   @SuppressWarnings("unchecked")
+   void close() {
+      T value = (T) values.remove(this);
+      destroyer.accept(value);
+   }
+
+   public String id() {
+      return name + "/" + test.toString();
+   }
+
+   @Override
+   public String toString() {
+      return id();
+   }
+
+   Object writeReplace() throws ObjectStreamException {
+      return new Token(id());
+   }
+
+   static class Token implements Serializable {
+      private String id;
+
+      Token(String id) {
+         this.id = id;
+      }
+
+      Object readResolve() throws ObjectStreamException {
+         return values.get(id);
+      }
+   }
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-8248

Use a latch instead of Thread.sleep().