### PR TITLE
ISPN-8281 Overloaded collect() to take SerializableSupplier

### DIFF
--- a/core/src/main/java/org/infinispan/CacheStream.java
+++ b/core/src/main/java/org/infinispan/CacheStream.java
@@ -1,5 +1,6 @@
 package org.infinispan;
 
+import java.io.Serializable;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.Optional;
@@ -308,7 +309,8 @@ public interface CacheStream<R> extends Stream<R>, BaseCacheStream<R, Stream<R>>
     * prevents the usage of {@link java.util.stream.Collectors} class.  However you can use the
     * {@link org.infinispan.stream.CacheCollectors} static factory methods to create a serializable wrapper, which then
     * creates the actual collector lazily after being deserialized.  This is useful to use any method from the
-    * {@link java.util.stream.Collectors} class as you would normally.</p>
+    * {@link java.util.stream.Collectors} class as you would normally.
+    * Alternatively, you can call {@link #collect(SerializableSupplier)} too.</p>
     * @param collector
     * @param <R1> collected type
     * @param <A> intermediate collected type if applicable
@@ -318,7 +320,58 @@ public interface CacheStream<R> extends Stream<R>, BaseCacheStream<R, Stream<R>>
    @Override
    <R1, A> R1 collect(Collector<? super R, A, R1> collector);
 
-   <R1, A> R1 collect(SerializableSupplier<Collector<? super R, A, R1>> supplier);
+   /**
+    * Performs a <a href="package-summary.html#MutableReduction">mutable
+    * reduction</a> operation on the elements of this stream using a
+    * {@code Collector} that is lazily created from the {@code SerializableSupplier}
+    * provided.
+    *
+    * This method behaves exactly the same as {@link #collect(Collector)} with
+    * the enhanced capability of working even when the mutable reduction
+    * operation has to run in a remote node and the operation is not
+    * {@link Serializable} or otherwise marshallable.
+    *
+    * So, this method is specially designed for situations when the user
+    * wants to use a {@link Collector} instance that has been created by
+    * {@link java.util.stream.Collectors} static factory methods.
+    *
+    * In this particular case, the function that instantiates the
+    * {@link Collector} will be marshalled according to the
+    * {@link Serializable} rules.
+    *
+    * @param supplier The supplier to create the collector that is specifically serializable
+    * @param <R1> The resulting type of the collector
+    * @return the collected value
+    * @since 9.2
+    */
+   <R1> R1 collect(SerializableSupplier<Collector<? super R, ?, R1>> supplier);
+
+   /**
+    * Performs a <a href="package-summary.html#MutableReduction">mutable
+    * reduction</a> operation on the elements of this stream using a
+    * {@code Collector} that is lazily created from the {@code Supplier}
+    * provided.
+    *
+    * This method behaves exactly the same as {@link #collect(Collector)} with
+    * the enhanced capability of working even when the mutable reduction
+    * operation has to run in a remote node and the operation is not
+    * {@link Serializable} or otherwise marshallable.
+    *
+    * So, this method is specially designed for situations when the user
+    * wants to use a {@link Collector} instance that has been created by
+    * {@link java.util.stream.Collectors} static factory methods.
+    *
+    * In this particular case, the function that instantiates the
+    * {@link Collector} will be marshalled using Infinispan
+    * {@link org.infinispan.commons.marshall.Externalizer} class or one of its
+    * subtypes.
+    *
+    * @param supplier The supplier to create the collector
+    * @param <R1> The resulting type of the collector
+    * @return the collected value
+    * @since 9.2
+    */
+   <R1> R1 collect(Supplier<Collector<? super R, ?, R1>> supplier);
 
    /**
     * Same as {@link CacheStream#collect(Supplier, BiConsumer, BiConsumer)} except that the various arguments must

--- a/core/src/main/java/org/infinispan/CacheStream.java
+++ b/core/src/main/java/org/infinispan/CacheStream.java
@@ -318,6 +318,8 @@ public interface CacheStream<R> extends Stream<R>, BaseCacheStream<R, Stream<R>>
    @Override
    <R1, A> R1 collect(Collector<? super R, A, R1> collector);
 
+   <R1, A> R1 collect(SerializableSupplier<Collector<? super R, A, R1>> supplier);
+
    /**
     * Same as {@link CacheStream#collect(Supplier, BiConsumer, BiConsumer)} except that the various arguments must
     * also implement <code>Serializable</code>

--- a/core/src/main/java/org/infinispan/filter/CacheFilters.java
+++ b/core/src/main/java/org/infinispan/filter/CacheFilters.java
@@ -9,6 +9,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
+import org.infinispan.CacheStream;
 import org.infinispan.commons.marshall.AdvancedExternalizer;
 import org.infinispan.commons.util.Util;
 import org.infinispan.container.InternalEntryFactory;
@@ -72,6 +73,12 @@ public final class CacheFilters {
            KeyValueFilterConverter<? super K, ? super V, C> filterConverter) {
       return stream.map(new FilterConverterAsCacheEntryFunction(filterConverter)).filter(
               StreamMarshalling.nonNullPredicate());
+   }
+
+   public static <K, V, C> CacheStream<CacheEntry<K, C>> filterAndConvert(CacheStream<CacheEntry<K, V>> stream,
+            KeyValueFilterConverter<? super K, ? super V, C> filterConverter) {
+      return stream.map(new FilterConverterAsCacheEntryFunction(filterConverter)).filter(
+         StreamMarshalling.nonNullPredicate());
    }
 
    private static class KeyValueFilterAsPredicate<K, V> implements Predicate<CacheEntry<K, V>> {

--- a/core/src/main/java/org/infinispan/stream/impl/DistributedCacheStream.java
+++ b/core/src/main/java/org/infinispan/stream/impl/DistributedCacheStream.java
@@ -73,6 +73,7 @@ import org.infinispan.stream.impl.intops.object.PeekOperation;
 import org.infinispan.stream.impl.termop.object.ForEachBiOperation;
 import org.infinispan.stream.impl.termop.object.ForEachOperation;
 import org.infinispan.stream.impl.termop.object.NoMapIteratorOperation;
+import org.infinispan.util.AbstractDelegatingCacheStream;
 import org.infinispan.util.CloseableSuppliedIterator;
 import org.infinispan.util.RangeSet;
 import org.infinispan.util.concurrent.TimeoutException;
@@ -454,6 +455,11 @@ public class DistributedCacheStream<R> extends AbstractCacheStream<R, Stream<R>,
                  new IdentifyFinishCollector<>(collector)), true, collector.combiner(), null);
          return collector.finisher().apply(intermediateResult);
       }
+   }
+
+   @Override
+   public <R1, A> R1 collect(SerializableSupplier<Collector<? super R, A, R1>> supplier) {
+      return collect(new AbstractDelegatingCacheStream.CollectorSupplier2<>(supplier));
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/stream/impl/IntermediateCacheStream.java
+++ b/core/src/main/java/org/infinispan/stream/impl/IntermediateCacheStream.java
@@ -342,7 +342,12 @@ public class IntermediateCacheStream<R> implements CacheStream<R> {
    }
 
    @Override
-   public <R1, A> R1 collect(SerializableSupplier<Collector<? super R, A, R1>> supplier) {
+   public <R1> R1 collect(SerializableSupplier<Collector<? super R, ?, R1>> supplier) {
+      return localStream.collect(supplier);
+   }
+
+   @Override
+   public <R1> R1 collect(Supplier<Collector<? super R, ?, R1>> supplier) {
       return localStream.collect(supplier);
    }
 

--- a/core/src/main/java/org/infinispan/stream/impl/IntermediateCacheStream.java
+++ b/core/src/main/java/org/infinispan/stream/impl/IntermediateCacheStream.java
@@ -342,6 +342,11 @@ public class IntermediateCacheStream<R> implements CacheStream<R> {
    }
 
    @Override
+   public <R1, A> R1 collect(SerializableSupplier<Collector<? super R, A, R1>> supplier) {
+      return localStream.collect(supplier);
+   }
+
+   @Override
    public <R1> R1 collect(Supplier<R1> supplier, BiConsumer<R1, ? super R> accumulator, BiConsumer<R1, R1> combiner) {
       return localStream.collect(supplier, accumulator, combiner);
    }

--- a/core/src/main/java/org/infinispan/stream/impl/local/LocalCacheStream.java
+++ b/core/src/main/java/org/infinispan/stream/impl/local/LocalCacheStream.java
@@ -361,7 +361,12 @@ public class LocalCacheStream<R> extends AbstractLocalCacheStream<R, Stream<R>, 
    }
 
    @Override
-   public <R1, A> R1 collect(SerializableSupplier<Collector<? super R, A, R1>> supplier) {
+   public <R1> R1 collect(SerializableSupplier<Collector<? super R, ?, R1>> supplier) {
+      return createStream().collect(supplier.get());
+   }
+
+   @Override
+   public <R1> R1 collect(Supplier<Collector<? super R, ?, R1>> supplier) {
       return createStream().collect(supplier.get());
    }
 

--- a/core/src/main/java/org/infinispan/stream/impl/local/LocalCacheStream.java
+++ b/core/src/main/java/org/infinispan/stream/impl/local/LocalCacheStream.java
@@ -361,6 +361,11 @@ public class LocalCacheStream<R> extends AbstractLocalCacheStream<R, Stream<R>, 
    }
 
    @Override
+   public <R1, A> R1 collect(SerializableSupplier<Collector<? super R, A, R1>> supplier) {
+      return createStream().collect(supplier.get());
+   }
+
+   @Override
    public Optional<R> min(Comparator<? super R> comparator) {
       return createStream().min(comparator);
    }

--- a/core/src/main/java/org/infinispan/util/AbstractDelegatingCacheStream.java
+++ b/core/src/main/java/org/infinispan/util/AbstractDelegatingCacheStream.java
@@ -1,5 +1,8 @@
 package org.infinispan.util;
 
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.Optional;
@@ -28,6 +31,9 @@ import org.infinispan.CacheStream;
 import org.infinispan.DoubleCacheStream;
 import org.infinispan.IntCacheStream;
 import org.infinispan.LongCacheStream;
+import org.infinispan.commons.marshall.Externalizer;
+import org.infinispan.commons.marshall.SerializeWith;
+import org.infinispan.stream.CacheCollectors;
 import org.infinispan.util.function.SerializableBiConsumer;
 import org.infinispan.util.function.SerializableBiFunction;
 import org.infinispan.util.function.SerializableBinaryOperator;
@@ -318,6 +324,11 @@ public class AbstractDelegatingCacheStream<R> implements CacheStream<R> {
    }
 
    @Override
+   public <R1, A> R1 collect(SerializableSupplier<Collector<? super R, A, R1>> supplier) {
+      return collect(new CollectorSupplier2<>(supplier));
+   }
+
+   @Override
    public Optional<R> min(Comparator<? super R> comparator) {
       return castStream(underlyingStream).min(comparator);
    }
@@ -441,4 +452,66 @@ public class AbstractDelegatingCacheStream<R> implements CacheStream<R> {
    public DoubleCacheStream flatMapToDouble(SerializableFunction<? super R, ? extends DoubleStream> mapper) {
       return flatMapToDouble((Function<? super R, ? extends DoubleStream>) mapper);
    }
+
+//   public static <T, R> Collector<T, ?, R> serializableCollector(SerializableSupplier<Collector<T, ?, R>> supplier) {
+//      return null;
+////      return new CacheCollectors.CollectorSupplier<>(supplier);
+//   }
+
+   @SerializeWith(value = CollectorSupplier2.CollectorSupplierExternalizer.class)
+   public static final class CollectorSupplier2<T, A, R> implements Collector<T, A, R> {
+      private final Supplier<Collector<? super T, A, R>> supplier;
+      private transient Collector<T, A, R> collector;
+
+      private Collector<T, A, R> getCollector() {
+         if (collector == null) {
+            collector = (Collector<T, A, R>) supplier.get();
+         }
+         return collector;
+      }
+
+      public CollectorSupplier2(Supplier<Collector<? super T, A, R>> supplier) {
+         this.supplier = supplier;
+      }
+
+      @Override
+      public Supplier<A> supplier() {
+         return getCollector().supplier();
+      }
+
+      @Override
+      public BiConsumer<A, T> accumulator() {
+         return getCollector().accumulator();
+      }
+
+      @Override
+      public BinaryOperator<A> combiner() {
+         return getCollector().combiner();
+      }
+
+      @Override
+      public Function<A, R> finisher() {
+         return getCollector().finisher();
+      }
+
+      @Override
+      public Set<Characteristics> characteristics() {
+         return getCollector().characteristics();
+      }
+
+      public static final class CollectorSupplierExternalizer
+            implements Externalizer<CollectorSupplier2<?, ?, ?>> {
+
+         @Override
+         public void writeObject(ObjectOutput output, CollectorSupplier2 object) throws IOException {
+            output.writeObject(object.supplier);
+         }
+
+         @Override
+         public CollectorSupplier2 readObject(ObjectInput input) throws IOException, ClassNotFoundException {
+            return new CollectorSupplier2((Supplier<Collector>) input.readObject());
+         }
+      }
+   }
+
 }

--- a/core/src/main/java/org/infinispan/util/AbstractDelegatingCacheStream.java
+++ b/core/src/main/java/org/infinispan/util/AbstractDelegatingCacheStream.java
@@ -33,7 +33,6 @@ import org.infinispan.IntCacheStream;
 import org.infinispan.LongCacheStream;
 import org.infinispan.commons.marshall.Externalizer;
 import org.infinispan.commons.marshall.SerializeWith;
-import org.infinispan.stream.CacheCollectors;
 import org.infinispan.util.function.SerializableBiConsumer;
 import org.infinispan.util.function.SerializableBiFunction;
 import org.infinispan.util.function.SerializableBinaryOperator;

--- a/core/src/main/java/org/infinispan/util/Casting.java
+++ b/core/src/main/java/org/infinispan/util/Casting.java
@@ -1,0 +1,25 @@
+package org.infinispan.util;
+
+import org.infinispan.util.function.SerializableSupplier;
+
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+
+public class Casting {
+
+   // The hacks here allow casts to work properly,
+   // since Java doesn't work as well with nested generics
+
+   @SuppressWarnings("unchecked")
+   public static <T, R> SerializableSupplier<Collector<T, ?, R>> toSerialSupplierCollect(
+      SerializableSupplier supplier) {
+      return supplier;
+   }
+
+   // This is a hack to allow for cast to work properly, since Java doesn't work as well with nested generics
+   @SuppressWarnings("unchecked")
+   public static <T, R> Supplier<Collector<T, ?, R>> toSupplierCollect(Supplier supplier) {
+      return supplier;
+   }
+
+}

--- a/core/src/test/java/org/infinispan/stream/BaseSetupStreamIteratorTest.java
+++ b/core/src/test/java/org/infinispan/stream/BaseSetupStreamIteratorTest.java
@@ -6,8 +6,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
+import org.infinispan.CacheStream;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.container.entries.CacheEntry;
@@ -75,9 +75,8 @@ public abstract class BaseSetupStreamIteratorTest extends MultipleCacheManagersT
       return map;
    }
 
-   protected static <K, V> Map<K, V> mapFromStream(Stream<CacheEntry<K, V>> stream) {
-      return stream.collect(CacheCollectors.serializableCollector(
-            () -> Collectors.toMap(CacheEntry::getKey, CacheEntry::getValue)));
+   protected static <K, V> Map<K, V> mapFromStream(CacheStream<CacheEntry<K, V>> stream) {
+      return stream.collect(() -> Collectors.toMap(CacheEntry::getKey, CacheEntry::getValue));
    }
 
    protected static class StringTruncator implements Converter<Object, String, String>, Serializable, ExternalPojo {

--- a/core/src/test/java/org/infinispan/stream/BaseStreamIteratorEvictionTest.java
+++ b/core/src/test/java/org/infinispan/stream/BaseStreamIteratorEvictionTest.java
@@ -8,6 +8,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import org.infinispan.Cache;
+import org.infinispan.CacheStream;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.container.entries.CacheEntry;
 import org.testng.annotations.Test;
@@ -43,7 +44,7 @@ public abstract class BaseStreamIteratorEvictionTest extends BaseSetupStreamIter
       Thread.sleep(TimeUnit.SECONDS.toMillis(expectedTime) + 50);
 
       Map<Object, String> results;
-      try (Stream<CacheEntry<Object, String>> stream = cache.getAdvancedCache().cacheEntrySet().stream()) {
+      try (CacheStream<CacheEntry<Object, String>> stream = cache.getAdvancedCache().cacheEntrySet().stream()) {
          results = mapFromStream(stream);
       }
 

--- a/core/src/test/java/org/infinispan/stream/BaseStreamIteratorEvictionTest.java
+++ b/core/src/test/java/org/infinispan/stream/BaseStreamIteratorEvictionTest.java
@@ -5,7 +5,6 @@ import static org.testng.AssertJUnit.assertEquals;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Stream;
 
 import org.infinispan.Cache;
 import org.infinispan.CacheStream;

--- a/core/src/test/java/org/infinispan/stream/BaseStreamIteratorTest.java
+++ b/core/src/test/java/org/infinispan/stream/BaseStreamIteratorTest.java
@@ -14,6 +14,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import org.infinispan.Cache;
+import org.infinispan.CacheStream;
 import org.infinispan.commands.write.RemoveCommand;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.container.entries.CacheEntry;
@@ -133,7 +134,7 @@ public abstract class BaseStreamIteratorTest extends BaseSetupStreamIteratorTest
       KeyValueFilterConverter<MagicKey, String, String> filterConverter = new CompositeKeyValueFilterConverter<>(
             new KeyFilterAsKeyValueFilter<>(new CollectionKeyFilter<>(Collections.singleton(excludedEntry.getKey()))),
             new StringTruncator(2, 5));
-      try (Stream<CacheEntry<MagicKey, String>> stream = CacheFilters.filterAndConvert(
+      try (CacheStream<CacheEntry<MagicKey, String>> stream = CacheFilters.filterAndConvert(
               cache.getAdvancedCache().cacheEntrySet().stream(), filterConverter)) {
          Map<MagicKey, String> results = mapFromStream(stream);
 

--- a/core/src/test/java/org/infinispan/stream/BaseStreamIteratorTest.java
+++ b/core/src/test/java/org/infinispan/stream/BaseStreamIteratorTest.java
@@ -11,7 +11,6 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Stream;
 
 import org.infinispan.Cache;
 import org.infinispan.CacheStream;

--- a/core/src/test/java/org/infinispan/stream/BaseStreamTest.java
+++ b/core/src/test/java/org/infinispan/stream/BaseStreamTest.java
@@ -155,8 +155,8 @@ public abstract class BaseStreamTest extends MultipleCacheManagersTest {
       assertEquals(range, cache.size());
       CacheSet<Map.Entry<Integer, String>> entrySet = cache.entrySet();
 
-      assertEquals(4.5, createStream(entrySet).collect(CacheCollectors.serializableCollector(
-            () -> Collectors.averagingInt(Map.Entry::getKey))));
+      assertEquals(4.5, createStream(entrySet).collect(
+            () -> Collectors.averagingInt(Map.Entry::getKey)));
    }
 
    public void testObjCollectorIntStatistics() {
@@ -168,8 +168,8 @@ public abstract class BaseStreamTest extends MultipleCacheManagersTest {
       assertEquals(range, cache.size());
       CacheSet<Map.Entry<Integer, String>> entrySet = cache.entrySet();
 
-      IntSummaryStatistics stats = createStream(entrySet).collect(CacheCollectors.serializableCollector(
-            () -> Collectors.summarizingInt(Map.Entry::getKey)));
+      IntSummaryStatistics stats = createStream(entrySet).collect(
+            () -> Collectors.summarizingInt(Map.Entry::getKey));
       assertEquals(10, stats.getCount());
       assertEquals(4.5, stats.getAverage());
       assertEquals(0, stats.getMin());
@@ -187,8 +187,7 @@ public abstract class BaseStreamTest extends MultipleCacheManagersTest {
       CacheSet<Map.Entry<Integer, String>> entrySet = cache.entrySet();
 
       ConcurrentMap<Boolean, List<Map.Entry<Integer, String>>> grouped = createStream(entrySet).collect(
-            CacheCollectors.serializableCollector(
-                  () -> Collectors.groupingByConcurrent(k -> k.getKey() % 2 == 0)));
+                  () -> Collectors.groupingByConcurrent(k -> k.getKey() % 2 == 0));
       grouped.get(true).parallelStream().forEach(e -> assertTrue(e.getKey() % 2 == 0));
       grouped.get(false).parallelStream().forEach(e -> assertTrue(e.getKey() % 2 == 1));
    }
@@ -219,7 +218,7 @@ public abstract class BaseStreamTest extends MultipleCacheManagersTest {
 
       List<Map.Entry<Integer, String>> list = createStream(entrySet).sorted(
             (e1, e2) -> Integer.compare(e1.getKey(), e2.getKey())).collect(
-            CacheCollectors.serializableCollector(Collectors::toList));
+            () -> Collectors.toList());
       assertEquals(cache.size(), list.size());
       AtomicInteger i = new AtomicInteger();
       list.forEach(e -> {

--- a/core/src/test/java/org/infinispan/stream/BaseStreamTest.java
+++ b/core/src/test/java/org/infinispan/stream/BaseStreamTest.java
@@ -218,7 +218,7 @@ public abstract class BaseStreamTest extends MultipleCacheManagersTest {
 
       List<Map.Entry<Integer, String>> list = createStream(entrySet).sorted(
             (e1, e2) -> Integer.compare(e1.getKey(), e2.getKey())).collect(
-            () -> Collectors.toList());
+            Collectors::<Map.Entry<Integer, String>>toList);
       assertEquals(cache.size(), list.size());
       AtomicInteger i = new AtomicInteger();
       list.forEach(e -> {

--- a/core/src/test/java/org/infinispan/stream/DistributedStreamIteratorTxTest.java
+++ b/core/src/test/java/org/infinispan/stream/DistributedStreamIteratorTxTest.java
@@ -17,6 +17,7 @@ import javax.transaction.SystemException;
 import javax.transaction.TransactionManager;
 
 import org.infinispan.Cache;
+import org.infinispan.CacheStream;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.filter.AcceptAllKeyValueFilter;
@@ -77,7 +78,7 @@ public class DistributedStreamIteratorTxTest extends DistributedStreamIteratorTe
          values.put(key, value);
          cache.put(key, "converted-value");
 
-         try (Stream<CacheEntry<Object, String>> stream = cache.getAdvancedCache().cacheEntrySet().stream().
+         try (CacheStream<CacheEntry<Object, String>> stream = cache.getAdvancedCache().cacheEntrySet().stream().
                  filter(CacheFilters.predicate(AcceptAllKeyValueFilter.getInstance())).
                  map(CacheFilters.function(new StringTruncator(2, 5)))) {
             Map<Object, String> results = mapFromStream(stream);
@@ -122,7 +123,7 @@ public class DistributedStreamIteratorTxTest extends DistributedStreamIteratorTe
                new CompositeKeyValueFilterConverter<>(
                      new KeyFilterAsKeyValueFilter<>(new CollectionKeyFilter<>(acceptedKeys, true)),
                      new StringTruncator(2, 5));
-         try (Stream<CacheEntry<Object, String>> stream = CacheFilters.filterAndConvert(
+         try (CacheStream<CacheEntry<Object, String>> stream = CacheFilters.filterAndConvert(
                  cache.getAdvancedCache().cacheEntrySet().stream(), filterConverter)) {
             Map<Object, String> results = mapFromStream(stream);
             assertEquals(values.size(), results.size());

--- a/core/src/test/java/org/infinispan/stream/DistributedStreamIteratorTxTest.java
+++ b/core/src/test/java/org/infinispan/stream/DistributedStreamIteratorTxTest.java
@@ -7,7 +7,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.stream.Stream;
 
 import javax.transaction.HeuristicMixedException;
 import javax.transaction.HeuristicRollbackException;

--- a/core/src/test/java/org/infinispan/stream/stress/DistributedStreamRehashStressTest.java
+++ b/core/src/test/java/org/infinispan/stream/stress/DistributedStreamRehashStressTest.java
@@ -82,7 +82,7 @@ public class DistributedStreamRehashStressTest extends StressTest {
          Map<Integer, Integer> results = cache.entrySet().stream().filter(
                  (Serializable & Predicate<Map.Entry<Integer, Integer>>)
                          e -> (e.getKey() & 1) == 1).collect(
-                 CacheCollectors.serializableCollector(() -> Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+                 () -> Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
          assertEquals(CACHE_ENTRY_COUNT / 2, results.size());
          for (Map.Entry<Integer, Integer> entry : results.entrySet()) {
             assertEquals(entry.getKey(), entry.getValue());

--- a/core/src/test/java/org/infinispan/stream/stress/DistributedStreamRehashStressTest.java
+++ b/core/src/test/java/org/infinispan/stream/stress/DistributedStreamRehashStressTest.java
@@ -27,7 +27,6 @@ import org.infinispan.container.entries.ImmortalCacheEntry;
 import org.infinispan.distribution.LocalizedCacheTopology;
 import org.infinispan.distribution.ch.KeyPartitioner;
 import org.infinispan.manager.EmbeddedCacheManager;
-import org.infinispan.stream.CacheCollectors;
 import org.infinispan.test.fwk.InCacheMode;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.test.fwk.TransportFlags;

--- a/documentation/src/main/asciidoc/user_guide/streams.adoc
+++ b/documentation/src/main/asciidoc/user_guide/streams.adoc
@@ -118,18 +118,16 @@ This relies on the spec to pick the most specific method as defined link:https:/
 
 In our previous example we used a `Collector` to collect all the results into a `Map`.
 Unfortunately the link:{jdkdocroot}/java/util/stream/Collectors.html[Collectors]
-class doesn't produce Serializable instances.  Thus if you need to use these, you can use the newly provided
-link:{javadocroot}/org/infinispan/stream/CacheCollectors.html[CacheCollectors]
-class which allows for a `Supplier<Collector>` to be provided.  This instance could then use the
-link:{jdkdocroot}/java/util/stream/Collectors.html[Collectors]
-to supply a `Collector` which is not serialized. You can read more details about how the
-collector peforms in a distributed fashion at link:user_guide.html#distributed_stream_execution[distributed execution].
+class doesn't produce Serializable instances.
+Thus if you need to use these, you should call the overloaded `collect`methods that take `Supplier<Collector>`.
+This can be serialized enabling the collector to be lazily instantiated in remote nodes.
+You can read more details about how the collector peforms in a distributed fashion at link:user_guide.html#distributed_stream_execution[distributed execution].
 
 [source,java]
 ----
 Map<Object, String> jbossValues = cache.entrySet().stream()
               .filter(e -> e.getValue().contains("Jboss"))
-              .collect(CacheCollectors.serializableCollector(() -> Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+              .collect(() -> Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 ----
 
 If however you are not able to use the `Cache` and `CacheStream` interfaces you cannot utilize `Serializable`
@@ -154,7 +152,7 @@ You can use an advanced externalizer as shown below:
 ----
    Map<Object, String> jbossValues = cache.entrySet().stream()
               .filter(new ContainsFilter("Jboss"))
-              .collect(CacheCollectors.serializableCollector(() -> Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+              .collect(() -> Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
    class ContainsFilter implements Predicate<Map.Entry<Object, String>> {
       private final String target;
@@ -193,14 +191,14 @@ You can use an advanced externalizer as shown below:
    }
 ----
 
-You could also use an advanced externalizer for the `CacheCollector` supplier to reduce the
+You could also use an advanced externalizer for the collector supplier to reduce the
 payload size even further.
 
 [source,java]
 ----
    Map<Object, String> jbossValues = cache.entrySet().stream()
               .filter(new ContainsFilter("Jboss"))
-              .collect(CacheCollectors.serializableCollector(ToMapCollectorSupplier.INSTANCE);
+              .collect(ToMapCollectorSupplier.INSTANCE);
 
  class ToMapCollectorSupplier<K, U> implements Supplier<Collector<Map.Entry<K, U>, ?, Map<K, U>>> {
       static final ToMapCollectorSupplier INSTANCE = new ToMapCollectorSupplier();
@@ -476,7 +474,7 @@ public class WordCountExample {
       Map<String, Integer> wordCountMap = c1.entrySet().parallelStream()
          .map(e -> e.getValue().split("\\s"))
          .flatMap(Arrays::stream)
-         .collect(CacheCollectors.serializableCollector(() -> Collectors.groupingBy(Function.identity(), Collectors.counting())));
+         .collect(() -> Collectors.groupingBy(Function.identity(), Collectors.counting()));
    }
 }
 
@@ -501,7 +499,7 @@ public class WordCountExample {
       String mostFrequentWord = c1.entrySet().parallelStream()
          .map(e -> e.getValue().split("\\s"))
          .flatMap(Arrays::stream)
-         .collect(CacheCollectors.serializableCollector(() -> Collectors.collectingAndThen(
+         .collect(() -> Collectors.collectingAndThen(
             Collectors.groupingBy(Function.identity(), Collectors.counting()),
                wordCountMap -> {
                   String mostFrequent = null;
@@ -514,7 +512,7 @@ public class WordCountExample {
                         }
                      }
                      return mostFrequent;
-               })));
+               }));
 
 }
 
@@ -535,7 +533,7 @@ public class WordFrequencyExample {
       Map<String, Long> wordCount = c1.entrySet().parallelStream()
               .map(e -> e.getValue().split("\\s"))
               .flatMap(Arrays::stream)
-              .collect(CacheCollectors.serializableCollector(() -> Collectors.groupingBy(Function.identity(), Collectors.counting())));
+              .collect(() -> Collectors.groupingBy(Function.identity(), Collectors.counting()));
       Optional<Map.Entry<String, Long>> mostFrequent = wordCount.entrySet().parallelStream().reduce(
               (e1, e2) -> e1.getValue() > e2.getValue() ? e1 : e2);
 ----

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/task/servertask/LocalMapReduceServerTask.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/task/servertask/LocalMapReduceServerTask.java
@@ -33,8 +33,7 @@ public class LocalMapReduceServerTask implements ServerTask {
         return cache.entrySet().stream()
                 .map((Serializable & Function<Map.Entry<String, String>, String[]>) e -> e.getValue().split("\\s+"))
                 .flatMap((Serializable & Function<String[], Stream<String>>) Arrays::stream)
-                .collect(CacheCollectors.serializableCollector(
-                        () -> Collectors.groupingBy(Function.identity(), Collectors.counting())));
+                .collect(() -> Collectors.groupingBy(Function.identity(), Collectors.counting()));
     }
 
     @Override

--- a/server/rest/src/main/java/org/infinispan/rest/operations/mediatypes/impl/BinaryOutputPrinter.java
+++ b/server/rest/src/main/java/org/infinispan/rest/operations/mediatypes/impl/BinaryOutputPrinter.java
@@ -8,7 +8,6 @@ import org.infinispan.CacheSet;
 import org.infinispan.rest.operations.exceptions.ServerInternalException;
 import org.infinispan.rest.operations.mediatypes.Charset;
 import org.infinispan.rest.operations.mediatypes.OutputPrinter;
-import org.infinispan.stream.CacheCollectors;
 
 /**
  * {@link OutputPrinter} for binary values.

--- a/server/rest/src/main/java/org/infinispan/rest/operations/mediatypes/impl/BinaryOutputPrinter.java
+++ b/server/rest/src/main/java/org/infinispan/rest/operations/mediatypes/impl/BinaryOutputPrinter.java
@@ -21,7 +21,7 @@ public class BinaryOutputPrinter implements OutputPrinter {
    public byte[] print(String cacheName, CacheSet<?> keys, Charset charset) {
       return keys.stream()
             .map(b -> b.toString())
-            .collect(CacheCollectors.serializableCollector(() -> Collectors.joining(",", "[", "]")))
+            .collect(() -> Collectors.joining(",", "[", "]"))
             .getBytes(charset.getJavaCharset());
    }
 

--- a/server/rest/src/main/java/org/infinispan/rest/operations/mediatypes/impl/JSONOutputPrinter.java
+++ b/server/rest/src/main/java/org/infinispan/rest/operations/mediatypes/impl/JSONOutputPrinter.java
@@ -28,7 +28,7 @@ public class JSONOutputPrinter implements OutputPrinter {
    public byte[] print(String cacheName, CacheSet<?> keys, Charset charset) {
       return keys.stream()
             .map(b -> Escaper.escapeJson(b.toString()))
-            .collect(CacheCollectors.serializableCollector(() -> Collectors.joining(",", "keys=[", "]")))
+            .collect(() -> Collectors.joining(",", "keys=[", "]"))
             .getBytes(charset.getJavaCharset());
    }
 

--- a/server/rest/src/main/java/org/infinispan/rest/operations/mediatypes/impl/JSONOutputPrinter.java
+++ b/server/rest/src/main/java/org/infinispan/rest/operations/mediatypes/impl/JSONOutputPrinter.java
@@ -8,7 +8,6 @@ import org.infinispan.rest.logging.Log;
 import org.infinispan.rest.operations.exceptions.ServerInternalException;
 import org.infinispan.rest.operations.mediatypes.Charset;
 import org.infinispan.rest.operations.mediatypes.OutputPrinter;
-import org.infinispan.stream.CacheCollectors;
 import org.infinispan.util.logging.LogFactory;
 
 /**

--- a/server/rest/src/main/java/org/infinispan/rest/operations/mediatypes/impl/XMLOutputPrinter.java
+++ b/server/rest/src/main/java/org/infinispan/rest/operations/mediatypes/impl/XMLOutputPrinter.java
@@ -30,7 +30,7 @@ public class XMLOutputPrinter implements OutputPrinter {
       return keys.stream()
             .map(b -> Escaper.escapeXml(b.toString()))
             .map(s -> "<key>" + s + "</key>")
-            .collect(CacheCollectors.serializableCollector(() -> Collectors.joining("", "<?xml version=\"1.0\" encoding=\"UTF-8\"?><keys>", "</keys>")))
+            .collect(() -> Collectors.joining("", "<?xml version=\"1.0\" encoding=\"UTF-8\"?><keys>", "</keys>"))
             .getBytes(charset.getJavaCharset());
    }
 

--- a/server/rest/src/main/java/org/infinispan/rest/operations/mediatypes/impl/XMLOutputPrinter.java
+++ b/server/rest/src/main/java/org/infinispan/rest/operations/mediatypes/impl/XMLOutputPrinter.java
@@ -7,7 +7,6 @@ import org.infinispan.rest.logging.Log;
 import org.infinispan.rest.operations.exceptions.ServerInternalException;
 import org.infinispan.rest.operations.mediatypes.Charset;
 import org.infinispan.rest.operations.mediatypes.OutputPrinter;
-import org.infinispan.stream.CacheCollectors;
 import org.infinispan.util.logging.LogFactory;
 
 import com.thoughtworks.xstream.XStream;


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-8281

Follows up on #5421 to fix some of the issues found.

One thing that I still can't to work is the `Collectors::toList` thing point out by @wburns [here](https://github.com/infinispan/infinispan/pull/5421#discussion_r138057754). I get error:

```
Error:(220, 75) java: incompatible types: cannot infer type-variable(s) R1,capture#1 of ?,T
    (argument mismatch; bad return type in method reference
      java.util.stream.Collector<T,capture#1 of ?,java.util.List<T>> cannot be converted to java.util.stream.Collector<? super java.util.Map.Entry<java.lang.Integer,java.lang.String>,?,R1>)
```

Any ideas?