### PR TITLE
ISPN-6395 Unify clustered queries with non clustered queries

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/QueryOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/QueryOperation.java
@@ -55,6 +55,7 @@ public final class QueryOperation extends RetryOnFailureOperation<QueryResponse>
          queryRequest.setMaxResults(remoteQuery.getMaxResults());
       }
       queryRequest.setNamedParameters(getNamedParameters());
+      queryRequest.setIndexedQueryMode(remoteQuery.getIndexedQueryMode().toString());
 
       // marshall and write the request
       byte[] requestBytes;

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/query/RemoteQuery.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/query/RemoteQuery.java
@@ -13,6 +13,7 @@ import org.infinispan.client.hotrod.impl.operations.QueryOperation;
 import org.infinispan.protostream.ProtobufUtil;
 import org.infinispan.protostream.SerializationContext;
 import org.infinispan.protostream.WrappedMessage;
+import org.infinispan.query.dsl.IndexedQueryMode;
 import org.infinispan.query.dsl.QueryFactory;
 import org.infinispan.query.dsl.impl.BaseQuery;
 import org.infinispan.query.remote.client.QueryResponse;
@@ -25,22 +26,25 @@ public final class RemoteQuery extends BaseQuery {
 
    private final RemoteCacheImpl<?, ?> cache;
    private final SerializationContext serializationContext;
+   private final IndexedQueryMode indexedQueryMode;
 
    private List<?> results = null;
    private int totalResults;
 
    RemoteQuery(QueryFactory queryFactory, RemoteCacheImpl<?, ?> cache, SerializationContext serializationContext,
-               String queryString) {
+               String queryString, IndexedQueryMode indexQueryMode) {
       super(queryFactory, queryString);
       this.cache = cache;
       this.serializationContext = serializationContext;
+      this.indexedQueryMode = indexQueryMode;
    }
 
-   RemoteQuery(QueryFactory queryFactory, RemoteCacheImpl cache, SerializationContext serializationContext,
+   RemoteQuery(QueryFactory queryFactory, RemoteCacheImpl<?, ?> cache, SerializationContext serializationContext,
                String queryString, Map<String, Object> namedParameters, String[] projection, long startOffset, int maxResults) {
       super(queryFactory, queryString, namedParameters, projection, startOffset, maxResults);
       this.cache = cache;
       this.serializationContext = serializationContext;
+      this.indexedQueryMode = IndexedQueryMode.FETCH;
    }
 
    @Override
@@ -110,6 +114,10 @@ public final class RemoteQuery extends BaseQuery {
 
    public RemoteCache<?, ?> getCache() {
       return cache;
+   }
+
+   public IndexedQueryMode getIndexedQueryMode() {
+      return indexedQueryMode;
    }
 
    @Override

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/query/RemoteQueryFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/query/RemoteQueryFactory.java
@@ -5,6 +5,7 @@ import org.infinispan.client.hotrod.impl.RemoteCacheImpl;
 import org.infinispan.client.hotrod.marshall.ProtoStreamMarshaller;
 import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.protostream.SerializationContext;
+import org.infinispan.query.dsl.IndexedQueryMode;
 import org.infinispan.query.dsl.Query;
 import org.infinispan.query.dsl.QueryBuilder;
 import org.infinispan.query.dsl.impl.BaseQueryFactory;
@@ -41,6 +42,11 @@ public final class RemoteQueryFactory extends BaseQueryFactory {
    @Override
    public Query create(String queryString) {
       return new RemoteQuery(this, cache, serializationContext, queryString);
+   }
+
+   @Override
+   public Query create(String queryString, IndexedQueryMode queryMode) {
+      return create(queryString);
    }
 
    @Override

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/query/RemoteQueryFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/query/RemoteQueryFactory.java
@@ -41,12 +41,12 @@ public final class RemoteQueryFactory extends BaseQueryFactory {
 
    @Override
    public Query create(String queryString) {
-      return new RemoteQuery(this, cache, serializationContext, queryString);
+      return new RemoteQuery(this, cache, serializationContext, queryString, IndexedQueryMode.FETCH);
    }
 
    @Override
    public Query create(String queryString, IndexedQueryMode queryMode) {
-      return create(queryString);
+      return new RemoteQuery(this, cache, serializationContext, queryString, queryMode);
    }
 
    @Override

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryStringBroadcastTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryStringBroadcastTest.java
@@ -1,0 +1,38 @@
+package org.infinispan.client.hotrod.query;
+
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.cache.Index;
+import org.infinispan.query.dsl.IndexedQueryMode;
+import org.infinispan.query.dsl.Query;
+import org.infinispan.query.dsl.QueryFactory;
+import org.testng.annotations.Test;
+
+/**
+ * Tests for {@link org.infinispan.query.dsl.IndexedQueryMode} from the Hot Rod client.
+ * Each node has a local index, and the client creates a query with BROADCAST to return
+ * correct results.
+ *
+ * @since 9.2
+ */
+@Test(groups = "functional", testName = "client.hotrod.query.RemoteQueryStringBroadcastTest")
+public class RemoteQueryStringBroadcastTest extends RemoteQueryStringTest {
+
+   @Override
+   protected ConfigurationBuilder getConfigurationBuilder() {
+      ConfigurationBuilder cfgBuilder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC);
+      cfgBuilder.indexing().index(Index.PRIMARY_OWNER).addProperty("default.directory_provider", "local-heap");
+      return cfgBuilder;
+   }
+
+   @Override
+   protected int getNodesCount() {
+      return 3;
+   }
+
+   @Override
+   protected Query createQueryFromString(String q) {
+      QueryFactory queryFactory = getQueryFactory();
+      return queryFactory.create(q, IndexedQueryMode.BROADCAST);
+   }
+}

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryStringTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryStringTest.java
@@ -97,10 +97,14 @@ public class RemoteQueryStringTest extends QueryStringTest {
       return cache;
    }
 
+   protected int getNodesCount() {
+      return 1;
+   }
+
    @Override
    protected void createCacheManagers() throws Throwable {
       ConfigurationBuilder cfg = getConfigurationBuilder();
-      createClusteredCaches(1, cfg, true);
+      createClusteredCaches(getNodesCount(), cfg, true);
 
       cache = manager(0).getCache();
 
@@ -194,9 +198,7 @@ public class RemoteQueryStringTest extends QueryStringTest {
     */
    @Override
    public void testInstant1() throws Exception {
-      QueryFactory qf = getQueryFactory();
-
-      Query q = qf.create("from " + getModelFactory().getUserTypeName() + " u where u.creationDate = " + Instant.parse("2011-12-03T10:15:30Z").toEpochMilli());
+      Query q = createQueryFromString("from " + getModelFactory().getUserTypeName() + " u where u.creationDate = " + Instant.parse("2011-12-03T10:15:30Z").toEpochMilli());
 
       List<User> list = q.list();
       assertEquals(3, list.size());
@@ -208,18 +210,14 @@ public class RemoteQueryStringTest extends QueryStringTest {
     */
    @Override
    public void testInstant2() throws Exception {
-      QueryFactory qf = getQueryFactory();
-
-      Query q = qf.create("from " + getModelFactory().getUserTypeName() + " u where u.passwordExpirationDate = " + Instant.parse("2011-12-03T10:15:30Z").toEpochMilli());
+      Query q = createQueryFromString("from " + getModelFactory().getUserTypeName() + " u where u.passwordExpirationDate = " + Instant.parse("2011-12-03T10:15:30Z").toEpochMilli());
 
       List<User> list = q.list();
       assertEquals(3, list.size());
    }
 
    public void testCustomFieldAnalyzer() throws Exception {
-      QueryFactory qf = getQueryFactory();
-
-      Query q = qf.create("from sample_bank_account.AnalyzerTestEntity where f1:'test'");
+      Query q = createQueryFromString("from sample_bank_account.AnalyzerTestEntity where f1:'test'");
 
       List<AnalyzerTestEntity> list = q.list();
       assertEquals(2, list.size());

--- a/core/src/test/java/org/infinispan/test/MultipleCacheManagersTest.java
+++ b/core/src/test/java/org/infinispan/test/MultipleCacheManagersTest.java
@@ -344,7 +344,7 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
 
    protected <K, V> List<Cache<K, V>> createClusteredCaches(int numMembersInCluster,
                                                             ConfigurationBuilder defaultConfigBuilder,
-                                                            boolean serverMode) {
+                                                            boolean serverMode, String... cacheNames) {
       List<Cache<K, V>> caches = new ArrayList<>(numMembersInCluster);
       for (int i = 0; i < numMembersInCluster; i++) {
          EmbeddedCacheManager cm;
@@ -356,11 +356,18 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
          } else {
             cm = addClusterEnabledCacheManager(defaultConfigBuilder);
          }
-         Cache<K, V> cache = cm.getCache();
-         caches.add(cache);
-
+         if (cacheNames.length == 0) {
+            Cache<K, V> cache = cm.getCache();
+            caches.add(cache);
+            waitForClusterToForm();
+         } else {
+            for (String cacheName : cacheNames) {
+               cm.defineConfiguration(cacheName, defaultConfigBuilder.build());
+               caches.add(cm.getCache(cacheName));
+            }
+            waitForClusterToForm(cacheNames);
+         }
       }
-      waitForClusterToForm();
       return caches;
    }
 

--- a/documentation/src/main/asciidoc/user_guide/query.adoc
+++ b/documentation/src/main/asciidoc/user_guide/query.adoc
@@ -957,20 +957,24 @@ List<Restaurant> nearBy = cacheQuery.list();
 More info on http://docs.jboss.org/hibernate/stable/search/reference/en-US/html_single/#spatial[Hibernate Search manual]
 
 
-===== Clustered Query API [[query.clustered-query-api]]
+====== IndexedQueryMode [[query.clustered-query-api]]
 
-The Clustered Query API allows to broadcast a query to each node of the cluster, retrieve the results and combine them before returning to the caller.
+It's possible to specify a query mode for indexed queries. IndexedQueryMode.BROADCAST allows to broadcast a query to each node of the cluster, retrieve the results and combine them before returning to the caller.
+It is suitable for use in conjunction with <<query.non-shared-index,non-shared indexes>>, since each node's local index will have only a subset of the data indexed.
 
-It supports only Lucene Queries at the moment (no Ickle and Infinispan Query DSL) and is suitable for use in conjunction with <<query.non-shared-index,non-shared indexes>>, since each node's local index will have only a subset of the data indexed.
+IndexedQueryMode.FETCH will execute the query in the caller. If all the indexes for the cluster wide data are available locally, performance will be optimal, otherwise this query mode
+may involve fetching indexes data from remote nodes.
 
-A clustered query can be obtained from the `Search` object, and then used the same way as a `CacheQuery` obtained from the <<query.hibernatesearch, Hibernate Search Query API>>
+The IndexedQueryMode is supported for Lucene Queries and Ickle String queries at the moment (no Infinispan Query DSL).
+
+Example:
 
 [source,java]
 ----
 
-CacheQuery<Person> clusteredQuery = Search.getSearchManager(cache).getClusteredQuery(new MatchAllDocsQuery(), Person.class);
+CacheQuery<Person> broadcastQuery = Search.getSearchManager(cache).getQuery(new MatchAllDocsQuery(), IndexedQueryMode.BROADCAST);
 
-List<Person> result = clusteredQuery.list();
+List<Person> result = broadcastQuery.list();
 
 ----
 

--- a/object-filter/src/test/java/org/infinispan/objectfilter/test/FilterQueryFactory.java
+++ b/object-filter/src/test/java/org/infinispan/objectfilter/test/FilterQueryFactory.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import org.infinispan.objectfilter.impl.logging.Log;
 import org.infinispan.protostream.SerializationContext;
+import org.infinispan.query.dsl.IndexedQueryMode;
 import org.infinispan.query.dsl.Query;
 import org.infinispan.query.dsl.QueryBuilder;
 import org.infinispan.query.dsl.QueryFactory;
@@ -32,6 +33,11 @@ final class FilterQueryFactory extends BaseQueryFactory {
 
    @Override
    public Query create(String queryString) {
+      return new FilterQuery(this, queryString, null, null, -1, -1);
+   }
+
+   @Override
+   public Query create(String queryString, IndexedQueryMode queryMode) {
       return new FilterQuery(this, queryString, null, null, -1, -1);
    }
 

--- a/query-dsl/src/main/java/org/infinispan/query/dsl/IndexedQueryMode.java
+++ b/query-dsl/src/main/java/org/infinispan/query/dsl/IndexedQueryMode.java
@@ -1,0 +1,20 @@
+package org.infinispan.query.dsl;
+
+/**
+ * Defines the execution mode of an indexed query.
+ *
+ * @since 9.2
+ */
+public enum IndexedQueryMode {
+   /**
+    * Query is sent to all nodes, and results are combined before returning to the caller. This allows each node to have
+    * its own index, and the query will return the cluster wide results.
+    */
+   BROADCAST,
+
+   /**
+    * Query is executed locally in the caller. The whole index must be available in order to return full
+    * results, otherwise only results available at the caller's local index are returned.
+    */
+   FETCH
+}

--- a/query-dsl/src/main/java/org/infinispan/query/dsl/Query.java
+++ b/query-dsl/src/main/java/org/infinispan/query/dsl/Query.java
@@ -27,5 +27,10 @@ public interface Query extends PaginationContext<Query>, ParameterContext<Query>
     */
    int getResultSize(); //todo [anistor] this should probably be a long?
 
+   /**
+    * @return the values for query projections or null if the query does not have projections.
+    */
+   String[] getProjection();
+
    //todo [anistor] also add long getStartOffset() ?
 }

--- a/query-dsl/src/main/java/org/infinispan/query/dsl/QueryFactory.java
+++ b/query-dsl/src/main/java/org/infinispan/query/dsl/QueryFactory.java
@@ -18,6 +18,12 @@ public interface QueryFactory {
    Query create(String queryString);
 
    /**
+    * Creates a Query based on an Ickle query string
+    * @param queryMode the {@link IndexedQueryMode} dictating the indexed query execution mode if applicable.
+    */
+   Query create(String queryString, IndexedQueryMode queryMode);
+
+   /**
     * Creates a QueryBuilder for the given entity type.
     *
     * @param entityType the Class of the entity

--- a/query-dsl/src/main/java/org/infinispan/query/dsl/impl/BaseQuery.java
+++ b/query-dsl/src/main/java/org/infinispan/query/dsl/impl/BaseQuery.java
@@ -169,6 +169,7 @@ public abstract class BaseQuery implements Query {
       }
    }
 
+   @Override
    public String[] getProjection() {
       return projection;
    }

--- a/query-dsl/src/test/java/org/infinispan/query/dsl/impl/DummyQuery.java
+++ b/query-dsl/src/test/java/org/infinispan/query/dsl/impl/DummyQuery.java
@@ -38,6 +38,11 @@ class DummyQuery implements Query {
    }
 
    @Override
+   public String[] getProjection() {
+      return new String[0];
+   }
+
+   @Override
    public Query startOffset(long startOffset) {
       return this;
    }

--- a/query-dsl/src/test/java/org/infinispan/query/dsl/impl/DummyQueryFactory.java
+++ b/query-dsl/src/test/java/org/infinispan/query/dsl/impl/DummyQueryFactory.java
@@ -1,5 +1,6 @@
 package org.infinispan.query.dsl.impl;
 
+import org.infinispan.query.dsl.IndexedQueryMode;
 import org.infinispan.query.dsl.Query;
 
 /**
@@ -10,6 +11,11 @@ class DummyQueryFactory extends BaseQueryFactory {
 
    @Override
    public Query create(String queryString) {
+      return new DummyQuery();
+   }
+
+   @Override
+   public Query create(String queryString, IndexedQueryMode queryMode) {
       return new DummyQuery();
    }
 

--- a/query/src/main/java/org/infinispan/query/QueryDefinition.java
+++ b/query/src/main/java/org/infinispan/query/QueryDefinition.java
@@ -1,0 +1,112 @@
+package org.infinispan.query;
+
+import java.util.Optional;
+
+import org.apache.lucene.search.Filter;
+import org.apache.lucene.search.Sort;
+import org.hibernate.search.filter.FullTextFilter;
+import org.hibernate.search.query.engine.spi.HSQuery;
+import org.infinispan.AdvancedCache;
+import org.infinispan.query.dsl.embedded.impl.EmbeddedQueryEngine;
+import org.infinispan.query.dsl.embedded.impl.HsQueryRequest;
+import org.infinispan.query.dsl.embedded.impl.QueryEngine;
+import org.infinispan.query.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
+/**
+ * Stores the query to be executed in a cache in either a String or {@link HSQuery} form together with pagination
+ * and sort information.
+ *
+ * @since 9.2
+ */
+public class QueryDefinition {
+
+   private static final Log log = LogFactory.getLog(QueryDefinition.class, Log.class);
+
+   private String queryString;
+   private HSQuery hsQuery;
+   private int maxResults = 100;
+   private int firstResult;
+
+   private transient Sort sort;
+
+   public QueryDefinition(String queryString) {
+      this.queryString = queryString;
+   }
+
+   public QueryDefinition(HSQuery hsQuery) {
+      this.hsQuery = hsQuery;
+   }
+
+   public Optional<String> getQueryString() {
+      return Optional.ofNullable(queryString);
+   }
+
+   public void initialize(AdvancedCache<?, ?> cache) {
+      if (hsQuery == null) {
+         QueryEngine queryEngine = cache.getComponentRegistry().getComponent(EmbeddedQueryEngine.class);
+         HsQueryRequest hsQueryRequest = queryEngine.createHsQuery(queryString);
+         this.hsQuery = hsQueryRequest.getHsQuery();
+         this.sort = hsQueryRequest.getSort();
+         hsQuery.firstResult(firstResult);
+         hsQuery.maxResults(maxResults);
+      }
+   }
+
+   public HSQuery getHsQuery() {
+      if (hsQuery == null) {
+         throw new IllegalStateException("The QueryDefinition has not been initialized, make sure to call initialize(...) first");
+      }
+      return hsQuery;
+   }
+
+   public int getMaxResults() {
+      return maxResults;
+   }
+
+   public void setMaxResults(int maxResults) {
+      this.maxResults = maxResults;
+      if (hsQuery != null) {
+         hsQuery.maxResults(maxResults);
+      }
+   }
+
+   public int getFirstResult() {
+      return firstResult;
+   }
+
+   public void setFirstResult(int firstResult) {
+      if (hsQuery != null) {
+         hsQuery.firstResult(firstResult);
+      }
+      this.firstResult = firstResult;
+   }
+
+   public Sort getSort() {
+      return sort;
+   }
+
+   public void setSort(Sort sort) {
+      if (queryString != null) {
+         throw log.sortNotSupportedWithQueryString();
+      }
+      hsQuery.sort(sort);
+      this.sort = sort;
+   }
+
+
+   public void filter(Filter filter) {
+      if (queryString != null) throw log.filterNotSupportedWithQueryString();
+      hsQuery.filter(filter);
+   }
+
+   public FullTextFilter enableFullTextFilter(String name) {
+      if (queryString != null) throw log.filterNotSupportedWithQueryString();
+      return hsQuery.enableFullTextFilter(name);
+   }
+
+   public void disableFullTextFilter(String name) {
+      if (queryString != null) throw log.filterNotSupportedWithQueryString();
+      hsQuery.disableFullTextFilter(name);
+   }
+}

--- a/query/src/main/java/org/infinispan/query/QueryDefinition.java
+++ b/query/src/main/java/org/infinispan/query/QueryDefinition.java
@@ -1,5 +1,7 @@
 package org.infinispan.query;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -35,6 +37,7 @@ public class QueryDefinition {
    private Set<String> sortableFields;
    private Class<?> indexedType;
 
+   private final Map<String, Object> namedParameters = new HashMap<>();
    private transient Sort sort;
 
    public QueryDefinition(String queryString) {
@@ -63,9 +66,9 @@ public class QueryDefinition {
          HsQueryRequest hsQueryRequest;
          if (indexedType != null && sortableFields != null) {
             IndexedTypeMap<CustomTypeMetadata> metadata = createMetadata();
-            hsQueryRequest = queryEngine.createHsQuery(queryString, metadata);
+            hsQueryRequest = queryEngine.createHsQuery(queryString, metadata, namedParameters);
          } else {
-            hsQueryRequest = queryEngine.createHsQuery(queryString, null);
+            hsQueryRequest = queryEngine.createHsQuery(queryString, null, namedParameters);
          }
          this.hsQuery = hsQueryRequest.getHsQuery();
          this.sort = hsQueryRequest.getSort();
@@ -91,6 +94,18 @@ public class QueryDefinition {
       if (hsQuery != null) {
          hsQuery.maxResults(maxResults);
       }
+   }
+
+   public void setNamedParameters(Map<String, Object> params) {
+      if (params == null) {
+         namedParameters.clear();
+      } else {
+         namedParameters.putAll(params);
+      }
+   }
+
+   public Map<String, Object> getNamedParameters() {
+      return namedParameters;
    }
 
    public int getFirstResult() {

--- a/query/src/main/java/org/infinispan/query/QueryDefinition.java
+++ b/query/src/main/java/org/infinispan/query/QueryDefinition.java
@@ -50,6 +50,7 @@ public class QueryDefinition {
          this.sort = hsQueryRequest.getSort();
          hsQuery.firstResult(firstResult);
          hsQuery.maxResults(maxResults);
+         hsQuery.projection(hsQueryRequest.getProjections());
       }
    }
 

--- a/query/src/main/java/org/infinispan/query/SearchManager.java
+++ b/query/src/main/java/org/infinispan/query/SearchManager.java
@@ -4,6 +4,7 @@ import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.Query;
 import org.hibernate.search.query.dsl.EntityContext;
 import org.hibernate.search.stat.Statistics;
+import org.infinispan.query.dsl.IndexedQueryMode;
 
 /**
  * The SearchManager is the entry point to create full text queries on top of a cache.
@@ -18,27 +19,40 @@ public interface SearchManager {
     * in.  If no classes are passed in, it is assumed that no type filtering is performed and so all known types will
     * be searched.
     *
-    * @param luceneQuery - {@link org.apache.lucene.search.Query}
-    * @param classes - optionally only return results of type that matches this list of acceptable types
-    * @return the CacheQuery object which can be used to iterate through results
+    * @param luceneQuery      {@link org.apache.lucene.search.Query}
+    * @param indexedQueryMode The {@link IndexedQueryMode} used when executing the query.
+    * @param classes          Optionally only return results of type that matches this list of acceptable types.
+    * @return the CacheQuery object which can be used to iterate through results.
+    */
+   <E> CacheQuery<E> getQuery(Query luceneQuery, IndexedQueryMode indexedQueryMode, Class<?>... classes);
+
+   /**
+    * Builds a {@link CacheQuery} from a query string.
+    *
+    * @throws org.hibernate.search.exception.SearchException if the queryString cannot be converted to an indexed query,
+    *                                                        due to lack of indexes to resolve it fully or if contains
+    *                                                        aggregations and grouping.
+    * @see #getQuery(Query, IndexedQueryMode, Class[])
+    */
+   <E> CacheQuery<E> getQuery(String queryString, IndexedQueryMode indexedQueryMode, Class<?>... classes);
+
+   /**
+    * @see #getQuery(Query, IndexedQueryMode, Class[])
     */
    <E> CacheQuery<E> getQuery(Query luceneQuery, Class<?>... classes);
 
-   /**
-    * Experimental.
-    * Provides Hibernate Search DSL to build full text queries
-    * @return
+   /***
+    * @return {@link EntityContext}
     */
    EntityContext buildQueryBuilderForClass(Class<?> entityType);
 
-   /**
-    * Experimental!
-    * Use it to try out the newly introduced distributed queries.
-    *
+   /***
     * @param luceneQuery
     * @param classes
     * @return
+    * @deprecated since 9.2, use {@link #getQuery(Query, IndexedQueryMode, Class[])} with QueryMode.BROADCAST
     */
+   @Deprecated
    <E> CacheQuery<E> getClusteredQuery(Query luceneQuery, Class<?>... classes);
 
    /**

--- a/query/src/main/java/org/infinispan/query/clustered/AbstractQueryDefinitionExternalizer.java
+++ b/query/src/main/java/org/infinispan/query/clustered/AbstractQueryDefinitionExternalizer.java
@@ -1,0 +1,52 @@
+package org.infinispan.query.clustered;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.Set;
+
+import org.hibernate.search.query.engine.spi.HSQuery;
+import org.infinispan.commons.marshall.AdvancedExternalizer;
+import org.infinispan.query.QueryDefinition;
+
+/**
+ * @since 9.2
+ */
+public abstract class AbstractQueryDefinitionExternalizer<Q extends QueryDefinition> implements AdvancedExternalizer<Q> {
+
+   @Override
+   public void writeObject(ObjectOutput output, Q object) throws IOException {
+      if (object.getQueryString().isPresent()) {
+         output.writeBoolean(true);
+         output.writeUTF(object.getQueryString().get());
+      } else {
+         output.writeBoolean(false);
+         output.writeObject(object.getHsQuery());
+      }
+      output.writeInt(object.getFirstResult());
+      output.writeInt(object.getMaxResults());
+      output.writeObject(object.getSortableFields());
+      output.writeObject(object.getIndexedType());
+   }
+
+   abstract protected Q createQueryDefinition(String q);
+
+   abstract protected Q createQueryDefinition(HSQuery hsQuery);
+
+   @Override
+   public Q readObject(ObjectInput input) throws IOException, ClassNotFoundException {
+      Q queryDefinition;
+      if (input.readBoolean()) {
+         queryDefinition = createQueryDefinition(input.readUTF());
+      } else {
+         queryDefinition = createQueryDefinition((HSQuery) input.readObject());
+      }
+      queryDefinition.setFirstResult(input.readInt());
+      queryDefinition.setMaxResults(input.readInt());
+      Set<String> sortableField = (Set<String>) input.readObject();
+      Class<?> indexedTypes = (Class<?>) input.readObject();
+      queryDefinition.setSortableField(sortableField);
+      queryDefinition.setIndexedType(indexedTypes);
+      return queryDefinition;
+   }
+}

--- a/query/src/main/java/org/infinispan/query/clustered/AbstractQueryDefinitionExternalizer.java
+++ b/query/src/main/java/org/infinispan/query/clustered/AbstractQueryDefinitionExternalizer.java
@@ -3,6 +3,8 @@ package org.infinispan.query.clustered;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import org.hibernate.search.query.engine.spi.HSQuery;
@@ -27,6 +29,13 @@ public abstract class AbstractQueryDefinitionExternalizer<Q extends QueryDefinit
       output.writeInt(object.getMaxResults());
       output.writeObject(object.getSortableFields());
       output.writeObject(object.getIndexedType());
+      Map<String, Object> namedParameters = object.getNamedParameters();
+      int size = namedParameters.size();
+      output.writeShort(size);
+      for (Map.Entry<String, Object> param : namedParameters.entrySet()) {
+         output.writeUTF(param.getKey());
+         output.writeObject(param.getValue());
+      }
    }
 
    abstract protected Q createQueryDefinition(String q);
@@ -47,6 +56,16 @@ public abstract class AbstractQueryDefinitionExternalizer<Q extends QueryDefinit
       Class<?> indexedTypes = (Class<?>) input.readObject();
       queryDefinition.setSortableField(sortableField);
       queryDefinition.setIndexedType(indexedTypes);
+      short paramSize = input.readShort();
+      if (paramSize > 0) {
+         Map<String, Object> params = new HashMap<>();
+         for (int i = 0; i < paramSize; i++) {
+            String key = input.readUTF();
+            Object value = input.readObject();
+            params.put(key, value);
+         }
+         queryDefinition.setNamedParameters(params);
+      }
       return queryDefinition;
    }
 }

--- a/query/src/main/java/org/infinispan/query/clustered/ClusteredCacheQueryImpl.java
+++ b/query/src/main/java/org/infinispan/query/clustered/ClusteredCacheQueryImpl.java
@@ -10,6 +10,8 @@ import java.util.concurrent.TimeUnit;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Sort;
 import org.hibernate.search.exception.SearchException;
+import org.hibernate.search.spi.CustomTypeMetadata;
+import org.hibernate.search.spi.IndexedTypeMap;
 import org.hibernate.search.spi.SearchIntegrator;
 import org.infinispan.AdvancedCache;
 import org.infinispan.query.CacheQuery;
@@ -43,11 +45,14 @@ public class ClusteredCacheQueryImpl<E> extends CacheQueryImpl<E> {
       this.asyncExecutor = asyncExecutor;
    }
 
-   public ClusteredCacheQueryImpl(String queryString, ExecutorService asyncExecutor, AdvancedCache<?, ?> cache,
-                                  KeyTransformationHandler keyTransformationHandler) {
-      super(queryString, cache, keyTransformationHandler);
+   public ClusteredCacheQueryImpl(QueryDefinition queryDefinition, ExecutorService asyncExecutor, AdvancedCache<?, ?> cache,
+                                  KeyTransformationHandler keyTransformationHandler, IndexedTypeMap<CustomTypeMetadata> metadata) {
+      super(queryDefinition, cache, keyTransformationHandler);
+      if (metadata != null) {
+         this.queryDefinition.setIndexedType(metadata.keySet().iterator().next().getPojoType());
+         this.queryDefinition.setSortableField(metadata.values().iterator().next().getSortableFields());
+      }
       this.asyncExecutor = asyncExecutor;
-      this.queryDefinition = new QueryDefinition(queryString);
    }
 
    @Override

--- a/query/src/main/java/org/infinispan/query/clustered/ClusteredQueryCommandType.java
+++ b/query/src/main/java/org/infinispan/query/clustered/ClusteredQueryCommandType.java
@@ -2,8 +2,8 @@ package org.infinispan.query.clustered;
 
 import java.util.UUID;
 
-import org.hibernate.search.query.engine.spi.HSQuery;
 import org.infinispan.Cache;
+import org.infinispan.query.QueryDefinition;
 import org.infinispan.query.clustered.commandworkers.CQCreateEagerQuery;
 import org.infinispan.query.clustered.commandworkers.CQCreateLazyQuery;
 import org.infinispan.query.clustered.commandworkers.CQGetResultSize;
@@ -55,11 +55,10 @@ public enum ClusteredQueryCommandType {
 
    protected abstract ClusteredQueryCommandWorker getNewInstance();
 
-   public ClusteredQueryCommandWorker getCommand(Cache<?, ?> cache, HSQuery query, UUID lazyQueryId,
-            int docIndex) {
-      ClusteredQueryCommandWorker command = null;
-      command = getNewInstance();
-      command.init(cache, query, lazyQueryId, docIndex);
+   public ClusteredQueryCommandWorker getCommand(Cache<?, ?> cache, QueryDefinition queryDefinition, UUID lazyQueryId,
+                                                 int docIndex) {
+      ClusteredQueryCommandWorker command = getNewInstance();
+      command.init(cache, queryDefinition, lazyQueryId, docIndex);
       return command;
    }
 

--- a/query/src/main/java/org/infinispan/query/clustered/DistributedIterator.java
+++ b/query/src/main/java/org/infinispan/query/clustered/DistributedIterator.java
@@ -51,7 +51,7 @@ public class DistributedIterator<E> implements ResultIterator<E> {
       this.partialResults = new ClusteredTopDocs[parallels];
       TopDocs[] partialTopDocs = sort != null ? new TopFieldDocs[parallels] : new TopDocs[parallels];
       this.partialPositionNext = new int[parallels];
-      int i=0;
+      int i = 0;
       for (Entry<UUID, ClusteredTopDocs> entry : topDocsResponses.entrySet()) {
          partialResults[i] = entry.getValue();
          partialTopDocs[i] = partialResults[i].getNodeTopDocs().topDocs;
@@ -81,7 +81,7 @@ public class DistributedIterator<E> implements ResultIterator<E> {
       // fetch and return the value
       ScoreDoc scoreDoc = mergedResults.scoreDocs[currentIndex];
       int index = scoreDoc.shardIndex;
-      if(partialPositionNext[index] == 0) {
+      if (partialPositionNext[index] == 0) {
          partialPositionNext[index] = findSpecificPosition(scoreDoc.doc, partialResults[index].getNodeTopDocs().topDocs);
       }
       int specificPosition = partialPositionNext[index];
@@ -91,14 +91,18 @@ public class DistributedIterator<E> implements ResultIterator<E> {
 
    private int findSpecificPosition(int docId, TopDocs topDocs) {
       for (int i = 0; i < topDocs.scoreDocs.length; i++) {
-         if(topDocs.scoreDocs[i].doc == docId) return i;
+         if (topDocs.scoreDocs[i].doc == docId) return i;
       }
       return 0;
    }
 
    protected E fetchValue(int scoreIndex, ClusteredTopDocs topDoc) {
       NodeTopDocs eagerTopDocs = topDoc.getNodeTopDocs();
-      return (E) cache.get(eagerTopDocs.keys[scoreIndex]);
+      Object[] keys = eagerTopDocs.keys;
+      if (keys != null && keys.length > 0) {
+         return (E) cache.get(eagerTopDocs.keys[scoreIndex]);
+      }
+      return (E) eagerTopDocs.projections[scoreIndex];
    }
 
    @Override

--- a/query/src/main/java/org/infinispan/query/clustered/NodeTopDocs.java
+++ b/query/src/main/java/org/infinispan/query/clustered/NodeTopDocs.java
@@ -14,14 +14,17 @@ public class NodeTopDocs {
 
    public final TopDocs topDocs;
    public final Object[] keys;
+   public final Object[] projections;
 
-   public NodeTopDocs(TopDocs topDocs, Object[] keys) {
+   public NodeTopDocs(TopDocs topDocs, Object[] keys, Object[] projections) {
       this.topDocs = topDocs;
       this.keys = keys;
+      this.projections = projections;
    }
 
    public NodeTopDocs(TopDocs topDocs) {
       this.topDocs = topDocs;
       this.keys = null;
+      this.projections = null;
    }
 }

--- a/query/src/main/java/org/infinispan/query/clustered/QueryDefinitionExternalizer.java
+++ b/query/src/main/java/org/infinispan/query/clustered/QueryDefinitionExternalizer.java
@@ -1,0 +1,51 @@
+package org.infinispan.query.clustered;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.Collections;
+import java.util.Set;
+
+import org.hibernate.search.query.engine.spi.HSQuery;
+import org.infinispan.commons.marshall.AdvancedExternalizer;
+import org.infinispan.query.QueryDefinition;
+import org.infinispan.query.impl.externalizers.ExternalizerIds;
+
+public class QueryDefinitionExternalizer implements AdvancedExternalizer<QueryDefinition> {
+
+   @Override
+   public Set<Class<? extends QueryDefinition>> getTypeClasses() {
+      return Collections.singleton(QueryDefinition.class);
+   }
+
+   @Override
+   public Integer getId() {
+      return ExternalizerIds.QUERY_DEFINITION;
+   }
+
+   @Override
+   public void writeObject(ObjectOutput output, QueryDefinition object) throws IOException {
+      if (object.getQueryString().isPresent()) {
+         output.writeBoolean(true);
+         output.writeUTF(object.getQueryString().get());
+      } else {
+         output.writeBoolean(false);
+         output.writeObject(object.getHsQuery());
+      }
+      output.writeInt(object.getFirstResult());
+      output.writeInt(object.getMaxResults());
+   }
+
+   @Override
+   public QueryDefinition readObject(ObjectInput input) throws IOException, ClassNotFoundException {
+      QueryDefinition queryDefinition;
+      if (input.readBoolean()) {
+         queryDefinition = new QueryDefinition(input.readUTF());
+      } else {
+         queryDefinition = new QueryDefinition((HSQuery) input.readObject());
+      }
+      queryDefinition.setFirstResult(input.readInt());
+      queryDefinition.setMaxResults(input.readInt());
+      return queryDefinition;
+   }
+}

--- a/query/src/main/java/org/infinispan/query/clustered/QueryDefinitionExternalizer.java
+++ b/query/src/main/java/org/infinispan/query/clustered/QueryDefinitionExternalizer.java
@@ -1,17 +1,16 @@
 package org.infinispan.query.clustered;
 
-import java.io.IOException;
-import java.io.ObjectInput;
-import java.io.ObjectOutput;
 import java.util.Collections;
 import java.util.Set;
 
 import org.hibernate.search.query.engine.spi.HSQuery;
-import org.infinispan.commons.marshall.AdvancedExternalizer;
 import org.infinispan.query.QueryDefinition;
 import org.infinispan.query.impl.externalizers.ExternalizerIds;
 
-public class QueryDefinitionExternalizer implements AdvancedExternalizer<QueryDefinition> {
+/**
+ * @since 9.2
+ */
+public class QueryDefinitionExternalizer extends AbstractQueryDefinitionExternalizer<QueryDefinition> {
 
    @Override
    public Set<Class<? extends QueryDefinition>> getTypeClasses() {
@@ -24,28 +23,12 @@ public class QueryDefinitionExternalizer implements AdvancedExternalizer<QueryDe
    }
 
    @Override
-   public void writeObject(ObjectOutput output, QueryDefinition object) throws IOException {
-      if (object.getQueryString().isPresent()) {
-         output.writeBoolean(true);
-         output.writeUTF(object.getQueryString().get());
-      } else {
-         output.writeBoolean(false);
-         output.writeObject(object.getHsQuery());
-      }
-      output.writeInt(object.getFirstResult());
-      output.writeInt(object.getMaxResults());
+   protected QueryDefinition createQueryDefinition(String q) {
+      return new QueryDefinition(q);
    }
 
    @Override
-   public QueryDefinition readObject(ObjectInput input) throws IOException, ClassNotFoundException {
-      QueryDefinition queryDefinition;
-      if (input.readBoolean()) {
-         queryDefinition = new QueryDefinition(input.readUTF());
-      } else {
-         queryDefinition = new QueryDefinition((HSQuery) input.readObject());
-      }
-      queryDefinition.setFirstResult(input.readInt());
-      queryDefinition.setMaxResults(input.readInt());
-      return queryDefinition;
+   protected QueryDefinition createQueryDefinition(HSQuery hsQuery) {
+      return new QueryDefinition(hsQuery);
    }
 }

--- a/query/src/main/java/org/infinispan/query/clustered/commandworkers/CQCreateLazyQuery.java
+++ b/query/src/main/java/org/infinispan/query/clustered/commandworkers/CQCreateLazyQuery.java
@@ -2,6 +2,7 @@ package org.infinispan.query.clustered.commandworkers;
 
 import org.apache.lucene.search.TopDocs;
 import org.hibernate.search.query.engine.spi.DocumentExtractor;
+import org.hibernate.search.query.engine.spi.HSQuery;
 import org.infinispan.query.clustered.NodeTopDocs;
 import org.infinispan.query.clustered.QueryBox;
 import org.infinispan.query.clustered.QueryResponse;
@@ -18,6 +19,7 @@ public class CQCreateLazyQuery extends ClusteredQueryCommandWorker {
 
    @Override
    public QueryResponse perform() {
+      HSQuery query = queryDefinition.getHsQuery();
       query.afterDeserialise(getSearchFactory());
       DocumentExtractor extractor = query.queryDocumentExtractor();
       int resultSize = query.queryResultSize();

--- a/query/src/main/java/org/infinispan/query/clustered/commandworkers/CQGetResultSize.java
+++ b/query/src/main/java/org/infinispan/query/clustered/commandworkers/CQGetResultSize.java
@@ -1,6 +1,7 @@
 package org.infinispan.query.clustered.commandworkers;
 
 import org.hibernate.search.query.engine.spi.DocumentExtractor;
+import org.hibernate.search.query.engine.spi.HSQuery;
 import org.infinispan.query.clustered.QueryResponse;
 
 /**
@@ -15,14 +16,11 @@ public class CQGetResultSize extends ClusteredQueryCommandWorker {
 
    @Override
    public QueryResponse perform() {
+      HSQuery query = queryDefinition.getHsQuery();
       query.afterDeserialise(getSearchFactory());
-      DocumentExtractor extractor = query.queryDocumentExtractor();
-      try {
+      try (DocumentExtractor ignored = query.queryDocumentExtractor()) {
          int resultSize = query.queryResultSize();
-         QueryResponse queryResponse = new QueryResponse(resultSize);
-         return queryResponse;
-      } finally {
-         extractor.close();
+         return new QueryResponse(resultSize);
       }
    }
 

--- a/query/src/main/java/org/infinispan/query/clustered/commandworkers/ClusteredQueryCommandWorker.java
+++ b/query/src/main/java/org/infinispan/query/clustered/commandworkers/ClusteredQueryCommandWorker.java
@@ -2,10 +2,10 @@ package org.infinispan.query.clustered.commandworkers;
 
 import java.util.UUID;
 
-import org.hibernate.search.query.engine.spi.HSQuery;
 import org.hibernate.search.spi.SearchIntegrator;
 import org.infinispan.Cache;
 import org.infinispan.factories.ComponentRegistry;
+import org.infinispan.query.QueryDefinition;
 import org.infinispan.query.clustered.QueryBox;
 import org.infinispan.query.clustered.QueryResponse;
 
@@ -27,13 +27,16 @@ public abstract class ClusteredQueryCommandWorker {
    private SearchIntegrator searchFactory;
 
    // the query
-   protected HSQuery query;
+   protected QueryDefinition queryDefinition;
    protected UUID lazyQueryId;
    protected int docIndex;
 
-   public void init(Cache<?, ?> cache, HSQuery query, UUID lazyQueryId, int docIndex) {
+   public void init(Cache<?, ?> cache, QueryDefinition queryDefinition, UUID lazyQueryId, int docIndex) {
       this.cache = cache;
-      this.query = query;
+      if (queryDefinition != null) {
+         this.queryDefinition = queryDefinition;
+         this.queryDefinition.initialize(cache.getAdvancedCache());
+      }
       this.lazyQueryId = lazyQueryId;
       this.docIndex = docIndex;
    }

--- a/query/src/main/java/org/infinispan/query/clustered/commandworkers/QueryExtractorUtil.java
+++ b/query/src/main/java/org/infinispan/query/clustered/commandworkers/QueryExtractorUtil.java
@@ -2,6 +2,7 @@ package org.infinispan.query.clustered.commandworkers;
 
 import java.io.IOException;
 
+import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.query.engine.spi.DocumentExtractor;
 import org.infinispan.Cache;
 import org.infinispan.query.backend.KeyTransformationHandler;
@@ -33,9 +34,16 @@ public class QueryExtractorUtil {
          return null;
       }
 
-      Object key = keyTransformationHandler.stringToKey(bufferDocumentId, cache
+      return keyTransformationHandler.stringToKey(bufferDocumentId, cache
             .getAdvancedCache().getClassLoader());
-      return key;
+   }
+
+   static Object[] extractProjection(DocumentExtractor extractor, int docIndex) {
+      try {
+         return extractor.extract(docIndex).getProjection();
+      } catch (IOException e) {
+         throw new SearchException("Error while extracting projection...", e);
+      }
    }
 
 }

--- a/query/src/main/java/org/infinispan/query/dsl/embedded/impl/DelegatingQuery.java
+++ b/query/src/main/java/org/infinispan/query/dsl/embedded/impl/DelegatingQuery.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.infinispan.objectfilter.impl.syntax.parser.IckleParsingResult;
+import org.infinispan.query.dsl.IndexedQueryMode;
 import org.infinispan.query.dsl.Query;
 import org.infinispan.query.dsl.QueryFactory;
 import org.infinispan.query.dsl.impl.BaseQuery;
@@ -22,6 +23,7 @@ final class DelegatingQuery<TypeMetadata> extends BaseQuery {
    private static final Log log = Logger.getMessageLogger(Log.class, DelegatingQuery.class.getName());
 
    private final QueryEngine<TypeMetadata> queryEngine;
+   private final IndexedQueryMode queryMode;
 
    private final IckleParsingResult<TypeMetadata> parsingResult;
 
@@ -30,9 +32,10 @@ final class DelegatingQuery<TypeMetadata> extends BaseQuery {
     */
    private BaseQuery query;
 
-   DelegatingQuery(QueryEngine<TypeMetadata> queryEngine, QueryFactory queryFactory, String queryString) {
+   DelegatingQuery(QueryEngine<TypeMetadata> queryEngine, QueryFactory queryFactory, String queryString, IndexedQueryMode queryMode) {
       super(queryFactory, queryString);
       this.queryEngine = queryEngine;
+      this.queryMode = queryMode;
 
       // parse and validate early
       parsingResult = queryEngine.parse(queryString);
@@ -49,6 +52,7 @@ final class DelegatingQuery<TypeMetadata> extends BaseQuery {
                    Map<String, Object> namedParameters, String[] projection, long startOffset, int maxResults) {
       super(queryFactory, queryString, namedParameters, projection, startOffset, maxResults);
       this.queryEngine = queryEngine;
+      this.queryMode = IndexedQueryMode.FETCH;
 
       // parse and validate early
       parsingResult = queryEngine.parse(queryString);
@@ -88,7 +92,7 @@ final class DelegatingQuery<TypeMetadata> extends BaseQuery {
    private Query createQuery() {
       // the query is created first time only
       if (query == null) {
-         query = queryEngine.buildQuery(queryFactory, parsingResult, namedParameters, startOffset, maxResults);
+         query = queryEngine.buildQuery(queryFactory, parsingResult, namedParameters, startOffset, maxResults, queryMode);
       }
       return query;
    }

--- a/query/src/main/java/org/infinispan/query/dsl/embedded/impl/EmbeddedLuceneQuery.java
+++ b/query/src/main/java/org/infinispan/query/dsl/embedded/impl/EmbeddedLuceneQuery.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import org.infinispan.objectfilter.impl.syntax.parser.IckleParsingResult;
 import org.infinispan.query.CacheQuery;
+import org.infinispan.query.dsl.IndexedQueryMode;
 import org.infinispan.query.dsl.QueryFactory;
 import org.infinispan.query.dsl.impl.BaseQuery;
 
@@ -34,16 +35,18 @@ final class EmbeddedLuceneQuery<TypeMetadata> extends BaseQuery {
     * The cached results, lazily evaluated.
     */
    private List<Object> results;
+   private final IndexedQueryMode queryMode;
 
    EmbeddedLuceneQuery(QueryEngine<TypeMetadata> queryEngine, QueryFactory queryFactory,
                        Map<String, Object> namedParameters, IckleParsingResult<TypeMetadata> parsingResult,
                        String[] projection, ResultProcessor resultProcessor,
-                       long startOffset, int maxResults) {
+                       long startOffset, int maxResults, IndexedQueryMode queryMode) {
       super(queryFactory, parsingResult.getQueryString(), namedParameters, projection, startOffset, maxResults);
       if (resultProcessor instanceof RowProcessor && (projection == null || projection.length == 0)) {
          throw new IllegalArgumentException("A RowProcessor can only be specified with projections");
       }
       this.queryEngine = queryEngine;
+      this.queryMode = queryMode;
       this.resultProcessor = resultProcessor;
       this.parsingResult = parsingResult;
    }
@@ -58,7 +61,7 @@ final class EmbeddedLuceneQuery<TypeMetadata> extends BaseQuery {
       // query is created first time only
       if (cacheQuery == null) {
          validateNamedParameters();
-         cacheQuery = queryEngine.buildLuceneQuery(parsingResult, namedParameters, startOffset, maxResults);
+         cacheQuery = queryEngine.buildLuceneQuery(parsingResult, namedParameters, startOffset, maxResults, queryMode);
       }
       return cacheQuery;
    }

--- a/query/src/main/java/org/infinispan/query/dsl/embedded/impl/EmbeddedQueryFactory.java
+++ b/query/src/main/java/org/infinispan/query/dsl/embedded/impl/EmbeddedQueryFactory.java
@@ -1,5 +1,7 @@
 package org.infinispan.query.dsl.embedded.impl;
 
+import org.infinispan.query.dsl.IndexedQueryMode;
+import org.infinispan.query.dsl.Query;
 import org.infinispan.query.dsl.QueryBuilder;
 import org.infinispan.query.dsl.impl.BaseQuery;
 import org.infinispan.query.dsl.impl.BaseQueryFactory;
@@ -21,7 +23,12 @@ public final class EmbeddedQueryFactory extends BaseQueryFactory {
 
    @Override
    public BaseQuery create(String queryString) {
-      return new DelegatingQuery<>(queryEngine, this, queryString);
+      return new DelegatingQuery<>(queryEngine, this, queryString, IndexedQueryMode.FETCH);
+   }
+
+   @Override
+   public Query create(String queryString, IndexedQueryMode queryMode) {
+      return new DelegatingQuery<>(queryEngine, this, queryString, queryMode);
    }
 
    @Override

--- a/query/src/main/java/org/infinispan/query/dsl/embedded/impl/HsQueryRequest.java
+++ b/query/src/main/java/org/infinispan/query/dsl/embedded/impl/HsQueryRequest.java
@@ -1,0 +1,34 @@
+package org.infinispan.query.dsl.embedded.impl;
+
+import org.apache.lucene.search.Sort;
+import org.hibernate.search.query.engine.spi.HSQuery;
+
+/**
+ * Stores the definition of a {@link HSQuery}.
+ *
+ * @since 9.2
+ */
+public class HsQueryRequest {
+
+   private final HSQuery hsQuery;
+   private final Sort sort;
+   private final String[] projections;
+
+   HsQueryRequest(HSQuery hsQuery, Sort sort, String[] projections) {
+      this.hsQuery = hsQuery;
+      this.sort = sort;
+      this.projections = projections;
+   }
+
+   public HSQuery getHsQuery() {
+      return hsQuery;
+   }
+
+   public Sort getSort() {
+      return sort;
+   }
+
+   public String[] getProjections() {
+      return projections;
+   }
+}

--- a/query/src/main/java/org/infinispan/query/dsl/embedded/impl/QueryEngine.java
+++ b/query/src/main/java/org/infinispan/query/dsl/embedded/impl/QueryEngine.java
@@ -722,12 +722,12 @@ public class QueryEngine<TypeMetadata> {
       return (CacheQuery<E>) cacheQuery;
    }
 
-   public HsQueryRequest createHsQuery(String queryString, IndexedTypeMap<CustomTypeMetadata> metadata) {
+   public HsQueryRequest createHsQuery(String queryString, IndexedTypeMap<CustomTypeMetadata> metadata, Map<String, Object> nameParameters) {
       IckleParsingResult<TypeMetadata> parsingResult = parse(queryString);
       if (parsingResult.hasGroupingOrAggregations()) {
          throw log.groupAggregationsNotSupported();
       }
-      LuceneQueryParsingResult luceneParsingResult = transformParsingResult(parsingResult, emptyMap());
+      LuceneQueryParsingResult luceneParsingResult = transformParsingResult(parsingResult, nameParameters);
       org.apache.lucene.search.Query luceneQuery = makeTypeQuery(luceneParsingResult.getQuery(), luceneParsingResult.getTargetEntityName());
       SearchIntegrator searchFactory = getSearchFactory();
       HSQuery hsQuery = metadata == null ? searchFactory.createHSQuery(luceneQuery) : searchFactory.createHSQuery(luceneQuery);
@@ -822,7 +822,7 @@ public class QueryEngine<TypeMetadata> {
          log.debugf("The resulting Lucene query is : %s", luceneQuery.toString());
       }
 
-      CacheQuery<?> cacheQuery = makeCacheQuery(ickleParsingResult, luceneQuery, queryMode);
+      CacheQuery<?> cacheQuery = makeCacheQuery(ickleParsingResult, luceneQuery, queryMode, namedParameters);
       // No need to set sort and projection if BROADCAST, as both are part of the query string already.
       if (queryMode != IndexedQueryMode.BROADCAST) {
          if (luceneParsingResult.getSort() != null) {
@@ -861,9 +861,10 @@ public class QueryEngine<TypeMetadata> {
       return (Class<?>) parsingResult.getTargetEntityMetadata();
    }
 
-   protected CacheQuery<?> makeCacheQuery(IckleParsingResult<TypeMetadata> ickleParsingResult, org.apache.lucene.search.Query luceneQuery, IndexedQueryMode queryMode) {
+   protected CacheQuery<?> makeCacheQuery(IckleParsingResult<TypeMetadata> ickleParsingResult, org.apache.lucene.search.Query luceneQuery, IndexedQueryMode queryMode, Map<String, Object> namedParameters) {
       if (queryMode == IndexedQueryMode.BROADCAST) {
          QueryDefinition queryDefinition = new QueryDefinition(ickleParsingResult.getQueryString());
+         queryDefinition.setNamedParameters(namedParameters);
          return getSearchManager().getQuery(queryDefinition, queryMode, null);
       }
       return getSearchManager().getQuery(luceneQuery, queryMode, getTargetedClass(ickleParsingResult));

--- a/query/src/main/java/org/infinispan/query/impl/CacheQueryImpl.java
+++ b/query/src/main/java/org/infinispan/query/impl/CacheQueryImpl.java
@@ -58,9 +58,9 @@ public class CacheQueryImpl<E> implements CacheQuery<E> {
             cache, keyTransformationHandler);
    }
 
-   public CacheQueryImpl(String queryString, AdvancedCache<?, ?> cache,
+   public CacheQueryImpl(QueryDefinition queryDefinition, AdvancedCache<?, ?> cache,
                          KeyTransformationHandler keyTransformationHandler) {
-      this.queryDefinition = new QueryDefinition(queryString);
+      this.queryDefinition = queryDefinition;
       this.cache = cache;
       this.keyTransformationHandler = keyTransformationHandler;
    }

--- a/query/src/main/java/org/infinispan/query/impl/LifecycleManager.java
+++ b/query/src/main/java/org/infinispan/query/impl/LifecycleManager.java
@@ -57,6 +57,7 @@ import org.infinispan.query.backend.QueryKnownClasses;
 import org.infinispan.query.backend.SearchableCacheConfiguration;
 import org.infinispan.query.backend.TxQueryInterceptor;
 import org.infinispan.query.clustered.QueryBox;
+import org.infinispan.query.clustered.QueryDefinitionExternalizer;
 import org.infinispan.query.continuous.impl.ContinuousQueryResult;
 import org.infinispan.query.continuous.impl.IckleContinuousQueryCacheEventFilterConverter;
 import org.infinispan.query.dsl.embedded.impl.EmbeddedQueryEngine;
@@ -444,6 +445,7 @@ public class LifecycleManager implements ModuleLifecycle {
       externalizerMap.put(ExternalizerIds.LUCENE_QUERY_PREFIX, new LucenePrefixQueryExternalizer());
       externalizerMap.put(ExternalizerIds.LUCENE_QUERY_WILDCARD, new LuceneWildcardQueryExternalizer());
       externalizerMap.put(ExternalizerIds.LUCENE_QUERY_FUZZY, new LuceneFuzzyQueryExternalizer());
+      externalizerMap.put(ExternalizerIds.QUERY_DEFINITION, new QueryDefinitionExternalizer());
    }
 
 }

--- a/query/src/main/java/org/infinispan/query/impl/externalizers/ClusteredTopDocsExternalizer.java
+++ b/query/src/main/java/org/infinispan/query/impl/externalizers/ClusteredTopDocsExternalizer.java
@@ -22,11 +22,16 @@ public class ClusteredTopDocsExternalizer extends AbstractExternalizer<NodeTopDo
    public NodeTopDocs readObject(final ObjectInput input) throws IOException, ClassNotFoundException {
       final int keysNumber = UnsignedNumeric.readUnsignedInt(input);
       final Object[] keys = new Object[keysNumber];
-      for (int i=0; i<keysNumber; i++) {
+      for (int i = 0; i < keysNumber; i++) {
          keys[i] = input.readObject();
       }
+      final int projectionsNumber = UnsignedNumeric.readUnsignedInt(input);
+      final Object[] projections = new Object[projectionsNumber];
+      for (int i = 0; i < projectionsNumber; i++) {
+         projections[i] = input.readObject();
+      }
       final TopDocs innerTopDocs = (TopDocs) input.readObject();
-      return new NodeTopDocs(innerTopDocs, keys);
+      return new NodeTopDocs(innerTopDocs, keys, projections);
    }
 
    @Override
@@ -37,7 +42,12 @@ public class ClusteredTopDocsExternalizer extends AbstractExternalizer<NodeTopDo
       for (int i = 0; i < size; i++) {
          output.writeObject(keys[i]);
       }
-
+      final Object[] projections = topDocs.projections;
+      int projectionSize = projections == null ? 0 : projections.length;
+      UnsignedNumeric.writeUnsignedInt(output, projectionSize);
+      for (int i = 0; i < projectionSize; i++) {
+         output.writeObject(projections[i]);
+      }
       output.writeObject(topDocs.topDocs);
    }
 

--- a/query/src/main/java/org/infinispan/query/impl/externalizers/ExternalizerIds.java
+++ b/query/src/main/java/org/infinispan/query/impl/externalizers/ExternalizerIds.java
@@ -52,4 +52,6 @@ public interface ExternalizerIds {
    Integer LUCENE_QUERY_WILDCARD = 1619;
 
    Integer LUCENE_QUERY_FUZZY = 1620;
+
+   Integer QUERY_DEFINITION = 1621;
 }

--- a/query/src/main/java/org/infinispan/query/logging/Log.java
+++ b/query/src/main/java/org/infinispan/query/logging/Log.java
@@ -12,6 +12,7 @@ import java.util.List;
 import javax.transaction.Transaction;
 
 import org.hibernate.search.backend.LuceneWork;
+import org.hibernate.search.exception.SearchException;
 import org.infinispan.commons.CacheException;
 import org.infinispan.objectfilter.ParsingException;
 import org.infinispan.remoting.transport.Address;
@@ -158,4 +159,13 @@ public interface Log extends org.infinispan.util.logging.Log {
 
    @Message(value = "infinispan-query.jar module is in the classpath but has not been properly initialised!", id = 14038)
    CacheException queryModuleNotInitialised();
+
+   @Message(value = "Queries containing groups or aggregations cannot be converted to an indexed query", id = 14039)
+   SearchException groupAggregationsNotSupported();
+
+   @Message(value = "Unable to define filters, please use filters in the query string instead.", id = 14040)
+   SearchException filterNotSupportedWithQueryString();
+
+   @Message(value = "Unable to define sort, please use sorting in the query string instead.", id = 14041)
+   SearchException sortNotSupportedWithQueryString();
 }

--- a/query/src/main/java/org/infinispan/query/spi/SearchManagerImplementor.java
+++ b/query/src/main/java/org/infinispan/query/spi/SearchManagerImplementor.java
@@ -1,8 +1,13 @@
 package org.infinispan.query.spi;
 
 import org.hibernate.search.query.engine.spi.TimeoutExceptionFactory;
+import org.hibernate.search.spi.CustomTypeMetadata;
+import org.hibernate.search.spi.IndexedTypeMap;
+import org.infinispan.query.CacheQuery;
+import org.infinispan.query.QueryDefinition;
 import org.infinispan.query.SearchManager;
 import org.infinispan.query.Transformer;
+import org.infinispan.query.dsl.IndexedQueryMode;
 
 public interface SearchManagerImplementor extends SearchManager {
 
@@ -28,4 +33,10 @@ public interface SearchManagerImplementor extends SearchManager {
     *           the timeout exception factory to use
     */
    void setTimeoutExceptionFactory(TimeoutExceptionFactory timeoutExceptionFactory);
+
+   /**
+    * Creates a cache query based on a {@link QueryDefinition} and a custom metadata.
+    */
+   <E> CacheQuery<E> getQuery(QueryDefinition queryDefinition, IndexedQueryMode indexedQueryMode, IndexedTypeMap<CustomTypeMetadata> indexedTypeMap);
+
 }

--- a/query/src/test/java/org/infinispan/query/blackbox/ClusteredQueryMultipleCachesTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/ClusteredQueryMultipleCachesTest.java
@@ -28,12 +28,12 @@ public class ClusteredQueryMultipleCachesTest extends ClusteredQueryTest {
             .addProperty("default.directory_provider", "local-heap")
             .addProperty("error_handler", "org.infinispan.query.helper.StaticTestingErrorHandler")
             .addProperty("lucene_version", "LUCENE_CURRENT");
-      enhanceConfig(cacheCfg);
       List<List<Cache<String, Person>>> caches = createClusteredCaches(2, cacheCfg, "cacheA", "cacheB");
       cacheAMachine1 = caches.get(0).get(0);
       cacheAMachine2 = caches.get(1).get(0);
       cacheBMachine1 = caches.get(0).get(1);
       cacheBMachine2 = caches.get(1).get(1);
+      populateCache();
    }
 
    @Override

--- a/query/src/test/java/org/infinispan/query/blackbox/ClusteredQueryTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/ClusteredQueryTest.java
@@ -7,8 +7,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.queryparser.classic.ParseException;
 import org.apache.lucene.queryparser.classic.QueryParser;
 import org.apache.lucene.search.BooleanClause.Occur;
@@ -18,6 +20,8 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.SortField.Type;
+import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
+import org.hibernate.search.exception.SearchException;
 import org.infinispan.Cache;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
@@ -28,9 +32,11 @@ import org.infinispan.query.FetchOptions;
 import org.infinispan.query.ResultIterator;
 import org.infinispan.query.Search;
 import org.infinispan.query.SearchManager;
+import org.infinispan.query.dsl.IndexedQueryMode;
 import org.infinispan.query.helper.StaticTestingErrorHandler;
 import org.infinispan.query.test.Person;
 import org.infinispan.test.MultipleCacheManagersTest;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
 /**
@@ -43,16 +49,11 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
 
    private final QueryParser queryParser = createQueryParser("blurb");
 
-   static final int NUM_ENTRIES = 30;
+   static final int NUM_ENTRIES = 50;
 
    Cache<String, Person> cacheAMachine1, cacheAMachine2;
-   CacheQuery<Person> cacheQuery;
+   private CacheQuery<Person> cacheQuery;
    protected StorageType storageType;
-
-   public ClusteredQueryTest() {
-      // BasicConfigurator.configure();
-      cleanup = CleanupPhase.AFTER_METHOD;
-   }
 
    public Object[] factory() {
       return new Object[]{
@@ -67,8 +68,10 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
       return this;
    }
 
-   protected void enhanceConfig(ConfigurationBuilder cacheCfg) {
-      // meant to be overridden
+   @AfterMethod
+   @Override
+   protected void clearContent() throws Throwable {
+      // Leave it be
    }
 
    @Override
@@ -83,10 +86,10 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
             .addProperty("lucene_version", "LUCENE_CURRENT");
       cacheCfg.memory()
             .storageType(storageType);
-      enhanceConfig(cacheCfg);
       List<Cache<String, Person>> caches = createClusteredCaches(2, cacheCfg);
       cacheAMachine1 = caches.get(0);
       cacheAMachine2 = caches.get(1);
+      populateCache();
    }
 
    protected CacheMode getCacheMode() {
@@ -105,16 +108,13 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
    }
 
    public void testLazyOrdered() throws ParseException {
-      populateCache();
-
       // applying sort
       SortField sortField = new SortField("age", Type.INT);
       Sort sort = new Sort(sortField);
       cacheQuery.sort(sort);
 
       for (int i = 0; i < 2; i++) {
-         ResultIterator<Person> iterator = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.LAZY));
-         try {
+         try (ResultIterator<Person> iterator = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.LAZY))) {
             assert cacheQuery.getResultSize() == 10 : cacheQuery.getResultSize();
 
             int previousAge = 0;
@@ -123,28 +123,19 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
                assert person.getAge() > previousAge;
                previousAge = person.getAge();
             }
-         } finally {
-            iterator.close();
          }
       }
       StaticTestingErrorHandler.assertAllGood(cacheAMachine1, cacheAMachine2);
    }
 
    public void testLazyNonOrdered() throws ParseException {
-      populateCache();
-
-      ResultIterator<Person> iterator = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.LAZY));
-      try {
+      try (ResultIterator<Person> ignored = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.LAZY))) {
          assert cacheQuery.getResultSize() == 10 : cacheQuery.getResultSize();
-      } finally {
-         iterator.close();
       }
       StaticTestingErrorHandler.assertAllGood(cacheAMachine1, cacheAMachine2);
    }
 
    public void testLocalQuery() throws ParseException {
-      populateCache();
-
       final SearchManager searchManager1 = Search.getSearchManager(cacheAMachine1);
       final CacheQuery<Person> localQuery1 = searchManager1.getQuery(createLuceneQuery());
       List<Person> results1 = localQuery1.list();
@@ -159,15 +150,12 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
    }
 
    public void testEagerOrdered() throws ParseException {
-      populateCache();
-
       // applying sort
       SortField sortField = new SortField("age", Type.INT);
       Sort sort = new Sort(sortField);
       cacheQuery.sort(sort);
 
-      ResultIterator<Person> iterator = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.EAGER));
-      try {
+      try (ResultIterator<Person> iterator = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.EAGER))) {
          assertEquals(10, cacheQuery.getResultSize());
 
          int previousAge = 0;
@@ -176,48 +164,34 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
             assert person.getAge() > previousAge;
             previousAge = person.getAge();
          }
-      } finally {
-         iterator.close();
       }
       StaticTestingErrorHandler.assertAllGood(cacheAMachine1, cacheAMachine2);
    }
 
    @Test(expectedExceptions = NoSuchElementException.class, expectedExceptionsMessageRegExp = "Out of boundaries")
    public void testIteratorNextOutOfBounds() throws Exception {
-      populateCache();
-
       cacheQuery.maxResults(1);
-      ResultIterator<Person> iterator = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.EAGER));
-      try {
+      try (ResultIterator<Person> iterator = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.EAGER))) {
          assert iterator.hasNext();
          iterator.next();
 
          assert !iterator.hasNext();
          iterator.next();
-      } finally {
-         iterator.close();
       }
       StaticTestingErrorHandler.assertAllGood(cacheAMachine1, cacheAMachine2);
    }
 
    @Test(expectedExceptions = UnsupportedOperationException.class)
    public void testIteratorRemove() throws Exception {
-      populateCache();
-
       cacheQuery.maxResults(1);
-      ResultIterator<Person> iterator = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.EAGER));
-      try {
+      try (ResultIterator<Person> iterator = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.EAGER))) {
          assert iterator.hasNext();
          iterator.remove();
-      } finally {
-         iterator.close();
       }
       StaticTestingErrorHandler.assertAllGood(cacheAMachine1, cacheAMachine2);
    }
 
    public void testList() throws ParseException {
-      populateCache();
-
       // applying sort
       SortField sortField = new SortField("age", Type.INT);
       Sort sort = new Sort(sortField);
@@ -235,13 +209,10 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
    }
 
    public void testGetResultSizeList() throws ParseException {
-      populateCache();
       assertEquals(10, cacheQuery.getResultSize());
    }
 
    public void testPagination() throws ParseException {
-      populateCache();
-
       cacheQuery.firstResult(2);
       cacheQuery.maxResults(1);
 
@@ -277,8 +248,6 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
    }
 
    private void testPaginationInternal(int pageSize, Sort sort) throws ParseException {
-      populateCache();
-
       CacheQuery<Person> paginationQuery = buildPaginationQuery(0, pageSize, sort);
 
       int idx = 0;
@@ -296,7 +265,7 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
 
    private CacheQuery<Person> buildPaginationQuery(int offset, int pageSize, Sort sort) throws ParseException {
       CacheQuery<Person> clusteredQuery = Search.getSearchManager(cacheAMachine1)
-            .getClusteredQuery(new MatchAllDocsQuery());
+            .getQuery(new MatchAllDocsQuery(), IndexedQueryMode.BROADCAST);
       clusteredQuery.firstResult(offset);
       clusteredQuery.maxResults(pageSize);
       if (sort != null) {
@@ -306,9 +275,8 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
    }
 
    public void testQueryAll() throws ParseException {
-      populateCache();
       CacheQuery<Person> clusteredQuery = Search.getSearchManager(cacheAMachine1)
-            .getClusteredQuery(new MatchAllDocsQuery(), Person.class);
+            .getQuery(new MatchAllDocsQuery(), IndexedQueryMode.BROADCAST, Person.class);
 
       assertEquals(NUM_ENTRIES, clusteredQuery.list().size());
       StaticTestingErrorHandler.assertAllGood(cacheAMachine1, cacheAMachine2);
@@ -326,10 +294,136 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
       StaticTestingErrorHandler.assertAllGood(cacheAMachine1, cacheAMachine2);
    }
 
+   public void testBroadcastIckleMatchAllQuery() throws Exception {
+      CacheQuery<Person> everybody = Search.getSearchManager(cacheAMachine1)
+            .getQuery(String.format("FROM %s", Person.class.getName()), IndexedQueryMode.BROADCAST, Person.class);
+
+      assertEquals(NUM_ENTRIES, everybody.list().size());
+      StaticTestingErrorHandler.assertAllGood(cacheAMachine1, cacheAMachine2);
+   }
+
+   public void testBroadcastIckleTermQuery() throws Exception {
+      String targetName = "name2";
+      CacheQuery<Person> singlePerson = Search.getSearchManager(cacheAMachine1)
+            .getQuery(String.format("FROM %s p where p.name:'%s'", Person.class.getName(), targetName),
+                  IndexedQueryMode.BROADCAST, Person.class);
+
+      assertEquals(1, singlePerson.list().size());
+      assertEquals(targetName, singlePerson.list().iterator().next().getName());
+      StaticTestingErrorHandler.assertAllGood(cacheAMachine1, cacheAMachine2);
+   }
+
+   public void testBroadcastFuzzyIckle() throws Exception {
+      CacheQuery<Person> persons0to10 = Search.getSearchManager(cacheAMachine1)
+            .getQuery(String.format("FROM %s p where p.name:'nome'~2", Person.class.getName()),
+                  IndexedQueryMode.BROADCAST, Person.class);
+
+      assertEquals(10, persons0to10.list().size());
+
+      StaticTestingErrorHandler.assertAllGood(cacheAMachine1, cacheAMachine2);
+   }
+
+   public void testBroadcastNumericRangeQuery() throws Exception {
+      CacheQuery<Person> infants = Search.getSearchManager(cacheAMachine1)
+            .getQuery(String.format("FROM %s p where p.age between 0 and 5", Person.class.getName()),
+                  IndexedQueryMode.BROADCAST, Person.class);
+
+      assertEquals(6, infants.list().size());
+
+      StaticTestingErrorHandler.assertAllGood(cacheAMachine1, cacheAMachine2);
+   }
+
+   public void testBroadcastProjectionIckleQuery() throws Exception {
+      SearchManager sm = Search.getSearchManager(cacheAMachine2);
+      CacheQuery<Object[]> onlyNames = sm.getQuery(
+            String.format("Select p.name FROM %s p", Person.class.getName()), IndexedQueryMode.BROADCAST, Person.class
+      );
+
+      List<Object[]> results = onlyNames.list();
+      assertEquals(NUM_ENTRIES, results.size());
+
+      Set<String> names = new HashSet<>();
+      results.iterator().forEachRemaining(s -> names.add((String) s[0]));
+
+      Set<String> allNames = IntStream.range(0, NUM_ENTRIES).boxed().map(i -> "name" + i).collect(Collectors.toSet());
+      assertEquals(allNames, names);
+      StaticTestingErrorHandler.assertAllGood(cacheAMachine1, cacheAMachine2);
+   }
+
+   public void testBroadcastSortedIckleQuery() throws Exception {
+      SearchManager sm = Search.getSearchManager(cacheAMachine2);
+      CacheQuery<Person> theLastWillBeFirst = sm.getQuery(
+            String.format("FROM %s p order by p.age desc", Person.class.getName()), IndexedQueryMode.BROADCAST, Person.class
+      );
+
+      List<Person> results = theLastWillBeFirst.list();
+      assertEquals(NUM_ENTRIES, results.size());
+      assertEquals(NUM_ENTRIES - 1, results.iterator().next().getAge());
+      StaticTestingErrorHandler.assertAllGood(cacheAMachine1, cacheAMachine2);
+   }
+
+   public void testPaginatedIckleQuery() throws Exception {
+      SearchManager sm = Search.getSearchManager(cacheAMachine1);
+      CacheQuery<Person> q = sm.getQuery(String.format("FROM %s p order by p.age", Person.class.getName()),
+            IndexedQueryMode.BROADCAST, Person.class);
+
+      q.firstResult(5);
+      q.maxResults(10);
+
+      List<Person> results = q.list();
+
+      assertEquals(10, results.size());
+      assertEquals("name5", results.iterator().next().getName());
+      assertEquals("name14", results.get(9).getName());
+   }
+
+   public void testPartialIckleQuery() throws Exception {
+      SearchManager searchManager1 = Search.getSearchManager(cacheAMachine1);
+      SearchManager searchManager2 = Search.getSearchManager(cacheAMachine2);
+      String query = String.format("FROM %s p", Person.class.getName());
+
+      CacheQuery<Person> machine1Results = searchManager1.getQuery(query, IndexedQueryMode.FETCH, Person.class);
+      CacheQuery<Person> machine2Results = searchManager2.getQuery(query, IndexedQueryMode.FETCH, Person.class);
+
+      int numDocsMachine1 = countLocalIndex(cacheAMachine1);
+      int numDocsMachine2 = countLocalIndex(cacheAMachine2);
+
+      assertEquals(NUM_ENTRIES, numDocsMachine1 + numDocsMachine2);
+      assertEquals(numDocsMachine1, machine1Results.list().size());
+      assertEquals(numDocsMachine2, machine2Results.list().size());
+
+      StaticTestingErrorHandler.assertAllGood(cacheAMachine1, cacheAMachine2);
+   }
+
+   private int countLocalIndex(Cache<String, Person> cache) {
+      SearchManager sm = Search.getSearchManager(cache);
+      ExtendedSearchIntegrator esi = sm.unwrap(ExtendedSearchIntegrator.class);
+      IndexReader indexReader = esi.getIndexManager("person").getReaderProvider().openIndexReader();
+      return indexReader.numDocs();
+   }
+
+   @Test(expectedExceptions = SearchException.class, expectedExceptionsMessageRegExp = ".*cannot be converted to an indexed Query")
+   public void testPreventHybridQuery() throws Exception {
+      CacheQuery<Person> hybridQuery = Search.getSearchManager(cacheAMachine1)
+            .getQuery(String.format("FROM %s p where p.nonSearchableField = 'nothing'", Person.class.getName()),
+                  IndexedQueryMode.BROADCAST, Person.class);
+
+      hybridQuery.list();
+   }
+
+   @Test(expectedExceptions = SearchException.class, expectedExceptionsMessageRegExp = ".*cannot be converted to an indexed Query")
+   public void testPreventAggregationQueries() throws Exception {
+      CacheQuery<Person> aggregationQuery = Search.getSearchManager(cacheAMachine1)
+            .getQuery(String.format("FROM %s p where p.name:'name3' group by p.name", Person.class.getName()),
+                  IndexedQueryMode.BROADCAST, Person.class);
+
+      aggregationQuery.list();
+   }
+
    protected void populateCache() throws ParseException {
       prepareTestData();
 
-      cacheQuery = Search.getSearchManager(cacheAMachine1).getClusteredQuery(createLuceneQuery());
+      cacheQuery = Search.getSearchManager(cacheAMachine1).getQuery(createLuceneQuery(), IndexedQueryMode.BROADCAST);
       StaticTestingErrorHandler.assertAllGood(cacheAMachine1, cacheAMachine2);
    }
 

--- a/query/src/test/java/org/infinispan/query/blackbox/TopologyAwareClusteredQueryTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/TopologyAwareClusteredQueryTest.java
@@ -19,9 +19,9 @@ public class TopologyAwareClusteredQueryTest extends ClusteredQueryTest {
    @Override
    protected void createCacheManagers() throws Throwable {
       List caches = TestQueryHelperFactory.createTopologyAwareCacheNodes(2, getCacheMode(), transactionEnabled(),
-                                                                         isIndexLocalOnly(), isRamDirectory(), "default", Person.class);
+            isIndexLocalOnly(), isRamDirectory(), "default", Person.class);
 
-      for(Object cache : caches) {
+      for (Object cache : caches) {
          cacheManagers.add(((Cache) cache).getCacheManager());
       }
 
@@ -29,6 +29,7 @@ public class TopologyAwareClusteredQueryTest extends ClusteredQueryTest {
       cacheAMachine2 = (Cache<String, Person>) caches.get(1);
 
       waitForClusterToForm();
+      populateCache();
    }
 
    public CacheMode getCacheMode() {

--- a/query/src/test/java/org/infinispan/query/distributed/ClusteredQueryMassIndexingTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/ClusteredQueryMassIndexingTest.java
@@ -7,6 +7,7 @@ import org.apache.lucene.search.TermQuery;
 import org.infinispan.Cache;
 import org.infinispan.query.CacheQuery;
 import org.infinispan.query.Search;
+import org.infinispan.query.dsl.IndexedQueryMode;
 import org.testng.annotations.Test;
 
 /**
@@ -22,7 +23,7 @@ public class ClusteredQueryMassIndexingTest extends DistributedMassIndexingTest 
 
    protected void verifyFindsCar(Cache cache, int expectedCount, String carMake) {
       CacheQuery<?> cacheQuery = Search.getSearchManager(cache)
-            .getClusteredQuery(new TermQuery(new Term("make", carMake)));
+            .getQuery(new TermQuery(new Term("make", carMake)), IndexedQueryMode.BROADCAST);
 
       assertEquals(expectedCount, cacheQuery.getResultSize());
    }

--- a/query/src/test/java/org/infinispan/query/distributed/UnsharedDistMassIndexTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/UnsharedDistMassIndexTest.java
@@ -8,6 +8,7 @@ import org.infinispan.Cache;
 import org.infinispan.query.CacheQuery;
 import org.infinispan.query.Search;
 import org.infinispan.query.SearchManager;
+import org.infinispan.query.dsl.IndexedQueryMode;
 import org.testng.annotations.Test;
 
 /**
@@ -27,7 +28,7 @@ public class UnsharedDistMassIndexTest extends DistributedMassIndexingTest {
    @Override
    protected void verifyFindsCar(Cache cache, int expectedCount, String carMake) {
       SearchManager searchManager = Search.getSearchManager(cache);
-      CacheQuery<?> cacheQuery = searchManager.getClusteredQuery(new TermQuery(new Term("make", carMake)));
+      CacheQuery<?> cacheQuery = searchManager.getQuery(new TermQuery(new Term("make", carMake)), IndexedQueryMode.BROADCAST);
       assertEquals(expectedCount, cacheQuery.getResultSize());
    }
 }

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/QueryStringTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/QueryStringTest.java
@@ -179,9 +179,7 @@ public class QueryStringTest extends AbstractQueryDslTest {
    }
 
    public void testParam() throws Exception {
-      QueryFactory qf = getQueryFactory();
-
-      Query q = qf.create("from " + getModelFactory().getTransactionTypeName() + " where id = :idParam");
+      Query q = createQueryFromString("from " + getModelFactory().getTransactionTypeName() + " where id = :idParam");
 
       q.setParameter("idParam", 1);
 
@@ -200,63 +198,49 @@ public class QueryStringTest extends AbstractQueryDslTest {
 
    @Test(enabled = false)
    public void testParamWithSpacePadding() throws Exception {
-      QueryFactory qf = getQueryFactory();
-
       //todo [anistor] need special tree nodes for all literal types (and for params) to be able to distinguish them better; QueryRendererDelegate.predicateXXX should receive such a tree node instead of a string
-      Query q = qf.create("from " + getModelFactory().getTransactionTypeName() + " where id = :  idParam");
+      Query q = createQueryFromString("from " + getModelFactory().getTransactionTypeName() + " where id = :  idParam");
       List<Transaction> list = q.list();
       assertEquals(1, list.size());
    }
 
    public void testExactMatch() throws Exception {
-      QueryFactory qf = getQueryFactory();
-
-      Query q = qf.create("from " + getModelFactory().getTransactionTypeName() + " where description = 'Birthday present'");
+      Query q = createQueryFromString("from " + getModelFactory().getTransactionTypeName() + " where description = 'Birthday present'");
 
       List<Transaction> list = q.list();
       assertEquals(1, list.size());
    }
 
    public void testFullTextTerm() throws Exception {
-      QueryFactory qf = getQueryFactory();
-
-      Query q = qf.create("from " + getModelFactory().getTransactionTypeName() + " where longDescription:'rent'");
+      Query q = createQueryFromString("from " + getModelFactory().getTransactionTypeName() + " where longDescription:'rent'");
 
       List<Transaction> list = q.list();
       assertEquals(1, list.size());
    }
 
    public void testFullTextTermRightOperandAnalyzed() throws Exception {
-      QueryFactory qf = getQueryFactory();
-
-      Query q = qf.create("from " + getModelFactory().getTransactionTypeName() + " where longDescription:'RENT'");
+      Query q = createQueryFromString("from " + getModelFactory().getTransactionTypeName() + " where longDescription:'RENT'");
 
       List<Transaction> list = q.list();
       assertEquals(1, list.size());
    }
 
    public void testFullTextTermBoost() throws Exception {
-      QueryFactory qf = getQueryFactory();
-
-      Query q = qf.create("from " + getModelFactory().getTransactionTypeName() + " where longDescription:('rent'^8 'shoes')");
+      Query q = createQueryFromString("from " + getModelFactory().getTransactionTypeName() + " where longDescription:('rent'^8 'shoes')");
 
       List<Transaction> list = q.list();
       assertEquals(51, list.size());
    }
 
    public void testFullTextPhrase() throws Exception {
-      QueryFactory qf = getQueryFactory();
-
-      Query q = qf.create("from " + getModelFactory().getTransactionTypeName() + " where longDescription:'expensive shoes'");
+      Query q = createQueryFromString("from " + getModelFactory().getTransactionTypeName() + " where longDescription:'expensive shoes'");
 
       List<Transaction> list = q.list();
       assertEquals(50, list.size());
    }
 
    public void testFullTextWithAggregation() throws Exception {
-      QueryFactory qf = getQueryFactory();
-
-      Query q = qf.create("select t.accountId, max(t.amount), max(t.description) from " + getModelFactory().getTransactionTypeName()
+      Query q = createQueryFromString("select t.accountId, max(t.amount), max(t.description) from " + getModelFactory().getTransactionTypeName()
             + " t where t.longDescription : (+'beer' && -'food') group by t.accountId");
 
       List<Object[]> list = q.list();
@@ -267,63 +251,49 @@ public class QueryStringTest extends AbstractQueryDslTest {
    }
 
    public void testFullTextTermBoostAndSorting() throws Exception {
-      QueryFactory qf = getQueryFactory();
-
-      Query q = qf.create("from " + getModelFactory().getTransactionTypeName() + " where longDescription:('rent'^8 'shoes') order by amount");
+      Query q = createQueryFromString("from " + getModelFactory().getTransactionTypeName() + " where longDescription:('rent'^8 'shoes') order by amount");
 
       List<Transaction> list = q.list();
       assertEquals(51, list.size());
    }
 
    public void testFullTextTermOccur() throws Exception {
-      QueryFactory qf = getQueryFactory();
-
-      Query q = qf.create("from " + getModelFactory().getTransactionTypeName() + " t where not (t.longDescription : (+'failed') or t.longDescription : 'blocked')");
+      Query q = createQueryFromString("from " + getModelFactory().getTransactionTypeName() + " t where not (t.longDescription : (+'failed') or t.longDescription : 'blocked')");
 
       List<Transaction> list = q.list();
       assertEquals(56, list.size());
    }
 
    public void testFullTextTermDoesntOccur() throws Exception {
-      QueryFactory qf = getQueryFactory();
-
-      Query q = qf.create("from " + getModelFactory().getTransactionTypeName() + " t where t.longDescription : (-'really')");
+      Query q = createQueryFromString("from " + getModelFactory().getTransactionTypeName() + " t where t.longDescription : (-'really')");
 
       List<Transaction> list = q.list();
       assertEquals(6, list.size());
    }
 
    public void testFullTextRangeWildcard() throws Exception {
-      QueryFactory qf = getQueryFactory();
-
-      Query q = qf.create("from " + getModelFactory().getTransactionTypeName() + " t where t.longDescription : [* to *]");
+      Query q = createQueryFromString("from " + getModelFactory().getTransactionTypeName() + " t where t.longDescription : [* to *]");
 
       List<Transaction> list = q.list();
       assertEquals(54, list.size());
    }
 
    public void testFullTextRange() throws Exception {
-      QueryFactory qf = getQueryFactory();
-
-      Query q = qf.create("from " + getModelFactory().getTransactionTypeName() + " t where t.amount : [23 to 45]");
+      Query q = createQueryFromString("from " + getModelFactory().getTransactionTypeName() + " t where t.amount : [23 to 45]");
 
       List<Transaction> list = q.list();
       assertEquals(2, list.size());
    }
 
    public void testFullTextPrefix() throws Exception {
-      QueryFactory qf = getQueryFactory();
-
-      Query q = qf.create("from " + getModelFactory().getTransactionTypeName() + " t where t.longDescription : 'ren*'");
+      Query q = createQueryFromString("from " + getModelFactory().getTransactionTypeName() + " t where t.longDescription : 'ren*'");
 
       List<Transaction> list = q.list();
       assertEquals(1, list.size());
    }
 
    public void testFullTextWildcard() throws Exception {
-      QueryFactory qf = getQueryFactory();
-
-      Query q = qf.create("from " + getModelFactory().getTransactionTypeName() + " t where t.longDescription : 're?t'");
+      Query q = createQueryFromString("from " + getModelFactory().getTransactionTypeName() + " t where t.longDescription : 're?t'");
 
       List<Transaction> list = q.list();
       assertEquals(1, list.size());
@@ -331,55 +301,45 @@ public class QueryStringTest extends AbstractQueryDslTest {
 
    @Test(expectedExceptions = ParsingException.class, expectedExceptionsMessageRegExp = "ISPN014036: Prefix, wildcard or regexp queries cannot be fuzzy.*")
    public void testFullTextWildcardFuzzyNotAllowed() throws Exception {
-      QueryFactory qf = getQueryFactory();
-
-      Query q = qf.create("from " + getModelFactory().getTransactionTypeName() + " t where t.longDescription : 're?t'~2");
+      Query q = createQueryFromString("from " + getModelFactory().getTransactionTypeName() + " t where t.longDescription : 're?t'~2");
 
       q.list();
    }
 
    public void testFullTextFuzzy() throws Exception {
-      QueryFactory qf = getQueryFactory();
-
-      Query q = qf.create("from " + getModelFactory().getTransactionTypeName() + " t where t.longDescription : 'retn'~");
+      Query q = createQueryFromString("from " + getModelFactory().getTransactionTypeName() + " t where t.longDescription : 'retn'~");
 
       List<Transaction> list = q.list();
       assertEquals(1, list.size());
    }
 
    public void testFullTextFuzzyDefaultEdits() throws Exception {
-      QueryFactory qf = getQueryFactory();
-
       // default number of edits should be 2
-      Query q = qf.create("from " + getModelFactory().getTransactionTypeName() + " t where t.longDescription : 'ertn'~");
+      Query q = createQueryFromString("from " + getModelFactory().getTransactionTypeName() + " t where t.longDescription : 'ertn'~");
 
       List<Transaction> list = q.list();
       assertEquals(1, list.size());
 
-      q = qf.create("from " + getModelFactory().getTransactionTypeName() + " t where t.longDescription : 'ajunayr'~");
+      q = createQueryFromString("from " + getModelFactory().getTransactionTypeName() + " t where t.longDescription : 'ajunayr'~");
 
       list = q.list();
       assertEquals(0, list.size());
    }
 
    public void testFullTextFuzzySpecifiedEdits() throws Exception {
-      QueryFactory qf = getQueryFactory();
-
-      Query q = qf.create("from " + getModelFactory().getTransactionTypeName() + " t where t.longDescription : 'ajnuary'~1");
+      Query q = createQueryFromString("from " + getModelFactory().getTransactionTypeName() + " t where t.longDescription : 'ajnuary'~1");
 
       List<Transaction> list = q.list();
       assertEquals(1, list.size());
 
-      q = qf.create("from " + getModelFactory().getTransactionTypeName() + " t where t.longDescription : 'ajunary'~1");
+      q = createQueryFromString("from " + getModelFactory().getTransactionTypeName() + " t where t.longDescription : 'ajunary'~1");
 
       list = q.list();
       assertEquals(0, list.size());
    }
 
    public void testFullTextRegexp() throws Exception {
-      QueryFactory qf = getQueryFactory();
-
-      Query q = qf.create("from " + getModelFactory().getTransactionTypeName() + " t where t.longDescription : /[R|r]ent/");
+      Query q = createQueryFromString("from " + getModelFactory().getTransactionTypeName() + " t where t.longDescription : /[R|r]ent/");
 
       List<Transaction> list = q.list();
       assertEquals(1, list.size());
@@ -387,56 +347,49 @@ public class QueryStringTest extends AbstractQueryDslTest {
 
    @Test(expectedExceptions = ParsingException.class, expectedExceptionsMessageRegExp = "ISPN028526: Invalid query.*")
    public void testFullTextRegexpFuzzyNotAllowed() throws Exception {
-      QueryFactory qf = getQueryFactory();
-
-      Query q = qf.create("from " + getModelFactory().getTransactionTypeName() + " t where t.longDescription : /[R|r]ent/~2");
+      Query q = createQueryFromString("from " + getModelFactory().getTransactionTypeName() + " t where t.longDescription : /[R|r]ent/~2");
 
       q.list();
    }
 
    @Test(expectedExceptions = ParsingException.class, expectedExceptionsMessageRegExp = "ISPN028522: .*property is analyzed.*")
    public void testExactMatchOnAnalyzedFieldNotAllowed() throws Exception {
-      QueryFactory qf = getQueryFactory();
-
-      Query q = qf.create("from " + getModelFactory().getTransactionTypeName() + " where longDescription = 'Birthday present'");
+      Query q = createQueryFromString("from " + getModelFactory().getTransactionTypeName() + " where longDescription = 'Birthday present'");
 
       q.list();
    }
 
    @Test(expectedExceptions = ParsingException.class, expectedExceptionsMessageRegExp = "ISPN028521: .*unless the property is indexed and analyzed.*")
    public void testFullTextTermOnNonAnalyzedFieldNotAllowed() throws Exception {
-      QueryFactory qf = getQueryFactory();
-
-      Query q = qf.create("from " + getModelFactory().getTransactionTypeName() + " where description:'rent'");
+      Query q = createQueryFromString("from " + getModelFactory().getTransactionTypeName() + " where description:'rent'");
 
       q.list();
    }
 
    @Test(enabled = false) //TODO [anistor] fix!
    public void testFullTextRegexp2() throws Exception {
-      QueryFactory qf = getQueryFactory();
-
-      Query q = qf.create("from " + getModelFactory().getTransactionTypeName() + " t where t.longDescription : ( -'beer' and '*')");
+      Query q = createQueryFromString("from " + getModelFactory().getTransactionTypeName() + " t where t.longDescription : ( -'beer' and '*')");
 
       List<Transaction> list = q.list();
       assertEquals(1, list.size());
    }
 
    public void testInstant1() throws Exception {
-      QueryFactory qf = getQueryFactory();
-
-      Query q = qf.create("from " + getModelFactory().getUserTypeName() + " u where u.creationDate = '2011-12-03T10:15:30Z'");
+      Query q = createQueryFromString("from " + getModelFactory().getUserTypeName() + " u where u.creationDate = '2011-12-03T10:15:30Z'");
 
       List<User> list = q.list();
       assertEquals(3, list.size());
    }
 
    public void testInstant2() throws Exception {
-      QueryFactory qf = getQueryFactory();
-
-      Query q = qf.create("from " + getModelFactory().getUserTypeName() + " u where u.passwordExpirationDate = '2011-12-03T10:15:30Z'");
+      Query q = createQueryFromString("from " + getModelFactory().getUserTypeName() + " u where u.passwordExpirationDate = '2011-12-03T10:15:30Z'");
 
       List<User> list = q.list();
       assertEquals(3, list.size());
+   }
+
+   protected Query createQueryFromString(String q) {
+      QueryFactory qf = getQueryFactory();
+      return qf.create(q);
    }
 }

--- a/query/src/test/java/org/infinispan/query/searchmanager/ClusteredCacheQueryTimeoutTest.java
+++ b/query/src/test/java/org/infinispan/query/searchmanager/ClusteredCacheQueryTimeoutTest.java
@@ -15,6 +15,7 @@ import org.infinispan.configuration.cache.Index;
 import org.infinispan.query.CacheQuery;
 import org.infinispan.query.Search;
 import org.infinispan.query.SearchManager;
+import org.infinispan.query.dsl.IndexedQueryMode;
 import org.infinispan.query.test.Person;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.testng.annotations.Test;
@@ -48,7 +49,7 @@ public class ClusteredCacheQueryTimeoutTest extends MultipleCacheManagersTest {
       QueryParser queryParser = createQueryParser("bar");
 
       org.apache.lucene.search.Query luceneQuery = queryParser.parse("fakebar");
-      CacheQuery<?> query = searchManager.getClusteredQuery(luceneQuery, Foo.class);
+      CacheQuery<?> query = searchManager.getQuery(luceneQuery, IndexedQueryMode.BROADCAST, Foo.class);
       query.timeout(1, TimeUnit.NANOSECONDS);
    }
 

--- a/query/src/test/java/org/infinispan/query/test/Person.java
+++ b/query/src/test/java/org/infinispan/query/test/Person.java
@@ -107,7 +107,8 @@ public class Person implements Serializable, ExternalPojo {
       if (age != person.age) return false;
       if (blurb != null ? !blurb.equals(person.blurb) : person.blurb != null) return false;
       if (name != null ? !name.equals(person.name) : person.name != null) return false;
-      if (dateOfGraduation != null ? !dateOfGraduation.equals(person.dateOfGraduation) : person.dateOfGraduation != null) return false;
+      if (dateOfGraduation != null ? !dateOfGraduation.equals(person.dateOfGraduation) : person.dateOfGraduation != null)
+         return false;
 
       return true;
    }

--- a/query/src/test/java/org/infinispan/query/test/Person.java
+++ b/query/src/test/java/org/infinispan/query/test/Person.java
@@ -48,6 +48,7 @@ public class Person implements Serializable, ExternalPojo {
       this.name = name;
       this.blurb = blurb;
       this.age = age;
+      this.nonSearchableField = name.substring(0, 2);
    }
 
    public Person(String name, String blurb, int age, Date dateOfGraduation) {

--- a/remote-query/remote-query-client/src/main/java/org/infinispan/query/remote/client/QueryRequest.java
+++ b/remote-query/remote-query-client/src/main/java/org/infinispan/query/remote/client/QueryRequest.java
@@ -25,6 +25,8 @@ public final class QueryRequest {
 
    private Integer maxResults;
 
+   private String indexedQueryMode;
+
    public String getQueryString() {
       return queryString;
    }
@@ -68,6 +70,14 @@ public final class QueryRequest {
       return params;
    }
 
+   public void setIndexedQueryMode(String indexedQueryMode) {
+      this.indexedQueryMode = indexedQueryMode;
+   }
+
+   public String getIndexedQueryMode() {
+      return indexedQueryMode;
+   }
+
    static final class Marshaller implements MessageMarshaller<QueryRequest> {
 
       @Override
@@ -77,6 +87,7 @@ public final class QueryRequest {
          queryRequest.setStartOffset(reader.readLong("startOffset"));
          queryRequest.setMaxResults(reader.readInt("maxResults"));
          queryRequest.setNamedParameters(reader.readCollection("namedParameters", new ArrayList<>(), NamedParameter.class));
+         queryRequest.setIndexedQueryMode(reader.readString("indexedQueryMode"));
          return queryRequest;
       }
 
@@ -86,6 +97,7 @@ public final class QueryRequest {
          writer.writeLong("startOffset", queryRequest.getStartOffset());
          writer.writeInt("maxResults", queryRequest.getMaxResults());
          writer.writeCollection("namedParameters", queryRequest.getNamedParameters(), NamedParameter.class);
+         writer.writeString("indexedQueryMode", queryRequest.getIndexedQueryMode());
       }
 
       @Override

--- a/remote-query/remote-query-client/src/main/resources/org/infinispan/query/remote/client/query.proto
+++ b/remote-query/remote-query-client/src/main/resources/org/infinispan/query/remote/client/query.proto
@@ -42,6 +42,8 @@ message QueryRequest {
        */
       required org.infinispan.protostream.WrappedMessage value = 2;
    }
+
+   optional String indexedQueryMode = 6;
 }
 
 /**

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/BaseRemoteQueryEngine.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/BaseRemoteQueryEngine.java
@@ -6,10 +6,11 @@ import org.infinispan.AdvancedCache;
 import org.infinispan.objectfilter.Matcher;
 import org.infinispan.protostream.SerializationContext;
 import org.infinispan.protostream.descriptors.Descriptor;
+import org.infinispan.query.dsl.IndexedQueryMode;
+import org.infinispan.query.dsl.Query;
 import org.infinispan.query.dsl.embedded.impl.EmbeddedQueryFactory;
 import org.infinispan.query.dsl.embedded.impl.LuceneQueryMaker;
 import org.infinispan.query.dsl.embedded.impl.QueryEngine;
-import org.infinispan.query.dsl.impl.BaseQuery;
 
 /**
  * @author anistor@redhat.com
@@ -21,8 +22,8 @@ public class BaseRemoteQueryEngine extends QueryEngine<Descriptor> {
 
    private final EmbeddedQueryFactory queryFactory = new EmbeddedQueryFactory(this);
 
-   protected BaseRemoteQueryEngine(AdvancedCache<?, ?> cache, boolean isIndexed, Class<? extends Matcher> matcherImplClass,
-                                   LuceneQueryMaker.FieldBridgeAndAnalyzerProvider<Descriptor> fieldBridgeAndAnalyzerProvider) {
+   BaseRemoteQueryEngine(AdvancedCache<?, ?> cache, boolean isIndexed, Class<? extends Matcher> matcherImplClass,
+                         LuceneQueryMaker.FieldBridgeAndAnalyzerProvider<Descriptor> fieldBridgeAndAnalyzerProvider) {
       super(cache, isIndexed, matcherImplClass, fieldBridgeAndAnalyzerProvider);
       serializationContext = ProtobufMetadataManagerImpl.getSerializationContextInternal(cache.getCacheManager());
    }
@@ -31,8 +32,12 @@ public class BaseRemoteQueryEngine extends QueryEngine<Descriptor> {
       return serializationContext;
    }
 
-   public BaseQuery makeQuery(String queryString, Map<String, Object> namedParameters, long startOffset, int maxResults) {
-      BaseQuery query = queryFactory.create(queryString);
+   Query makeQuery(String queryString, Map<String, Object> namedParameters, long startOffset, int maxResults) {
+      return makeQuery(queryString, namedParameters, startOffset, maxResults, IndexedQueryMode.FETCH);
+   }
+
+   Query makeQuery(String queryString, Map<String, Object> namedParameters, long startOffset, int maxResults, IndexedQueryMode queryMode) {
+      Query query = queryFactory.create(queryString, queryMode);
       query.startOffset(startOffset);
       query.maxResults(maxResults);
       if (namedParameters != null) {

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/ExternalizerIds.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/ExternalizerIds.java
@@ -25,4 +25,6 @@ public interface ExternalizerIds {
    Integer ICKLE_CONTINUOUS_QUERY_RESULT = 1705;
 
    Integer ICKLE_FILTER_RESULT = 1706;
+
+   Integer REMOTE_QUERY_DEFINITION = 1707;
 }

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/LifecycleManager.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/LifecycleManager.java
@@ -61,6 +61,7 @@ public final class LifecycleManager implements ModuleLifecycle {
       externalizerMap.put(ExternalizerIds.ICKLE_BINARY_PROTOBUF_FILTER_AND_CONVERTER, new IckleBinaryProtobufFilterAndConverter.Externalizer());
       externalizerMap.put(ExternalizerIds.ICKLE_CONTINUOUS_QUERY_RESULT, new ContinuousQueryResultExternalizer());
       externalizerMap.put(ExternalizerIds.ICKLE_FILTER_RESULT, new FilterResultExternalizer());
+      externalizerMap.put(ExternalizerIds.REMOTE_QUERY_DEFINITION, new RemoteQueryDefinitionExternalizer());
    }
 
    @Override

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/QueryFacadeImpl.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/QueryFacadeImpl.java
@@ -6,7 +6,7 @@ import java.util.List;
 import org.infinispan.AdvancedCache;
 import org.infinispan.commons.logging.LogFactory;
 import org.infinispan.protostream.WrappedMessage;
-import org.infinispan.query.dsl.impl.BaseQuery;
+import org.infinispan.query.dsl.Query;
 import org.infinispan.query.remote.client.QueryRequest;
 import org.infinispan.query.remote.client.QueryResponse;
 import org.infinispan.query.remote.impl.logging.Log;
@@ -51,7 +51,7 @@ public final class QueryFacadeImpl implements QueryFacade {
          int maxResults = request.getMaxResults() == null ? -1 : request.getMaxResults();
 
          // create the query
-         BaseQuery q = queryEngine.makeQuery(request.getQueryString(), request.getNamedParametersMap(), startOffset, maxResults);
+         Query q = queryEngine.makeQuery(request.getQueryString(), request.getNamedParametersMap(), startOffset, maxResults);
 
          // execute query and make the response object
          QueryResponse response = makeResponse(q);
@@ -64,7 +64,7 @@ public final class QueryFacadeImpl implements QueryFacade {
       }
    }
 
-   private QueryResponse makeResponse(BaseQuery query) {
+   private QueryResponse makeResponse(Query query) {
       List<?> list = query.list();
       int numResults = list.size();
       String[] projection = query.getProjection();

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/QueryFacadeImpl.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/QueryFacadeImpl.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.infinispan.AdvancedCache;
 import org.infinispan.commons.logging.LogFactory;
 import org.infinispan.protostream.WrappedMessage;
+import org.infinispan.query.dsl.IndexedQueryMode;
 import org.infinispan.query.dsl.Query;
 import org.infinispan.query.remote.client.QueryRequest;
 import org.infinispan.query.remote.client.QueryResponse;
@@ -51,7 +52,11 @@ public final class QueryFacadeImpl implements QueryFacade {
          int maxResults = request.getMaxResults() == null ? -1 : request.getMaxResults();
 
          // create the query
-         Query q = queryEngine.makeQuery(request.getQueryString(), request.getNamedParametersMap(), startOffset, maxResults);
+         IndexedQueryMode queryMode = IndexedQueryMode.FETCH;
+         if (request.getIndexedQueryMode() != null) {
+            queryMode = IndexedQueryMode.valueOf(request.getIndexedQueryMode());
+         }
+         Query q = queryEngine.makeQuery(request.getQueryString(), request.getNamedParametersMap(), startOffset, maxResults, queryMode);
 
          // execute query and make the response object
          QueryResponse response = makeResponse(q);

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/RemoteQueryDefinition.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/RemoteQueryDefinition.java
@@ -1,0 +1,22 @@
+package org.infinispan.query.remote.impl;
+
+import org.hibernate.search.query.engine.spi.HSQuery;
+import org.infinispan.AdvancedCache;
+import org.infinispan.query.QueryDefinition;
+import org.infinispan.query.dsl.embedded.impl.QueryEngine;
+
+public class RemoteQueryDefinition extends QueryDefinition {
+
+   public RemoteQueryDefinition(String queryString) {
+      super(queryString);
+   }
+
+   public RemoteQueryDefinition(HSQuery query) {
+      super(query);
+   }
+
+   @Override
+   protected QueryEngine getQueryEngine(AdvancedCache<?, ?> cache) {
+      return cache.getComponentRegistry().getComponent(RemoteQueryManager.class).getQueryEngine();
+   }
+}

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/RemoteQueryDefinitionExternalizer.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/RemoteQueryDefinitionExternalizer.java
@@ -1,0 +1,36 @@
+package org.infinispan.query.remote.impl;
+
+import static org.infinispan.query.remote.impl.ExternalizerIds.REMOTE_QUERY_DEFINITION;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.hibernate.search.query.engine.spi.HSQuery;
+import org.infinispan.query.clustered.AbstractQueryDefinitionExternalizer;
+
+/**
+ * @since 9.2
+ */
+public class RemoteQueryDefinitionExternalizer extends AbstractQueryDefinitionExternalizer<RemoteQueryDefinition> {
+
+   @Override
+   public Set<Class<? extends RemoteQueryDefinition>> getTypeClasses() {
+      return Collections.singleton(RemoteQueryDefinition.class);
+   }
+
+   @Override
+   public Integer getId() {
+      return REMOTE_QUERY_DEFINITION;
+   }
+
+   @Override
+   protected RemoteQueryDefinition createQueryDefinition(String q) {
+      return new RemoteQueryDefinition(q);
+   }
+
+   @Override
+   protected RemoteQueryDefinition createQueryDefinition(HSQuery hsQuery) {
+      return new RemoteQueryDefinition(hsQuery);
+   }
+
+}

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/RemoteQueryEngine.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/RemoteQueryEngine.java
@@ -3,13 +3,13 @@ package org.infinispan.query.remote.impl;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
-import org.hibernate.search.query.engine.spi.HSQuery;
 import org.hibernate.search.spi.CustomTypeMetadata;
 import org.hibernate.search.spi.IndexedTypeMap;
 import org.hibernate.search.spi.impl.IndexedTypeMaps;
@@ -22,7 +22,6 @@ import org.infinispan.query.CacheQuery;
 import org.infinispan.query.dsl.IndexedQueryMode;
 import org.infinispan.query.dsl.embedded.impl.IckleFilterAndConverter;
 import org.infinispan.query.dsl.embedded.impl.RowProcessor;
-import org.infinispan.query.impl.SearchManagerImpl;
 import org.infinispan.query.remote.impl.filter.IckleProtobufFilterAndConverter;
 import org.infinispan.query.remote.impl.indexing.IndexingMetadata;
 import org.infinispan.query.remote.impl.indexing.ProtobufValueWrapper;
@@ -91,13 +90,16 @@ final class RemoteQueryEngine extends BaseRemoteQueryEngine {
 
    @Override
    protected CacheQuery<?> makeCacheQuery(IckleParsingResult<Descriptor> ickleParsingResult, Query luceneQuery, IndexedQueryMode queryMode) {
-      CustomTypeMetadata customTypeMetadata = () -> {
-         IndexingMetadata indexingMetadata = ickleParsingResult.getTargetEntityMetadata().getProcessedAnnotation(IndexingMetadata.INDEXED_ANNOTATION);
-         return indexingMetadata != null ? indexingMetadata.getSortableFields() : Collections.emptySet();
-      };
-      IndexedTypeMap<CustomTypeMetadata> queryMetadata = IndexedTypeMaps.singletonMapping(ProtobufValueWrapper.INDEXING_TYPE, customTypeMetadata);
-      HSQuery hSearchQuery = getSearchFactory().createHSQuery(luceneQuery, queryMetadata);
-      return ((SearchManagerImpl) getSearchManager()).getQuery(hSearchQuery);
+      IndexingMetadata indexingMetadata = ickleParsingResult.getTargetEntityMetadata().getProcessedAnnotation(IndexingMetadata.INDEXED_ANNOTATION);
+      final Set<String> sortableFields = indexingMetadata != null ? indexingMetadata.getSortableFields() : Collections.emptySet();
+      IndexedTypeMap<CustomTypeMetadata> queryMetadata = IndexedTypeMaps.singletonMapping(ProtobufValueWrapper.INDEXING_TYPE, () -> sortableFields);
+      RemoteQueryDefinition queryDefinition;
+      if (queryMode == IndexedQueryMode.BROADCAST) {
+         queryDefinition = new RemoteQueryDefinition(ickleParsingResult.getQueryString());
+      } else {
+         queryDefinition = new RemoteQueryDefinition(getSearchFactory().createHSQuery(luceneQuery, queryMetadata));
+      }
+      return getSearchManager().getQuery(queryDefinition, queryMode, queryMetadata);
    }
 
    @Override

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/RemoteQueryEngine.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/RemoteQueryEngine.java
@@ -89,7 +89,7 @@ final class RemoteQueryEngine extends BaseRemoteQueryEngine {
    }
 
    @Override
-   protected CacheQuery<?> makeCacheQuery(IckleParsingResult<Descriptor> ickleParsingResult, Query luceneQuery, IndexedQueryMode queryMode) {
+   protected CacheQuery<?> makeCacheQuery(IckleParsingResult<Descriptor> ickleParsingResult, Query luceneQuery, IndexedQueryMode queryMode, Map<String, Object> namedParameters) {
       IndexingMetadata indexingMetadata = ickleParsingResult.getTargetEntityMetadata().getProcessedAnnotation(IndexingMetadata.INDEXED_ANNOTATION);
       final Set<String> sortableFields = indexingMetadata != null ? indexingMetadata.getSortableFields() : Collections.emptySet();
       IndexedTypeMap<CustomTypeMetadata> queryMetadata = IndexedTypeMaps.singletonMapping(ProtobufValueWrapper.INDEXING_TYPE, () -> sortableFields);
@@ -99,6 +99,7 @@ final class RemoteQueryEngine extends BaseRemoteQueryEngine {
       } else {
          queryDefinition = new RemoteQueryDefinition(getSearchFactory().createHSQuery(luceneQuery, queryMetadata));
       }
+      queryDefinition.setNamedParameters(namedParameters);
       return getSearchManager().getQuery(queryDefinition, queryMode, queryMetadata);
    }
 

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/RemoteQueryEngine.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/RemoteQueryEngine.java
@@ -19,6 +19,7 @@ import org.infinispan.objectfilter.impl.ProtobufMatcher;
 import org.infinispan.objectfilter.impl.syntax.parser.IckleParsingResult;
 import org.infinispan.protostream.descriptors.Descriptor;
 import org.infinispan.query.CacheQuery;
+import org.infinispan.query.dsl.IndexedQueryMode;
 import org.infinispan.query.dsl.embedded.impl.IckleFilterAndConverter;
 import org.infinispan.query.dsl.embedded.impl.RowProcessor;
 import org.infinispan.query.impl.SearchManagerImpl;
@@ -89,7 +90,7 @@ final class RemoteQueryEngine extends BaseRemoteQueryEngine {
    }
 
    @Override
-   protected CacheQuery<?> makeCacheQuery(IckleParsingResult<Descriptor> ickleParsingResult, Query luceneQuery) {
+   protected CacheQuery<?> makeCacheQuery(IckleParsingResult<Descriptor> ickleParsingResult, Query luceneQuery, IndexedQueryMode queryMode) {
       CustomTypeMetadata customTypeMetadata = () -> {
          IndexingMetadata indexingMetadata = ickleParsingResult.getTargetEntityMetadata().getProcessedAnnotation(IndexingMetadata.INDEXED_ANNOTATION);
          return indexingMetadata != null ? indexingMetadata.getSortableFields() : Collections.emptySet();

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/RemoteQueryManager.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/RemoteQueryManager.java
@@ -4,8 +4,9 @@ import java.util.List;
 
 import org.infinispan.commons.dataconversion.Encoder;
 import org.infinispan.objectfilter.Matcher;
+import org.infinispan.query.dsl.IndexedQueryMode;
+import org.infinispan.query.dsl.Query;
 import org.infinispan.query.dsl.embedded.impl.QueryEngine;
-import org.infinispan.query.dsl.impl.BaseQuery;
 import org.infinispan.query.remote.client.FilterResult;
 import org.infinispan.query.remote.client.QueryRequest;
 import org.infinispan.query.remote.client.QueryResponse;
@@ -62,11 +63,11 @@ public interface RemoteQueryManager {
       return results;
    }
 
-   default RemoteQueryResult executeQuery(String q, Integer offset, Integer maxResults) {
-      BaseQuery baseQuery = getQueryEngine().makeQuery(q, null, offset, maxResults);
-      List<Object> results = baseQuery.list();
-      String[] projection = baseQuery.getProjection();
-      int totalResults = baseQuery.getResultSize();
+   default RemoteQueryResult executeQuery(String q, Integer offset, Integer maxResults, IndexedQueryMode queryMode) {
+      Query query = getQueryEngine().makeQuery(q, null, offset, maxResults, queryMode);
+      List<Object> results = query.list();
+      String[] projection = query.getProjection();
+      int totalResults = query.getResultSize();
       if (projection == null) {
          return new RemoteQueryResult(null, totalResults, encodeQueryResults(results));
       } else {

--- a/server/rest/src/main/java/org/infinispan/rest/JSONConstants.java
+++ b/server/rest/src/main/java/org/infinispan/rest/JSONConstants.java
@@ -11,6 +11,7 @@ public interface JSONConstants {
    String HITS = "hits";
    String MAX_RESULTS = "max_results";
    String OFFSET = "offset";
+   String QUERY_MODE = "query_mode";
    String QUERY_STRING = "query";
    String TOTAL_RESULTS = "total_results";
    String TYPE = "_type";

--- a/server/rest/src/main/java/org/infinispan/rest/operations/SearchOperations.java
+++ b/server/rest/src/main/java/org/infinispan/rest/operations/SearchOperations.java
@@ -34,7 +34,7 @@ public class SearchOperations extends AbstractOperations {
       String queryString = query.getQuery();
       try {
          RemoteQueryManager remoteQueryManager = cache.getComponentRegistry().getComponent(RemoteQueryManager.class);
-         RemoteQueryResult remoteQueryResult = remoteQueryManager.executeQuery(queryString, query.getStartOffset(), query.getMaxResults());
+         RemoteQueryResult remoteQueryResult = remoteQueryManager.executeQuery(queryString, query.getStartOffset(), query.getMaxResults(), query.getQueryMode());
          int totalResults = remoteQueryResult.getTotalResults();
          List<Object> results = remoteQueryResult.getResults();
          String[] projections = remoteQueryResult.getProjections();

--- a/server/rest/src/main/java/org/infinispan/rest/search/InfinispanSearchRequest.java
+++ b/server/rest/src/main/java/org/infinispan/rest/search/InfinispanSearchRequest.java
@@ -2,6 +2,7 @@ package org.infinispan.rest.search;
 
 import static org.infinispan.rest.JSONConstants.MAX_RESULTS;
 import static org.infinispan.rest.JSONConstants.OFFSET;
+import static org.infinispan.rest.JSONConstants.QUERY_MODE;
 import static org.infinispan.rest.JSONConstants.QUERY_STRING;
 
 import java.io.IOException;
@@ -10,6 +11,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.codehaus.jackson.map.ObjectMapper;
+import org.infinispan.query.dsl.IndexedQueryMode;
 import org.infinispan.rest.InfinispanRequest;
 import org.infinispan.rest.operations.SearchOperations;
 import org.infinispan.rest.operations.exceptions.NoCacheFoundException;
@@ -53,19 +55,26 @@ public class InfinispanSearchRequest extends InfinispanRequest {
       }
    }
 
-
    private QueryRequest getQueryRequest() throws IOException {
       QueryRequest queryRequest = null;
       if (request.method() == HttpMethod.GET) {
-         String queryString = getParameterValue(QUERY_STRING);
-         String strOffset = getParameterValue(OFFSET);
-         Integer offset = strOffset != null ? Integer.valueOf(strOffset) : null;
-         String strMaxResults = getParameterValue(MAX_RESULTS);
-         Integer maxResults = strMaxResults != null ? Integer.valueOf(strMaxResults) : null;
-         queryRequest = new QueryRequest(queryString, offset, maxResults);
+         queryRequest = getQueryFromString();
       } else if (request.method() == HttpMethod.POST || request.method() == HttpMethod.PUT) {
          queryRequest = getQueryFromJSON();
       }
+      return queryRequest;
+   }
+
+   private QueryRequest getQueryFromString() {
+      QueryRequest queryRequest;
+      String queryString = getParameterValue(QUERY_STRING);
+      String strOffset = getParameterValue(OFFSET);
+      String queryMode = getParameterValue(QUERY_MODE);
+      Integer offset = strOffset != null ? Integer.valueOf(strOffset) : null;
+      String strMaxResults = getParameterValue(MAX_RESULTS);
+      Integer maxResults = strMaxResults != null ? Integer.valueOf(strMaxResults) : null;
+      IndexedQueryMode qm = queryMode == null ? IndexedQueryMode.FETCH : IndexedQueryMode.valueOf(queryMode);
+      queryRequest = new QueryRequest(queryString, offset, maxResults, qm);
       return queryRequest;
    }
 

--- a/server/rest/src/main/java/org/infinispan/rest/search/QueryRequest.java
+++ b/server/rest/src/main/java/org/infinispan/rest/search/QueryRequest.java
@@ -2,9 +2,11 @@ package org.infinispan.rest.search;
 
 import static org.infinispan.rest.JSONConstants.MAX_RESULTS;
 import static org.infinispan.rest.JSONConstants.OFFSET;
+import static org.infinispan.rest.JSONConstants.QUERY_MODE;
 import static org.infinispan.rest.JSONConstants.QUERY_STRING;
 
 import org.codehaus.jackson.annotate.JsonProperty;
+import org.infinispan.query.dsl.IndexedQueryMode;
 
 /**
  * @since 9.2
@@ -24,16 +26,18 @@ public class QueryRequest {
    @JsonProperty(MAX_RESULTS)
    private final Integer maxResults;
 
-   QueryRequest(String query, Integer startOffset, Integer maxResults) {
+   @JsonProperty(QUERY_MODE)
+   private IndexedQueryMode queryMode;
+
+   QueryRequest(String query, Integer startOffset, Integer maxResults, IndexedQueryMode queryMode) {
       this.query = query;
       this.startOffset = startOffset == null ? DEFAULT_OFFSET : startOffset;
       this.maxResults = maxResults == null ? DEFAULT_MAX_RESULTS : maxResults;
+      this.queryMode = queryMode;
    }
 
    private QueryRequest(String query) {
-      this.query = query;
-      this.startOffset = DEFAULT_OFFSET;
-      this.maxResults = DEFAULT_MAX_RESULTS;
+      this(query, DEFAULT_OFFSET, DEFAULT_MAX_RESULTS, IndexedQueryMode.FETCH);
    }
 
    private QueryRequest() {
@@ -50,5 +54,9 @@ public class QueryRequest {
 
    public Integer getMaxResults() {
       return maxResults;
+   }
+
+   public IndexedQueryMode getQueryMode() {
+      return queryMode;
    }
 }

--- a/server/rest/src/test/java/org/infinispan/rest/helper/RestServerHelper.java
+++ b/server/rest/src/test/java/org/infinispan/rest/helper/RestServerHelper.java
@@ -25,7 +25,7 @@ public class RestServerHelper {
    private Authenticator authenticator = new VoidAuthenticator();
    private String host;
 
-   private RestServerHelper(EmbeddedCacheManager cacheManager) {
+   public RestServerHelper(EmbeddedCacheManager cacheManager) {
       this.cacheManager = cacheManager;
       restServerConfigurationBuilder.host("localhost").port(0).maxContentLength(1_000_000);
    }

--- a/server/rest/src/test/java/org/infinispan/rest/search/CompatNonIndexedDefaultMarshallerTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/search/CompatNonIndexedDefaultMarshallerTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.rest.search;
 
+import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.testng.annotations.Test;
 
@@ -13,7 +14,7 @@ public class CompatNonIndexedDefaultMarshallerTest extends BaseRestSearchTest {
 
    @Override
    ConfigurationBuilder getConfigBuilder() {
-      ConfigurationBuilder configurationBuilder = new ConfigurationBuilder();
+      ConfigurationBuilder configurationBuilder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC);
       configurationBuilder.compatibility().enable();
       return configurationBuilder;
    }

--- a/server/rest/src/test/java/org/infinispan/rest/search/IndexedRestOffHeapSearch.java
+++ b/server/rest/src/test/java/org/infinispan/rest/search/IndexedRestOffHeapSearch.java
@@ -1,8 +1,10 @@
 package org.infinispan.rest.search;
 
+import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.Index;
 import org.infinispan.configuration.cache.StorageType;
+import org.infinispan.query.indexmanager.InfinispanIndexManager;
 import org.testng.annotations.Test;
 
 /**
@@ -15,10 +17,10 @@ public class IndexedRestOffHeapSearch extends BaseRestSearchTest {
 
    @Override
    ConfigurationBuilder getConfigBuilder() {
-      ConfigurationBuilder configurationBuilder = new ConfigurationBuilder();
+      ConfigurationBuilder configurationBuilder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC);
       configurationBuilder.indexing()
             .index(Index.PRIMARY_OWNER)
-            .addProperty("default.directory_provider", "ram");
+            .addProperty("default.indexmanager", InfinispanIndexManager.class.getName());
       configurationBuilder.memory().storageType(StorageType.OFF_HEAP);
       return configurationBuilder;
    }

--- a/server/rest/src/test/java/org/infinispan/rest/search/IndexedRestSearchTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/search/IndexedRestSearchTest.java
@@ -1,7 +1,9 @@
 package org.infinispan.rest.search;
 
+import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.Index;
+import org.infinispan.query.indexmanager.InfinispanIndexManager;
 import org.testng.annotations.Test;
 
 /**
@@ -14,10 +16,10 @@ public class IndexedRestSearchTest extends BaseRestSearchTest {
 
    @Override
    ConfigurationBuilder getConfigBuilder() {
-      ConfigurationBuilder configurationBuilder = new ConfigurationBuilder();
+      ConfigurationBuilder configurationBuilder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC);
       configurationBuilder.indexing()
             .index(Index.PRIMARY_OWNER)
-            .addProperty("default.directory_provider", "ram");
+            .addProperty("default.indexmanager", InfinispanIndexManager.class.getName());
       return configurationBuilder;
    }
 

--- a/server/rest/src/test/java/org/infinispan/rest/search/NonIndexedRestOffHeapSearch.java
+++ b/server/rest/src/test/java/org/infinispan/rest/search/NonIndexedRestOffHeapSearch.java
@@ -1,6 +1,7 @@
 package org.infinispan.rest.search;
 
 import org.infinispan.commons.dataconversion.MediaType;
+import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.StorageType;
 import org.testng.annotations.Test;
@@ -13,7 +14,7 @@ public class NonIndexedRestOffHeapSearch extends BaseRestSearchTest {
 
    @Override
    ConfigurationBuilder getConfigBuilder() {
-      ConfigurationBuilder configurationBuilder = new ConfigurationBuilder();
+      ConfigurationBuilder configurationBuilder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC);
       configurationBuilder.encoding().key().mediaType(MediaType.APPLICATION_PROTOSTREAM_TYPE);
       configurationBuilder.encoding().value().mediaType(MediaType.APPLICATION_PROTOSTREAM_TYPE);
       configurationBuilder.memory().storageType(StorageType.OFF_HEAP);

--- a/server/rest/src/test/java/org/infinispan/rest/search/NonIndexedRestSearchTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/search/NonIndexedRestSearchTest.java
@@ -1,6 +1,7 @@
 package org.infinispan.rest.search;
 
 import org.infinispan.commons.dataconversion.MediaType;
+import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.testng.annotations.Test;
 
@@ -12,7 +13,7 @@ public class NonIndexedRestSearchTest extends BaseRestSearchTest {
 
    @Override
    ConfigurationBuilder getConfigBuilder() {
-      ConfigurationBuilder configurationBuilder = new ConfigurationBuilder();
+      ConfigurationBuilder configurationBuilder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC);
       configurationBuilder.encoding().key().mediaType(MediaType.APPLICATION_PROTOSTREAM_TYPE);
       configurationBuilder.encoding().value().mediaType(MediaType.APPLICATION_PROTOSTREAM_TYPE);
       return configurationBuilder;

--- a/server/rest/src/test/java/org/infinispan/rest/search/NonSharedIndexSearchTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/search/NonSharedIndexSearchTest.java
@@ -1,0 +1,30 @@
+package org.infinispan.rest.search;
+
+import static org.infinispan.query.dsl.IndexedQueryMode.BROADCAST;
+
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.cache.Index;
+import org.infinispan.query.dsl.IndexedQueryMode;
+import org.testng.annotations.Test;
+
+/**
+ * Test for indexed search over Rest when using a non-shared index.
+ *
+ * @since 9.2
+ */
+@Test(groups = "functional", testName = "rest.NonSharedIndexSearchTest")
+public class NonSharedIndexSearchTest extends BaseRestSearchTest {
+
+   @Override
+   ConfigurationBuilder getConfigBuilder() {
+      ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC);
+      builder.indexing().index(Index.PRIMARY_OWNER).addProperty("default.directory_provider", "local-heap");
+      return builder;
+   }
+
+   @Override
+   IndexedQueryMode getQueryMode() {
+      return BROADCAST;
+   }
+}

--- a/server/rest/src/test/java/org/infinispan/rest/search/SingleNodeLocalIndexTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/search/SingleNodeLocalIndexTest.java
@@ -1,0 +1,27 @@
+package org.infinispan.rest.search;
+
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.cache.Index;
+import org.testng.annotations.Test;
+
+/**
+ * @since 9.2
+ */
+@Test(groups = "functional", testName = "rest.SingleNodeLocalIndexTest")
+public class SingleNodeLocalIndexTest extends BaseRestSearchTest {
+
+   @Override
+   ConfigurationBuilder getConfigBuilder() {
+      ConfigurationBuilder configurationBuilder = new ConfigurationBuilder();
+      configurationBuilder.clustering().cacheMode(CacheMode.LOCAL);
+      configurationBuilder.indexing().index(Index.ALL)
+            .addProperty("default.directory_provider", "local-heap");
+      return configurationBuilder;
+   }
+
+   @Override
+   protected int getNumNodes() {
+      return 1;
+   }
+}

--- a/server/rest/src/test/java/org/infinispan/rest/search/entity/Address.java
+++ b/server/rest/src/test/java/org/infinispan/rest/search/entity/Address.java
@@ -1,10 +1,14 @@
 package org.infinispan.rest.search.entity;
 
+import java.io.Serializable;
+
+import org.infinispan.marshall.core.ExternalPojo;
+
 /**
  * @since 9.2
  */
 @SuppressWarnings("unused")
-public class Address {
+public class Address implements Serializable, ExternalPojo {
 
    private String street;
    private String postCode;

--- a/server/rest/src/test/java/org/infinispan/rest/search/entity/Gender.java
+++ b/server/rest/src/test/java/org/infinispan/rest/search/entity/Gender.java
@@ -1,10 +1,14 @@
 package org.infinispan.rest.search.entity;
 
+import java.io.Serializable;
+
+import org.infinispan.marshall.core.ExternalPojo;
+
 /**
  * @since 9.2
  */
 @SuppressWarnings("unused")
-public enum Gender {
+public enum Gender implements Serializable, ExternalPojo {
    MALE,
    FEMALE
 }

--- a/server/rest/src/test/java/org/infinispan/rest/search/entity/Person.java
+++ b/server/rest/src/test/java/org/infinispan/rest/search/entity/Person.java
@@ -1,18 +1,20 @@
 package org.infinispan.rest.search.entity;
 
+import java.io.Serializable;
 import java.util.Set;
 
 import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.Indexed;
 import org.hibernate.search.annotations.IndexedEmbedded;
 import org.hibernate.search.annotations.NumericField;
+import org.infinispan.marshall.core.ExternalPojo;
 
 /**
  * @since 9.2
  */
 @Indexed
 @SuppressWarnings("unused")
-public class Person {
+public class Person implements Serializable, ExternalPojo {
 
    @Field
    private Integer id;

--- a/server/rest/src/test/java/org/infinispan/rest/search/entity/PhoneNumber.java
+++ b/server/rest/src/test/java/org/infinispan/rest/search/entity/PhoneNumber.java
@@ -1,10 +1,14 @@
 package org.infinispan.rest.search.entity;
 
+import java.io.Serializable;
+
+import org.infinispan.marshall.core.ExternalPojo;
+
 /**
  * @since 9.2
  */
 @SuppressWarnings("unused")
-public class PhoneNumber {
+public class PhoneNumber implements Serializable, ExternalPojo {
 
    private String number;
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6395

~Preview, just to gather feedback (from @anistor mainly) on the backwards compatible API changes.~

This PR introduces a ```IndexQueryQueryMode``` that specifies **how an indexed query is executed**. BROADCAST mean the query is sent to all nodes (and results aggregated), while ~CALLER~ FETCH (the default) executes the query directly (thus needs a distributed index to work).

Why is this relevant? Because with BROADCAST, each node can index its own data on its own index, so both indexing and querying is way more scalable than having a single global index handled by the ```InfinispanIndexManager```