### PR TITLE
ISPN-8796 - Jolokia must be secured by default

### DIFF
--- a/server/integration/feature-pack/src/main/resources/content/bin/agent.conf
+++ b/server/integration/feature-pack/src/main/resources/content/bin/agent.conf
@@ -1,1 +1,1 @@
-jolokia=port=8778
+jolokia=port=8778,policyLocation=file://${env:JBOSS_HOME}/modules/system/layers/base/io/fabric8/agent-bond/main/jolokia-access.xml

--- a/server/integration/feature-pack/src/main/resources/modules/system/layers/base/io/fabric8/agent-bond/main/jolokia-access.xml
+++ b/server/integration/feature-pack/src/main/resources/modules/system/layers/base/io/fabric8/agent-bond/main/jolokia-access.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitationsjolokia=port=8778
+under the License.
+-->
+
+<!-- This policy file controls the Jolokia JMX-HTTP bridge security options for the web console.
+   see: https://jolokia.org/reference/html/security.html -->
+<restrict>
+
+   <remote>
+     <host>127.0.0.1</host>
+   </remote>
+
+   <http>
+     <method>post</method>
+   </http>
+
+</restrict>


### PR DESCRIPTION
The intention with this commit is allow only request from localhost
and using the post http method.

We can use also the following placeholders
$host or ${host} : Host name (if possible), otherwise address
$ip or ${ip} : IP Address
${prop:foo} : System property foo
${env:FOO} : Environment variable FOO