### PR TITLE
ISPN-8933 NullPointerException in StreamResponseCommand

### DIFF
--- a/core/src/main/java/org/infinispan/stream/impl/ClusterStreamManagerImpl.java
+++ b/core/src/main/java/org/infinispan/stream/impl/ClusterStreamManagerImpl.java
@@ -704,7 +704,7 @@ public class ClusterStreamManagerImpl<K> implements ClusterStreamManager<K> {
          }
          callback.onCompletion(origin, completedSegments, result);
          synchronized (this) {
-            if (earlyTerminatePredicate != null  && earlyTerminatePredicate.test(result)) {
+            if (earlyTerminatePredicate != null && result != null && earlyTerminatePredicate.test(result)) {
                awaitingResponse.clear();
             } else {
                awaitingResponse.remove(origin);


### PR DESCRIPTION
* Added null check for response tracker due to cache shutdown

https://issues.jboss.org/browse/ISPN-8933