### PR TITLE
Single port client

### DIFF
--- a/client/hotrod-client/pom.xml
+++ b/client/hotrod-client/pom.xml
@@ -45,6 +45,11 @@
 
       <dependency>
          <groupId>io.netty</groupId>
+         <artifactId>netty-codec-http</artifactId>
+      </dependency>
+
+      <dependency>
+         <groupId>io.netty</groupId>
          <artifactId>netty-transport-native-epoll</artifactId>
          <classifier>linux-x86_64</classifier>
       </dependency>

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/Configuration.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/Configuration.java
@@ -55,11 +55,12 @@ public class Configuration {
    private final StatisticsConfiguration statistics;
    private final TransactionConfiguration transaction;
    private final Features features;
+   private final SinglePortMode singlePort;
 
    Configuration(ExecutorFactoryConfiguration asyncExecutorFactory, Supplier<FailoverRequestBalancingStrategy> balancingStrategyFactory, ClassLoader classLoader,
                  ClientIntelligence clientIntelligence, ConnectionPoolConfiguration connectionPool, int connectionTimeout, Class<? extends ConsistentHash>[] consistentHashImpl, boolean forceReturnValues, int keySizeEstimate,
                  Marshaller marshaller, Class<? extends Marshaller> marshallerClass,
-                 ProtocolVersion protocolVersion, List<ServerConfiguration> servers, int socketTimeout, SecurityConfiguration security, boolean tcpNoDelay, boolean tcpKeepAlive,
+                 ProtocolVersion protocolVersion, List<ServerConfiguration> servers, SinglePortMode singlePort, int socketTimeout, SecurityConfiguration security, boolean tcpNoDelay, boolean tcpKeepAlive,
                  int valueSizeEstimate, int maxRetries, NearCacheConfiguration nearCache,
                  List<ClusterConfiguration> clusters, List<String> serialWhitelist, int batchSize,
                  TransactionConfiguration transaction, StatisticsConfiguration statistics, Features features) {
@@ -89,6 +90,7 @@ public class Configuration {
       this.batchSize = batchSize;
       this.transaction = transaction;
       this.statistics = statistics;
+      this.singlePort = singlePort;
       this.features = features;
    }
 
@@ -327,6 +329,8 @@ public class Configuration {
       }
       properties.setProperty(ConfigurationProperties.SERVER_LIST, servers.toString());
 
+      properties.setProperty(ConfigurationProperties.SINGLE_PORT, singlePort.name());
+
       properties.setProperty(ConfigurationProperties.USE_SSL, Boolean.toString(security.ssl().enabled()));
 
       if (security.ssl().keyStoreFileName() != null)
@@ -382,5 +386,9 @@ public class Configuration {
          properties.setProperty(ConfigurationProperties.NEAR_CACHE_NAME_PATTERN, nearCache.cacheNamePattern().pattern());
 
       return properties;
+   }
+
+   public SinglePortMode getSinglePort() {
+      return singlePort;
    }
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/SinglePortMode.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/SinglePortMode.java
@@ -1,0 +1,23 @@
+package org.infinispan.client.hotrod.configuration;
+
+/**
+ * Single port settings.
+ */
+public enum SinglePortMode {
+   /**
+    * Enabled.
+    */
+   ENABLED,
+
+   /**
+    * Disabled.
+    */
+   DISABLED,
+
+   /**
+    * Automatic mode. In this mode the Hotrod client tries to automatically discover single port on the
+    * server by analyzing port. If the port is set to <code>80</code> or <code>8xxxx</code>, it will use
+    * Single Port feature.
+    */
+   AUTO
+}

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/ConfigurationProperties.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/ConfigurationProperties.java
@@ -82,6 +82,7 @@ public class ConfigurationProperties {
    public static final String STATISTICS = ICH + "statistics";
    // Transaction properties
    public static final String TRANSACTION_MANAGER_LOOKUP = ICH + "transaction.transaction_manager_lookup";
+   public static final String SINGLE_PORT = "infinispan.client.hotrod.single_port";
    public static final String TRANSACTION_MODE = ICH + "transaction.transaction_mode";
    public static final String TRANSACTION_TIMEOUT = ICH + "transaction.timeout";
    // Near cache properties

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/ActivationHandler.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/ActivationHandler.java
@@ -14,12 +14,12 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
  * Its task is to complete {@link ChannelRecord}.
  */
 @Sharable
-class ActivationHandler extends ChannelInboundHandlerAdapter {
+public class ActivationHandler extends ChannelInboundHandlerAdapter {
    static final String NAME = "activation-handler";
    static final ActivationHandler INSTANCE = new ActivationHandler();
    private static final Log log = LogFactory.getLog(ActivationHandler.class);
    private static final boolean trace = log.isTraceEnabled();
-   static final Object ACTIVATION_EVENT = new Object();
+   public static final Object ACTIVATION_EVENT = new Object();
 
    @Override
    public void channelActive(ChannelHandlerContext ctx) throws Exception {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/InitialPingHandler.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/InitialPingHandler.java
@@ -39,4 +39,44 @@ public class InitialPingHandler extends ActivationHandler {
       });
       ctx.pipeline().remove(this);
    }
+
+   @Override
+   public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+      super.userEventTriggered(ctx, evt);    // TODO: Customise this generated block
+   }
+
+   @Override
+   public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+      super.exceptionCaught(ctx, cause);    // TODO: Customise this generated block
+   }
+
+   @Override
+   public void channelRegistered(ChannelHandlerContext ctx) throws Exception {
+      super.channelRegistered(ctx);    // TODO: Customise this generated block
+   }
+
+   @Override
+   public void channelUnregistered(ChannelHandlerContext ctx) throws Exception {
+      super.channelUnregistered(ctx);    // TODO: Customise this generated block
+   }
+
+   @Override
+   public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+      super.channelInactive(ctx);    // TODO: Customise this generated block
+   }
+
+   @Override
+   public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+      super.channelRead(ctx, msg);    // TODO: Customise this generated block
+   }
+
+   @Override
+   public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
+      super.channelReadComplete(ctx);    // TODO: Customise this generated block
+   }
+
+   @Override
+   public void channelWritabilityChanged(ChannelHandlerContext ctx) throws Exception {
+      super.channelWritabilityChanged(ctx);    // TODO: Customise this generated block
+   }
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/SslHandlerHelper.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/SslHandlerHelper.java
@@ -1,0 +1,81 @@
+package org.infinispan.client.hotrod.impl.transport.netty;
+
+import java.io.File;
+import java.util.Collections;
+
+import javax.net.ssl.SNIHostName;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+
+import org.infinispan.client.hotrod.configuration.Configuration;
+import org.infinispan.client.hotrod.configuration.SslConfiguration;
+import org.infinispan.commons.CacheConfigurationException;
+import org.infinispan.commons.util.SslContextFactory;
+
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.handler.ssl.ApplicationProtocolConfig;
+import io.netty.handler.ssl.ClientAuth;
+import io.netty.handler.ssl.JdkSslContext;
+import io.netty.handler.ssl.OpenSsl;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslHandler;
+import io.netty.handler.ssl.SslProvider;
+
+public class SslHandlerHelper {
+
+   public static SslHandler createSslHandler(Configuration configuration, ByteBufAllocator alloc, String... alpnProtocols) {
+      SslConfiguration ssl = configuration.security().ssl();
+      SslContext nettySslContext;
+      SSLContext jdkSslContext = ssl.sslContext();
+      if (jdkSslContext == null) {
+         SslContextBuilder builder = SslContextBuilder.forClient();
+         try {
+            if (ssl.keyStoreFileName() != null) {
+               builder.keyManager(SslContextFactory.getKeyManagerFactory(
+                     ssl.keyStoreFileName(),
+                     ssl.keyStoreType(),
+                     ssl.keyStorePassword(),
+                     ssl.keyStoreCertificatePassword(),
+                     ssl.keyAlias(),
+                     configuration.classLoader()));
+            }
+            if (ssl.trustStoreFileName() != null) {
+               builder.trustManager(SslContextFactory.getTrustManagerFactory(
+                     ssl.trustStoreFileName(),
+                     ssl.trustStoreType(),
+                     ssl.trustStorePassword(),
+                     configuration.classLoader()));
+            }
+            if (ssl.trustStorePath() != null) {
+               builder.trustManager(new File(ssl.trustStorePath()));
+            }
+            if (ssl.protocol() != null) {
+               builder.protocols(ssl.protocol());
+            }
+            //Single Port ALPN negotiation part
+            if (alpnProtocols != null && alpnProtocols.length > 0) {
+               builder.sslProvider(OpenSsl.isAlpnSupported() ? SslProvider.OPENSSL : SslProvider.JDK);
+               builder.applicationProtocolConfig(new ApplicationProtocolConfig(
+                     ApplicationProtocolConfig.Protocol.ALPN,
+                     ApplicationProtocolConfig.SelectorFailureBehavior.CHOOSE_MY_LAST_PROTOCOL,
+                     ApplicationProtocolConfig.SelectedListenerFailureBehavior.ACCEPT,
+                     alpnProtocols));
+            }
+            nettySslContext = builder.build();
+         } catch (Exception e) {
+            throw new CacheConfigurationException(e);
+         }
+      } else {
+         nettySslContext = new JdkSslContext(jdkSslContext, true, ClientAuth.NONE);
+      }
+      SslHandler sslHandler = nettySslContext.newHandler(alloc, ssl.sniHostName(), -1);
+      if (ssl.sniHostName() != null) {
+         SSLParameters sslParameters = sslHandler.engine().getSSLParameters();
+         sslParameters.setServerNames(Collections.singletonList(new SNIHostName(ssl.sniHostName())));
+         sslHandler.engine().setSSLParameters(sslParameters);
+      }
+      return sslHandler;
+   }
+
+}

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/singleport/CustomProtocolUpgradeCodec.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/singleport/CustomProtocolUpgradeCodec.java
@@ -1,0 +1,48 @@
+package org.infinispan.client.hotrod.impl.transport.netty.singleport;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpClientUpgradeHandler;
+import io.netty.handler.codec.http.HttpRequest;
+
+/**
+ * Codec responsible for switching to target protocol.
+ *
+ * @author Sebastian Łaskawiec
+ */
+public class CustomProtocolUpgradeCodec implements HttpClientUpgradeHandler.UpgradeCodec {
+
+   private final String protocolName;
+   private final ChannelHandler handler;
+
+   public CustomProtocolUpgradeCodec(String protocolName, ChannelHandler handler) {
+      this.protocolName = protocolName;
+      this.handler = handler;
+   }
+
+   @Override
+   public String protocol() {
+      return protocolName;
+   }
+
+   @Override
+   public Collection<CharSequence> setUpgradeHeaders(ChannelHandlerContext ctx, HttpRequest upgradeRequest) {
+      return Collections.emptyList();
+   }
+
+   @Override
+   public void upgradeTo(ChannelHandlerContext ctx, FullHttpResponse upgradeResponse) throws Exception {
+      // Since we reached this state, we know that the whole upgrade procedure (client sending HTTP/1.1 Upgrade,
+      // and Server responding with Switching Protocols) went fine. No need for validation, just update
+      // the pipeline and we are done.
+      ctx.pipeline().addAfter(ctx.name(), null, handler);
+   }
+
+   public ChannelHandler getHandler() {
+      return handler;
+   }
+}

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/singleport/SinglePortAdapter.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/singleport/SinglePortAdapter.java
@@ -1,0 +1,82 @@
+package org.infinispan.client.hotrod.impl.transport.netty.singleport;
+
+import org.infinispan.client.hotrod.impl.transport.netty.ActivationHandler;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.handler.codec.http.HttpClientCodec;
+import io.netty.handler.codec.http.HttpClientUpgradeHandler;
+import io.netty.handler.ssl.ApplicationProtocolNegotiationHandler;
+
+/**
+ * Handles upgrades for multiple protocols.
+ *
+ * @author Sebastian Łaskawiec
+ */
+public class SinglePortAdapter extends ChannelInitializer<Channel> {
+
+   public static final int HTTP_MAX_CONTENT_LENGTH = 1024 * 10;
+
+   private final CustomProtocolUpgradeCodec targetProtocol;
+   private final SslHandlerFactory sslHandlerFactory;
+
+   public SinglePortAdapter(SslHandlerFactory sslHandlerFactory, CustomProtocolUpgradeCodec targetProtocol) {
+      this.sslHandlerFactory = sslHandlerFactory;
+      this.targetProtocol = targetProtocol;
+   }
+
+   @Override
+   protected void initChannel(Channel ch) {
+      if (sslHandlerFactory != null) {
+         configureSsl(ch);
+      } else {
+         configureClearText(ch);
+      }
+   }
+
+   private void configureClearText(Channel ch) {
+      HttpClientCodec sourceCodec = new HttpClientCodec();
+      CustomProtocolUpgradeCodec upgradeCodec = targetProtocol;
+      HttpClientUpgradeHandler upgradeHandler = new HttpClientUpgradeHandler(sourceCodec, upgradeCodec, HTTP_MAX_CONTENT_LENGTH);
+
+      ch.pipeline().addLast(sourceCodec, upgradeHandler, new UpgradeRequestSenderHandler(), new ChannelInboundHandlerAdapter() {
+
+         @Override
+         public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+            if (evt == HttpClientUpgradeHandler.UpgradeEvent.UPGRADE_SUCCESSFUL) {
+               // All handlers in the upgrade procedure are responsible for removing themselves from
+               // the pipeline once we finish.
+               ctx.pipeline().remove(this);
+               fireActivateEvent(ctx.channel());
+            }
+            ctx.fireUserEventTriggered(evt);
+         }
+      });
+   }
+
+   private void configureSsl(Channel ch) {
+      sslHandlerFactory.assertAlpnSupported();
+      ChannelPipeline pipeline = ch.pipeline();
+      pipeline.addLast(null, sslHandlerFactory.getSslHandlerName(), sslHandlerFactory.getSslHandler(ch.alloc()));
+      //The ALPN needs to be added after SSL.
+      pipeline.addAfter(sslHandlerFactory.getSslHandlerName(), "alpn", new ApplicationProtocolNegotiationHandler("Unknown") {
+         @Override
+         protected void configurePipeline(ChannelHandlerContext ctx, String protocol) {
+            if (!targetProtocol.protocol().equals(protocol)) {
+               ctx.close();
+               throw new IllegalStateException("Unknown protocol: " + protocol);
+            }
+            ctx.pipeline().addLast(targetProtocol.getHandler());
+            fireActivateEvent(ch);
+         }
+      });
+   }
+
+   private void fireActivateEvent(Channel channel) {
+      channel.pipeline().fireUserEventTriggered(ActivationHandler.ACTIVATION_EVENT);
+   }
+
+}

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/singleport/SslHandlerFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/singleport/SslHandlerFactory.java
@@ -1,0 +1,32 @@
+package org.infinispan.client.hotrod.impl.transport.netty.singleport;
+
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.handler.ssl.OpenSsl;
+import io.netty.handler.ssl.SslHandler;
+
+/**
+ * Creates SSLHandler
+ *
+ * <p>
+ *    The SSLHandler can be created with different ways - with or without ALPN, based on OpenSSL or JDK etc.
+ *    This will probably get unified after JDK9+ when we get support for ALPN. However, till then, we need
+ *    To use some workarounds...
+ * </p>
+ *
+ * @author Sebastian Łaskawiec
+ */
+public interface SslHandlerFactory {
+
+   SslHandler getSslHandler(ByteBufAllocator alloc);
+
+   default String getSslHandlerName() {
+      return SslHandler.class.getSimpleName();
+   }
+
+   default void assertAlpnSupported() {
+      if (!OpenSsl.isAlpnSupported()) {
+         throw new IllegalStateException("OpenSSL is not present, can not use TLS/ALPN. Version: " + OpenSsl.versionString() + " Cause: " + OpenSsl.unavailabilityCause());
+      }
+   }
+
+}

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/singleport/UpgradeRequestSenderHandler.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/singleport/UpgradeRequestSenderHandler.java
@@ -1,0 +1,36 @@
+package org.infinispan.client.hotrod.impl.transport.netty.singleport;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+
+/**
+ * Sends an HTTP/1.1 Upgrade request on root path. This procedure initiates HTTP/1.1 Upgrade procedure.
+ * The next step happens on the server side, where the server sends Switching Protocols header.
+ *
+ * @author Sebastian Łaskawiec
+ */
+class UpgradeRequestSenderHandler extends ChannelInboundHandlerAdapter {
+   @Override
+   public void channelActive(ChannelHandlerContext ctx) {
+      DefaultFullHttpRequest upgradeRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
+
+      SocketAddress address = ctx.channel().remoteAddress();
+      String host = address.toString();
+      if (address instanceof InetSocketAddress) {
+         host = ((InetSocketAddress) address).getHostName();
+      }
+
+      // OpenShift uses Host header to figure out the destination Pod.
+      upgradeRequest.headers().add("Host", host);
+      ctx.writeAndFlush(upgradeRequest);
+      ctx.pipeline().remove(this);
+   }
+
+
+}

