### PR TITLE
Jenkins logs/artifacts improvements

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,8 +48,8 @@ pipeline {
                         testDataPublishers: [[$class: 'ClaimTestDataPublisher']],
                         healthScaleFactor: 100
 
-                sh 'find . -name \'*.log\' -exec xz {} \\;'
-                archiveArtifacts allowEmptyArchive: true, artifacts: '**/*log.xz'
+                sh 'find . \\( -name "*.log" -o -name "*.dump*" -o -name "hs_err_*" \\) -exec xz {} \\;'
+                archiveArtifacts allowEmptyArchive: true, artifacts: '**/*.xz'
             }
         }
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1546,6 +1546,9 @@
                         <build.directory>${project.build.directory}</build.directory>
 
                         <infinispan.module-suffix>${infinispan.module-suffix}</infinispan.module-suffix>
+                        <!-- Log the correct thread name after we call Thread.setName(),
+                             see https://issues.apache.org/jira/browse/LOG4J2-2052 -->
+                        <AsyncLogger.ThreadNameStrategy>UNCACHED</AsyncLogger.ThreadNameStrategy>
                     </systemPropertyVariables>
                     <trimStackTrace>false</trimStackTrace>
                     <properties>


### PR DESCRIPTION
Archive the dump/dumpstream files generated by Surefire
Log the correct thread name after we call Thread.setName()