### PR TITLE
ISPN-9219 ISPN-9266 (Weak|Strong)CounterAPITest.testAdd random failures

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/counter/AbstractCounterTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/counter/AbstractCounterTest.java
@@ -11,6 +11,7 @@ import java.util.stream.Collectors;
 import org.infinispan.client.hotrod.RemoteCounterManagerFactory;
 import org.infinispan.client.hotrod.test.MultiHotRodServersTest;
 import org.infinispan.counter.api.CounterManager;
+import org.infinispan.counter.impl.CounterModuleLifecycle;
 import org.infinispan.lifecycle.ComponentStatus;
 import org.testng.annotations.BeforeMethod;
 
@@ -25,7 +26,7 @@ public abstract class AbstractCounterTest extends MultiHotRodServersTest {
    private static final int NUMBER_SERVERS = 3;
 
    @BeforeMethod(alwaysRun = true)
-   public void restoreServer() throws Throwable {
+   public void restoreServer() {
       if (servers.size() < NUMBER_SERVERS) {
          // Start Hot Rod servers
          while (servers.size() < NUMBER_SERVERS) {
@@ -38,6 +39,7 @@ public abstract class AbstractCounterTest extends MultiHotRodServersTest {
             blockUntilCacheStatusAchieved(manager(i).getCache(), ComponentStatus.RUNNING, 10000);
          }
       }
+      waitForClusterToForm(CounterModuleLifecycle.COUNTER_CACHE_NAME);
    }
 
    List<CounterManager> counterManagers() {

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/counter/CounterManagerOperationTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/counter/CounterManagerOperationTest.java
@@ -12,6 +12,7 @@ import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.counter.api.CounterManager;
+import org.infinispan.counter.impl.CounterModuleLifecycle;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.server.hotrod.HotRodMultiNodeTest;
 import org.infinispan.server.hotrod.HotRodVersion;
@@ -111,6 +112,7 @@ public class CounterManagerOperationTest extends HotRodMultiNodeTest implements 
          EmbeddedCacheManager cm = createClusteredCacheManager(builder, hotRodCacheConfiguration());
          cacheManagers.add(cm);
       }
+      waitForClusterToForm(CounterModuleLifecycle.COUNTER_CACHE_NAME);
    }
 
    @Override

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/counter/StrongCounterAPITest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/counter/StrongCounterAPITest.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.counter.api.CounterManager;
+import org.infinispan.counter.impl.CounterModuleLifecycle;
 import org.infinispan.server.hotrod.HotRodMultiNodeTest;
 import org.infinispan.server.hotrod.HotRodVersion;
 import org.infinispan.server.hotrod.counter.impl.StrongCounterImplTestStrategy;
@@ -93,6 +94,12 @@ public class StrongCounterAPITest extends HotRodMultiNodeTest implements StrongC
 
    private Collection<CounterManager> allTestCounterManager() {
       return clients().stream().map(TestCounterManager::new).collect(Collectors.toList());
+   }
+
+   @Override
+   protected void createCacheManagers() {
+      super.createCacheManagers();
+      waitForClusterToForm(CounterModuleLifecycle.COUNTER_CACHE_NAME);
    }
 
 }

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/counter/WeakCounterAPITest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/counter/WeakCounterAPITest.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.counter.api.CounterManager;
 import org.infinispan.counter.api.WeakCounter;
+import org.infinispan.counter.impl.CounterModuleLifecycle;
 import org.infinispan.server.hotrod.HotRodMultiNodeTest;
 import org.infinispan.server.hotrod.HotRodVersion;
 import org.infinispan.server.hotrod.counter.impl.TestCounterManager;
@@ -76,4 +77,9 @@ public class WeakCounterAPITest extends HotRodMultiNodeTest implements WeakCount
       return clients().stream().map(TestCounterManager::new).collect(Collectors.toList());
    }
 
+   @Override
+   protected void createCacheManagers() {
+      super.createCacheManagers();
+      waitForClusterToForm(CounterModuleLifecycle.COUNTER_CACHE_NAME);
+   }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-9219
https://issues.jboss.org/browse/ISPN-9266

at least locally, the failures are caused by retried functional commands. 

https://github.com/infinispan/infinispan/pull/5381 should fix those. In the meanwhile, lets make sure the counter's cache is started before start the testing.