### PR TITLE
ISPN-9175 Ignore Hibernate 2LC unstable tests

### DIFF
--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/entity/EntityRegionAccessStrategyTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/entity/EntityRegionAccessStrategyTest.java
@@ -179,6 +179,7 @@ public class EntityRegionAccessStrategyTest extends
 	}
 
 	@Test
+	@Ignore("ISPN-9175")
 	public void testUpdate() throws Exception {
 		if (accessType == AccessType.READ_ONLY) {
 			return;

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/cluster/EntityCollectionInvalidationTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/cluster/EntityCollectionInvalidationTest.java
@@ -44,6 +44,7 @@ import org.infinispan.notifications.cachelistener.annotation.CacheEntryVisited;
 import org.infinispan.notifications.cachelistener.event.CacheEntryVisitedEvent;
 import org.infinispan.test.hibernate.cache.commons.util.TestRegionFactory;
 import org.infinispan.util.ControlledTimeService;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -127,6 +128,7 @@ public class EntityCollectionInvalidationTest extends DualNodeTest {
 	}
 
 	@Test
+	@Ignore("ISPN-9175")
 	public void testAll() throws Exception {
 		assertEmptyCaches();
 		assertTrue( remoteListener.isEmpty() );


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-9175

* Currently no grouping mechanism for JUnit tests, so just ignore them.