### PR TITLE
Switched some orElse to orElseGet

### DIFF
--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/iteration/DefaultIterationManager.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/iteration/DefaultIterationManager.java
@@ -178,7 +178,7 @@ public class DefaultIterationManager implements IterationManager {
    }
 
    private Object[] unmarshallParams(byte[][] params, Object factory) {
-      Marshaller m = marshaller.orElse(MarshallerBuilder.genericFromInstance(Optional.of(factory)));
+      Marshaller m = marshaller.orElseGet(() -> MarshallerBuilder.genericFromInstance(Optional.of(factory)));
       try {
          Object[] objectParams = new Object[params.length];
          int i = 0;

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/iteration/IterationFilter.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/iteration/IterationFilter.java
@@ -66,7 +66,7 @@ public class IterationFilter<K, V, C> extends AbstractKeyValueFilterConverter<K,
    @Inject
    public void injectDependencies(Cache cache) {
       filterMarshaller = compat ? cache.getCacheConfiguration().compatibility().marshaller() :
-            marshaller.orElse(MarshallerBuilder.genericFromInstance(providedFilter));
+            marshaller.orElseGet(() -> MarshallerBuilder.genericFromInstance(providedFilter));
       providedFilter.ifPresent(kvfc -> cache.getAdvancedCache().getComponentRegistry().wireDependencies(kvfc));
 
    }

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/iteration/MarshallerBuilder.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/iteration/MarshallerBuilder.java
@@ -30,13 +30,13 @@ class MarshallerBuilder {
          } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
             throw new CacheException(e);
          }
-      })).orElse(marshallerClass.map(c -> {
+      })).orElseGet(() -> marshallerClass.map(c -> {
          try {
             return c.newInstance();
          } catch (InstantiationException | IllegalAccessException e) {
             throw new CacheException(e);
          }
-      }).orElse(genericFromInstance(filter)));
+      }).orElseGet(() -> genericFromInstance(filter)));
    }
 
    static Marshaller genericFromInstance(Optional<?> instance) {


### PR DESCRIPTION
Some orElse didn't use constants but created objects. Didn't seem to cause any problems however so this is just a small optimization to not create objects unless they are actually needed.