### PR TITLE
[ISPN-8551] cache.put(already present key) on ms sqlserver fixed

### DIFF
--- a/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/table/management/SQLServerTableManager.java
+++ b/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/table/management/SQLServerTableManager.java
@@ -24,8 +24,8 @@ class SQLServerTableManager extends AbstractTableManager {
          // for deadlocks to occur.
          upsertRowSql = String.format("MERGE %1$s WITH (TABLOCK) " +
                      "USING (VALUES (?, ?, ?)) AS tmp (%2$s, %3$s, %4$s) " +
-                     "ON (%1$s.%2$s = tmp.%2$s) " +
-                     "WHEN MATCHED THEN UPDATE SET %3$s = tmp.%3$s, %4$s = tmp.%4$s " +
+                     "ON (%1$s.%4$s = tmp.%4$s) " +
+                     "WHEN MATCHED THEN UPDATE SET %2$s = tmp.%2$s, %3$s = tmp.%3$s " +
                      "WHEN NOT MATCHED THEN INSERT (%2$s, %3$s, %4$s) VALUES (tmp.%2$s, tmp.%3$s, tmp.%4$s);",
                getTableName(), config.dataColumnName(), config.timestampColumnName(), config.idColumnName());
       }


### PR DESCRIPTION
The current (infinispan 9.1.3.Final) SQLServer implementation of AbstractTableManager (the class SQLServerTableManager) fails on updating cache entries.