### PR TITLE
ISPN-9016 Delete temporary SingleFileStore .dat files after tests

### DIFF
--- a/core/src/test/java/org/infinispan/expiration/impl/ExpirationSingleFileStoreListenerFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/expiration/impl/ExpirationSingleFileStoreListenerFunctionalTest.java
@@ -1,6 +1,9 @@
 package org.infinispan.expiration.impl;
 
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.test.TestingUtil;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 @Test(groups = "functional", testName = "expiration.impl.ExpirationSingleFileStoreListenerFunctionalTest")
@@ -8,8 +11,13 @@ public class ExpirationSingleFileStoreListenerFunctionalTest extends ExpirationS
    @Override
    protected void configure(ConfigurationBuilder config) {
       config
-              // Prevent the reaper from running, reaperEnabled(false) doesn't work when a store is present
-              .expiration().wakeUpInterval(Long.MAX_VALUE)
-              .persistence().addSingleFileStore();
+         // Prevent the reaper from running, reaperEnabled(false) doesn't work when a store is present
+         .expiration().wakeUpInterval(Long.MAX_VALUE)
+         .persistence().addSingleFileStore().location(TestingUtil.tmpDirectory(this.getClass()));
+   }
+
+   @AfterClass(alwaysRun = true)
+   protected void clearTempDir() {
+      Util.recursiveFileRemove(TestingUtil.tmpDirectory(this.getClass()));
    }
 }

--- a/core/src/test/java/org/infinispan/persistence/file/SingleFileStoreFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/persistence/file/SingleFileStoreFunctionalTest.java
@@ -1,19 +1,20 @@
 package org.infinispan.persistence.file;
 
-import static org.infinispan.test.TestingUtil.withCacheManager;
 import static org.testng.AssertJUnit.assertEquals;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.InputStream;
+import java.util.List;
 
-import org.infinispan.Cache;
 import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.PersistenceConfigurationBuilder;
+import org.infinispan.configuration.cache.SingleFileStoreConfiguration;
+import org.infinispan.configuration.cache.StoreConfiguration;
+import org.infinispan.configuration.parsing.ConfigurationBuilderHolder;
+import org.infinispan.configuration.parsing.ParserRegistry;
 import org.infinispan.persistence.BaseStoreFunctionalTest;
-import org.infinispan.test.CacheManagerCallable;
 import org.infinispan.test.TestingUtil;
-import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -59,19 +60,12 @@ public class SingleFileStoreFunctionalTest extends BaseStoreFunctionalTest {
             "      </persistence>\n" +
             "   </local-cache>\n" +
             "</cache-container>");
-      InputStream is = new ByteArrayInputStream(config.getBytes());
-      withCacheManager(new CacheManagerCallable(TestCacheManagerFactory.fromStream(is)) {
-         @Override
-         public void call() {
-            Cache<Object, Object> cache = cm.getCache();
-            cache.put(1, "v1");
-            assertEquals("v1", cache.get(1));
-            SingleFileStore cacheLoader = (SingleFileStore) TestingUtil.getFirstLoader(cache);
-            assertEquals("Infinispan-SingleFileStore", cacheLoader.getConfiguration().location());
-            assertEquals(-1, cacheLoader.getConfiguration().maxEntries());
-         }
-      });
-      Util.recursiveFileRemove("Infinispan-SingleFileStore");
+      ConfigurationBuilderHolder holder = new ParserRegistry().parse(config);
+      List<StoreConfiguration> storeConfigs = holder.getDefaultConfigurationBuilder().build().persistence().stores();
+      assertEquals(1, storeConfigs.size());
+      SingleFileStoreConfiguration fileStoreConfig = (SingleFileStoreConfiguration) storeConfigs.get(0);
+      assertEquals("Infinispan-SingleFileStore", fileStoreConfig.location());
+      assertEquals(-1, fileStoreConfig.maxEntries());
    }
 
    public void testParsingElement() throws Exception {
@@ -84,18 +78,13 @@ public class SingleFileStoreFunctionalTest extends BaseStoreFunctionalTest {
             "   </local-cache>\n" +
             "</cache-container>");
       InputStream is = new ByteArrayInputStream(config.getBytes());
-      withCacheManager(new CacheManagerCallable(TestCacheManagerFactory.fromStream(is)) {
-         @Override
-         public void call() {
-            Cache<Object, Object> cache = cm.getCache();
-            cache.put(1, "v1");
-            assertEquals("v1", cache.get(1));
-            SingleFileStore store = (SingleFileStore) TestingUtil.getFirstLoader(cache);
-            assertEquals("other-location", store.getConfiguration().location());
-            assertEquals(100, store.getConfiguration().maxEntries());
-            assertEquals(0.75f, store.getConfiguration().fragmentationFactor(), 0f);
-         }
-      });
+      ConfigurationBuilderHolder holder = new ParserRegistry().parse(config);
+      List<StoreConfiguration> storeConfigs = holder.getDefaultConfigurationBuilder().build().persistence().stores();
+      assertEquals(1, storeConfigs.size());
+      SingleFileStoreConfiguration fileStoreConfig = (SingleFileStoreConfiguration) storeConfigs.get(0);
+      assertEquals("other-location", fileStoreConfig.location());
+      assertEquals(100, fileStoreConfig.maxEntries());
+      assertEquals(0.75f, fileStoreConfig.fragmentationFactor(), 0f);
       Util.recursiveFileRemove("other-location");
    }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-9016 removed the gitignore for *.dat files, and this exposed a problem in ExpirationSingleFileStoreListenerFunctionalTest

I initially thought the stale files were from SingleFileStoreFunctionalTest, so I changed it to skip the cache instantiation in the parse tests as well.