### PR TITLE
HHH-12457 Local Infinispan read-write caches become stale on rollback

### DIFF
--- a/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/InvalidationSynchronization.java
+++ b/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/InvalidationSynchronization.java
@@ -17,7 +17,9 @@ import javax.transaction.Status;
  */
 public class InvalidationSynchronization implements javax.transaction.Synchronization {
    private final static InfinispanMessageLogger log = InfinispanMessageLogger.Provider.getLog(InvalidationSynchronization.class);
-	public final Object lockOwner;
+   private final static boolean trace = log.isTraceEnabled();
+
+	private final Object lockOwner;
 	private final NonTxPutFromLoadInterceptor nonTxPutFromLoadInterceptor;
 	private final Object key;
 
@@ -33,7 +35,9 @@ public class InvalidationSynchronization implements javax.transaction.Synchroniz
 
 	@Override
 	public void afterCompletion(int status) {
-      log.tracef("After completion callback with status %d", status);
+		if (trace) {
+			log.tracef("After completion callback with status %d", status);
+		}
 		nonTxPutFromLoadInterceptor.endInvalidating(key, lockOwner, status == Status.STATUS_COMMITTED || status == Status.STATUS_COMMITTING);
 	}
 }

--- a/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/LocalInvalidationSynchronization.java
+++ b/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/LocalInvalidationSynchronization.java
@@ -1,0 +1,33 @@
+package org.infinispan.hibernate.cache.commons.access;
+
+import javax.transaction.Status;
+import javax.transaction.Synchronization;
+
+import org.infinispan.hibernate.cache.commons.util.InfinispanMessageLogger;
+
+public class LocalInvalidationSynchronization implements Synchronization {
+   private final static InfinispanMessageLogger log = InfinispanMessageLogger.Provider.getLog(LocalInvalidationSynchronization.class);
+   private final static boolean trace = log.isTraceEnabled();
+
+   private final Object lockOwner;
+   private final PutFromLoadValidator validator;
+   private final Object key;
+
+   public LocalInvalidationSynchronization(PutFromLoadValidator validator, Object key, Object lockOwner) {
+      assert lockOwner != null;
+      this.validator = validator;
+      this.key = key;
+      this.lockOwner = lockOwner;
+   }
+
+   @Override
+   public void beforeCompletion() {}
+
+   @Override
+   public void afterCompletion(int status) {
+      if (trace) {
+         log.tracef("After completion callback with status %d", status);
+      }
+      validator.endInvalidatingKey(lockOwner, key, status == Status.STATUS_COMMITTED || status == Status.STATUS_COMMITTING);
+   }
+}

--- a/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/NonTxInvalidationCacheAccessDelegate.java
+++ b/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/NonTxInvalidationCacheAccessDelegate.java
@@ -8,7 +8,6 @@ package org.infinispan.hibernate.cache.commons.access;
 
 import org.hibernate.cache.CacheException;
 import org.infinispan.commands.CommandsFactory;
-import org.infinispan.commands.write.AbstractDataWriteCommand;
 import org.infinispan.commands.write.RemoveCommand;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.InvocationContextFactory;
@@ -35,9 +34,11 @@ public class NonTxInvalidationCacheAccessDelegate extends InvalidationCacheAcces
    private final KeyPartitioner keyPartitioner;
 	private final InvocationContextFactory contextFactory;
 	protected final NonTxPutFromLoadInterceptor nonTxPutFromLoadInterceptor;
+	protected final boolean isLocal;
 
 	public NonTxInvalidationCacheAccessDelegate(InfinispanDataRegion region, PutFromLoadValidator validator) {
 		super(region, validator);
+		isLocal = !region.getCache().getCacheConfiguration().clustering().cacheMode().isClustered();
 		ComponentRegistry cr = region.getCache().getComponentRegistry();
 		invoker = cr.getComponent(AsyncInterceptorChain.class);
 		commandsFactory = cr.getComponent(CommandsFactory.class);
@@ -75,19 +76,30 @@ public class NonTxInvalidationCacheAccessDelegate extends InvalidationCacheAcces
 		write(session, key, null);
 	}
 
