### PR TITLE
ISPN-9020 Remote query: disabling indexing for a type with @Indexed(false) still creates empty documents in index

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryDisableLegacyIndexingTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryDisableLegacyIndexingTest.java
@@ -141,8 +141,7 @@ public class RemoteQueryDisableLegacyIndexingTest extends AbstractQueryDslTest {
       assertNotNull(searchIntegrator.getIndexManager(indexName));
 
       // index must be empty
-      //TODO [anistor] this assert is disabled due to https://issues.jboss.org/browse/ISPN-9020
-      //assertEquals(0, searchIntegrator.getStatistics().getNumberOfIndexedEntities(ProtobufValueWrapper.class.getName()));
+      assertEquals(0, searchIntegrator.getStatistics().getNumberOfIndexedEntities(ProtobufValueWrapper.class.getName()));
    }
 
    public void testEqNonIndexedType() {

--- a/commons/src/main/java/org/infinispan/commons/dataconversion/WrapperIds.java
+++ b/commons/src/main/java/org/infinispan/commons/dataconversion/WrapperIds.java
@@ -6,6 +6,6 @@ package org.infinispan.commons.dataconversion;
 public interface WrapperIds {
 
    byte BYTE_ARRAY_WRAPPER = 1;
-   byte PROTOSTREAM_WRAPPER = 2;
+   byte PROTOBUF_WRAPPER = 2;
    byte IDENTITY_WRAPPER = 3;
 }

--- a/commons/src/main/java/org/infinispan/commons/marshall/WrappedByteArray.java
+++ b/commons/src/main/java/org/infinispan/commons/marshall/WrappedByteArray.java
@@ -91,7 +91,7 @@ public class WrappedByteArray implements WrappedBytes {
             '}';
    }
 
-   public static class Externalizer extends AbstractExternalizer<WrappedByteArray> {
+   public static final class Externalizer extends AbstractExternalizer<WrappedByteArray> {
 
       @Override
       public Set<Class<? extends WrappedByteArray>> getTypeClasses() {

--- a/remote-query/remote-query-client/src/main/java/org/infinispan/query/remote/client/BaseProtoStreamMarshaller.java
+++ b/remote-query/remote-query-client/src/main/java/org/infinispan/query/remote/client/BaseProtoStreamMarshaller.java
@@ -35,7 +35,7 @@ public abstract class BaseProtoStreamMarshaller extends AbstractMarshaller {
 
    @Override
    public boolean isMarshallable(Object o) {
-      // Protostream can handle all of these type as well even if we do not
+      // our marshaller can handle all of these primitive/scalar types as well even if we do not
       // have a per-type marshaller defined in our SerializationContext
       return o instanceof String ||
             o instanceof Long ||

--- a/remote-query/remote-query-client/src/test/java/org/infinispan/query/remote/client/BaseProtoStreamMarshallerTest.java
+++ b/remote-query/remote-query-client/src/test/java/org/infinispan/query/remote/client/BaseProtoStreamMarshallerTest.java
@@ -2,13 +2,17 @@ package org.infinispan.query.remote.client;
 
 import static org.junit.Assert.assertTrue;
 
+import java.time.Instant;
+import java.util.Date;
+
 import org.infinispan.protostream.ProtobufUtil;
 import org.infinispan.protostream.SerializationContext;
 import org.infinispan.protostream.config.Configuration;
 import org.junit.Test;
 
 /**
- * Ensure BaseProtoStreamMarshaller is able to handle primitive types besides actual protobuf messages and enums.
+ * A simple smoke test to ensure BaseProtoStreamMarshaller is able to handle primitive types besides actual protobuf
+ * messages and enums.
  *
  * @author anistor@redhat.com
  */
@@ -18,12 +22,17 @@ public class BaseProtoStreamMarshallerTest {
    public void testBasicTypesAreMarshallable() {
       BaseProtoStreamMarshaller marshaller = makeIstance();
 
-      assertTrue(marshaller.isMarshallable(""));
+      assertTrue(marshaller.isMarshallable("a"));
+      assertTrue(marshaller.isMarshallable('a'));
       assertTrue(marshaller.isMarshallable(0));
       assertTrue(marshaller.isMarshallable(0L));
-      assertTrue(marshaller.isMarshallable(0.0));
-      assertTrue(marshaller.isMarshallable(0.0f));
+      assertTrue(marshaller.isMarshallable(0.0D));
+      assertTrue(marshaller.isMarshallable(0.0F));
+      assertTrue(marshaller.isMarshallable((byte) 0));
+      assertTrue(marshaller.isMarshallable((short) 0));
       assertTrue(marshaller.isMarshallable(true));
+      assertTrue(marshaller.isMarshallable(new Date(0)));
+      assertTrue(marshaller.isMarshallable(Instant.now()));
       assertTrue(marshaller.isMarshallable(new byte[0]));
    }
 

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/ProgrammaticSearchMappingProviderImpl.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/ProgrammaticSearchMappingProviderImpl.java
@@ -34,6 +34,7 @@ public final class ProgrammaticSearchMappingProviderImpl implements Programmatic
       searchMapping.entity(ProtobufValueWrapper.class)
             .indexed()
             .indexName(cache.getName() + INDEX_NAME_SUFFIX)
+            .interceptor(ProtobufValueWrapperIndexingInterceptor.class)
             .analyzerDiscriminator(ProtobufValueWrapperAnalyzerDiscriminator.class)
             .classBridgeInstance(new ProtobufValueWrapperFieldBridge(cache))
             .norms(Norms.NO)

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/ProtobufRemoteQueryManager.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/ProtobufRemoteQueryManager.java
@@ -48,7 +48,7 @@ class ProtobufRemoteQueryManager implements RemoteQueryManager {
       boolean isIndexed = cr.getComponent(Configuration.class).indexing().index().isEnabled();
       if (isIndexed) {
          DataConversion valueDataConversion = cache.getAdvancedCache().getValueDataConversion();
-         valueDataConversion.overrideWrapper(ProtostreamWrapper.class, cr);
+         valueDataConversion.overrideWrapper(ProtobufWrapper.class, cr);
       }
       this.queryEngine = new RemoteQueryEngine(cache, isIndexed);
       this.keyEncoder = cache.getKeyDataConversion().getEncoder();

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/ProtobufValueWrapperIndexingInterceptor.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/ProtobufValueWrapperIndexingInterceptor.java
@@ -1,0 +1,48 @@
+package org.infinispan.query.remote.impl;
+
+import org.hibernate.search.indexes.interceptor.EntityIndexingInterceptor;
+import org.hibernate.search.indexes.interceptor.IndexingOverride;
+import org.infinispan.protostream.descriptors.Descriptor;
+import org.infinispan.query.remote.impl.indexing.IndexingMetadata;
+import org.infinispan.query.remote.impl.indexing.ProtobufValueWrapper;
+
+/**
+ * Hibernate Search interceptor for conditional indexing of protobuf message types based on the value of the
+ * {@literal @}Indexed protobuf documentation annotation.
+ *
+ * @author anistor@redhat.com
+ * @since 9.3
+ */
+public final class ProtobufValueWrapperIndexingInterceptor implements EntityIndexingInterceptor<ProtobufValueWrapper> {
+
+   @Override
+   public IndexingOverride onAdd(ProtobufValueWrapper entity) {
+      return isIndexed(entity) ? IndexingOverride.APPLY_DEFAULT : IndexingOverride.SKIP;
+   }
+
+   @Override
+   public IndexingOverride onUpdate(ProtobufValueWrapper entity) {
+      return isIndexed(entity) ? IndexingOverride.APPLY_DEFAULT : IndexingOverride.SKIP;
+   }
+
+   @Override
+   public IndexingOverride onDelete(ProtobufValueWrapper entity) {
+      return isIndexed(entity) ? IndexingOverride.APPLY_DEFAULT : IndexingOverride.SKIP;
+   }
+
+   @Override
+   public IndexingOverride onCollectionUpdate(ProtobufValueWrapper entity) {
+      return isIndexed(entity) ? IndexingOverride.APPLY_DEFAULT : IndexingOverride.SKIP;
+   }
+
+   private boolean isIndexed(ProtobufValueWrapper entity) {
+      Descriptor messageDescriptor = entity.getMessageDescriptor();
+      // lack of message descriptor means scalar type, which we do not currently index!
+      if (messageDescriptor == null) {
+         return false;
+      }
+      IndexingMetadata indexingMetadata = messageDescriptor.getProcessedAnnotation(IndexingMetadata.INDEXED_ANNOTATION);
+      return indexingMetadata == null && IndexingMetadata.isLegacyIndexingEnabled(messageDescriptor)
+            || indexingMetadata != null && indexingMetadata.isIndexed();
+   }
+}

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/ProtobufWrapper.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/ProtobufWrapper.java
@@ -10,11 +10,11 @@ import org.infinispan.query.remote.impl.indexing.ProtobufValueWrapper;
  *
  * @since 9.1
  */
-public class ProtostreamWrapper implements Wrapper {
+public class ProtobufWrapper implements Wrapper {
 
-   public static final ProtostreamWrapper INSTANCE = new ProtostreamWrapper();
+   public static final ProtobufWrapper INSTANCE = new ProtobufWrapper();
 
-   private ProtostreamWrapper() {
+   private ProtobufWrapper() {
    }
 
    @Override
@@ -33,20 +33,19 @@ public class ProtostreamWrapper implements Wrapper {
       if (target instanceof ProtobufValueWrapper) {
          return ((ProtobufValueWrapper) target).getBinary();
       }
-      if(target instanceof WrappedByteArray) {
-         return WrappedByteArray.class.cast(target).getBytes();
+      if (target instanceof WrappedByteArray) {
+         return ((WrappedByteArray) target).getBytes();
       }
       return target;
    }
 
    @Override
    public byte id() {
-      return WrapperIds.PROTOSTREAM_WRAPPER;
+      return WrapperIds.PROTOBUF_WRAPPER;
    }
 
    @Override
    public boolean isFilterable() {
       return true;
    }
-
 }

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/RemoteQueryEngine.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/RemoteQueryEngine.java
@@ -33,7 +33,7 @@ import org.infinispan.query.remote.impl.indexing.ProtobufValueWrapper;
 final class RemoteQueryEngine extends BaseRemoteQueryEngine {
 
    RemoteQueryEngine(AdvancedCache<?, ?> cache, boolean isIndexed) {
-      super(isIndexed ? cache.withWrapping(ByteArrayWrapper.class, ProtostreamWrapper.class) : cache,
+      super(isIndexed ? cache.withWrapping(ByteArrayWrapper.class, ProtobufWrapper.class) : cache,
             isIndexed, ProtobufMatcher.class, new ProtobufFieldBridgeAndAnalyzerProvider());
    }
 

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/filter/IckleFilterConverterUtils.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/filter/IckleFilterConverterUtils.java
@@ -15,6 +15,7 @@ import org.infinispan.query.remote.client.BaseProtoStreamMarshaller;
  */
 class IckleFilterConverterUtils {
 
+   // This marshaller is able to handle primitive/scalar types only
    private static final BaseProtoStreamMarshaller paramMarshaller = new BaseProtoStreamMarshaller() {
 
       private final SerializationContext serializationContext = ProtobufUtil.newSerializationContext(Configuration.builder().build());

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/indexing/IndexingWrappedMessageTagHandler.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/indexing/IndexingWrappedMessageTagHandler.java
@@ -1,0 +1,54 @@
+package org.infinispan.query.remote.impl.indexing;
+
+import java.io.IOException;
+
+import org.apache.lucene.document.Document;
+import org.hibernate.search.bridge.LuceneOptions;
+import org.infinispan.commons.CacheException;
+import org.infinispan.protostream.ProtobufParser;
+import org.infinispan.protostream.SerializationContext;
+
+/**
+ * Protostream tag handler for {@code org.infinispan.protostream.WrappedMessage} protobuf type defined in
+ * message-wrapping.proto which also indexes the message.
+ *
+ * @author anistor@redhat.com
+ * @since 9.3
+ */
+final class IndexingWrappedMessageTagHandler extends WrappedMessageTagHandler {
+
+   private final Document document;
+   private final LuceneOptions luceneOptions;
+
+   IndexingWrappedMessageTagHandler(ProtobufValueWrapper valueWrapper, SerializationContext serCtx, Document document, LuceneOptions luceneOptions) {
+      super(valueWrapper, serCtx);
+      this.document = document;
+      this.luceneOptions = luceneOptions;
+   }
+
+   @Override
+   public void onEnd() {
+      super.onEnd();
+
+      if (bytes != null) {
+         IndexingMetadata indexingMetadata = messageDescriptor.getProcessedAnnotation(IndexingMetadata.INDEXED_ANNOTATION);
+         // if the message definition is not annotated at all we consider all fields indexed and stored (but not analyzed), just to be backwards compatible
+         if (indexingMetadata == null && IndexingMetadata.isLegacyIndexingEnabled(messageDescriptor) || indexingMetadata != null && indexingMetadata.isIndexed()) {
+            if (indexingMetadata == null) {
+               log.legacyIndexingIsDeprecated(messageDescriptor.getFullName(), messageDescriptor.getFileDescriptor().getName());
+            }
+            valueWrapper.setMessageDescriptor(messageDescriptor);
+            try {
+               ProtobufParser.INSTANCE.parse(new IndexingTagHandler(messageDescriptor, document), messageDescriptor, bytes);
+            } catch (IOException e) {
+               throw new CacheException(e);
+            }
+         }
+      } else if (numericValue != null) {
+         //todo [anistor] how do we index a scalar value?
+         luceneOptions.addNumericFieldToDocument("theValue", numericValue, document);
+      } else if (stringValue != null) {
+         luceneOptions.addFieldToDocument("theValue", stringValue, document);
+      }
+   }
+}

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/indexing/ProtobufValueWrapper.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/indexing/ProtobufValueWrapper.java
@@ -31,10 +31,10 @@ public final class ProtobufValueWrapper implements WrappedBytes {
    // The protobuf encoded payload
    private final byte[] binary;
 
-   private int hashCode = 0;
+   private transient int hashCode = 0;
 
    // The Descriptor of the message (if it's a Message and not a primitive value). Transient field!
-   private Descriptor messageDescriptor;
+   private transient Descriptor messageDescriptor;
 
    public ProtobufValueWrapper(byte[] binary) {
       if (binary == null) {

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/indexing/ProtobufValueWrapperFieldBridge.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/indexing/ProtobufValueWrapperFieldBridge.java
@@ -61,7 +61,7 @@ public final class ProtobufValueWrapperFieldBridge implements FieldBridge {
       }
 
       try {
-         ProtobufParser.INSTANCE.parse(new WrappedMessageTagHandler(valueWrapper, document, luceneOptions, serializationContext), wrapperDescriptor, valueWrapper.getBinary());
+         ProtobufParser.INSTANCE.parse(new IndexingWrappedMessageTagHandler(valueWrapper, serializationContext, document, luceneOptions), wrapperDescriptor, valueWrapper.getBinary());
       } catch (IOException e) {
          throw new CacheException(e);
       }

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/indexing/ProtobufValueWrapperInterceptor.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/indexing/ProtobufValueWrapperInterceptor.java
@@ -1,0 +1,93 @@
+package org.infinispan.query.remote.impl.indexing;
+
+import java.io.IOException;
+
+import org.infinispan.commands.write.PutKeyValueCommand;
+import org.infinispan.commands.write.PutMapCommand;
+import org.infinispan.commands.write.RemoveCommand;
+import org.infinispan.commands.write.ReplaceCommand;
+import org.infinispan.commons.CacheException;
+import org.infinispan.context.InvocationContext;
+import org.infinispan.interceptors.DDAsyncInterceptor;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.protostream.ProtobufParser;
+import org.infinispan.protostream.SerializationContext;
+import org.infinispan.protostream.WrappedMessage;
+import org.infinispan.protostream.descriptors.Descriptor;
+import org.infinispan.query.remote.impl.ProtobufMetadataManagerImpl;
+
+/**
+ * Intercepts write operations to the cache where the value is a ProtobufValueWrapper object and parses the underlying
+ * WrappedMessage to discover the inner message type. The message type is needed in order to be able to tell later in
+ * the interceptor chain if it gets indexed or not.
+ *
+ * @author anistor@redhat.com
+ * @since 9.3
+ */
+public final class ProtobufValueWrapperInterceptor extends DDAsyncInterceptor {
+
+   private final EmbeddedCacheManager cacheManager;
+
+   /**
+    * This is lazily initialised in {@code discoverMessageType} method. This does not need to be volatile nor do we need
+    * to synchronize before accessing it. It may happen to initialize it multiple times but that is not harmful.
+    */
+   private SerializationContext serializationContext = null;
+
+   /**
+    * Lazily initialized in {@code discoverMessageType} method, similarly to {@code serializationContext} field.
+    */
+   private Descriptor wrapperDescriptor = null;
+
+   public ProtobufValueWrapperInterceptor(EmbeddedCacheManager cacheManager) {
+      this.cacheManager = cacheManager;
+   }
+
+   @Override
+   public Object visitPutKeyValueCommand(InvocationContext ctx, PutKeyValueCommand command) {
+      intercept(command.getValue());
+      return invokeNext(ctx, command);
+   }
+
+   @Override
+   public Object visitPutMapCommand(InvocationContext ctx, PutMapCommand command) {
+      for (Object value : command.getMap().values()) {
+         intercept(value);
+      }
+      return invokeNext(ctx, command);
+   }
+
+   @Override
+   public Object visitReplaceCommand(InvocationContext ctx, ReplaceCommand command) throws Throwable {
+      intercept(command.getOldValue());
+      intercept(command.getNewValue());
+      return super.visitReplaceCommand(ctx, command);
+   }
+
+   @Override
+   public Object visitRemoveCommand(InvocationContext ctx, RemoveCommand command) throws Throwable {
+      intercept(command.getValue());
+      return super.visitRemoveCommand(ctx, command);
+   }
+
+   private void intercept(Object value) {
+      if (value instanceof ProtobufValueWrapper) {
+         discoverMessageType((ProtobufValueWrapper) value);
+      }
+   }
+
+   private void discoverMessageType(ProtobufValueWrapper valueWrapper) {
+      if (serializationContext == null) {
+         serializationContext = ProtobufMetadataManagerImpl.getSerializationContextInternal(cacheManager);
+      }
+      if (wrapperDescriptor == null) {
+         wrapperDescriptor = serializationContext.getMessageDescriptor(WrappedMessage.PROTOBUF_TYPE_NAME);
+      }
+
+      try {
+         ProtobufParser.INSTANCE.parse(new WrappedMessageTagHandler(valueWrapper, serializationContext), wrapperDescriptor, valueWrapper.getBinary());
+      } catch (IOException e) {
+         throw new CacheException(e);
+      }
+   }
+}

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/indexing/WrappedMessageTagHandler.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/indexing/WrappedMessageTagHandler.java
@@ -1,12 +1,6 @@
 package org.infinispan.query.remote.impl.indexing;
 
-import java.io.IOException;
-
-import org.apache.lucene.document.Document;
-import org.hibernate.search.bridge.LuceneOptions;
-import org.infinispan.commons.CacheException;
 import org.infinispan.commons.logging.LogFactory;
-import org.infinispan.protostream.ProtobufParser;
 import org.infinispan.protostream.SerializationContext;
 import org.infinispan.protostream.TagHandler;
 import org.infinispan.protostream.WrappedMessage;
@@ -16,27 +10,27 @@ import org.infinispan.protostream.descriptors.GenericDescriptor;
 import org.infinispan.query.remote.impl.logging.Log;
 
 /**
+ * Protostream tag handler for {@code org.infinispan.protostream.WrappedMessage} protobuf type defined in
+ * message-wrapping.proto. This handler extracts the embedded value or message but does not parse the message, it just
+ * discovers its type.
+ *
  * @author anistor@redhat.com
  * @since 6.0
  */
-final class WrappedMessageTagHandler implements TagHandler {
+class WrappedMessageTagHandler implements TagHandler {
 
-   private static final Log log = LogFactory.getLog(WrappedMessageTagHandler.class, Log.class);
+   protected static final Log log = LogFactory.getLog(WrappedMessageTagHandler.class, Log.class);
 
-   private final ProtobufValueWrapper valueWrapper;
-   private final Document document;
-   private final LuceneOptions luceneOptions;
-   private final SerializationContext serCtx;
+   protected final ProtobufValueWrapper valueWrapper;
+   protected final SerializationContext serCtx;
 
-   private Descriptor messageDescriptor;
-   private byte[] bytes;
-   private Number numericValue;
-   private String stringValue;
+   protected Descriptor messageDescriptor;
+   protected byte[] bytes;          // message bytes
+   protected Number numericValue;
+   protected String stringValue;
 
-   WrappedMessageTagHandler(ProtobufValueWrapper valueWrapper, Document document, LuceneOptions luceneOptions, SerializationContext serCtx) {
+   WrappedMessageTagHandler(ProtobufValueWrapper valueWrapper, SerializationContext serCtx) {
       this.valueWrapper = valueWrapper;
-      this.document = document;
-      this.luceneOptions = luceneOptions;
       this.serCtx = serCtx;
    }
 
@@ -96,29 +90,12 @@ final class WrappedMessageTagHandler implements TagHandler {
    @Override
    public void onEnd() {
       if (bytes != null) {
-         // it's a message, not a primitive value
+         // it's a message, not a primitive value; we must have a type now
          if (messageDescriptor == null) {
             throw new IllegalStateException("Type name or type id is missing");
          }
 
-         IndexingMetadata indexingMetadata = messageDescriptor.getProcessedAnnotation(IndexingMetadata.INDEXED_ANNOTATION);
-         // if the message definition is not annotated at all we consider all fields indexed and stored (but not analyzed), just to be backwards compatible
-         if (indexingMetadata == null && IndexingMetadata.isLegacyIndexingEnabled(messageDescriptor) || indexingMetadata != null && indexingMetadata.isIndexed()) {
-            if (indexingMetadata == null) {
-               log.legacyIndexingIsDeprecated(messageDescriptor.getFullName(), messageDescriptor.getFileDescriptor().getName());
-            }
-            valueWrapper.setMessageDescriptor(messageDescriptor);
-            try {
-               ProtobufParser.INSTANCE.parse(new IndexingTagHandler(messageDescriptor, document), messageDescriptor, bytes);
-            } catch (IOException e) {
-               throw new CacheException(e);
-            }
-         }
-      } else if (numericValue != null) {
-         //todo [anistor] how do we index a scalar value?
-         luceneOptions.addNumericFieldToDocument("theValue", numericValue, document);
-      } else if (stringValue != null) {
-         luceneOptions.addFieldToDocument("theValue", stringValue, document);
+         valueWrapper.setMessageDescriptor(messageDescriptor);
       }
    }
 }

--- a/tasks/manager/src/test/java/org/infinispan/tasks/SecurityTaskManagerTest.java
+++ b/tasks/manager/src/test/java/org/infinispan/tasks/SecurityTaskManagerTest.java
@@ -35,7 +35,7 @@ public class SecurityTaskManagerTest extends SingleCacheManagerTest {
     static final Subject ADMIN = TestingUtil.makeSubject("admin", "admin");
     static final Subject HACKER = TestingUtil.makeSubject("hacker", "hacker");
 
-    protected TaskManagerImpl taskManager;
+    private TaskManagerImpl taskManager;
     private DummyTaskEngine taskEngine;
 
     @Override
@@ -89,7 +89,7 @@ public class SecurityTaskManagerTest extends SingleCacheManagerTest {
         });
     }
 
-    @Test(dataProvider = "principleProvider")
+    @Test(dataProvider = "principalProvider")
     public void testTaskExecutionWithAuthorization(String principal, Subject subject) throws Exception {
         Security.doAs(subject, new PrivilegedAction<Void>() {
             @Override
@@ -116,8 +116,8 @@ public class SecurityTaskManagerTest extends SingleCacheManagerTest {
         });
     }
 
-    @DataProvider(name = "principleProvider")
-    private static Object[][] providePrinciples() {
+    @DataProvider(name = "principalProvider")
+    private static Object[][] providePrincipals() {
         return new Object[][] {{"admin", ADMIN}, {"hacker", HACKER}};
     }
 }


### PR DESCRIPTION
…ng to handle conditional indexing for @Indexed(false)

https://issues.jboss.org/browse/ISPN-9020

* add ProtobufValueWrapperInterceptor to intercept writing of ProtobufValueWrapper objects in the cache and discover the inner message type
* add ProtobufValueWrapperIndexingInterceptor to provide conditional indexing
* rename ProtostreamWrapper to ProtobufWrapper because it's really the encoding format not the encoding library that's important
