### PR TITLE
ISPN-8534 Make off heap memory based eviction a better estimation

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/cache/ConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/ConfigurationBuilder.java
@@ -228,7 +228,7 @@ public class ConfigurationBuilder implements ConfigurationChildBuilder {
       for (Builder<?> validatable:
             asList(clustering, customInterceptors, dataContainer, deadlockDetection, eviction, expiration, indexing,
                    invocationBatching, jmxStatistics, persistence, locking, storeAsBinary, transaction,
-                   versioning, unsafe, sites, compatibility)) {
+                   versioning, unsafe, sites, compatibility, memory)) {
          try {
             validatable.validate();
          } catch (RuntimeException e) {
@@ -264,7 +264,7 @@ public class ConfigurationBuilder implements ConfigurationChildBuilder {
       for (ConfigurationChildBuilder validatable:
             asList(clustering, customInterceptors, dataContainer, deadlockDetection, eviction, expiration, indexing,
                    invocationBatching, jmxStatistics, persistence, locking, storeAsBinary, transaction,
-                   versioning, unsafe, sites, compatibility, security)) {
+                   versioning, unsafe, sites, compatibility, security, memory)) {
          try {
             validatable.validate(globalConfig);
          } catch (RuntimeException e) {

--- a/core/src/main/java/org/infinispan/configuration/cache/MemoryConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/MemoryConfigurationBuilder.java
@@ -10,6 +10,7 @@ import org.infinispan.commons.configuration.attributes.AttributeSet;
 import org.infinispan.commons.logging.LogFactory;
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.container.offheap.OffHeapDataContainer;
+import org.infinispan.container.offheap.UnpooledOffHeapMemoryAllocator;
 import org.infinispan.eviction.EvictionType;
 import org.infinispan.util.logging.Log;
 
@@ -97,8 +98,8 @@ public class MemoryConfigurationBuilder extends AbstractConfigurationChildBuilde
                case OFF_HEAP:
                   int addressCount = attributes.attribute(ADDRESS_COUNT).get();
                   // Note this is cast to long as we have to multiply by 8 below which could overflow
-                  long actualAddressCount = OffHeapDataContainer.getActualAddressCount(addressCount);
-                  actualAddressCount *= 8;
+                  long actualAddressCount = OffHeapDataContainer.getActualAddressCount(addressCount << 3);
+                  actualAddressCount = UnpooledOffHeapMemoryAllocator.estimateSizeOverhead(actualAddressCount);
                   if (size < actualAddressCount) {
                      throw log.offHeapMemoryEvictionSizeNotLargeEnoughForAddresses(size, actualAddressCount, addressCount);
                   }

--- a/core/src/main/java/org/infinispan/container/offheap/BoundedOffHeapDataContainer.java
+++ b/core/src/main/java/org/infinispan/container/offheap/BoundedOffHeapDataContainer.java
@@ -44,7 +44,7 @@ public class BoundedOffHeapDataContainer extends OffHeapDataContainer {
          // Use size of entry plus 16 for our LRU pointers
          sizeCalculator = i -> offHeapEntryFactory.getSize(i);
          // We have to make sure to count the address hash as part of our size
-         initialSize = memoryAddressCount << 3;
+         initialSize = UnpooledOffHeapMemoryAllocator.estimateSizeOverhead(memoryAddressCount << 3);
          currentSize = initialSize;
       }
       this.lruLock = new ReentrantLock();

--- a/core/src/main/java/org/infinispan/container/offheap/MemoryAddressHash.java
+++ b/core/src/main/java/org/infinispan/container/offheap/MemoryAddressHash.java
@@ -16,11 +16,13 @@ public class MemoryAddressHash {
 
    private final long memory;
    private final int pointerCount;
+   private final OffHeapMemoryAllocator allocator;
 
-   public MemoryAddressHash(int pointers) {
+   public MemoryAddressHash(int pointers, OffHeapMemoryAllocator allocator) {
       this.pointerCount = nextPowerOfTwo(pointers);
       long bytes = ((long) pointerCount) << 3;
-      memory = MEMORY.allocate(bytes);
+      this.allocator = allocator;
+      memory = allocator.allocate(bytes);
       // Have to clear out bytes to make sure no bad stuff was read in
       UNSAFE.setMemory(memory, bytes, (byte) 0);
    }
@@ -45,7 +47,7 @@ public class MemoryAddressHash {
    }
 
    public void deallocate() {
-      MEMORY.free(memory);
+      allocator.deallocate(memory, pointerCount << 3);
    }
 
    /**

--- a/core/src/main/java/org/infinispan/container/offheap/OffHeapEntryFactory.java
+++ b/core/src/main/java/org/infinispan/container/offheap/OffHeapEntryFactory.java
@@ -22,9 +22,9 @@ public interface OffHeapEntryFactory {
 
    /**
     * Returns how many bytes in memory this address location uses assuming it is an {@link InternalCacheEntry}.
-    * This will be rounded up to the nearest number divisible by 8.
+    * This will estimate the size assuming 8 byte alignment and 16 byte allocation overhead
     * @param address the address of the entry
-    * @return how many bytes this address was allocated as
+    * @return how many bytes this address was estimated to be
     */
    long getSize(long address);
 

--- a/core/src/main/java/org/infinispan/container/offheap/OffHeapEntryFactory.java
+++ b/core/src/main/java/org/infinispan/container/offheap/OffHeapEntryFactory.java
@@ -21,7 +21,8 @@ public interface OffHeapEntryFactory {
    long create(WrappedBytes key, WrappedBytes value, Metadata metadata);
 
    /**
-    * Returns how many bytes in memory this address location uses assuming it is an {@link InternalCacheEntry}
+    * Returns how many bytes in memory this address location uses assuming it is an {@link InternalCacheEntry}.
+    * This will be rounded up to the nearest number divisible by 8.
     * @param address the address of the entry
     * @return how many bytes this address was allocated as
     */

--- a/core/src/main/java/org/infinispan/container/offheap/OffHeapEntryFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/container/offheap/OffHeapEntryFactoryImpl.java
@@ -187,7 +187,7 @@ public class OffHeapEntryFactoryImpl implements OffHeapEntryFactory {
       int valueLength = MEMORY.getInt(entryAddress, headerOffset);
       headerOffset += 4;
 
-      return headerOffset + keyLength + metadataLength + valueLength;
+      return UnpooledOffHeapMemoryAllocator.roundUpTo8(headerOffset + keyLength + metadataLength + valueLength);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/container/offheap/OffHeapEntryFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/container/offheap/OffHeapEntryFactoryImpl.java
@@ -187,7 +187,7 @@ public class OffHeapEntryFactoryImpl implements OffHeapEntryFactory {
       int valueLength = MEMORY.getInt(entryAddress, headerOffset);
       headerOffset += 4;
 
-      return UnpooledOffHeapMemoryAllocator.roundUpTo8(headerOffset + keyLength + metadataLength + valueLength);
+      return UnpooledOffHeapMemoryAllocator.estimateSizeOverhead(headerOffset + keyLength + metadataLength + valueLength);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/container/offheap/OffHeapEntryFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/container/offheap/OffHeapEntryFactoryImpl.java
@@ -179,7 +179,7 @@ public class OffHeapEntryFactoryImpl implements OffHeapEntryFactory {
       int metadataLength;
       if ((type & (CUSTOM | HAS_VERSION)) != 0) {
          metadataLength = MEMORY.getInt(entryAddress, headerOffset);
-         metadataLength += 4;
+         headerOffset += 4;
       } else {
          metadataLength = 0;
       }

--- a/core/src/main/java/org/infinispan/container/offheap/OffHeapMemoryAllocator.java
+++ b/core/src/main/java/org/infinispan/container/offheap/OffHeapMemoryAllocator.java
@@ -21,7 +21,8 @@ public interface OffHeapMemoryAllocator {
    void deallocate(long memoryAddress);
 
    /**
-    * Deallocates the memory at the given address assuming a given size
+    * Deallocates the memory at the given address assuming a given size. This size is the size that was provided
+    * to allocate.
     * @param memoryAddress the address to deallocate from
     * @param size the total size
     */

--- a/core/src/main/java/org/infinispan/container/offheap/UnpooledOffHeapMemoryAllocator.java
+++ b/core/src/main/java/org/infinispan/container/offheap/UnpooledOffHeapMemoryAllocator.java
@@ -1,6 +1,6 @@
 package org.infinispan.container.offheap;
 
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.function.LongUnaryOperator;
 
 import org.infinispan.factories.annotations.Inject;
@@ -18,7 +18,7 @@ public class UnpooledOffHeapMemoryAllocator implements OffHeapMemoryAllocator {
    private static final Log log = LogFactory.getLog(UnpooledOffHeapMemoryAllocator.class, Log.class);
    private static final boolean trace = log.isTraceEnabled();
    private static final OffHeapMemory MEMORY = OffHeapMemory.INSTANCE;
-   private final AtomicLong amountAllocated = new AtomicLong();
+   private final LongAdder amountAllocated = new LongAdder();
    private LongUnaryOperator sizeCalculator;
 
    @Inject
@@ -28,11 +28,12 @@ public class UnpooledOffHeapMemoryAllocator implements OffHeapMemoryAllocator {
 
    @Override
    public long allocate(long memoryLength) {
+      long roundedMemoryLength = roundUpTo8(memoryLength);
       long memoryLocation = MEMORY.allocate(memoryLength);
-      long currentSize = amountAllocated.addAndGet(memoryLength);
+      amountAllocated.add(roundedMemoryLength);
       if (trace) {
-         log.tracef("Allocated off heap memory at 0x%016x with %d bytes. Total size: %d", memoryLocation, memoryLength,
-               currentSize);
+         log.tracef("Allocated off heap memory at 0x%016x with %d bytes. Total size: %d", memoryLocation,
+               roundedMemoryLength, amountAllocated.sum());
       }
       return memoryLocation;
    }
@@ -44,16 +45,26 @@ public class UnpooledOffHeapMemoryAllocator implements OffHeapMemoryAllocator {
 
    @Override
    public void deallocate(long memoryAddress, long size) {
-      long currentSize = amountAllocated.addAndGet(- size);
+      long roundedMemoryLength = roundUpTo8(size);
+      amountAllocated.add(- roundedMemoryLength);
       if (trace) {
-         log.tracef("Deallocating off heap memory at 0x%016x with %d bytes. Total size: %d", memoryAddress, size,
-               currentSize);
+         log.tracef("Deallocating off heap memory at 0x%016x with %d bytes. Total size: %d", memoryAddress,
+               roundedMemoryLength, amountAllocated.sum());
       }
       MEMORY.free(memoryAddress);
    }
 
    @Override
    public long getAllocatedAmount() {
-      return amountAllocated.get();
+      return amountAllocated.sum();
+   }
+
+   /**
+    * Round up the size to a multiple of 8 to account for most memory allocators aligning allocations to a multiple of 8
+    * @param size the size to align to 8
+    * @return the resulting aligned value
+    */
+   public static long roundUpTo8(long size) {
+      return (size + 7) & ~0x7;
    }
 }

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -37,6 +37,7 @@ import org.infinispan.commons.marshall.AdvancedExternalizer;
 import org.infinispan.commons.util.TypedProperties;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.configuration.cache.StorageType;
 import org.infinispan.configuration.parsing.Element;
 import org.infinispan.container.versioning.EntryVersion;
 import org.infinispan.jmx.JmxDomainConflictException;
@@ -1715,4 +1716,15 @@ public interface Log extends BasicLogger {
 
    @Message(value = "Error while persisting global configuration state", id = 502)
    CacheConfigurationException errorPersistingGlobalConfiguration(@Cause Throwable cause);
+
+   @Message(value = "Compatibility mode requires OBJECT storage type but was: %s", id = 503)
+   CacheConfigurationException compatibilityModeOnlyCompatibleWithObjectStorage(StorageType storageType);
+
+   @Message(value = "MEMORY based eviction is not supported with OBJECT storage", id = 504)
+   CacheConfigurationException offHeapMemoryEvictionNotSupportedWithObject();
+
+   @Message(value = "MEMORY based OFF_HEAP eviction configured size %d must be larger than %d to store configured " +
+         "address count of %d", id = 505)
+   CacheConfigurationException offHeapMemoryEvictionSizeNotLargeEnoughForAddresses(long configuredSize,
+         long addressMemorySize, int addressCount);
 }

--- a/core/src/test/java/org/infinispan/container/offheap/OffHeapBoundedMemoryTest.java
+++ b/core/src/test/java/org/infinispan/container/offheap/OffHeapBoundedMemoryTest.java
@@ -29,7 +29,7 @@ public class OffHeapBoundedMemoryTest extends AbstractInfinispanTest {
       ConfigurationBuilder builder = new ConfigurationBuilder();
       builder.memory()
             // Only allocate enough for address count - oops
-            .size(MemoryConfiguration.ADDRESS_COUNT.getDefaultValue() * 8)
+            .size(16 + MemoryConfiguration.ADDRESS_COUNT.getDefaultValue() * 8)
             .evictionType(EvictionType.MEMORY)
             .storageType(StorageType.OFF_HEAP);
       EmbeddedCacheManager manager = TestCacheManagerFactory.createCacheManager(builder);
@@ -56,11 +56,13 @@ public class OffHeapBoundedMemoryTest extends AbstractInfinispanTest {
       EmbeddedCacheManager manager = TestCacheManagerFactory.createCacheManager(builder);
       AdvancedCache<Object, Object> cache = manager.getCache().getAdvancedCache();
 
-      cache.put(1, 2);
-
       OffHeapMemoryAllocator allocator = cache.getComponentRegistry().getComponent(
             OffHeapMemoryAllocator.class);
       BoundedOffHeapDataContainer container = (BoundedOffHeapDataContainer) getContainer(cache);
+      assertEquals(allocator.getAllocatedAmount(), container.currentSize);
+
+      cache.put(1, 2);
+
       assertEquals(allocator.getAllocatedAmount(), container.currentSize);
 
       cache.clear();

--- a/core/src/test/java/org/infinispan/eviction/impl/MemoryBasedEvictionFunctionalStoreAsBinaryTest.java
+++ b/core/src/test/java/org/infinispan/eviction/impl/MemoryBasedEvictionFunctionalStoreAsBinaryTest.java
@@ -9,6 +9,7 @@ import org.infinispan.configuration.cache.StorageType;
 import org.infinispan.marshall.CustomClass;
 import org.infinispan.remoting.transport.jgroups.JGroupsAddress;
 import org.jgroups.util.UUID;
+import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 
 @Test(groups = "functional", testName = "eviction.MemoryBasedEvictionFunctionalStoreAsBinaryTest")
@@ -17,7 +18,14 @@ public class MemoryBasedEvictionFunctionalStoreAsBinaryTest extends MemoryBasedE
    @Override
    protected void configure(ConfigurationBuilder cb) {
       super.configure(cb);
-      cb.memory().storageType(StorageType.BINARY);
+      cb.memory().storageType(storageType);
+   }
+
+   @Factory
+   public Object[] factory() {
+      return new Object[]{
+            new MemoryBasedEvictionFunctionalStoreAsBinaryTest().storageType(StorageType.BINARY),
+      };
    }
 
    public void testCustomClass() throws Exception {

--- a/server/rest/src/test/java/org/infinispan/rest/BaseRestOperationsTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/BaseRestOperationsTest.java
@@ -41,6 +41,8 @@ public abstract class BaseRestOperationsTest {
 
    protected abstract ConfigurationBuilder getDefaultCacheBuilder();
 
+   protected abstract boolean enableCompatibility();
+
    @BeforeClass
    public void beforeSuite() throws Exception {
       restServer = RestServerHelper.defaultRestServer(getDefaultCacheBuilder(), "default");
@@ -75,7 +77,7 @@ public abstract class BaseRestOperationsTest {
 
       ConfigurationBuilder compat = getDefaultCacheBuilder();
 //      compat.encoding().value().mediaType(MediaType.APPLICATION_OCTET_STREAM_TYPE);
-      compat.compatibility().enable();
+      compat.compatibility().enabled(enableCompatibility());
 
       restServer.defineCache("expiration", expirationConfiguration);
       restServer.defineCache("xml", xmlCacheConfiguration);

--- a/server/rest/src/test/java/org/infinispan/rest/RestOperationsOffHeapTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/RestOperationsOffHeapTest.java
@@ -17,6 +17,11 @@ public class RestOperationsOffHeapTest extends BaseRestOperationsTest {
    }
 
    @Override
+   protected boolean enableCompatibility() {
+      return false;
+   }
+
+   @Override
    protected Class<? extends Encoder> getKeyEncoding() {
       return UTF8Encoder.class;
    }

--- a/server/rest/src/test/java/org/infinispan/rest/RestOperationsTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/RestOperationsTest.java
@@ -19,6 +19,11 @@ public class RestOperationsTest extends BaseRestOperationsTest {
    }
 
    @Override
+   protected boolean enableCompatibility() {
+      return true;
+   }
+
+   @Override
    protected void defineCaches() {
       super.defineCaches();
       ConfigurationBuilder object = getDefaultCacheBuilder();


### PR DESCRIPTION
* Add address count to memory based eviction count
* Align sizes of off heap to 8 bytes
* Also changed allocated count to LongAdder
* Fixed issue that MemoryConfiguration wasn't being validated

https://issues.jboss.org/browse/ISPN-8534
https://issues.jboss.org/browse/ISPN-8545
https://issues.jboss.org/browse/ISPN-8550