### PR TITLE
ISPN-9326 Marshall error when using <modules> config in the server

### DIFF
--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLWriter.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLWriter.java
@@ -86,20 +86,6 @@ public class InfinispanSubsystemXMLWriter implements XMLElementWriter<SubsystemM
                     writer.writeEndElement();
                 }
 
-                if (container.hasDefined(ModelKeys.MODULES)) {
-                    writer.writeStartElement(Element.MODULES.getLocalName());
-                    ModelNode modules = container.get(ModelKeys.MODULES, ModelKeys.MODULES_NAME);
-                    for (ModelNode moduleNode : modules.asList()) {
-                        writer.writeStartElement(Element.MODULE.getLocalName());
-                        CacheContainerModuleResource.NAME.marshallAsAttribute(moduleNode.get(ModelKeys.NAME), writer);
-                        if (moduleNode.hasDefined(ModelKeys.SLOT)) {
-                            CacheContainerModuleResource.SLOT.marshallAsAttribute(moduleNode.get(ModelKeys.SLOT), false, writer);
-                        }
-                        writer.writeEndElement();
-                    }
-                    writer.writeEndElement();
-                }
-
                 if (container.hasDefined(ModelKeys.SECURITY)) {
                     writer.writeStartElement(Element.SECURITY.getLocalName());
                     ModelNode security = container.get(ModelKeys.SECURITY, ModelKeys.SECURITY_NAME);
@@ -183,6 +169,22 @@ public class InfinispanSubsystemXMLWriter implements XMLElementWriter<SubsystemM
 
                 ModelNode configurations = container.get(ModelKeys.CONFIGURATIONS, ModelKeys.CONFIGURATIONS_NAME);
 
+                if (container.hasDefined(ModelKeys.MODULES)) {
+                    writer.writeStartElement(Element.MODULES.getLocalName());
+                    ModelNode modules = container.get(ModelKeys.MODULES, ModelKeys.MODULES_NAME, ModelKeys.MODULE);
+                    for (ModelNode moduleNode : modules.asList()) {
+                        if(moduleNode.isDefined()) {
+                            ModelNode modelNode = moduleNode.get(0);
+                            writer.writeStartElement(Element.MODULE.getLocalName());
+                            writeAttribute(writer, modelNode, CacheContainerModuleResource.NAME);
+                            if (modelNode.hasDefined(ModelKeys.SLOT)) {
+                                writeAttribute(writer, modelNode, CacheContainerModuleResource.SLOT);
+                            }
+                            writer.writeEndElement();
+                        }
+                    }
+                    writer.writeEndElement();
+                }
                 // write any existent cache types
                 processCacheConfiguration(writer, container, configurations, ModelKeys.LOCAL_CACHE);
                 processCacheConfiguration(writer, container, configurations, ModelKeys.INVALIDATION_CACHE);

--- a/server/integration/infinispan/src/test/java/org/jboss/as/clustering/infinispan/subsystem/SubsystemParsingTestCase.java
+++ b/server/integration/infinispan/src/test/java/org/jboss/as/clustering/infinispan/subsystem/SubsystemParsingTestCase.java
@@ -78,7 +78,7 @@ public class SubsystemParsingTestCase extends ClusteringSubsystemTest {
               {Namespace.INFINISPAN_SERVER_9_0, 142, null, null},
               {Namespace.INFINISPAN_SERVER_9_1, 144, null, null},
               {Namespace.INFINISPAN_SERVER_9_2, 154, null, null},
-              {Namespace.INFINISPAN_SERVER_9_3, 154, "schema/jboss-infinispan-core_9_3.xsd", new String[]{"/subsystem-templates/infinispan-core.xml"}},
+              {Namespace.INFINISPAN_SERVER_9_3, 157, "schema/jboss-infinispan-core_9_3.xsd", new String[]{"/subsystem-templates/infinispan-core.xml"}},
         };
         return Arrays.asList(data);
     }

--- a/server/integration/infinispan/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan_9_3.xml
+++ b/server/integration/infinispan/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan_9_3.xml
@@ -34,6 +34,10 @@
                                queue-length="42"
                                max-threads="43"
                                keepalive-time="44"/>
+        <modules>
+            <module name="module1"/>
+            <module name="module2" slot="slot2"/>
+        </modules>
         <local-cache-configuration name="local-template">
         </local-cache-configuration>
         <local-cache name="local-instance" configuration="local-template"/>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-9326

The model generated for this configuration is kind of weird

```
 "modules" => {"MODULES" => {"module" => {
        "module1" => {
            "name" => "module1",
            "slot" => undefined
        },
        "module2" => {
            "name" => "module2",
            "slot" => "slot2"
        }
    }}}
```

But I could not figure out how to improve it after 1h, so I just fixed the serialization bug