### PR TITLE
ISPN-8994 fix cleanAfterMethod

### DIFF
--- a/core/src/test/java/org/infinispan/health/ClusterHealthImplTest.java
+++ b/core/src/test/java/org/infinispan/health/ClusterHealthImplTest.java
@@ -63,11 +63,10 @@ public class ClusterHealthImplTest {
 
    @AfterMethod
    private void cleanAfterMethod() {
-      Cache testCache = cacheManager.getCache(CACHE_NAME, false);
-      if (testCache != null)
-         testCache.shutdown();
+      cacheManager.administration().removeCache(CACHE_NAME);
       cacheManager.undefineConfiguration(CACHE_NAME);
 
+      cacheManager.administration().removeCache(INTERNAL_CACHE_NAME);
       internalCacheRegistry.unregisterInternalCache(INTERNAL_CACHE_NAME);
    }
 


### PR DESCRIPTION
The cleanup is not properly done and if the order of the tests changez, we can have unhealthy caches and user created caches from other tests