### PR TITLE
ISPN-9030 Avoid anonymous classes inside lambdas

### DIFF
--- a/query/src/main/java/org/infinispan/query/dsl/embedded/impl/HibernateSearchPropertyHelper.java
+++ b/query/src/main/java/org/infinispan/query/dsl/embedded/impl/HibernateSearchPropertyHelper.java
@@ -294,33 +294,7 @@ public final class HibernateSearchPropertyHelper extends ReflectionPropertyHelpe
          if (entityIndexBinding == null) {
             return IndexedFieldProvider.NO_INDEXING;
          }
-         return new IndexedFieldProvider.FieldIndexingMetadata() {
-
-            @Override
-            public boolean isIndexed(String[] propertyPath) {
-               DocumentFieldMetadata fieldMetadata = getDocumentFieldMetadata(entityIndexBinding, propertyPath);
-               return fieldMetadata != null && fieldMetadata.getIndex().isIndexed();
-            }
-
-            @Override
-            public boolean isAnalyzed(String[] propertyPath) {
-               DocumentFieldMetadata fieldMetadata = getDocumentFieldMetadata(entityIndexBinding, propertyPath);
-               return fieldMetadata != null && fieldMetadata.getIndex().isAnalyzed();
-            }
-
-            @Override
-            public boolean isStored(String[] propertyPath) {
-               DocumentFieldMetadata fieldMetadata = getDocumentFieldMetadata(entityIndexBinding, propertyPath);
-               return fieldMetadata != null && fieldMetadata.getStore() != Store.NO;
-            }
-
-            @Override
-            public Object getNullMarker(String[] propertyPath) {
-               DocumentFieldMetadata fieldMetadata = getDocumentFieldMetadata(entityIndexBinding, propertyPath);
-               return fieldMetadata != null && fieldMetadata.getNullMarkerCodec() != null && fieldMetadata.getNullMarkerCodec().getNullMarker() != null
-                     ? fieldMetadata.getNullMarkerCodec().getNullMarker().nullEncoded() : null;
-            }
-         };
+         return new HibernateSearchFieldIndexingMetadata(entityIndexBinding);
       };
    }
 
@@ -382,5 +356,38 @@ public final class HibernateSearchPropertyHelper extends ReflectionPropertyHelpe
          }
       }
       return null;
+   }
+
+   private class HibernateSearchFieldIndexingMetadata implements IndexedFieldProvider.FieldIndexingMetadata {
+      private final EntityIndexBinding entityIndexBinding;
+
+      HibernateSearchFieldIndexingMetadata(EntityIndexBinding entityIndexBinding) {
+         this.entityIndexBinding = entityIndexBinding;
+      }
+
+      @Override
+      public boolean isIndexed(String[] propertyPath) {
+         DocumentFieldMetadata fieldMetadata = getDocumentFieldMetadata(entityIndexBinding, propertyPath);
+         return fieldMetadata != null && fieldMetadata.getIndex().isIndexed();
+      }
+
+      @Override
+      public boolean isAnalyzed(String[] propertyPath) {
+         DocumentFieldMetadata fieldMetadata = getDocumentFieldMetadata(entityIndexBinding, propertyPath);
+         return fieldMetadata != null && fieldMetadata.getIndex().isAnalyzed();
+      }
+
+      @Override
+      public boolean isStored(String[] propertyPath) {
+         DocumentFieldMetadata fieldMetadata = getDocumentFieldMetadata(entityIndexBinding, propertyPath);
+         return fieldMetadata != null && fieldMetadata.getStore() != Store.NO;
+      }
+
+      @Override
+      public Object getNullMarker(String[] propertyPath) {
+         DocumentFieldMetadata fieldMetadata = getDocumentFieldMetadata(entityIndexBinding, propertyPath);
+         return fieldMetadata != null && fieldMetadata.getNullMarkerCodec() != null && fieldMetadata.getNullMarkerCodec().getNullMarker() != null
+               ? fieldMetadata.getNullMarkerCodec().getNullMarker().nullEncoded() : null;
+      }
    }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-9030

Only changing TxInterceptor and HibernateSearchPropertyHelper for now because that's where we saw the errors.

I've been trying to find all the lambdas that contain an inner class but I've hit a bug in structural search ([IDEA-189344](https://youtrack.jetbrains.com/issue/IDEA-189344)), and I have a feeling the 2 IntelliJ bugs are related.