### PR TITLE
ISPN-8538 TwoWaySplitAndMerge[DIST_SYNC] deadlock in conflict resolution

### DIFF
--- a/core/src/main/java/org/infinispan/conflict/impl/DefaultConflictManager.java
+++ b/core/src/main/java/org/infinispan/conflict/impl/DefaultConflictManager.java
@@ -460,7 +460,6 @@ public class DefaultConflictManager<K, V> implements InternalConflictManager<K, 
                   Thread.currentThread().interrupt();
                   throw new CacheException(e);
                } catch (ExecutionException | CancellationException e) {
-                  stateReceiver.stop();
                   throw new CacheException(e.getMessage(), e.getCause());
                }
             } else {


### PR DESCRIPTION
Deadlock caused by StateReceiverImpl::stop synchronizing on
StateReceiverImpl.this, but then attempting to cancel a
StateRequestImpl.SegmentRequest whoms cancel() method synchs on itself.
However, a SegmentRequest can also be cancelled by another thread
when a CompletableFuture completes exceptionally. This results in
Thread-A acquiring StateReceiverImpl.this in StateReceiverImpl::stop and
calling SegmentRequest::cancel, however Thread-B has called SegmentRequest::cancel and
is now waiting to synchronize on StateReceiverImpl.this, hence deadlock.

Also, we shouldn't call StateReceiverImpl::stop in the
DefaultConflictManager.ReplicaSpliterator::tryAdvance when a
Cancellation/Execution Exception occurs as failed requests are already
cancelled on an exception in StateReceiverImpl.

https://issues.jboss.org/browse/ISPN-8538