### PR TITLE
ISPN-8250

### DIFF
--- a/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/AbstractClusterListenerNonTxTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/AbstractClusterListenerNonTxTest.java
@@ -1,7 +1,7 @@
 package org.infinispan.notifications.cachelistener.cluster;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
 
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -61,25 +61,24 @@ public abstract class AbstractClusterListenerNonTxTest extends AbstractClusterLi
 
       TestingUtil.waitForNoRebalance(cache0, cache2);
 
-      // The command is retried during rebalance, but there are two topologies - in the first (rebalancing) topology
-      // one node can be primary owner and in the second (rebalanced) the other. In this case, it's possible that
-      // the listener is fired both in the first topology and then after the response from primary owner arrives
-      // and the originator now has become the new primary owner.
-      // Similar situation is possible with triangle algorithm (TODO pruivo: elaborate)
-      assertTrue(clusterListener.events.size() >= 2);
-      assertTrue(clusterListener.events.size() <= 3);
+      // The command is retried during rebalance, but there are 5 topology updates (thus up to 5 retries)
+      // 1: top - 1 NO_REBALANCE
+      // 2: top     READ_OLD_WRITE_ALL
+      // 3: top     READ_ALL_WRITE_ALL
+      // 4: top     READ_NEW_WRITE_ALL
+      // 5: top     NO_REBALANCE
+      assertTrue("Expected 2 - 6 events, but received " + clusterListener.events,
+            clusterListener.events.size() >= 2 && clusterListener.events.size() <= 6);
+      // Since the first event was generated properly it is a create without retry
       checkEvent(clusterListener.events.get(0), key, true, false);
 
       Address cache0primary = cache0.getAdvancedCache().getDistributionManager().getPrimaryLocation(key);
       Address cache2primary = cache2.getAdvancedCache().getDistributionManager().getPrimaryLocation(key);
       // we expect that now both nodes have the same topology
       assertEquals(cache0primary, cache2primary);
-      // This is possible after rebalance; when rebalancing, primary owner is always the old backup
 
-      checkEvent(clusterListener.events.get(1), key, false, true);
-      if (clusterListener.events.size() == 3) {
-         checkEvent(clusterListener.events.get(2), key, false, true);
-      }
+      // Any extra events would be retries as modifications
+      clusterListener.events.stream().skip(1).forEach(e -> checkEvent(e, key, false, true));
    }
 
    protected void checkEvent(CacheEntryEvent<Object, String> event, MagicKey key, boolean isCreated, boolean isRetried) {

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/ClusterListenerDistTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/ClusterListenerDistTest.java
@@ -1,7 +1,7 @@
 package org.infinispan.notifications.cachelistener.cluster;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
 
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
@@ -62,23 +62,20 @@ public class ClusterListenerDistTest extends AbstractClusterListenerNonTxTest {
 
       TestingUtil.waitForNoRebalance(cache0, cache2);
 
-      // The command is retried during rebalance, but there are two topologies - in the first (rebalancing) topology
-      // one node can be primary owner and in the second (rebalanced) the other. In this case, it's possible that
-      // the listener is fired both in the first topology and then after the response from primary owner arrives
-      // and the originator now has become the new primary owner.
-      // Similar situation is possible with triangle algorithm (TODO pruivo: elaborate)
-      assertTrue(clusterListener.events.size() >= 1);
-      assertTrue(clusterListener.events.size() <= 2);
+      // The command is retried during rebalance, but there are 5 topology updates (thus up to 5 retries)
+      // 1: top - 1 NO_REBALANCE
+      // 2: top     READ_OLD_WRITE_ALL
+      // 3: top     READ_ALL_WRITE_ALL
+      // 4: top     READ_NEW_WRITE_ALL
+      // 5: top     NO_REBALANCE
+      assertTrue("Expected 1 - 5 events, but received " + clusterListener.events,
+            clusterListener.events.size() >= 1 && clusterListener.events.size() <= 5);
 
       Address cache0primary = cache0.getAdvancedCache().getDistributionManager().getCacheTopology().getDistribution(key).primary();
       Address cache2primary = cache2.getAdvancedCache().getDistributionManager().getCacheTopology().getDistribution(key).primary();
       // we expect that now both nodes have the same topology
       assertEquals(cache0primary, cache2primary);
-      checkEvent(clusterListener.events.get(0), key, false, true);
 
-      // This is possible after rebalance; when rebalancing, primary owner is always the old backup
-      if (clusterListener.events.size() == 2) {
-         checkEvent(clusterListener.events.get(1), key, false, true);
-      }
+      clusterListener.events.forEach(e -> checkEvent(e, key, false, true));
    }
 }


### PR DESCRIPTION
ClusterListenerDistTest.testPrimaryOwnerGoesDownBeforeSendingEvent
random failures

* Update to reflect how many CH updates there can be now

https://issues.jboss.org/browse/ISPN-8250