### PR TITLE
ISPN-9087 Timeout during put operation when a node is blocked

### DIFF
--- a/cloud/src/main/resources/default-configs/default-jgroups-ec2.xml
+++ b/cloud/src/main/resources/default-configs/default-jgroups-ec2.xml
@@ -24,11 +24,12 @@
            max_interval="30000" 
    />
    <FD_SOCK />
-   <FD_ALL timeout="60000" 
-           interval="15000" 
-           timeout_check_interval="5000" 
+   <!-- Suspect node `timeout` to `timeout + timeout_check_interval` millis after the last heartbeat -->
+   <FD_ALL timeout="10000"
+           interval="2000"
+           timeout_check_interval="1000"
    />
-   <VERIFY_SUSPECT timeout="5000" />
+   <VERIFY_SUSPECT timeout="1000"/>
    <pbcast.NAKACK2 use_mcast_xmit="false"
                    xmit_interval="100"
                    xmit_table_num_rows="50"
@@ -48,7 +49,7 @@
    <pbcast.GMS print_local_addr="false"
                join_timeout="${jgroups.join_timeout:5000}"
    />
-   <MFC max_credits="2m" 
+   <MFC max_credits="2m"
         min_threshold="0.40"
    />
    <FRAG3/>

--- a/cloud/src/main/resources/default-configs/default-jgroups-google.xml
+++ b/cloud/src/main/resources/default-configs/default-jgroups-google.xml
@@ -22,11 +22,12 @@
            max_interval="30000" 
    />
    <FD_SOCK />
-   <FD_ALL timeout="60000" 
-           interval="15000" 
-           timeout_check_interval="5000" 
+   <!-- Suspect node `timeout` to `timeout + timeout_check_interval` millis after the last heartbeat -->
+   <FD_ALL timeout="10000"
+           interval="2000"
+           timeout_check_interval="1000"
    />
-   <VERIFY_SUSPECT timeout="5000" />
+   <VERIFY_SUSPECT timeout="1000"/>
    <pbcast.NAKACK2 use_mcast_xmit="false"
                    xmit_interval="100"
                    xmit_table_num_rows="50"

--- a/cloud/src/main/resources/default-configs/default-jgroups-kubernetes.xml
+++ b/cloud/src/main/resources/default-configs/default-jgroups-kubernetes.xml
@@ -21,11 +21,12 @@
            max_interval="30000" 
    />
    <FD_SOCK />
-   <FD_ALL timeout="60000" 
-           interval="15000" 
-           timeout_check_interval="5000" 
+   <!-- Suspect node `timeout` to `timeout + timeout_check_interval` millis after the last heartbeat -->
+   <FD_ALL timeout="10000"
+           interval="2000"
+           timeout_check_interval="1000"
    />
-   <VERIFY_SUSPECT timeout="5000" />
+   <VERIFY_SUSPECT timeout="1000"/>
    <pbcast.NAKACK2 use_mcast_xmit="false"
                    xmit_interval="100"
                    xmit_table_num_rows="50"

