### PR TITLE
Align Hibernate versions with WildFly 13

### DIFF
--- a/all/embedded/src/main/resources/features.xml
+++ b/all/embedded/src/main/resources/features.xml
@@ -30,8 +30,7 @@
       <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.dom4j/${version.hibernate_dep.dom4j}</bundle>
       <bundle>mvn:com.fasterxml/classmate/${version.hibernate_dep.classmate}</bundle>
       <bundle>mvn:org.javassist/javassist/${version.hibernate_dep.javassist}</bundle>
-      <!--Hardcoded for now: Hibernate ORM requires this version, which would clash with the Mockito dependency used elsewhere -->
-      <bundle>mvn:net.bytebuddy/byte-buddy/1.8.0</bundle>
+      <bundle>mvn:net.bytebuddy/byte-buddy/${version.mockito_dep.bytebuddy}</bundle>
       <bundle>mvn:org.hibernate.common/hibernate-commons-annotations/${version.hibernate_dep.hibernate-commons-annotations}</bundle>
       <bundle>mvn:org.jboss/jandex/${version.hibernate_dep.jandex}</bundle>
    </feature>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -74,9 +74,9 @@
       <version.caffeine>2.6.2</version.caffeine>
       <version.cdi>1.2</version.cdi>
       <version.groovy>2.4.8</version.groovy>
-      <version.hibernate.core>5.3.0.Final</version.hibernate.core>
+      <version.hibernate.core>5.3.1.Final</version.hibernate.core>
       <version.javax.persistence>2.2</version.javax.persistence>
-      <version.hibernate.search>5.10.0.Final</version.hibernate.search>
+      <version.hibernate.search>5.10.1.Final</version.hibernate.search>
       <version.hikaricp>2.4.6</version.hikaricp>
       <version.javax.cache>1.1.0</version.javax.cache>
       <version.jboss.logging>3.3.1.Final</version.jboss.logging>

--- a/distribution/src/main/release/server/docs/licenses/licenses.xml
+++ b/distribution/src/main/release/server/docs/licenses/licenses.xml
@@ -2210,10 +2210,10 @@
       <version>5.3.1.Final</version>
       <licenses>
         <license>
-          <name>GNU Lesser General Public License v2 (or 2.1) only</name>
-          <url>http://www.gnu.org/licenses/lgpl-2.1.html</url>
+          <name>GNU Lesser General Public License v2.1 or later</name>
+          <url>http://www.opensource.org/licenses/LGPL-2.1</url>
           <distribution>repo</distribution>
-          <comments>See discussion at http://hibernate.org/license for more details.</comments>
+          <comments>See http://hibernate.org/community/license/ for more details.</comments>
         </license>
       </licenses>
     </dependency>
@@ -2223,10 +2223,10 @@
       <version>5.3.1.Final</version>
       <licenses>
         <license>
-          <name>GNU Lesser General Public License v2 (or 2.1) only</name>
-          <url>http://www.gnu.org/licenses/lgpl-2.1.html</url>
+          <name>GNU Lesser General Public License v2.1 or later</name>
+          <url>http://www.opensource.org/licenses/LGPL-2.1</url>
           <distribution>repo</distribution>
-          <comments>See discussion at http://hibernate.org/license for more details.</comments>
+          <comments>See http://hibernate.org/community/license/ for more details.</comments>
         </license>
       </licenses>
     </dependency>
@@ -2236,9 +2236,9 @@
       <version>5.10.1.Final</version>
       <licenses>
         <license>
-          <name>GNU Lesser General Public License v2 (or 2.1) only</name>
-          <url>http://www.gnu.org/licenses/lgpl-2.1.html</url>
-          <comments>See also: http://hibernate.org/license</comments>
+          <name>GNU Lesser General Public License v2.1 or later</name>
+          <url>http://www.opensource.org/licenses/LGPL-2.1</url>
+          <comments>See http://hibernate.org/community/license/ for more details.</comments>
         </license>
       </licenses>
     </dependency>
@@ -2248,9 +2248,9 @@
       <version>5.10.1.Final</version>
       <licenses>
         <license>
-          <name>GNU Lesser General Public License v2 (or 2.1) only</name>
-          <url>http://www.gnu.org/licenses/lgpl-2.1.html</url>
-          <comments>See also: http://hibernate.org/license</comments>
+          <name>GNU Lesser General Public License v2.1 or later</name>
+          <url>http://www.opensource.org/licenses/LGPL-2.1</url>
+          <comments>See http://hibernate.org/community/license/ for more details.</comments>
         </license>
       </licenses>
     </dependency>
