### PR TITLE
ISPN-8111 OffHeapBoundedSingleNodeTest.testMultiThreaded fails with

### DIFF
--- a/core/src/test/java/org/infinispan/container/offheap/OffHeapBoundedSingleNodeTest.java
+++ b/core/src/test/java/org/infinispan/container/offheap/OffHeapBoundedSingleNodeTest.java
@@ -30,7 +30,7 @@ public class OffHeapBoundedSingleNodeTest extends OffHeapSingleNodeTest {
 
    @Override
    protected void createCacheManagers() throws Throwable {
-      ConfigurationBuilder dcc = getDefaultClusteredCacheConfig(CacheMode.LOCAL, true);
+      ConfigurationBuilder dcc = getDefaultClusteredCacheConfig(CacheMode.LOCAL, false);
       dcc.memory().storageType(StorageType.OFF_HEAP).size(COUNT).evictionType(EvictionType.COUNT);
       dcc.locking().isolationLevel(IsolationLevel.READ_COMMITTED);
       // Only start up the 1 cache

--- a/core/src/test/java/org/infinispan/container/offheap/OffHeapMultiNodeTest.java
+++ b/core/src/test/java/org/infinispan/container/offheap/OffHeapMultiNodeTest.java
@@ -24,7 +24,7 @@ public class OffHeapMultiNodeTest extends MultipleCacheManagersTest {
 
    @Override
    protected void createCacheManagers() throws Throwable {
-      ConfigurationBuilder dcc = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, true);
+      ConfigurationBuilder dcc = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false);
       dcc.memory().storageType(StorageType.OFF_HEAP);
       createCluster(dcc, 4);
       waitForClusterToForm();

--- a/core/src/test/java/org/infinispan/container/offheap/OffHeapSingleNodeTest.java
+++ b/core/src/test/java/org/infinispan/container/offheap/OffHeapSingleNodeTest.java
@@ -29,7 +29,7 @@ public class OffHeapSingleNodeTest extends OffHeapMultiNodeTest {
 
    @Override
    protected void createCacheManagers() throws Throwable {
-      ConfigurationBuilder dcc = getDefaultClusteredCacheConfig(CacheMode.LOCAL, true);
+      ConfigurationBuilder dcc = getDefaultClusteredCacheConfig(CacheMode.LOCAL, false);
       dcc.memory().storageType(StorageType.OFF_HEAP);
       // Only start up the 1 cache
       addClusterEnabledCacheManager(dcc);


### PR DESCRIPTION
trace logging enabled

* Disabled transactions which should let it run faster

https://issues.jboss.org/browse/ISPN-8111