### PR TITLE
ISPN-8719 KeySet.(iterator|spliterator|stream) not compatible with

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/ProtocolVersion.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/ProtocolVersion.java
@@ -14,21 +14,28 @@ import java.util.stream.Collectors;
  */
 public enum ProtocolVersion {
 
-   PROTOCOL_VERSION_27(2, 7),
-   PROTOCOL_VERSION_26(2, 6),
-   PROTOCOL_VERSION_25(2, 5),
-   PROTOCOL_VERSION_24(2, 4),
-   PROTOCOL_VERSION_23(2, 3),
-   PROTOCOL_VERSION_22(2, 2),
-   PROTOCOL_VERSION_21(2, 1),
-   PROTOCOL_VERSION_20(2, 0),
-   PROTOCOL_VERSION_13(1, 3),
-   PROTOCOL_VERSION_12(1, 2),
-   PROTOCOL_VERSION_11(1, 1),
+   // These need to go in order of lowest version is first - this way compareTo works for versions
    PROTOCOL_VERSION_10(1, 0),
+   PROTOCOL_VERSION_11(1, 1),
+   PROTOCOL_VERSION_12(1, 2),
+   PROTOCOL_VERSION_13(1, 3),
+   PROTOCOL_VERSION_20(2, 0),
+   PROTOCOL_VERSION_21(2, 1),
+   PROTOCOL_VERSION_22(2, 2),
+   PROTOCOL_VERSION_23(2, 3),
+   PROTOCOL_VERSION_24(2, 4),
+   PROTOCOL_VERSION_25(2, 5),
+   PROTOCOL_VERSION_26(2, 6),
+   PROTOCOL_VERSION_27(2, 7),
+   // New versions go above this line to satisfy compareTo of enum working for versions
    ;
 
-   public static final ProtocolVersion DEFAULT_PROTOCOL_VERSION = PROTOCOL_VERSION_27;
+   public static final ProtocolVersion DEFAULT_PROTOCOL_VERSION;
+
+   static {
+      ProtocolVersion[] versions = values();
+      DEFAULT_PROTOCOL_VERSION = versions[versions.length - 1];
+   }
 
    private final String version;
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/RemoteCacheImpl.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/RemoteCacheImpl.java
@@ -5,7 +5,6 @@ import static org.infinispan.client.hotrod.filter.Filters.makeFactoryParams;
 import static org.infinispan.client.hotrod.impl.Util.await;
 
 import java.util.AbstractCollection;
-import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -513,12 +512,8 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
 
       @Override
       public CloseableIterator<K> iterator() {
-         return new RemovableCloseableIterator<>(
-               // Use the ToEmptyBytesKeyValueFilterConverter to reduce value payload
-               new CloseableIteratorMapper<>(retrieveEntries(
-                     "org.infinispan.server.hotrod.HotRodServer$ToEmptyBytesKeyValueFilterConverter",
-                     batchSize), e -> (K) e.getKey()),
-               RemoteCacheImpl.this::remove);
+         CloseableIterator<K> keyIterator = operationsFactory.getCodec().keyIterator(RemoteCacheImpl.this, operationsFactory, batchSize);
+         return new RemovableCloseableIterator<>(keyIterator, this::remove);
       }
 
       @Override
@@ -567,10 +562,6 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
       }
    }
 
-   private CloseableIterator<Entry<K, VersionedValue<V>>> castIterator(CloseableIterator iterator) {
-      return iterator;
-   }
-
    private boolean removeEntry(Map.Entry<K, V> entry) {
       return removeEntry(entry.getKey(), entry.getValue());
    }
@@ -585,13 +576,8 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
 
       @Override
       public CloseableIterator<Entry<K, V>> iterator() {
-         return new CloseableIteratorMapper<>(new RemovableCloseableIterator<>(
-               // First make <K, VersionedValue<V>>
-               castIterator(retrieveEntriesWithMetadata(null, batchSize)),
-               // Apply remove using version
-               e -> removeWithVersion(e.getKey(), e.getValue().getVersion())),
-               // Convert to <K, V> for user
-               e -> new AbstractMap.SimpleImmutableEntry<>(e.getKey(), e.getValue().getValue()));
+         return new RemovableCloseableIterator<>(operationsFactory.getCodec().entryIterator(RemoteCacheImpl.this, batchSize),
+               this::remove);
       }
 
       @Override