--- a/client/hotrod-client/src/main/resources/features.xml
+++ b/client/hotrod-client/src/main/resources/features.xml
@@ -9,6 +9,7 @@
       <bundle>mvn:org.infinispan/infinispan-client-hotrod/${project.version}</bundle>
       <bundle>wrap:mvn:io.netty/netty-buffer/${version.netty}</bundle>
       <bundle>wrap:mvn:io.netty/netty-codec/${version.netty}</bundle>
+      <bundle>wrap:mvn:io.netty/netty-codec-http/${version.netty}</bundle>
       <bundle>wrap:mvn:io.netty/netty-common/${version.netty}</bundle>
       <bundle>wrap:mvn:io.netty/netty-handler/${version.netty}</bundle>
       <bundle>wrap:mvn:io.netty/netty-resolver/${version.netty}</bundle>

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/configuration/ConfigurationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/configuration/ConfigurationTest.java
@@ -27,6 +27,7 @@ import static org.infinispan.client.hotrod.impl.ConfigurationProperties.SASL_MEC
 import static org.infinispan.client.hotrod.impl.ConfigurationProperties.SASL_PROPERTIES_PREFIX;
 import static org.infinispan.client.hotrod.impl.ConfigurationProperties.JAVA_SERIAL_WHITELIST;
 import static org.infinispan.client.hotrod.impl.ConfigurationProperties.SERVER_LIST;
