### PR TITLE
ISPN-8090 Functional commands don't support Data conversions In Transactional Caches

### DIFF
--- a/core/src/main/java/org/infinispan/cache/impl/EncoderEntryMapper.java
+++ b/core/src/main/java/org/infinispan/cache/impl/EncoderEntryMapper.java
@@ -75,14 +75,14 @@ public class EncoderEntryMapper<K, V> implements RemovableFunction<CacheEntry<K,
 
       @Override
       public void writeObject(ObjectOutput output, EncoderEntryMapper object) throws IOException {
-         output.writeObject(object.keyDataConversion);
-         output.writeObject(object.valueDataConversion);
+         DataConversion.writeTo(output, object.keyDataConversion);
+         DataConversion.writeTo(output, object.valueDataConversion);
       }
 
       @Override
       @SuppressWarnings("unchecked")
       public EncoderEntryMapper readObject(ObjectInput input) throws IOException, ClassNotFoundException {
-         return new EncoderEntryMapper((DataConversion) input.readObject(), (DataConversion) input.readObject());
+         return new EncoderEntryMapper(DataConversion.readFrom(input), DataConversion.readFrom(input));
       }
    }
 }

--- a/core/src/main/java/org/infinispan/cache/impl/EncoderKeyMapper.java
+++ b/core/src/main/java/org/infinispan/cache/impl/EncoderKeyMapper.java
@@ -51,13 +51,13 @@ public class EncoderKeyMapper<K> implements RemovableFunction<K, K> {
 
       @Override
       public void writeObject(ObjectOutput output, EncoderKeyMapper object) throws IOException {
-         output.writeObject(object.dataConversion);
+         DataConversion.writeTo(output, object.dataConversion);
       }
 
       @Override
       @SuppressWarnings("unchecked")
       public EncoderKeyMapper readObject(ObjectInput input) throws IOException, ClassNotFoundException {
-         return new EncoderKeyMapper((DataConversion) input.readObject());
+         return new EncoderKeyMapper(DataConversion.readFrom(input));
       }
    }
 }

--- a/core/src/main/java/org/infinispan/cache/impl/EncoderValueMapper.java
+++ b/core/src/main/java/org/infinispan/cache/impl/EncoderValueMapper.java
@@ -53,13 +53,13 @@ public class EncoderValueMapper<V> implements RemovableFunction<V, V> {
 
       @Override
       public void writeObject(ObjectOutput output, EncoderValueMapper object) throws IOException {
-         output.writeObject(object.dataConversion);
+         DataConversion.writeTo(output, object.dataConversion);
       }
 
       @Override
       @SuppressWarnings("unchecked")
       public EncoderValueMapper readObject(ObjectInput input) throws IOException, ClassNotFoundException {
-         return new EncoderValueMapper((DataConversion) input.readObject());
+         return new EncoderValueMapper(DataConversion.readFrom(input));
       }
    }
 }

--- a/core/src/main/java/org/infinispan/commands/CommandsFactory.java
+++ b/core/src/main/java/org/infinispan/commands/CommandsFactory.java
@@ -516,32 +516,32 @@ public interface CommandsFactory {
 
    StreamIteratorCloseCommand buildStreamIteratorCloseCommand(Object id);
 
-   <K, V, R> ReadOnlyKeyCommand<K, V, R> buildReadOnlyKeyCommand(K key, Function<ReadEntryView<K, V>, R> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion);
+   <K, V, R> ReadOnlyKeyCommand<K, V, R> buildReadOnlyKeyCommand(Object key, Function<ReadEntryView<K, V>, R> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion);
 
-   <K, V, R> ReadOnlyManyCommand<K, V, R> buildReadOnlyManyCommand(Collection<? extends K> keys, Function<ReadEntryView<K, V>, R> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion);
+   <K, V, R> ReadOnlyManyCommand<K, V, R> buildReadOnlyManyCommand(Collection<?> keys, Function<ReadEntryView<K, V>, R> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion);
 
    <K, V> WriteOnlyKeyCommand<K, V> buildWriteOnlyKeyCommand(
-         K key, Consumer<WriteEntryView<V>> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion);
+         Object key, Consumer<WriteEntryView<V>> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion);
 
    <K, V, R> ReadWriteKeyValueCommand<K, V, R> buildReadWriteKeyValueCommand(
-         K key, V value, BiFunction<V, ReadWriteEntryView<K, V>, R> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion);
+         Object key, Object value, BiFunction<V, ReadWriteEntryView<K, V>, R> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion);
 
    <K, V, R> ReadWriteKeyCommand<K, V, R> buildReadWriteKeyCommand(
-         K key, Function<ReadWriteEntryView<K, V>, R> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion);
+         Object key, Function<ReadWriteEntryView<K, V>, R> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion);
 
    <K, V> WriteOnlyManyEntriesCommand<K, V> buildWriteOnlyManyEntriesCommand(
-         Map<? extends K, ? extends V> entries, BiConsumer<V, WriteEntryView<V>> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion);
+         Map<?, ?> entries, BiConsumer<V, WriteEntryView<V>> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion);
 
    <K, V> WriteOnlyKeyValueCommand<K, V> buildWriteOnlyKeyValueCommand(
-         K key, V value, BiConsumer<V, WriteEntryView<V>> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion);
+         Object key, Object value, BiConsumer<V, WriteEntryView<V>> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion);
 
