### PR TITLE
ISPN-8538 TwoWaySplitAndMerge[DIST_SYNC] deadlock in conflict resolution

### DIFF
--- a/core/src/main/java/org/infinispan/conflict/impl/DefaultConflictManager.java
+++ b/core/src/main/java/org/infinispan/conflict/impl/DefaultConflictManager.java
@@ -460,7 +460,6 @@ public class DefaultConflictManager<K, V> implements InternalConflictManager<K, 
                   Thread.currentThread().interrupt();
                   throw new CacheException(e);
                } catch (ExecutionException | CancellationException e) {
-                  stateReceiver.stop();
                   throw new CacheException(e.getMessage(), e.getCause());
                }
             } else {


### PR DESCRIPTION
We shouldn't call StateReceiverImpl::stop in the
DefaultConflictManager.ReplicaSpliterator::tryAdvance when a
Cancellation/Execution Exception occurs as failed requests are already
cancelled on an exception in StateReceiverImpl.