### PR TITLE
ISPN-8978 Remove usage of deprecated GMS#install_view_locally_first

### DIFF
--- a/cloud/src/main/resources/default-configs/default-jgroups-ec2.xml
+++ b/cloud/src/main/resources/default-configs/default-jgroups-ec2.xml
@@ -47,7 +47,6 @@
                   max_bytes="1M"
    />
    <pbcast.GMS print_local_addr="false"
-               install_view_locally_first="true"
                join_timeout="${jgroups.join_timeout:5000}"
    />
    <MFC max_credits="2m" 

--- a/cloud/src/main/resources/default-configs/default-jgroups-google.xml
+++ b/cloud/src/main/resources/default-configs/default-jgroups-google.xml
@@ -45,7 +45,6 @@
                   max_bytes="1M"
    />
    <pbcast.GMS print_local_addr="false"
-               install_view_locally_first="true"
                join_timeout="${jgroups.join_timeout:5000}"
    />
    <MFC max_credits="2m" 

--- a/cloud/src/main/resources/default-configs/default-jgroups-kubernetes.xml
+++ b/cloud/src/main/resources/default-configs/default-jgroups-kubernetes.xml
@@ -44,7 +44,6 @@
                   max_bytes="1M"
    />
    <pbcast.GMS print_local_addr="false"
-               install_view_locally_first="true"
                join_timeout="${jgroups.join_timeout:5000}"
    />
    <MFC max_credits="2m" 

--- a/core/src/main/resources/default-configs/default-jgroups-tcp.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-tcp.xml
@@ -45,7 +45,6 @@
                   max_bytes="1M"
    />
    <pbcast.GMS print_local_addr="false"
-               install_view_locally_first="true"
                join_timeout="${jgroups.join_timeout:5000}"
    />
    <MFC max_credits="2m" 

--- a/core/src/main/resources/default-configs/default-jgroups-udp.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-udp.xml
@@ -45,7 +45,6 @@
                   max_bytes="1M"
    />
    <pbcast.GMS print_local_addr="false"
-               install_view_locally_first="true"
                join_timeout="${jgroups.join_timeout:5000}"
    />
    <UFC max_credits="2m" 

--- a/core/src/test/resources/configs/xsite/bridge.xml
+++ b/core/src/test/resources/configs/xsite/bridge.xml
@@ -50,7 +50,6 @@
                    max_bytes="8m"/>
     <pbcast.GMS print_local_addr="false"
                 join_timeout="${jgroups.join_timeout:2000}"
-                install_view_locally_first="true"
                 view_bundling="false"/>
 
     <MFC max_credits="2M"

--- a/core/src/test/resources/stacks/tcp.xml
+++ b/core/src/test/resources/stacks/tcp.xml
@@ -61,7 +61,6 @@
    <pbcast.STABLE stability_delay="500" desired_avg_gossip="5000" max_bytes="1m"/>
    <pbcast.GMS print_local_addr="false"
                join_timeout="${jgroups.join_timeout:2000}"
-               install_view_locally_first="true"
                view_bundling="false"/>
    <tom.TOA/> <!-- the Total Order Anycast is only needed for total order transactions (in distributed mode)-->
 

--- a/core/src/test/resources/stacks/tcp_mping/tcp1.xml
+++ b/core/src/test/resources/stacks/tcp_mping/tcp1.xml
@@ -49,7 +49,6 @@
                   max_bytes="400000"/>
    <pbcast.GMS print_local_addr="false"
                join_timeout="${jgroups.join_timeout:2000}"
-               install_view_locally_first="true"
                view_bundling="false"/>
    <tom.TOA/> <!-- the Total Order Anycast is only needed for total order transactions (in distributed mode)-->
    <MFC max_credits="2M" min_threshold="0.40"/>

--- a/core/src/test/resources/stacks/tcp_mping/tcp2.xml
+++ b/core/src/test/resources/stacks/tcp_mping/tcp2.xml
@@ -49,7 +49,6 @@
                   max_bytes="400000"/>
    <pbcast.GMS print_local_addr="false"
                join_timeout="${jgroups.join_timeout:2000}"
-               install_view_locally_first="true"
                view_bundling="false"/>
    <tom.TOA/> <!-- the Total Order Anycast is only needed for total order transactions (in distributed mode)-->
    <MFC max_credits="2M" min_threshold="0.40"/>

--- a/core/src/test/resources/stacks/udp.xml
+++ b/core/src/test/resources/stacks/udp.xml
@@ -44,7 +44,6 @@
    <pbcast.STABLE stability_delay="1000" desired_avg_gossip="5000" max_bytes="1m"/>
    <pbcast.GMS print_local_addr="false"
                join_timeout="${jgroups.join_timeout:2000}"
-               install_view_locally_first="true"
                view_bundling="false"/>
    <tom.TOA/> <!-- the Total Order Anycast is only needed for total order transactions (in distributed mode)-->
 

