### PR TITLE
ISPN-8263 Taming Hibernate Cache size related random failures

### DIFF
--- a/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/util/Tombstone.java
+++ b/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/util/Tombstone.java
@@ -195,9 +195,9 @@ public class Tombstone {
 
 		@Override
 		public boolean accept(Object key, Object value, Metadata metadata) {
-         boolean b = !(value instanceof Tombstone);
-         log.tracef("Is value %s for key %s is tombstone? %b", value, key, b);
-         return b;
+         boolean isTombstone = value instanceof Tombstone;
+         log.tracef("Is {key=%s,value=%s} tombstone? %b", key, value, isTombstone);
+         return !isTombstone;
 		}
 	}
 

--- a/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/AbstractRegionAccessStrategyTest.java
+++ b/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/AbstractRegionAccessStrategyTest.java
@@ -15,7 +15,6 @@ import javax.transaction.SystemException;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
-import org.infinispan.commons.test.categories.Unstable;
 import org.infinispan.hibernate.cache.access.PutFromLoadValidator;
 import org.infinispan.hibernate.cache.impl.BaseRegion;
 import org.infinispan.hibernate.cache.util.Caches;
@@ -55,7 +54,6 @@ import org.infinispan.test.fwk.TestResourceTracker;
 import org.infinispan.AdvancedCache;
 import org.infinispan.commands.write.PutKeyValueCommand;
 import org.junit.After;
-import org.junit.Ignore;
 import org.junit.Test;
 import junit.framework.AssertionFailedError;
 
@@ -63,7 +61,6 @@ import org.infinispan.Cache;
 import org.infinispan.test.TestingUtil;
 
 import org.jboss.logging.Logger;
-import org.junit.experimental.categories.Category;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -403,13 +400,11 @@ public abstract class AbstractRegionAccessStrategyTest<R extends BaseRegion, S e
 	protected abstract S getAccessStrategy(R region);
 
 	@Test
-	@Category(Unstable.class) // ISPN-8263
 	public void testRemove() throws Exception {
 		evictOrRemoveTest( false );
 	}
 
 	@Test
-	@Category(Unstable.class) // ISPN-8263
 	public void testEvict() throws Exception {
 		evictOrRemoveTest( true );
 	}
@@ -492,13 +487,11 @@ public abstract class AbstractRegionAccessStrategyTest<R extends BaseRegion, S e
 	}
 
 	@Test
-	@Category(Unstable.class) // ISPN-8263
    public void testRemoveAll() throws Exception {
 		evictOrRemoveAllTest(false);
 	}
 
 	@Test
-	@Category(Unstable.class) // ISPN-8263
    public void testEvictAll() throws Exception {
 		evictOrRemoveAllTest(true);
 	}

--- a/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/AbstractRegionAccessStrategyTest.java
+++ b/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/AbstractRegionAccessStrategyTest.java
@@ -278,9 +278,13 @@ public abstract class AbstractRegionAccessStrategyTest<R extends BaseRegion, S e
 	}
 
    protected void assertPutFromLoadLatches(CountDownLatch[] latches) {
+      // In some cases, both puts might execute, so make sure you wait for both
+      // If waiting directly in the || condition, the right side might not wait
+      boolean await0 = await(latches[0]);
+      boolean await1 = await(latches[1]);
       assertTrue(String.format(
          "One of the latches in %s should have at least completed", Arrays.toString(latches)),
-         await(latches[0]) || await(latches[1]));
+         await0 || await1);
    }
 
    private boolean await(CountDownLatch latch) {

--- a/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/functional/AbstractFunctionalTest.java
+++ b/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/functional/AbstractFunctionalTest.java
@@ -236,7 +236,7 @@ public abstract class AbstractFunctionalTest extends BaseNonConfigCoreFunctional
 	}
 
 	protected CountDownLatch expectPutWithValue(AdvancedCache cache, Predicate<Object> valuePredicate, int numUpdates) {
-		if (!cacheMode.isInvalidation() && accessType != AccessType.NONSTRICT_READ_WRITE) {
+		if (!cacheMode.isInvalidation()) {
 			CountDownLatch latch = new CountDownLatch(numUpdates);
 			ExpectingInterceptor.get(cache)
 				.when((ctx, cmd) -> cmd instanceof PutKeyValueCommand && valuePredicate.test(((PutKeyValueCommand) cmd).getValue()))

--- a/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/functional/BulkOperationsTest.java
+++ b/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/functional/BulkOperationsTest.java
@@ -13,14 +13,11 @@ import java.util.Set;
 import org.hibernate.FlushMode;
 import org.hibernate.stat.SecondLevelCacheStatistics;
 
-import org.infinispan.commons.test.categories.Unstable;
 import org.infinispan.test.hibernate.cache.util.InfinispanTestingSetup;
 import org.infinispan.test.hibernate.cache.functional.entities.Contact;
 import org.infinispan.test.hibernate.cache.functional.entities.Customer;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -55,7 +52,6 @@ public class BulkOperationsTest extends SingleNodeTest {
 	}
 
 	@Test
-	@Category(Unstable.class) // ISPN-8263
 	public void testBulkOperations() throws Throwable {
 		boolean cleanedUp = false;
 		try {

--- a/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/functional/cluster/NaturalIdInvalidationTest.java
+++ b/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/functional/cluster/NaturalIdInvalidationTest.java
@@ -15,7 +15,6 @@ import org.hibernate.Criteria;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.infinispan.commons.test.categories.Smoke;
-import org.infinispan.commons.test.categories.Unstable;
 import org.infinispan.hibernate.cache.util.InfinispanMessageLogger;
 import org.hibernate.criterion.Restrictions;
 import org.infinispan.test.hibernate.cache.functional.entities.Citizen;
@@ -63,7 +62,6 @@ public class NaturalIdInvalidationTest extends DualNodeTest {
 	}
 
 	@Test
-	@Category(Unstable.class) // ISPN-8263
 	public void testAll() throws Exception {
       log.infof("*** %s", name.getMethodName());
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-8263

Marking this as preview to get a few CI runs to verify this is working fine.

I've been running the full Hibernate Cache testsuite with TRACE for a day in one of the CI machines and has not failed again, but I want to leave it over the weekend to run and see whether anything else fails.