@@ -2260,9 +2260,9 @@
       <version>5.10.1.Final</version>
       <licenses>
         <license>
-          <name>GNU Lesser General Public License v2 (or 2.1) only</name>
-          <url>http://www.gnu.org/licenses/lgpl-2.1.html</url>
-          <comments>See also: http://hibernate.org/license</comments>
+          <name>GNU Lesser General Public License v2.1 or later</name>
+          <url>http://www.opensource.org/licenses/LGPL-2.1</url>
+          <comments>See http://hibernate.org/community/license/ for more details.</comments>
         </license>
       </licenses>
     </dependency>
@@ -2272,9 +2272,9 @@
       <version>5.10.1.Final</version>
       <licenses>
         <license>
-          <name>GNU Lesser General Public License v2 (or 2.1) only</name>
-          <url>http://www.gnu.org/licenses/lgpl-2.1.html</url>
-          <comments>See also: http://hibernate.org/license</comments>
+          <name>GNU Lesser General Public License v2.1 or later</name>
+          <url>http://www.opensource.org/licenses/LGPL-2.1</url>
+          <comments>See http://hibernate.org/community/license/ for more details.</comments>
         </license>
       </licenses>
     </dependency>
@@ -2284,9 +2284,9 @@
       <version>5.10.1.Final</version>
       <licenses>
         <license>
-          <name>GNU Lesser General Public License v2 (or 2.1) only</name>
-          <url>http://www.gnu.org/licenses/lgpl-2.1.html</url>
-          <comments>See also: http://hibernate.org/license</comments>
+          <name>GNU Lesser General Public License v2.1 or later</name>
+          <url>http://www.opensource.org/licenses/LGPL-2.1</url>
+          <comments>See http://hibernate.org/community/license/ for more details.</comments>
         </license>
       </licenses>
     </dependency>
@@ -2296,9 +2296,9 @@
       <version>5.10.1.Final</version>
       <licenses>
         <license>
-          <name>GNU Lesser General Public License v2 (or 2.1) only</name>
-          <url>http://www.gnu.org/licenses/lgpl-2.1.html</url>
-          <comments>See also: http://hibernate.org/license</comments>
+          <name>GNU Lesser General Public License v2.1 or later</name>
+          <url>http://www.opensource.org/licenses/LGPL-2.1</url>
+          <comments>See http://hibernate.org/community/license/ for more details.</comments>
         </license>
       </licenses>
     </dependency>
@@ -2330,10 +2330,10 @@
       <version>5.0.3.Final</version>
       <licenses>
         <license>
-          <name>GNU Lesser General Public License v2 (or 2.1) only</name>
-          <url>http://www.gnu.org/licenses/lgpl-2.1.html</url>
+          <name>GNU Lesser General Public License v2.1 or later</name>
+          <url>http://www.opensource.org/licenses/LGPL-2.1</url>
           <distribution>repo</distribution>
-          <comments>See discussion at http://hibernate.org/license for more details.</comments>
+          <comments>See http://hibernate.org/community/license/ for more details.</comments>
         </license>
       </licenses>
     </dependency>

--- a/distribution/src/main/release/server/docs/licenses/licenses.xml
+++ b/distribution/src/main/release/server/docs/licenses/licenses.xml
@@ -2207,7 +2207,7 @@
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-core</artifactId>
-      <version>5.3.0.Final</version>
+      <version>5.3.1.Final</version>
       <licenses>
         <license>
           <name>GNU Lesser General Public License v2 (or 2.1) only</name>
@@ -2220,7 +2220,7 @@
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-envers</artifactId>
-      <version>5.3.0.Final</version>
+      <version>5.3.1.Final</version>
       <licenses>
         <license>
           <name>GNU Lesser General Public License v2 (or 2.1) only</name>
@@ -2233,7 +2233,7 @@
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-search-backend-jgroups</artifactId>
-      <version>5.10.0.Final</version>
+      <version>5.10.1.Final</version>
       <licenses>
         <license>
           <name>GNU Lesser General Public License v2 (or 2.1) only</name>
