### PR TITLE
ISPN-8478 Reduce build memory usage

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ GREP="grep"
 ROOT="/"
 MVN="mvn"
 
-MAVEN_OPTS="$MAVEN_OPTS -Xmx1G"
+MAVEN_OPTS="$MAVEN_OPTS -Xmx700m -XX:+HeapDumpOnOutOfMemoryError"
 if $JAVA_HOME/bin/java -fullversion 2>&1 | grep -q 'java full version "9' ; then
   MAVEN_OPTS="$MAVEN_OPTS --add-modules java.xml.bind"
 fi

--- a/etc/log4j2.xml
+++ b/etc/log4j2.xml
@@ -9,7 +9,7 @@
 
   <Appenders>
     <Console name="STDOUT">
-      <PatternLayout pattern="%d{HH:mm:ss,SSS} %-5p (%t) [%c{1}] %m%n%throwable{10}"/>
+      <PatternLayout pattern="%d{HH:mm:ss,SSS} %-5p (%t) [%c{1}] %m%throwable{10}%n"/>
     </Console>
     <File name="File" fileName="${sys:infinispan.log.path}/infinispan${sys:infinispan.module-suffix}.log"
           append="false">

--- a/integrationtests/all-remote-it/src/test/resources/arquillian.xml
+++ b/integrationtests/all-remote-it/src/test/resources/arquillian.xml
@@ -11,7 +11,8 @@
                 <property name="serverConfig">clustered.xml</property>
                 <property name="javaVmArguments">
                     ${jigsawForkJvmArgs}
-                    -Xmx512m -Djava.net.preferIPv4Stack=true
+                    -Xmx500m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${user.dir}
+                    -Djava.net.preferIPv4Stack=true
                     -Djgroups.bind_addr=127.0.0.1 -Djboss.server.default.config=clustered.xml
                     -Djboss.node.name=node1 -Djgroups.join_timeout=2000
                 </property>
@@ -23,7 +24,8 @@
                 <property name="serverConfig">clustered.xml</property>
                 <property name="javaVmArguments">
                     ${jigsawForkJvmArgs}
-                    -Xmx512m -Djava.net.preferIPv4Stack=true
+                    -Xmx500m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${user.dir}
+                    -Djava.net.preferIPv4Stack=true
                     -Djgroups.bind_addr=127.0.0.1 -Djboss.server.default.config=clustered.xml
                     -Djboss.node.name=node2 -Djboss.socket.binding.port-offset=10000
                     -Djgroups.join_timeout=2000

--- a/integrationtests/as-lucene-directory/src/test/resources/arquillian.xml
+++ b/integrationtests/as-lucene-directory/src/test/resources/arquillian.xml
@@ -15,8 +15,9 @@
                 <!-- Here you can add debug arguments, e.g. -Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y -->
                 <property name="javaVmArguments">
                     ${jigsawForkJvmArgs}
-                    -Xmx512m -Djava.net.preferIPv4Stack=true
-                    -Djgroups.bind_addr=127.0.0.1 -Djgroups.join_timeout=2000 -XX:+IgnoreUnrecognizedVMOptions
+                    -Xmx500m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${user.dir}
+                    -Djava.net.preferIPv4Stack=true -Djgroups.bind_addr=127.0.0.1
+                    -Djgroups.join_timeout=2000 -XX:+IgnoreUnrecognizedVMOptions
                 </property>
             </configuration>
         </container>
@@ -28,7 +29,8 @@
                 <property name="serverConfig">standalone-full-testqueues.xml</property>
                 <property name="javaVmArguments">
                     ${jigsawForkJvmArgs}
-                    -Djboss.socket.binding.port-offset=10000 -Xmx512m
+                    -Xmx500m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${user.dir}
+                    -Djboss.socket.binding.port-offset=10000
                     -Djava.net.preferIPv4Stack=true -Djgroups.bind_addr=127.0.0.1
                     -Djgroups.join_timeout=2000 -XX:+IgnoreUnrecognizedVMOptions
                 </property>

