### PR TITLE
ISPN-8458 Biased reads in scattered cache

### DIFF
--- a/core/src/main/java/org/infinispan/commands/CommandsFactory.java
+++ b/core/src/main/java/org/infinispan/commands/CommandsFactory.java
@@ -38,6 +38,8 @@ import org.infinispan.commands.read.SizeCommand;
 import org.infinispan.commands.remote.ClusteredGetAllCommand;
 import org.infinispan.commands.remote.ClusteredGetCommand;
 import org.infinispan.commands.remote.GetKeysInGroupCommand;
+import org.infinispan.commands.remote.RenewBiasCommand;
+import org.infinispan.commands.remote.RevokeBiasCommand;
 import org.infinispan.commands.remote.SingleRpcCommand;
 import org.infinispan.commands.remote.recovery.CompleteTransactionCommand;
 import org.infinispan.commands.remote.recovery.GetInDoubtTransactionsCommand;
@@ -61,6 +63,7 @@ import org.infinispan.commands.write.EvictCommand;
 import org.infinispan.commands.write.ExceptionAckCommand;
 import org.infinispan.commands.write.InvalidateCommand;
 import org.infinispan.commands.write.InvalidateVersionsCommand;
+import org.infinispan.commands.write.PrimaryAckCommand;
 import org.infinispan.commands.write.PutKeyValueCommand;
 import org.infinispan.commands.write.PutMapCommand;
 import org.infinispan.commands.write.RemoveCommand;
