### PR TITLE
ISPN-8708 Remote iteration with limited batch sends finished segments

### DIFF
--- a/core/src/main/java/org/infinispan/stream/impl/AbstractRehashPublisherDecorator.java
+++ b/core/src/main/java/org/infinispan/stream/impl/AbstractRehashPublisherDecorator.java
@@ -1,0 +1,65 @@
+package org.infinispan.stream.impl;
+
+import java.util.PrimitiveIterator;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.infinispan.commons.util.IntSet;
+import org.infinispan.commons.util.SmallIntSet;
+import org.infinispan.distribution.DistributionManager;
+import org.infinispan.distribution.ch.ConsistentHash;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.util.logging.Log;
+import org.reactivestreams.Publisher;
+
+import io.reactivex.Flowable;
+
+/**
+ * Abstract publisher decorator that is used to notify segment listener of loss of segments while entries are
+ * being retrieved.
+ * @author wburns
+ * @since 9.0
+ */
+public abstract class AbstractRehashPublisherDecorator<S> implements PublisherDecorator<S> {
+   final AbstractCacheStream.IteratorOperation iteratorOperation;
+   final DistributionManager dm;
+   final Address localAddress;
+   final Consumer<? super Supplier<PrimitiveIterator.OfInt>> lostSegments;
+   final Consumer<Object> keyConsumer;
+
+   AbstractRehashPublisherDecorator(AbstractCacheStream.IteratorOperation iteratorOperation, DistributionManager dm,
+         Address localAddress, Consumer<? super Supplier<PrimitiveIterator.OfInt>> lostSegments,
+         Consumer<Object> keyConsumer) {
+      this.iteratorOperation = iteratorOperation;
+      this.dm = dm;
+      this.localAddress = localAddress;
+      this.lostSegments = lostSegments;
+      this.keyConsumer = keyConsumer;
+   }
+
+   abstract Log getLog();
+
+   Publisher<S> decorateLocal(Consumer<? super Supplier<PrimitiveIterator.OfInt>> completedSegments,
+         ConsistentHash beginningCh, boolean onlyLocal, IntSet segmentsToFilter,
+         Publisher<S> localPublisher) {
+      Publisher<S> convertedPublisher = Flowable.fromPublisher(localPublisher).doOnComplete(() -> {
+         IntSet ourSegments;
+         if (onlyLocal) {
+            ourSegments = SmallIntSet.from(beginningCh.getSegmentsForOwner(localAddress));
+         } else {
+            ourSegments = SmallIntSet.from(beginningCh.getPrimarySegmentsForOwner(localAddress));
+         }
+         ourSegments.retainAll(segmentsToFilter);
+         // This will notify both completed and suspect of segments that may not even exist or were completed before
+         // on a rehash
+         if (dm.getReadConsistentHash().equals(beginningCh)) {
+            getLog().tracef("Local iterator has completed segments %s", ourSegments);
+            completedSegments.accept((Supplier<PrimitiveIterator.OfInt>) ourSegments::iterator);
+         } else {
+            getLog().tracef("Local iterator segments %s are all suspect as consistent hash has changed", ourSegments);
+            lostSegments.accept((Supplier<PrimitiveIterator.OfInt>) ourSegments::iterator);
+         }
+      });
+      return iteratorOperation.handlePublisher(convertedPublisher, keyConsumer);
+   }
+}

--- a/core/src/main/java/org/infinispan/stream/impl/CompletionRehashPublisherDecorator.java
+++ b/core/src/main/java/org/infinispan/stream/impl/CompletionRehashPublisherDecorator.java
@@ -1,0 +1,33 @@
+package org.infinispan.stream.impl;
+
+import java.util.PrimitiveIterator;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.infinispan.distribution.DistributionManager;
+import org.infinispan.remoting.transport.Address;
+import org.reactivestreams.Publisher;
+
+import io.reactivex.Flowable;
+
+/**
+ * @author wburns
+ * @since 9.0
+ */
+public class CompletionRehashPublisherDecorator<S> extends RehashPublisherDecorator<S> {
+   private final KeyWatchingCompletionListener completionListener;
+
+   CompletionRehashPublisherDecorator(AbstractCacheStream.IteratorOperation iteratorOperation, DistributionManager dm,
+         Address localAddress, KeyWatchingCompletionListener completionListener,
+         Consumer<? super Supplier<PrimitiveIterator.OfInt>> completedSegments,
+         Consumer<? super Supplier<PrimitiveIterator.OfInt>> lostSegments, Consumer<Object> keyConsumer) {
+      super(iteratorOperation, dm, localAddress, completedSegments, lostSegments, keyConsumer);
+      this.completionListener = completionListener;
+   }
+
+   @Override
+   protected Publisher<S> decorateBeforeReturn(Publisher<S> publisher) {
+      return Flowable.fromPublisher(super.decorateBeforeReturn(publisher)).doOnNext(
+            completionListener::valueAdded);
+   }
+}

