### PR TITLE
ISPN-8918 When a cache is stopped and restarted, its configuration re…

### DIFF
--- a/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
@@ -403,6 +403,7 @@ public class DefaultCacheManager implements EmbeddedCacheManager {
             }
          }
          configurationManager.removeConfiguration(configurationName);
+         this.getGlobalComponentRegistry().removeCache(configurationName);
       }
    }
 


### PR DESCRIPTION
…ference within component registry is not refreshed with defineConfiguration/undefineConfiguration

When a cache is stopped and restarted, its configuration reference within component registry is not refreshed with defineConfiguration/undefineConfiguration.
The problem is that org/infinispan/factories/ComponentRegistry.java:77 is only called once the cache is being wired thus registerComponent(configuration, Configuration.class); is the only place where the configuration is put into the registry.
The best solution is to remove the cache in TERMINATED state once configuration is undefined thus establishing a clear terminal lifecycle.

Jira
https://issues.jboss.org/browse/ISPN-8918

Workaround is possible in wildfly, so not urgent.