### PR TITLE
ISPN-8395 Allow duplicate JMX domains by default

### DIFF
--- a/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/DefaultTestEmbeddedCacheManagerProducer.java
+++ b/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/DefaultTestEmbeddedCacheManagerProducer.java
@@ -34,7 +34,6 @@ public class DefaultTestEmbeddedCacheManagerProducer {
 
       ConfigurationBuilder builder = new ConfigurationBuilder();
       GlobalConfigurationBuilder globalConfigurationBuilder = new GlobalConfigurationBuilder();
-      globalConfigurationBuilder.globalJmxStatistics().allowDuplicateDomains(true);
       builder.read(defaultConfiguration);
       return TestCacheManagerFactory.createClusteredCacheManager(globalConfigurationBuilder, builder);
    }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/HotRodQueryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/HotRodQueryTest.java
@@ -58,7 +58,6 @@ public class HotRodQueryTest extends SingleCacheManagerTest {
       GlobalConfigurationBuilder gcb = new GlobalConfigurationBuilder().nonClusteredDefault();
       gcb.globalJmxStatistics()
             .enable()
-            .allowDuplicateDomains(true)
             .jmxDomain(getClass().getSimpleName())
             .mBeanServerLookup(new PerThreadMBeanServerLookup());
       gcb.addModule(PrivateGlobalConfigurationBuilder.class).serverMode(true);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryJmxTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryJmxTest.java
@@ -70,7 +70,6 @@ public class RemoteQueryJmxTest extends SingleCacheManagerTest {
       GlobalConfigurationBuilder gcb = new GlobalConfigurationBuilder().nonClusteredDefault();
       gcb.globalJmxStatistics()
             .enable()
-            .allowDuplicateDomains(true)
             .jmxDomain(jmxDomain)
             .mBeanServerLookup(new PerThreadMBeanServerLookup());
       gcb.addModule(PrivateGlobalConfigurationBuilder.class).serverMode(true);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/xsite/AbstractHotRodSiteFailoverTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/xsite/AbstractHotRodSiteFailoverTest.java
@@ -95,7 +95,6 @@ abstract class AbstractHotRodSiteFailoverTest extends AbstractXSiteTest {
       backup.site(backupSiteName).strategy(BackupStrategy.SYNC);
 
       GlobalConfigurationBuilder globalBuilder = GlobalConfigurationBuilder.defaultClusteredBuilder();
-      globalBuilder.globalJmxStatistics().allowDuplicateDomains(true);
       globalBuilder.site().localSite(siteName);
       TestSite site = createSite(siteName, NODES_PER_SITE, globalBuilder, builder);
       Collection<EmbeddedCacheManager> cacheManagers = site.cacheManagers();

--- a/core/src/main/java/org/infinispan/configuration/global/GlobalJmxStatisticsConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/global/GlobalJmxStatisticsConfiguration.java
@@ -14,7 +14,7 @@ public class GlobalJmxStatisticsConfiguration {
    public static final AttributeDefinition<Boolean> ENABLED = AttributeDefinition.builder("enabled", false).immutable().build();
    public static final AttributeDefinition<String> JMX_DOMAIN = AttributeDefinition.builder("jmxDomain", "org.infinispan").immutable().build();
    public static final AttributeDefinition<MBeanServerLookup> MBEAN_SERVER_LOOKUP = AttributeDefinition.builder("mBeanServerLookup", (MBeanServerLookup) Util.getInstance(PlatformMBeanServerLookup.class)).copier(IdentityAttributeCopier.INSTANCE).immutable().build();
-   public static final AttributeDefinition<Boolean> ALLOW_DUPLICATE_DOMAINS = AttributeDefinition.builder("allowDuplicateDomains", false).immutable().build();
+   public static final AttributeDefinition<Boolean> ALLOW_DUPLICATE_DOMAINS = AttributeDefinition.builder("allowDuplicateDomains", true).immutable().build();
    public static final AttributeDefinition<String> CACHE_MANAGER_NAME = AttributeDefinition.builder("cacheManagerName", "DefaultCacheManager").immutable().build();
    public static final AttributeDefinition<TypedProperties> PROPERTIES = AttributeDefinition.builder("properties", null, TypedProperties.class).immutable().initializer(new AttributeInitializer<TypedProperties>() {
       @Override

--- a/core/src/test/java/org/infinispan/configuration/ConfigurationUnitTest.java
+++ b/core/src/test/java/org/infinispan/configuration/ConfigurationUnitTest.java
@@ -231,7 +231,6 @@ public class ConfigurationUnitTest extends AbstractInfinispanTest {
 
    public void testConfigureMarshaller() {
       GlobalConfigurationBuilder gc = new GlobalConfigurationBuilder();
-      gc.globalJmxStatistics().allowDuplicateDomains(true);
       TestObjectStreamMarshaller marshaller = new TestObjectStreamMarshaller();
       gc.serialization().marshaller(marshaller);
       withCacheManager(new CacheManagerCallable(

--- a/core/src/test/java/org/infinispan/jmx/AbstractClusterMBeanTest.java
+++ b/core/src/test/java/org/infinispan/jmx/AbstractClusterMBeanTest.java
@@ -43,7 +43,7 @@ abstract class AbstractClusterMBeanTest extends MultipleCacheManagersTest {
 
    private CacheContainer createManager(ConfigurationBuilder builder) {
       GlobalConfigurationBuilder gcb1 = GlobalConfigurationBuilder.defaultClusteredBuilder();
-      gcb1.globalJmxStatistics().enable().allowDuplicateDomains(true).jmxDomain(jmxDomain)
+      gcb1.globalJmxStatistics().enable().jmxDomain(jmxDomain)
             .mBeanServerLookup(new PerThreadMBeanServerLookup());
       CacheContainer cacheManager = TestCacheManagerFactory.createClusteredCacheManager(gcb1, builder,
             new TransportFlags(), true);

--- a/core/src/test/java/org/infinispan/jmx/CacheContainerStatsMBeanTest.java
+++ b/core/src/test/java/org/infinispan/jmx/CacheContainerStatsMBeanTest.java
@@ -33,14 +33,14 @@ public class CacheContainerStatsMBeanTest extends MultipleCacheManagersTest {
    protected void createCacheManagers() throws Throwable {
       ConfigurationBuilder defaultConfig = new ConfigurationBuilder();
       GlobalConfigurationBuilder gcb1 = GlobalConfigurationBuilder.defaultClusteredBuilder();
-      gcb1.globalJmxStatistics().enable().allowDuplicateDomains(true).jmxDomain(JMX_DOMAIN)
+      gcb1.globalJmxStatistics().enable().jmxDomain(JMX_DOMAIN)
             .mBeanServerLookup(new PerThreadMBeanServerLookup());
       CacheContainer cacheManager1 = TestCacheManagerFactory.createClusteredCacheManager(gcb1, defaultConfig,
             new TransportFlags(), true);
       cacheManager1.start();
 
       GlobalConfigurationBuilder gcb2 = GlobalConfigurationBuilder.defaultClusteredBuilder();
-      gcb2.globalJmxStatistics().enable().allowDuplicateDomains(true).jmxDomain(JMX_DOMAIN)
+      gcb2.globalJmxStatistics().enable().jmxDomain(JMX_DOMAIN)
             .mBeanServerLookup(new PerThreadMBeanServerLookup());
       CacheContainer cacheManager2 = TestCacheManagerFactory.createClusteredCacheManager(gcb2, defaultConfig,
             new TransportFlags(), true);

--- a/core/src/test/java/org/infinispan/jmx/CacheMBeanTest.java
+++ b/core/src/test/java/org/infinispan/jmx/CacheMBeanTest.java
@@ -111,7 +111,7 @@ public class CacheMBeanTest extends MultipleCacheManagersTest {
    public void testDuplicateJmxDomainOnlyCacheExposesJmxStatistics() throws Exception {
       CacheContainer otherContainer = null;
       try {
-         otherContainer = TestCacheManagerFactory.createCacheManagerEnforceJmxDomain(JMX_DOMAIN, false, true);
+         otherContainer = TestCacheManagerFactory.createCacheManagerEnforceJmxDomain(JMX_DOMAIN, false, true, false);
          otherContainer.getCache();
          assert false : "Failure expected, " + JMX_DOMAIN + " is a duplicate!";
       } catch (CacheException e) {
@@ -124,7 +124,7 @@ public class CacheMBeanTest extends MultipleCacheManagersTest {
    public void testAvoidLeakOfCacheMBeanWhenCacheStatisticsDisabled(Method m) {
       final String jmxDomain = "jmx_" + m.getName();
       withCacheManager(new CacheManagerCallable(
-            TestCacheManagerFactory.createCacheManagerEnforceJmxDomain(jmxDomain, false, false)) {
+            TestCacheManagerFactory.createCacheManagerEnforceJmxDomain(jmxDomain, false, false, true)) {
          @Override
          public void call() throws Exception {
             cm.getCache();

--- a/core/src/test/java/org/infinispan/jmx/CacheManagerMBeanTest.java
+++ b/core/src/test/java/org/infinispan/jmx/CacheManagerMBeanTest.java
@@ -44,7 +44,7 @@ public class CacheManagerMBeanTest extends SingleCacheManagerTest {
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
-      cacheManager = TestCacheManagerFactory.createCacheManagerEnforceJmxDomain(JMX_DOMAIN, true, false);
+      cacheManager = TestCacheManagerFactory.createCacheManagerEnforceJmxDomain(JMX_DOMAIN, true, false, true);
       name = getCacheManagerObjectName(JMX_DOMAIN);
       server = PerThreadMBeanServerLookup.getThreadMBeanServer();
       server.invoke(name, "startCache", new Object[]{}, new String[]{});
@@ -92,7 +92,7 @@ public class CacheManagerMBeanTest extends SingleCacheManagerTest {
 
    public void testJmxRegistrationAtStartupAndStop(Method m) throws Exception {
       final String otherJmxDomain = getMethodSpecificJmxDomain(m, JMX_DOMAIN);
-      CacheContainer otherContainer = TestCacheManagerFactory.createCacheManagerEnforceJmxDomain(otherJmxDomain, true, false);
+      CacheContainer otherContainer = TestCacheManagerFactory.createCacheManagerEnforceJmxDomain(otherJmxDomain, true, false, true);
       ObjectName otherName = getCacheManagerObjectName(otherJmxDomain);
       try {
          assertEquals("0", server.getAttribute(otherName, "CreatedCacheCount"));
@@ -105,7 +105,7 @@ public class CacheManagerMBeanTest extends SingleCacheManagerTest {
 
    public void testCustomCacheManagerName(Method m) throws Exception {
       final String otherJmxDomain = getMethodSpecificJmxDomain(m, JMX_DOMAIN);
-      CacheContainer otherContainer = TestCacheManagerFactory.createCacheManagerEnforceJmxDomain(otherJmxDomain, "Hibernate2LC", true, false);
+      CacheContainer otherContainer = TestCacheManagerFactory.createCacheManagerEnforceJmxDomain(otherJmxDomain, "Hibernate2LC", true, false, true);
       ObjectName otherName = getCacheManagerObjectName(otherJmxDomain, "Hibernate2LC");
       try {
          assertEquals("0", server.getAttribute(otherName, "CreatedCacheCount"));

--- a/core/src/test/java/org/infinispan/jmx/ComponentsJmxRegistrationTest.java
+++ b/core/src/test/java/org/infinispan/jmx/ComponentsJmxRegistrationTest.java
@@ -85,7 +85,7 @@ public class ComponentsJmxRegistrationTest extends AbstractInfinispanTest {
 
    public void testRegisterReplicatedCache() throws Exception {
       GlobalConfigurationBuilder globalConfiguration = GlobalConfigurationBuilder.defaultClusteredBuilder();
-      globalConfiguration.globalJmxStatistics().enable().allowDuplicateDomains(true);
+      globalConfiguration.globalJmxStatistics().enable();
       EmbeddedCacheManager cm = TestCacheManagerFactory.createClusteredCacheManager(globalConfiguration, new ConfigurationBuilder());
       cacheContainers.add(cm);
       cm.start();
@@ -106,7 +106,7 @@ public class ComponentsJmxRegistrationTest extends AbstractInfinispanTest {
 
    public void testLocalAndReplicatedCache() throws Exception {
       GlobalConfigurationBuilder globalConfiguration = GlobalConfigurationBuilder.defaultClusteredBuilder();
-      globalConfiguration.globalJmxStatistics().enable().allowDuplicateDomains(true);
+      globalConfiguration.globalJmxStatistics().enable();
       EmbeddedCacheManager cm = TestCacheManagerFactory.createClusteredCacheManager(globalConfiguration, new ConfigurationBuilder());
       cacheContainers.add(cm);
       cm.start();

--- a/core/src/test/java/org/infinispan/jmx/JmxStatsFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/jmx/JmxStatsFunctionalTest.java
@@ -208,7 +208,7 @@ public class JmxStatsFunctionalTest extends AbstractInfinispanTest {
       assert existsObject(getCacheObjectName(jmxDomain, "local_cache(local)", "Statistics"));
 
       GlobalConfigurationBuilder globalConfiguration2 = GlobalConfigurationBuilder.defaultClusteredBuilder();
-      globalConfiguration2.globalJmxStatistics().enable().mBeanServerLookup(new PerThreadMBeanServerLookup()).allowDuplicateDomains(true);
+      globalConfiguration2.globalJmxStatistics().enable().mBeanServerLookup(new PerThreadMBeanServerLookup());
       cm2 = TestCacheManagerFactory.createClusteredCacheManager(globalConfiguration2, new ConfigurationBuilder());
       String jmxDomain2 = cm2.getCacheManagerConfiguration().globalJmxStatistics().domain();
 
@@ -219,7 +219,7 @@ public class JmxStatsFunctionalTest extends AbstractInfinispanTest {
       assert existsObject(getCacheObjectName(jmxDomain2, "local_cache(local)", "Statistics"));
 
       GlobalConfigurationBuilder globalConfiguration3 = GlobalConfigurationBuilder.defaultClusteredBuilder();
-      globalConfiguration3.globalJmxStatistics().enable().mBeanServerLookup(new PerThreadMBeanServerLookup()).allowDuplicateDomains(true);
+      globalConfiguration3.globalJmxStatistics().enable().mBeanServerLookup(new PerThreadMBeanServerLookup());
       cm3 = TestCacheManagerFactory.createClusteredCacheManager(globalConfiguration3, new ConfigurationBuilder());
       String jmxDomain3 = cm3.getCacheManagerConfiguration().globalJmxStatistics().domain();
 
@@ -261,7 +261,7 @@ public class JmxStatsFunctionalTest extends AbstractInfinispanTest {
 
       //now register a global one
       GlobalConfigurationBuilder globalConfiguration2 = GlobalConfigurationBuilder.defaultClusteredBuilder();
-      globalConfiguration2.globalJmxStatistics().enable().mBeanServerLookup(new PerThreadMBeanServerLookup()).allowDuplicateDomains(true);
+      globalConfiguration2.globalJmxStatistics().enable().mBeanServerLookup(new PerThreadMBeanServerLookup());
       cm2 = TestCacheManagerFactory.createClusteredCacheManager(globalConfiguration2, new ConfigurationBuilder());
       ConfigurationBuilder remoteCache = new ConfigurationBuilder();
       remoteCache.jmxStatistics().enable();

--- a/core/src/test/java/org/infinispan/manager/CacheManagerTest.java
+++ b/core/src/test/java/org/infinispan/manager/CacheManagerTest.java
@@ -461,7 +461,6 @@ public class CacheManagerTest extends AbstractInfinispanTest {
                .cacheMode(isClustered ? CacheMode.REPL_SYNC : CacheMode.LOCAL);
 
       GlobalConfigurationBuilder gcb = new GlobalConfigurationBuilder().clusteredDefault();
-      gcb.globalJmxStatistics().allowDuplicateDomains(true);
       EmbeddedCacheManager cm = TestCacheManagerFactory.createClusteredCacheManager(gcb, c);
       cm.defineConfiguration("cache", c.build());
 

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/ClusterListenerStressTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/ClusterListenerStressTest.java
@@ -48,7 +48,6 @@ public class ClusterListenerStressTest extends MultipleCacheManagersTest {
       Configuration distConfig = getDefaultClusteredCacheConfig(cacheMode, false).build();
       for (int i = 0; i < NUM_NODES; i++) {
          GlobalConfigurationBuilder gcb = new GlobalConfigurationBuilder();
-         gcb.globalJmxStatistics().allowDuplicateDomains(true);
          gcb.transport().defaultTransport().nodeName(TestResourceTracker.getNameForIndex(i));
          BlockingThreadPoolExecutorFactory remoteExecutorFactory = new BlockingThreadPoolExecutorFactory(
                10, 1, 0, 60000);

--- a/core/src/test/java/org/infinispan/statetransfer/ConcurrentStartChanelLookupTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/ConcurrentStartChanelLookupTest.java
@@ -104,7 +104,6 @@ public class ConcurrentStartChanelLookupTest extends MultipleCacheManagersTest {
    private EmbeddedCacheManager createCacheManager(String name1, JChannel ch1) {
       GlobalConfigurationBuilder gcb1 = new GlobalConfigurationBuilder();
       gcb1.transport().nodeName(ch1.getName()).distributedSyncTimeout(10, SECONDS);
-      gcb1.globalJmxStatistics().allowDuplicateDomains(true);
       CustomChannelLookup.registerChannel(gcb1, ch1, name1, false);
 
       ConfigurationBuilder replCfg = new ConfigurationBuilder();

--- a/core/src/test/java/org/infinispan/statetransfer/ConcurrentStartForkChannelTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/ConcurrentStartForkChannelTest.java
@@ -99,7 +99,6 @@ public class ConcurrentStartForkChannelTest extends MultipleCacheManagersTest {
          Exception {
       GlobalConfigurationBuilder gcb = new GlobalConfigurationBuilder();
       gcb.transport().nodeName(channel.getName());
-      gcb.globalJmxStatistics().allowDuplicateDomains(true);
       gcb.transport().distributedSyncTimeout(30, TimeUnit.SECONDS);
 
       FORK fork = new FORK();

--- a/core/src/test/java/org/infinispan/statetransfer/ConcurrentStartTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/ConcurrentStartTest.java
@@ -115,7 +115,6 @@ public class ConcurrentStartTest extends MultipleCacheManagersTest {
 
    private EmbeddedCacheManager createCacheManager(int index) {
       GlobalConfigurationBuilder gcb = new GlobalConfigurationBuilder();
-      gcb.globalJmxStatistics().disable().allowDuplicateDomains(true);
       gcb.transport().defaultTransport();
       TestCacheManagerFactory.amendGlobalConfiguration(gcb, new TransportFlags().withPortRange(index));
       EmbeddedCacheManager cm = new DefaultCacheManager(gcb.build(), false);

--- a/core/src/test/java/org/infinispan/stress/LargeCluster2StressTest.java
+++ b/core/src/test/java/org/infinispan/stress/LargeCluster2StressTest.java
@@ -100,7 +100,6 @@ public class LargeCluster2StressTest extends MultipleCacheManagersTest {
                @Override
                public Void call() throws Exception {
                   GlobalConfigurationBuilder gcb = new GlobalConfigurationBuilder();
-                  gcb.globalJmxStatistics().allowDuplicateDomains(true);
                   gcb.transport().defaultTransport().nodeName(nodeName)
                         .addProperty(JGroupsTransport.CONFIGURATION_STRING, configurator.getProtocolStackString());
                   BlockingThreadPoolExecutorFactory transportExecutorFactory = new BlockingThreadPoolExecutorFactory(

--- a/core/src/test/java/org/infinispan/stress/LargeClusterStressTest.java
+++ b/core/src/test/java/org/infinispan/stress/LargeClusterStressTest.java
@@ -67,7 +67,6 @@ public class LargeClusterStressTest extends MultipleCacheManagersTest {
                @Override
                public Object call() throws Exception {
                   GlobalConfigurationBuilder gcb = new GlobalConfigurationBuilder();
-                  gcb.globalJmxStatistics().allowDuplicateDomains(true);
                   gcb.transport().defaultTransport().nodeName(nodeName);
 //                  gcb.transport().machineId(machineId);
                   BlockingThreadPoolExecutorFactory remoteExecutorFactory = new BlockingThreadPoolExecutorFactory(

--- a/core/src/test/java/org/infinispan/test/fwk/TestCacheManagerFactory.java
+++ b/core/src/test/java/org/infinispan/test/fwk/TestCacheManagerFactory.java
@@ -267,7 +267,7 @@ public class TestCacheManagerFactory {
     * @see #createCacheManagerEnforceJmxDomain(String)
     */
    public static EmbeddedCacheManager createCacheManagerEnforceJmxDomain(String jmxDomain) {
-      return createCacheManagerEnforceJmxDomain(jmxDomain, true, true);
+      return createCacheManagerEnforceJmxDomain(jmxDomain, true, true, true);
    }
 
    public static EmbeddedCacheManager createClusteredCacheManagerEnforceJmxDomain(String jmxDomain) {
@@ -311,17 +311,18 @@ public class TestCacheManagerFactory {
    /**
     * @see #createCacheManagerEnforceJmxDomain(String)
     */
-   public static EmbeddedCacheManager createCacheManagerEnforceJmxDomain(String jmxDomain, boolean exposeGlobalJmx, boolean exposeCacheJmx) {
-      return createCacheManagerEnforceJmxDomain(jmxDomain, null, exposeGlobalJmx, exposeCacheJmx);
+   public static EmbeddedCacheManager createCacheManagerEnforceJmxDomain(String jmxDomain, boolean exposeGlobalJmx, boolean exposeCacheJmx, boolean allowDuplicates) {
+      return createCacheManagerEnforceJmxDomain(jmxDomain, null, exposeGlobalJmx, exposeCacheJmx, allowDuplicates);
    }
 
    /**
     * @see #createCacheManagerEnforceJmxDomain(String)
     */
-   public static EmbeddedCacheManager createCacheManagerEnforceJmxDomain(String jmxDomain, String cacheManagerName, boolean exposeGlobalJmx, boolean exposeCacheJmx) {
+   public static EmbeddedCacheManager createCacheManagerEnforceJmxDomain(String jmxDomain, String cacheManagerName, boolean exposeGlobalJmx, boolean exposeCacheJmx, boolean allowDuplicates) {
       GlobalConfigurationBuilder globalConfiguration = new GlobalConfigurationBuilder();
       globalConfiguration
             .globalJmxStatistics()
+            .allowDuplicateDomains(allowDuplicates)
             .jmxDomain(jmxDomain)
             .mBeanServerLookup(new PerThreadMBeanServerLookup())
             .enabled(exposeGlobalJmx);

--- a/core/src/test/java/org/infinispan/tx/DefaultEnlistmentModeTest.java
+++ b/core/src/test/java/org/infinispan/tx/DefaultEnlistmentModeTest.java
@@ -69,6 +69,6 @@ public class DefaultEnlistmentModeTest extends AbstractCacheTest {
    }
 
    private GlobalConfiguration getGlobalConfig() {
-      return new GlobalConfigurationBuilder().globalJmxStatistics().allowDuplicateDomains(true).build();
+      return new GlobalConfigurationBuilder().build();
    }
 }

--- a/core/src/test/java/org/infinispan/tx/recovery/admin/SimpleCacheRecoveryAdminTest.java
+++ b/core/src/test/java/org/infinispan/tx/recovery/admin/SimpleCacheRecoveryAdminTest.java
@@ -79,7 +79,7 @@ public class SimpleCacheRecoveryAdminTest extends AbstractRecoveryTest {
       GlobalConfigurationBuilder globalConfiguration = GlobalConfigurationBuilder.defaultClusteredBuilder();
       globalConfiguration.globalJmxStatistics().enable()
             .mBeanServerLookup(new PerThreadMBeanServerLookup())
-            .jmxDomain(JMX_DOMAIN).allowDuplicateDomains(true);
+            .jmxDomain(JMX_DOMAIN);
       return globalConfiguration;
    }
 

--- a/core/src/test/java/org/infinispan/util/ThreadLocalLeakTest.java
+++ b/core/src/test/java/org/infinispan/util/ThreadLocalLeakTest.java
@@ -18,7 +18,6 @@ import java.util.regex.Pattern;
 import org.infinispan.Cache;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
-import org.infinispan.configuration.global.GlobalJmxStatisticsConfigurationBuilder;
 import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.AbstractInfinispanTest;
@@ -97,9 +96,8 @@ public class ThreadLocalLeakTest extends AbstractInfinispanTest {
    }
 
    private Thread doStuffWithCache(ConfigurationBuilder builder) {
-      GlobalJmxStatisticsConfigurationBuilder globalBuilder =
-            new GlobalConfigurationBuilder().nonClusteredDefault()
-                  .globalJmxStatistics().allowDuplicateDomains(true);
+      GlobalConfigurationBuilder globalBuilder =
+            new GlobalConfigurationBuilder().nonClusteredDefault();
       final EmbeddedCacheManager[] cm = {new DefaultCacheManager(globalBuilder.build(), builder.build(),
             true)};
       Thread forkedThread = null;

--- a/counter/src/test/java/org/infinispan/counter/ConfigurationTest.java
+++ b/counter/src/test/java/org/infinispan/counter/ConfigurationTest.java
@@ -52,7 +52,6 @@ public class ConfigurationTest extends AbstractCacheTest {
 
    private static GlobalConfigurationBuilder defaultGlobalConfigurationBuilder(boolean globalStateEnabled) {
       GlobalConfigurationBuilder builder = GlobalConfigurationBuilder.defaultClusteredBuilder();
-      builder.globalJmxStatistics().enabled(false).allowDuplicateDomains(true);
       builder.globalState().enabled(globalStateEnabled).persistentLocation(PERSISTENT_FOLDER)
             .temporaryLocation(TEMP_PERSISTENT_FOLDER);
       return builder;

--- a/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/util/TestInfinispanRegionFactory.java
+++ b/hibernate-cache/src/test/java/org/infinispan/test/hibernate/cache/util/TestInfinispanRegionFactory.java
@@ -56,7 +56,6 @@ public class TestInfinispanRegionFactory extends InfinispanRegionFactory {
 	}
 
 	protected void amendConfiguration(ConfigurationBuilderHolder holder) {
-		holder.getGlobalConfigurationBuilder().globalJmxStatistics().allowDuplicateDomains(true);
 		TransportConfigurationBuilder transport = holder.getGlobalConfigurationBuilder().transport();
 		transport.nodeName(TestResourceTracker.getNextNodeName());
 		transport.clusterName(TestResourceTracker.getCurrentTestName());

--- a/integrationtests/all-embedded-it/src/test/java/org/infinispan/all/embedded/EmbeddedAllTest.java
+++ b/integrationtests/all-embedded-it/src/test/java/org/infinispan/all/embedded/EmbeddedAllTest.java
@@ -46,12 +46,12 @@ public class EmbeddedAllTest {
    public static void beforeTest() throws Exception {
 
       GlobalConfiguration globalConfiguration = GlobalConfigurationBuilder
-            .defaultClusteredBuilder().globalJmxStatistics().allowDuplicateDomains(true)
+            .defaultClusteredBuilder()
             .transport().nodeName("node1")
             .build();
 
       GlobalConfiguration globalConfiguration2 = GlobalConfigurationBuilder
-            .defaultClusteredBuilder().globalJmxStatistics().allowDuplicateDomains(true)
+            .defaultClusteredBuilder()
             .transport().nodeName("node2")
             .build();
 

--- a/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/AbstractQueryTest.java
+++ b/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/AbstractQueryTest.java
@@ -39,7 +39,6 @@ public abstract class AbstractQueryTest {
 
    protected static EmbeddedCacheManager createCacheManager() throws Exception {
       GlobalConfigurationBuilder gcfg = new GlobalConfigurationBuilder();
-      gcfg.globalJmxStatistics().allowDuplicateDomains(true);
 
       ConfigurationBuilder cfg = new ConfigurationBuilder();
       cfg.transaction()

--- a/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/IndexedEntityAutodetectTest.java
+++ b/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/IndexedEntityAutodetectTest.java
@@ -21,7 +21,6 @@ public class IndexedEntityAutodetectTest extends LocalCacheTest {
 
    protected static EmbeddedCacheManager createCacheManager() throws Exception {
       GlobalConfigurationBuilder gcfg = new GlobalConfigurationBuilder();
-      gcfg.globalJmxStatistics().allowDuplicateDomains(true);
 
       // this configuration does not declare any indexed types on purpose, so they are autodetected
       ConfigurationBuilder cfg = new ConfigurationBuilder();

--- a/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/QueryDslConditionsTest.java
+++ b/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/QueryDslConditionsTest.java
@@ -73,7 +73,6 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
    protected static EmbeddedCacheManager createCacheManager() throws Exception {
       GlobalConfigurationBuilder gcfg = new GlobalConfigurationBuilder();
-      gcfg.globalJmxStatistics().allowDuplicateDomains(true);
 
       ConfigurationBuilder cfg = new ConfigurationBuilder();
       cfg.transaction()

--- a/integrationtests/wildfly-modules/src/test/java/org/infinispan/test/integration/as/InfinispanCoreIT.java
+++ b/integrationtests/wildfly-modules/src/test/java/org/infinispan/test/integration/as/InfinispanCoreIT.java
@@ -54,7 +54,6 @@ public class InfinispanCoreIT {
    @Test
    public void testCacheManager() {
       GlobalConfigurationBuilder gcb = new GlobalConfigurationBuilder();
-      gcb.globalJmxStatistics().allowDuplicateDomains(true);
 
       cm = new DefaultCacheManager(gcb.build(), new ConfigurationBuilder().build());
       Cache<String, String> cache = cm.getCache();

--- a/integrationtests/wildfly-modules/src/test/java/org/infinispan/test/integration/as/InfinispanStoreJdbcIT.java
+++ b/integrationtests/wildfly-modules/src/test/java/org/infinispan/test/integration/as/InfinispanStoreJdbcIT.java
@@ -58,7 +58,6 @@ public class InfinispanStoreJdbcIT {
    @Test
    public void testCacheManager() {
       GlobalConfigurationBuilder gcb = new GlobalConfigurationBuilder();
-      gcb.globalJmxStatistics().allowDuplicateDomains(true);
 
       ConfigurationBuilder builder = new ConfigurationBuilder();
       builder.persistence().addStore(JdbcStringBasedStoreConfigurationBuilder.class)

--- a/integrationtests/wildfly-modules/src/test/java/org/infinispan/test/integration/as/InfinispanStoreJpaIT.java
+++ b/integrationtests/wildfly-modules/src/test/java/org/infinispan/test/integration/as/InfinispanStoreJpaIT.java
@@ -64,7 +64,6 @@ public class InfinispanStoreJpaIT {
    @Test
    public void testCacheManager() {
       GlobalConfigurationBuilder gcb = new GlobalConfigurationBuilder();
-      gcb.globalJmxStatistics().allowDuplicateDomains(true);
 
       ConfigurationBuilder builder = new ConfigurationBuilder();
       builder.persistence().addStore(JpaStoreConfigurationBuilder.class)

--- a/integrationtests/wildfly-modules/src/test/java/org/infinispan/test/integration/as/InfinispanStoreRocksDBIT.java
+++ b/integrationtests/wildfly-modules/src/test/java/org/infinispan/test/integration/as/InfinispanStoreRocksDBIT.java
@@ -71,7 +71,6 @@ public class InfinispanStoreRocksDBIT {
    @Test
    public void testCacheManager() {
       GlobalConfigurationBuilder gcb = new GlobalConfigurationBuilder();
-      gcb.globalJmxStatistics().allowDuplicateDomains(true);
 
       ConfigurationBuilder builder = new ConfigurationBuilder();
       builder.persistence()

--- a/persistence/leveldb/src/test/java/org/infinispan/persistence/leveldb/config/ConfigurationTest.java
+++ b/persistence/leveldb/src/test/java/org/infinispan/persistence/leveldb/config/ConfigurationTest.java
@@ -45,7 +45,6 @@ public class ConfigurationTest extends AbstractInfinispanTest {
 
    public void testConfigBuilder() {
       GlobalConfiguration globalConfig = new GlobalConfigurationBuilder()
-            .globalJmxStatistics().allowDuplicateDomains(true)
             .transport().defaultTransport()
             .build();
 

--- a/persistence/remote/src/test/java/org/infinispan/persistence/remote/RemoteStoreTest.java
+++ b/persistence/remote/src/test/java/org/infinispan/persistence/remote/RemoteStoreTest.java
@@ -38,7 +38,7 @@ public class RemoteStoreTest extends BaseStoreTest {
       localBuilder.memory().evictionType(EvictionType.COUNT).size(WRITE_DELETE_BATCH_MAX_ENTRIES).expiration().wakeUpInterval(10L);
 
       GlobalConfigurationBuilder globalConfig = new GlobalConfigurationBuilder().nonClusteredDefault();
-      globalConfig.globalJmxStatistics().allowDuplicateDomains(true).defaultCacheName(REMOTE_CACHE);
+      globalConfig.globalJmxStatistics().defaultCacheName(REMOTE_CACHE);
 
       localCacheManager = TestCacheManagerFactory.createCacheManager(
             globalConfig, hotRodCacheConfiguration(localBuilder));

--- a/persistence/rest/src/test/java/org/infinispan/persistence/rest/RestStoreTest.java
+++ b/persistence/rest/src/test/java/org/infinispan/persistence/rest/RestStoreTest.java
@@ -40,7 +40,6 @@ public class RestStoreTest extends BaseStoreTest {
       localBuilder.memory().evictionType(EvictionType.COUNT).size(WRITE_DELETE_BATCH_MAX_ENTRIES).expiration().wakeUpInterval(10L);
 
       GlobalConfigurationBuilder globalConfig = new GlobalConfigurationBuilder().nonClusteredDefault();
-      globalConfig.globalJmxStatistics().allowDuplicateDomains(true);
 
       localCacheManager = TestCacheManagerFactory.createCacheManager(globalConfig, localBuilder);
       localCacheManager.defineConfiguration(REMOTE_CACHE, localCacheManager.getDefaultCacheConfiguration());

--- a/persistence/rocksdb/src/test/java/org/infinispan/persistence/rocksdb/config/ConfigurationTest.java
+++ b/persistence/rocksdb/src/test/java/org/infinispan/persistence/rocksdb/config/ConfigurationTest.java
@@ -38,7 +38,6 @@ public class ConfigurationTest extends AbstractInfinispanTest {
 
    public void testConfigBuilder() {
       GlobalConfiguration globalConfig = new GlobalConfigurationBuilder()
-            .globalJmxStatistics().allowDuplicateDomains(true)
             .transport().defaultTransport()
             .build();
 

--- a/query/src/test/java/org/infinispan/query/backend/QueryInterceptorTest.java
+++ b/query/src/test/java/org/infinispan/query/backend/QueryInterceptorTest.java
@@ -206,7 +206,7 @@ public class QueryInterceptorTest {
 
    protected EmbeddedCacheManager createCacheManager(int maxEntries) throws Exception {
       return new DefaultCacheManager(
-              new GlobalConfigurationBuilder().globalJmxStatistics().allowDuplicateDomains(true).build(),
+              new GlobalConfigurationBuilder().build(),
               new ConfigurationBuilder()
                       .memory().evictionType(EvictionType.COUNT).size(maxEntries)
                       .persistence().passivation(true)
@@ -223,7 +223,7 @@ public class QueryInterceptorTest {
 
    protected EmbeddedCacheManager createVolatileCacheManager() throws Exception {
       return new DefaultCacheManager(
-            new GlobalConfigurationBuilder().globalJmxStatistics().allowDuplicateDomains(true).build(),
+            new GlobalConfigurationBuilder().build(),
             new ConfigurationBuilder()
                   .indexing().index(Index.ALL)
                   .addIndexedEntity(Person.class)

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodSharedContainerTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodSharedContainerTest.java
@@ -35,7 +35,6 @@ public class HotRodSharedContainerTest extends MultipleCacheManagersTest {
    @Override
    protected void createCacheManagers() {
       GlobalConfigurationBuilder globalCfg = GlobalConfigurationBuilder.defaultClusteredBuilder();
-      globalCfg.globalJmxStatistics().allowDuplicateDomains(true);
       EmbeddedCacheManager cm =
             TestCacheManagerFactory.createClusteredCacheManager(globalCfg, hotRodCacheConfiguration());
       cacheManagers.add(cm);

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/test/HotRodTestingUtil.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/test/HotRodTestingUtil.java
@@ -123,7 +123,6 @@ public class HotRodTestingUtil {
 
    public static HotRodServer startHotRodServerWithoutTransport(HotRodServerConfigurationBuilder builder) {
       GlobalConfigurationBuilder globalConfiguration = new GlobalConfigurationBuilder();
-      globalConfiguration.globalJmxStatistics().allowDuplicateDomains(true);
 
       ConfigurationBuilder cacheConfiguration = new ConfigurationBuilder();
       cacheConfiguration.compatibility().enable();

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerConfigurationBuilder.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerConfigurationBuilder.java
@@ -239,8 +239,7 @@ public class CacheContainerConfigurationBuilder implements Builder<GlobalConfigu
                 .enabled(this.statisticsEnabled)
                 .cacheManagerName(this.name)
                 .mBeanServerLookup(new MBeanServerProvider(this.server.getValue()))
-                .jmxDomain(CacheContainerServiceName.CACHE_CONTAINER.getServiceName(CacheServiceNameFactory.DEFAULT_CACHE).getParent().getCanonicalName())
-                .allowDuplicateDomains(true);
+                .jmxDomain(CacheContainerServiceName.CACHE_CONTAINER.getServiceName(CacheServiceNameFactory.DEFAULT_CACHE).getParent().getCanonicalName());
 
         builder.addModule(PrivateGlobalConfigurationBuilder.class).serverMode(true);
         return builder.build();

--- a/server/rest/src/test/java/org/infinispan/rest/helper/RestServerHelper.java
+++ b/server/rest/src/test/java/org/infinispan/rest/helper/RestServerHelper.java
@@ -38,7 +38,6 @@ public class RestServerHelper {
       GlobalConfigurationBuilder globalConfigurationBuilder = new GlobalConfigurationBuilder();
       globalConfigurationBuilder.addModule(PrivateGlobalConfigurationBuilder.class).serverMode(true);
       GlobalConfigurationBuilder globalConfiguration = globalConfigurationBuilder.nonClusteredDefault();
-      globalConfiguration.globalJmxStatistics().allowDuplicateDomains(true);
       DefaultCacheManager cacheManager = new DefaultCacheManager(globalConfiguration.build(), configuration.build());
       for (String cacheConfiguration : cachesDefined) {
          cacheManager.defineConfiguration(cacheConfiguration, configuration.build());

--- a/server/router/src/test/java/org/infinispan/server/router/utils/CacheManagerTestingUtil.java
+++ b/server/router/src/test/java/org/infinispan/server/router/utils/CacheManagerTestingUtil.java
@@ -12,8 +12,6 @@ public class CacheManagerTestingUtil {
     }
 
     public static GlobalConfigurationBuilder createDefaultGlobalConfiguration() {
-        GlobalConfigurationBuilder configurationBuilder = new GlobalConfigurationBuilder();
-        configurationBuilder.globalJmxStatistics().disable().allowDuplicateDomains(true);
-        return configurationBuilder;
+       return new GlobalConfigurationBuilder();
     }
 }

--- a/spring/spring4/spring4-embedded/src/main/java/org/infinispan/spring/AbstractEmbeddedCacheManagerFactory.java
+++ b/spring/spring4/spring4-embedded/src/main/java/org/infinispan/spring/AbstractEmbeddedCacheManagerFactory.java
@@ -56,7 +56,6 @@ public class AbstractEmbeddedCacheManagerFactory {
             if (logger.isDebugEnabled()) logger.debug("GlobalConfigurationBuilder is null. Using default new " +
                                                             "instance.");
             gcb = new GlobalConfigurationBuilder();
-            gcb.globalJmxStatistics().allowDuplicateDomains(true);
          }
 
          if (builder == null) {

--- a/spring/spring4/spring4-embedded/src/test/java/org/infinispan/spring/config/DuplicateDomainAwareCacheManager.java
+++ b/spring/spring4/spring4-embedded/src/test/java/org/infinispan/spring/config/DuplicateDomainAwareCacheManager.java
@@ -11,6 +11,6 @@ import org.infinispan.manager.DefaultCacheManager;
 public class DuplicateDomainAwareCacheManager extends DefaultCacheManager {
 
    public DuplicateDomainAwareCacheManager() {
-      super(new GlobalConfigurationBuilder().globalJmxStatistics().allowDuplicateDomains(true).build());
+      super(new GlobalConfigurationBuilder().build());
    }
 }

--- a/spring/spring4/spring4-embedded/src/test/java/org/infinispan/spring/provider/SpringEmbeddedCacheManagerFactoryBeanTest.java
+++ b/spring/spring4/spring4-embedded/src/test/java/org/infinispan/spring/provider/SpringEmbeddedCacheManagerFactoryBeanTest.java
@@ -105,7 +105,7 @@ public class SpringEmbeddedCacheManagerFactoryBeanTest {
    public void testIfSpringEmbeddedCacheManagerFactoryBeanStopsTheCreatedEmbeddedCacheManagerWhenBeingDestroyed()
          throws Exception {
       GlobalConfigurationBuilder builder = new GlobalConfigurationBuilder();
-      builder.defaultCacheName("default").globalJmxStatistics().allowDuplicateDomains(true);
+      builder.defaultCacheName("default");
       objectUnderTest = SpringEmbeddedCacheManagerFactoryBeanBuilder
             .defaultBuilder().withGlobalConfiguration(builder).build();
 
@@ -125,7 +125,6 @@ public class SpringEmbeddedCacheManagerFactoryBeanTest {
    public void testIfSpringEmbeddedCacheManagerFactoryBeanAllowesOverridingGlobalConfiguration() throws Exception {
       GlobalConfigurationBuilder overriddenConfiguration = new GlobalConfigurationBuilder();
       overriddenConfiguration.transport().rackId("r2");
-      overriddenConfiguration.globalJmxStatistics().allowDuplicateDomains(true);
 
       objectUnderTest = SpringEmbeddedCacheManagerFactoryBeanBuilder
             .defaultBuilder().fromFile(NAMED_ASYNC_CACHE_CONFIG_LOCATION, getClass())
@@ -169,11 +168,7 @@ public class SpringEmbeddedCacheManagerFactoryBeanTest {
       objectUnderTest = SpringEmbeddedCacheManagerFactoryBeanBuilder
             .defaultBuilder().build();
 
-      // Allow duplicate domains. A good little configuration modification to make. If this isn't enabled,
-      // JMXDomainConflicts occur which break the testsuite. This way we can also have a non-default configuration to
-      // check.
       GlobalConfigurationBuilder gcb = new GlobalConfigurationBuilder();
-      gcb.globalJmxStatistics().allowDuplicateDomains(true);
 
       // Now prepare a cache configuration.
       ConfigurationBuilder builder = new ConfigurationBuilder();

--- a/spring/spring4/spring4-embedded/src/test/java/org/infinispan/spring/support/embedded/InfinispanEmbeddedCacheManagerFactoryBeanTest.java
+++ b/spring/spring4/spring4-embedded/src/test/java/org/infinispan/spring/support/embedded/InfinispanEmbeddedCacheManagerFactoryBeanTest.java
@@ -165,11 +165,7 @@ public class InfinispanEmbeddedCacheManagerFactoryBeanTest {
    public final void testAddConfigurations() throws Exception {
       final InfinispanEmbeddedCacheManagerFactoryBean objectUnderTest = new InfinispanEmbeddedCacheManagerFactoryBean();
 
-      // Allow duplicate domains. A good little configuration modification to make. If this isn't enabled,
-      // JMXDomainConflicts occur which break the testsuite. This way we can also have a non-default configuration to
-      // check.
       GlobalConfigurationBuilder gcb = new GlobalConfigurationBuilder();
-      gcb.globalJmxStatistics().allowDuplicateDomains(true);
 
       // Now prepare a cache configuration.
       ConfigurationBuilder builder = new ConfigurationBuilder();

--- a/tools/src/main/java/org/infinispan/tools/jdbc/migrator/JDBCMigrator.java
+++ b/tools/src/main/java/org/infinispan/tools/jdbc/migrator/JDBCMigrator.java
@@ -65,9 +65,7 @@ public class JDBCMigrator {
    private AdvancedCache initAndGetTargetCache() {
       MigratorConfiguration config = new MigratorConfiguration(false, properties);
       GlobalConfigurationBuilder builder = new GlobalConfigurationBuilder();
-      builder.defaultCacheName(defaultCacheName)
-            .globalJmxStatistics()
-            .allowDuplicateDomains(true);
+      builder.defaultCacheName(defaultCacheName);
 
       SerializationConfigurationBuilder serialBuilder = builder.serialization().marshaller(config.getMarshaller());
       config.addExternalizersToConfig(serialBuilder);

--- a/tools/src/main/java/org/infinispan/tools/jdbc/migrator/MigratorConfiguration.java
+++ b/tools/src/main/java/org/infinispan/tools/jdbc/migrator/MigratorConfiguration.java
@@ -183,8 +183,6 @@ class MigratorConfiguration {
                return null;
 
             GlobalConfigurationBuilder globalConfig = new GlobalConfigurationBuilder()
-                  .globalJmxStatistics()
-                  .allowDuplicateDomains(true)
                   .defaultCacheName(cacheName);
             addExternalizersToConfig(globalConfig.serialization());
 

--- a/tools/src/test/java/org/infinispan/tools/jdbc/migrator/MigratorSerializerTest.java
+++ b/tools/src/test/java/org/infinispan/tools/jdbc/migrator/MigratorSerializerTest.java
@@ -61,10 +61,7 @@ public class MigratorSerializerTest {
    private static final String TABLE_TS_COL = "TIMESTAMP_COLUMN";
    private static final String TABLE_TS_TYPE = "BIGINT";
 
-   private static final GlobalConfiguration GLOBAL_CONFIG = new GlobalConfigurationBuilder()
-         .globalJmxStatistics()
-         .allowDuplicateDomains(true)
-         .build();
+   private static final GlobalConfiguration GLOBAL_CONFIG = new GlobalConfigurationBuilder().build();
 
    private JDBCMigrator migrator;
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-8395

* Ever since MBeans have been registered by default, not allowing
  duplicate JMX domains has been a usability issue.
* To be able to create a cluster of 2 or more nodes on same JMV, users
  had to explicitly allow jmx name duplicates, or provide different
  jmx names for each cache manager.