### PR TITLE
ISPN-8557 Test that REST can delete entries created directly

### DIFF
--- a/server/rest/src/test/java/org/infinispan/rest/RestOperationsTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/RestOperationsTest.java
@@ -2,8 +2,10 @@ package org.infinispan.rest;
 
 import static org.infinispan.rest.JSONConstants.TYPE;
 
+import org.assertj.core.api.Assertions;
 import org.eclipse.jetty.client.api.ContentResponse;
 import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpMethod;
 import org.infinispan.Cache;
 import org.infinispan.commons.dataconversion.IdentityEncoder;
 import org.infinispan.commons.dataconversion.MediaType;
@@ -197,4 +199,18 @@ public class RestOperationsTest extends BaseRestOperationsTest {
       ResponseAssertion.assertThat(response).isOk();
    }
 
+   @Test
+   public void shouldDeleteExistingValueEvenWithoutMetadata() throws Exception {
+      putValueInCache("default", "test", "test");
+
+      //when
+      ContentResponse response = client
+            .newRequest(String.format("http://localhost:%d/rest/%s/%s", restServer.getPort(), "default", "test"))
+            .method(HttpMethod.DELETE)
+            .send();
+
+      //then
+      ResponseAssertion.assertThat(response).isOk();
+      Assertions.assertThat(restServer.getCacheManager().getCache("default")).isEmpty();
+   }
 }


### PR DESCRIPTION
Extracted the test from https://github.com/infinispan/infinispan/pull/5608 for master

https://github.com/infinispan/infinispan/pull/5608