### PR TITLE
Ispn 8790 distributed iterator performance tweaks

### DIFF
--- a/commons/src/main/java/org/infinispan/commons/util/Closeables.java
+++ b/commons/src/main/java/org/infinispan/commons/util/Closeables.java
@@ -38,6 +38,9 @@ public class Closeables {
     * @return A spliterator that does nothing when closed
     */
    public static <T> CloseableSpliterator<T> spliterator(Spliterator<T> spliterator) {
+      if (spliterator instanceof CloseableSpliterator) {
+         return (CloseableSpliterator<T>) spliterator;
+      }
       return new SpliteratorAsCloseableSpliterator<>(spliterator);
    }
 
@@ -48,7 +51,11 @@ public class Closeables {
     * @return A spliterator that when closed will also close the underlying stream
     */
    public static <R> CloseableSpliterator<R> spliterator(BaseStream<R, Stream<R>> stream) {
-      return new StreamToCloseableSpliterator<>(stream);
+      Spliterator<R> spliterator = stream.spliterator();
+      if (spliterator instanceof CloseableSpliterator) {
+         return (CloseableSpliterator<R>) spliterator;
+      }
+      return new StreamToCloseableSpliterator<>(stream, spliterator);
    }
 
    /**
@@ -58,7 +65,11 @@ public class Closeables {
     * @return An iterator that when closed will also close the underlying stream
     */
    public static <R> CloseableIterator<R> iterator(BaseStream<R, Stream<R>> stream) {
-      return new StreamToCloseableIterator<>(stream);
+      Iterator<R> iterator = stream.iterator();
+      if (iterator instanceof CloseableIterator) {
+         return (CloseableIterator<R>) iterator;
+      }
+      return new StreamToCloseableIterator<>(stream, iterator);
    }
 
    /**
@@ -68,6 +79,9 @@ public class Closeables {
     * @return An iterator that does nothing when closed
     */
    public static <E> CloseableIterator<E> iterator(Iterator<? extends E> iterator) {
+      if (iterator instanceof CloseableIterator) {
+         return (CloseableIterator<E>) iterator;
+      }
       return new IteratorAsCloseableIterator<>(iterator);
    }
 
@@ -177,8 +191,8 @@ public class Closeables {
    private static class StreamToCloseableIterator<E> extends IteratorAsCloseableIterator<E> {
       private final BaseStream<E, Stream<E>> stream;
 
-      public StreamToCloseableIterator(BaseStream<E, Stream<E>> stream) {
-         super(stream.iterator());
+      public StreamToCloseableIterator(BaseStream<E, Stream<E>> stream, Iterator<E> iterator) {
+         super(iterator);
          this.stream = stream;
       }
 
@@ -191,8 +205,8 @@ public class Closeables {
    private static class StreamToCloseableSpliterator<T> extends SpliteratorAsCloseableSpliterator<T> {
       private final BaseStream<T, Stream<T>> stream;
 
-      public StreamToCloseableSpliterator(BaseStream<T, Stream<T>> stream) {
-         super(stream.spliterator());
+      public StreamToCloseableSpliterator(BaseStream<T, Stream<T>> stream, Spliterator<T> spliterator) {
+         super(spliterator);
          this.stream = stream;
       }
 

--- a/commons/src/main/java/org/infinispan/commons/util/SmallIntSet.java
+++ b/commons/src/main/java/org/infinispan/commons/util/SmallIntSet.java
@@ -256,6 +256,9 @@ public class SmallIntSet implements IntSet {
 
    @Override
    public boolean containsAll(Collection<?> c) {
+      if (c instanceof IntSet) {
+         return containsAll((IntSet) c);
+      }
       return c.stream().allMatch(this::contains);
    }
 

--- a/core/src/main/java/org/infinispan/cache/impl/CacheImpl.java
+++ b/core/src/main/java/org/infinispan/cache/impl/CacheImpl.java
@@ -67,6 +67,8 @@ import org.infinispan.commands.write.ValueMatcher;
 import org.infinispan.commons.CacheException;
 import org.infinispan.commons.api.BasicCacheContainer;
 import org.infinispan.commons.dataconversion.Encoder;
+import org.infinispan.commons.dataconversion.IdentityEncoder;
+import org.infinispan.commons.dataconversion.IdentityWrapper;
 import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.commons.dataconversion.Wrapper;
 import org.infinispan.commons.marshall.StreamingMarshaller;
@@ -619,29 +621,41 @@ public class CacheImpl<K, V> implements AdvancedCache<K, V> {
 
    @Override
    public AdvancedCache<K, V> withEncoding(Class<? extends Encoder> encoderClass) {
-      return new EncoderCache<>(this, DataConversion.DEFAULT_KEY.withEncoding(encoderClass), DataConversion.DEFAULT_VALUE.withEncoding(encoderClass));
+      if (encoderClass == IdentityEncoder.class) {
+         return this;
+      }
+      return new EncoderCache<>(this, getKeyDataConversion().withEncoding(encoderClass), getValueDataConversion().withEncoding(encoderClass));
    }
 
    @Override
    public AdvancedCache<?, ?> withKeyEncoding(Class<? extends Encoder> encoderClass) {
-      return new EncoderCache<>(this, DataConversion.DEFAULT_KEY.withEncoding(encoderClass), DataConversion.DEFAULT_VALUE);
+      if (encoderClass == IdentityEncoder.class) {
+         return this;
+      }
+      return new EncoderCache<>(this, getKeyDataConversion().withEncoding(encoderClass), getValueDataConversion());
    }
 
    @Override
    public AdvancedCache<K, V> withEncoding(Class<? extends Encoder> keyEncoderClass, Class<? extends Encoder> valueEncoderClass) {
-      return new EncoderCache<>(this, DataConversion.DEFAULT_KEY.withEncoding(keyEncoderClass), DataConversion.DEFAULT_VALUE.withEncoding(valueEncoderClass));
+      if (keyEncoderClass == IdentityEncoder.class && valueEncoderClass == IdentityEncoder.class) {
+         return this;
+      }
+      return new EncoderCache<>(this, getKeyDataConversion().withEncoding(keyEncoderClass), getValueDataConversion().withEncoding(valueEncoderClass));
    }
 
    @Override
    public AdvancedCache<K, V> withWrapping(Class<? extends Wrapper> wrapperClass) {
-      return new EncoderCache<>(this, DataConversion.DEFAULT_KEY.withWrapping(wrapperClass), DataConversion.DEFAULT_VALUE.withWrapping(wrapperClass));
+      if (wrapperClass == IdentityWrapper.class) {
+         return this;
+      }
+      return new EncoderCache<>(this, getKeyDataConversion().withWrapping(wrapperClass), getValueDataConversion().withWrapping(wrapperClass));
    }
 
    @Override
    public AdvancedCache<K, V> withMediaType(String keyMediaType, String valueMediaType) {
       MediaType km = MediaType.fromString(keyMediaType);
       MediaType vm = MediaType.fromString(valueMediaType);
-      return new EncoderCache<>(this, DataConversion.DEFAULT_KEY.withRequestMediaType(km), DataConversion.DEFAULT_VALUE.withRequestMediaType(vm));
+      return new EncoderCache<>(this, getKeyDataConversion().withRequestMediaType(km), getValueDataConversion().withRequestMediaType(vm));
    }
 
 
@@ -667,17 +681,20 @@ public class CacheImpl<K, V> implements AdvancedCache<K, V> {
 
    @Override
    public AdvancedCache<K, V> withWrapping(Class<? extends Wrapper> keyWrapperClass, Class<? extends Wrapper> valueWrapperClass) {
-      return new EncoderCache<>(this, DataConversion.DEFAULT_KEY.withWrapping(keyWrapperClass), DataConversion.DEFAULT_VALUE.withWrapping(valueWrapperClass));
+      if (keyWrapperClass == IdentityWrapper.class && valueWrapperClass == IdentityWrapper.class) {
+         return this;
+      }
+      return new EncoderCache<>(this, getKeyDataConversion().withWrapping(keyWrapperClass), getValueDataConversion().withWrapping(valueWrapperClass));
    }
 
    @Override
    public DataConversion getKeyDataConversion() {
-      return DataConversion.DEFAULT_KEY;
+      return DataConversion.IDENTITY_KEY;
    }
 
    @Override
    public DataConversion getValueDataConversion() {
-      return DataConversion.DEFAULT_VALUE;
+      return DataConversion.IDENTITY_VALUE;
    }
 
    @ManagedOperation(

--- a/core/src/main/java/org/infinispan/cache/impl/DecoratedCache.java
+++ b/core/src/main/java/org/infinispan/cache/impl/DecoratedCache.java
@@ -22,7 +22,6 @@ import org.infinispan.commons.util.EnumUtil;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.context.Flag;
 import org.infinispan.context.InvocationContext;
-import org.infinispan.encoding.DataConversion;
 import org.infinispan.filter.KeyFilter;
 import org.infinispan.metadata.EmbeddedMetadata;
 import org.infinispan.metadata.Metadata;
@@ -105,27 +104,27 @@ public class DecoratedCache<K, V> extends AbstractDelegatingAdvancedCache<K, V> 
 
    @Override
    public AdvancedCache<K, V> withEncoding(Class<? extends Encoder> encoderClass) {
-      return new EncoderCache<>(this, DataConversion.DEFAULT_KEY.withEncoding(encoderClass),
-            DataConversion.DEFAULT_VALUE.withEncoding(encoderClass));
+      return new EncoderCache<>(this, getKeyDataConversion().withEncoding(encoderClass),
+            getValueDataConversion().withEncoding(encoderClass));
    }
 
 
    @Override
    public AdvancedCache<K, V> withEncoding(Class<? extends Encoder> keyEncoderClass, Class<? extends Encoder> valueEncoderClass) {
-      return new EncoderCache<>(this, DataConversion.DEFAULT_KEY.withEncoding(keyEncoderClass),
-            DataConversion.DEFAULT_VALUE.withEncoding(valueEncoderClass));
+      return new EncoderCache<>(this, getKeyDataConversion().withEncoding(keyEncoderClass),
+            getValueDataConversion().withEncoding(valueEncoderClass));
    }
 
    @Override
    public AdvancedCache<K, V> withWrapping(Class<? extends Wrapper> wrapperClass) {
-      return new EncoderCache<>(this, DataConversion.DEFAULT_KEY.withWrapping(wrapperClass),
-            DataConversion.DEFAULT_VALUE.withWrapping(wrapperClass));
+      return new EncoderCache<>(this, getKeyDataConversion().withWrapping(wrapperClass),
+            getValueDataConversion().withWrapping(wrapperClass));
    }
 
    @Override
    public AdvancedCache<K, V> withWrapping(Class<? extends Wrapper> keyWrapperClass, Class<? extends Wrapper> valueWrapperClass) {
-      return new EncoderCache<>(this, DataConversion.DEFAULT_KEY.withWrapping(keyWrapperClass),
-            DataConversion.DEFAULT_VALUE.withWrapping(valueWrapperClass));
+      return new EncoderCache<>(this, getKeyDataConversion().withWrapping(keyWrapperClass),
+            getValueDataConversion().withWrapping(valueWrapperClass));
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/cache/impl/SimpleCacheImpl.java
+++ b/core/src/main/java/org/infinispan/cache/impl/SimpleCacheImpl.java
@@ -130,7 +130,7 @@ public class SimpleCacheImpl<K, V> implements AdvancedCache<K, V> {
    private boolean hasListeners = false;
 
    public SimpleCacheImpl(String cacheName) {
-      this(cacheName, DataConversion.DEFAULT_KEY, DataConversion.DEFAULT_VALUE);
+      this(cacheName, DataConversion.IDENTITY_KEY, DataConversion.IDENTITY_VALUE);
    }
 
    public SimpleCacheImpl(String cacheName, DataConversion keyDataConversion, DataConversion valueDataConversion) {

--- a/core/src/main/java/org/infinispan/cache/impl/SimpleCacheImpl.java
+++ b/core/src/main/java/org/infinispan/cache/impl/SimpleCacheImpl.java
@@ -1581,13 +1581,13 @@ public class SimpleCacheImpl<K, V> implements AdvancedCache<K, V> {
 
       @Override
       public CacheStream<Entry<K, V>> stream() {
-         return cacheStreamCast(new LocalCacheStream<>(new EntryStreamSupplier<>(SimpleCacheImpl.this, null,
+         return cacheStreamCast(new LocalCacheStream<>(new EntryStreamSupplier<>(SimpleCacheImpl.this, false, null,
                getStreamSupplier(false)), false, componentRegistry));
       }
 
       @Override
       public CacheStream<Entry<K, V>> parallelStream() {
-         return cacheStreamCast(new LocalCacheStream<>(new EntryStreamSupplier<>(SimpleCacheImpl.this, null,
+         return cacheStreamCast(new LocalCacheStream<>(new EntryStreamSupplier<>(SimpleCacheImpl.this, false, null,
                getStreamSupplier(false)), true, componentRegistry));
       }
    }
@@ -1621,13 +1621,13 @@ public class SimpleCacheImpl<K, V> implements AdvancedCache<K, V> {
 
       @Override
       public CacheStream<CacheEntry<K, V>> stream() {
-         return new LocalCacheStream<>(new EntryStreamSupplier<>(SimpleCacheImpl.this, null, getStreamSupplier(false)),
+         return new LocalCacheStream<>(new EntryStreamSupplier<>(SimpleCacheImpl.this, false, null, getStreamSupplier(false)),
                false, componentRegistry);
       }
 
       @Override
       public CacheStream<CacheEntry<K, V>> parallelStream() {
-         return new LocalCacheStream<>(new EntryStreamSupplier<>(SimpleCacheImpl.this, null, getStreamSupplier(true)),
+         return new LocalCacheStream<>(new EntryStreamSupplier<>(SimpleCacheImpl.this, false, null, getStreamSupplier(true)),
                true, componentRegistry);
       }
    }
@@ -1704,14 +1704,14 @@ public class SimpleCacheImpl<K, V> implements AdvancedCache<K, V> {
       @Override
       public CacheStream<V> stream() {
          LocalCacheStream<CacheEntry<K, V>> lcs = new LocalCacheStream<>(new EntryStreamSupplier<>(SimpleCacheImpl.this,
-               null, getStreamSupplier(false)), false, componentRegistry);
+               false, null, getStreamSupplier(false)), false, componentRegistry);
          return lcs.map(CacheEntry::getValue);
       }
 
       @Override
       public CacheStream<V> parallelStream() {
          LocalCacheStream<CacheEntry<K, V>> lcs = new LocalCacheStream<>(new EntryStreamSupplier<>(SimpleCacheImpl.this,
-               null, getStreamSupplier(false)), true, componentRegistry);
+               false, null, getStreamSupplier(false)), true, componentRegistry);
          return lcs.map(CacheEntry::getValue);
       }
    }

--- a/core/src/main/java/org/infinispan/container/DataContainer.java
+++ b/core/src/main/java/org/infinispan/container/DataContainer.java
@@ -3,6 +3,8 @@ package org.infinispan.container;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Set;
+import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.function.BiConsumer;
 
 import org.infinispan.container.entries.InternalCacheEntry;
@@ -198,10 +200,30 @@ public interface DataContainer<K, V> extends Iterable<InternalCacheEntry<K, V>> 
    Iterator<InternalCacheEntry<K, V>> iterator();
 
    /**
+    * {@inheritDoc}
+    * <p>This spliterator only returns entries that are not expired, however it will not remove them while doing so.</p>
+    * @return spliterator that doesn't produce expired entries
+    */
+   @Override
+   default Spliterator<InternalCacheEntry<K, V>> spliterator() {
+      return Spliterators.spliterator(iterator(), sizeIncludingExpired(),
+            Spliterator.CONCURRENT | Spliterator.NONNULL | Spliterator.DISTINCT);
+   }
+
+   /**
     * Same as {@link DataContainer#iterator()} except that is also returns expired entries.
     * @return iterator that returns all entries including expired ones
     */
    Iterator<InternalCacheEntry<K, V>> iteratorIncludingExpired();
+
+   /**
+    * Same as {@link DataContainer#spliterator()} except that is also returns expired entries.
+    * @return spliterator that returns all entries including expired ones
+    */
+   default Spliterator<InternalCacheEntry<K, V>> spliteratorIncludingExpired() {
+      return Spliterators.spliterator(iteratorIncludingExpired(), sizeIncludingExpired(),
+            Spliterator.CONCURRENT | Spliterator.NONNULL | Spliterator.DISTINCT);
+   }
 
    interface ComputeAction<K, V> {
 

--- a/core/src/main/java/org/infinispan/container/DefaultDataContainer.java
+++ b/core/src/main/java/org/infinispan/container/DefaultDataContainer.java
@@ -414,7 +414,9 @@ public class DefaultDataContainer<K, V> implements DataContainer<K, V> {
          while (it.hasNext()) {
             InternalCacheEntry<K, V> entry = it.next();
             if (includeExpired || !entry.canExpire()) {
-               log.tracef("Return next entry %s", entry);
+               if (trace) {
+                  log.tracef("Return next entry %s", entry);
+               }
                return entry;
             } else {
                if (!initializedTime) {
@@ -422,14 +424,18 @@ public class DefaultDataContainer<K, V> implements DataContainer<K, V> {
                   initializedTime = true;
                }
                if (!entry.isExpired(now)) {
-                  log.tracef("Return next entry %s", entry);
+                  if (trace) {
+                     log.tracef("Return next entry %s", entry);
+                  }
                   return entry;
-               } else {
+               } else if (trace) {
                   log.tracef("%s is expired", entry);
                }
             }
          }
-         log.tracef("Return next null");
+         if (trace) {
+            log.tracef("Return next null");
+         }
          return null;
       }
 

--- a/core/src/main/java/org/infinispan/context/Flag.java
+++ b/core/src/main/java/org/infinispan/context/Flag.java
@@ -273,7 +273,12 @@ public enum Flag {
    /**
     * Flag to identity that data is being written as part of a Rolling Upgrade.
     */
-   ROLLING_UPGRADE
+   ROLLING_UPGRADE,
+
+   /**
+    * Flag to identify that this iteration is done on a remote node and thus no additional wrappings are required
+    */
+   REMOTE_ITERATION,
 
    ;
 

--- a/core/src/main/java/org/infinispan/context/impl/FlagBitSets.java
+++ b/core/src/main/java/org/infinispan/context/impl/FlagBitSets.java
@@ -41,6 +41,7 @@ public class FlagBitSets {
    public static final long SKIP_INDEX_CLEANUP = EnumUtil.bitSetOf(Flag.SKIP_INDEX_CLEANUP);
    public static final long COMMAND_RETRY = EnumUtil.bitSetOf(Flag.COMMAND_RETRY);
    public static final long ROLLING_UPGRADE = EnumUtil.bitSetOf(Flag.ROLLING_UPGRADE);
+   public static final long REMOTE_ITERATION = EnumUtil.bitSetOf(Flag.REMOTE_ITERATION);
 
    /**
     * Creates a copy of a Flag BitSet removing instances of FAIL_SILENTLY.

--- a/core/src/main/java/org/infinispan/encoding/DataConversion.java
+++ b/core/src/main/java/org/infinispan/encoding/DataConversion.java
@@ -13,6 +13,7 @@ import org.infinispan.commons.dataconversion.Encoder;
 import org.infinispan.commons.dataconversion.EncodingException;
 import org.infinispan.commons.dataconversion.GlobalMarshallerEncoder;
 import org.infinispan.commons.dataconversion.IdentityEncoder;
+import org.infinispan.commons.dataconversion.IdentityWrapper;
 import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.commons.dataconversion.Transcoder;
 import org.infinispan.commons.dataconversion.Wrapper;
@@ -40,6 +41,8 @@ public final class DataConversion {
 
    public static final DataConversion DEFAULT_KEY = new DataConversion(IdentityEncoder.INSTANCE, ByteArrayWrapper.INSTANCE, true);
    public static final DataConversion DEFAULT_VALUE = new DataConversion(IdentityEncoder.INSTANCE, ByteArrayWrapper.INSTANCE, false);
+   public static final DataConversion IDENTITY_KEY = new DataConversion(IdentityEncoder.INSTANCE, IdentityWrapper.INSTANCE, true);
+   public static final DataConversion IDENTITY_VALUE = new DataConversion(IdentityEncoder.INSTANCE, IdentityWrapper.INSTANCE, false);
 
    private Class<? extends Encoder> encoderClass;
    private Class<? extends Wrapper> wrapperClass;

--- a/core/src/main/java/org/infinispan/interceptors/impl/PrefetchInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/PrefetchInterceptor.java
@@ -568,13 +568,13 @@ public class PrefetchInterceptor extends DDAsyncInterceptor {
 
       @Override
       public CacheStream<CacheEntry<K, V>> stream() {
-         return new LocalCacheStream<>(new EntryStreamSupplier<>(cache, dm.getCacheTopology()::getSegment,
+         return new LocalCacheStream<>(new EntryStreamSupplier<>(cache, false, dm.getCacheTopology()::getSegment,
             () -> super.stream()), false, cache.getAdvancedCache().getComponentRegistry());
       }
 
       @Override
       public CacheStream<CacheEntry<K, V>> parallelStream() {
-         return new LocalCacheStream<>(new EntryStreamSupplier<>(cache, dm.getCacheTopology()::getSegment,
+         return new LocalCacheStream<>(new EntryStreamSupplier<>(cache, false, dm.getCacheTopology()::getSegment,
             () -> super.stream()), true, cache.getAdvancedCache().getComponentRegistry());
       }
    }

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/CacheNotifierImpl.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/CacheNotifierImpl.java
@@ -784,8 +784,9 @@ public final class CacheNotifierImpl<K, V> extends AbstractListenerImpl<Event<K,
       final CacheMode cacheMode = config.clustering().cacheMode();
       FilterIndexingServiceProvider indexingProvider = null;
       boolean foundMethods = false;
-      DataConversion keyConversion = keyDataConversion == null ? DataConversion.DEFAULT_KEY : keyDataConversion;
-      DataConversion valueConversion = valueDataConversion == null ? DataConversion.DEFAULT_VALUE : valueDataConversion;
+      // We use identity for null as this means it was invoked by a non encoder cache
+      DataConversion keyConversion = keyDataConversion == null ? DataConversion.IDENTITY_KEY : keyDataConversion;
+      DataConversion valueConversion = valueDataConversion == null ? DataConversion.IDENTITY_VALUE: valueDataConversion;
       if (filter instanceof IndexedFilter) {
          IndexedFilter indexedFilter = (IndexedFilter) filter;
          indexingProvider = findIndexingServiceProvider(indexedFilter);
@@ -1050,8 +1051,9 @@ public final class CacheNotifierImpl<K, V> extends AbstractListenerImpl<Event<K,
 
       FilterIndexingServiceProvider indexingProvider = null;
       boolean foundMethods = false;
-      DataConversion keyConversion = keyDataConversion == null ? DataConversion.DEFAULT_KEY : keyDataConversion;
-      DataConversion valueConversion = valueDataConversion == null ? DataConversion.DEFAULT_VALUE : valueDataConversion;
+      // We use identity for null as this means it was invoked by a non encoder cache
+      DataConversion keyConversion = keyDataConversion == null ? DataConversion.IDENTITY_KEY : keyDataConversion;
+      DataConversion valueConversion = valueDataConversion == null ? DataConversion.IDENTITY_VALUE : valueDataConversion;
       if (filter instanceof IndexedFilter) {
          IndexedFilter indexedFilter = (IndexedFilter) filter;
          indexingProvider = findIndexingServiceProvider(indexedFilter);

--- a/core/src/main/java/org/infinispan/stream/impl/ClusterStreamManagerImpl.java
+++ b/core/src/main/java/org/infinispan/stream/impl/ClusterStreamManagerImpl.java
@@ -2,11 +2,11 @@ package org.infinispan.stream.impl;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.PrimitiveIterator;
 import java.util.Set;
+import java.util.Spliterator;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -24,7 +24,6 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import io.reactivex.internal.subscriptions.EmptySubscription;
 import org.infinispan.commands.CommandsFactory;
 import org.infinispan.commons.CacheException;
 import org.infinispan.commons.util.IntSet;
@@ -49,6 +48,8 @@ import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
+
+import io.reactivex.internal.subscriptions.EmptySubscription;
 
 /**
  * Cluster stream manager that sends all requests using the {@link RpcManager} to do the underlying communications.
@@ -555,13 +556,12 @@ public class ClusterStreamManagerImpl<K> implements ClusterStreamManager<K> {
                         if (trace) {
                            log.tracef("Received valid response %s for id %s from node %s", iteratorResponse, id, target.getKey());
                         }
-                        long returnedAmount = 0;
-                        Iterator<V> iter = iteratorResponse.getIterator();
-                        while (iter.hasNext()) {
-                           returnedAmount++;
-                           s.onNext(iter.next());
+                        Spliterator<V> spliterator = iteratorResponse.getSpliterator();
+                        long returnedAmount = spliterator.getExactSizeIfKnown();
+                        if (trace) {
+                           log.tracef("Received %d entries for id %s from %s", returnedAmount, id, sendee);
                         }
-                        log.tracef("Received %d entries for id %s from %s", returnedAmount, id, sendee);
+                        spliterator.forEachRemaining(s::onNext);
 
                         if (iteratorResponse.isComplete()) {
                            Set<Integer> lostSegments = iteratorResponse.getSuspectedSegments();

--- a/core/src/main/java/org/infinispan/stream/impl/DistributedCacheStream.java
+++ b/core/src/main/java/org/infinispan/stream/impl/DistributedCacheStream.java
@@ -559,7 +559,7 @@ public class DistributedCacheStream<R> extends AbstractCacheStream<R, Stream<R>,
       PublisherDecorator<S> publisherDecorator(Consumer<? super Supplier<PrimitiveIterator.OfInt>> completedSegments,
             Consumer<? super Supplier<PrimitiveIterator.OfInt>> lostSegments, Consumer<Object> keyConsumer) {
          return new RehashPublisherDecorator<>(iteratorOperation, dm, localAddress, completedSegments, lostSegments,
-               keyConsumer);
+               executor, keyConsumer);
       }
 
       @Override
@@ -601,7 +601,7 @@ public class DistributedCacheStream<R> extends AbstractCacheStream<R, Stream<R>,
       PublisherDecorator<S> publisherDecorator(Consumer<? super Supplier<PrimitiveIterator.OfInt>> completedSegments,
             Consumer<? super Supplier<PrimitiveIterator.OfInt>> lostSegments, Consumer<Object> keyConsumer) {
          completionRehashPublisherDecorator = new CompletionRehashPublisherDecorator<>(iteratorOperation, dm,
-               localAddress, userListener, completedSegments, lostSegments, keyConsumer);
+               localAddress, userListener, completedSegments, lostSegments, executor, keyConsumer);
 
          return completionRehashPublisherDecorator;
       }

--- a/core/src/main/java/org/infinispan/stream/impl/DistributedCacheStream.java
+++ b/core/src/main/java/org/infinispan/stream/impl/DistributedCacheStream.java
@@ -511,8 +511,8 @@ public class DistributedCacheStream<R> extends AbstractCacheStream<R, Stream<R>,
             }
             // For each completed segment we remove that segment and decrement our counter
             completed.get().forEachRemaining((int i) -> {
-               // This way keys are able to be GC'd
-               receivedKeys.set(i, null);
+               // This way keys are able to be GC'd - lazySet is fine as we synchronize below
+               receivedKeys.lazySet(i, null);
                if (intSet != null) {
                   intSet.set(i);
                }

--- a/core/src/main/java/org/infinispan/stream/impl/IteratorResponse.java
+++ b/core/src/main/java/org/infinispan/stream/impl/IteratorResponse.java
@@ -1,7 +1,7 @@
 package org.infinispan.stream.impl;
 
-import java.util.Iterator;
 import java.util.Set;
+import java.util.Spliterator;
 
 /**
  * Iterator response returned when an iterator batch is sent back which contains the iterator, if any segments
@@ -11,10 +11,11 @@ import java.util.Set;
  */
 public interface IteratorResponse<V> {
    /**
-    * The iterator containing the elements from the response
-    * @return the iterator
+    * The spliterator containing the elements from the response. This spliterator is guaranteed to have a known
+    * exact size when invoking {@link Spliterator#getExactSizeIfKnown()}.
+    * @return the spliterator
     */
-   Iterator<V> getIterator();
+   Spliterator<V> getSpliterator();
 
    /**
     * Whether the iterator is the end or if more requests are needed

--- a/core/src/main/java/org/infinispan/stream/impl/RehashPublisherDecorator.java
+++ b/core/src/main/java/org/infinispan/stream/impl/RehashPublisherDecorator.java
@@ -2,6 +2,7 @@ package org.infinispan.stream.impl;
 
 import java.lang.invoke.MethodHandles;
 import java.util.PrimitiveIterator;
+import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -13,6 +14,9 @@ import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 import org.reactivestreams.Publisher;
 
+import io.reactivex.Flowable;
+import io.reactivex.schedulers.Schedulers;
+
 /**
  * PublisherDecorator that decorates the publisher to notify of when segments are completed for these invocations
  * @author wburns
@@ -22,12 +26,14 @@ class RehashPublisherDecorator<S> extends AbstractRehashPublisherDecorator<S> {
    private static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
 
    final Consumer<? super Supplier<PrimitiveIterator.OfInt>> completedSegments;
+   final Executor executor;
 
    RehashPublisherDecorator(AbstractCacheStream.IteratorOperation iteratorOperation, DistributionManager dm,
          Address localAddress, Consumer<? super Supplier<PrimitiveIterator.OfInt>> completedSegments,
-         Consumer<? super Supplier<PrimitiveIterator.OfInt>> lostSegments, Consumer<Object> keyConsumer) {
+         Consumer<? super Supplier<PrimitiveIterator.OfInt>> lostSegments, Executor executor, Consumer<Object> keyConsumer) {
       super(iteratorOperation, dm, localAddress, lostSegments, keyConsumer);
       this.completedSegments = completedSegments;
+      this.executor = executor;
    }
 
    @Override
@@ -35,10 +41,16 @@ class RehashPublisherDecorator<S> extends AbstractRehashPublisherDecorator<S> {
       return log;
    }
 
+   Publisher<S> applySubscribeExecutor(Publisher<S> publisher) {
+      return Flowable.fromPublisher(publisher).subscribeOn(Schedulers.from(executor));
+   }
+
    @Override
    public Publisher<S> decorateRemote(ClusterStreamManager.RemoteIteratorPublisher<S> remotePublisher) {
       Publisher<S> convertedPublisher = s -> remotePublisher.subscribe(s, completedSegments, lostSegments);
-      return iteratorOperation.handlePublisher(convertedPublisher, keyConsumer);
+      // When we subscribe on this do it in async thread - including requests so user thread doesn't take
+      // the cost of serialization and rpc invocation
+      return iteratorOperation.handlePublisher(applySubscribeExecutor(convertedPublisher), keyConsumer);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/stream/impl/interceptor/AbstractDelegatingEntryCacheSet.java
+++ b/core/src/main/java/org/infinispan/stream/impl/interceptor/AbstractDelegatingEntryCacheSet.java
@@ -44,7 +44,7 @@ public abstract class AbstractDelegatingEntryCacheSet<K, V> extends AbstractDele
    protected CacheStream<CacheEntry<K, V>> getStream(boolean parallel) {
       DistributionManager dm = cache.getAdvancedCache().getDistributionManager();
       CloseableSpliterator<CacheEntry<K, V>> closeableSpliterator = spliterator();
-      CacheStream<CacheEntry<K, V>> stream = new LocalCacheStream<>(new EntryStreamSupplier<>(cache, dm != null ?
+      CacheStream<CacheEntry<K, V>> stream = new LocalCacheStream<>(new EntryStreamSupplier<>(cache, false, dm != null ?
               dm.getCacheTopology()::getSegment : null, () -> StreamSupport.stream(closeableSpliterator, false)), parallel,
               cache.getAdvancedCache().getComponentRegistry());
       // We rely on the fact that on close returns the same instance

--- a/core/src/main/java/org/infinispan/stream/impl/local/EntryStreamSupplier.java
+++ b/core/src/main/java/org/infinispan/stream/impl/local/EntryStreamSupplier.java
@@ -27,11 +27,14 @@ public class EntryStreamSupplier<K, V> implements AbstractLocalCacheStream.Strea
    private static final boolean trace = log.isTraceEnabled();
 
    private final Cache<K, V> cache;
+   private final boolean remoteIterator;
    private final ToIntFunction<Object> toIntFunction;
    private final Supplier<Stream<CacheEntry<K, V>>> supplier;
 
-   public EntryStreamSupplier(Cache<K, V> cache, ToIntFunction<Object> toIntFunction, Supplier<Stream<CacheEntry<K, V>>> supplier) {
+   public EntryStreamSupplier(Cache<K, V> cache, boolean remoteIterator, ToIntFunction<Object> toIntFunction,
+         Supplier<Stream<CacheEntry<K, V>>> supplier) {
       this.cache = cache;
+      this.remoteIterator = remoteIterator;
       this.toIntFunction = toIntFunction;
       this.supplier = supplier;
    }
@@ -71,6 +74,9 @@ public class EntryStreamSupplier<K, V> implements AbstractLocalCacheStream.Strea
 
    @Override
    public CloseableIterator<CacheEntry<K, V>> removableIterator(CloseableIterator<CacheEntry<K, V>> realIterator) {
+      if (remoteIterator) {
+         return realIterator;
+      }
       return new RemovableCloseableIterator<>(realIterator, e -> cache.remove(e.getKey(), e.getValue()));
    }
 }

--- a/core/src/test/java/org/infinispan/stream/DistributedStreamIteratorExceptionTest.java
+++ b/core/src/test/java/org/infinispan/stream/DistributedStreamIteratorExceptionTest.java
@@ -35,7 +35,7 @@ public class DistributedStreamIteratorExceptionTest extends BaseSetupStreamItera
       DataContainer dataContainer = TestingUtil.extractComponent(cache1, DataContainer.class);
       try {
          Throwable t = new AssertionError();
-         DataContainer mockContainer = when(mock(DataContainer.class).iterator()).thenThrow(t).getMock();
+         DataContainer mockContainer = when(mock(DataContainer.class).spliterator()).thenThrow(t).getMock();
          TestingUtil.replaceComponent(cache1, DataContainer.class, mockContainer, true);
 
          try {

--- a/core/src/test/java/org/infinispan/stream/DistributedStreamIteratorTest.java
+++ b/core/src/test/java/org/infinispan/stream/DistributedStreamIteratorTest.java
@@ -458,7 +458,7 @@ public class DistributedStreamIteratorTest extends BaseClusteredStreamIteratorTe
                checkPoint.awaitStrict("post_iterator_released", 10, TimeUnit.SECONDS);
             }
          }
-      }).when(mocaContainer).iterator();
+      }).when(mocaContainer).spliterator();
       TestingUtil.replaceComponent(cache, DataContainer.class, mocaContainer, true);
    }
 }

--- a/core/src/test/java/org/infinispan/stream/LocalStreamIteratorExceptionTest.java
+++ b/core/src/test/java/org/infinispan/stream/LocalStreamIteratorExceptionTest.java
@@ -30,7 +30,7 @@ public class LocalStreamIteratorExceptionTest extends BaseSetupStreamIteratorTes
       DataContainer dataContainer = TestingUtil.extractComponent(cache, DataContainer.class);
       try {
          Throwable t = new CacheException();
-         DataContainer mockContainer = when(mock(DataContainer.class).iterator()).thenThrow(t).getMock();
+         DataContainer mockContainer = when(mock(DataContainer.class).spliterator()).thenThrow(t).getMock();
          TestingUtil.replaceComponent(cache, DataContainer.class, mockContainer, true);
 
          try {

--- a/core/src/test/java/org/infinispan/stream/impl/CompletionRehashPublisherDecoratorTest.java
+++ b/core/src/test/java/org/infinispan/stream/impl/CompletionRehashPublisherDecoratorTest.java
@@ -21,6 +21,7 @@ import org.infinispan.container.entries.ImmortalCacheEntry;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.remoting.transport.Address;
+import org.infinispan.util.concurrent.WithinThreadExecutor;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.reactivestreams.Publisher;
@@ -42,7 +43,7 @@ public class CompletionRehashPublisherDecoratorTest {
          Consumer<Object> entryConsumer) {
       return new CompletionRehashPublisherDecorator<>(AbstractCacheStream.IteratorOperation.NO_MAP, null, null, userListener,
             // Just ignore early completed segments and lost ones
-            i -> {}, i -> {}, entryConsumer);
+            i -> {}, i -> {}, new WithinThreadExecutor(), entryConsumer);
    }
 
    <S> CompletionRehashPublisherDecorator<S> createDecorator(ConsistentHash ch, Set<Integer> segmentsForOwner,
@@ -61,7 +62,7 @@ public class CompletionRehashPublisherDecoratorTest {
 
       return new CompletionRehashPublisherDecorator<>(AbstractCacheStream.IteratorOperation.NO_MAP, dm, address,
             // Just ignore early completed segments and lost ones
-            internalListener, i -> {}, i -> {}, entryConsumer);
+            internalListener, i -> {}, i -> {}, new WithinThreadExecutor(), entryConsumer);
    }
 
    void simpleAssert(Publisher<Object> resultingPublisher, PublishProcessor<Object> valuePublisher,


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-8790
https://issues.jboss.org/browse/ISPN-8806

Most of these changes are about trying to remove as many wrappers and needless invocations when using an iterator. Also a lot of places using a spliterator will give better performance than using an iterator.

The other big change is that subscriptions are now performed on the async executor. This way the user thread doesn't incur the cost of marshalling and sending a request and can go back to returning entries much faster.

There was also a bug found in requesting a new batch that could cause it to request 2x batch size on accident and is fixed in the ISPN-8806 commit.