### PR TITLE
ISPN-8871 Do not create an ACL cache if one isn't needed

### DIFF
--- a/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
@@ -247,11 +247,13 @@ public class DefaultCacheManager implements EmbeddedCacheManager {
             defaultCacheName = null;
          }
       }
-      this.authzHelper = new AuthorizationHelper(globalConfiguration.security(), AuditContext.CACHEMANAGER, globalConfiguration.globalJmxStatistics().cacheManagerName());
       this.globalComponentRegistry = new GlobalComponentRegistry(globalConfiguration, this, caches.keySet());
       this.globalComponentRegistry.registerComponent(configurationManager, ConfigurationManager.class);
       this.globalComponentRegistry.registerComponent(cacheDependencyGraph, CACHE_DEPENDENCY_GRAPH, false);
+
+      this.authzHelper = new AuthorizationHelper(globalConfiguration.security(), AuditContext.CACHEMANAGER, globalConfiguration.globalJmxStatistics().cacheManagerName());
       this.globalComponentRegistry.registerComponent(authzHelper, AuthorizationHelper.class);
+
       this.stats = new CacheContainerStatsImpl(this);
       health = new HealthImpl(this);
       globalComponentRegistry.registerComponent(new HealthJMXExposerImpl(health), HealthJMXExposer.class);
@@ -323,10 +325,14 @@ public class DefaultCacheManager implements EmbeddedCacheManager {
          globalComponentRegistry = new GlobalComponentRegistry(globalConfiguration, this, caches.keySet());
          globalComponentRegistry.registerComponent(configurationManager, ConfigurationManager.class);
          globalComponentRegistry.registerComponent(cacheDependencyGraph, CACHE_DEPENDENCY_GRAPH, false);
-         authzHelper = new AuthorizationHelper(globalConfiguration.security(), AuditContext.CACHEMANAGER, globalConfiguration.globalJmxStatistics().cacheManagerName());
+
          stats = new CacheContainerStatsImpl(this);
          health = new HealthImpl(this);
          globalComponentRegistry.registerComponent(new HealthJMXExposerImpl(health), HealthJMXExposer.class);
+
+         authzHelper = new AuthorizationHelper(globalConfiguration.security(), AuditContext.CACHEMANAGER, globalConfiguration.globalJmxStatistics().cacheManagerName());
+         this.globalComponentRegistry.registerComponent(authzHelper, AuthorizationHelper.class);
+
          cacheManagerAdmin = new DefaultCacheManagerAdmin(this, authzHelper, EnumSet.noneOf(CacheContainerAdmin.AdminFlag.class));
       } catch (CacheConfigurationException ce) {
          throw ce;

--- a/core/src/main/java/org/infinispan/security/impl/AuthorizationHelper.java
+++ b/core/src/main/java/org/infinispan/security/impl/AuthorizationHelper.java
@@ -50,7 +50,7 @@ public class AuthorizationHelper {
    }
 
    public AuthorizationHelper(GlobalSecurityConfiguration security, AuditContext context, String name) {
-      this(security, context, name, CollectionFactory.makeBoundedConcurrentMap(10));
+      this(security, context, name, security.authorization().enabled() ? CollectionFactory.makeBoundedConcurrentMap(10) : null);
    }
 
    public void checkPermission(AuthorizationPermission perm) {


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-8871

Avoids initializing Caffeine when we don't need it (unbounded and off-heap)