### PR TITLE
ISPN-9062 JGroupsTransport should only send messages to nodes in the …

### DIFF
--- a/core/src/main/java/org/infinispan/remoting/transport/AbstractRequest.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/AbstractRequest.java
@@ -7,6 +7,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
+import org.infinispan.remoting.transport.impl.Request;
 import org.infinispan.remoting.transport.impl.RequestRepository;
 
 /**

--- a/core/src/main/java/org/infinispan/remoting/transport/impl/Request.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/impl/Request.java
@@ -1,10 +1,10 @@
-package org.infinispan.remoting.transport;
+package org.infinispan.remoting.transport.impl;
 
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
 
-import org.infinispan.commons.util.Experimental;
 import org.infinispan.remoting.responses.Response;
+import org.infinispan.remoting.transport.Address;
 
 /**
  * A remote command invocation request.
@@ -12,7 +12,6 @@ import org.infinispan.remoting.responses.Response;
  * @author Dan Berindei
  * @since 9.1
  */
-@Experimental
 public interface Request<T> extends CompletionStage<T> {
    long NO_REQUEST_ID = 0;
 
@@ -28,8 +27,10 @@ public interface Request<T> extends CompletionStage<T> {
 
    /**
     * Called when the node received a new cluster view.
+    *
+    * @return {@code true} if any of the request targets is not in the view.
     */
-   void onNewView(Set<Address> members);
+   boolean onNewView(Set<Address> members);
 
    /**
     * Complete the request with an exception and release its resources.

--- a/core/src/main/java/org/infinispan/remoting/transport/impl/RequestRepository.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/impl/RequestRepository.java
@@ -6,7 +6,6 @@ import java.util.function.Consumer;
 
 import org.infinispan.remoting.responses.Response;
 import org.infinispan.remoting.transport.Address;
-import org.infinispan.remoting.transport.Request;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 

--- a/core/src/main/java/org/infinispan/remoting/transport/impl/SingleTargetRequest.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/impl/SingleTargetRequest.java
@@ -36,11 +36,12 @@ public class SingleTargetRequest<T> extends AbstractRequest<T> {
    }
 
    @Override
-   public void onNewView(Set<Address> members) {
+   public boolean onNewView(Set<Address> members) {
       boolean targetIsMissing = !members.contains(target);
       if (targetIsMissing) {
          receiveResponse(target, CacheNotFoundResponse.INSTANCE);
       }
+      return targetIsMissing;
    }
 
    private void receiveResponse(Address sender, Response response) {

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/ClusterView.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/ClusterView.java
@@ -65,6 +65,10 @@ public class ClusterView {
       return isCoordinator;
    }
 
+   boolean contains(Address address) {
+      return getMembersSet().contains(address);
+   }
+
    @Override
    public String toString() {
       return coordinator + "|" + viewId + members;

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
@@ -271,6 +271,7 @@ public class JGroupsTransport implements Transport {
    }
 
    @Override
+   @Deprecated
    public Map<Address, Response> invokeRemotely(Map<Address, ReplicableCommand> commands, ResponseMode mode,
                                                 long timeout, ResponseFilter responseFilter, DeliverOrder deliverOrder,
                                                 boolean anycast)
@@ -813,8 +814,10 @@ public class JGroupsTransport implements Transport {
       logRequest(requestId, command, target);
       SingleTargetRequest<T> request = new SingleTargetRequest<>(collector, requestId, requests, target);
       addRequest(request);
-      boolean checkView = request.onNewView(clusterView.getMembersSet());
-      sendCommand(target, command, requestId, deliverOrder, isRsvpCommand(command), true, checkView);
+      boolean invalidTarget = request.onNewView(clusterView.getMembersSet());
+      if (!invalidTarget) {
+         sendCommand(target, command, requestId, deliverOrder, isRsvpCommand(command), true, false);
+      }
       if (timeout > 0) {
          request.setTimeout(timeoutExecutor, timeout, unit);
       }

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/SingleSiteRequest.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/SingleSiteRequest.java
@@ -33,8 +33,9 @@ public class SingleSiteRequest<T> extends AbstractRequest<T> {
    }
 
    @Override
-   public void onNewView(Set<Address> members) {
+   public boolean onNewView(Set<Address> members) {
       // Ignore cluster views.
+      return false;
    }
 
    private void receiveResponse(Address sender, Response response) {

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/StaggeredRequest.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/StaggeredRequest.java
@@ -92,7 +92,7 @@ public class StaggeredRequest<T> extends MultiTargetRequest<T> {
          }
 
          // Sending may block in flow-control or even in TCP, so we must do it outside the critical section
-         transport.sendCommand(target, command, requestId, deliverOrder, false, true);
+         transport.sendCommand(target, command, requestId, deliverOrder, false, true, false);
 
          // Scheduling the timeout task may also block
          // If this is the last target, set the request timeout at the deadline

--- a/core/src/test/java/org/infinispan/util/CountingRequestRepository.java
+++ b/core/src/test/java/org/infinispan/util/CountingRequestRepository.java
@@ -8,7 +8,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.infinispan.factories.GlobalComponentRegistry;
 import org.infinispan.manager.EmbeddedCacheManager;
-import org.infinispan.remoting.transport.Request;
+import org.infinispan.remoting.transport.impl.Request;
 import org.infinispan.remoting.transport.impl.RequestRepository;
 import org.infinispan.remoting.transport.Transport;
 import org.infinispan.remoting.transport.jgroups.JGroupsTransport;


### PR DESCRIPTION
…cluster view

https://issues.jboss.org/browse/ISPN-9062

* Only check the view if Request.onNewView removed a target
* Move Request to the impl package, it's too low-level to expose
  in the Transport/RpcManager API