### PR TITLE
ISPN-9333 Delete destination file before rename

### DIFF
--- a/commons/src/main/java/org/infinispan/commons/util/Util.java
+++ b/commons/src/main/java/org/infinispan/commons/util/Util.java
@@ -20,6 +20,8 @@ import java.lang.reflect.Modifier;
 import java.net.Socket;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileLock;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.text.NumberFormat;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
@@ -33,7 +35,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
-import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
 import javax.naming.Context;
@@ -1103,14 +1104,12 @@ public final class Util {
       return length == 0 ? EMPTY_STRING_ARRAY : new String[length];
    }
 
-   public static void renameTempFile(File tempFile, File lockFile, File dstFile, BiConsumer<File, File> renameFailed)
+   public static void renameTempFile(File tempFile, File lockFile, File dstFile)
          throws IOException {
       FileLock lock = null;
       try (FileOutputStream lockFileOS = new FileOutputStream(lockFile)) {
          lock = lockFileOS.getChannel().lock();
-         if (!tempFile.renameTo(dstFile)) {
-            renameFailed.accept(tempFile, dstFile);
-         }
+         Files.move(tempFile.toPath(), dstFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
       } finally {
          if (lock != null && lock.isValid()) {
             lock.release();

--- a/core/src/main/java/org/infinispan/globalstate/impl/OverlayLocalConfigurationStorage.java
+++ b/core/src/main/java/org/infinispan/globalstate/impl/OverlayLocalConfigurationStorage.java
@@ -76,10 +76,6 @@ public class OverlayLocalConfigurationStorage extends VolatileLocalConfiguration
       }
    }
 
-   private static void renameFailed(File tmpFile, File dstFile) {
-      throw log.cannotRenamePersistentFile(tmpFile.getAbsolutePath(), dstFile);
-   }
-
    private void storeAll() {
       try {
          File sharedDirectory = new File(globalConfiguration.globalState().sharedPersistentLocation());
@@ -92,8 +88,12 @@ public class OverlayLocalConfigurationStorage extends VolatileLocalConfiguration
          try (FileOutputStream f = new FileOutputStream(temp)) {
             parserRegistry.serialize(f, null, configurationMap);
          }
-         renameTempFile(temp, getPersistentFileLock(), getPersistentFile(),
-               OverlayLocalConfigurationStorage::renameFailed);
+         File persistentFile = getPersistentFile();
+         try {
+            renameTempFile(temp, getPersistentFileLock(), persistentFile);
+         } catch (Exception e) {
+             throw log.cannotRenamePersistentFile(temp.getAbsolutePath(), persistentFile, e);
+         }
       } catch (Exception e) {
          throw log.errorPersistingGlobalConfiguration(e);
       }

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -1737,7 +1737,7 @@ public interface Log extends BasicLogger {
    CacheConfigurationException cacheExists(String cacheName);
 
    @Message(value = "Cannot rename file %s to %s", id = 508)
-   CacheConfigurationException cannotRenamePersistentFile(String absolutePath, File persistentFile);
+   CacheConfigurationException cannotRenamePersistentFile(String absolutePath, File persistentFile, @Cause Throwable cause);
 
    @Message(value = "Unable to add a 'null' EntryMergePolicyFactory", id = 509)
    IllegalArgumentException unableToAddNullEntryMergePolicyFactory();

--- a/counter/src/main/java/org/infinispan/counter/logging/Log.java
+++ b/counter/src/main/java/org/infinispan/counter/logging/Log.java
@@ -95,7 +95,7 @@ public interface Log extends BasicLogger {
    CounterConfigurationException invalidSameLowerAndUpperBound(long lower, long upper);
 
    @Message(value = "Cannot rename file %s to %s", id = 28025)
-   CounterConfigurationException cannotRenamePersistentFile(String absolutePath, File persistentFile);
+   CounterConfigurationException cannotRenamePersistentFile(String absolutePath, File persistentFile, @Cause Throwable cause);
 
    @Message(value = "Error while persisting counter's configurations", id = 28026)
    CounterConfigurationException errorPersistingCountersConfiguration(@Cause Throwable cause);


### PR DESCRIPTION
On windows File.renameTo() fails if destination file exists. Quick fix provided.

https://issues.jboss.org/browse/ISPN-9333