--- a/integrationtests/as-lucene-directory/src/test/resources/default-jgroups4-udp.xml
+++ b/integrationtests/as-lucene-directory/src/test/resources/default-jgroups4-udp.xml
@@ -45,7 +45,6 @@
                   max_bytes="1M"
    />
    <pbcast.GMS print_local_addr="false"
-               install_view_locally_first="true"
                join_timeout="${jgroups.join_timeout:5000}"
    />
    <UFC max_credits="2m" 

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node0.xml
@@ -44,7 +44,6 @@
    <pbcast.STABLE stability_delay="500" desired_avg_gossip="5000" max_bytes="1m"/>
    <pbcast.GMS print_local_addr="false"
                join_timeout="${jgroups.join_timeout:2000}"
-               install_view_locally_first="true"
                view_bundling="false"/>
 
    <MFC max_credits="2m" min_threshold="0.40"/>

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1-fail.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1-fail.xml
@@ -43,7 +43,6 @@
    <pbcast.STABLE stability_delay="500" desired_avg_gossip="5000" max_bytes="1m"/>
    <pbcast.GMS print_local_addr="false"
                join_timeout="${jgroups.join_timeout:2000}"
-               install_view_locally_first="true"
                view_bundling="false"/>
    
 

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1.xml
@@ -43,7 +43,6 @@
    <pbcast.STABLE stability_delay="500" desired_avg_gossip="5000" max_bytes="1m"/>
    <pbcast.GMS print_local_addr="false"
                join_timeout="${jgroups.join_timeout:2000}"
-               install_view_locally_first="true"
                view_bundling="false"/>
 
    <MFC max_credits="2m" min_threshold="0.40"/>

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node0.xml
@@ -46,7 +46,6 @@
    <pbcast.STABLE stability_delay="500" desired_avg_gossip="5000" max_bytes="1m"/>
    <pbcast.GMS print_local_addr="false"
                join_timeout="${jgroups.join_timeout:2000}"
-               install_view_locally_first="true"
                view_bundling="false"/>
 
    <MFC max_credits="2m" min_threshold="0.40"/>

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node1.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node1.xml
@@ -42,7 +42,6 @@
    <pbcast.STABLE stability_delay="500" desired_avg_gossip="5000" max_bytes="1m"/>
    <pbcast.GMS print_local_addr="false"
                join_timeout="${jgroups.join_timeout:2000}"
-               install_view_locally_first="true"
                view_bundling="false"/>
 
    <MFC max_credits="2m" min_threshold="0.40"/>

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-user-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-user-node0.xml
@@ -46,7 +46,6 @@
    <pbcast.STABLE stability_delay="500" desired_avg_gossip="5000" max_bytes="1m"/>
    <pbcast.GMS print_local_addr="false"
                join_timeout="${jgroups.join_timeout:2000}"
-               install_view_locally_first="true"
                view_bundling="false"/>
 
    <MFC max_credits="2m" min_threshold="0.40"/>

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node0.xml
@@ -44,7 +44,6 @@
    <pbcast.STABLE stability_delay="500" desired_avg_gossip="5000" max_bytes="1m"/>
    <pbcast.GMS print_local_addr="false"
                join_timeout="${jgroups.join_timeout:2000}"
-               install_view_locally_first="true"
                view_bundling="false"/>
 
    <MFC max_credits="2m" min_threshold="0.40"/>

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node1.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node1.xml
@@ -42,7 +42,6 @@
    <pbcast.STABLE stability_delay="500" desired_avg_gossip="5000" max_bytes="1m"/>
    <pbcast.GMS print_local_addr="false"
                join_timeout="${jgroups.join_timeout:2000}"
-               install_view_locally_first="true"
                view_bundling="false"/>
 
    <MFC max_credits="2m" min_threshold="0.40"/>

--- a/lucene/directory-provider/src/test/resources/testing-flush-loopback.xml
+++ b/lucene/directory-provider/src/test/resources/testing-flush-loopback.xml
@@ -30,7 +30,6 @@
 	<pbcast.GMS
 			print_local_addr="true"
 			join_timeout="${jgroups.join_timeout:500}"
-			install_view_locally_first="true"
 			view_bundling="false" />
 	<RSVP resend_interval="20" timeout="10000" ack_on_delivery="false" />
 </config>

--- a/server/integration/jgroups/src/main/resources/jgroups-defaults.xml
+++ b/server/integration/jgroups/src/main/resources/jgroups-defaults.xml
@@ -72,7 +72,6 @@
       desired_avg_gossip="5000"
       max_bytes="1M"/>
    <pbcast.GMS
-      install_view_locally_first="true"
       print_local_addr="false"
       join_timeout="${jgroups.join_timeout:5000}"/>
    <UFC


### PR DESCRIPTION
Jira
https://issues.jboss.org/browse/ISPN-8978

GMS#install_view_locally_first was deprecated and is never used but does not issue a warning message (JGRP-2258).

This should be removed from the stack configuration.

Cross-check
https://github.com/belaban/JGroups/blob/master/src/org/jgroups/protocols/pbcast/GMS.java#L107