### PR TITLE
ISPN-9259 Feature-packs should utilise modules/system/add-ons dir

### DIFF
--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -165,6 +165,7 @@
                                 <experimental>true</experimental>
                                 <infinispanversion>${infinispan.base.version}</infinispanversion>
                                 <brandname>${infinispan.brand.name}</brandname>
+                                <moduleprefix>${infinispan.module.slot.prefix}</moduleprefix>
                                 <infinispanslot>${infinispan.module.slot.prefix}-${parsedVersion.majorVersion}.${parsedVersion.minorVersion}</infinispanslot>
                                 <defaults>${defaults.file}</defaults>
                                 <javadocroot>${javadoc.root}</javadocroot>

--- a/documentation/src/main/asciidoc/upgrading/upgrading.asciidoc
+++ b/documentation/src/main/asciidoc/upgrading/upgrading.asciidoc
@@ -30,6 +30,10 @@ Max idle in a transactional clustered cache does not remove expired entries on a
 
 Iteration in a clustered cache will still show entries that are expired via maxIdle to ensure good performance, but could be removed at any point due to expiration reaper.
 
+=== Wildfly Modules
+The {brandname} Wildfly modules are now located in the `system/add-ons/{moduleprefix}` dir as per the
+link:https://developer.jboss.org/wiki%20/LayeredDistributionsAndModulePathOrganization[Wildfly module conventions].
+
 == Upgrading from 9.0 to 9.1
 
 === Kubernetes Ping changes

--- a/documentation/src/main/asciidoc/user_guide/integrations.adoc
+++ b/documentation/src/main/asciidoc/user_guide/integrations.adoc
@@ -549,7 +549,7 @@ Also, there will be no conflict with WildFly / EAP's internal modules since the 
 [[_Modules_installation_section]]
 ==== Installation
 
-The modules for WildFly / EAP are available in the link:http://infinispan.org/download/[downloads] section of our site. The zip should be extracted to `WILDFLY_HOME/modules`, so that for example the infinispan core module would be under `WILDFLY_HOME/modules/org/infinispan/core`.
+The modules for WildFly / EAP are available in the link:http://infinispan.org/download/[downloads] section of our site. The zip should be extracted to `WILDFLY_HOME/modules`, so that for example the infinispan core module would be under `WILDFLY_HOME/modules/system/add-ons/{moduleprefix}/org/infinispan/core`.
 
 ==== Application Dependencies
 

--- a/feature-pack/build.xml
+++ b/feature-pack/build.xml
@@ -1,7 +1,7 @@
 <project name="feature-pack" basedir="." default="branding">
     <target name="branding">
-        <move todir="${feature-pack.dir}" filtering="true">
-            <fileset dir="${feature-pack.dir}"/>
+        <move todir="${feature-pack.modules}" filtering="true">
+            <fileset dir="${feature-pack.modules}"/>
             <filterset>
                 <filter token="infinispan.brand.name" value="${infinispan.brand.name}"/>
                 <filter token="infinispan.brand.version" value="${infinispan.brand.version}"/>
@@ -13,7 +13,7 @@
             <regexpmapper from="(.*)/slot/(.*)" to="\1/${infinispan.module.slot}/\2" />
         </move>
         <delete includeemptydirs="true">
-            <fileset dir="${feature-pack.dir}">
+            <fileset dir="${feature-pack.modules}">
                 <include name="**/slot" />
             </fileset>
         </delete>

--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -23,7 +23,8 @@
 
     <properties>
         <module.skipMavenRemoteResource>true</module.skipMavenRemoteResource>
-        <feature-pack.dir>${project.build.directory}/feature-pack</feature-pack.dir>
+        <feature-pack.root>${project.build.directory}/feature-pack</feature-pack.root>
+        <feature-pack.modules>${feature-pack.root}/modules/system/add-ons/${infinispan.module.slot.prefix}</feature-pack.modules>
     </properties>
 
     <dependencies>
@@ -59,16 +60,33 @@
                     <artifactId>maven-resources-plugin</artifactId>
                     <executions>
                         <execution>
+                            <id>copy-modules</id>
                             <phase>generate-resources</phase>
                             <goals>
                                 <goal>copy-resources</goal>
                             </goals>
                             <configuration>
-                                <outputDirectory>${feature-pack.dir}</outputDirectory>
+                                <outputDirectory>${feature-pack.modules}</outputDirectory>
+                                <resources>
+                                    <resource>
+                                        <directory>src/main/resources/modules</directory>
+                                        <filtering>true</filtering>
+                                    </resource>
+                                </resources>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>copy-config</id>
+                            <phase>generate-resources</phase>
+                            <goals>
+                                <goal>copy-resources</goal>
+                            </goals>
+                            <configuration>
+                                <outputDirectory>${feature-pack.root}</outputDirectory>
                                 <resources>
                                     <resource>
                                         <directory>src/main/resources</directory>
-                                        <filtering>true</filtering>
+                                        <include>feature-pack-build.xml</include>
                                     </resource>
                                 </resources>
                             </configuration>
@@ -87,7 +105,7 @@
                             <phase>compile</phase>
                             <configuration>
                                 <config-file>feature-pack-build.xml</config-file>
-                                <config-dir>${feature-pack.dir}</config-dir>
+                                <config-dir>${feature-pack.root}</config-dir>
                                 <resourcesDir>/</resourcesDir>
                             </configuration>
                         </execution>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-9259

@Sanne @fax4ever FYI after becoming aware of the following [guidelines](https://developer.jboss.org/wiki%20/LayeredDistributionsAndModulePathOrganization) we're moving the wildfly-modules to `modules/system/add-ons/ispn`. Let me know if you know of any issues etc.