### PR TITLE
ISPN-8647 Initialize all loggers statically

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/EmbeddedCompatClientListenerWithDslFilterTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/EmbeddedCompatClientListenerWithDslFilterTest.java
@@ -10,6 +10,7 @@ import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertNull;
 
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -296,7 +297,7 @@ public class EmbeddedCompatClientListenerWithDslFilterTest extends MultiHotRodSe
          useRawData = true, includeCurrentState = true)
    private static class ClientEntryListener {
 
-      private final Log log = LogFactory.getLog(getClass());
+      private static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
 
       public final BlockingQueue<FilterResult> createEvents = new LinkedBlockingQueue<>();
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/RemoteListenerWithDslFilterTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/RemoteListenerWithDslFilterTest.java
@@ -10,6 +10,7 @@ import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertNull;
 
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -313,7 +314,7 @@ public class RemoteListenerWithDslFilterTest extends MultiHotRodServersTest {
          useRawData = true, includeCurrentState = true)
    private static class ClientEntryListener {
 
-      private final Log log = LogFactory.getLog(getClass());
+      private static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
 
       public final BlockingQueue<FilterResult> createEvents = new LinkedBlockingQueue<>();
 

--- a/core/src/main/java/org/infinispan/container/offheap/OffHeapDataContainer.java
+++ b/core/src/main/java/org/infinispan/container/offheap/OffHeapDataContainer.java
@@ -1,5 +1,6 @@
 package org.infinispan.container.offheap;
 
+import java.lang.invoke.MethodHandles;
 import java.util.AbstractCollection;
 import java.util.AbstractSet;
 import java.util.Collection;
@@ -39,8 +40,8 @@ import org.infinispan.util.logging.LogFactory;
  * @since 9.0
  */
 public class OffHeapDataContainer implements DataContainer<WrappedBytes, WrappedBytes> {
-   protected final Log log = LogFactory.getLog(getClass());
-   protected final boolean trace = log.isTraceEnabled();
+   private static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
+   protected final boolean trace = getLog().isTraceEnabled();
 
    protected final AtomicLong size = new AtomicLong();
    protected final int lockCount;
@@ -115,7 +116,7 @@ public class OffHeapDataContainer implements DataContainer<WrappedBytes, Wrapped
       locks.lockAll();
       try {
          if (size.get() != 0) {
-            log.warn("Container was not cleared before deallocating memory lookup tables!  Memory leak " +
+            getLog().warn("Container was not cleared before deallocating memory lookup tables!  Memory leak " +
                   "will have occurred!");
          }
          clear();
@@ -431,7 +432,7 @@ public class OffHeapDataContainer implements DataContainer<WrappedBytes, Wrapped
 
    protected void performClear() {
       if (trace) {
-         log.trace("Clearing off heap data");
+         getLog().trace("Clearing off heap data");
       }
       memoryLookup.toStreamRemoved().forEach(address -> {
          while (address != 0) {
@@ -442,7 +443,7 @@ public class OffHeapDataContainer implements DataContainer<WrappedBytes, Wrapped
       });
       size.set(0);
       if (trace) {
-         log.trace("Cleared off heap data");
+         getLog().trace("Cleared off heap data");
       }
    }
 
@@ -679,5 +680,9 @@ public class OffHeapDataContainer implements DataContainer<WrappedBytes, Wrapped
    @Override
    public long evictionSize() {
       return size.get();
+   }
+
+   public Log getLog() {
+      return log;
    }
 }

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/BaseQueueingSegmentListener.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/BaseQueueingSegmentListener.java
@@ -10,7 +10,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.notifications.cachelistener.event.Event;
 import org.infinispan.util.logging.Log;
-import org.infinispan.util.logging.LogFactory;
 
 /**
  * This is the base class for use when listening to segment completions when doing initial event
@@ -26,14 +25,14 @@ import org.infinispan.util.logging.LogFactory;
  * @since 7.0
  */
 abstract class BaseQueueingSegmentListener<K, V, E extends Event<K, V>> implements QueueingSegmentListener<K, V, E> {
-   protected final Log log = LogFactory.getLog(getClass());
-   protected boolean trace = log.isTraceEnabled();
+   protected final boolean trace;
 
    protected final AtomicBoolean completed = new AtomicBoolean(false);
    protected final ConcurrentMap<K, Object> notifiedKeys;
 
    protected BaseQueueingSegmentListener() {
       this.notifiedKeys = new ConcurrentHashMap<>();
+      trace = getLog().isTraceEnabled();
    }
 
    @Override
@@ -43,7 +42,7 @@ abstract class BaseQueueingSegmentListener<K, V, E extends Event<K, V>> implemen
       Object value = notifiedKeys.put(key, NOTIFIED);
       if (value != null) {
          if (trace) {
-            log.tracef("Processing key %s as a concurrent update occurred with value %s", key, value);
+            getLog().tracef("Processing key %s as a concurrent update occurred with value %s", key, value);
          }
       }
       return value;
@@ -104,4 +103,6 @@ abstract class BaseQueueingSegmentListener<K, V, E extends Event<K, V>> implemen
       }
       return returnValue;
    }
+
+   protected abstract Log getLog();
 }

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/DistributedQueueingSegmentListener.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/DistributedQueueingSegmentListener.java
@@ -1,5 +1,6 @@
 package org.infinispan.notifications.cachelistener;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -14,6 +15,8 @@ import org.infinispan.notifications.cachelistener.event.CacheEntryEvent;
 import org.infinispan.notifications.cachelistener.event.Event;
 import org.infinispan.notifications.impl.ListenerInvocation;
 import org.infinispan.util.KeyValuePair;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
 
 /**
  * This handler is to be used with a clustered distributed cache.  This handler does special optimizations to
@@ -24,6 +27,7 @@ import org.infinispan.util.KeyValuePair;
  * @since 7.0
  */
 class DistributedQueueingSegmentListener<K, V> extends BaseQueueingSegmentListener<K, V, CacheEntryEvent<K, V>> {
+   private static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
    private final AtomicReferenceArray<Queue<KeyValuePair<CacheEntryEvent<K, V>, ListenerInvocation<Event<K, V>>>>> queues;
 
    private final ToIntFunction<Object> intFunction;
@@ -116,5 +120,10 @@ class DistributedQueueingSegmentListener<K, V> extends BaseQueueingSegmentListen
 
    public void segmentCompleted(Set<Integer> segments) {
       justCompletedSegments = segments.stream().filter(s -> queues.get(s) != null);
+   }
+
+   @Override
+   protected Log getLog() {
+      return log;
    }
 }

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/QueueingAllSegmentListener.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/QueueingAllSegmentListener.java
@@ -1,5 +1,6 @@
 package org.infinispan.notifications.cachelistener;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Iterator;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -10,6 +11,8 @@ import org.infinispan.notifications.cachelistener.event.CacheEntryEvent;
 import org.infinispan.notifications.cachelistener.event.Event;
 import org.infinispan.notifications.impl.ListenerInvocation;
 import org.infinispan.util.KeyValuePair;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
 
 /**
  * This handler is to be used when all the events must be queued until the iteration process is complete.
@@ -21,6 +24,7 @@ import org.infinispan.util.KeyValuePair;
  * @since 7.0
  */
 class QueueingAllSegmentListener<K, V> extends BaseQueueingSegmentListener<K, V, Event<K, V>> {
+   private static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
    protected final Queue<KeyValuePair<Event<K, V>, ListenerInvocation<Event<K, V>>>> queue =
          new ConcurrentLinkedQueue<>();
    protected final InternalEntryFactory entryFactory;
@@ -66,5 +70,10 @@ class QueueingAllSegmentListener<K, V> extends BaseQueueingSegmentListener<K, V,
          iterator.remove();
       }
       completed.set(true);
+   }
+
+   @Override
+   protected Log getLog() {
+      return log;
    }
 }

--- a/core/src/main/java/org/infinispan/stream/impl/AbstractCacheStream.java
+++ b/core/src/main/java/org/infinispan/stream/impl/AbstractCacheStream.java
@@ -53,7 +53,6 @@ import org.infinispan.topology.CacheTopology;
 import org.infinispan.util.KeyValuePair;
 import org.infinispan.util.concurrent.TimeoutException;
 import org.infinispan.util.logging.Log;
-import org.infinispan.util.logging.LogFactory;
 import org.jboss.marshalling.util.IdentityIntMap;
 import org.reactivestreams.Publisher;
 
@@ -66,8 +65,6 @@ import io.reactivex.Flowable;
  * @param <S> The stream interface
  */
 public abstract class AbstractCacheStream<T, S extends BaseStream<T, S>, S2 extends S> implements BaseStream<T, S> {
-   protected final Log log = LogFactory.getLog(getClass());
-
    protected final Queue<IntermediateOperation> intermediateOperations;
    protected final Address localAddress;
    protected final DistributionManager dm;

--- a/core/src/main/java/org/infinispan/stream/impl/local/AbstractLocalCacheStream.java
+++ b/core/src/main/java/org/infinispan/stream/impl/local/AbstractLocalCacheStream.java
@@ -11,16 +11,12 @@ import org.infinispan.commons.util.CloseableIterator;
 import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.stream.impl.intops.IntermediateOperation;
 import org.infinispan.stream.impl.intops.UnorderedOperation;
-import org.infinispan.util.logging.Log;
-import org.infinispan.util.logging.LogFactory;
 
 /**
  * Implements the base operations required for a local stream.
  * stream is populated
  */
 public abstract class AbstractLocalCacheStream<T, S extends BaseStream<T, S>, S2 extends S> implements BaseStream<T, S> {
-   protected final Log log = LogFactory.getLog(getClass());
-
    protected final StreamSupplier<T, S> streamSupplier;
    protected final ComponentRegistry registry;
 

--- a/core/src/test/java/org/infinispan/api/ClearTest.java
+++ b/core/src/test/java/org/infinispan/api/ClearTest.java
@@ -3,6 +3,8 @@ package org.infinispan.api;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertTrue;
 
+import java.lang.invoke.MethodHandles;
+
 import org.infinispan.AdvancedCache;
 import org.infinispan.configuration.cache.BiasAcquisition;
 import org.infinispan.configuration.cache.CacheMode;
@@ -27,7 +29,7 @@ import org.testng.annotations.Test;
 @Test(groups = "functional", testName = "api.ClearTest")
 public class ClearTest extends MultipleCacheManagersTest {
 
-   protected final Log log = LogFactory.getLog(getClass());
+   protected static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
 
    protected AdvancedCache<Integer, String> c0;
    protected AdvancedCache<Integer, String> c1;

--- a/core/src/test/java/org/infinispan/api/ConditionalOperationsConcurrentTest.java
+++ b/core/src/test/java/org/infinispan/api/ConditionalOperationsConcurrentTest.java
@@ -4,6 +4,7 @@ import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertTrue;
 
+import java.lang.invoke.MethodHandles;
 import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.BrokenBarrierException;
@@ -42,7 +43,7 @@ import org.testng.annotations.Test;
 @Test(groups = "functional", testName = "api.ConditionalOperationsConcurrentTest")
 public class ConditionalOperationsConcurrentTest extends MultipleCacheManagersTest {
 
-   private final Log log = LogFactory.getLog(getClass());
+   private static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
 
    @Override
    public Object[] factory() {

--- a/core/src/test/java/org/infinispan/expiration/impl/ClusterExpirationFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/expiration/impl/ClusterExpirationFunctionalTest.java
@@ -3,6 +3,7 @@ package org.infinispan.expiration.impl;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNull;
 
+import java.lang.invoke.MethodHandles;
 import java.util.concurrent.TimeUnit;
 
 import org.infinispan.Cache;
@@ -29,7 +30,7 @@ import org.testng.annotations.Test;
 @InCacheMode({CacheMode.DIST_SYNC, CacheMode.REPL_SYNC, CacheMode.SCATTERED_SYNC})
 public class ClusterExpirationFunctionalTest extends MultipleCacheManagersTest {
 
-   protected final Log log = LogFactory.getLog(getClass());
+   protected static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
 
    protected ControlledTimeService ts0;
    protected ControlledTimeService ts1;

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/BaseCacheNotifierImplInitialTransferTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/BaseCacheNotifierImplInitialTransferTest.java
@@ -15,6 +15,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.BrokenBarrierException;
@@ -512,7 +513,7 @@ public abstract class BaseCacheNotifierImplInitialTransferTest extends AbstractI
 
    protected static abstract class StateListener<K, V> {
       final List<CacheEntryEvent<K, V>> events = new ArrayList<>();
-      private final Log log = LogFactory.getLog(getClass());
+      private static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
 
       @CacheEntryCreated
       @CacheEntryModified

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/CacheNotifierImplInitialTransferDistTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/CacheNotifierImplInitialTransferDistTest.java
@@ -14,6 +14,7 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -663,7 +664,7 @@ public class CacheNotifierImplInitialTransferDistTest extends MultipleCacheManag
 
    protected static abstract class StateListener<K, V> {
       final List<CacheEntryEvent<K, V>> events = Collections.synchronizedList(new ArrayList<>());
-      private final Log log = LogFactory.getLog(getClass());
+      private static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
 
       @CacheEntryCreated
       @CacheEntryModified

--- a/core/src/test/java/org/infinispan/partitionhandling/BasePartitionHandlingTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/BasePartitionHandlingTest.java
@@ -4,6 +4,7 @@ import static org.infinispan.test.Exceptions.expectException;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -48,7 +49,7 @@ import org.testng.annotations.Test;
 
 @Test(groups = "functional", testName = "partitionhandling.BasePartitionHandlingTest")
 public class BasePartitionHandlingTest extends MultipleCacheManagersTest {
-   protected Log log = LogFactory.getLog(getClass());
+   protected static Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
 
    private final AtomicInteger viewId = new AtomicInteger(5);
    protected int numMembersInCluster = 4;

--- a/core/src/test/java/org/infinispan/test/AbstractInfinispanTest.java
+++ b/core/src/test/java/org/infinispan/test/AbstractInfinispanTest.java
@@ -3,6 +3,7 @@ package org.infinispan.test;
 import static org.testng.AssertJUnit.assertTrue;
 import static org.testng.AssertJUnit.fail;
 
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.IdentityHashMap;
 import java.util.List;
@@ -56,7 +57,7 @@ import org.testng.internal.MethodInstance;
 @TestSelector(interceptors = AbstractInfinispanTest.OrderByInstance.class)
 public class AbstractInfinispanTest {
 
-   protected final Log log = LogFactory.getLog(getClass());
+   protected static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
 
    private final ThreadFactory defaultThreadFactory = getTestThreadFactory("ForkThread");
    private final ThreadPoolExecutor defaultExecutorService = new ThreadPoolExecutor(0, Integer.MAX_VALUE,

--- a/core/src/test/java/org/infinispan/tx/DummyTxTest.java
+++ b/core/src/test/java/org/infinispan/tx/DummyTxTest.java
@@ -3,6 +3,7 @@ package org.infinispan.tx;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
 
+import java.lang.invoke.MethodHandles;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -28,7 +29,7 @@ import org.testng.annotations.Test;
 @Test(groups = "functional", testName = "tx.DummyTxTest")
 public class DummyTxTest extends SingleCacheManagerTest {
 
-   protected final Log log = LogFactory.getLog(getClass());
+   protected static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
 
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(false);  // also try this test with 'true' so you can tell the difference between DummyTransactionManager and JBoss TM

--- a/core/src/test/java/org/infinispan/util/AbstractControlledRpcManager.java
+++ b/core/src/test/java/org/infinispan/util/AbstractControlledRpcManager.java
@@ -1,5 +1,6 @@
 package org.infinispan.util;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -28,7 +29,7 @@ import org.infinispan.util.logging.LogFactory;
  */
 public abstract class AbstractControlledRpcManager implements RpcManager {
 
-   protected final Log log = LogFactory.getLog(getClass());
+   protected static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
    protected final RpcManager realOne;
 
    public AbstractControlledRpcManager(RpcManager realOne) {

--- a/extended-statistics/src/main/java/org/infinispan/stats/TransactionStatistics.java
+++ b/extended-statistics/src/main/java/org/infinispan/stats/TransactionStatistics.java
@@ -10,6 +10,8 @@ import static org.infinispan.stats.container.ExtendedStatistic.RO_TX_SUCCESSFUL_
 import static org.infinispan.stats.container.ExtendedStatistic.WR_TX_ABORTED_EXECUTION_TIME;
 import static org.infinispan.stats.container.ExtendedStatistic.WR_TX_SUCCESSFUL_EXECUTION_TIME;
 
+import java.lang.invoke.MethodHandles;
+
 import org.infinispan.stats.container.ConcurrentGlobalContainer;
 import org.infinispan.stats.container.ExtendedStatistic;
 import org.infinispan.stats.container.ExtendedStatisticsContainer;
@@ -32,7 +34,7 @@ public abstract class TransactionStatistics {
 
    //Here the elements which are common for local and remote transactions
    protected final long initTime;
-   protected final Log log = LogFactory.getLog(getClass(), Log.class);
+   protected static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass(), Log.class);
    protected final boolean trace = log.isTraceEnabled();
    protected final TimeService timeService;
    private final ExtendedStatisticsContainer container;

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/AbstractNonInvalidationTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/AbstractNonInvalidationTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.test.hibernate.cache.commons.functional;
 
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -54,7 +55,7 @@ public abstract class AbstractNonInvalidationTest extends SingleNodeTest {
 
    protected long TIMEOUT;
    protected ExecutorService executor;
-   protected InfinispanMessageLogger log = InfinispanMessageLogger.Provider.getLog(getClass());
+   protected static InfinispanMessageLogger log = InfinispanMessageLogger.Provider.getLog(MethodHandles.lookup().lookupClass());
    protected AdvancedCache entityCache;
    protected long itemId;
    protected Region region;

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/AbstractEncoder1x.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/AbstractEncoder1x.java
@@ -1,5 +1,6 @@
 package org.infinispan.server.hotrod;
 
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -36,7 +37,7 @@ import io.netty.buffer.ByteBuf;
  */
 public abstract class AbstractEncoder1x implements VersionedEncoder {
 
-   protected final Log log = LogFactory.getLog(getClass(), Log.class);
+   protected static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass(), Log.class);
    protected final boolean trace = log.isTraceEnabled();
 
    @Override

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/query/RemoteListenerWithDslFilterIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/query/RemoteListenerWithDslFilterIT.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -154,7 +155,7 @@ public class RemoteListenerWithDslFilterIT extends RemoteQueryBaseIT {
          useRawData = true, includeCurrentState = true)
    public static class ClientEntryListener {
 
-      private final Log log = LogFactory.getLog(getClass());
+      private static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
 
       public final BlockingQueue<FilterResult> createEvents = new LinkedBlockingQueue<>();
 

--- a/server/memcached/src/main/java/org/infinispan/server/memcached/MemcachedServer.java
+++ b/server/memcached/src/main/java/org/infinispan/server/memcached/MemcachedServer.java
@@ -1,5 +1,6 @@
 package org.infinispan.server.memcached;
 
+import java.lang.invoke.MethodHandles;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -32,7 +33,7 @@ public class MemcachedServer extends AbstractProtocolServer<MemcachedServerConfi
       super("Memcached");
    }
 
-   private final JavaLog log = LogFactory.getLog(getClass(), JavaLog.class);
+   private final static JavaLog log = LogFactory.getLog(MethodHandles.lookup().lookupClass(), JavaLog.class);
    protected ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
    private AdvancedCache<String, byte[]> memcachedCache;
 

--- a/spring/spring4/spring4-embedded/src/main/java/org/infinispan/spring/InfinispanDefaultCacheFactoryBean.java
+++ b/spring/spring4/spring4-embedded/src/main/java/org/infinispan/spring/InfinispanDefaultCacheFactoryBean.java
@@ -1,5 +1,7 @@
 package org.infinispan.spring;
 
+import java.lang.invoke.MethodHandles;
+
 import org.infinispan.Cache;
 import org.infinispan.commons.logging.Log;
 import org.infinispan.commons.logging.LogFactory;
@@ -32,7 +34,7 @@ import org.springframework.beans.factory.InitializingBean;
 public class InfinispanDefaultCacheFactoryBean<K, V> implements FactoryBean<Cache<K, V>>,
                                                                 InitializingBean, DisposableBean {
 
-   protected final Log logger = LogFactory.getLog(getClass());
+   protected static final Log logger = LogFactory.getLog(MethodHandles.lookup().lookupClass());
 
    private CacheContainer infinispanCacheContainer;
 

--- a/spring/spring4/spring4-embedded/src/main/java/org/infinispan/spring/support/embedded/InfinispanNamedEmbeddedCacheFactoryBean.java
+++ b/spring/spring4/spring4-embedded/src/main/java/org/infinispan/spring/support/embedded/InfinispanNamedEmbeddedCacheFactoryBean.java
@@ -1,5 +1,7 @@
 package org.infinispan.spring.support.embedded;
 
+import java.lang.invoke.MethodHandles;
+
 import org.infinispan.Cache;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -127,7 +129,7 @@ public class InfinispanNamedEmbeddedCacheFactoryBean<K, V> implements FactoryBea
       NAMED
    }
 
-   private final Log logger = LogFactory.getLog(getClass());
+   private static final Log logger = LogFactory.getLog(MethodHandles.lookup().lookupClass());
 
    private EmbeddedCacheManager infinispanEmbeddedCacheManager;
 

--- a/spring/spring4/spring4-embedded/src/test/java/org/infinispan/spring/provider/sample/AbstractTestTemplate.java
+++ b/spring/spring4/spring4-embedded/src/test/java/org/infinispan/spring/provider/sample/AbstractTestTemplate.java
@@ -1,5 +1,6 @@
 package org.infinispan.spring.provider.sample;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Random;
 
 import org.infinispan.commons.api.BasicCache;
@@ -25,7 +26,7 @@ import org.testng.annotations.Test;
 @Test(groups = "functional")
 public abstract class AbstractTestTemplate extends AbstractTransactionalTestNGSpringContextTests {
 
-   protected final Log log = LogFactory.getLog(getClass());
+   protected static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
 
    @AfterMethod
    public void clearBookCache() {

--- a/spring/spring4/spring4-embedded/src/test/java/org/infinispan/spring/provider/sample/dao/JdbcBookDao.java
+++ b/spring/spring4/spring4-embedded/src/test/java/org/infinispan/spring/provider/sample/dao/JdbcBookDao.java
@@ -1,5 +1,6 @@
 package org.infinispan.spring.provider.sample.dao;
 
+import java.lang.invoke.MethodHandles;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Collection;
@@ -33,7 +34,7 @@ import org.springframework.stereotype.Repository;
 @Repository(value = "jdbcBookDao")
 public class JdbcBookDao implements BaseBookDao {
 
-   private final Log log = LogFactory.getLog(getClass());
+   private static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
 
    private NamedParameterJdbcTemplate jdbcTemplate;
 

--- a/spring/spring4/spring4-remote/src/main/java/org/infinispan/spring/AbstractRemoteCacheManagerFactory.java
+++ b/spring/spring4/spring4-remote/src/main/java/org/infinispan/spring/AbstractRemoteCacheManagerFactory.java
@@ -2,6 +2,7 @@ package org.infinispan.spring;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.invoke.MethodHandles;
 import java.net.InetSocketAddress;
 import java.util.Collection;
 import java.util.Properties;
@@ -23,7 +24,7 @@ import org.springframework.core.io.Resource;
  */
 public abstract class AbstractRemoteCacheManagerFactory {
 
-   protected final Log logger = LogFactory.getLog(getClass());
+   protected static final Log logger = LogFactory.getLog(MethodHandles.lookup().lookupClass());
 
    protected boolean startAutomatically = true;
 

--- a/spring/spring4/spring4-remote/src/main/java/org/infinispan/spring/support/remote/InfinispanNamedRemoteCacheFactoryBean.java
+++ b/spring/spring4/spring4-remote/src/main/java/org/infinispan/spring/support/remote/InfinispanNamedRemoteCacheFactoryBean.java
@@ -1,5 +1,6 @@
 package org.infinispan.spring.support.remote;
 
+import java.lang.invoke.MethodHandles;
 import java.util.concurrent.ConcurrentMap;
 
 import org.infinispan.client.hotrod.RemoteCache;
@@ -29,7 +30,7 @@ import org.springframework.util.StringUtils;
 public class InfinispanNamedRemoteCacheFactoryBean<K, V> implements FactoryBean<RemoteCache<K, V>>,
                                                                     BeanNameAware, InitializingBean {
 
-   private final Log logger = LogFactory.getLog(getClass());
+   private static final Log logger = LogFactory.getLog(MethodHandles.lookup().lookupClass());
 
    private RemoteCacheManager infinispanRemoteCacheManager;
 

--- a/spring/spring4/spring4-remote/src/test/java/org/infinispan/spring/provider/sample/AbstractTestTemplate.java
+++ b/spring/spring4/spring4-remote/src/test/java/org/infinispan/spring/provider/sample/AbstractTestTemplate.java
@@ -1,5 +1,6 @@
 package org.infinispan.spring.provider.sample;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Random;
 
 import org.infinispan.commons.api.BasicCache;
@@ -28,7 +29,7 @@ import org.testng.annotations.Test;
 @Test(groups = "functional")
 public abstract class AbstractTestTemplate extends AbstractTransactionalTestNGSpringContextTests {
 
-   protected final Log log = LogFactory.getLog(getClass());
+   protected static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
 
    @BeforeTest(alwaysRun = true)
    public void beforeTest() {

--- a/spring/spring4/spring4-remote/src/test/java/org/infinispan/spring/provider/sample/dao/JdbcBookDao.java
+++ b/spring/spring4/spring4-remote/src/test/java/org/infinispan/spring/provider/sample/dao/JdbcBookDao.java
@@ -1,5 +1,6 @@
 package org.infinispan.spring.provider.sample.dao;
 
+import java.lang.invoke.MethodHandles;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Collection;
@@ -33,7 +34,7 @@ import org.springframework.stereotype.Repository;
 @Repository(value = "jdbcBookDao")
 public class JdbcBookDao implements BaseBookDao {
 
-   private final Log log = LogFactory.getLog(getClass());
+   private static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
 
    private NamedParameterJdbcTemplate jdbcTemplate;
 

--- a/tree/src/test/java/org/infinispan/api/tree/BaseNodeMoveAPITest.java
+++ b/tree/src/test/java/org/infinispan/api/tree/BaseNodeMoveAPITest.java
@@ -5,6 +5,7 @@ import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertTrue;
 import static org.testng.AssertJUnit.fail;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -42,7 +43,7 @@ import org.testng.annotations.Test;
  */
 @Test(groups = "functional", testName = "api.tree.BaseNodeMoveAPITest")
 public abstract class BaseNodeMoveAPITest extends SingleCacheManagerTest {
-   protected final Log log = LogFactory.getLog(getClass());
+   protected static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
 
    protected static final Fqn A = Fqn.fromString("/a"), B = Fqn.fromString("/b"), C = Fqn.fromString("/c"), D = Fqn.fromString("/d"), E = Fqn.fromString("/e");
    static final Fqn A_B = Fqn.fromRelativeFqn(A, B);


### PR DESCRIPTION
This prevents a potential deadlock in the Logger factory which synchronizes on the ClassLoader.

https://issues.jboss.org/browse/ISPN-8647