--- a/core/src/main/java/org/infinispan/stream/impl/CompletionRehashPublisherDecorator.java
+++ b/core/src/main/java/org/infinispan/stream/impl/CompletionRehashPublisherDecorator.java
@@ -1,33 +1,95 @@
 package org.infinispan.stream.impl;
 
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.PrimitiveIterator;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import org.infinispan.commons.util.IntSet;
 import org.infinispan.distribution.DistributionManager;
+import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.remoting.transport.Address;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
 import org.reactivestreams.Publisher;
 
 import io.reactivex.Flowable;
 
 /**
+ * PublisherDecorator that only notifies a user listener of segment completion after the last entry for a given
+ * segment has been retrieved from iteration.
  * @author wburns
  * @since 9.0
  */
 public class CompletionRehashPublisherDecorator<S> extends RehashPublisherDecorator<S> {
-   private final KeyWatchingCompletionListener completionListener;
+   private static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
+
+   private final Consumer<? super Supplier<PrimitiveIterator.OfInt>> userListener;
+   private final List<KeyWatchingCompletionListener> completionListeners;
 
    CompletionRehashPublisherDecorator(AbstractCacheStream.IteratorOperation iteratorOperation, DistributionManager dm,
-         Address localAddress, KeyWatchingCompletionListener completionListener,
+         Address localAddress, Consumer<? super Supplier<PrimitiveIterator.OfInt>> userListener,
          Consumer<? super Supplier<PrimitiveIterator.OfInt>> completedSegments,
          Consumer<? super Supplier<PrimitiveIterator.OfInt>> lostSegments, Consumer<Object> keyConsumer) {
       super(iteratorOperation, dm, localAddress, completedSegments, lostSegments, keyConsumer);
-      this.completionListener = completionListener;
+      this.userListener = userListener;
+      this.completionListeners = Collections.synchronizedList(new ArrayList<>(4));
+   }
+
+   public void valueIterated(Object obj) {
+      for (KeyWatchingCompletionListener kwcl : completionListeners) {
+         kwcl.valueIterated(obj);
+      }
+   }
+
+   public void complete() {
+      completionListeners.forEach(KeyWatchingCompletionListener::completed);
    }
 
    @Override
-   protected Publisher<S> decorateBeforeReturn(Publisher<S> publisher) {
-      return Flowable.fromPublisher(super.decorateBeforeReturn(publisher)).doOnNext(
-            completionListener::valueAdded);
+   Log getLog() {
+      return log;
+   }
+
+   @Override
+   public Publisher<S> decorateRemote(ClusterStreamManager.RemoteIteratorPublisher<S> remotePublisher) {
+      // We have to have a listener per remote publisher, since we receive results concurrently and we
+      // can't properly track the completion of keys per segment without them being separated
+      KeyWatchingCompletionListener kwcl = new KeyWatchingCompletionListener(userListener);
+      completionListeners.add(kwcl);
+
+      Publisher<S> convertedPublisher = s -> remotePublisher.subscribe(s, i -> {
+         // Remote we always notify the provided completed segments as it tracks segment completion
+         // for retries
+         completedSegments.accept(i);
+         // however we have to wait before notifying the user segment completion until
+         // we iterate upon the last key of the block of segments
+         kwcl.accept(i);
+      }, lostSegments);
+      // We have to track each key received from this publisher as it would map to all segments when completed
+      return Flowable.fromPublisher(iteratorOperation.handlePublisher(convertedPublisher, keyConsumer)).doOnNext(
+            kwcl::valueAdded);
+   }
+
+   @Override
+   public Publisher<S> decorateLocal(ConsistentHash beginningCh, boolean onlyLocal, IntSet segmentsToFilter,
+         Publisher<S> localPublisher) {
+      KeyWatchingCompletionListener kwcl = new KeyWatchingCompletionListener(userListener);
+      completionListeners.add(kwcl);
+
+      Publisher<S> convertedLocalPublisher = decorateLocal(i -> {
+         // Remote we always notify the provided completed segments as it tracks segment completion
+         // for retries
+         completedSegments.accept(i);
+         // however we have to wait before notifying the user segment completion until
+         // we iterate upon the last key of the block of segments
+         kwcl.accept(i);
+      }, beginningCh, onlyLocal, segmentsToFilter, localPublisher);
+      // We have to track each key received from this publisher as it would map to all segments when completed
+      return Flowable.fromPublisher(iteratorOperation.handlePublisher(convertedLocalPublisher, keyConsumer))
+            .doOnNext(kwcl::valueAdded);
    }
 }

--- a/core/src/main/java/org/infinispan/stream/impl/IdentityPublisherDecorator.java
+++ b/core/src/main/java/org/infinispan/stream/impl/IdentityPublisherDecorator.java
@@ -5,6 +5,7 @@ import org.infinispan.distribution.ch.ConsistentHash;
 import org.reactivestreams.Publisher;
 
 /**
+ * PublishDecorator that just returns the publisher provided by the caller
  * @author wburns
  * @since 9.0
  */

--- a/core/src/main/java/org/infinispan/stream/impl/IdentityPublisherDecorator.java
+++ b/core/src/main/java/org/infinispan/stream/impl/IdentityPublisherDecorator.java
@@ -1,0 +1,31 @@
+package org.infinispan.stream.impl;
+
+import org.infinispan.commons.util.IntSet;
+import org.infinispan.distribution.ch.ConsistentHash;
+import org.reactivestreams.Publisher;
+
+/**
+ * @author wburns
+ * @since 9.0
+ */
+class IdentityPublisherDecorator<S, R> implements PublisherDecorator<S> {
+   private static final IdentityPublisherDecorator decorator = new IdentityPublisherDecorator();
+
+   private IdentityPublisherDecorator() {
+   }
+
+   static <S, R> IdentityPublisherDecorator<S, R> getInstance() {
+      return decorator;
+   }
+
+   @Override
+   public Publisher<S> decorateRemote(ClusterStreamManager.RemoteIteratorPublisher<S> remotePublisher) {
+      return remotePublisher;
+   }
+
+   @Override
+   public Publisher<S> decorateLocal(ConsistentHash beginningCh, boolean onlyLocal, IntSet segmentsToFilter,
+         Publisher<S> localPublisher) {
+      return localPublisher;
+   }
+}

--- a/core/src/main/java/org/infinispan/stream/impl/KeyWatchingCompletionListener.java
+++ b/core/src/main/java/org/infinispan/stream/impl/KeyWatchingCompletionListener.java
@@ -1,0 +1,81 @@
+package org.infinispan.stream.impl;
+
+import java.util.Map;
+import java.util.PrimitiveIterator;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.infinispan.commons.util.ByRef;
+
+/**
+ * Only notifies a completion listener when the last key for a segment has been found. The last key for a segment
+ * is assumed to be the last key seen {@link KeyWatchingCompletionListener#valueAdded(Object)} before segments
+ * are encountered {@link KeyWatchingCompletionListener#segmentsEncountered(Supplier)}.
+ */
+class KeyWatchingCompletionListener {
+   private final AtomicReference<Object> currentKey = new AtomicReference<>();
+   private final Map<Object, Supplier<PrimitiveIterator.OfInt>> pendingSegments = new ConcurrentHashMap<>();
+   private final Consumer<? super Supplier<PrimitiveIterator.OfInt>> completionListener;
+   // The next 2 variables are possible assuming that the iterator is not used concurrently. This way we don't
+   // have to allocate them on every entry iterated
+   private final ByRef<Supplier<PrimitiveIterator.OfInt>> ref = new ByRef<>(null);
+   private final BiFunction<Object, Supplier<PrimitiveIterator.OfInt>, Supplier<PrimitiveIterator.OfInt>> iteratorMapping;
+
+   KeyWatchingCompletionListener(Consumer<? super Supplier<PrimitiveIterator.OfInt>> completionListener) {
+      this.completionListener = completionListener;
+      this.iteratorMapping = (k, v) -> {
+         if (v != null) {
+            ref.set(v);
+         }
+         currentKey.compareAndSet(k, null);
+         return null;
+      };
+   }
+
+   public void valueAdded(Object key) {
+      currentKey.set(key);
+   }
+
+   public void valueIterated(Object key) {
+      pendingSegments.compute(key, iteratorMapping);
+      Supplier<PrimitiveIterator.OfInt> segments = ref.get();
+      if (segments != null) {
+         ref.set(null);
+         completionListener.accept(segments);
+      }
+   }
+
+   public void segmentsEncountered(Supplier<PrimitiveIterator.OfInt> segments) {
+      // This code assumes that valueAdded and segmentsEncountered are not invoked concurrently and that all values
+      // added for a response before the segments are completed.
+      // The valueIterated method can be invoked at any point however.
+      // See ClusterStreamManagerImpl$ClusterStreamSubscription.sendRequest where the added and segments are called into
+      ByRef<Supplier<PrimitiveIterator.OfInt>> segmentsToNotify = new ByRef<>(segments);
+      Object key = currentKey.get();
+      if (key != null) {
+         pendingSegments.compute(key, (k, v) -> {
+            // The iterator has consumed all the keys, so there is no reason to wait: just notify of segment
+            // completion immediately
+            if (currentKey.get() == null) {
+               return null;
+            }
+            // This means we didn't iterate on a key before segments were completed - means it was empty. The
+            // valueIterated notifies the completion of non-empty segments, but we need to notify the completion of
+            // empty segments here
+            segmentsToNotify.set(v);
+            return segments;
+         });
+      }
+      Supplier<PrimitiveIterator.OfInt> notifyThese = segmentsToNotify.get();
+      if (notifyThese != null) {
+         completionListener.accept(notifyThese);
+      }
+   }
+
+   public void completed() {
+      pendingSegments.forEach((k, v) -> completionListener.accept(v));
+   }
+}

--- a/core/src/main/java/org/infinispan/stream/impl/PublisherDecorator.java
+++ b/core/src/main/java/org/infinispan/stream/impl/PublisherDecorator.java
@@ -5,12 +5,27 @@ import org.infinispan.distribution.ch.ConsistentHash;
 import org.reactivestreams.Publisher;
 
 /**
+ * Decorator that decorates publishers based on if it is local or remote to handle segment completions
  * @author wburns
  * @since 9.0
  */
 interface PublisherDecorator<S> {
+   /**
+    * Invoked for each remote publisher to provide additional functionality
+    * @param remotePublisher the provided remote publisher
+    * @return the resulting publisher (usually wrapped in some way)
+    */
    Publisher<S> decorateRemote(ClusterStreamManager.RemoteIteratorPublisher<S> remotePublisher);
 
+   /**
+    * Invoked for a local publisher, which only completes segments if the consistent hash after completion is the same
+    * as the one provided
+    * @param beginningCh the consistent has to test against
+    * @param onlyLocal whether this publisher is only done locally (that is there are no other remote publishers)
+    * @param segmentsToFilter the segments to use for this invocation
+    * @param localPublisher the internal local publisher
+    * @return the resulting publisher (usually wrapped in some way)
+    */
    Publisher<S> decorateLocal(ConsistentHash beginningCh, boolean onlyLocal, IntSet segmentsToFilter,
          Publisher<S> localPublisher);
 }

--- a/core/src/main/java/org/infinispan/stream/impl/PublisherDecorator.java
+++ b/core/src/main/java/org/infinispan/stream/impl/PublisherDecorator.java
@@ -1,0 +1,16 @@
+package org.infinispan.stream.impl;
+
+import org.infinispan.commons.util.IntSet;
+import org.infinispan.distribution.ch.ConsistentHash;
+import org.reactivestreams.Publisher;
+
+/**
+ * @author wburns
+ * @since 9.0
+ */
+interface PublisherDecorator<S> {
+   Publisher<S> decorateRemote(ClusterStreamManager.RemoteIteratorPublisher<S> remotePublisher);
+
+   Publisher<S> decorateLocal(ConsistentHash beginningCh, boolean onlyLocal, IntSet segmentsToFilter,
+         Publisher<S> localPublisher);
+}

--- a/core/src/main/java/org/infinispan/stream/impl/RehashPublisherDecorator.java
+++ b/core/src/main/java/org/infinispan/stream/impl/RehashPublisherDecorator.java
@@ -1,0 +1,77 @@
+package org.infinispan.stream.impl;
+
+import java.lang.invoke.MethodHandles;
+import java.util.PrimitiveIterator;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.infinispan.commons.util.IntSet;
+import org.infinispan.commons.util.SmallIntSet;
+import org.infinispan.distribution.DistributionManager;
+import org.infinispan.distribution.ch.ConsistentHash;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+import org.reactivestreams.Publisher;
+
+import io.reactivex.Flowable;
+
+/**
+ * @author wburns
+ * @since 9.0
+ */
+class RehashPublisherDecorator<S> implements PublisherDecorator<S> {
+   private static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
+
+   final AbstractCacheStream.IteratorOperation iteratorOperation;
+   final DistributionManager dm;
+   final Address localAddress;
+   final Consumer<? super Supplier<PrimitiveIterator.OfInt>> completedSegments;
+   final Consumer<? super Supplier<PrimitiveIterator.OfInt>> lostSegments;
+   final Consumer<Object> keyConsumer;
+
+   RehashPublisherDecorator(AbstractCacheStream.IteratorOperation iteratorOperation, DistributionManager dm,
+         Address localAddress, Consumer<? super Supplier<PrimitiveIterator.OfInt>> completedSegments,
+         Consumer<? super Supplier<PrimitiveIterator.OfInt>> lostSegments, Consumer<Object> keyConsumer) {
+      this.iteratorOperation = iteratorOperation;
+      this.dm = dm;
+      this.localAddress = localAddress;
+      this.completedSegments = completedSegments;
+      this.lostSegments = lostSegments;
+      this.keyConsumer = keyConsumer;
+   }
+
+   @Override
+   public Publisher<S> decorateRemote(ClusterStreamManager.RemoteIteratorPublisher<S> remotePublisher) {
+      Publisher<S> convertedPublisher = s -> remotePublisher.subscribe(s, completedSegments, lostSegments);
+      return decorateBeforeReturn(convertedPublisher);
+   }
+
+   @Override
+   public Publisher<S> decorateLocal(ConsistentHash beginningCh, boolean onlyLocal, IntSet segmentsToFilter,
+         Publisher<S> localPublisher) {
+      Publisher<S> convertedPublisher = Flowable.fromPublisher(localPublisher).doOnComplete(() -> {
+         IntSet ourSegments;
+         if (onlyLocal) {
+            ourSegments = SmallIntSet.from(beginningCh.getSegmentsForOwner(localAddress));
+         } else {
+            ourSegments = SmallIntSet.from(beginningCh.getPrimarySegmentsForOwner(localAddress));
+         }
+         ourSegments.retainAll(segmentsToFilter);
+         // This will notify both completed and suspect of segments that may not even exist or were completed before
+         // on a rehash
+         if (dm.getReadConsistentHash().equals(beginningCh)) {
+            log.tracef("Local iterator has completed segments %s", ourSegments);
+            completedSegments.accept((Supplier<PrimitiveIterator.OfInt>) ourSegments::iterator);
+         } else {
+            log.tracef("Local iterator segments %s are all suspect as consistent hash has changed", ourSegments);
+            lostSegments.accept((Supplier<PrimitiveIterator.OfInt>) ourSegments::iterator);
+         }
+      });
+      return decorateBeforeReturn(convertedPublisher);
+   }
+
+   protected Publisher<S> decorateBeforeReturn(Publisher<S> publisher) {
+      return iteratorOperation.handlePublisher(publisher, keyConsumer);
+   }
+}

--- a/core/src/main/java/org/infinispan/stream/impl/RehashPublisherDecorator.java
+++ b/core/src/main/java/org/infinispan/stream/impl/RehashPublisherDecorator.java
@@ -6,7 +6,6 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import org.infinispan.commons.util.IntSet;
-import org.infinispan.commons.util.SmallIntSet;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.remoting.transport.Address;
@@ -14,64 +13,37 @@ import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 import org.reactivestreams.Publisher;
 
-import io.reactivex.Flowable;
-
 /**
+ * PublisherDecorator that decorates the publisher to notify of when segments are completed for these invocations
  * @author wburns
  * @since 9.0
  */
-class RehashPublisherDecorator<S> implements PublisherDecorator<S> {
+class RehashPublisherDecorator<S> extends AbstractRehashPublisherDecorator<S> {
    private static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
 
-   final AbstractCacheStream.IteratorOperation iteratorOperation;
-   final DistributionManager dm;
-   final Address localAddress;
    final Consumer<? super Supplier<PrimitiveIterator.OfInt>> completedSegments;
-   final Consumer<? super Supplier<PrimitiveIterator.OfInt>> lostSegments;
-   final Consumer<Object> keyConsumer;
 
    RehashPublisherDecorator(AbstractCacheStream.IteratorOperation iteratorOperation, DistributionManager dm,
          Address localAddress, Consumer<? super Supplier<PrimitiveIterator.OfInt>> completedSegments,
          Consumer<? super Supplier<PrimitiveIterator.OfInt>> lostSegments, Consumer<Object> keyConsumer) {
-      this.iteratorOperation = iteratorOperation;
-      this.dm = dm;
-      this.localAddress = localAddress;
+      super(iteratorOperation, dm, localAddress, lostSegments, keyConsumer);
       this.completedSegments = completedSegments;
-      this.lostSegments = lostSegments;
-      this.keyConsumer = keyConsumer;
+   }
+
+   @Override
+   Log getLog() {
+      return log;
    }
 
    @Override
    public Publisher<S> decorateRemote(ClusterStreamManager.RemoteIteratorPublisher<S> remotePublisher) {
       Publisher<S> convertedPublisher = s -> remotePublisher.subscribe(s, completedSegments, lostSegments);
-      return decorateBeforeReturn(convertedPublisher);
+      return iteratorOperation.handlePublisher(convertedPublisher, keyConsumer);
    }
 
    @Override
    public Publisher<S> decorateLocal(ConsistentHash beginningCh, boolean onlyLocal, IntSet segmentsToFilter,
          Publisher<S> localPublisher) {
-      Publisher<S> convertedPublisher = Flowable.fromPublisher(localPublisher).doOnComplete(() -> {
-         IntSet ourSegments;
-         if (onlyLocal) {
-            ourSegments = SmallIntSet.from(beginningCh.getSegmentsForOwner(localAddress));
-         } else {
-            ourSegments = SmallIntSet.from(beginningCh.getPrimarySegmentsForOwner(localAddress));
-         }
-         ourSegments.retainAll(segmentsToFilter);
-         // This will notify both completed and suspect of segments that may not even exist or were completed before
-         // on a rehash
-         if (dm.getReadConsistentHash().equals(beginningCh)) {
-            log.tracef("Local iterator has completed segments %s", ourSegments);
-            completedSegments.accept((Supplier<PrimitiveIterator.OfInt>) ourSegments::iterator);
-         } else {
-            log.tracef("Local iterator segments %s are all suspect as consistent hash has changed", ourSegments);
-            lostSegments.accept((Supplier<PrimitiveIterator.OfInt>) ourSegments::iterator);
-         }
-      });
-      return decorateBeforeReturn(convertedPublisher);
-   }
-
-   protected Publisher<S> decorateBeforeReturn(Publisher<S> publisher) {
-      return iteratorOperation.handlePublisher(publisher, keyConsumer);
+      return decorateLocal(completedSegments, beginningCh, onlyLocal, segmentsToFilter, localPublisher);
    }
 }

--- a/core/src/test/java/org/infinispan/stream/impl/CompletionRehashPublisherDecoratorTest.java
+++ b/core/src/test/java/org/infinispan/stream/impl/CompletionRehashPublisherDecoratorTest.java
@@ -1,0 +1,260 @@
+package org.infinispan.stream.impl;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.AssertJUnit.assertEquals;
+
+import java.util.PrimitiveIterator;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.infinispan.commons.util.IntSet;
+import org.infinispan.commons.util.SmallIntSet;
+import org.infinispan.container.entries.CacheEntry;
+import org.infinispan.container.entries.ImmortalCacheEntry;
+import org.infinispan.distribution.DistributionManager;
+import org.infinispan.distribution.ch.ConsistentHash;
+import org.infinispan.remoting.transport.Address;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.reactivestreams.Publisher;
+import org.testng.annotations.Test;
+
+import io.reactivex.Flowable;
+import io.reactivex.processors.PublishProcessor;
+import io.reactivex.subscribers.TestSubscriber;
+
+/**
+ * @author wburns
+ * @since 9.0
+ */
+@Test(testName = "stream.impl.AbstractWriteSkewStressTest", groups = "functional")
+public class CompletionRehashPublisherDecoratorTest {
+
+   <S> CompletionRehashPublisherDecorator<S> createDecorator(KeyWatchingCompletionListener kwcl, Consumer<Object> entryConsumer) {
+      return new CompletionRehashPublisherDecorator<>(AbstractCacheStream.IteratorOperation.NO_MAP, null, null, kwcl,
+            i -> kwcl.segmentsEncountered(i), i -> {}, entryConsumer);
+   }
+
+   <S> CompletionRehashPublisherDecorator<S> createDecorator(ConsistentHash ch, Set<Integer> segmentsForOwner,
+         Set<Integer> primarySegmentsForOwner, KeyWatchingCompletionListener kwcl, Consumer<Object> entryConsumer) {
+      Address address = Mockito.mock(Address.class);
+
+      if (segmentsForOwner != null) {
+         when(ch.getSegmentsForOwner(eq(address))).thenReturn(segmentsForOwner);
+      }
+      if (primarySegmentsForOwner != null) {
+         when(ch.getPrimarySegmentsForOwner(eq(address))).thenReturn(primarySegmentsForOwner);
+      }
+
+      DistributionManager dm = when(mock(DistributionManager.class).getReadConsistentHash()).thenReturn(ch).getMock();
+
+      return new CompletionRehashPublisherDecorator<>(AbstractCacheStream.IteratorOperation.NO_MAP, dm, address, kwcl,
+            i -> kwcl.segmentsEncountered(i), i -> {}, entryConsumer);
+   }
+
+   void simpleAssert(Publisher<Object> resultingPublisher, PublishProcessor<Object> valuePublisher,
+         Consumer<Supplier<PrimitiveIterator.OfInt>> segmentConsumer, KeyWatchingCompletionListener kwcl,
+         Consumer<IntSet> notifySegmentsCompleted, IntSet segments) {
+      // This will store the result once the stream is done
+      TestSubscriber<Object> test = Flowable.fromPublisher(resultingPublisher).test();
+
+      test.assertNotComplete();
+
+      CacheEntry entry1 = new ImmortalCacheEntry(1, 1);
+      valuePublisher.onNext(entry1);
+      CacheEntry entry2 = new ImmortalCacheEntry(2, 2);
+      valuePublisher.onNext(entry2);
+      CacheEntry entry3 = new ImmortalCacheEntry(3, 3);
+      valuePublisher.onNext(entry3);
+
+      // We should have received 3 entries down now
+      test.assertValueCount(3);
+
+      test.assertNotComplete();
+
+      Mockito.verify(segmentConsumer, Mockito.never()).accept(Mockito.any());
+
+      // Finally complete the publisher which will in turn complete any further down the line
+      valuePublisher.onComplete();
+
+      test.assertComplete();
+
+      // We still shouldn't be notified since we haven't iterated upon the last entry though
+      Mockito.verify(segmentConsumer, Mockito.never()).accept(Mockito.any());
+
+      // Now let our iterate over the entries
+      kwcl.valueIterated(entry1);
+      Mockito.verify(segmentConsumer, Mockito.never()).accept(Mockito.any());
+      kwcl.valueIterated(entry2);
+      Mockito.verify(segmentConsumer, Mockito.never()).accept(Mockito.any());
+      kwcl.valueIterated(entry3);
+
+      notifySegmentsCompleted.accept(segments);
+
+      // Now that we iterated over entry3 we should be completed!
+      ArgumentCaptor<Supplier<PrimitiveIterator.OfInt>> captor = ArgumentCaptor.forClass(Supplier.class);
+
+      Mockito.verify(segmentConsumer, Mockito.times(1)).accept(captor.capture());
+
+      PrimitiveIterator.OfInt completedSegments = captor.getValue().get();
+
+      assertEquals(segments, SmallIntSet.of(completedSegments));
+   }
+
+   /**
+    * Test to verify when local only stream is used and all entries are published and completed before iteration
+    */
+   public void testLocalOnlyStreamCompletes() {
+      IntSet segments = SmallIntSet.of(1, 4);
+
+      Consumer<Supplier<PrimitiveIterator.OfInt>> segmentConsumer = mock(Consumer.class);
+      KeyWatchingCompletionListener kwcl = new KeyWatchingCompletionListener(segmentConsumer);
+      Consumer<Object> entryConsumer = mock(Consumer.class);
+      ConsistentHash ch = mock(ConsistentHash.class);
+
+      CompletionRehashPublisherDecorator<Object> crpd = createDecorator(ch, segments, null, kwcl, entryConsumer);
+
+      PublishProcessor<Object> localPublisherProcessor = PublishProcessor.create();
+
+      // This is local only iteration
+      Publisher<Object> localPublisher = crpd.decorateLocal(ch, true, segments, localPublisherProcessor);
+
+      simpleAssert(localPublisher, localPublisherProcessor, segmentConsumer, kwcl, s -> { }, segments);
+   }
+
+   public void testRemoteOnlyStreamCompletes() {
+      IntSet segments = SmallIntSet.of(1, 4);
+
+      Consumer<Supplier<PrimitiveIterator.OfInt>> segmentConsumer = mock(Consumer.class);
+      KeyWatchingCompletionListener kwcl = new KeyWatchingCompletionListener(segmentConsumer);
+      Consumer<Object> entryConsumer = mock(Consumer.class);
+
+      CompletionRehashPublisherDecorator<Object> crpd = createDecorator(kwcl, entryConsumer);
+
+      TestRemoteIteratorPublisher<Object> remoteIteratorPublisher = new TestRemoteIteratorPublisher<>();
+
+      // Remote only iteration
+      Publisher<Object> resultingPublisher = crpd.decorateRemote(remoteIteratorPublisher);
+
+      simpleAssert(resultingPublisher, remoteIteratorPublisher.publishProcessor(), segmentConsumer, kwcl, s ->
+            remoteIteratorPublisher.notifyCompleted(s::iterator), segments);
+   }
+
+   public void testRemoteAndLocal() {
+      IntSet segments = SmallIntSet.of(1, 4);
+
+      Consumer<Supplier<PrimitiveIterator.OfInt>> segmentConsumer = mock(Consumer.class);
+      KeyWatchingCompletionListener kwcl = new KeyWatchingCompletionListener(segmentConsumer);
+      Consumer<Object> entryConsumer = mock(Consumer.class);
+      ConsistentHash ch = mock(ConsistentHash.class);
+
+      CompletionRehashPublisherDecorator<Object> crpd = createDecorator(ch, segments, null, kwcl, entryConsumer);
+
+      PublishProcessor<Object> localPublisherProcessor = PublishProcessor.create();
+
+      Publisher<Object> localPublisher = crpd.decorateLocal(ch, true, segments,
+            localPublisherProcessor);
+
+      simpleAssert(localPublisher, localPublisherProcessor, segmentConsumer, kwcl, s -> { }, segments);
+      // Reset the mock so remote can test it now
+      reset(segmentConsumer);
+
+      TestRemoteIteratorPublisher<Object> remoteIteratorPublisher = new TestRemoteIteratorPublisher<>();
+
+      Publisher<Object> remotePublisher = crpd.decorateRemote(remoteIteratorPublisher);
+
+      simpleAssert(remotePublisher, remoteIteratorPublisher.publishProcessor(), segmentConsumer, kwcl, s ->
+            remoteIteratorPublisher.notifyCompleted(s::iterator), segments);
+   }
+
+   public void testRemoteAndLocalCompleteSameTime() {
+      IntSet localSegments = SmallIntSet.of(1, 4);
+      IntSet remoteSegments = SmallIntSet.of(2, 3);
+
+      Consumer<Supplier<PrimitiveIterator.OfInt>> segmentConsumer = mock(Consumer.class);
+      KeyWatchingCompletionListener kwcl = new KeyWatchingCompletionListener(segmentConsumer);
+      Consumer<Object> entryConsumer = mock(Consumer.class);
+      ConsistentHash ch = mock(ConsistentHash.class);
+
+      CompletionRehashPublisherDecorator<Object> crpd = createDecorator(ch, localSegments, null, kwcl, entryConsumer);
+
+      PublishProcessor<Object> localPublisherProcessor = PublishProcessor.create();
+
+      Publisher<Object> localPublisher = crpd.decorateLocal(ch, true, localSegments, localPublisherProcessor);
+
+      TestSubscriber<Object> localSubscriber = Flowable.fromPublisher(localPublisher).test();
+
+      TestRemoteIteratorPublisher<Object> remoteIteratorPublisher = new TestRemoteIteratorPublisher<>();
+      PublishProcessor<Object> remotePublisherProcessor = remoteIteratorPublisher.publishProcessor();
+
+      Publisher<Object> remotePublisher = crpd.decorateRemote(remoteIteratorPublisher);
+
+      TestSubscriber<Object> remoteSubscriber = Flowable.fromPublisher(remotePublisher).test();
+
+      localSubscriber.assertNotComplete();
+      remoteSubscriber.assertNotComplete();
+
+      // 1 local
+      // 2 remote
+      // 3 remote
+      // 4 local
+      // 5 remote
+      CacheEntry entry1 = new ImmortalCacheEntry(1, 1);
+      localPublisherProcessor.onNext(entry1);
+      CacheEntry entry2 = new ImmortalCacheEntry(2, 2);
+      remotePublisherProcessor.onNext(entry2);
+      CacheEntry entry3 = new ImmortalCacheEntry(3, 3);
+      remotePublisherProcessor.onNext(entry3);
+      CacheEntry entry4 = new ImmortalCacheEntry(4, 4);
+      localPublisherProcessor.onNext(entry4);
+      CacheEntry entry5 = new ImmortalCacheEntry(5, 5);
+      remotePublisherProcessor.onNext(entry5);
+
+      localSubscriber.assertValueCount(2);
+      remoteSubscriber.assertValueCount(3);
+
+      localSubscriber.assertNotComplete();
+      remoteSubscriber.assertNotComplete();
+
+      localPublisherProcessor.onComplete();
+      remoteIteratorPublisher.notifyCompleted(remoteSegments::iterator);
+      remotePublisherProcessor.onComplete();
+
+      localSubscriber.assertComplete();
+      remoteSubscriber.assertComplete();
+
+      // Even though the publishers are all complete, we haven't iterated so no segments should be notified yet!
+      verify(segmentConsumer, never()).accept(any());
+
+      // Now we finally iterate upon them - note that 4 wasn't iterated upon yet since remote took priority
+      kwcl.valueIterated(entry1);
+      kwcl.valueIterated(entry2);
+      kwcl.valueIterated(entry3);
+      kwcl.valueIterated(entry5);
+
+      ArgumentCaptor<Supplier<PrimitiveIterator.OfInt>> captor = ArgumentCaptor.forClass(Supplier.class);
+
+      Mockito.verify(segmentConsumer, Mockito.times(1)).accept(captor.capture());
+
+      PrimitiveIterator.OfInt completedSegments = captor.getValue().get();
+
+      assertEquals(remoteSegments, SmallIntSet.of(completedSegments));
+
+      reset(segmentConsumer);
+
+      kwcl.valueIterated(entry4);
+
+      Mockito.verify(segmentConsumer, Mockito.times(1)).accept(captor.capture());
+
+      completedSegments = captor.getValue().get();
+
+      assertEquals(localSegments, SmallIntSet.of(completedSegments));
+   }
+}

--- a/core/src/test/java/org/infinispan/stream/impl/TestRemoteIteratorPublisher.java
+++ b/core/src/test/java/org/infinispan/stream/impl/TestRemoteIteratorPublisher.java
@@ -8,7 +8,6 @@ import java.util.function.Supplier;
 import org.reactivestreams.Subscriber;
 
 import io.reactivex.processors.PublishProcessor;
-import io.reactivex.subscribers.TestSubscriber;
 
 /**
  * Publisher that also allows signaling completed or lost signals. Note this publisher only allows a single subscription

--- a/core/src/test/java/org/infinispan/stream/impl/TestRemoteIteratorPublisher.java
+++ b/core/src/test/java/org/infinispan/stream/impl/TestRemoteIteratorPublisher.java
@@ -1,0 +1,59 @@
+package org.infinispan.stream.impl;
+
+import java.util.Objects;
+import java.util.PrimitiveIterator;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.reactivestreams.Subscriber;
+
+import io.reactivex.processors.PublishProcessor;
+import io.reactivex.subscribers.TestSubscriber;
+
+/**
+ * Publisher that also allows signaling completed or lost signals. Note this publisher only allows a single subscription
+ * at a time.
+ * @author wburns
+ * @since 9.0
+ */
+public class TestRemoteIteratorPublisher<T> implements ClusterStreamManager.RemoteIteratorPublisher<T> {
+   private PublishProcessor<T> processor;
+   private Consumer<? super Supplier<PrimitiveIterator.OfInt>> completedSegments;
+   private Consumer<? super Supplier<PrimitiveIterator.OfInt>> lostSegments;
+
+   public TestRemoteIteratorPublisher() {
+      processor = PublishProcessor.create();
+   }
+
+   private <R> R requireNonNull(R object) {
+      return Objects.requireNonNull(object, "No one has subscribed yet!");
+   }
+
+   public PublishProcessor<T> publishProcessor() {
+      return processor;
+   }
+
+   public void notifyCompleted(Supplier<PrimitiveIterator.OfInt> segments) {
+      Consumer<? super Supplier<PrimitiveIterator.OfInt>> completed = requireNonNull(completedSegments);
+      completed.accept(segments);
+   }
+
+   public void notifyLost(Supplier<PrimitiveIterator.OfInt> segments) {
+      Consumer<? super Supplier<PrimitiveIterator.OfInt>> lost = requireNonNull(lostSegments);
+      lost.accept(segments);
+   }
+
+   @Override
+   public void subscribe(Subscriber<? super T> s, Consumer<? super Supplier<PrimitiveIterator.OfInt>> completedSegments,
+         Consumer<? super Supplier<PrimitiveIterator.OfInt>> lostSegments) {
+      if (processor.hasSubscribers()) {
+         throw new IllegalStateException("Only 1 subscriber allowed");
+      }
+      processor.subscribe(s);
+
+      this.completedSegments = Objects.requireNonNull(completedSegments);
+      this.lostSegments = Objects.requireNonNull(lostSegments);
+   }
+
+
+}


### PR DESCRIPTION
too early

* Use KeyWatchingListener for each publisher

https://issues.jboss.org/browse/ISPN-8708