### PR TITLE
ISPN-9081 Expose Query.getQueryString() as official API

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/event/ContinuousQueryImpl.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/event/ContinuousQueryImpl.java
@@ -19,7 +19,6 @@ import org.infinispan.protostream.SerializationContext;
 import org.infinispan.query.api.continuous.ContinuousQuery;
 import org.infinispan.query.api.continuous.ContinuousQueryListener;
 import org.infinispan.query.dsl.Query;
-import org.infinispan.query.dsl.impl.BaseQuery;
 import org.infinispan.query.remote.client.ContinuousQueryResult;
 
 /**
@@ -67,8 +66,7 @@ public final class ContinuousQueryImpl<K, V> implements ContinuousQuery<K, V> {
     * @param query    the query to be used for determining the matching set
     */
    public <C> void addContinuousQueryListener(Query query, ContinuousQueryListener<K, C> listener) {
-      BaseQuery baseQuery = (BaseQuery) query;
-      addContinuousQueryListener(baseQuery.getQueryString(), baseQuery.getParameters(), listener);
+      addContinuousQueryListener(query.getQueryString(), query.getParameters(), listener);
    }
 
    public void removeContinuousQueryListener(ContinuousQueryListener<K, ?> listener) {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/filter/Filters.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/filter/Filters.java
@@ -3,7 +3,6 @@ package org.infinispan.client.hotrod.filter;
 import java.util.Map;
 
 import org.infinispan.query.dsl.Query;
-import org.infinispan.query.dsl.impl.BaseQuery;
 
 /**
  * @author gustavonalle
@@ -39,7 +38,6 @@ public final class Filters {
    }
 
    public static Object[] makeFactoryParams(Query query) {
-      BaseQuery baseQuery = (BaseQuery) query;
-      return makeFactoryParams(baseQuery.getQueryString(), baseQuery.getParameters());
+      return makeFactoryParams(query.getQueryString(), query.getParameters());
    }
 }

--- a/object-filter/src/main/java/org/infinispan/objectfilter/impl/BaseMatcher.java
+++ b/object-filter/src/main/java/org/infinispan/objectfilter/impl/BaseMatcher.java
@@ -19,7 +19,6 @@ import org.infinispan.objectfilter.impl.syntax.parser.IckleParsingResult;
 import org.infinispan.objectfilter.impl.syntax.parser.IckleParser;
 import org.infinispan.objectfilter.impl.syntax.parser.ObjectPropertyHelper;
 import org.infinispan.query.dsl.Query;
-import org.infinispan.query.dsl.impl.BaseQuery;
 import org.jboss.logging.Logger;
 
 /**
@@ -123,7 +122,7 @@ public abstract class BaseMatcher<TypeMetadata, AttributeMetadata, AttributeId e
 
    @Override
    public ObjectFilter getObjectFilter(Query query) {
-      return getObjectFilter(((BaseQuery) query).getQueryString(), null);
+      return getObjectFilter(query.getQueryString(), null);
    }
 
    @Override
@@ -168,8 +167,7 @@ public abstract class BaseMatcher<TypeMetadata, AttributeMetadata, AttributeId e
 
    @Override
    public FilterSubscription registerFilter(Query query, FilterCallback callback, boolean isDeltaFilter, Object... eventType) {
-      BaseQuery baseQuery = (BaseQuery) query;
-      return registerFilter(baseQuery.getQueryString(), baseQuery.getParameters(), callback, isDeltaFilter, eventType);
+      return registerFilter(query.getQueryString(), query.getParameters(), callback, isDeltaFilter, eventType);
    }
 
    @Override

--- a/query-dsl/src/main/java/org/infinispan/query/dsl/Query.java
+++ b/query-dsl/src/main/java/org/infinispan/query/dsl/Query.java
@@ -14,6 +14,11 @@ import java.util.List;
 public interface Query extends PaginationContext<Query>, ParameterContext<Query> {
 
    /**
+    * Returns the Ickle query string.
+    */
+   String getQueryString();
+
+   /**
     * Returns the results of a search as a list.
     *
     * @return list of objects that were found from the search.

--- a/query-dsl/src/main/java/org/infinispan/query/dsl/impl/BaseQuery.java
+++ b/query-dsl/src/main/java/org/infinispan/query/dsl/impl/BaseQuery.java
@@ -66,10 +66,11 @@ public abstract class BaseQuery implements Query {
    }
 
    /**
-    * Returns the query string.
+    * Returns the Ickle query string.
     *
-    * @return the query string
+    * @return the Ickle query string
     */
+   @Override
    public String getQueryString() {
       return queryString;
    }

--- a/query-dsl/src/test/java/org/infinispan/query/dsl/impl/DummyQuery.java
+++ b/query-dsl/src/test/java/org/infinispan/query/dsl/impl/DummyQuery.java
@@ -28,6 +28,11 @@ class DummyQuery implements Query {
    }
 
    @Override
+   public String getQueryString() {
+      return null;
+   }
+
+   @Override
    public <T> List<T> list() {
       return Collections.emptyList();
    }

--- a/query/src/main/java/org/infinispan/query/Search.java
+++ b/query/src/main/java/org/infinispan/query/Search.java
@@ -15,7 +15,6 @@ import org.infinispan.query.dsl.embedded.impl.EmbeddedQueryEngine;
 import org.infinispan.query.dsl.embedded.impl.EmbeddedQueryFactory;
 import org.infinispan.query.dsl.embedded.impl.IckleCacheEventFilterConverter;
 import org.infinispan.query.dsl.embedded.impl.IckleFilterAndConverter;
-import org.infinispan.query.dsl.impl.BaseQuery;
 import org.infinispan.query.impl.SearchManagerImpl;
 import org.infinispan.query.logging.Log;
 import org.infinispan.security.AuthorizationManager;
@@ -45,8 +44,7 @@ public final class Search {
    }
 
    public static <K, V> CacheEventFilterConverter<K, V, ObjectFilter.FilterResult> makeFilter(Query query) {
-      BaseQuery baseQuery = (BaseQuery) query;
-      return makeFilter(baseQuery.getQueryString(), baseQuery.getParameters());
+      return makeFilter(query.getQueryString(), query.getParameters());
    }
 
    public static QueryFactory getQueryFactory(Cache<?, ?> cache) {

--- a/query/src/main/java/org/infinispan/query/continuous/impl/ContinuousQueryImpl.java
+++ b/query/src/main/java/org/infinispan/query/continuous/impl/ContinuousQueryImpl.java
@@ -16,7 +16,6 @@ import org.infinispan.objectfilter.impl.ReflectionMatcher;
 import org.infinispan.query.api.continuous.ContinuousQuery;
 import org.infinispan.query.api.continuous.ContinuousQueryListener;
 import org.infinispan.query.dsl.Query;
-import org.infinispan.query.dsl.impl.BaseQuery;
 
 /**
  * A container of continuous query listeners for a cache.
@@ -54,8 +53,7 @@ public final class ContinuousQueryImpl<K, V> implements ContinuousQuery<K, V> {
 
    @Override
    public <C> void addContinuousQueryListener(Query query, ContinuousQueryListener<K, C> listener) {
-      BaseQuery baseQuery = (BaseQuery) query;
-      addContinuousQueryListener(baseQuery.getQueryString(), baseQuery.getParameters(), listener);
+      addContinuousQueryListener(query.getQueryString(), query.getParameters(), listener);
    }
 
    @Override


### PR DESCRIPTION
* we no longer need to cast to BaseQuery in order to access it

https://issues.jboss.org/browse/ISPN-9081