### PR TITLE
ISPN-8988 Cache item can be expired after loading immediately

### DIFF
--- a/core/src/main/java/org/infinispan/persistence/PersistenceUtil.java
+++ b/core/src/main/java/org/infinispan/persistence/PersistenceUtil.java
@@ -147,13 +147,6 @@ public class PersistenceUtil {
       if (trace) {
          log.tracef("Loaded %s for key %s from persistence.", loaded, key);
       }
-      if (loaded == null) {
-         return null;
-      }
-      InternalMetadata metadata = loaded.getMetadata();
-      if (metadata != null && metadata.isExpired(timeService.wallClockTime())) {
-         return null;
-      }
       return loaded;
    }
 


### PR DESCRIPTION
* Removed extra expiration check
* CacheLoader should handle check

https://issues.jboss.org/browse/ISPN-8988
