### PR TITLE
ISPN-9111 x-site configuration for protobuf metadata cache

### DIFF
--- a/core/src/main/java/org/infinispan/interceptors/xsite/PessimisticBackupInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/xsite/PessimisticBackupInterceptor.java
@@ -1,7 +1,16 @@
 package org.infinispan.interceptors.xsite;
 
+import org.infinispan.commands.VisitableCommand;
+import org.infinispan.commands.read.GetKeyValueCommand;
 import org.infinispan.commands.tx.CommitCommand;
+import org.infinispan.container.DataContainer;
+import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.TxInvocationContext;
+import org.infinispan.factories.ComponentRegistry;
+import org.infinispan.factories.annotations.Inject;
+import org.infinispan.interceptors.InvocationSuccessFunction;
+import org.infinispan.metadata.Metadata;
+import org.infinispan.remoting.transport.BackupResponse;
 
 /**
  * Handles x-site data backups for pessimistic transactional caches.
@@ -11,10 +20,55 @@ import org.infinispan.context.impl.TxInvocationContext;
  */
 public class PessimisticBackupInterceptor extends BaseBackupInterceptor {
 
+   @Inject private ComponentRegistry componentRegistry;
+   @Inject protected DataContainer<Object, Object> dataContainer;
+
+   private final InvocationSuccessFunction handleLocalGetReturn = this::handleLocalGetReturn;
+
    @Override
    public Object visitCommitCommand(TxInvocationContext ctx, CommitCommand command) throws Throwable {
       //for pessimistic transaction we don't do a 2PC (as we already own the remote lock) but just
       //a 1PC
       throw new IllegalStateException("This should never happen!");
    }
+
+   @Override
+   public Object visitGetKeyValueCommand(InvocationContext ctx, GetKeyValueCommand command) throws Throwable {
+      final String cacheName = componentRegistry.getCacheName();
+
+      // TODO temporary until protobuf metadata interceptor is in place
+      if (cacheName.equals("___protobuf_metadata")) {
+         return invokeNextThenApply(ctx, command, handleLocalGetReturn);
+      } else {
+         return invokeNext(ctx, command);
+      }
+   }
+
+   private Object handleLocalGetReturn(InvocationContext ctx, VisitableCommand rCommand, Object rv) throws Throwable {
+      if (rv == null) {
+         final GetKeyValueCommand getCmd = (GetKeyValueCommand) rCommand;
+         BackupResponse backupResponse =
+            backupSender.backupGet(getCmd);
+
+         backupSender.processResponses(backupResponse, rCommand);
+         final Object value = getValue(backupResponse);
+
+         if (value != null)
+            dataContainer.compute(getCmd.getKey(),
+               (k, oldEntry, factory) ->
+                  factory.create(k, value, (Metadata) null)
+            );
+
+         return value;
+      }
+
+      return rv;
+   }
+
+   private Object getValue(BackupResponse backupResponse) {
+      return backupResponse.getValues().values().stream()
+         .findFirst()
+         .orElse(null);
+   }
+
 }

--- a/core/src/main/java/org/infinispan/remoting/transport/BackupResponse.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/BackupResponse.java
@@ -1,5 +1,6 @@
 package org.infinispan.remoting.transport;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
