### PR TITLE
PostStart annotation, trace logs on component lifecycle, docs

### DIFF
--- a/cli/cli-interpreter/src/main/java/org/infinispan/cli/interpreter/LifecycleCallbacks.java
+++ b/cli/cli-interpreter/src/main/java/org/infinispan/cli/interpreter/LifecycleCallbacks.java
@@ -11,12 +11,12 @@ import org.infinispan.jmx.CacheManagerJmxRegistration;
 import org.infinispan.jmx.ComponentsJmxRegistration;
 import org.infinispan.jmx.JmxUtil;
 import org.infinispan.jmx.ResourceDMBean;
-import org.infinispan.lifecycle.AbstractModuleLifecycle;
+import org.infinispan.lifecycle.ModuleLifecycle;
 import org.infinispan.util.logging.LogFactory;
 import org.kohsuke.MetaInfServices;
 
 @MetaInfServices(org.infinispan.lifecycle.ModuleLifecycle.class)
-public class LifecycleCallbacks extends AbstractModuleLifecycle {
+public class LifecycleCallbacks implements ModuleLifecycle {
    private static final Log log = LogFactory.getLog(LifecycleCallbacks.class, Log.class);
 
    private ObjectName interpreterObjName;

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
@@ -1,5 +1,6 @@
 package org.infinispan.client.hotrod;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
@@ -52,7 +53,7 @@ import org.infinispan.commons.util.uberjar.UberJarDuplicatedJarsWarner;
  * @author Mircea.Markus@jboss.com
  * @since 4.1
  */
-public class RemoteCacheManager implements RemoteCacheContainer {
+public class RemoteCacheManager implements RemoteCacheContainer, Closeable {
 
    private static final Log log = LogFactory.getLog(RemoteCacheManager.class);
 
@@ -344,6 +345,11 @@ public class RemoteCacheManager implements RemoteCacheContainer {
    public RemoteCacheManagerAdmin administration() {
       OperationsFactory operationsFactory = new OperationsFactory(transportFactory, codec, asyncExecutorService, configuration);
       return new RemoteCacheManagerAdminImpl(operationsFactory);
+   }
+
+   @Override
+   public void close() throws IOException {
+      stop();
    }
 
    private static class RemoteCacheKey {

--- a/core/src/main/java/org/infinispan/factories/ComponentRegistry.java
+++ b/core/src/main/java/org/infinispan/factories/ComponentRegistry.java
@@ -231,6 +231,8 @@ public class ComponentRegistry extends AbstractComponentRegistry {
 
       super.start();
 
+      super.postStart();
+
       if (needToNotify && state == ComponentStatus.RUNNING) {
          cacheManagerNotifier.notifyCacheStarted(cacheName);
       }

--- a/core/src/main/java/org/infinispan/factories/ComponentRegistry.java
+++ b/core/src/main/java/org/infinispan/factories/ComponentRegistry.java
@@ -250,12 +250,18 @@ public class ComponentRegistry extends AbstractComponentRegistry {
       boolean needToNotify = state == ComponentStatus.RUNNING || state == ComponentStatus.INITIALIZING;
       if (needToNotify) {
          for (ModuleLifecycle l : globalComponents.moduleLifecycles) {
+            if (log.isTraceEnabled()) {
+               log.tracef("Invoking %s.cacheStopping()", l);
+            }
             l.cacheStopping(this, cacheName);
          }
       }
       super.stop();
       if (state == ComponentStatus.TERMINATED && needToNotify) {
          for (ModuleLifecycle l : globalComponents.moduleLifecycles) {
+            if (log.isTraceEnabled()) {
+               log.tracef("Invoking %s.cacheStopped()", l);
+            }
             l.cacheStopped(this, cacheName);
          }
          cacheManagerNotifier.notifyCacheStopped(cacheName);

--- a/core/src/main/java/org/infinispan/factories/GlobalComponentRegistry.java
+++ b/core/src/main/java/org/infinispan/factories/GlobalComponentRegistry.java
@@ -237,6 +237,9 @@ public class GlobalComponentRegistry extends AbstractComponentRegistry {
             needToNotify = state != ComponentStatus.RUNNING && state != ComponentStatus.INITIALIZING;
             if (needToNotify) {
                for (ModuleLifecycle l : moduleLifecycles) {
+                  if (log.isTraceEnabled()) {
+                     log.tracef("Invoking %s.cacheManagerStarting()", l);
+                  }
                   l.cacheManagerStarting(this, globalConfiguration);
                }
             }
@@ -251,6 +254,9 @@ public class GlobalComponentRegistry extends AbstractComponentRegistry {
 
          if (needToNotify && state == ComponentStatus.RUNNING) {
             for (ModuleLifecycle l : moduleLifecycles) {
+               if (log.isTraceEnabled()) {
+                  log.tracef("Invoking %s.cacheManagerStarted()", l);
+               }
                l.cacheManagerStarted(this);
             }
          }
@@ -282,6 +288,9 @@ public class GlobalComponentRegistry extends AbstractComponentRegistry {
       boolean needToNotify = state == ComponentStatus.RUNNING || state == ComponentStatus.INITIALIZING;
       if (needToNotify) {
          for (ModuleLifecycle l : moduleLifecycles) {
+            if (log.isTraceEnabled()) {
+               log.tracef("Invoking %s.cacheManagerStopping()", l);
+            }
             l.cacheManagerStopping(this);
          }
       }
@@ -290,6 +299,9 @@ public class GlobalComponentRegistry extends AbstractComponentRegistry {
 
       if (state == ComponentStatus.TERMINATED && needToNotify) {
          for (ModuleLifecycle l : moduleLifecycles) {
+            if (log.isTraceEnabled()) {
+               log.tracef("Invoking %s.cacheManagerStopped()", l);
+            }
             l.cacheManagerStopped(this);
          }
       }
@@ -298,6 +310,9 @@ public class GlobalComponentRegistry extends AbstractComponentRegistry {
    public void notifyCacheStarted(String cacheName) {
       ComponentRegistry cr = getNamedComponentRegistry(cacheName);
       for (ModuleLifecycle l : moduleLifecycles) {
+         if (log.isTraceEnabled()) {
+            log.tracef("Invoking %s.cacheStarted()", l);
+         }
          l.cacheStarted(cr, cacheName);
       }
    }

--- a/core/src/main/java/org/infinispan/factories/annotations/PostStart.java
+++ b/core/src/main/java/org/infinispan/factories/annotations/PostStart.java
@@ -1,0 +1,26 @@
+package org.infinispan.factories.annotations;
+
+import static java.lang.annotation.ElementType.METHOD;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Method level annotation that indicates a (no-param) method to be called on a component after the
+ * {@link org.infinispan.factories.ComponentRegistry} has been fully initialized
+ * <p/>
+ *
+ * @author Tristan Tarrant
+ * @since 9.2
+ */
+@Target(METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PostStart {
+   /**
+    * Optional parameter which defines the order in which this method will be called.  Defaults to 10.
+    *
+    * @return execution priority
+    */
+   int priority() default 10;
+}

--- a/core/src/main/java/org/infinispan/factories/components/ComponentMetadataPersister.java
+++ b/core/src/main/java/org/infinispan/factories/components/ComponentMetadataPersister.java
@@ -16,6 +16,7 @@ import org.infinispan.commons.util.Util;
 import org.infinispan.factories.KnownComponentNames;
 import org.infinispan.factories.annotations.DefaultFactoryFor;
 import org.infinispan.factories.annotations.Inject;
+import org.infinispan.factories.annotations.PostStart;
 import org.infinispan.factories.annotations.Start;
 import org.infinispan.factories.annotations.Stop;
 import org.infinispan.factories.annotations.SurvivesRestarts;
@@ -126,6 +127,7 @@ public class ComponentMetadataPersister {
 
       List<Method> injectMethods = ReflectionUtil.getAllMethods(clazz, Inject.class);
       List<Method> startMethods = ReflectionUtil.getAllMethods(clazz, Start.class);
+      List<Method> postStartMethods = ReflectionUtil.getAllMethods(clazz, PostStart.class);
       List<Method> stopMethods = ReflectionUtil.getAllMethods(clazz, Stop.class);
 
       ComponentMetadata metadata = null;
@@ -134,13 +136,13 @@ public class ComponentMetadataPersister {
          List<Method> managedAttributeMethods = ReflectionUtil.getAllMethods(clazz, ManagedAttribute.class);
          List<Field> managedAttributeFields = ReflectionUtil.getAnnotatedFields(clazz, ManagedAttribute.class);
          List<Method> managedOperationMethods = ReflectionUtil.getAllMethods(clazz, ManagedOperation.class);
-         metadata = new ManageableComponentMetadata(clazz, injectMethods, startMethods, stopMethods, isGlobal,
+         metadata = new ManageableComponentMetadata(clazz, injectMethods, startMethods, postStartMethods, stopMethods, isGlobal,
                                                     survivesRestarts, managedAttributeFields, managedAttributeMethods,
                                                     managedOperationMethods, mbean);
       } else if (!injectMethods.isEmpty() || !startMethods.isEmpty() || !stopMethods.isEmpty()
             || isGlobal || survivesRestarts || ReflectionUtil.isAnnotationPresent(clazz, Scope.class)) {
          // Then this still is a component!
-         metadata = new ComponentMetadata(clazz, injectMethods, startMethods, stopMethods, isGlobal, survivesRestarts);
+         metadata = new ComponentMetadata(clazz, injectMethods, startMethods, postStartMethods, stopMethods, isGlobal, survivesRestarts);
       }
 
       if (metadata != null) {

--- a/core/src/main/java/org/infinispan/factories/components/ComponentMetadataPersister.java
+++ b/core/src/main/java/org/infinispan/factories/components/ComponentMetadataPersister.java
@@ -95,8 +95,8 @@ public class ComponentMetadataPersister {
       }
       writeMetadata(repo, outputFile);
 
-      System.out.printf(" [ComponentMetadataPersister] %s components and %s factories analyzed and persisted in %s.%n%n",
-            repo.componentMetadataMap.size(), repo.factories.size(), 0);
+      System.out.printf(" [ComponentMetadataPersister] %s components and %s factories.%n%n",
+            repo.componentMetadataMap.size(), repo.factories.size());
    }
 
    private static void process(ComponentMetadataRepo repo, String path, File f) throws ClassNotFoundException {

--- a/core/src/main/java/org/infinispan/factories/components/ComponentMetadataRepo.java
+++ b/core/src/main/java/org/infinispan/factories/components/ComponentMetadataRepo.java
@@ -12,6 +12,8 @@ import org.infinispan.commons.CacheException;
 import org.infinispan.commons.util.FileLookup;
 import org.infinispan.commons.util.FileLookupFactory;
 import org.infinispan.factories.annotations.DefaultFactoryFor;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
 
 /**
  * This is a repository of component metadata, which is populated when the Infinispan core jar is loaded up.  Actual
@@ -22,6 +24,7 @@ import org.infinispan.factories.annotations.DefaultFactoryFor;
  * @see ComponentMetadata
  */
 public class ComponentMetadataRepo {
+   private static final Log log = LogFactory.getLog(ComponentMetadataRepo.class);
    final Map<String, ComponentMetadata> componentMetadataMap = new HashMap<String, ComponentMetadata>(128);
    final Map<String, String> factories = new HashMap<String, String>(16);
    private final ComponentMetadata dependencyFreeComponent = new ComponentMetadata();
@@ -41,6 +44,9 @@ public class ComponentMetadataRepo {
 
       componentMetadataMap.putAll(comp);
       factories.putAll(fact);
+      if (log.isTraceEnabled()) {
+         log.tracef("Loaded metadata from '%s': %d components, %d factories", metadataFile, comp.size(), fact.size());
+      }
    }
 
    /**

--- a/core/src/main/java/org/infinispan/factories/components/ManageableComponentMetadata.java
+++ b/core/src/main/java/org/infinispan/factories/components/ManageableComponentMetadata.java
@@ -25,8 +25,8 @@ public class ManageableComponentMetadata extends ComponentMetadata {
    private Set<JmxAttributeMetadata> attributeMetadata;
    private Set<JmxOperationMetadata> operationMetadata;
 
-   public ManageableComponentMetadata(Class<?> component, List<Method> injectMethods, List<Method> startMethods, List<Method> stopMethods, boolean global, boolean survivesRestarts, List<Field> managedAttributeFields, List<Method> managedAttributeMethods, List<Method> managedOperationMethods, MBean mbean) {
-      super(component, injectMethods, startMethods, stopMethods, global, survivesRestarts);
+   public ManageableComponentMetadata(Class<?> component, List<Method> injectMethods, List<Method> startMethods, List<Method> postStartMethods, List<Method> stopMethods, boolean global, boolean survivesRestarts, List<Field> managedAttributeFields, List<Method> managedAttributeMethods, List<Method> managedOperationMethods, MBean mbean) {
+      super(component, injectMethods, startMethods, postStartMethods, stopMethods, global, survivesRestarts);
       if ((managedAttributeFields != null && !managedAttributeFields.isEmpty()) || (managedAttributeMethods != null && !managedAttributeMethods.isEmpty())) {
          attributeMetadata =  new HashSet<JmxAttributeMetadata>((managedAttributeFields == null ? 0 : managedAttributeFields.size()) + (managedAttributeMethods == null ? 0 : managedAttributeMethods.size()));
 

--- a/core/src/main/java/org/infinispan/lifecycle/AbstractModuleLifecycle.java
+++ b/core/src/main/java/org/infinispan/lifecycle/AbstractModuleLifecycle.java
@@ -12,7 +12,9 @@ import org.infinispan.factories.GlobalComponentRegistry;
  *
  * @author Manik Surtani
  * @version 4.0
+ * @deprecated since 9.1. Just implement {@link ModuleLifecycle} instead.
  */
+@Deprecated
 public class AbstractModuleLifecycle implements ModuleLifecycle {
 
    @Override

--- a/core/src/main/java/org/infinispan/lifecycle/ModuleLifecycle.java
+++ b/core/src/main/java/org/infinispan/lifecycle/ModuleLifecycle.java
@@ -34,20 +34,20 @@ import org.infinispan.factories.GlobalComponentRegistry;
  */
 public interface ModuleLifecycle {
 
-    void cacheManagerStarting(GlobalComponentRegistry gcr, GlobalConfiguration globalConfiguration);
+    default void cacheManagerStarting(GlobalComponentRegistry gcr, GlobalConfiguration globalConfiguration) {}
 
-    void cacheManagerStarted(GlobalComponentRegistry gcr);
+    default void cacheManagerStarted(GlobalComponentRegistry gcr) {}
 
-    void cacheManagerStopping(GlobalComponentRegistry gcr);
+    default void cacheManagerStopping(GlobalComponentRegistry gcr) {}
 
-    void cacheManagerStopped(GlobalComponentRegistry gcr);
+    default void cacheManagerStopped(GlobalComponentRegistry gcr) {}
 
-    void cacheStarting(ComponentRegistry cr, Configuration configuration, String cacheName);
+    default void cacheStarting(ComponentRegistry cr, Configuration configuration, String cacheName) {}
 
-    void cacheStarted(ComponentRegistry cr, String cacheName);
+    default void cacheStarted(ComponentRegistry cr, String cacheName) {}
 
-    void cacheStopping(ComponentRegistry cr, String cacheName);
+    default void cacheStopping(ComponentRegistry cr, String cacheName) {}
 
-    void cacheStopped(ComponentRegistry cr, String cacheName);
+    default void cacheStopped(ComponentRegistry cr, String cacheName) {}
 
 }

--- a/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
@@ -1016,4 +1016,9 @@ public class DefaultCacheManager implements EmbeddedCacheManager {
                globalComponentRegistry.getComponent(ScheduledExecutorService.class, KnownComponentNames.TIMEOUT_SCHEDULE_EXECUTOR));
       }
    }
+
+   @Override
+   public void close() throws IOException {
+      stop();
+   }
 }

--- a/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
@@ -876,17 +876,20 @@ public class DefaultCacheManager implements EmbeddedCacheManager {
 
    @ManagedAttribute(description = "The total number of defined cache configurations.", displayName = "Number of caches defined", displayType = DisplayType.SUMMARY)
    public String getDefinedCacheCount() {
-      return String.valueOf(configurationManager.getDefinedCaches().size());
+      return String.valueOf(getCacheConfigurationNames().size());
    }
 
    @ManagedAttribute(description = "The total number of created caches, including the default cache.", displayName = "Number of caches created", displayType = DisplayType.SUMMARY)
    public String getCreatedCacheCount() {
-      return String.valueOf(this.caches.keySet().size());
+      InternalCacheRegistry internalCacheRegistry = globalComponentRegistry.getComponent(InternalCacheRegistry.class);
+      long created = caches.keySet().stream().filter(c -> !internalCacheRegistry.isInternalCache(c)).count();
+      return String.valueOf(created);
    }
 
    @ManagedAttribute(description = "The total number of running caches, including the default cache.", displayName = "Number of running caches", displayType = DisplayType.SUMMARY)
    public String getRunningCacheCount() {
-      long running = caches.keySet().stream().filter(this::isRunning).count();
+      InternalCacheRegistry internalCacheRegistry = globalComponentRegistry.getComponent(InternalCacheRegistry.class);
+      long running = caches.keySet().stream().filter(c -> isRunning(c) && !internalCacheRegistry.isInternalCache(c)).count();
       return String.valueOf(running);
    }
 

--- a/core/src/main/java/org/infinispan/manager/EmbeddedCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/EmbeddedCacheManager.java
@@ -1,5 +1,6 @@
 package org.infinispan.manager;
 
+import java.io.Closeable;
 import java.util.List;
 import java.util.Set;
 
@@ -43,7 +44,7 @@ import org.infinispan.stats.CacheContainerStats;
  */
 @Scope(Scopes.GLOBAL)
 @SurvivesRestarts
-public interface EmbeddedCacheManager extends CacheContainer, Listenable {
+public interface EmbeddedCacheManager extends CacheContainer, Listenable, Closeable {
 
    /**
     * Defines a named cache's configuration by using the provided configuration

--- a/core/src/main/java/org/infinispan/manager/impl/AbstractDelegatingEmbeddedCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/impl/AbstractDelegatingEmbeddedCacheManager.java
@@ -1,5 +1,6 @@
 package org.infinispan.manager.impl;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 
@@ -207,5 +208,10 @@ public class AbstractDelegatingEmbeddedCacheManager implements EmbeddedCacheMana
    @Override
    public CacheContainerStats getStats() {
       return cm.getStats();
+   }
+
+   @Override
+   public void close() throws IOException {
+      cm.close();
    }
 }

--- a/core/src/test/java/org/infinispan/api/StartCacheFromListenerTest.java
+++ b/core/src/test/java/org/infinispan/api/StartCacheFromListenerTest.java
@@ -15,7 +15,6 @@ import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.factories.GlobalComponentRegistry;
-import org.infinispan.lifecycle.AbstractModuleLifecycle;
 import org.infinispan.lifecycle.ModuleLifecycle;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.MultipleCacheManagersTest;
@@ -46,7 +45,7 @@ public class StartCacheFromListenerTest extends MultipleCacheManagersTest {
       GlobalComponentRegistry registry = (GlobalComponentRegistry) TestingUtil.extractField(cacheManager, "globalComponentRegistry");
       List<ModuleLifecycle> lifecycles = new LinkedList<ModuleLifecycle>();
       TestingUtil.replaceField(lifecycles, "moduleLifecycles", registry, GlobalComponentRegistry.class);
-      lifecycles.add(new AbstractModuleLifecycle() {
+      lifecycles.add(new ModuleLifecycle() {
          @Override
          public void cacheStarting(ComponentRegistry cr, Configuration configuration, String cacheName) {
             log.debug("StartCacheFromListenerTest.cacheStarting");
@@ -90,7 +89,7 @@ public class StartCacheFromListenerTest extends MultipleCacheManagersTest {
       GlobalComponentRegistry registry = (GlobalComponentRegistry) TestingUtil.extractField(cacheManager, "globalComponentRegistry");
       List<ModuleLifecycle> lifecycles = new LinkedList<>();
       TestingUtil.replaceField(lifecycles, "moduleLifecycles", registry, GlobalComponentRegistry.class);
-      lifecycles.add(new AbstractModuleLifecycle() {
+      lifecycles.add(new ModuleLifecycle() {
          @Override
          public void cacheStarted(ComponentRegistry cr,  String cacheName) {
             Cache cache = cacheManager.getCache("single");

--- a/core/src/test/java/org/infinispan/test/TestingUtil.java
+++ b/core/src/test/java/org/infinispan/test/TestingUtil.java
@@ -80,7 +80,6 @@ import org.infinispan.interceptors.AsyncInterceptor;
 import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.interceptors.base.CommandInterceptor;
 import org.infinispan.jmx.PerThreadMBeanServerLookup;
-import org.infinispan.lifecycle.AbstractModuleLifecycle;
 import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.lifecycle.ModuleLifecycle;
 import org.infinispan.manager.CacheContainer;
@@ -984,7 +983,7 @@ public class TestingUtil {
       extractField(gcr, "moduleLifecycles");
       TestingUtil.<Collection<ModuleLifecycle>>replaceField(gcr, "moduleLifecycles", moduleLifecycles -> {
          Collection<ModuleLifecycle> copy = new ArrayList<>(moduleLifecycles);
-         copy.add(new AbstractModuleLifecycle() {
+         copy.add(new ModuleLifecycle() {
             @Override
             public void cacheStarting(ComponentRegistry cr, Configuration configuration, String cacheName) {
                consumer.accept(cacheName, cr);

--- a/counter/src/main/java/org/infinispan/counter/impl/CounterModuleLifecycle.java
+++ b/counter/src/main/java/org/infinispan/counter/impl/CounterModuleLifecycle.java
@@ -35,7 +35,6 @@ import org.infinispan.counter.impl.strong.StrongCounterKey;
 import org.infinispan.counter.impl.weak.WeakCounterKey;
 import org.infinispan.factories.GlobalComponentRegistry;
 import org.infinispan.interceptors.impl.EntryWrappingInterceptor;
-import org.infinispan.lifecycle.AbstractModuleLifecycle;
 import org.infinispan.lifecycle.ModuleLifecycle;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.partitionhandling.PartitionHandling;
@@ -50,7 +49,7 @@ import org.kohsuke.MetaInfServices;
  * @since 9.0
  */
 @MetaInfServices(value = ModuleLifecycle.class)
-public class CounterModuleLifecycle extends AbstractModuleLifecycle {
+public class CounterModuleLifecycle implements ModuleLifecycle {
 
    public static final String COUNTER_CACHE_NAME = "___counters";
    public static final String COUNTER_CONFIGURATION_CACHE_NAME = "___counter_configuration";

--- a/documentation/src/main/asciidoc/user_guide/cache_api.adoc
+++ b/documentation/src/main/asciidoc/user_guide/cache_api.adoc
@@ -1,9 +1,9 @@
 == The Cache API
 
 === The Cache interface
-Infinispan exposes a simple, link:http://jcp.org/en/jsr/detail?id=107[JSR-107] compliant link:{javadocroot}/org/infinispan/Cache.html[Cache] interface.
+Infinispan's Caches are manipulated through the link:{javadocroot}/org/infinispan/Cache.html[Cache] interface.
 
-The Cache interface exposes simple methods for adding, retrieving and removing entries, including atomic mechanisms exposed by the JDK's ConcurrentMap interface.  Based on the cache mode used, invoking these methods will trigger a number of things to happen, potentially even including replicating an entry to a remote node or looking up an entry from a remote node, or potentially a cache store.
+A Cache exposes simple methods for adding, retrieving and removing entries, including atomic mechanisms exposed by the JDK's ConcurrentMap interface.  Based on the cache mode used, invoking these methods will trigger a number of things to happen, potentially even including replicating an entry to a remote node or looking up an entry from a remote node, or potentially a cache store.
 
 NOTE: For simple usage, using the Cache API should be no different from using the JDK Map API, and hence migrating from simple in-memory caches based on a Map to Infinispan's Cache should be trivial.
 

--- a/documentation/src/main/asciidoc/user_guide/cache_manager.adoc
+++ b/documentation/src/main/asciidoc/user_guide/cache_manager.adoc
@@ -1,8 +1,69 @@
-== The CacheManager API
-Infinispan provides the `EmbeddedCacheManager`, as mentioned in the configuration section,
-as the API for exposing various operations related to the Infinispan cache container
-and its supporting elements.  This section is to go over some of these pieces
-as well as when you may need to use them.
+== The Embedded CacheManager
+The CacheManager is Infinispan's main entry point. You use a CacheManager to
+
+* configure and obtain caches
+* manage and monitor your nodes
+* execute code across a cluster
+* more...
+
+Depending on whether you are embedding Infinispan in your application or you are using it remotely, you will be
+dealing with either an `EmbeddedCacheManager` or a `RemoteCacheManager`. While they share some methods and properties,
+be aware that there are semantic differences between them. The following chapters focus mostly on the _embedded_
+implementation. For details on the _remote_ implementation refer to <<hotrod:java-client>>.
+
+CacheManagers are heavyweight objects, and we foresee no more than one CacheManager being used per JVM
+(unless specific setups require more than one; but either way, this would be a minimal and finite
+number of instances).
+
+The simplest way to create a CacheManager is:
+
+[source,java]
+----
+
+EmbeddedCacheManager manager = new DefaultCacheManager();
+
+----
+
+which starts the most basic, local mode, non-clustered cache manager with no caches. CacheManagers have a lifecycle
+and the default constructors also call link:{javadocroot}/org/infinispan/manager/EmbeddedCacheManager.html#start--[start()].
+Overloaded versions of the constructors are available, that do not start the CacheManager, although keep in
+mind that CacheManagers need to be started before they can be used to create Cache instances.
+
+Once constructed, CacheManagers should be made available to any component that require to interact with it via some form
+of application-wide scope such as JNDI, a ServletContext or via some other mechanism such as an IoC container.
+
+When you are done with a CacheManager, you must stop it so that it can release its resources:
+
+[source,java]
+----
+
+manager.stop();
+
+----
+
+This will ensure all caches within its scope are properly stopped, thread pools are shutdown. If the CacheManager was
+clustered it will also leave the cluster gracefully.
+
+include::configuration.adoc[]
+
+=== Obtaining caches
+
+Once you have configured the CacheManager, the main thing you will want to do is to use it to control and obtain caches.
+The main way to get to a cache is to just invoke
+link:{javadocroot}/org/infinispan/manager/EmbeddedCacheManager.html#getCache--[getCache()]:
+
+[source,java]
+----
+
+Cache<String, String> myCache = manager.getCache("myCache");
+
+----
+
+The above code will create the cache `myCache` (if it doesn't already exist) and return it. One important thing to
+remember is that using this method, cache creation is only performed on the local node. This means that, in order for
+the cache to exist on all nodes, this operation must be invoked locally everywhere. In a typical application deployed
+across multiple nodes, where you obtain caches during initialization, this ensures that the caches are _symmetric_, i.e.
+they exist on every node.
 
 === Clustering Information
 The `EmbeddedCacheManager` has quite a few methods to provide information
@@ -14,24 +75,25 @@ is configured).
 When you are using a cluster it is very important to be able to find information
 about membership in the cluster including who is the owner of the cluster.
 
-.link:{javadocroot}/org/infinispan/manager/EmbeddedCacheManager.html#getMembers--[getMembers]
+.link:{javadocroot}/org/infinispan/manager/EmbeddedCacheManager.html#getMembers--[getMembers()]
 The +getMembers()+ method returns all of the nodes in the current cluster.
 
-.link:{javadocroot}/org/infinispan/manager/EmbeddedCacheManager.html#getCoordinator--[getCoordinator]
+.link:{javadocroot}/org/infinispan/manager/EmbeddedCacheManager.html#getCoordinator--[getCoordinator()]
 The +getCoordinator()+ method will tell you which one of the members is the coordinator
 of the cluster.  For most intents you shouldn't need to care who the coordinator is.
-You can use link:{javadocroot}/org/infinispan/manager/EmbeddedCacheManager.html#isCoordinator--[isCoordinator]
+You can use link:{javadocroot}/org/infinispan/manager/EmbeddedCacheManager.html#isCoordinator--[isCoordinator()]
 method directly to see if the local node is the coordinator as well.
 
 ==== Other methods
 
-.link:{javadocroot}/org/infinispan/manager/EmbeddedCacheManager.html#getTransport--[getTransport]
+.link:{javadocroot}/org/infinispan/manager/EmbeddedCacheManager.html#getTransport--[getTransport()]
 This method provides you access to the underlying Transport that is used to send
 messages to other nodes.  In most cases a user wouldn't ever need to go to
 this level, but if you want to get Transport specific information (in this
 case JGroups) you can use this mechanism.
 
-.link:{javadocroot}/org/infinispan/manager/EmbeddedCacheManager.html#getStats--[getStats]
+.link:{javadocroot}/org/infinispan/manager/EmbeddedCacheManager.html#getStats--[getStats()]
 The stats provided here are coalesced from all of the active caches in this manager.
 These stats can be useful to see if there is something wrong going on with your
-cluster overall.
+cluster overall. If you want to see cluster-wide statistics, use the
+link:{javadocroot}/org/infinispan/manager/ClusterCacheManager.html#getStats--[_cluster().getStats()_] method.

--- a/documentation/src/main/asciidoc/user_guide/configuration.adoc
+++ b/documentation/src/main/asciidoc/user_guide/configuration.adoc
@@ -1,11 +1,14 @@
-==  Configuration
+===  Configuration
 
 Infinispan offers both declarative and programmatic configuration.
 
-Declarative configuration comes in a form of XML document that adheres to a provided Infinispan configuration XML link:http://www.infinispan.org/schemas/infinispan-config-{infinispanversion}.xsd[schema].
+====  Configuring caches declaratively
 
-Every aspect of Infinispan that can be configured declaratively can also be configured programmatically
-In fact, declarative configuration, behind the scenes, invokes programmatic configuration API as the XML configuration file is being processed.
+Declarative configuration comes in a form of XML document that adheres to a provided Infinispan configuration XML
+link:http://www.infinispan.org/schemas/infinispan-config-{infinispanversion}.xsd[schema].
+
+Every aspect of Infinispan that can be configured declaratively can also be configured programmatically.
+In fact, declarative configuration, behind the scenes, invokes the programmatic configuration API as the XML configuration file is being processed.
 One can even use a combination of these approaches.
 For example, you can read static XML configuration files and at runtime programmatically tune that same configuration.
 Or you can use a certain static configuration defined in XML as a starting point or template for defining additional configurations in runtime.
@@ -28,7 +31,7 @@ allowing multiple caches to share the same settings, or overriding specific para
 NOTE: Embedded and Server configuration use different schemas, but we strive to maintain them as compatible as possible so that you
 can easily migrate between the two.
 
-===  Configuring caches declaratively
+
 One of the major goals of Infinispan is to aim for zero configuration.
 A simple XML configuration file containing nothing more than a single infinispan element is enough to get you started.
 The configuration file listed below provides sensible defaults and is perfectly valid.
@@ -84,7 +87,7 @@ The following example shows the simplest possible configuration for each of the 
 
 ----
 
-==== Cache configuration templates
+===== Cache configuration templates
 
 As mentioned above, Infinispan supports the notion of _configuration templates_. These are full or partial configuration
 declarations which can be shared among multiple caches or as the basis for more complex configurations.
@@ -142,12 +145,12 @@ configuration and `local-bounded` which uses the `extended-template` configurati
 
 WARNING: Be aware that for multi-valued elements (such as `properties`) the inheritance is additive, i.e. the child configuration will be the result of merging the properties from the parent and its own.
 
-==== Declarative configuration reference
+===== Declarative configuration reference
 
 For more details on the declarative configuration schema, refer to the link:http://docs.jboss.org/infinispan/{infinispanversion}/configdocs[configuration reference].
 If you are using XML editing tools for configuration writing you can use the provided Infinispan link:http://infinispan.org/schemas/infinispan-config-{infinispanversion}.xsd[schema] to assist you.
 
-===  Configuring caches programmatically
+====  Configuring caches programmatically
 Programmatic Infinispan configuration is centered around the CacheManager and ConfigurationBuilder API.
 Although every single aspect of Infinispan configuration could be set programmatically, the most usual approach is to create a starting point in a form of XML configuration file and then in runtime, if needed, programmatically tune a specific configuration to suit the use case best.
 
@@ -205,7 +208,7 @@ Cache<String, String> cache = manager.getCache(newCacheName);
 
 Refer to link:{javadocroot}/org/infinispan/manager/CacheManager.html[CacheManager] , link:{javadocroot}/org/infinispan/configuration/cache/ConfigurationBuilder.html[ConfigurationBuilder] , link:{javadocroot}/org/infinispan/configuration/cache/Configuration.html[Configuration] , and link:{javadocroot}/org/infinispan/configuration/global/GlobalConfiguration.html[GlobalConfiguration] javadocs for more details.
 
-==== ConfigurationBuilder Programmatic Configuration API
+===== ConfigurationBuilder Programmatic Configuration API
 While the above paragraph shows how to combine declarative and programmatic configuration, starting from an XML configuration is completely optional.
 The ConfigurationBuilder fluent interface style allows for easier to write and more readable programmatic configuration.
 This approach can be used for both the global and the cache level configuration.
@@ -319,7 +322,7 @@ Configuration config = new ConfigurationBuilder()
    .preload(false).shared(false).threadPoolSize(20).build();
 ----
 
-==== Advanced programmatic configuration
+===== Advanced programmatic configuration
 
 The fluent configuration can also be used to configure more advanced or exotic options, such as advanced externalizers:
 
@@ -350,7 +353,7 @@ Configuration config = new ConfigurationBuilder()
 
 For information on the individual configuration options, please check the link:http://docs.jboss.org/infinispan/{infinispanversion}/configdocs/[configuration guide] .
 
-===  Configuration Migration Tools
+====  Configuration Migration Tools
 The configuration format of Infinispan has changed since version 6.0 in order to align the embedded schema with the one used
 by the server. For this reason, when upgrading to Infinispan 7.x or later, you should use the configuration converter included in the
 _all_ distribution. Simply invoke it from the command-line passing the old configuration file as the first parameter and the name
@@ -376,11 +379,11 @@ bin\config-converter.bat oldconfig.xml newconfig.xml
 
 TIP: If you wish to help write conversion tools from other caching systems, please contact link:https://lists.jboss.org/mailman/listinfo/infinispan-dev[infinispan-dev].
 
-===  Clustered Configuration
+====  Clustered Configuration
 Infinispan uses link:http://www.jgroups.org[JGroups] for network communications when in clustered mode.
 Infinispan ships with _pre-configured_ JGroups stacks that make it easy for you to jump-start a clustered configuration.
 
-==== Using an external JGroups file
+===== Using an external JGroups file
 If you are configuring your cache programmatically, all you need to do is:
 
 [source,java]
@@ -413,7 +416,7 @@ and if you happen to use an XML file to configure Infinispan, just use:
 
 In both cases above, Infinispan looks for _jgroups.xml_ first in your classpath, and then for an absolute path name if not found in the classpath.
 
-==== Use one of the pre-configured JGroups files
+===== Use one of the pre-configured JGroups files
 Infinispan ships with a few different JGroups files (packaged in infinispan-core.jar) which means they will already be on your classpath by default.
 All you need to do is specify the file name, e.g., instead of `jgroups.xml` above, specify `/default-configs/default-jgroups-tcp.xml`.
 
@@ -424,7 +427,7 @@ The configurations available are:
 *  default-jgroups-ec2.xml - Uses TCP as a transport and link:http://jgroups.org/manual/index.html#_s3_ping[S3_PING] for discovery.  Suitable on link:http://aws.amazon.com/ec2/[Amazon EC2] nodes where UDP multicast isn't available.
 *  default-jgroups-kubernetes.xml - Uses TCP as a transport and link:https://github.com/jgroups-extras/jgroups-kubernetes[KUBE_PING] for discovery.  Suitable on link:http://kubernetes.io/[Kubernetes] and link:https://www.openshift.org/[OpenShift] nodes where UDP multicast is not always available.
 
-===== Tuning JGroups settings
+====== Tuning JGroups settings
 The settings above can be further tuned without editing the XML files themselves.
 Passing in certain system properties to your JVM at startup can affect the behaviour of some of these settings.  The table below shows you which settings can be configured in this way.  E.g.,
 
@@ -468,7 +471,7 @@ $ java -cp ... -Djgroups.tcp.port=1234 -Djgroups.tcp.address=10.11.12.13
 |===============
 
 
-==== Further reading
+===== Further reading
 JGroups also supports more system property overrides, details of which can be found on this page: link:http://www.jgroups.org/manual4/index.html#SystemProperties[SystemProps]
 
 In addition, the JGroups configuration files shipped with Infinispan are intended as a jumping off point to getting something up and running, and working.  More often than not though, you will want to fine-tune your JGroups stack further to extract every ounce of performance from your network equipment.  For this, your next stop should be the JGroups manual which has a link:http://jgroups.org/manual/html/protlist.html[detailed section] on configuring each of the protocols you see in a JGroups configuration file.

--- a/documentation/src/main/asciidoc/user_guide/server_protocols_hotrod.adoc
+++ b/documentation/src/main/asciidoc/user_guide/server_protocols_hotrod.adoc
@@ -8,7 +8,8 @@ tools such as <<integrations:hibernate-ogm,Hibernate OGM>>.
 
 include::server_protocols_hotrod_wire.adoc[]
 
-===  Java Hot Rod client
+
+===  Java Hot Rod client [[hotrod:java-client]]
 Hot Rod is a binary, language neutral protocol. This article explains how a Java client can interact with a server via the Hot Rod protocol. A reference implementation of the protocol written in Java can be found in all Infinispan distributions, and this article focuses on the capabilities of this java client.
 
 TIP: Looking for more clients?  Visit link:http://infinispan.org/hotrod-clients[this website] for clients written in a variety of different languages.

--- a/documentation/src/main/asciidoc/user_guide/user_guide.asciidoc
+++ b/documentation/src/main/asciidoc/user_guide/user_guide.asciidoc
@@ -10,7 +10,6 @@ The Infinispan community
 include::{defaults}[]
 
 include::introduction.adoc[]
-include::configuration.adoc[]
 include::cache_manager.adoc[]
 include::cache_api.adoc[]
 include::eviction.adoc[]

--- a/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/util/LifecycleCallbacks.java
+++ b/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/util/LifecycleCallbacks.java
@@ -6,14 +6,14 @@
  */
 package org.infinispan.hibernate.cache.util;
 
+import java.util.Map;
+
 import org.infinispan.commons.marshall.AdvancedExternalizer;
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.factories.GlobalComponentRegistry;
-import org.infinispan.lifecycle.AbstractModuleLifecycle;
+import org.infinispan.lifecycle.ModuleLifecycle;
 
-import java.util.Map;
-
-public class LifecycleCallbacks extends AbstractModuleLifecycle {
+public class LifecycleCallbacks implements ModuleLifecycle {
 
 	@Override
 	public void cacheManagerStarting(GlobalComponentRegistry gcr, GlobalConfiguration globalCfg) {

--- a/lucene/lucene-directory/src/main/java/org/infinispan/lucene/LifecycleCallbacks.java
+++ b/lucene/lucene-directory/src/main/java/org/infinispan/lucene/LifecycleCallbacks.java
@@ -6,7 +6,7 @@ import java.util.Map;
 import org.infinispan.commons.marshall.AdvancedExternalizer;
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.factories.GlobalComponentRegistry;
-import org.infinispan.lifecycle.AbstractModuleLifecycle;
+import org.infinispan.lifecycle.ModuleLifecycle;
 import org.infinispan.lucene.impl.FileListCacheValue;
 
 /**
@@ -17,7 +17,7 @@ import org.infinispan.lucene.impl.FileListCacheValue;
  * @author Sanne Grinovero
  * @since 5.0
  */
-public class LifecycleCallbacks extends AbstractModuleLifecycle {
+public class LifecycleCallbacks implements ModuleLifecycle {
 
    @Override
    public void cacheManagerStarting(GlobalComponentRegistry gcr, GlobalConfiguration globalCfg) {

--- a/multimap/src/main/java/org/infinispan/multimap/impl/MultimapModuleLifecycle.java
+++ b/multimap/src/main/java/org/infinispan/multimap/impl/MultimapModuleLifecycle.java
@@ -5,7 +5,6 @@ import java.util.Map;
 import org.infinispan.commons.marshall.AdvancedExternalizer;
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.factories.GlobalComponentRegistry;
-import org.infinispan.lifecycle.AbstractModuleLifecycle;
 import org.infinispan.lifecycle.ModuleLifecycle;
 import org.infinispan.multimap.impl.function.ContainsFunction;
 import org.infinispan.multimap.impl.function.GetFunction;
@@ -21,7 +20,7 @@ import org.kohsuke.MetaInfServices;
  * @since 9.2
  */
 @MetaInfServices(value = ModuleLifecycle.class)
-public class MultimapModuleLifecycle extends AbstractModuleLifecycle {
+public class MultimapModuleLifecycle implements ModuleLifecycle {
 
    private static void addAdvancedExternalizer(Map<Integer, AdvancedExternalizer<?>> map, AdvancedExternalizer<?> ext) {
       map.put(ext.getId(), ext);

--- a/persistence/jpa/src/main/java/org/infinispan/persistence/jpa/impl/JpaStoreLifecycleManager.java
+++ b/persistence/jpa/src/main/java/org/infinispan/persistence/jpa/impl/JpaStoreLifecycleManager.java
@@ -2,11 +2,11 @@ package org.infinispan.persistence.jpa.impl;
 
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.factories.GlobalComponentRegistry;
-import org.infinispan.lifecycle.AbstractModuleLifecycle;
+import org.infinispan.lifecycle.ModuleLifecycle;
 import org.kohsuke.MetaInfServices;
 
 @MetaInfServices(org.infinispan.lifecycle.ModuleLifecycle.class)
-public class JpaStoreLifecycleManager extends AbstractModuleLifecycle {
+public class JpaStoreLifecycleManager implements ModuleLifecycle {
    @Override
    public void cacheManagerStarting(GlobalComponentRegistry gcr, GlobalConfiguration globalConfiguration) {
       gcr.registerComponent(new EntityManagerFactoryRegistry(), EntityManagerFactoryRegistry.class);

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/LifecycleCallbacks.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/LifecycleCallbacks.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import org.infinispan.commons.marshall.AdvancedExternalizer;
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.factories.GlobalComponentRegistry;
-import org.infinispan.lifecycle.AbstractModuleLifecycle;
+import org.infinispan.lifecycle.ModuleLifecycle;
 import org.infinispan.persistence.remote.upgrade.MigrationTask;
 import org.infinispan.persistence.remote.upgrade.RemovedFilter;
 
@@ -13,7 +13,7 @@ import org.infinispan.persistence.remote.upgrade.RemovedFilter;
  * @author gustavonalle
  * @since 8.2
  */
-public class LifecycleCallbacks extends AbstractModuleLifecycle {
+public class LifecycleCallbacks implements ModuleLifecycle {
 
    @Override
    public void cacheManagerStarting(GlobalComponentRegistry gcr, GlobalConfiguration globalCfg) {

--- a/query/src/main/java/org/infinispan/query/impl/LifecycleManager.java
+++ b/query/src/main/java/org/infinispan/query/impl/LifecycleManager.java
@@ -42,7 +42,7 @@ import org.infinispan.interceptors.impl.VersionedEntryWrappingInterceptor;
 import org.infinispan.interceptors.totalorder.TotalOrderVersionedEntryWrappingInterceptor;
 import org.infinispan.jmx.JmxUtil;
 import org.infinispan.jmx.ResourceDMBean;
-import org.infinispan.lifecycle.AbstractModuleLifecycle;
+import org.infinispan.lifecycle.ModuleLifecycle;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.objectfilter.impl.ReflectionMatcher;
 import org.infinispan.objectfilter.impl.syntax.parser.ReflectionEntityNamesResolver;
@@ -93,7 +93,7 @@ import org.kohsuke.MetaInfServices;
  */
 @MetaInfServices(org.infinispan.lifecycle.ModuleLifecycle.class)
 @SuppressWarnings("unused")
-public class LifecycleManager extends AbstractModuleLifecycle {
+public class LifecycleManager implements ModuleLifecycle {
 
    private static final Log log = LogFactory.getLog(LifecycleManager.class, Log.class);
 

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/LifecycleManager.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/LifecycleManager.java
@@ -19,7 +19,7 @@ import org.infinispan.factories.components.ComponentMetadataRepo;
 import org.infinispan.factories.components.ManageableComponentMetadata;
 import org.infinispan.jmx.JmxUtil;
 import org.infinispan.jmx.ResourceDMBean;
-import org.infinispan.lifecycle.AbstractModuleLifecycle;
+import org.infinispan.lifecycle.ModuleLifecycle;
 import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.marshall.core.EncoderRegistry;
@@ -48,7 +48,7 @@ import org.kohsuke.MetaInfServices;
  */
 @MetaInfServices(org.infinispan.lifecycle.ModuleLifecycle.class)
 @SuppressWarnings("unused")
-public final class LifecycleManager extends AbstractModuleLifecycle {
+public final class LifecycleManager implements ModuleLifecycle {
 
    private static final Log log = LogFactory.getLog(LifecycleManager.class, Log.class);
 

--- a/server/core/src/main/java/org/infinispan/server/core/LifecycleCallbacks.java
+++ b/server/core/src/main/java/org/infinispan/server/core/LifecycleCallbacks.java
@@ -3,7 +3,7 @@ package org.infinispan.server.core;
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.factories.GlobalComponentRegistry;
 import org.infinispan.factories.components.ComponentMetadataRepo;
-import org.infinispan.lifecycle.AbstractModuleLifecycle;
+import org.infinispan.lifecycle.ModuleLifecycle;
 
 /**
  * Module lifecycle callbacks implementation that enables module specific
@@ -12,7 +12,7 @@ import org.infinispan.lifecycle.AbstractModuleLifecycle;
  * @author Galder Zamarreño
  * @since 5.0
  */
-public class LifecycleCallbacks extends AbstractModuleLifecycle {
+public class LifecycleCallbacks implements ModuleLifecycle {
 
    static ComponentMetadataRepo componentMetadataRepo;
 

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/LifecycleCallbacks.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/LifecycleCallbacks.java
@@ -13,7 +13,7 @@ import java.util.Map;
 import org.infinispan.commons.marshall.AdvancedExternalizer;
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.factories.GlobalComponentRegistry;
-import org.infinispan.lifecycle.AbstractModuleLifecycle;
+import org.infinispan.lifecycle.ModuleLifecycle;
 import org.infinispan.server.hotrod.ClientListenerRegistry.UnmarshallConverterExternalizer;
 import org.infinispan.server.hotrod.ClientListenerRegistry.UnmarshallFilterConverterExternalizer;
 import org.infinispan.server.hotrod.ClientListenerRegistry.UnmarshallFilterExternalizer;
@@ -27,7 +27,7 @@ import org.infinispan.server.hotrod.iteration.IterationFilter;
  * @author Galder Zamarreño
  * @since 5.0
  */
-public class LifecycleCallbacks extends AbstractModuleLifecycle {
+public class LifecycleCallbacks implements ModuleLifecycle {
 
    @Override
    public void cacheManagerStarting(GlobalComponentRegistry gcr, GlobalConfiguration globalCfg) {

--- a/server/integration/event-logger/src/main/java/org/infinispan/server/eventlogger/LifecycleCallbacks.java
+++ b/server/integration/event-logger/src/main/java/org/infinispan/server/eventlogger/LifecycleCallbacks.java
@@ -8,7 +8,6 @@ import org.infinispan.commons.marshall.AdvancedExternalizer;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.factories.GlobalComponentRegistry;
-import org.infinispan.lifecycle.AbstractModuleLifecycle;
 import org.infinispan.lifecycle.ModuleLifecycle;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.registry.InternalCacheRegistry;
@@ -24,7 +23,7 @@ import org.kohsuke.MetaInfServices;
  * @since 8.2
  */
 @MetaInfServices(ModuleLifecycle.class)
-public class LifecycleCallbacks extends AbstractModuleLifecycle {
+public class LifecycleCallbacks implements ModuleLifecycle {
 
    private EventLogger oldEventLogger;
 

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/jmx/management/JmxManagementIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/jmx/management/JmxManagementIT.java
@@ -178,14 +178,14 @@ public class JmxManagementIT {
 
     @Test
     public void testCacheManagerAttributes() throws Exception {
-        assertEquals(6, Integer.parseInt(getAttribute(provider, cacheManagerMBean, "CreatedCacheCount")));
-        assertEquals(6, Integer.parseInt(getAttribute(provider, cacheManagerMBean, "DefinedCacheCount")));
+        assertEquals(2, Integer.parseInt(getAttribute(provider, cacheManagerMBean, "CreatedCacheCount")));
+        assertEquals(4, Integer.parseInt(getAttribute(provider, cacheManagerMBean, "DefinedCacheCount")));
         assertEquals("clustered", getAttribute(provider, cacheManagerMBean, "Name"));
         assertEquals(2, Integer.parseInt(getAttribute(provider, cacheManagerMBean, "ClusterSize")));
         assertEquals("RUNNING", getAttribute(provider, cacheManagerMBean, "CacheManagerStatus"));
         assertNotEquals(0, getAttribute(provider, cacheManagerMBean, "ClusterMembers").length());
         assertNotEquals(0, getAttribute(provider, cacheManagerMBean, "NodeAddress").length());
-        assertEquals(6, Integer.parseInt(getAttribute(provider, cacheManagerMBean, "RunningCacheCount")));
+        assertEquals(2, Integer.parseInt(getAttribute(provider, cacheManagerMBean, "RunningCacheCount")));
         assertNotEquals(0, getAttribute(provider, cacheManagerMBean, "PhysicalAddresses").length());
         assertEquals(Version.getVersion(), getAttribute(provider, cacheManagerMBean, "Version"));
         String names = getAttribute(provider, cacheManagerMBean, "DefinedCacheNames");

--- a/server/memcached/src/main/java/org/infinispan/server/memcached/LifecycleCallbacks.java
+++ b/server/memcached/src/main/java/org/infinispan/server/memcached/LifecycleCallbacks.java
@@ -4,7 +4,7 @@ import static org.infinispan.server.core.ExternalizerIds.MEMCACHED_METADATA;
 
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.factories.GlobalComponentRegistry;
-import org.infinispan.lifecycle.AbstractModuleLifecycle;
+import org.infinispan.lifecycle.ModuleLifecycle;
 
 /**
  * Module lifecycle callbacks implementation that enables module specific
@@ -13,11 +13,10 @@ import org.infinispan.lifecycle.AbstractModuleLifecycle;
  * @author Galder Zamarreño
  * @since 5.0
  */
-public class LifecycleCallbacks extends AbstractModuleLifecycle {
+public class LifecycleCallbacks implements ModuleLifecycle {
    @Override
    public void cacheManagerStarting(GlobalComponentRegistry gcr, GlobalConfiguration globalConfiguration) {
       globalConfiguration.serialization().advancedExternalizers().put(MEMCACHED_METADATA,
             new MemcachedMetadataExternalizer());
    }
-
 }

--- a/server/rest/src/main/java/org/infinispan/rest/LifecycleCallbacks.java
+++ b/server/rest/src/main/java/org/infinispan/rest/LifecycleCallbacks.java
@@ -4,17 +4,17 @@ import static org.infinispan.server.core.ExternalizerIds.MIME_METADATA;
 
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.factories.GlobalComponentRegistry;
-import org.infinispan.lifecycle.AbstractModuleLifecycle;
+import org.infinispan.lifecycle.ModuleLifecycle;
 import org.infinispan.rest.operations.mime.MimeMetadata;
 
 /**
- * Module lifecycle callbacks implementation that enables module specific {@link org.infinispan.marshall.AdvancedExternalizer}
+ * Module lifecycle callbacks implementation that enables module specific {@link org.infinispan.commons.marshall.AdvancedExternalizer}
  * implementations to be registered.
  *
  * @author Galder Zamarreño
  * @since 5.3
  */
-public class LifecycleCallbacks extends AbstractModuleLifecycle {
+public class LifecycleCallbacks implements ModuleLifecycle {
 
    @Override
    public void cacheManagerStarting(GlobalComponentRegistry gcr, GlobalConfiguration globalConfiguration) {

--- a/tasks/manager/src/main/java/org/infinispan/tasks/impl/LifecycleCallbacks.java
+++ b/tasks/manager/src/main/java/org/infinispan/tasks/impl/LifecycleCallbacks.java
@@ -2,7 +2,6 @@ package org.infinispan.tasks.impl;
 
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.factories.GlobalComponentRegistry;
-import org.infinispan.lifecycle.AbstractModuleLifecycle;
 import org.infinispan.lifecycle.ModuleLifecycle;
 import org.infinispan.tasks.TaskManager;
 import org.kohsuke.MetaInfServices;
@@ -14,7 +13,7 @@ import org.kohsuke.MetaInfServices;
  * @since 8.1
  */
 @MetaInfServices(ModuleLifecycle.class)
-public class LifecycleCallbacks extends AbstractModuleLifecycle {
+public class LifecycleCallbacks implements ModuleLifecycle {
 
    @Override
    public void cacheManagerStarting(GlobalComponentRegistry gcr, GlobalConfiguration gc) {

--- a/tasks/scripting/src/main/java/org/infinispan/scripting/impl/LifecycleCallbacks.java
+++ b/tasks/scripting/src/main/java/org/infinispan/scripting/impl/LifecycleCallbacks.java
@@ -5,7 +5,6 @@ import java.util.Map;
 import org.infinispan.commons.marshall.AdvancedExternalizer;
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.factories.GlobalComponentRegistry;
-import org.infinispan.lifecycle.AbstractModuleLifecycle;
 import org.infinispan.lifecycle.ModuleLifecycle;
 import org.infinispan.scripting.ScriptingManager;
 import org.kohsuke.MetaInfServices;
@@ -17,7 +16,7 @@ import org.kohsuke.MetaInfServices;
  * @since 7.2
  */
 @MetaInfServices(ModuleLifecycle.class)
-public class LifecycleCallbacks extends AbstractModuleLifecycle {
+public class LifecycleCallbacks implements ModuleLifecycle {
 
    @Override
    public void cacheManagerStarting(GlobalComponentRegistry gcr, GlobalConfiguration gc) {

--- a/tree/src/main/java/org/infinispan/tree/impl/LifecycleCallbacks.java
+++ b/tree/src/main/java/org/infinispan/tree/impl/LifecycleCallbacks.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import org.infinispan.commons.marshall.AdvancedExternalizer;
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.factories.GlobalComponentRegistry;
-import org.infinispan.lifecycle.AbstractModuleLifecycle;
+import org.infinispan.lifecycle.ModuleLifecycle;
 import org.infinispan.tree.Fqn;
 import org.kohsuke.MetaInfServices;
 
@@ -19,7 +19,7 @@ import org.kohsuke.MetaInfServices;
  * @since 5.0
  */
 @MetaInfServices(org.infinispan.lifecycle.ModuleLifecycle.class)
-public class LifecycleCallbacks extends AbstractModuleLifecycle {
+public class LifecycleCallbacks implements ModuleLifecycle {
 
    @Override
    public void cacheManagerStarting(GlobalComponentRegistry gcr, GlobalConfiguration globalCfg) {


### PR DESCRIPTION
Sorry for the kitchen sink PR...

ISPN-8246 Add a PostStart annotation
    - Deprecate AbstractModuleLifecycle and add default methods to ModuleLifecycle
    - Invoke modulelifecycle.cacheManagerStarted outside of the GCR start lock
ISPN-8343 Add TRACE logs for component metadata loading and lifecycle invocations
ISPN-8332 Created and Running Cache stats should not count internal caches
ISPN-8352 EmbeddedCacheManager and RemoteCacheManager implement java.io.Closeable
Flesh out CacheManager docs
    - Add simple examples of initializing a CacheManager and describe shutdown
    - Make configuration a subchapter of the CacheManager chapter

https://issues.jboss.org/browse/ISPN-8246
https://issues.jboss.org/browse/ISPN-8343
https://issues.jboss.org/browse/ISPN-8332
https://issues.jboss.org/browse/ISPN-8352