### PR TITLE
ISPN-8850 NPE in ConsistentHashV2IntegrationTest.cleanUp

### DIFF
--- a/checkstyle/src/main/resources/checkstyle.xml
+++ b/checkstyle/src/main/resources/checkstyle.xml
@@ -98,6 +98,13 @@
             <!--<property name="message" value="Stop using the AssertionFailure from commons-annotations." />-->
         <!--</module>-->
 
+       <!-- In TestNG a test is a group of classes, so it's always better to use @AfterClass and @BeforeClass -->
+       <!-- This might have been faster with the IllegalImport module, but that always flags our use of sun.reflect.Reflection -->
+       <module name="RegexpSinglelineJava">
+          <property name="format" value="@AfterTest|@BeforeTest"/>
+          <property name="message" value="In TestNG a test is a group of classes, so it's always better to use @AfterClass and @BeforeClass"/>
+       </module>
+
         <!-- The severity of following rules should be eventually set to error -->
         <module name="org.infinispan.checkstyle.checks.interceptors.InterceptorDefinesAllReadsCheck">
             <property name="severity" value="${checkstyle.interceptors.reads.severity}" default="warning"/>

--- a/cli/cli-interpreter/src/test/java/org/infinispan/cli/interpreter/HotRodEncodingTest.java
+++ b/cli/cli-interpreter/src/test/java/org/infinispan/cli/interpreter/HotRodEncodingTest.java
@@ -21,7 +21,7 @@ import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
-import org.testng.annotations.AfterTest;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 /**
@@ -68,7 +68,7 @@ public class HotRodEncodingTest extends SingleCacheManagerTest {
       interpreter = gcr.getComponent(Interpreter.class);
    }
 
-   @AfterTest
+   @AfterClass(alwaysRun = true)
    public void release() {
       HotRodClientTestingUtil.killRemoteCacheManager(remoteCacheManager);
       HotRodClientTestingUtil.killServers(hotrodServer);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/CacheContainerTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/CacheContainerTest.java
@@ -10,7 +10,7 @@ import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.server.hotrod.HotRodServer;
 import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
-import org.testng.annotations.AfterTest;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 /**
@@ -39,7 +39,7 @@ public class CacheContainerTest extends SingleCacheManagerTest {
       return cacheManager;
    }
 
-   @AfterTest
+   @AfterClass(alwaysRun = true)
    public void release() {
       killCacheManagers(cacheManager);
       killRemoteCacheManager(remoteCacheManager);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/CacheManagerStoppedTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/CacheManagerStoppedTest.java
@@ -13,7 +13,7 @@ import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.server.hotrod.HotRodServer;
 import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
-import org.testng.annotations.AfterTest;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 /**
@@ -42,7 +42,7 @@ public class CacheManagerStoppedTest extends SingleCacheManagerTest {
       return cacheManager;
    }
 
-   @AfterTest
+   @AfterClass(alwaysRun = true)
    public void release() {
       killRemoteCacheManager(remoteCacheManager);
       killCacheManagers(cacheManager);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ConsistentHashV2IntegrationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ConsistentHashV2IntegrationTest.java
@@ -23,8 +23,8 @@ import org.infinispan.remoting.transport.Address;
 import org.infinispan.server.hotrod.HotRodServer;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
-import org.testng.annotations.AfterTest;
 import org.testng.annotations.Test;
 
 /**
@@ -89,7 +89,7 @@ public class ConsistentHashV2IntegrationTest extends MultipleCacheManagersTest {
    protected void clearContent() throws Throwable {
    }
 
-   @AfterTest
+   @AfterClass(alwaysRun = true)
    public void cleanUp() {
       ex.shutdownNow();
       kas.stop();

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/RemoteCacheManagerExtendedTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/RemoteCacheManagerExtendedTest.java
@@ -1,5 +1,8 @@
 package org.infinispan.client.hotrod;
 
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.testng.AssertJUnit.assertTrue;
+
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
 import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
 import org.infinispan.commons.marshall.jboss.GenericJBossMarshaller;
@@ -8,11 +11,8 @@ import org.infinispan.server.hotrod.HotRodServer;
 import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
-import org.testng.annotations.AfterTest;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
-
-import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
-import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * @author Mircea.Markus@jboss.com
@@ -42,7 +42,7 @@ public class RemoteCacheManagerExtendedTest extends SingleCacheManagerTest {
       remoteCacheManager = null;
    }
 
-   @AfterTest
+   @AfterClass(alwaysRun = true)
    public void release() {
       TestingUtil.killCacheManagers(cacheManager);
       HotRodClientTestingUtil.killServers(hotrodServer);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/RemoteCacheManagerTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/RemoteCacheManagerTest.java
@@ -11,7 +11,7 @@ import org.infinispan.server.hotrod.HotRodServer;
 import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
-import org.testng.annotations.AfterTest;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 /**
@@ -39,7 +39,7 @@ public class RemoteCacheManagerTest extends SingleCacheManagerTest {
       remoteCacheManager = null;
    }
 
-   @AfterTest
+   @AfterClass(alwaysRun = true)
    public void release() {
       TestingUtil.killCacheManagers(cacheManager);
       HotRodClientTestingUtil.killServers(hotrodServer);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/RoundRobinBalancingIntegrationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/RoundRobinBalancingIntegrationTest.java
@@ -21,7 +21,7 @@ import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
-import org.testng.annotations.AfterTest;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 /**
@@ -71,7 +71,7 @@ public class RoundRobinBalancingIntegrationTest extends MultipleCacheManagersTes
       remoteCache = remoteCacheManager.getCache();
    }
 
-   @AfterTest
+   @AfterClass(alwaysRun = true)
    public void tearDown() {
       killRemoteCacheManager(remoteCacheManager);
       killServers(hotRodServer1, hotRodServer2, hotRodServer3, hotRodServer4);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/PrimitiveEmbeddedCompatTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/PrimitiveEmbeddedCompatTest.java
@@ -17,7 +17,7 @@ import org.infinispan.query.remote.CompatibilityProtoStreamMarshaller;
 import org.infinispan.server.hotrod.HotRodServer;
 import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
-import org.testng.annotations.AfterTest;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 /**
@@ -60,7 +60,7 @@ public class PrimitiveEmbeddedCompatTest extends SingleCacheManagerTest {
       return builder;
    }
 
-   @AfterTest
+   @AfterClass(alwaysRun = true)
    public void release() {
       killRemoteCacheManager(remoteCacheManager);
       killServers(hotRodServer);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/PrimitiveProtoStreamMarshallerTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/PrimitiveProtoStreamMarshallerTest.java
@@ -15,7 +15,7 @@ import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.server.hotrod.HotRodServer;
 import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
-import org.testng.annotations.AfterTest;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 /**
@@ -47,7 +47,7 @@ public class PrimitiveProtoStreamMarshallerTest extends SingleCacheManagerTest {
       return cacheManager;
    }
 
-   @AfterTest
+   @AfterClass(alwaysRun = true)
    public void release() {
       killRemoteCacheManager(remoteCacheManager);
       killServers(hotRodServer);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/ProtoStreamMarshallerTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/ProtoStreamMarshallerTest.java
@@ -24,7 +24,7 @@ import org.infinispan.server.hotrod.HotRodServer;
 import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
-import org.testng.annotations.AfterTest;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 /**
@@ -61,7 +61,7 @@ public class ProtoStreamMarshallerTest extends SingleCacheManagerTest {
       return cacheManager;
    }
 
-   @AfterTest
+   @AfterClass(alwaysRun = true)
    public void release() {
       killRemoteCacheManager(remoteCacheManager);
       killServers(hotRodServer);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/ProtoStreamMarshallerWithAnnotationsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/ProtoStreamMarshallerWithAnnotationsTest.java
@@ -21,7 +21,7 @@ import org.infinispan.server.hotrod.HotRodServer;
 import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
-import org.testng.annotations.AfterTest;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 /**
@@ -93,7 +93,7 @@ public class ProtoStreamMarshallerWithAnnotationsTest extends SingleCacheManager
       return cacheManager;
    }
 
-   @AfterTest
+   @AfterClass(alwaysRun = true)
    public void release() {
       killRemoteCacheManager(remoteCacheManager);
       killServers(hotRodServer);

--- a/core/src/test/java/org/infinispan/affinity/impl/BaseKeyAffinityServiceTest.java
+++ b/core/src/test/java/org/infinispan/affinity/impl/BaseKeyAffinityServiceTest.java
@@ -18,7 +18,7 @@ import org.infinispan.distribution.LocalizedCacheTopology;
 import org.infinispan.manager.CacheContainer;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.test.TestingUtil;
-import org.testng.annotations.AfterTest;
+import org.testng.annotations.AfterClass;
 
 /**
  * @author Mircea.Markus@jboss.com
@@ -30,7 +30,7 @@ public abstract class BaseKeyAffinityServiceTest extends BaseDistFunctionalTest<
    protected ExecutorService executor  = Executors.newSingleThreadExecutor(threadFactory);
    protected KeyAffinityServiceImpl<Object> keyAffinityService;
 
-   @AfterTest
+   @AfterClass(alwaysRun = true)
    public void stopExecutorService() throws InterruptedException {
       if (keyAffinityService != null) keyAffinityService.stop();
       if (executor != null) {

--- a/core/src/test/java/org/infinispan/affinity/impl/ConcurrentStartupTest.java
+++ b/core/src/test/java/org/infinispan/affinity/impl/ConcurrentStartupTest.java
@@ -16,7 +16,7 @@ import org.infinispan.remoting.transport.Address;
 import org.infinispan.test.AbstractCacheTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
-import org.testng.annotations.AfterTest;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -59,7 +59,7 @@ public class ConcurrentStartupTest extends AbstractCacheTest {
       Thread.sleep(5000);
    }
 
-   @AfterTest
+   @AfterClass(alwaysRun = true)
    protected void tearDown() throws Exception {
       if (ex1 != null)
          ex1.shutdownNow();

--- a/core/src/test/java/org/infinispan/distribution/ConcurrentStartWithReplTest.java
+++ b/core/src/test/java/org/infinispan/distribution/ConcurrentStartWithReplTest.java
@@ -16,7 +16,7 @@ import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.test.fwk.TestResourceTracker;
 import org.infinispan.util.concurrent.CompletableFutures;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /**
@@ -30,7 +30,7 @@ public class ConcurrentStartWithReplTest extends AbstractInfinispanTest {
 
    private ConfigurationBuilder replCfg, distCfg;
 
-   @BeforeTest
+   @BeforeClass(alwaysRun = true)
    public void setUp() {
       replCfg = MultipleCacheManagersTest.getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, false);
       replCfg.clustering().stateTransfer().fetchInMemoryState(true);

--- a/core/src/test/java/org/infinispan/distribution/UnknownCacheStartTest.java
+++ b/core/src/test/java/org/infinispan/distribution/UnknownCacheStartTest.java
@@ -15,8 +15,8 @@ import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestResourceTracker;
 import org.testng.TestException;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 @Test(groups = "unstable", testName = "distribution.UnknownCacheStartTest", description = "original group: functional")
@@ -25,12 +25,12 @@ public class UnknownCacheStartTest extends AbstractInfinispanTest {
    ConfigurationBuilder configuration;
    EmbeddedCacheManager cm1, cm2;
 
-   @BeforeTest
+   @BeforeClass(alwaysRun = true)
    public void setUp() {
       configuration = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false);
    }
 
-   @AfterTest
+   @AfterClass(alwaysRun = true)
    public void tearDown() {
       killCacheManagers(cm1, cm2);
    }

--- a/core/src/test/java/org/infinispan/stress/AsyncStoreStressTest.java
+++ b/core/src/test/java/org/infinispan/stress/AsyncStoreStressTest.java
@@ -44,8 +44,8 @@ import org.infinispan.util.concurrent.locks.impl.LockContainer;
 import org.infinispan.util.concurrent.locks.impl.PerKeyLockContainer;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -74,12 +74,12 @@ public class AsyncStoreStressTest {
    private Map<Object, InternalCacheEntry> expectedState = new ConcurrentHashMap<Object, InternalCacheEntry>();
    private TestObjectStreamMarshaller marshaller;
 
-   @BeforeTest
+   @BeforeClass(alwaysRun = true)
    void startMarshaller() {
       marshaller = new TestObjectStreamMarshaller();
    }
 
-   @AfterTest
+   @AfterClass(alwaysRun = true)
    void stopMarshaller() {
       marshaller.stop();
    }

--- a/core/src/test/java/org/infinispan/stress/MemoryCleanupTest.java
+++ b/core/src/test/java/org/infinispan/stress/MemoryCleanupTest.java
@@ -4,7 +4,7 @@ import org.infinispan.Cache;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /**
@@ -14,7 +14,7 @@ import org.testng.annotations.Test;
 public class MemoryCleanupTest {
 
 
-   @BeforeTest
+   @BeforeClass(alwaysRun = true)
    public void createCm() {
    }
 

--- a/core/src/test/java/org/infinispan/test/AbstractInfinispanTest.java
+++ b/core/src/test/java/org/infinispan/test/AbstractInfinispanTest.java
@@ -31,9 +31,9 @@ import java.util.stream.Stream;
 import javax.transaction.TransactionManager;
 
 import org.infinispan.commons.api.BasicCache;
+import org.infinispan.commons.api.BasicCacheContainer;
 import org.infinispan.functional.FunctionalMap;
 import org.infinispan.interceptors.AsyncInterceptor;
-import org.infinispan.manager.CacheContainer;
 import org.infinispan.partitionhandling.BasePartitionHandlingTest;
 import org.infinispan.remoting.transport.impl.RequestRepository;
 import org.infinispan.test.fwk.ChainMethodInterceptor;
@@ -407,7 +407,7 @@ public class AbstractInfinispanTest {
    }
 
    private boolean fieldIsMemoryHog(Field field) {
-      Class<?>[] memoryHogs = {CacheContainer.class, BasicCache.class, FunctionalMap.class, Protocol.class,
+      Class<?>[] memoryHogs = {BasicCacheContainer.class, BasicCache.class, FunctionalMap.class, Protocol.class,
                                AsyncInterceptor.class, RequestRepository.class,
                                BasePartitionHandlingTest.Partition.class};
       return Stream.of(memoryHogs).anyMatch(clazz -> fieldIsMemoryHog(field, clazz));

--- a/jcache/embedded/src/test/java/org/infinispan/jcache/JCacheTwoCachesAnnotationsTest.java
+++ b/jcache/embedded/src/test/java/org/infinispan/jcache/JCacheTwoCachesAnnotationsTest.java
@@ -4,7 +4,6 @@ import static org.infinispan.test.AbstractCacheTest.getDefaultClusteredCacheConf
 
 import java.lang.reflect.Method;
 import java.net.URI;
-
 import javax.cache.Cache;
 import javax.inject.Inject;
 
@@ -19,9 +18,9 @@ import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /**
@@ -60,7 +59,7 @@ public class JCacheTwoCachesAnnotationsTest extends AbstractTwoCachesAnnotations
       return jCacheManager.getCache("annotation");
    }
 
-   @BeforeTest
+   @BeforeClass(alwaysRun = true)
    public void initCacheManagers() {
       cacheManager1 = TestCacheManagerFactory.createClusteredCacheManager(getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC));
       cacheManager1.defineConfiguration("annotation", getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC).build());
@@ -76,7 +75,7 @@ public class JCacheTwoCachesAnnotationsTest extends AbstractTwoCachesAnnotations
       TestingUtil.clearContent(cacheManager1, cacheManager2);
    }
 
-   @AfterTest
+   @AfterClass(alwaysRun = true)
    public void killCacheManagers() {
       TestingUtil.killCacheManagers(cacheManager1, cacheManager2);
    }

--- a/remote-query/remote-query-server/src/test/java/org/infinispan/query/remote/impl/dataconversion/ProtostreamJsonTranscoderTest.java
+++ b/remote-query/remote-query-server/src/test/java/org/infinispan/query/remote/impl/dataconversion/ProtostreamJsonTranscoderTest.java
@@ -6,7 +6,7 @@ import org.infinispan.protostream.ProtobufUtil;
 import org.infinispan.protostream.SerializationContext;
 import org.infinispan.protostream.config.Configuration;
 import org.infinispan.test.dataconversion.AbstractTranscoderTest;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -38,7 +38,7 @@ public class ProtostreamJsonTranscoderTest extends AbstractTranscoderTest {
 
    protected String dataSrc;
 
-   @BeforeTest
+   @BeforeClass(alwaysRun = true)
    public void setUp() throws IOException {
 
       dataSrc = "{\"_type\":\"Person\", \"name\":\"joe\", \"address\":{\"_type\":\"Address\", \"street\":\"\", \"city\":\"London\", \"zip\":\"0\"}}";

--- a/remote-query/remote-query-server/src/test/java/org/infinispan/query/remote/impl/dataconversion/ProtostreamTextTranscoderTest.java
+++ b/remote-query/remote-query-server/src/test/java/org/infinispan/query/remote/impl/dataconversion/ProtostreamTextTranscoderTest.java
@@ -6,7 +6,7 @@ import org.infinispan.protostream.ProtobufUtil;
 import org.infinispan.protostream.SerializationContext;
 import org.infinispan.protostream.config.Configuration;
 import org.infinispan.test.dataconversion.AbstractTranscoderTest;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -19,7 +19,7 @@ public class ProtostreamTextTranscoderTest extends AbstractTranscoderTest {
 
    protected String dataSrc;
 
-   @BeforeTest
+   @BeforeClass(alwaysRun = true)
    public void setUp() throws IOException {
       dataSrc = " !\"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~";
       SerializationContext serCtx = ProtobufUtil.newSerializationContext(Configuration.builder().build());

--- a/server/rest/src/test/java/org/infinispan/rest/dataconversion/JavaSerializationTranscoderTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/dataconversion/JavaSerializationTranscoderTest.java
@@ -4,7 +4,7 @@ import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.test.data.Address;
 import org.infinispan.test.data.Person;
 import org.infinispan.test.dataconversion.AbstractTranscoderTest;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -14,7 +14,7 @@ import static org.testng.Assert.assertTrue;
 public class JavaSerializationTranscoderTest extends AbstractTranscoderTest {
    protected Person dataSrc;
 
-   @BeforeTest
+   @BeforeClass(alwaysRun = true)
    public void setUp() {
       dataSrc = new Person("Joe");
       Address address = new Address();

--- a/server/rest/src/test/java/org/infinispan/rest/dataconversion/JsonObjectTranscoderTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/dataconversion/JsonObjectTranscoderTest.java
@@ -7,7 +7,7 @@ import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.test.data.Address;
 import org.infinispan.test.data.Person;
 import org.infinispan.test.dataconversion.AbstractTranscoderTest;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /**
@@ -17,7 +17,7 @@ import org.testng.annotations.Test;
 public class JsonObjectTranscoderTest extends AbstractTranscoderTest {
    protected Person dataSrc;
 
-   @BeforeTest
+   @BeforeClass(alwaysRun = true)
    public void setUp() {
       dataSrc = new Person("joe");
       Address address = new Address();

--- a/server/rest/src/test/java/org/infinispan/rest/dataconversion/TextBinaryTranscoderTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/dataconversion/TextBinaryTranscoderTest.java
@@ -6,14 +6,14 @@ import static org.testng.Assert.assertTrue;
 import org.infinispan.commons.dataconversion.DefaultTranscoder;
 import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.test.dataconversion.AbstractTranscoderTest;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 @Test(groups = "functional", testName = "rest.TextBinaryTranscoderTest")
 public class TextBinaryTranscoderTest extends AbstractTranscoderTest {
    protected String dataSrc;
 
-   @BeforeTest
+   @BeforeClass(alwaysRun = true)
    public void setUp() {
       dataSrc = " !\"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~";
       transcoder = DefaultTranscoder.INSTANCE;

--- a/server/rest/src/test/java/org/infinispan/rest/dataconversion/TextObjectTranscoderTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/dataconversion/TextObjectTranscoderTest.java
@@ -8,7 +8,7 @@ import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.test.data.Address;
 import org.infinispan.test.data.Person;
 import org.infinispan.test.dataconversion.AbstractTranscoderTest;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 
@@ -16,7 +16,7 @@ import org.testng.annotations.Test;
 public class TextObjectTranscoderTest extends AbstractTranscoderTest {
    protected Person dataSrc;
 
-   @BeforeTest
+   @BeforeClass(alwaysRun = true)
    public void setUp() {
       dataSrc = new Person("Joe");
       Address address = new Address();

--- a/server/rest/src/test/java/org/infinispan/rest/dataconversion/XMLTranscoderTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/dataconversion/XMLTranscoderTest.java
@@ -7,14 +7,14 @@ import static org.testng.Assert.assertEquals;
 import org.infinispan.test.data.Address;
 import org.infinispan.test.data.Person;
 import org.infinispan.test.dataconversion.AbstractTranscoderTest;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 @Test(groups = "functional", testName = "rest.XMLTranscoderTest")
 public class XMLTranscoderTest extends AbstractTranscoderTest {
    protected Person dataSrc;
 
-   @BeforeTest
+   @BeforeClass(alwaysRun = true)
    public void setUp() {
       dataSrc = new Person("Joe");
       Address address = new Address();

--- a/spring/spring4/spring4-embedded/src/test/java/org/infinispan/spring/provider/SpringEmbeddedCacheManagerFactoryBeanTest.java
+++ b/spring/spring4/spring4-embedded/src/test/java/org/infinispan/spring/provider/SpringEmbeddedCacheManagerFactoryBeanTest.java
@@ -11,7 +11,7 @@ import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.spring.builders.SpringEmbeddedCacheManagerFactoryBeanBuilder;
 import org.infinispan.transaction.TransactionMode;
-import org.testng.annotations.AfterTest;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 /**
@@ -32,7 +32,7 @@ public class SpringEmbeddedCacheManagerFactoryBeanTest {
 
    private SpringEmbeddedCacheManagerFactoryBean objectUnderTest;
 
-   @AfterTest
+   @AfterClass(alwaysRun = true)
    public void closeCacheManager() throws Exception {
       if(objectUnderTest != null) {
          objectUnderTest.destroy();

--- a/spring/spring4/spring4-embedded/src/test/java/org/infinispan/spring/support/embedded/InfinispanDefaultCacheFactoryBeanContextTest.java
+++ b/spring/spring4/spring4-embedded/src/test/java/org/infinispan/spring/support/embedded/InfinispanDefaultCacheFactoryBeanContextTest.java
@@ -9,13 +9,13 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /**
  * <p>
- * Test {@link InfinispanDefaultCacheFactoryBean} deployed in a Spring application context.
+ * Test {@link org.infinispan.spring.InfinispanDefaultCacheFactoryBean} deployed in a Spring application context.
  * </p>
  *
  * @author <a href="mailto:olaf DOT bergner AT gmx DOT de">Olaf Bergner</a>
@@ -28,12 +28,12 @@ public class InfinispanDefaultCacheFactoryBeanContextTest extends AbstractTestNG
 
    private static final String DEFAULT_CACHE_NAME = "testDefaultCache";
 
-   @BeforeTest(alwaysRun = true)
+   @BeforeClass(alwaysRun = true)
    public void beforeTest() {
        TestResourceTracker.testStarted(getClass().getName());
    }
 
-   @AfterTest(alwaysRun = true)
+   @AfterClass(alwaysRun = true)
    public void afterTest() {
        TestResourceTracker.testFinished(getClass().getName());
    }

--- a/spring/spring4/spring4-remote/src/test/java/org/infinispan/spring/provider/sample/AbstractTestTemplate.java
+++ b/spring/spring4/spring4-remote/src/test/java/org/infinispan/spring/provider/sample/AbstractTestTemplate.java
@@ -11,9 +11,9 @@ import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 import org.springframework.cache.CacheManager;
 import org.springframework.test.context.testng.AbstractTransactionalTestNGSpringContextTests;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /**
@@ -31,12 +31,12 @@ public abstract class AbstractTestTemplate extends AbstractTransactionalTestNGSp
 
    protected static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
 
-   @BeforeTest(alwaysRun = true)
+   @BeforeClass(alwaysRun = true)
    public void beforeTest() {
       TestResourceTracker.testStarted(getClass().getName());
    }
 
-   @AfterTest(alwaysRun = true)
+   @AfterClass(alwaysRun = true)
    public void afterTest() {
       TestResourceTracker.testFinished(getClass().getName());
    }

--- a/tools/src/test/java/org/infinispan/tools/jdbc/migrator/marshaller/LegacyVersionAwareMarshallerTest.java
+++ b/tools/src/test/java/org/infinispan/tools/jdbc/migrator/marshaller/LegacyVersionAwareMarshallerTest.java
@@ -42,7 +42,7 @@ import org.infinispan.metadata.impl.InternalMetadataImpl;
 import org.infinispan.test.data.Key;
 import org.infinispan.test.data.Person;
 import org.infinispan.util.KeyValuePair;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /**
@@ -61,7 +61,7 @@ public class LegacyVersionAwareMarshallerTest {
       marshaller = new LegacyVersionAwareMarshaller(externalizerMap);
    }
 
-   @BeforeTest
+   @BeforeClass(alwaysRun = true)
    public void beforeTest() throws Exception {
       Path path = new File("src/test/resources/marshalled_bytes_8.x.bin").toPath();
       byte[] bytes = Files.readAllBytes(path);


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-8850

Always use @AfterClass(alwaysRun = true) instead of @AfterTest.

AbstractInfinispanTest.destroy() runs on @AfterClass and sets all
cache-like fields to null (ISPN-8478).