### PR TITLE
ISPN-8829 LockedStream doesn't override BaseCacheStream methods

### DIFF
--- a/core/src/main/java/org/infinispan/LockedStream.java
+++ b/core/src/main/java/org/infinispan/LockedStream.java
@@ -3,6 +3,7 @@ package org.infinispan;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
 import java.util.Spliterator;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
@@ -136,18 +137,54 @@ public interface LockedStream<K, V> extends BaseCacheStream<CacheEntry<K, V>, Lo
    }
 
    /**
+    * {@inheritDoc}
+    */
+   @Override
+   LockedStream<K, V> sequentialDistribution();
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   LockedStream<K, V> parallelDistribution();
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   LockedStream<K, V> filterKeySegments(Set<Integer> segments);
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   LockedStream<K, V> filterKeys(Set<?> keys);
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   LockedStream<K, V> distributedBatchSize(int batchSize);
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   LockedStream<K, V> disableRehashAware();
+
+   /**
     * Sets the timeout for the acquisition of the lock for each entry.
     * @param time the maximum time to wait
     * @param unit the time unit of the timeout argument
     * @return a LockedStream with the timeout applied
     */
-   LockedStream timeout(long time, TimeUnit unit);
+   LockedStream<K, V> timeout(long time, TimeUnit unit);
 
    /**
     * This method is not supported when using a {@link LockedStream}
     */
    @Override
-   LockedStream segmentCompletionListener(SegmentCompletionListener listener) throws UnsupportedOperationException;
+   LockedStream<K, V> segmentCompletionListener(SegmentCompletionListener listener) throws UnsupportedOperationException;
 
    /**
     * This method is not supported when using a {@link LockedStream}

--- a/core/src/main/java/org/infinispan/stream/impl/LockedStreamImpl.java
+++ b/core/src/main/java/org/infinispan/stream/impl/LockedStreamImpl.java
@@ -16,7 +16,6 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-import org.infinispan.BaseCacheStream;
 import org.infinispan.Cache;
 import org.infinispan.CacheStream;
 import org.infinispan.LockedStream;
@@ -113,27 +112,27 @@ public class LockedStreamImpl<K, V> implements LockedStream<K, V> {
    }
 
    @Override
-   public BaseCacheStream sequentialDistribution() {
+   public LockedStream<K, V> sequentialDistribution() {
       return newOrReuse(realStream.sequentialDistribution());
    }
 
    @Override
-   public BaseCacheStream parallelDistribution() {
+   public LockedStream<K, V> parallelDistribution() {
       return newOrReuse(realStream.parallelDistribution());
    }
 
    @Override
-   public BaseCacheStream filterKeySegments(Set<Integer> segments) {
+   public LockedStream<K, V> filterKeySegments(Set<Integer> segments) {
       return newOrReuse(realStream.filterKeySegments(segments));
    }
 
    @Override
-   public BaseCacheStream filterKeys(Set<?> keys) {
+   public LockedStream<K, V> filterKeys(Set<?> keys) {
       return newOrReuse(realStream.filterKeys(keys));
    }
 
    @Override
-   public BaseCacheStream distributedBatchSize(int batchSize) {
+   public LockedStream<K, V> distributedBatchSize(int batchSize) {
       return newOrReuse(realStream.distributedBatchSize(batchSize));
    }
 
@@ -143,7 +142,7 @@ public class LockedStreamImpl<K, V> implements LockedStream<K, V> {
    }
 
    @Override
-   public BaseCacheStream disableRehashAware() {
+   public LockedStream<K, V> disableRehashAware() {
       return newOrReuse(realStream.disableRehashAware());
    }
 


### PR DESCRIPTION
* Added methods to interface

https://issues.jboss.org/browse/ISPN-8829