### PR TITLE
ISPN-8930 RestOperationsTest random test failures

### DIFF
--- a/core/src/main/java/org/infinispan/container/offheap/OffHeapEntryFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/container/offheap/OffHeapEntryFactoryImpl.java
@@ -105,8 +105,8 @@ public class OffHeapEntryFactoryImpl implements OffHeapEntryFactory {
          } else {
             type |= TRANSIENT_MORTAL;
             metadataBytes = new byte[32 + versionBytes.length];
-            Bits.putLong(metadataBytes, 0, maxIdle);
-            Bits.putLong(metadataBytes, 8, lifespan);
+            Bits.putLong(metadataBytes, 0, lifespan);
+            Bits.putLong(metadataBytes, 8, maxIdle);
             long time = timeService.wallClockTime();
             Bits.putLong(metadataBytes, 16, time);
             Bits.putLong(metadataBytes, 24, time);

--- a/server/rest/src/test/java/org/infinispan/rest/BaseRestOperationsTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/BaseRestOperationsTest.java
@@ -65,9 +65,12 @@ public abstract class BaseRestOperationsTest extends AbstractInfinispanTest {
       client.start();
    }
 
+   private static final long DEFAULT_LIFESPAN = 45190;
+   private static final long DEFAULT_MAX_IDLE = 1859446;
+
    protected void defineCaches() {
       ConfigurationBuilder expirationConfiguration = getDefaultCacheBuilder();
-      expirationConfiguration.expiration().lifespan(100).maxIdle(100);
+      expirationConfiguration.expiration().lifespan(DEFAULT_LIFESPAN).maxIdle(DEFAULT_MAX_IDLE);
 
       ConfigurationBuilder xmlCacheConfiguration = getDefaultCacheBuilder();
       xmlCacheConfiguration.encoding().value().mediaType("application/xml");
@@ -816,8 +819,8 @@ public abstract class BaseRestOperationsTest extends AbstractInfinispanTest {
 
       //then
       ResponseAssertion.assertThat(response).isOk();
-      Assertions.assertThat(metadata.lifespan()).isEqualTo(100);
-      Assertions.assertThat(metadata.maxIdle()).isEqualTo(100);
+      Assertions.assertThat(metadata.lifespan()).isEqualTo(DEFAULT_LIFESPAN);
+      Assertions.assertThat(metadata.maxIdle()).isEqualTo(DEFAULT_MAX_IDLE);
    }
 
    @Test
@@ -854,8 +857,8 @@ public abstract class BaseRestOperationsTest extends AbstractInfinispanTest {
 
       //then
       ResponseAssertion.assertThat(response).isOk();
-      Assertions.assertThat(metadata.lifespan()).isEqualTo(100);
-      Assertions.assertThat(metadata.maxIdle()).isEqualTo(100);
+      Assertions.assertThat(metadata.lifespan()).isEqualTo(DEFAULT_LIFESPAN);
+      Assertions.assertThat(metadata.maxIdle()).isEqualTo(DEFAULT_MAX_IDLE);
    }
 
    @Test

--- a/server/rest/src/test/java/org/infinispan/rest/helper/RestServerHelper.java
+++ b/server/rest/src/test/java/org/infinispan/rest/helper/RestServerHelper.java
@@ -66,7 +66,7 @@ public class RestServerHelper {
             .getComponent(InternalCacheRegistry.class);
       cacheManager.getCacheNames().stream()
             .filter(cacheName -> !registry.isInternalCache(cacheName))
-            .forEach(cacheName -> cacheManager.getCache(cacheName).clear());
+            .forEach(cacheName -> cacheManager.getCache(cacheName).getAdvancedCache().getDataContainer().clear());
    }
 
    public void stop() {


### PR DESCRIPTION
RestOperationsTest#shouldPutImmortalEntryWithZeroTtlAndIdleTime random
failure

* Increased expiration times so they shouldn't expire with thread delay

https://issues.jboss.org/browse/ISPN-8930