### PR TITLE
Deps fix

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -371,26 +371,6 @@
          </dependency>
          <dependency>
             <groupId>org.infinispan</groupId>
-            <artifactId>infinispan-hibernate-cache-spi</artifactId>
-            <version>${project.version}</version>
-         </dependency>
-         <dependency>
-            <groupId>org.infinispan</groupId>
-            <artifactId>infinispan-hibernate-cache-commons</artifactId>
-            <version>${project.version}</version>
-         </dependency>
-         <dependency>
-            <groupId>org.infinispan</groupId>
-            <artifactId>infinispan-hibernate-cache-v51</artifactId>
-            <version>${project.version}</version>
-         </dependency>
-         <dependency>
-            <groupId>org.infinispan</groupId>
-            <artifactId>infinispan-hibernate-cache-v53</artifactId>
-            <version>${project.version}</version>
-         </dependency>
-         <dependency>
-            <groupId>org.infinispan</groupId>
             <artifactId>infinispan-feature-pack-commons</artifactId>
             <version>${project.version}</version>
             <type>zip</type>

--- a/hibernate/cache-commons/pom.xml
+++ b/hibernate/cache-commons/pom.xml
@@ -22,13 +22,13 @@
       <dependency>
          <groupId>org.infinispan</groupId>
          <artifactId>infinispan-hibernate-cache-spi</artifactId>
+         <version>${project.version}</version>
       </dependency>
       <dependency>
          <groupId>org.hibernate</groupId>
          <artifactId>hibernate-core</artifactId>
          <version>${version.hibernate.core}</version>
       </dependency>
-
       <dependency>
          <groupId>org.hibernate</groupId>
          <artifactId>hibernate-testing</artifactId>

--- a/hibernate/cache-v51/pom.xml
+++ b/hibernate/cache-v51/pom.xml
@@ -22,6 +22,7 @@
       <dependency>
          <groupId>org.infinispan</groupId>
          <artifactId>infinispan-hibernate-cache-commons</artifactId>
+         <version>${project.version}</version>
       </dependency>
       <dependency>
          <groupId>org.infinispan</groupId>

--- a/hibernate/cache-v53/pom.xml
+++ b/hibernate/cache-v53/pom.xml
@@ -22,16 +22,13 @@
       <dependency>
          <groupId>org.infinispan</groupId>
          <artifactId>infinispan-hibernate-cache-commons</artifactId>
+         <version>${project.version}</version>
       </dependency>
       <dependency>
          <groupId>org.infinispan</groupId>
          <artifactId>infinispan-hibernate-cache-commons</artifactId>
          <type>test-jar</type>
          <scope>test</scope>
-      </dependency>
-      <dependency>
-         <groupId>org.infinispan</groupId>
-         <artifactId>infinispan-hibernate-cache-spi</artifactId>
       </dependency>
       <dependency>
          <groupId>org.glassfish.jaxb</groupId>

--- a/integrationtests/as-lucene-directory/pom.xml
+++ b/integrationtests/as-lucene-directory/pom.xml
@@ -99,19 +99,6 @@
          <artifactId>infinispan-lucene-directory</artifactId>
          <scope>test</scope>
       </dependency>
-      <!-- The wildfly-provision-plugin tries to access /target folders of other modules and this does no work for parallel builds.
-      Adding an anchor here to make sure deps are available -->
-      <dependency>
-         <groupId>org.infinispan</groupId>
-         <artifactId>infinispan-query</artifactId>
-         <scope>test</scope>
-      </dependency>
-      <dependency>
-         <groupId>org.infinispan</groupId>
-         <artifactId>infinispan-feature-pack-server</artifactId>
-         <type>zip</type>
-         <scope>test</scope>
-      </dependency>
       <dependency>
          <groupId>com.h2database</groupId>
          <artifactId>h2</artifactId>


### PR DESCRIPTION
I did not create a JIRA or include a JIRA reference as I'm fixing an issue debated on team chat but I don't know if there is a related JIRA... please feel free to edit the commits and merge, I am unlikely to have time for that myself tomorrow.

Fundamentally the problem is that the BOM enforces Dependency Management, and thus overrides components which are defined by the WildFly feature pack - we really need to test with whatever library versions come with WildFly, at least when it comes to those modules which are meant to be used as additional modules for a vanilla WildFly server.

I suggest most modules should not inherit from the BOM, making the BOM import optional and making it easier for each module to opt-in (or not) to the global version enforcement.

