### PR TITLE
ISPN-8895 TestResourceTracker integrated with Spring's TestExecutionL…

### DIFF
--- a/spring/spring4/spring4-common/pom.xml
+++ b/spring/spring4/spring4-common/pom.xml
@@ -34,6 +34,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/spring/spring4/spring4-common/src/test/java/org/infinispan/spring/test/InfinispanTestExecutionListener.java
+++ b/spring/spring4/spring4-common/src/test/java/org/infinispan/spring/test/InfinispanTestExecutionListener.java
@@ -1,0 +1,23 @@
+package org.infinispan.spring.test;
+
+import org.infinispan.test.fwk.TestResourceTracker;
+import org.springframework.test.context.TestContext;
+import org.springframework.test.context.support.AbstractTestExecutionListener;
+
+/**
+ * Ensures that we register with {@link TestResourceTracker} within the lifecycle of Spring Context tests. This is
+ * because Spring calls createCacheManager from the superclass BeforeClass method and we need to manipulate the tracker
+ * beforehand.
+ */
+public class InfinispanTestExecutionListener extends AbstractTestExecutionListener {
+
+   @Override
+   public void beforeTestClass(TestContext testContext) throws Exception {
+      TestResourceTracker.testStarted(testContext.getTestClass().getName());
+   }
+
+   @Override
+   public void afterTestClass(TestContext testContext) throws Exception {
+      TestResourceTracker.testFinished(testContext.getTestClass().getName());
+   }
+}

--- a/spring/spring4/spring4-embedded/src/test/java/org/infinispan/spring/support/embedded/InfinispanDefaultCacheFactoryBeanContextTest.java
+++ b/spring/spring4/spring4-embedded/src/test/java/org/infinispan/spring/support/embedded/InfinispanDefaultCacheFactoryBeanContextTest.java
@@ -4,13 +4,12 @@ import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertSame;
 
 import org.infinispan.Cache;
-import org.infinispan.test.fwk.TestResourceTracker;
+import org.infinispan.spring.test.InfinispanTestExecutionListener;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /**
@@ -24,19 +23,10 @@ import org.testng.annotations.Test;
 @DirtiesContext(classMode = ClassMode.AFTER_CLASS)
 @ContextConfiguration("classpath:/org/infinispan/spring/support/embedded/InfinispanDefaultCacheFactoryBeanContextTest.xml")
 @Test(testName = "spring.support.InfinispanDefaultCacheFactoryBeanContextTest", groups = "unit")
+@TestExecutionListeners(InfinispanTestExecutionListener.class)
 public class InfinispanDefaultCacheFactoryBeanContextTest extends AbstractTestNGSpringContextTests {
 
    private static final String DEFAULT_CACHE_NAME = "testDefaultCache";
-
-   @BeforeClass(alwaysRun = true)
-   public void beforeTest() {
-       TestResourceTracker.testStarted(getClass().getName());
-   }
-
-   @AfterClass(alwaysRun = true)
-   public void afterTest() {
-       TestResourceTracker.testFinished(getClass().getName());
-   }
 
    @Test
    public final void shouldProduceANonNullCache() {

--- a/spring/spring4/spring4-remote/src/test/java/org/infinispan/spring/provider/sample/AbstractTestTemplate.java
+++ b/spring/spring4/spring4-remote/src/test/java/org/infinispan/spring/provider/sample/AbstractTestTemplate.java
@@ -6,14 +6,13 @@ import java.util.Random;
 import org.infinispan.commons.api.BasicCache;
 import org.infinispan.spring.provider.sample.entity.Book;
 import org.infinispan.spring.provider.sample.service.CachedBookService;
-import org.infinispan.test.fwk.TestResourceTracker;
+import org.infinispan.spring.test.InfinispanTestExecutionListener;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 import org.springframework.cache.CacheManager;
+import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.testng.AbstractTransactionalTestNGSpringContextTests;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /**
@@ -27,19 +26,10 @@ import org.testng.annotations.Test;
  * @author Matej Cimbora (mcimbora@redhat.com)
  */
 @Test(groups = "functional")
+@TestExecutionListeners(InfinispanTestExecutionListener.class)
 public abstract class AbstractTestTemplate extends AbstractTransactionalTestNGSpringContextTests {
 
    protected static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
-
-   @BeforeClass(alwaysRun = true)
-   public void beforeTest() {
-      TestResourceTracker.testStarted(getClass().getName());
-   }
-
-   @AfterClass(alwaysRun = true)
-   public void afterTest() {
-      TestResourceTracker.testFinished(getClass().getName());
-   }
 
    @AfterMethod
    public void clearBookCache() {


### PR DESCRIPTION
…istener

https://issues.jboss.org/browse/ISPN-8895

Fixes two tests:
org.infinispan.spring.support.embedded.InfinispanDefaultCacheFactoryBeanContextTest.springTestContextPrepareTestInstance
org.infinispan.spring.provider.sample.SampleRemoteCacheTest.springTestContextPrepareTestInstance