### PR TITLE
ISPN-8409 Change off heap eviction to store everything in same allocated

### DIFF
--- a/core/src/main/java/org/infinispan/container/offheap/BoundedOffHeapDataContainer.java
+++ b/core/src/main/java/org/infinispan/container/offheap/BoundedOffHeapDataContainer.java
@@ -25,13 +25,13 @@ import org.infinispan.metadata.Metadata;
  * @since 9.0
  */
 public class BoundedOffHeapDataContainer extends OffHeapDataContainer {
-   private final long maxSize;
-   private final Lock lruLock;
-   private final LongUnaryOperator sizeCalculator;
+   protected final long maxSize;
+   protected final Lock lruLock;
+   protected final LongUnaryOperator sizeCalculator;
 
-   private long currentSize;
-   private long firstAddress;
-   private long lastAddress;
+   protected long currentSize;
+   protected long firstAddress;
+   protected long lastAddress;
 
    public BoundedOffHeapDataContainer(int desiredSize, long maxSize, EvictionType type) {
       super(desiredSize);
@@ -40,7 +40,7 @@ public class BoundedOffHeapDataContainer extends OffHeapDataContainer {
          sizeCalculator = i -> 1;
       } else {
          // Use size of entry plus 16 for our LRU pointers
-         sizeCalculator = i -> offHeapEntryFactory.getSize(i) + OffHeapLruNode.getSize();
+         sizeCalculator = i -> offHeapEntryFactory.getSize(i);
       }
       this.lruLock = new ReentrantLock();
       firstAddress = 0;

--- a/core/src/main/java/org/infinispan/container/offheap/OffHeapLruNode.java
+++ b/core/src/main/java/org/infinispan/container/offheap/OffHeapLruNode.java
@@ -12,13 +12,8 @@ class OffHeapLruNode {
 
    private static final int PREVIOUS_NODE_OFFSET = 0;
    private static final int NEXT_NODE_OFFSET = PREVIOUS_NODE_OFFSET + ADDRESS_SIZE;
-   private static final int SIZE = NEXT_NODE_OFFSET + ADDRESS_SIZE;
 
    private OffHeapLruNode() {
-   }
-
-   static int getSize() {
-      return SIZE;
    }
 
    static long getNext(long lruNodeAddress) {

--- a/core/src/test/java/org/infinispan/container/offheap/OffHeapBoundedMemoryTest.java
+++ b/core/src/test/java/org/infinispan/container/offheap/OffHeapBoundedMemoryTest.java
@@ -3,9 +3,11 @@ package org.infinispan.container.offheap;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNull;
 
+import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.StorageType;
+import org.infinispan.container.DataContainer;
 import org.infinispan.eviction.EvictionType;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.AbstractInfinispanTest;
@@ -30,5 +32,28 @@ public class OffHeapBoundedMemoryTest extends AbstractInfinispanTest {
       // Put something larger than size
       assertNull(smallHeapCache.put(1, 3));
       assertEquals(0, smallHeapCache.size());
+   }
+
+   private static DataContainer getContainer(AdvancedCache cache) {
+      return cache.getDataContainer();
+   }
+
+   /**
+    * Test to ensure that off heap allocated amount equals the total size used by the container
+    */
+   public void testAllocatedAmountEqual() {
+      ConfigurationBuilder builder = new ConfigurationBuilder();
+      builder.memory()
+            .size(100)
+            .evictionType(EvictionType.MEMORY)
+            .storageType(StorageType.OFF_HEAP);
+      EmbeddedCacheManager manager = TestCacheManagerFactory.createCacheManager(builder);
+      AdvancedCache<Object, Object> cache = manager.getCache().getAdvancedCache();
+      cache.put(1, 2);
+      OffHeapMemoryAllocator allocator = cache.getComponentRegistry().getComponent(
+            OffHeapMemoryAllocator.class);
+      BoundedOffHeapDataContainer container = (BoundedOffHeapDataContainer) getContainer(cache);
+      assertEquals(allocator.getAllocatedAmount(), container.currentSize);
+
    }
 }


### PR DESCRIPTION
memory block

* Memory count doesn't require separate amount for lru nodes anymore

https://issues.jboss.org/browse/ISPN-8409