### PR TITLE
ISPN-8798 Allow ByteString lengths up to 255.

### DIFF
--- a/core/src/main/java/org/infinispan/util/ByteString.java
+++ b/core/src/main/java/org/infinispan/util/ByteString.java
@@ -22,8 +22,8 @@ public class ByteString {
    private final transient int hash;
 
    private ByteString(byte[] b) {
-      if (b.length > 127) {
-         throw new IllegalArgumentException("ByteString must be shorter than 127 bytes");
+      if (b.length > 255) {
+         throw new IllegalArgumentException("ByteString must be shorter than 255 bytes");
       }
       this.b = b;
       this.hash = Arrays.hashCode(b);
@@ -69,8 +69,8 @@ public class ByteString {
       }
    }
 
-   public static ByteString readObject(ObjectInput input) throws IOException, ClassNotFoundException {
-      short len = input.readByte();
+   public static ByteString readObject(ObjectInput input) throws IOException {
+      int len = input.readUnsignedByte();
       if (len == 0)
          return EMPTY;
 

--- a/core/src/test/java/org/infinispan/util/ByteStringTest.java
+++ b/core/src/test/java/org/infinispan/util/ByteStringTest.java
@@ -49,10 +49,18 @@ public class ByteStringTest extends AbstractInfinispanTest {
       }
    }
 
-   @Test(expectedExceptions = IllegalArgumentException.class)
    public void testLargeString() throws Exception {
       StringBuilder sb = new StringBuilder(128);
       for (int i = 0; i < 128; i++) {
+         sb.append("a");
+      }
+      ByteString.fromString(sb.toString());
+   }
+
+   @Test(expectedExceptions = IllegalArgumentException.class)
+   public void testTooLargeString() throws Exception {
+      StringBuilder sb = new StringBuilder(256);
+      for (int i = 0; i < 256; i++) {
          sb.append("a");
       }
       ByteString.fromString(sb.toString());


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-8798

@tristantarrant Please backport to 9.1.x.  We'll need a prompt 9.1.6.Final release containing this fix, or else we'll need to revert back to 8.2.x for WF12. :(