### PR TITLE
ISPN-8712 BiasRevocationTest.testFailedRevocationDuringPutAllOnNonOwn…

### DIFF
--- a/core/src/main/java/org/infinispan/commands/write/ExceptionAckCommand.java
+++ b/core/src/main/java/org/infinispan/commands/write/ExceptionAckCommand.java
@@ -5,8 +5,12 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 
 import org.infinispan.commands.remote.BaseRpcCommand;
+import org.infinispan.commons.CacheException;
+import org.infinispan.remoting.transport.ResponseCollectors;
 import org.infinispan.util.ByteString;
 import org.infinispan.util.concurrent.CommandAckCollector;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
 
 /**
  * A command that represents an exception acknowledge sent by any owner.
@@ -17,6 +21,7 @@ import org.infinispan.util.concurrent.CommandAckCollector;
  * @since 9.0
  */
 public class ExceptionAckCommand extends BaseRpcCommand {
+   private static final Log log = LogFactory.getLog(ExceptionAckCommand.class);
 
    public static final byte COMMAND_ID = 42;
    private CommandAckCollector commandAckCollector;
@@ -40,7 +45,8 @@ public class ExceptionAckCommand extends BaseRpcCommand {
    }
 
    public void ack() {
-      commandAckCollector.completeExceptionally(id, throwable, topologyId);
+      CacheException remoteException = ResponseCollectors.wrapRemoteException(getOrigin(), this.throwable);
+      commandAckCollector.completeExceptionally(id, remoteException, topologyId);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/interceptors/impl/EntryWrappingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/EntryWrappingInterceptor.java
@@ -337,7 +337,10 @@ public class EntryWrappingInterceptor extends DDAsyncInterceptor {
          }
          for (Object key : keys) {
             MVCCEntry entry = (MVCCEntry) ctx.lookupEntry(key);
-            entry.resetCurrentValue();
+            // When a non-transactional command is retried remotely, the context is going to be empty
+            if (entry != null) {
+               entry.resetCurrentValue();
+            }
          }
       } else {
          ctx.removeLookedUpEntries(keys);

--- a/core/src/main/java/org/infinispan/remoting/inboundhandler/TrianglePerCacheInboundInvocationHandler.java
+++ b/core/src/main/java/org/infinispan/remoting/inboundhandler/TrianglePerCacheInboundInvocationHandler.java
@@ -21,7 +21,6 @@ import org.infinispan.distribution.TriangleOrderManager;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
 import org.infinispan.interceptors.locking.ClusteringDependentLogic;
-import org.infinispan.remoting.RemoteException;
 import org.infinispan.remoting.inboundhandler.action.Action;
 import org.infinispan.remoting.inboundhandler.action.ActionState;
 import org.infinispan.remoting.inboundhandler.action.ActionStatus;
@@ -235,7 +234,7 @@ public class TrianglePerCacheInboundInvocationHandler extends BasePerCacheInboun
       return new DefaultTopologyRunnable(this, command, Reply.NO_OP, TopologyMode.READY_TX_DATA, commandTopologyId, false) {
          @Override
          protected void onException(Throwable throwable) {
-            sendExceptionAck(writeCommand.getCommandInvocationId(), new RemoteException("Exception on " + localAddress, throwable), commandTopologyId);
+            sendExceptionAck(writeCommand.getCommandInvocationId(), throwable, commandTopologyId);
          }
       };
    }

--- a/core/src/main/java/org/infinispan/remoting/transport/ResponseCollectors.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/ResponseCollectors.java
@@ -16,7 +16,7 @@ import org.infinispan.util.logging.LogFactory;
 public class ResponseCollectors {
    private static final Log log = LogFactory.getLog(ResponseCollectors.class);
 
-   public static CacheException wrapRemoteException(Address sender, Exception exception) {
+   public static CacheException wrapRemoteException(Address sender, Throwable exception) {
       CacheException e;
       if (exception instanceof SuspectException) {
          e = log.thirdPartySuspected(sender, (SuspectException) exception);


### PR DESCRIPTION
…erThrowBefore random failures
https://issues.jboss.org/browse/ISPN-8712

* Avoid NullPointerException in EntryWrappingInterceptor
  when resetting the context entries for a retried command.
* Wrap triangle ACK exceptions on the originator
* Use the same logic as for synchronous commands, preserving
  OutdatedTopologyExceptions.