### PR TITLE
ISPN-8870 Remove logger inheritance to reduce class metadata

### DIFF
--- a/cli/cli-interpreter/src/main/java/org/infinispan/cli/interpreter/logging/Log.java
+++ b/cli/cli-interpreter/src/main/java/org/infinispan/cli/interpreter/logging/Log.java
@@ -10,6 +10,7 @@ import javax.transaction.SystemException;
 import org.infinispan.cli.interpreter.codec.CodecException;
 import org.infinispan.cli.interpreter.result.StatementException;
 import org.infinispan.commons.CacheException;
+import org.jboss.logging.BasicLogger;
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
@@ -23,7 +24,7 @@ import org.jboss.logging.annotations.MessageLogger;
  * @since 5.2
  */
 @MessageLogger(projectCode = "ISPN")
-public interface Log extends org.infinispan.util.logging.Log {
+public interface Log extends BasicLogger {
    @LogMessage(level = ERROR)
    @Message(value = "Could not register interpreter MBean", id = 19001)
    void jmxRegistrationFailed();

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -299,9 +299,9 @@ public interface Log extends BasicLogger {
 //   @Message(value = "Problems creating the directory: %s", id = 64)
 //   void problemsCreatingDirectory(File dir);
 
-   @LogMessage(level = ERROR)
-   @Message(value = "Exception while marshalling object: %s", id = 65)
-   void errorMarshallingObject(@Cause Throwable ioe, Object obj);
+//   @LogMessage(level = ERROR)
+//   @Message(value = "Exception while marshalling object: %s", id = 65)
+//   void errorMarshallingObject(@Cause Throwable ioe, Object obj);
 
    @LogMessage(level = ERROR)
    @Message(value = "Unable to read version id from first two bytes of stream, barfing.", id = 66)
@@ -323,9 +323,9 @@ public interface Log extends BasicLogger {
    @Message(value = "Unexpected error while replicating", id = 73)
    void unexpectedErrorReplicating(@Cause Throwable t);
 
-   @LogMessage(level = ERROR)
-   @Message(value = "Message or message buffer is null or empty.", id = 77)
-   void msgOrMsgBufferEmpty();
+//   @LogMessage(level = ERROR)
+//   @Message(value = "Message or message buffer is null or empty.", id = 77)
+//   void msgOrMsgBufferEmpty();
 
    @LogMessage(level = INFO)
    @Message(value = "Starting JGroups channel %s", id = 78)
@@ -343,9 +343,9 @@ public interface Log extends BasicLogger {
    @Message(value = "Problem closing channel %s; setting it to null", id = 81)
    void problemClosingChannel(@Cause Exception e, String cluster);
 
-   @LogMessage(level = INFO)
-   @Message(value = "Stopping the RpcDispatcher for channel %s", id = 82)
-   void stoppingRpcDispatcher(String cluster);
+//   @LogMessage(level = INFO)
+//   @Message(value = "Stopping the RpcDispatcher for channel %s", id = 82)
+//   void stoppingRpcDispatcher(String cluster);
 
    @LogMessage(level = ERROR)
    @Message(value = "Class [%s] cannot be cast to JGroupsChannelLookup! Not using a channel lookup.", id = 83)
@@ -821,9 +821,9 @@ public interface Log extends BasicLogger {
    @Message(value = "Shutdown while handling command %s", id = 219)
    void shutdownHandlingCommand(ReplicableCommand command);
 
-   @LogMessage(level = WARN)
-   @Message(value = "Problems un-marshalling remote command from byte buffer", id = 220)
-   void errorUnMarshallingCommand(@Cause Throwable throwable);
+//   @LogMessage(level = WARN)
+//   @Message(value = "Problems un-marshalling remote command from byte buffer", id = 220)
+//   void errorUnMarshallingCommand(@Cause Throwable throwable);
 
    //@LogMessage(level = WARN)
    //@Message(value = "Unknown response value [%s]. Expected [%s]", id = 221)
@@ -1170,8 +1170,8 @@ public interface Log extends BasicLogger {
    @Message(value = "Unable to invoke method %s on Object instance %s ", id = 331)
    void unableToInvokeListenerMethod(Method m, Object target, @Cause Throwable e);
 
-   @Message(value = "Remote transaction %s rolled back because originator is no longer in the cluster", id = 332)
-   CacheException orphanTransactionRolledBack(GlobalTransaction gtx);
+//   @Message(value = "Remote transaction %s rolled back because originator is no longer in the cluster", id = 332)
+//   CacheException orphanTransactionRolledBack(GlobalTransaction gtx);
 
 //   @Message(value = "The site must be specified.", id = 333)
 //   CacheConfigurationException backupSiteNullName();
@@ -1371,8 +1371,8 @@ public interface Log extends BasicLogger {
    @Message(value = "Received unsolicited state from node %s for segment %d of cache %s", id = 396)
    void ignoringUnsolicitedState(Address node, int segment, String cacheName);
 
-   @Message(value = "Could not migrate data for cache %s, check remote store config in the target cluster. Make sure only one remote store is present and is pointing to the source cluster", id = 397)
-   CacheException couldNotMigrateData(String name);
+//   @Message(value = "Could not migrate data for cache %s, check remote store config in the target cluster. Make sure only one remote store is present and is pointing to the source cluster", id = 397)
+//   CacheException couldNotMigrateData(String name);
 
    @Message(value = "CH Factory '%s' cannot restore a persisted CH of class '%s'", id = 398)
    IllegalStateException persistentConsistentHashMismatch(String hashFactory, String consistentHashClass);
@@ -1394,8 +1394,8 @@ public interface Log extends BasicLogger {
    @Message(value = "No indexable classes were defined for this indexed cache; switching to autodetection (support for autodetection will be removed in Infinispan 10.0).", id = 403)
    void noIndexableClassesDefined();
 
-   @Message(value = "The configured entity class %s is not indexable. Please remove it from the indexing configuration.", id = 404)
-   CacheConfigurationException classNotIndexable(String className);
+//   @Message(value = "The configured entity class %s is not indexable. Please remove it from the indexing configuration.", id = 404)
+//   CacheConfigurationException classNotIndexable(String className);
 
    @LogMessage(level = ERROR)
    @Message(value = "Caught exception while invoking a cache manager listener!", id = 405)
@@ -1594,8 +1594,8 @@ public interface Log extends BasicLogger {
    @Message(value = "The partition handling 'enable' attribute has been deprecated. Please update your configuration file to use the 'type' attribute instead", id = 464)
    void partitionHandlingConfigurationEnabledDeprecated();
 
-   @Message(value = "Keys '%s' are not available. No owners exist in this partition", id = 465)
-   AvailabilityException degradedModeNoOwnersExist(Object key);
+//   @Message(value = "Keys '%s' are not available. No owners exist in this partition", id = 465)
+//   AvailabilityException degradedModeNoOwnersExist(Object key);
 
    @LogMessage(level = WARN)
    @Message(value = "Exception encountered when trying to resolve conflict on Keys '%s': %s", id = 466)
@@ -1686,11 +1686,11 @@ public interface Log extends BasicLogger {
    @Message(value = "Cannot find transcoder between '%s' to '%s'", id = 492)
    EncodingException cannotFindTranscoder(MediaType mediaType, MediaType another);
 
-   @Message(value = "Invalid text format: '%s'", id = 493)
-   EncodingException invalidTextFormat(Object content);
+//   @Message(value = "Invalid text format: '%s'", id = 493)
+//   EncodingException invalidTextFormat(Object content);
 
-   @Message(value = "Invalid binary format: '%s'", id = 494)
-   EncodingException invalidBinaryFormat(Object content);
+//   @Message(value = "Invalid binary format: '%s'", id = 494)
+//   EncodingException invalidBinaryFormat(Object content);
 
    @Message(value = "Error transcoding content", id = 495)
    EncodingException errorTranscoding(@Cause Throwable cause);

--- a/counter/src/main/java/org/infinispan/counter/impl/strong/BoundedStrongCounter.java
+++ b/counter/src/main/java/org/infinispan/counter/impl/strong/BoundedStrongCounter.java
@@ -6,13 +6,13 @@ import static org.infinispan.counter.exception.CounterOutOfBoundsException.UPPER
 import java.util.concurrent.CompletionException;
 
 import org.infinispan.AdvancedCache;
+import org.infinispan.commons.logging.Log;
 import org.infinispan.commons.logging.LogFactory;
 import org.infinispan.counter.api.CounterConfiguration;
 import org.infinispan.counter.api.CounterState;
 import org.infinispan.counter.exception.CounterOutOfBoundsException;
 import org.infinispan.counter.impl.entries.CounterValue;
 import org.infinispan.counter.impl.listener.CounterManagerNotificationManager;
-import org.infinispan.counter.logging.Log;
 
 /**
  * A bounded strong consistent counter.

--- a/counter/src/main/java/org/infinispan/counter/logging/Log.java
+++ b/counter/src/main/java/org/infinispan/counter/logging/Log.java
@@ -7,6 +7,7 @@ import org.infinispan.configuration.parsing.ParserScope;
 import org.infinispan.counter.exception.CounterConfigurationException;
 import org.infinispan.counter.exception.CounterException;
 import org.infinispan.util.ByteString;
+import org.jboss.logging.BasicLogger;
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
@@ -19,7 +20,7 @@ import org.jboss.logging.annotations.MessageLogger;
  * @since 9.0
  */
 @MessageLogger(projectCode = "ISPN")
-public interface Log extends org.infinispan.commons.logging.Log {
+public interface Log extends BasicLogger {
 
    //28001 is in commons log
 
@@ -63,12 +64,14 @@ public interface Log extends org.infinispan.commons.logging.Log {
    @Message(value = "Exception while waiting for counter manager caches.", id = 28013)
    void exceptionWhileWaitingForCached(@Cause Throwable cause);
 
-   //28014 is in commons log
+   @Message(value = "Invalid counter type. Expected=%s but got %s", id = 28014)
+   CounterException invalidCounterType(String expected, String actual);
 
    @Message(value = "Unable to fetch counter manager caches.", id = 28015)
    CounterException unableToFetchCaches();
 
-   //28016 is in commons log
+   @Message(value = "Counter '%s' is not defined.", id = 28016)
+   CounterException undefinedCounter(String name);
 
    @Message(value = "Duplicated counter name found. Counter '%s' already exists.", id = 28017)
    CounterConfigurationException duplicatedCounterName(String counter);

--- a/extended-statistics/src/main/java/org/infinispan/stats/logging/Log.java
+++ b/extended-statistics/src/main/java/org/infinispan/stats/logging/Log.java
@@ -5,6 +5,7 @@ import static org.jboss.logging.Logger.Level.WARN;
 
 import org.infinispan.stats.container.ExtendedStatistic;
 import org.infinispan.stats.percentiles.PercentileStatistic;
+import org.jboss.logging.BasicLogger;
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
@@ -18,7 +19,7 @@ import org.jboss.logging.annotations.MessageLogger;
  * @since 6.0
  */
 @MessageLogger(projectCode = "ISPN")
-public interface Log extends org.infinispan.util.logging.Log {
+public interface Log extends BasicLogger {
 
    @LogMessage(level = WARN)
    @Message(id = 25001, value = "Extended Statistic [%s] not found while tried to add a percentile sample.")

--- a/jcache/commons/src/main/java/org/infinispan/jcache/logging/Log.java
+++ b/jcache/commons/src/main/java/org/infinispan/jcache/logging/Log.java
@@ -11,6 +11,7 @@ import javax.cache.CacheException;
 import javax.cache.configuration.Configuration;
 import javax.cache.processor.EntryProcessorException;
 
+import org.jboss.logging.BasicLogger;
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
@@ -23,7 +24,7 @@ import org.jboss.logging.annotations.MessageLogger;
  * @since 5.3
  */
 @MessageLogger(projectCode = "ISPN")
-public interface Log extends org.infinispan.commons.logging.Log {
+public interface Log extends BasicLogger {
 
    @Message(value = "Allocation stack trace:", id = 21001)
    LeakDescription cacheManagerNotClosed();

--- a/lock/src/main/java/org/infinispan/lock/impl/log/Log.java
+++ b/lock/src/main/java/org/infinispan/lock/impl/log/Log.java
@@ -1,6 +1,7 @@
 package org.infinispan.lock.impl.log;
 
 import org.infinispan.lock.exception.ClusteredLockException;
+import org.jboss.logging.BasicLogger;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 
@@ -11,7 +12,7 @@ import org.jboss.logging.annotations.MessageLogger;
  * @since 9.2
  */
 @MessageLogger(projectCode = "ISPN")
-public interface Log extends org.infinispan.util.logging.Log {
+public interface Log extends BasicLogger {
    String LOCK_DELETE_MSG = "The lock was deleted.";
 
    @Message(value = LOCK_DELETE_MSG, id = 29001)

--- a/lucene/directory-provider/src/main/java/org/infinispan/hibernate/search/logging/Log.java
+++ b/lucene/directory-provider/src/main/java/org/infinispan/hibernate/search/logging/Log.java
@@ -6,6 +6,7 @@ import static org.jboss.logging.Logger.Level.WARN;
 import javax.naming.NamingException;
 
 import org.hibernate.search.exception.SearchException;
+import org.jboss.logging.BasicLogger;
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
@@ -19,7 +20,7 @@ import org.jboss.logging.annotations.MessageLogger;
  * @since 4.0
  */
 @MessageLogger(projectCode = "ISPN")
-public interface Log extends org.infinispan.commons.logging.Log {
+public interface Log extends BasicLogger {
 
    @LogMessage(level = ERROR)
    @Message(id = 26001, value = "Unable to retrieve CacheManager from JNDI [%s]")

--- a/lucene/lucene-directory/src/main/java/org/infinispan/lucene/logging/Log.java
+++ b/lucene/lucene-directory/src/main/java/org/infinispan/lucene/logging/Log.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import org.infinispan.commons.CacheException;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.persistence.spi.PersistenceException;
+import org.jboss.logging.BasicLogger;
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
@@ -23,7 +24,10 @@ import org.jboss.logging.annotations.MessageLogger;
  * @since 5.0
  */
 @MessageLogger(projectCode = "ISPN")
-public interface Log extends org.infinispan.util.logging.Log {
+public interface Log extends BasicLogger {
+   @LogMessage(level = ERROR)
+   @Message(value = "Error executing parallel store task", id = 252)
+   void errorExecutingParallelStoreTask(@Cause Throwable cause);
 
    @LogMessage(level = ERROR)
    @Message(value = "Error in suspending transaction", id = 15001)

--- a/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/logging/Log.java
+++ b/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/logging/Log.java
@@ -11,6 +11,7 @@ import javax.naming.NamingException;
 
 import org.infinispan.commons.CacheConfigurationException;
 import org.infinispan.persistence.spi.PersistenceException;
+import org.jboss.logging.BasicLogger;
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
@@ -24,7 +25,10 @@ import org.jboss.logging.annotations.MessageLogger;
  * @since 5.0
  */
 @MessageLogger(projectCode = "ISPN")
-public interface Log extends org.infinispan.util.logging.Log {
+public interface Log extends BasicLogger {
+   @LogMessage(level = ERROR)
+   @Message(value = "Exception while marshalling object: %s", id = 65)
+   void errorMarshallingObject(@Cause Throwable ioe, Object obj);
 
    @LogMessage(level = ERROR)
    @Message(value = "Failed clearing cache store", id = 8001)

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/logging/Log.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/logging/Log.java
@@ -1,10 +1,11 @@
 package org.infinispan.persistence.remote.logging;
 
-import static org.jboss.logging.Logger.Level.ERROR;
+import static org.jboss.logging.Logger.Level.INFO;
+import static org.jboss.logging.Logger.Level.WARN;
 
 import org.infinispan.commons.CacheConfigurationException;
 import org.infinispan.commons.CacheException;
-import org.infinispan.persistence.spi.PersistenceException;
+import org.jboss.logging.BasicLogger;
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
@@ -18,20 +19,23 @@ import org.jboss.logging.annotations.MessageLogger;
  * @since 5.0
  */
 @MessageLogger(projectCode = "ISPN")
-public interface Log extends org.infinispan.util.logging.Log {
+public interface Log extends BasicLogger {
+   @Message(value = "Could not find migration data in cache %s", id = 276)
+   CacheException missingMigrationData(String name);
 
-   @LogMessage(level = ERROR)
-   @Message(value = "RemoteStore can only run in shared mode! This method shouldn't be called in shared mode", id = 10001)
-   void sharedModeOnlyAllowed();
+   @LogMessage(level = WARN)
+   @Message(value = "Could not migrate key %s", id = 277)
+   void keyMigrationFailed(String key, @Cause Throwable cause);
 
-   @Message(value = "Wrapper cannot handle values of class %s", id = 10004)
-   PersistenceException unsupportedValueFormat(String name);
+   @LogMessage(level = INFO)
+   @Message(value = "Ignoring XML attribute %s, please remove from configuration file", id = 293)
+   void ignoreXmlAttribute(Object attribute);
+
+   @Message(value = "Could not migrate data for cache %s, check remote store config in the target cluster. Make sure only one remote store is present and is pointing to the source cluster", id = 397)
+   CacheException couldNotMigrateData(String name);
 
    @Message(value = "Cannot enable HotRod wrapping if a marshaller and/or an entryWrapper have already been set", id = 10005)
    CacheConfigurationException cannotEnableHotRodWrapping();
-
-   @Message(value = "Cannot load the HotRodEntryWrapper class (make sure the infinispan-server-hotrod classes are available)", id = 10006)
-   CacheConfigurationException cannotLoadHotRodEntryWrapper(@Cause Exception e);
 
    @Message(value = "The RemoteCacheStore for cache %s should be configured with hotRodWrapping enabled", id = 10007)
    CacheException remoteStoreNoHotRodWrapping(String cacheName);

--- a/persistence/rest/src/main/java/org/infinispan/persistence/rest/configuration/RestStoreConfigurationParser.java
+++ b/persistence/rest/src/main/java/org/infinispan/persistence/rest/configuration/RestStoreConfigurationParser.java
@@ -14,7 +14,7 @@ import org.infinispan.configuration.parsing.Namespaces;
 import org.infinispan.configuration.parsing.ParseUtils;
 import org.infinispan.configuration.parsing.Parser;
 import org.infinispan.configuration.parsing.XMLExtendedStreamReader;
-import org.infinispan.persistence.rest.logging.Log;
+import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 import org.kohsuke.MetaInfServices;
 

--- a/persistence/rest/src/main/java/org/infinispan/persistence/rest/logging/Log.java
+++ b/persistence/rest/src/main/java/org/infinispan/persistence/rest/logging/Log.java
@@ -22,9 +22,13 @@
 
 package org.infinispan.persistence.rest.logging;
 
+import static org.jboss.logging.Logger.Level.ERROR;
+
 import org.infinispan.commons.CacheConfigurationException;
 import org.infinispan.persistence.spi.PersistenceException;
+import org.jboss.logging.BasicLogger;
 import org.jboss.logging.annotations.Cause;
+import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 
@@ -36,9 +40,10 @@ import org.jboss.logging.annotations.MessageLogger;
  * @since 6.0
  */
 @MessageLogger(projectCode = "ISPN")
-public interface Log extends org.infinispan.util.logging.Log {
-   @Message(value = "The REST cache store needs to have at least one server configured", id = 22001)
-   CacheConfigurationException noServersConfigured();
+public interface Log extends BasicLogger {
+   @LogMessage(level = ERROR)
+   @Message(value = "Error executing parallel store task", id = 252)
+   void errorExecutingParallelStoreTask(@Cause Throwable cause);
 
    @Message(value = "HTTP error: %s", id = 22002)
    PersistenceException httpError(String status);

--- a/persistence/rest/src/main/java/org/infinispan/persistence/rest/upgrade/RestTargetMigrator.java
+++ b/persistence/rest/src/main/java/org/infinispan/persistence/rest/upgrade/RestTargetMigrator.java
@@ -13,9 +13,9 @@ import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.persistence.PersistenceUtil;
 import org.infinispan.persistence.manager.PersistenceManager;
 import org.infinispan.persistence.rest.RestStore;
-import org.infinispan.persistence.rest.logging.Log;
 import org.infinispan.persistence.spi.PersistenceException;
 import org.infinispan.upgrade.TargetMigrator;
+import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 import org.kohsuke.MetaInfServices;
 

--- a/persistence/rocksdb/src/main/java/org/infinispan/persistence/rocksdb/logging/Log.java
+++ b/persistence/rocksdb/src/main/java/org/infinispan/persistence/rocksdb/logging/Log.java
@@ -1,33 +1,25 @@
 package org.infinispan.persistence.rocksdb.logging;
 
+import static org.jboss.logging.Logger.Level.ERROR;
+import static org.jboss.logging.Logger.Level.INFO;
+
+import org.jboss.logging.BasicLogger;
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
-
-import static org.jboss.logging.Logger.Level.DEBUG;
-import static org.jboss.logging.Logger.Level.WARN;
 
 /**
  * Log abstraction for the RocksDB cache store. For this module, message ids ranging from 23001 to
  * 24000 inclusively have been reserved.
  */
 @MessageLogger(projectCode = "ISPN")
-public interface Log extends org.infinispan.util.logging.Log {
+public interface Log extends BasicLogger {
+   @LogMessage(level = ERROR)
+   @Message(value = "Error executing parallel store task", id = 252)
+   void errorExecutingParallelStoreTask(@Cause Throwable cause);
 
-   @LogMessage(level = WARN)
-   @Message(value = "unable to close iterator", id = 23001)
-   void warnUnableToCloseDbIterator(@Cause Throwable throwable);
-
-   @LogMessage(level = WARN)
-   @Message(value = "unable to close db", id = 23002)
-   void warnUnableToCloseDb(@Cause Throwable throwable);
-
-   @LogMessage(level = WARN)
-   @Message(value = "unable to close expired db", id = 23003)
-   void warnUnableToCloseExpiredDb(@Cause Throwable throwable);
-
-   @LogMessage(level = DEBUG)
-   @Message(value = "An internal RocksDB exception occurred", id = 23008)
-   void warnAboutExceptionInRocksDB(@Cause Exception e);
+   @LogMessage(level = INFO)
+   @Message(value = "Ignoring XML attribute %s, please remove from configuration file", id = 293)
+   void ignoreXmlAttribute(Object attribute);
 }

--- a/query/src/main/java/org/infinispan/query/logging/Log.java
+++ b/query/src/main/java/org/infinispan/query/logging/Log.java
@@ -13,9 +13,11 @@ import javax.transaction.Transaction;
 
 import org.hibernate.search.backend.LuceneWork;
 import org.hibernate.search.exception.SearchException;
+import org.infinispan.commons.CacheConfigurationException;
 import org.infinispan.commons.CacheException;
 import org.infinispan.objectfilter.ParsingException;
 import org.infinispan.remoting.transport.Address;
+import org.jboss.logging.BasicLogger;
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
@@ -30,7 +32,9 @@ import org.jboss.logging.annotations.MessageLogger;
  * @since 5.0
  */
 @MessageLogger(projectCode = "ISPN")
-public interface Log extends org.infinispan.util.logging.Log {
+public interface Log extends BasicLogger {
+   @Message(value = "The configured entity class %s is not indexable. Please remove it from the indexing configuration.", id = 404)
+   CacheConfigurationException classNotIndexable(String className);
 
    @LogMessage(level = ERROR)
    @Message(value = "Could not locate key class %s", id = 14001)
@@ -138,18 +142,11 @@ public interface Log extends org.infinispan.util.logging.Log {
    @Message(value = "The type %s is not an indexed entity.", id = 14030)
    IllegalArgumentException getNoIndexedEntityException(String typeName);
 
-   @Message(value = "Could not locate error handler class %s", id = 14032)
-   IllegalArgumentException unsupportedErrorHandlerConfigurationValueType(Class<?> type);
-
    @Message(value = "Unable to resume suspended transaction %s", id = 14033)
    CacheException unableToResumeSuspendedTx(Transaction transaction, @Cause Throwable cause);
 
    @Message(value = "Unable to suspend transaction", id = 14034)
    CacheException unableToSuspendTx(@Cause Throwable cause);
-
-   @LogMessage(level = WARN)
-   @Message(value = "Error occurred while applying changes to the index", id = 14035)
-   void errorOccurredApplyingChanges(@Cause Throwable cause);
 
    @Message(value = "Prefix, wildcard or regexp queries cannot be fuzzy: %s", id = 14036)
    ParsingException getPrefixWildcardOrRegexpQueriesCannotBeFuzzy(String s); //todo [anistor] this should be thrown earlier at parsing time

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/dataconversion/ProtostreamJsonTranscoder.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/dataconversion/ProtostreamJsonTranscoder.java
@@ -16,8 +16,7 @@ import org.infinispan.commons.dataconversion.Transcoder;
 import org.infinispan.commons.logging.LogFactory;
 import org.infinispan.protostream.ProtobufUtil;
 import org.infinispan.protostream.SerializationContext;
-import org.infinispan.query.remote.impl.logging.Log;
-
+import org.infinispan.util.logging.Log;
 
 /**
  * @since 9.2

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/dataconversion/ProtostreamObjectTranscoder.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/dataconversion/ProtostreamObjectTranscoder.java
@@ -12,7 +12,7 @@ import org.infinispan.commons.dataconversion.Transcoder;
 import org.infinispan.commons.logging.LogFactory;
 import org.infinispan.protostream.ProtobufUtil;
 import org.infinispan.protostream.SerializationContext;
-import org.infinispan.query.remote.impl.logging.Log;
+import org.infinispan.util.logging.Log;
 
 public class ProtostreamObjectTranscoder implements Transcoder {
 

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/dataconversion/ProtostreamTextTranscoder.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/dataconversion/ProtostreamTextTranscoder.java
@@ -9,7 +9,7 @@ import org.infinispan.commons.dataconversion.Transcoder;
 import org.infinispan.commons.logging.LogFactory;
 import org.infinispan.protostream.ProtobufUtil;
 import org.infinispan.protostream.SerializationContext;
-import org.infinispan.query.remote.impl.logging.Log;
+import org.infinispan.util.logging.Log;
 
 /**
  *

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/logging/Log.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/logging/Log.java
@@ -1,6 +1,7 @@
 package org.infinispan.query.remote.impl.logging;
 
 import org.infinispan.commons.CacheException;
+import org.jboss.logging.BasicLogger;
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
@@ -13,7 +14,7 @@ import org.jboss.logging.annotations.MessageLogger;
  * @since 6.0
  */
 @MessageLogger(projectCode = "ISPN")
-public interface Log extends org.infinispan.util.logging.Log {
+public interface Log extends BasicLogger {
 
    @Message(value = "Unknown field %s in type %s", id = 28001)
    IllegalArgumentException unknownField(String fieldName, String fullyQualifiedTypeName);

--- a/server/core/src/main/java/org/infinispan/server/core/logging/Log.java
+++ b/server/core/src/main/java/org/infinispan/server/core/logging/Log.java
@@ -1,15 +1,12 @@
 package org.infinispan.server.core.logging;
 
 import static org.jboss.logging.Logger.Level.DEBUG;
-import static org.jboss.logging.Logger.Level.ERROR;
-import static org.jboss.logging.Logger.Level.INFO;
 import static org.jboss.logging.Logger.Level.WARN;
 
 import java.net.SocketAddress;
 
 import org.infinispan.commons.CacheConfigurationException;
-import org.infinispan.distribution.ch.ConsistentHash;
-import org.jboss.logging.annotations.Cause;
+import org.jboss.logging.BasicLogger;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
@@ -24,19 +21,7 @@ import io.netty.channel.Channel;
  * @since 5.0
  */
 @MessageLogger(projectCode = "ISPN")
-public interface Log extends org.infinispan.util.logging.Log {
-   @LogMessage(level = INFO)
-   @Message(value = "Start main with args: %s", id = 5001)
-   void startWithArgs(String args);
-
-   @LogMessage(level = INFO)
-   @Message(value = "Posting Shutdown Request to the server...", id = 5002)
-   void postingShutdownRequest();
-
-   @LogMessage(level = ERROR)
-   @Message(value = "Exception reported", id = 5003)
-   void exceptionReported(@Cause Throwable t);
-
+public interface Log extends BasicLogger {
    @LogMessage(level = WARN)
    @Message(value = "Server channel group did not completely unbind", id = 5004)
    void serverDidNotUnbind();
@@ -52,14 +37,6 @@ public interface Log extends org.infinispan.util.logging.Log {
    @LogMessage(level = WARN)
    @Message(value = "%s is still connected to %s", id = 5007)
    void channelStillConnected(Channel ch, SocketAddress address);
-
-   @LogMessage(level = WARN)
-   @Message(value = "Setting the number of master threads is no longer supported", id = 5008)
-   void settingMasterThreadsNotSupported();
-
-   @LogMessage(level = ERROR)
-   @Message(value = "Unexpected error before any request parameters read", id = 5009)
-   void errorBeforeReadingRequest(@Cause Throwable t);
 
    @Message(value = "Illegal number of workerThreads: %d", id = 5010)
    IllegalArgumentException illegalWorkerThreads(int workerThreads);
@@ -84,30 +61,6 @@ public interface Log extends org.infinispan.util.logging.Log {
 
    @Message(value = "Cannot configure custom KeyStore and/or TrustStore when specifying a SSLContext", id = 5018)
    CacheConfigurationException xorSSLContext();
-
-   @LogMessage(level = WARN)
-   @Message(value = "No members for new topology after applying consistent hash %s filtering into base topology %s", id = 5019)
-   void noMembersInHashTopology(ConsistentHash ch, String topologyMap);
-
-   @LogMessage(level = WARN)
-   @Message(value = "No members in new topology", id = 5020)
-   void noMembersInTopology();
-
-   @LogMessage(level = WARN)
-   @Message(value = "Server endpoint topology is empty, and cluster members are %s", id = 5021)
-   void serverEndpointTopologyEmpty(String clusterMembers);
-
-   @LogMessage(level = ERROR)
-   @Message(value = "Exception writing response with messageId=%s", id = 5022)
-   void errorWritingResponse(long msgId, @Cause Throwable t);
-
-   @LogMessage(level = ERROR)
-   @Message(value = "Exception encoding message %s", id = 5023)
-   void errorEncodingMessage(Object msg, @Cause Throwable t);
-
-   @LogMessage(level = ERROR)
-   @Message(value = "Request to encode unexpected message %s", id = 5024)
-   void errorUnexpectedMessage(Object msg);
 
    @LogMessage(level = DEBUG)
    @Message(value = "Using Netty SocketChannel %s for %s", id = 5025)

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/logging/Log.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/logging/Log.java
@@ -8,9 +8,11 @@ import java.util.Set;
 import org.infinispan.commons.CacheConfigurationException;
 import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.counter.exception.CounterException;
+import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.notifications.cachelistener.event.Event;
 import org.infinispan.server.hotrod.MissingFactoryException;
 import org.infinispan.util.concurrent.IsolationLevel;
+import org.jboss.logging.BasicLogger;
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
@@ -24,7 +26,34 @@ import org.jboss.logging.annotations.MessageLogger;
  * @since 5.0
  */
 @MessageLogger(projectCode = "ISPN")
-public interface Log extends org.infinispan.server.core.logging.Log {
+public interface Log extends BasicLogger {
+   @LogMessage(level = ERROR)
+   @Message(value = "Exception reported", id = 5003)
+   void exceptionReported(@Cause Throwable t);
+
+   @LogMessage(level = WARN)
+   @Message(value = "No members for new topology after applying consistent hash %s filtering into base topology %s", id = 5019)
+   void noMembersInHashTopology(ConsistentHash ch, String topologyMap);
+
+   @LogMessage(level = WARN)
+   @Message(value = "No members in new topology", id = 5020)
+   void noMembersInTopology();
+
+   @LogMessage(level = WARN)
+   @Message(value = "Server endpoint topology is empty, and cluster members are %s", id = 5021)
+   void serverEndpointTopologyEmpty(String clusterMembers);
+
+   @LogMessage(level = ERROR)
+   @Message(value = "Exception writing response with messageId=%s", id = 5022)
+   void errorWritingResponse(long msgId, @Cause Throwable t);
+
+   @LogMessage(level = ERROR)
+   @Message(value = "Exception encoding message %s", id = 5023)
+   void errorEncodingMessage(Object msg, @Cause Throwable t);
+
+   @LogMessage(level = ERROR)
+   @Message(value = "Request to encode unexpected message %s", id = 5024)
+   void errorUnexpectedMessage(Object msg);
 
    @LogMessage(level = WARN)
    @Message(value = "While trying to detect a crashed member, current view returned null", id = 6000)

--- a/server/memcached/src/main/java/org/infinispan/server/memcached/MemcachedDecoder.java
+++ b/server/memcached/src/main/java/org/infinispan/server/memcached/MemcachedDecoder.java
@@ -66,7 +66,7 @@ import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.metadata.Metadata;
 import org.infinispan.remoting.rpc.RpcManager;
 import org.infinispan.server.core.transport.NettyTransport;
-import org.infinispan.server.memcached.logging.JavaLog;
+import org.infinispan.server.memcached.logging.Log;
 import org.infinispan.stats.Stats;
 import org.infinispan.util.KeyValuePair;
 
@@ -108,7 +108,7 @@ public class MemcachedDecoder extends ReplayingDecoder<MemcachedDecoderState> {
    protected final NettyTransport transport;
    protected final Predicate<? super String> ignoreCache;
 
-   private final static JavaLog log = LogFactory.getLog(MemcachedDecoder.class, JavaLog.class);
+   private final static Log log = LogFactory.getLog(MemcachedDecoder.class, Log.class);
    private final static boolean isTrace = log.isTraceEnabled();
 
    private static final int SecondsInAMonth = 60 * 60 * 24 * 30;

--- a/server/memcached/src/main/java/org/infinispan/server/memcached/MemcachedServer.java
+++ b/server/memcached/src/main/java/org/infinispan/server/memcached/MemcachedServer.java
@@ -14,7 +14,7 @@ import org.infinispan.server.core.AbstractProtocolServer;
 import org.infinispan.server.core.transport.NettyChannelInitializer;
 import org.infinispan.server.core.transport.NettyInitializers;
 import org.infinispan.server.memcached.configuration.MemcachedServerConfiguration;
-import org.infinispan.server.memcached.logging.JavaLog;
+import org.infinispan.server.memcached.logging.Log;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelInboundHandler;
@@ -33,7 +33,7 @@ public class MemcachedServer extends AbstractProtocolServer<MemcachedServerConfi
       super("Memcached");
    }
 
-   private final static JavaLog log = LogFactory.getLog(MethodHandles.lookup().lookupClass(), JavaLog.class);
+   private final static Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass(), Log.class);
    protected ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
    private AdvancedCache<String, byte[]> memcachedCache;
 

--- a/server/memcached/src/main/java/org/infinispan/server/memcached/logging/Log.java
+++ b/server/memcached/src/main/java/org/infinispan/server/memcached/logging/Log.java
@@ -1,7 +1,11 @@
 package org.infinispan.server.memcached.logging;
 
+import static org.jboss.logging.Logger.Level.ERROR;
+
 import org.infinispan.commons.CacheConfigurationException;
-import org.infinispan.server.core.logging.Log;
+import org.jboss.logging.BasicLogger;
+import org.jboss.logging.annotations.Cause;
+import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 
@@ -13,7 +17,11 @@ import org.jboss.logging.annotations.MessageLogger;
  * @since 5.0
  */
 @MessageLogger(projectCode = "ISPN")
-public interface JavaLog extends Log {
+public interface Log extends BasicLogger {
+   @LogMessage(level = ERROR)
+   @Message(value = "Exception reported", id = 5003)
+   void exceptionReported(@Cause Throwable t);
+
    @Message(value = "Cache '%s' has expiration enabled which violates the Memcached protocol", id = 11001)
    CacheConfigurationException invalidExpiration(String cacheName);
 }

--- a/server/memcached/src/test/java/org/infinispan/server/memcached/MemcachedFunctionalTest.java
+++ b/server/memcached/src/test/java/org/infinispan/server/memcached/MemcachedFunctionalTest.java
@@ -37,7 +37,7 @@ import org.infinispan.notifications.Listener;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryRemoved;
 import org.infinispan.notifications.cachelistener.event.CacheEntryRemovedEvent;
 import org.infinispan.server.memcached.configuration.MemcachedServerConfigurationBuilder;
-import org.infinispan.server.memcached.logging.JavaLog;
+import org.infinispan.server.memcached.logging.Log;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.testng.annotations.Test;
 
@@ -634,7 +634,7 @@ public class MemcachedFunctionalTest extends MemcachedSingleNodeTest {
 class NoReplyListener {
    private final CountDownLatch latch;
 
-   JavaLog log = LogFactory.getLog(NoReplyListener.class, JavaLog.class);
+   Log log = LogFactory.getLog(NoReplyListener.class, Log.class);
 
    NoReplyListener(CountDownLatch latch) {
       this.latch = latch;

--- a/server/memcached/src/test/java/org/infinispan/server/memcached/test/MemcachedTestingUtil.java
+++ b/server/memcached/src/test/java/org/infinispan/server/memcached/test/MemcachedTestingUtil.java
@@ -11,7 +11,7 @@ import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.server.memcached.MemcachedDecoder;
 import org.infinispan.server.memcached.MemcachedServer;
 import org.infinispan.server.memcached.configuration.MemcachedServerConfigurationBuilder;
-import org.infinispan.server.memcached.logging.JavaLog;
+import org.infinispan.server.memcached.logging.Log;
 import org.infinispan.test.fwk.TestResourceTracker;
 
 import io.netty.channel.ChannelInboundHandler;
@@ -25,7 +25,7 @@ import net.spy.memcached.MemcachedClient;
  * @since 4.1
  */
 public class MemcachedTestingUtil {
-   private static final JavaLog log = LogFactory.getLog(MemcachedTestingUtil.class, JavaLog.class);
+   private static final Log log = LogFactory.getLog(MemcachedTestingUtil.class, Log.class);
 
    private static final String host = "127.0.0.1";
 

--- a/server/rest/src/main/java/org/infinispan/rest/dataconversion/JBossMarshallingTranscoder.java
+++ b/server/rest/src/main/java/org/infinispan/rest/dataconversion/JBossMarshallingTranscoder.java
@@ -12,7 +12,7 @@ import org.infinispan.commons.dataconversion.GenericJbossMarshallerEncoder;
 import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.commons.dataconversion.OneToManyTranscoder;
 import org.infinispan.marshall.core.EncoderRegistry;
-import org.infinispan.rest.logging.Log;
+import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
 /**

--- a/server/rest/src/main/java/org/infinispan/rest/dataconversion/JavaSerializationTranscoder.java
+++ b/server/rest/src/main/java/org/infinispan/rest/dataconversion/JavaSerializationTranscoder.java
@@ -7,7 +7,7 @@ import java.util.Set;
 import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.commons.dataconversion.Transcoder;
 import org.infinispan.commons.marshall.JavaSerializationMarshaller;
-import org.infinispan.rest.logging.Log;
+import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
 /**

--- a/server/rest/src/main/java/org/infinispan/rest/dataconversion/JsonTranscoder.java
+++ b/server/rest/src/main/java/org/infinispan/rest/dataconversion/JsonTranscoder.java
@@ -17,7 +17,7 @@ import org.infinispan.commons.CacheException;
 import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.commons.dataconversion.OneToManyTranscoder;
 import org.infinispan.commons.dataconversion.StandardConversions;
-import org.infinispan.rest.logging.Log;
+import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
 /**

--- a/server/rest/src/main/java/org/infinispan/rest/logging/Log.java
+++ b/server/rest/src/main/java/org/infinispan/rest/logging/Log.java
@@ -1,14 +1,14 @@
 package org.infinispan.rest.logging;
 
-import static org.jboss.logging.Logger.Level.ERROR;
-import static org.jboss.logging.Logger.Level.INFO;
 import static org.jboss.logging.Logger.Level.TRACE;
 import static org.jboss.logging.Logger.Level.WARN;
 
+import org.infinispan.commons.dataconversion.EncodingException;
 import org.infinispan.rest.cachemanager.exceptions.CacheUnavailableException;
 import org.infinispan.rest.operations.exceptions.NoCacheFoundException;
 import org.infinispan.rest.operations.exceptions.ServiceUnavailableException;
 import org.infinispan.rest.operations.exceptions.UnacceptableDataFormatException;
+import org.jboss.logging.BasicLogger;
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
@@ -22,19 +22,9 @@ import org.jboss.logging.annotations.MessageLogger;
  * @since 5.0
  */
 @MessageLogger(projectCode = "ISPN")
-public interface Log extends org.infinispan.util.logging.Log {
-
-   @LogMessage(level = ERROR)
-   @Message(value = "Error reading configuration file for REST server: %s", id = 12001)
-   void errorReadingConfigurationFile(@Cause Throwable t, String path);
-
-   @LogMessage(level = ERROR)
-   @Message(value = "Error while retrieving cache manager from JBoss Microcontainer", id = 12002)
-   void errorRetrievingCacheManagerFromMC(@Cause Throwable t);
-
-   @LogMessage(level = INFO)
-   @Message(value = "REST server starting, listening on %s:%s", id = 12003)
-   void startRestServer(String host, int port);
+public interface Log extends BasicLogger {
+   @Message(value = "Error transcoding content", id = 495)
+   EncodingException errorTranscoding(@Cause Throwable cause);
 
    @Message(value = "Unsupported configuration option", id = 12004)
    UnsupportedOperationException unsupportedConfigurationOption();

--- a/server/router/src/main/java/org/infinispan/server/router/logging/RouterLogger.java
+++ b/server/router/src/main/java/org/infinispan/server/router/logging/RouterLogger.java
@@ -5,6 +5,7 @@ import static org.jboss.logging.Logger.Level.ERROR;
 import static org.jboss.logging.Logger.Level.INFO;
 
 import org.infinispan.server.router.RoutingTable;
+import org.jboss.logging.BasicLogger;
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
@@ -19,7 +20,7 @@ import io.netty.util.DomainNameMapping;
  * @author Sebastian Łaskawiec
  */
 @MessageLogger(projectCode = "ISPN")
-public interface RouterLogger extends org.infinispan.util.logging.Log {
+public interface RouterLogger extends BasicLogger {
 
     @LogMessage(level = DEBUG)
     @Message(value = "Using SNI Handler with domain mapping %s", id = 14001)

--- a/server/websocket/src/main/java/org/infinispan/server/websocket/logging/Log.java
+++ b/server/websocket/src/main/java/org/infinispan/server/websocket/logging/Log.java
@@ -1,6 +1,7 @@
 package org.infinispan.server.websocket.logging;
 
 import org.infinispan.server.websocket.json.JsonConversionException;
+import org.jboss.logging.BasicLogger;
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
@@ -13,7 +14,7 @@ import org.jboss.logging.annotations.MessageLogger;
  * @since 5.0
  */
 @MessageLogger(projectCode = "ISPN")
-public interface Log extends org.infinispan.util.logging.Log {
+public interface Log extends BasicLogger {
 
    @Message(value = "Could not convert from String to Json: %s", id = 13001)
    JsonConversionException unableToConvertFromStringToJson(String json, @Cause Throwable e);

--- a/tasks/manager/src/main/java/org/infinispan/tasks/logging/Log.java
+++ b/tasks/manager/src/main/java/org/infinispan/tasks/logging/Log.java
@@ -1,5 +1,6 @@
 package org.infinispan.tasks.logging;
 
+import org.jboss.logging.BasicLogger;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 
@@ -11,7 +12,7 @@ import org.jboss.logging.annotations.MessageLogger;
  * @since 8.1
  */
 @MessageLogger(projectCode = "ISPN")
-public interface Log extends org.infinispan.util.logging.Log {
+public interface Log extends BasicLogger {
    @Message(value = "Task Engine '%s' has already been registered", id = 27001)
    IllegalStateException duplicateTaskEngineRegistration(String taskEngineName);
 

--- a/tasks/scripting/src/main/java/org/infinispan/scripting/logging/Log.java
+++ b/tasks/scripting/src/main/java/org/infinispan/scripting/logging/Log.java
@@ -3,6 +3,7 @@ package org.infinispan.scripting.logging;
 import static org.jboss.logging.Logger.Level.ERROR;
 
 import org.infinispan.commons.CacheException;
+import org.jboss.logging.BasicLogger;
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
@@ -16,7 +17,7 @@ import org.jboss.logging.annotations.MessageLogger;
  * @since 7.2
  */
 @MessageLogger(projectCode = "ISPN")
-public interface Log extends org.infinispan.util.logging.Log {
+public interface Log extends BasicLogger {
    @LogMessage(level = ERROR)
    @Message(value = "Could not register interpreter MBean", id = 27501)
    void jmxRegistrationFailed();

--- a/tree/src/main/java/org/infinispan/tree/logging/Log.java
+++ b/tree/src/main/java/org/infinispan/tree/logging/Log.java
@@ -1,5 +1,6 @@
 package org.infinispan.tree.logging;
 
+import org.jboss.logging.BasicLogger;
 import org.jboss.logging.annotations.MessageLogger;
 
 /**
@@ -10,5 +11,5 @@ import org.jboss.logging.annotations.MessageLogger;
  * @since 5.0
  */
 @MessageLogger(projectCode = "ISPN")
-public interface Log extends org.infinispan.util.logging.Log {
+public interface Log extends BasicLogger {
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-8870

This saves about 2MB of metaspace when running the default standalone server.