### PR TITLE
ISPN-8701 IndexOutOfBoundsException in SIFS during shutdown

### DIFF
--- a/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/Index.java
+++ b/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/Index.java
@@ -359,17 +359,18 @@ class Index {
          }
          int headerWithoutMagic = INDEX_FILE_HEADER_SIZE - 4;
          buffer = buffer.capacity() < headerWithoutMagic ? ByteBuffer.allocate(headerWithoutMagic) : buffer;
+         buffer.position(0);
+         // we need to set limit ahead, otherwise the putLong could throw IndexOutOfBoundsException
+         buffer.limit(headerWithoutMagic);
          buffer.putLong(0, rootSpace.offset);
          buffer.putShort(8, (short) rootSpace.length);
          buffer.putLong(10, indexFileSize);
          buffer.putLong(18, size.get());
-         buffer.position(0);
-         buffer.limit(headerWithoutMagic);
          indexFile.position(4);
          write(indexFile, buffer);
-         buffer.putInt(0, GRACEFULLY);
          buffer.position(0);
          buffer.limit(4);
+         buffer.putInt(0, GRACEFULLY);
          indexFile.position(0);
          write(indexFile, buffer);
       }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-8701

I started working on a reproducer but finding a sequence operations that would take the index to the desired state (see JIRA) seemed too complicated.