-	private void write(Object session, Object key, Object value) {
-		// We need to be invalidating even for regular writes; if we were not and the write was followed by eviction
-		// (or any other invalidation), naked put that was started after the eviction ended but before this insert/update
-		// ended could insert the stale entry into the cache (since the entry was removed by eviction).
-		RemoveCommand command = commandsFactory.buildRemoveCommand(key, null, keyPartitioner.getSegment(key), REMOVE_FLAGS);
-		registerRemoteInvalidation(command, session);
-		if (!putValidator.beginInvalidatingWithPFER(command.getKeyLockOwner(), key, value)) {
-			throw log.failedInvalidatePendingPut(key, region.getName());
-		}
-		InvocationContext ctx = contextFactory.createSingleKeyNonTxInvocationContext();
-		ctx.setLockOwner(command.getKeyLockOwner());
-		invoke(session, ctx, command);
-	}
+   private void write(Object session, Object key, Object value) {
+      // We need to be invalidating even for regular writes; if we were not and the write was followed by eviction
+      // (or any other invalidation), naked put that was started after the eviction ended but before this insert/update
+      // ended could insert the stale entry into the cache (since the entry was removed by eviction).
+      if (isLocal) {
+         // Lock owner is not serialized in local mode so we can use anything (only equals and hashCode are needed)
+         Object lockOwner = new Object();
+         registerLocalInvalidation(session, lockOwner, key);
+         if (!putValidator.beginInvalidatingWithPFER(lockOwner, key, value)) {
+            throw log.failedInvalidatePendingPut(key, region.getName());
+         }
+         // Make use of the simple cache mode here
+         cache.remove(key);
+      } else {
+         RemoveCommand command = commandsFactory.buildRemoveCommand(key, null, keyPartitioner.getSegment(key), REMOVE_FLAGS);
+         registerClusteredInvalidation(session, command.getKeyLockOwner(), command.getKey());
+         if (!putValidator.beginInvalidatingWithPFER(command.getKeyLockOwner(), key, value)) {
+            throw log.failedInvalidatePendingPut(key, region.getName());
+         }
+         InvocationContext ctx = contextFactory.createSingleKeyNonTxInvocationContext();
+         ctx.setLockOwner(command.getKeyLockOwner());
+         invoke(session, ctx, command);
+      }
+   }
 
 	protected void invoke(Object session, InvocationContext ctx, RemoveCommand command) {
 		invoker.invoke(ctx, command);
@@ -118,15 +130,25 @@ public class NonTxInvalidationCacheAccessDelegate extends InvalidationCacheAcces
 		}
 	}
 