@@ -14,6 +15,10 @@ public interface BackupResponse {
    void waitForBackupToFinish() throws Exception;
 
    Map<String,Throwable> getFailedBackups();
+
+   default Map<String, Object> getValues() {
+      return Collections.emptyMap();
+   };
 
    /**
     * Returns the list of sites where the backups failed due to a bridge communication error (as opposed to an

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
@@ -89,7 +89,6 @@ import org.jgroups.Header;
 import org.jgroups.JChannel;
 import org.jgroups.MergeView;
 import org.jgroups.Message;
-import org.jgroups.Receiver;
 import org.jgroups.UpHandler;
 import org.jgroups.View;
 import org.jgroups.blocks.RequestCorrelator;
@@ -388,7 +387,7 @@ public class JGroupsTransport implements Transport {
 
       initChannel();
 
-      channel.setReceiver(channelCallbacks);
+      channel.setUpHandler(channelCallbacks);
       setXSiteViewListener(channelCallbacks);
       setSiteMasterPicker(new SiteMasterPickerImpl());
 
@@ -1161,7 +1160,7 @@ public class JGroupsTransport implements Transport {
    private void siteUnreachable(String site) {
       requests.forEach(request -> {
          if (request instanceof SingleSiteRequest) {
-            ((SingleSiteRequest) request).sitesUnreachable(Collections.singleton(site));
+            ((SingleSiteRequest) request).sitesUnreachable(site);
          }
       });
    }
@@ -1358,12 +1357,7 @@ public class JGroupsTransport implements Transport {
       throw new IllegalArgumentException("Unable to decode order from flags " + flags);
    }
 
-   private class ChannelCallbacks implements Receiver, RouteStatusListener, UpHandler {
-      @Override
-      public void viewAccepted(View new_view) {
-         receiveClusterView(new_view);
-      }
-
+   private class ChannelCallbacks implements RouteStatusListener, UpHandler {
       @Override
       public void sitesUp(String... sites) {
          updateSitesView(Arrays.asList(sites), Collections.emptyList());
@@ -1375,20 +1369,15 @@ public class JGroupsTransport implements Transport {
       }
 
       @Override
-      public void receive(Message message) {
-         processMessage(message);
-      }
-
-      @Override
-      public void receive(MessageBatch batch) {
-         batch.forEach((message, messages) -> processMessage(message));
-      }
-
-      @Override
       public Object up(Event evt) {
          switch (evt.getType()) {
+            case Event.VIEW_CHANGE:
+               receiveClusterView(evt.getArg());
+               break;
             case Event.SITE_UNREACHABLE:
-               siteUnreachable(evt.getArg());
+               SiteMaster site_master=evt.getArg();
+               String site=site_master.getSite();
+               siteUnreachable(site);
                break;
          }
          return null;
@@ -1396,12 +1385,13 @@ public class JGroupsTransport implements Transport {
 
       @Override
       public Object up(Message msg) {
+         processMessage(msg);
          return null;
       }
 
       @Override
       public void up(MessageBatch batch) {
-
+         batch.forEach((message, messages) -> processMessage(message));
       }
    }
 }

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/SingleSiteRequest.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/SingleSiteRequest.java
@@ -63,8 +63,8 @@ public class SingleSiteRequest<T> extends AbstractRequest<T> {
       completeExceptionally(log.requestTimedOut(requestId, site));
    }
 
-   public void sitesUnreachable(Set<String> sites) {
-      if (sites.contains(site)) {
+   public void sitesUnreachable(String unreachableSite) {
+      if (site.equals(unreachableSite)) {
          receiveResponse(null, CacheNotFoundResponse.INSTANCE);
       }
    }

--- a/core/src/main/java/org/infinispan/xsite/BackupSender.java
+++ b/core/src/main/java/org/infinispan/xsite/BackupSender.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import javax.transaction.Transaction;
 
 import org.infinispan.commands.VisitableCommand;
+import org.infinispan.commands.read.GetKeyValueCommand;
 import org.infinispan.commands.tx.CommitCommand;
 import org.infinispan.commands.tx.PrepareCommand;
 import org.infinispan.commands.tx.RollbackCommand;
@@ -38,6 +39,8 @@ public interface BackupSender {
    BackupResponse backupCommit(CommitCommand command) throws Exception;
 
    BackupResponse backupRollback(RollbackCommand command) throws Exception;
+
+   BackupResponse backupGet(GetKeyValueCommand command) throws Exception;
 
    void processResponses(BackupResponse backupResponse, VisitableCommand command, Transaction transaction) throws Throwable;
 

--- a/core/src/main/java/org/infinispan/xsite/BackupSenderImpl.java
+++ b/core/src/main/java/org/infinispan/xsite/BackupSenderImpl.java
@@ -27,6 +27,7 @@ import org.infinispan.commands.functional.WriteOnlyKeyCommand;
 import org.infinispan.commands.functional.WriteOnlyKeyValueCommand;
 import org.infinispan.commands.functional.WriteOnlyManyCommand;
 import org.infinispan.commands.functional.WriteOnlyManyEntriesCommand;
+import org.infinispan.commands.read.GetKeyValueCommand;
 import org.infinispan.commands.tx.CommitCommand;
 import org.infinispan.commands.tx.PrepareCommand;
 import org.infinispan.commands.tx.RollbackCommand;
@@ -190,6 +191,11 @@ public class BackupSenderImpl implements BackupSender {
       return backupCommand(command, xSiteBackups);
    }
 
+   @Override
+   public BackupResponse backupGet(GetKeyValueCommand command) throws Exception {
+      List<XSiteBackup> xSiteBackups = calculateBackupInfo(BackupFilter.KEEP_ALL);
+      return backupCommand(command, xSiteBackups);
+   }
 
    @Override
    public BringSiteOnlineResponse bringSiteOnline(String siteName) {

--- a/core/src/main/java/org/infinispan/xsite/BaseBackupReceiver.java
+++ b/core/src/main/java/org/infinispan/xsite/BaseBackupReceiver.java
@@ -13,6 +13,7 @@ import org.infinispan.commands.AbstractVisitor;
 import org.infinispan.commands.CommandsFactory;
 import org.infinispan.commands.VisitableCommand;
 import org.infinispan.commands.functional.WriteOnlyManyEntriesCommand;
+import org.infinispan.commands.read.GetKeyValueCommand;
 import org.infinispan.commands.tx.CommitCommand;
 import org.infinispan.commands.tx.PrepareCommand;
 import org.infinispan.commands.tx.RollbackCommand;
@@ -133,6 +134,11 @@ public abstract class BaseBackupReceiver implements BackupReceiver {
          // TODO: execute asynchronously
          backupCache.clear();
          return null;
+      }
+
+      @Override
+      public Object visitGetKeyValueCommand(InvocationContext ctx, GetKeyValueCommand command) throws Throwable {
+         return backupCache.get(command.getKey());
       }
 
       @Override

--- a/core/src/test/java/org/infinispan/xsite/backupfailure/tx/BaseLocalClusterTxFailureTest.java
+++ b/core/src/test/java/org/infinispan/xsite/backupfailure/tx/BaseLocalClusterTxFailureTest.java
@@ -2,16 +2,19 @@ package org.infinispan.xsite.backupfailure.tx;
 
 import static org.testng.AssertJUnit.assertNull;
 
-import javax.transaction.xa.XAException;
+import javax.transaction.RollbackException;
 
+import org.infinispan.commons.CacheException;
 import org.infinispan.test.Exceptions;
 import org.infinispan.xsite.AbstractTwoSitesTest;
 import org.infinispan.xsite.backupfailure.BaseBackupFailureTest;
+import org.testng.annotations.Test;
 
 /**
  * @author Mircea Markus
  * @since 5.2
  */
+@Test(groups = "xsite")
 public abstract class BaseLocalClusterTxFailureTest extends AbstractTwoSitesTest {
 
    private BaseBackupFailureTest.FailureInterceptor failureInterceptor;
@@ -26,7 +29,7 @@ public abstract class BaseLocalClusterTxFailureTest extends AbstractTwoSitesTest
    public void testPrepareFailure() {
       failureInterceptor.enable();
       try {
-         Exceptions.expectException(XAException.class, () -> cache("LON", 0).put("k", "v"));
+         Exceptions.expectException(CacheException.class, RollbackException.class, () -> cache("LON", 0).put("k", "v"));
       } finally {
          failureInterceptor.disable();
       }

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/ProtobufMetadataManagerImpl.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/ProtobufMetadataManagerImpl.java
@@ -8,8 +8,6 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Stream;
 
 import javax.management.MBeanException;
 import javax.management.ObjectName;
@@ -151,7 +149,7 @@ public final class ProtobufMetadataManagerImpl implements ProtobufMetadataManage
                .site(siteName)
                .strategy(BackupConfiguration.BackupStrategy.SYNC)
                .replicationTimeout(30_000)
-               .backupFailurePolicy(BackupFailurePolicy.FAIL);
+               .backupFailurePolicy(BackupFailurePolicy.WARN);
          });
 
       return cfg;

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/ProtobufMetadataManagerImpl.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/ProtobufMetadataManagerImpl.java
@@ -117,7 +117,7 @@ public final class ProtobufMetadataManagerImpl implements ProtobufMetadataManage
 
       ConfigurationBuilder cfg = new ConfigurationBuilder();
       cfg.transaction()
-            .transactionMode(TransactionMode.TRANSACTIONAL).invocationBatching().enable()
+            .transactionMode(TransactionMode.TRANSACTIONAL)
             .transaction().lockingMode(LockingMode.PESSIMISTIC)
             .locking().isolationLevel(IsolationLevel.READ_COMMITTED).useLockStriping(false)
             .clustering().cacheMode(cacheMode).sync()

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/ProtobufMetadataManagerImpl.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/ProtobufMetadataManagerImpl.java
@@ -150,7 +150,7 @@ public final class ProtobufMetadataManagerImpl implements ProtobufMetadataManage
                .addBackup()
                .site(siteName)
                .strategy(BackupConfiguration.BackupStrategy.SYNC)
-               .replicationTimeout(120_000)
+               .replicationTimeout(30_000)
                .backupFailurePolicy(BackupFailurePolicy.FAIL);
          });
 