@@ -544,6 +547,8 @@ public interface CommandsFactory {
 
    BackupMultiKeyAckCommand buildBackupMultiKeyAckCommand(long id, int segment, int topologyId);
 
+   PrimaryAckCommand buildPrimaryAckCommand(long id, boolean success, Object value, Address[] waitFor);
+
    ExceptionAckCommand buildExceptionAckCommand(long id, Throwable throwable, int topologyId);
 
    BackupWriteRpcCommand buildBackupWriteRpcCommand(DataWriteCommand command);
@@ -551,4 +556,8 @@ public interface CommandsFactory {
    BackupPutMapRpcCommand buildBackupPutMapRpcCommand(PutMapCommand command);
 
    InvalidateVersionsCommand buildInvalidateVersionsCommand(int topologyId, Object[] keys, int[] topologyIds, long[] versions, boolean removed);
+
+   RevokeBiasCommand buildRevokeBiasCommand(Address ackTarget, long id, int topologyId, Collection<Object> keys);
+
+   RenewBiasCommand buildRenewBiasCommand(Object[] keys);
 }

--- a/core/src/main/java/org/infinispan/commands/RemoteCommandsFactory.java
+++ b/core/src/main/java/org/infinispan/commands/RemoteCommandsFactory.java
@@ -23,6 +23,8 @@ import org.infinispan.commands.remote.CacheRpcCommand;
 import org.infinispan.commands.remote.ClusteredGetAllCommand;
 import org.infinispan.commands.remote.ClusteredGetCommand;
 import org.infinispan.commands.remote.GetKeysInGroupCommand;
+import org.infinispan.commands.remote.RenewBiasCommand;
+import org.infinispan.commands.remote.RevokeBiasCommand;
 import org.infinispan.commands.remote.SingleRpcCommand;
 import org.infinispan.commands.remote.recovery.CompleteTransactionCommand;
 import org.infinispan.commands.remote.recovery.GetInDoubtTransactionsCommand;
@@ -335,6 +337,12 @@ public class RemoteCommandsFactory {
                break;
             case InvalidateVersionsCommand.COMMAND_ID:
                command = new InvalidateVersionsCommand(cacheName);
+               break;
+            case RevokeBiasCommand.COMMAND_ID:
+               command = new RevokeBiasCommand(cacheName);
+               break;
+            case RenewBiasCommand.COMMAND_ID:
+               command = new RenewBiasCommand(cacheName);
                break;
             default:
                throw new CacheException("Unknown command id " + id + "!");

--- a/core/src/main/java/org/infinispan/commands/functional/AbstractWriteManyCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/AbstractWriteManyCommand.java
@@ -34,6 +34,7 @@ public abstract class AbstractWriteManyCommand<K, V> implements WriteCommand, Fu
 
    protected <K, V> AbstractWriteManyCommand(AbstractWriteManyCommand<K, V> command) {
       this.commandInvocationId = command.commandInvocationId;
+      this.topologyId = command.topologyId;
       this.params = command.params;
       this.flags = command.flags;
    }
@@ -110,6 +111,11 @@ public abstract class AbstractWriteManyCommand<K, V> implements WriteCommand, Fu
 
    @Override
    public Object getKeyLockOwner() {
+      return commandInvocationId;
+   }
+
+   @Override
+   public CommandInvocationId getCommandInvocationId() {
       return commandInvocationId;
    }
 

--- a/core/src/main/java/org/infinispan/commands/functional/ReadWriteManyCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/ReadWriteManyCommand.java
@@ -31,7 +31,6 @@ public final class ReadWriteManyCommand<K, V, R> extends AbstractWriteManyComman
    private Collection<? extends K> keys;
    private Function<ReadWriteEntryView<K, V>, R> f;
 
-   private int topologyId = -1;
    boolean isForwarded = false;
 
    public ReadWriteManyCommand(Collection<? extends K> keys,
@@ -108,16 +107,6 @@ public final class ReadWriteManyCommand<K, V, R> extends AbstractWriteManyComman
    @Override
    public boolean isReturnValueExpected() {
       return true;
-   }
-
-   @Override
-   public int getTopologyId() {
-      return topologyId;
-   }
-
-   @Override
-   public void setTopologyId(int topologyId) {
-      this.topologyId = topologyId;
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/commands/functional/ReadWriteManyEntriesCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/ReadWriteManyEntriesCommand.java
@@ -33,7 +33,6 @@ public final class ReadWriteManyEntriesCommand<K, V, R> extends AbstractWriteMan
    private Map<? extends K, ? extends V> entries;
    private BiFunction<V, ReadWriteEntryView<K, V>, R> f;
 
-   private int topologyId = -1;
    boolean isForwarded = false;
 
    public ReadWriteManyEntriesCommand(Map<? extends K, ? extends V> entries,
@@ -116,16 +115,6 @@ public final class ReadWriteManyEntriesCommand<K, V, R> extends AbstractWriteMan
    @Override
    public boolean isReturnValueExpected() {
       return true;
-   }
-
-   @Override
-   public int getTopologyId() {
-      return topologyId;  // TODO: Customise this generated block
-   }
-
-   @Override
-   public void setTopologyId(int topologyId) {
-      this.topologyId = topologyId;
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/commands/remote/RenewBiasCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/RenewBiasCommand.java
@@ -1,0 +1,61 @@
+package org.infinispan.commands.remote;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+import org.infinispan.commons.marshall.MarshallUtil;
+import org.infinispan.scattered.BiasManager;
+import org.infinispan.util.ByteString;
+
+public class RenewBiasCommand extends BaseRpcCommand {
+   public static final byte COMMAND_ID = 75;
+
+   Object[] keys;
+   transient BiasManager biasManager;
+
+   public RenewBiasCommand() {
+      super(null);
+   }
+
+   public RenewBiasCommand(ByteString cacheName) {
+      super(cacheName);
+   }
+
+   public RenewBiasCommand(ByteString cacheName, Object[] keys) {
+      super(cacheName);
+      this.keys = keys;
+   }
+
+   public void init(BiasManager biasManager) {
+      this.biasManager = biasManager;
+   }
+
+   @Override
+   public Object invoke() throws Throwable {
+      for (Object key : keys) {
+         biasManager.renewRemoteBias(key, getOrigin());
+      }
+      return null;
+   }
+
+   @Override
+   public byte getCommandId() {
+      return COMMAND_ID;
+   }
+
+   @Override
+   public boolean isReturnValueExpected() {
+      return false;
+   }
+
+   @Override
+   public void writeTo(ObjectOutput output) throws IOException {
+      MarshallUtil.marshallArray(keys, output);
+   }
+
+   @Override
+   public void readFrom(ObjectInput input) throws IOException, ClassNotFoundException {
+      keys = MarshallUtil.unmarshallArray(input, Object[]::new);
+   }
+}

--- a/core/src/main/java/org/infinispan/commands/remote/RevokeBiasCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/RevokeBiasCommand.java
@@ -1,0 +1,109 @@
+package org.infinispan.commands.remote;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.infinispan.commands.CommandsFactory;
+import org.infinispan.commands.write.BackupAckCommand;
+import org.infinispan.commons.marshall.MarshallUtil;
+import org.infinispan.remoting.inboundhandler.DeliverOrder;
+import org.infinispan.remoting.rpc.RpcManager;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.scattered.BiasManager;
+import org.infinispan.util.ByteString;
+
+/**
+ * Informs node that it is not allowed to serve reads from the local record anymore.
+ * After local bias is revoked a {@link BackupAckCommand} is sent to the originator.*
+ */
+//TODO: consolidate this with InvalidateVersionsCommand
+public class RevokeBiasCommand extends BaseRpcCommand {
+   public static final byte COMMAND_ID = 74;
+
+   private Address ackTarget;
+   private long id;
+   private int topologyId;
+   private Collection<Object> keys;
+   private transient BiasManager biasManager;
+   private transient CommandsFactory commandsFactory;
+   private transient RpcManager rpcManager;
+
+   public RevokeBiasCommand() {
+      super(null);
+   }
+
+   public RevokeBiasCommand(ByteString cacheName) {
+      super(cacheName);
+   }
+
+   public RevokeBiasCommand(ByteString cacheName, Address ackTarget, long id, int topologyId, Collection<Object> keys) {
+      super(cacheName);
+      this.ackTarget = ackTarget;
+      this.id = id;
+      this.topologyId = topologyId;
+      this.keys = keys;
+   }
+
+   public void init(BiasManager biasManager, CommandsFactory commandsFactory, RpcManager rpcManager) {
+      this.biasManager = biasManager;
+      this.commandsFactory = commandsFactory;
+      this.rpcManager = rpcManager;
+   }
+
+   @Override
+   public Object invoke() throws Throwable {
+      for (Object key : keys) {
+         biasManager.revokeLocalBias(key);
+      }
+      // ackTarget null means that this message is sent synchronously by primary owner == originator
+      if (ackTarget != null) {
+         BackupAckCommand backupAckCommand = commandsFactory.buildBackupAckCommand(id, topologyId);
+         rpcManager.sendTo(ackTarget, backupAckCommand, DeliverOrder.NONE);
+      }
+      return null;
+   }
+
+   @Override
+   public byte getCommandId() {
+      return COMMAND_ID;
+   }
+
+   @Override
+   public boolean isReturnValueExpected() {
+      return false;
+   }
+
+   @Override
+   public void writeTo(ObjectOutput output) throws IOException {
+      output.writeObject(ackTarget);
+      if (ackTarget != null) {
+         output.writeLong(id);
+      }
+      output.writeInt(topologyId);
+      MarshallUtil.marshallCollection(keys, output);
+   }
+
+   @Override
+   public void readFrom(ObjectInput input) throws IOException, ClassNotFoundException {
+      ackTarget = (Address) input.readObject();
+      if (ackTarget != null) {
+         id = input.readLong();
+      }
+      topologyId = input.readInt();
+      keys = MarshallUtil.unmarshallCollection(input, ArrayList::new);
+   }
+
+   @Override
+   public String toString() {
+      final StringBuilder sb = new StringBuilder("RevokeBiasCommand{");
+      sb.append("ackTarget=").append(ackTarget);
+      sb.append(", id=").append(id);
+      sb.append(", topologyId=").append(topologyId);
+      sb.append(", keys=").append(keys);
+      sb.append('}');
+      return sb.toString();
+   }
+}

--- a/core/src/main/java/org/infinispan/commands/write/ClearCommand.java
+++ b/core/src/main/java/org/infinispan/commands/write/ClearCommand.java
@@ -7,6 +7,7 @@ import java.util.Collection;
 import java.util.Collections;
 
 import org.infinispan.commands.AbstractTopologyAffectedCommand;
+import org.infinispan.commands.CommandInvocationId;
 import org.infinispan.commands.Visitor;
 import org.infinispan.container.DataContainer;
 import org.infinispan.context.InvocationContext;
@@ -101,6 +102,11 @@ public class ClearCommand extends AbstractTopologyAffectedCommand implements Wri
    @Override
    public void fail() {
       throw new UnsupportedOperationException();
+   }
+
+   @Override
+   public CommandInvocationId getCommandInvocationId() {
+      return null;
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/commands/write/DataWriteCommand.java
+++ b/core/src/main/java/org/infinispan/commands/write/DataWriteCommand.java
@@ -1,6 +1,5 @@
 package org.infinispan.commands.write;
 
-import org.infinispan.commands.CommandInvocationId;
 import org.infinispan.commands.DataCommand;
 
 /**
@@ -10,12 +9,6 @@ import org.infinispan.commands.DataCommand;
  * @since 4.0
  */
 public interface DataWriteCommand extends WriteCommand, DataCommand {
-
-   /**
-    * @return the {@link CommandInvocationId} associated to the command.
-    */
-   CommandInvocationId getCommandInvocationId();
-
    /**
     * Initializes the {@link BackupWriteRpcCommand} to send the update to backup owner of a key.
     * <p>

--- a/core/src/main/java/org/infinispan/commands/write/InvalidateCommand.java
+++ b/core/src/main/java/org/infinispan/commands/write/InvalidateCommand.java
@@ -158,6 +158,11 @@ public class InvalidateCommand extends AbstractTopologyAffectedCommand implement
    }
 
    @Override
+   public CommandInvocationId getCommandInvocationId() {
+      return commandInvocationId;
+   }
+
+   @Override
    public Collection<?> getKeysToLock() {
       return Arrays.asList(keys);
    }

--- a/core/src/main/java/org/infinispan/commands/write/PrimaryAckCommand.java
+++ b/core/src/main/java/org/infinispan/commands/write/PrimaryAckCommand.java
@@ -1,0 +1,94 @@
+package org.infinispan.commands.write;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.Arrays;
+
+import org.infinispan.commands.remote.BaseRpcCommand;
+import org.infinispan.commons.marshall.MarshallUtil;
+import org.infinispan.commons.util.Util;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.util.ByteString;
+import org.infinispan.util.concurrent.CommandAckCollector;
+
+/**
+ * Used in scattered cache with biased reads. Carries both the return value of the command
+ * and list of nodes that need to confirm local bias revocation before the originator can
+ * finish the operation.
+ */
+public class PrimaryAckCommand extends BaseRpcCommand {
+   public static final int COMMAND_ID = 73;
+
+   private transient CommandAckCollector commandAckCollector;
+
+   private long id;
+   private boolean success;
+   private Object value;
+   private Address[] waitFor;
+
+   public PrimaryAckCommand() {
+      super(null);
+   }
+
+   public PrimaryAckCommand(ByteString cacheName) {
+      super(cacheName);
+   }
+
+   public PrimaryAckCommand(ByteString cacheName, long id, boolean success, Object value, Address[] waitFor) {
+      super(cacheName);
+      this.id = id;
+      this.success = success;
+      this.value = value;
+      this.waitFor = waitFor;
+   }
+
+   public void setCommandAckCollector(CommandAckCollector commandAckCollector) {
+      this.commandAckCollector = commandAckCollector;
+   }
+
+   public void ack() {
+      commandAckCollector.primaryAck(id, getOrigin(), value, success, waitFor);
+   }
+
+   @Override
+   public byte getCommandId() {
+      return COMMAND_ID;
+   }
+
+   @Override
+   public boolean isReturnValueExpected() {
+      return false;
+   }
+
+   @Override
+   public void writeTo(ObjectOutput output) throws IOException {
+      output.writeLong(id);
+      output.writeBoolean(success);
+      output.writeObject(value);
+      if (success) {
+         MarshallUtil.marshallArray(waitFor, output);
+      }
+   }
+
+   @Override
+   public void readFrom(ObjectInput input) throws IOException, ClassNotFoundException {
+      id = input.readLong();
+      success = input.readBoolean();
+      value = input.readObject();
+      if (success) {
+         waitFor = MarshallUtil.unmarshallArray(input, Address[]::new);
+      }
+   }
+
+   @Override
+   public String toString() {
+      final StringBuilder sb = new StringBuilder("PrimaryAckCommand{");
+      sb.append("id=").append(id);
+      sb.append(", success=").append(success);
+      sb.append(", value=").append(Util.toStr(value));
+      sb.append(", waitFor=").append(Arrays.toString(waitFor));
+      sb.append('}');
+      return sb.toString();
+   }
+}

--- a/core/src/main/java/org/infinispan/commands/write/WriteCommand.java
+++ b/core/src/main/java/org/infinispan/commands/write/WriteCommand.java
@@ -2,6 +2,7 @@ package org.infinispan.commands.write;
 
 import java.util.Collection;
 
+import org.infinispan.commands.CommandInvocationId;
 import org.infinispan.commands.FlagAffectedCommand;
 import org.infinispan.commands.TopologyAffectedCommand;
 import org.infinispan.commands.VisitableCommand;
@@ -73,4 +74,8 @@ public interface WriteCommand extends VisitableCommand, FlagAffectedCommand, Top
       return false;
    }
 
+   /**
+    * @return the {@link CommandInvocationId} associated to the command.
+    */
+   CommandInvocationId getCommandInvocationId();
 }

--- a/core/src/main/java/org/infinispan/configuration/cache/BiasAcquisition.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/BiasAcquisition.java
@@ -1,0 +1,21 @@
+package org.infinispan.configuration.cache;
+
+/**
+ * Specifies when is a node allowed to acquire a bias on an entry, serving further reads
+ * to the same key locally (despite not being an owner).
+ */
+public enum BiasAcquisition {
+   /**
+    * The bias is never acquired.
+    */
+   NEVER,
+   /**
+    * Bias is acquired by the writing entry.
+    */
+   ON_WRITE,
+   /**
+    * Bias is acquired when the entry is read
+    * TODO: Not implemented yet
+    */
+   ON_READ,
+}

--- a/core/src/main/java/org/infinispan/configuration/cache/ClusteringConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/ClusteringConfiguration.java
@@ -19,9 +19,11 @@ public class ClusteringConfiguration implements Matchable<ClusteringConfiguratio
    public static final AttributeDefinition<Long> REMOTE_TIMEOUT =
          AttributeDefinition.builder("remoteTimeout", TimeUnit.SECONDS.toMillis(15)).build();
    public static final AttributeDefinition<Integer> INVALIDATION_BATCH_SIZE = AttributeDefinition.builder("invalidationBatchSize",  128).immutable().build();
+   public static final AttributeDefinition<BiasAcquisition> BIAS_ACQUISITION = AttributeDefinition.builder("biasAcquisition", BiasAcquisition.ON_WRITE).immutable().build();
+   public static final AttributeDefinition<Long> BIAS_LIFESPAN = AttributeDefinition.builder("biasLifespan", TimeUnit.MINUTES.toMillis(5)).immutable().build();
 
    static AttributeSet attributeDefinitionSet() {
-      return new AttributeSet(ClusteringConfiguration.class, CACHE_MODE, REMOTE_TIMEOUT, INVALIDATION_BATCH_SIZE);
+      return new AttributeSet(ClusteringConfiguration.class, CACHE_MODE, REMOTE_TIMEOUT, INVALIDATION_BATCH_SIZE, BIAS_ACQUISITION, BIAS_LIFESPAN);
    }
 
    private final Attribute<CacheMode> cacheMode;
@@ -83,6 +85,20 @@ public class ClusteringConfiguration implements Matchable<ClusteringConfiguratio
     */
    public int invalidationBatchSize() {
       return attributes.attribute(INVALIDATION_BATCH_SIZE).get();
+   }
+
+   /**
+    * For scattered cache, specifies if the nodes is allowed to cache the entry, serving reads locally.
+    */
+   public BiasAcquisition biasAcquisition() {
+      return attributes.attribute(BIAS_ACQUISITION).get();
+   }
+
+   /**
+    * For scattered cache, specifies how long is the node allowed to read the cached entry locally.
+    */
+   public long biasLifespan() {
+      return attributes.attribute(BIAS_LIFESPAN).get();
    }
 
    /**

--- a/core/src/main/java/org/infinispan/factories/InboundInvocationHandlerFactory.java
+++ b/core/src/main/java/org/infinispan/factories/InboundInvocationHandlerFactory.java
@@ -1,5 +1,6 @@
 package org.infinispan.factories;
 
+import org.infinispan.configuration.cache.BiasAcquisition;
 import org.infinispan.configuration.cache.Configurations;
 import org.infinispan.factories.annotations.DefaultFactoryFor;
 import org.infinispan.remoting.inboundhandler.NonTotalOrderPerCacheInboundInvocationHandler;
@@ -27,9 +28,12 @@ public class InboundInvocationHandlerFactory extends AbstractNamedCacheComponent
                componentType.cast(new TotalOrderTxPerCacheInboundInvocationHandler()) :
                componentType.cast(new NonTotalOrderTxPerCacheInboundInvocationHandler());
       } else {
-         return configuration.clustering().cacheMode().isDistributed() && Configurations.isEmbeddedMode(globalConfiguration) ?
-               componentType.cast(new TrianglePerCacheInboundInvocationHandler()) :
-               componentType.cast(new NonTotalOrderPerCacheInboundInvocationHandler());
+         if (configuration.clustering().cacheMode().isDistributed() && Configurations.isEmbeddedMode(globalConfiguration)
+               || configuration.clustering().cacheMode().isScattered() && configuration.clustering().biasAcquisition() != BiasAcquisition.NEVER) {
+            return componentType.cast(new TrianglePerCacheInboundInvocationHandler());
+         } else {
+            return componentType.cast(new NonTotalOrderPerCacheInboundInvocationHandler());
+         }
       }
    }
 }

--- a/core/src/main/java/org/infinispan/interceptors/distribution/BiasedScatteredDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/BiasedScatteredDistributionInterceptor.java
@@ -1,0 +1,237 @@
+package org.infinispan.interceptors.distribution;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiConsumer;
+import java.util.stream.Stream;
+
+import org.infinispan.commands.CommandInvocationId;
+import org.infinispan.commands.VisitableCommand;
+import org.infinispan.commands.remote.RevokeBiasCommand;
+import org.infinispan.commands.write.DataWriteCommand;
+import org.infinispan.commands.write.WriteCommand;
+import org.infinispan.context.InvocationContext;
+import org.infinispan.factories.annotations.Inject;
+import org.infinispan.remoting.inboundhandler.DeliverOrder;
+import org.infinispan.remoting.responses.Response;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.scattered.BiasManager;
+import org.infinispan.util.concurrent.CommandAckCollector;
+import org.infinispan.util.concurrent.CompletableFutures;
+
+public class BiasedScatteredDistributionInterceptor extends ScatteredDistributionInterceptor {
+   private CommandAckCollector commandAckCollector;
+   private BiasManager biasManager;
+
+   @Inject
+   public void inject(CommandAckCollector collector, BiasManager biasManager) {
+      this.commandAckCollector = collector;
+      this.biasManager = biasManager;
+   }
+
+   @Override
+   protected CompletableFuture<Map<Address, Response>> singleWriteOnRemotePrimary(Address target, DataWriteCommand command) {
+      Collector<Response> collector = commandAckCollector.createBiased(command.getCommandInvocationId().getId(),
+            target, command.getTopologyId());
+      rpcManager.sendTo(target, command, DeliverOrder.NONE);
+      return collector.getFuture().thenApply(value -> Collections.singletonMap(target, value));
+   }
+
+   @Override
+   protected CompletableFuture<Map<Address, Response>> manyWriteOnRemotePrimary(Address target, WriteCommand command) {
+      Collector<Response> collector = commandAckCollector.createMultiTargetCollector(command.getCommandInvocationId().getId(), target, command.getTopologyId());
+      rpcManager.sendTo(target, command, DeliverOrder.NONE);
+      return collector.getFuture().thenApply(value -> Collections.singletonMap(target, value));
+   }
+
+   @Override
+   protected CompletableFuture<?> completeSingleWriteOnPrimaryOriginator(DataWriteCommand command, Address backup, CompletableFuture<?> rpcFuture) {
+      CompletableFuture<?> revokeFuture = revokeBiasSync(command.getKey(), backup, command.getTopologyId());
+      return CompletableFuture.allOf(rpcFuture, revokeFuture);
+   }
+
+   private CompletableFuture<?> revokeBiasSync(Object key, Address backup, int topologyId) {
+      BiasManager.Revocation revocation = biasManager.startRevokingRemoteBias(key, backup);
+      if (revocation == null) {
+         // No need to revoke from anyone
+         return CompletableFutures.completedNull();
+      }
+      if (revocation.shouldRevoke()) {
+         CompletableFuture<?> revocationRequest = sendRevokeBias(revocation.biased(), Collections.singleton(key), topologyId, null);
+         revocationRequest.whenComplete(revocation);
+         return revocationRequest;
+      } else {
+         // there's other ongoing revocation, wait until it completes and retry (possibly having to revoke as well)
+         return revocation.handleCompose(() -> revokeBiasSync(key, backup, topologyId));
+      }
+   }
+
+   @Override
+   protected void completeManyWriteOnPrimaryOriginator(WriteCommand command, Address backup, CountDownCompletableFuture future) {
+      revokeManyKeys(backup, future, command.getAffectedKeys(), command.getTopologyId());
+   }
+
+   private void revokeManyKeys(Address backup, CountDownCompletableFuture future, Collection<?> keys, int topologyId) {
+      Map<Address, GroupRevocation> revokedKeys = new HashMap<>();
+      for (Object key : keys) {
+         BiasManager.Revocation revocation = biasManager.startRevokingRemoteBias(key, backup);
+         if (revocation != null) {
+            if (revocation.shouldRevoke()) {
+               for (Address member : revocation.biased()) {
+                  revokedKeys.computeIfAbsent(member, m -> new GroupRevocation()).add(key, revocation);
+               }
+            } else {
+               future.increment();
+               revocation.handleCompose(() -> {
+                  CompletableFuture<?> revokeFuture = revokeBiasSync(key, backup, topologyId);
+                  revokeFuture.thenRun(future::countDown);
+                  return CompletableFutures.completedNull();
+               });
+            }
+         }
+      }
+      for (Map.Entry<Address, GroupRevocation> mapping : revokedKeys.entrySet()) {
+         future.increment();
+         sendRevokeBias(Collections.singleton(mapping.getKey()), mapping.getValue().keys, topologyId, null).whenComplete((nil, throwable) -> {
+            if (throwable != null) {
+               mapping.getValue().revocations.forEach(BiasManager.Revocation::fail);
+               future.completeExceptionally(throwable);
+            } else {
+               mapping.getValue().revocations.forEach(BiasManager.Revocation::complete);
+               future.countDown();
+            }
+         });
+      }
+   }
+
+   private static class GroupRevocation implements BiConsumer<Object, Throwable> {
+      final Collection<Object> keys = new ArrayList<>();
+      final Collection<BiasManager.Revocation> revocations = new ArrayList<>();
+
+      public void add(Object key, BiasManager.Revocation revocation) {
+         keys.add(key);
+         revocations.add(revocation);
+      }
+
+      @Override
+      public void accept(Object o, Throwable throwable) {
+         if (throwable != null) {
+            revocations.forEach(BiasManager.Revocation::fail);
+         } else {
+            revocations.forEach(BiasManager.Revocation::complete);
+         }
+      }
+   }
+
+   @Override
+   protected void singleWriteResponse(InvocationContext ctx, DataWriteCommand cmd, Object returnValue) {
+      BiasManager.Revocation revocation;
+      if (!cmd.isSuccessful() || (revocation = biasManager.startRevokingRemoteBias(cmd.getKey(), ctx.getOrigin())) == null) {
+         rpcManager.sendTo(ctx.getOrigin(), cf.buildPrimaryAckCommand(cmd.getCommandInvocationId().getId(),
+               cmd.isSuccessful(), returnValue, null), DeliverOrder.NONE);
+      } else if (revocation.shouldRevoke()) {
+         Address[] waitFor = revocation.biased().toArray(new Address[revocation.biased().size()]);
+         sendRevokeBias(revocation.biased(), Collections.singleton(cmd.getKey()), cmd.getTopologyId(), cmd.getCommandInvocationId())
+               .whenComplete(revocation);
+         // When the revocation does not succeed this node does not care; originator will get timeout
+         // expecting BackupAckCommand from the node that had the bias revoked
+         rpcManager.sendTo(ctx.getOrigin(), cf.buildPrimaryAckCommand(cmd.getCommandInvocationId().getId(),
+               cmd.isSuccessful(), returnValue, waitFor), DeliverOrder.NONE);
+      } else {
+         // We'll send the response & revocations later but the command
+         // will be already completed on this node
+         revocation.handleCompose(() -> {
+            singleWriteResponse(ctx, cmd, returnValue);
+            return null;
+         });
+      }
+   }
+
+   @Override
+   protected void manyWriteResponse(InvocationContext ctx, WriteCommand cmd, Object returnValue) {
+      List<Address> waitFor = null;
+      if (cmd.isSuccessful()) {
+         Collection<?> keys = cmd.getAffectedKeys();
+         Map<Address, GroupRevocation> revocations = new HashMap<>();
+         List<CompletableFuture<List<Address>>> futures = null;
+         for (Object key : keys) {
+            BiasManager.Revocation revocation = biasManager.startRevokingRemoteBias(key, ctx.getOrigin());
+            if (revocation == null) {
+               continue;
+            } else if (revocation.shouldRevoke()) {
+               if (waitFor == null)
+                  waitFor = new ArrayList<>(keys.size());
+               waitFor.addAll(revocation.biased());
+               for (Address b : revocation.biased()) {
+                  revocations.computeIfAbsent(b, a -> new GroupRevocation()).add(key, revocation);
+               }
+            } else {
+               if (futures == null)
+                  futures = new ArrayList<>();
+               futures.add(revocation.handleCompose(() -> revokeBiasAsync(cmd, key, ctx.getOrigin())));
+            }
+         }
+         for (Map.Entry<Address, GroupRevocation> pair : revocations.entrySet()) {
+            sendRevokeBias(Collections.singleton(pair.getKey()), pair.getValue().keys, cmd.getTopologyId(), cmd.getCommandInvocationId())
+                  .whenComplete(pair.getValue());
+         }
+         if (futures != null) {
+            List<Address> waitForFinal = waitFor;
+            CompletableFuture<List<Address>>[] cfs = futures.toArray(new CompletableFuture[futures.size()]);
+            CompletableFuture.allOf(cfs).thenRun(() -> {
+               Address[] waitForAddresses = null;
+               if (waitForFinal != null) {
+                  Stream.of(cfs).map(CompletableFuture::join).filter(Objects::nonNull).forEach(waitForFinal::addAll);
+                  waitForAddresses = waitForFinal.toArray(new Address[waitForFinal.size()]);
+               }
+               rpcManager.sendTo(ctx.getOrigin(), cf.buildPrimaryAckCommand(cmd.getCommandInvocationId().getId(),
+                     cmd.isSuccessful(), returnValue, waitForAddresses), DeliverOrder.NONE);
+            });
+            return;
+         }
+      }
+      Address[] waitForAddresses = waitFor == null ? null : waitFor.toArray(new Address[waitFor.size()]);
+      rpcManager.sendTo(ctx.getOrigin(), cf.buildPrimaryAckCommand(cmd.getCommandInvocationId().getId(),
+            cmd.isSuccessful(), returnValue, waitForAddresses), DeliverOrder.NONE);
+   }
+
+   private CompletableFuture<List<Address>> revokeBiasAsync(WriteCommand cmd, Object key, Address backup) {
+      BiasManager.Revocation revocation = biasManager.startRevokingRemoteBias(key, backup);
+      if (revocation == null) {
+         return CompletableFutures.completedNull();
+      } else if (revocation.shouldRevoke()) {
+         sendRevokeBias(revocation.biased(), Collections.singleton(key), cmd.getTopologyId(), cmd.getCommandInvocationId())
+               .whenComplete(revocation);
+         return CompletableFuture.completedFuture(revocation.biased());
+      } else {
+         return revocation.handleCompose(() -> revokeBiasAsync(cmd, key, backup));
+      }
+   }
+
+   private CompletableFuture<?> sendRevokeBias(Collection<Address> targets, Collection<Object> keys, int topologyId, CommandInvocationId commandInvocationId) {
+      try {
+         Address ackTarget = null;
+         long id = 0;
+         if (commandInvocationId != null) {
+            ackTarget = commandInvocationId.getAddress();
+            id = commandInvocationId.getId();
+         }
+         RevokeBiasCommand revokeBiasCommand = cf.buildRevokeBiasCommand(ackTarget, id, topologyId, keys);
+         return rpcManager.invokeRemotelyAsync(targets, revokeBiasCommand, syncIgnoreLeavers);
+      } catch (Throwable t) {
+         return CompletableFutures.completedExceptionFuture(t);
+      }
+   }
+
+   @Override
+   protected void handleClear(InvocationContext ctx, VisitableCommand command, Object ignored) {
+      super.handleClear(ctx, command, ignored);
+      biasManager.clear();
+   }
+}

--- a/core/src/main/java/org/infinispan/interceptors/distribution/CountDownCompletableFuture.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/CountDownCompletableFuture.java
@@ -8,6 +8,7 @@ class CountDownCompletableFuture extends CompletableFuture<Object> {
 
    public CountDownCompletableFuture(int participants) {
       this.counter = new AtomicInteger(participants);
+      assert participants != 0;
    }
 
    public void countDown() {

--- a/core/src/main/java/org/infinispan/interceptors/distribution/TriangleDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/TriangleDistributionInterceptor.java
@@ -194,7 +194,7 @@ public class TriangleDistributionInterceptor extends NonTxDistributionIntercepto
 
       if (sync) {
          Collector<Map<Object, Object>> collector = commandAckCollector
-               .createMultiKeyCollector(command.getCommandInvocationId().getId(), filter.primaries.keySet(),
+               .createSegmentBasedCollector(command.getCommandInvocationId().getId(), filter.primaries.keySet(),
                      filter.backups, command.getTopologyId());
          CompletableFuture<Map<Object, Object>> localResult = new CompletableFuture<>();
          final Map<Object, Object> localEntries = filter.primaries.remove(localAddress);

--- a/core/src/main/java/org/infinispan/interceptors/impl/BiasedEntryWrappingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/BiasedEntryWrappingInterceptor.java
@@ -1,0 +1,71 @@
+package org.infinispan.interceptors.impl;
+
+import org.infinispan.commands.VisitableCommand;
+import org.infinispan.commands.write.DataWriteCommand;
+import org.infinispan.commands.write.WriteCommand;
+import org.infinispan.context.InvocationContext;
+import org.infinispan.context.impl.FlagBitSets;
+import org.infinispan.factories.annotations.Inject;
+import org.infinispan.interceptors.InvocationFinallyFunction;
+import org.infinispan.scattered.BiasManager;
+
+public class BiasedEntryWrappingInterceptor extends RetryingEntryWrappingInterceptor {
+   private static final long NOT_BIASING_FLAGS = FlagBitSets.PUT_FOR_STATE_TRANSFER |
+         FlagBitSets.PUT_FOR_X_SITE_STATE_TRANSFER | FlagBitSets.CACHE_MODE_LOCAL;
+
+   private BiasManager biasManager;
+   private final InvocationFinallyFunction handleDataWriteReturn = this::handleDataWriteReturn;
+   private final InvocationFinallyFunction handleManyWriteReturn = this::handleManyWriteReturn;
+
+   @Inject
+   public void inject(BiasManager biasManager) {
+      this.biasManager = biasManager;
+   }
+
+   @Override
+   protected boolean canRead(Object key) {
+      return biasManager.hasLocalBias(key) || super.canRead(key);
+   }
+
+   @Override
+   protected Object setSkipRemoteGetsAndInvokeNextForDataCommand(InvocationContext ctx, DataWriteCommand command) {
+      return invokeNextAndHandle(ctx, command, handleDataWriteReturn);
+   }
+
+   @Override
+   protected Object setSkipRemoteGetsAndInvokeNextForManyEntriesCommand(InvocationContext ctx, WriteCommand command) {
+      return invokeNextAndHandle(ctx, command, handleManyWriteReturn);
+   }
+
+   private Object handleDataWriteReturn(InvocationContext ctx, VisitableCommand command, Object rv, Throwable throwable) throws Throwable {
+      if (throwable != null) {
+         return super.handleDataWriteReturn(ctx, command, throwable);
+      } else if (command.isSuccessful() && ctx.isOriginLocal()) {
+         DataWriteCommand dataWriteCommand = (DataWriteCommand) command;
+         if (dataWriteCommand.hasAnyFlag(NOT_BIASING_FLAGS)) {
+            return rv;
+         }
+         if (!distributionManager.getCacheTopology().getDistribution(dataWriteCommand.getKey()).isPrimary()) {
+            biasManager.addLocalBias(dataWriteCommand.getKey(), dataWriteCommand.getTopologyId());
+         }
+      }
+      return rv;
+   }
+
+   private Object handleManyWriteReturn(InvocationContext ctx, VisitableCommand command, Object rv, Throwable throwable) throws Throwable {
+      if (throwable != null) {
+         return super.handleManyWriteReturn(ctx, command, throwable);
+      } else if (command.isSuccessful() && ctx.isOriginLocal()) {
+         WriteCommand writeCommand = (WriteCommand) command;
+         if (writeCommand.hasAnyFlag(NOT_BIASING_FLAGS)) {
+            return rv;
+         }
+         for (Object key : writeCommand.getAffectedKeys()) {
+            if (!distributionManager.getCacheTopology().getDistribution(key).isPrimary()) {
+               biasManager.addLocalBias(key, writeCommand.getTopologyId());
+            }
+         }
+      }
+      return rv;
+   }
+}

--- a/core/src/main/java/org/infinispan/interceptors/impl/EntryWrappingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/EntryWrappingInterceptor.java
@@ -93,7 +93,7 @@ public class EntryWrappingInterceptor extends DDAsyncInterceptor {
    private DataContainer<Object, Object> dataContainer;
    protected ClusteringDependentLogic cdl;
    private VersionGenerator versionGenerator;
-   private DistributionManager distributionManager;
+   protected DistributionManager distributionManager;
    private final EntryWrappingVisitor entryWrappingVisitor = new EntryWrappingVisitor();
    private boolean isInvalidation;
    private boolean isSync;
@@ -178,7 +178,7 @@ public class EntryWrappingInterceptor extends DDAsyncInterceptor {
       return stateTransferManager == null || command.hasAnyFlag(FlagBitSets.CACHE_MODE_LOCAL | FlagBitSets.SKIP_OWNERSHIP_CHECK);
    }
 
-   private boolean canRead(Object key) {
+   protected boolean canRead(Object key) {
       return distributionManager.getCacheTopology().isReadOwner(key);
    }
 

--- a/core/src/main/java/org/infinispan/interceptors/impl/RetryingEntryWrappingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/RetryingEntryWrappingInterceptor.java
@@ -38,7 +38,7 @@ public class RetryingEntryWrappingInterceptor extends EntryWrappingInterceptor {
       return invokeNextAndExceptionally(ctx, command, handleDataWriteReturn);
    }
 
-   private Object handleDataWriteReturn(InvocationContext ctx, VisitableCommand command, Throwable throwable) throws Throwable {
+   Object handleDataWriteReturn(InvocationContext ctx, VisitableCommand command, Throwable throwable) throws Throwable {
       if (throwable instanceof ConcurrentChangeException) {
          if (trace) {
             log.tracef(throwable, "Retrying %s after concurrent change", command);
@@ -56,7 +56,7 @@ public class RetryingEntryWrappingInterceptor extends EntryWrappingInterceptor {
       return invokeNextAndExceptionally(ctx, command, handleManyWriteReturn);
    }
 
-   private Object handleManyWriteReturn(InvocationContext ctx, VisitableCommand command, Throwable throwable) throws Throwable {
+   Object handleManyWriteReturn(InvocationContext ctx, VisitableCommand command, Throwable throwable) throws Throwable {
       if (throwable instanceof ConcurrentChangeException) {
          if (trace) {
             log.tracef(throwable, "Retrying %s after concurrent change", command);

--- a/core/src/main/java/org/infinispan/marshall/exts/CacheRpcCommandExternalizer.java
+++ b/core/src/main/java/org/infinispan/marshall/exts/CacheRpcCommandExternalizer.java
@@ -13,6 +13,8 @@ import org.infinispan.commands.read.DistributedExecuteCommand;
 import org.infinispan.commands.remote.CacheRpcCommand;
 import org.infinispan.commands.remote.ClusteredGetAllCommand;
 import org.infinispan.commands.remote.ClusteredGetCommand;
+import org.infinispan.commands.remote.RenewBiasCommand;
+import org.infinispan.commands.remote.RevokeBiasCommand;
 import org.infinispan.commands.remote.SingleRpcCommand;
 import org.infinispan.commands.remote.recovery.CompleteTransactionCommand;
 import org.infinispan.commands.remote.recovery.GetInDoubtTransactionsCommand;
@@ -85,7 +87,8 @@ public final class CacheRpcCommandExternalizer extends AbstractExternalizer<Cach
                StreamRequestCommand.class, StreamSegmentResponseCommand.class, StreamResponseCommand.class,
                BackupWriteRpcCommand.class, BackupPutMapRpcCommand.class,
                InvalidateVersionsCommand.class, StreamIteratorRequestCommand.class,
-               StreamIteratorNextCommand.class, StreamIteratorCloseCommand.class);
+               StreamIteratorNextCommand.class, StreamIteratorCloseCommand.class,
+               RevokeBiasCommand.class, RenewBiasCommand.class);
       // Only interested in cache specific replicable commands
       coreCommands.addAll(gcr.getModuleProperties().moduleCacheRpcCommands());
       return coreCommands;

--- a/core/src/main/java/org/infinispan/marshall/exts/TriangleAckExternalizer.java
+++ b/core/src/main/java/org/infinispan/marshall/exts/TriangleAckExternalizer.java
@@ -11,6 +11,7 @@ import org.infinispan.commands.remote.CacheRpcCommand;
 import org.infinispan.commands.write.BackupAckCommand;
 import org.infinispan.commands.write.BackupMultiKeyAckCommand;
 import org.infinispan.commands.write.ExceptionAckCommand;
+import org.infinispan.commands.write.PrimaryAckCommand;
 import org.infinispan.commons.marshall.AdvancedExternalizer;
 import org.infinispan.commons.util.Util;
 import org.infinispan.util.ByteString;
@@ -25,7 +26,7 @@ public class TriangleAckExternalizer implements AdvancedExternalizer<CacheRpcCom
 
    public Set<Class<? extends CacheRpcCommand>> getTypeClasses() {
       //noinspection unchecked
-      return Util.asSet(BackupAckCommand.class, ExceptionAckCommand.class, BackupMultiKeyAckCommand.class);
+      return Util.asSet(BackupAckCommand.class, ExceptionAckCommand.class, BackupMultiKeyAckCommand.class, PrimaryAckCommand.class);
    }
 
    public Integer getId() {
@@ -46,6 +47,8 @@ public class TriangleAckExternalizer implements AdvancedExternalizer<CacheRpcCom
             return exceptionAckCommand(input);
          case BackupMultiKeyAckCommand.COMMAND_ID:
             return backupMultiKeyAckCommand(input);
+         case PrimaryAckCommand.COMMAND_ID:
+            return primaryAckCommand(input);
          default:
             throw new IllegalStateException();
       }
@@ -69,4 +72,11 @@ public class TriangleAckExternalizer implements AdvancedExternalizer<CacheRpcCom
       command.readFrom(input);
       return command;
    }
+
+   private PrimaryAckCommand primaryAckCommand(ObjectInput input) throws IOException, ClassNotFoundException {
+      PrimaryAckCommand command = new PrimaryAckCommand(ByteString.readObject(input));
+      command.readFrom(input);
+      return command;
+   }
+
 }

--- a/core/src/main/java/org/infinispan/scattered/BiasManager.java
+++ b/core/src/main/java/org/infinispan/scattered/BiasManager.java
@@ -1,0 +1,104 @@
+package org.infinispan.scattered;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.infinispan.remoting.transport.Address;
+
+/**
+ * This component tracks if this node can read the data stored locally despite not being an owner
+ * and which nodes will read the local data that is primary-owned by this node.
+ *
+ * Since tracking these remote nodes has a memory overhead this component can deliberately
+ * revoke the bias sending the {@link org.infinispan.commands.remote.RevokeBiasCommand}.
+ */
+public interface BiasManager {
+   /**
+    * Allow reading local data if the topology is still actual.
+    * @param key
+    * @param topologyId
+    */
+   void addLocalBias(Object key, int topologyId);
+
+   /**
+    * Stop reading local data.
+    * @param key
+    */
+   void revokeLocalBias(Object key);
+
+   /**
+    * Stop reading local data from this segment.
+    * @param segments
+    */
+   void revokeLocalBiasForSegments(Set<Integer> segments);
+
+   /**
+    * Check if we can read local data and update last-read timestamp for this key.
+    * @param key
+    * @return
+    */
+   boolean hasLocalBias(Object key);
+
+   List<Address> getRemoteBias(Object key); // testing only
+
+   /**
+    * Check if there are any nodes that have local bias, and starting replacing them
+    * with the provided address. The caller can find out the currently biased nodes
+    * from {@link Revocation#biased()} and is expected to send
+    * {@link org.infinispan.commands.remote.RevokeBiasCommand} to the holders and when
+    * this completes call {@link Revocation#complete()} or {@link Revocation#fail()}.
+    *
+    * This method returns <code>null</code> when there is no need to revoke any bias
+    * on remote nodes. When {@link Revocation#shouldRevoke()} returns false, the caller
+    * should set up a handler through {@link Revocation#handleCompose(Supplier)} and
+    * retry calling this method in the handler.
+    *
+    * @param key
+    * @param newBiased
+    * @return
+    */
+   Revocation startRevokingRemoteBias(Object key, Address newBiased);
+
+   /**
+    * Notify the component that the node is reading the biased entry and the bias
+    * should not be revoked unless necessary.
+    *
+    * @param key
+    * @param origin
+    */
+   void renewRemoteBias(Object key, Address origin);
+
+   /**
+    * The cache has been cleared and therefore all biases are forgotten.
+    */
+   void clear();
+
+   interface Revocation extends BiConsumer<Object, Throwable> {
+      boolean shouldRevoke();
+      List<Address> biased();
+      void complete();
+      void fail();
+
+      /**
+       * Similar to {@link CompletableFuture#thenCompose(Function)}, returns future provided by the supplier
+       * after the current revocation has been finished
+       * @param supplier
+       * @return
+       */
+      <T> CompletableFuture<T> handleCompose(Supplier<CompletionStage<T>> supplier);
+
+      @Override
+      default void accept(Object nil, Throwable throwable) {
+         if (throwable == null) {
+            complete();
+         } else {
+            fail();
+         }
+      }
+   }
+}

--- a/core/src/main/java/org/infinispan/scattered/impl/BiasManagerImpl.java
+++ b/core/src/main/java/org/infinispan/scattered/impl/BiasManagerImpl.java
@@ -1,0 +1,386 @@
+package org.infinispan.scattered.impl;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+
+import org.infinispan.AdvancedCache;
+import org.infinispan.commands.CommandsFactory;
+import org.infinispan.commands.remote.RenewBiasCommand;
+import org.infinispan.commands.remote.RevokeBiasCommand;
+import org.infinispan.commons.util.ByRef;
+import org.infinispan.configuration.cache.ClusteringConfiguration;
+import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.distribution.DistributionInfo;
+import org.infinispan.distribution.DistributionManager;
+import org.infinispan.distribution.ch.ConsistentHash;
+import org.infinispan.distribution.ch.KeyPartitioner;
+import org.infinispan.factories.KnownComponentNames;
+import org.infinispan.factories.annotations.ComponentName;
+import org.infinispan.factories.annotations.Inject;
+import org.infinispan.factories.annotations.Start;
+import org.infinispan.notifications.Listener;
+import org.infinispan.notifications.cachelistener.annotation.TopologyChanged;
+import org.infinispan.notifications.cachelistener.event.TopologyChangedEvent;
+import org.infinispan.remoting.inboundhandler.DeliverOrder;
+import org.infinispan.remoting.rpc.ResponseMode;
+import org.infinispan.remoting.rpc.RpcManager;
+import org.infinispan.remoting.rpc.RpcOptions;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.scattered.BiasManager;
+import org.infinispan.util.TimeService;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
+@Listener
+public class BiasManagerImpl implements BiasManager {
+   private static Log log = LogFactory.getLog(BiasManager.class);
+   private static final boolean trace = log.isTraceEnabled();
+   // TODO: size bounding?
+   // TODO: we could keep last access timestamp for local bias and refresh the lease
+   // if this gets close to acquisition timestamp so that the primary owner does not withdraw it
+   private ConcurrentMap<Object, LocalBias> localBias = new ConcurrentHashMap<>();
+   private ConcurrentMap<Object, RemoteBias> remoteBias = new ConcurrentHashMap<>();
+   private long renewLeasePeriod;
+   private RpcOptions syncIgnoreLeavers;
+
+   private AdvancedCache cache;
+   private Configuration configuration;
+   private TimeService timeService;
+   private DistributionManager distributionManager;
+   private CommandsFactory commandsFactory;
+   private RpcManager rpcManager;
+   private KeyPartitioner keyPartitioner;
+   private ScheduledExecutorService executor;
+
+   @Inject
+   public void init(AdvancedCache cache, Configuration configuration, TimeService timeService, DistributionManager distributionManager,
+                    CommandsFactory commandsFactory, RpcManager rpcManager, KeyPartitioner keyPartitioner,
+                    @ComponentName(KnownComponentNames.EXPIRATION_SCHEDULED_EXECUTOR) ScheduledExecutorService executor) {
+      this.cache = cache;
+      this.configuration = configuration;
+      this.timeService = timeService;
+      this.distributionManager = distributionManager;
+      this.commandsFactory = commandsFactory;
+      this.rpcManager = rpcManager;
+      this.keyPartitioner = keyPartitioner;
+      this.executor = executor;
+   }
+
+   @Start
+   public void start() {
+      configuration.clustering().attributes().attribute(ClusteringConfiguration.REMOTE_TIMEOUT)
+            .addListener((a, ignored) -> updateRpcOptions());
+      updateRpcOptions();
+      // TODO: Should we add another configuration option?
+      executor.scheduleAtFixedRate(this::removeOldBiasses, 0, configuration.expiration().wakeUpInterval(), TimeUnit.MILLISECONDS);
+      executor.scheduleAtFixedRate(this::renewLocalBiasses, 0, configuration.expiration().wakeUpInterval(), TimeUnit.MILLISECONDS);
+      renewLeasePeriod = configuration.clustering().biasLifespan() - configuration.clustering().remoteTimeout();
+      cache.addListener(this);
+   }
+
+   private void updateRpcOptions() {
+      syncIgnoreLeavers = rpcManager.getRpcOptionsBuilder(ResponseMode.SYNCHRONOUS_IGNORE_LEAVERS, DeliverOrder.NONE).build();
+   }
+
+   @TopologyChanged
+   public void onTopologyChange(TopologyChangedEvent event) {
+      // Forget about remote nodes if we're no longer the primary owner
+      ConsistentHash ch = event.getWriteConsistentHashAtEnd();
+      Set<Integer> localSegments = ch.getMembers().contains(rpcManager.getAddress()) ?
+            ch.getSegmentsForOwner(rpcManager.getAddress()) : Collections.emptySet();
+      remoteBias.keySet().removeIf(key -> !localSegments.contains(keyPartitioner.getSegment(key)));
+      // If we haven't been members of the last topology, then we probably had a split brain and we should just forget
+      // all local biasses.
+      ConsistentHash previousHash = event.getReadConsistentHashAtStart();
+      if (previousHash != null && !previousHash.getMembers().contains(rpcManager.getAddress())) {
+         localBias.clear();
+      }
+   }
+
+   private void removeOldBiasses() {
+      log.trace("Purging old biasses");
+      long minTimestamp = timeService.wallClockTime() - configuration.clustering().biasLifespan();
+      remoteBias.forEach((key, bias) -> {
+         if (bias.acquiredTimestamp < minTimestamp && bias.revoking == null) {
+            RemoteBias bias3 = remoteBias.computeIfPresent(key, (k, bias2) -> {
+               bias2.revoking = bias2.biased;
+               bias2.future = new CompletableFuture<>();
+               return bias2;
+            });
+            if (bias3 == null)
+               return;
+            if (trace) {
+               log.tracef("Revoking old bias for key %s from %s", key, bias3.biased);
+            }
+            // TODO: maybe some batching here; on the other side we don't want to block writes for too long
+            RevokeBiasCommand revokeBiasCommand = commandsFactory.buildRevokeBiasCommand(null, 0, 0, Collections.singleton(key));
+            rpcManager.invokeRemotelyAsync(bias3.biased, revokeBiasCommand, syncIgnoreLeavers).whenComplete((nil, throwable) -> {
+               CompletableFuture<?> future = bias3.future;
+               if (throwable != null) {
+                  if (trace) {
+                     log.tracef(throwable, "Bias revocation for %s failed", key);
+                  }
+                  remoteBias.compute(key, (k, bias4) -> {
+                     assert bias4 != null;
+                     bias4.revoking = null;
+                     bias4.future = null;
+                     return bias4;
+                  });
+               } else {
+                  remoteBias.remove(key);
+                  if (trace) {
+                     log.tracef("Bias for %s has been revoked", key);
+                  }
+               }
+               future.complete(null);
+            });
+         }
+      });
+      log.trace("Purge completed");
+   }
+
+   private void renewLocalBiasses() {
+      log.trace("Renewing local biasses");
+      long timestamp = timeService.wallClockTime();
+      // TODO: again, another configuration option?
+      int batchSize = configuration.clustering().invalidationBatchSize();
+      Map<Address, Collection<Object>> toRenew = new HashMap<>();
+      localBias.forEach((key, bias) -> {
+         // In order to renew the timestamp, we expect at least one read after acquisition.
+         // This may be refined (requiring read within shorter interval)
+         if (bias.acquisitionTimestamp + renewLeasePeriod < timestamp && bias.lastAccessTimestamp > bias.acquisitionTimestamp) {
+            DistributionInfo distribution = distributionManager.getCacheTopology().getDistribution(key);
+            if (distribution.primary() != null) {
+               Collection<Object> keys = toRenew.computeIfAbsent(distribution.primary(), a -> new ArrayList<>(batchSize));
+               keys.add(key);
+               bias.acquisitionTimestamp = timestamp;
+               if (keys.size() >= batchSize) {
+                  RenewBiasCommand renewBiasCommand = commandsFactory.buildRenewBiasCommand(keys.toArray(new Object[batchSize]));
+                  rpcManager.sendTo(distribution.primary(), renewBiasCommand, DeliverOrder.NONE);
+                  keys.clear();
+               }
+            }
+         }
+      });
+      for (Map.Entry<Address, Collection<Object>> entry : toRenew.entrySet()) {
+         Collection<Object> keys = entry.getValue();
+         if (keys.isEmpty()) continue;
+         RenewBiasCommand renewBiasCommand = commandsFactory.buildRenewBiasCommand(keys.toArray(new Object[keys.size()]));
+         rpcManager.sendTo(entry.getKey(), renewBiasCommand, DeliverOrder.NONE);
+      }
+      log.trace("Renewal completed local biasses");
+   }
+
+   @Override
+   public void addLocalBias(Object key, int topologyId) {
+      int currentTopologyId = distributionManager.getCacheTopology().getTopologyId();
+      if (topologyId >= currentTopologyId) {
+         if (trace) {
+            log.tracef("%s: adding local bias for %s in topology %d", rpcManager.getAddress(), key, topologyId);
+         }
+         localBias.put(key, new LocalBias(timeService.wallClockTime()));
+      } else if (trace) {
+         log.tracef("%s: not adding local bias for %s in topology %d as current topology is %d",
+               rpcManager.getAddress(), key, topologyId, currentTopologyId);
+      }
+   }
+
+   @Override
+   public void revokeLocalBias(Object key) {
+      if (trace) {
+         log.tracef("%s: revoking local bias for %s", rpcManager.getAddress(), key);
+      }
+      localBias.remove(key);
+   }
+
+   @Override
+   public void revokeLocalBiasForSegments(Set<Integer> segments) {
+      localBias.keySet().removeIf(key -> segments.contains(keyPartitioner.getSegment(key)));
+   }
+
+   @Override
+   public boolean hasLocalBias(Object key) {
+      LocalBias localBias = this.localBias.get(key);
+      if (trace) {
+         log.tracef("%s: local bias for %s? %s", rpcManager.getAddress(), key, localBias);
+      }
+      if (localBias != null && renewLeasePeriod > 0) {
+         localBias.lastAccessTimestamp = timeService.wallClockTime();
+      }
+      return localBias != null;
+   }
+
+   @Override
+   public List<Address> getRemoteBias(Object key) {
+      RemoteBias remoteBias = this.remoteBias.get(key);
+      return remoteBias != null ? remoteBias.biased : null;
+   }
+
+   @Override
+   public Revocation startRevokingRemoteBias(Object key, Address newBiased) {
+      ByRef<Revocation> ref = new ByRef<>(null);
+      remoteBias.compute(key, (k, bias) -> {
+         if (bias == null) {
+            if (trace) {
+               log.tracef("No bias for %s no need to revoke.", key);
+            }
+            return new RemoteBias(newBiased, timeService.wallClockTime());
+         } else if (bias.revoking == null) {
+            List<Address> revoking;
+            if (bias.biased.contains(newBiased)) {
+               if (bias.biased.size() == 1) {
+                  if (trace) {
+                     log.tracef("Not revoking bias for %s as the new biased is the same as previous: %s", k, newBiased);
+                  }
+                  bias.acquiredTimestamp = timeService.wallClockTime();
+                  return bias;
+               } else {
+                  revoking = new ArrayList<>(bias.biased);
+                  revoking.remove(newBiased);
+               }
+            } else {
+               revoking = bias.biased;
+            }
+            if (trace) {
+               log.tracef("Revoking remote bias for %s, %s -> %s", key, bias.biased, newBiased);
+            }
+            bias.revoking = revoking;
+            bias.newBiased = Collections.singletonList(newBiased);
+            bias.future = new CompletableFuture<>();
+            ref.set(new RevocationImpl(k, revoking, bias.future));
+            return bias;
+         } else {
+            if (trace) {
+               log.tracef("Revocation already in progress for %s, %s -> %s", key, bias.revoking, bias.newBiased);
+            }
+            ref.set(new RevocationImpl(k, null, bias.future));
+            return bias;
+         }
+      });
+      return ref.get();
+   }
+
+   @Override
+   public void renewRemoteBias(Object key, Address origin) {
+      RemoteBias bias = this.remoteBias.get(key);
+      if (bias != null) {
+         bias.acquiredTimestamp = timeService.wallClockTime();
+      }
+   }
+
+   @Override
+   public void clear() {
+      localBias.clear();
+      remoteBias.clear();
+   }
+
+   private static class RemoteBias {
+      private List<Address> biased;
+      private List<Address> revoking;
+      private List<Address> newBiased;
+      private CompletableFuture<?> future;
+      private long acquiredTimestamp;
+
+      public RemoteBias(Address newBiased, long acquiredTimestamp) {
+         biased = Collections.singletonList(newBiased);
+         this.acquiredTimestamp = acquiredTimestamp;
+      }
+   }
+
+   private class RevocationImpl implements Revocation, BiFunction<Object, RemoteBias, RemoteBias> {
+      private final Object key;
+      private final List<Address> biased;
+      private final CompletableFuture<?> future;
+
+      private RevocationImpl(Object key, List<Address> biased, CompletableFuture<?> future) {
+         this.key = key;
+         this.biased = biased;
+         this.future = future;
+      }
+
+      @Override
+      public boolean shouldRevoke() {
+         return biased != null;
+      }
+
+      @Override
+      public List<Address> biased() {
+         return biased;
+      }
+
+      @Override
+      public void complete() {
+         remoteBias.compute(key, this);
+      }
+
+      @Override
+      public RemoteBias apply(Object key, RemoteBias bias) {
+         if (bias == null) {
+            // this happens when a clear was called
+            log.tracef("Missing bias information for %s", key);
+            return null;
+         }
+         bias.biased = bias.newBiased;
+         bias.revoking = null;
+         bias.newBiased = null;
+         bias.acquiredTimestamp = timeService.wallClockTime();
+         bias.future = null;
+         if (trace) {
+            log.tracef("Bias for %s has been transferred to %s", key, bias.biased);
+         }
+         future.complete(null);
+         return bias;
+      }
+
+      @Override
+      public void fail() {
+         remoteBias.compute(key, (k, bias) -> {
+            if (bias == null) {
+               // this happens when a clear was called
+               log.tracef("Missing bias information for %s", key);
+               return null;
+            }
+            if (trace) {
+               log.tracef("Bias transfer for %s to %s failed, keeping %s", key, bias.newBiased, bias.biased);
+            }
+            bias.revoking = null;
+            bias.newBiased = null;
+            bias.future = null;
+            future.complete(null);
+            return bias;
+         });
+      }
+
+      @Override
+      public <T> CompletableFuture<T> handleCompose(Supplier<CompletionStage<T>> supplier) {
+         return future.handle((nil, throwable) -> null).thenCompose(nil -> supplier.get());
+      }
+   }
+
+   private static class LocalBias {
+      private volatile long acquisitionTimestamp;
+      private volatile long lastAccessTimestamp;
+
+      public LocalBias(long timestamp) {
+         acquisitionTimestamp = lastAccessTimestamp = timestamp;
+      }
+
+      @Override
+      public String toString() {
+         return "LocalBias{acq=" + acquisitionTimestamp + ", last=" + lastAccessTimestamp + '}';
+      }
+   }
+}

--- a/core/src/main/java/org/infinispan/scattered/impl/ScatteredStateConsumerImpl.java
+++ b/core/src/main/java/org/infinispan/scattered/impl/ScatteredStateConsumerImpl.java
@@ -149,7 +149,7 @@ public class ScatteredStateConsumerImpl extends StateConsumerImpl {
 
       rpcManager.invokeRemotelyAsync(null, commandsFactory.buildStateRequestCommand(
             StateRequestCommand.Type.CONFIRM_REVOKED_SEGMENTS,
-            rpcManager.getAddress(), cacheTopology.getTopologyId(), null),
+            rpcManager.getAddress(), cacheTopology.getTopologyId(), addedSegments),
             synchronousIgnoreLeaversRpcOptions).whenComplete((responses, throwable) -> {
          if (throwable == null) {
             try {

--- a/core/src/main/java/org/infinispan/scattered/impl/ScatteredVersionManagerImpl.java
+++ b/core/src/main/java/org/infinispan/scattered/impl/ScatteredVersionManagerImpl.java
@@ -533,7 +533,7 @@ public class ScatteredVersionManagerImpl<K> implements ScatteredVersionManager<K
          }
       });
       // remove the entries on self, too
-      removeCommand.init(dataContainer, orderedUpdatesManager, null, null);
+      removeCommand.init(dataContainer, orderedUpdatesManager, null, null, null);
       removeCommand.invokeAsync();
    }
 

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -1727,4 +1727,7 @@ public interface Log extends BasicLogger {
          "address count of %d", id = 505)
    CacheConfigurationException offHeapMemoryEvictionSizeNotLargeEnoughForAddresses(long configuredSize,
          long addressMemorySize, int addressCount);
+
+   @Message(value = "Biased reads are supported only in scattered cache. Maybe you were looking for L1?", id = 506)
+   CacheConfigurationException biasedReadsAppliesOnlyToScattered();
 }

--- a/core/src/test/java/org/infinispan/api/ClearTest.java
+++ b/core/src/test/java/org/infinispan/api/ClearTest.java
@@ -4,6 +4,7 @@ import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertTrue;
 
 import org.infinispan.AdvancedCache;
+import org.infinispan.configuration.cache.BiasAcquisition;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.container.DataContainer;
@@ -38,7 +39,8 @@ public class ClearTest extends MultipleCacheManagersTest {
          new ClearTest().cacheMode(CacheMode.DIST_SYNC).transactional(false),
          new ClearTest().cacheMode(CacheMode.DIST_SYNC).transactional(true).lockingMode(LockingMode.OPTIMISTIC),
          new ClearTest().cacheMode(CacheMode.DIST_SYNC).transactional(true).lockingMode(LockingMode.PESSIMISTIC),
-         new ClearTest().cacheMode(CacheMode.SCATTERED_SYNC).transactional(false),
+         new ClearTest().cacheMode(CacheMode.SCATTERED_SYNC).biasAcquisition(BiasAcquisition.NEVER).transactional(false),
+         new ClearTest().cacheMode(CacheMode.SCATTERED_SYNC).biasAcquisition(BiasAcquisition.ON_WRITE).transactional(false),
       };
    }
 
@@ -53,6 +55,9 @@ public class ClearTest extends MultipleCacheManagersTest {
          builder.transaction().transactionMode(TransactionMode.TRANSACTIONAL)
             .transactionManagerLookup(new EmbeddedTransactionManagerLookup())
             .lockingMode(lockingMode);
+      }
+      if (biasAcquisition != null) {
+         builder.clustering().biasAcquisition(biasAcquisition);
       }
       createCluster(builder, 3);
       waitForClusterToForm();

--- a/core/src/test/java/org/infinispan/api/ConcurrentOperationsTest.java
+++ b/core/src/test/java/org/infinispan/api/ConcurrentOperationsTest.java
@@ -48,6 +48,9 @@ public class ConcurrentOperationsTest extends MultipleCacheManagersTest {
    @Override
    protected void createCacheManagers() throws Throwable {
       ConfigurationBuilder dcc = getDefaultClusteredCacheConfig(cacheMode, false);
+      if (biasAcquisition != null) {
+         dcc.clustering().biasAcquisition(biasAcquisition);
+      }
       dcc.clustering().l1().disable();
       createClusteredCaches(nodes, dcc);
    }

--- a/core/src/test/java/org/infinispan/api/ConditionalOperationsConcurrentOptimisticStressTest.java
+++ b/core/src/test/java/org/infinispan/api/ConditionalOperationsConcurrentOptimisticStressTest.java
@@ -2,6 +2,7 @@ package org.infinispan.api;
 
 import java.util.List;
 
+import org.infinispan.configuration.cache.CacheMode;
 import org.testng.annotations.Test;
 
 /**
@@ -13,6 +14,7 @@ import org.testng.annotations.Test;
 public class ConditionalOperationsConcurrentOptimisticStressTest extends ConditionalOperationsConcurrentStressTest {
 
    public ConditionalOperationsConcurrentOptimisticStressTest() {
+      cacheMode = CacheMode.DIST_SYNC;
       transactional = true;
    }
 

--- a/core/src/test/java/org/infinispan/api/ConditionalOperationsConcurrentOptimisticTest.java
+++ b/core/src/test/java/org/infinispan/api/ConditionalOperationsConcurrentOptimisticTest.java
@@ -2,6 +2,7 @@ package org.infinispan.api;
 
 import java.util.List;
 
+import org.infinispan.configuration.cache.CacheMode;
 import org.testng.annotations.Test;
 
 /**
@@ -12,6 +13,7 @@ import org.testng.annotations.Test;
 public class ConditionalOperationsConcurrentOptimisticTest extends ConditionalOperationsConcurrentTest {
 
    public ConditionalOperationsConcurrentOptimisticTest() {
+      cacheMode = CacheMode.DIST_SYNC;
       transactional = true;
    }
 

--- a/core/src/test/java/org/infinispan/api/ConditionalOperationsConcurrentPessimisticStressTest.java
+++ b/core/src/test/java/org/infinispan/api/ConditionalOperationsConcurrentPessimisticStressTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.api;
 
+import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.transaction.LockingMode;
 import org.testng.annotations.Test;
 
@@ -12,6 +13,7 @@ import org.testng.annotations.Test;
 public class ConditionalOperationsConcurrentPessimisticStressTest extends ConditionalOperationsConcurrentStressTest {
 
    public ConditionalOperationsConcurrentPessimisticStressTest() {
+      cacheMode = CacheMode.DIST_SYNC;
       transactional = true;
       lockingMode = LockingMode.PESSIMISTIC;
    }

--- a/core/src/test/java/org/infinispan/api/ConditionalOperationsConcurrentPessimisticTest.java
+++ b/core/src/test/java/org/infinispan/api/ConditionalOperationsConcurrentPessimisticTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.api;
 
+import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.transaction.LockingMode;
 import org.testng.annotations.Test;
 
@@ -7,6 +8,7 @@ import org.testng.annotations.Test;
 public class ConditionalOperationsConcurrentPessimisticTest extends ConditionalOperationsConcurrentTest {
 
    public ConditionalOperationsConcurrentPessimisticTest() {
+      cacheMode = CacheMode.DIST_SYNC;
       transactional = true;
       lockingMode = LockingMode.PESSIMISTIC;
    }

--- a/core/src/test/java/org/infinispan/api/ConditionalOperationsConcurrentStressTest.java
+++ b/core/src/test/java/org/infinispan/api/ConditionalOperationsConcurrentStressTest.java
@@ -1,7 +1,7 @@
 package org.infinispan.api;
 
+import org.infinispan.configuration.cache.BiasAcquisition;
 import org.infinispan.configuration.cache.CacheMode;
-import org.infinispan.test.fwk.InCacheMode;
 import org.testng.annotations.Test;
 
 /**
@@ -13,9 +13,17 @@ import org.testng.annotations.Test;
  * @see java.util.concurrent.ConcurrentMap#replace(Object, Object, Object)
  * @since 7.0
  */
-@Test(groups = "stress", testName = "api.ConditionalOperationsConcurrentStressTest", timeOut = 15*60*1000)
-@InCacheMode({CacheMode.DIST_SYNC, CacheMode.SCATTERED_SYNC})
+@Test(groups = "stress", testName = "api.ConditionalOperationsConcurrentStressTest", timeOut = 15*60*1000, invocationCount = 1000)
 public class ConditionalOperationsConcurrentStressTest extends ConditionalOperationsConcurrentTest {
+   @Override
+   public Object[] factory() {
+      return new Object[] {
+            new ConditionalOperationsConcurrentStressTest().cacheMode(CacheMode.DIST_SYNC),
+            new ConditionalOperationsConcurrentStressTest().cacheMode(CacheMode.SCATTERED_SYNC).biasAcquisition(BiasAcquisition.NEVER),
+            new ConditionalOperationsConcurrentStressTest().cacheMode(CacheMode.SCATTERED_SYNC).biasAcquisition(BiasAcquisition.ON_WRITE)
+      };
+   }
+
    public ConditionalOperationsConcurrentStressTest() {
       super(3, 500, 4);
    }

--- a/core/src/test/java/org/infinispan/api/ConditionalOperationsConcurrentWriteSkewStressTest.java
+++ b/core/src/test/java/org/infinispan/api/ConditionalOperationsConcurrentWriteSkewStressTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.api;
 
+import org.infinispan.configuration.cache.CacheMode;
 import org.testng.annotations.Test;
 
 /**
@@ -11,6 +12,7 @@ import org.testng.annotations.Test;
 public class ConditionalOperationsConcurrentWriteSkewStressTest extends ConditionalOperationsConcurrentStressTest {
 
    public ConditionalOperationsConcurrentWriteSkewStressTest() {
+      cacheMode = CacheMode.DIST_SYNC;
       transactional = true;
       writeSkewCheck = true;
    }

--- a/core/src/test/java/org/infinispan/api/IgnoreReturnValueForConditionalOperationsTest.java
+++ b/core/src/test/java/org/infinispan/api/IgnoreReturnValueForConditionalOperationsTest.java
@@ -4,6 +4,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
+import org.infinispan.configuration.cache.BiasAcquisition;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.context.Flag;
@@ -21,13 +22,17 @@ public class IgnoreReturnValueForConditionalOperationsTest extends MultipleCache
       return new Object[] {
          new IgnoreReturnValueForConditionalOperationsTest().cacheMode(CacheMode.DIST_SYNC).transactional(false),
          new IgnoreReturnValueForConditionalOperationsTest().cacheMode(CacheMode.DIST_SYNC).transactional(true),
-         new IgnoreReturnValueForConditionalOperationsTest().cacheMode(CacheMode.SCATTERED_SYNC).transactional(false)
+         new IgnoreReturnValueForConditionalOperationsTest().cacheMode(CacheMode.SCATTERED_SYNC).transactional(false).biasAcquisition(BiasAcquisition.NEVER),
+         new IgnoreReturnValueForConditionalOperationsTest().cacheMode(CacheMode.SCATTERED_SYNC).transactional(false).biasAcquisition(BiasAcquisition.ON_WRITE)
       };
    }
 
    @Override
    protected void createCacheManagers() throws Throwable {
       ConfigurationBuilder dcc = getDefaultClusteredCacheConfig(cacheMode, transactional);
+      if (biasAcquisition != null) {
+         dcc.clustering().biasAcquisition(biasAcquisition);
+      }
       createCluster(dcc, 2);
       waitForClusterToForm();
    }

--- a/core/src/test/java/org/infinispan/api/ScatteredConcurrentOperationsTest.java
+++ b/core/src/test/java/org/infinispan/api/ScatteredConcurrentOperationsTest.java
@@ -1,6 +1,7 @@
 package org.infinispan.api;
 
 import org.infinispan.Cache;
+import org.infinispan.configuration.cache.BiasAcquisition;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.container.versioning.EntryVersion;
@@ -15,6 +16,14 @@ import java.util.List;
  */
 @Test(groups = "functional", testName = "api.ScatteredConcurrentOperationsTest")
 public class ScatteredConcurrentOperationsTest extends ConcurrentOperationsTest {
+   @Override
+   public Object[] factory() {
+      return new Object[] {
+            new ScatteredConcurrentOperationsTest().biasAcquisition(BiasAcquisition.NEVER),
+            new ScatteredConcurrentOperationsTest().biasAcquisition(BiasAcquisition.ON_WRITE)
+      };
+   }
+
    public ScatteredConcurrentOperationsTest() {
       super(CacheMode.SCATTERED_SYNC, 2, 2, 4);
    }

--- a/core/src/test/java/org/infinispan/api/mvcc/PutForExternalReadTest.java
+++ b/core/src/test/java/org/infinispan/api/mvcc/PutForExternalReadTest.java
@@ -21,6 +21,7 @@ import org.infinispan.Cache;
 import org.infinispan.commands.VisitableCommand;
 import org.infinispan.commands.write.PutKeyValueCommand;
 import org.infinispan.commands.write.RemoveCommand;
+import org.infinispan.configuration.cache.BiasAcquisition;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.container.entries.InternalCacheEntry;
@@ -59,7 +60,8 @@ public class PutForExternalReadTest extends MultipleCacheManagersTest {
          new PutForExternalReadTest().cacheMode(CacheMode.REPL_SYNC).transactional(true).lockingMode(LockingMode.OPTIMISTIC),
          new PutForExternalReadTest().cacheMode(CacheMode.REPL_SYNC).transactional(true).lockingMode(LockingMode.PESSIMISTIC),
          new PutForExternalReadTest().cacheMode(CacheMode.REPL_SYNC).transactional(true).totalOrder(true),
-         new PutForExternalReadTest().cacheMode(CacheMode.SCATTERED_SYNC).transactional(false),
+         new PutForExternalReadTest().cacheMode(CacheMode.SCATTERED_SYNC).biasAcquisition(BiasAcquisition.NEVER).transactional(false),
+         new PutForExternalReadTest().cacheMode(CacheMode.SCATTERED_SYNC).biasAcquisition(BiasAcquisition.ON_WRITE).transactional(false),
       };
    }
 
@@ -80,6 +82,9 @@ public class PutForExternalReadTest extends MultipleCacheManagersTest {
       }
       if (totalOrder != null && totalOrder) {
          c.transaction().transactionProtocol(TransactionProtocol.TOTAL_ORDER);
+      }
+      if (biasAcquisition != null) {
+         c.clustering().biasAcquisition(biasAcquisition);
       }
       return c;
    }

--- a/core/src/test/java/org/infinispan/commands/PutMapCommandStressTest.java
+++ b/core/src/test/java/org/infinispan/commands/PutMapCommandStressTest.java
@@ -8,6 +8,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import org.infinispan.commons.executors.BlockingThreadPoolExecutorFactory;
+import org.infinispan.configuration.cache.BiasAcquisition;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
@@ -35,9 +36,10 @@ public class PutMapCommandStressTest extends StressTest {
    @Override
    public Object[] factory() {
       return new Object[] {
-//         new PutMapCommandStressTest().cacheMode(CacheMode.DIST_SYNC).transactional(false),
-//         new PutMapCommandStressTest().cacheMode(CacheMode.DIST_SYNC).transactional(true),
-         new PutMapCommandStressTest().cacheMode(CacheMode.SCATTERED_SYNC).transactional(false),
+         new PutMapCommandStressTest().cacheMode(CacheMode.DIST_SYNC).transactional(false),
+         new PutMapCommandStressTest().cacheMode(CacheMode.DIST_SYNC).transactional(true),
+         new PutMapCommandStressTest().cacheMode(CacheMode.SCATTERED_SYNC).transactional(false).biasAcquisition(BiasAcquisition.NEVER),
+         new PutMapCommandStressTest().cacheMode(CacheMode.SCATTERED_SYNC).transactional(false).biasAcquisition(BiasAcquisition.ON_WRITE),
       };
    }
 
@@ -53,6 +55,9 @@ public class PutMapCommandStressTest extends StressTest {
       builderUsed.clustering().remoteTimeout(12000);
       if (transactional) {
          builderUsed.transaction().transactionMode(TransactionMode.TRANSACTIONAL);
+      }
+      if (biasAcquisition != null) {
+         builderUsed.clustering().biasAcquisition(biasAcquisition);
       }
       createClusteredCaches(CACHE_COUNT, CACHE_NAME, builderUsed);
    }

--- a/core/src/test/java/org/infinispan/distribution/MultipleNodesLeavingTest.java
+++ b/core/src/test/java/org/infinispan/distribution/MultipleNodesLeavingTest.java
@@ -2,11 +2,12 @@ package org.infinispan.distribution;
 
 import java.util.List;
 
+import org.infinispan.configuration.cache.BiasAcquisition;
 import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
-import org.infinispan.test.fwk.InCacheMode;
 import org.testng.annotations.Test;
 
 /**
@@ -14,12 +15,23 @@ import org.testng.annotations.Test;
  * @since 5.0
  */
 @Test (groups = "functional", testName = "distribution.MultipleNodesLeavingTest")
-@InCacheMode({CacheMode.DIST_SYNC, CacheMode.SCATTERED_SYNC})
 public class MultipleNodesLeavingTest extends MultipleCacheManagersTest {
+   @Override
+   public Object[] factory() {
+      return new Object[] {
+            new MultipleNodesLeavingTest().cacheMode(CacheMode.DIST_SYNC),
+            new MultipleNodesLeavingTest().cacheMode(CacheMode.SCATTERED_SYNC).biasAcquisition(BiasAcquisition.NEVER),
+            new MultipleNodesLeavingTest().cacheMode(CacheMode.SCATTERED_SYNC).biasAcquisition(BiasAcquisition.ON_WRITE),
+      };
+   }
 
    @Override
    protected void createCacheManagers() throws Throwable {
-      createCluster(getDefaultClusteredCacheConfig(cacheMode, false), 4);
+      ConfigurationBuilder builder = getDefaultClusteredCacheConfig(cacheMode, false);
+      if (biasAcquisition != null) {
+         builder.clustering().biasAcquisition(biasAcquisition);
+      }
+      createCluster(builder, 4);
       waitForClusterToForm();
    }
 

--- a/core/src/test/java/org/infinispan/distribution/rehash/NonTxPutIfAbsentDuringJoinStressTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/NonTxPutIfAbsentDuringJoinStressTest.java
@@ -10,11 +10,11 @@ import java.util.concurrent.TimeUnit;
 
 import org.infinispan.Cache;
 import org.infinispan.commons.util.CollectionFactory;
+import org.infinispan.configuration.cache.BiasAcquisition;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.fwk.CleanupAfterMethod;
-import org.infinispan.test.fwk.InCacheMode;
 import org.infinispan.util.concurrent.locks.LockManager;
 import org.testng.annotations.Test;
 
@@ -27,7 +27,6 @@ import org.testng.annotations.Test;
 //unstable. test fails with DIST_SYNC and SCATTERED_SYNC (ISPN-3918)
 @Test(groups = {"functional", "unstable"}, testName = "distribution.rehash.NonTxPutIfAbsentDuringJoinStressTest")
 @CleanupAfterMethod
-@InCacheMode({ CacheMode.DIST_SYNC, CacheMode.SCATTERED_SYNC })
 public class NonTxPutIfAbsentDuringJoinStressTest extends MultipleCacheManagersTest {
 
    private static final int NUM_WRITERS = 4;
@@ -35,6 +34,15 @@ public class NonTxPutIfAbsentDuringJoinStressTest extends MultipleCacheManagersT
    private static final int NUM_KEYS = 100;
    private final ConcurrentMap<String, String> insertedValues = CollectionFactory.makeConcurrentMap();
    private volatile boolean stop = false;
+
+   @Override
+   public Object[] factory() {
+      return new Object[] {
+            new NonTxPutIfAbsentDuringJoinStressTest().cacheMode(CacheMode.DIST_SYNC),
+            new NonTxPutIfAbsentDuringJoinStressTest().cacheMode(CacheMode.SCATTERED_SYNC).biasAcquisition(BiasAcquisition.NEVER),
+            new NonTxPutIfAbsentDuringJoinStressTest().cacheMode(CacheMode.SCATTERED_SYNC).biasAcquisition(BiasAcquisition.ON_WRITE),
+      };
+   }
 
    @Override
    protected void createCacheManagers() throws Throwable {

--- a/core/src/test/java/org/infinispan/distribution/rehash/NonTxPutIfAbsentDuringLeaveStressTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/NonTxPutIfAbsentDuringLeaveStressTest.java
@@ -10,12 +10,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.infinispan.Cache;
 import org.infinispan.commons.util.CollectionFactory;
+import org.infinispan.configuration.cache.BiasAcquisition;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.CleanupAfterMethod;
-import org.infinispan.test.fwk.InCacheMode;
 import org.testng.annotations.Test;
 
 /**
@@ -26,12 +26,20 @@ import org.testng.annotations.Test;
  */
 @Test(groups = "functional", testName = "distribution.rehash.NonTxPutIfAbsentDuringLeaveStressTest")
 @CleanupAfterMethod
-@InCacheMode({ CacheMode.DIST_SYNC, CacheMode.SCATTERED_SYNC })
 public class NonTxPutIfAbsentDuringLeaveStressTest extends MultipleCacheManagersTest {
 
    private static final int NUM_WRITERS = 4;
    private static final int NUM_ORIGINATORS = 2;
    private static final int NUM_KEYS = 100;
+
+   @Override
+   public Object[] factory() {
+      return new Object[] {
+            new NonTxPutIfAbsentDuringLeaveStressTest().cacheMode(CacheMode.DIST_SYNC),
+            new NonTxPutIfAbsentDuringLeaveStressTest().cacheMode(CacheMode.SCATTERED_SYNC).biasAcquisition(BiasAcquisition.NEVER),
+            new NonTxPutIfAbsentDuringLeaveStressTest().cacheMode(CacheMode.SCATTERED_SYNC).biasAcquisition(BiasAcquisition.ON_WRITE),
+      };
+   }
 
    @Override
    protected void createCacheManagers() throws Throwable {

--- a/core/src/test/java/org/infinispan/distribution/rehash/StateTransferOverwritingValueTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/StateTransferOverwritingValueTest.java
@@ -22,9 +22,8 @@ import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.distribution.BlockingInterceptor;
 import org.infinispan.globalstate.NoOpGlobalConfigurationManager;
-import org.infinispan.interceptors.DDAsyncInterceptor;
+import org.infinispan.interceptors.AsyncInterceptor;
 import org.infinispan.interceptors.impl.EntryWrappingInterceptor;
-import org.infinispan.interceptors.impl.RetryingEntryWrappingInterceptor;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.remoting.rpc.RpcManager;
 import org.infinispan.remoting.transport.Address;
@@ -159,7 +158,8 @@ public class StateTransferOverwritingValueTest extends MultipleCacheManagersTest
             true, false, cacheMode.isScattered() ? t -> t instanceof PutKeyValueCommand || t instanceof RemoveCommand
             : t -> t.getClass().equals(op.getCommandClass()));
 
-      Class<? extends DDAsyncInterceptor> ewi = cacheMode.isScattered() ? RetryingEntryWrappingInterceptor.class : EntryWrappingInterceptor.class;
+      Class<? extends AsyncInterceptor> ewi = cache1.getAsyncInterceptorChain().getInterceptors().stream()
+            .filter(i -> i instanceof EntryWrappingInterceptor).findFirst().orElseThrow(IllegalStateException::new).getClass();
       assertTrue(cache1.getAsyncInterceptorChain().addInterceptorAfter(blockingInterceptor1, ewi));
 
       // Wait for cache0 to collect the state to send to cache1 (including our previous value).

--- a/core/src/test/java/org/infinispan/functional/AbstractFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/functional/AbstractFunctionalTest.java
@@ -52,6 +52,9 @@ abstract class AbstractFunctionalTest extends MultipleCacheManagersTest {
       if (!Boolean.TRUE.equals(transactional)) {
          ConfigurationBuilder scatteredBuilder = new ConfigurationBuilder();
          scatteredBuilder.clustering().cacheMode(CacheMode.SCATTERED_SYNC);
+         if (biasAcquisition != null) {
+            scatteredBuilder.clustering().biasAcquisition(biasAcquisition);
+         }
          configureCache(scatteredBuilder);
          cacheManagers.stream().forEach(cm -> cm.defineConfiguration(SCATTERED, scatteredBuilder.build()));
       }

--- a/core/src/test/java/org/infinispan/functional/FunctionalScatteredInMemoryTest.java
+++ b/core/src/test/java/org/infinispan/functional/FunctionalScatteredInMemoryTest.java
@@ -11,12 +11,20 @@ import java.util.NoSuchElementException;
 import java.util.concurrent.CompletionException;
 
 import org.infinispan.commons.CacheException;
+import org.infinispan.configuration.cache.BiasAcquisition;
 import org.infinispan.remoting.RemoteException;
 import org.infinispan.scattered.Utils;
 import org.infinispan.test.TestException;
 import org.testng.annotations.Test;
 
 public class FunctionalScatteredInMemoryTest extends AbstractFunctionalOpTest {
+   @Override
+   public Object[] factory() {
+      return new Object[] {
+            new FunctionalScatteredInMemoryTest().biasAcquisition(BiasAcquisition.NEVER),
+            new FunctionalScatteredInMemoryTest().biasAcquisition(BiasAcquisition.ON_WRITE)
+      };
+   }
 
    @Test(dataProvider = "owningModeAndWriteMethod")
    public void testWrite(boolean isOwner, WriteMethod method) {

--- a/core/src/test/java/org/infinispan/partitionhandling/BasePartitionHandlingTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/BasePartitionHandlingTest.java
@@ -65,6 +65,9 @@ public class BasePartitionHandlingTest extends MultipleCacheManagersTest {
    protected void createCacheManagers() throws Throwable {
       ConfigurationBuilder dcc = cacheConfiguration();
       dcc.clustering().cacheMode(cacheMode).partitionHandling().whenSplit(partitionHandling).mergePolicy(mergePolicy);
+      if (biasAcquisition != null) {
+         dcc.clustering().biasAcquisition(biasAcquisition);
+      }
       createClusteredCaches(numMembersInCluster, dcc, new TransportFlags().withFD(true).withMerge(true));
       waitForClusterToForm();
    }

--- a/core/src/test/java/org/infinispan/partitionhandling/ScatteredSplitAndMergeTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/ScatteredSplitAndMergeTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.partitionhandling;
 
+import org.infinispan.configuration.cache.BiasAcquisition;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.distribution.MagicKey;
 import org.infinispan.util.logging.Log;
@@ -19,6 +20,14 @@ public class ScatteredSplitAndMergeTest extends BasePartitionHandlingTest {
 
    {
       cacheMode = CacheMode.SCATTERED_SYNC;
+   }
+
+   @Override
+   public Object[] factory() {
+      return new Object[] {
+            new ScatteredSplitAndMergeTest().biasAcquisition(BiasAcquisition.NEVER),
+            new ScatteredSplitAndMergeTest().biasAcquisition(BiasAcquisition.ON_WRITE)
+      };
    }
 
    public void testSplitAndMerge1() throws Exception {

--- a/core/src/test/java/org/infinispan/scattered/APIScatteredTest.java
+++ b/core/src/test/java/org/infinispan/scattered/APIScatteredTest.java
@@ -7,6 +7,7 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.AssertJUnit.assertNotNull;
 
 import org.infinispan.Cache;
+import org.infinispan.configuration.cache.BiasAcquisition;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.container.versioning.EntryVersion;
 import org.infinispan.container.versioning.InequalVersionComparisonResult;
@@ -28,6 +29,14 @@ public class APIScatteredTest extends BaseScatteredTest {
    private static final String VALUE1 = "VALUE1";
    private static final String VALUE2 = "VALUE2";
    private static final String VALUE3 = "VALUE3";
+
+   @Override
+   public Object[] factory() {
+      return new Object[] {
+            new APIScatteredTest().biasAcquisition(BiasAcquisition.NEVER),
+            new APIScatteredTest().biasAcquisition(BiasAcquisition.ON_WRITE),
+      };
+   }
 
    public void testPut() {
       testPut(false);

--- a/core/src/test/java/org/infinispan/scattered/BaseScatteredTest.java
+++ b/core/src/test/java/org/infinispan/scattered/BaseScatteredTest.java
@@ -21,6 +21,9 @@ public abstract class BaseScatteredTest extends MultipleCacheManagersTest {
    @Override
    protected void createCacheManagers() throws Throwable {
       ConfigurationBuilder cfg = getDefaultClusteredCacheConfig(CacheMode.SCATTERED_SYNC, false);
+      if (biasAcquisition != null) {
+         cfg.clustering().biasAcquisition(biasAcquisition);
+      }
       cfg.clustering().hash().numSegments(16);
       cfg.clustering().remoteTimeout(1, TimeUnit.DAYS); // for debugging
       cm1 = TestCacheManagerFactory.createClusteredCacheManager(cfg);

--- a/core/src/test/java/org/infinispan/scattered/BiasLeaseTest.java
+++ b/core/src/test/java/org/infinispan/scattered/BiasLeaseTest.java
@@ -1,0 +1,124 @@
+package org.infinispan.scattered;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertTrue;
+
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import org.infinispan.Cache;
+import org.infinispan.commands.remote.CacheRpcCommand;
+import org.infinispan.commands.remote.RenewBiasCommand;
+import org.infinispan.commands.remote.RevokeBiasCommand;
+import org.infinispan.configuration.cache.BiasAcquisition;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ClusteringConfiguration;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.distribution.MagicKey;
+import org.infinispan.remoting.inboundhandler.DeliverOrder;
+import org.infinispan.remoting.inboundhandler.PerCacheInboundInvocationHandler;
+import org.infinispan.remoting.inboundhandler.Reply;
+import org.infinispan.remoting.rpc.RpcManager;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.tx.dld.ControlledRpcManager;
+import org.infinispan.util.ControlledTimeService;
+import org.infinispan.util.CountingRpcManager;
+import org.infinispan.util.TimeService;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+@Test(groups = "functional", testName = "scattered.BiasLeaseTest")
+public class BiasLeaseTest extends MultipleCacheManagersTest {
+   private static final long BIAS_LIFESPAN = ClusteringConfiguration.BIAS_LIFESPAN.getDefaultValue();
+   private ControlledRpcManager rpcManager0;
+   private CountingRpcManager rpcManager1;
+   private ControlledTimeService timeService = new ControlledTimeService();
+   private RenewWaitingInvocationHandler handler0;
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.SCATTERED_SYNC, false);
+      builder.clustering().biasAcquisition(BiasAcquisition.ON_WRITE);
+      // Scan biasses frequently
+      builder.expiration().wakeUpInterval(100);
+      createCluster(builder, 3);
+
+      IntStream.of(0, 1, 2).mapToObj(this::cache).forEach(
+            c -> TestingUtil.replaceComponent(c, TimeService.class, timeService, true));
+      TestingUtil.wrapComponent(cache(0), RpcManager.class, rpcManager -> rpcManager0 = new ControlledRpcManager(rpcManager));
+      TestingUtil.wrapComponent(cache(1), RpcManager.class, rpcManager -> rpcManager1 = new CountingRpcManager(rpcManager));
+      TestingUtil.wrapInboundInvocationHandler(cache(0), handler -> handler0 = new RenewWaitingInvocationHandler(handler));
+   }
+
+   @AfterMethod
+   public void cleanup() {
+      IntStream.of(0, 1, 2).mapToObj(this::cache).forEach(Cache::clear);
+   }
+
+   public void testBiasTimesOut() throws InterruptedException {
+      MagicKey key = new MagicKey(cache(0));
+      cache(1).put(key, "v0");
+      assertTrue(biasManager(1).hasLocalBias(key));
+
+      rpcManager0.blockAfter(RevokeBiasCommand.class);
+      timeService.advance(BIAS_LIFESPAN + 1);
+      rpcManager0.waitForCommandToBlock();
+      rpcManager0.stopBlocking();
+
+      // The local bias is invalidated synchronously with the sync command, but it may take few moments
+      // to remove the remote bias.
+      assertFalse(biasManager(1).hasLocalBias(key));
+      eventuallyEquals(null, () -> biasManager(0).getRemoteBias(key));
+   }
+
+   public void testBiasLeaseRenewed() throws InterruptedException {
+      MagicKey key = new MagicKey(cache(0));
+      cache(1).put(key, "v0");
+      assertEquals(Collections.singletonList(address(1)), biasManager(0).getRemoteBias(key));
+      assertTrue(biasManager(1).hasLocalBias(key));
+
+      for (int i = 0; i < 3; ++i) {
+         CountDownLatch latch = new CountDownLatch(1);
+         handler0.latch = latch;
+         timeService.advance(BIAS_LIFESPAN - 1);
+
+         rpcManager1.resetStats();
+         assertEquals("v0", cache(1).get(key));
+         assertEquals(0, rpcManager1.clusterGet);
+         assertTrue(latch.await(30, TimeUnit.SECONDS));
+
+         assertEquals(Collections.singletonList(address(1)), biasManager(0).getRemoteBias(key));
+      }
+   }
+
+   protected BiasManager biasManager(int index) {
+      return cache(index).getAdvancedCache().getComponentRegistry().getComponent(BiasManager.class);
+   }
+
+   private class RenewWaitingInvocationHandler implements PerCacheInboundInvocationHandler {
+      private final PerCacheInboundInvocationHandler delegate;
+      private volatile CountDownLatch latch;
+
+      private RenewWaitingInvocationHandler(PerCacheInboundInvocationHandler delegate) {
+         this.delegate = delegate;
+      }
+
+      @Override
+      public void handle(CacheRpcCommand command, Reply reply, DeliverOrder order) {
+         CountDownLatch latch = this.latch;
+         if (command instanceof RenewBiasCommand && latch != null) {
+            delegate.handle(command, response -> {
+               reply.reply(response);
+               this.latch = null;
+               latch.countDown();
+            }, order);
+         } else {
+            delegate.handle(command, reply, order);
+         }
+      }
+   }
+}

--- a/core/src/test/java/org/infinispan/scattered/BiasRevocationTest.java
+++ b/core/src/test/java/org/infinispan/scattered/BiasRevocationTest.java
@@ -1,0 +1,157 @@
+package org.infinispan.scattered;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertTrue;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import org.infinispan.Cache;
+import org.infinispan.commands.ReplicableCommand;
+import org.infinispan.commands.remote.RevokeBiasCommand;
+import org.infinispan.configuration.cache.BiasAcquisition;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.distribution.MagicKey;
+import org.infinispan.remoting.RemoteException;
+import org.infinispan.remoting.responses.Response;
+import org.infinispan.remoting.rpc.RpcManager;
+import org.infinispan.remoting.rpc.RpcOptions;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.test.Exceptions;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.util.AbstractControlledRpcManager;
+import org.infinispan.util.CountingRpcManager;
+import org.infinispan.util.concurrent.CompletableFutures;
+import org.infinispan.util.concurrent.TimeoutException;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+@Test(groups = "functional", testName = "scattered.BiasRevocationTest")
+public class BiasRevocationTest extends MultipleCacheManagersTest {
+   private FailingRpcManager rpcManager0;
+   private CountingRpcManager rpcManager2;
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.SCATTERED_SYNC, false);
+      builder.clustering().biasAcquisition(BiasAcquisition.ON_WRITE).remoteTimeout(1000);
+      createCluster(builder, 3);
+
+      TestingUtil.wrapComponent(cache(0), RpcManager.class, rpcManager -> rpcManager0 = new FailingRpcManager(rpcManager));
+      cache(1); // just touch to start it
+      TestingUtil.wrapComponent(cache(2), RpcManager.class, rpcManager -> rpcManager2 = new CountingRpcManager(rpcManager));
+   }
+
+   protected static void put(Cache cache, Object key, Object value) {
+      cache.put(key, value);
+   }
+
+   protected static void putAll(Cache cache, Object key, Object value) {
+      cache.putAll(Collections.singletonMap(key, value));
+   }
+
+   public void testFailedRevocationDuringPutOnPrimaryThrowBefore() {
+      testFailedRevocation(() -> rpcManager0.throwBefore = !rpcManager0.throwBefore, BiasRevocationTest::put, true);
+   }
+
+   public void testFailedRevocationDuringPutOnPrimaryThrowInFuture() {
+      testFailedRevocation(() -> rpcManager0.throwInFuture = !rpcManager0.throwInFuture, BiasRevocationTest::put, true);
+   }
+
+   public void testFailedRevocationDuringPutAllOnPrimaryThrowBefore() {
+      testFailedRevocation(() -> rpcManager0.throwBefore = !rpcManager0.throwBefore, BiasRevocationTest::putAll, true);
+   }
+
+   public void testFailedRevocationDuringPutAllOnPrimaryThrowInFuture() {
+      testFailedRevocation(() -> rpcManager0.throwInFuture = !rpcManager0.throwInFuture, BiasRevocationTest::putAll, true);
+   }
+
+   public void testFailedRevocationDuringPutOnNonOwnerThrowBefore() {
+      testFailedRevocation(() -> rpcManager0.throwBefore = !rpcManager0.throwBefore, BiasRevocationTest::put, false);
+   }
+
+   public void testFailedRevocationDuringPutOnNonOwnerThrowInFuture() {
+      testFailedRevocation(() -> rpcManager0.throwInFuture = !rpcManager0.throwInFuture, BiasRevocationTest::put, false);
+   }
+
+   public void testFailedRevocationDuringPutAllOnNonOwnerThrowBefore() {
+      testFailedRevocation(() -> rpcManager0.throwBefore = !rpcManager0.throwBefore, BiasRevocationTest::putAll, false);
+   }
+
+   public void testFailedRevocationDuringPutAllOnNonOwnerThrowInFuture() {
+      testFailedRevocation(() -> rpcManager0.throwInFuture = !rpcManager0.throwInFuture, BiasRevocationTest::putAll, false);
+   }
+
+   protected void testFailedRevocation(Runnable switchFailure, Operation operation, boolean primary) {
+      MagicKey key = new MagicKey(cache(0));
+      cache(2).put(key, "v0");
+      assertTrue(biasManager(2).hasLocalBias(key));
+      assertEquals(Collections.singletonList(address(2)), biasManager(0).getRemoteBias(key));
+
+      // Assert the read is local
+      rpcManager2.resetStats();
+      assertEquals("v0", cache(2).get(key));
+      assertEquals(0, rpcManager2.clusterGet);
+      assertEquals(0, rpcManager2.otherCount);
+
+      switchFailure.run();
+      if (primary) {
+         Exceptions.expectException(RemoteException.class, () -> operation.apply(cache(0), key, "v1"));
+      } else {
+         Exceptions.expectException(TimeoutException.class, () -> operation.apply(cache(1), key, "v1"));
+      }
+
+      // The replication to backup does not fail; only the revocation. Since cache(1) will be the backup for primary
+      // updates, the value will be properly updated there
+      assertTrue(biasManager(2).hasLocalBias(key));
+      assertEquals("v1", cache(0).get(key));
+      assertEquals("v1", cache(1).get(key));
+      assertEquals("v0", cache(2).get(key));
+
+      switchFailure.run();
+      assertEquals("v1", cache(1).put(key, "v2"));
+      assertFalse(biasManager(2).hasLocalBias(key));
+      assertEquals("v2", cache(2).get(key));
+   }
+
+   @AfterMethod
+   public void resetFailures() {
+      rpcManager0.throwBefore = false;
+      rpcManager0.throwInFuture = false;
+      caches().forEach(Cache::clear);
+   }
+
+   protected BiasManager biasManager(int index) {
+      return cache(index).getAdvancedCache().getComponentRegistry().getComponent(BiasManager.class);
+   }
+
+   private interface Operation {
+      void apply(Cache cache, Object key, Object value);
+   }
+
+   private class FailingRpcManager extends AbstractControlledRpcManager {
+      public boolean throwBefore = false;
+      public boolean throwInFuture = false;
+
+      public FailingRpcManager(RpcManager realOne) {
+         super(realOne);
+      }
+
+      @Override
+      public CompletableFuture<Map<Address, Response>> invokeRemotelyAsync(Collection<Address> recipients, ReplicableCommand rpc, RpcOptions options) {
+         if (rpc instanceof RevokeBiasCommand) {
+            if (throwBefore)
+               throw new RemoteException("Induced", null);
+            if (throwInFuture) {
+               return CompletableFutures.completedExceptionFuture(new RemoteException("Induced", null));
+            }
+         }
+         return super.invokeRemotelyAsync(recipients, rpc, options);
+      }
+   }
+}

--- a/core/src/test/java/org/infinispan/scattered/ScatteredSyncFuncTest.java
+++ b/core/src/test/java/org/infinispan/scattered/ScatteredSyncFuncTest.java
@@ -3,7 +3,9 @@ package org.infinispan.scattered;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNotNull;
 
+import org.infinispan.configuration.cache.BiasAcquisition;
 import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.distribution.DistSyncFuncTest;
 import org.infinispan.distribution.MagicKey;
@@ -14,10 +16,25 @@ import org.testng.annotations.Test;
  */
 @Test(groups = "functional")
 public class ScatteredSyncFuncTest extends DistSyncFuncTest {
+   @Override
+   public Object[] factory() {
+      return new Object[] {
+            new ScatteredSyncFuncTest().biasAcquisition(BiasAcquisition.NEVER),
+            new ScatteredSyncFuncTest().biasAcquisition(BiasAcquisition.ON_WRITE),
+      };
+   }
+
    public ScatteredSyncFuncTest() {
       cacheMode = CacheMode.SCATTERED_SYNC;
       numOwners = 1;
       l1CacheEnabled = false;
+   }
+
+   @Override
+   protected ConfigurationBuilder buildConfiguration() {
+      ConfigurationBuilder builder = super.buildConfiguration();
+      builder.clustering().biasAcquisition(biasAcquisition);
+      return builder;
    }
 
    @Override

--- a/core/src/test/java/org/infinispan/scattered/statetransfer/AbstractStateTransferTest.java
+++ b/core/src/test/java/org/infinispan/scattered/statetransfer/AbstractStateTransferTest.java
@@ -63,6 +63,7 @@ public abstract class AbstractStateTransferTest extends MultipleCacheManagersTes
    protected void createCacheManagers() throws Throwable {
       defaultConfig = getDefaultClusteredCacheConfig(CacheMode.SCATTERED_SYNC, false);
       defaultConfig.clustering().hash().numSegments(16);
+      defaultConfig.clustering().biasAcquisition(biasAcquisition);
       defaultConfig.clustering().stateTransfer().fetchInMemoryState(true).chunkSize(3);
       createClusteredCaches(3, defaultConfig, TRANSPORT_FLAGS, CACHE_NAME);
 

--- a/core/src/test/java/org/infinispan/scattered/statetransfer/PushTransferTest.java
+++ b/core/src/test/java/org/infinispan/scattered/statetransfer/PushTransferTest.java
@@ -9,6 +9,7 @@ import java.util.stream.Stream;
 
 import org.infinispan.Cache;
 import org.infinispan.commands.ReplicableCommand;
+import org.infinispan.configuration.cache.BiasAcquisition;
 import org.infinispan.distribution.MagicKey;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.remoting.responses.Response;
@@ -30,6 +31,14 @@ import org.testng.annotations.Test;
  */
 @Test(groups = "functional", testName = "scattered.statetransfer.PushTransferTest")
 public class PushTransferTest extends AbstractStateTransferTest {
+
+   @Override
+   public Object[] factory() {
+      return new Object[]{
+            new PushTransferTest().biasAcquisition(BiasAcquisition.NEVER),
+            new PushTransferTest().biasAcquisition(BiasAcquisition.ON_WRITE)
+      };
+   };
 
    public void testNodeJoin() throws Exception {
       List<MagicKey> keys = init();

--- a/core/src/test/java/org/infinispan/test/MultipleCacheManagersTest.java
+++ b/core/src/test/java/org/infinispan/test/MultipleCacheManagersTest.java
@@ -25,6 +25,7 @@ import javax.transaction.TransactionManager;
 
 import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
+import org.infinispan.configuration.cache.BiasAcquisition;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
@@ -98,6 +99,7 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
    protected Boolean transactional;
    protected LockingMode lockingMode;
    protected Boolean totalOrder;
+   protected BiasAcquisition biasAcquisition;
    protected IsolationLevel isolationLevel;
    private boolean parametrizedInstance = false;
 
@@ -623,6 +625,11 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
       return this;
    }
 
+   public MultipleCacheManagersTest biasAcquisition(BiasAcquisition biasAcquisition) {
+      this.biasAcquisition = biasAcquisition;
+      return this;
+   }
+
    public TransactionMode transactionMode() {
       return transactional ? TransactionMode.TRANSACTIONAL : TransactionMode.NON_TRANSACTIONAL;
    }
@@ -657,11 +664,11 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
    }
 
    protected String[] parameterNames() {
-      return new String[]{ null, "tx", "locking", "TO", "isolation" };
+      return new String[]{ null, "tx", "locking", "TO", "isolation", "bias" };
    }
 
    protected Object[] parameterValues() {
-      return new Object[]{ cacheMode, transactional, lockingMode, totalOrder, isolationLevel };
+      return new Object[]{ cacheMode, transactional, lockingMode, totalOrder, isolationLevel, biasAcquisition };
    }
 
    protected static <T> T[] concat(T[] a1, T... a2) {

--- a/core/src/test/java/org/infinispan/tx/dld/ControlledRpcManager.java
+++ b/core/src/test/java/org/infinispan/tx/dld/ControlledRpcManager.java
@@ -1,5 +1,7 @@
 package org.infinispan.tx.dld;
 
+import static org.testng.AssertJUnit.assertTrue;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -67,7 +69,7 @@ public class ControlledRpcManager extends AbstractControlledRpcManager {
 
    public void waitForCommandToBlock() throws InterruptedException {
       log.tracef("Waiting for at least one command to block");
-      blockingLatch.await(30, TimeUnit.SECONDS);
+      assertTrue(blockingLatch.await(30, TimeUnit.SECONDS));
    }
 
    public boolean waitForCommandToBlock(long time, TimeUnit unit) throws InterruptedException {
@@ -109,7 +111,7 @@ public class ControlledRpcManager extends AbstractControlledRpcManager {
          }
 
          log.debugf("Replication trigger called, waiting for latch to open.");
-         replicationLatch.await(30, TimeUnit.SECONDS);
+         assertTrue(replicationLatch.await(30, TimeUnit.SECONDS));
          log.trace("Replication latch opened, continuing.");
          return true;
       } catch (Exception e) {

--- a/core/src/test/java/org/infinispan/util/mocks/ControlledCommandFactory.java
+++ b/core/src/test/java/org/infinispan/util/mocks/ControlledCommandFactory.java
@@ -46,6 +46,8 @@ import org.infinispan.commands.read.SizeCommand;
 import org.infinispan.commands.remote.ClusteredGetAllCommand;
 import org.infinispan.commands.remote.ClusteredGetCommand;
 import org.infinispan.commands.remote.GetKeysInGroupCommand;
+import org.infinispan.commands.remote.RenewBiasCommand;
+import org.infinispan.commands.remote.RevokeBiasCommand;
 import org.infinispan.commands.remote.SingleRpcCommand;
 import org.infinispan.commands.remote.recovery.CompleteTransactionCommand;
 import org.infinispan.commands.remote.recovery.GetInDoubtTransactionsCommand;
@@ -68,6 +70,7 @@ import org.infinispan.commands.write.EvictCommand;
 import org.infinispan.commands.write.ExceptionAckCommand;
 import org.infinispan.commands.write.InvalidateCommand;
 import org.infinispan.commands.write.InvalidateVersionsCommand;
+import org.infinispan.commands.write.PrimaryAckCommand;
 import org.infinispan.commands.write.PutKeyValueCommand;
 import org.infinispan.commands.write.PutMapCommand;
 import org.infinispan.commands.write.RemoveCommand;
@@ -492,6 +495,11 @@ public class ControlledCommandFactory implements CommandsFactory {
    }
 
    @Override
+   public PrimaryAckCommand buildPrimaryAckCommand(long id, boolean success, Object value, Address[] waitFor) {
+      return actual.buildPrimaryAckCommand(id, success, value, waitFor);
+   }
+
+   @Override
    public ExceptionAckCommand buildExceptionAckCommand(long id, Throwable throwable, int topologyId) {
       return actual.buildExceptionAckCommand(id, throwable, topologyId);
    }
@@ -509,6 +517,16 @@ public class ControlledCommandFactory implements CommandsFactory {
    @Override
    public InvalidateVersionsCommand buildInvalidateVersionsCommand(int topologyId, Object[] keys, int[] topologyIds, long[] versions, boolean removed) {
       return actual.buildInvalidateVersionsCommand(topologyId, keys, topologyIds, versions, removed);
+   }
+
+   @Override
+   public RevokeBiasCommand buildRevokeBiasCommand(Address ackTarget, long id, int topologyId, Collection<Object> keys) {
+      return actual.buildRevokeBiasCommand(ackTarget, id, topologyId, keys);
+   }
+
+   @Override
+   public RenewBiasCommand buildRenewBiasCommand(Object[] keys) {
+      return actual.buildRenewBiasCommand(keys);
    }
 
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-8458

Since I've made some changes to CommandAckCollector we'll need a perf ack for dist mode.

I'd like to get some perf tests for scattered cache, too, but these will be heavily skewed: the perfack testing scenario always reads/writes the same keys from the same thread and therefore the reads should be almost as fast as in non-biased scattered cache and reads should be served locally. An interesting comparison would be between random-spread keys, scattered mode bias on write vs. distributed mode (triangle) as scattered mode should degenerate to that scenario (though there's more overhead).