-   <K, V> WriteOnlyManyCommand<K, V> buildWriteOnlyManyCommand(Collection<? extends K> keys, Consumer<WriteEntryView<V>> f,
+   <K, V> WriteOnlyManyCommand<K, V> buildWriteOnlyManyCommand(Collection<?> keys, Consumer<WriteEntryView<V>> f,
                                                                Params params, DataConversion keyDataConversion, DataConversion valueDataConversion);
 
-   <K, V, R> ReadWriteManyCommand<K, V, R> buildReadWriteManyCommand(Collection<? extends K> keys, Function<ReadWriteEntryView<K, V>, R> f,
+   <K, V, R> ReadWriteManyCommand<K, V, R> buildReadWriteManyCommand(Collection<?> keys, Function<ReadWriteEntryView<K, V>, R> f,
                                                                      Params params, DataConversion keyDataConversion, DataConversion valueDataConversion);
 
-   <K, V, R> ReadWriteManyEntriesCommand<K, V, R> buildReadWriteManyEntriesCommand(Map<? extends K, ? extends V> entries, BiFunction<V, ReadWriteEntryView<K, V>, R> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion);
+   <K, V, R> ReadWriteManyEntriesCommand<K, V, R> buildReadWriteManyEntriesCommand(Map<?, ?> entries, BiFunction<V, ReadWriteEntryView<K, V>, R> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion);
 
    BackupAckCommand buildBackupAckCommand(long id, int topologyId);
 

--- a/core/src/main/java/org/infinispan/commands/CommandsFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/commands/CommandsFactoryImpl.java
@@ -727,17 +727,17 @@ public class CommandsFactoryImpl implements CommandsFactory {
    }
 
    @Override
-   public <K, V, R> ReadOnlyKeyCommand<K, V, R> buildReadOnlyKeyCommand(K key, Function<ReadEntryView<K, V>, R> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion) {
+   public <K, V, R> ReadOnlyKeyCommand<K, V, R> buildReadOnlyKeyCommand(Object key, Function<ReadEntryView<K, V>, R> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion) {
       return new ReadOnlyKeyCommand<>(key, f, params, keyDataConversion, valueDataConversion, componentRegistry);
    }
 
    @Override
-   public <K, V, R> ReadOnlyManyCommand<K, V, R> buildReadOnlyManyCommand(Collection<? extends K> keys, Function<ReadEntryView<K, V>, R> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion) {
+   public <K, V, R> ReadOnlyManyCommand<K, V, R> buildReadOnlyManyCommand(Collection<?> keys, Function<ReadEntryView<K, V>, R> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion) {
       return new ReadOnlyManyCommand<>(keys, f, params, keyDataConversion, valueDataConversion, componentRegistry);
    }
 
    @Override
-   public <K, V, R> ReadWriteKeyValueCommand<K, V, R> buildReadWriteKeyValueCommand(K key, V value, BiFunction<V, ReadWriteEntryView<K, V>, R> f,
+   public <K, V, R> ReadWriteKeyValueCommand<K, V, R> buildReadWriteKeyValueCommand(Object key, Object value, BiFunction<V, ReadWriteEntryView<K, V>, R> f,
                                                                                     Params params, DataConversion keyDataConversion, DataConversion valueDataConversion) {
       return new ReadWriteKeyValueCommand(key, value, f, generateUUID(transactional), getValueMatcher(f),
             params, keyDataConversion, valueDataConversion, componentRegistry);
@@ -745,17 +745,17 @@ public class CommandsFactoryImpl implements CommandsFactory {
 
    @Override
    public <K, V, R> ReadWriteKeyCommand<K, V, R> buildReadWriteKeyCommand(
-         K key, Function<ReadWriteEntryView<K, V>, R> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion) {
+         Object key, Function<ReadWriteEntryView<K, V>, R> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion) {
       return new ReadWriteKeyCommand<>(key, f, generateUUID(transactional), getValueMatcher(f), params, keyDataConversion, valueDataConversion, componentRegistry);
    }
 
    @Override
-   public <K, V, R> ReadWriteManyCommand<K, V, R> buildReadWriteManyCommand(Collection<? extends K> keys, Function<ReadWriteEntryView<K, V>, R> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion) {
+   public <K, V, R> ReadWriteManyCommand<K, V, R> buildReadWriteManyCommand(Collection<?> keys, Function<ReadWriteEntryView<K, V>, R> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion) {
       return new ReadWriteManyCommand<>(keys, f, params, generateUUID(transactional), keyDataConversion, valueDataConversion, componentRegistry);
    }
 
    @Override
-   public <K, V, R> ReadWriteManyEntriesCommand<K, V, R> buildReadWriteManyEntriesCommand(Map<? extends K, ? extends V> entries, BiFunction<V, ReadWriteEntryView<K, V>, R> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion) {
+   public <K, V, R> ReadWriteManyEntriesCommand<K, V, R> buildReadWriteManyEntriesCommand(Map<?, ?> entries, BiFunction<V, ReadWriteEntryView<K, V>, R> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion) {
       return new ReadWriteManyEntriesCommand<>(entries, f, params, generateUUID(transactional), keyDataConversion, valueDataConversion, componentRegistry);
    }
 
@@ -766,23 +766,23 @@ public class CommandsFactoryImpl implements CommandsFactory {
 
    @Override
    public <K, V> WriteOnlyKeyCommand<K, V> buildWriteOnlyKeyCommand(
-         K key, Consumer<WriteEntryView<V>> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion) {
+         Object key, Consumer<WriteEntryView<V>> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion) {
       return new WriteOnlyKeyCommand<>(key, f, generateUUID(transactional), getValueMatcher(f), params, keyDataConversion, valueDataConversion, componentRegistry);
    }
 
    @Override
-   public <K, V> WriteOnlyKeyValueCommand<K, V> buildWriteOnlyKeyValueCommand(K key, V value, BiConsumer<V, WriteEntryView<V>> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion) {
+   public <K, V> WriteOnlyKeyValueCommand<K, V> buildWriteOnlyKeyValueCommand(Object key, Object value, BiConsumer<V, WriteEntryView<V>> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion) {
       return new WriteOnlyKeyValueCommand<>(key, value, f, generateUUID(transactional), getValueMatcher(f), params, keyDataConversion, valueDataConversion, componentRegistry);
    }
 
    @Override
-   public <K, V> WriteOnlyManyCommand<K, V> buildWriteOnlyManyCommand(Collection<? extends K> keys, Consumer<WriteEntryView<V>> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion) {
+   public <K, V> WriteOnlyManyCommand<K, V> buildWriteOnlyManyCommand(Collection<?> keys, Consumer<WriteEntryView<V>> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion) {
       return new WriteOnlyManyCommand<>(keys, f, params, generateUUID(transactional), keyDataConversion, valueDataConversion, componentRegistry);
    }
 
    @Override
    public <K, V> WriteOnlyManyEntriesCommand<K, V> buildWriteOnlyManyEntriesCommand(
-         Map<? extends K, ? extends V> entries, BiConsumer<V, WriteEntryView<V>> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion) {
+         Map<?, ?> entries, BiConsumer<V, WriteEntryView<V>> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion) {
       return new WriteOnlyManyEntriesCommand<>(entries, f, params, generateUUID(transactional), keyDataConversion, valueDataConversion, componentRegistry);
    }
 

--- a/core/src/main/java/org/infinispan/commands/functional/AbstractWriteKeyCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/AbstractWriteKeyCommand.java
@@ -18,7 +18,7 @@ public abstract class AbstractWriteKeyCommand<K, V> extends AbstractDataWriteCom
    DataConversion keyDataConversion;
    DataConversion valueDataConversion;
 
-   public AbstractWriteKeyCommand(K key, ValueMatcher valueMatcher,
+   public AbstractWriteKeyCommand(Object key, ValueMatcher valueMatcher,
                                   CommandInvocationId id, Params params,
                                   DataConversion keyDataConversion,
                                   DataConversion valueDataConversion) {

--- a/core/src/main/java/org/infinispan/commands/functional/FunctionalCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/FunctionalCommand.java
@@ -9,7 +9,7 @@ import org.infinispan.functional.impl.Params;
 public interface FunctionalCommand<K, V> {
 
    Params getParams();
-   Mutation<K, V, ?> toMutation(K key);
+   Mutation<K, V, ?> toMutation(Object key);
 
    DataConversion getKeyDataConversion();
 

--- a/core/src/main/java/org/infinispan/commands/functional/Mutation.java
+++ b/core/src/main/java/org/infinispan/commands/functional/Mutation.java
@@ -1,11 +1,13 @@
 package org.infinispan.commands.functional;
 
+import org.infinispan.commands.functional.functions.InjectableComponent;
+import org.infinispan.encoding.DataConversion;
 import org.infinispan.functional.EntryView;
 
 /**
  * Simplified version of functional command used for read-only operations after transactional modifications.
  */
-public interface Mutation<K, V, R> {
+public interface Mutation<K, V, R> extends InjectableComponent {
 
    /**
     * @return Internal identifier used for purposes of marshalling
@@ -14,8 +16,11 @@ public interface Mutation<K, V, R> {
 
    /**
     * Mutate the view
-    *
-    * @param view
-    */
+    *  @param view
+    * */
    R apply(EntryView.ReadWriteEntryView<K, V> view);
+
+   DataConversion keyDataConversion();
+
+   DataConversion valueDataConversion();
 }

--- a/core/src/main/java/org/infinispan/commands/functional/Mutations.java
+++ b/core/src/main/java/org/infinispan/commands/functional/Mutations.java
@@ -8,7 +8,12 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.configuration.global.GlobalConfiguration;
+import org.infinispan.encoding.DataConversion;
+import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.functional.EntryView;
+import org.infinispan.marshall.core.EncoderRegistry;
 
 /**
  * Helper class for marshalling, also hiding implementations of {@link Mutation} from the interface.
@@ -18,6 +23,9 @@ final class Mutations {
 
    // No need to occupy externalizer ids when we have a limited set of options
    static <K, V, R> void writeTo(ObjectOutput output, Mutation<K, V, R> mutation) throws IOException {
+      BaseMutation bm = (BaseMutation) mutation;
+      DataConversion.writeTo(output, bm.keyDataConversion);
+      DataConversion.writeTo(output, bm.valueDataConversion);
       byte type = mutation.type();
       output.writeByte(type);
       switch (type) {
@@ -25,39 +33,71 @@ final class Mutations {
             output.writeObject(((ReadWrite<K, V, ?>) mutation).f);
             break;
          case ReadWriteWithValue.TYPE:
-            output.writeObject(((ReadWriteWithValue<K, V, R>) mutation).value);
-            output.writeObject(((ReadWriteWithValue<K, V, R>) mutation).f);
+            ReadWriteWithValue<K, V, R> rwwv = (ReadWriteWithValue<K, V, R>) mutation;
+            output.writeObject(rwwv.value);
+            output.writeObject(rwwv.f);
             break;
          case Write.TYPE:
             output.writeObject(((Write<K, V>) mutation).f);
             break;
          case WriteWithValue.TYPE:
-            output.writeObject(((WriteWithValue<K, V>) mutation).value);
-            output.writeObject(((WriteWithValue<K, V>) mutation).f);
+            WriteWithValue<K, V> wwv = (WriteWithValue<K, V>) mutation;
+            output.writeObject(wwv.value);
+            output.writeObject(wwv.f);
             break;
       }
    }
 
    static <K, V> Mutation<K, V, ?> readFrom(ObjectInput input) throws IOException, ClassNotFoundException {
+      DataConversion keyDataConversion = DataConversion.readFrom(input);
+      DataConversion valueDataConversion = DataConversion.readFrom(input);
       switch (input.readByte()) {
          case ReadWrite.TYPE:
-            return new ReadWrite<>((Function<EntryView.ReadWriteEntryView<K, V>, ?>) input.readObject());
+            return new ReadWrite<>(keyDataConversion, valueDataConversion, (Function<EntryView.ReadWriteEntryView<K, V>, ?>) input.readObject());
          case ReadWriteWithValue.TYPE:
-            return new ReadWriteWithValue<>((V) input.readObject(), (BiFunction<V, EntryView.ReadWriteEntryView<K, V>, ?>) input.readObject());
+            return new ReadWriteWithValue<>(keyDataConversion, valueDataConversion, input.readObject(), (BiFunction<V, EntryView.ReadWriteEntryView<K, V>, ?>) input.readObject());
          case Write.TYPE:
-            return new Write<K, V>((Consumer<EntryView.WriteEntryView<V>>) input.readObject());
+            return new Write<>(keyDataConversion, valueDataConversion, (Consumer<EntryView.WriteEntryView<V>>) input.readObject());
          case WriteWithValue.TYPE:
-            return new WriteWithValue<K, V>((V) input.readObject(), (BiConsumer<V, EntryView.WriteEntryView<V>>) input.readObject());
+            return new WriteWithValue<>(keyDataConversion, valueDataConversion, input.readObject(), (BiConsumer<V, EntryView.WriteEntryView<V>>) input.readObject());
          default:
             throw new IllegalStateException("Unknown type of mutation, broken input?");
       }
    }
 
-   static class ReadWrite<K, V, R> implements Mutation<K, V, R> {
+   static abstract class BaseMutation<K, V, R> implements Mutation<K, V, R> {
+      protected final DataConversion keyDataConversion;
+      protected final DataConversion valueDataConversion;
+
+      BaseMutation(DataConversion keyDataConversion, DataConversion valueDataConversion) {
+         this.keyDataConversion = keyDataConversion;
+         this.valueDataConversion = valueDataConversion;
+      }
+
+      public DataConversion keyDataConversion() {
+         return keyDataConversion;
+      }
+
+      public DataConversion valueDataConversion() {
+         return valueDataConversion;
+      }
+
+      @Override
+      public void inject(ComponentRegistry registry) {
+         GlobalConfiguration globalConfiguration = registry.getGlobalComponentRegistry().getGlobalConfiguration();
+         EncoderRegistry encoderRegistry = registry.getComponent(EncoderRegistry.class);
+         Configuration configuration = registry.getComponent(Configuration.class);
+         keyDataConversion.injectDependencies(globalConfiguration, encoderRegistry, configuration);
+         valueDataConversion.injectDependencies(globalConfiguration, encoderRegistry, configuration);
+      }
+   }
+
+   static class ReadWrite<K, V, R> extends BaseMutation<K, V, R> {
       static final byte TYPE = 0;
       private final Function<EntryView.ReadWriteEntryView<K, V>, R> f;
 
-      public ReadWrite(Function<EntryView.ReadWriteEntryView<K, V>, R> f) {
+      public ReadWrite(DataConversion keyDataConversion, DataConversion valueDataConversion, Function<EntryView.ReadWriteEntryView<K, V>, R> f) {
+         super(keyDataConversion, valueDataConversion);
          this.f = f;
       }
 
@@ -72,12 +112,13 @@ final class Mutations {
       }
    }
 
-   static class ReadWriteWithValue<K, V, R> implements Mutation<K, V, R> {
+   static class ReadWriteWithValue<K, V, R> extends BaseMutation<K, V, R> {
       static final byte TYPE = 1;
-      private final V value;
+      private final Object value;
       private final BiFunction<V, EntryView.ReadWriteEntryView<K, V>, R> f;
 
-      public ReadWriteWithValue(V value, BiFunction<V, EntryView.ReadWriteEntryView<K, V>, R> f) {
+      public ReadWriteWithValue(DataConversion keyDataConversion, DataConversion valueDataConversion, Object value, BiFunction<V, EntryView.ReadWriteEntryView<K, V>, R> f) {
+         super(keyDataConversion, valueDataConversion);
          this.value = value;
          this.f = f;
       }
@@ -89,15 +130,16 @@ final class Mutations {
 
       @Override
       public R apply(EntryView.ReadWriteEntryView<K, V> view) {
-         return f.apply(value, view);
+         return f.apply((V) valueDataConversion.fromStorage(value), view);
       }
    }
 
-   static class Write<K, V> implements Mutation<K, V, Void> {
+   static class Write<K, V> extends BaseMutation<K, V, Void> {
       static final byte TYPE = 2;
       private final Consumer<EntryView.WriteEntryView<V>> f;
 
-      public Write(Consumer<EntryView.WriteEntryView<V>> f) {
+      public Write(DataConversion keyDataConversion, DataConversion valueDataConversion, Consumer<EntryView.WriteEntryView<V>> f) {
+         super(keyDataConversion, valueDataConversion);
          this.f = f;
       }
 
@@ -113,12 +155,13 @@ final class Mutations {
       }
    }
 
-   static class WriteWithValue<K, V> implements Mutation<K, V, Void> {
+   static class WriteWithValue<K, V> extends BaseMutation<K, V, Void> {
       static final byte TYPE = 3;
-      private final V value;
+      private final Object value;
       private final BiConsumer<V, EntryView.WriteEntryView<V>> f;
 
-      public WriteWithValue(V value, BiConsumer<V, EntryView.WriteEntryView<V>> f) {
+      public WriteWithValue(DataConversion keyDataConversion, DataConversion valueDataConversion, Object value, BiConsumer<V, EntryView.WriteEntryView<V>> f) {
+         super(keyDataConversion, valueDataConversion);
          this.value = value;
          this.f = f;
       }
@@ -130,7 +173,7 @@ final class Mutations {
 
       @Override
       public Void apply(EntryView.ReadWriteEntryView<K, V> view) {
-         f.accept(value, view);
+         f.accept((V) valueDataConversion.fromStorage(value), view);
          return null;
       }
    }

--- a/core/src/main/java/org/infinispan/commands/functional/ReadOnlyKeyCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/ReadOnlyKeyCommand.java
@@ -60,8 +60,8 @@ public class ReadOnlyKeyCommand<K, V, R> extends AbstractDataCommand {
       output.writeObject(key);
       output.writeObject(f);
       Params.writeObject(output, params);
-      output.writeObject(keyDataConversion);
-      output.writeObject(valueDataConversion);
+      DataConversion.writeTo(output, keyDataConversion);
+      DataConversion.writeTo(output, valueDataConversion);
    }
 
    @Override
@@ -70,8 +70,8 @@ public class ReadOnlyKeyCommand<K, V, R> extends AbstractDataCommand {
       f = (Function<ReadEntryView<K, V>, R>) input.readObject();
       params = Params.readObject(input);
       this.setFlagsBitSet(params.toFlagsBitSet());
-      keyDataConversion = (DataConversion) input.readObject();
-      valueDataConversion = (DataConversion) input.readObject();
+      keyDataConversion = DataConversion.readFrom(input);
+      valueDataConversion = DataConversion.readFrom(input);
    }
 
    // Not really invoked unless in local mode

--- a/core/src/main/java/org/infinispan/commands/functional/TxReadOnlyKeyCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/TxReadOnlyKeyCommand.java
@@ -59,11 +59,22 @@ public class TxReadOnlyKeyCommand<K, V, R> extends ReadOnlyKeyCommand<K, V, R> {
    }
 
    @Override
+   public void init(ComponentRegistry componentRegistry) {
+      super.init(componentRegistry);
+      // This may be called from parent's constructor when mutations are not initialized yet
+      if (mutations != null) {
+         for (Mutation<?, ?, ?> m : mutations) {
+            m.inject(componentRegistry);
+         }
+      }
+   }
+
+   @Override
    public Object perform(InvocationContext ctx) throws Throwable {
       if (mutations == null || mutations.isEmpty()) {
          return super.perform(ctx);
       }
-      MVCCEntry<K, V> entry = (MVCCEntry<K, V>) ctx.lookupEntry(key);
+      MVCCEntry entry = (MVCCEntry) ctx.lookupEntry(key);
       EntryView.ReadWriteEntryView<K, V> rw = EntryViews.readWrite(entry, keyDataConversion, valueDataConversion);
       Object ret = null;
       for (Mutation<K, V, ?> mutation : mutations) {

--- a/core/src/main/java/org/infinispan/commands/functional/TxReadOnlyManyCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/TxReadOnlyManyCommand.java
@@ -28,7 +28,7 @@ public class TxReadOnlyManyCommand<K, V, R> extends ReadOnlyManyCommand<K, V, R>
    public TxReadOnlyManyCommand() {
    }
 
-   public TxReadOnlyManyCommand(Collection<? extends K> keys, List<List<Mutation<K, V, ?>>> mutations,
+   public TxReadOnlyManyCommand(Collection<?> keys, List<List<Mutation<K, V, ?>>> mutations,
                                 DataConversion keyDataConversion,
                                 DataConversion valueDataConversion,
                                 ComponentRegistry componentRegistry) {
@@ -40,6 +40,18 @@ public class TxReadOnlyManyCommand<K, V, R> extends ReadOnlyManyCommand<K, V, R>
    public TxReadOnlyManyCommand(ReadOnlyManyCommand c, List<List<Mutation<K, V, ?>>> mutations) {
       super(c);
       this.mutations = mutations;
+   }
+
+   @Override
+   public void init(ComponentRegistry componentRegistry) {
+      super.init(componentRegistry);
+      if (mutations != null) {
+         for (List<Mutation<K, V, ?>> list : mutations) {
+            for (Mutation<K, V, ?> m : list) {
+               m.inject(componentRegistry);
+            }
+         }
+      }
    }
 
    @Override
@@ -102,9 +114,9 @@ public class TxReadOnlyManyCommand<K, V, R> extends ReadOnlyManyCommand<K, V, R>
       }
       ArrayList<R> retvals = new ArrayList<>(keys.size());
       Iterator<List<Mutation<K, V, ?>>> mutIt = mutations.iterator();
-      for (K k : keys) {
+      for (Object k : keys) {
          List<Mutation<K, V, ?>> mutations = mutIt.next();
-         MVCCEntry<K, V> entry = (MVCCEntry<K, V>) lookupCacheEntry(ctx, k);
+         MVCCEntry entry = (MVCCEntry) lookupCacheEntry(ctx, k);
          EntryView.ReadEntryView<K, V> ro;
          Object ret = null;
          if (mutations.isEmpty()) {

--- a/core/src/main/java/org/infinispan/commands/functional/WriteOnlyKeyCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/WriteOnlyKeyCommand.java
@@ -25,7 +25,7 @@ public final class WriteOnlyKeyCommand<K, V> extends AbstractWriteKeyCommand<K, 
 
    private Consumer<WriteEntryView<V>> f;
 
-   public WriteOnlyKeyCommand(K key,
+   public WriteOnlyKeyCommand(Object key,
                               Consumer<WriteEntryView<V>> f,
                               CommandInvocationId id,
                               ValueMatcher valueMatcher,
@@ -54,8 +54,8 @@ public final class WriteOnlyKeyCommand<K, V> extends AbstractWriteKeyCommand<K, 
       Params.writeObject(output, params);
       output.writeLong(FlagBitSets.copyWithoutRemotableFlags(getFlagsBitSet()));
       CommandInvocationId.writeTo(output, commandInvocationId);
-      output.writeObject(keyDataConversion);
-      output.writeObject(valueDataConversion);
+      DataConversion.writeTo(output, keyDataConversion);
+      DataConversion.writeTo(output, valueDataConversion);
    }
 
    @Override
@@ -66,8 +66,8 @@ public final class WriteOnlyKeyCommand<K, V> extends AbstractWriteKeyCommand<K, 
       params = Params.readObject(input);
       setFlagsBitSet(input.readLong());
       commandInvocationId = CommandInvocationId.readFrom(input);
-      keyDataConversion = (DataConversion) input.readObject();
-      valueDataConversion = (DataConversion) input.readObject();
+      keyDataConversion = DataConversion.readFrom(input);
+      valueDataConversion = DataConversion.readFrom(input);
    }
 
    @Override
@@ -87,7 +87,7 @@ public final class WriteOnlyKeyCommand<K, V> extends AbstractWriteKeyCommand<K, 
 
    @Override
    public Object perform(InvocationContext ctx) throws Throwable {
-      CacheEntry<K, V> e = ctx.lookupEntry(key);
+      CacheEntry e = ctx.lookupEntry(key);
 
       // Could be that the key is not local
       if (e == null) return null;
@@ -102,8 +102,8 @@ public final class WriteOnlyKeyCommand<K, V> extends AbstractWriteKeyCommand<K, 
    }
 
    @Override
-   public Mutation<K, V, ?> toMutation(K key) {
-      return new Mutations.Write(f);
+   public Mutation<K, V, ?> toMutation(Object key) {
+      return new Mutations.Write(keyDataConversion, valueDataConversion, f);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/compat/BiFunctionMapper.java
+++ b/core/src/main/java/org/infinispan/compat/BiFunctionMapper.java
@@ -57,15 +57,14 @@ public class BiFunctionMapper implements BiFunction {
       @Override
       public void writeObject(ObjectOutput output, BiFunctionMapper object) throws IOException {
          output.writeObject(object.biFunction);
-         output.writeObject(object.keyDataConversion);
-         output.writeObject(object.valueDataConversion);
+         DataConversion.writeTo(output, object.keyDataConversion);
+         DataConversion.writeTo(output, object.valueDataConversion);
       }
 
       @Override
       public BiFunctionMapper readObject(ObjectInput input) throws IOException, ClassNotFoundException {
          return new BiFunctionMapper((BiFunction) input.readObject(),
-               (DataConversion) input.readObject(),
-               (DataConversion) input.readObject());
+               DataConversion.readFrom(input), DataConversion.readFrom(input));
       }
    }
 }

--- a/core/src/main/java/org/infinispan/compat/FunctionMapper.java
+++ b/core/src/main/java/org/infinispan/compat/FunctionMapper.java
@@ -56,15 +56,14 @@ public class FunctionMapper implements Function {
       @Override
       public void writeObject(ObjectOutput output, FunctionMapper object) throws IOException {
          output.writeObject(object.function);
-         output.writeObject(object.keyDataConversion);
-         output.writeObject(object.valueDataConversion);
+         DataConversion.writeTo(output, object.keyDataConversion);
+         DataConversion.writeTo(output, object.valueDataConversion);
       }
 
       @Override
       public FunctionMapper readObject(ObjectInput input) throws IOException, ClassNotFoundException {
          return new FunctionMapper((Function) input.readObject(),
-               (DataConversion) input.readObject(),
-               (DataConversion) input.readObject());
+               DataConversion.readFrom(input), DataConversion.readFrom(input));
       }
    }
 }

--- a/core/src/main/java/org/infinispan/functional/impl/AbstractFunctionalMap.java
+++ b/core/src/main/java/org/infinispan/functional/impl/AbstractFunctionalMap.java
@@ -161,11 +161,11 @@ abstract class AbstractFunctionalMap<K, V> implements FunctionalMap<K, V> {
       }
    }
 
-   protected Set encodeKeys(Set<? extends K> keys) {
+   protected Set<?> encodeKeys(Set<? extends K> keys) {
       return keys.stream().map(k -> keyDataConversion.toStorage(k)).collect(Collectors.toSet());
    }
 
-   protected Map encodeEntries(Map<? extends K, ? extends V> entries) {
+   protected Map<?, ?> encodeEntries(Map<? extends K, ? extends V> entries) {
       Map encodedEntries = new HashMap<>();
       entries.entrySet().forEach(e -> {
          Object keyEncoded = keyDataConversion.toStorage(e.getKey());

--- a/core/src/main/java/org/infinispan/functional/impl/EntryViews.java
+++ b/core/src/main/java/org/infinispan/functional/impl/EntryViews.java
@@ -39,7 +39,7 @@ public final class EntryViews {
       return new EntryBackedReadOnlyView<>(entry, keyDataConversion, valueDataConversion);
    }
 
-   public static <K, V> ReadEntryView<K, V> readOnly(CacheEntry<K, V> entry) {
+   public static <K, V> ReadEntryView<K, V> readOnly(CacheEntry entry) {
       return new EntryBackedReadOnlyView<>(entry, DataConversion.DEFAULT_KEY, DataConversion.DEFAULT_VALUE);
    }
 
@@ -47,23 +47,23 @@ public final class EntryViews {
       return new ReadOnlySnapshotView<>(key, value, metadata);
    }
 
-   public static <K, V> WriteEntryView<V> writeOnly(CacheEntry<K, V> entry, DataConversion valueDataConversion) {
+   public static <K, V> WriteEntryView<V> writeOnly(CacheEntry entry, DataConversion valueDataConversion) {
       return new EntryBackedWriteOnlyView<>(entry, valueDataConversion);
    }
 
-   public static <K, V> ReadWriteEntryView<K, V> readWrite(CacheEntry<K, V> entry, DataConversion keyDataConversion, DataConversion valueDataConversion) {
+   public static <K, V> ReadWriteEntryView<K, V> readWrite(CacheEntry entry, DataConversion keyDataConversion, DataConversion valueDataConversion) {
       return new EntryBackedReadWriteView<>(entry, keyDataConversion, valueDataConversion);
    }
 
-   public static <K, V> ReadWriteEntryView<K, V> readWrite(CacheEntry<K, V> entry, V prevValue, Metadata prevMetadata, DataConversion keyDataConversion, DataConversion valueDataConversion) {
+   public static <K, V> ReadWriteEntryView<K, V> readWrite(CacheEntry entry, Object prevValue, Metadata prevMetadata, DataConversion keyDataConversion, DataConversion valueDataConversion) {
       return new EntryAndPreviousReadWriteView<>(entry, prevValue, prevMetadata, keyDataConversion, valueDataConversion);
    }
 
-   public static <K, V> ReadEntryView<K, V> noValue(K key) {
+   public static <K, V> ReadEntryView<K, V> noValue(Object key) {
       return new NoValueReadOnlyView<>(key, null);
    }
 
-   public static <K, V> ReadEntryView<K, V> noValue(K key, DataConversion keyDataConversion) {
+   public static <K, V> ReadEntryView<K, V> noValue(Object key, DataConversion keyDataConversion) {
       return new NoValueReadOnlyView<>(key, keyDataConversion);
    }
 
@@ -197,7 +197,7 @@ public final class EntryViews {
       final CacheEntry entry;
       private final DataConversion valueDataConversion;
 
-      private EntryBackedWriteOnlyView(CacheEntry<K, V> entry, DataConversion valueDataConversion) {
+      private EntryBackedWriteOnlyView(CacheEntry entry, DataConversion valueDataConversion) {
          this.entry = entry;
          this.valueDataConversion = valueDataConversion;
       }
@@ -244,7 +244,7 @@ public final class EntryViews {
       private K decodedKey;
       private V decodedValue;
 
-      private EntryBackedReadWriteView(CacheEntry<K, V> entry, DataConversion keyDataConversion, DataConversion valueDataConversion) {
+      private EntryBackedReadWriteView(CacheEntry entry, DataConversion keyDataConversion, DataConversion valueDataConversion) {
          this.entry = entry;
          this.keyDataConversion = keyDataConversion;
          this.valueDataConversion = valueDataConversion;
@@ -340,7 +340,7 @@ public final class EntryViews {
 
    private static final class EntryAndPreviousReadWriteView<K, V> implements ReadWriteEntryView<K, V> {
       final CacheEntry entry;
-      final V prevValue;
+      final Object prevValue;
       final Metadata prevMetadata;
       private final DataConversion keyDataConversion;
       private final DataConversion valueDataConversion;
@@ -348,8 +348,8 @@ public final class EntryViews {
       private V decodedPrevValue;
       private V decodedValue;
 
-      private EntryAndPreviousReadWriteView(CacheEntry<K, V> entry,
-                                            V prevValue,
+      private EntryAndPreviousReadWriteView(CacheEntry entry,
+                                            Object prevValue,
                                             Metadata prevMetadata,
                                             DataConversion keyDataConversion,
                                             DataConversion valueDataConversion) {
@@ -456,10 +456,10 @@ public final class EntryViews {
    }
 
    private static final class NoValueReadOnlyView<K, V> implements ReadEntryView<K, V> {
-      final K key;
+      final Object key;
       private final DataConversion keyDataConversion;
 
-      public NoValueReadOnlyView(K key, DataConversion keyDataConversion) {
+      public NoValueReadOnlyView(Object key, DataConversion keyDataConversion) {
          this.key = key;
          this.keyDataConversion = keyDataConversion;
       }

--- a/core/src/main/java/org/infinispan/functional/impl/ReadOnlyMapImpl.java
+++ b/core/src/main/java/org/infinispan/functional/impl/ReadOnlyMapImpl.java
@@ -46,7 +46,7 @@ public final class ReadOnlyMapImpl<K, V> extends AbstractFunctionalMap<K, V> imp
    public <R> CompletableFuture<R> eval(K key, Function<ReadEntryView<K, V>, R> f) {
       log.tracef("Invoked eval(k=%s, %s)", key, params);
       Object keyEncoded = keyDataConversion.toStorage(key);
-      ReadOnlyKeyCommand cmd = fmap.commandsFactory.buildReadOnlyKeyCommand(keyEncoded, (Function) f, params, keyDataConversion, valueDataConversion);
+      ReadOnlyKeyCommand<K, V, R> cmd = fmap.commandsFactory.buildReadOnlyKeyCommand(keyEncoded, f, params, keyDataConversion, valueDataConversion);
       InvocationContext ctx = fmap.invCtxFactory.createInvocationContext(false, 1);
       return (CompletableFuture<R>) fmap.chain.invokeAsync(ctx, cmd);
    }
@@ -54,7 +54,7 @@ public final class ReadOnlyMapImpl<K, V> extends AbstractFunctionalMap<K, V> imp
    @Override
    public <R> Traversable<R> evalMany(Set<? extends K> keys, Function<ReadEntryView<K, V>, R> f) {
       log.tracef("Invoked evalMany(m=%s, %s)", keys, params);
-      Set encodedKeys = encodeKeys(keys);
+      Set<?> encodedKeys = encodeKeys(keys);
       ReadOnlyManyCommand<K, V, R> cmd = fmap.commandsFactory.buildReadOnlyManyCommand(encodedKeys, f, params, keyDataConversion, valueDataConversion);
       InvocationContext ctx = fmap.invCtxFactory.createInvocationContext(false, keys.size());
       return Traversables.of((Stream<R>) fmap.chain.invokeAsync(ctx, cmd).join());

--- a/core/src/main/java/org/infinispan/functional/impl/ReadWriteMapImpl.java
+++ b/core/src/main/java/org/infinispan/functional/impl/ReadWriteMapImpl.java
@@ -47,7 +47,7 @@ public final class ReadWriteMapImpl<K, V> extends AbstractFunctionalMap<K, V> im
    public <R> CompletableFuture<R> eval(K key, Function<ReadWriteEntryView<K, V>, R> f) {
       log.tracef("Invoked eval(k=%s, %s)", key, params);
       Object keyEncoded = keyDataConversion.toStorage(key);
-      ReadWriteKeyCommand cmd = fmap.commandsFactory.buildReadWriteKeyCommand(keyEncoded, (Function) f, params, keyDataConversion, valueDataConversion);
+      ReadWriteKeyCommand<K, V, R> cmd = fmap.commandsFactory.buildReadWriteKeyCommand(keyEncoded, (Function) f, params, keyDataConversion, valueDataConversion);
       InvocationContext ctx = getInvocationContext(true, 1);
       if (ctx.getLockOwner() == null) {
          ctx.setLockOwner(cmd.getKeyLockOwner());
@@ -60,7 +60,7 @@ public final class ReadWriteMapImpl<K, V> extends AbstractFunctionalMap<K, V> im
       log.tracef("Invoked eval(k=%s, v=%s, %s)", key, value, params);
       Object keyEncoded = keyDataConversion.toStorage(key);
       Object valueEncoded = valueDataConversion.toStorage(value);
-      ReadWriteKeyValueCommand cmd = fmap.commandsFactory.buildReadWriteKeyValueCommand(keyEncoded, valueEncoded, (BiFunction) f, params, keyDataConversion, valueDataConversion);
+      ReadWriteKeyValueCommand<K, V, R> cmd = fmap.commandsFactory.buildReadWriteKeyValueCommand(keyEncoded, valueEncoded, (BiFunction) f, params, keyDataConversion, valueDataConversion);
       InvocationContext ctx = getInvocationContext(true, 1);
       if (ctx.getLockOwner() == null) {
          ctx.setLockOwner(cmd.getKeyLockOwner());
@@ -71,8 +71,8 @@ public final class ReadWriteMapImpl<K, V> extends AbstractFunctionalMap<K, V> im
    @Override
    public <R> Traversable<R> evalMany(Map<? extends K, ? extends V> entries, BiFunction<V, ReadWriteEntryView<K, V>, R> f) {
       log.tracef("Invoked evalMany(entries=%s, %s)", entries, params);
-      Map encodedEntries = encodeEntries(entries);
-      ReadWriteManyEntriesCommand cmd = fmap.commandsFactory.buildReadWriteManyEntriesCommand(encodedEntries, f, params, keyDataConversion, valueDataConversion);
+      Map<?, ?> encodedEntries = encodeEntries(entries);
+      ReadWriteManyEntriesCommand<K, V, R> cmd = fmap.commandsFactory.buildReadWriteManyEntriesCommand(encodedEntries, f, params, keyDataConversion, valueDataConversion);
       InvocationContext ctx = getInvocationContext(true, entries.size());
       if (ctx.getLockOwner() == null) {
          ctx.setLockOwner(cmd.getKeyLockOwner());
@@ -83,8 +83,8 @@ public final class ReadWriteMapImpl<K, V> extends AbstractFunctionalMap<K, V> im
    @Override
    public <R> Traversable<R> evalMany(Set<? extends K> keys, Function<ReadWriteEntryView<K, V>, R> f) {
       log.tracef("Invoked evalMany(keys=%s, %s)", keys, params);
-      Set encodedKeys = encodeKeys(keys);
-      ReadWriteManyCommand cmd = fmap.commandsFactory.buildReadWriteManyCommand(encodedKeys, f, params, keyDataConversion, valueDataConversion);
+      Set<?> encodedKeys = encodeKeys(keys);
+      ReadWriteManyCommand<K, V, R> cmd = fmap.commandsFactory.buildReadWriteManyCommand(encodedKeys, f, params, keyDataConversion, valueDataConversion);
       InvocationContext ctx = getInvocationContext(true, keys.size());
       if (ctx.getLockOwner() == null) {
          ctx.setLockOwner(cmd.getKeyLockOwner());
@@ -98,8 +98,8 @@ public final class ReadWriteMapImpl<K, V> extends AbstractFunctionalMap<K, V> im
       // TODO: during commmand execution the set is iterated multiple times, and can execute remote operations
       // therefore we should rather have separate command (or different semantics for keys == null)
       Set<K> keys = new HashSet<>(fmap.cache.keySet());
-      Set<K> encodedKeys = encodeKeys(keys);
-      ReadWriteManyCommand cmd = fmap.commandsFactory.buildReadWriteManyCommand(encodedKeys, f, params, keyDataConversion, valueDataConversion);
+      Set<?> encodedKeys = encodeKeys(keys);
+      ReadWriteManyCommand<K, V, R> cmd = fmap.commandsFactory.buildReadWriteManyCommand(encodedKeys, f, params, keyDataConversion, valueDataConversion);
       InvocationContext ctx = getInvocationContext(true, encodedKeys.size());
       if (ctx.getLockOwner() == null) {
          ctx.setLockOwner(cmd.getKeyLockOwner());

--- a/core/src/main/java/org/infinispan/functional/impl/WriteOnlyMapImpl.java
+++ b/core/src/main/java/org/infinispan/functional/impl/WriteOnlyMapImpl.java
@@ -45,7 +45,7 @@ public final class WriteOnlyMapImpl<K, V> extends AbstractFunctionalMap<K, V> im
    public CompletableFuture<Void> eval(K key, Consumer<WriteEntryView<V>> f) {
       log.tracef("Invoked eval(k=%s, %s)", key, params);
       Object keyEncoded = keyDataConversion.toStorage(key);
-      WriteOnlyKeyCommand cmd = fmap.commandsFactory.buildWriteOnlyKeyCommand(keyEncoded, f, params, keyDataConversion, valueDataConversion);
+      WriteOnlyKeyCommand<K, V> cmd = fmap.commandsFactory.buildWriteOnlyKeyCommand(keyEncoded, f, params, keyDataConversion, valueDataConversion);
       InvocationContext ctx = getInvocationContext(true, 1);
       if (ctx.getLockOwner() == null) {
          ctx.setLockOwner(cmd.getKeyLockOwner());
@@ -58,7 +58,7 @@ public final class WriteOnlyMapImpl<K, V> extends AbstractFunctionalMap<K, V> im
       log.tracef("Invoked eval(k=%s, v=%s, %s)", key, value, params);
       Object keyEncoded = keyDataConversion.toStorage(key);
       Object valueEncoded = valueDataConversion.toStorage(value);
-      WriteOnlyKeyValueCommand cmd = fmap.commandsFactory.buildWriteOnlyKeyValueCommand(keyEncoded, valueEncoded, (BiConsumer) f, params, keyDataConversion, valueDataConversion);
+      WriteOnlyKeyValueCommand<K, V> cmd = fmap.commandsFactory.buildWriteOnlyKeyValueCommand(keyEncoded, valueEncoded, (BiConsumer) f, params, keyDataConversion, valueDataConversion);
       InvocationContext ctx = getInvocationContext(true, 1);
       if (ctx.getLockOwner() == null) {
          ctx.setLockOwner(cmd.getKeyLockOwner());
@@ -69,8 +69,8 @@ public final class WriteOnlyMapImpl<K, V> extends AbstractFunctionalMap<K, V> im
    @Override
    public CompletableFuture<Void> evalMany(Map<? extends K, ? extends V> entries, BiConsumer<V, WriteEntryView<V>> f) {
       log.tracef("Invoked evalMany(entries=%s, %s)", entries, params);
-      Map encodedEntries = encodeEntries(entries);
-      WriteOnlyManyEntriesCommand cmd = fmap.commandsFactory.buildWriteOnlyManyEntriesCommand(encodedEntries, f, params, keyDataConversion, valueDataConversion);
+      Map<?, ?> encodedEntries = encodeEntries(entries);
+      WriteOnlyManyEntriesCommand<K, V> cmd = fmap.commandsFactory.buildWriteOnlyManyEntriesCommand(encodedEntries, f, params, keyDataConversion, valueDataConversion);
       InvocationContext ctx = getInvocationContext(true, entries.size());
       if (ctx.getLockOwner() == null) {
          ctx.setLockOwner(cmd.getKeyLockOwner());
@@ -81,8 +81,8 @@ public final class WriteOnlyMapImpl<K, V> extends AbstractFunctionalMap<K, V> im
    @Override
    public CompletableFuture<Void> evalMany(Set<? extends K> keys, Consumer<WriteEntryView<V>> f) {
       log.tracef("Invoked evalMany(keys=%s, %s)", keys, params);
-      Set encodedKeys = encodeKeys(keys);
-      WriteOnlyManyCommand cmd = fmap.commandsFactory.buildWriteOnlyManyCommand(encodedKeys, f, params, keyDataConversion, valueDataConversion);
+      Set<?> encodedKeys = encodeKeys(keys);
+      WriteOnlyManyCommand<K, V> cmd = fmap.commandsFactory.buildWriteOnlyManyCommand(encodedKeys, f, params, keyDataConversion, valueDataConversion);
       InvocationContext ctx = getInvocationContext(true, keys.size());
       if (ctx.getLockOwner() == null) {
          ctx.setLockOwner(cmd.getKeyLockOwner());
@@ -96,8 +96,8 @@ public final class WriteOnlyMapImpl<K, V> extends AbstractFunctionalMap<K, V> im
       // TODO: during commmand execution the set is iterated multiple times, and can execute remote operations
       // therefore we should rather have separate command (or different semantics for keys == null)
       Set<K> keys = new HashSet<>(fmap.cache.keySet());
-      Set<K> encodedKeys = encodeKeys(keys);
-      WriteOnlyManyCommand cmd = fmap.commandsFactory.buildWriteOnlyManyCommand(encodedKeys, f, params, keyDataConversion, valueDataConversion);
+      Set<?> encodedKeys = encodeKeys(keys);
+      WriteOnlyManyCommand<K, V> cmd = fmap.commandsFactory.buildWriteOnlyManyCommand(encodedKeys, f, params, keyDataConversion, valueDataConversion);
       InvocationContext ctx = getInvocationContext(true, encodedKeys.size());
       if (ctx.getLockOwner() == null) {
          ctx.setLockOwner(cmd.getKeyLockOwner());

--- a/core/src/main/java/org/infinispan/interceptors/distribution/TxDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/TxDistributionInterceptor.java
@@ -561,9 +561,9 @@ public class TxDistributionInterceptor extends BaseDistributionInterceptor {
       return cf.thenRun(() -> {
          entryFactory.wrapEntryForWriting(ctx, key, false, true);
          MVCCEntry cacheEntry = (MVCCEntry) ctx.lookupEntry(key);
-         // TODO: ISPN-8090 support full cache encoding in tx cache
-         EntryView.ReadWriteEntryView readWriteEntryView = EntryViews.readWrite(cacheEntry, DataConversion.DEFAULT_KEY, DataConversion.DEFAULT_VALUE);
          for (Mutation mutation : mutationsOnKey) {
+            EntryView.ReadWriteEntryView readWriteEntryView =
+                  EntryViews.readWrite(cacheEntry, mutation.keyDataConversion(), mutation.valueDataConversion());
             mutation.apply(readWriteEntryView);
             cacheEntry.updatePreviousValue();
          }

--- a/core/src/main/java/org/infinispan/marshall/core/EncoderRegistry.java
+++ b/core/src/main/java/org/infinispan/marshall/core/EncoderRegistry.java
@@ -14,6 +14,8 @@ public interface EncoderRegistry {
 
    Encoder getEncoder(Class<? extends Encoder> encoderClass, Short encoderId);
 
+   boolean isRegistered(Class<? extends Encoder> encoderClass);
+
    Wrapper getWrapper(Class<? extends Wrapper> wrapperClass, Byte wrapperId);
 
    /**

--- a/core/src/main/java/org/infinispan/marshall/core/EncoderRegistryImpl.java
+++ b/core/src/main/java/org/infinispan/marshall/core/EncoderRegistryImpl.java
@@ -98,6 +98,11 @@ public class EncoderRegistryImpl implements EncoderRegistry {
    }
 
    @Override
+   public boolean isRegistered(Class<? extends Encoder> encoderClass) {
+      return encoderMap.containsKey(encoderClass);
+   }
+
+   @Override
    public Wrapper getWrapper(Class<? extends Wrapper> clazz, Byte wrapperId) {
       if (clazz == null && wrapperId == null) {
          throw new NullPointerException("Wrapper class or identifier must be provided!");

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/cluster/ClusterListenerReplicateCallable.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/cluster/ClusterListenerReplicateCallable.java
@@ -162,8 +162,8 @@ public class ClusterListenerReplicateCallable<K, V> implements DistributedCallab
          }
          output.writeBoolean(object.sync);
          MarshallUtil.marshallCollection(object.filterAnnotations, output);
-         output.writeObject(object.keyDataConversion);
-         output.writeObject(object.valueDataConversion);
+         DataConversion.writeTo(output, object.keyDataConversion);
+         DataConversion.writeTo(output, object.valueDataConversion);
       }
 
       @Override
@@ -180,8 +180,8 @@ public class ClusterListenerReplicateCallable<K, V> implements DistributedCallab
          }
          boolean sync = input.readBoolean();
          Set<Class<? extends Annotation>> listenerAnnots = MarshallUtil.unmarshallCollection(input, HashSet::new);
-         DataConversion keyDataConversion = (DataConversion) input.readObject();
-         DataConversion valueDataConversion = (DataConversion) input.readObject();
+         DataConversion keyDataConversion = DataConversion.readFrom(input);
+         DataConversion valueDataConversion = DataConversion.readFrom(input);
          return new ClusterListenerReplicateCallable(id, address, filter, converter, sync, listenerAnnots,
                keyDataConversion, valueDataConversion);
       }

--- a/core/src/test/java/org/infinispan/functional/AbstractFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/functional/AbstractFunctionalTest.java
@@ -1,8 +1,10 @@
 package org.infinispan.functional;
 
+import org.infinispan.AdvancedCache;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.functional.impl.FunctionalMapImpl;
+import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.persistence.dummy.DummyInMemoryStoreConfigurationBuilder;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.testng.annotations.BeforeClass;
@@ -103,14 +105,17 @@ abstract class AbstractFunctionalTest extends MultipleCacheManagersTest {
    }
 
    protected void initMaps() {
-      fmapL1 = FunctionalMapImpl.create(cacheManagers.get(0).<Integer, String>getCache().getAdvancedCache());
-      fmapL2 = FunctionalMapImpl.create(cacheManagers.get(0).<Integer, String>getCache().getAdvancedCache());
-      fmapD1 = FunctionalMapImpl.create(cacheManagers.get(0).<Object, String>getCache(DIST).getAdvancedCache());
-      fmapD2 = FunctionalMapImpl.create(cacheManagers.get(1).<Object, String>getCache(DIST).getAdvancedCache());
-      fmapR1 = FunctionalMapImpl.create(cacheManagers.get(0).<Object, String>getCache(REPL).getAdvancedCache());
-      fmapR2 = FunctionalMapImpl.create(cacheManagers.get(1).<Object, String>getCache(REPL).getAdvancedCache());
-      fmapS1 = FunctionalMapImpl.create(cacheManagers.get(0).<Object, String>getCache(SCATTERED).getAdvancedCache());
-      fmapS2 = FunctionalMapImpl.create(cacheManagers.get(1).<Object, String>getCache(SCATTERED).getAdvancedCache());
+      fmapL1 = FunctionalMapImpl.create(getAdvancedCache(cacheManagers.get(0), null));
+      fmapL2 = FunctionalMapImpl.create(getAdvancedCache(cacheManagers.get(0), null));
+      fmapD1 = FunctionalMapImpl.create(getAdvancedCache(cacheManagers.get(0), DIST));
+      fmapD2 = FunctionalMapImpl.create(getAdvancedCache(cacheManagers.get(1), DIST));
+      fmapR1 = FunctionalMapImpl.create(getAdvancedCache(cacheManagers.get(0), REPL));
+      fmapR2 = FunctionalMapImpl.create(getAdvancedCache(cacheManagers.get(1), REPL));
+      fmapS1 = FunctionalMapImpl.create(getAdvancedCache(cacheManagers.get(0), SCATTERED));
+      fmapS2 = FunctionalMapImpl.create(getAdvancedCache(cacheManagers.get(1), SCATTERED));
    }
 
+   protected <K, V> AdvancedCache<K, V> getAdvancedCache(EmbeddedCacheManager cm, String cacheName) {
+      return (AdvancedCache<K, V>) (cacheName == null ? cm.getCache() : cm.getCache(cacheName));
+   }
 }

--- a/core/src/test/java/org/infinispan/functional/FunctionalEncodingTypeTest.java
+++ b/core/src/test/java/org/infinispan/functional/FunctionalEncodingTypeTest.java
@@ -1,39 +1,292 @@
 package org.infinispan.functional;
 
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+
+import java.io.Serializable;
+
+import javax.transaction.Status;
+import javax.transaction.TransactionManager;
+
 import org.infinispan.AdvancedCache;
-import org.infinispan.commons.dataconversion.IdentityEncoder;
-import org.infinispan.commons.dataconversion.JavaSerializationEncoder;
+import org.infinispan.commons.dataconversion.Encoder;
+import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.functional.impl.FunctionalMapImpl;
+import org.infinispan.functional.impl.ReadWriteMapImpl;
 import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.marshall.core.EncoderRegistry;
+import org.infinispan.marshall.core.ExternalPojo;
+import org.infinispan.test.fwk.InTransactionMode;
+import org.infinispan.transaction.TransactionMode;
 import org.testng.annotations.Test;
 
 @Test(groups = "functional", testName = "functional.FunctionalEncoderTest")
 public class FunctionalEncodingTypeTest extends FunctionalMapTest {
 
    @Override
-   protected void initMaps() {
-      AdvancedCache advancedCacheL1 = cacheManagers.get(0).<Integer, String>getCache().getAdvancedCache()
-            .withEncoding(IdentityEncoder.class, JavaSerializationEncoder.class);
-      AdvancedCache advancedCacheL2 = cacheManagers.get(0).<Integer, String>getCache().getAdvancedCache()
-            .withEncoding(IdentityEncoder.class, JavaSerializationEncoder.class);
-      AdvancedCache advancedCacheDist1 = cacheManagers.get(0).<Integer, String>getCache(DIST).getAdvancedCache()
-            .withEncoding(IdentityEncoder.class, JavaSerializationEncoder.class);
-      AdvancedCache advancedCacheDist2 = cacheManagers.get(1).<Integer, String>getCache(DIST).getAdvancedCache()
-            .withEncoding(IdentityEncoder.class, JavaSerializationEncoder.class);
-      AdvancedCache advancedCacheRep1 = cacheManagers.get(0).<Integer, String>getCache(REPL).getAdvancedCache()
-            .withEncoding(IdentityEncoder.class, JavaSerializationEncoder.class);
-      AdvancedCache advancedCacheRep2 = cacheManagers.get(1).<Integer, String>getCache(REPL).getAdvancedCache()
-            .withEncoding(IdentityEncoder.class, JavaSerializationEncoder.class);
-      fmapL1 = FunctionalMapImpl.create(advancedCacheL1);
-      fmapL2 = FunctionalMapImpl.create(advancedCacheL2);
-      fmapD1 = FunctionalMapImpl.create(advancedCacheDist1);
-      fmapD2 = FunctionalMapImpl.create(advancedCacheDist2);
-      fmapR1 = FunctionalMapImpl.create(advancedCacheRep1);
-      fmapR2 = FunctionalMapImpl.create(advancedCacheRep2);
+   public Object[] factory() {
+      return new Object[] {
+            new FunctionalEncodingTypeTest().transactional(false),
+            new FunctionalEncodingTypeTest().transactional(true)
+      };
    }
 
    @Override
    protected AdvancedCache<?, ?> getAdvancedCache(EmbeddedCacheManager cm, String cacheName) {
-      return cm.getCache(cacheName).getAdvancedCache().withEncoding(IdentityEncoder.class, JavaSerializationEncoder.class);
+      AdvancedCache<?, ?> cache = super.getAdvancedCache(cm, cacheName);
+      ensureEncoders(cache);
+      return cache.withEncoding(TestKeyEncoder.class, TestValueEncoder.class);
+   }
+
+   private void ensureEncoders(AdvancedCache<?, ?> cache) {
+      EncoderRegistry encoderRegistry = cache.getComponentRegistry().getComponent(EncoderRegistry.class);
+      if (!encoderRegistry.isRegistered(TestKeyEncoder.class)) {
+         encoderRegistry.registerEncoder(new TestKeyEncoder());
+         encoderRegistry.registerEncoder(new TestValueEncoder());
+         encoderRegistry.registerEncoder(new UserType1Encoder());
+         encoderRegistry.registerEncoder(new UserType2Encoder());
+      }
+   }
+
+   @InTransactionMode(TransactionMode.TRANSACTIONAL)
+   public void testDifferentEncoders() throws Exception {
+      AdvancedCache<UserType<String>, UserType<String>> ac1 = (AdvancedCache<UserType<String>, UserType<String>>) advancedCache(0).withEncoding(UserType1Encoder.class, UserType1Encoder.class);
+      AdvancedCache<UserType<String>, UserType<String>> ac2 = (AdvancedCache<UserType<String>, UserType<String>>) advancedCache(0).withEncoding(UserType2Encoder.class, UserType2Encoder.class);
+      FunctionalMap.ReadWriteMap<UserType<String>, UserType<String>> rw1 = ReadWriteMapImpl.create(FunctionalMapImpl.create(ac1));
+      FunctionalMap.ReadWriteMap<UserType<String>, UserType<String>> rw2 = ReadWriteMapImpl.create(FunctionalMapImpl.create(ac2));
+
+      assertEquals(0, ac1.size());
+      TransactionManager tm = tm(0);
+      tm.begin();
+      try {
+         rw1.eval(new UserType<>(1, "key"), view -> {
+            assertFalse(view.find().isPresent());
+            view.set(new UserType<>(1, "value"));
+            return null;
+         });
+         rw2.eval(new UserType<>(2, "key"), view -> {
+            UserType<String> value = view.find().orElseThrow(() -> new AssertionError());
+            assertEquals(2, value.type);
+            assertEquals("value", value.instance);
+            view.set(new UserType<>(2, "value2"));
+            return null;
+         });
+         UserType<String> value2 = ac1.get(new UserType<>(1, "key"));
+         assertEquals(1, value2.type);
+         assertEquals("value2", value2.instance);
+      } finally {
+         if (tm.getStatus() == Status.STATUS_ACTIVE) {
+            tm.commit();
+         } else {
+            tm.rollback();
+         }
+      }
+      assertEquals(1, ac1.size());
+      UserType<String> value2 = ac2.get(new UserType<>(2, "key"));
+      assertEquals(2, value2.type);
+      assertEquals("value2", value2.instance);
+   }
+
+   static class TestKeyEncoder implements Encoder {
+      private static final short ID = 42;
+
+      @Override
+      public Object toStorage(Object content) {
+         return content == null ? null : new Wrapper(content);
+      }
+
+      @Override
+      public Object fromStorage(Object content) {
+         return content == null ? null : ((Wrapper) content).content;
+      }
+
+      @Override
+      public boolean isStorageFormatFilterable() {
+         return false;
+      }
+
+      @Override
+      public MediaType getStorageFormat() {
+         return MediaType.APPLICATION_OBJECT;
+      }
+
+      @Override
+      public short id() {
+         return ID;
+      }
+
+      static class Wrapper implements Serializable, ExternalPojo {
+         private final Object content;
+
+         Wrapper(Object content) {
+            this.content = content;
+         }
+
+         @Override
+         public String toString() {
+            return "TestKey#" + content;
+         }
+
+         @Override
+         public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            Wrapper wrapper = (Wrapper) o;
+
+            return content.equals(wrapper.content);
+         }
+
+         @Override
+         public int hashCode() {
+            return content.hashCode();
+         }
+      }
+   }
+
+   static class TestValueEncoder implements Encoder {
+
+      private static final short ID = 43;
+
+      @Override
+      public Object toStorage(Object content) {
+         return content == null ? null : new Wrapper(content);
+      }
+
+      @Override
+      public Object fromStorage(Object content) {
+         return content == null ? null : ((Wrapper) content).content;
+      }
+
+      @Override
+      public boolean isStorageFormatFilterable() {
+         return false;
+      }
+
+      @Override
+      public MediaType getStorageFormat() {
+         return MediaType.APPLICATION_OBJECT;
+      }
+
+      @Override
+      public short id() {
+         return ID;
+      }
+
+      static class Wrapper implements Serializable, ExternalPojo {
+         private final Object content;
+
+         Wrapper(Object content) {
+            this.content = content;
+         }
+
+         @Override
+         public String toString() {
+            return "TestValue#" + content;
+         }
+
+         @Override
+         public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            Wrapper wrapper = (Wrapper) o;
+
+            return content.equals(wrapper.content);
+         }
+
+         @Override
+         public int hashCode() {
+            return content.hashCode();
+         }
+      }
+   }
+
+   // Not serializable!
+   static final class UserType<T> {
+      public final int type;
+      public final T instance;
+
+      UserType(int type, T instance) {
+         this.type = type;
+         this.instance = instance;
+      }
+
+      @Override
+      public boolean equals(Object o) {
+         if (this == o) return true;
+         if (o == null || getClass() != o.getClass()) return false;
+
+         UserType<?> userType = (UserType<?>) o;
+         return type == userType.type && instance.equals(userType.instance);
+      }
+
+      @Override
+      public int hashCode() {
+         return instance.hashCode();
+      }
+
+      @Override
+      public String toString() {
+         return "UserType#" + type + "#" + instance;
+      }
+   }
+
+   static class UserType1Encoder implements Encoder {
+      @Override
+      public Object toStorage(Object content) {
+         UserType<?> ut = (UserType<?>) content;
+         assert ut.type == 1;
+         return content == null ? null : ut.instance;
+      }
+
+      @Override
+      public Object fromStorage(Object content) {
+         return content == null ? null : new UserType<>(1, content);
+      }
+
+      @Override
+      public boolean isStorageFormatFilterable() {
+         return false;
+      }
+
+      @Override
+      public MediaType getStorageFormat() {
+         return MediaType.APPLICATION_OBJECT;
+      }
+
+      @Override
+      public short id() {
+         return (short) 44;
+      }
+   }
+
+   static class UserType2Encoder implements Encoder {
+      @Override
+      public Object toStorage(Object content) {
+         UserType<?> ut = (UserType<?>) content;
+         assert ut.type == 2;
+         return content == null ? null : ut.instance;
+      }
+
+      @Override
+      public Object fromStorage(Object content) {
+         return content == null ? null : new UserType<>(1, content);
+      }
+
+      @Override
+      public boolean isStorageFormatFilterable() {
+         return false;
+      }
+
+      @Override
+      public MediaType getStorageFormat() {
+         return MediaType.APPLICATION_OBJECT;
+      }
+
+      @Override
+      public short id() {
+         return (short) 45;
+      }
    }
 }

--- a/core/src/test/java/org/infinispan/functional/FunctionalMapTest.java
+++ b/core/src/test/java/org/infinispan/functional/FunctionalMapTest.java
@@ -60,9 +60,10 @@ import org.infinispan.functional.impl.FunctionalMapImpl;
 import org.infinispan.functional.impl.ReadOnlyMapImpl;
 import org.infinispan.functional.impl.ReadWriteMapImpl;
 import org.infinispan.functional.impl.WriteOnlyMapImpl;
-import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.CacheManagerCallable;
+import org.infinispan.test.fwk.InTransactionMode;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.transaction.TransactionMode;
 import org.infinispan.util.function.SerializableConsumer;
 import org.infinispan.util.function.SerializableFunction;
 import org.testng.annotations.Test;
@@ -279,22 +280,28 @@ public class FunctionalMapTest extends AbstractFunctionalTest {
       }
    }
 
+   // Transactions use SimpleClusteredVersions, not NumericVersions, and user is not supposed to modify those
+   @InTransactionMode(TransactionMode.NON_TRANSACTIONAL)
    public void testLocalReadWriteForConditionalParamBasedReplace() {
       doReadWriteForConditionalParamBasedReplace(supplyIntKey(), rw(fmapL1), rw(fmapL2));
    }
 
+   @InTransactionMode(TransactionMode.NON_TRANSACTIONAL)
    public void testReplReadWriteForConditionalParamBasedReplaceOnNonOwner() {
       doReadWriteForConditionalParamBasedReplace(supplyKeyForCache(0, REPL), rw(fmapR1), rw(fmapR2));
    }
 
+   @InTransactionMode(TransactionMode.NON_TRANSACTIONAL)
    public void testReplReadWriteForConditionalParamBasedReplaceOnOwner() {
       doReadWriteForConditionalParamBasedReplace(supplyKeyForCache(1, REPL), rw(fmapR1), rw(fmapR2));
    }
 
+   @InTransactionMode(TransactionMode.NON_TRANSACTIONAL)
    public void testDistReadWriteForConditionalParamBasedReplaceOnNonOwner() {
       doReadWriteForConditionalParamBasedReplace(supplyKeyForCache(0, DIST), rw(fmapD1), rw(fmapD2));
    }
 
+   @InTransactionMode(TransactionMode.NON_TRANSACTIONAL)
    public void testDistReadWriteForConditionalParamBasedReplaceOnOwner() {
       doReadWriteForConditionalParamBasedReplace(supplyKeyForCache(1, DIST), rw(fmapD1), rw(fmapD2));
    }
@@ -603,7 +610,4 @@ public class FunctionalMapTest extends AbstractFunctionalTest {
          };
    }
 
-   protected AdvancedCache<?, ?> getAdvancedCache(EmbeddedCacheManager cm, String cacheName) {
-      return cm.getCache(cacheName).getAdvancedCache();
-   }
 }

--- a/core/src/test/java/org/infinispan/util/mocks/ControlledCommandFactory.java
+++ b/core/src/test/java/org/infinispan/util/mocks/ControlledCommandFactory.java
@@ -431,56 +431,56 @@ public class ControlledCommandFactory implements CommandsFactory {
    }
 
    @Override
-   public <K, V, R> ReadOnlyKeyCommand<K, V, R> buildReadOnlyKeyCommand(K key, Function<EntryView.ReadEntryView<K, V>, R> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion) {
+   public <K, V, R> ReadOnlyKeyCommand<K, V, R> buildReadOnlyKeyCommand(Object key, Function<EntryView.ReadEntryView<K, V>, R> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion) {
       return actual.buildReadOnlyKeyCommand(key, f, params, keyDataConversion, valueDataConversion);
    }
 
    @Override
-   public <K, V, R> ReadOnlyManyCommand<K, V, R> buildReadOnlyManyCommand(Collection<? extends K> keys, Function<EntryView.ReadEntryView<K, V>, R> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion) {
+   public <K, V, R> ReadOnlyManyCommand<K, V, R> buildReadOnlyManyCommand(Collection<?> keys, Function<EntryView.ReadEntryView<K, V>, R> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion) {
       return actual.buildReadOnlyManyCommand(keys, f, params, keyDataConversion, valueDataConversion);
    }
 
    @Override
-   public <K, V, R> ReadWriteKeyValueCommand<K, V, R> buildReadWriteKeyValueCommand(K key, V value, BiFunction<V, EntryView.ReadWriteEntryView<K, V>, R> f,
+   public <K, V, R> ReadWriteKeyValueCommand<K, V, R> buildReadWriteKeyValueCommand(Object key, Object value, BiFunction<V, EntryView.ReadWriteEntryView<K, V>, R> f,
                                                                                     Params params, DataConversion keyDataConversion, DataConversion valueDataConversion) {
       return actual.buildReadWriteKeyValueCommand(key, value, f, params, keyDataConversion, valueDataConversion);
    }
 
    @Override
    public <K, V, R> ReadWriteKeyCommand<K, V, R> buildReadWriteKeyCommand(
-         K key, Function<EntryView.ReadWriteEntryView<K, V>, R> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion) {
+         Object key, Function<EntryView.ReadWriteEntryView<K, V>, R> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion) {
       return actual.buildReadWriteKeyCommand(key, f, params, keyDataConversion, valueDataConversion);
    }
 
    @Override
-   public <K, V, R> ReadWriteManyCommand<K, V, R> buildReadWriteManyCommand(Collection<? extends K> keys, Function<EntryView.ReadWriteEntryView<K, V>, R> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion) {
+   public <K, V, R> ReadWriteManyCommand<K, V, R> buildReadWriteManyCommand(Collection<?> keys, Function<EntryView.ReadWriteEntryView<K, V>, R> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion) {
       return actual.buildReadWriteManyCommand(keys, f, params, keyDataConversion, valueDataConversion);
    }
 
    @Override
-   public <K, V, R> ReadWriteManyEntriesCommand<K, V, R> buildReadWriteManyEntriesCommand(Map<? extends K, ? extends V> entries, BiFunction<V, EntryView.ReadWriteEntryView<K, V>, R> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion) {
+   public <K, V, R> ReadWriteManyEntriesCommand<K, V, R> buildReadWriteManyEntriesCommand(Map<?, ?> entries, BiFunction<V, EntryView.ReadWriteEntryView<K, V>, R> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion) {
       return actual.buildReadWriteManyEntriesCommand(entries, f, params, keyDataConversion, valueDataConversion);
    }
 
    @Override
    public <K, V> WriteOnlyKeyCommand<K, V> buildWriteOnlyKeyCommand(
-         K key, Consumer<EntryView.WriteEntryView<V>> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion) {
+         Object key, Consumer<EntryView.WriteEntryView<V>> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion) {
       return actual.buildWriteOnlyKeyCommand(key, f, params, keyDataConversion, valueDataConversion);
    }
 
    @Override
-   public <K, V> WriteOnlyKeyValueCommand<K, V> buildWriteOnlyKeyValueCommand(K key, V value, BiConsumer<V, EntryView.WriteEntryView<V>> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion) {
+   public <K, V> WriteOnlyKeyValueCommand<K, V> buildWriteOnlyKeyValueCommand(Object key, Object value, BiConsumer<V, EntryView.WriteEntryView<V>> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion) {
       return actual.buildWriteOnlyKeyValueCommand(key, value, f, params, keyDataConversion, valueDataConversion);
    }
 
    @Override
-   public <K, V> WriteOnlyManyCommand<K, V> buildWriteOnlyManyCommand(Collection<? extends K> keys, Consumer<EntryView.WriteEntryView<V>> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion) {
+   public <K, V> WriteOnlyManyCommand<K, V> buildWriteOnlyManyCommand(Collection<?> keys, Consumer<EntryView.WriteEntryView<V>> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion) {
       return actual.buildWriteOnlyManyCommand(keys, f, params, keyDataConversion, valueDataConversion);
    }
 
    @Override
    public <K, V> WriteOnlyManyEntriesCommand<K, V> buildWriteOnlyManyEntriesCommand(
-         Map<? extends K, ? extends V> entries, BiConsumer<V, EntryView.WriteEntryView<V>> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion) {
+         Map<?, ?> entries, BiConsumer<V, EntryView.WriteEntryView<V>> f, Params params, DataConversion keyDataConversion, DataConversion valueDataConversion) {
       return actual.buildWriteOnlyManyEntriesCommand(entries, f, params, keyDataConversion, valueDataConversion);
    }
 


### PR DESCRIPTION
* Remove some generics in functional commands that don't make sense;
  the function generics no longer match to the stored keys and values
* Add DataConversion to Mutations
* Use DataConversion.writeTo/readFrom directly

https://issues.jboss.org/browse/ISPN-8090