### PR TITLE
ISPN-7140 Concurrent modifications succeed in pessimistic cache

### DIFF
--- a/core/src/main/java/org/infinispan/interceptors/locking/AbstractLockingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/locking/AbstractLockingInterceptor.java
@@ -186,7 +186,8 @@ public abstract class AbstractLockingInterceptor extends DDAsyncInterceptor {
 
    @Override
    public Object visitPutMapCommand(InvocationContext ctx, PutMapCommand command) throws Throwable {
-      return handleWriteManyCommand(ctx, command, command.getMap().keySet(), command.isForwarded());
+      return handleWriteManyCommand(ctx, command, command.getMap().keySet(), command.isForwarded(),
+            command.getTopologyId());
    }
 
    @Override
@@ -216,37 +217,42 @@ public abstract class AbstractLockingInterceptor extends DDAsyncInterceptor {
 
    @Override
    public Object visitWriteOnlyManyEntriesCommand(InvocationContext ctx, WriteOnlyManyEntriesCommand command) throws Throwable {
-      return handleWriteManyCommand(ctx, command, command.getAffectedKeys(), command.isForwarded());
+      return handleWriteManyCommand(ctx, command, command.getAffectedKeys(), command.isForwarded(), command.getTopologyId());
    }
 
    @Override
    public Object visitWriteOnlyManyCommand(InvocationContext ctx, WriteOnlyManyCommand command) throws Throwable {
-      return handleWriteManyCommand(ctx, command, command.getAffectedKeys(), command.isForwarded());
+      return handleWriteManyCommand(ctx, command, command.getAffectedKeys(), command.isForwarded(),
+            command.getTopologyId());
    }
 
    @Override
    public Object visitReadWriteManyCommand(InvocationContext ctx, ReadWriteManyCommand command) throws Throwable {
-      return handleWriteManyCommand(ctx, command, command.getAffectedKeys(), command.isForwarded());
+      return handleWriteManyCommand(ctx, command, command.getAffectedKeys(), command.isForwarded(),
+            command.getTopologyId());
    }
 
    @Override
    public Object visitReadWriteManyEntriesCommand(InvocationContext ctx, ReadWriteManyEntriesCommand command) throws Throwable {
-      return handleWriteManyCommand(ctx, command, command.getAffectedKeys(), command.isForwarded());
+      return handleWriteManyCommand(ctx, command, command.getAffectedKeys(), command.isForwarded(),
+            command.getTopologyId());
    }
 
    @Override
    public Object visitGetAllCommand(InvocationContext ctx, GetAllCommand command) throws Throwable {
-      return handleReadManyCommand(ctx, command, command.getKeys());
+      return handleReadManyCommand(ctx, command, command.getKeys(), command.getTopologyId());
    }
 
    @Override
    public Object visitReadOnlyManyCommand(InvocationContext ctx, ReadOnlyManyCommand command) throws Throwable {
-      return handleReadManyCommand(ctx, command, command.getKeys());
+      return handleReadManyCommand(ctx, command, command.getKeys(), command.getTopologyId());
    }
 
-   protected abstract Object handleReadManyCommand(InvocationContext ctx, FlagAffectedCommand command, Collection<?> keys) throws Throwable;
+   protected abstract Object handleReadManyCommand(InvocationContext ctx, FlagAffectedCommand command,
+         Collection<?> keys, int topologyId) throws Throwable;
 
-   protected abstract <K> Object handleWriteManyCommand(InvocationContext ctx, FlagAffectedCommand command, Collection<K> keys, boolean forwarded) throws Throwable;
+   protected abstract <K> Object handleWriteManyCommand(InvocationContext ctx, FlagAffectedCommand command,
+         Collection<K> keys, boolean forwarded, int topologyId) throws Throwable;
 
    protected final long getLockTimeoutMillis(FlagAffectedCommand command) {
       return command.hasAnyFlag(FlagBitSets.ZERO_LOCK_ACQUISITION_TIMEOUT) ? 0 :

--- a/core/src/main/java/org/infinispan/interceptors/locking/AbstractTxLockingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/locking/AbstractTxLockingInterceptor.java
@@ -47,7 +47,8 @@ public abstract class AbstractTxLockingInterceptor extends AbstractLockingInterc
    }
 
    @Override
-   protected Object handleReadManyCommand(InvocationContext ctx, FlagAffectedCommand command, Collection<?> keys) throws Throwable {
+   protected Object handleReadManyCommand(InvocationContext ctx, FlagAffectedCommand command, Collection<?> keys,
+         int topologyId) throws Throwable {
       if (ctx.isInTxScope())
          return invokeNext(ctx, command);
 

--- a/core/src/main/java/org/infinispan/interceptors/locking/NonTransactionalLockingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/locking/NonTransactionalLockingInterceptor.java
@@ -39,13 +39,15 @@ public class NonTransactionalLockingInterceptor extends AbstractLockingIntercept
    }
 
    @Override
-   protected Object handleReadManyCommand(InvocationContext ctx, FlagAffectedCommand command, Collection<?> keys) {
+   protected Object handleReadManyCommand(InvocationContext ctx, FlagAffectedCommand command, Collection<?> keys,
+         int topologyId) {
       assertNonTransactional(ctx);
       return invokeNext(ctx, command);
    }
 
    @Override
-   protected <K> Object handleWriteManyCommand(InvocationContext ctx, FlagAffectedCommand command, Collection<K> keys, boolean forwarded) throws Throwable {
+   protected <K> Object handleWriteManyCommand(InvocationContext ctx, FlagAffectedCommand command, Collection<K> keys,
+         boolean forwarded, int topologyId) throws Throwable {
       assertNonTransactional(ctx);
       if (forwarded || hasSkipLocking(command)) {
          return invokeNext(ctx, command);

--- a/core/src/main/java/org/infinispan/interceptors/locking/OptimisticLockingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/locking/OptimisticLockingInterceptor.java
@@ -58,13 +58,14 @@ public class OptimisticLockingInterceptor extends AbstractTxLockingInterceptor {
    }
 
    @Override
-   protected Object handleReadManyCommand(InvocationContext ctx, FlagAffectedCommand command, Collection<?> keys) {
+   protected Object handleReadManyCommand(InvocationContext ctx, FlagAffectedCommand command, Collection<?> keys,
+         int topologyId) {
       return invokeNext(ctx, command);
    }
 
    @Override
    protected <K> Object handleWriteManyCommand(InvocationContext ctx, FlagAffectedCommand command,
-                                               Collection<K> keys, boolean forwarded) throws Throwable {
+         Collection<K> keys, boolean forwarded, int topologyId) throws Throwable {
       // TODO: can locks be acquired here with optimistic locking at all? Shouldn't we unlock only when exception is thrown?
       return invokeNextAndFinally(ctx, command, unlockAllReturnHandler);
    }

--- a/core/src/main/java/org/infinispan/interceptors/locking/PessimisticLockingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/locking/PessimisticLockingInterceptor.java
@@ -1,6 +1,7 @@
 package org.infinispan.interceptors.locking;
 
 import java.util.Collection;
+import java.util.Collections;
 
 import org.infinispan.commands.CommandsFactory;
 import org.infinispan.commands.DataCommand;
@@ -8,40 +9,62 @@ import org.infinispan.commands.FlagAffectedCommand;
 import org.infinispan.commands.control.LockControlCommand;
 import org.infinispan.commands.tx.PrepareCommand;
 import org.infinispan.commands.write.DataWriteCommand;
+import org.infinispan.context.Flag;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.FlagBitSets;
 import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.factories.annotations.Inject;
-import org.infinispan.interceptors.InvocationSuccessFunction;
-import org.infinispan.statetransfer.StateTransferManager;
-import org.infinispan.transaction.impl.LocalTransaction;
+import org.infinispan.interceptors.distribution.TxDistributionInterceptor;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
 /**
- * Locking interceptor to be used by pessimistic caches.
- * Design note: when a lock "k" needs to be acquired (e.g. cache.put("k", "v")), if the lock owner is the local node,
- * no remote call is performed to migrate locking logic to the other (numOwners - 1) lock owners. This is a good
- * optimisation for  in-vm transactions: if the local node crashes before prepare then the replicated lock information
- * would be useless as the tx is rolled back. OTOH for remote hotrod/transactions this additional RPC makes sense because
- * there's no such thing as transaction originator node, so this might become a configuration option when HotRod tx are
- * in place.
- *
- * Implementation note: current implementation acquires locks remotely first and then locally. This is required
- * by the deadlock detection logic, but might not be optimal: acquiring locks locally first might help to fail fast the
- * in the case of keys being locked.
+ * Locking interceptor to be used by pessimistic transactions.
+ * <p>
+ * Design (from 9.1):
+ * <p>
+ * This interceptor is skipped when {@link Flag#SKIP_LOCKING} is used or when all affected keys are already locked.
+ * Read-only commands can acquire the locks when {@link Flag#FORCE_WRITE_LOCK}.
+ * <p>
+ * The new design has 2 concepts. The primary lock and the backup lock. The primary lock is acquired in the primary
+ * owner and it is exclusive; only one transaction can acquire it. The backup lock is acquired by the backup owner and
+ * it is shared; multiple transactions can acquire simultaneously. The backup locks are associated with the topology id
+ * and they are only used when the primary owner leaves or crashes.
+ * <p>
+ * This algorithm contacts all owners and acquires the primary lock in the primary owner and the backup lock in the
+ * backup owners. So, lock acquisition (single or multiple keys) happens in a single RPC to all the owners of the
+ * key(s). This is triggered in {@link TxDistributionInterceptor#visitLockControlCommand(TxInvocationContext,
+ * LockControlCommand)}.
+ * <p>
+ * The {@link Flag#CACHE_MODE_LOCAL} changes this behaviour; it makes the lock acquisition only local. So, only local
+ * the primary (if primary owner) or backup lock (if backup owner) is acquired. No RPC is create and if the node isn't
+ * an owner, no locks are acquired.
+ * <p>
+ * <p>
+ * In case of primary owner changes, there are 2 cases.
+ * <p>
+ * 1) a new node joins and it is the new primary owner. In this case, the old primary owner transfers the lock
+ * information to the new primary owner.
+ * <p>
+ * 2) the primary owner crashes or leaves. In this case, a backup owner will be promoted to the primary owner. All
+ * primary lock requests are hold until its previous backup locks are released. Note that a transaction only acquires
+ * the lock once. If a transaction requests a primary lock but has the backup lock acquired, it doesn't grant the
+ * primary lock if there are other backup locks from other transactions.
+ * <p>
+ * Know Issue: There is small deadlock probably is 2 or more transaction try to acquire the lock of a key and the
+ * primary owner dies before any of them receives a reply. In that case, none of the transactions (and future
+ * transactions) are able to acquire the primary lock until all backup lock are cleared. Eventually, the transactions
+ * will rollback and the backup lock will be released. One way to solve it is to acquire the backup locks after the
+ * primary lock. However, this will increase the performance penalty for all locks by generating 2 RPCs.
  *
  * @author Mircea Markus
+ * @author Pedro Ruivo
  */
 public class PessimisticLockingInterceptor extends AbstractTxLockingInterceptor {
    private static final Log log = LogFactory.getLog(PessimisticLockingInterceptor.class);
-   public static final boolean trace = log.isTraceEnabled();
-
-   private final InvocationSuccessFunction localLockCommandWork =
-         (rCtx, rCommand, rv) -> localLockCommandWork(rCtx, (LockControlCommand) rCommand);
+   private static final boolean trace = log.isTraceEnabled();
 
    private CommandsFactory cf;
-   private StateTransferManager stateTransferManager;
 
    @Override
    protected Log getLog() {
@@ -49,78 +72,23 @@ public class PessimisticLockingInterceptor extends AbstractTxLockingInterceptor 
    }
 
    @Inject
-   public void init(CommandsFactory factory, StateTransferManager stateTransferManager) {
+   public void init(CommandsFactory factory) {
       this.cf = factory;
-      this.stateTransferManager = stateTransferManager;
    }
 
    @Override
-   protected final Object visitDataReadCommand(InvocationContext ctx, DataCommand command)
-         throws Throwable {
-      if (!readNeedsLock(ctx, command)) {
-         return invokeNext(ctx, command);
-      }
-
-      if (!readNeedsLock(ctx, command)) {
-         return invokeNext(ctx, command);
-      }
-
-      Object key = command.getKey();
-      if (!needRemoteLocks(ctx, key, command)) {
-         acquireLocalLock(ctx, command);
-         return invokeNext(ctx, command);
-      }
-
-      TxInvocationContext txContext = (TxInvocationContext) ctx;
-      LockControlCommand lcc = cf.buildLockControlCommand(key, command.getFlagsBitSet(),
-            txContext.getGlobalTransaction());
-      return invokeNextThenApply(ctx, lcc, (rCtx, rCommand, rv) -> {
-         acquireLocalLock(rCtx, command);
-         return invokeNext(rCtx, command);
-      });
-
-   }
-
-   private boolean readNeedsLock(InvocationContext ctx, FlagAffectedCommand command) {
-      return ctx.isInTxScope() && command.hasAnyFlag(FlagBitSets.FORCE_WRITE_LOCK) && !hasSkipLocking(command);
-   }
-
-   private void acquireLocalLock(InvocationContext ctx, DataCommand command) throws InterruptedException {
-      if (trace)
-         log.tracef("acquireLocalLock");
-      final TxInvocationContext txContext = (TxInvocationContext) ctx;
-      Object key = command.getKey();
-      lockOrRegisterBackupLock(txContext, key, getLockTimeoutMillis(command));
-      txContext.addAffectedKey(key);
+   protected final Object visitDataReadCommand(InvocationContext ctx, DataCommand command) throws Throwable {
+      return readNeedsLock(ctx, command) ?
+             invokeLockCommandAndContinue(Collections.singleton(command.getKey()), command, (TxInvocationContext<?>) ctx, command.getTopologyId()) :
+             invokeNext(ctx, command);
    }
 
    @Override
-   protected Object handleReadManyCommand(InvocationContext ctx, FlagAffectedCommand command, Collection<?> keys) throws Throwable {
-      Object maybeStage;
-      if (!readNeedsLock(ctx, command)) {
-         maybeStage = invokeNext(ctx, command);
-      } else {
-         if (!needRemoteLocks(ctx, keys, command)) {
-            acquireLocalLocks(ctx, command, keys);
-            maybeStage = invokeNext(ctx, command);
-         } else {
-            // Acquire the remote locks first, then the local locks
-            final TxInvocationContext txContext = (TxInvocationContext) ctx;
-            LockControlCommand lcc = cf.buildLockControlCommand(keys, command.getFlagsBitSet(),
-                  txContext.getGlobalTransaction());
-            maybeStage = invokeNextThenApply(ctx, lcc, (rCtx, rLockCommand, rv) -> {
-               acquireLocalLocks(rCtx, command, keys);
-               return invokeNext(rCtx, command);
-            });
-         }
-      }
-      return maybeStage;
-   }
-
-   private void acquireLocalLocks(InvocationContext ctx, FlagAffectedCommand command, Collection<?> keys)
-         throws InterruptedException {
-      lockAllOrRegisterBackupLock((TxInvocationContext<?>) ctx, keys, getLockTimeoutMillis(command));
-      ((TxInvocationContext<?>) ctx).addAllAffectedKeys(keys);
+   protected Object handleReadManyCommand(InvocationContext ctx, FlagAffectedCommand command, Collection<?> keys,
+         int topologyId) throws Throwable {
+      return readNeedsLock(ctx, command) ?
+             invokeLockCommandAndContinue(keys, command, (TxInvocationContext) ctx, topologyId) :
+             invokeNext(ctx, command);
    }
 
    @Override
@@ -134,151 +102,133 @@ public class PessimisticLockingInterceptor extends AbstractTxLockingInterceptor 
    }
 
    @Override
-   protected <K> Object handleWriteManyCommand(InvocationContext ctx, FlagAffectedCommand command, Collection<K> keys, boolean forwarded) throws Throwable {
-      Object maybeStage;
-      if (hasSkipLocking(command)) {
-         maybeStage = invokeNext(ctx, command);
+   protected <K> Object handleWriteManyCommand(InvocationContext ctx, FlagAffectedCommand command, Collection<K> keys,
+         boolean forwarded, int topologyId) throws Throwable {
+      final TxInvocationContext<?> txCtx = (TxInvocationContext<?>) ctx;
+      if (skipLockingForKeys(command, txCtx, keys)) {
+         txCtx.addAllAffectedKeys(keys);
+         return invokeNext(ctx, command);
+      } else if (isLocalOnly(command)) {
+         lockAllOrRegisterBackupLock(txCtx, keys, getLockTimeoutMillis(command));
+         txCtx.addAllAffectedKeys(keys);
+         return invokeNext(ctx, command);
       } else {
-         if (!needRemoteLocks(ctx, keys, command)) {
-            acquireLocalLocks(ctx, command, keys);
-            maybeStage = invokeNext(ctx, command);
-         } else {
-            final TxInvocationContext txContext = (TxInvocationContext) ctx;
-            LockControlCommand lcc = cf.buildLockControlCommand(keys, command.getFlagsBitSet(),
-                  txContext.getGlobalTransaction());
-            maybeStage = invokeNextThenApply(ctx, lcc, (rCtx, rCommand, rv) -> {
-               acquireLocalLocks(rCtx, command, keys);
-               return invokeNext(rCtx, command);
-            });
-         }
+         return invokeLockCommandAndContinue(keys, command, txCtx, topologyId);
       }
-      return maybeStage;
    }
 
    @Override
    protected Object visitDataWriteCommand(InvocationContext ctx, DataWriteCommand command)
          throws Throwable {
-      Object maybeStage;
-      Object key = command.getKey();
-      if (hasSkipLocking(command)) {
-         // Non-modifying functional write commands are executed in non-transactional context on non-originators
-         if (ctx.isInTxScope()) {
-            // Mark the key as affected even with SKIP_LOCKING
-            ((TxInvocationContext<?>) ctx).addAffectedKey(key);
-         }
-         maybeStage = invokeNext(ctx, command);
+      assert ctx.isInTxScope() : "Unable to handle non-transactional commands";
+      final Object key = command.getKey();
+      final TxInvocationContext<?> txCtx = (TxInvocationContext<?>) ctx;
+      if (skipLockingForKey(command, txCtx, key)) {
+         txCtx.addAffectedKey(key);
+         return invokeNext(ctx, command);
+      } else if (isLocalOnly(command)) {
+         lockOrRegisterBackupLock(txCtx, key, getLockTimeoutMillis(command));
+         txCtx.addAffectedKey(key);
+         return invokeNext(ctx, command);
       } else {
-         if (!needRemoteLocks(ctx, key, command)) {
-            acquireLocalLock(ctx, command);
-            maybeStage = invokeNext(ctx, command);
-         } else {
-            final TxInvocationContext txContext = (TxInvocationContext) ctx;
-            LockControlCommand lcc = cf.buildLockControlCommand(key, command.getFlagsBitSet(),
-                  txContext.getGlobalTransaction());
-            return invokeNextThenApply(ctx, lcc, (rCtx, rCommand, rv) -> {
-               acquireLocalLock(rCtx, command);
-               return invokeNext(rCtx, command);
-            });
-         }
+         return invokeLockCommandAndContinue(Collections.singleton(key), command, txCtx, command.getTopologyId());
       }
-      return maybeStage;
    }
 
    @Override
    public Object visitLockControlCommand(TxInvocationContext ctx, LockControlCommand command)
          throws Throwable {
-      if (!ctx.isInTxScope())
-         throw new IllegalStateException("Locks should only be acquired within the scope of a transaction!");
+      assert ctx.isInTxScope() : "Locks should only be acquired within the scope of a transaction!";
 
-      boolean skipLocking = hasSkipLocking(command);
-      if (skipLocking) {
+      if (command.isUnlock()) { //TODO double check unlock. it isn't used anymore!
+         assert !ctx.isOriginLocal() : "There's no advancedCache.unlock so this must have originated remotely.";
          return false;
       }
 
-      // First go through the distribution interceptor to acquire the remote lock - required by DLD.
-      // Only acquire remote lock if multiple keys or the single key primary owner is not the local node.
-      if (ctx.isOriginLocal()) {
-         final boolean isSingleKeyAndLocal =
-               !command.multipleKeys() && cdl.getCacheTopology().getDistribution(command.getSingleKey()).isPrimary();
-         boolean needBackupLocks = !isSingleKeyAndLocal || isStateTransferInProgress();
-         if (needBackupLocks && !command.hasAnyFlag(FlagBitSets.CACHE_MODE_LOCAL)) {
-            LocalTransaction localTx = (LocalTransaction) ctx.getCacheTransaction();
-            if (localTx.getAffectedKeys().containsAll(command.getKeys())) {
-               if (trace)
-                  log.tracef("Already own locks on keys: %s, skipping remote call", command.getKeys());
-               return true;
-            }
-         } else {
-            if (trace)
-               log.tracef("Single key %s and local, skipping remote call", command.getSingleKey());
-            return localLockCommandWork(ctx, command);
+      if (hasSkipLocking(command)) {
+         throw log.lockCommandWithSkipLocking();
+      }
+
+      if (hasSkipLocking(command) || areAllKeysAlreadyLocked(ctx, command.getKeys())) {
+         //lock control with skip locking?? that is weird...
+         if (trace) {
+            log.tracef("Skip locking or keys already locked. Skipping command %s", command);
          }
-      }
-
-      return invokeNextThenApply(ctx, command, localLockCommandWork);
-   }
-
-   private boolean localLockCommandWork(InvocationContext ctx, LockControlCommand command)
-         throws InterruptedException {
-      TxInvocationContext<?> txInvocationContext = (TxInvocationContext<?>) ctx;
-      if (ctx.isOriginLocal()) {
-         txInvocationContext.addAllAffectedKeys(command.getKeys());
-      }
-
-      if (command.isUnlock()) {
-         if (ctx.isOriginLocal()) throw new AssertionError(
-               "There's no advancedCache.unlock so this must have originated remotely.");
          return false;
-      }
-
-      lockAllOrRegisterBackupLock(txInvocationContext, command.getKeys(), getLockTimeoutMillis(command));
-      return true;
-   }
-
-   private boolean needRemoteLocks(InvocationContext ctx, Collection<?> keys,
-         FlagAffectedCommand command) throws Throwable {
-      boolean needBackupLocks = ctx.isOriginLocal() && (!isLockOwner(keys) || isStateTransferInProgress());
-      boolean needRemoteLock = false;
-      if (needBackupLocks && !command.hasAnyFlag(FlagBitSets.CACHE_MODE_LOCAL)) {
-         final TxInvocationContext txContext = (TxInvocationContext) ctx;
-         LocalTransaction localTransaction = (LocalTransaction) txContext.getCacheTransaction();
-         needRemoteLock = !localTransaction.getAffectedKeys().containsAll(keys);
-         if (!needRemoteLock) {
-            if (trace) log.tracef("We already have lock for keys %s, skip remote lock acquisition", keys);
-         }
-      }
-      return needRemoteLock;
-   }
-
-   private boolean needRemoteLocks(InvocationContext ctx, Object key, FlagAffectedCommand command)
-         throws Throwable {
-      boolean needBackupLocks = ctx.isOriginLocal() && (!isLockOwner(key) || isStateTransferInProgress());
-      boolean needRemoteLock = false;
-      if (needBackupLocks && !command.hasAnyFlag(FlagBitSets.CACHE_MODE_LOCAL)) {
-         final TxInvocationContext txContext = (TxInvocationContext) ctx;
-         LocalTransaction localTransaction = (LocalTransaction) txContext.getCacheTransaction();
-         needRemoteLock = !localTransaction.getAffectedKeys().contains(key);
-         if (!needRemoteLock) {
-            if (trace)
-               log.tracef("We already have lock for key %s, skip remote lock acquisition", key);
-         }
+      } else if (isLocalOnly(command)) {
+         lockOrRegisterBackupLock(ctx, command.getKeys(), getLockTimeoutMillis(command));
+         ctx.addAffectedKey(command.getKeys());
+         return invokeNext(ctx, command);
       } else {
-         if (trace)
-            log.tracef("Don't need backup locks %s", needBackupLocks);
+         return ctx.isOriginLocal() ?
+                handleLocalLockCommand(ctx, command) :
+                handleRemoteLockCommand(ctx, command);
       }
-      return needRemoteLock;
    }
 
-   private boolean isLockOwner(Collection<?> keys) {
-      for (Object key : keys) {
-         if (!isLockOwner(key)) {
-            return false;
+   private boolean readNeedsLock(InvocationContext ctx, FlagAffectedCommand command) {
+      if (ctx.isInTxScope() && ctx.isOriginLocal()) {
+         boolean forceWriteLock = command.hasAnyFlag(FlagBitSets.FORCE_WRITE_LOCK);
+         if (forceWriteLock && hasSkipLocking(command)) {
+            throw log.invalidForceWriteLockAndSkipLockingFlags();
          }
+         return forceWriteLock;
+      } else {
+         return false;
       }
-      return true;
    }
 
-   private boolean isStateTransferInProgress() {
-      return stateTransferManager != null && stateTransferManager.isStateTransferInProgress();
+   private boolean areAllKeysAlreadyLocked(TxInvocationContext<?> context, Collection<?> keys) {
+      return context.getAffectedKeys().containsAll(keys);
    }
+
+   private boolean isKeysAlreadyLocked(TxInvocationContext<?> context, Object key) {
+      return context.getAffectedKeys().contains(key);
+   }
+
+   private Object handleRemoteLockCommand(TxInvocationContext context, LockControlCommand command)
+         throws InterruptedException {
+      lockAllOrRegisterBackupLock(context, command.getKeys(), getLockTimeoutMillis(command));
+      return invokeNext(context, command);
+   }
+
+   private boolean skipLockingForKey(FlagAffectedCommand command, TxInvocationContext<?> ctx, Object key) {
+      return !ctx.isOriginLocal() ||
+             hasSkipLocking(command) ||
+             isKeysAlreadyLocked(ctx, key);
+   }
+
+   private boolean skipLockingForKeys(FlagAffectedCommand command, TxInvocationContext<?> ctx,
+         Collection<?> keys) {
+      return !ctx.isOriginLocal() ||
+             hasSkipLocking(command) ||
+             areAllKeysAlreadyLocked(ctx, keys);
+   }
+
+   private boolean isLocalOnly(FlagAffectedCommand command) {
+      return command.hasAnyFlag(FlagBitSets.CACHE_MODE_LOCAL);
+   }
+
+   private Object invokeLockCommandAndContinue(Collection<?> keys, FlagAffectedCommand command,
+         TxInvocationContext<?> ctx, int topologyId) throws InterruptedException {
+      //we need to acquire locks
+      LockControlCommand lcc = cf.buildLockControlCommand(keys, command.getFlagsBitSet(), ctx.getGlobalTransaction());
+      lcc.setTopologyId(topologyId);
+      return makeStage(handleLocalLockCommand(ctx, lcc))
+            .thenApply(ctx, command, (rCtx, rCommand, rv) -> invokeNext(rCtx, rCommand));
+   }
+
+   private Object handleLocalLockCommand(TxInvocationContext context, LockControlCommand command)
+         throws InterruptedException {
+      //TODO blocking method. change it to non-blocking? [minor, only blocks local commands]
+      lockAllOrRegisterBackupLock(context, command.getKeys(), getLockTimeoutMillis(command));
+      return invokeNextThenApply(context, command, (rCtx, rCommand, rv) -> {
+         TxInvocationContext<?> ctx = (TxInvocationContext) rCtx;
+         LockControlCommand cmd = (LockControlCommand) rCommand;
+         ctx.addAllAffectedKeys(cmd.getKeys());
+         return true;
+      });
+   }
+
+
 }

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -1650,4 +1650,10 @@ public interface Log extends BasicLogger {
 
    @Message(value = "Cannot create remote transaction %s, already completed", id = 482)
    CacheException remoteTransactionAlreadyCompleted(GlobalTransaction gtx);
+
+   @Message(value = "AdvancedCache.lock() with SKIP_LOCKING flag is not allowed.", id = 483)
+   IllegalArgumentException lockCommandWithSkipLocking();
+
+   @Message(value = "FORCE_WRITE_LOCK and SKIP_LOCKING can't be used together.", id = 484)
+   IllegalArgumentException invalidForceWriteLockAndSkipLockingFlags();
 }

--- a/core/src/test/java/org/infinispan/distribution/rehash/PessimisticStateTransferLocksTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/PessimisticStateTransferLocksTest.java
@@ -85,7 +85,7 @@ public class PessimisticStateTransferLocksTest extends MultipleCacheManagersTest
 
       startTxWithPut();
       startRebalance();
-      checkLocksBeforeCommit(false);
+      checkLocksBeforeCommit();
       waitRebalanceEnd();
       endTx();
       checkLocksAfterCommit();
@@ -101,7 +101,7 @@ public class PessimisticStateTransferLocksTest extends MultipleCacheManagersTest
 
       startTxWithLock();
       startRebalance();
-      checkLocksBeforeCommit(false);
+      checkLocksBeforeCommit();
       waitRebalanceEnd();
       endTx();
       checkLocksAfterCommit();
@@ -118,7 +118,7 @@ public class PessimisticStateTransferLocksTest extends MultipleCacheManagersTest
 
       startRebalance();
       startTxWithPut();
-      checkLocksBeforeCommit(true);
+      checkLocksBeforeCommit();
       waitRebalanceEnd();
       endTx();
       checkLocksAfterCommit();
@@ -134,7 +134,7 @@ public class PessimisticStateTransferLocksTest extends MultipleCacheManagersTest
 
       startRebalance();
       startTxWithLock();
-      checkLocksBeforeCommit(true);
+      checkLocksBeforeCommit();
       waitRebalanceEnd();
       endTx();
       checkLocksAfterCommit();
@@ -177,7 +177,7 @@ public class PessimisticStateTransferLocksTest extends MultipleCacheManagersTest
       tm(0).commit();
    }
 
-   private void checkLocksBeforeCommit(boolean backupLockOnCache1) throws Exception {
+   private void checkLocksBeforeCommit() throws Exception {
       sequencer.enter("tx:check_locks");
       assertFalse(getTransactionTable(cache(0)).getLocalTransactions().isEmpty());
       assertTrue(getTransactionTable(cache(0)).getRemoteTransactions().isEmpty());
@@ -186,7 +186,7 @@ public class PessimisticStateTransferLocksTest extends MultipleCacheManagersTest
       assertEquals(Collections.emptySet(), localTx.getBackupLockedKeys());
 
       assertTrue(getTransactionTable(cache(1)).getLocalTransactions().isEmpty());
-      assertEquals(backupLockOnCache1, !getTransactionTable(cache(1)).getRemoteTransactions().isEmpty());
+      assertFalse(getTransactionTable(cache(1)).getRemoteTransactions().isEmpty()); //backup locks always acquired
 
       assertTrue(getTransactionTable(cache(2)).getLocalTransactions().isEmpty());
       assertFalse(getTransactionTable(cache(2)).getRemoteTransactions().isEmpty());
@@ -200,12 +200,7 @@ public class PessimisticStateTransferLocksTest extends MultipleCacheManagersTest
       for (Cache<Object, Object> c : caches()) {
          final TransactionTable txTable = getTransactionTable(c);
          assertTrue(txTable.getLocalTransactions().isEmpty());
-         eventually(new Condition() {
-            @Override
-            public boolean isSatisfied() throws Exception {
-               return txTable.getRemoteTransactions().isEmpty();
-            }
-         });
+         eventually(() -> txTable.getRemoteTransactions().isEmpty());
       }
    }
 

--- a/core/src/test/java/org/infinispan/lock/singlelock/replicated/pessimistic/BasicSingleLockRepPessimisticTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/replicated/pessimistic/BasicSingleLockRepPessimisticTest.java
@@ -81,8 +81,8 @@ public class BasicSingleLockRepPessimisticTest extends AbstractNoCrashTest {
       EmbeddedTransaction dtm = (EmbeddedTransaction) tm(0).suspend();
 
       assert checkTxCount(0, 1, 0);
-      assert checkTxCount(1, 0, 0);
-      assert checkTxCount(2, 0, 0);
+      assert checkTxCount(1, 0, 1);
+      assert checkTxCount(2, 0, 1);
 
       tm(0).begin();
       try {
@@ -92,7 +92,7 @@ public class BasicSingleLockRepPessimisticTest extends AbstractNoCrashTest {
          tm(0).rollback();
       }
 
-      eventually(() -> checkTxCount(0, 1, 0) && checkTxCount(1, 0, 0) && checkTxCount(2, 0, 0));
+      eventually(() -> checkTxCount(0, 1, 0) && checkTxCount(1, 0, 1) && checkTxCount(2, 0, 1));
 
 
       tm(1).begin();
@@ -103,7 +103,7 @@ public class BasicSingleLockRepPessimisticTest extends AbstractNoCrashTest {
          tm(0).rollback();
       }
 
-      eventually(() -> checkTxCount(0, 1, 0) && checkTxCount(1, 0, 0) && checkTxCount(2, 0, 0));
+      eventually(() -> checkTxCount(0, 1, 0) && checkTxCount(1, 0, 1) && checkTxCount(2, 0, 1));
 
 
       tm(0).resume(dtm);


### PR DESCRIPTION
Change pessimistic locking. See the javadoc in PessimistLockingInterceptor.

It should fix random failures of InfinispanNodeFailureTest

https://issues.jboss.org/browse/ISPN-7140
https://issues.jboss.org/browse/ISPN-5076