### PR TITLE
ISPN-8322 Cache.evict(...) ignores Flag.SKIP_LISTENER_NOTIFICATION

### DIFF
--- a/core/src/main/java/org/infinispan/interceptors/impl/EntryWrappingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/EntryWrappingInterceptor.java
@@ -394,7 +394,7 @@ public class EntryWrappingInterceptor extends DDAsyncInterceptor {
 
    @Override
    public Object visitEvictCommand(InvocationContext ctx, EvictCommand command) throws Throwable {
-      command.setFlagsBitSet(EVICT_FLAGS_BITSET); //to force the wrapping
+      command.setFlagsBitSet(command.getFlagsBitSet() | EVICT_FLAGS_BITSET); //to force the wrapping
       return visitRemoveCommand(ctx, command);
    }
 

--- a/core/src/test/java/org/infinispan/eviction/impl/EvictionFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/eviction/impl/EvictionFunctionalTest.java
@@ -11,6 +11,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.StorageType;
+import org.infinispan.context.Flag;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.notifications.Listener;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntriesEvicted;
@@ -98,6 +99,17 @@ public class EvictionFunctionalTest extends SingleCacheManagerTest {
       timeService.advance(1000);
       cache.getAdvancedCache().getExpirationManager().processExpiration();
       assert 0 == cache.size() : "cache size should be zero: " + cache.size();
+   }
+
+   public void testEvictionNotificationSkipped() {
+      String key = "key";
+      String value = "value";
+
+      cache.put(key, value);
+
+      cache.getAdvancedCache().withFlags(Flag.SKIP_LISTENER_NOTIFICATION).evict(key);
+
+      assertEquals(0, evictionListener.getEvictedEvents().size());
    }
 
    @Listener


### PR DESCRIPTION
* evict now takes into account configured Flags

https://issues.jboss.org/browse/ISPN-8322