### PR TITLE
ISPN-8344 DSL queries filtering only on type are always executed with…

### DIFF
--- a/object-filter/src/main/java/org/infinispan/objectfilter/impl/syntax/BooleShannonExpansion.java
+++ b/object-filter/src/main/java/org/infinispan/objectfilter/impl/syntax/BooleShannonExpansion.java
@@ -6,9 +6,12 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * Expands a filter expression into a superset of it, using only indexed fields. The expanded expression is computed by
- * applying <a href="http://en.wikipedia.org/wiki/Boole%27s_expansion_theorem">Boole's expansion theorem</a> to all
- * non-indexed fields and then ignoring the non-indexed fields from the resulting product.
+ * Expands an input filter expression composed of indexed and unindexed fields into a superset of it
+ * (matching the set of the input filter plus some more false positives), using only indexed fields.
+ * The expanded expression is computed by applying <a href="http://en.wikipedia.org/wiki/Boole%27s_expansion_theorem">Boole's expansion theorem</a>
+ * to all non-indexed fields and then ignoring the non-indexed fields from the resulting product. The resulting product
+ * is a more complex expression but it can be executed fully indexed. In some exterme cases it can become a tautology
+ * (TRUE), indicating that the filter should be executed fully non-indexed by doing a full scan.
  *
  * @author anistor@redhat.com
  * @since 8.0
@@ -275,7 +278,11 @@ public final class BooleShannonExpansion {
 
    /**
     * Creates a less restrictive (expanded) query that matches the same objects as the input query plus potentially some
-    * more.
+    * more (false positives). This query can be executed fully indexed and the result can be filtered in a second pass
+    * to remove the false positives. This method can eventually return TRUE and in that case the expansion is useless
+    * and it is better to just run the entire query unindexed (full scan).
+    * <p>
+    * If all fields used by the input query are indexed then the expansion is identical to the input query.
     *
     * @param booleanExpr the expression to expand
     * @return the expanded query if some of the fields are non-indexed or the input query if all fields are indexed

--- a/query/src/main/java/org/infinispan/query/dsl/embedded/impl/QueryEngine.java
+++ b/query/src/main/java/org/infinispan/query/dsl/embedded/impl/QueryEngine.java
@@ -514,9 +514,7 @@ public class QueryEngine<TypeMetadata> {
          return new EmptyResultQuery(queryFactory, cache, queryString, namedParameters, startOffset, maxResults);
       }
 
-      // if cache is indexed but there is no actual 'where' filter clause and we do have sorting or projections we should still use the index, otherwise just go for a non-indexed fetch-all
-      if (!isIndexed || (normalizedWhereClause == null || normalizedWhereClause == ConstantBooleanExpr.TRUE) && parsingResult.getProjections() == null && parsingResult.getSortFields() == null) {
-         // fully non-indexed execution because the filter matches everything or there is no indexing at all
+      if (!isIndexed) {
          return new EmbeddedQuery(this, queryFactory, cache, queryString, namedParameters, parsingResult.getProjections(), startOffset, maxResults);
       }
 

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/impl/EmbeddedQueryEngineTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/impl/EmbeddedQueryEngineTest.java
@@ -1,6 +1,7 @@
 package org.infinispan.query.dsl.embedded.impl;
 
 import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
 
 import java.text.DateFormat;
 import java.text.ParseException;
@@ -16,8 +17,8 @@ import org.hibernate.search.exception.SearchException;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.Index;
 import org.infinispan.objectfilter.ParsingException;
-import org.infinispan.objectfilter.impl.syntax.parser.IckleParsingResult;
 import org.infinispan.objectfilter.impl.syntax.parser.IckleParser;
+import org.infinispan.objectfilter.impl.syntax.parser.IckleParsingResult;
 import org.infinispan.query.CacheQuery;
 import org.infinispan.query.dsl.Query;
 import org.infinispan.query.dsl.embedded.impl.model.TheEntity;
@@ -254,6 +255,7 @@ public class EmbeddedQueryEngineTest extends MultipleCacheManagersTest {
 
    public void testNoGroupingOrAggregation() {
       Query q = buildQuery("from org.infinispan.query.dsl.embedded.testdomain.hsearch.UserHS");
+      assertTrue(q instanceof EmbeddedLuceneQuery);
       List<User> list = q.list();
       assertEquals(3, list.size());
    }


### PR DESCRIPTION
…out index

https://issues.jboss.org/browse/ISPN-8344