@@ -648,13 +634,11 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
 
       @Override
       public CloseableIterator<V> iterator() {
-         return new CloseableIteratorMapper<>(new RemovableCloseableIterator<>(
-               // First make <K, VersionedValue<V>>
-               castIterator(retrieveEntriesWithMetadata(null, batchSize)),
-               // Apply remove using version
-               e -> removeWithVersion(e.getKey(), e.getValue().getVersion())),
+         CloseableIterator<Map.Entry<K, V>> entryIterator = operationsFactory.getCodec().entryIterator(
+               RemoteCacheImpl.this, batchSize);
+         return new CloseableIteratorMapper<>(new RemovableCloseableIterator<>(entryIterator, e -> RemoteCacheImpl.this.remove(e.getKey(), e.getValue())),
                // Convert to V for user
-               e -> e.getValue().getValue());
+               Entry::getValue);
       }
 
       @Override

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/IterationNextOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/IterationNextOperation.java
@@ -72,11 +72,11 @@ public class IterationNextOperation<E> extends HotRodOperation<IterationNextResp
             return;
          }
          entries = new ArrayList<>(entriesSize);
-         projectionsSize = ByteBufUtil.readVInt(buf);
+         projectionsSize = codec.readProjectionSize(buf);
          decoder.checkpoint();
       }
       while (entries.size() + untrackedEntries < entriesSize) {
-         short meta = buf.readUnsignedByte();
+         short meta = codec.readMeta(buf);
          long creation = -1;
          int lifespan = -1;
          long lastUsed = -1;

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/IterationStartOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/IterationStartOperation.java
@@ -1,8 +1,5 @@
 package org.infinispan.client.hotrod.impl.operations;
 
-import static java.util.Arrays.stream;
-
-import java.util.BitSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -50,25 +47,7 @@ public class IterationStartOperation extends RetryOnFailureOperation<IterationSt
       ByteBuf buf = channel.alloc().buffer();
 
       codec.writeHeader(buf, header);
-      if (segments == null) {
-         ByteBufUtil.writeSignedVInt(buf, -1);
-      } else {
-         // TODO use a more compact BitSet implementation, like http://roaringbitmap.org/
-         BitSet bitSet = new BitSet();
-         segments.stream().forEach(bitSet::set);
-         ByteBufUtil.writeOptionalArray(buf, bitSet.toByteArray());
-      }
-      ByteBufUtil.writeOptionalString(buf, filterConverterFactory);
-      if (filterConverterFactory != null) {
-         if (filterParameters != null && filterParameters.length > 0) {
-            buf.writeByte(filterParameters.length);
-            stream(filterParameters).forEach(param -> ByteBufUtil.writeArray(buf, param));
-         } else {
-            buf.writeByte(0);
-         }
-      }
-      ByteBufUtil.writeVInt(buf, batchSize);
-      buf.writeByte(metadata ? 1 : 0);
+      codec.writeIteratorStartOperation(buf, segments, filterConverterFactory, batchSize, metadata, filterParameters);
       channel.writeAndFlush(buf);
    }
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec.java
@@ -3,15 +3,19 @@ package org.infinispan.client.hotrod.impl.protocol;
 import java.lang.annotation.Annotation;
 import java.net.SocketAddress;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.annotation.ClientListener;
 import org.infinispan.client.hotrod.counter.impl.HotRodCounterEvent;
 import org.infinispan.client.hotrod.event.ClientEvent;
+import org.infinispan.client.hotrod.impl.operations.OperationsFactory;
 import org.infinispan.client.hotrod.impl.transport.netty.ChannelFactory;
 import org.infinispan.client.hotrod.logging.Log;
 import org.infinispan.commons.marshall.Marshaller;
+import org.infinispan.commons.util.CloseableIterator;
 import org.infinispan.commons.util.Either;
 
 import io.netty.buffer.ByteBuf;
