### PR TITLE
Jenkinsfile: Run tests with mvn --fail-at-end

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,7 @@ pipeline {
         stage('Main tests') {
             steps {
                 configFileProvider([configFile(fileId: 'maven-settings-with-deploy-snapshot', variable: 'MAVEN_SETTINGS')]) {
-                    sh "$MAVEN_HOME/bin/mvn verify -B -V -s $MAVEN_SETTINGS -Dmaven.test.failure.ignore=true"
+                    sh "$MAVEN_HOME/bin/mvn verify -B -V -s $MAVEN_SETTINGS --fail-at-end"
                 }
                 // TODO Add StabilityTestDataPublisher after https://issues.jenkins-ci.org/browse/JENKINS-42610 is fixed
                 // Capture target/surefire-reports/*.xml, target/failsafe-reports/*.xml,


### PR DESCRIPTION
mvn -Dmaven.test.failure.ignore ignores crashes in the
forked JVMs, mvn --fail-at-at end doesn't.