### PR TITLE
ISPN-8448 Retried prepare times out while partition is in degraded mode

### DIFF
--- a/core/src/main/java/org/infinispan/partitionhandling/impl/PartitionHandlingInterceptor.java
+++ b/core/src/main/java/org/infinispan/partitionhandling/impl/PartitionHandlingInterceptor.java
@@ -173,6 +173,14 @@ public class PartitionHandlingInterceptor extends DDAsyncInterceptor {
       if (!ctx.isOriginLocal()) {
          return invokeNext(ctx, command);
       }
+
+      // Don't send a 2PC prepare at all if the cache is in degraded mode
+      if (partitionHandlingManager.getAvailabilityMode() != AvailabilityMode.AVAILABLE &&
+            !command.isOnePhaseCommit() && ctx.hasModifications()) {
+         for (Object key : ctx.getAffectedKeys()) {
+            partitionHandlingManager.checkWrite(key);
+         }
+      }
       return invokeNextThenAccept(ctx, command, postTxCommandCheck);
    }
 
@@ -186,7 +194,9 @@ public class PartitionHandlingInterceptor extends DDAsyncInterceptor {
 
    protected void postTxCommandCheck(InvocationContext rCtx, VisitableCommand rCommand, Object rv) {
       TxInvocationContext ctx = (TxInvocationContext) rCtx;
-      if (ctx.hasModifications() && partitionHandlingManager.getAvailabilityMode() != AvailabilityMode.AVAILABLE && !partitionHandlingManager.isTransactionPartiallyCommitted(ctx.getGlobalTransaction())) {
+      if (partitionHandlingManager.getAvailabilityMode() != AvailabilityMode.AVAILABLE &&
+            !partitionHandlingManager.isTransactionPartiallyCommitted(ctx.getGlobalTransaction()) &&
+            ctx.hasModifications()) {
          for (Object key : ctx.getAffectedKeys()) {
             partitionHandlingManager.checkWrite(key);
          }

--- a/core/src/test/java/org/infinispan/test/Exceptions.java
+++ b/core/src/test/java/org/infinispan/test/Exceptions.java
@@ -67,6 +67,16 @@ public class Exceptions {
       assertException(exceptionClass, t.getCause().getCause());
    }
 
+   public static void assertException(Class<? extends Throwable> wrapperExceptionClass3,
+                                      Class<? extends Throwable> wrapperExceptionClass2,
+                                      Class<? extends Throwable> wrapperExceptionClass,
+                                      Class<? extends Throwable> exceptionClass, Throwable t) {
+      assertException(wrapperExceptionClass3, t);
+      assertException(wrapperExceptionClass2, t.getCause());
+      assertException(wrapperExceptionClass, t.getCause().getCause());
+      assertException(exceptionClass, t.getCause().getCause().getCause());
+   }
+
    public static void expectException(Class<? extends Throwable> exceptionClass, String messageRegex,
          ExceptionRunnable runnable) {
       Throwable t = extractException(runnable);


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-8448

Updated to throw the AvailabilityException *before* sending the prepare command remotely.
After a CacheNotFoundResponse, the AvailabilityException is sent during the retry.

Opened ISPN-8453 to deal more directly with CacheNotFoundResponses.

Please cherry-pick to 9.1.x as well.