### PR TITLE
ISPN-9194 EntityRegionAccessStrategyTest.testRemoveAll failing randomly

### DIFF
--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/entity/EntityRegionAccessStrategyTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/entity/EntityRegionAccessStrategyTest.java
@@ -79,7 +79,7 @@ public class EntityRegionAccessStrategyTest extends
 		final CountDownLatch commitLatch = new CountDownLatch(1);
 		final CountDownLatch completionLatch = new CountDownLatch(2);
 
-		CountDownLatch asyncInsertLatch = expectAfterUpdate();
+		CountDownLatch asyncInsertLatch = expectAfterUpdate(KEY);
 
 		Thread inserter = new Thread(() -> {
 				try {
@@ -151,7 +151,7 @@ public class EntityRegionAccessStrategyTest extends
 	protected void putFromLoadTestReadOnly(boolean minimal) throws Exception {
 		final Object KEY = TestingKeyFactory.generateEntityCacheKey( KEY_BASE + testCount++ );
 
-		CountDownLatch remotePutFromLoadLatch = expectPutFromLoad();
+		CountDownLatch remotePutFromLoadLatch = expectPutFromLoad(KEY);
 
 		Object session = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE);
 		withTx(localEnvironment, session, () -> {
@@ -179,8 +179,8 @@ public class EntityRegionAccessStrategyTest extends
 	}
 
 	@Test
-	@Ignore("ISPN-9175")
 	public void testUpdate() throws Exception {
+      log.infof(name.getMethodName());
 		if (accessType == AccessType.READ_ONLY) {
 			return;
 		}
@@ -194,7 +194,7 @@ public class EntityRegionAccessStrategyTest extends
       testRemoteAccessStrategy.putFromLoad(s2, KEY, VALUE1, SESSION_ACCESS.getTimestamp(s2), VALUE1.getVersion());
 
 		// both nodes are updated, we don't have to wait for any async replication of putFromLoad
-		CountDownLatch asyncUpdateLatch = expectAfterUpdate();
+		CountDownLatch asyncUpdateLatch = expectAfterUpdate(KEY);
 
 		final CountDownLatch readLatch = new CountDownLatch(1);
 		final CountDownLatch commitLatch = new CountDownLatch(1);


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-9194

Please find details about the actual issue in the JIRA. The problem was that a `FutureUpdate` put was leaking from one test to other, resulting in the latches in the latter test passing when they shouldn't.

The fix contains:

* Wait for the `FutureUpdate` put at the end of testRemove.
* When checking for put latches, make sure the key is the expected one.
* Logging to make it easier to diagnose problems in the future.