### PR TITLE
DistSyncTxL1FuncTest.testGetBlockingAnotherGetCacheEntry random failures

### DIFF
--- a/core/src/test/java/org/infinispan/distribution/BaseDistSyncL1Test.java
+++ b/core/src/test/java/org/infinispan/distribution/BaseDistSyncL1Test.java
@@ -512,7 +512,7 @@ public abstract class BaseDistSyncL1Test extends BaseDistFunctionalTest<Object, 
       try {
          log.warn("Doing get here - ignore all previous");
 
-         Future<String> getFuture = nonOwnerCache.getAsync(key);
+         Future<String> getFuture = fork(() -> nonOwnerCache.get(key));
 
          // Wait until we are about to write value into data container on non owner
          checkPoint.awaitStrict("pre_acquire_shared_topology_lock_invoked", 10, TimeUnit.SECONDS);

--- a/core/src/test/java/org/infinispan/test/AbstractInfinispanTest.java
+++ b/core/src/test/java/org/infinispan/test/AbstractInfinispanTest.java
@@ -3,7 +3,6 @@ package org.infinispan.test;
 import static org.testng.AssertJUnit.assertTrue;
 import static org.testng.AssertJUnit.fail;
 
-import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.IdentityHashMap;
@@ -57,7 +56,7 @@ public class AbstractInfinispanTest {
       boolean isSatisfied() throws Exception;
    }
 
-   protected static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
+   protected final Log log = LogFactory.getLog(getClass());
 
    private final ThreadFactory defaultThreadFactory = getTestThreadFactory("ForkThread");
    private final ThreadPoolExecutor defaultExecutorService = new ThreadPoolExecutor(0, Integer.MAX_VALUE,


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-8742

getAsync() doesn't always run interceptor callbacks on a separate thread.
The remote get can finish before the calling thread calls thenAccept(),
especially when the test suite is limited to a single CPU.

The fix is trivial, figuring how the next test was affected took me much longer :)