### PR TITLE
ISPN-9204 Single node JgroupsTransport invoke* methods that take a

### DIFF
--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
@@ -837,6 +837,10 @@ public class JGroupsTransport implements Transport {
       Address excludedTarget = deliverOrder == DeliverOrder.TOTAL ? null : getAddress();
       MultiTargetRequest<T> request =
             new MultiTargetRequest<>(collector, requestId, requests, targets, excludedTarget);
+      // Request may be completed due to exclusion of target nodes, so only send it if it isn't complete
+      if (request.isDone()) {
+         return request;
+      }
       try {
          addRequest(request);
          boolean checkView = request.onNewView(clusterView.getMembersSet());
@@ -859,6 +863,10 @@ public class JGroupsTransport implements Transport {
       Address excludedTarget = deliverOrder == DeliverOrder.TOTAL ? null : getAddress();
       MultiTargetRequest<T> request =
             new MultiTargetRequest<>(collector, requestId, requests, clusterView.getMembers(), excludedTarget);
+      // Request may be completed due to exclusion of target nodes, so only send it if it isn't complete
+      if (request.isDone()) {
+         return request;
+      }
       try {
          addRequest(request);
          request.onNewView(clusterView.getMembersSet());
@@ -882,6 +890,10 @@ public class JGroupsTransport implements Transport {
       Address excludedTarget = deliverOrder == DeliverOrder.TOTAL ? null : getAddress();
       MultiTargetRequest<T> request =
          new MultiTargetRequest<>(collector, requestId, requests, requiredTargets, excludedTarget);
+      // Request may be completed due to exclusion of target nodes, so only send it if it isn't complete
+      if (request.isDone()) {
+         return request;
+      }
       try {
          addRequest(request);
          request.onNewView(clusterView.getMembersSet());
@@ -926,6 +938,10 @@ public class JGroupsTransport implements Transport {
       Address excludedTarget = getAddress();
       MultiTargetRequest<T> request =
             new MultiTargetRequest<>(collector, requestId, requests, targets, excludedTarget);
+      // Request may be completed due to exclusion of target nodes, so only send it if it isn't complete
+      if (request.isDone()) {
+         return request;
+      }
       addRequest(request);
       boolean checkView = request.onNewView(clusterView.getMembersSet());
       try {

--- a/core/src/test/java/org/infinispan/remoting/rpc/RpcManagerTest.java
+++ b/core/src/test/java/org/infinispan/remoting/rpc/RpcManagerTest.java
@@ -207,7 +207,7 @@ public class RpcManagerTest extends MultipleCacheManagersTest {
       RpcManager rpcManager0 = cache(0).getAdvancedCache().getRpcManager();
 
       Exceptions.expectException(IllegalArgumentException.class, () -> {
-         rpcManager0.invokeCommands(Arrays.asList(address(0)), a -> command, MapResponseCollector.validOnly(),
+         rpcManager0.invokeCommands(Arrays.asList(address(1)), a -> command, MapResponseCollector.validOnly(),
                                     rpcManager0.getSyncRpcOptions());
       });
 


### PR DESCRIPTION
collection leak memory

* Add check to only send command if not already complete

https://issues.jboss.org/browse/ISPN-9204