### PR TITLE
add javadoc, Hot Rod Transaction properties

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/ConfigurationBuilder.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/ConfigurationBuilder.java
@@ -285,6 +285,18 @@ import org.infinispan.commons.util.Util;
  *       <td>10000</td>
  *       <td>{@link #batchSize(int)}</td>
  *    </tr>
+ *    <tr>
+ *       <td><b>infinispan.client.hotrod.transaction.transaction_manager_lookup</b></td>
+ *       <td>String (class name)</td>
+ *       <td>{@link TransactionConfigurationBuilder#defaultTransactionManagerLookup()}</td>
+ *       <td>{@link TransactionConfigurationBuilder#transactionManagerLookup(TransactionManagerLookup)}</td>
+ *    </tr>
+ *    <tr>
+ *       <td><b>infinispan.client.hotrod.transaction.transaction_mode</b></td>
+ *       <td>String ({@link TransactionMode} enum name)</td>
+ *       <td>{@link TransactionMode#NONE NONE}</td>
+ *       <td>{@link TransactionConfigurationBuilder#transactionMode(TransactionMode)}</td>
+ *    </tr>
  * </table>
  *
  * @author Tristan Tarrant


### PR DESCRIPTION
I added the following two properties to the ConfigurationBuilder Javadoc of Hot Rod Client.

* infinispan.client.hotrod.transaction.transaction_manager_lookup
* infinispan.client.hotrod.transaction.transaction_mode

It is a property added by Hot Rod Transaction, so I think that it was better to have a description in Javadoc.