### PR TITLE
ISPN-8988 Cache item can be expired after loading immediately

### DIFF
--- a/core/src/main/java/org/infinispan/persistence/PersistenceUtil.java
+++ b/core/src/main/java/org/infinispan/persistence/PersistenceUtil.java
@@ -143,6 +143,8 @@ public class PersistenceUtil {
 
    public static <K, V> MarshalledEntry<K, V> loadAndCheckExpiration(PersistenceManager persistenceManager, Object key,
                                                         InvocationContext context, TimeService timeService) {
+      long expireCheckTime = timeService.wallClockTime();
+
       final MarshalledEntry<K, V> loaded = persistenceManager.loadFromAllStores(key, context.isOriginLocal());
       if (trace) {
          log.tracef("Loaded %s for key %s from persistence.", loaded, key);
@@ -151,7 +153,7 @@ public class PersistenceUtil {
          return null;
       }
       InternalMetadata metadata = loaded.getMetadata();
-      if (metadata != null && metadata.isExpired(timeService.wallClockTime())) {
+      if (metadata != null && metadata.isExpired(expireCheckTime)) {
          return null;
       }
       return loaded;


### PR DESCRIPTION
In case of CacheLoader usage (e.g. JCache's CacheLoader)

Problem:
1. Element loaded throw CacheLoader with current time
2. Then checked by expiration
3. Expiration failed
4. Returned null instead of loaded element

More complex case:
1. Element in cache
2. Element requested from JCache
3. No expiration happend when check for reloading in JCache
4. Second check in PersistenceUtil and expiration happend
5. Returned null