### PR TITLE
ISPN-8629 Javadoc modules' build invokes a new instance of Maven

### DIFF
--- a/javadoc/javadoc-all/pom.xml
+++ b/javadoc/javadoc-all/pom.xml
@@ -313,6 +313,13 @@
                   </configuration>
                </execution>
             </executions>
+            <dependencies>
+               <dependency>
+                  <groupId>org.infinispan</groupId>
+                  <artifactId>infinispan-tools</artifactId>
+                  <version>${project.version}</version>
+               </dependency>
+            </dependencies>
          </plugin>
          <plugin>
             <artifactId>maven-surefire-plugin</artifactId>

--- a/javadoc/javadoc-embedded/pom.xml
+++ b/javadoc/javadoc-embedded/pom.xml
@@ -305,6 +305,13 @@
                   </configuration>
                </execution>
             </executions>
+            <dependencies>
+               <dependency>
+                  <groupId>org.infinispan</groupId>
+                  <artifactId>infinispan-tools</artifactId>
+                  <version>${project.version}</version>
+               </dependency>
+            </dependencies>
          </plugin>
          <plugin>
             <artifactId>maven-surefire-plugin</artifactId>

--- a/javadoc/javadoc-remote/pom.xml
+++ b/javadoc/javadoc-remote/pom.xml
@@ -97,6 +97,13 @@
                   </configuration>
                </execution>
             </executions>
+            <dependencies>
+               <dependency>
+                  <groupId>org.infinispan</groupId>
+                  <artifactId>infinispan-tools</artifactId>
+                  <version>${project.version}</version>
+               </dependency>
+            </dependencies>
          </plugin>
          <plugin>
             <artifactId>maven-surefire-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1282,6 +1282,15 @@
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-javadoc-plugin</artifactId>
                <version>3.0.0-M1</version>
+               <configuration>
+                  <!--
+                  The javadoc plugin only runs in the javadoc and rhq-plugin modules.
+                  But with the default configuration it tries to run a new maven instance
+                  in every dependency, in order to generate the apidocs there as well.
+                  (http://maven.apache.org/plugins-archives/maven-javadoc-plugin-2.10.3/javadoc-mojo.html#detectOfflineLinks)
+                  -->
+                  <detectOfflineLinks>false</detectOfflineLinks>
+               </configuration>
             </plugin>
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-8629

* Configure maven-javadoc-plugin with detectOfflineLinks=false
* Add explicit dependency on the tools module in the javadoc modules