### PR TITLE
 ISPN-8555 Fix deadlock in CacheManagerTest

### DIFF
--- a/core/src/main/java/org/infinispan/distribution/LocalizedCacheTopology.java
+++ b/core/src/main/java/org/infinispan/distribution/LocalizedCacheTopology.java
@@ -17,6 +17,7 @@ import org.infinispan.distribution.ch.KeyPartitioner;
 import org.infinispan.distribution.ch.impl.ReplicatedConsistentHash;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.topology.CacheTopology;
+import org.infinispan.util.RangeSet;
 
 /**
  * Extends {@link CacheTopology} with information about keys owned by the local node.
@@ -35,6 +36,7 @@ public class LocalizedCacheTopology extends CacheTopology {
    private final int maxOwners;
    private final DistributionInfo[] distributionInfos;
    private final boolean isScattered;
+   private final Set<Integer> localReadSegments;
 
    public static LocalizedCacheTopology makeSingletonTopology(CacheMode cacheMode, Address localAddress) {
       List<Address> members = Collections.singletonList(localAddress);
@@ -59,9 +61,11 @@ public class LocalizedCacheTopology extends CacheTopology {
       boolean isReplicated = cacheMode.isReplicated();
       this.isSegmented = isDistributed || isReplicated || isScattered;
       this.numSegments = readCH.getNumSegments();
+
       if (isDistributed || isScattered) {
          this.distributionInfos = new DistributionInfo[numSegments];
          int maxOwners = 1;
+         Set<Integer> localReadSegments = new SmallIntSet(numSegments);
          for (int segmentId = 0; segmentId < numSegments; segmentId++) {
             Address primary = readCH.locatePrimaryOwnerForSegment(segmentId);
             List<Address> readOwners = readCH.locateOwnersForSegment(segmentId);
@@ -70,9 +74,13 @@ public class LocalizedCacheTopology extends CacheTopology {
             this.distributionInfos[segmentId] =
                   new DistributionInfo(segmentId, primary, readOwners, writeOwners, writeBackups, localAddress);
             maxOwners = Math.max(maxOwners, writeOwners.size());
+            if (readOwners.contains(localAddress)) {
+               localReadSegments.add(segmentId);
+            }
          }
          this.maxOwners = maxOwners;
          this.allLocal = false;
+         this.localReadSegments = Collections.unmodifiableSet(localReadSegments);
       } else if (isReplicated) {
          // Writes must be broadcast to the entire cluster
          Map<Address, List<Address>> readOwnersMap = new HashMap<>();
@@ -91,6 +99,7 @@ public class LocalizedCacheTopology extends CacheTopology {
          }
          this.maxOwners = cacheTopology.getMembers().size();
          this.allLocal = readOwnersMap.containsKey(localAddress);
+         this.localReadSegments = new RangeSet(allLocal ? numSegments : 0);
       } else { // Invalidation/Local
          assert cacheMode.isInvalidation() || cacheMode == CacheMode.LOCAL;
          // Reads and writes are local, only the invalidation is replicated
@@ -101,6 +110,7 @@ public class LocalizedCacheTopology extends CacheTopology {
          };
          this.maxOwners = 1;
          this.allLocal = true;
+         this.localReadSegments = new RangeSet(numSegments);
       }
    }
 
@@ -183,6 +193,13 @@ public class LocalizedCacheTopology extends CacheTopology {
       } else {
          return getDistributionForSegment(0).writeOwners();
       }
+   }
+
+   /**
+    * @return The segments owned by the local node for reading.
+    */
+   public Set<Integer> getLocalReadSegments() {
+      return localReadSegments;
    }
 
    /**

--- a/core/src/main/java/org/infinispan/statetransfer/StateTransferManager.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateTransferManager.java
@@ -43,6 +43,7 @@ public interface StateTransferManager {
     */
    boolean isStateTransferInProgressForKey(Object key);
 
+   @Deprecated
    CacheTopology getCacheTopology();
 
    void start() throws Exception;

--- a/core/src/main/java/org/infinispan/stream/impl/LocalStreamManagerImpl.java
+++ b/core/src/main/java/org/infinispan/stream/impl/LocalStreamManagerImpl.java
@@ -21,6 +21,8 @@ import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.context.Flag;
+import org.infinispan.distribution.DistributionManager;
+import org.infinispan.distribution.LocalizedCacheTopology;
 import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.factories.annotations.Inject;
@@ -31,8 +33,6 @@ import org.infinispan.notifications.cachelistener.annotation.DataRehashed;
 import org.infinispan.notifications.cachelistener.event.DataRehashedEvent;
 import org.infinispan.remoting.rpc.RpcManager;
 import org.infinispan.remoting.transport.Address;
