### PR TITLE
ISPN-8516 OSGI integration tests random failure listening to RMI port

### DIFF
--- a/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/BasicInfinispanOSGiTest.java
+++ b/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/BasicInfinispanOSGiTest.java
@@ -40,7 +40,7 @@ public class BasicInfinispanOSGiTest extends BaseInfinispanCoreOSGiTest {
    }
 
    @Override
-   protected void createCacheManagers() throws Throwable {
+   protected void createCacheManagers() {
       //not used
    }
 

--- a/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/features/OSGiKarafFeaturesTest.java
+++ b/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/features/OSGiKarafFeaturesTest.java
@@ -7,8 +7,6 @@ import java.net.URI;
 import java.util.Properties;
 
 import org.apache.karaf.features.FeaturesService;
-import org.infinispan.commons.test.skip.OS;
-import org.infinispan.commons.test.skip.SkipJunit;
 import org.infinispan.it.osgi.util.CustomPaxExamRunner;
 import org.infinispan.it.osgi.util.MavenUtils;
 import org.infinispan.it.osgi.util.PaxExamUtils;
@@ -57,8 +55,6 @@ public class OSGiKarafFeaturesTest {
     */
    @Test
    public void testCleanInstall() throws Exception {
-      SkipJunit.skipOnOS(OS.SOLARIS, OS.WINDOWS);
-
       Bundle bundle = FrameworkUtil.getBundle(getClass());
       Assert.assertNotNull("Failed to find class bundle.", bundle);
 
@@ -95,7 +91,7 @@ public class OSGiKarafFeaturesTest {
       try {
          service.installFeature(feature, version);
          Assert.fail("Feature install should fail before the repository is added.");
-      } catch (Exception ex) {
+      } catch (Exception ignored) {
       }
 
       URI repoUri = new URI(String.format("mvn:org.infinispan/%s/%s/xml/features", artifactId, version));

--- a/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/util/CustomPaxExamRunner.java
+++ b/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/util/CustomPaxExamRunner.java
@@ -2,6 +2,7 @@ package org.infinispan.it.osgi.util;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.lang.reflect.Field;
 import java.util.Arrays;
 
 import org.junit.experimental.categories.Category;
@@ -11,6 +12,8 @@ import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.model.InitializationError;
 import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerSuite;
+import org.ops4j.pax.exam.spi.reactors.SingletonStagedReactor;
 
 /**
  * Custom runner to work around https://issues.apache.org/jira/browse/SUREFIRE-1374
@@ -20,56 +23,100 @@ import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
  */
 public class CustomPaxExamRunner extends PaxExam {
    private static InputStream savedIn;
+   private static Class<?> hookTriggerClass = null;
+
+   private final Class<?> testClass;
 
    public CustomPaxExamRunner(Class<?> klass) throws InitializationError {
+      // Replace System.in in constructor instead of a static constructor
+      // The static constructor might be called before Surefire started pumping System.in
       super(replaceSystemIn(klass));
+      testClass = klass;
    }
 
    private static Class<?> replaceSystemIn(Class<?> klass) {
-      // Replace System.in so that KarafJavaRunner's can't steal master commands from surefire's CommandReader
-      savedIn = System.in;
+      if (savedIn == null) {
+         // Replace System.in so that KarafJavaRunner's can't steal master commands from surefire's CommandReader
+         savedIn = System.in;
 
-      System.setIn(new ByteArrayInputStream(new byte[0]));
+         System.setIn(new ByteArrayInputStream(new byte[0]));
+      }
       return klass;
    }
 
    @Override
    public void run(RunNotifier notifier) {
+      // Per-suite Karaf container is not stopped when some test classes are filtered by strategy
+      // Add here the shutdown hook promised in the SingletonStagedReactor javadoc
+      ExamReactorStrategy strategy = testClass.getAnnotation(ExamReactorStrategy.class);
+      if (strategy == null || Arrays.asList(strategy.value()).contains(PerSuite.class)) {
+         addShutdownHook(testClass);
+      }
+
+      // Require matching @Category and @ExamReactorStrategy annotations on all tests
       notifier.addListener(new RunListener() {
-
          @Override
-         public void testStarted(Description description) throws Exception {
-            Class<?> testClass = description.getTestClass();
-            if (testClass == null)
-               return;
-
-            Category categoryAnnotation = testClass.getAnnotation(Category.class);
-            if (categoryAnnotation == null)
-               throw new IllegalStateException(
-                     "Class " + testClass.getName() + " doesn't have a @Category annotation. " +
-                           "All tests in the integrationtests/osgi module must have " +
-                           "matching @Category and @ExamReactorStrategy annotations.");
-
-            ExamReactorStrategy reactorStrategyAnnotation = testClass.getAnnotation(ExamReactorStrategy.class);
-            if (reactorStrategyAnnotation == null) {
-               throw new IllegalStateException(
-                     "Class " + testClass.getName() + " doesn't have a @ExamReactorStrategy annotation. " +
-                           "All tests in the integrationtests/osgi module must have " +
-                           "matching @Category and @ExamReactorStrategy annotations.");
-            }
-
-            if (!Arrays.equals(categoryAnnotation.value(), reactorStrategyAnnotation.value())) {
-               throw new IllegalStateException(
-                     "The @Category and @ExamReactorStrategy annotations in class " + testClass.getName() +
-                           " do not match.");
-            }
+         public void testStarted(Description description) {
+            requireMatchingAnnotations(description);
          }
 
          @Override
-         public void testRunStarted(Description description) throws Exception {
-            super.testRunStarted(description);
+         public void testRunStarted(Description description) {
          }
       });
       super.run(notifier);
+   }
+
+   private void requireMatchingAnnotations(Description description) {
+      Class<?> testClass = description.getTestClass();
+      if (testClass == null)
+         return;
+
+      Category categoryAnnotation = testClass.getAnnotation(Category.class);
+      if (categoryAnnotation == null)
+         throw new IllegalStateException(
+               "Class " + testClass.getName() + " doesn't have a @Category annotation. " +
+                     "All tests in the integrationtests/osgi module must have " +
+                     "matching @Category and @ExamReactorStrategy annotations.");
+
+      ExamReactorStrategy reactorStrategyAnnotation = testClass.getAnnotation(ExamReactorStrategy.class);
+      if (reactorStrategyAnnotation == null) {
+         throw new IllegalStateException(
+               "Class " + testClass.getName() + " doesn't have a @ExamReactorStrategy annotation. " +
+                     "All tests in the integrationtests/osgi module must have " +
+                     "matching @Category and @ExamReactorStrategy annotations.");
+      }
+
+      if (!Arrays.equals(categoryAnnotation.value(), reactorStrategyAnnotation.value())) {
+         throw new IllegalStateException(
+               "The @Category and @ExamReactorStrategy annotations in class " + testClass.getName() +
+                     " do not match.");
+      }
+   }
+
+   private static void addShutdownHook(Class<?> klass) {
+      if (hookTriggerClass != null)
+         return;
+
+      hookTriggerClass = klass;
+      Runtime.getRuntime().addShutdownHook(new Thread("CustomPaxExamRunner-ShutdownHook") {
+         @Override
+         public void run() {
+            stopSingletonStagedReactor();
+         }
+      });
+   }
+
+   private static void stopSingletonStagedReactor() {
+      try {
+         Field instanceField = SingletonStagedReactor.class.getDeclaredField("instance");
+         instanceField.setAccessible(true);
+         SingletonStagedReactor instance = (SingletonStagedReactor) instanceField.get(null);
+
+         System.out.println("Forcing shutdown of Karaf container for test " + hookTriggerClass);
+         instance.afterSuite();
+      } catch (Exception e) {
+         System.err.println("Failed to shut down suite reactor: " + e.getMessage());
+      }
    }
 }

--- a/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/util/IspnKarafOptions.java
+++ b/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/util/IspnKarafOptions.java
@@ -19,7 +19,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.jar.Attributes;
@@ -183,12 +182,6 @@ public class IspnKarafOptions {
    /**
     * Wraps the specified test jars as bundles fragments and attaches them to the specified host bundle. The host bundle
     * must be the one exporting the packages contained in the test jar.
-    *
-    * @param groupId
-    * @param artifactId
-    * @param hostBundle
-    * @return
-    * @throws Exception
     */
    public static WrappedUrlProvisionOption mvnTestsAsFragmentBundle(String groupId, String artifactId, String hostBundle, String... instructions) throws Exception {
       PaxURLUtils.registerURLHandlers();
@@ -224,9 +217,6 @@ public class IspnKarafOptions {
    /**
     * Some test packages are split across several Maven modules this option repackages them and exposes them through a
     * single bundle.
-    *
-    * @return
-    * @throws Exception
     */
    public static Option bundleSplitTestPackages() throws Exception {
       PaxURLUtils.registerURLHandlers();
@@ -255,32 +245,26 @@ public class IspnKarafOptions {
                        wrappedSplitTestBundle);
    }
 
-   public static UrlProvisionOption asStreamBundle(AbstractUrlProvisionOption<?> option, String newURLFormat, String... args) throws MalformedURLException, IOException {
-      return asStreamBundle(option.getURL(), newURLFormat, args);
+   public static UrlProvisionOption asStreamBundle(AbstractUrlProvisionOption<?> option, String newURLFormat, String... args) throws IOException {
+      return asStreamBundle(option.getURL(), newURLFormat);
    }
 
-   public static UrlProvisionOption asStreamBundle(String url) throws MalformedURLException, IOException {
+   public static UrlProvisionOption asStreamBundle(String url) throws IOException {
       return asStreamBundle(url, "%s");
    }
 
    /**
     * Some PAX-URL protocols are not supported by Karaf. This method can be used when one of the unsupported protocol is
     * required. The URLs are resolved outside Karaf and the bundles are provided as stream bundles.
-    *
-    * @param newURLFormat
-    * @param args
-    * @return
-    * @throws MalformedURLException
-    * @throws IOException
     */
-   public static UrlProvisionOption asStreamBundle(String url, String newURLFormat, String... args) throws MalformedURLException, IOException {
-      InputStream in = new URL(String.format(newURLFormat, url, args)).openStream();
+   public static UrlProvisionOption asStreamBundle(String url, String newURLFormat) throws IOException {
+      InputStream in = new URL(String.format(newURLFormat, url)).openStream();
       try {
          return streamBundle(in);
       } finally {
          try {
             in.close();
-         } catch (IOException ex) {
+         } catch (IOException ignored) {
          }
       }
    }
@@ -294,7 +278,6 @@ public class IspnKarafOptions {
     * container.
     *
     * @return an Option or null if no custom repo location is specified by the maven build.
-    * @throws Exception
     */
    public static Option localRepoForPAXUrl() throws Exception {
       String localRepo = MavenUtils.getLocalRepository();
@@ -333,7 +316,7 @@ public class IspnKarafOptions {
       return composite(karafContainer(),
                        vmOptions("-Djava.net.preferIPv4Stack=true", "-Djgroups.bind_addr=127.0.0.1"),
                        vmOptions("-Xmx500m", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=" + System.getProperty("user.dir")),
-//                       vmOptions("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=8000"),
+//                       vmOptions("-agentlib:jdwp=transport=dt_socket,server=n,suspend=y,address=5006"),
                        verboseKaraf(),
                        runWithoutConsole(),
                        junitBundles(),
@@ -374,9 +357,9 @@ public class IspnKarafOptions {
    }
 
    /* Run tests with uberjar by default */
-   private static boolean useUberJar() throws Exception {
+   private static boolean useUberJar() {
       String uberJar = System.getProperty(PROP_UBER_JAR);
-      return uberJar == null ? true : Boolean.parseBoolean(uberJar);
+      return uberJar == null || Boolean.parseBoolean(uberJar);
    }
 
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-8516

Kill per-suite Karaf container in a shutdown hook.

Please cherry-pick to 9.1.x as well.