### PR TITLE
ISPN-9104 Majority partition nodes can process minority topology updates

### DIFF
--- a/core/src/main/java/org/infinispan/topology/LocalTopologyManagerImpl.java
+++ b/core/src/main/java/org/infinispan/topology/LocalTopologyManagerImpl.java
@@ -310,11 +310,11 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager, GlobalSta
             return false;
          }
 
-         CacheTopologyHandler handler = cacheStatus.getHandler();
-         resetLocalTopologyBeforeRebalance(cacheName, cacheTopology, existingTopology, handler);
-
          if (!updateCacheTopology(cacheName, cacheTopology, viewId, sender, cacheStatus))
             return false;
+
+         CacheTopologyHandler handler = cacheStatus.getHandler();
+         resetLocalTopologyBeforeRebalance(cacheName, cacheTopology, existingTopology, handler);
 
          ConsistentHash currentCH = cacheTopology.getCurrentCH();
          ConsistentHash pendingCH = cacheTopology.getPendingCH();
@@ -414,7 +414,7 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager, GlobalSta
             return;
 
          // We only need a reset if we missed a topology update
-         if (newCacheTopology.getTopologyId() == oldCacheTopology.getTopologyId() + 1)
+         if (newCacheTopology.getTopologyId() <= oldCacheTopology.getTopologyId() + 1)
             return;
 
          // We have missed a topology update, and that topology might have removed some of our segments.


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-9104

After a merge NAKACK2 may replay topology updates from the minority
partition to the nodes of the majority partition. Fix the coordinator
check in doHandleTopologyUpdate so that we don't apply the updates.