@@ -2245,7 +2245,7 @@
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-search-backend-jms</artifactId>
-      <version>5.10.0.Final</version>
+      <version>5.10.1.Final</version>
       <licenses>
         <license>
           <name>GNU Lesser General Public License v2 (or 2.1) only</name>
@@ -2257,7 +2257,7 @@
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-search-elasticsearch</artifactId>
-      <version>5.10.0.Final</version>
+      <version>5.10.1.Final</version>
       <licenses>
         <license>
           <name>GNU Lesser General Public License v2 (or 2.1) only</name>
@@ -2269,7 +2269,7 @@
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-search-engine</artifactId>
-      <version>5.10.0.Final</version>
+      <version>5.10.1.Final</version>
       <licenses>
         <license>
           <name>GNU Lesser General Public License v2 (or 2.1) only</name>
@@ -2281,7 +2281,7 @@
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-search-orm</artifactId>
-      <version>5.10.0.Final</version>
+      <version>5.10.1.Final</version>
       <licenses>
         <license>
           <name>GNU Lesser General Public License v2 (or 2.1) only</name>
@@ -2293,7 +2293,7 @@
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-search-serialization-avro</artifactId>
-      <version>5.10.0.Final</version>
+      <version>5.10.1.Final</version>
       <licenses>
         <license>
           <name>GNU Lesser General Public License v2 (or 2.1) only</name>

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/stress/PutFromLoadStressTestCase.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/stress/PutFromLoadStressTestCase.java
@@ -31,6 +31,8 @@ import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.RootClass;
 
 import org.infinispan.test.hibernate.cache.commons.functional.entities.Age;
+import org.infinispan.test.hibernate.cache.commons.tm.NarayanaStandaloneJtaPlatform;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
@@ -75,7 +77,7 @@ public class PutFromLoadStressTestCase {
               )
               .applySetting(
                       Environment.JTA_PLATFORM,
-                      "org.hibernate.service.jta.platform.internal.JBossStandAloneJtaPlatform"
+                      new NarayanaStandaloneJtaPlatform()
               )
               // Force minimal puts off to simplify stressing putFromLoad logic
               .applySetting( Environment.USE_MINIMAL_PUTS, "false" )

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/stress/SecondLevelCacheStressTestCase.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/stress/SecondLevelCacheStressTestCase.java
@@ -40,6 +40,7 @@ import org.hibernate.mapping.RootClass;
 import org.infinispan.test.hibernate.cache.commons.stress.entities.Address;
 import org.infinispan.test.hibernate.cache.commons.stress.entities.Family;
 import org.infinispan.test.hibernate.cache.commons.stress.entities.Person;
+import org.infinispan.test.hibernate.cache.commons.tm.NarayanaStandaloneJtaPlatform;
 import org.infinispan.test.hibernate.cache.commons.util.TestRegionFactoryProvider;
 import org.junit.After;
 import org.junit.Before;
