### PR TITLE
ISPN-7070

### DIFF
--- a/core/src/main/java/org/infinispan/notifications/cachelistener/CacheNotifierImpl.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/CacheNotifierImpl.java
@@ -954,11 +954,11 @@ public final class CacheNotifierImpl<K, V> extends AbstractListenerImpl<Event<K,
             raiseEventForInitialTransfer(generatedId, entry, l.clustered());
          }
 
+         handler.transferComplete();
+
          if (trace) {
             log.tracef("Listener %s initial state for cache completed", generatedId);
          }
-
-         handler.transferComplete();
       }
 
    }
@@ -1226,11 +1226,11 @@ public final class CacheNotifierImpl<K, V> extends AbstractListenerImpl<Event<K,
             raiseEventForInitialTransfer(generatedId, entry, l.clustered());
          }
 
+         handler.transferComplete();
+
          if (trace) {
             log.tracef("Listener %s initial state for cache completed", generatedId);
          }
-
-         handler.transferComplete();
       }
 
    }

--- a/core/src/main/java/org/infinispan/stream/impl/ClusterStreamManager.java
+++ b/core/src/main/java/org/infinispan/stream/impl/ClusterStreamManager.java
@@ -208,15 +208,15 @@ public interface ClusterStreamManager<K> {
        * it is possible that a key returned could be mapped to a segment that was found to be suspected or completed.
        * @see Publisher#subscribe(Subscriber)
        * @param s the subscriber to subscribe
-       * @param lostSegments the consumer to be notified of lost segments
        * @param completedSegments the consumer to  be notified of completed segments
+       * @param lostSegments the consumer to be notified of lost segments
        */
-      void subscribe(Subscriber<? super K> s, Consumer<? super Supplier<PrimitiveIterator.OfInt>> lostSegments,
-            Consumer<? super Supplier<PrimitiveIterator.OfInt>> completedSegments);
+      void subscribe(Subscriber<? super K> s, Consumer<? super Supplier<PrimitiveIterator.OfInt>> completedSegments,
+            Consumer<? super Supplier<PrimitiveIterator.OfInt>> lostSegments);
 
       @Override
       default void subscribe(Subscriber<? super K> s) {
-         subscribe(s, lostSegments -> { }, completedSegments -> { });
+         subscribe(s, completedSegments -> { }, lostSegments -> { });
       }
    }
 }

--- a/core/src/main/java/org/infinispan/stream/impl/ClusterStreamManagerImpl.java
+++ b/core/src/main/java/org/infinispan/stream/impl/ClusterStreamManagerImpl.java
@@ -452,8 +452,8 @@ public class ClusterStreamManagerImpl<K> implements ClusterStreamManager<K> {
       }
 
       @Override
-      public void subscribe(Subscriber<? super V> s, Consumer<? super Supplier<PrimitiveIterator.OfInt>> onLostSegments,
-            Consumer<? super Supplier<PrimitiveIterator.OfInt>> onSegmentsComplete) {
+      public void subscribe(Subscriber<? super V> s, Consumer<? super Supplier<PrimitiveIterator.OfInt>> onSegmentsComplete,
+            Consumer<? super Supplier<PrimitiveIterator.OfInt>> onLostSegments) {
          Map.Entry<Address, IntSet> target = targets.get();
          if (target == null) {
             EmptySubscription.complete(s);
@@ -463,7 +463,7 @@ public class ClusterStreamManagerImpl<K> implements ClusterStreamManager<K> {
                log.tracef("Starting request: %s", id);
             }
             iteratorsRunning.add(s);
-            s.onSubscribe(new ClusterStreamSubscription<V>(s, this, onLostSegments, onSegmentsComplete, id, target));
+            s.onSubscribe(new ClusterStreamSubscription<V>(s, this, onSegmentsComplete, onLostSegments, id, target));
          }
       }
    }


### PR DESCRIPTION
CacheNotifierImplInitialTransferDistTest.testIterationBeganAndSegmentNotComplete
random failures

* Changed test to wait for both key and segment completion
* Fixed issue where iterator could be complete before segment was

https://issues.jboss.org/browse/ISPN-7070