### PR TITLE
ISPN-9008 RpcManager.invokeCommandOnAll ignores cache member missing from cluster view

### DIFF
--- a/commons/src/main/java/org/infinispan/commons/util/ImmutableHopscotchHashSet.java
+++ b/commons/src/main/java/org/infinispan/commons/util/ImmutableHopscotchHashSet.java
@@ -1,0 +1,104 @@
+package org.infinispan.commons.util;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+/**
+ * Wrap a {@link HopscotchHashMap} and allow using it as a {@link Set}.
+ *
+ * @param <E> The element type
+ * @since 9.3
+ * @author Dan Berindei
+ */
+public class ImmutableHopscotchHashSet<E> implements Set<E> {
+   private static final Object PRESENT = new Object();
+
+   private final HopscotchHashMap<E, Object> map;
+
+   public ImmutableHopscotchHashSet(Collection<E> collection) {
+      map = new HopscotchHashMap<>(collection.size());
+      for (E e : collection) {
+         map.put(e, PRESENT);
+      }
+   }
+
+   @Override
+   public int size() {
+      return map.size();
+   }
+
+   @Override
+   public boolean isEmpty() {
+      return map.isEmpty();
+   }
+
+   @Override
+   public boolean contains(Object o) {
+      return map.containsKey(o);
+   }
+
+   @Override
+   public Iterator<E> iterator() {
+      return new Immutables.ImmutableIteratorWrapper<>(map.keySet().iterator());
+   }
+
+   @Override
+   public void forEach(Consumer<? super E> action) {
+      map.keySet().forEach(action);
+   }
+
+   @Override
+   public Object[] toArray() {
+      return map.keySet().toArray();
+   }
+
+   @Override
+   public <T> T[] toArray(T[] a) {
+      return map.keySet().toArray(a);
+   }
+
+   @Override
+   public boolean add(E e) {
+      throw new UnsupportedOperationException("add");
+   }
+
+   @Override
+   public boolean remove(Object o) {
+      throw new UnsupportedOperationException("remove");
+   }
+
+   @Override
+   public boolean containsAll(Collection<?> c) {
+      return map.keySet().containsAll(c);
+   }
+
+   @Override
+   public boolean addAll(Collection<? extends E> c) {
+      throw new UnsupportedOperationException("addAll");
+   }
+
+   @Override
+   public boolean retainAll(Collection<?> c) {
+      throw new UnsupportedOperationException("retainAll");
+   }
+
+   @Override
+   public boolean removeAll(Collection<?> c) {
+      throw new UnsupportedOperationException("removeAll");
+   }
+
+   @Override
+   public boolean removeIf(Predicate<? super E> filter) {
+      throw new UnsupportedOperationException("removeIf");
+   }
+
+   @Override
+   public void clear() {
+      throw new UnsupportedOperationException("clear");
+   }
+
+   // Use the default implementation of spliterator(), stream(), and parallelStream()
+}

--- a/commons/src/main/java/org/infinispan/commons/util/Immutables.java
+++ b/commons/src/main/java/org/infinispan/commons/util/Immutables.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import org.infinispan.commons.marshall.AbstractExternalizer;
 import org.infinispan.commons.marshall.Ids;