@@ -118,7 +119,7 @@ public class SecondLevelCacheStressTestCase {
 
    protected void applyCacheSettings(StandardServiceRegistryBuilder ssrb) {
       ssrb.applySetting( Environment.CACHE_REGION_FACTORY, TestRegionFactoryProvider.load().getRegionFactoryClass().getName() );
-      ssrb.applySetting( Environment.JTA_PLATFORM, "org.hibernate.service.jta.platform.internal.JBossStandAloneJtaPlatform" );
+      ssrb.applySetting( Environment.JTA_PLATFORM, new NarayanaStandaloneJtaPlatform() );
       ssrb.applySetting( InfinispanProperties.INFINISPAN_CONFIG_RESOURCE_PROP, "stress-local-infinispan.xml" );
    }
 

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/tm/JBossStandaloneJtaExampleTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/tm/JBossStandaloneJtaExampleTest.java
@@ -25,7 +25,6 @@ import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.resource.transaction.spi.TransactionStatus;
 import org.infinispan.hibernate.cache.commons.util.InfinispanMessageLogger;
 import org.hibernate.cfg.Environment;
-import org.hibernate.engine.transaction.jta.platform.internal.JBossStandAloneJtaPlatform;
 import org.hibernate.mapping.Collection;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.RootClass;
@@ -250,7 +249,7 @@ public class JBossStandaloneJtaExampleTest {
 				  .applySetting( Environment.RELEASE_CONNECTIONS, "auto" )
 				  .applySetting( Environment.USE_SECOND_LEVEL_CACHE, "true" )
 				  .applySetting( Environment.USE_QUERY_CACHE, "true" )
-				  .applySetting( Environment.JTA_PLATFORM, new JBossStandAloneJtaPlatform() )
+				  .applySetting( Environment.JTA_PLATFORM, new NarayanaStandaloneJtaPlatform() )
 				  .applySetting( Environment.CACHE_REGION_FACTORY, TestRegionFactoryProvider.load().getRegionFactoryClass().getName() );
 
 		StandardServiceRegistry serviceRegistry = ssrb.build();

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/tm/NarayanaStandaloneJtaPlatform.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/tm/NarayanaStandaloneJtaPlatform.java
@@ -1,0 +1,33 @@
+package org.infinispan.test.hibernate.cache.commons.tm;
+
+
+import javax.transaction.TransactionManager;
+import javax.transaction.UserTransaction;
+
+import org.hibernate.engine.transaction.jta.platform.internal.AbstractJtaPlatform;
+import org.hibernate.engine.transaction.jta.platform.spi.JtaPlatformException;
+
+public class NarayanaStandaloneJtaPlatform extends AbstractJtaPlatform {
+
+   public NarayanaStandaloneJtaPlatform() {
+   }
+
+   @Override
+   protected TransactionManager locateTransactionManager() {
+      try {
+         return com.arjuna.ats.jta.TransactionManager.transactionManager();
+      } catch (Exception e) {
+         throw new JtaPlatformException("Could not obtain JBoss Transactions transaction manager instance", e);
+      }
+   }
+
+   @Override
+   protected UserTransaction locateUserTransaction() {
+      try {
+         return com.arjuna.ats.jta.UserTransaction.userTransaction();
+      } catch (Exception e) {
+         throw new JtaPlatformException("Could not obtain JBoss Transactions user transaction instance", e);
+      }
+   }
+
+}

--- a/hibernate/cache-v53/pom.xml
+++ b/hibernate/cache-v53/pom.xml
@@ -15,7 +15,7 @@
 
    <properties>
       <module.skipComponentMetaDataProcessing>true</module.skipComponentMetaDataProcessing>
-      <version.hibernate.core>5.3.0.Final</version.hibernate.core>
+      <version.hibernate.core>5.3.1.Final</version.hibernate.core>
    </properties>
 
    <dependencies>

--- a/persistence/jpa/src/main/resources/features.xml
+++ b/persistence/jpa/src/main/resources/features.xml
@@ -25,8 +25,7 @@
       <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.dom4j/${version.hibernate_dep.dom4j}</bundle>
       <bundle>mvn:com.fasterxml/classmate/${version.hibernate_dep.classmate}</bundle>
       <bundle>mvn:org.javassist/javassist/${version.hibernate_dep.javassist}</bundle>
-      <!--Hardcoded for now: Hibernate ORM requires this version, which would clash with the Mockito dependency used elsewhere -->
-      <bundle>mvn:net.bytebuddy/byte-buddy/1.8.0</bundle>
+      <bundle>mvn:net.bytebuddy/byte-buddy/${version.mockito_dep.bytebuddy}</bundle>
       <bundle>mvn:org.hibernate.common/hibernate-commons-annotations/${version.hibernate_dep.hibernate-commons-annotations}</bundle>
       <bundle>mvn:org.jboss/jandex/${version.hibernate_dep.jandex}</bundle>
    </feature>

--- a/pom.xml
+++ b/pom.xml
@@ -220,9 +220,9 @@
       <version.cdi>1.2</version.cdi>
       <version.commonslang3>3.4</version.commonslang3>
       <version.groovy>2.4.8</version.groovy>
-      <version.hibernate.core>5.3.0.Final</version.hibernate.core>
+      <version.hibernate.core>5.3.1.Final</version.hibernate.core>
       <version.javax.persistence>2.2</version.javax.persistence>
-      <version.hibernate.search>5.10.0.Final</version.hibernate.search>
+      <version.hibernate.search>5.10.1.Final</version.hibernate.search>
       <version.hikaricp>2.4.6</version.hikaricp>
       <version.javax.activation>1.1.1</version.javax.activation>
       <version.javax.cache>1.0.0</version.javax.cache>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-9213

Hardcoding of the byte buddy version is no longer required so I removed that too - this ORM version is compatible with any 1.8x (the previous wasn't)