### PR TITLE
ISPN-8719 KeySet.(iterator|spliterator|stream) not compatible with

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/ProtocolVersion.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/ProtocolVersion.java
@@ -14,20 +14,27 @@ import java.util.stream.Collectors;
  */
 public enum ProtocolVersion {
 
-   PROTOCOL_VERSION_26(2, 6),
-   PROTOCOL_VERSION_25(2, 5),
-   PROTOCOL_VERSION_24(2, 4),
-   PROTOCOL_VERSION_23(2, 3),
-   PROTOCOL_VERSION_22(2, 2),
-   PROTOCOL_VERSION_21(2, 1),
-   PROTOCOL_VERSION_20(2, 0),
-   PROTOCOL_VERSION_13(1, 3),
-   PROTOCOL_VERSION_12(1, 2),
-   PROTOCOL_VERSION_11(1, 1),
+   // These need to go in order of lowest version is first - this way compareTo works for versions
    PROTOCOL_VERSION_10(1, 0),
+   PROTOCOL_VERSION_11(1, 1),
+   PROTOCOL_VERSION_12(1, 2),
+   PROTOCOL_VERSION_13(1, 3),
+   PROTOCOL_VERSION_20(2, 0),
+   PROTOCOL_VERSION_21(2, 1),
+   PROTOCOL_VERSION_22(2, 2),
+   PROTOCOL_VERSION_23(2, 3),
+   PROTOCOL_VERSION_24(2, 4),
+   PROTOCOL_VERSION_25(2, 5),
+   PROTOCOL_VERSION_26(2, 6),
+   // New versions go above this line to satisfy compareTo of enum working for versions
    ;
 
-   public static final ProtocolVersion DEFAULT_PROTOCOL_VERSION = PROTOCOL_VERSION_26;
+   public static final ProtocolVersion DEFAULT_PROTOCOL_VERSION;
+
+   static {
+      ProtocolVersion[] versions = values();
+      DEFAULT_PROTOCOL_VERSION = versions[versions.length - 1];
+   }
 
    private final String version;
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/IterationNextOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/IterationNextOperation.java
@@ -54,9 +54,9 @@ public class IterationNextOperation<E> extends HotRodOperation {
       int entriesSize = transport.readVInt();
       List<Entry<Object, E>> entries = new ArrayList<>(entriesSize);
       if (entriesSize > 0) {
-         int projectionsSize = transport.readVInt();
+         int projectionsSize = codec.readProjectionSize(transport);
          for (int i = 0; i < entriesSize; i++) {
-            short meta = transport.readByte();
+            short meta = codec.readMeta(transport);
             long creation = -1;
             int lifespan = -1;
             long lastUsed = -1;

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/IterationStartOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/IterationStartOperation.java
@@ -1,9 +1,6 @@
 package org.infinispan.client.hotrod.impl.operations;
 
-import static java.util.Arrays.stream;
-
 import java.net.SocketAddress;
-import java.util.BitSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -47,25 +44,8 @@ public class IterationStartOperation extends RetryOnFailureOperation<IterationSt
    @Override
    protected IterationStartResponse executeOperation(Transport transport) {
       HeaderParams params = writeHeader(transport, ITERATION_START_REQUEST);
-      if (segments == null) {
-         transport.writeSignedVInt(-1);
-      } else {
-         // TODO use a more compact BitSet implementation, like http://roaringbitmap.org/
-         BitSet bitSet = new BitSet();
-         segments.stream().forEach(bitSet::set);
-         transport.writeOptionalArray(bitSet.toByteArray());
-      }
-      transport.writeOptionalString(filterConverterFactory);
-      if (filterConverterFactory != null) {
-         if (filterParameters != null && filterParameters.length > 0) {
-            transport.writeByte((short) filterParameters.length);
-            stream(filterParameters).forEach(transport::writeArray);
-         } else {
-            transport.writeByte((short) 0);
-         }
-      }
-      transport.writeVInt(batchSize);
-      transport.writeByte((short) (metadata ? 1 : 0));
+
+      codec.writeIteratorStartOperation(transport, segments, filterConverterFactory, batchSize, metadata, filterParameters);
 
       transport.flush();
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/OperationsFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/OperationsFactory.java
@@ -76,6 +76,10 @@ public class OperationsFactory implements HotRodConstants {
       return cacheNameBytes;
    }
 
+   public Codec getCodec() {
+      return codec;
+   }
+
    public <V> GetOperation<V> newGetKeyOperation(Object key, byte[] keyBytes) {
       return new GetOperation<>(
             codec, transportFactory, key, keyBytes, cacheNameBytes, topologyId, flags(), cfg);

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec.java
@@ -4,15 +4,19 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.VersionedMetadata;
 import org.infinispan.client.hotrod.annotation.ClientListener;
 import org.infinispan.client.hotrod.event.ClientEvent;
+import org.infinispan.client.hotrod.impl.operations.OperationsFactory;
 import org.infinispan.client.hotrod.impl.transport.Transport;
 import org.infinispan.client.hotrod.logging.Log;
 import org.infinispan.commons.marshall.Marshaller;
+import org.infinispan.commons.util.CloseableIterator;
 import org.infinispan.commons.util.Either;
 
 /**
@@ -74,4 +78,49 @@ public interface Codec {
 
    void writeClientListenerInterests(Transport transport, Set<Class<? extends Annotation>> classes);
 
+   /**
+    * Iteration read for projection size
+    * @param transport
+    * @return
+    */
+   default int readProjectionSize(Transport transport) {
+      return 0;
+   }
+
+   /**
+    * Iteration read to tell if metadata is present for entry
+    * @param transport
+    * @return
+    */
+   default short readMeta(Transport transport) {
+      return 0;
+   }
+
+   default void writeIteratorStartOperation(Transport transport, Set<Integer> segments, String filterConverterFactory, int batchSize,
+         boolean metadata, byte[][] filterParameters) {
+      throw new UnsupportedOperationException("This version doesn't support iterating upon entries!");
+   }
+
+   /**
+    * Creates a key iterator with the given batch size if applicable. This iterator does not support removal.
+    * @param remoteCache
+    * @param batchSize
+    * @param <K>
+    * @return
+    */
+   default <K> CloseableIterator<K> keyIterator(RemoteCache<K, ?> remoteCache, OperationsFactory operationsFactory, int batchSize) {
+      throw new UnsupportedOperationException("This version doesn't support iterating upon keys!");
+   }
+
+   /**
+    * Creates an entry iterator with the given batch size if applicable. This iterator does not support removal.
+    * @param remoteCache
+    * @param batchSize
+    * @param <K>
+    * @param <V>
+    * @return
+    */
+   default <K, V> CloseableIterator<Map.Entry<K, V>> entryIterator(RemoteCache<K, V> remoteCache, int batchSize) {
+      throw new UnsupportedOperationException("This version doesn't support iterating upon entries!");
+   }
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec12.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec12.java
@@ -1,8 +1,15 @@
 package org.infinispan.client.hotrod.impl.protocol;
 
+import java.util.Set;
+
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.impl.operations.BulkGetKeysOperation;
+import org.infinispan.client.hotrod.impl.operations.OperationsFactory;
 import org.infinispan.client.hotrod.impl.transport.Transport;
 import org.infinispan.client.hotrod.logging.Log;
 import org.infinispan.client.hotrod.logging.LogFactory;
+import org.infinispan.commons.util.CloseableIterator;
+import org.infinispan.commons.util.Closeables;
 
 /**
  * A Hot Rod encoder/decoder for version 1.2 of the protocol.
@@ -44,4 +51,10 @@ public class Codec12 extends Codec11 {
       return log;
    }
 
+   @Override
+   public <K> CloseableIterator<K> keyIterator(RemoteCache<K, ?> remoteCache, OperationsFactory operationsFactory, int batchSize) {
+      BulkGetKeysOperation<K> op = operationsFactory.newBulkGetKeysOperation(0);
+      Set<K> keys = op.execute();
+      return Closeables.iterator(keys.iterator());
+   }
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec20.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec20.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.VersionedMetadata;
 import org.infinispan.client.hotrod.annotation.ClientListener;
 import org.infinispan.client.hotrod.configuration.ClientIntelligence;
@@ -27,12 +28,16 @@ import org.infinispan.client.hotrod.exceptions.HotRodClientException;
 import org.infinispan.client.hotrod.exceptions.InvalidResponseException;
 import org.infinispan.client.hotrod.exceptions.RemoteIllegalLifecycleStateException;
 import org.infinispan.client.hotrod.exceptions.RemoteNodeSuspectException;
+import org.infinispan.client.hotrod.impl.operations.BulkGetKeysOperation;
+import org.infinispan.client.hotrod.impl.operations.OperationsFactory;
 import org.infinispan.client.hotrod.impl.transport.Transport;
 import org.infinispan.client.hotrod.impl.transport.TransportFactory;
 import org.infinispan.client.hotrod.logging.Log;
 import org.infinispan.client.hotrod.logging.LogFactory;
 import org.infinispan.client.hotrod.marshall.MarshallerUtil;
 import org.infinispan.commons.marshall.Marshaller;
+import org.infinispan.commons.util.CloseableIterator;
+import org.infinispan.commons.util.Closeables;
 import org.infinispan.commons.util.Either;
 
 /**
@@ -218,6 +223,13 @@ public class Codec20 implements Codec, HotRodConstants {
                throw log.unknownEvent(eventTypeId);
          }
       }
+   }
+
+   @Override
+   public <K> CloseableIterator<K> keyIterator(RemoteCache<K, ?> remoteCache, OperationsFactory operationsFactory, int batchSize) {
+      BulkGetKeysOperation<K> op = operationsFactory.newBulkGetKeysOperation(0);
+      Set<K> keys = op.execute();
+      return Closeables.iterator(keys.iterator());
    }
 
    @Override

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec23.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec23.java
@@ -1,6 +1,14 @@
 package org.infinispan.client.hotrod.impl.protocol;
 
+import java.util.BitSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.impl.operations.OperationsFactory;
 import org.infinispan.client.hotrod.impl.transport.Transport;
+import org.infinispan.commons.util.CloseableIterator;
+import org.infinispan.commons.util.CloseableIteratorMapper;
 
 /**
  * @author gustavonalle
@@ -11,5 +19,41 @@ public class Codec23 extends Codec22 {
    @Override
    public HeaderParams writeHeader(Transport transport, HeaderParams params) {
       return writeHeader(transport, params, HotRodConstants.VERSION_23);
+   }
+
+   @Override
+   public <K> CloseableIterator<K> keyIterator(RemoteCache<K, ?> remoteCache, OperationsFactory operationsFactory, int batchSize) {
+      // Retrieve key and entry but map to key
+      return new CloseableIteratorMapper<>(remoteCache.retrieveEntries(null, batchSize), e -> (K) e.getKey());
+   }
+
+   @Override
+   public <K, V> CloseableIterator<Map.Entry<K, V>> entryIterator(RemoteCache<K, V> remoteCache, int batchSize) {
+      return castEntryIterator(remoteCache.retrieveEntries(null, batchSize));
+   }
+
+   protected <K, V> CloseableIterator<Map.Entry<K, V>> castEntryIterator(CloseableIterator iterator) {
+      return iterator;
+   }
+
+   @Override
+   public void writeIteratorStartOperation(Transport transport, Set<Integer> segments, String filterConverterFactory,
+         int batchSize, boolean metadata, byte[][] filterParameters) {
+      if (metadata) {
+         throw new UnsupportedOperationException("Metadata for entry iteration not supported in this version!");
+      }
+      if (segments == null) {
+         transport.writeSignedVInt(-1);
+      } else {
+         if (filterParameters != null && filterParameters.length > 0) {
+            throw new UnsupportedOperationException("The filterParamters for entry iteration are not supported in this version!");
+         }
+         // TODO use a more compact BitSet implementation, like http://roaringbitmap.org/
+         BitSet bitSet = new BitSet();
+         segments.stream().forEach(bitSet::set);
+         transport.writeOptionalArray(bitSet.toByteArray());
+      }
+      transport.writeOptionalString(filterConverterFactory);
+      transport.writeVInt(batchSize);
    }
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec24.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec24.java
@@ -1,5 +1,9 @@
 package org.infinispan.client.hotrod.impl.protocol;
 
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.Set;
+
 import org.infinispan.client.hotrod.impl.transport.Transport;
 
 public class Codec24 extends Codec23 {
@@ -9,4 +13,32 @@ public class Codec24 extends Codec23 {
       return writeHeader(transport, params, HotRodConstants.VERSION_24);
    }
 
+   @Override
+   public void writeIteratorStartOperation(Transport transport, Set<Integer> segments, String filterConverterFactory,
+         int batchSize, boolean metadata, byte[][] filterParameters) {
+      if (segments == null) {
+         transport.writeSignedVInt(-1);
+      } else {
+         // TODO use a more compact BitSet implementation, like http://roaringbitmap.org/
+         BitSet bitSet = new BitSet();
+         segments.stream().forEach(bitSet::set);
+         transport.writeOptionalArray(bitSet.toByteArray());
+      }
+      transport.writeOptionalString(filterConverterFactory);
+      if (filterConverterFactory != null) {
+         if (filterParameters != null && filterParameters.length > 0) {
+            transport.writeByte((short) filterParameters.length);
+            Arrays.stream(filterParameters).forEach(transport::writeArray);
+         } else {
+            transport.writeByte((short) 0);
+         }
+      }
+      transport.writeVInt(batchSize);
+      transport.writeByte((short) (metadata ? 1 : 0));
+   }
+
+   @Override
+   public int readProjectionSize(Transport transport) {
+      return transport.readVInt();
+   }
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec25.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec25.java
@@ -12,4 +12,9 @@ public class Codec25 extends Codec24 {
    public HeaderParams writeHeader(Transport transport, HeaderParams params) {
       return writeHeader(transport, params, HotRodConstants.VERSION_25);
    }
+
+   @Override
+   public short readMeta(Transport transport) {
+      return transport.readByte();
+   }
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec26.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec26.java
@@ -3,11 +3,15 @@ package org.infinispan.client.hotrod.impl.protocol;
 import java.lang.annotation.Annotation;
 import java.util.Set;
 
+import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.annotation.ClientCacheEntryCreated;
 import org.infinispan.client.hotrod.annotation.ClientCacheEntryExpired;
 import org.infinispan.client.hotrod.annotation.ClientCacheEntryModified;
 import org.infinispan.client.hotrod.annotation.ClientCacheEntryRemoved;
+import org.infinispan.client.hotrod.impl.operations.OperationsFactory;
 import org.infinispan.client.hotrod.impl.transport.Transport;
+import org.infinispan.commons.util.CloseableIterator;
+import org.infinispan.commons.util.CloseableIteratorMapper;
 
 /**
  * @since 8.2
@@ -34,4 +38,12 @@ public class Codec26 extends Codec25 {
       transport.writeVInt(listenerInterests);
    }
 
+   @Override
+   public <K> CloseableIterator<K> keyIterator(RemoteCache<K, ?> remoteCache, OperationsFactory operationsFactory,
+         int batchSize) {
+      return new CloseableIteratorMapper<>(remoteCache.retrieveEntries(
+            // Use the ToEmptyBytesKeyValueFilterConverter to remove value payload
+            "org.infinispan.server.hotrod.HotRodServer$ToEmptyBytesKeyValueFilterConverter", batchSize),
+            e -> (K) e.getKey());
+   }
 }


### PR DESCRIPTION
versions before 9.1

* Added iterator methods to Codecs
* Put appropriate methods on each Codec version

https://issues.jboss.org/browse/ISPN-8719