@@ -75,4 +79,50 @@ public interface Codec {
     * Reads a {@link HotRodCounterEvent} with the {@code listener-id}.
     */
    HotRodCounterEvent readCounterEvent(ByteBuf buf, byte[] listenerId);
+
+   /**
+    * Iteration read for projection size
+    * @param buf
+    * @return
+    */
+   default int readProjectionSize(ByteBuf buf) {
+      return 0;
+   }
+
+   /**
+    * Iteration read to tell if metadata is present for entry
+    * @param buf
+    * @return
+    */
+   default short readMeta(ByteBuf buf) {
+      return 0;
+   }
+
+   default void writeIteratorStartOperation(ByteBuf buf, Set<Integer> segments, String filterConverterFactory, int batchSize,
+         boolean metadata, byte[][] filterParameters) {
+      throw new UnsupportedOperationException("This version doesn't support iterating upon entries!");
+   }
+
+   /**
+    * Creates a key iterator with the given batch size if applicable. This iterator does not support removal.
+    * @param remoteCache
+    * @param batchSize
+    * @param <K>
+    * @return
+    */
+   default <K> CloseableIterator<K> keyIterator(RemoteCache<K, ?> remoteCache, OperationsFactory operationsFactory, int batchSize) {
+      throw new UnsupportedOperationException("This version doesn't support iterating upon keys!");
+   }
+
+   /**
+    * Creates an entry iterator with the given batch size if applicable. This iterator does not support removal.
+    * @param remoteCache
+    * @param batchSize
+    * @param <K>
+    * @param <V>
+    * @return
+    */
+   default <K, V> CloseableIterator<Map.Entry<K, V>> entryIterator(RemoteCache<K, V> remoteCache, int batchSize) {
+      throw new UnsupportedOperationException("This version doesn't support iterating upon entries!");
+   }
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec12.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec12.java
@@ -1,8 +1,17 @@
 package org.infinispan.client.hotrod.impl.protocol;
 
+import static org.infinispan.client.hotrod.impl.Util.await;
+
+import java.util.Set;
+
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.impl.operations.BulkGetKeysOperation;
+import org.infinispan.client.hotrod.impl.operations.OperationsFactory;
 import org.infinispan.client.hotrod.impl.transport.netty.ByteBufUtil;
 import org.infinispan.client.hotrod.logging.Log;
 import org.infinispan.client.hotrod.logging.LogFactory;
+import org.infinispan.commons.util.CloseableIterator;
+import org.infinispan.commons.util.Closeables;
 
 import io.netty.buffer.ByteBuf;
 
@@ -46,4 +55,10 @@ public class Codec12 extends Codec11 {
       return log;
    }
 
+   @Override
+   public <K> CloseableIterator<K> keyIterator(RemoteCache<K, ?> remoteCache, OperationsFactory operationsFactory, int batchSize) {
+      BulkGetKeysOperation<K> op = operationsFactory.newBulkGetKeysOperation(0);
+      Set<K> keys = await(op.execute());
+      return Closeables.iterator(keys.iterator());
+   }
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec23.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec23.java
@@ -1,5 +1,15 @@
 package org.infinispan.client.hotrod.impl.protocol;
 
+import java.util.BitSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.impl.operations.OperationsFactory;
+import org.infinispan.client.hotrod.impl.transport.netty.ByteBufUtil;
+import org.infinispan.commons.util.CloseableIterator;
+import org.infinispan.commons.util.CloseableIteratorMapper;
+
 import io.netty.buffer.ByteBuf;
 
 /**
@@ -11,5 +21,41 @@ public class Codec23 extends Codec22 {
    @Override
    public HeaderParams writeHeader(ByteBuf buf, HeaderParams params) {
       return writeHeader(buf, params, HotRodConstants.VERSION_23);
+   }
+
+   @Override
+   public <K> CloseableIterator<K> keyIterator(RemoteCache<K, ?> remoteCache, OperationsFactory operationsFactory, int batchSize) {
+      // Retrieve key and entry but map to key
+      return new CloseableIteratorMapper<>(remoteCache.retrieveEntries(null, batchSize), e -> (K) e.getKey());
+   }
+
+   @Override
+   public <K, V> CloseableIterator<Map.Entry<K, V>> entryIterator(RemoteCache<K, V> remoteCache, int batchSize) {
+      return castEntryIterator(remoteCache.retrieveEntries(null, batchSize));
+   }
+
+   protected <K, V> CloseableIterator<Map.Entry<K, V>> castEntryIterator(CloseableIterator iterator) {
+      return iterator;
+   }
+
+   @Override
+   public void writeIteratorStartOperation(ByteBuf buf, Set<Integer> segments, String filterConverterFactory,
+         int batchSize, boolean metadata, byte[][] filterParameters) {
+      if (metadata) {
+         throw new UnsupportedOperationException("Metadata for entry iteration not supported in this version!");
+      }
+      if (segments == null) {
+         ByteBufUtil.writeSignedVInt(buf, -1);
+      } else {
+         if (filterParameters != null && filterParameters.length > 0) {
+            throw new UnsupportedOperationException("The filterParamters for entry iteration are not supported in this version!");
+         }
+         // TODO use a more compact BitSet implementation, like http://roaringbitmap.org/
+         BitSet bitSet = new BitSet();
+         segments.stream().forEach(bitSet::set);
+         ByteBufUtil.writeOptionalArray(buf, bitSet.toByteArray());
+      }
+      ByteBufUtil.writeOptionalString(buf, filterConverterFactory);
+      ByteBufUtil.writeVInt(buf, batchSize);
    }
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec24.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec24.java
@@ -1,5 +1,11 @@
 package org.infinispan.client.hotrod.impl.protocol;
 
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.Set;
+
+import org.infinispan.client.hotrod.impl.transport.netty.ByteBufUtil;
+
 import io.netty.buffer.ByteBuf;
 
 public class Codec24 extends Codec23 {
@@ -9,4 +15,31 @@ public class Codec24 extends Codec23 {
       return writeHeader(buf, params, HotRodConstants.VERSION_24);
    }
 
+   @Override
+   public void writeIteratorStartOperation(ByteBuf buf, Set<Integer> segments, String filterConverterFactory, int batchSize, boolean metadata, byte[][] filterParameters) {
+      if (segments == null) {
+         ByteBufUtil.writeSignedVInt(buf, -1);
+      } else {
+         // TODO use a more compact BitSet implementation, like http://roaringbitmap.org/
+         BitSet bitSet = new BitSet();
+         segments.stream().forEach(bitSet::set);
+         ByteBufUtil.writeOptionalArray(buf, bitSet.toByteArray());
+      }
+      ByteBufUtil.writeOptionalString(buf, filterConverterFactory);
+      if (filterConverterFactory != null) {
+         if (filterParameters != null && filterParameters.length > 0) {
+            buf.writeByte(filterParameters.length);
+            Arrays.stream(filterParameters).forEach(param -> ByteBufUtil.writeArray(buf, param));
+         } else {
+            buf.writeByte(0);
+         }
+      }
+      ByteBufUtil.writeVInt(buf, batchSize);
+      buf.writeByte(metadata ? 1 : 0);
+   }
+
+   @Override
+   public int readProjectionSize(ByteBuf buf) {
+      return ByteBufUtil.readVInt(buf);
+   }
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec25.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec25.java
@@ -12,4 +12,9 @@ public class Codec25 extends Codec24 {
    public HeaderParams writeHeader(ByteBuf buf, HeaderParams params) {
       return writeHeader(buf, params, HotRodConstants.VERSION_25);
    }
+
+   @Override
+   public short readMeta(ByteBuf buf) {
+      return buf.readUnsignedByte();
+   }
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec26.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec26.java
@@ -3,11 +3,15 @@ package org.infinispan.client.hotrod.impl.protocol;
 import java.lang.annotation.Annotation;
 import java.util.Set;
 
+import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.annotation.ClientCacheEntryCreated;
 import org.infinispan.client.hotrod.annotation.ClientCacheEntryExpired;
 import org.infinispan.client.hotrod.annotation.ClientCacheEntryModified;
 import org.infinispan.client.hotrod.annotation.ClientCacheEntryRemoved;
+import org.infinispan.client.hotrod.impl.operations.OperationsFactory;
 import org.infinispan.client.hotrod.impl.transport.netty.ByteBufUtil;
+import org.infinispan.commons.util.CloseableIterator;
+import org.infinispan.commons.util.CloseableIteratorMapper;
 
 import io.netty.buffer.ByteBuf;
 
@@ -36,4 +40,12 @@ public class Codec26 extends Codec25 {
       ByteBufUtil.writeVInt(buf, listenerInterests);
    }
 
+   @Override
+   public <K> CloseableIterator<K> keyIterator(RemoteCache<K, ?> remoteCache, OperationsFactory operationsFactory,
+         int batchSize) {
+      return new CloseableIteratorMapper<>(remoteCache.retrieveEntries(
+            // Use the ToEmptyBytesKeyValueFilterConverter to remove value payload
+            "org.infinispan.server.hotrod.HotRodServer$ToEmptyBytesKeyValueFilterConverter", batchSize),
+            e -> (K) e.getKey());
+   }
 }

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/Encoder2x.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/Encoder2x.java
@@ -430,7 +430,7 @@ class Encoder2x implements VersionedEncoder {
             Optional<Integer> projectionLength = projectionInfo(entries, r.version);
             projectionLength.ifPresent(i -> ExtendedByteBuf.writeUnsignedInt(i, buf));
             entries.forEach(cacheEntry -> {
-               if (HotRodVersion.HOTROD_24.isAtLeast(r.version)) {
+               if (HotRodVersion.HOTROD_25.isAtLeast(r.version)) {
                   if (r.iterationResult.isMetadata()) {
                      buf.writeByte(1);
                      InternalCacheEntry ice = (InternalCacheEntry) cacheEntry;


### PR DESCRIPTION
versions before 9.2

* Added iterator methods to Codecs
* Put appropriate methods on each Codec version

https://issues.jboss.org/browse/ISPN-8719