### PR TITLE
ISPN-9359 RocksDB clear always reinitializes the database

### DIFF
--- a/persistence/rocksdb/src/main/java/org/infinispan/persistence/rocksdb/RocksDBStore.java
+++ b/persistence/rocksdb/src/main/java/org/infinispan/persistence/rocksdb/RocksDBStore.java
@@ -176,7 +176,7 @@ public class RocksDBStore<K,V> implements AdvancedLoadWriteStore<K,V> {
                 throw new PersistenceException("RocksDB is stopped");
             }
             Optional<RocksIterator> optionalIterator = wrapIterator(this.db);
-            if (optionalIterator.isPresent() && configuration.clearThreshold() <= 0) {
+            if (optionalIterator.isPresent() && configuration.clearThreshold() > 0) {
                 try (RocksIterator it = optionalIterator.get()) {
                     for(it.seekToFirst(); it.isValid(); it.next()) {
                         db.delete(it.key());


### PR DESCRIPTION
* Make sure to properly use clearThreshold variable

https://issues.jboss.org/browse/ISPN-9359