### PR TITLE
ISPN-8525 StaleLocksWithLockOnlyTxDuringStateTransferTest.testSync fa…

### DIFF
--- a/core/src/test/java/org/infinispan/statetransfer/StaleLocksWithLockOnlyTxDuringStateTransferTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StaleLocksWithLockOnlyTxDuringStateTransferTest.java
@@ -77,7 +77,9 @@ public class StaleLocksWithLockOnlyTxDuringStateTransferTest extends MultipleCac
                   .withMatcher(1, new CacheTopologyMatcher(finalTopologyId)).build())
             .before("st:block_ch_update_on_0", "st:resume_ch_update_on_0");
       advanceOnGlobalComponentMethod(sequencer, manager(1), LocalTopologyManager.class,
-            matchMethodCall("handleTopologyUpdate").withMatcher(1, new CacheTopologyMatcher(finalTopologyId)).build())
+            matchMethodCall("handleTopologyUpdate")
+               .withMatcher(0, CoreMatchers.equalTo(CACHE_NAME))
+               .withMatcher(1, new CacheTopologyMatcher(finalTopologyId)).build())
             .before("st:block_ch_update_on_1", "st:resume_ch_update_on_1");
 
       // Start cache 1, but the state request will be blocked on cache 0


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-8525

Missed the second handleTopologyUpdate matcher