### PR TITLE
ISPN-8248 Missing timeout exceptions in distributed executor tests

### DIFF
--- a/core/src/test/java/org/infinispan/distexec/BasicDistributedExecutorTest.java
+++ b/core/src/test/java/org/infinispan/distexec/BasicDistributedExecutorTest.java
@@ -462,7 +462,6 @@ public class BasicDistributedExecutorTest extends AbstractCacheTest {
          des = new DefaultExecutorService(cache1);
          Address target = cache1.getAdvancedCache().getRpcManager().getAddress();
 
-         latchHolder.get().close();
          DistributedTaskBuilder<Integer> builder = des
                .createDistributedTaskBuilder(new DistributedExecutorTest.SleepingSimpleCallable(latchHolder));
 
@@ -494,7 +493,6 @@ public class BasicDistributedExecutorTest extends AbstractCacheTest {
          des = new DefaultExecutorService(cache1);
          Address target = cache2.getAdvancedCache().getRpcManager().getAddress();
 
-         latchHolder.get().close();
          DistributedTaskBuilder<Integer> builder = des
                .createDistributedTaskBuilder(new DistributedExecutorTest.SleepingSimpleCallable(latchHolder));
 

--- a/core/src/test/java/org/infinispan/distexec/DistributedExecutorTest.java
+++ b/core/src/test/java/org/infinispan/distexec/DistributedExecutorTest.java
@@ -67,13 +67,11 @@ public class DistributedExecutorTest extends LocalDistributedExecutorTest {
       DistributedExecutorService des = createDES(cache1);
       Address target = address(0);
 
-      latchHolder.get().close();
       DistributedTaskBuilder builder = des.createDistributedTaskBuilder(new SleepingSimpleCallable(latchHolder));
       builder.timeout(100, TimeUnit.MILLISECONDS);
 
       Future<Integer> future = des.submit(target, builder.build());
       expectException(ExecutionException.class, () -> future.get());
-      latchHolder.get().open();
    }
 
    public void testBasicTargetRemoteDistributedCallableWithException() throws Exception {
@@ -98,7 +96,6 @@ public class DistributedExecutorTest extends LocalDistributedExecutorTest {
       DistributedExecutorService des = createDES(cache1);
       Address target = cache1.getAdvancedCache().getRpcManager().getAddress();
 
-      latchHolder.get().close();
       DistributedTaskBuilder builder = des
             .createDistributedTaskBuilder(new SleepingSimpleCallable(latchHolder));
       builder.timeout(100, TimeUnit.MILLISECONDS);
@@ -115,7 +112,6 @@ public class DistributedExecutorTest extends LocalDistributedExecutorTest {
       DistributedExecutorService des = createDES(cache1);
       Address target = cache1.getAdvancedCache().getRpcManager().getAddress();
 
-      latchHolder.get().close();
       DistributedTaskBuilder builder = des
             .createDistributedTaskBuilder(new SleepingSimpleCallable(latchHolder));
       builder.timeout(10000, TimeUnit.MILLISECONDS);
@@ -133,7 +129,6 @@ public class DistributedExecutorTest extends LocalDistributedExecutorTest {
       DistributedExecutorService des = createDES(cache1);
       Address target = cache2.getAdvancedCache().getRpcManager().getAddress();
 
-      latchHolder.get().close();
       DistributedTaskBuilder builder = des
             .createDistributedTaskBuilder(new SleepingSimpleCallable(latchHolder));
       builder.timeout(100, TimeUnit.MILLISECONDS);
@@ -151,7 +146,6 @@ public class DistributedExecutorTest extends LocalDistributedExecutorTest {
       DistributedExecutorService des = createDES(cache1);
       Address target = cache2.getAdvancedCache().getRpcManager().getAddress();
 
-      latchHolder.get().close();
       DistributedTaskBuilder builder = des
             .createDistributedTaskBuilder(new SleepingSimpleCallable(latchHolder));
       builder.timeout(10000, TimeUnit.MILLISECONDS);
@@ -170,8 +164,10 @@ public class DistributedExecutorTest extends LocalDistributedExecutorTest {
 
       DistributedTaskBuilder builder = des
             .createDistributedTaskBuilder(new SleepingSimpleCallable(latchHolder));
-
       Future<Integer> future = des.submit(target, builder.build());
+
+      Thread.sleep(100);
+      latchHolder.get().open();
 
       assertEquals((Integer) 1, future.get());
    }
@@ -218,12 +214,13 @@ public class DistributedExecutorTest extends LocalDistributedExecutorTest {
 
       future.cancel(true);
       expectException(CancellationException.class, () -> future.get());
+      latchHolder.get().open();
    }
 
    public void testTimeoutOnLocalNode() throws Exception {
       AdvancedCache<Object, Object> localCache = getCache().getAdvancedCache();
       DistributedExecutorService des = createDES(localCache);
-      latchHolder.get().close();
+
       Future<Integer> future = des.submit(localCache.getRpcManager().getAddress(), new SleepingSimpleCallable(latchHolder));
       expectException(TimeoutException.class, () -> future.get(100, TimeUnit.MILLISECONDS));
       latchHolder.get().open();
@@ -278,7 +275,8 @@ public class DistributedExecutorTest extends LocalDistributedExecutorTest {
       builder.timeout(10, TimeUnit.MILLISECONDS);
 
       Future<Integer> future = des.submit(target, builder.build());
-      expectException(ExecutionException.class, () -> future.get());
+      expectException(ExecutionException.class, TimeoutException.class, () -> future.get());
+      latchHolder.get().open();
    }
 
    public void testBasicTargetCallableWithNullTask() {

--- a/core/src/test/java/org/infinispan/distexec/LocalDistributedExecutorTest.java
+++ b/core/src/test/java/org/infinispan/distexec/LocalDistributedExecutorTest.java
@@ -260,7 +260,16 @@ public class LocalDistributedExecutorTest extends MultipleCacheManagersTest {
       List<Callable<Integer>> tasks = new ArrayList<>();
       tasks.add(new ExceptionThrowingCallable());
       tasks.add(new SleepingSimpleCallable(latchHolder));
+
+      // invokeAny is synchronous, so we need to open the latch in a new thread
+      fork(() -> {
+         Thread.sleep(100);
+         latchHolder.get().open();
+         return null;
+      });
+
       Object result = des.invokeAny(tasks);
+
       assertEquals(1, result);
    }
 
@@ -268,7 +277,7 @@ public class LocalDistributedExecutorTest extends MultipleCacheManagersTest {
       DistributedExecutorService des = createDES(getCache());
       List<SleepingSimpleCallable> tasks = new ArrayList<>();
       tasks.add(new SleepingSimpleCallable(latchHolder));
-      latchHolder.get().close();
+
       expectException(TimeoutException.class, () -> des.invokeAny(tasks, 100, TimeUnit.MILLISECONDS));
       latchHolder.get().open();
    }
@@ -327,6 +336,10 @@ public class LocalDistributedExecutorTest extends MultipleCacheManagersTest {
    public void testSleepingCallableWithTimeoutOption() throws Exception {
       DistributedExecutorService des = createDES(getCache());
       Future<Integer> future = des.submit(new SleepingSimpleCallable(latchHolder));
+
+      Thread.sleep(100);
+      latchHolder.get().open();
+
       Integer r = future.get(10, TimeUnit.SECONDS);
       assertEquals((Integer) 1, r);
 
@@ -334,13 +347,17 @@ public class LocalDistributedExecutorTest extends MultipleCacheManagersTest {
       DistributedTaskBuilder<Integer> taskBuilder =
             des.createDistributedTaskBuilder(new SleepingSimpleCallable(latchHolder));
       DistributedTask<Integer> distributedTask = taskBuilder.build();
+
       future = des.submit(distributedTask);
+
+      Thread.sleep(100);
+      latchHolder.get().open();
+
       r = future.get(10, TimeUnit.SECONDS);
       assertEquals((Integer) 1, r);
    }
 
    public void testSleepingCallableWithTimeoutExc() throws Exception {
-      latchHolder.get().close();
       DistributedExecutorService des = createDES(getCache());
       Future<Integer> future = des.submit(new SleepingSimpleCallable(latchHolder));
       log.tracef("Sleeping task submitted");
@@ -349,7 +366,6 @@ public class LocalDistributedExecutorTest extends MultipleCacheManagersTest {
    }
 
    public void testSleepingCallableWithTimeoutExcDistApi() throws Exception {
-      latchHolder.get().close();
       DistributedExecutorService des = createDES(getCache());
       DistributedTaskBuilder<Integer> taskBuilder =
             des.createDistributedTaskBuilder(new SleepingSimpleCallable(latchHolder));
@@ -362,7 +378,6 @@ public class LocalDistributedExecutorTest extends MultipleCacheManagersTest {
 
    public void testExceptionCallableWithTimedCall() throws Exception {
       DistributedExecutorService des = createDES(getCache());
-      latchHolder.get().close();
       Future<Integer> future = des.submit(new ExceptionThrowingCallable(latchHolder, true));
 
       expectException(TimeoutException.class, () -> future.get(100, TimeUnit.MILLISECONDS));
@@ -372,7 +387,6 @@ public class LocalDistributedExecutorTest extends MultipleCacheManagersTest {
    public void testExceptionCallableWithTimedCallDistApi() throws Exception {
       DistributedExecutorService des = createDES(getCache());
 
-      latchHolder.get().close();
       DistributedTaskBuilder<Integer> taskBuilder =
             des.createDistributedTaskBuilder(new ExceptionThrowingCallable(latchHolder, true));
       DistributedTask<Integer> distributedTask = taskBuilder.build();
@@ -596,12 +610,13 @@ public class LocalDistributedExecutorTest extends MultipleCacheManagersTest {
 
       SleepingSimpleCallable(TestClassLocal<ReclosableLatch> latchHolder) {
          this.latchHolder = latchHolder;
+         latchHolder.get().close();
       }
 
       @Override
       public Integer call() throws Exception {
          log.tracef("Waiting on latch %s", latchHolder);
-         latchHolder.get().await(10, TimeUnit.SECONDS);
+         latchHolder.get().await(15, TimeUnit.SECONDS);
 
          return 1;
       }
@@ -633,6 +648,9 @@ public class LocalDistributedExecutorTest extends MultipleCacheManagersTest {
       public ExceptionThrowingCallable(TestClassLocal<ReclosableLatch> latchHolder, boolean needToSleep) {
          this.latchHolder = latchHolder;
          this.needToSleep = needToSleep;
+         if (needToSleep) {
+            latchHolder.get().close();
+         }
       }
 
       @Override


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-8248

Make SleepingSimpleCallable close the latch automatically

The previous PR didn't close/open the latch for some test methods, so they could pass or fail depending on the order they ran in.