### PR TITLE
ISPN-8907 Prevent CacheManager start when global state is corrupt

### DIFF
--- a/core/src/main/java/org/infinispan/globalstate/ScopedPersistentState.java
+++ b/core/src/main/java/org/infinispan/globalstate/ScopedPersistentState.java
@@ -59,4 +59,9 @@ public interface ScopedPersistentState {
     * Returns the checksum of the properties excluding those prefixed with @
     */
    int getChecksum();
+
+   /**
+    * Returns whether the state contains a property
+    */
+   boolean containsProperty(String key);
 }

--- a/core/src/main/java/org/infinispan/globalstate/impl/GlobalStateManagerImpl.java
+++ b/core/src/main/java/org/infinispan/globalstate/impl/GlobalStateManagerImpl.java
@@ -103,6 +103,9 @@ public class GlobalStateManagerImpl implements GlobalStateManager {
             throw log.nonWritableStateFile(stateFile);
          }
          // Validate the state before proceeding
+         if (!state.containsProperty(VERSION) || !state.containsProperty(VERSION_MAJOR) || !state.containsProperty(TIMESTAMP)) {
+            throw log.invalidPersistentState(GLOBAL_SCOPE);
+         }
          log.globalStateLoad(state.getProperty(VERSION), state.getProperty(TIMESTAMP));
 
          stateProviders.forEach(provider -> provider.prepareForRestore(state));

--- a/core/src/main/java/org/infinispan/globalstate/impl/ScopedPersistentStateImpl.java
+++ b/core/src/main/java/org/infinispan/globalstate/impl/ScopedPersistentStateImpl.java
@@ -86,4 +86,9 @@ public class ScopedPersistentStateImpl implements ScopedPersistentState {
       result += state.entrySet().stream().filter(e -> !e.getKey().startsWith("@")).mapToInt(Map.Entry::hashCode).sum();
       return result;
    }
+
+   @Override
+   public boolean containsProperty(String key) {
+      return state.containsKey(key);
+   }
 }

--- a/core/src/main/java/org/infinispan/topology/LocalTopologyManagerImpl.java
+++ b/core/src/main/java/org/infinispan/topology/LocalTopologyManagerImpl.java
@@ -792,6 +792,9 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager, GlobalSta
 
    @Override
    public void prepareForRestore(ScopedPersistentState state) {
+      if (!state.containsProperty("uuid")) {
+         throw log.invalidPersistentState(ScopedPersistentState.GLOBAL_SCOPE);
+      }
       persistentUUID = PersistentUUID.fromString(state.getProperty("uuid"));
    }
 

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -1758,4 +1758,7 @@ public interface Log extends BasicLogger {
 
    @Message(value = "The configuration is immutable", id = 515)
    UnsupportedOperationException immutableConfiguration();
+
+   @Message(value = "The state file for '%s' is invalid. Startup halted to prevent further corruption of persistent state", id = 516)
+   CacheConfigurationException invalidPersistentState(String globalScope);
 }

--- a/core/src/test/java/org/infinispan/globalstate/GlobalStateTest.java
+++ b/core/src/test/java/org/infinispan/globalstate/GlobalStateTest.java
@@ -1,6 +1,9 @@
 package org.infinispan.globalstate;
 
 import java.io.File;
+import java.io.FileWriter;
+import java.io.Writer;
+import java.lang.reflect.Method;
 
 import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
@@ -22,16 +25,48 @@ public class GlobalStateTest extends AbstractInfinispanTest {
 
    public void testLockPersistentLocation() {
       String stateDirectory = TestingUtil.tmpDirectory(this.getClass().getSimpleName() + File.separator + "COMMON");
-      Util.recursiveFileRemove(stateDirectory);
-      GlobalConfigurationBuilder global = GlobalConfigurationBuilder.defaultClusteredBuilder();
-      global.globalState().enable().persistentLocation(stateDirectory);
-      EmbeddedCacheManager cm1 = TestCacheManagerFactory.createClusteredCacheManager(false, global, new ConfigurationBuilder(), new TransportFlags(), false);
-      EmbeddedCacheManager cm2 = TestCacheManagerFactory.createClusteredCacheManager(false, global, new ConfigurationBuilder(), new TransportFlags(), false);
+
+      GlobalConfigurationBuilder global1 = statefulGlobalBuilder(stateDirectory, true);
+      GlobalConfigurationBuilder global2 = statefulGlobalBuilder(stateDirectory, true);
+
+      EmbeddedCacheManager cm1 = TestCacheManagerFactory.createClusteredCacheManager(false, global1, new ConfigurationBuilder(), new TransportFlags(), false);
+      EmbeddedCacheManager cm2 = TestCacheManagerFactory.createClusteredCacheManager(false, global2, new ConfigurationBuilder(), new TransportFlags(), false);
       try {
          cm1.start();
          Exceptions.expectException(EmbeddedCacheManagerStartupException.class, "org.infinispan.commons.CacheConfigurationException: ISPN000512: Cannot acquire lock.*", () -> cm2.start());
       } finally {
          TestingUtil.killCacheManagers(cm1, cm2);
       }
+   }
+
+   public void testCorruptGlobalState(Method m) throws Exception {
+      String state1 = TestingUtil.tmpDirectory(this.getClass().getSimpleName() + File.separator + m.getName() + "1");
+      GlobalConfigurationBuilder global1 = statefulGlobalBuilder(state1, true);
+      String state2 = TestingUtil.tmpDirectory(this.getClass().getSimpleName() + File.separator + m.getName() + "2");
+      GlobalConfigurationBuilder global2 = statefulGlobalBuilder(state2, true);
+      EmbeddedCacheManager cm1 = TestCacheManagerFactory.createClusteredCacheManager(false, global1, new ConfigurationBuilder(), new TransportFlags(), false);
+      EmbeddedCacheManager cm2 = TestCacheManagerFactory.createClusteredCacheManager(false, global2, new ConfigurationBuilder(), new TransportFlags(), false);
+      try {
+         cm1.start();
+         cm2.start();
+         cm1.stop();
+         cm2.stop();
+         // corrupt one of the state files
+         Writer w = new FileWriter(new File(state1, ScopedPersistentState.GLOBAL_SCOPE + ".state"));
+         w.write("'Cause I want to be anarchy\nIt's the only way to be");
+         w.close();
+         global1 = statefulGlobalBuilder(state1, false);
+         EmbeddedCacheManager newCm1 = TestCacheManagerFactory.createClusteredCacheManager(false, global1, new ConfigurationBuilder(), new TransportFlags(), false);
+         Exceptions.expectException(EmbeddedCacheManagerStartupException.class, "org.infinispan.commons.CacheConfigurationException: ISPN000516: The state file for '___global' is invalid.*", () -> newCm1.start());
+      } finally {
+         TestingUtil.killCacheManagers(cm1, cm2);
+      }
+   }
+
+   private GlobalConfigurationBuilder statefulGlobalBuilder(String stateDirectory, boolean clear) {
+      if (clear) Util.recursiveFileRemove(stateDirectory);
+      GlobalConfigurationBuilder global = GlobalConfigurationBuilder.defaultClusteredBuilder();
+      global.globalState().enable().persistentLocation(stateDirectory);
+      return global;
    }
 }


### PR DESCRIPTION
- perform validation of the global state file on startup

https://issues.jboss.org/browse/ISPN-8907