### PR TITLE
Overloaded collect() to take SerializableSupplier

### DIFF
--- a/core/src/main/java/org/infinispan/CacheStream.java
+++ b/core/src/main/java/org/infinispan/CacheStream.java
@@ -318,6 +318,8 @@ public interface CacheStream<R> extends Stream<R>, BaseCacheStream<R, Stream<R>>
    @Override
    <R1, A> R1 collect(Collector<? super R, A, R1> collector);
 
+   <R1, A> R1 collect(SerializableSupplier<Collector<? super R, A, R1>> supplier);
+
    /**
     * Same as {@link CacheStream#collect(Supplier, BiConsumer, BiConsumer)} except that the various arguments must
     * also implement <code>Serializable</code>

--- a/core/src/main/java/org/infinispan/stream/impl/DistributedCacheStream.java
+++ b/core/src/main/java/org/infinispan/stream/impl/DistributedCacheStream.java
@@ -73,6 +73,7 @@ import org.infinispan.stream.impl.intops.object.PeekOperation;
 import org.infinispan.stream.impl.termop.object.ForEachBiOperation;
 import org.infinispan.stream.impl.termop.object.ForEachOperation;
 import org.infinispan.stream.impl.termop.object.NoMapIteratorOperation;
+import org.infinispan.util.AbstractDelegatingCacheStream;
 import org.infinispan.util.CloseableSuppliedIterator;
 import org.infinispan.util.RangeSet;
 import org.infinispan.util.concurrent.TimeoutException;
@@ -454,6 +455,11 @@ public class DistributedCacheStream<R> extends AbstractCacheStream<R, Stream<R>,
                  new IdentifyFinishCollector<>(collector)), true, collector.combiner(), null);
          return collector.finisher().apply(intermediateResult);
       }
+   }
+
+   @Override
+   public <R1, A> R1 collect(SerializableSupplier<Collector<? super R, A, R1>> supplier) {
+      return collect(new AbstractDelegatingCacheStream.CollectorSupplier2<>(supplier));
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/stream/impl/IntermediateCacheStream.java
+++ b/core/src/main/java/org/infinispan/stream/impl/IntermediateCacheStream.java
@@ -342,6 +342,11 @@ public class IntermediateCacheStream<R> implements CacheStream<R> {
    }
 
    @Override
+   public <R1, A> R1 collect(SerializableSupplier<Collector<? super R, A, R1>> supplier) {
+      return localStream.collect(supplier);
+   }
+
+   @Override
    public <R1> R1 collect(Supplier<R1> supplier, BiConsumer<R1, ? super R> accumulator, BiConsumer<R1, R1> combiner) {
       return localStream.collect(supplier, accumulator, combiner);
    }

--- a/core/src/main/java/org/infinispan/stream/impl/local/LocalCacheStream.java
+++ b/core/src/main/java/org/infinispan/stream/impl/local/LocalCacheStream.java
@@ -361,6 +361,11 @@ public class LocalCacheStream<R> extends AbstractLocalCacheStream<R, Stream<R>, 
    }
 
    @Override
+   public <R1, A> R1 collect(SerializableSupplier<Collector<? super R, A, R1>> supplier) {
+      return createStream().collect(supplier.get());
+   }
+
+   @Override
    public Optional<R> min(Comparator<? super R> comparator) {
       return createStream().min(comparator);
    }

--- a/core/src/main/java/org/infinispan/util/AbstractDelegatingCacheStream.java
+++ b/core/src/main/java/org/infinispan/util/AbstractDelegatingCacheStream.java
@@ -1,5 +1,8 @@
 package org.infinispan.util;
 
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.Optional;
@@ -28,6 +31,9 @@ import org.infinispan.CacheStream;
 import org.infinispan.DoubleCacheStream;
 import org.infinispan.IntCacheStream;
 import org.infinispan.LongCacheStream;
+import org.infinispan.commons.marshall.Externalizer;
+import org.infinispan.commons.marshall.SerializeWith;
+import org.infinispan.stream.CacheCollectors;
 import org.infinispan.util.function.SerializableBiConsumer;
 import org.infinispan.util.function.SerializableBiFunction;
 import org.infinispan.util.function.SerializableBinaryOperator;
@@ -318,6 +324,11 @@ public class AbstractDelegatingCacheStream<R> implements CacheStream<R> {
    }
 
    @Override
+   public <R1, A> R1 collect(SerializableSupplier<Collector<? super R, A, R1>> supplier) {
+      return collect(new CollectorSupplier2<>(supplier));
+   }
+
+   @Override
    public Optional<R> min(Comparator<? super R> comparator) {
       return castStream(underlyingStream).min(comparator);
    }
@@ -441,4 +452,66 @@ public class AbstractDelegatingCacheStream<R> implements CacheStream<R> {
    public DoubleCacheStream flatMapToDouble(SerializableFunction<? super R, ? extends DoubleStream> mapper) {
       return flatMapToDouble((Function<? super R, ? extends DoubleStream>) mapper);
    }
+
+//   public static <T, R> Collector<T, ?, R> serializableCollector(SerializableSupplier<Collector<T, ?, R>> supplier) {
+//      return null;
+////      return new CacheCollectors.CollectorSupplier<>(supplier);
+//   }
+
+   @SerializeWith(value = CollectorSupplier2.CollectorSupplierExternalizer.class)
+   public static final class CollectorSupplier2<T, A, R> implements Collector<T, A, R> {
+      private final Supplier<Collector<? super T, A, R>> supplier;
+      private transient Collector<T, A, R> collector;
+
+      private Collector<T, A, R> getCollector() {
+         if (collector == null) {
+            collector = (Collector<T, A, R>) supplier.get();
+         }
+         return collector;
+      }
+
+      public CollectorSupplier2(Supplier<Collector<? super T, A, R>> supplier) {
+         this.supplier = supplier;
+      }
+
+      @Override
+      public Supplier<A> supplier() {
+         return getCollector().supplier();
+      }
+
+      @Override
+      public BiConsumer<A, T> accumulator() {
+         return getCollector().accumulator();
+      }
+
+      @Override
+      public BinaryOperator<A> combiner() {
+         return getCollector().combiner();
+      }
+
+      @Override
+      public Function<A, R> finisher() {
+         return getCollector().finisher();
+      }
+
+      @Override
+      public Set<Characteristics> characteristics() {
+         return getCollector().characteristics();
+      }
+
+      public static final class CollectorSupplierExternalizer
+            implements Externalizer<CollectorSupplier2<?, ?, ?>> {
+
+         @Override
+         public void writeObject(ObjectOutput output, CollectorSupplier2 object) throws IOException {
+            output.writeObject(object.supplier);
+         }
+
+         @Override
+         public CollectorSupplier2 readObject(ObjectInput input) throws IOException, ClassNotFoundException {
+            return new CollectorSupplier2((Supplier<Collector>) input.readObject());
+         }
+      }
+   }
+
 }

--- a/core/src/main/java/org/infinispan/util/AbstractDelegatingCacheStream.java
+++ b/core/src/main/java/org/infinispan/util/AbstractDelegatingCacheStream.java
@@ -33,7 +33,6 @@ import org.infinispan.IntCacheStream;
 import org.infinispan.LongCacheStream;
 import org.infinispan.commons.marshall.Externalizer;
 import org.infinispan.commons.marshall.SerializeWith;
-import org.infinispan.stream.CacheCollectors;
 import org.infinispan.util.function.SerializableBiConsumer;
 import org.infinispan.util.function.SerializableBiFunction;
 import org.infinispan.util.function.SerializableBinaryOperator;

--- a/core/src/test/java/org/infinispan/stream/BaseStreamTest.java
+++ b/core/src/test/java/org/infinispan/stream/BaseStreamTest.java
@@ -155,8 +155,8 @@ public abstract class BaseStreamTest extends MultipleCacheManagersTest {
       assertEquals(range, cache.size());
       CacheSet<Map.Entry<Integer, String>> entrySet = cache.entrySet();
 
-      assertEquals(4.5, createStream(entrySet).collect(CacheCollectors.serializableCollector(
-            () -> Collectors.averagingInt(Map.Entry::getKey))));
+      assertEquals(4.5, createStream(entrySet).collect(
+            () -> Collectors.averagingInt(Map.Entry::getKey)));
    }
 
    public void testObjCollectorIntStatistics() {
@@ -168,8 +168,8 @@ public abstract class BaseStreamTest extends MultipleCacheManagersTest {
       assertEquals(range, cache.size());
       CacheSet<Map.Entry<Integer, String>> entrySet = cache.entrySet();
 
-      IntSummaryStatistics stats = createStream(entrySet).collect(CacheCollectors.serializableCollector(
-            () -> Collectors.summarizingInt(Map.Entry::getKey)));
+      IntSummaryStatistics stats = createStream(entrySet).collect(
+            () -> Collectors.summarizingInt(Map.Entry::getKey));
       assertEquals(10, stats.getCount());
       assertEquals(4.5, stats.getAverage());
       assertEquals(0, stats.getMin());
@@ -187,8 +187,7 @@ public abstract class BaseStreamTest extends MultipleCacheManagersTest {
       CacheSet<Map.Entry<Integer, String>> entrySet = cache.entrySet();
 
       ConcurrentMap<Boolean, List<Map.Entry<Integer, String>>> grouped = createStream(entrySet).collect(
-            CacheCollectors.serializableCollector(
-                  () -> Collectors.groupingByConcurrent(k -> k.getKey() % 2 == 0)));
+                  () -> Collectors.groupingByConcurrent(k -> k.getKey() % 2 == 0));
       grouped.get(true).parallelStream().forEach(e -> assertTrue(e.getKey() % 2 == 0));
       grouped.get(false).parallelStream().forEach(e -> assertTrue(e.getKey() % 2 == 1));
    }
@@ -219,7 +218,7 @@ public abstract class BaseStreamTest extends MultipleCacheManagersTest {
 
       List<Map.Entry<Integer, String>> list = createStream(entrySet).sorted(
             (e1, e2) -> Integer.compare(e1.getKey(), e2.getKey())).collect(
-            CacheCollectors.serializableCollector(Collectors::toList));
+            () -> Collectors.toList());
       assertEquals(cache.size(), list.size());
       AtomicInteger i = new AtomicInteger();
       list.forEach(e -> {


### PR DESCRIPTION
This is just a quick preview to see if @wburns likes this idea :)

Whenever a collect() is called in a distributed environment, you have to wrap up in a serializable supplier method call to make it serializable, e.g.

    Map<Integer, Long> totalPerHour = cache.values().stream()
       .collect(
           CacheCollectors.serializableCollector(() -> Collectors.groupingBy(
               e -> getHourOfDay(e.departureTs),
               Collectors.counting()
           )));

This is a bit clunky and on Thursday I was wondering if we could overload `collect` to take a `SerializableSupplier` in `CacheStream`.

At first glance, it seems to work. I had to use a slightly different CollectionSupplier class to the one used by CacheCollectors.serializableCollector to get the types to work.

One slightly odd thing about this is IntelliJ, which seems to indicate there are some compilation errors in BaseStreamTest, but when I run it, it's just runs fine.

@wburns WDYT? Have you considered doing this before?