### PR TITLE
ISPN-8444 JPA cache store failed to deploy in OSGi

### DIFF
--- a/persistence/jpa/pom.xml
+++ b/persistence/jpa/pom.xml
@@ -121,6 +121,15 @@
                </execution>
             </executions>
          </plugin>
+         <plugin>
+            <groupId>org.apache.karaf.tooling</groupId>
+            <artifactId>karaf-maven-plugin</artifactId>
+            <configuration>
+               <features>
+                  <feature>${project.artifactId}</feature>
+               </features>
+            </configuration>
+         </plugin>
       </plugins>
    </build>
    <dependencies>
@@ -246,15 +255,6 @@
                         <db.username>${db.username}</db.username>
                         <db.password>${db.password}</db.password>
                      </systemPropertyVariables>
-                  </configuration>
-               </plugin>
-               <plugin>
-                  <groupId>org.apache.karaf.tooling</groupId>
-                  <artifactId>karaf-maven-plugin</artifactId>
-                  <configuration>
-                     <features>
-                        <feature>${project.artifactId}</feature>
-                     </features>
                   </configuration>
                </plugin>
             </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -212,6 +212,7 @@
       <version.h2.driver>1.4.180</version.h2.driver>
       <version.h2.driver-within-wildfly>1.3.173</version.h2.driver-within-wildfly>
       <version.hibernate.core>5.2.7.Final</version.hibernate.core>
+      <version.hibernate.javax.persistence>1.0.0.Final</version.hibernate.javax.persistence>
       <version.hibernate.osgi>${version.hibernate.core}</version.hibernate.osgi>
       <version.hibernate.search>5.8.0.Final</version.hibernate.search>
       <version.hibernate_dep.antlr>2.7.7_5</version.hibernate_dep.antlr>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-8444

This was caused by the fact that the features.xml file for JPA cache store was not generated properly as the maven plugins use filtering and they couldn't see the javax.persistence property. 