### PR TITLE
[9.2] ISPN-9205 LocalInvalidationSynchronization#afterCompletion calls Pu

### DIFF
--- a/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/LocalInvalidationSynchronization.java
+++ b/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/LocalInvalidationSynchronization.java
@@ -20,6 +20,6 @@ public class LocalInvalidationSynchronization implements Synchronization {
 
    @Override
    public void afterCompletion(int status) {
-      validator.endInvalidatingKey(key, lockOwner, status == Status.STATUS_COMMITTED || status == Status.STATUS_COMMITTING);
+      validator.endInvalidatingKey(lockOwner, key, status == Status.STATUS_COMMITTED || status == Status.STATUS_COMMITTING);
    }
 }


### PR DESCRIPTION
…tFromLoadValidator#endInvalidatingKey with arguments in incorrect order