### PR TITLE
ISPN-8839 ClusterTopologyManagerImplTest failures

### DIFF
--- a/core/src/test/java/org/infinispan/topology/ClusterTopologyManagerImplTest.java
+++ b/core/src/test/java/org/infinispan/topology/ClusterTopologyManagerImplTest.java
@@ -40,7 +40,7 @@ import org.testng.annotations.Test;
 public class ClusterTopologyManagerImplTest extends AbstractInfinispanTest {
    private static final String CACHE_NAME = "testCache";
 
-   ExecutorService transportExecutor = Executors.newSingleThreadExecutor(getTestThreadFactory("Transport"));
+   ExecutorService transportExecutor = Executors.newFixedThreadPool(2, getTestThreadFactory("Transport"));
 
    private static final Address A = new TestAddress(0, "A");
    private static final Address B = new TestAddress(1, "B");


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-8839

I missed the fact that `testCoordinatorLostDuringRebalance` needs 2 threads in the transport thread pool in the initial fix.