### PR TITLE
ISPN-8280 RemoteStoreRawValuesTest.testStopStartDoesNotNukeValues fails

### DIFF
--- a/core/src/main/java/org/infinispan/expiration/impl/ExpirationManagerImpl.java
+++ b/core/src/main/java/org/infinispan/expiration/impl/ExpirationManagerImpl.java
@@ -132,14 +132,16 @@ public class ExpirationManagerImpl<K, V> implements ExpirationManager<K, V> {
    @Override
    public void handleInMemoryExpiration(InternalCacheEntry<K, V> entry, long currentTime) {
       dataContainer.compute(entry.getKey(), ((k, oldEntry, factory) -> {
-         synchronized (oldEntry) {
-            if (oldEntry.isExpired(currentTime)) {
-               deleteFromStoresAndNotify(k, oldEntry.getValue(), oldEntry.getMetadata());
-               return null;
-            } else {
-               return oldEntry;
+         if (oldEntry != null) {
+            synchronized (oldEntry) {
+               if (oldEntry.isExpired(currentTime)) {
+                  deleteFromStoresAndNotify(k, oldEntry.getValue(), oldEntry.getMetadata());
+               } else {
+                  return oldEntry;
+               }
             }
          }
+         return null;
       }));
    }
 


### PR DESCRIPTION
randomly

* Added null check in case if expired entry is removed at same time

https://issues.jboss.org/browse/ISPN-8280