--- a/integrationtests/osgi/pom.xml
+++ b/integrationtests/osgi/pom.xml
@@ -220,6 +220,7 @@
       <defaultExcludedTestGroup />
       <infinispan.test.parallel.threads>1</infinispan.test.parallel.threads>
       <infinispan.test.jgroups.protocol>tcp</infinispan.test.jgroups.protocol>
+      <forkJvmArgs>-Xmx500m -XX:HeapDumpPath=${user.dir}</forkJvmArgs>
       <target.tmp.dir>${project.build.directory}/tmp/</target.tmp.dir>
       <skipOSGiTests>${skipTests}</skipOSGiTests>
       <verbose.karaf>false</verbose.karaf>

--- a/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/util/IspnKarafOptions.java
+++ b/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/util/IspnKarafOptions.java
@@ -332,6 +332,7 @@ public class IspnKarafOptions {
    public static Option commonOptions() throws Exception {
       return composite(karafContainer(),
                        vmOptions("-Djava.net.preferIPv4Stack=true", "-Djgroups.bind_addr=127.0.0.1"),
+                       vmOptions("-Xmx500m", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=" + System.getProperty("user.dir")),
 //                       vmOptions("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=8000"),
                        verboseKaraf(),
                        runWithoutConsole(),

--- a/integrationtests/pom.xml
+++ b/integrationtests/pom.xml
@@ -15,7 +15,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <forkJvmArgs>-Xmx2G</forkJvmArgs>
+        <forkJvmArgs>-Xmx500m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${user.dir}</forkJvmArgs>
         <jigsawForkJvmArgs></jigsawForkJvmArgs>
     </properties>
 

--- a/integrationtests/security-it/src/test/resources/arquillian.xml
+++ b/integrationtests/security-it/src/test/resources/arquillian.xml
@@ -18,7 +18,8 @@
             <property name="serverConfig">standalone.xml</property>
             <property name="javaVmArguments">
                 ${jigsawForkJvmArgs}
-                -Djboss.node.name=testnode -Djgroups.join_timeout=2000
+               -Xmx500m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${user.dir}
+               -Djboss.node.name=testnode -Djgroups.join_timeout=2000
             </property>
             <property name="managementPort">9990</property>
          </configuration>
@@ -34,6 +35,7 @@
             <property name="serverConfig">standalone-ha.xml</property>
             <property name="javaVmArguments">
                ${jigsawForkJvmArgs}
+               -Xmx500m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${user.dir}
                -Djboss.node.name=node0
                -Djboss.socket.binding.port-offset=100
                -Djava.net.preferIPv4Stack=true
@@ -56,6 +58,7 @@
             <property name="serverConfig">standalone-ha.xml</property>
             <property name="javaVmArguments">
                ${jigsawForkJvmArgs}
+               -Xmx500m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${user.dir}
                -Djboss.node.name=node1
                -Djboss.socket.binding.port-offset=200
                -Djava.net.preferIPv4Stack=true
@@ -77,6 +80,7 @@
             <property name="serverConfig">standalone-ha.xml</property>
             <property name="javaVmArguments">
                ${jigsawForkJvmArgs}
+               -Xmx500m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${user.dir}
                -Djboss.node.name=node1
                -Djboss.socket.binding.port-offset=200
                -Djava.net.preferIPv4Stack=true
@@ -99,6 +103,7 @@
             <property name="serverConfig">standalone-ha.xml</property>
             <property name="javaVmArguments">
                ${jigsawForkJvmArgs}
+               -Xmx500m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${user.dir}
                -Djboss.node.name=node0
                -Djboss.socket.binding.port-offset=100
                -Djava.net.preferIPv4Stack=true
@@ -120,6 +125,7 @@
             <property name="serverConfig">standalone-ha.xml</property>
             <property name="javaVmArguments">
                ${jigsawForkJvmArgs}
+               -Xmx500m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${user.dir}
                -Djboss.node.name=node1
                -Djboss.socket.binding.port-offset=200
                -Djava.net.preferIPv4Stack=true

--- a/integrationtests/wildfly-modules/pom.xml
+++ b/integrationtests/wildfly-modules/pom.xml
@@ -19,14 +19,14 @@
       <ispnserver.dist>${basedir}/target/infinispan-server</ispnserver.dist>
       <server.jvm>${env.JAVA_HOME}</server.jvm>
       <resources.dir>${basedir}/src/test/resources</resources.dir>
-      <jvm.memory.args>-Xmx1G</jvm.memory.args>
+      <serverMemoryJvmArgs>-Xmx300m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${user.dir}</serverMemoryJvmArgs>
       <jvm.x64.args />
       <default.transport.stack>udp</default.transport.stack>
       <transport.stack>-Djboss.default.jgroups.stack=${default.transport.stack}</transport.stack>
       <jvm.ip.stack>-Djava.net.preferIPv4Stack=true</jvm.ip.stack>
       <mcast.ip>234.99.54.14</mcast.ip>
       <jvm.ip.stack>-Djava.net.preferIPv4Stack=true -Djava.net.preferIPv6Addresses=false -Djboss.default.multicast.address=${mcast.ip}</jvm.ip.stack>
-      <server.jvm.args>${jvm.ip.stack} ${jvm.memory.args} ${transport.stack} ${jvm.x64.args} ${jigsawForkJvmArgs}</server.jvm.args>
+      <server.jvm.args>${jvm.ip.stack} ${serverMemoryJvmArgs} ${transport.stack} ${jvm.x64.args} ${jigsawForkJvmArgs}</server.jvm.args>
       <log4j.configurationFile>log4j2.xml</log4j.configurationFile>
    </properties>
 

--- a/integrationtests/wildfly-modules/src/test/resources/arquillian.xml
+++ b/integrationtests/wildfly-modules/src/test/resources/arquillian.xml
@@ -12,6 +12,7 @@
                 <property name="jbossHome">${basedir}/target/node1/wildfly-${version.org.wildfly}</property>
                 <property name="javaVmArguments">
                     ${jigsawForkJvmArgs}
+                    -Xmx500m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${user.dir}
                     -Djboss.socket.binding.port-offset=100 -Xmx512m -Djava.net.preferIPv4Stack=true
                     -Djgroups.bind_addr=127.0.0.1 -Djgroups.join_timeout=2000
                 </property>
@@ -29,7 +30,8 @@
                 <property name="jbossHome">${basedir}/target/node2/wildfly-${version.org.wildfly}</property>
                 <property name="javaVmArguments">
                     ${jigsawForkJvmArgs}
-                    -Djboss.socket.binding.port-offset=200 -Xmx512m
+                    -Xmx500m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${user.dir}
+                    -Djboss.socket.binding.port-offset=200
                     -Djava.net.preferIPv4Stack=true -Djgroups.bind_addr=127.0.0.1 -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">10190</property>

--- a/jcache/tck-runner/pom.xml
+++ b/jcache/tck-runner/pom.xml
@@ -34,6 +34,7 @@
       <server.dir.parent>${project.build.directory}</server.dir.parent>
       <server.dir.name>infinispan-server-${project.version}</server.dir.name>
       <server.dir>${server.dir.parent}/${server.dir.name}</server.dir>
+      <serverMemoryJvmArgs>-Xmx500m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${user.dir}</serverMemoryJvmArgs>
 
       <failsafe.reportdir.embedded>${project.build.directory}/failsafe-reports-embedded</failsafe.reportdir.embedded>
       <failsafe.reportdir.remote>${project.build.directory}/failsafe-reports-remote</failsafe.reportdir.remote>
@@ -182,6 +183,7 @@
                   <configuration>
                      <skip>${skipTests}</skip>
                      <jbossHome>${server.dir}</jbossHome>
+                     <jvm-args>${serverMemoryJvmArgs} ${jigsawForkJvmArgs}</jvm-args>
                      <!--java-opts>
                         <java-opt>-agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=y</java-opt>
                      </java-opts-->

--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
       <dir.jacoco>${session.executionRootDirectory}/jacoco/</dir.jacoco>
       <dir.jacoco.merged>../jacoco/merged/</dir.jacoco.merged>
       <dir.jacoco.report>../jacoco/report/</dir.jacoco.report>
-      <forkJvmArgs>-Xmx2G</forkJvmArgs>
+      <forkJvmArgs>-Xmx1G -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${user.dir}</forkJvmArgs>
       <infinispan.codename>Bastille</infinispan.codename>
       <infinispan.module-suffix>-${project.artifactId}</infinispan.module-suffix>
       <infinispan.test.jgroups.protocol>tcp</infinispan.test.jgroups.protocol>

--- a/server/integration/testsuite/pom.xml
+++ b/server/integration/testsuite/pom.xml
@@ -316,7 +316,7 @@
         <server.jvm>${env.JAVA_HOME}</server.jvm>
         <resources.dir>${project.build.testOutputDirectory}</resources.dir>
 
-        <jvm.memory.args>-Xmx512m</jvm.memory.args>
+        <serverMemoryJvmArgs>-Xmx300m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${user.dir}</serverMemoryJvmArgs>
         <jvm.x64.args />
         <default.transport.stack>udp</default.transport.stack>
         <transport.stack>-Djboss.default.jgroups.stack=${default.transport.stack}</transport.stack>
@@ -335,7 +335,7 @@
         <jvm.ip.stack>-Djava.net.preferIPv4Stack=true -Djava.net.preferIPv6Addresses=false
             -Djboss.default.multicast.address=${mcast.ip}
         </jvm.ip.stack>
-        <server.jvm.args>${jvm.ip.stack} ${jvm.memory.args} ${transport.stack} ${jvm.x64.args} ${jigsawForkJvmArgs}</server.jvm.args>
+        <server.jvm.args>${jvm.ip.stack} ${serverMemoryJvmArgs} ${transport.stack} ${jvm.x64.args} ${jigsawForkJvmArgs}</server.jvm.args>
         <log4j.configurationFile>log4j2.xml</log4j.configurationFile>
         <suite.manual.phase>integration-test</suite.manual.phase>
         <suite.queries.phase>integration-test</suite.queries.phase>
@@ -870,7 +870,7 @@
 
                         <server.jmx.domain>jboss.datagrid-infinispan</server.jmx.domain>
                     </systemPropertyVariables>
-                    <argLine>${jigsawForkJvmArgs}</argLine>
+                    <argLine>${forkJvmArgs} ${jigsawForkJvmArgs}</argLine>
                     <!--add jdbc driver to classpath-->
                     <additionalClasspathElements>
                         <element>${driver.dir}/${driver.jar}</element>

--- a/server/integration/versions/pom.xml
+++ b/server/integration/versions/pom.xml
@@ -23,7 +23,7 @@
       <maven.compiler.target>1.8</maven.compiler.target>
       <maven.compiler.source>1.8</maven.compiler.source>
       <server.output.dir.prefix>infinispan-server</server.output.dir.prefix>
-      <forkJvmArgs></forkJvmArgs>
+      <forkJvmArgs>-Xmx500m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${user.dir}</forkJvmArgs>
       <jigsawForkJvmArgs></jigsawForkJvmArgs>
 
       <!-- Override plugin versions defined in the JBoss parent POM to work with JDK9-->


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-8478

Since I first opened the PR, the ANSI escape codes in test suite output which were causing the OSGi tests OOME have been reverted.

So I've changed the target of the PR to get the build running on the new agents that only have 4GB of RAM.