### PR TITLE
ISPN-8430 Create Online Service Configuration Templates

### DIFF
--- a/server/integration/feature-pack/feature-pack-build.xml
+++ b/server/integration/feature-pack/feature-pack-build.xml
@@ -16,6 +16,10 @@
           template="configuration/standalone/template.xml"
           subsystems="configuration/standalone/subsystems-cloud.xml"
           output-file="standalone/configuration/cloud.xml" />
+        <standalone
+                template="configuration/standalone/template.xml"
+                subsystems="configuration/standalone/subsystems-services.xml"
+                output-file="standalone/configuration/services.xml" />
         <domain
           template="configuration/domain/template.xml"
           subsystems="configuration/domain/subsystems.xml"

--- a/server/integration/feature-pack/src/main/resources/configuration/standalone/subsystems-services.xml
+++ b/server/integration/feature-pack/src/main/resources/configuration/standalone/subsystems-services.xml
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
+<config>
+    <subsystems>
+        <subsystem>infinispan-logging.xml</subsystem>
+        <subsystem>deployment-scanner.xml</subsystem>
+        <subsystem>datasources.xml</subsystem>
+        <subsystem supplement="services">infinispan-core.xml</subsystem>
+        <subsystem supplement="clustered">infinispan-endpoint.xml</subsystem>
+        <subsystem>cloud-jgroups.xml</subsystem>
+        <subsystem>io.xml</subsystem>
+        <subsystem>jca.xml</subsystem>
+        <subsystem>jdr.xml</subsystem>
+        <subsystem>jmx.xml</subsystem>
+        <subsystem>naming.xml</subsystem>
+        <subsystem>remoting.xml</subsystem>
+        <subsystem>security.xml</subsystem>
+        <subsystem>transactions.xml</subsystem>
+    </subsystems>
+</config>

--- a/server/integration/infinispan/src/main/resources/subsystem-templates/infinispan-core.xml
+++ b/server/integration/infinispan/src/main/resources/subsystem-templates/infinispan-core.xml
@@ -80,6 +80,24 @@
          </cache-container>
       </replacement>
    </supplement>
+   <supplement name="services">
+      <replacement placeholder="@@default-cache-container@@" attributeValue="clustered" />
+      <replacement placeholder="CACHE-CONTAINERS">
+         <cache-container name="clustered" default-cache="default" statistics="true">
+            <transport lock-timeout="60000" />
+            <global-state />
+
+            <distributed-cache-configuration name="shared-memory-service" owners="2">
+               <partition-handling when-split="ALLOW_READ_WRITES" merge-policy="REMOVE_ALL"/>
+            </distributed-cache-configuration>
+
+            <distributed-cache-configuration name="caching-service" owners="1">
+            </distributed-cache-configuration>
+
+            <distributed-cache name="default" />
+         </cache-container>
+      </replacement>
+   </supplement>
    <!-- Examples -->
    <supplement name="fcs-local">
       <replacement placeholder="@@default-cache-container@@" attributeValue="local" />


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-8430

@slaskawi I think this is all we need for now. This way we can just pass "services" as an argument to docker and we will only have to remove the "shared-memory-service" or "caching-service" template via the cli script depending on the mode we're operating. 