### PR TITLE
ISPN-8719 KeySet.(iterator|spliterator|stream) not compatible with

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec26.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec26.java
@@ -3,15 +3,11 @@ package org.infinispan.client.hotrod.impl.protocol;
 import java.lang.annotation.Annotation;
 import java.util.Set;
 
-import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.annotation.ClientCacheEntryCreated;
 import org.infinispan.client.hotrod.annotation.ClientCacheEntryExpired;
 import org.infinispan.client.hotrod.annotation.ClientCacheEntryModified;
 import org.infinispan.client.hotrod.annotation.ClientCacheEntryRemoved;
-import org.infinispan.client.hotrod.impl.operations.OperationsFactory;
 import org.infinispan.client.hotrod.impl.transport.Transport;
-import org.infinispan.commons.util.CloseableIterator;
-import org.infinispan.commons.util.CloseableIteratorMapper;
 
 /**
  * @since 8.2
@@ -36,14 +32,5 @@ public class Codec26 extends Codec25 {
          listenerInterests = (byte) (listenerInterests | 0x08);
 
       transport.writeVInt(listenerInterests);
-   }
-
-   @Override
-   public <K> CloseableIterator<K> keyIterator(RemoteCache<K, ?> remoteCache, OperationsFactory operationsFactory,
-         int batchSize) {
-      return new CloseableIteratorMapper<>(remoteCache.retrieveEntries(
-            // Use the ToEmptyBytesKeyValueFilterConverter to remove value payload
-            "org.infinispan.server.hotrod.HotRodServer$ToEmptyBytesKeyValueFilterConverter", batchSize),
-            e -> (K) e.getKey());
    }
 }


### PR DESCRIPTION
versions before 9.1

* Fixed issue where 9.1+ clients couldn't talk to 9.0 still

https://issues.jboss.org/browse/ISPN-8719