### PR TITLE
ISPN-8822 Fix performance regression

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/Util.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/Util.java
@@ -11,16 +11,20 @@ import org.infinispan.client.hotrod.exceptions.TransportException;
 import org.infinispan.commons.CacheException;
 
 public class Util {
+   private final static long BIG_DELAY_NANOS = TimeUnit.DAYS.toNanos(1);
    private Util() {
    }
 
    public static <T> T await(CompletableFuture<T> cf) {
       try {
-         return cf.get();
+         // timed wait does not do busy waiting
+         return cf.get(BIG_DELAY_NANOS, TimeUnit.NANOSECONDS);
       } catch (InterruptedException e) {
          throw new CacheException(e);
       } catch (ExecutionException e) {
          throw rewrap(e);
+      } catch (TimeoutException e) {
+         throw new IllegalStateException(e);
       }
    }
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/HotRodOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/HotRodOperation.java
@@ -81,7 +81,8 @@ public abstract class HotRodOperation<T> extends CompletableFuture<T> implements
 
    protected HeaderDecoder<T> scheduleRead(Channel channel, HeaderParams header) {
       HeaderDecoder<T> decoder = new HeaderDecoder<>(codec, header, channelFactory, this);
-      channel.pipeline().addLast(decoder, this);
+      channel.pipeline().addLast(HeaderDecoder.NAME, decoder);
+      channel.pipeline().addLast(getClass().getSimpleName(), this);
       return decoder;
    }
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/HeaderDecoder.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/HeaderDecoder.java
@@ -14,6 +14,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.Signal;
 
 public class HeaderDecoder<T> extends HintedReplayingDecoder<HeaderDecoder.State> implements Runnable {
+   public static final String NAME = "header-decoder";
    private final Codec codec;
    private final HeaderParams headerParams;
    private final ChannelFactory channelFactory;
@@ -28,6 +29,11 @@ public class HeaderDecoder<T> extends HintedReplayingDecoder<HeaderDecoder.State
       this.headerParams = headerParams;
       this.channelFactory = channelFactory;
       this.operation = operation;
+   }
+
+   @Override
+   public boolean isSharable() {
+      return false;
    }
 
    @Override


### PR DESCRIPTION
* use non-busy-waiting get when expecting response
* avoid some thread-local lookups in Netty

https://issues.jboss.org/browse/ISPN-8822

@gustavonalle When checking, please make sure that you set the same GC for both runs (recently G1 was set as default in the testsuite and this has a huge impact).