### PR TITLE
ISPN-8969 Make Global Configuration more robust

### DIFF
--- a/core/src/main/java/org/infinispan/registry/impl/InternalCacheRegistryImpl.java
+++ b/core/src/main/java/org/infinispan/registry/impl/InternalCacheRegistryImpl.java
@@ -54,7 +54,7 @@ public class InternalCacheRegistryImpl implements InternalCacheRegistry {
          // TODO: choose a merge policy
          builder.clustering()
                .cacheMode(CacheMode.REPL_SYNC)
-               .sync().stateTransfer().fetchInMemoryState(true).awaitInitialTransfer(false);
+               .sync().stateTransfer().fetchInMemoryState(true).awaitInitialTransfer(true);
       }
       if (flags.contains(Flag.PERSISTENT) && globalConfiguration.globalState().enabled()) {
          builder.persistence().addSingleFileStore().location(globalConfiguration.globalState().persistentLocation()).purgeOnStartup(false).preload(true).fetchPersistentState(true);


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-8969
* Await initial state transfer for internal global caches
* Disable rebalancing before removing a cache through the CacheManagerAdmin API