--- a/remote-query/remote-query-server/src/test/java/org/infinispan/query/remote/impl/xsite/ProtobufMetadataXSiteStateTransferTest.java
+++ b/remote-query/remote-query-server/src/test/java/org/infinispan/query/remote/impl/xsite/ProtobufMetadataXSiteStateTransferTest.java
@@ -1,0 +1,82 @@
+package org.infinispan.query.remote.impl.xsite;
+
+import org.infinispan.Cache;
+import org.infinispan.configuration.cache.BackupConfiguration;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.xsite.AbstractTwoSitesTest;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static org.infinispan.query.remote.client.ProtobufMetadataManagerConstants.PROTOBUF_METADATA_CACHE_NAME;
+import static org.testng.AssertJUnit.assertEquals;
+
+@Test(groups = "functional", testName = "query.remote.impl.xsite.ProtobufMetadataXSiteStateTransferTest")
+public class ProtobufMetadataXSiteStateTransferTest extends AbstractTwoSitesTest {
+
+   public ProtobufMetadataXSiteStateTransferTest() {
+      cacheMode = CacheMode.DIST_SYNC;
+      implicitBackupCache = true;
+   }
+
+   @Override
+   protected void createSites() {
+      ConfigurationBuilder lon = lonConfigurationBuilder();
+      createSite(LON, initialClusterSize, globalConfigurationBuilderForSite(LON), lon);
+      waitForSites(LON);
+   }
+
+   @Override
+   protected ConfigurationBuilder getNycActiveConfig() {
+      return getDefaultClusteredCacheConfig(cacheMode);
+   }
+
+   @Override
+   protected ConfigurationBuilder getLonActiveConfig() {
+      return getNycActiveConfig();
+   }
+
+   public void testMetadataStateTransfer() {
+//      stopNYC();
+//      waitForSites(LON);
+//      TestingUtil.sleepThread(10_000);
+
+      final String cacheName = PROTOBUF_METADATA_CACHE_NAME;
+      final List<Cache<String, String>> lonMetaCaches = caches("LON", cacheName);
+
+      final Cache<String, String> lonWriteMetaCache = lonMetaCaches.get(0);
+      final String protoFileName = "testA.proto";
+      final String protoFileContents = "package A;";
+      lonWriteMetaCache.put(protoFileName, protoFileContents);
+
+      final Cache<String, String> lonReadMetaCache = lonMetaCaches.get(1);
+      assertEquals(lonReadMetaCache.get(protoFileName), protoFileContents);
+
+      createNYC();
+      waitForSites(LON, NYC);
+
+      final List<Cache<String, String>> nycMetaCaches = caches("NYC", cacheName);
+      final Cache<String, String> nycReadMetaCache0 = nycMetaCaches.get(0);
+      assertEquals(nycReadMetaCache0.get(protoFileName), protoFileContents);
+
+      final Cache<String, String> nycReadMetaCache1 = nycMetaCaches.get(1);
+      assertEquals(nycReadMetaCache1.get(protoFileName), protoFileContents);
+   }
+
+//   private void stopNYC() {
+//      final TestSite site = site(NYC);
+//      site.cacheManagers.forEach(Lifecycle::stop);
+//      sites.remove(site);
+//   }
+
+   private void createNYC() {
+      ConfigurationBuilder nyc = getNycActiveConfig();
+      nyc.sites().addBackup()
+         .site(LON)
+         .strategy(BackupConfiguration.BackupStrategy.SYNC)
+         .sites().addInUseBackupSite(LON);
+      createSite(NYC, initialClusterSize, globalConfigurationBuilderForSite(NYC), nyc);
+   }
+
+}