+import static org.infinispan.client.hotrod.impl.ConfigurationProperties.SINGLE_PORT;
 import static org.infinispan.client.hotrod.impl.ConfigurationProperties.SNI_HOST_NAME;
 import static org.infinispan.client.hotrod.impl.ConfigurationProperties.SO_TIMEOUT;
 import static org.infinispan.client.hotrod.impl.ConfigurationProperties.SSL_CONTEXT;
@@ -125,6 +126,7 @@ public class ConfigurationTest {
       OPTIONS.put(SASL_PROPERTIES_PREFIX + ".C", c -> c.security().authentication().saslProperties().get("C"));
       OPTIONS.put(JAVA_SERIAL_WHITELIST, Configuration::serialWhitelist);
       OPTIONS.put(NEAR_CACHE_MODE, c -> c.nearCache().mode());
+      OPTIONS.put(SINGLE_PORT, c-> c.getSinglePort().name());
       OPTIONS.put(NEAR_CACHE_MAX_ENTRIES, c -> c.nearCache().maxEntries());
       OPTIONS.put(NEAR_CACHE_NAME_PATTERN, c -> c.nearCache().cacheNamePattern().pattern());
 
@@ -201,6 +203,7 @@ public class ConfigurationTest {
             .valueSizeEstimate(1024)
             .maxRetries(0)
             .tcpKeepAlive(true)
+            .singlePort(SinglePortMode.ENABLED)
             .security()
             .ssl()
             .enable()
@@ -283,6 +286,7 @@ public class ConfigurationTest {
       p.setProperty(SASL_PROPERTIES_PREFIX + ".C", "3");
       p.setProperty(JAVA_SERIAL_WHITELIST, ".*Person.*,.*Employee.*");
       p.setProperty(NEAR_CACHE_MODE, NearCacheMode.INVALIDATED.name());
+      p.setProperty(SINGLE_PORT, SinglePortMode.ENABLED.name());
       p.setProperty(NEAR_CACHE_MAX_ENTRIES, "10000");
       p.setProperty(NEAR_CACHE_NAME_PATTERN, "near.*");
       p.setProperty(CLUSTER_PROPERTIES_PREFIX + ".siteA", "hostA1:11222; hostA2:11223");
@@ -559,6 +563,7 @@ public class ConfigurationTest {
       assertEqualsConfig(ProtocolVersion.PROTOCOL_VERSION_13, PROTOCOL_VERSION, configuration);
       assertEqualsConfig(Arrays.asList(".*Person.*", ".*Employee.*"), JAVA_SERIAL_WHITELIST, configuration);
       assertEqualsConfig(NearCacheMode.INVALIDATED, NEAR_CACHE_MODE, configuration);
+      assertEqualsConfig(SinglePortMode.ENABLED.name(), SINGLE_PORT, configuration);
       assertEqualsConfig(10_000, NEAR_CACHE_MAX_ENTRIES, configuration);
       assertEqualsConfig("near.*", NEAR_CACHE_NAME_PATTERN, configuration);
       assertEquals(2, configuration.clusters().size());

--- a/documentation/src/main/asciidoc/server_guide/server_guide.asciidoc
+++ b/documentation/src/main/asciidoc/server_guide/server_guide.asciidoc
@@ -6,3 +6,121 @@ The {brandname} community
 :numbered:
 
 include::topics.adoc[]
+
+== Single Port
+
+Single Port features allows to expose multiple protocols over the same TCP port.
+This approach is very convenient in Cloud Environments such as OpenShift or Kubernetes where the application
+(a Pod) is hidden behind the frontend proxy (a Route or an Ingress).
+
+For protocol switching, Infinispan Server uses HTTP/1.1 Upgrade header or TLS/ALPN.
+
+NOTE: The initial implementation supports only HTTP/1.1, HTTP/2 and Hot Rod protocols.
+
+==== Single Port router
+
+Internally, Single Port reuses router component, therefore the configuration looks very similar to
+the Multi-tenancy.
+
+[source,xml]
+----
+
+<!-- TLS/ALPN negotiation -->
+<router-connector name="router-ssl" single-port-socket-binding="rest-ssl">
+    <single-port security-realm="SSLRealm1">
+        <hotrod name="hotrod" />
+        <rest name="rest" />
+    </single-port>
+</router-connector>
+<!-- HTTP 1.1/Upgrade procedure -->
+<router-connector name="router" single-port-socket-binding="rest">
+    <single-port>
+        <hotrod name="hotrod" />
+        <rest name="rest" />
+    </single-port>
+</router-connector>
+
+----
+
+With the configuration above, the Single Port Router will operate on `rest` and `rest-ssl` socket
+bindings. The router named `router` should typically operate on port `8080` and will use HTTP/1.1 Upgrade
+(also known as Plan Text Upgrade) procedure. The other router instance (called `router-ssl`) should typically
+operate on port `8443` and will use TLS/ALPN.
+
+==== Curl client
+
+A well-known `curl` tool can be used to access cache using both Plain Text Upgrade or TLS/ALPN. Here's an example:
+
+[source,bash]
+----
+
+curl -v -k --http2-prior-knowledge https://127.0.0.1:8443/rest/default/test
+
+----
+
+The `--http2-prior-knowledge` can be exchanged with `--http2` switch allowing to control how the switch procedure
+is being done (via Plain Text Upgrade or TLS/ALPN).
+
+==== Hotrod client
+
+Hot Rod client also supports Single Port functionality with both type of upgrades. Here's a configuration example
+for Plain Text Upgrade:
+
+[source,java]
+----
+
+ConfigurationBuilder builder = new ConfigurationBuilder()
+      .addServers("127.0.0.1:8080");
+
+RemoteCacheManager remoteCacheManager = new RemoteCacheManager(builder.build());
+RemoteCache<String, String> cache = remoteCacheManager.getCache("default"");
+
+----
+
+The Hotrod client detects if Single Port has been enabled on the server by checking the port number. If the port is
+specific to REST (ports 80, 8080, 8443 or similar), the Single Port functionality will be enabled on the client.
+
+Another supported way to do the upgrade is to use TLS/ALPN. Unfortunately ALPN extension is not supported in JDK8.
+Therefore, the suggested way is to use Boring SSL Library which turns on OpenSSL support in Netty (which is
+used in the Hotrod client):
+
+[source,xml]
+----
+
+<dependencyManagement>
+      <dependency>
+         <groupId>io.netty</groupId>
+         <artifactId>netty-bom</artifactId>
+         <!-- Pulled from Infinispan BOM -->
+         <version>${version.netty}</version>
+         <type>pom</type>
+         <scope>import</scope>
+      </dependency>
+   </dependencies>
+</dependencyManagement>
+
+<dependency>
+   <groupId>io.netty</groupId>
+   <artifactId>netty-tcnative-boringssl-static</artifactId>
+   <!-- The version is defined in Netty BOM -->
+</dependency>
+
+----
+
+After adding the library, configure your trust store accordingly:
+
+[source,java]
+----
+
+ConfigurationBuilder builder = new ConfigurationBuilder()
+      .addServers("127.0.0.1:8443")
+      .singlePort(true);
+
+builder.security().ssl().enable()
+      .trustStoreFileName("truststore.pkcs12")
+      .trustStorePassword(DEFAULT_TRUSTSTORE_PASSWORD.toCharArray());
+
+RemoteCacheManager remoteCacheManager = new RemoteCacheManager(builder.build());
+RemoteCache<String, String> cache = remoteCacheManager.getCache("default"");
+
+----

--- a/pom.xml
+++ b/pom.xml
@@ -2387,6 +2387,12 @@
          </dependency>
          <dependency>
             <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-server-router</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+         </dependency>
+         <dependency>
+            <groupId>org.infinispan</groupId>
             <artifactId>infinispan-spring5-common</artifactId>
             <type>test-jar</type>
             <scope>test</scope>

--- a/server/integration/testsuite/pom.xml
+++ b/server/integration/testsuite/pom.xml
@@ -260,6 +260,34 @@
           <type>test-jar</type>
           <scope>test</scope>
        </dependency>
+
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-server-router</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-server-router</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-server-hotrod</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-tcnative-boringssl-static</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-server-rest</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/router/SinglePortIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/router/SinglePortIT.java
@@ -9,9 +9,16 @@ import java.util.Queue;
 
 import org.infinispan.arquillian.core.RunningServer;
 import org.infinispan.arquillian.core.WithRunningServer;
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
 import org.infinispan.rest.http2.NettyHttpClient;
 import org.infinispan.server.test.category.Security;
+import org.infinispan.server.test.util.security.SecurityConfigurationHelper;
+import org.infinispan.test.fwk.TestResourceTracker;
 import org.jboss.arquillian.junit.Arquillian;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -25,16 +32,7 @@ import io.netty.util.CharsetUtil;
 /**
  * Tests Single Port feature.
  *
- * Note: This is still a work-in-progress effort!
- *
- * <p>
- *    This testsuite is very far from being completed. Unfortunately at the moment, all we can test is
- *    whether the Endpoint Router is really serving requests. In order to test it more, we need to write
- *    a new Hot Rod client, which will be capable of using both REST and Hot Rod protocol.
- * </p>
- *
  * @author Sebastian Łaskawiec
- * @since 9.3
  */
 @RunWith(Arquillian.class)
 @Category({Security.class})
@@ -43,21 +41,82 @@ public class SinglePortIT {
 
    public static final String CACHE_NAME = "default";
 
+   @BeforeClass
+   public static void beforeClass() {
+      TestResourceTracker.testStarted(SinglePortIT.class.getName());
+   }
+
+   @AfterClass
+   public static void afterClass() {
+      TestResourceTracker.testFinished(SinglePortIT.class.getName());
+   }
+
    @Test
-   public void testRestPlainTextUpgrade() throws Exception {
-      //when
+   public void testHttp2SwitchThroughUpgradeHeader() throws Exception {
+      //given
+      FullHttpRequest putValueInCacheRequest = new DefaultFullHttpRequest(HTTP_1_1, POST, "/rest/" + CACHE_NAME + "/testHttp2SwitchThroughUpgradeHeader",
+            wrappedBuffer("test".getBytes(CharsetUtil.UTF_8)));
+
       NettyHttpClient client = NettyHttpClient.newHttp2ClientWithHttp11Upgrade();
       client.start("localhost", 8080);
 
-      FullHttpRequest putValueInCacheRequest = new DefaultFullHttpRequest(HTTP_1_1, POST, "/rest/default/test",
-            wrappedBuffer("test".getBytes(CharsetUtil.UTF_8)));
-
+      //when
       client.sendRequest(putValueInCacheRequest);
       Queue<FullHttpResponse> responses = client.getResponses();
 
       //then
       assertEquals(1, responses.size());
       assertEquals(HttpResponseStatus.OK, responses.poll().status());
+   }
+
+   @Test
+   public void testHttp2SwitchThroughALPN() throws Exception {
+      //given
+      FullHttpRequest putValueInCacheRequest = new DefaultFullHttpRequest(HTTP_1_1, POST, "/rest/" + CACHE_NAME + "/testHttp2SwitchThroughALPN",
+            wrappedBuffer("test".getBytes(CharsetUtil.UTF_8)));
+
+      NettyHttpClient client = NettyHttpClient
+            .newHttp2ClientWithALPN(SecurityConfigurationHelper.DEFAULT_TRUSTSTORE_PATH, SecurityConfigurationHelper.DEFAULT_TRUSTSTORE_PASSWORD);
+      client.start("localhost", 8443);
+
+      //when
+      client.sendRequest(putValueInCacheRequest);
+      Queue<FullHttpResponse> responses = client.getResponses();
+
+      //then
+      assertEquals(1, responses.size());
+      assertEquals(HttpResponseStatus.OK, responses.poll().status());
+   }
+
+   @Test
+   public void testHotRodSwitchThroughUpgradeHeader() {
+      //given
+      ConfigurationBuilder builder = new ConfigurationBuilder()
+            .addServers("localhost:" + 8080);
+
+      //when
+      RemoteCacheManager remoteCacheManager = new RemoteCacheManager(builder.build());
+      RemoteCache<String, String> cache = remoteCacheManager.getCache(CACHE_NAME);
+      cache.put("testHotRodSwitchThroughUpgradeHeader", "test");
+
+      //then
+      assertEquals("test", cache.get("testHotRodSwitchThroughUpgradeHeader"));
+   }
+
+   @Test
+   public void testHotRodSwitchThroughALPN() {
+      //given
+      ConfigurationBuilder builder = new SecurityConfigurationHelper()
+            .withDefaultSsl()
+            .addServers("localhost:" + 8443);
+
+      //when
+      RemoteCacheManager remoteCacheManager = new RemoteCacheManager(builder.build());
+      RemoteCache<String, String> cache = remoteCacheManager.getCache(CACHE_NAME);
+      cache.put("testHotRodSwitchThroughALPN", "test");
+
+      //then
+      assertEquals("test", cache.get("testHotRodSwitchThroughALPN"));
    }
 
 }

--- a/server/integration/testsuite/src/test/resources/config/parts/cachecontainer-endpoints-single-port.xml
+++ b/server/integration/testsuite/src/test/resources/config/parts/cachecontainer-endpoints-single-port.xml
@@ -1,8 +1,14 @@
         <subsystem xmlns="urn:infinispan:server:endpoint:${infinispan.core.schema.version}">
             <hotrod-connector name="single-port-hotrod" cache-container="clustered" />
             <rest-connector name="single-port-rest" cache-container="clustered" />
-            <router-connector single-port-socket-binding="rest">
+            <router-connector name="router-ssl" single-port-socket-binding="rest-ssl">
                 <single-port security-realm="ClientCertRealm">
+                    <hotrod name="single-port-hotrod" />
+                    <rest name="single-port-rest" />
+                </single-port>
+            </router-connector>
+            <router-connector name="router" single-port-socket-binding="rest">
+                <single-port>
                     <hotrod name="single-port-hotrod" />
                     <rest name="single-port-rest" />
                 </single-port>

--- a/server/rest/src/test/java/org/infinispan/rest/http2/NettyHttpClient.java
+++ b/server/rest/src/test/java/org/infinispan/rest/http2/NettyHttpClient.java
@@ -42,7 +42,7 @@ public class NettyHttpClient {
    }
 
    public static NettyHttpClient newHttp2ClientWithHttp11Upgrade() {
-      return new NettyHttpClient(null, new Http2ClientInitializer(null, Integer.MAX_VALUE));
+      return new NettyHttpClient(null, new Http2ClientInitializer(null, Integer.MAX_VALUE, null));
    }
 
    public static NettyHttpClient newHttp11Client() {
@@ -50,8 +50,12 @@ public class NettyHttpClient {
    }
 
    public static NettyHttpClient newHttp2ClientWithALPN(String keystorePath, String keystorePassword) throws Exception {
+      return newHttp2ClientWithALPN(keystorePath, keystorePassword, null);
+   }
+
+   public static NettyHttpClient newHttp2ClientWithALPN(String keystorePath, String keystorePassword, String sniName) throws Exception {
       SslContext sslContext = NettyTruststoreUtil.createTruststoreContext(keystorePath, keystorePassword.toCharArray(), ApplicationProtocolNames.HTTP_2);
-      return new NettyHttpClient(sslContext, new Http2ClientInitializer(sslContext, Integer.MAX_VALUE));
+      return new NettyHttpClient(sslContext, new Http2ClientInitializer(sslContext, Integer.MAX_VALUE, sniName));
    }
 
    public void start(String host, int port) throws Exception {

--- a/server/router/src/main/java/org/infinispan/server/router/configuration/builder/SinglePortRouterBuilder.java
+++ b/server/router/src/main/java/org/infinispan/server/router/configuration/builder/SinglePortRouterBuilder.java
@@ -45,7 +45,7 @@ public class SinglePortRouterBuilder extends AbstractRouterBuilder {
             }
             SslConfigurationBuilder sslConfigurationBuilder = new SslConfigurationBuilder(null);
             if (sslContext != null) {
-                sslConfigurationBuilder.sslContext(sslContext);
+                sslConfigurationBuilder.sslContext(sslContext).enable();
             }
             else if (keystorePath != null) {
                 sslConfigurationBuilder.keyStoreFileName(keystorePath).keyStorePassword(keystorePassword).enable();


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-8756

This PR combines https://github.com/infinispan/infinispan/pull/6035 and provides implementation for Single Port support in the Hotrod client. The implementation works with TLS/ALPN (but a user must provide an OpenSSL library for Netty, like BoringSSL - see the docs) and, so called, Plain Text Upgrade (using `HTTP 1.1 Upgrade` header).

Since the tests need to use both Hotrod Server and Client, I had to put them in the server testsuite. 