-import org.infinispan.statetransfer.StateTransferManager;
-import org.infinispan.topology.CacheTopology;
 import org.infinispan.util.ByteString;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -50,7 +50,7 @@ public class LocalStreamManagerImpl<K, V> implements LocalStreamManager<K> {
 
    private AdvancedCache<K, V> cache;
    private ComponentRegistry registry;
-   private StateTransferManager stm;
+   private DistributionManager dm;
    private RpcManager rpc;
    private CommandsFactory factory;
    private boolean hasLoader;
@@ -103,7 +103,7 @@ public class LocalStreamManagerImpl<K, V> implements LocalStreamManager<K> {
    }
 
    @Inject
-   public void inject(Cache<K, V> cache, ComponentRegistry registry, StateTransferManager stm, RpcManager rpc,
+   public void inject(Cache<K, V> cache, ComponentRegistry registry, DistributionManager dm, RpcManager rpc,
            Configuration configuration, CommandsFactory factory) {
       // We need to unwrap the cache as a local stream should only deal with BOXED values and obviously only
       // with local entries.  Any mappings will be provided by the originator node in their intermediate operation
@@ -111,7 +111,7 @@ public class LocalStreamManagerImpl<K, V> implements LocalStreamManager<K> {
       this.cache = AbstractDelegatingCache.unwrapCache(cache).getAdvancedCache().withFlags(Flag.CACHE_MODE_LOCAL);
       this.cacheName = ByteString.fromString(cache.getName());
       this.registry = registry;
-      this.stm = stm;
+      this.dm = dm;
       this.rpc = rpc;
       this.factory = factory;
       this.hasLoader = configuration.persistence().usingStores();
@@ -194,7 +194,7 @@ public class LocalStreamManagerImpl<K, V> implements LocalStreamManager<K> {
    private Stream<CacheEntry<K, V>> getRehashStream(CacheSet<CacheEntry<K, V>> cacheEntrySet, Object requestId,
            SegmentListener listener, boolean parallelStream, Set<Integer> segments, Set<K> keysToInclude,
            Set<K> keysToExclude) {
-      CacheTopology topology = stm.getCacheTopology();
+      LocalizedCacheTopology topology = dm.getCacheTopology();
       if (trace) {
          log.tracef("Topology for supplier is %s for id %s", topology, requestId);
       }
@@ -206,10 +206,10 @@ public class LocalStreamManagerImpl<K, V> implements LocalStreamManager<K> {
          while (iterator.hasNext()) {
             Integer segment = iterator.next();
             // This is to ensure we only unbox the value once, as below will twice most times (happy path)
-            int intSegment = segment.intValue();
+            int intSegment = segment;
             // If the segment is not owned by both CHs we can't use it during rehash
-            if (!pendingCH.locateOwnersForSegment(intSegment).contains(localAddress)
-                    || !readCH.locateOwnersForSegment(intSegment).contains(localAddress)) {
+            if (!pendingCH.isSegmentLocalToNode(localAddress, intSegment)
+                    || !readCH.isSegmentLocalToNode(localAddress, intSegment)) {
                iterator.remove();
                lostSegments.add(segment);
             }
@@ -223,7 +223,7 @@ public class LocalStreamManagerImpl<K, V> implements LocalStreamManager<K> {
             log.tracef("Currently in the middle of a rehash for id %s", requestId);
          }
       } else {
-         Set<Integer> ourSegments = readCH.getSegmentsForOwner(localAddress);
+         Set<Integer> ourSegments = topology.getLocalReadSegments();
          if (segments.retainAll(ourSegments)) {
             if (trace) {
                log.tracef("We found to be missing some segments requested for id %s", requestId);

--- a/core/src/main/java/org/infinispan/topology/ClusterTopologyManagerImpl.java
+++ b/core/src/main/java/org/infinispan/topology/ClusterTopologyManagerImpl.java
@@ -453,7 +453,7 @@ public class ClusterTopologyManagerImpl implements ClusterTopologyManager {
          } else {
             availabilityStrategy = new PreferAvailabilityStrategy(eventLogManager, persistentUUIDManager, lostDataCheck, resolveConflictsOnMerge);
          }
-         Optional<GlobalStateManager> globalStateManager = cacheManager.getGlobalComponentRegistry().getOptionalComponent(GlobalStateManager.class);
+         Optional<GlobalStateManager> globalStateManager = gcr.getOptionalComponent(GlobalStateManager.class);
          Optional<ScopedPersistentState> persistedState = globalStateManager.flatMap(gsm -> gsm.readScopedState(cacheName));
          return new ClusterCacheStatus(cacheManager, cacheName, availabilityStrategy, RebalanceType.from(cacheMode),
                this, transport,

--- a/core/src/test/java/org/infinispan/distribution/TestAddress.java
+++ b/core/src/test/java/org/infinispan/distribution/TestAddress.java
@@ -1,5 +1,7 @@
 package org.infinispan.distribution;
 
+import java.util.Objects;
+
 import org.infinispan.remoting.transport.Address;
 
 /**
@@ -7,9 +9,9 @@ import org.infinispan.remoting.transport.Address;
  * @since 4.2
  */
 public class TestAddress implements Address {
-   final int addressNum;
+   private final int addressNum;
 
-   String name;
+   private String name;
 
    public void setName(String name) {
       this.name = name;
@@ -31,9 +33,7 @@ public class TestAddress implements Address {
 
       TestAddress that = (TestAddress) o;
 
-      if (addressNum != that.addressNum) return false;
-
-      return true;
+      return addressNum == that.addressNum && Objects.equals(name, that.name);
    }
 
    @Override

--- a/core/src/test/java/org/infinispan/manager/CacheManagerTest.java
+++ b/core/src/test/java/org/infinispan/manager/CacheManagerTest.java
@@ -260,11 +260,11 @@ public class CacheManagerTest extends AbstractInfinispanTest {
 
    public void testConcurrentCacheManagerStopAndGetCache() throws Exception {
       EmbeddedCacheManager manager = createCacheManager(false);
+      CompletableFuture<Void> cacheStartBlocked = new CompletableFuture<>();
+      CompletableFuture<Void> cacheStartResumed = new CompletableFuture<>();
+      CompletableFuture<Void> managerStopBlocked = new CompletableFuture<>();
+      CompletableFuture<Void> managerStopResumed = new CompletableFuture<>();
       try {
-         CompletableFuture<Void> cacheStartBlocked = new CompletableFuture<>();
-         CompletableFuture<Void> cacheStartResumed = new CompletableFuture<>();
-         CompletableFuture<Void> managerStopBlocked = new CompletableFuture<>();
-         CompletableFuture<Void> managerStopResumed = new CompletableFuture<>();
          manager.addListener(new MyListener(cacheStartBlocked, cacheStartResumed));
          TestingUtil.replaceComponent(manager, GlobalMarshaller.class, new GlobalMarshaller() {
             @Override
@@ -292,6 +292,11 @@ public class CacheManagerTest extends AbstractInfinispanTest {
          managerStopResumed.complete(null);
          managerStopFuture.get(10, SECONDS);
       } finally {
+         cacheStartBlocked.complete(null);
+         cacheStartResumed.complete(null);
+         managerStopBlocked.complete(null);
+         managerStopResumed.complete(null);
+
          TestingUtil.killCacheManagers(manager);
       }
    }

--- a/core/src/test/java/org/infinispan/remoting/transport/MockTransport.java
+++ b/core/src/test/java/org/infinispan/remoting/transport/MockTransport.java
@@ -1,0 +1,568 @@
+package org.infinispan.remoting.transport;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertNull;
+import static org.testng.AssertJUnit.assertTrue;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.infinispan.commands.ReplicableCommand;
+import org.infinispan.commons.util.Util;
+import org.infinispan.remoting.inboundhandler.DeliverOrder;
+import org.infinispan.remoting.responses.CacheNotFoundResponse;
+import org.infinispan.remoting.responses.ExceptionResponse;
+import org.infinispan.remoting.responses.Response;
+import org.infinispan.remoting.rpc.ResponseFilter;
+import org.infinispan.remoting.rpc.ResponseMode;
+import org.infinispan.remoting.transport.jgroups.SyncMapResponseCollector;
+import org.infinispan.topology.CacheTopologyControlCommand;
+import org.infinispan.util.concurrent.CompletableFutures;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+import org.infinispan.xsite.XSiteBackup;
+import org.infinispan.xsite.XSiteReplicateCommand;
+
+/**
+ * Mock implementation of {@link Transport} that allows intercepting remote calls and replying asynchronously.
+ * <p>
+ * TODO Allow blocking invocations until the test explicitly unblocks them
+ *
+ * @author Dan Berindei
+ * @since 9.2
+ */
+public class MockTransport implements Transport {
+   private static final Log log = LogFactory.getLog(MockTransport.class);
+
+   private final Address localAddress;
+   private final BlockingQueue<FutureRemoteInvocation> expectedInvocations = new LinkedBlockingDeque<>();
+   private final BlockingQueue<RecordedRemoteInvocation> recordedInvocations = new LinkedBlockingDeque<>();
+
+   private int viewId;
+   private List<Address> members;
+   private CompletableFuture<Void> nextViewFuture;
+
+   public MockTransport(Address localAddress) {
+      this.localAddress = localAddress;
+   }
+
+   public void init(int viewId, List<Address> members) {
+      this.viewId = viewId;
+      this.members = members;
+      this.nextViewFuture = new CompletableFuture<>();
+   }
+
+   public void updateView(int viewId, List<Address> members) {
+      this.viewId = viewId;
+      this.members = members;
+
+      CompletableFuture<Void> nextViewFuture = this.nextViewFuture;
+      this.nextViewFuture = new CompletableFuture<>();
+      nextViewFuture.complete(null);
+   }
+
+   /**
+    * Expect a command to be invoked remotely in the future.
+    * <p>
+    * The operations on the {@link FutureRemoteInvocation} return value are queued and they run on the
+    * actual {@link ResponseCollector} the command is invoked with.
+    * The test must still call {@link #verifyRemoteCommand(Class)}, and any exceptions thrown by the checker will be
+    * rethrown when calling a {@link RecordedRemoteInvocation} method.
+    */
+   public <T extends ReplicableCommand> FutureRemoteInvocation expectRemoteCommand(Class<T> expectedCommandClass,
+                                                                                   Consumer<T> checker) {
+      verifyNoMoreCommands();
+      FutureRemoteInvocation collector = new FutureRemoteInvocation(c -> {
+         T command = expectedCommandClass.cast(c);
+         checker.accept(command);
+      });
+      expectedInvocations.add(collector);
+      return collector;
+   }
+
+   /**
+    * Expect a command to be invoked remotely in the future.
+    * <p>
+    *
+    * @see #expectRemoteCommand(Class, Consumer)
+    */
+   public <T extends ReplicableCommand> FutureRemoteInvocation expectRemoteCommand(Class<T> expectedCommandClass) {
+      verifyNoMoreCommands();
+      FutureRemoteInvocation collector = new FutureRemoteInvocation(expectedCommandClass::cast);
+      expectedInvocations.add(collector);
+      return collector;
+   }
+
+   /**
+    * Expect a {@link CacheTopologyControlCommand} to be invoked remotely in the future.
+    *
+    * @see #expectRemoteCommand(Class, Consumer)
+    */
+   public FutureRemoteInvocation expectTopologyCommand(CacheTopologyControlCommand.Type type,
+                                                       Consumer<CacheTopologyControlCommand> checker) {
+      verifyNoMoreCommands();
+      FutureRemoteInvocation collector = new FutureRemoteInvocation(c -> {
+         CacheTopologyControlCommand topologyCommand = (CacheTopologyControlCommand) c;
+         assertEquals(type, topologyCommand.getType());
+         checker.accept(topologyCommand);
+      });
+      expectedInvocations.add(collector);
+      return collector;
+   }
+
+   /**
+    * Expect a {@link CacheTopologyControlCommand} to be invoked remotely in the future.
+    *
+    * @see #expectRemoteCommand(Class, Consumer)
+    */
+   public FutureRemoteInvocation expectTopologyCommand(CacheTopologyControlCommand.Type type) {
+      verifyNoMoreCommands();
+      FutureRemoteInvocation collector = new FutureRemoteInvocation(c -> {
+         CacheTopologyControlCommand topologyCommand = (CacheTopologyControlCommand) c;
+         assertEquals(type, topologyCommand.getType());
+      });
+      expectedInvocations.add(collector);
+      return collector;
+   }
+
+   /**
+    * Verify that a command was invoked remotely and send replies using the {@link RecordedRemoteInvocation} methods.
+    */
+   public <T extends ReplicableCommand> RecordedRemoteInvocation verifyRemoteCommand(Class<T> expectedCommandClass,
+                                                                                     Consumer<T> checker)
+      throws InterruptedException {
+      RecordedRemoteInvocation invocation = recordedInvocations.poll(10, TimeUnit.SECONDS);
+      assertNotNull("Timed out waiting for invocation", invocation);
+      T command = expectedCommandClass.cast(invocation.getCommand());
+      checker.accept(command);
+      return invocation;
+   }
+
+   /**
+    * Verify that a command was invoked remotely and send replies using the {@link RecordedRemoteInvocation} methods.
+    */
+   public <T extends ReplicableCommand> RecordedRemoteInvocation verifyRemoteCommand(Class<T> expectedCommandClass)
+      throws InterruptedException {
+      return verifyRemoteCommand(expectedCommandClass, c -> {});
+   }
+
+   /**
+    * Verify that a command was invoked remotely and send replies using the {@link RecordedRemoteInvocation} methods.
+    */
+   public RecordedRemoteInvocation verifyRemoteCommand() throws InterruptedException {
+      return verifyRemoteCommand(ReplicableCommand.class);
+   }
+
+   /**
+    * Verify that a command was invoked remotely and send replies using the {@link RecordedRemoteInvocation} methods.
+    */
+   public RecordedRemoteInvocation verifyTopologyCommand(CacheTopologyControlCommand.Type type)
+      throws InterruptedException {
+      return verifyTopologyCommand(type, c -> {});
+   }
+
+   /**
+    * Verify that a command was invoked remotely and send replies using the {@link RecordedRemoteInvocation} methods.
+    */
+   public RecordedRemoteInvocation verifyTopologyCommand(CacheTopologyControlCommand.Type type,
+                                                         Consumer<CacheTopologyControlCommand> checker)
+      throws InterruptedException {
+      RecordedRemoteInvocation invocation = recordedInvocations.poll(10, TimeUnit.SECONDS);
+      assertNotNull("Timed out waiting for invocation", invocation);
+      CacheTopologyControlCommand command = (CacheTopologyControlCommand) invocation.getCommand();
+      assertEquals(type, command.getType());
+      checker.accept(command);
+      return invocation;
+   }
+
+   /**
+    * Assert that all the commands already invoked remotely have been verified.
+    */
+   public void verifyNoMoreCommands() {
+      assertTrue("Unexpected remote invocations: " +
+                    recordedInvocations.stream().map(i -> i.getCommand().toString()).collect(Collectors.joining(", ")),
+                 recordedInvocations.isEmpty());
+   }
+
+   @Override
+   public Map<Address, Response> invokeRemotely(Collection<Address> recipients, ReplicableCommand rpcCommand,
+                                                ResponseMode mode, long timeout, ResponseFilter responseFilter,
+                                                DeliverOrder deliverOrder, boolean anycast)
+      throws Exception {
+      Collection<Address> targets = recipients != null ? recipients : members;
+      if (mode == ResponseMode.ASYNCHRONOUS) {
+         addInvocation(rpcCommand, new SyncMapResponseCollector(false, targets.size()));
+         return Collections.emptyMap();
+      } else {
+         return addInvocationSync(rpcCommand, targets, shouldIgnoreLeavers(mode));
+      }
+   }
+
+   @Override
+   public CompletableFuture<Map<Address, Response>> invokeRemotelyAsync(Collection<Address> recipients,
+                                                                        ReplicableCommand rpcCommand, ResponseMode
+                                                                           mode, long timeout, ResponseFilter
+                                                                           responseFilter, DeliverOrder
+                                                                           deliverOrder, boolean anycast) {
+      Collection<Address> targets = recipients != null ? recipients : members;
+      SyncMapResponseCollector collector =
+         mode.isSynchronous() ? new SyncMapResponseCollector(shouldIgnoreLeavers(mode), targets.size()) : null;
+      return addInvocation(rpcCommand, collector);
+   }
+
+   @Override
+   public void sendTo(Address destination, ReplicableCommand rpcCommand, DeliverOrder deliverOrder) {
+      addInvocation(rpcCommand, null);
+   }
+
+   @Override
+   public void sendToMany(Collection<Address> destinations, ReplicableCommand rpcCommand, DeliverOrder deliverOrder) {
+      addInvocation(rpcCommand, null);
+   }
+
+   @Override
+   public Map<Address, Response> invokeRemotely(Map<Address, ReplicableCommand> rpcCommands, ResponseMode mode, long
+      timeout, boolean usePriorityQueue, ResponseFilter responseFilter, boolean totalOrder, boolean anycast) {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   public Map<Address, Response> invokeRemotely(Map<Address, ReplicableCommand> rpcCommands, ResponseMode mode, long
+      timeout, ResponseFilter responseFilter, DeliverOrder deliverOrder, boolean anycast) {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   public BackupResponse backupRemotely(Collection<XSiteBackup> backups, XSiteReplicateCommand rpcCommand) {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   public boolean isCoordinator() {
+      return localAddress.equals(members.get(0));
+   }
+
+   @Override
+   public Address getCoordinator() {
+      return members.get(0);
+   }
+
+   @Override
+   public Address getAddress() {
+      return localAddress;
+   }
+
+   @Override
+   public List<Address> getPhysicalAddresses() {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   public List<Address> getMembers() {
+      return members;
+   }
+
+   @Override
+   public boolean isMulticastCapable() {
+      return true;
+   }
+
+   @Override
+   public void start() {
+
+   }
+
+   @Override
+   public void stop() {
+
+   }
+
+   @Override
+   public int getViewId() {
+      return viewId;
+   }
+
+   @Override
+   public CompletableFuture<Void> withView(int expectedViewId) {
+      if (viewId <= expectedViewId) {
+         return CompletableFutures.completedNull();
+      }
+
+      return nextViewFuture.thenCompose(v -> withView(expectedViewId));
+   }
+
+   @Override
+   public void waitForView(int viewId) throws InterruptedException {
+      try {
+         withView(viewId).get();
+      } catch (ExecutionException e) {
+         throw new AssertionError(e);
+      }
+   }
+
+   @Override
+   public Log getLog() {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   public void checkTotalOrderSupported() {
+   }
+
+   @Override
+   public Set<String> getSitesView() {
+      return null;
+   }
+
+   @Override
+   public <T> CompletionStage<T> invokeCommand(Address target, ReplicableCommand command, ResponseCollector<T>
+      collector, DeliverOrder deliverOrder, long timeout, TimeUnit unit) {
+      return addInvocation(command, collector);
+   }
+
+   @Override
+   public <T> CompletionStage<T> invokeCommand(Collection<Address> targets, ReplicableCommand command,
+                                               ResponseCollector<T> collector, DeliverOrder deliverOrder, long
+                                                  timeout, TimeUnit unit) {
+      return addInvocation(command, collector);
+   }
+
+   @Override
+   public <T> CompletionStage<T> invokeCommandOnAll(ReplicableCommand command, ResponseCollector<T> collector,
+                                                    DeliverOrder deliverOrder, long timeout, TimeUnit unit) {
+      return addInvocation(command, collector);
+   }
+
+   @Override
+   public <T> CompletionStage<T> invokeCommandStaggered(Collection<Address> targets, ReplicableCommand command,
+                                                        ResponseCollector<T> collector, DeliverOrder deliverOrder,
+                                                        long timeout, TimeUnit unit) {
+      return addInvocation(command, collector);
+   }
+
+   @Override
+   public <T> CompletionStage<T> invokeCommands(Collection<Address> targets, Function<Address, ReplicableCommand>
+      commandGenerator, ResponseCollector<T> responseCollector, long timeout, DeliverOrder deliverOrder) {
+      throw new UnsupportedOperationException();
+   }
+
+   private <T> CompletableFuture<T> addInvocation(ReplicableCommand command, ResponseCollector<T> collector) {
+      FutureRemoteInvocation expectedInvocation = expectedInvocations.poll();
+      if (expectedInvocation != null) {
+         log.debugf("Intercepted expected command %s", command);
+         try {
+            RecordedRemoteInvocation invocation = new CompletedRemoteInvocation(command);
+            recordedInvocations.add(invocation);
+            return expectedInvocation.apply(command, collector);
+         } catch (Throwable t) {
+            recordedInvocations.add(new RemoteInvocationException(t));
+            throw t;
+         }
+      } else {
+         log.debugf("Intercepted command %s", command);
+         RecordedRemoteInvocation remoteInvocation = new RecordedRemoteInvocation(command, collector);
+         recordedInvocations.add(remoteInvocation);
+         return remoteInvocation.getResultFuture();
+      }
+   }
+
+   private Map<Address, Response> addInvocationSync(ReplicableCommand command, Collection<Address> targets, boolean
+      ignoreLeavers)
+      throws Exception {
+      try {
+         return addInvocation(command, new SyncMapResponseCollector(ignoreLeavers, targets.size()))
+            .get(10, TimeUnit.SECONDS);
+      } catch (ExecutionException e) {
+         throw Util.rewrapAsCacheException(e.getCause());
+      }
+   }
+
+   private boolean shouldIgnoreLeavers(ResponseMode mode) {
+      return mode == ResponseMode.SYNCHRONOUS_IGNORE_LEAVERS;
+   }
+
+   /**
+    * Mock responses for a remote invocation.
+    * <p>
+    * For example, {@code remoteInvocation.addResponse(a1, r1).addResponse(a2, r2).finish()},
+    * or {@code remoteInvocation.singleResponse(a, r)}
+    */
+   private static abstract class RemoteInvocation<T extends RemoteInvocation> {
+      private final CompletableFuture<Object> resultFuture = new CompletableFuture<>();
+
+      public abstract T addResponse(Address sender, Response response);
+
+      public T addLeaver(Address a) {
+         return addResponse(a, CacheNotFoundResponse.INSTANCE);
+      }
+
+      public T addException(Address a, Exception e) {
+         return addResponse(a, new ExceptionResponse(e));
+      }
+
+      public abstract void finish();
+
+      public void singleResponse(Address sender, Response response) {
+         addResponse(sender, response);
+         if (!isDone()) {
+            finish();
+         }
+      }
+
+      public boolean isDone() {
+         return resultFuture.isDone();
+      }
+
+      public void complete(Object result) {
+         resultFuture.complete(result);
+      }
+
+      public void assertDone() {
+         assertTrue(resultFuture.isDone());
+      }
+
+      @SuppressWarnings("unchecked")
+      <U> CompletableFuture<U> getResultFuture() {
+         return (CompletableFuture<U>) resultFuture;
+      }
+   }
+
+   public static class RecordedRemoteInvocation extends RemoteInvocation<RecordedRemoteInvocation> {
+      private final ReplicableCommand command;
+      private final ResponseCollector<?> collector;
+
+      private RecordedRemoteInvocation(ReplicableCommand command, ResponseCollector collector) {
+         this.command = command;
+         this.collector = collector;
+      }
+
+      @Override
+      public RecordedRemoteInvocation addResponse(Address sender, Response response) {
+         assertFalse(isDone());
+
+         log.debugf("Replying to remote invocation %s with %s from %s", command, response, sender);
+         Object result = collector.addResponse(sender, response);
+         if (result != null) {
+            complete(result);
+         }
+         return this;
+      }
+
+      @Override
+      public void finish() {
+         Object result = collector.finish();
+         complete(result);
+      }
+
+      public ReplicableCommand getCommand() {
+         return command;
+      }
+   }
+
+   private static class CompletedRemoteInvocation extends RecordedRemoteInvocation {
+      private CompletedRemoteInvocation(ReplicableCommand command) {
+         super(command, null);
+         complete(null);
+      }
+
+      @Override
+      public CompletedRemoteInvocation addResponse(Address sender, Response response) {
+         throw new UnsupportedOperationException("No responses expected");
+      }
+
+      @Override
+      public void finish() {
+         throw new UnsupportedOperationException("No responses expected");
+      }
+   }
+
+   private static class RemoteInvocationException extends RecordedRemoteInvocation {
+      private final RuntimeException exception;
+
+      private RemoteInvocationException(Throwable throwable) {
+         super(null, null);
+         this.exception = new RuntimeException(throwable);
+      }
+
+      @Override
+      public RemoteInvocationException addResponse(Address sender, Response response) {
+         throw exception;
+      }
+
+      @Override
+      public void finish() {
+         throw exception;
+      }
+
+      @Override
+      public void assertDone() {
+         throw exception;
+      }
+   }
+
+   public static class FutureRemoteInvocation extends RemoteInvocation<FutureRemoteInvocation> {
+      private final Consumer<ReplicableCommand> checker;
+      private final CompletableFuture<ReplicableCommand> commandFuture;
+      private final CompletableFuture<ResponseCollector<?>> collectorFuture;
+      private CompletableFuture<Object> operationsFuture;
+
+      private FutureRemoteInvocation(Consumer<ReplicableCommand> checker) {
+         this.checker = checker;
+         this.collectorFuture = new CompletableFuture<>();
+         this.commandFuture = new CompletableFuture<>();
+         this.operationsFuture = collectorFuture.thenApply(r -> null);
+      }
+
+      @Override
+      public FutureRemoteInvocation addResponse(Address sender, Response response) {
+         operationsFuture = operationsFuture.thenApply(result -> {
+            assertFalse(isDone());
+            assertNull(result);
+
+            // join() won't block
+            log.debugf("Replying to remote invocation %s with %s from %s", commandFuture.join(), response, sender);
+            result = collectorFuture.join().addResponse(sender, response);
+            if (result != null) {
+               complete(result);
+            }
+            return result;
+         });
+         return this;
+      }
+
+      @Override
+      public void finish() {
+         operationsFuture = operationsFuture.thenApply(result -> {
+            assertFalse(isDone());
+            assertNull(result);
+
+            // join() won't block
+            result = collectorFuture.join().finish();
+            complete(result);
+            return result;
+         });
+      }
+
+      @SuppressWarnings("unchecked")
+      private <T> CompletableFuture<T> apply(ReplicableCommand command, ResponseCollector<T> responseCollector) {
+         checker.accept(command);
+         commandFuture.complete(command);
+         collectorFuture.complete(responseCollector);
+         return (CompletableFuture<T>) operationsFuture;
+      }
+   }
+}

--- a/core/src/test/java/org/infinispan/topology/ClusterTopologyManagerImplTest.java
+++ b/core/src/test/java/org/infinispan/topology/ClusterTopologyManagerImplTest.java
@@ -1,0 +1,296 @@
+package org.infinispan.topology;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.mockito.Mockito.mock;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNull;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.infinispan.commons.hash.MurmurHash3;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.global.GlobalConfiguration;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.distribution.TestAddress;
+import org.infinispan.distribution.ch.ConsistentHash;
+import org.infinispan.distribution.ch.ConsistentHashFactory;
+import org.infinispan.distribution.ch.impl.ReplicatedConsistentHashFactory;
+import org.infinispan.factories.GlobalComponentRegistry;
+import org.infinispan.factories.KnownComponentNames;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.notifications.cachemanagerlistener.CacheManagerNotifier;
+import org.infinispan.notifications.cachemanagerlistener.CacheManagerNotifierImpl;
+import org.infinispan.partitionhandling.AvailabilityMode;
+import org.infinispan.remoting.responses.SuccessfulResponse;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.remoting.transport.MockTransport;
+import org.infinispan.remoting.transport.Transport;
+import org.infinispan.test.AbstractInfinispanTest;
+import org.testng.annotations.Test;
+
+@Test(groups = "unit", testName = "topology.ClusterTopologyManagerImplTest")
+public class ClusterTopologyManagerImplTest extends AbstractInfinispanTest {
+   private static final String CACHE_NAME = "testCache";
+
+   private static final Address A = new TestAddress(0, "A");
+   private static final Address B = new TestAddress(1, "B");
+   private final ConsistentHashFactory replicatedChf = new ReplicatedConsistentHashFactory();
+   // The persistent UUIDs are different, the rest of the join info is the same
+   private final CacheJoinInfo joinInfoA = makeJoinInfo();
+   private final CacheJoinInfo joinInfoB = makeJoinInfo();
+
+   private CacheJoinInfo makeJoinInfo() {
+      return new CacheJoinInfo(replicatedChf, MurmurHash3.getInstance(), 16, 1, 1000, false,
+                               CacheMode.REPL_SYNC, false, 1.0f, PersistentUUID.randomUUID(),
+                               Optional.empty());
+   }
+
+   /**
+    * Start two nodes and make both join the cache.
+    */
+   public void testClusterStartupWith2Nodes() throws Exception {
+      // Create global component registry with dependencies
+      GlobalConfiguration gc = GlobalConfigurationBuilder.defaultClusteredBuilder().build();
+      EmbeddedCacheManager cacheManager = mock(EmbeddedCacheManager.class);
+      GlobalComponentRegistry gcr = new GlobalComponentRegistry(gc, cacheManager, Collections.emptySet());
+
+      CacheManagerNotifierImpl managerNotifier = new CacheManagerNotifierImpl();
+      gcr.registerComponent(managerNotifier, CacheManagerNotifier.class);
+      managerNotifier.start();
+
+      MockTransport transport = new MockTransport(A);
+      gcr.registerComponent(transport, Transport.class);
+
+      PersistentUUIDManager persistentUUIDManager = new PersistentUUIDManagerImpl();
+      gcr.registerComponent(persistentUUIDManager, PersistentUUIDManager.class);
+
+      ExecutorService transportExecutor = Executors.newSingleThreadExecutor(getTestThreadFactory("Transport"));
+      gcr.registerComponent(transportExecutor, KnownComponentNames.ASYNC_TRANSPORT_EXECUTOR);
+
+      MockLocalTopologyManager ltm = new MockLocalTopologyManager(CACHE_NAME);
+      gcr.registerComponent(ltm, LocalTopologyManager.class);
+
+      // Initial conditions
+      transport.init(1, singletonList(A));
+      ltm.init(null, null, null, null);
+
+      // Component under test: ClusterTopologyManagerImpl on the coordinator (A)
+      ClusterTopologyManagerImpl ctm = new ClusterTopologyManagerImpl();
+      gcr.registerComponent(ctm, ClusterTopologyManager.class);
+
+      ctm.start();
+
+      // CTMI becomes coordinator and fetches the cluster status
+      transport.verifyTopologyCommand(CacheTopologyControlCommand.Type.GET_STATUS).finish();
+
+      // CTMI fetches rebalance status/confirm members are available
+      transport.verifyTopologyCommand(CacheTopologyControlCommand.Type.POLICY_GET_STATUS).finish();
+
+      // First node joins the cache
+      CacheStatusResponse joinResponseA = ctm.handleJoin(CACHE_NAME, A, joinInfoA, 1);
+      assertEquals(1, joinResponseA.getCacheTopology().getTopologyId());
+      assertCHMembers(joinResponseA.getCacheTopology().getCurrentCH(), A);
+      assertNull(joinResponseA.getCacheTopology().getPendingCH());
+
+      // LTMI normally updates the topology when receiving the join response
+      ltm.handleTopologyUpdate(CACHE_NAME, joinResponseA.getCacheTopology(), joinResponseA.getAvailabilityMode(), 1, A);
+      ltm.expectTopology(1, singletonList(A), null, CacheTopology.Phase.NO_REBALANCE);
+
+      // CTMI replies to the initial stable topology broadcast
+      transport.verifyTopologyCommand(CacheTopologyControlCommand.Type.STABLE_TOPOLOGY_UPDATE, c -> {
+         assertCHMembers(c.getCurrentCH(), A);
+         assertNull(c.getPendingCH());
+      }).finish();
+
+      // Add a second node
+      transport.updateView(2, asList(A, B));
+      managerNotifier.notifyViewChange(asList(A, B), singletonList(A), A, 2);
+
+      // CTMI confirms availability
+      transport.verifyTopologyCommand(CacheTopologyControlCommand.Type.POLICY_GET_STATUS).finish();
+
+      // Second node joins the cache, receives the initial topology
+      CacheStatusResponse joinResponseB = ctm.handleJoin(CACHE_NAME, B, joinInfoB, 2);
+      assertEquals(1, joinResponseB.getCacheTopology().getTopologyId());
+      assertCHMembers(joinResponseB.getCacheTopology().getCurrentCH(), A);
+      assertNull(joinResponseB.getCacheTopology().getPendingCH());
+
+      verifyRebalance(transport, ltm, ctm, 2, 1, singletonList(A), asList(A, B));
+
+      transport.verifyNoMoreCommands();
+   }
+
+   /**
+    * Assume there are already 2 nodes and the coordinator leaves during rebalance
+    */
+   public void testCoordinatorLostDuringRebalance() throws Exception {
+      // Create global component registry with dependencies
+      GlobalConfiguration gc = GlobalConfigurationBuilder.defaultClusteredBuilder().build();
+      EmbeddedCacheManager cacheManager = mock(EmbeddedCacheManager.class);
+      GlobalComponentRegistry gcr = new GlobalComponentRegistry(gc, cacheManager, Collections.emptySet());
+
+      CacheManagerNotifierImpl managerNotifier = new CacheManagerNotifierImpl();
+      gcr.registerComponent(managerNotifier, CacheManagerNotifier.class);
+      managerNotifier.start();
+
+      MockTransport transport = new MockTransport(B);
+      gcr.registerComponent(transport, Transport.class);
+
+      PersistentUUIDManager persistentUUIDManager = new PersistentUUIDManagerImpl();
+      gcr.registerComponent(persistentUUIDManager, PersistentUUIDManager.class);
+
+      ExecutorService transportExecutor = Executors.newFixedThreadPool(2, getTestThreadFactory("Transport"));
+      gcr.registerComponent(transportExecutor, KnownComponentNames.ASYNC_TRANSPORT_EXECUTOR);
+
+      MockLocalTopologyManager ltm = new MockLocalTopologyManager(CACHE_NAME);
+      gcr.registerComponent(ltm, LocalTopologyManager.class);
+
+      // Initial conditions (rebalance in phase 3, READ_NEW_WRITE_ALL)
+      transport.init(2, asList(A, B));
+      ConsistentHash stableCH = replicatedChf.create(MurmurHash3.getInstance(), joinInfoA.getNumOwners(),
+                                                     joinInfoA.getNumSegments(), singletonList(A), null);
+      ConsistentHash pendingCH = replicatedChf.create(MurmurHash3.getInstance(), joinInfoA.getNumOwners(),
+                                                      joinInfoA.getNumSegments(), asList(A, B), null);
+      CacheTopology initialTopology = new CacheTopology(4, 2, stableCH, pendingCH,
+                                                        CacheTopology.Phase.READ_NEW_WRITE_ALL, asList(A, B),
+                                                        asList(joinInfoA.getPersistentUUID(),
+                                                               joinInfoB.getPersistentUUID()));
+      CacheTopology stableTopology = new CacheTopology(1, 1, stableCH, null,
+                                                       CacheTopology.Phase.NO_REBALANCE, singletonList(A),
+                                                       singletonList(joinInfoA.getPersistentUUID()));
+      ltm.init(joinInfoA, initialTopology, stableTopology, AvailabilityMode.AVAILABLE);
+      // Normally LocalTopologyManagerImpl.start()/doHandleTopologyUpdate() registers the persistent UUIDs
+      // TODO Write test with asymmetric caches leaving the PersistentUUIDManager cache incomplete
+      persistentUUIDManager.addPersistentAddressMapping(A, joinInfoA.getPersistentUUID());
+      persistentUUIDManager.addPersistentAddressMapping(B, joinInfoB.getPersistentUUID());
+
+      // Component under test: ClusterTopologyManagerImpl on the new coordinator (B)
+      ClusterTopologyManagerImpl ctm = new ClusterTopologyManagerImpl();
+      gcr.registerComponent(ctm, ClusterTopologyManager.class);
+
+      // As CTMI starts as regular member it will request the rebalancing status from the coordinator
+      transport.expectTopologyCommand(CacheTopologyControlCommand.Type.POLICY_GET_STATUS)
+               .singleResponse(A, SuccessfulResponse.create(true));
+
+      ctm.start();
+      transport.verifyTopologyCommand(CacheTopologyControlCommand.Type.POLICY_GET_STATUS).assertDone();
+
+      // The coordinator (node A) leaves the cluster
+      transport.updateView(3, singletonList(B));
+      managerNotifier.notifyViewChange(singletonList(B), asList(A, B), B, 3);
+
+      // Node B becomes coordinator and CTMI tries to recover the cluster status
+      transport.verifyTopologyCommand(CacheTopologyControlCommand.Type.GET_STATUS).finish();
+
+      // CTMI broadcasts the only cache topology it got, but without the pending CH
+      ltm.expectTopology(5, singletonList(A), null, CacheTopology.Phase.NO_REBALANCE);
+      transport.verifyTopologyCommand(CacheTopologyControlCommand.Type.CH_UPDATE, c -> {
+         assertEquals(5, c.getTopologyId());
+         assertCHMembers(c.getCurrentCH(), A);
+         assertNull(c.getPendingCH());
+      });
+      transport.verifyTopologyCommand(CacheTopologyControlCommand.Type.STABLE_TOPOLOGY_UPDATE, c -> {
+         assertEquals(1, c.getTopologyId());
+         assertCHMembers(c.getCurrentCH(), A);
+         assertNull(c.getPendingCH());
+      });
+
+      // CTMI broadcasts a new cache topology with only node B
+      ltm.expectTopology(6, singletonList(B), null, CacheTopology.Phase.NO_REBALANCE);
+      transport.verifyTopologyCommand(CacheTopologyControlCommand.Type.CH_UPDATE, c -> {
+         assertEquals(6, c.getTopologyId());
+         assertCHMembers(c.getCurrentCH(), B);
+         assertNull(c.getPendingCH());
+      });
+
+      // CTMI confirms members are available in case it needs to starts a rebalance
+      transport.verifyTopologyCommand(CacheTopologyControlCommand.Type.POLICY_GET_STATUS).finish();
+
+      // Node A restarts
+      transport.updateView(4, asList(B, A));
+      managerNotifier.notifyViewChange(asList(B, A), singletonList(B), A, 4);
+
+      // CTMI confirms members are available in case it needs to starts a rebalance
+      transport.verifyTopologyCommand(CacheTopologyControlCommand.Type.POLICY_GET_STATUS)
+               .singleResponse(A, SuccessfulResponse.create(true));
+
+      // Node A rejoins
+      ctm.handleJoin(CACHE_NAME, A, joinInfoA, 4);
+
+      verifyRebalance(transport, ltm, ctm, 7, 4, singletonList(B), asList(B, A));
+
+      transport.verifyNoMoreCommands();
+   }
+
+   private void verifyRebalance(MockTransport transport, MockLocalTopologyManager ltm, ClusterTopologyManagerImpl ctm,
+                                int rebalanceTopologyId, int rebalanceViewId, List<Address> initialMembers,
+                                List<Address> finalMembers) throws Exception {
+      // CTMI starts rebalance
+      ltm.expectTopology(rebalanceTopologyId, initialMembers, finalMembers,
+                         CacheTopology.Phase.READ_OLD_WRITE_ALL);
+      transport.verifyTopologyCommand(CacheTopologyControlCommand.Type.REBALANCE_START, c -> {
+         assertEquals(rebalanceTopologyId, c.getTopologyId());
+         assertEquals(CacheTopology.Phase.READ_OLD_WRITE_ALL, c.getPhase());
+         assertEquals(initialMembers, c.getCurrentCH().getMembers());
+         assertEquals(finalMembers, c.getPendingCH().getMembers());
+      }).finish();
+
+      // Confirm state transfer (phase 1, READ_OLD_WRITE_ALL)
+      ctm.handleRebalancePhaseConfirm(CACHE_NAME, A, rebalanceTopologyId, null, rebalanceViewId);
+      ctm.handleRebalancePhaseConfirm(CACHE_NAME, B, rebalanceTopologyId, null, rebalanceViewId);
+
+      // CTMI starts phase 2, READ_ALL_WRITE_ALL
+      ltm.expectTopology(rebalanceTopologyId + 1, initialMembers, finalMembers,
+                         CacheTopology.Phase.READ_ALL_WRITE_ALL);
+      transport.verifyTopologyCommand(CacheTopologyControlCommand.Type.CH_UPDATE, c -> {
+         assertEquals(rebalanceTopologyId + 1, c.getTopologyId());
+         assertEquals(CacheTopology.Phase.READ_ALL_WRITE_ALL, c.getPhase());
+         assertEquals(initialMembers, c.getCurrentCH().getMembers());
+         assertEquals(finalMembers, c.getPendingCH().getMembers());
+      }).finish();
+
+      // Confirm phase 2
+      ctm.handleRebalancePhaseConfirm(CACHE_NAME, A, rebalanceTopologyId + 1, null, rebalanceViewId);
+      ctm.handleRebalancePhaseConfirm(CACHE_NAME, B, rebalanceTopologyId + 1, null, rebalanceViewId);
+
+      // CTMI starts phase 3: READ_NEW_WRITE_ALL
+      ltm.expectTopology(rebalanceTopologyId + 2, initialMembers, finalMembers,
+                         CacheTopology.Phase.READ_NEW_WRITE_ALL);
+      transport.verifyTopologyCommand(CacheTopologyControlCommand.Type.CH_UPDATE, c -> {
+         assertEquals(rebalanceTopologyId + 2, c.getTopologyId());
+         assertEquals(CacheTopology.Phase.READ_NEW_WRITE_ALL, c.getPhase());
+         assertEquals(initialMembers, c.getCurrentCH().getMembers());
+         assertEquals(finalMembers, c.getPendingCH().getMembers());
+      }).finish();
+
+      // Confirm phase 3
+      ctm.handleRebalancePhaseConfirm(CACHE_NAME, A, rebalanceTopologyId + 2, null, rebalanceViewId);
+      ctm.handleRebalancePhaseConfirm(CACHE_NAME, B, rebalanceTopologyId + 2, null, rebalanceViewId);
+
+      // CTMI finishes rebalance
+      ltm.expectTopology(rebalanceTopologyId + 3, finalMembers, null, CacheTopology.Phase.NO_REBALANCE);
+      transport.verifyTopologyCommand(CacheTopologyControlCommand.Type.CH_UPDATE, c -> {
+         assertEquals(rebalanceTopologyId + 3, c.getTopologyId());
+         assertEquals(CacheTopology.Phase.NO_REBALANCE, c.getPhase());
+         assertEquals(finalMembers, c.getCurrentCH().getMembers());
+         assertNull(c.getPendingCH());
+      }).finish();
+
+      transport.verifyTopologyCommand(CacheTopologyControlCommand.Type.STABLE_TOPOLOGY_UPDATE, c -> {
+         assertEquals(rebalanceTopologyId + 3, c.getTopologyId());
+         assertEquals(CacheTopology.Phase.NO_REBALANCE, c.getPhase());
+         assertEquals(finalMembers, c.getCurrentCH().getMembers());
+         assertNull(c.getPendingCH());
+      }).finish();
+   }
+
+   private void assertCHMembers(ConsistentHash ch, Address... members) {
+      assertEquals(asList(members), ch.getMembers());
+   }
+
+}

--- a/core/src/test/java/org/infinispan/topology/MockLocalTopologyManager.java
+++ b/core/src/test/java/org/infinispan/topology/MockLocalTopologyManager.java
@@ -1,0 +1,172 @@
+package org.infinispan.topology;
+
+import static java.util.Collections.singletonMap;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertNull;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+
+import org.infinispan.partitionhandling.AvailabilityMode;
+import org.infinispan.partitionhandling.impl.PartitionHandlingManager;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
+/**
+ * Mock implementation of {@link LocalTopologyManager} with a single cache.
+ *
+ * @author Dan Berindei
+ * @since 9.2
+ */
+class MockLocalTopologyManager implements LocalTopologyManager {
+   private static final Log log = LogFactory.getLog(MockLocalTopologyManager.class);
+
+   private final String cacheName;
+   private final BlockingQueue<CacheTopology> topologies = new LinkedBlockingDeque<>();
+
+   private CacheStatusResponse status;
+
+
+   MockLocalTopologyManager(String cacheName) {
+      this.cacheName = cacheName;
+   }
+
+   public void init(CacheJoinInfo joinInfo, CacheTopology topology, CacheTopology stableTopology,
+                    AvailabilityMode availabilityMode) {
+      this.status = new CacheStatusResponse(joinInfo, topology, stableTopology, availabilityMode);
+   }
+
+   public void verifyTopology(CacheTopology topology, int topologyId, List<Address> currentMembers,
+                              List<Address> pendingMembers, CacheTopology.Phase phase) {
+      log.debugf("Verifying topology %s", topology);
+      assertEquals(topologyId, topology.getTopologyId());
+      assertEquals(phase, topology.getPhase());
+      assertEquals(currentMembers, topology.getCurrentCH().getMembers());
+      if (pendingMembers != null) {
+         assertEquals(pendingMembers, topology.getPendingCH().getMembers());
+      } else {
+         assertNull(topology.getPendingCH());
+      }
+   }
+
+   public void expectTopology(int topologyId, List<Address> currentMembers, List<Address> pendingMembers,
+                              CacheTopology.Phase phase) throws Exception {
+      CacheTopology topology = topologies.poll(10, TimeUnit.SECONDS);
+      assertNotNull("Timed out waiting for topology " + topologyId, topology);
+
+      verifyTopology(topology, topologyId, currentMembers, pendingMembers, phase);
+   }
+
+   @Override
+   public CacheTopology join(String cacheName, CacheJoinInfo joinInfo, CacheTopologyHandler stm,
+                             PartitionHandlingManager phm) {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   public void leave(String cacheName) {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   public void confirmRebalancePhase(String cacheName, int topologyId, int rebalanceId, Throwable throwable) {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   public ManagerStatusResponse handleStatusRequest(int viewId) {
+      return new ManagerStatusResponse(
+         status.getCacheJoinInfo() != null ? singletonMap(cacheName, status) : Collections.emptyMap(), true);
+   }
+
+   @Override
+   public void handleTopologyUpdate(String cacheName, CacheTopology cacheTopology, AvailabilityMode availabilityMode,
+                                    int viewId, Address sender) {
+      status = new CacheStatusResponse(status.getCacheJoinInfo(), cacheTopology,
+                                       status.getStableTopology(), availabilityMode);
+      topologies.add(cacheTopology);
+   }
+
+   @Override
+   public void handleStableTopologyUpdate(String cacheName, CacheTopology cacheTopology, Address sender, int viewId) {
+      status = new CacheStatusResponse(status.getCacheJoinInfo(), status.getCacheTopology(),
+                                       cacheTopology, status.getAvailabilityMode());
+   }
+
+   @Override
+   public void handleRebalance(String cacheName, CacheTopology cacheTopology, int viewId, Address sender) {
+      status = new CacheStatusResponse(status.getCacheJoinInfo(), cacheTopology,
+                                       status.getStableTopology(), status.getAvailabilityMode());
+      topologies.add(cacheTopology);
+   }
+
+   @Override
+   public CacheTopology getCacheTopology(String cacheName) {
+      return status.getCacheTopology();
+   }
+
+   @Override
+   public CacheTopology getStableCacheTopology(String cacheName) {
+      return status.getStableTopology();
+   }
+
+   @Override
+   public boolean isTotalOrderCache(String cacheName) {
+      return false;
+   }
+
+   @Override
+   public boolean isRebalancingEnabled() {
+      return true;
+   }
+
+   @Override
+   public boolean isCacheRebalancingEnabled(String cacheName) {
+      return true;
+   }
+
+   @Override
+   public void setRebalancingEnabled(boolean enabled) {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   public void setCacheRebalancingEnabled(String cacheName, boolean enabled) {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   public RebalancingStatus getRebalancingStatus(String cacheName) {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   public AvailabilityMode getCacheAvailability(String cacheName) {
+      return status.getAvailabilityMode();
+   }
+
+   @Override
+   public void setCacheAvailability(String cacheName, AvailabilityMode availabilityMode) {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   public PersistentUUID getPersistentUUID() {
+      return null;
+   }
+
+   @Override
+   public void cacheShutdown(String name) {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   public void handleCacheShutdown(String cacheName) {
+      throw new UnsupportedOperationException();
+   }
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-8555
https://issues.jboss.org/browse/ISPN-8587

Backport of https://github.com/infinispan/infinispan/pull/5617

The main difference is that `IntSet` doesn't exist in 9.1, so I'm using `Collections.unmodifiableSet()` instead of backporting `ImmutableIntSet`.