### PR TITLE
ISPN-8888 Wrong warn message for eviction "EvictionConfigurationBuilder

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/cache/EvictionConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/EvictionConfigurationBuilder.java
@@ -125,7 +125,7 @@ public class EvictionConfigurationBuilder extends AbstractConfigurationChildBuil
       }
       if (attributes.attribute(TYPE).get() == EvictionType.MEMORY) {
          String javaVM = SecurityActions.getSystemProperty("java.vm.name");
-         if (!javaVM.contains("HotSpot")) {
+         if (!javaVM.contains("HotSpot") && !javaVM.contains("OpenJDK")) {
             log.memoryApproximationUnsupportedVM(javaVM);
          }
       }


### PR DESCRIPTION
ISPN000368: Memory approximation calculation for eviction is unsupported
for the 'OpenJDK 64-Bit Server VM' Java VM"

* Don't warn when OpenJDK VM is used

Wrong warn message for eviction "EvictionConfigurationBuilder ISPN000368: Memory approximation calculation for eviction is unsupported for the 'OpenJDK 64-Bit Server VM' Java VM"