### PR TITLE
ISPN-9258 javax.transaction dependency is not provided

### DIFF
--- a/client/hotrod-client/pom.xml
+++ b/client/hotrod-client/pom.xml
@@ -123,7 +123,6 @@
       <dependency>
          <groupId>org.jboss.spec.javax.transaction</groupId>
          <artifactId>jboss-transaction-api_1.1_spec</artifactId>
-         <scope>provided</scope>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-9258

Not really a provided dependency based on how the code is laid out right now. 

Let's integrate this and @pruivo can take over to really make it provided?