### PR TITLE
ISPN-8408 integrationtests-parent no longer users pom inheritance

### DIFF
--- a/integrationtests/pom.xml
+++ b/integrationtests/pom.xml
@@ -2,14 +2,9 @@
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.infinispan</groupId>
-        <artifactId>infinispan-parent</artifactId>
-        <version>9.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
-    </parent>
-
+    <groupId>org.infinispan</groupId>
     <artifactId>infinispan-integrationtests-parent</artifactId>
+    <version>9.2.0-SNAPSHOT</version>
     <name>Infinispan Integration Tests Parent</name>
     <description>Infinispan Integration Tests Parent</description>
     <packaging>pom</packaging>
@@ -17,7 +12,31 @@
     <properties>
         <forkJvmArgs>-Xmx2G</forkJvmArgs>
         <jigsawForkJvmArgs></jigsawForkJvmArgs>
+        <version.java>1.8</version.java>
+        <version.maven-compiler-plugin>3.6.1</version.maven-compiler-plugin>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>infinispan-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>infinispan-embedded</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>infinispan-embedded-query</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <profiles>
         <profile>
@@ -91,6 +110,19 @@
                     <configuration>
                         <trimStackTrace>false</trimStackTrace>
                         <argLine>${forkJvmArgs} ${jigsawForkJvmArgs}</argLine>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${version.maven-compiler-plugin}</version>
+                    <configuration>
+                        <source>${version.java}</source>
+                        <target>${version.java}</target>
+                        <encoding>UTF-8</encoding>
+                        <excludes>
+                            <exclude>**/package-info.java</exclude>
+                        </excludes>
+                        <compilerArgument>-AtranslationFilesPath=${project.basedir}/target/generated-translation-files</compilerArgument>
                     </configuration>
                 </plugin>
             </plugins>


### PR DESCRIPTION
The only downside to this fix is that we have to have the compiler settings explicit on the integration-tests pom. 