@@ -281,8 +282,7 @@ public class Immutables {
     * We have to re-implement Collections.unmodifiableXXX, since it is not
     * simple to detect them (the class names are JDK dependent).
     */
-
-   private static class ImmutableIteratorWrapper<E> implements Iterator<E> {
+   public static class ImmutableIteratorWrapper<E> implements Iterator<E> {
       private Iterator<? extends E> iterator;
 
       public ImmutableIteratorWrapper(Iterator<? extends E> iterator) {
@@ -299,9 +299,11 @@ public class Immutables {
          return iterator.next();
       }
 
+      // Use the default remove() implementation
+
       @Override
-      public void remove() {
-         throw new UnsupportedOperationException();
+      public void forEachRemaining(Consumer<? super E> action) {
+         iterator.forEachRemaining(action);
       }
    }
 

--- a/core/src/main/java/org/infinispan/distribution/LocalizedCacheTopology.java
+++ b/core/src/main/java/org/infinispan/distribution/LocalizedCacheTopology.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.infinispan.commons.hash.MurmurHash3;
+import org.infinispan.commons.util.ImmutableHopscotchHashSet;
 import org.infinispan.commons.util.ImmutableIntSet;
 import org.infinispan.commons.util.Immutables;
 import org.infinispan.commons.util.IntSet;
@@ -30,6 +31,7 @@ import org.infinispan.topology.CacheTopology;
 public class LocalizedCacheTopology extends CacheTopology {
 
    private final Address localAddress;
+   private final Set<Address> membersSet;
    private final KeyPartitioner keyPartitioner;
    private final boolean isDistributed;
    private final boolean allLocal;
@@ -57,6 +59,7 @@ public class LocalizedCacheTopology extends CacheTopology {
       ConsistentHash writeCH = getWriteConsistentHash();
 
       this.localAddress = localAddress;
+      this.membersSet = new ImmutableHopscotchHashSet<>(cacheTopology.getMembers());
       this.keyPartitioner = keyPartitioner;
       this.isDistributed = cacheMode.isDistributed();
       isScattered = cacheMode.isScattered();
@@ -209,5 +212,9 @@ public class LocalizedCacheTopology extends CacheTopology {
     */
    public Address getLocalAddress() {
       return localAddress;
+   }
+
+   public Set<Address> getMembersSet() {
+      return membersSet;
    }
 }

--- a/core/src/main/java/org/infinispan/remoting/transport/Transport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/Transport.java
@@ -324,6 +324,21 @@ public interface Transport extends Lifecycle {
    }
 
    /**
+    * Invoke a command on all the nodes in the cluster and pass the responses to a {@link ResponseCollector}.
+    * <p>
+    * The command is only executed on the local node if the delivery order is {@link DeliverOrder#TOTAL}.
+    * The command is not sent across RELAY2 bridges to remote sites.
+    *
+    * @since 9.3
+    */
+   @Experimental
+   default <T> CompletionStage<T> invokeCommandOnAll(Collection<Address> requiredTargets, ReplicableCommand command,
+                                                       ResponseCollector<T> collector, DeliverOrder deliverOrder,
+                                                       long timeout, TimeUnit unit) {
+      return invokeCommand(requiredTargets, command, collector, deliverOrder, timeout, unit);
+   }
+
+   /**
     * Invoke a command on a collection of nodes and pass the responses to a {@link ResponseCollector}.
     * <p>
     * The command is only sent immediately to the first target, and there is an implementation-dependent

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/ClusterView.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/ClusterView.java
@@ -1,10 +1,9 @@
 package org.infinispan.remoting.transport.jgroups;
 
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.infinispan.commons.util.ImmutableHopscotchHashSet;
 import org.infinispan.commons.util.Immutables;
 import org.infinispan.remoting.transport.Address;
 
@@ -27,7 +26,7 @@ public class ClusterView {
    ClusterView(int viewId, List<Address> members, Address self) {
       this.viewId = viewId;
       this.members = Immutables.immutableListCopy(members);
-      this.membersSet = Collections.unmodifiableSet(new HashSet<>(members));
+      this.membersSet = new ImmutableHopscotchHashSet<>(members);
       if (!members.isEmpty()) {
          this.coordinator = members.get(0);
          this.isCoordinator = coordinator.equals(self);

--- a/core/src/test/java/org/infinispan/invalidation/BaseInvalidationTest.java
+++ b/core/src/test/java/org/infinispan/invalidation/BaseInvalidationTest.java
@@ -10,24 +10,19 @@ import static org.testng.AssertJUnit.assertNull;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
-
 import javax.transaction.RollbackException;
 import javax.transaction.Transaction;
 import javax.transaction.TransactionManager;
 
 import org.infinispan.AdvancedCache;
 import org.infinispan.api.mvcc.LockAssert;
-import org.infinispan.commands.ReplicableCommand;
 import org.infinispan.commands.write.ClearCommand;
 import org.infinispan.commands.write.InvalidateCommand;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
-import org.infinispan.remoting.inboundhandler.DeliverOrder;
 import org.infinispan.remoting.rpc.RpcManager;
 import org.infinispan.remoting.rpc.RpcManagerImpl;
 import org.infinispan.remoting.transport.Address;
-import org.infinispan.remoting.transport.ResponseCollector;
 import org.infinispan.remoting.transport.Transport;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
@@ -208,8 +203,7 @@ public abstract class BaseInvalidationTest extends MultipleCacheManagersTest {
 
          when(mockTransport.getMembers()).thenReturn(members);
          when(mockTransport.getAddress()).thenReturn(addressOne);
-         when(mockTransport.invokeCommandOnAll(any(ReplicableCommand.class), any(ResponseCollector.class),
-                                               any(DeliverOrder.class), anyLong(), any(TimeUnit.class)))
+         when(mockTransport.invokeCommandOnAll(any(), any(), any(), any(), anyLong(), any()))
                .thenReturn(CompletableFutures.completedNull());
 
          cache1.put("k", "v");

--- a/core/src/test/java/org/infinispan/jmx/RpcManagerMBeanTest.java
+++ b/core/src/test/java/org/infinispan/jmx/RpcManagerMBeanTest.java
@@ -2,8 +2,8 @@ package org.infinispan.jmx;
 
 import static org.infinispan.test.TestingUtil.checkMBeanOperationParameterNaming;
 import static org.infinispan.test.TestingUtil.getCacheObjectName;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyLong;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -15,6 +15,7 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -24,6 +25,8 @@ import javax.management.ObjectName;
 
 import org.infinispan.Cache;
 import org.infinispan.commands.ReplicableCommand;
+import org.infinispan.commons.CacheException;
+import org.infinispan.distribution.MagicKey;
 import org.infinispan.marshall.core.ExternalPojo;
 import org.infinispan.remoting.inboundhandler.DeliverOrder;
 import org.infinispan.remoting.rpc.RpcManager;
@@ -31,6 +34,7 @@ import org.infinispan.remoting.rpc.RpcManagerImpl;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.remoting.transport.ResponseCollector;
 import org.infinispan.remoting.transport.Transport;
+import org.infinispan.test.Exceptions;
 import org.infinispan.test.TestingUtil;
 import org.testng.annotations.Test;
 
@@ -92,7 +96,7 @@ public class RpcManagerMBeanTest extends AbstractClusterMBeanTest {
 
    @Test(dependsOnMethods = "testEnableJmxStats")
    public void testSuccessRatio() throws Exception {
-      Cache<String, Serializable> cache1 = manager(0).getCache(cachename);
+      Cache<MagicKey, Serializable> cache1 = manager(0).getCache(cachename);
       Cache cache2 = manager(1).getCache(cachename);
       MBeanServer mBeanServer = PerThreadMBeanServerLookup.getThreadMBeanServer();
       ObjectName rpcManager1 = getCacheObjectName(jmxDomain, cachename + "(repl_sync)", "RpcManager");
@@ -102,18 +106,15 @@ public class RpcManagerMBeanTest extends AbstractClusterMBeanTest {
       assertEquals(mBeanServer.getAttribute(rpcManager1, "ReplicationFailures"), (long) 0);
       assertEquals(mBeanServer.getAttribute(rpcManager1, "SuccessRatio"), "N/A");
 
-      cache1.put("a1", new SlowToSerialize("b1", 50));
-      cache1.put("a2", new SlowToSerialize("b2", 50));
-      cache1.put("a3", new SlowToSerialize("b3", 50));
-      cache1.put("a4", new SlowToSerialize("b4", 50));
-      assertEquals(mBeanServer.getAttribute(rpcManager1, "ReplicationCount"), (long) 4);
+      cache1.put(new MagicKey("a1", cache1), new SlowToSerialize("b1", 50));
+      cache1.put(new MagicKey("a2", cache2), new SlowToSerialize("b2", 50));
+      assertEquals(mBeanServer.getAttribute(rpcManager1, "ReplicationCount"), (long) 2);
       assertEquals(mBeanServer.getAttribute(rpcManager1, "SuccessRatio"), "100%");
       Object avgReplTime = mBeanServer.getAttribute(rpcManager1, "AverageReplicationTime");
       assertNotEquals(avgReplTime, (long) 0);
 
       RpcManagerImpl rpcManager = (RpcManagerImpl) TestingUtil.extractComponent(cache1, RpcManager.class);
       Transport originalTransport = rpcManager.getTransport();
-
       try {
          Address mockAddress1 = mock(Address.class);
          Address mockAddress2 = mock(Address.class);
@@ -127,16 +128,13 @@ public class RpcManagerMBeanTest extends AbstractClusterMBeanTest {
          when(transport.invokeCommand(any(Address.class), any(ReplicableCommand.class), any(ResponseCollector.class),
                                       any(DeliverOrder.class), anyLong(), any(TimeUnit.class)))
                .thenThrow(new RuntimeException());
-         when(transport.invokeCommandOnAll(any(ReplicableCommand.class), any(ResponseCollector.class),
-               any(DeliverOrder.class), anyLong(), any(TimeUnit.class))).thenThrow(new RuntimeException());
+         when(transport.invokeCommandOnAll(any(Collection.class), any(ReplicableCommand.class), any(ResponseCollector.class),
+                                           any(DeliverOrder.class), anyLong(), any(TimeUnit.class))).thenThrow(new RuntimeException());
          rpcManager.setTransport(transport);
-         cache1.put("a5", "b5");
-         assert false : "rpc manager should have thrown an exception";
-      } catch (Throwable expected) {
-         //expected
-         assertEquals(mBeanServer.getAttribute(rpcManager1, "SuccessRatio"), ("80%"));
-      }
-      finally {
+         Exceptions.expectException(CacheException.class, () -> cache1.put(new MagicKey("a3", cache1), "b3"));
+         Exceptions.expectException(CacheException.class, () -> cache1.put(new MagicKey("a4", cache2), "b4"));
+         assertEquals(mBeanServer.getAttribute(rpcManager1, "SuccessRatio"), ("50%"));
+      } finally {
          rpcManager.setTransport(originalTransport);
       }
    }

--- a/core/src/test/java/org/infinispan/remoting/rpc/RpcManagerTest.java
+++ b/core/src/test/java/org/infinispan/remoting/rpc/RpcManagerTest.java
@@ -3,23 +3,34 @@ package org.infinispan.remoting.rpc;
 import static org.infinispan.remoting.responses.SuccessfulResponse.SUCCESSFUL_EMPTY_RESPONSE;
 import static org.testng.AssertJUnit.assertEquals;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletionStage;
 
 import org.infinispan.commands.remote.ClusteredGetCommand;
+import org.infinispan.commons.hash.MurmurHash3;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.distribution.DistributionManager;
+import org.infinispan.distribution.ch.ConsistentHash;
+import org.infinispan.distribution.ch.impl.ReplicatedConsistentHashFactory;
 import org.infinispan.remoting.responses.Response;
 import org.infinispan.remoting.responses.ValidResponse;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.remoting.transport.impl.MapResponseCollector;
 import org.infinispan.remoting.transport.impl.SingleResponseCollector;
+import org.infinispan.remoting.transport.jgroups.JGroupsAddress;
+import org.infinispan.remoting.transport.jgroups.SuspectException;
 import org.infinispan.test.Exceptions;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
+import org.infinispan.topology.CacheTopology;
+import org.jgroups.util.NameCache;
+import org.jgroups.util.UUID;
 import org.testng.annotations.Test;
 
 /**
@@ -28,9 +39,12 @@ import org.testng.annotations.Test;
  */
 @Test(groups = "functional", testName = "remoting.rpc.RpcManagerTest")
 public class RpcManagerTest extends MultipleCacheManagersTest {
+   private static final JGroupsAddress SUSPECT = new JGroupsAddress(UUID.randomUUID());
 
    @Override
    protected void createCacheManagers() throws Throwable {
+      NameCache.add(SUSPECT.getJGroupsAddress(), "SUSPECT");
+
       ConfigurationBuilder builder = new ConfigurationBuilder();
       builder.clustering().cacheMode(CacheMode.REPL_SYNC);
       createCluster(builder, 3);
@@ -56,6 +70,11 @@ public class RpcManagerTest extends MultipleCacheManagersTest {
          rpcManager0.invokeCommand(address(1), command, SingleResponseCollector.validOnly(),
                                    rpcManager0.getSyncRpcOptions());
       assertResponse(SUCCESSFUL_EMPTY_RESPONSE, stage2);
+
+      CompletionStage<ValidResponse> stage3 =
+         rpcManager0.invokeCommand(SUSPECT, command, SingleResponseCollector.validOnly(),
+                                   rpcManager0.getSyncRpcOptions());
+      Exceptions.expectExecutionException(SuspectException.class, stage3.toCompletableFuture());
    }
 
    public void testInvokeCommandCollection() throws Exception {
@@ -84,6 +103,28 @@ public class RpcManagerTest extends MultipleCacheManagersTest {
       assertResponse(Collections.singletonMap(address(1), SUCCESSFUL_EMPTY_RESPONSE), stage3);
    }
 
+   public void testInvokeCommandCollectionSuspect() throws Exception {
+      ClusteredGetCommand command =
+         TestingUtil.extractCommandsFactory(cache(0)).buildClusteredGetCommand("key", 0L);
+      RpcManager rpcManager0 = cache(0).getAdvancedCache().getRpcManager();
+
+      command.setTopologyId(rpcManager0.getTopologyId());
+      CompletionStage<Map<Address, Response>> stage1 =
+         rpcManager0.invokeCommand(Arrays.asList(SUSPECT), command, MapResponseCollector.validOnly(),
+                                   rpcManager0.getSyncRpcOptions());
+      Exceptions.expectExecutionException(SuspectException.class, stage1.toCompletableFuture());
+
+      CompletionStage<Map<Address, Response>> stage2 =
+         rpcManager0.invokeCommand(Arrays.asList(address(0), SUSPECT), command, MapResponseCollector.validOnly(),
+                                   rpcManager0.getSyncRpcOptions());
+      Exceptions.expectExecutionException(SuspectException.class, stage2.toCompletableFuture());
+
+      CompletionStage<Map<Address, Response>> stage3 =
+         rpcManager0.invokeCommand(Arrays.asList(address(0), address(1), SUSPECT), command,
+                                   MapResponseCollector.validOnly(), rpcManager0.getSyncRpcOptions());
+      Exceptions.expectExecutionException(SuspectException.class, stage3.toCompletableFuture());
+   }
+
    public void testInvokeCommandOnAll() throws Exception {
       ClusteredGetCommand command =
          TestingUtil.extractCommandsFactory(cache(0)).buildClusteredGetCommand("key", 0L);
@@ -98,6 +139,35 @@ public class RpcManagerTest extends MultipleCacheManagersTest {
          rpcManager0.invokeCommandOnAll(command, MapResponseCollector.validOnly(),
                                         rpcManager0.getSyncRpcOptions());
       assertResponse(makeMap(address(1), SUCCESSFUL_EMPTY_RESPONSE, address(2), SUCCESSFUL_EMPTY_RESPONSE), stage1);
+   }
+
+   public void testInvokeCommandOnAllSuspect() throws Exception {
+      DistributionManager distributionManager = cache(0).getAdvancedCache().getDistributionManager();
+      CacheTopology initialTopology = distributionManager.getCacheTopology();
+      assertEquals(CacheTopology.Phase.NO_REBALANCE, initialTopology.getPhase());
+
+      try {
+         ClusteredGetCommand command =
+            TestingUtil.extractCommandsFactory(cache(0)).buildClusteredGetCommand("key", 0L);
+         RpcManager rpcManager0 = cache(0).getAdvancedCache().getRpcManager();
+
+         // Add a node to the cache topology, but not to the JGroups cluster view
+         List<Address> newMembers = new ArrayList<>(initialTopology.getMembers());
+         newMembers.add(SUSPECT);
+         ConsistentHash newCH = new ReplicatedConsistentHashFactory().create(MurmurHash3.getInstance(), 1, 1,
+                                                                             newMembers, null);
+         CacheTopology suspectTopology =
+            new CacheTopology(initialTopology.getTopologyId(), initialTopology.getRebalanceId(), newCH, null, null,
+                              CacheTopology.Phase.NO_REBALANCE, newCH.getMembers(), null);
+         distributionManager.setCacheTopology(suspectTopology);
+
+         command.setTopologyId(rpcManager0.getTopologyId());
+         CompletionStage<Map<Address, Response>> stage1 =
+            rpcManager0.invokeCommandOnAll(command, MapResponseCollector.validOnly(), rpcManager0.getSyncRpcOptions());
+         Exceptions.expectExecutionException(SuspectException.class, stage1.toCompletableFuture());
+      } finally {
+         distributionManager.setCacheTopology(initialTopology);
+      }
    }
 
    public void testInvokeCommandStaggered() throws Exception {

--- a/core/src/test/java/org/infinispan/replication/ForceSyncAsyncFlagsTest.java
+++ b/core/src/test/java/org/infinispan/replication/ForceSyncAsyncFlagsTest.java
@@ -6,8 +6,6 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
-import java.util.concurrent.TimeUnit;
-
 import org.infinispan.AdvancedCache;
 import org.infinispan.commands.ReplicableCommand;
 import org.infinispan.configuration.cache.CacheMode;
@@ -16,7 +14,6 @@ import org.infinispan.context.Flag;
 import org.infinispan.remoting.inboundhandler.DeliverOrder;
 import org.infinispan.remoting.rpc.RpcManager;
 import org.infinispan.remoting.rpc.RpcManagerImpl;
-import org.infinispan.remoting.transport.ResponseCollector;
 import org.infinispan.remoting.transport.Transport;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
@@ -55,9 +52,7 @@ public class ForceSyncAsyncFlagsTest extends MultipleCacheManagersTest {
 
       // check that the replication call was sync
       cache1.put("k", "v");
-      verify(mockTransport)
-            .invokeCommandOnAll(any(ReplicableCommand.class), any(ResponseCollector.class), any(DeliverOrder.class),
-                                anyLong(), any(TimeUnit.class));
+      verify(mockTransport).invokeCommandOnAll(any(), any(), any(), any(), anyLong(), any());
 
       reset(mockTransport);
 
@@ -88,8 +83,6 @@ public class ForceSyncAsyncFlagsTest extends MultipleCacheManagersTest {
 
       // verify FORCE_SYNCHRONOUS flag on ASYNC cache
       cache1.withFlags(Flag.FORCE_SYNCHRONOUS).put("k", "v");
-      verify(mockTransport)
-            .invokeCommandOnAll(any(ReplicableCommand.class), any(ResponseCollector.class), any(DeliverOrder.class),
-                                anyLong(), any(TimeUnit.class));
+      verify(mockTransport).invokeCommandOnAll(any(), any(), any(), any(), anyLong(), any());
    }
 }

--- a/core/src/test/java/org/infinispan/replication/SyncReplTest.java
+++ b/core/src/test/java/org/infinispan/replication/SyncReplTest.java
@@ -8,8 +8,6 @@ import static org.mockito.Mockito.verify;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNull;
 
-import java.util.concurrent.TimeUnit;
-
 import org.infinispan.Cache;
 import org.infinispan.commands.ReplicableCommand;
 import org.infinispan.configuration.cache.CacheMode;
@@ -17,7 +15,6 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.remoting.inboundhandler.DeliverOrder;
 import org.infinispan.remoting.rpc.RpcManager;
 import org.infinispan.remoting.rpc.RpcManagerImpl;
-import org.infinispan.remoting.transport.ResponseCollector;
 import org.infinispan.remoting.transport.Transport;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
@@ -153,8 +150,7 @@ public class SyncReplTest extends MultipleCacheManagersTest {
          // check that the replication call was sync
          cache1.put("k", "v");
          verify(mockTransport)
-               .invokeCommandOnAll(any(ReplicableCommand.class), any(ResponseCollector.class), any(DeliverOrder.class),
-                                   anyLong(), any(TimeUnit.class));
+               .invokeCommandOnAll(any(), any(), any(), any(), anyLong(), any());
 
          // resume to test for async
          asyncRpcManager = (RpcManagerImpl) TestingUtil.extractComponent(asyncCache1, RpcManager.class);

--- a/core/src/test/java/org/infinispan/test/TestingUtil.java
+++ b/core/src/test/java/org/infinispan/test/TestingUtil.java
@@ -2,6 +2,7 @@ package org.infinispan.test;
 
 import static java.io.File.separator;
 import static org.infinispan.commons.api.BasicCacheContainer.DEFAULT_CACHE_NAME;
+import static org.infinispan.commons.util.Util.EMPTY_OBJECT_ARRAY;
 import static org.infinispan.persistence.manager.PersistenceManager.AccessMode.BOTH;
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.fail;
@@ -13,6 +14,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.Serializable;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -49,7 +51,6 @@ import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
 import javax.management.MBeanInfo;
 import javax.management.MBeanOperationInfo;
 import javax.management.MBeanParameterInfo;
@@ -1856,6 +1857,13 @@ public class TestingUtil {
                matching = currentMatch;
             }
          }
+      }
+   }
+
+   public static void invokeLifecycle(Object component, Class<? extends Annotation> lifecycle) {
+      List<Method> methods = ReflectionUtil.getAllMethods(component.getClass(), lifecycle);
+      for (Method m : methods) {
+         ReflectionUtil.invokeAccessibly(component, m, EMPTY_OBJECT_ARRAY);
       }
    }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-9008

I added an `ImmutableHopscotchHashSet` mainly because I didn't want to have both a `unmodifiableSet()` wrapper and `HashSet` wrapping `HashMap`. Considering addresses are random numbers I don't think hopscotch hashing per se can help with performance, but maybe we could do something to optimize `containsAll` @rvansa?