### PR TITLE
Hibernate Search 5.8.0.Final

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -70,7 +70,7 @@
       <version.groovy>2.4.8</version.groovy>
       <version.hibernate.javax.persistence>1.0.0.Final</version.hibernate.javax.persistence>
       <version.hibernate.core>5.2.7.Final</version.hibernate.core>
-      <version.hibernate.search>5.8.0.Beta4</version.hibernate.search>
+      <version.hibernate.search>5.8.0.Final</version.hibernate.search>
       <version.hikaricp>2.4.6</version.hikaricp>
       <version.javax.cache>1.0.0</version.javax.cache>
       <version.cdi>1.2</version.cdi>

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/JBMARRemoteQueryDslConditionsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/JBMARRemoteQueryDslConditionsTest.java
@@ -10,6 +10,7 @@ import static org.testng.AssertJUnit.assertNull;
 import static org.testng.AssertJUnit.assertTrue;
 
 import org.hibernate.search.spi.SearchIntegrator;
+import org.hibernate.search.spi.impl.PojoIndexedTypeIdentifier;
 import org.infinispan.Cache;
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.RemoteCacheManager;
@@ -91,17 +92,20 @@ public class JBMARRemoteQueryDslConditionsTest extends QueryDslConditionsTest {
    public void testIndexPresence() {
       SearchIntegrator searchIntegrator = org.infinispan.query.Search.getSearchManager(getEmbeddedCache()).unwrap(SearchIntegrator.class);
 
-      assertTrue(searchIntegrator.getIndexBindings().containsKey(getModelFactory().getUserImplClass()));
-      assertNotNull(searchIntegrator.getIndexManager(getModelFactory().getUserImplClass().getName()));
+      verifyClassIsIndexed(searchIntegrator, getModelFactory().getUserImplClass());
+      verifyClassIsIndexed(searchIntegrator, getModelFactory().getAccountImplClass());
+      verifyClassIsIndexed(searchIntegrator, getModelFactory().getTransactionImplClass());
+      verifyClassIsNotIndexed(searchIntegrator, getModelFactory().getAddressImplClass());
+   }
 
-      assertTrue(searchIntegrator.getIndexBindings().containsKey(getModelFactory().getAccountImplClass()));
-      assertNotNull(searchIntegrator.getIndexManager(getModelFactory().getAccountImplClass().getName()));
+   private void verifyClassIsNotIndexed(SearchIntegrator searchIntegrator, Class<?> type) {
+      assertFalse(searchIntegrator.getIndexBindings().containsKey(PojoIndexedTypeIdentifier.convertFromLegacy(type)));
+      assertNull(searchIntegrator.getIndexManager(type.getName()));
+   }
 
-      assertTrue(searchIntegrator.getIndexBindings().containsKey(getModelFactory().getTransactionImplClass()));
-      assertNotNull(searchIntegrator.getIndexManager(getModelFactory().getTransactionImplClass().getName()));
-
-      assertFalse(searchIntegrator.getIndexBindings().containsKey(getModelFactory().getAddressImplClass()));
-      assertNull(searchIntegrator.getIndexManager(getModelFactory().getAddressImplClass().getName()));
+   private void verifyClassIsIndexed(SearchIntegrator searchIntegrator, Class<?> type) {
+      assertTrue(searchIntegrator.getIndexBindings().containsKey(PojoIndexedTypeIdentifier.convertFromLegacy(type)));
+      assertNotNull(searchIntegrator.getIndexManager(type.getName()));
    }
 
    @Override

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryDslConditionsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryDslConditionsTest.java
@@ -135,7 +135,7 @@ public class RemoteQueryDslConditionsTest extends QueryDslConditionsTest {
    public void testIndexPresence() {
       SearchIntegrator searchIntegrator = org.infinispan.query.Search.getSearchManager(cache).unwrap(SearchIntegrator.class);
 
-      assertTrue(searchIntegrator.getIndexBindings().containsKey(ProtobufValueWrapper.class));
+      assertTrue(searchIntegrator.getIndexBindings().containsKey(ProtobufValueWrapper.INDEXING_TYPE));
       assertNotNull(searchIntegrator.getIndexManager(ProtobufValueWrapper.class.getName()));
    }
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryDslConditionsTunedTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryDslConditionsTunedTest.java
@@ -39,7 +39,7 @@ public class RemoteQueryDslConditionsTunedTest extends RemoteQueryDslConditionsF
    @Override
    public void testIndexPresence() {
       SearchIntegrator searchIntegrator = Search.getSearchManager(getEmbeddedCache()).unwrap(SearchIntegrator.class);
-      assertTrue(searchIntegrator.getIndexBindings().containsKey(ProtobufValueWrapper.class));
+      assertTrue(searchIntegrator.getIndexBindings().containsKey(ProtobufValueWrapper.INDEXING_TYPE));
       for (int shard = 0; shard < 6 ; shard++)
           assertNotNull(searchIntegrator.getIndexManager(ProtobufValueWrapper.class.getName() + "." + shard));
    }

--- a/integrationtests/as-lucene-directory/pom.xml
+++ b/integrationtests/as-lucene-directory/pom.xml
@@ -197,7 +197,7 @@
                             <groupId>org.hibernate</groupId>
                             <artifactId>hibernate-search-modules</artifactId>
                             <version>${version.hibernate.search}</version>
-                            <classifier>wildfly-10-dist</classifier>
+                            <classifier>wildfly-11-dist</classifier>
                             <type>zip</type>
                             <overWrite>false</overWrite>
                             <outputDirectory>${project.build.directory}/node1/wildfly-${version.org.wildfly}/modules</outputDirectory>
@@ -206,7 +206,7 @@
                             <groupId>org.hibernate</groupId>
                             <artifactId>hibernate-search-modules</artifactId>
                             <version>${version.hibernate.search}</version>
-                            <classifier>wildfly-10-dist</classifier>
+                            <classifier>wildfly-11-dist</classifier>
                             <type>zip</type>
                             <overWrite>false</overWrite>
                             <outputDirectory>${project.build.directory}/node2/wildfly-${version.org.wildfly}/modules</outputDirectory>

--- a/lucene/directory-provider/src/test/java/org/infinispan/hibernate/search/ClusterTestHelper.java
+++ b/lucene/directory-provider/src/test/java/org/infinispan/hibernate/search/ClusterTestHelper.java
@@ -163,7 +163,7 @@ public final class ClusterTestHelper {
    public static int clusterSize(FullTextSessionBuilder node, IndexedTypeIdentifier entityType) {
       SearchIntegrator integrator = node.getSearchFactory().unwrap(SearchIntegrator.class);
       EntityIndexBinding indexBinding = integrator.getIndexBinding(entityType);
-      DirectoryBasedIndexManager indexManager = (DirectoryBasedIndexManager) indexBinding.getIndexManagers()[0];
+      DirectoryBasedIndexManager indexManager = (DirectoryBasedIndexManager) indexBinding.getIndexManagerSelector().all().iterator().next();
       InfinispanDirectoryProvider directoryProvider = (InfinispanDirectoryProvider) indexManager.getDirectoryProvider();
       EmbeddedCacheManager cacheManager = directoryProvider.getCacheManager();
       List<Address> members = cacheManager.getMembers();

--- a/lucene/directory-provider/src/test/java/org/infinispan/hibernate/search/sharedIndex/SharedIndexTest.java
+++ b/lucene/directory-provider/src/test/java/org/infinispan/hibernate/search/sharedIndex/SharedIndexTest.java
@@ -107,7 +107,7 @@ public class SharedIndexTest {
    protected int clusterSize(FullTextSessionBuilder node, Class<?> entityType) {
       SearchIntegrator integrator = node.getSearchFactory().unwrap(SearchIntegrator.class);
       EntityIndexBinding indexBinding = integrator.getIndexBinding(TOASTER_TYPE);
-      DirectoryBasedIndexManager indexManager = (DirectoryBasedIndexManager) indexBinding.getIndexManagers()[0];
+      DirectoryBasedIndexManager indexManager = (DirectoryBasedIndexManager) indexBinding.getIndexManagerSelector().all().iterator().next();
       InfinispanDirectoryProvider directoryProvider = (InfinispanDirectoryProvider) indexManager.getDirectoryProvider();
       EmbeddedCacheManager cacheManager = directoryProvider.getCacheManager();
       List<Address> members = cacheManager.getMembers();

--- a/query/src/main/java/org/infinispan/query/impl/massindex/MassIndexStrategyFactory.java
+++ b/query/src/main/java/org/infinispan/query/impl/massindex/MassIndexStrategyFactory.java
@@ -1,5 +1,7 @@
 package org.infinispan.query.impl.massindex;
 
+import java.util.Set;
+
 import org.hibernate.search.engine.spi.EntityIndexBinding;
 import org.hibernate.search.indexes.spi.DirectoryBasedIndexManager;
 import org.hibernate.search.indexes.spi.IndexManager;
@@ -17,10 +19,10 @@ final class MassIndexStrategyFactory {
    }
 
    static MassIndexStrategy calculateStrategy(EntityIndexBinding indexBinding, Configuration cacheConfiguration) {
-      IndexManager[] indexManagers = indexBinding.getIndexManagers();
-      IndexManager indexManager = indexBinding.getIndexManagers()[0];
+      Set<IndexManager> indexManagers = indexBinding.getIndexManagerSelector().all();
+      IndexManager indexManager = indexManagers.iterator().next();
 
-      boolean sharded = indexManagers.length > 1;
+      boolean sharded = indexManagers.size() > 1;
       boolean replicated = cacheConfiguration.clustering().cacheMode().isReplicated();
       boolean singleMaster = !sharded && indexManager instanceof InfinispanIndexManager;
       boolean multiMaster = indexManager instanceof AffinityIndexManager;

--- a/query/src/test/java/org/infinispan/query/backend/MultipleEntitiesTest.java
+++ b/query/src/test/java/org/infinispan/query/backend/MultipleEntitiesTest.java
@@ -71,7 +71,8 @@ public class MultipleEntitiesTest extends SingleCacheManagerTest {
    }
 
    private void assertEfficientIndexingUsed(SearchIntegrator searchIntegrator, Class<?> clazz) {
-      DirectoryBasedIndexManager im = (DirectoryBasedIndexManager) searchIntegrator.getIndexBindings().get(clazz).getIndexManagers()[0];
+      DirectoryBasedIndexManager im = (DirectoryBasedIndexManager) searchIntegrator.getIndexBindings().get(clazz)
+            .getIndexManagerSelector().all().iterator().next();
       WorkspaceHolder workspaceHolder = im.getWorkspaceHolder();
       LuceneBackendResources indexResources = workspaceHolder.getIndexResources();
       IndexWorkVisitor<Void, LuceneWorkExecutor> visitor = indexResources.getWorkVisitor();

--- a/query/src/test/java/org/infinispan/query/backend/QueryInterceptorIndexingOperationsTest.java
+++ b/query/src/test/java/org/infinispan/query/backend/QueryInterceptorIndexingOperationsTest.java
@@ -145,7 +145,8 @@ public class QueryInterceptorIndexingOperationsTest extends SingleCacheManagerTe
    private Directory initializeAndExtractDirectory(Cache cache) {
       QueryInterceptor queryInterceptor = extractComponent(cache, QueryInterceptor.class);
       SearchIntegrator searchFactory = queryInterceptor.getSearchFactory();
-      DirectoryBasedIndexManager indexManager = (DirectoryBasedIndexManager) searchFactory.getIndexBindings().get(Entity1.class).getIndexManagers()[0];
+      DirectoryBasedIndexManager indexManager = (DirectoryBasedIndexManager) searchFactory.getIndexBindings().get(Entity1.class)
+            .getIndexManagerSelector().all().iterator().next();
       return indexManager.getDirectoryProvider().getDirectory();
    }
 

--- a/query/src/test/java/org/infinispan/query/config/DeclarativeConfigTest.java
+++ b/query/src/test/java/org/infinispan/query/config/DeclarativeConfigTest.java
@@ -7,6 +7,7 @@ import static org.testng.AssertJUnit.assertTrue;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.lucene.queryparser.classic.ParseException;
 import org.hibernate.search.engine.spi.EntityIndexBinding;
@@ -66,11 +67,12 @@ public class DeclarativeConfigTest extends SingleCacheManagerTest {
    public void testPropertiesWhereRead() {
       SearchIntegrator searchFactory = TestQueryHelperFactory.extractSearchFactory(cache);
       EntityIndexBinding indexBindingForEntity = searchFactory.getIndexBindings().get(Person.class);
-      IndexManager[] managers = indexBindingForEntity.getIndexManagers();
-      assertEquals(1, managers.length);
-      assertNotNull(managers[0]);
-      assertTrue(managers[0] instanceof DirectoryBasedIndexManager);
-      DirectoryBasedIndexManager dbim = (DirectoryBasedIndexManager) managers[0];
+      Set<IndexManager> managers = indexBindingForEntity.getIndexManagerSelector().all();
+      assertEquals(1, managers.size());
+      IndexManager manager = managers.iterator().next();
+      assertNotNull(manager);
+      assertTrue(manager instanceof DirectoryBasedIndexManager);
+      DirectoryBasedIndexManager dbim = (DirectoryBasedIndexManager) manager;
       assertTrue(dbim.getDirectoryProvider() instanceof RAMDirectoryProvider);
    }
 

--- a/query/src/test/java/org/infinispan/query/config/MultipleCachesTest.java
+++ b/query/src/test/java/org/infinispan/query/config/MultipleCachesTest.java
@@ -5,6 +5,7 @@ import static org.testng.AssertJUnit.assertEquals;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.lucene.queryparser.classic.ParseException;
 import org.hibernate.search.indexes.spi.DirectoryBasedIndexManager;
@@ -100,9 +101,9 @@ public class MultipleCachesTest extends SingleCacheManagerTest {
 
       SearchManager queryFactory = Search.getSearchManager(indexedCache);
       SearchIntegrator searchImpl = queryFactory.unwrap(SearchIntegrator.class);
-      IndexManager[] indexManagers = searchImpl.getIndexBindings().get(Person.class).getIndexManagers();
-      assert indexManagers != null && indexManagers.length == 1;
-      DirectoryBasedIndexManager directory = (DirectoryBasedIndexManager)indexManagers[0];
+      Set<IndexManager> indexManagers = searchImpl.getIndexBindings().get(Person.class).getIndexManagerSelector().all();
+      assert indexManagers != null && indexManagers.size() == 1;
+      DirectoryBasedIndexManager directory = (DirectoryBasedIndexManager)indexManagers.iterator().next();
       DirectoryProvider directoryProvider = directory.getDirectoryProvider();
       assert directoryProvider instanceof RAMDirectoryProvider : "configuration properties where ignored";
    }

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/ClusteredQueryDslConditionsTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/ClusteredQueryDslConditionsTest.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.hibernate.search.spi.SearchIntegrator;
+import org.hibernate.search.spi.impl.PojoIndexedTypeIdentifier;
 import org.infinispan.Cache;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
@@ -84,18 +85,21 @@ public class ClusteredQueryDslConditionsTest extends QueryDslConditionsTest {
    }
 
    private void checkIndexPresence(Cache cache) {
-      SearchIntegrator searchFactory = Search.getSearchManager(cache).unwrap(SearchIntegrator.class);
+      SearchIntegrator searchIntegrator = Search.getSearchManager(cache).unwrap(SearchIntegrator.class);
 
-      assertTrue(searchFactory.getIndexBindings().containsKey(getModelFactory().getUserImplClass()));
-      assertNotNull(searchFactory.getIndexManager(getModelFactory().getUserImplClass().getName()));
+      verifyClassIsIndexed(searchIntegrator, getModelFactory().getUserImplClass());
+      verifyClassIsIndexed(searchIntegrator, getModelFactory().getAccountImplClass());
+      verifyClassIsIndexed(searchIntegrator, getModelFactory().getTransactionImplClass());
+      verifyClassIsNotIndexed(searchIntegrator, getModelFactory().getAddressImplClass());
+   }
 
-      assertTrue(searchFactory.getIndexBindings().containsKey(getModelFactory().getAccountImplClass()));
-      assertNotNull(searchFactory.getIndexManager(getModelFactory().getAccountImplClass().getName()));
+   private void verifyClassIsNotIndexed(SearchIntegrator searchIntegrator, Class<?> type) {
+      assertFalse(searchIntegrator.getIndexBindings().containsKey(PojoIndexedTypeIdentifier.convertFromLegacy(type)));
+      assertNull(searchIntegrator.getIndexManager(type.getName()));
+   }
 
-      assertTrue(searchFactory.getIndexBindings().containsKey(getModelFactory().getTransactionImplClass()));
-      assertNotNull(searchFactory.getIndexManager(getModelFactory().getTransactionImplClass().getName()));
-
-      assertFalse(searchFactory.getIndexBindings().containsKey(getModelFactory().getAddressImplClass()));
-      assertNull(searchFactory.getIndexManager(getModelFactory().getAddressImplClass().getName()));
+   private void verifyClassIsIndexed(SearchIntegrator searchIntegrator, Class<?> type) {
+      assertTrue(searchIntegrator.getIndexBindings().containsKey(PojoIndexedTypeIdentifier.convertFromLegacy(type)));
+      assertNotNull(searchIntegrator.getIndexManager(type.getName()));
    }
 }

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/QueryDslConditionsTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/QueryDslConditionsTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.hibernate.search.spi.SearchIntegrator;
+import org.hibernate.search.spi.impl.PojoIndexedTypeIdentifier;
 import org.infinispan.Cache;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.Index;
@@ -232,17 +233,20 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
    public void testIndexPresence() {
       SearchIntegrator searchIntegrator = Search.getSearchManager((Cache) getCacheForQuery()).unwrap(SearchIntegrator.class);
 
-      assertTrue(searchIntegrator.getIndexBindings().containsKey(getModelFactory().getUserImplClass()));
-      assertNotNull(searchIntegrator.getIndexManager(getModelFactory().getUserImplClass().getName()));
+      verifyClassIsIndexed(searchIntegrator, getModelFactory().getUserImplClass());
+      verifyClassIsIndexed(searchIntegrator, getModelFactory().getAccountImplClass());
+      verifyClassIsIndexed(searchIntegrator, getModelFactory().getTransactionImplClass());
+      verifyClassIsNotIndexed(searchIntegrator, getModelFactory().getAddressImplClass());
+   }
 
-      assertTrue(searchIntegrator.getIndexBindings().containsKey(getModelFactory().getAccountImplClass()));
-      assertNotNull(searchIntegrator.getIndexManager(getModelFactory().getAccountImplClass().getName()));
+   private void verifyClassIsNotIndexed(SearchIntegrator searchIntegrator, Class<?> type) {
+      assertFalse(searchIntegrator.getIndexBindings().containsKey(PojoIndexedTypeIdentifier.convertFromLegacy(type)));
+      assertNull(searchIntegrator.getIndexManager(type.getName()));
+   }
 
-      assertTrue(searchIntegrator.getIndexBindings().containsKey(getModelFactory().getTransactionImplClass()));
-      assertNotNull(searchIntegrator.getIndexManager(getModelFactory().getTransactionImplClass().getName()));
-
-      assertFalse(searchIntegrator.getIndexBindings().containsKey(getModelFactory().getAddressImplClass()));
-      assertNull(searchIntegrator.getIndexManager(getModelFactory().getAddressImplClass().getName()));
+   private void verifyClassIsIndexed(SearchIntegrator searchIntegrator, Class<?> type) {
+      assertTrue(searchIntegrator.getIndexBindings().containsKey(PojoIndexedTypeIdentifier.convertFromLegacy(type)));
+      assertNotNull(searchIntegrator.getIndexManager(type.getName()));
    }
 
    public void testQueryFactoryType() {

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/RemoteQueryEngine.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/RemoteQueryEngine.java
@@ -13,6 +13,8 @@ import org.apache.lucene.search.TermQuery;
 import org.hibernate.search.query.engine.spi.HSQuery;
 import org.hibernate.search.spi.CustomTypeMetadata;
 import org.hibernate.search.spi.IndexedTypeIdentifier;
+import org.hibernate.search.spi.IndexedTypeMap;
+import org.hibernate.search.spi.impl.IndexedTypeMaps;
 import org.infinispan.AdvancedCache;
 import org.infinispan.commons.dataconversion.ByteArrayWrapper;
 import org.infinispan.objectfilter.impl.ProtobufMatcher;
@@ -75,17 +77,13 @@ final class RemoteQueryEngine extends BaseRemoteQueryEngine {
    protected CacheQuery<?> makeCacheQuery(IckleParsingResult<Descriptor> ickleParsingResult, Query luceneQuery) {
       CustomTypeMetadata customTypeMetadata = new CustomTypeMetadata() {
          @Override
-         public IndexedTypeIdentifier getEntityType() {
-            return ProtobufValueWrapper.INDEXING_TYPE;
-         }
-
-         @Override
          public Set<String> getSortableFields() {
             IndexingMetadata indexingMetadata = ickleParsingResult.getTargetEntityMetadata().getProcessedAnnotation(IndexingMetadata.INDEXED_ANNOTATION);
             return indexingMetadata != null ? indexingMetadata.getSortableFields() : Collections.emptySet();
          }
       };
-      HSQuery hSearchQuery = getSearchFactory().createHSQuery(luceneQuery, customTypeMetadata);
+      IndexedTypeMap<CustomTypeMetadata> queryMetadata = IndexedTypeMaps.singletonMapping(ProtobufValueWrapper.INDEXING_TYPE, customTypeMetadata);
+      HSQuery hSearchQuery = getSearchFactory().createHSQuery(luceneQuery, queryMetadata);
       return ((SearchManagerImpl) getSearchManager()).getQuery(hSearchQuery);
    }
 

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/RemoteQueryEngine.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/RemoteQueryEngine.java
@@ -12,7 +12,6 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.hibernate.search.query.engine.spi.HSQuery;
 import org.hibernate.search.spi.CustomTypeMetadata;
-import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.spi.IndexedTypeMap;
 import org.hibernate.search.spi.impl.IndexedTypeMaps;
 import org.infinispan.AdvancedCache;

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/indexing/ProtobufValueWrapper.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/indexing/ProtobufValueWrapper.java
@@ -23,7 +23,7 @@ import org.infinispan.query.remote.impl.ExternalizerIds;
  */
 public final class ProtobufValueWrapper {
 
-   public static final IndexedTypeIdentifier INDEXING_TYPE = new PojoIndexedTypeIdentifier(ProtobufValueWrapper.class);
+   public static final IndexedTypeIdentifier INDEXING_TYPE = PojoIndexedTypeIdentifier.convertFromLegacy(ProtobufValueWrapper.class);
 
    // The protobuf encoded payload
    private final byte[] binary;

--- a/wildfly-modules/build.xml
+++ b/wildfly-modules/build.xml
@@ -25,7 +25,7 @@
     </target>
 
     <target name="prepare-hibernate-search-module">
-        <external-module-zip group="org.hibernate" artifact="hibernate-search-modules" classifier="wildfly-10-dist"
+        <external-module-zip group="org.hibernate" artifact="hibernate-search-modules" classifier="wildfly-11-dist"
                              dest="${hibernate-search-modules.dir}"
                              source-slot="${version.hibernate.search}" target-slot="${infinispan.slot}" >
             <exclusions>

--- a/wildfly-modules/pom.xml
+++ b/wildfly-modules/pom.xml
@@ -185,7 +185,7 @@
          <groupId>org.hibernate</groupId>
          <artifactId>hibernate-search-modules</artifactId>
          <version>${version.hibernate.search}</version>
-         <classifier>wildfly-10-dist</classifier>
+         <classifier>wildfly-11-dist</classifier>
          <type>zip</type>
       </dependency>
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-8302

N.B. The modules released by Hibernate Search are now aiming for WildFly 11 as primary targed. I see no reason for them not to work on WildFly 10 though.
Hibernate ORM also released modules compatible with WildFly 11; in that case those modules are not going to work on WildFly 10, so I'm intentionally not following up with an update of the Hibernate ORM component until Infinispan updates its target WildFly version as well.