### PR TITLE
ISPN-8893 Do not ignore the asking thread stack trace when reporting a remoting exception.

### DIFF
--- a/core/src/main/java/org/infinispan/interceptors/impl/SimpleAsyncInvocationStage.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/SimpleAsyncInvocationStage.java
@@ -36,7 +36,9 @@ public class SimpleAsyncInvocationStage extends InvocationStage {
       try {
          return CompletableFutures.await(future);
       } catch (ExecutionException e) {
-         throw e.getCause();
+         Throwable cause = e.getCause();
+         cause.addSuppressed(e);
+         throw cause;
       }
    }
 

--- a/core/src/main/java/org/infinispan/remoting/rpc/RpcManagerImpl.java
+++ b/core/src/main/java/org/infinispan/remoting/rpc/RpcManagerImpl.java
@@ -263,6 +263,7 @@ public class RpcManagerImpl implements RpcManager, JmxStatisticsExposer {
          throw new CacheException("Thread interrupted while invoking RPC", e);
       } catch (ExecutionException e) {
          Throwable cause = e.getCause();
+         cause.addSuppressed(e);
          if (cause instanceof CacheException) {
             throw ((CacheException) cause);
          } else {

--- a/core/src/main/java/org/infinispan/remoting/transport/Transport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/Transport.java
@@ -70,7 +70,9 @@ public interface Transport extends Lifecycle {
          // milliseconds
          return CompletableFutures.await(future);
       } catch (ExecutionException e) {
-         throw Util.rewrapAsCacheException(e.getCause());
+         Throwable cause = e.getCause();
+         cause.addSuppressed(e);
+         throw Util.rewrapAsCacheException(cause);
       }
    }
 
@@ -167,7 +169,9 @@ public interface Transport extends Lifecycle {
          CompletableFutures.await(CompletableFuture.allOf(futures.toArray(new CompletableFuture[rpcCommands.size()])));
          return result;
       } catch (ExecutionException e) {
-         throw Util.rewrapAsCacheException(e.getCause());
+         Throwable cause = e.getCause();
+         cause.addSuppressed(e);
+         throw Util.rewrapAsCacheException(cause);
       }
    }
 

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsBackupResponse.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsBackupResponse.java
@@ -77,8 +77,10 @@ public class JGroupsBackupResponse implements BackupResponse {
             errors.put(siteName, newTimeoutException(xSiteBackup.getTimeout(), xSiteBackup));
             addCommunicationError(siteName);
          } catch (ExecutionException ue) {
-            log.tracef(ue.getCause(), "Communication error with site %s", siteName);
-            errors.put(siteName, filterException(ue.getCause()));
+            Throwable cause = ue.getCause();
+            cause.addSuppressed(ue);
+            log.tracef(cause, "Communication error with site %s", siteName);
+            errors.put(siteName, filterException(cause));
             addCommunicationError(siteName);
          } finally {
             elapsedTime += timeService.timeDuration(startNanos, MILLISECONDS);

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
@@ -288,7 +288,9 @@ public class JGroupsTransport implements Transport {
          try {
             return CompletableFutures.await(request);
          } catch (ExecutionException e) {
-            throw Util.rewrapAsCacheException(e.getCause());
+            Throwable cause = e.getCause();
+            cause.addSuppressed(e);
+            throw Util.rewrapAsCacheException(cause);
          }
       } else {
          commands.forEach(


### PR DESCRIPTION
In general, the code relays on getting the remote exception when it is getting the result of completable future which manages the invoked command, so it is not possible to change the return type of the exception throwing directly an ExecutionException.

This is a tentative solution using the suppressed exception featured to encapsulate the current thread stack trace in the exception thrown.

Jira issue: https://issues.jboss.org/browse/ISPN-8893