### PR TITLE
ISPN-8026 Size related fixes in Hibernate Cache tests

### DIFF
--- a/core/src/main/java/org/infinispan/container/DefaultDataContainer.java
+++ b/core/src/main/java/org/infinispan/container/DefaultDataContainer.java
@@ -413,6 +413,7 @@ public class DefaultDataContainer<K, V> implements DataContainer<K, V> {
          while (it.hasNext()) {
             InternalCacheEntry<K, V> entry = it.next();
             if (includeExpired || !entry.canExpire()) {
+               log.tracef("Return next entry %s", entry);
                return entry;
             } else {
                if (!initializedTime) {
@@ -420,10 +421,14 @@ public class DefaultDataContainer<K, V> implements DataContainer<K, V> {
                   initializedTime = true;
                }
                if (!entry.isExpired(now)) {
+                  log.tracef("Return next entry %s", entry);
                   return entry;
+               } else {
+                  log.tracef("%s is expired", entry);
                }
             }
          }
+         log.tracef("Return next null");
          return null;
       }
 

--- a/core/src/main/java/org/infinispan/stream/impl/TerminalFunctions.java
+++ b/core/src/main/java/org/infinispan/stream/impl/TerminalFunctions.java
@@ -43,11 +43,15 @@ import org.infinispan.IntCacheStream;
 import org.infinispan.LongCacheStream;
 import org.infinispan.commons.marshall.Externalizer;
 import org.infinispan.commons.marshall.SerializeWith;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
 
 /**
  * Static factory class used to provide marshallable terminal operations
  */
 final class TerminalFunctions {
+   private static final Log log = LogFactory.getLog(TerminalFunctions.class);
+
    private TerminalFunctions() { }
 
    public static <T> Function<Stream<T>, Boolean> allMatchFunction(Predicate<? super T> predicate) {
@@ -615,7 +619,9 @@ final class TerminalFunctions {
 
       @Override
       public Long apply(Stream<T> stream) {
-         return stream.count();
+         long count = stream.count();
+         log.tracef("Count value is %d", count);
+         return count;
       }
 
       public static final class CountFunctionExternalizer implements Externalizer<CountFunction> {

--- a/core/src/main/java/org/infinispan/stream/impl/local/EntryStreamSupplier.java
+++ b/core/src/main/java/org/infinispan/stream/impl/local/EntryStreamSupplier.java
@@ -72,7 +72,14 @@ public class EntryStreamSupplier<K, V> implements AbstractLocalCacheStream.Strea
          }
          BitSet bitSet = new BitSet(hash.getNumSegments());
          segmentsToFilter.forEach(bitSet::set);
-         stream = stream.filter(k -> bitSet.get(hash.getSegment(k.getKey())));
+         stream = stream.filter(k -> {
+            K key = k.getKey();
+            int segment = hash.getSegment(key);
+            boolean isPresent = bitSet.get(segment);
+            if (trace)
+               log.tracef("Is key %s present in segment %d? %b", key, segment, isPresent);
+            return isPresent;
+         });
       }
       return stream;
    }

--- a/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/access/InvalidationSynchronization.java
+++ b/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/access/InvalidationSynchronization.java
@@ -6,6 +6,8 @@
  */
 package org.infinispan.hibernate.cache.access;
 
+import org.infinispan.hibernate.cache.util.InfinispanMessageLogger;
+
 import javax.transaction.Status;
 
 /**
@@ -14,6 +16,7 @@ import javax.transaction.Status;
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
 public class InvalidationSynchronization implements javax.transaction.Synchronization {
+   private final static InfinispanMessageLogger log = InfinispanMessageLogger.Provider.getLog(InvalidationSynchronization.class);
 	public final Object lockOwner;
 	private final NonTxPutFromLoadInterceptor nonTxPutFromLoadInterceptor;
 	private final Object key;
@@ -29,6 +32,7 @@ public class InvalidationSynchronization implements javax.transaction.Synchroniz
 
 	@Override
 	public void afterCompletion(int status) {
+      log.tracef("After completion callback with status %d", status);
 		nonTxPutFromLoadInterceptor.endInvalidating(key, lockOwner, status == Status.STATUS_COMMITTED || status == Status.STATUS_COMMITTING);
 	}
 }

--- a/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/access/PutFromLoadValidator.java
+++ b/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/access/PutFromLoadValidator.java
@@ -224,7 +224,7 @@ public class PutFromLoadValidator {
          chain.addInterceptor(nonTxPutFromLoadInterceptor, entryWrappingPosition);
 			validator.nonTxPutFromLoadInterceptor = nonTxPutFromLoadInterceptor;
 		}
-		log.debug("New interceptor chain is: " + cache.getInterceptorChain());
+		log.debug("New interceptor chain is: " + cache.getAsyncInterceptorChain());
 
 		CacheCommandInitializer cacheCommandInitializer = cache.getComponentRegistry().getComponent(CacheCommandInitializer.class);
 		cacheCommandInitializer.addPutFromLoadValidator(cache.getName(), validator);
@@ -587,7 +587,7 @@ public class PutFromLoadValidator {
 					}
 					long now = regionFactory.nextTimestamp();
                if (trace) {
-                  log.tracef("endInvalidatingKey(%s#%s, %s) remove invalidator from %s", cache.getName(), key, lockOwnerToString(lockOwner), pending);
+                  log.tracef("beginInvalidatingKey(%s#%s, %s) remove invalidator from %s", cache.getName(), key, lockOwnerToString(lockOwner), pending);
                }
 					pending.invalidate(now);
 					pending.addInvalidator(lockOwner, valueForPFER, now);

--- a/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/access/PutFromLoadValidator.java
+++ b/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/access/PutFromLoadValidator.java
@@ -185,7 +185,7 @@ public class PutFromLoadValidator {
 	public static void addToCache(AdvancedCache cache, PutFromLoadValidator validator) {
       AsyncInterceptorChain chain = cache.getAsyncInterceptorChain();
       List<AsyncInterceptor> interceptors = chain.getInterceptors();
-      log.debug("Interceptor chain was: " + interceptors);
+      log.debugf("Interceptor chain was: ", interceptors);
       int position = 0;
 		// add interceptor before uses exact match, not instanceof match
 		int invalidationPosition = 0;
@@ -224,7 +224,7 @@ public class PutFromLoadValidator {
          chain.addInterceptor(nonTxPutFromLoadInterceptor, entryWrappingPosition);
 			validator.nonTxPutFromLoadInterceptor = nonTxPutFromLoadInterceptor;
 		}
-		log.debug("New interceptor chain is: " + cache.getAsyncInterceptorChain());
+		log.debugf("New interceptor chain is: ", cache.getAsyncInterceptorChain());
 
 		CacheCommandInitializer cacheCommandInitializer = cache.getComponentRegistry().getComponent(CacheCommandInitializer.class);
 		cacheCommandInitializer.addPutFromLoadValidator(cache.getName(), validator);

--- a/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/access/TombstoneCallInterceptor.java
+++ b/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/access/TombstoneCallInterceptor.java
@@ -194,19 +194,8 @@ public class TombstoneCallInterceptor extends DDAsyncInterceptor {
 			decoratedCache = decoratedCache.withFlags(flags.toArray(new Flag[flags.size()]));
 		}
 		// In non-transactional caches we don't care about context
-      CloseableIterator<CacheEntry<Object, Object>> it = Closeables.iterator(decoratedCache.cacheEntrySet().stream()
-            .filter(CacheFilters.predicate(Tombstone.EXCLUDE_TOMBSTONES)));
-		try {
-         while (it.hasNext()) {
-            CacheEntry<Object, Object> entry = it.next();
-				if (size++ == Integer.MAX_VALUE) {
-					return Integer.MAX_VALUE;
-				}
-			}
-		}
-		finally {
-         it.close();
-		}
-		return size;
+      return (int) decoratedCache.cacheEntrySet().stream()
+         .filter(CacheFilters.predicate(Tombstone.EXCLUDE_TOMBSTONES))
+         .count();
 	}
 }

--- a/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/access/TombstoneCallInterceptor.java
+++ b/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/access/TombstoneCallInterceptor.java
@@ -194,8 +194,9 @@ public class TombstoneCallInterceptor extends DDAsyncInterceptor {
 			decoratedCache = decoratedCache.withFlags(flags.toArray(new Flag[flags.size()]));
 		}
 		// In non-transactional caches we don't care about context
-      return (int) decoratedCache.cacheEntrySet().stream()
-         .filter(CacheFilters.predicate(Tombstone.EXCLUDE_TOMBSTONES))
-         .count();
+      return Math.min(Integer.MAX_VALUE,
+         (int) decoratedCache.cacheEntrySet().stream()
+            .filter(CacheFilters.predicate(Tombstone.EXCLUDE_TOMBSTONES))
+            .count());
 	}
 }

--- a/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/access/VersionedCallInterceptor.java
+++ b/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/access/VersionedCallInterceptor.java
@@ -147,8 +147,9 @@ public class VersionedCallInterceptor extends DDAsyncInterceptor {
 			decoratedCache = decoratedCache.withFlags(flags.toArray(new Flag[flags.size()]));
 		}
 		// In non-transactional caches we don't care about context
-      return (int) CacheFilters.filterAndConvert(decoratedCache.entrySet().stream(),
+      return Math.min(Integer.MAX_VALUE,
+         (int) CacheFilters.filterAndConvert(decoratedCache.entrySet().stream(),
             new FilterNullValueConverter(VersionedEntry.EXCLUDE_EMPTY_EXTRACT_VALUE))
-            .count();
+            .count());
 	}
 }

--- a/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/util/Tombstone.java
+++ b/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/util/Tombstone.java
@@ -6,6 +6,8 @@
  */
 package org.infinispan.hibernate.cache.util;
 
+import org.infinispan.commons.logging.Log;
+import org.infinispan.commons.logging.LogFactory;
 import org.infinispan.commons.marshall.AdvancedExternalizer;
 import org.infinispan.filter.KeyValueFilter;
 import org.infinispan.metadata.Metadata;
@@ -23,6 +25,8 @@ import java.util.UUID;
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
 public class Tombstone {
+   private static final Log log = LogFactory.getLog(Tombstone.class);
+
 	public static final ExcludeTombstonesFilter EXCLUDE_TOMBSTONES = new ExcludeTombstonesFilter();
 
 	// the format of data is repeated (timestamp, UUID.LSB, UUID.MSB)
@@ -191,7 +195,9 @@ public class Tombstone {
 
 		@Override
 		public boolean accept(Object key, Object value, Metadata metadata) {
-			return !(value instanceof Tombstone);
+         boolean b = !(value instanceof Tombstone);
+         log.tracef("Is value %s for key %s is tombstone? %b", value, key, b);
+         return b;
 		}
 	}
 

--- a/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/util/VersionedEntry.java
+++ b/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/util/VersionedEntry.java
@@ -10,6 +10,8 @@ import org.infinispan.commons.marshall.AdvancedExternalizer;
 import org.infinispan.filter.Converter;
 import org.infinispan.filter.KeyValueFilter;
 import org.infinispan.metadata.Metadata;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
 
 import java.io.IOException;
 import java.io.ObjectInput;
@@ -55,8 +57,11 @@ public class VersionedEntry {
 	}
 
 	private static class ExcludeEmptyFilter implements KeyValueFilter<Object, Object>, Converter<Object, Object, Object> {
+      private static final Log log = LogFactory.getLog(ExcludeEmptyFilter.class);
+
 		@Override
 		public boolean accept(Object key, Object value, Metadata metadata) {
+         log.tracef("Filter check for %s", value);
 			if (value instanceof VersionedEntry) {
 				return ((VersionedEntry) value).getValue() != null;
 			}

--- a/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/AbstractRegionAccessStrategyTest.java
+++ b/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/AbstractRegionAccessStrategyTest.java
@@ -279,10 +279,9 @@ public abstract class AbstractRegionAccessStrategyTest<R extends BaseRegion, S e
 	}
 
    protected void assertPutFromLoadLatches(CountDownLatch[] latches) {
-      if (!await(latches[0]) && !await(latches[1]))
-         throw new AssertionError(String.format(
-            "One of the latches in %s should have at least completed",
-            Arrays.toString(latches)));
+      assertTrue(String.format(
+         "One of the latches in %s should have at least completed", Arrays.toString(latches)),
+         await(latches[0]) || await(latches[1]));
    }
 
    private boolean await(CountDownLatch latch) {
@@ -652,6 +651,4 @@ public abstract class AbstractRegionAccessStrategyTest<R extends BaseRegion, S e
 		}
 		return putFromLoadLatch;
 	}
-
-
 }

--- a/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/AbstractRegionAccessStrategyTest.java
+++ b/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/AbstractRegionAccessStrategyTest.java
@@ -569,9 +569,10 @@ public abstract class AbstractRegionAccessStrategyTest<R extends BaseRegion, S e
 		SessionImplementor s10 = mockedSession();
       log.infof("Call remote strategy get for key=%s", KEY);
 		assertEquals(VALUE1, remoteAccessStrategy.get(s10, KEY, s10.getTimestamp()));
+      // Wait for change to be applied in local, otherwise the count might not be correct
+      assertTrue(lastPutFromLoadLatch.await(1, TimeUnit.SECONDS));
 		assertEquals(1, remoteRegion.getCache().size());
 
-		assertTrue(lastPutFromLoadLatch.await(1, TimeUnit.SECONDS));
 
 		SessionImplementor s11 = mockedSession();
 		assertEquals((isUsingInvalidation() ? null : VALUE1), localAccessStrategy.get(s11, KEY, s11.getTimestamp()));

--- a/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/AbstractRegionAccessStrategyTest.java
+++ b/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/AbstractRegionAccessStrategyTest.java
@@ -349,7 +349,6 @@ public abstract class AbstractRegionAccessStrategyTest<R extends BaseRegion, S e
 	protected abstract S getAccessStrategy(R region);
 
 	@Test
-   @Ignore("Randomly failing on CI - ISPN-8026")
 	public void testRemove() throws Exception {
 		evictOrRemoveTest( false );
 	}
@@ -433,13 +432,11 @@ public abstract class AbstractRegionAccessStrategyTest<R extends BaseRegion, S e
 	}
 
 	@Test
-   @Ignore("Randomly failing on CI - ISPN-8026")
    public void testRemoveAll() throws Exception {
 		evictOrRemoveAllTest(false);
 	}
 
 	@Test
-   @Ignore("Randomly failing on CI - ISPN-8026")
    public void testEvictAll() throws Exception {
 		evictOrRemoveAllTest(true);
 	}

--- a/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/AbstractRegionAccessStrategyTest.java
+++ b/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/AbstractRegionAccessStrategyTest.java
@@ -460,12 +460,12 @@ public abstract class AbstractRegionAccessStrategyTest<R extends BaseRegion, S e
 
 		SessionImplementor s7 = mockedSession();
 		assertNull(localAccessStrategy.get(s7, KEY, s7.getTimestamp()));
-		assertEquals(0, localRegion.getCache().size());
-		SessionImplementor s8 = mockedSession();
+      SessionImplementor s8 = mockedSession();
 		assertNull(remoteAccessStrategy.get(s8, KEY, s8.getTimestamp()));
-		assertEquals(0, remoteRegion.getCache().size());
 
       assertTrue(endInvalidationLatch.await(1, TimeUnit.SECONDS));
+      assertEquals(0, localRegion.getCache().size());
+		assertEquals(0, remoteRegion.getCache().size());
 	}
 
 	protected void doRemove(S strategy, SessionImplementor session, Object key) throws SystemException, RollbackException {

--- a/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/functional/BulkOperationsTest.java
+++ b/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/functional/BulkOperationsTest.java
@@ -30,7 +30,6 @@ import static org.junit.Assert.assertNull;
  * @author Galder Zamarreño
  * @since 3.5
  */
-@Ignore("Randomly failing on CI - ISPN-8026")
 public class BulkOperationsTest extends SingleNodeTest {
 	@Override
 	public List<Object[]> getParameters() {

--- a/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/util/ExpectingInterceptor.java
+++ b/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/util/ExpectingInterceptor.java
@@ -109,7 +109,10 @@ public class ExpectingInterceptor extends BaseCustomAsyncInterceptor {
       }
 
       public Condition countDown(CountDownLatch latch) {
-         return run(() -> latch.countDown()).removeWhen(() -> latch.getCount() == 0);
+         return run(() -> {
+               log.debugf("Count down latch %s", latch);
+               latch.countDown();
+            }).removeWhen(() -> latch.getCount() == 0);
       }
 
       public Condition removeWhen(BooleanSupplier check) {


### PR DESCRIPTION
A bunch of fixes to avoid the following problems:
* Async puts from tests that linger affecting other tests. This applies to both remove put from load calls, and remove end invalidation calls.
* Wait for end invalidation and putFromLoad calls before asserting cache size. Although cache gets might work fine, getting an accurate size count requires all remote ops to end well, so that streams can be correctly processed, filtered and counted.