### PR TITLE
ISPN-8349 More tests for off-heap query

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteOffHeapNonIndexedQueryDslConditionsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteOffHeapNonIndexedQueryDslConditionsTest.java
@@ -1,0 +1,18 @@
+package org.infinispan.client.hotrod.query;
+
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.cache.StorageType;
+import org.testng.annotations.Test;
+
+/**
+ * @author anistor@redhat.com
+ */
+@Test(groups = "functional", testName = "client.hotrod.query.RemoteOffHeapNonIndexedQueryDslConditionsTest")
+public class RemoteOffHeapNonIndexedQueryDslConditionsTest extends RemoteNonIndexedQueryDslConditionsTest {
+
+   protected ConfigurationBuilder getConfigurationBuilder() {
+      ConfigurationBuilder builder = super.getConfigurationBuilder();
+      builder.memory().storageType(StorageType.OFF_HEAP);
+      return builder;
+   }
+}

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteOffHeapQueryDslConditionsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteOffHeapQueryDslConditionsTest.java
@@ -1,0 +1,18 @@
+package org.infinispan.client.hotrod.query;
+
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.cache.StorageType;
+import org.testng.annotations.Test;
+
+/**
+ * @author anistor@redhat.com
+ */
+@Test(groups = "functional", testName = "client.hotrod.query.RemoteOffHeapQueryDslConditionsTest")
+public class RemoteOffHeapQueryDslConditionsTest extends RemoteQueryDslConditionsTest {
+
+   protected ConfigurationBuilder getConfigurationBuilder() {
+      ConfigurationBuilder builder = super.getConfigurationBuilder();
+      builder.memory().storageType(StorageType.OFF_HEAP);
+      return builder;
+   }
+}

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/query/RemoteQueryOffHeapIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/query/RemoteQueryOffHeapIT.java
@@ -2,7 +2,6 @@ package org.infinispan.server.test.query;
 
 import org.infinispan.server.test.category.Queries;
 import org.jboss.arquillian.junit.Arquillian;
-import org.junit.Ignore;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
@@ -12,7 +11,6 @@ import org.junit.runner.RunWith;
  * @author vjuranek
  * @since 9.2
  */
-@Ignore //ISPN-8349
 @Category(Queries.class)
 @RunWith(Arquillian.class)
 public class RemoteQueryOffHeapIT extends RemoteQueryIT {


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-8349

Added some more tests but no fix yet. 

* RemoteOffHeapQueryDslConditionsTest and RemoteQueryOffHeapIT are failing while RemoteOffHeapNonIndexedQueryDslConditionsTest is working