### PR TITLE
ISPN-9021 Remote query: add option to disable default/legacy indexing per schema file

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryDslConditionsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryDslConditionsTest.java
@@ -12,7 +12,6 @@ import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheCon
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertTrue;
-import static org.testng.AssertJUnit.fail;
 
 import java.io.IOException;
 import java.util.List;
@@ -109,7 +108,7 @@ public class RemoteQueryDslConditionsTest extends QueryDslConditionsTest {
       RemoteCache<String, String> metadataCache = remoteCacheManager.getCache(ProtobufMetadataManagerConstants.PROTOBUF_METADATA_CACHE_NAME);
       metadataCache.put("sample_bank_account/bank.proto", loadSchema());
       metadataCache.put("not_indexed.proto", NOT_INDEXED_PROTO_SCHEMA);
-      checkSchemaErrors(metadataCache);
+      RemoteQueryTestUtils.checkSchemaErrors(metadataCache);
 
       //initialize client-side serialization context
       SerializationContext serCtx = ProtoStreamMarshaller.getSerializationContext(remoteCacheManager);
@@ -120,22 +119,6 @@ public class RemoteQueryDslConditionsTest extends QueryDslConditionsTest {
 
    protected String loadSchema() throws IOException {
       return Util.getResourceAsString("/sample_bank_account/bank.proto", getClass().getClassLoader());
-   }
-
-   /**
-    * Logs the Protobuf schema errors (if any) and fails the test appropriately.
-    */
-   protected void checkSchemaErrors(RemoteCache<String, String> metadataCache) {
-      if (metadataCache.containsKey(ProtobufMetadataManagerConstants.ERRORS_KEY_SUFFIX)) {
-         // The existence of this key indicates there are errors in some files
-         String files = metadataCache.get(ProtobufMetadataManagerConstants.ERRORS_KEY_SUFFIX);
-         for (String fname : files.split("\n")) {
-            String errorKey = fname + ProtobufMetadataManagerConstants.ERRORS_KEY_SUFFIX;
-            log.errorf("Found errors in Protobuf schema file: %s\n%s\n", fname, metadataCache.get(errorKey));
-         }
-
-         fail("There are errors in the following Protobuf schema files:\n" + files);
-      }
    }
 
    protected ConfigurationBuilder getConfigurationBuilder() {

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryTestUtils.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryTestUtils.java
@@ -1,0 +1,33 @@
+package org.infinispan.client.hotrod.query;
+
+import static org.testng.AssertJUnit.fail;
+
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.commons.logging.LogFactory;
+import org.infinispan.query.remote.client.ProtobufMetadataManagerConstants;
+import org.infinispan.query.remote.impl.logging.Log;
+
+/**
+ * @author anistor@redhat.com
+ * @since 9.3
+ */
+public final class RemoteQueryTestUtils {
+
+   private static final Log log = LogFactory.getLog(RemoteQueryTestUtils.class, Log.class);
+
+   /**
+    * Logs the Protobuf schema errors (if any) and fails the test if there are schema errors.
+    */
+   public static void checkSchemaErrors(RemoteCache<String, String> metadataCache) {
+      if (metadataCache.containsKey(ProtobufMetadataManagerConstants.ERRORS_KEY_SUFFIX)) {
+         // The existence of this key indicates there are errors in some files
+         String files = metadataCache.get(ProtobufMetadataManagerConstants.ERRORS_KEY_SUFFIX);
+         for (String fname : files.split("\n")) {
+            String errorKey = fname + ProtobufMetadataManagerConstants.ERRORS_KEY_SUFFIX;
+            log.errorf("Found errors in Protobuf schema file: %s\n%s\n", fname, metadataCache.get(errorKey));
+         }
+
+         fail("There are errors in the following Protobuf schema files:\n" + files);
+      }
+   }
+}

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryWithProtostreamAnnotationsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryWithProtostreamAnnotationsTest.java
@@ -157,7 +157,7 @@ public class RemoteQueryWithProtostreamAnnotationsTest extends SingleHotRodServe
          }
 
          @Override
-         public Class<? extends Author> getJavaClass() {
+         public Class<Author> getJavaClass() {
             return Author.class;
          }
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/testdomain/protobuf/marshallers/AnalyzerTestEntityMarshaller.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/testdomain/protobuf/marshallers/AnalyzerTestEntityMarshaller.java
@@ -25,7 +25,7 @@ public class AnalyzerTestEntityMarshaller implements MessageMarshaller<AnalyzerT
    }
 
    @Override
-   public Class<? extends AnalyzerTestEntity> getJavaClass() {
+   public Class<AnalyzerTestEntity> getJavaClass() {
       return AnalyzerTestEntity.class;
    }
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/testdomain/protobuf/marshallers/NotIndexedMarshaller.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/testdomain/protobuf/marshallers/NotIndexedMarshaller.java
@@ -23,7 +23,7 @@ public class NotIndexedMarshaller implements MessageMarshaller<NotIndexed> {
    }
 
    @Override
-   public Class<? extends NotIndexed> getJavaClass() {
+   public Class<NotIndexed> getJavaClass() {
       return NotIndexed.class;
    }
 

--- a/commons/src/main/java/org/infinispan/commons/marshall/WrappedByteArray.java
+++ b/commons/src/main/java/org/infinispan/commons/marshall/WrappedByteArray.java
@@ -115,7 +115,7 @@ public class WrappedByteArray implements WrappedBytes {
       }
 
       @Override
-      public WrappedByteArray readObject(ObjectInput input) throws IOException, ClassNotFoundException {
+      public WrappedByteArray readObject(ObjectInput input) throws IOException {
          byte[] bytes = MarshallUtil.unmarshallByteArray(input);
          boolean hasHashCode = input.readBoolean();
          if (hasHashCode) {

--- a/core/src/main/java/org/infinispan/configuration/cache/CustomInterceptorsConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/CustomInterceptorsConfigurationBuilder.java
@@ -15,7 +15,7 @@ import org.infinispan.configuration.global.GlobalConfiguration;
  */
 public class CustomInterceptorsConfigurationBuilder extends AbstractConfigurationChildBuilder implements Builder<CustomInterceptorsConfiguration> {
 
-   private List<InterceptorConfigurationBuilder> interceptorBuilders = new LinkedList<InterceptorConfigurationBuilder>();
+   private List<InterceptorConfigurationBuilder> interceptorBuilders = new LinkedList<>();
 
    CustomInterceptorsConfigurationBuilder(ConfigurationBuilder builder) {
       super(builder);
@@ -45,7 +45,7 @@ public class CustomInterceptorsConfigurationBuilder extends AbstractConfiguratio
       if (interceptorBuilders.isEmpty()) {
          return new CustomInterceptorsConfiguration();
       } else {
-         List<InterceptorConfiguration> interceptors = new ArrayList<InterceptorConfiguration>(interceptorBuilders.size());
+         List<InterceptorConfiguration> interceptors = new ArrayList<>(interceptorBuilders.size());
          for (InterceptorConfigurationBuilder builder : interceptorBuilders) interceptors.add(builder.create());
          return new CustomInterceptorsConfiguration(interceptors);
       }
@@ -53,7 +53,7 @@ public class CustomInterceptorsConfigurationBuilder extends AbstractConfiguratio
 
    @Override
    public CustomInterceptorsConfigurationBuilder read(CustomInterceptorsConfiguration template) {
-      this.interceptorBuilders = new LinkedList<InterceptorConfigurationBuilder>();
+      this.interceptorBuilders = new LinkedList<>();
       for (InterceptorConfiguration c : template.interceptors()) {
          this.interceptorBuilders.add(new InterceptorConfigurationBuilder(this).read(c));
       }

--- a/documentation/src/main/asciidoc/user_guide/query.adoc
+++ b/documentation/src/main/asciidoc/user_guide/query.adoc
@@ -1002,7 +1002,7 @@ QueryFactory qf = org.infinispan.query.Search.getQueryFactory(cache);
 // create a query for all the books that have a title which contains "engine":
 org.infinispan.query.dsl.Query query = qf.from(Book.class)
       .having("title").like("%engine%")
-      .toBuilder().build();
+      .build();
 
 // get the results:
 List<Book> list = query.list();
@@ -1103,7 +1103,7 @@ is a valid query:
 // match all books that have an author named "Manik"
 Query query = queryFactory.from(Book.class)
       .having("author.name").eq("Manik")
-      .toBuilder().build();
+      .build();
 ----
 
 Each part of the attribute path must refer to an existing indexed attribute in the corresponding entity or embedded
@@ -1123,7 +1123,7 @@ Query query = queryFactory.from(Book.class)
   .having("title").like("%Data Grid%")
   .or().having("author.name").eq("Manik")
   .and().having("description").like("%clustering%")
-  .toBuilder().build();
+  .build();
 ----
 
 Boolean negation is achieved with the `not` operator, which has highest precedence among logical operators and applies
@@ -1135,7 +1135,7 @@ only to the next simple attribute condition.
 Query query = queryFactory.from(Book.class)
   .not().having("title").like("%Data Grid%")
   .and().having("author.name").eq("Manik")
-  .toBuilder().build();
+  .build();
 ----
 
 ====== Nested conditions
@@ -1148,10 +1148,10 @@ subsequent complex condition created with the same query factory.
 // match all books that have an author named "Manik" and their title contains
 // "Data Grid" or their description contains "clustering"
 Query query = queryFactory.from(Book.class)
-  .having("author.name").eq("Manik");
+  .having("author.name").eq("Manik")
   .and(queryFactory.having("title").like("%Data Grid%")
           .or().having("description").like("%clustering%"))
-  .toBuilder().build();
+  .build();
 ----
 
 ====== Projections
@@ -1171,7 +1171,7 @@ Query query = queryFactory.from(Book.class)
   .select("title", "publicationYear")
   .having("title").like("%Data Grid%")
   .or().having("description").like("%Data Grid%"))
-  .toBuilder().build();
+  .build();
 ----
 
 ====== Sorting
@@ -1192,7 +1192,7 @@ Query query = queryFactory.from(Book.class)
   .orderBy("title", SortOrder.ASC)
   .having("title").like("%Data Grid%")
   .or().having("description").like("%Data Grid%"))
-  .toBuilder().build();
+  .build();
 ----
 
 ====== Pagination
@@ -1208,10 +1208,10 @@ conjunction with setting the _startOffset_ in order to achieve pagination of the
 Query query = queryFactory.from(Book.class)
   .orderBy("publicationYear", SortOrder.DESC)
   .orderBy("title", SortOrder.ASC)
-  .setStartOffset(20)
+  .startOffset(20)
   .maxResults(10)
   .having("title").like("%clustering%")
-  .toBuilder().build();
+  .build();
 ----
 
 NOTE: Even if the results being fetched are limited to _maxResults_ you can still find the total number of matching
@@ -1237,7 +1237,6 @@ Example: Grouping Books by author and counting them.
 Query query = queryFactory.from(Book.class)
     .select(Expression.property("author"), Expression.count("title"))
     .having("title").like("%engine%")
-    .toBuilder()
     .groupBy("author")
     .build();
 ----
@@ -1309,7 +1308,7 @@ Query query = queryFactory.from(Book.class)
     .having("author").eq(Expression.param("authorName"))
     .and()
     .having("publicationYear").eq(Expression.param("publicationYear"))
-    .toBuilder().build();
+    .build();
 
 // Set actual parameter values
 query.setParameter("authorName", "Doe");
@@ -1537,7 +1536,7 @@ ContinuousQuery<Integer, Person> continuousQuery = Search.getContinuousQuery(cac
 QueryFactory queryFactory = Search.getQueryFactory(cache);
 Query query = queryFactory.from(Person.class)
     .having("age").lt(21)
-    .toBuilder().build();
+    .build();
 
 final Map<Integer, Person> matches = new ConcurrentHashMap<Integer, Person>();
 
@@ -1782,7 +1781,7 @@ remoteCache.put(2, book2);
 
 QueryFactory qf = Search.getQueryFactory(remoteCache);
 Query query = qf.from(Book.class)
-            .having("title").like("%Hibernate Search%").toBuilder()
+            .having("title").like("%Hibernate Search%")
             .build();
 
 List<Book> list = query.list(); // Voila! We have our book back from the cache!

--- a/documentation/src/main/asciidoc/user_guide/query.adoc
+++ b/documentation/src/main/asciidoc/user_guide/query.adoc
@@ -1549,7 +1549,7 @@ ContinuousQueryListener<Integer, Person> listener = new ContinuousQueryListener<
 
     @Override
     public void resultUpdated(Integer key, Person value) {
-        // just ignore it
+        // we do not process this event
     }
 
     @Override
@@ -1722,7 +1722,7 @@ public class BookMarshaller implements MessageMarshaller<Book> {
       String title = reader.readString("title");
       String description = reader.readString("description");
       int publicationYear = reader.readInt("publicationYear");
-      Set<Author> authors = reader.readCollection("authors", new HashSet<Author>(), Author.class);
+      Set<Author> authors = reader.readCollection("authors", new HashSet<>(), Author.class);
       return new Book(title, description, publicationYear, authors);
    }
 }
@@ -1747,16 +1747,28 @@ is detailed in the <<query:configuration,Querying {brandname}>> chapter.
 There is however an extra configuration step involved. While in embedded mode the indexing metadata is obtained via Java
 reflection by analyzing the presence of various Hibernate Search annotations on the entry's class, this is obviously not
 possible if the entry is protobuf encoded.
-The server needs to extract the relevant metadata from the same descriptor (.proto file) as the client.
-The descriptors are stored in a dedicated cache on the server _'___protobuf_metadata'_.
-Registering a new schema is therefore as simple as performing a _put_ operation on that cache using the schema's name as
-a key and the schema itself as the value.
-Alternatively you can use the CLI (via the cache-container=*:register-proto-schemas() operation), the Console or the
-_ProtobufMetadataManager_ MBean via JMX.
+The server needs to obtain the relevant metadata from the same descriptor (.proto file) as the client.
+The descriptors are stored in a dedicated cache on the server named _'___protobuf_metadata'_. Both keys and values in
+this cache are plain strings. Registering a new schema is therefore as simple as performing a _put_ operation on this
+cache using the schema's name as key and the schema file itself as the value.
+Alternatively you can use the CLI (via the cache-container=*:register-proto-schemas() operation), the Management Console
+or the _ProtobufMetadataManager_ MBean via JMX.
 Be aware that, when security is enabled, access to the schema cache via the remote protocols requires
 that the user belongs to the pass:['___schema_manager'] role.
-NOTE: Once indexing is enabled for a cache all fields of Protobuf encoded entries are going to be indexed.
-Future versions will allow you to select which fields to index (see link:https://issues.jboss.org/browse/ISPN-3718[ISPN-3718]).
+
+NOTE: Once indexing is enabled for a cache all fields of Protobuf encoded entries will be fully indexed unless you use
+the _@Indexed_ and _@Field_ protobuf schema pseudo-annotations in order to control precisely what fields need to get
+indexed. The default behaviour can be very inefficient when dealing with types having many or very larger fields so we
+encourage you to always specify what fields should be indexed instead of relying on the default indexing behaviour.
+The indexing behaviour for protobuf message types that are not annotated can also be modified per each schema file by
+setting the protobuf schema option _'indexed_by_default'_ to _false_ (its default value is considered _true_) at
+the beginning of your schema file.
+
+[source,protobuf]
+----
+option indexed_by_default = false;  // This disables indexing of types that are not annotated for indexing
+----
+
 
 ==== A remote query example
 You've managed to configure both client and server to talk protobuf and you've enabled indexing. Let's put some data in
@@ -1803,7 +1815,7 @@ SearchManager searchManager = Search.getSearchManager(cache);
 org.hibernate.search.stat.Statistics statistics = searchManager.getStatistics();
 ----
 
-TIP: This data is also available via JMX through the link:http://docs.jboss.org/hibernate/search/4.4/reference/en-US/html/search-monitoring.html#d0e7624[Hibernate Search StatisticsInfoMBean]
+TIP: This data is also available via JMX through the link:https://docs.jboss.org/hibernate/stable/search/reference/en-US/html_single/#_statisticsinfombean[Hibernate Search StatisticsInfoMBean]
 registered under the name `org.infinispan:type=Query,manager="{name-of-cache-manager}",cache="{name-of-cache}",component=Statistics`.
 Please note this MBean is always registered by {brandname} but the statistics are collected only if
 link:#enabling_jmx_statistics[statistics collection is enabled] at cache level.

--- a/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/QueryDslConditionsTest.java
+++ b/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/QueryDslConditionsTest.java
@@ -71,7 +71,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       return DATE_FORMAT.parse(dateStr);
    }
 
-   protected static EmbeddedCacheManager createCacheManager() throws Exception {
+   protected static EmbeddedCacheManager createCacheManager() {
       GlobalConfigurationBuilder gcfg = new GlobalConfigurationBuilder();
 
       ConfigurationBuilder cfg = new ConfigurationBuilder();
@@ -280,7 +280,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testEq1() throws Exception {
+   public void testEq1() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -294,7 +294,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testEqEmptyString() throws Exception {
+   public void testEqEmptyString() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -306,7 +306,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testEqSentence() throws Exception {
+   public void testEqSentence() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getAccountImplClass())
@@ -319,7 +319,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testEq() throws Exception {
+   public void testEq() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -331,7 +331,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testEqNonIndexedType() throws Exception {
+   public void testEqNonIndexedType() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(NotIndexed.class)
@@ -344,7 +344,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testEqNonIndexedField() throws Exception {
+   public void testEqNonIndexedField() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -357,7 +357,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testEqHybridQuery() throws Exception {
+   public void testEqHybridQuery() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -371,7 +371,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testEqHybridQueryWithParam() throws Exception {
+   public void testEqHybridQueryWithParam() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -387,7 +387,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testEqHybridQueryWithPredicateOptimisation() throws Exception {
+   public void testEqHybridQueryWithPredicateOptimisation() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -402,7 +402,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testEqInNested1() throws Exception {
+   public void testEqInNested1() {
       QueryFactory qf = getQueryFactory();
 
       // all users in a given post code
@@ -416,7 +416,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testEqInNested2() throws Exception {
+   public void testEqInNested2() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -429,7 +429,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testLike() throws Exception {
+   public void testLike() {
       QueryFactory qf = getQueryFactory();
 
       // all rent payments made from a given account
@@ -444,7 +444,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test(expected = IllegalArgumentException.class)
-   public void testBetweenArgsAreComparable() throws Exception {
+   public void testBetweenArgsAreComparable() {
       QueryFactory qf = getQueryFactory();
 
       qf.from(getModelFactory().getTransactionImplClass())
@@ -504,7 +504,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testGt() throws Exception {
+   public void testGt() {
       QueryFactory qf = getQueryFactory();
 
       // all the transactions greater than a given amount
@@ -518,7 +518,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testGte() throws Exception {
+   public void testGte() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getTransactionImplClass())
@@ -533,7 +533,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testLt() throws Exception {
+   public void testLt() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getTransactionImplClass())
@@ -548,7 +548,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testLte() throws Exception {
+   public void testLte() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getTransactionImplClass())
@@ -564,7 +564,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
    // This tests against https://hibernate.atlassian.net/browse/HSEARCH-2030
    @Test
-   public void testLteOnFieldWithNullToken() throws Exception {
+   public void testLteOnFieldWithNullToken() {
       QueryFactory qf = getQueryFactory();
 
       // all the transactions that happened in January 2013
@@ -578,7 +578,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testAnd1() throws Exception {
+   public void testAnd1() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -592,7 +592,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testAnd2() throws Exception {
+   public void testAnd2() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -606,7 +606,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testAnd3() throws Exception {
+   public void testAnd3() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -619,7 +619,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testAnd4() throws Exception {
+   public void testAnd4() {
       QueryFactory qf = getQueryFactory();
 
       //test for parenthesis, "and" should have higher priority
@@ -634,7 +634,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testOr1() throws Exception {
+   public void testOr1() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -650,7 +650,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testOr2() throws Exception {
+   public void testOr2() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -666,7 +666,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testOr3() throws Exception {
+   public void testOr3() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -679,7 +679,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testOr4() throws Exception {
+   public void testOr4() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -697,7 +697,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testOr5() throws Exception {
+   public void testOr5() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -713,7 +713,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testNot1() throws Exception {
+   public void testNot1() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -726,7 +726,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testNot2() throws Exception {
+   public void testNot2() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -739,7 +739,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testNot3() throws Exception {
+   public void testNot3() {
       QueryFactory qf = getQueryFactory();
 
       // NOT should have higher priority than AND
@@ -754,7 +754,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testNot4() throws Exception {
+   public void testNot4() {
       QueryFactory qf = getQueryFactory();
 
       // NOT should have higher priority than AND
@@ -769,7 +769,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testNot5() throws Exception {
+   public void testNot5() {
       QueryFactory qf = getQueryFactory();
 
       // NOT should have higher priority than OR
@@ -786,7 +786,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testNot6() throws Exception {
+   public void testNot6() {
       QueryFactory qf = getQueryFactory();
 
       // QueryFactory.not() test
@@ -800,7 +800,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testNot7() throws Exception {
+   public void testNot7() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -813,7 +813,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testNot8() throws Exception {
+   public void testNot8() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -829,7 +829,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testNot9() throws Exception {
+   public void testNot9() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -848,7 +848,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testNot10() throws Exception {
+   public void testNot10() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -863,7 +863,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testNot11() throws Exception {
+   public void testNot11() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -878,7 +878,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testEmptyQuery() throws Exception {
+   public void testEmptyQuery() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass()).build();
@@ -912,7 +912,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test(expected = ParsingException.class)
-   public void testInvalidEmbeddedAttributeQuery() throws Exception {
+   public void testInvalidEmbeddedAttributeQuery() {
       QueryFactory qf = getQueryFactory();
 
       QueryBuilder queryBuilder = qf.from(getModelFactory().getUserImplClass())
@@ -933,7 +933,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testIsNull1() throws Exception {
+   public void testIsNull1() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -945,7 +945,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testIsNull2() throws Exception {
+   public void testIsNull2() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -957,7 +957,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testIsNull3() throws Exception {
+   public void testIsNull3() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -970,7 +970,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testIsNullNumericWithProjection1() throws Exception {
+   public void testIsNullNumericWithProjection1() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -992,7 +992,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testIsNullNumericWithProjection2() throws Exception {
+   public void testIsNullNumericWithProjection2() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -1007,7 +1007,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testContains1() throws Exception {
+   public void testContains1() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -1020,7 +1020,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testContains2() throws Exception {
+   public void testContains2() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -1032,7 +1032,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testContainsAll1() throws Exception {
+   public void testContainsAll1() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -1045,7 +1045,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testContainsAll2() throws Exception {
+   public void testContainsAll2() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -1058,7 +1058,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testContainsAll3() throws Exception {
+   public void testContainsAll3() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -1070,7 +1070,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testContainsAll4() throws Exception {
+   public void testContainsAll4() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -1082,7 +1082,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testContainsAny1() throws Exception {
+   public void testContainsAny1() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -1097,7 +1097,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testContainsAny2() throws Exception {
+   public void testContainsAny2() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -1109,7 +1109,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testContainsAny3() throws Exception {
+   public void testContainsAny3() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -1121,7 +1121,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testIn1() throws Exception {
+   public void testIn1() {
       QueryFactory qf = getQueryFactory();
 
       List<Integer> ids = Arrays.asList(1, 3);
@@ -1137,7 +1137,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testIn2() throws Exception {
+   public void testIn2() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -1149,30 +1149,28 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test(expected = IllegalArgumentException.class)
-   public void testIn3() throws Exception {
+   public void testIn3() {
       QueryFactory qf = getQueryFactory();
 
       qf.from(getModelFactory().getUserImplClass()).having("id").in(Collections.emptySet());
    }
 
    @Test(expected = IllegalArgumentException.class)
-   public void testIn4() throws Exception {
+   public void testIn4() {
       QueryFactory qf = getQueryFactory();
 
-      Collection collection = null;
-      qf.from(getModelFactory().getUserImplClass()).having("id").in(collection);
+      qf.from(getModelFactory().getUserImplClass()).having("id").in((Collection) null);
    }
 
    @Test(expected = IllegalArgumentException.class)
-   public void testIn5() throws Exception {
+   public void testIn5() {
       QueryFactory qf = getQueryFactory();
 
-      Object[] array = null;
-      qf.from(getModelFactory().getUserImplClass()).having("id").in(array);
+      qf.from(getModelFactory().getUserImplClass()).having("id").in((Object[]) null);
    }
 
    @Test(expected = IllegalArgumentException.class)
-   public void testIn6() throws Exception {
+   public void testIn6() {
       QueryFactory qf = getQueryFactory();
 
       Object[] array = new Object[0];
@@ -1180,7 +1178,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testSampleDomainQuery1() throws Exception {
+   public void testSampleDomainQuery1() {
       QueryFactory qf = getQueryFactory();
 
       // all male users
@@ -1196,7 +1194,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testSampleDomainQuery2() throws Exception {
+   public void testSampleDomainQuery2() {
       QueryFactory qf = getQueryFactory();
 
       // all male users, but this time retrieved in a twisted manner
@@ -1213,7 +1211,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testStringLiteralEscape() throws Exception {
+   public void testStringLiteralEscape() {
       QueryFactory qf = getQueryFactory();
 
       // all transactions that have a given description. the description contains characters that need to be escaped.
@@ -1227,7 +1225,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testSortByDate() throws Exception {
+   public void testSortByDate() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getAccountImplClass())
@@ -1242,7 +1240,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testSampleDomainQuery3() throws Exception {
+   public void testSampleDomainQuery3() {
       QueryFactory qf = getQueryFactory();
 
       // all male users
@@ -1258,7 +1256,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testSampleDomainQuery4() throws Exception {
+   public void testSampleDomainQuery4() {
       QueryFactory qf = getQueryFactory();
 
       // all users ordered descendingly by name
@@ -1274,7 +1272,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testSampleDomainQuery4With2SortingOptions() throws Exception {
+   public void testSampleDomainQuery4With2SortingOptions() {
       QueryFactory qf = getQueryFactory();
 
       // all users ordered descendingly by name
@@ -1296,7 +1294,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testSampleDomainQuery5() throws Exception {
+   public void testSampleDomainQuery5() {
       QueryFactory qf = getQueryFactory();
 
       // name projection of all users ordered descendingly by name
@@ -1316,7 +1314,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testSampleDomainQuery6() throws Exception {
+   public void testSampleDomainQuery6() {
       QueryFactory qf = getQueryFactory();
 
       // all users with a given name and surname
@@ -1332,7 +1330,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testSampleDomainQuery7() throws Exception {
+   public void testSampleDomainQuery7() {
       QueryFactory qf = getQueryFactory();
 
       // all rent payments made from a given account
@@ -1390,7 +1388,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testSampleDomainQuery10() throws Exception {
+   public void testSampleDomainQuery10() {
       QueryFactory qf = getQueryFactory();
 
       // all the transactions for a an account having amount greater than a given amount
@@ -1406,7 +1404,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testSampleDomainQuery11() throws Exception {
+   public void testSampleDomainQuery11() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -1421,7 +1419,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testSampleDomainQuery12() throws Exception {
+   public void testSampleDomainQuery12() {
       QueryFactory qf = getQueryFactory();
 
       // all the transactions that represents credits to the account
@@ -1436,7 +1434,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testSampleDomainQuery13() throws Exception {
+   public void testSampleDomainQuery13() {
       QueryFactory qf = getQueryFactory();
 
       // the user that has the bank account with id 3
@@ -1450,7 +1448,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testSampleDomainQuery14() throws Exception {
+   public void testSampleDomainQuery14() {
       QueryFactory qf = getQueryFactory();
 
       // the user that has all the specified bank accounts
@@ -1465,7 +1463,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testSampleDomainQuery15() throws Exception {
+   public void testSampleDomainQuery15() {
       QueryFactory qf = getQueryFactory();
 
       // the user that has at least one of the specified accounts
@@ -1479,7 +1477,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testSampleDomainQuery16() throws Exception {
+   public void testSampleDomainQuery16() {
       QueryFactory qf = getQueryFactory();
 
       // third batch of 10 transactions for a given account
@@ -1498,7 +1496,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testSampleDomainQuery17() throws Exception {
+   public void testSampleDomainQuery17() {
       QueryFactory qf = getQueryFactory();
 
       // all accounts for a user. first get the user by id and then get his account.
@@ -1517,7 +1515,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testSampleDomainQuery18() throws Exception {
+   public void testSampleDomainQuery18() {
       QueryFactory qf = getQueryFactory();
 
       // all transactions of account with id 2 which have an amount larger than 1600 or their description contains the word 'rent'
@@ -1534,7 +1532,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testProjectionOnOptionalField() throws Exception {
+   public void testProjectionOnOptionalField() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -1553,7 +1551,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testNullOnIntegerField() throws Exception {
+   public void testNullOnIntegerField() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -1567,7 +1565,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testIsNotNullOnIntegerField() throws Exception {
+   public void testIsNotNullOnIntegerField() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -1582,7 +1580,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testSampleDomainQuery19() throws Exception {
+   public void testSampleDomainQuery19() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -1595,7 +1593,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testSampleDomainQuery20() throws Exception {
+   public void testSampleDomainQuery20() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -1608,7 +1606,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testSampleDomainQuery21() throws Exception {
+   public void testSampleDomainQuery21() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -1621,7 +1619,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testSampleDomainQuery22() throws Exception {
+   public void testSampleDomainQuery22() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -1634,7 +1632,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testSampleDomainQuery23() throws Exception {
+   public void testSampleDomainQuery23() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -1647,7 +1645,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testSampleDomainQuery24() throws Exception {
+   public void testSampleDomainQuery24() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -1662,7 +1660,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testSampleDomainQuery25() throws Exception {
+   public void testSampleDomainQuery25() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -1733,14 +1731,14 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test(expected = IllegalStateException.class)
-   public void testWrongQueryBuilding1() throws Exception {
+   public void testWrongQueryBuilding1() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.not().having("name").eq("John").build();
    }
 
    @Test(expected = IllegalStateException.class)
-   public void testWrongQueryBuilding2() throws Exception {
+   public void testWrongQueryBuilding2() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -1750,7 +1748,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test(expected = IllegalStateException.class)
-   public void testWrongQueryBuilding3() throws Exception {
+   public void testWrongQueryBuilding3() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -1760,7 +1758,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test(expected = IllegalStateException.class)
-   public void testWrongQueryBuilding4() throws Exception {
+   public void testWrongQueryBuilding4() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -1770,7 +1768,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test(expected = IllegalStateException.class)
-   public void testWrongQueryBuilding5() throws Exception {
+   public void testWrongQueryBuilding5() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -1780,7 +1778,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test(expected = IllegalArgumentException.class)
-   public void testWrongQueryBuilding6() throws Exception {
+   public void testWrongQueryBuilding6() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -1789,7 +1787,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test(expected = IllegalStateException.class)
-   public void testWrongQueryBuilding7() throws Exception {
+   public void testWrongQueryBuilding7() {
       QueryFactory qf = getQueryFactory();
 
       FilterConditionEndContext q1 = qf.from(getModelFactory().getUserImplClass())
@@ -1800,7 +1798,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test(expected = IllegalArgumentException.class)
-   public void testPagination1() throws Exception {
+   public void testPagination1() {
       QueryFactory qf = getQueryFactory();
 
       qf.from(getModelFactory().getUserImplClass())
@@ -1808,7 +1806,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test(expected = IllegalArgumentException.class)
-   public void testPagination2() throws Exception {
+   public void testPagination2() {
       QueryFactory qf = getQueryFactory();
 
       qf.from(getModelFactory().getUserImplClass())
@@ -1816,7 +1814,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test(expected = IllegalArgumentException.class)
-   public void testPagination3() throws Exception {
+   public void testPagination3() {
       QueryFactory qf = getQueryFactory();
 
       qf.from(getModelFactory().getUserImplClass())
@@ -1824,7 +1822,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testOrderedPagination4() throws Exception {
+   public void testOrderedPagination4() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -1838,7 +1836,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testUnorderedPagination4() throws Exception {
+   public void testUnorderedPagination4() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -1851,7 +1849,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testOrderedPagination5() throws Exception {
+   public void testOrderedPagination5() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -1865,7 +1863,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testUnorderedPagination5() throws Exception {
+   public void testUnorderedPagination5() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -1878,7 +1876,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testOrderedPagination6() throws Exception {
+   public void testOrderedPagination6() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -1892,7 +1890,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testUnorderedPagination6() throws Exception {
+   public void testUnorderedPagination6() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -1905,7 +1903,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testOrderedPagination7() throws Exception {
+   public void testOrderedPagination7() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -1919,7 +1917,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testUnorderedPagination7() throws Exception {
+   public void testUnorderedPagination7() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -1932,7 +1930,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testOrderedPagination8() throws Exception {
+   public void testOrderedPagination8() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -1946,7 +1944,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testUnorderedPagination8() throws Exception {
+   public void testUnorderedPagination8() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -1959,7 +1957,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testGroupBy1() throws Exception {
+   public void testGroupBy1() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -1977,7 +1975,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testGroupBy2() throws Exception {
+   public void testGroupBy2() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -1995,7 +1993,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test(expected = ParsingException.class)
-   public void testGroupBy3() throws Exception {
+   public void testGroupBy3() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -2122,7 +2120,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testSum() throws Exception {
+   public void testSum() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -2665,7 +2663,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testParam() throws Exception {
+   public void testParam() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -2689,7 +2687,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testWithParameterMap() throws Exception {
+   public void testWithParameterMap() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -2754,7 +2752,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test(expected = IllegalArgumentException.class)
-   public void testUnknownParam() throws Exception {
+   public void testUnknownParam() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -2765,7 +2763,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test(expected = IllegalArgumentException.class)
-   public void testUnknownParamWithParameterMap() throws Exception {
+   public void testUnknownParamWithParameterMap() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -2779,7 +2777,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test(expected = IllegalStateException.class)
-   public void testQueryWithNoParams() throws Exception {
+   public void testQueryWithNoParams() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -2789,7 +2787,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test(expected = IllegalStateException.class)
-   public void testQueryWithNoParamsWithParameterMap() throws Exception {
+   public void testQueryWithNoParamsWithParameterMap() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -2803,7 +2801,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test(expected = IllegalArgumentException.class)
-   public void testNullParamName() throws Exception {
+   public void testNullParamName() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -2814,7 +2812,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test(expected = IllegalArgumentException.class)
-   public void testEmptyParamName() throws Exception {
+   public void testEmptyParamName() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -2825,7 +2823,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test(expected = IllegalStateException.class)
-   public void testMissingParam() throws Exception {
+   public void testMissingParam() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -2839,7 +2837,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test(expected = IllegalStateException.class)
-   public void testMissingParamWithParameterMap() throws Exception {
+   public void testMissingParamWithParameterMap() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -2856,7 +2854,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test(expected = IllegalArgumentException.class)
-   public void testQueryWithNoParamsWithNullParameterMap() throws Exception {
+   public void testQueryWithNoParamsWithNullParameterMap() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -2923,7 +2921,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testNotIndexedProjection() throws Exception {
+   public void testNotIndexedProjection() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getTransactionImplClass())
@@ -2943,7 +2941,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testNotStoredProjection() throws Exception {
+   public void testNotStoredProjection() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getTransactionImplClass())
@@ -2963,7 +2961,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testNotIndexedOrderBy() throws Exception {
+   public void testNotIndexedOrderBy() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getTransactionImplClass())
@@ -2984,7 +2982,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testNotStoredOrderBy() throws Exception {
+   public void testNotStoredOrderBy() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getTransactionImplClass())
@@ -3169,7 +3167,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testCompareLongWithInt() throws Exception {
+   public void testCompareLongWithInt() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -3183,7 +3181,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testCompareDoubleWithInt() throws Exception {
+   public void testCompareDoubleWithInt() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getTransactionImplClass())
@@ -3197,7 +3195,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testFullTextTerm() throws Exception {
+   public void testFullTextTerm() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.create("from " + getModelFactory().getTransactionTypeName() + " where longDescription:'rent'");
@@ -3207,7 +3205,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testFullTextPhrase() throws Exception {
+   public void testFullTextPhrase() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.create("from " + getModelFactory().getTransactionTypeName() + " where longDescription:'expensive shoes'");
@@ -3217,7 +3215,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testInstant1() throws Exception {
+   public void testInstant1() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
@@ -3229,7 +3227,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testInstant2() throws Exception {
+   public void testInstant2() {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())

--- a/query-dsl/src/main/java/org/infinispan/query/dsl/impl/BaseCondition.java
+++ b/query-dsl/src/main/java/org/infinispan/query/dsl/impl/BaseCondition.java
@@ -30,6 +30,7 @@ abstract class BaseCondition implements FilterConditionContextQueryBuilder, Visi
       this.queryFactory = queryFactory;
    }
 
+   @SuppressWarnings("deprecation")
    @Override
    public QueryBuilder toBuilder() {
       return getQueryBuilder();

--- a/query/src/main/java/org/infinispan/query/spi/ProgrammaticSearchMappingProvider.java
+++ b/query/src/main/java/org/infinispan/query/spi/ProgrammaticSearchMappingProvider.java
@@ -4,13 +4,13 @@ import org.hibernate.search.cfg.SearchMapping;
 import org.infinispan.Cache;
 
 /**
- * An advanced SPI to be implemented by Infinispan modules that want to customize the {@link SearchMapping} object
- * before the bootstrap of the {@link org.hibernate.search.SearchFactory} belonging to an indexed {@link Cache}. The
- * {@link SearchMapping} object provided via the "hibernate.search.model_mapping" config property is used as a starting
- * point if it was present, otherwise an empty {@link SearchMapping} is used.
+ * An advanced SPI to be implemented by Infinispan modules that want to customize the {@link SearchMapping} object right
+ * before the bootstrap of the {@link org.hibernate.search.spi.SearchIntegrator} belonging to an indexed {@link Cache}.
+ * The {@link SearchMapping} object provided via the "hibernate.search.model_mapping" config property is used as a
+ * starting point if it was present, otherwise an empty {@link SearchMapping} is used.
  * <p>
- * Please note that in case multiple providers are found the order of invocation is not predictable so implementations
- * must be careful not to step on each others toes.
+ * Please note that in case multiple providers are found in classpath the order of invocation is not predictable so
+ * implementations must be careful not to step on each others toes.
  *
  * @author anistor@redhat.com
  * @since 6.0
@@ -18,9 +18,9 @@ import org.infinispan.Cache;
 public interface ProgrammaticSearchMappingProvider {
 
    /**
-    * Supply some custom programmatic mappings.
+    * Supply some custom programmatic mappings to Hibernate Search.
     *
-    * @param cache         the indexed cache
+    * @param cache         the indexed cache instance
     * @param searchMapping the mapping object to customize
     */
    void defineMappings(Cache cache, SearchMapping searchMapping);

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/QueryStringTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/QueryStringTest.java
@@ -14,6 +14,7 @@ import org.infinispan.configuration.cache.Index;
 import org.infinispan.objectfilter.ParsingException;
 import org.infinispan.query.dsl.Query;
 import org.infinispan.query.dsl.embedded.testdomain.Address;
+import org.infinispan.query.dsl.embedded.testdomain.NotIndexed;
 import org.infinispan.query.dsl.embedded.testdomain.Transaction;
 import org.infinispan.query.dsl.embedded.testdomain.User;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
@@ -175,6 +176,9 @@ public class QueryStringTest extends AbstractQueryDslTest {
          transaction.setValid(true);
          getCacheForWrite().put("transaction_" + transaction.getId(), transaction);
       }
+
+      getCacheForWrite().put("notIndexed1", new NotIndexed("testing 123"));
+      getCacheForWrite().put("notIndexed2", new NotIndexed("xyz"));
    }
 
    public void testParam() {
@@ -385,6 +389,14 @@ public class QueryStringTest extends AbstractQueryDslTest {
 
       List<User> list = q.list();
       assertEquals(3, list.size());
+   }
+
+   public void testEqNonIndexedType() {
+      Query q = createQueryFromString("from " + NotIndexed.class.getName() + " where notIndexedField = 'testing 123'");
+
+      List<NotIndexed> list = q.list();
+      assertEquals(1, list.size());
+      assertEquals("testing 123", list.get(0).notIndexedField);
    }
 
    protected Query createQueryFromString(String q) {

--- a/remote-query/remote-query-client/src/main/java/org/infinispan/query/remote/client/ContinuousQueryResult.java
+++ b/remote-query/remote-query-client/src/main/java/org/infinispan/query/remote/client/ContinuousQueryResult.java
@@ -50,7 +50,7 @@ public final class ContinuousQueryResult {
          }
 
          @Override
-         public Class<? extends ResultType> getJavaClass() {
+         public Class<ResultType> getJavaClass() {
             return ResultType.class;
          }
 
@@ -138,7 +138,7 @@ public final class ContinuousQueryResult {
       }
 
       @Override
-      public Class<? extends ContinuousQueryResult> getJavaClass() {
+      public Class<ContinuousQueryResult> getJavaClass() {
          return ContinuousQueryResult.class;
       }
 

--- a/remote-query/remote-query-client/src/main/java/org/infinispan/query/remote/client/FilterResult.java
+++ b/remote-query/remote-query-client/src/main/java/org/infinispan/query/remote/client/FilterResult.java
@@ -108,7 +108,7 @@ public final class FilterResult {
       }
 
       @Override
-      public Class<? extends FilterResult> getJavaClass() {
+      public Class<FilterResult> getJavaClass() {
          return FilterResult.class;
       }
 

--- a/remote-query/remote-query-client/src/main/java/org/infinispan/query/remote/client/QueryRequest.java
+++ b/remote-query/remote-query-client/src/main/java/org/infinispan/query/remote/client/QueryRequest.java
@@ -153,7 +153,7 @@ public final class QueryRequest {
          }
 
          @Override
-         public Class<? extends NamedParameter> getJavaClass() {
+         public Class<NamedParameter> getJavaClass() {
             return NamedParameter.class;
          }
 

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/ProgrammaticSearchMappingProviderImpl.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/ProgrammaticSearchMappingProviderImpl.java
@@ -5,12 +5,16 @@ import org.hibernate.search.annotations.Norms;
 import org.hibernate.search.annotations.Store;
 import org.hibernate.search.cfg.SearchMapping;
 import org.infinispan.Cache;
+import org.infinispan.commons.logging.LogFactory;
 import org.infinispan.query.remote.impl.indexing.ProtobufValueWrapper;
 import org.infinispan.query.remote.impl.indexing.ProtobufValueWrapperFieldBridge;
+import org.infinispan.query.remote.impl.logging.Log;
 import org.infinispan.query.spi.ProgrammaticSearchMappingProvider;
 import org.kohsuke.MetaInfServices;
 
 /**
+ * A ProgrammaticSearchMappingProvider that defines indexing for ProtobufValueWrapper with hibernate-search.
+ *
  * @author anistor@redhat.com
  * @since 6.0
  */
@@ -18,10 +22,15 @@ import org.kohsuke.MetaInfServices;
 @SuppressWarnings("unused")
 public final class ProgrammaticSearchMappingProviderImpl implements ProgrammaticSearchMappingProvider {
 
+   private static final Log log = LogFactory.getLog(ProgrammaticSearchMappingProviderImpl.class, Log.class);
+
    public static final String INDEX_NAME_SUFFIX = "_protobuf";
 
    @Override
    public void defineMappings(Cache cache, SearchMapping searchMapping) {
+      if (log.isDebugEnabled()) {
+         log.debugf("Enabling indexing for ProtobufValueWrapper in cache %s", cache.getName());
+      }
       searchMapping.entity(ProtobufValueWrapper.class)
             .indexed()
             .indexName(cache.getName() + INDEX_NAME_SUFFIX)

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/ProtobufFieldIndexingMetadata.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/ProtobufFieldIndexingMetadata.java
@@ -18,26 +18,29 @@ final class ProtobufFieldIndexingMetadata implements IndexedFieldProvider.FieldI
 
    private final Descriptor messageDescriptor;
 
+   private final boolean isLegacyIndexingEnabled;
+
    ProtobufFieldIndexingMetadata(Descriptor messageDescriptor) {
       if (messageDescriptor == null) {
          throw new IllegalArgumentException("argument cannot be null");
       }
       this.messageDescriptor = messageDescriptor;
+      this.isLegacyIndexingEnabled = IndexingMetadata.isLegacyIndexingEnabled(messageDescriptor);
    }
 
    @Override
    public boolean isIndexed(String[] propertyPath) {
-      return getMetadata(propertyPath, IndexingMetadata::isFieldIndexed, true);
+      return getFlag(propertyPath, IndexingMetadata::isFieldIndexed, isLegacyIndexingEnabled);
    }
 
    @Override
    public boolean isAnalyzed(String[] propertyPath) {
-      return getMetadata(propertyPath, IndexingMetadata::isFieldAnalyzed, false);
+      return getFlag(propertyPath, IndexingMetadata::isFieldAnalyzed, false);
    }
 
    @Override
    public boolean isStored(String[] propertyPath) {
-      return getMetadata(propertyPath, IndexingMetadata::isFieldStored, true);
+      return getFlag(propertyPath, IndexingMetadata::isFieldStored, isLegacyIndexingEnabled);
    }
 
    @Override
@@ -62,7 +65,7 @@ final class ProtobufFieldIndexingMetadata implements IndexedFieldProvider.FieldI
       return null;
    }
 
-   private boolean getMetadata(String[] propertyPath, BiFunction<IndexingMetadata, String, Boolean> metadataFun, boolean defVal) {
+   private boolean getFlag(String[] propertyPath, BiFunction<IndexingMetadata, String, Boolean> metadataFun, boolean defVal) {
       Descriptor md = messageDescriptor;
       int i = 0;
       for (String p : propertyPath) {

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/ProtobufMetadataManagerInterceptor.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/ProtobufMetadataManagerInterceptor.java
@@ -148,7 +148,7 @@ final class ProtobufMetadataManagerInterceptor extends BaseCustomAsyncIntercepto
       }
 
       @Override
-      public Object visitRemoveCommand(InvocationContext ctx, RemoveCommand command) throws Throwable {
+      public Object visitRemoveCommand(InvocationContext ctx, RemoveCommand command) {
          final String key = (String) command.getKey();
          if (shouldIntercept(key)) {
             if (serializationContext.getFileDescriptors().containsKey(key)) {
@@ -159,7 +159,7 @@ final class ProtobufMetadataManagerInterceptor extends BaseCustomAsyncIntercepto
       }
 
       @Override
-      public Object visitClearCommand(InvocationContext ctx, ClearCommand command) throws Throwable {
+      public Object visitClearCommand(InvocationContext ctx, ClearCommand command) {
          for (String fileName : serializationContext.getFileDescriptors().keySet()) {
             serializationContext.unregisterProtoFile(fileName);
          }
@@ -175,7 +175,7 @@ final class ProtobufMetadataManagerInterceptor extends BaseCustomAsyncIntercepto
    }
 
    @Override
-   public Object visitPrepareCommand(TxInvocationContext ctx, PrepareCommand command) throws Throwable {
+   public Object visitPrepareCommand(TxInvocationContext ctx, PrepareCommand command) {
       return invokeNextThenAccept(ctx, command, (rCtx, rCommand, rv) -> {
          if (!rCtx.isOriginLocal()) {
             // apply updates to the serialization context
@@ -187,7 +187,7 @@ final class ProtobufMetadataManagerInterceptor extends BaseCustomAsyncIntercepto
    }
 
    @Override
-   public Object visitPutKeyValueCommand(final InvocationContext ctx, PutKeyValueCommand command) throws Throwable {
+   public Object visitPutKeyValueCommand(InvocationContext ctx, PutKeyValueCommand command) {
       final Object key = command.getKey();
       final Object value = command.getValue();
 
@@ -250,7 +250,7 @@ final class ProtobufMetadataManagerInterceptor extends BaseCustomAsyncIntercepto
    }
 
    @Override
-   public Object visitPutMapCommand(final InvocationContext ctx, PutMapCommand command) throws Throwable {
+   public Object visitPutMapCommand(InvocationContext ctx, PutMapCommand command) {
       final Map<Object, Object> map = command.getMap();
 
       FileDescriptorSource source = new FileDescriptorSource();
@@ -297,7 +297,7 @@ final class ProtobufMetadataManagerInterceptor extends BaseCustomAsyncIntercepto
    }
 
    @Override
-   public Object visitRemoveCommand(InvocationContext ctx, RemoveCommand command) throws Throwable {
+   public Object visitRemoveCommand(InvocationContext ctx, RemoveCommand command) {
       if (ctx.isOriginLocal()) {
          if (!(command.getKey() instanceof String)) {
             throw log.keyMustBeString(command.getKey().getClass());
@@ -347,7 +347,7 @@ final class ProtobufMetadataManagerInterceptor extends BaseCustomAsyncIntercepto
    }
 
    @Override
-   public Object visitReplaceCommand(final InvocationContext ctx, ReplaceCommand command) throws Throwable {
+   public Object visitReplaceCommand(InvocationContext ctx, ReplaceCommand command) {
       final Object key = command.getKey();
       final Object value = command.getNewValue();
 
@@ -374,7 +374,7 @@ final class ProtobufMetadataManagerInterceptor extends BaseCustomAsyncIntercepto
       return invokeNextThenAccept(ctx, command, (rCtx, rCommand, rv) -> {
          if (rCommand.isSuccessful()) {
             FileDescriptorSource source = new FileDescriptorSource()
-                        .addProtoFile((String) key, (String) value);
+                  .addProtoFile((String) key, (String) value);
 
             long flagsBitSet = copyFlags(((WriteCommand) rCommand));
             ProgressCallback progressCallback = null;
@@ -399,7 +399,7 @@ final class ProtobufMetadataManagerInterceptor extends BaseCustomAsyncIntercepto
    }
 
    @Override
-   public Object visitClearCommand(InvocationContext ctx, ClearCommand command) throws Throwable {
+   public Object visitClearCommand(InvocationContext ctx, ClearCommand command) {
       for (String fileName : serializationContext.getFileDescriptors().keySet()) {
          serializationContext.unregisterProtoFile(fileName);
       }

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/RemoteQueryEngine.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/RemoteQueryEngine.java
@@ -91,7 +91,7 @@ final class RemoteQueryEngine extends BaseRemoteQueryEngine {
    @Override
    protected CacheQuery<?> makeCacheQuery(IckleParsingResult<Descriptor> ickleParsingResult, Query luceneQuery, IndexedQueryMode queryMode, Map<String, Object> namedParameters) {
       IndexingMetadata indexingMetadata = ickleParsingResult.getTargetEntityMetadata().getProcessedAnnotation(IndexingMetadata.INDEXED_ANNOTATION);
-      final Set<String> sortableFields = indexingMetadata != null ? indexingMetadata.getSortableFields() : Collections.emptySet();
+      Set<String> sortableFields = indexingMetadata != null ? indexingMetadata.getSortableFields() : Collections.emptySet();
       IndexedTypeMap<CustomTypeMetadata> queryMetadata = IndexedTypeMaps.singletonMapping(ProtobufValueWrapper.INDEXING_TYPE, () -> sortableFields);
       RemoteQueryDefinition queryDefinition;
       if (queryMode == IndexedQueryMode.BROADCAST) {

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/indexing/IndexingMetadataCreator.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/indexing/IndexingMetadataCreator.java
@@ -120,7 +120,7 @@ final class IndexingMetadataCreator implements AnnotationMetadataCreator<Indexin
                FieldMapping fieldMapping = new FieldMapping(fieldName, isIndexed, fieldLevelBoost, isAnalyzed, isStored, isSortable, fieldLevelAnalyzer, indexNullAs, luceneOptions, fd, false);
                fields.put(fieldName, fieldMapping);
                if (log.isEnabled(Logger.Level.DEBUG)) {
-                  log.debugf("fieldName=%s fieldMapping=%s" , fieldName, fieldMapping);
+                  log.debugf("fieldName=%s fieldMapping=%s", fieldName, fieldMapping);
                }
             }
 
@@ -129,7 +129,7 @@ final class IndexingMetadataCreator implements AnnotationMetadataCreator<Indexin
             if (indexedFieldAnnotation != null) {
                if (log.isEnabled(Logger.Level.WARN)) {
                   log.warnf("Detected usage of deprecated annotation '%s' on field %s. Please consider replacing it with "
-                              + IndexingMetadata.FIELD_ANNOTATION + ".", IndexingMetadata.INDEXED_FIELD_ANNOTATION, fd.getFullName());
+                        + IndexingMetadata.FIELD_ANNOTATION + ".", IndexingMetadata.INDEXED_FIELD_ANNOTATION, fd.getFullName());
                }
                if (fieldAnnotation != null) {
                   throw new IllegalStateException("Annotation '" + IndexingMetadata.INDEXED_FIELD_ANNOTATION +
@@ -159,14 +159,14 @@ final class IndexingMetadataCreator implements AnnotationMetadataCreator<Indexin
                FieldMapping fieldMapping = new FieldMapping(fd.getName(), isIndexed, 1.0f, false, isStored, false, null, indexNullAs, luceneOptions, fd, true);
                fields.put(fd.getName(), fieldMapping);
                if (log.isEnabled(Logger.Level.DEBUG)) {
-                  log.debugf("fieldName=%s fieldMapping=%s" , fd.getName(), fieldMapping);
+                  log.debugf("fieldName=%s fieldMapping=%s", fd.getName(), fieldMapping);
                }
             }
          }
 
          IndexingMetadata indexingMetadata = new IndexingMetadata(true, indexName, entityAnalyzer, fields);
          if (log.isEnabled(Logger.Level.DEBUG)) {
-            log.debugf("Descriptor name=%s indexingMetadata=%s" , descriptor.getFullName() , indexingMetadata);
+            log.debugf("Descriptor name=%s indexingMetadata=%s", descriptor.getFullName(), indexingMetadata);
          }
          return indexingMetadata;
       } else {

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/indexing/IndexingTagHandler.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/indexing/IndexingTagHandler.java
@@ -45,9 +45,12 @@ final class IndexingTagHandler implements TagHandler {
 
    private MessageContext<? extends MessageContext> messageContext;
 
+   private final boolean isLegacyIndexingEnabled;
+
    IndexingTagHandler(Descriptor messageDescriptor, Document document) {
       this.document = document;
       this.messageContext = new MessageContext<>(null, null, messageDescriptor);
+      isLegacyIndexingEnabled = IndexingMetadata.isLegacyIndexingEnabled(messageDescriptor);
    }
 
    @Override
@@ -64,7 +67,7 @@ final class IndexingTagHandler implements TagHandler {
       if (fieldDescriptor != null) {
          IndexingMetadata indexingMetadata = messageContext.getMessageDescriptor().getProcessedAnnotation(IndexingMetadata.INDEXED_ANNOTATION);
          FieldMapping fieldMapping = indexingMetadata != null ? indexingMetadata.getFieldMapping(fieldDescriptor.getName()) : null;
-         if (indexingMetadata == null || fieldMapping != null && fieldMapping.index()) {
+         if (indexingMetadata == null && isLegacyIndexingEnabled || fieldMapping != null && fieldMapping.index()) {
             //TODO [anistor] should we still store if isStore==true but isIndexed==false?
             addFieldToDocument(fieldDescriptor, tagValue, fieldMapping);
          }
@@ -174,7 +177,7 @@ final class IndexingTagHandler implements TagHandler {
                   || fieldDescriptor.hasDefaultValue() ? fieldDescriptor.getDefaultValue() : null;
             IndexingMetadata indexingMetadata = messageContext.getMessageDescriptor().getProcessedAnnotation(IndexingMetadata.INDEXED_ANNOTATION);
             FieldMapping fieldMapping = indexingMetadata != null ? indexingMetadata.getFieldMapping(fieldDescriptor.getName()) : null;
-            if (indexingMetadata == null || fieldMapping != null && fieldMapping.index()) {
+            if (indexingMetadata == null && isLegacyIndexingEnabled || fieldMapping != null && fieldMapping.index()) {
                addFieldToDocument(fieldDescriptor, defaultValue, fieldMapping);
             }
          }

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/indexing/ProtobufValueWrapper.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/indexing/ProtobufValueWrapper.java
@@ -26,6 +26,8 @@ public final class ProtobufValueWrapper implements WrappedBytes {
 
    public static final IndexedTypeIdentifier INDEXING_TYPE = PojoIndexedTypeIdentifier.convertFromLegacy(ProtobufValueWrapper.class);
 
+   private static final int MAX_BYTES_IN_TOSTRING = 40;
+
    // The protobuf encoded payload
    private final byte[] binary;
 
@@ -45,10 +47,16 @@ public final class ProtobufValueWrapper implements WrappedBytes {
       return binary;
    }
 
+   /**
+    * Returns the Protobuf descriptor of the message type of the payload.
+    */
    public Descriptor getMessageDescriptor() {
       return messageDescriptor;
    }
 
+   /**
+    * Sets the Protobuf descriptor of the message type of the payload.
+    */
    public void setMessageDescriptor(Descriptor messageDescriptor) {
       this.messageDescriptor = messageDescriptor;
    }
@@ -73,7 +81,7 @@ public final class ProtobufValueWrapper implements WrappedBytes {
    @Override
    public String toString() {
       // Render only max 40 bytes
-      int len = Math.min(binary.length, 40);
+      int len = Math.min(binary.length, MAX_BYTES_IN_TOSTRING);
       StringBuilder sb = new StringBuilder(50 + 3 * len);
       sb.append("ProtobufValueWrapper(length=").append(binary.length).append(", binary=[");
       for (int i = 0; i < len; i++) {

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/indexing/ProtobufValueWrapperFieldBridge.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/indexing/ProtobufValueWrapperFieldBridge.java
@@ -7,17 +7,21 @@ import org.hibernate.search.bridge.FieldBridge;
 import org.hibernate.search.bridge.LuceneOptions;
 import org.infinispan.Cache;
 import org.infinispan.commons.CacheException;
+import org.infinispan.commons.logging.LogFactory;
 import org.infinispan.protostream.ProtobufParser;
 import org.infinispan.protostream.SerializationContext;
 import org.infinispan.protostream.WrappedMessage;
 import org.infinispan.protostream.descriptors.Descriptor;
 import org.infinispan.query.remote.impl.ProtobufMetadataManagerImpl;
+import org.infinispan.query.remote.impl.logging.Log;
 
 /**
  * @author anistor@redhat.com
  * @since 6.0
  */
 public final class ProtobufValueWrapperFieldBridge implements FieldBridge {
+
+   private static final Log log = LogFactory.getLog(ProtobufValueWrapperFieldBridge.class, Log.class);
 
    private final Cache cache;
 
@@ -42,6 +46,9 @@ public final class ProtobufValueWrapperFieldBridge implements FieldBridge {
          throw new IllegalArgumentException("This FieldBridge can only be applied to a " + ProtobufValueWrapper.class.getName());
       }
       ProtobufValueWrapper valueWrapper = (ProtobufValueWrapper) value;
+      if (log.isDebugEnabled()) {
+         log.debugf("Setting Lucene document properties for %s in cache %s", valueWrapper.toString(), cache.getName());
+      }
       decodeAndIndex(valueWrapper, document, luceneOptions);
    }
 

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/logging/Log.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/logging/Log.java
@@ -1,8 +1,11 @@
 package org.infinispan.query.remote.impl.logging;
 
+import static org.jboss.logging.Logger.Level.WARN;
+
 import org.infinispan.commons.CacheException;
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.annotations.Cause;
+import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 
@@ -48,4 +51,11 @@ public interface Log extends BasicLogger {
 
    @Message(value = "Failed to parse proto file : %s", id = 28011)
    CacheException failedToParseProtoFile(String fileName, @Cause Throwable cause);
+
+   @LogMessage(level = WARN)
+   @Message(value = "Using deprecated legacy indexing mode (all fields) for message type '%s' missing indexing" +
+         " annotations defined in file '%s'. Please annotate your message type for indexing or add" +
+         " 'option indexed_by_default = false;' to your schema file to disable indexing of message types" +
+         " that do not have indexing annotations.", id = 28012)
+   void legacyIndexingIsDeprecated(String typeName, String fileName);
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-9021

This should improve performance for types that do not need indexing and thus are not annotated for indexing.