--- a/remote-query/remote-query-server/src/test/java/org/infinispan/query/remote/impl/xsite/ProtobufMetadataXSiteTest.java
+++ b/remote-query/remote-query-server/src/test/java/org/infinispan/query/remote/impl/xsite/ProtobufMetadataXSiteTest.java
@@ -1,0 +1,51 @@
+package org.infinispan.query.remote.impl.xsite;
+
+import org.infinispan.Cache;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.xsite.AbstractTwoSitesTest;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static org.infinispan.query.remote.client.ProtobufMetadataManagerConstants.PROTOBUF_METADATA_CACHE_NAME;
+import static org.testng.AssertJUnit.assertEquals;
+
+@Test(groups = "functional", testName = "query.remote.impl.xsite.ProtobufMetadataXSiteTest")
+public class ProtobufMetadataXSiteTest extends AbstractTwoSitesTest {
+
+   public ProtobufMetadataXSiteTest() {
+      cacheMode = CacheMode.DIST_SYNC;
+   }
+
+   @Override
+   protected ConfigurationBuilder getNycActiveConfig() {
+      return getDefaultClusteredCacheConfig(cacheMode);
+   }
+
+   @Override
+   protected ConfigurationBuilder getLonActiveConfig() {
+      return getNycActiveConfig();
+   }
+
+   public void testMetadataReplicatedXSite() {
+      final String cacheName = PROTOBUF_METADATA_CACHE_NAME;
+      final List<Cache<String, String>> nycMetaCaches = caches("NYC", cacheName);
+
+      final Cache<String, String> nycWriteMetaCache = nycMetaCaches.get(0);
+      final String protoFileName = "testA.proto";
+      final String protoFileContents = "package A;";
+      nycWriteMetaCache.put(protoFileName, protoFileContents);
+
+      final Cache<String, String> nyReadMetaCache = nycMetaCaches.get(1);
+      assertEquals(nyReadMetaCache.get(protoFileName), protoFileContents);
+
+      final List<Cache<String, String>> lonMetaCaches = caches("LON", cacheName);
+      final Cache<String, String> lonReadMetaCache0 = lonMetaCaches.get(0);
+      assertEquals(lonReadMetaCache0.get(protoFileName), protoFileContents);
+
+      final Cache<String, String> lonReadMetaCache1 = lonMetaCaches.get(1);
+      assertEquals(lonReadMetaCache1.get(protoFileName), protoFileContents);
+   }
+
+}


### PR DESCRIPTION
This is just a prototype. If we're happy with the approach a different interceptor should be created and injected into protobuf metadata cache.

Ideally we'd use SYNC x-site configuration but that's not fully working as expected. The reason for that is that you'd not want protobuf metadata updates to be applied partially cluster wide. However, SYNC with FAIL backup policy has a number of issues. So, SYNC with WARN is the best we can do maybe now.

On top of that, lazy get functionality has been implemented so that if a site protobuf lookup fails to find anything, this lookup can be pushed to other sites. This is needed because there's no state transfer in place for x-site data. Alternatively we could have tried to push state when a new node joins the x-site cluster, but at the point when this is known, the channel is not set up yet.