### PR TITLE
ISPN-8110 OffHeapBoundedDataContainer.ensureSize() busy loop takes too

### DIFF
--- a/core/src/test/java/org/infinispan/container/offheap/OffHeapBoundedSingleNodeTest.java
+++ b/core/src/test/java/org/infinispan/container/offheap/OffHeapBoundedSingleNodeTest.java
@@ -26,7 +26,7 @@ import org.testng.annotations.Test;
 @Test(groups = "functional", testName = "container.offheap.OffHeapBoundedSingleNodeTest")
 public class OffHeapBoundedSingleNodeTest extends OffHeapSingleNodeTest {
 
-   private static final int COUNT = 100;
+   private static final int COUNT = 51;
 
    @Override
    protected void createCacheManagers() throws Throwable {


### PR DESCRIPTION
long

* Replaced yield with lock acquisition and retry

https://issues.jboss.org/browse/ISPN-8110

This should help resolve timeout issues in test when TRACE is enabled.