### PR TITLE
A POC for replacing explicit null-checks by automatically generated

### DIFF
--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -25,6 +25,11 @@
       </dependency>
 
       <dependency>
+         <groupId>com.google.code.findbugs</groupId>
+         <artifactId>jsr305</artifactId>
+      </dependency>
+
+      <dependency>
          <groupId>org.jboss.spec.javax.transaction</groupId>
          <artifactId>jboss-transaction-api_1.1_spec</artifactId>
          <scope>provided</scope>

--- a/commons/src/main/java/org/infinispan/commons/util/ArrayMap.java
+++ b/commons/src/main/java/org/infinispan/commons/util/ArrayMap.java
@@ -1,5 +1,6 @@
 package org.infinispan.commons.util;
 
+import javax.annotation.Nonnull;
 import java.util.AbstractCollection;
 import java.util.AbstractSet;
 import java.util.Arrays;
@@ -44,8 +45,7 @@ public abstract class ArrayMap<K, V> extends java.util.AbstractMap<K, V> {
    }
 
    @Override
-   public boolean containsValue(Object value) {
-      Objects.requireNonNull(value);
+   public boolean containsValue(@Nonnull Object value) {
       for (int i = 0; i < values.length; ++i) {
          Object v = values[i];
          if (v != null && v.equals(value)) return true;

--- a/pom.xml
+++ b/pom.xml
@@ -269,6 +269,7 @@
       <version.jgoodies.forms>1.0.7</version.jgoodies.forms>
       <version.jmh>1.12</version.jmh>
       <version.jsap>2.1</version.jsap>
+      <version.jsr305>3.0.2</version.jsr305>
       <version.jstl>1.2</version.jstl>
       <version.junit>4.12</version.junit>
       <version.karaf-maven-plugin>4.1.2</version.karaf-maven-plugin>
@@ -313,6 +314,7 @@
       <version.spymemcached>2.12.1</version.spymemcached>
       <version.testng.arquillian>6.5.2</version.testng.arquillian>
       <version.testng>6.8.8</version.testng>
+      <version.traute>1.1.8</version.traute>
       <version.webdav.servlet>2.0.1</version.webdav.servlet>
       <version.weld-se>2.3.4.Final</version.weld-se>
       <version.weld>2.3.4.Final</version.weld>
@@ -1069,6 +1071,11 @@
             <version>${version.latency.utils}</version>
          </dependency>
          <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>${version.jsr305}</version>
+         </dependency>
+         <dependency>
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>
             <version>${version.elasticsearch}</version>
@@ -1449,6 +1456,17 @@
                      <exclude>**/package-info.java</exclude>
                   </excludes>
                   <compilerArgument>-AtranslationFilesPath=${project.basedir}/target/generated-translation-files</compilerArgument>
+                  <compilerArgs>
+                     <arg>-Xplugin:Traute</arg>
+                     <arg>-Atraute.failure.text.parameter=$${PARAMETER_NAME} is mandatory</arg>
+                  </compilerArgs>
+                  <annotationProcessorPaths>
+                     <path>
+                        <groupId>tech.harmonysoft</groupId>
+                        <artifactId>traute-javac</artifactId>
+                        <version>${version.traute}</version>
+                     </path>
+                  </annotationProcessorPaths>
                </configuration>
             </plugin>
          </plugins>


### PR DESCRIPTION
This *PR* illustrates an approach when explicit *null*-checks are replaced by those automatically generated during compilation based on source code annotations.  

Let's consider [ArrayMap. containsValue()](https://github.com/infinispan/infinispan/blob/master/commons/src/main/java/org/infinispan/commons/util/ArrayMap.java#L47) as an example:  

*Source code before*  

```java
public boolean containsValue(Object value) {
   Objects.requireNonNull(value);
   for (int i = 0; i < values.length; ++i) {
      Object v = values[i];
      if (v != null && v.equals(value)) return true;
   }
   return false;
}
```  

*Source code after*  

```java
public boolean containsValue(@Nonnull Object value) {
   for (int i = 0; i < values.length; ++i) {
      Object v = values[i];
      if (v != null && v.equals(value)) return true;
   }
   return false;
}
```  

Resulting bytecode looks like if it's compiled from the source below:  

```java
public boolean containsValue(@Nonnull Object value) {
   if (value == null) {
      throw new NullPointerException("value is mandatory");
   }
   for (int i = 0; i < values.length; ++i) {
      Object v = values[i];
      if (v != null && v.equals(value)) return true;
   }
   return false;
}
```  

That is achieved by the [Traute](http://traute.oss.harmonysoft.tech/) *javac* plugin. If the team likes the approach, I'm ok with applying it to the whole project in a current/new *PR*.