--- a/core/src/main/java/org/infinispan/configuration/cache/BackupConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/BackupConfiguration.java
@@ -11,7 +11,7 @@ import org.infinispan.commons.configuration.attributes.AttributeSet;
 public class BackupConfiguration {
    public static final AttributeDefinition<String> SITE = AttributeDefinition.builder("site", null, String.class).immutable().build();
    public static final AttributeDefinition<BackupConfiguration.BackupStrategy> STRATEGY = AttributeDefinition.builder("strategy", BackupConfiguration.BackupStrategy.ASYNC).immutable().build();
-   public static final AttributeDefinition<Long> REPLICATION_TIMEOUT = AttributeDefinition.builder("replicationTimeout", 10000l).xmlName("timeout").build();
+   public static final AttributeDefinition<Long> REPLICATION_TIMEOUT = AttributeDefinition.builder("replicationTimeout", 15000L).xmlName("timeout").build();
    public static final AttributeDefinition<BackupFailurePolicy> FAILURE_POLICY = AttributeDefinition.builder("backupFailurePolicy", BackupFailurePolicy.WARN).xmlName("failure-policy").build();
    public static final AttributeDefinition<String> FAILURE_POLICY_CLASS = AttributeDefinition.builder("failurePolicyClass", null, String.class).immutable().build();
    public static final AttributeDefinition<Boolean> USE_TWO_PHASE_COMMIT = AttributeDefinition.builder("useTwoPhaseCommit", false).immutable().xmlName("two-phase-commit").build();

--- a/core/src/main/resources/default-configs/default-jgroups-tcp.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-tcp.xml
@@ -22,11 +22,12 @@
            max_interval="30000" 
    />
    <FD_SOCK />
-   <FD_ALL timeout="60000" 
-           interval="15000" 
-           timeout_check_interval="5000" 
+   <!-- Suspect node `timeout` to `timeout + timeout_check_interval` millis after the last heartbeat -->
+   <FD_ALL timeout="10000"
+           interval="2000"
+           timeout_check_interval="1000"
    />
-   <VERIFY_SUSPECT timeout="5000" />
+   <VERIFY_SUSPECT timeout="1000"/>
    <pbcast.NAKACK2 use_mcast_xmit="false"
                    xmit_interval="100"
                    xmit_table_num_rows="50"

--- a/core/src/main/resources/default-configs/default-jgroups-udp.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-udp.xml
@@ -22,12 +22,12 @@
            max_interval="30000" 
    />
    <FD_SOCK />
-   <FD_ALL timeout="60000" 
-           interval="15000" 
-           timeout_check_interval="5000" 
+   <!-- Suspect node `timeout` to `timeout + timeout_check_interval` millis after the last heartbeat -->
+   <FD_ALL timeout="10000"
+           interval="2000"
+           timeout_check_interval="1000"
    />
-   <VERIFY_SUSPECT timeout="5000" 
-   />
+   <VERIFY_SUSPECT timeout="1000"/>
    <pbcast.NAKACK2 xmit_interval="100"
                    xmit_table_num_rows="50"
                    xmit_table_msgs_per_row="1024"

--- a/core/src/test/java/org/infinispan/xsite/XSiteFileParsing2Test.java
+++ b/core/src/test/java/org/infinispan/xsite/XSiteFileParsing2Test.java
@@ -61,10 +61,10 @@ public class XSiteFileParsing2Test extends SingleCacheManagerTest {
             .backupFailurePolicy(BackupFailurePolicy.IGNORE).failurePolicyClass(null).replicationTimeout(12003)
             .useTwoPhaseCommit(false).enabled(true).create();
       BackupConfiguration sfo = new BackupConfigurationBuilder(null).site("SFO").strategy(BackupStrategy.ASYNC)
-            .backupFailurePolicy(BackupFailurePolicy.WARN).failurePolicyClass(null).replicationTimeout(10000)
+            .backupFailurePolicy(BackupFailurePolicy.WARN).failurePolicyClass(null).replicationTimeout(15000)
             .useTwoPhaseCommit(false).enabled(true).create();
       BackupConfiguration lon = new BackupConfigurationBuilder(null).site("LON").strategy(BackupStrategy.SYNC)
-            .backupFailurePolicy(BackupFailurePolicy.WARN).failurePolicyClass(null).replicationTimeout(10000)
+            .backupFailurePolicy(BackupFailurePolicy.WARN).failurePolicyClass(null).replicationTimeout(15000)
             .useTwoPhaseCommit(false).enabled(false).create();
       assertTrue(dcc.sites().allBackups().contains(nyc));
       assertTrue(dcc.sites().allBackups().contains(sfo));

--- a/core/src/test/java/org/infinispan/xsite/XSiteFileParsingTest.java
+++ b/core/src/test/java/org/infinispan/xsite/XSiteFileParsingTest.java
@@ -76,7 +76,7 @@ public class XSiteFileParsingTest extends SingleCacheManagerTest {
             .useTwoPhaseCommit(false).enabled(true);
       assertTrue(dcc.sites().allBackups().contains(nyc.create()));
       BackupConfigurationBuilder sfo = new BackupConfigurationBuilder(null).site("SFO").strategy(BackupStrategy.ASYNC)
-            .backupFailurePolicy(BackupFailurePolicy.WARN).failurePolicyClass(null).replicationTimeout(10000)
+            .backupFailurePolicy(BackupFailurePolicy.WARN).failurePolicyClass(null).replicationTimeout(15000)
             .useTwoPhaseCommit(false).enabled(true);
       assertTrue(dcc.sites().allBackups().contains(sfo.create()));
    }

--- a/core/src/test/resources/configs/xsite/bridge.xml
+++ b/core/src/test/resources/configs/xsite/bridge.xml
@@ -43,8 +43,10 @@
             xmit_table_msgs_per_row="1024"
             xmit_table_max_compaction_time="30000"
     />
-    <pbcast.STABLE stability_delay="1000" desired_avg_gossip="50000"
-                   max_bytes="8m"/>
+    <pbcast.STABLE stability_delay="200"
+                   desired_avg_gossip="2000"
+                   max_bytes="1M"
+    />
     <pbcast.GMS print_local_addr="false"
                 join_timeout="${jgroups.join_timeout:2000}"/>
 

--- a/core/src/test/resources/stacks/tcp.xml
+++ b/core/src/test/resources/stacks/tcp.xml
@@ -56,7 +56,10 @@
               xmit_table_msgs_per_row="1024"
               xmit_table_max_compaction_time="30000"
    />
-   <pbcast.STABLE stability_delay="500" desired_avg_gossip="5000" max_bytes="1m"/>
+   <pbcast.STABLE stability_delay="200"
+                  desired_avg_gossip="2000"
+                  max_bytes="1M"
+   />
    <pbcast.GMS print_local_addr="false"
                join_timeout="${jgroups.join_timeout:2000}"/>
    <tom.TOA/> <!-- the Total Order Anycast is only needed for total order transactions (in distributed mode)-->

--- a/core/src/test/resources/stacks/tcp.xml
+++ b/core/src/test/resources/stacks/tcp.xml
@@ -35,12 +35,11 @@
    <MERGE3 min_interval="1000" max_interval="5000"/>
 
    <FD_SOCK sock_conn_timeout="3000"/>
-   <!--
-       Note that this is an atypically short timeout and a small number of retries
-       configured this way to speed up unit testing, since we know all nodes run in the same JVM
-       and hence failure detections will be very quick.
-          -->
-   <FD_ALL interval="1000" timeout="4000" timeout_check_interval="1000"/>
+   <!-- Suspect node `timeout` to `timeout + timeout_check_interval` millis after the last heartbeat -->
+   <FD_ALL timeout="3000"
+           interval="1000"
+           timeout_check_interval="1000"
+   />
    <VERIFY_SUSPECT timeout="1000"/>
 
    <!-- resend_last_seqno_max_times=10000 is a workaround for JGRP-2167  -->

--- a/core/src/test/resources/stacks/tcp_mping/tcp1.xml
+++ b/core/src/test/resources/stacks/tcp_mping/tcp1.xml
@@ -25,13 +25,12 @@
 
    <MERGE3/>
    <FD_SOCK/>
-   <!--
-       Note that this is an atypically short timeout and a small number of retries
-       configured this way to speed up unit testing, since we know all nodes run in the same JVM
-       and hence failure detections will be very quick.
-          -->
-   <FD_ALL interval="1000" timeout="4000" timeout_check_interval="1000"/>
-   <VERIFY_SUSPECT timeout="1500"/>
+   <!-- Suspect node `timeout` to `timeout + timeout_check_interval` millis after the last heartbeat -->
+   <FD_ALL timeout="3000"
+           interval="1000"
+           timeout_check_interval="1000"
+   />
+   <VERIFY_SUSPECT timeout="1000"/>
    <pbcast.NAKACK2
    					use_mcast_xmit="false"
                     xmit_interval="100"

--- a/core/src/test/resources/stacks/tcp_mping/tcp1.xml
+++ b/core/src/test/resources/stacks/tcp_mping/tcp1.xml
@@ -43,9 +43,11 @@
               xmit_table_msgs_per_row="1024"
               xmit_table_max_compaction_time="30000"
    />
-   <RSVP />           
-   <pbcast.STABLE stability_delay="1000" desired_avg_gossip="50000"
-                  max_bytes="400000"/>
+   <RSVP />
+   <pbcast.STABLE stability_delay="200"
+                  desired_avg_gossip="2000"
+                  max_bytes="1M"
+   />
    <pbcast.GMS print_local_addr="false"
                join_timeout="${jgroups.join_timeout:2000}"/>
    <tom.TOA/> <!-- the Total Order Anycast is only needed for total order transactions (in distributed mode)-->

--- a/core/src/test/resources/stacks/tcp_mping/tcp2.xml
+++ b/core/src/test/resources/stacks/tcp_mping/tcp2.xml
@@ -25,12 +25,11 @@
 
    <MERGE3/>
    <FD_SOCK/>
-   <!--
-       Note that this is an atypically short timeout and a small number of retries
-       configured this way to speed up unit testing, since we know all nodes run in the same JVM
-       and hence failure detections will be very quick.
-          -->
-   <FD_ALL interval="1000" timeout="4000" timeout_check_interval="1000"/>
+   <!-- Suspect node `timeout` to `timeout + timeout_check_interval` millis after the last heartbeat -->
+   <FD_ALL timeout="3000"
+           interval="1000"
+           timeout_check_interval="1000"
+   />
    <VERIFY_SUSPECT timeout="1000"/>
    <pbcast.NAKACK2
    					use_mcast_xmit="false"

--- a/core/src/test/resources/stacks/tcp_mping/tcp2.xml
+++ b/core/src/test/resources/stacks/tcp_mping/tcp2.xml
@@ -44,8 +44,10 @@
               xmit_table_max_compaction_time="30000"
    />
    <RSVP />
-   <pbcast.STABLE stability_delay="1000" desired_avg_gossip="50000"
-                  max_bytes="400000"/>
+   <pbcast.STABLE stability_delay="200"
+                  desired_avg_gossip="2000"
+                  max_bytes="1M"
+   />
    <pbcast.GMS print_local_addr="false"
                join_timeout="${jgroups.join_timeout:2000}"/>
    <tom.TOA/> <!-- the Total Order Anycast is only needed for total order transactions (in distributed mode)-->

--- a/core/src/test/resources/stacks/udp.xml
+++ b/core/src/test/resources/stacks/udp.xml
@@ -26,7 +26,11 @@
 
    <MERGE3 min_interval="1000" max_interval="5000"/>
    <FD_SOCK sock_conn_timeout="3000"/>
-   <FD_ALL interval="1000" timeout="4000" timeout_check_interval="1000"/>
+   <!-- Suspect node `timeout` to `timeout + timeout_check_interval` millis after the last heartbeat -->
+   <FD_ALL timeout="3000"
+           interval="1000"
+           timeout_check_interval="1000"
+   />
    <VERIFY_SUSPECT timeout="1000"/>
 
    <pbcast.NAKACK2

--- a/core/src/test/resources/stacks/udp.xml
+++ b/core/src/test/resources/stacks/udp.xml
@@ -44,7 +44,10 @@
          xmit_table_msgs_per_row="1024"
          xmit_table_max_compaction_time="30000"
    />
-   <pbcast.STABLE stability_delay="1000" desired_avg_gossip="5000" max_bytes="1m"/>
+   <pbcast.STABLE stability_delay="200"
+                  desired_avg_gossip="2000"
+                  max_bytes="1M"
+   />
    <pbcast.GMS print_local_addr="false"
                join_timeout="${jgroups.join_timeout:2000}"/>
    <tom.TOA/> <!-- the Total Order Anycast is only needed for total order transactions (in distributed mode)-->

--- a/demos/gui/src/main/release/etc/config/jgroups-relay1.xml
+++ b/demos/gui/src/main/release/etc/config/jgroups-relay1.xml
@@ -32,8 +32,12 @@
     <PING/>
     <MERGE3/>
     <FD_SOCK />
-    <FD_ALL />
-    <VERIFY_SUSPECT timeout="1500"  />
+   <!-- Suspect node `timeout` to `timeout + timeout_check_interval` millis after the last heartbeat -->
+    <FD_ALL timeout="10000"
+            interval="2000"
+            timeout_check_interval="1000"
+    />
+    <VERIFY_SUSPECT timeout="1000"/>
     <pbcast.NAKACK2 use_mcast_xmit="true"
                    discard_delivered_msgs="true"/>
     <UNICAST3/>

--- a/demos/gui/src/main/release/etc/config/jgroups-relay1.xml
+++ b/demos/gui/src/main/release/etc/config/jgroups-relay1.xml
@@ -41,8 +41,10 @@
     <pbcast.NAKACK2 use_mcast_xmit="true"
                    discard_delivered_msgs="true"/>
     <UNICAST3/>
-    <pbcast.STABLE stability_delay="1000" desired_avg_gossip="50000"
-                   max_bytes="1000000"/>
+    <pbcast.STABLE stability_delay="500"
+                   desired_avg_gossip="5000"
+                   max_bytes="1M"
+    />
     <pbcast.GMS print_local_addr="true" join_timeout="${jgroups.join_timeout:5000}"
                 max_bundling_time="200"/>
     <UFC max_credits="2M"

--- a/demos/gui/src/main/release/etc/config/jgroups-relay2.xml
+++ b/demos/gui/src/main/release/etc/config/jgroups-relay2.xml
@@ -33,8 +33,12 @@
     <PING/>
     <MERGE3/>
     <FD_SOCK/>
-    <FD_ALL/>
-    <VERIFY_SUSPECT timeout="1500"  />
+    <!-- Suspect node `timeout` to `timeout + timeout_check_interval` millis after the last heartbeat -->
+    <FD_ALL timeout="10000"
+            interval="2000"
+            timeout_check_interval="1000"
+    />
+    <VERIFY_SUSPECT timeout="1000"/>
     <pbcast.NAKACK2 use_mcast_xmit="true"
                    discard_delivered_msgs="true"/>
     <UNICAST3/>

--- a/demos/gui/src/main/release/etc/config/jgroups-relay2.xml
+++ b/demos/gui/src/main/release/etc/config/jgroups-relay2.xml
@@ -42,8 +42,10 @@
     <pbcast.NAKACK2 use_mcast_xmit="true"
                    discard_delivered_msgs="true"/>
     <UNICAST3/>
-    <pbcast.STABLE stability_delay="1000" desired_avg_gossip="50000"
-                   max_bytes="1000000"/>
+    <pbcast.STABLE stability_delay="500"
+                   desired_avg_gossip="5000"
+                   max_bytes="1M"
+    />
     <pbcast.GMS print_local_addr="true" join_timeout="${jgroups.join_timeout:5000}"
                 max_bundling_time="200"/>
     <UFC max_credits="2M"

--- a/demos/gui/src/main/release/etc/config/jgroups-tcp.xml
+++ b/demos/gui/src/main/release/etc/config/jgroups-tcp.xml
@@ -31,8 +31,12 @@
     <MERGE3/>
 
     <FD_SOCK/>
-    <FD_ALL interval="2000" timeout="5000" />
-    <VERIFY_SUSPECT timeout="500"  />
+    <!-- Suspect node `timeout` to `timeout + timeout_check_interval` millis after the last heartbeat -->
+    <FD_ALL timeout="10000"
+            interval="2000"
+            timeout_check_interval="1000"
+    />
+    <VERIFY_SUSPECT timeout="1000"/>
     <pbcast.NAKACK2 use_mcast_xmit="false"
                    discard_delivered_msgs="true" />
     <UNICAST3/>

--- a/demos/gui/src/main/release/etc/config/jgroups-tcp.xml
+++ b/demos/gui/src/main/release/etc/config/jgroups-tcp.xml
@@ -41,8 +41,10 @@
                    discard_delivered_msgs="true" />
     <UNICAST3/>
 
-    <pbcast.STABLE stability_delay="1000" desired_avg_gossip="50000"
-                   max_bytes="10m"/>
+    <pbcast.STABLE stability_delay="500"
+                   desired_avg_gossip="5000"
+                   max_bytes="1M"
+    />
     <pbcast.GMS print_local_addr="true" join_timeout="${jgroups.join_timeout:5000}"
                 max_bundling_time="30"/>
     <MFC max_credits="2M"

--- a/integrationtests/as-lucene-directory/src/test/resources/default-jgroups4-udp.xml
+++ b/integrationtests/as-lucene-directory/src/test/resources/default-jgroups4-udp.xml
@@ -40,8 +40,8 @@
              xmit_table_msgs_per_row="1024"
              xmit_table_max_compaction_time="30000"
    />
-   <pbcast.STABLE stability_delay="500"
-                  desired_avg_gossip="5000"
+   <pbcast.STABLE stability_delay="200"
+                  desired_avg_gossip="2000"
                   max_bytes="1M"
    />
    <pbcast.GMS print_local_addr="false"

--- a/integrationtests/as-lucene-directory/src/test/resources/default-jgroups4-udp.xml
+++ b/integrationtests/as-lucene-directory/src/test/resources/default-jgroups4-udp.xml
@@ -22,11 +22,12 @@
            max_interval="30000" 
    />
    <FD_SOCK />
-   <FD_ALL timeout="60000" 
-           interval="15000" 
-           timeout_check_interval="5000" 
+   <!-- Suspect node `timeout` to `timeout + timeout_check_interval` millis after the last heartbeat -->
+   <FD_ALL timeout="10000"
+           interval="2000"
+           timeout_check_interval="1000"
    />
-   <VERIFY_SUSPECT timeout="5000" 
+   <VERIFY_SUSPECT timeout="1000"
    />
    <pbcast.NAKACK2 xmit_interval="100"
                    xmit_table_num_rows="50"

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node0.xml
@@ -44,8 +44,11 @@
          server_name="node0/clustered"
          login_module_name="krb-node0"
          server_callback_handler_class="org.infinispan.test.integration.security.utils.SaslPropCallbackHandler" />
-         
-   <pbcast.STABLE stability_delay="500" desired_avg_gossip="5000" max_bytes="1m"/>
+
+   <pbcast.STABLE stability_delay="500"
+                  desired_avg_gossip="5000"
+                  max_bytes="1M"
+   />
    <pbcast.GMS print_local_addr="false"
                join_timeout="${jgroups.join_timeout:2000}"/>
 

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node0.xml
@@ -22,7 +22,12 @@
    <MERGE3/>
  
    <FD_SOCK/>
-   <FD_ALL timeout="15000" interval="3000"/>
+   <!-- Suspect node `timeout` to `timeout + timeout_check_interval` millis after the last heartbeat -->
+   <FD_ALL timeout="10000"
+           interval="2000"
+           timeout_check_interval="1000"
+   />
+   <VERIFY_SUSPECT timeout="1000"/>
 
    <pbcast.NAKACK2
                     xmit_interval="100"

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1-fail.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1-fail.xml
@@ -44,7 +44,10 @@
          server_name="node0/clustered"
          login_module_name="krb-node1-fail" />
 
-   <pbcast.STABLE stability_delay="500" desired_avg_gossip="5000" max_bytes="1m"/>
+   <pbcast.STABLE stability_delay="500"
+                  desired_avg_gossip="5000"
+                  max_bytes="1M"
+   />
    <pbcast.GMS print_local_addr="false"
                join_timeout="${jgroups.join_timeout:2000}"/>
    

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1-fail.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1-fail.xml
@@ -22,7 +22,12 @@
    <MERGE3/>
 
    <FD_SOCK/>
-   <FD_ALL timeout="15000" interval="3000"/>
+   <!-- Suspect node `timeout` to `timeout + timeout_check_interval` millis after the last heartbeat -->
+   <FD_ALL timeout="10000"
+           interval="2000"
+           timeout_check_interval="1000"
+   />
+   <VERIFY_SUSPECT timeout="1000"/>
 
    <pbcast.NAKACK2
                     xmit_interval="100"

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1.xml
@@ -44,7 +44,10 @@
          server_name="node0/clustered"
          login_module_name="krb-node1" />
 
-   <pbcast.STABLE stability_delay="500" desired_avg_gossip="5000" max_bytes="1m"/>
+   <pbcast.STABLE stability_delay="500"
+                  desired_avg_gossip="5000"
+                  max_bytes="1M"
+   />
    <pbcast.GMS print_local_addr="false"
                join_timeout="${jgroups.join_timeout:2000}"/>
 

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1.xml
@@ -22,7 +22,12 @@
    <MERGE3/>
 
    <FD_SOCK/>
-   <FD_ALL timeout="15000" interval="3000"/>
+   <!-- Suspect node `timeout` to `timeout + timeout_check_interval` millis after the last heartbeat -->
+   <FD_ALL timeout="10000"
+           interval="2000"
+           timeout_check_interval="1000"
+   />
+   <VERIFY_SUSPECT timeout="1000"/>
 
    <pbcast.NAKACK2
                     xmit_interval="100"

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node0.xml
@@ -46,8 +46,11 @@
          server_callback_handler_class="org.infinispan.test.integration.security.utils.SaslPropCallbackHandler"
          client_callback_handler_class="org.infinispan.test.integration.security.utils.SaslPropCallbackHandler" 
          sasl_props="com.sun.security.sasl.digest.realm=test_realm" />
-         
-   <pbcast.STABLE stability_delay="500" desired_avg_gossip="5000" max_bytes="1m"/>
+
+   <pbcast.STABLE stability_delay="500"
+                  desired_avg_gossip="5000"
+                  max_bytes="1M"
+   />
    <pbcast.GMS print_local_addr="false"
                join_timeout="${jgroups.join_timeout:2000}"/>
 

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node0.xml
@@ -22,7 +22,12 @@
    <MERGE3/>
 
    <FD_SOCK/>
-   <FD_ALL timeout="15000" interval="3000"/>
+   <!-- Suspect node `timeout` to `timeout + timeout_check_interval` millis after the last heartbeat -->
+   <FD_ALL timeout="10000"
+           interval="2000"
+           timeout_check_interval="1000"
+   />
+   <VERIFY_SUSPECT timeout="1000"/>
 
    <pbcast.NAKACK2
                     xmit_interval="100"

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node1.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node1.xml
@@ -43,7 +43,10 @@
    <SASL mech="DIGEST-MD5" 
          client_callback_handler_class="org.infinispan.test.integration.security.utils.SaslPropCallbackHandler" />
 
-   <pbcast.STABLE stability_delay="500" desired_avg_gossip="5000" max_bytes="1m"/>
+   <pbcast.STABLE stability_delay="500"
+                  desired_avg_gossip="5000"
+                  max_bytes="1M"
+   />
    <pbcast.GMS print_local_addr="false"
                join_timeout="${jgroups.join_timeout:2000}"/>
 

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node1.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node1.xml
@@ -22,7 +22,12 @@
    <MERGE3/>
 
    <FD_SOCK/>
-   <FD_ALL timeout="15000" interval="3000"/>
+   <!-- Suspect node `timeout` to `timeout + timeout_check_interval` millis after the last heartbeat -->
+   <FD_ALL timeout="10000"
+           interval="2000"
+           timeout_check_interval="1000"
+   />
+   <VERIFY_SUSPECT timeout="1000"/>
 
    <pbcast.NAKACK2
                     xmit_interval="100"

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-user-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-user-node0.xml
@@ -22,7 +22,12 @@
    <MERGE3/>
 
    <FD_SOCK/>
-   <FD_ALL timeout="15000" interval="3000"/>
+   <!-- Suspect node `timeout` to `timeout + timeout_check_interval` millis after the last heartbeat -->
+   <FD_ALL timeout="10000"
+           interval="2000"
+           timeout_check_interval="1000"
+   />
+   <VERIFY_SUSPECT timeout="1000"/>
 
    <pbcast.NAKACK2
                     xmit_interval="100"

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-user-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-user-node0.xml
@@ -46,8 +46,11 @@
          server_callback_handler_class="org.infinispan.test.integration.security.utils.SaslPropAuthUserCallbackHandler"
          client_callback_handler_class="org.infinispan.test.integration.security.utils.SaslPropCallbackHandler" 
          sasl_props="com.sun.security.sasl.digest.realm=test_realm" />
-         
-   <pbcast.STABLE stability_delay="500" desired_avg_gossip="5000" max_bytes="1m"/>
+
+   <pbcast.STABLE stability_delay="500"
+                  desired_avg_gossip="5000"
+                  max_bytes="1M"
+   />
    <pbcast.GMS print_local_addr="false"
                join_timeout="${jgroups.join_timeout:2000}"/>
 

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node0.xml
@@ -44,8 +44,11 @@
          server_callback_handler_class="org.jgroups.auth.sasl.SimpleAuthorizingCallbackHandler"
          client_callback_handler_class="org.jgroups.auth.sasl.SimpleAuthorizingCallbackHandler" 
          sasl_props="com.sun.security.sasl.digest.realm=test_realm" />
-         
-   <pbcast.STABLE stability_delay="500" desired_avg_gossip="5000" max_bytes="1m"/>
+
+   <pbcast.STABLE stability_delay="500"
+                  desired_avg_gossip="5000"
+                  max_bytes="1M"
+   />
    <pbcast.GMS print_local_addr="false"
                join_timeout="${jgroups.join_timeout:2000}"/>
 

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node0.xml
@@ -22,7 +22,12 @@
    <MERGE3/>
 
    <FD_SOCK/>
-   <FD_ALL timeout="15000" interval="3000"/>
+   <!-- Suspect node `timeout` to `timeout + timeout_check_interval` millis after the last heartbeat -->
+   <FD_ALL timeout="10000"
+           interval="2000"
+           timeout_check_interval="1000"
+   />
+   <VERIFY_SUSPECT timeout="1000"/>
 
    <pbcast.NAKACK2
                     xmit_interval="100"

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node1.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node1.xml
@@ -43,7 +43,10 @@
    <SASL mech="DIGEST-MD5" 
          client_callback_handler_class="org.jgroups.auth.sasl.SimpleAuthorizingCallbackHandler" />
 
-   <pbcast.STABLE stability_delay="500" desired_avg_gossip="5000" max_bytes="1m"/>
+   <pbcast.STABLE stability_delay="500"
+                  desired_avg_gossip="5000"
+                  max_bytes="1M"
+   />
    <pbcast.GMS print_local_addr="false"
                join_timeout="${jgroups.join_timeout:2000}"/>
 

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node1.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node1.xml
@@ -22,7 +22,12 @@
    <MERGE3/>
 
    <FD_SOCK/>
-   <FD_ALL timeout="15000" interval="3000"/>
+   <!-- Suspect node `timeout` to `timeout + timeout_check_interval` millis after the last heartbeat -->
+   <FD_ALL timeout="10000"
+           interval="2000"
+           timeout_check_interval="1000"
+   />
+   <VERIFY_SUSPECT timeout="1000"/>
 
    <pbcast.NAKACK2
                     xmit_interval="100"

--- a/lucene/directory-provider/src/test/resources/testing-flush-loopback.xml
+++ b/lucene/directory-provider/src/test/resources/testing-flush-loopback.xml
@@ -11,7 +11,11 @@
 
 	<MERGE3 max_interval="30000" min_interval="1000"/>
 	<FD_SOCK bind_addr="127.0.0.1" />
-	<FD_ALL />
+   <!-- Suspect node `timeout` to `timeout + timeout_check_interval` millis after the last heartbeat -->
+   <FD_ALL timeout="10000"
+           interval="2000"
+           timeout_check_interval="1000"
+   />
 	<VERIFY_SUSPECT timeout="500" bind_addr="127.0.0.1" />
 	<pbcast.NAKACK2
 			use_mcast_xmit="false"

--- a/lucene/directory-provider/src/test/resources/testing-flush-loopback.xml
+++ b/lucene/directory-provider/src/test/resources/testing-flush-loopback.xml
@@ -29,8 +29,10 @@
 			xmit_table_msgs_per_row="1024"
 			xmit_table_max_compaction_time="30000"
 	/>
-	<pbcast.STABLE stability_delay="1000" desired_avg_gossip="50000"
-		max_bytes="400000" />
+   <pbcast.STABLE stability_delay="500"
+                  desired_avg_gossip="5000"
+                  max_bytes="1M"
+   />
 	<pbcast.GMS
 			print_local_addr="false"
 			join_timeout="${jgroups.join_timeout:500}" />

--- a/persistence/jdbc/src/test/resources/configs/as7/jdbc-standalone.xml
+++ b/persistence/jdbc/src/test/resources/configs/as7/jdbc-standalone.xml
@@ -156,6 +156,7 @@
                 <protocol type="MERGE3"/>
                 <protocol type="FD_SOCK" socket-binding="jgroups-udp-fd"/>
                 <protocol type="FD_ALL"/>
+                <protocol type="VERIFY_SUSPECT"/>
                 <protocol type="pbcast.NAKACK2"/>
                 <protocol type="UNICAST3">
                 </protocol>

--- a/server/integration/jgroups/src/main/resources/jgroups-defaults.xml
+++ b/server/integration/jgroups/src/main/resources/jgroups-defaults.xml
@@ -47,13 +47,14 @@
       max_interval="30000"/>
    <FD_SOCK/>
    <FD timeout="6000" max_tries="5" msg_counts_as_heartbeat="false"/>
-   <FD_ALL2 interval="3000" timeout="15000"/>
+   <FD_ALL2 timeout="10000" interval="2000"/>
+   <!-- Suspect node `timeout` to `timeout + timeout_check_interval` millis after the last heartbeat -->
    <FD_ALL
-      timeout="60000"
-      interval="15000"
-      timeout_check_interval="5000"/>
+      timeout="10000"
+      interval="2000"
+      timeout_check_interval="1000"/>
    <VERIFY_SUSPECT
-      timeout="5000"/>
+      timeout="1000"/>
    <BARRIER/>
    <pbcast.NAKACK2
       xmit_interval="100"


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-9087

* Replace FD_ALL with FD_ALL2 and change the timeout from 60s to 10s.
* Keep the default cache replication timeout at 15s
* Increase the default backup site timeout from 10s to 15s