### PR TITLE
ISPN-9342 Lock timeout when writing to index caches for the first time

### DIFF
--- a/query/src/main/java/org/infinispan/query/backend/QueryKnownClasses.java
+++ b/query/src/main/java/org/infinispan/query/backend/QueryKnownClasses.java
@@ -208,7 +208,7 @@ public final class QueryKnownClasses {
             if (knownClassesCache == null) {
                internalCacheRegistry.registerInternalCache(QUERY_KNOWN_CLASSES_CACHE_NAME, getInternalCacheConfig(), EnumSet.of(InternalCacheRegistry.Flag.PERSISTENT));
                Cache<KeyValuePair<String, Class<?>>, Boolean> knownClassesCache = SecurityActions.getCache(cacheManager, QUERY_KNOWN_CLASSES_CACHE_NAME);
-               this.knownClassesCache = knownClassesCache.getAdvancedCache().withFlags(Flag.IGNORE_RETURN_VALUES);
+               this.knownClassesCache = knownClassesCache.getAdvancedCache().withFlags(Flag.SKIP_LOCKING, Flag.IGNORE_RETURN_VALUES);
                transactionHelper = new TransactionHelper(this.knownClassesCache.getTransactionManager());
             }
          }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-9342

This is a regression that was originally fixed in https://bugzilla.redhat.com/show_bug.cgi?id=1309181.

Please cherry-pick to ```9.3.x.``` as well.