### PR TITLE
Multiple testsuite cleanups

### DIFF
--- a/atomic-factory/src/test/java/org/infinispan/atomic/AtomicObjectFactoryTest.java
+++ b/atomic-factory/src/test/java/org/infinispan/atomic/AtomicObjectFactoryTest.java
@@ -37,8 +37,6 @@ public class AtomicObjectFactoryTest extends MultipleCacheManagersTest {
 
     private static Log log = LogFactory.getLog(AtomicObjectFactory.class);
 
-
-    @Test(enabled = true)
     public void basicUsageTest() throws Exception {
         Cache<?, ?> cache = cache(0);
         AtomicObjectFactory factory = new AtomicObjectFactory(cache);
@@ -61,7 +59,6 @@ public class AtomicObjectFactoryTest extends MultipleCacheManagersTest {
 
     }
 
-    @Test(enabled = true)
     public void basicPerformanceTest() throws Exception {
         Cache<?, ?> cache = cache(0);
         AtomicObjectFactory factory = new AtomicObjectFactory(cache);
@@ -80,7 +77,7 @@ public class AtomicObjectFactoryTest extends MultipleCacheManagersTest {
 
     }
 
-    @Test(enabled = false, description = "To be fixed by ISPN-5530")
+    @Test(groups = "unstable", description = "ISPN-5530")
     public void distributedCacheTest() throws Exception {
 
         List<HashSet<Integer>> sets = new ArrayList<>();
@@ -107,7 +104,6 @@ public class AtomicObjectFactoryTest extends MultipleCacheManagersTest {
 
     }
 
-    @Test(enabled = true)
     public void distributedPersistenceTest() throws Exception {
 
         Iterator<EmbeddedCacheManager> it = cacheManagers.iterator();

--- a/atomic-factory/src/test/java/org/infinispan/atomic/sharded/collections/ShardedTreeMapTest.java
+++ b/atomic-factory/src/test/java/org/infinispan/atomic/sharded/collections/ShardedTreeMapTest.java
@@ -31,7 +31,6 @@ public class ShardedTreeMapTest extends MultipleCacheManagersTest {
     private static int NCACHES = 3;
     private static List<Cache> caches = new ArrayList<Cache>();
 
-    @Test(enabled = true)
     public void basicUsageTest() throws  Exception{
         EmbeddedCacheManager cacheManager = cacheManagers.iterator().next();
         Cache cache = cacheManager.getCache();

--- a/cli/cli-interpreter/src/test/java/org/infinispan/cli/interpreter/SiteStatementTest.java
+++ b/cli/cli-interpreter/src/test/java/org/infinispan/cli/interpreter/SiteStatementTest.java
@@ -65,6 +65,7 @@ public class SiteStatementTest extends AbstractTwoSitesTest {
 
    }
 
+   @Test(groups = "unstable", description = "ISPN-8202")
    public void testSiteStateTransfer() throws Exception {
       Interpreter lonInterpreter = interpreter("LON", 0);
       String lonCache = cache("LON", 0).getName();

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteNonIndexedQueryStringTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteNonIndexedQueryStringTest.java
@@ -121,7 +121,7 @@ public class RemoteNonIndexedQueryStringTest extends RemoteQueryStringTest {
       super.testFullTextRegexp();
    }
 
-   @Test(enabled = false)
+   @Test(enabled = false, description = "Not applicable to non-indexed caches")
    public void testExactMatchOnAnalyzedFieldNotAllowed() throws Exception {
       // this test does not make sense in non-indexed mode
    }
@@ -138,7 +138,7 @@ public class RemoteNonIndexedQueryStringTest extends RemoteQueryStringTest {
       super.testFullTextRegexp2();
    }
 
-   @Test(enabled = false)
+   @Test(enabled = false, description = "Not applicable to non-indexed caches")
    public void testCustomFieldAnalyzer() {
       //not working with non-indexed caches
    }

--- a/commons-test/src/main/java/org/infinispan/commons/test/categories/Profiling.java
+++ b/commons-test/src/main/java/org/infinispan/commons/test/categories/Profiling.java
@@ -1,4 +1,4 @@
-package org.infinispan.commons.test.annotations;
+package org.infinispan.commons.test.categories;
 
 /**
  * JUnit category for profiling tests.

--- a/commons-test/src/main/java/org/infinispan/commons/test/categories/Smoke.java
+++ b/commons-test/src/main/java/org/infinispan/commons/test/categories/Smoke.java
@@ -1,7 +1,7 @@
 package org.infinispan.commons.test.categories;
 
 /**
- * {@link org.junit.experimental.categories.Category} tag for smoke tests.
+ * JUnit category for smoke tests.
  */
-public class Smoke {
+public interface Smoke {
 }

--- a/commons-test/src/main/java/org/infinispan/commons/test/categories/Stress.java
+++ b/commons-test/src/main/java/org/infinispan/commons/test/categories/Stress.java
@@ -1,0 +1,7 @@
+package org.infinispan.commons.test.categories;
+
+/**
+ * JUnit category for stress tests.
+ */
+public interface Stress {
+}

--- a/commons-test/src/main/java/org/infinispan/commons/test/categories/Unstable.java
+++ b/commons-test/src/main/java/org/infinispan/commons/test/categories/Unstable.java
@@ -1,0 +1,7 @@
+package org.infinispan.commons.test.categories;
+
+/**
+ * JUnit category for unstable tests.
+ */
+public interface Unstable {
+}

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -56,6 +56,12 @@
       </dependency>
 
       <dependency>
+         <groupId>org.infinispan</groupId>
+         <artifactId>infinispan-commons-test</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
          <groupId>junit</groupId>
          <artifactId>junit</artifactId>
          <scope>test</scope>
@@ -101,11 +107,9 @@
                   <Export-Package>
                      ${project.groupId}.commons.*;version=${project.version};-split-package:=error
                   </Export-Package>
-                  
                   <Import-Package>
                   !sun.misc,
                   *
-                  
                   </Import-Package>
                   <DynamicImport-Package>*</DynamicImport-Package>
                </instructions>
@@ -115,7 +119,9 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-               <excludedGroups combine.self="override">${suite.exclude.groups}</excludedGroups>
+               <parallel>classes</parallel>
+               <groups combine.self="override">${defaultJUnitGroups}</groups>
+               <excludedGroups combine.self="override">${defaultExcludedJUnitGroups}</excludedGroups>
                <systemPropertyVariables combine.self="override">
                   <log4j.configurationFile>${log4j.configurationFile}</log4j.configurationFile>
                   <build.directory>${project.build.directory}</build.directory>
@@ -132,12 +138,12 @@
             <dependencies>
                <dependency>
                   <groupId>org.apache.maven.surefire</groupId>
-                  <artifactId>surefire-junit4</artifactId>
+                  <artifactId>surefire-junit47</artifactId>
                   <version>${version.maven.surefire}</version>
                </dependency>
             </dependencies>
          </plugin>
-         
+
          <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>build-helper-maven-plugin</artifactId>

--- a/core/src/test/java/org/infinispan/distribution/ch/CapacityFactorsFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/distribution/ch/CapacityFactorsFunctionalTest.java
@@ -21,7 +21,7 @@ import org.testng.annotations.Test;
  * @author Dan Berindei
  * @since 6.0
  */
-@Test(groups = "functional", testName = "distribution.ch.CapacityFactorsFunctionalTest", enabled = false, description = "to be fixed by ISPN-6470")
+@Test(groups = "unstable", testName = "distribution.ch.CapacityFactorsFunctionalTest", description = "to be fixed by ISPN-6470")
 public class CapacityFactorsFunctionalTest extends MultipleCacheManagersTest {
 
    public static final int NUM_SEGMENTS = 60;

--- a/hibernate-cache/pom.xml
+++ b/hibernate-cache/pom.xml
@@ -98,7 +98,8 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration combine.self="override">
-               <excludedGroups>${suite.exclude.groups}</excludedGroups>
+               <groups combine.self="override">${defaultJUnitGroups}</groups>
+               <excludedGroups combine.self="override">${defaultExcludedJUnitGroups}</excludedGroups>
                <trimStackTrace>false</trimStackTrace>
                <systemPropertyVariables>
                   <java.net.preferIPv4Stack>true</java.net.preferIPv4Stack>

--- a/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/AbstractRegionAccessStrategyTest.java
+++ b/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/AbstractRegionAccessStrategyTest.java
@@ -15,6 +15,7 @@ import javax.transaction.SystemException;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.infinispan.commons.test.categories.Unstable;
 import org.infinispan.hibernate.cache.access.PutFromLoadValidator;
 import org.infinispan.hibernate.cache.impl.BaseRegion;
 import org.infinispan.hibernate.cache.util.Caches;
@@ -62,6 +63,7 @@ import org.infinispan.Cache;
 import org.infinispan.test.TestingUtil;
 
 import org.jboss.logging.Logger;
+import org.junit.experimental.categories.Category;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -401,11 +403,13 @@ public abstract class AbstractRegionAccessStrategyTest<R extends BaseRegion, S e
 	protected abstract S getAccessStrategy(R region);
 
 	@Test
+	@Category(Unstable.class) // ISPN-8263
 	public void testRemove() throws Exception {
 		evictOrRemoveTest( false );
 	}
 
 	@Test
+	@Category(Unstable.class) // ISPN-8263
 	public void testEvict() throws Exception {
 		evictOrRemoveTest( true );
 	}
@@ -488,11 +492,13 @@ public abstract class AbstractRegionAccessStrategyTest<R extends BaseRegion, S e
 	}
 
 	@Test
+	@Category(Unstable.class) // ISPN-8263
    public void testRemoveAll() throws Exception {
 		evictOrRemoveAllTest(false);
 	}
 
 	@Test
+	@Category(Unstable.class) // ISPN-8263
    public void testEvictAll() throws Exception {
 		evictOrRemoveAllTest(true);
 	}

--- a/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/functional/BulkOperationsTest.java
+++ b/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/functional/BulkOperationsTest.java
@@ -13,12 +13,14 @@ import java.util.Set;
 import org.hibernate.FlushMode;
 import org.hibernate.stat.SecondLevelCacheStatistics;
 
+import org.infinispan.commons.test.categories.Unstable;
 import org.infinispan.test.hibernate.cache.util.InfinispanTestingSetup;
 import org.infinispan.test.hibernate.cache.functional.entities.Contact;
 import org.infinispan.test.hibernate.cache.functional.entities.Customer;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -53,6 +55,7 @@ public class BulkOperationsTest extends SingleNodeTest {
 	}
 
 	@Test
+	@Category(Unstable.class) // ISPN-8263
 	public void testBulkOperations() throws Throwable {
 		boolean cleanedUp = false;
 		try {

--- a/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/functional/cluster/NaturalIdInvalidationTest.java
+++ b/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/functional/cluster/NaturalIdInvalidationTest.java
@@ -15,6 +15,7 @@ import org.hibernate.Criteria;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.infinispan.commons.test.categories.Smoke;
+import org.infinispan.commons.test.categories.Unstable;
 import org.infinispan.hibernate.cache.util.InfinispanMessageLogger;
 import org.hibernate.criterion.Restrictions;
 import org.infinispan.test.hibernate.cache.functional.entities.Citizen;
@@ -62,6 +63,7 @@ public class NaturalIdInvalidationTest extends DualNodeTest {
 	}
 
 	@Test
+	@Category(Unstable.class) // ISPN-8263
 	public void testAll() throws Exception {
       log.infof("*** %s", name.getMethodName());
 

--- a/integrationtests/spring-boot-it/pom.xml
+++ b/integrationtests/spring-boot-it/pom.xml
@@ -132,7 +132,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration combine.self="override">
-                    <excludedGroups>${suite.exclude.groups}</excludedGroups>
+                    <groups combine.self="override">${defaultJUnitGroups}</groups>
+                    <excludedGroups combine.self="override">${defaultExcludedJUnitGroups}</excludedGroups>
                     <systemPropertyVariables>
                         <log4j.configurationFile>${log4j.configurationFile}</log4j.configurationFile>
                         <build.directory>${project.build.directory}</build.directory>
@@ -143,7 +144,7 @@
                 <dependencies>
                     <dependency>
                         <groupId>org.apache.maven.surefire</groupId>
-                        <artifactId>surefire-junit4</artifactId>
+                        <artifactId>surefire-junit47</artifactId>
                         <version>${version.maven.surefire}</version>
                     </dependency>
                 </dependencies>

--- a/jcache/tck-runner/pom.xml
+++ b/jcache/tck-runner/pom.xml
@@ -304,7 +304,7 @@
             <dependencies>
                <dependency>
                   <groupId>org.apache.maven.surefire</groupId>
-                  <artifactId>surefire-junit4</artifactId>
+                  <artifactId>surefire-junit47</artifactId>
                   <version>${version.maven.surefire}</version>
                </dependency>
             </dependencies>

--- a/lucene/directory-provider/pom.xml
+++ b/lucene/directory-provider/pom.xml
@@ -23,7 +23,7 @@
             <artifactId>hibernate-search-engine</artifactId>
         </dependency>
 
-        
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -45,6 +45,10 @@
                 <exclusion>
                     <groupId>org.jboss.byteman</groupId>
                     <artifactId>byteman-bmunit</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -120,7 +124,8 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration combine.self="override">
                     <argLine>-javaagent:${project.build.directory}/agents/byteman.jar=port:9091,boot:${project.build.directory}/agents/byteman.jar ${forkJvmArgs} ${jigsawForkJvmArgs}</argLine>
-                    <excludedGroups>${suite.exclude.groups}</excludedGroups>
+                    <groups combine.self="override">${defaultJUnitGroups}</groups>
+                    <excludedGroups combine.self="override">${defaultExcludedJUnitGroups}</excludedGroups>
                     <systemPropertyVariables>
                         <log4j.configurationFile>${log4j.configurationFile}</log4j.configurationFile>
                         <build.directory>${project.build.directory}</build.directory>
@@ -131,7 +136,7 @@
                 <dependencies>
                     <dependency>
                         <groupId>org.apache.maven.surefire</groupId>
-                        <artifactId>surefire-junit4</artifactId>
+                        <artifactId>surefire-junit47</artifactId>
                         <version>${version.maven.surefire}</version>
                     </dependency>
                 </dependencies>

--- a/lucene/directory-provider/src/test/java/org/infinispan/hibernate/search/LiveRunningTest.java
+++ b/lucene/directory-provider/src/test/java/org/infinispan/hibernate/search/LiveRunningTest.java
@@ -16,12 +16,13 @@ import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.spi.IndexedTypeSet;
 import org.hibernate.search.spi.impl.PojoIndexedTypeIdentifier;
 import org.hibernate.search.test.util.FullTextSessionBuilder;
+import org.infinispan.commons.test.categories.Unstable;
 import org.infinispan.hibernate.search.ClusterTestHelper.ExclusiveIndexUse;
 import org.infinispan.hibernate.search.ClusterTestHelper.IndexingFlushMode;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * In this test we initially start a master node which will stay alive for the full test duration and constantly
@@ -49,7 +50,7 @@ public class LiveRunningTest {
    private int storedEmailsCount = 0;
 
    @Test
-   @Ignore("ISPN-8075")
+   @Category(Unstable.class) // ISPN-8075
    public void liveRun() {
       try {
          for (int i = 0; i < TEST_RUNS; i++) {

--- a/lucene/pom.xml
+++ b/lucene/pom.xml
@@ -40,7 +40,8 @@
                <threadCount>${infinispan.test.parallel.threads}</threadCount>
                <forkCount>1</forkCount>
                <reuseForks>true</reuseForks>
-               <groups>${defaultTestGroup}</groups>
+               <groups>${defaultTestNGGroups}</groups>
+               <excludedGroups>${defaultExcludedTestNGGroups}</excludedGroups>
                <systemPropertyVariables>
                   <log4j.configurationFile>${log4j.configurationFile}</log4j.configurationFile>
                </systemPropertyVariables>

--- a/object-filter/pom.xml
+++ b/object-filter/pom.xml
@@ -56,7 +56,7 @@
    </dependencies>
 
    <properties>
-      <suite.exclude.groups>org.infinispan.commons.test.annotations.Profiling</suite.exclude.groups>
+      <suite.exclude.groups>org.infinispan.commons.test.categories.Profiling</suite.exclude.groups>
       <intermediary_jar_name>intermediary-${project.build.finalName}</intermediary_jar_name>
       <intermediary_jar_path>${project.build.directory}/${intermediary_jar_name}.jar</intermediary_jar_path>
    </properties>

--- a/object-filter/pom.xml
+++ b/object-filter/pom.xml
@@ -56,7 +56,6 @@
    </dependencies>
 
    <properties>
-      <suite.exclude.groups>org.infinispan.commons.test.categories.Profiling</suite.exclude.groups>
       <intermediary_jar_name>intermediary-${project.build.finalName}</intermediary_jar_name>
       <intermediary_jar_path>${project.build.directory}/${intermediary_jar_name}.jar</intermediary_jar_path>
    </properties>
@@ -67,7 +66,8 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration combine.self="override">
-               <excludedGroups>${suite.exclude.groups}</excludedGroups>
+               <groups combine.self="override">${defaultJUnitGroups}</groups>
+               <excludedGroups combine.self="override">${defaultExcludedJUnitGroups}</excludedGroups>
                <systemPropertyVariables>
                   <log4j.configurationFile>${log4j.configurationFile}</log4j.configurationFile>
                   <build.directory>${project.build.directory}</build.directory>
@@ -78,7 +78,7 @@
             <dependencies>
                <dependency>
                   <groupId>org.apache.maven.surefire</groupId>
-                  <artifactId>surefire-junit4</artifactId>
+                  <artifactId>surefire-junit47</artifactId>
                   <version>${version.maven.surefire}</version>
                </dependency>
             </dependencies>

--- a/object-filter/src/test/java/org/infinispan/objectfilter/test/perf/PerfTest.java
+++ b/object-filter/src/test/java/org/infinispan/objectfilter/test/perf/PerfTest.java
@@ -5,7 +5,7 @@ import static org.junit.Assert.assertNotNull;
 
 import java.util.Arrays;
 
-import org.infinispan.commons.test.annotations.Profiling;
+import org.infinispan.commons.test.categories.Profiling;
 import org.infinispan.objectfilter.Matcher;
 import org.infinispan.objectfilter.ObjectFilter;
 import org.infinispan.objectfilter.impl.ReflectionMatcher;

--- a/object-filter/src/test/java/org/infinispan/objectfilter/test/perf/ProtobufPerfTest.java
+++ b/object-filter/src/test/java/org/infinispan/objectfilter/test/perf/ProtobufPerfTest.java
@@ -1,6 +1,6 @@
 package org.infinispan.objectfilter.test.perf;
 
-import org.infinispan.commons.test.annotations.Profiling;
+import org.infinispan.commons.test.categories.Profiling;
 import org.infinispan.objectfilter.Matcher;
 import org.infinispan.objectfilter.impl.ProtobufMatcher;
 import org.infinispan.objectfilter.test.model.MarshallerRegistration;

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -81,9 +81,10 @@
         <buildDirectory>target</buildDirectory>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <defaultTestGroup>functional,unit,xsite,arquillian</defaultTestGroup>
-
-        <defaultExcludedTestGroup>unstable,stress</defaultExcludedTestGroup>
+        <defaultTestNGGroups>functional,unit,xsite,arquillian</defaultTestNGGroups>
+        <defaultJUnitGroups></defaultJUnitGroups>
+        <defaultExcludedTestNGGroups>unstable,stress</defaultExcludedTestNGGroups>
+        <defaultExcludedJUnitGroups>org.infinispan.commons.test.categories.Unstable,org.infinispan.commons.test.categories.Stress,org.infinispan.commons.test.categories.Profiling</defaultExcludedJUnitGroups>
         <forkJvmArgs>-Xmx2G</forkJvmArgs>
         <jigsawForkJvmArgs></jigsawForkJvmArgs>
         <testNGListeners>
@@ -1531,8 +1532,8 @@
                     <threadCount>${infinispan.test.parallel.threads}</threadCount>
                     <forkCount>1</forkCount>
                     <reuseForks>true</reuseForks>
-                    <groups>${defaultTestGroup}</groups>
-                    <excludedGroups>${defaultExcludedTestGroup}</excludedGroups>
+                    <groups>${defaultTestNGGroups}</groups>
+                    <excludedGroups>${defaultExcludedTestNGGroups}</excludedGroups>
                     <disableXmlReport>true</disableXmlReport>
                     <useFile>false</useFile>
                     <systemPropertyVariables>
@@ -1775,38 +1776,42 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <defaultTestGroup>functional,unit,xsite,arquillian</defaultTestGroup>
+                <defaultTestNGGroups>functional,unit,xsite,arquillian</defaultTestNGGroups>
                 <infinispan.test.jgroups.protocol>tcp</infinispan.test.jgroups.protocol>
             </properties>
         </profile>
         <profile>
             <id>test-functional</id>
             <properties>
-                <defaultTestGroup>functional</defaultTestGroup>
+                <defaultTestNGGroups>functional</defaultTestNGGroups>
                 <infinispan.test.jgroups.protocol>tcp</infinispan.test.jgroups.protocol>
             </properties>
         </profile>
         <profile>
             <id>smoke</id>
             <properties>
-                <defaultTestGroup>smoke</defaultTestGroup>
+                <defaultTestNGGroups>smoke</defaultTestNGGroups>
+                <defaultJUnitGroups>org.infinispan.commons.test.categories.Smoke</defaultJUnitGroups>
                 <infinispan.test.jgroups.protocol>tcp</infinispan.test.jgroups.protocol>
             </properties>
         </profile>
         <profile>
             <id>test-unstable</id>
             <properties>
-                <defaultTestGroup>unstable</defaultTestGroup>
-
-                <defaultExcludedTestGroup/>
+                <defaultTestNGGroups>unstable</defaultTestNGGroups>
+                <defaultJUnitGroups>org.infinispan.commons.test.categories.Unstable</defaultJUnitGroups>
+                <defaultExcludedTestNGGroups/>
+                <defaultExcludedJUnitGroups/>
                 <infinispan.test.jgroups.protocol>tcp</infinispan.test.jgroups.protocol>
             </properties>
         </profile>
         <profile>
             <id>test-stress</id>
             <properties>
-                <defaultTestGroup>stress</defaultTestGroup>
-                <defaultExcludedTestGroup/>
+                <defaultTestNGGroups>stress</defaultTestNGGroups>
+                <defaultJUnitGroups>org.infinispan.commons.test.categories.Stress</defaultJUnitGroups>
+                <defaultExcludedTestNGGroups/>
+                <defaultExcludedJUnitGroups/>
                 <infinispan.test.parallel.threads>1</infinispan.test.parallel.threads>
                 <infinispan.test.jgroups.protocol>tcp</infinispan.test.jgroups.protocol>
             </properties>
@@ -1814,19 +1819,19 @@
         <profile>
             <id>test-unit</id>
             <properties>
-                <defaultTestGroup>unit</defaultTestGroup>
+                <defaultTestNGGroups>unit</defaultTestNGGroups>
             </properties>
         </profile>
         <profile>
             <id>test-jgroups</id>
             <properties>
-                <defaultTestGroup>jgroups</defaultTestGroup>
+                <defaultTestNGGroups>jgroups</defaultTestNGGroups>
             </properties>
         </profile>
         <profile>
             <id>test-transaction</id>
             <properties>
-                <defaultTestGroup>transaction</defaultTestGroup>
+                <defaultTestNGGroups>transaction</defaultTestNGGroups>
             </properties>
         </profile>
         <profile>

--- a/persistence/jpa/src/test/java/org/infinispan/persistence/jpa/JpaStoreFunctionalTest.java
+++ b/persistence/jpa/src/test/java/org/infinispan/persistence/jpa/JpaStoreFunctionalTest.java
@@ -34,7 +34,7 @@ public class JpaStoreFunctionalTest extends BaseStoreFunctionalTest {
       return ((KeyValueEntity) wrapper).getValue();
    }
 
-   @Test(enabled = false)
+   @Test(enabled = false, description = "Not applicable")
    @Override
    public void testTwoCachesSameCacheStore() {
       // With JPA, we must use different persistence configurations for each cache
@@ -42,24 +42,24 @@ public class JpaStoreFunctionalTest extends BaseStoreFunctionalTest {
       // in the entity class.
    }
 
-   @Test(enabled = false)
+   @Test(enabled = false, description = "Not applicable")
    public void testPreloadStoredAsBinary() {
       // byte arrays are not entities (no need to test how we can wrap them)
    }
 
-   @Test(enabled = false)
+   @Test(enabled = false, description = "Not applicable")
    @Override
    public void testStoreByteArrays(Method m) throws PersistenceException {
       // byte arrays are not entities  (no need to test how we can wrap them)
    }
 
-   @Test(enabled = false)
+   @Test(enabled = false, description = "Not applicable")
    @Override
    public void testRestoreAtomicMap(Method m) {
       // Atomic maps are not entities
    }
 
-   @Test(enabled = false)
+   @Test(enabled = false, description = "Not applicable")
    @Override
    public void testRestoreTransactionalAtomicMap(Method m) throws Exception {
       // Atomic maps are not entities

--- a/persistence/jpa/src/test/java/org/infinispan/persistence/jpa/JpaStoreNoMetadataTest.java
+++ b/persistence/jpa/src/test/java/org/infinispan/persistence/jpa/JpaStoreNoMetadataTest.java
@@ -25,32 +25,32 @@ public class JpaStoreNoMetadataTest extends JpaStoreTest {
       return "org.infinispan.persistence.jpa.no_metadata";
    }
 
-   @Test(enabled = false)
+   @Test(enabled = false, description = "Not applicable")
    @Override
    public void testLoadAndStoreWithLifespan() throws Exception {
       // no metadata => cannot test lifespan
    }
 
-   @Test(enabled = false)
+   @Test(enabled = false, description = "Not applicable")
    @Override
    public void testLoadAndStoreWithIdle() throws Exception {
       // no metadata => cannot test idle
    }
 
-   @Test(enabled = false)
+   @Test(enabled = false, description = "Not applicable")
    @Override
    public void testLoadAndStoreWithLifespanAndIdle() throws Exception {
       // no metadata => cannot test lifespan or idle
    }
 
-   @Test(enabled = false)
+   @Test(enabled = false, description = "Not applicable")
    @Override
    public void testLoadAndStoreWithLifespanAndIdle2() throws Exception {
       // no metadata => cannot test lifespan or idle
    }
 
 
-   @Test(enabled = false)
+   @Test(enabled = false, description = "Not applicable")
    @Override
    public void testReplaceExpiredEntry() throws Exception {
       // no metadata => cannot test lifespan

--- a/persistence/jpa/src/test/java/org/infinispan/persistence/jpa/JpaStoreTest.java
+++ b/persistence/jpa/src/test/java/org/infinispan/persistence/jpa/JpaStoreTest.java
@@ -54,9 +54,9 @@ public class JpaStoreTest extends BaseStoreTest {
       return ((KeyValueEntity) wrapper).getValue();
    }
 
-   @Test(enabled = false)
+   @Test(enabled = false, description = "Not applicable")
    @Override
    public void testLoadAndStoreBytesValues() throws PersistenceException, IOException, InterruptedException {
-      super.testLoadAndStoreBytesValues();
+      // byte values make no sense for this store
    }
 }

--- a/query-dsl/pom.xml
+++ b/query-dsl/pom.xml
@@ -21,6 +21,12 @@
       </dependency>
 
       <dependency>
+         <groupId>org.infinispan</groupId>
+         <artifactId>infinispan-commons-test</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
          <groupId>junit</groupId>
          <artifactId>junit</artifactId>
          <scope>test</scope>
@@ -33,6 +39,8 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration combine.self="override">
+               <groups combine.self="override">${defaultJUnitGroups}</groups>
+               <excludedGroups combine.self="override">${defaultExcludedJUnitGroups}</excludedGroups>
                <systemPropertyVariables>
                   <log4j.configurationFile>${log4j.configurationFile}</log4j.configurationFile>
                   <build.directory>${project.build.directory}</build.directory>
@@ -43,7 +51,7 @@
             <dependencies>
                <dependency>
                   <groupId>org.apache.maven.surefire</groupId>
-                  <artifactId>surefire-junit4</artifactId>
+                  <artifactId>surefire-junit47</artifactId>
                   <version>${version.maven.surefire}</version>
                </dependency>
             </dependencies>

--- a/query/src/test/java/org/infinispan/query/distributed/MultiNodeDistributedTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/MultiNodeDistributedTest.java
@@ -40,7 +40,7 @@ public class MultiNodeDistributedTest extends AbstractInfinispanTest {
       if (transactionsEnabled()) transactionManager.commit();
    }
 
-   @Test(enabled = false, description = "ISPN-8076")
+   @Test(groups = "unstable", description = "ISPN-8076")
    public void testIndexingWorkDistribution() throws Exception {
       try {
          cluster.startNewNode();

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/NonIndexedQueryStringTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/NonIndexedQueryStringTest.java
@@ -124,7 +124,7 @@ public class NonIndexedQueryStringTest extends QueryStringTest {
       super.testFullTextRegexp();
    }
 
-   @Test(enabled = false)
+   @Test(enabled = false, description = "Not applicable in non-indexed mode")
    public void testExactMatchOnAnalyzedFieldNotAllowed() throws Exception {
       // this test does not make sense in non-indexed mode
    }

--- a/remote-query/remote-query-client/pom.xml
+++ b/remote-query/remote-query-client/pom.xml
@@ -25,6 +25,12 @@
       </dependency>
 
       <dependency>
+         <groupId>org.infinispan</groupId>
+         <artifactId>infinispan-commons-test</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
          <groupId>junit</groupId>
          <artifactId>junit</artifactId>
          <scope>test</scope>
@@ -37,13 +43,15 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration combine.self="override">
+               <groups combine.self="override">${defaultJUnitGroups}</groups>
+               <excludedGroups combine.self="override">${defaultExcludedJUnitGroups}</excludedGroups>
                <trimStackTrace>false</trimStackTrace>
                <argLine>-Xmx512m</argLine>
             </configuration>
             <dependencies>
                <dependency>
                   <groupId>org.apache.maven.surefire</groupId>
-                  <artifactId>surefire-junit4</artifactId>
+                  <artifactId>surefire-junit47</artifactId>
                   <version>${version.maven.surefire}</version>
                </dependency>
             </dependencies>

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/jmx/management/JmxManagementIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/jmx/management/JmxManagementIT.java
@@ -24,10 +24,12 @@ import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.configuration.Configuration;
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
 import org.infinispan.server.infinispan.spi.InfinispanSubsystem;
+import org.infinispan.server.test.category.Unstable;
 import org.infinispan.server.test.client.memcached.MemcachedClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
@@ -105,6 +107,7 @@ public class JmxManagementIT {
     }
 
     @Test
+    @Category(Unstable.class) // ISPN-8291
     public void testHotRodConnectionCount() throws Exception {
 
         // get number of current local/global connections
@@ -128,6 +131,7 @@ public class JmxManagementIT {
     }
 
     @Test
+    @Category(Unstable.class) // ISPN-8291
     public void testMemCachedConnectionCount() throws Exception {
         int initialLocal = getNumberOfLocalConnections(provider, memCachedServerMBean);
         int initialGlobal = getNumberOfGlobalConnections(provider, memCachedServerMBean);

--- a/server/router/pom.xml
+++ b/server/router/pom.xml
@@ -15,7 +15,6 @@
 
     <properties>
         <module.skipComponentMetaDataProcessing>false</module.skipComponentMetaDataProcessing>
-        <suite.exclude.groups>org.infinispan.commons.test.categories.Profiling</suite.exclude.groups>
         <certificate.dname>CN=HotRod_1,OU=Infinispan,O=JBoss,L=Red Hat,ST=World,C=WW</certificate.dname>
     </properties>
 
@@ -192,7 +191,8 @@
                     <trimStackTrace>false</trimStackTrace>
                     <parallel>suitesAndClasses</parallel>
                     <threadCount>${infinispan.test.parallel.threads}</threadCount>
-                    <excludedGroups>${suite.exclude.groups}</excludedGroups>
+                    <groups combine.self="override">${defaultJUnitGroups}</groups>
+                    <excludedGroups combine.self="override">${defaultExcludedJUnitGroups}</excludedGroups>
                     <systemPropertyVariables>
                         <log4j.configurationFile>${log4j.configurationFile}</log4j.configurationFile>
                         <build.directory>${project.build.directory}</build.directory>

--- a/server/router/pom.xml
+++ b/server/router/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <module.skipComponentMetaDataProcessing>false</module.skipComponentMetaDataProcessing>
-        <suite.exclude.groups>org.infinispan.commons.test.annotations.Profiling</suite.exclude.groups>
+        <suite.exclude.groups>org.infinispan.commons.test.categories.Profiling</suite.exclude.groups>
         <certificate.dname>CN=HotRod_1,OU=Infinispan,O=JBoss,L=Red Hat,ST=World,C=WW</certificate.dname>
     </properties>
 

--- a/server/router/src/test/java/org/infinispan/server/router/profiling/RouterPerfTest.java
+++ b/server/router/src/test/java/org/infinispan/server/router/profiling/RouterPerfTest.java
@@ -6,7 +6,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.infinispan.client.hotrod.RemoteCacheManager;
-import org.infinispan.commons.test.annotations.Profiling;
+import org.infinispan.commons.test.categories.Profiling;
 import org.infinispan.server.hotrod.HotRodServer;
 import org.infinispan.server.router.MultiTenantRouter;
 import org.infinispan.server.router.routes.Route;


### PR DESCRIPTION
- Consolidate junit categories
- Use surefire-junit47 everywhere so that categories work
- Move some disabled tests to the unstable group/category
- Clarify the reasons for tests being disabled
- Adds some more unstable tests (incorporates @galderz 's #5417 )