### PR TITLE
ISPN-9218 Wrap InterruptedException in HotRodClientException

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/Util.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/Util.java
@@ -20,7 +20,9 @@ public class Util {
          // timed wait does not do busy waiting
          return cf.get(BIG_DELAY_NANOS, TimeUnit.NANOSECONDS);
       } catch (InterruptedException e) {
-         throw new CacheException(e);
+         // Need to restore interrupt status because InterruptedException cannot be sent back as is
+         Thread.currentThread().interrupt();
+         throw new HotRodClientException(e);
       } catch (ExecutionException e) {
          throw rewrap(e);
       } catch (TimeoutException e) {
@@ -32,7 +34,9 @@ public class Util {
       try {
          return cf.get(timeoutMillis, TimeUnit.MILLISECONDS);
       } catch (InterruptedException e) {
-         throw new CacheException(e);
+         // Need to restore interrupt status because InterruptedException cannot be sent back as is
+         Thread.currentThread().interrupt();
+         throw new HotRodClientException(e);
       } catch (ExecutionException e) {
          throw rewrap(e);
       } catch (TimeoutException e) {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/ChannelFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/ChannelFactory.java
@@ -415,9 +415,6 @@ public class ChannelFactory {
    }
 
    public int getMaxRetries() {
-      if (Thread.currentThread().isInterrupted()) {
-         return -1;
-      }
       return maxRetries;
    }
 


### PR DESCRIPTION
* When catching InterruptedException, since we cannot send the
exception as is, also restore its interrupt status.