### PR TITLE
ISPN-9189 ExceptionEvictionTest test failure causes testng to panic

### DIFF
--- a/commons-test/src/main/java/org/infinispan/commons/test/TestNGTestListener.java
+++ b/commons-test/src/main/java/org/infinispan/commons/test/TestNGTestListener.java
@@ -147,7 +147,7 @@ public class TestNGTestListener implements ITestListener, IConfigurationListener
 
    @Override
    public void onConfigurationSkip(ITestResult testResult) {
-      RunningTestsRegistry.unregisterThreadWithTest();
+      // beforeConfiguration didn't run, no need to unregister thread
       if (testResult.getThrowable() != null) {
          progressLogger.testIgnored(testName(testResult));
       }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-9189

