### PR TITLE
ISPN-9327 Always use UTF-8 in memcached server and tests

### DIFF
--- a/server/memcached/src/main/java/org/infinispan/server/memcached/MemcachedDecoder.java
+++ b/server/memcached/src/main/java/org/infinispan/server/memcached/MemcachedDecoder.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.io.StreamCorruptedException;
 import java.math.BigInteger;
 import java.nio.channels.ClosedChannelException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -965,7 +966,7 @@ public class MemcachedDecoder extends ReplayingDecoder<MemcachedDecoderState> {
                                        int extraSpace) {
       byte[] data = entry.getValue();
       byte[] dataSize = String.valueOf(data.length).getBytes();
-      byte[] key = k.getBytes();
+      byte[] key = k.getBytes(StandardCharsets.UTF_8);
 
       byte[] flags;
       Metadata metadata = entry.getMetadata();

--- a/server/memcached/src/test/java/org/infinispan/server/memcached/MemcachedFunctionalTest.java
+++ b/server/memcached/src/test/java/org/infinispan/server/memcached/MemcachedFunctionalTest.java
@@ -15,7 +15,7 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.math.BigInteger;
 import java.net.SocketAddress;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -605,8 +605,8 @@ public class MemcachedFunctionalTest extends MemcachedSingleNodeTest {
 
    public void testBufferOverflowCausesUnknownException() throws Exception {
       List<String> keys = Files.readAllLines(
-            Paths.get(getClass().getClassLoader().getResource("keys.txt").toURI()),
-            Charset.defaultCharset()
+         Paths.get(getClass().getClassLoader().getResource("keys.txt").toURI()),
+         StandardCharsets.UTF_8
       );
 
       for (String key : keys) {


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-9327

The test is failing because both the test and the server assume the platform encoding is UTF-8. E.g. the server uses UTF-8 when reading the key, and the platform encoding when writing it back.

On this machine the platform encoding is US-ASCII, and that breaks the test and the server.

@tristantarrant do you think it's useful for the server to use the platform encoding instead? (We'd have to change the way we read keys as well.)

Could you also explain a bit what kind of buffer overflow we are testing? If it's the buffer replay in the server, I think it would be better to include this in every test by using `SingleByteFrameDecoderChannelInitializer` to force a replay on every byte, without a separate test.