-	protected void registerRemoteInvalidation(AbstractDataWriteCommand command, Object session) {
+	protected void registerLocalInvalidation(Object session, Object lockOwner, Object key) {
 		SessionAccess.TransactionCoordinatorAccess transactionCoordinator = SESSION_ACCESS.getTransactionCoordinator(session);
 		if (transactionCoordinator == null) {
 			return;
 		}
 		if (trace) {
-         log.tracef("Registering synchronization on transaction in %s, cache %s: %s", command.getKeyLockOwner(), cache.getName(), command.getKey());
+			log.tracef("Registering synchronization on transaction in %s, cache %s: %s", lockOwner, cache.getName(), key);
+		}
+		transactionCoordinator.registerLocalSynchronization(new LocalInvalidationSynchronization(putValidator, key, lockOwner));
+	}
+
+	protected void registerClusteredInvalidation(Object session, Object lockOwner, Object key) {
+		SessionAccess.TransactionCoordinatorAccess transactionCoordinator = SESSION_ACCESS.getTransactionCoordinator(session);
+		if (transactionCoordinator == null) {
+			return;
+		}
+		if (trace) {
+         log.tracef("Registering synchronization on transaction in %s, cache %s: %s", lockOwner, cache.getName(), key);
       }
-		InvalidationSynchronization sync = new InvalidationSynchronization(nonTxPutFromLoadInterceptor, command.getKey(), command.getKeyLockOwner());
-		transactionCoordinator.registerLocalSynchronization(sync);
+		transactionCoordinator.registerLocalSynchronization(new InvalidationSynchronization(nonTxPutFromLoadInterceptor, key, lockOwner));
 	}
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/LocalCacheTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/LocalCacheTest.java
@@ -1,0 +1,58 @@
+package org.infinispan.test.hibernate.cache.commons.functional;
+
+import static org.infinispan.hibernate.cache.spi.InfinispanProperties.INFINISPAN_CONFIG_LOCAL_RESOURCE;
+import static org.infinispan.hibernate.cache.spi.InfinispanProperties.INFINISPAN_CONFIG_RESOURCE_PROP;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.hibernate.cache.spi.access.AccessType;
+import org.hibernate.engine.transaction.jta.platform.internal.NoJtaPlatform;
+import org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorBuilderImpl;
+import org.hibernate.testing.TestForIssue;
+import org.infinispan.commons.util.ByRef;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.test.Exceptions;
+import org.infinispan.test.TestException;
+import org.infinispan.test.hibernate.cache.commons.functional.entities.Customer;
+import org.junit.Test;
+
+public class LocalCacheTest extends SingleNodeTest {
+   @Override
+   public List<Object[]> getParameters() {
+      return Collections.singletonList(new Object[]{
+            "local", NoJtaPlatform.class, JdbcResourceLocalTransactionCoordinatorBuilderImpl.class, null, AccessType.READ_WRITE, CacheMode.LOCAL, false
+      });
+   }
+
+   @Override
+   protected void addSettings(Map settings) {
+      super.addSettings(settings);
+      settings.put(INFINISPAN_CONFIG_RESOURCE_PROP, INFINISPAN_CONFIG_LOCAL_RESOURCE);
+   }
+
+   @Test
+   @TestForIssue(jiraKey = "HHH-12457")
+   public void testRollback() throws Exception {
+      ByRef<Integer> idRef = new ByRef<>(0);
+      withTxSession(s -> {
+         Customer c = new Customer();
+         c.setName("Foo");
+         s.persist(c);
+         idRef.set(c.getId());
+      });
+      Exceptions.expectException(TestException.class, () -> withTxSession(s -> {
+         Customer c = s.load(Customer.class, idRef.get());
+         c.setName("Bar");
+         s.persist(c);
+         s.flush();
+         throw new TestException("Roll me back");
+      }));
+      withTxSession(s -> {
+         Customer c = s.load(Customer.class, idRef.get());
+         assertEquals("Foo", c.getName());
+      });
+   }
+}

--- a/hibernate/cache-v53/src/main/java/org/infinispan/hibernate/cache/v53/impl/LocalInvalidationInvocation.java
+++ b/hibernate/cache-v53/src/main/java/org/infinispan/hibernate/cache/v53/impl/LocalInvalidationInvocation.java
@@ -8,7 +8,7 @@ package org.infinispan.hibernate.cache.v53.impl;
 
 import java.util.concurrent.CompletableFuture;
 
-import org.infinispan.hibernate.cache.commons.access.NonTxPutFromLoadInterceptor;
+import org.infinispan.hibernate.cache.commons.access.PutFromLoadValidator;
 import org.infinispan.hibernate.cache.commons.util.InfinispanMessageLogger;
 
 /**
@@ -16,17 +16,17 @@ import org.infinispan.hibernate.cache.commons.util.InfinispanMessageLogger;
  *
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
-public class InvalidationInvocation implements Invocation {
-   private final static InfinispanMessageLogger log = InfinispanMessageLogger.Provider.getLog(InvalidationInvocation.class);
+public class LocalInvalidationInvocation implements Invocation {
+   private final static InfinispanMessageLogger log = InfinispanMessageLogger.Provider.getLog(LocalInvalidationInvocation.class);
    private final static boolean trace = log.isTraceEnabled();
 
    private final Object lockOwner;
-   private final NonTxPutFromLoadInterceptor nonTxPutFromLoadInterceptor;
+   private final PutFromLoadValidator validator;
    private final Object key;
 
-   public InvalidationInvocation(NonTxPutFromLoadInterceptor nonTxPutFromLoadInterceptor, Object key, Object lockOwner) {
+   public LocalInvalidationInvocation(PutFromLoadValidator validator, Object key, Object lockOwner) {
       assert lockOwner != null;
-      this.nonTxPutFromLoadInterceptor = nonTxPutFromLoadInterceptor;
+      this.validator = validator;
       this.key = key;
       this.lockOwner = lockOwner;
    }
@@ -36,7 +36,7 @@ public class InvalidationInvocation implements Invocation {
       if (trace) {
          log.tracef("After completion callback, success=%b", success);
       }
-      nonTxPutFromLoadInterceptor.endInvalidating(key, lockOwner, success);
+      validator.endInvalidatingKey(lockOwner, key, success);
       return null;
    }
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-12457

Backport #5970 already integrated, but this has dependency to #5954 and #5964 

https://issues.jboss.org/browse/ISPN-9205 which was introduced in the backport is fixed here.