### PR TITLE
Separating User and Internal Marshaller

### DIFF
--- a/commons/src/main/java/org/infinispan/commons/marshall/AbstractDelegatingMarshaller.java
+++ b/commons/src/main/java/org/infinispan/commons/marshall/AbstractDelegatingMarshaller.java
@@ -16,6 +16,7 @@ import org.infinispan.commons.io.ByteBuffer;
  * @author Galder Zamarreño
  * @since 5.0
  */
+@Deprecated
 public abstract class AbstractDelegatingMarshaller implements StreamingMarshaller {
 
    protected StreamingMarshaller marshaller;

--- a/commons/src/main/java/org/infinispan/commons/marshall/MarshallUtil.java
+++ b/commons/src/main/java/org/infinispan/commons/marshall/MarshallUtil.java
@@ -28,7 +28,7 @@ import net.jcip.annotations.Immutable;
 @Immutable
 public class MarshallUtil {
 
-   private static final byte NULL_VALUE = -1;
+   public static final byte NULL_VALUE = -1;
 
    private static final Log log = LogFactory.getLog(MarshallUtil.class);
 
@@ -195,6 +195,22 @@ public class MarshallUtil {
     * @see #marshallArray(Object[], ObjectOutput).
     */
    public static <E> E[] unmarshallArray(ObjectInput in, ArrayBuilder<E> builder) throws IOException, ClassNotFoundException {
+      return unmarshallArray(in, builder, i -> (E) i.readObject());
+   }
+
+   /**
+    * Unmarshall arrays.
+    *
+    * @param in      {@link ObjectInput} to read.
+    * @param builder {@link ArrayBuilder} to build the array.
+    * @param reader {@link ElementReader} reads one element from the input.
+    * @param <E>     Array type.
+    * @return The populated array.
+    * @throws IOException            If any of the usual Input/Output related exceptions occur.
+    * @throws ClassNotFoundException If the class of a serialized object cannot be found.
+    * @see #marshallArray(Object[], ObjectOutput).
+    */
+   public static <E> E[] unmarshallArray(ObjectInput in, ArrayBuilder<E> builder, ElementReader<E> reader) throws IOException, ClassNotFoundException {
       final int size = unmarshallSize(in);
       if (size == NULL_VALUE) {
          return null;
@@ -202,7 +218,7 @@ public class MarshallUtil {
       final E[] array = Objects.requireNonNull(builder, "ArrayBuilder must be non-null").build(size);
       for (int i = 0; i < size; ++i) {
          //noinspection unchecked
-         array[i] = (E) in.readObject();
+         array[i] = reader.readFrom(in);
       }
       return array;
    }

--- a/core/src/main/java/org/infinispan/atomic/impl/ApplyDelta.java
+++ b/core/src/main/java/org/infinispan/atomic/impl/ApplyDelta.java
@@ -43,6 +43,7 @@ public final class ApplyDelta<K> implements BiFunction<Object, EntryView.ReadWri
             deltaAware = ((CopyableDeltaAware) value).copy();
          } else if (value instanceof DeltaAware) {
             try {
+               // TODO should this be user or internal marshaller?
                byte[] bytes = marshaller.objectToByteBuffer(value);
                deltaAware = (DeltaAware) marshaller.objectFromByteBuffer(bytes);
             } catch (InterruptedException e) {

--- a/core/src/main/java/org/infinispan/commands/CancelCommand.java
+++ b/core/src/main/java/org/infinispan/commands/CancelCommand.java
@@ -8,6 +8,7 @@ import java.util.concurrent.CompletableFuture;
 
 import org.infinispan.commands.remote.BaseRpcCommand;
 import org.infinispan.commons.marshall.MarshallUtil;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.util.ByteString;
 import org.infinispan.util.concurrent.CompletableFutures;
 import org.infinispan.util.logging.Log;
@@ -58,7 +59,7 @@ public class CancelCommand extends BaseRpcCommand {
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
       MarshallUtil.marshallUUID(commandToCancel, output, false);
    }
 

--- a/core/src/main/java/org/infinispan/commands/CommandsFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/commands/CommandsFactoryImpl.java
@@ -1,5 +1,6 @@
 package org.infinispan.commands;
 
+import static org.infinispan.factories.KnownComponentNames.INTERNAL_MARSHALLER;
 import static org.infinispan.xsite.XSiteAdminCommand.AdminOperation;
 import static org.infinispan.xsite.statetransfer.XSiteStateTransferControlCommand.StateTransferControl;
 
@@ -195,7 +196,7 @@ public class CommandsFactoryImpl implements CommandsFactory {
    @Inject private ComponentRegistry componentRegistry;
    @Inject private OrderedUpdatesManager orderedUpdatesManager;
    @Inject private StateTransferLock stateTransferLock;
-   @Inject private StreamingMarshaller marshaller;
+   @Inject @ComponentName(INTERNAL_MARSHALLER) private StreamingMarshaller marshaller;
    @Inject private BiasManager biasManager;
    @Inject private RpcManager rpcManager;
    @Inject @ComponentName(KnownComponentNames.MODULE_COMMAND_INITIALIZERS)

--- a/core/src/main/java/org/infinispan/commands/CreateCacheCommand.java
+++ b/core/src/main/java/org/infinispan/commands/CreateCacheCommand.java
@@ -13,6 +13,7 @@ import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.statetransfer.StateTransferLock;
 import org.infinispan.topology.CacheTopology;
 import org.infinispan.util.ByteString;
@@ -108,7 +109,7 @@ public class CreateCacheCommand extends BaseRpcCommand {
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
       output.writeUTF(cacheNameToCreate);
       output.writeUTF(cacheConfigurationName);
       output.writeInt(expectedMembers);

--- a/core/src/main/java/org/infinispan/commands/RemoveCacheCommand.java
+++ b/core/src/main/java/org/infinispan/commands/RemoveCacheCommand.java
@@ -15,6 +15,7 @@ import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.factories.GlobalComponentRegistry;
 import org.infinispan.jmx.CacheJmxRegistration;
 import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.persistence.manager.PersistenceManager;
 import org.infinispan.util.ByteString;
 import org.infinispan.util.DependencyGraph;
@@ -76,7 +77,7 @@ public class RemoveCacheCommand extends BaseRpcCommand {
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
       // No parameters
    }
 

--- a/core/src/main/java/org/infinispan/commands/ReplicableCommand.java
+++ b/core/src/main/java/org/infinispan/commands/ReplicableCommand.java
@@ -7,6 +7,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
 import org.infinispan.context.InvocationContext;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.util.concurrent.CompletableFutures;
 
@@ -103,11 +104,26 @@ public interface ReplicableCommand {
     *
     * @param output the stream.
     * @throws IOException if an error occurred during the I/O.
+    * @deprecated since 9.4 use {@link #writeTo(ObjectOutput, MarshalledEntryFactory)} instead
     */
-   void writeTo(ObjectOutput output) throws IOException;
+   default void writeTo(ObjectOutput output) throws IOException {
+      // no-op
+   }
 
    /**
-    * Reads this instance from the stream written by {@link #writeTo(ObjectOutput)}.
+    * Writes this instance to the {@link ObjectOutput}.
+    *
+    * @since 9.4
+    * @param output the stream.
+    * @param entryFactory the {@link MarshalledEntryFactory} that should be used to marshall all user objects such as key/entries/metadata
+    * @throws IOException if an error occurred during the I/O.
+    */
+   default void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
+      writeTo(output);
+   }
+
+   /**
+    * Reads this instance from the stream written by {@link #writeTo(ObjectOutput, MarshalledEntryFactory)}.
     *
     * @param input the stream to read.
     * @throws IOException            if an error occurred during the I/O.

--- a/core/src/main/java/org/infinispan/commands/control/LockControlCommand.java
+++ b/core/src/main/java/org/infinispan/commands/control/LockControlCommand.java
@@ -21,6 +21,8 @@ import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.FlagBitSets;
 import org.infinispan.context.impl.RemoteTxInvocationContext;
 import org.infinispan.context.impl.TxInvocationContext;
+import org.infinispan.marshall.MarshalledEntryUtil;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.transaction.impl.RemoteTransaction;
 import org.infinispan.transaction.xa.GlobalTransaction;
 import org.infinispan.util.ByteString;
@@ -147,10 +149,10 @@ public class LockControlCommand extends AbstractTransactionBoundaryCommand imple
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
-      super.writeTo(output);
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
+      super.writeTo(output, entryFactory);
       output.writeBoolean(unlock);
-      MarshallUtil.marshallCollection(keys, output);
+      MarshalledEntryUtil.marshallCollection(keys, entryFactory, output, MarshalledEntryUtil::writeKey);
       output.writeLong(FlagBitSets.copyWithoutRemotableFlags(flags));
    }
 
@@ -159,7 +161,7 @@ public class LockControlCommand extends AbstractTransactionBoundaryCommand imple
    public void readFrom(ObjectInput input) throws IOException, ClassNotFoundException {
       super.readFrom(input);
       unlock = input.readBoolean();
-      keys = MarshallUtil.unmarshallCollection(input, ArrayList::new);
+      keys = MarshallUtil.unmarshallCollection(input, ArrayList::new, MarshalledEntryUtil::readKey);
       flags = input.readLong();
    }
 

--- a/core/src/main/java/org/infinispan/commands/functional/ReadOnlyKeyCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/ReadOnlyKeyCommand.java
@@ -21,6 +21,8 @@ import org.infinispan.functional.Param.StatisticsMode;
 import org.infinispan.functional.impl.EntryViews;
 import org.infinispan.functional.impl.Params;
 import org.infinispan.functional.impl.StatsEnvelope;
+import org.infinispan.marshall.MarshalledEntryUtil;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 
 public class ReadOnlyKeyCommand<K, V, R> extends AbstractDataCommand {
 
@@ -59,8 +61,8 @@ public class ReadOnlyKeyCommand<K, V, R> extends AbstractDataCommand {
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
-      output.writeObject(key);
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
+      MarshalledEntryUtil.writeKey(key, entryFactory, output);
       output.writeObject(f);
       UnsignedNumeric.writeUnsignedInt(output, segment);
       Params.writeObject(output, params);
@@ -70,7 +72,7 @@ public class ReadOnlyKeyCommand<K, V, R> extends AbstractDataCommand {
 
    @Override
    public void readFrom(ObjectInput input) throws IOException, ClassNotFoundException {
-      key = input.readObject();
+      key = MarshalledEntryUtil.readKey(input);
       f = (Function<ReadEntryView<K, V>, R>) input.readObject();
       segment = UnsignedNumeric.readUnsignedInt(input);
       params = Params.readObject(input);

--- a/core/src/main/java/org/infinispan/commands/functional/ReadOnlyManyCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/ReadOnlyManyCommand.java
@@ -22,6 +22,8 @@ import org.infinispan.functional.Param;
 import org.infinispan.functional.impl.EntryViews;
 import org.infinispan.functional.impl.Params;
 import org.infinispan.functional.impl.StatsEnvelope;
+import org.infinispan.marshall.MarshalledEntryUtil;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 
 public class ReadOnlyManyCommand<K, V, R> extends AbstractTopologyAffectedCommand implements LocalCommand {
    public static final int COMMAND_ID = 63;
@@ -93,8 +95,8 @@ public class ReadOnlyManyCommand<K, V, R> extends AbstractTopologyAffectedComman
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
-      MarshallUtil.marshallCollection(keys, output);
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
+      MarshalledEntryUtil.marshallCollection(keys, entryFactory, output, MarshalledEntryUtil::writeKey);
       output.writeObject(f);
       Params.writeObject(output, params);
       DataConversion.writeTo(output, keyDataConversion);
@@ -103,7 +105,7 @@ public class ReadOnlyManyCommand<K, V, R> extends AbstractTopologyAffectedComman
 
    @Override
    public void readFrom(ObjectInput input) throws IOException, ClassNotFoundException {
-      this.keys = MarshallUtil.unmarshallCollection(input, ArrayList::new);
+      this.keys = MarshallUtil.unmarshallCollection(input, ArrayList::new, MarshalledEntryUtil::readKey);
       this.f = (Function<ReadEntryView<K, V>, R>) input.readObject();
       this.params = Params.readObject(input);
       this.setFlagsBitSet(params.toFlagsBitSet());

--- a/core/src/main/java/org/infinispan/commands/functional/ReadWriteKeyCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/ReadWriteKeyCommand.java
@@ -25,6 +25,8 @@ import org.infinispan.functional.impl.EntryViews;
 import org.infinispan.functional.impl.EntryViews.AccessLoggingReadWriteView;
 import org.infinispan.functional.impl.Params;
 import org.infinispan.functional.impl.StatsEnvelope;
+import org.infinispan.marshall.MarshalledEntryUtil;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 
 // TODO: the command does not carry previous values to backup, so it can cause
 // the values on primary and backup owners to diverge in case of topology change
@@ -54,8 +56,8 @@ public final class ReadWriteKeyCommand<K, V, R> extends AbstractWriteKeyCommand<
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
-      output.writeObject(key);
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
+      MarshalledEntryUtil.writeKey(key, entryFactory, output);
       output.writeObject(f);
       MarshallUtil.marshallEnum(valueMatcher, output);
       UnsignedNumeric.writeUnsignedInt(output, segment);
@@ -68,7 +70,7 @@ public final class ReadWriteKeyCommand<K, V, R> extends AbstractWriteKeyCommand<
 
    @Override
    public void readFrom(ObjectInput input) throws IOException, ClassNotFoundException {
-      key = input.readObject();
+      key = MarshalledEntryUtil.readKey(input);
       f = (Function<ReadWriteEntryView<K, V>, R>) input.readObject();
       valueMatcher = MarshallUtil.unmarshallEnum(input, ValueMatcher::valueOf);
       segment = UnsignedNumeric.readUnsignedInt(input);

--- a/core/src/main/java/org/infinispan/commands/functional/TxReadOnlyKeyCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/TxReadOnlyKeyCommand.java
@@ -18,6 +18,8 @@ import org.infinispan.functional.Param.StatisticsMode;
 import org.infinispan.functional.impl.EntryViews;
 import org.infinispan.functional.impl.Params;
 import org.infinispan.functional.impl.StatsEnvelope;
+import org.infinispan.marshall.MarshalledEntryUtil;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 
 public class TxReadOnlyKeyCommand<K, V, R> extends ReadOnlyKeyCommand<K, V, R> {
    public static final byte COMMAND_ID = 64;
@@ -50,9 +52,9 @@ public class TxReadOnlyKeyCommand<K, V, R> extends ReadOnlyKeyCommand<K, V, R> {
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
-      super.writeTo(output);
-      MarshallUtil.marshallCollection(mutations, output, Mutations::writeTo);
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
+      super.writeTo(output, entryFactory);
+      MarshalledEntryUtil.marshallCollection(mutations, entryFactory, output, Mutations::writeTo);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/commands/functional/TxReadOnlyManyCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/TxReadOnlyManyCommand.java
@@ -20,6 +20,7 @@ import org.infinispan.functional.Param;
 import org.infinispan.functional.impl.EntryViews;
 import org.infinispan.functional.impl.Params;
 import org.infinispan.functional.impl.StatsEnvelope;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 
 public class TxReadOnlyManyCommand<K, V, R> extends ReadOnlyManyCommand<K, V, R> {
    public static final byte COMMAND_ID = 65;
@@ -62,8 +63,8 @@ public class TxReadOnlyManyCommand<K, V, R> extends ReadOnlyManyCommand<K, V, R>
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
-      super.writeTo(output);
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
+      super.writeTo(output, entryFactory);
       // TODO: if the marshaller does not support object counting we could marshall the same functions many times
       // This encoding is optimized for mostly-empty inner lists but is as efficient as regular collection
       // encoding from MarshallUtil if all the inner lists are non-empty
@@ -75,7 +76,7 @@ public class TxReadOnlyManyCommand<K, V, R> extends ReadOnlyManyCommand<K, V, R>
             if (emptyLists > 0) output.writeInt(-emptyLists);
             output.writeInt(list.size());
             for (Mutation<K, V, ?> mut : list) {
-               Mutations.writeTo(output, mut);
+               Mutations.writeTo(mut, entryFactory, output);
             }
             emptyLists = 0;
          }

--- a/core/src/main/java/org/infinispan/commands/functional/WriteOnlyKeyCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/WriteOnlyKeyCommand.java
@@ -21,6 +21,8 @@ import org.infinispan.functional.Param;
 import org.infinispan.functional.impl.EntryViews;
 import org.infinispan.functional.impl.Params;
 import org.infinispan.functional.impl.StatsEnvelope;
+import org.infinispan.marshall.MarshalledEntryUtil;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 
 public final class WriteOnlyKeyCommand<K, V> extends AbstractWriteKeyCommand<K, V> {
 
@@ -50,8 +52,8 @@ public final class WriteOnlyKeyCommand<K, V> extends AbstractWriteKeyCommand<K, 
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
-      output.writeObject(key);
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
+      MarshalledEntryUtil.writeKey(key, entryFactory, output);
       output.writeObject(f);
       MarshallUtil.marshallEnum(valueMatcher, output);
       UnsignedNumeric.writeUnsignedInt(output, segment);
@@ -64,7 +66,7 @@ public final class WriteOnlyKeyCommand<K, V> extends AbstractWriteKeyCommand<K, 
 
    @Override
    public void readFrom(ObjectInput input) throws IOException, ClassNotFoundException {
-      key = input.readObject();
+      key = MarshalledEntryUtil.readKey(input);
       f = (Consumer<WriteEntryView<K, V>>) input.readObject();
       valueMatcher = MarshallUtil.unmarshallEnum(input, ValueMatcher::valueOf);
       segment = UnsignedNumeric.readUnsignedInt(input);

--- a/core/src/main/java/org/infinispan/commands/functional/WriteOnlyManyCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/WriteOnlyManyCommand.java
@@ -18,6 +18,8 @@ import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.functional.EntryView.WriteEntryView;
 import org.infinispan.functional.impl.EntryViews;
 import org.infinispan.functional.impl.Params;
+import org.infinispan.marshall.MarshalledEntryUtil;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 
 public final class WriteOnlyManyCommand<K, V> extends AbstractWriteManyCommand<K, V> {
 
@@ -69,9 +71,9 @@ public final class WriteOnlyManyCommand<K, V> extends AbstractWriteManyCommand<K
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
       CommandInvocationId.writeTo(output, commandInvocationId);
-      MarshallUtil.marshallCollection(keys, output);
+      MarshalledEntryUtil.marshallCollection(keys, entryFactory, output, MarshalledEntryUtil::writeKey);
       output.writeObject(f);
       output.writeBoolean(isForwarded);
       Params.writeObject(output, params);
@@ -84,7 +86,7 @@ public final class WriteOnlyManyCommand<K, V> extends AbstractWriteManyCommand<K
    @Override
    public void readFrom(ObjectInput input) throws IOException, ClassNotFoundException {
       commandInvocationId = CommandInvocationId.readFrom(input);
-      keys = MarshallUtil.unmarshallCollectionUnbounded(input, ArrayList::new);
+      keys = MarshallUtil.unmarshallCollection(input, ArrayList::new, MarshalledEntryUtil::readKey);
       f = (Consumer<WriteEntryView<K, V>>) input.readObject();
       isForwarded = input.readBoolean();
       params = Params.readObject(input);

--- a/core/src/main/java/org/infinispan/commands/functional/WriteOnlyManyEntriesCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/WriteOnlyManyEntriesCommand.java
@@ -11,7 +11,6 @@ import java.util.function.BiConsumer;
 import org.infinispan.commands.CommandInvocationId;
 import org.infinispan.commands.Visitor;
 import org.infinispan.commands.functional.functions.InjectableComponent;
-import org.infinispan.commons.marshall.MarshallUtil;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.encoding.DataConversion;
@@ -19,6 +18,8 @@ import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.functional.EntryView.WriteEntryView;
 import org.infinispan.functional.impl.EntryViews;
 import org.infinispan.functional.impl.Params;
+import org.infinispan.marshall.MarshalledEntryUtil;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 
 public final class WriteOnlyManyEntriesCommand<K, V, T> extends AbstractWriteManyCommand<K, V> {
 
@@ -74,9 +75,9 @@ public final class WriteOnlyManyEntriesCommand<K, V, T> extends AbstractWriteMan
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
       CommandInvocationId.writeTo(output, commandInvocationId);
-      MarshallUtil.marshallMap(arguments, output);
+      MarshalledEntryUtil.marshallMap(arguments, entryFactory, output);
       output.writeObject(f);
       output.writeBoolean(isForwarded);
       Params.writeObject(output, params);
@@ -90,7 +91,7 @@ public final class WriteOnlyManyEntriesCommand<K, V, T> extends AbstractWriteMan
    public void readFrom(ObjectInput input) throws IOException, ClassNotFoundException {
       commandInvocationId = CommandInvocationId.readFrom(input);
       // We use LinkedHashMap in order to guarantee the same order of iteration
-      arguments = MarshallUtil.unmarshallMap(input, LinkedHashMap::new);
+      arguments = MarshalledEntryUtil.unmarshallMap(input, LinkedHashMap::new);
       f = (BiConsumer<T, WriteEntryView<K, V>>) input.readObject();
       isForwarded = input.readBoolean();
       params = Params.readObject(input);

--- a/core/src/main/java/org/infinispan/commands/read/AbstractLocalCommand.java
+++ b/core/src/main/java/org/infinispan/commands/read/AbstractLocalCommand.java
@@ -6,6 +6,7 @@ import java.io.ObjectOutput;
 
 import org.infinispan.commands.AbstractFlagAffectedCommand;
 import org.infinispan.commands.LocalCommand;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 
 /**
  * Abstract class
@@ -20,7 +21,7 @@ public abstract class AbstractLocalCommand extends AbstractFlagAffectedCommand i
       return 0;  // no-op
    }
 
-   public final void writeTo(ObjectOutput output) throws IOException {
+   public final void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
       //no-op
    }
 

--- a/core/src/main/java/org/infinispan/commands/read/DistributedExecuteCommand.java
+++ b/core/src/main/java/org/infinispan/commands/read/DistributedExecuteCommand.java
@@ -20,6 +20,8 @@ import org.infinispan.commons.marshall.MarshallUtil;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.distexec.DistributedCallable;
 import org.infinispan.distexec.spi.DistributedTaskLifecycleService;
+import org.infinispan.marshall.MarshalledEntryUtil;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.util.ByteString;
 
 /**
@@ -126,15 +128,15 @@ public class DistributedExecuteCommand<V> extends BaseRpcCommand implements Visi
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
-      MarshallUtil.marshallCollection(keys, output);
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
+      MarshalledEntryUtil.marshallCollection(keys, entryFactory, output, MarshalledEntryUtil::writeKey);
       output.writeObject(callable);
       MarshallUtil.marshallUUID(uuid, output, false);
    }
 
    @Override
    public void readFrom(ObjectInput input) throws IOException, ClassNotFoundException {
-      keys = MarshallUtil.unmarshallCollectionUnbounded(input, HashSet::new);
+      keys = MarshallUtil.unmarshallCollection(input, HashSet::new, MarshalledEntryUtil::readKey);
       callable = (Callable<V>) input.readObject();
       uuid = MarshallUtil.unmarshallUUID(input, false);
    }

--- a/core/src/main/java/org/infinispan/commands/read/GetAllCommand.java
+++ b/core/src/main/java/org/infinispan/commands/read/GetAllCommand.java
@@ -13,10 +13,12 @@ import java.util.Map;
 import org.infinispan.commands.AbstractTopologyAffectedCommand;
 import org.infinispan.commands.Visitor;
 import org.infinispan.commons.marshall.MarshallUtil;
-import org.infinispan.container.impl.InternalEntryFactory;
 import org.infinispan.container.entries.CacheEntry;
+import org.infinispan.container.impl.InternalEntryFactory;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.FlagBitSets;
+import org.infinispan.marshall.MarshalledEntryUtil;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -110,15 +112,15 @@ public class GetAllCommand extends AbstractTopologyAffectedCommand {
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
-      MarshallUtil.marshallCollection(keys, output);
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
+      MarshalledEntryUtil.marshallCollection(keys, entryFactory, output, MarshalledEntryUtil::writeKey);
       output.writeLong(FlagBitSets.copyWithoutRemotableFlags(getFlagsBitSet()));
       output.writeBoolean(returnEntries);
    }
 
    @Override
    public void readFrom(ObjectInput input) throws IOException, ClassNotFoundException {
-      keys = MarshallUtil.unmarshallCollection(input, ArrayList::new);
+      keys = MarshallUtil.unmarshallCollection(input, ArrayList::new, MarshalledEntryUtil::readKey);
       setFlagsBitSet(input.readLong());
       returnEntries = input.readBoolean();
    }

--- a/core/src/main/java/org/infinispan/commands/read/GetCacheEntryCommand.java
+++ b/core/src/main/java/org/infinispan/commands/read/GetCacheEntryCommand.java
@@ -8,10 +8,12 @@ import java.io.ObjectOutput;
 
 import org.infinispan.commands.Visitor;
 import org.infinispan.commons.io.UnsignedNumeric;
-import org.infinispan.container.impl.InternalEntryFactory;
 import org.infinispan.container.entries.CacheEntry;
+import org.infinispan.container.impl.InternalEntryFactory;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.FlagBitSets;
+import org.infinispan.marshall.MarshalledEntryUtil;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 
 /**
  * Used to fetch a full CacheEntry rather than just the value.
@@ -60,15 +62,15 @@ public final class GetCacheEntryCommand extends AbstractDataCommand {
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
-      output.writeObject(key);
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
+      MarshalledEntryUtil.writeKey(key, entryFactory, output);
       UnsignedNumeric.writeUnsignedInt(output, segment);
       output.writeLong(FlagBitSets.copyWithoutRemotableFlags(getFlagsBitSet()));
    }
 
    @Override
    public void readFrom(ObjectInput input) throws IOException, ClassNotFoundException {
-      key = input.readObject();
+      key = MarshalledEntryUtil.readKey(input);
       segment = UnsignedNumeric.readUnsignedInt(input);
       setFlagsBitSet(input.readLong());
    }

--- a/core/src/main/java/org/infinispan/commands/read/GetKeyValueCommand.java
+++ b/core/src/main/java/org/infinispan/commands/read/GetKeyValueCommand.java
@@ -11,6 +11,8 @@ import org.infinispan.commons.io.UnsignedNumeric;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.FlagBitSets;
+import org.infinispan.marshall.MarshalledEntryUtil;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -63,15 +65,15 @@ public class GetKeyValueCommand extends AbstractDataCommand {
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
-      output.writeObject(key);
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
+      MarshalledEntryUtil.writeKey(key, entryFactory, output);
       UnsignedNumeric.writeUnsignedInt(output, segment);
       output.writeLong(FlagBitSets.copyWithoutRemotableFlags(getFlagsBitSet()));
    }
 
    @Override
    public void readFrom(ObjectInput input) throws IOException, ClassNotFoundException {
-      key = input.readObject();
+      key = MarshalledEntryUtil.readKey(input);
       segment = UnsignedNumeric.readUnsignedInt(input);
       setFlagsBitSet(input.readLong());
    }

--- a/core/src/main/java/org/infinispan/commands/remote/ClusteredGetAllCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/ClusteredGetAllCommand.java
@@ -13,14 +13,16 @@ import org.infinispan.commands.control.LockControlCommand;
 import org.infinispan.commands.read.GetAllCommand;
 import org.infinispan.commons.marshall.MarshallUtil;
 import org.infinispan.commons.util.EnumUtil;
-import org.infinispan.container.impl.InternalEntryFactory;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.container.entries.InternalCacheValue;
+import org.infinispan.container.impl.InternalEntryFactory;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.InvocationContextFactory;
 import org.infinispan.context.impl.FlagBitSets;
 import org.infinispan.interceptors.AsyncInterceptorChain;
+import org.infinispan.marshall.MarshalledEntryUtil;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.remoting.responses.Response;
 import org.infinispan.transaction.impl.TransactionTable;
 import org.infinispan.transaction.xa.GlobalTransaction;
@@ -128,15 +130,15 @@ public class ClusteredGetAllCommand<K, V> extends BaseClusteredReadCommand {
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
-      MarshallUtil.marshallCollection(keys, output);
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
+      MarshalledEntryUtil.marshallCollection(keys, entryFactory, output, MarshalledEntryUtil::writeKey);
       output.writeLong(FlagBitSets.copyWithoutRemotableFlags(getFlagsBitSet()));
       output.writeObject(gtx);
    }
 
    @Override
    public void readFrom(ObjectInput input) throws IOException, ClassNotFoundException {
-      keys = MarshallUtil.unmarshallCollection(input, ArrayList::new);
+      keys = MarshallUtil.unmarshallCollection(input, ArrayList::new, MarshalledEntryUtil::readKey);
       setFlagsBitSet(input.readLong());
       gtx = (GlobalTransaction) input.readObject();
    }

--- a/core/src/main/java/org/infinispan/commands/remote/ClusteredGetCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/ClusteredGetCommand.java
@@ -11,14 +11,16 @@ import org.infinispan.commands.SegmentSpecificCommand;
 import org.infinispan.commands.read.GetCacheEntryCommand;
 import org.infinispan.commons.io.UnsignedNumeric;
 import org.infinispan.commons.util.EnumUtil;
-import org.infinispan.container.impl.InternalEntryFactory;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.container.entries.MVCCEntry;
+import org.infinispan.container.impl.InternalEntryFactory;
 import org.infinispan.context.Flag;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.InvocationContextFactory;
 import org.infinispan.context.impl.FlagBitSets;
 import org.infinispan.interceptors.AsyncInterceptorChain;
+import org.infinispan.marshall.MarshalledEntryUtil;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.transaction.xa.GlobalTransaction;
 import org.infinispan.util.ByteString;
 import org.infinispan.util.logging.Log;
@@ -115,15 +117,15 @@ public class ClusteredGetCommand extends BaseClusteredReadCommand implements Seg
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
-      output.writeObject(key);
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
+      MarshalledEntryUtil.writeKey(key, entryFactory, output);
       UnsignedNumeric.writeUnsignedInt(output, segment);
       output.writeLong(FlagBitSets.copyWithoutRemotableFlags(getFlagsBitSet()));
    }
 
    @Override
    public void readFrom(ObjectInput input) throws IOException, ClassNotFoundException {
-      key = input.readObject();
+      key = MarshalledEntryUtil.readKey(input);
       segment = UnsignedNumeric.readUnsignedInt(input);
       setFlagsBitSet(input.readLong());
    }

--- a/core/src/main/java/org/infinispan/commands/remote/GetKeysInGroupCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/GetKeysInGroupCommand.java
@@ -15,6 +15,7 @@ import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.FlagBitSets;
 import org.infinispan.distribution.group.impl.GroupManager;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 
 /**
  * {@link org.infinispan.commands.VisitableCommand} that fetches the keys belonging to a group.
@@ -65,7 +66,7 @@ public class GetKeysInGroupCommand extends AbstractTopologyAffectedCommand imple
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
       output.writeObject(groupName);
       output.writeLong(FlagBitSets.copyWithoutRemotableFlags(getFlagsBitSet()));
    }

--- a/core/src/main/java/org/infinispan/commands/remote/RenewBiasCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/RenewBiasCommand.java
@@ -5,6 +5,8 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 
 import org.infinispan.commons.marshall.MarshallUtil;
+import org.infinispan.marshall.MarshalledEntryUtil;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.scattered.BiasManager;
 import org.infinispan.util.ByteString;
 
@@ -50,12 +52,12 @@ public class RenewBiasCommand extends BaseRpcCommand {
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
-      MarshallUtil.marshallArray(keys, output);
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
+      MarshalledEntryUtil.marshallArray(keys, entryFactory, output, MarshalledEntryUtil::writeKey);
    }
 
    @Override
    public void readFrom(ObjectInput input) throws IOException, ClassNotFoundException {
-      keys = MarshallUtil.unmarshallArray(input, Object[]::new);
+      keys = MarshallUtil.unmarshallArray(input, Object[]::new, MarshalledEntryUtil::readKey);
    }
 }

--- a/core/src/main/java/org/infinispan/commands/remote/RevokeBiasCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/RevokeBiasCommand.java
@@ -9,6 +9,8 @@ import java.util.Collection;
 import org.infinispan.commands.CommandsFactory;
 import org.infinispan.commands.write.BackupAckCommand;
 import org.infinispan.commons.marshall.MarshallUtil;
+import org.infinispan.marshall.MarshalledEntryUtil;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.remoting.inboundhandler.DeliverOrder;
 import org.infinispan.remoting.rpc.RpcManager;
 import org.infinispan.remoting.transport.Address;
@@ -77,13 +79,13 @@ public class RevokeBiasCommand extends BaseRpcCommand {
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
       output.writeObject(ackTarget);
       if (ackTarget != null) {
          output.writeLong(id);
       }
       output.writeInt(topologyId);
-      MarshallUtil.marshallCollection(keys, output);
+      MarshalledEntryUtil.marshallCollection(keys, entryFactory, output, MarshalledEntryUtil::writeKey);
    }
 
    @Override
@@ -93,7 +95,7 @@ public class RevokeBiasCommand extends BaseRpcCommand {
          id = input.readLong();
       }
       topologyId = input.readInt();
-      keys = MarshallUtil.unmarshallCollection(input, ArrayList::new);
+      keys = MarshallUtil.unmarshallCollection(input, ArrayList::new, MarshalledEntryUtil::readKey);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/commands/remote/SingleRpcCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/SingleRpcCommand.java
@@ -7,6 +7,7 @@ import java.util.concurrent.CompletableFuture;
 
 import org.infinispan.commands.ReplicableCommand;
 import org.infinispan.context.InvocationContext;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.util.ByteString;
 
 /**
@@ -38,7 +39,7 @@ public class SingleRpcCommand extends BaseRpcInvokingCommand {
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
       output.writeObject(command);
    }
 

--- a/core/src/main/java/org/infinispan/commands/remote/expiration/RetrieveLastAccessCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/expiration/RetrieveLastAccessCommand.java
@@ -12,6 +12,9 @@ import org.infinispan.commands.remote.BaseRpcCommand;
 import org.infinispan.commons.io.UnsignedNumeric;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.container.impl.InternalDataContainer;
+import org.infinispan.marshall.MarshalledEntryUtil;
+import org.infinispan.marshall.core.MarshalledEntry;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.util.ByteString;
 import org.infinispan.util.TimeService;
 import org.infinispan.util.concurrent.CompletableFutures;
@@ -67,24 +70,16 @@ public class RetrieveLastAccessCommand extends BaseRpcCommand implements Topolog
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
-      output.writeObject(key);
-      if (value == null) {
-         output.writeBoolean(false);
-      } else {
-         output.writeBoolean(true);
-         output.writeObject(value);
-      }
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
+      MarshalledEntryUtil.writeKeyValue(key, value, entryFactory, output);
       UnsignedNumeric.writeUnsignedInt(output, segment);
    }
 
    @Override
    public void readFrom(ObjectInput input) throws IOException, ClassNotFoundException {
-      key = input.readObject();
-      boolean hasValue = input.readBoolean();
-      if (hasValue) {
-         value = input.readObject();
-      }
+      MarshalledEntry me = MarshalledEntryUtil.read(input);
+      key = me.getKey();
+      value = me.getValue();
       segment = UnsignedNumeric.readUnsignedInt(input);
    }
 

--- a/core/src/main/java/org/infinispan/commands/remote/expiration/UpdateLastAccessCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/expiration/UpdateLastAccessCommand.java
@@ -11,6 +11,8 @@ import org.infinispan.commands.remote.BaseRpcCommand;
 import org.infinispan.commons.io.UnsignedNumeric;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.container.impl.InternalDataContainer;
+import org.infinispan.marshall.MarshalledEntryUtil;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.util.ByteString;
 import org.infinispan.util.concurrent.CompletableFutures;
 
@@ -60,15 +62,15 @@ public class UpdateLastAccessCommand extends BaseRpcCommand implements TopologyA
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
-      output.writeObject(key);
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
+      MarshalledEntryUtil.writeKey(key, entryFactory, output);
       UnsignedNumeric.writeUnsignedInt(output, segment);
       UnsignedNumeric.writeUnsignedLong(output, acessTime);
    }
 
    @Override
    public void readFrom(ObjectInput input) throws IOException, ClassNotFoundException {
-      key = input.readObject();
+      key = MarshalledEntryUtil.readKey(input);
       segment = UnsignedNumeric.readUnsignedInt(input);
       acessTime = UnsignedNumeric.readUnsignedLong(input);
    }

--- a/core/src/main/java/org/infinispan/commands/remote/recovery/CompleteTransactionCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/recovery/CompleteTransactionCommand.java
@@ -7,6 +7,7 @@ import java.util.concurrent.CompletableFuture;
 
 import javax.transaction.xa.Xid;
 
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.util.ByteString;
 
 /**
@@ -54,7 +55,7 @@ public class CompleteTransactionCommand extends RecoveryCommand {
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
       output.writeObject(xid);
       output.writeBoolean(commit);
    }

--- a/core/src/main/java/org/infinispan/commands/remote/recovery/GetInDoubtTransactionsCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/recovery/GetInDoubtTransactionsCommand.java
@@ -8,6 +8,7 @@ import java.util.List;
 import javax.transaction.xa.Xid;
 
 import org.infinispan.context.InvocationContext;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.util.ByteString;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -46,7 +47,7 @@ public class GetInDoubtTransactionsCommand extends RecoveryCommand {
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
       // No parameters
    }
 

--- a/core/src/main/java/org/infinispan/commands/remote/recovery/GetInDoubtTxInfoCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/recovery/GetInDoubtTxInfoCommand.java
@@ -5,6 +5,7 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.concurrent.CompletableFuture;
 
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.util.ByteString;
 
 /**
@@ -36,7 +37,7 @@ public class GetInDoubtTxInfoCommand extends RecoveryCommand {
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
       // No parameters
    }
 

--- a/core/src/main/java/org/infinispan/commands/remote/recovery/TxCompletionNotificationCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/recovery/TxCompletionNotificationCommand.java
@@ -11,6 +11,7 @@ import java.util.concurrent.CompletableFuture;
 import javax.transaction.xa.Xid;
 
 import org.infinispan.commands.TopologyAffectedCommand;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.statetransfer.StateTransferManager;
 import org.infinispan.transaction.impl.RemoteTransaction;
 import org.infinispan.transaction.impl.TransactionTable;
@@ -127,7 +128,7 @@ public class TxCompletionNotificationCommand  extends RecoveryCommand implements
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
       if (xid == null) {
          output.writeBoolean(true);
          output.writeLong(internalId);

--- a/core/src/main/java/org/infinispan/commands/triangle/MultiEntriesFunctionalBackupWriteCommand.java
+++ b/core/src/main/java/org/infinispan/commands/triangle/MultiEntriesFunctionalBackupWriteCommand.java
@@ -13,10 +13,11 @@ import org.infinispan.commands.functional.AbstractWriteManyCommand;
 import org.infinispan.commands.functional.ReadWriteManyEntriesCommand;
 import org.infinispan.commands.functional.WriteOnlyManyEntriesCommand;
 import org.infinispan.commands.write.WriteCommand;
-import org.infinispan.commons.marshall.MarshallUtil;
 import org.infinispan.context.InvocationContextFactory;
 import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.interceptors.AsyncInterceptorChain;
+import org.infinispan.marshall.MarshalledEntryUtil;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.util.ByteString;
 import org.infinispan.util.TriangleFunctionsUtil;
 
@@ -44,7 +45,7 @@ public class MultiEntriesFunctionalBackupWriteCommand extends FunctionalBackupWr
    }
 
    public void init(InvocationContextFactory factory, AsyncInterceptorChain chain,
-         ComponentRegistry componentRegistry) {
+                    ComponentRegistry componentRegistry) {
       injectDependencies(factory, chain);
       this.componentRegistry = componentRegistry;
    }
@@ -71,11 +72,11 @@ public class MultiEntriesFunctionalBackupWriteCommand extends FunctionalBackupWr
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
       writeBase(output);
       writeFunctionAndParams(output);
       output.writeBoolean(writeOnly);
-      MarshallUtil.marshallMap(entries, output);
+      MarshalledEntryUtil.marshallMap(entries, entryFactory, output);
    }
 
    @Override
@@ -83,7 +84,7 @@ public class MultiEntriesFunctionalBackupWriteCommand extends FunctionalBackupWr
       readBase(input);
       readFunctionAndParams(input);
       writeOnly = input.readBoolean();
-      entries = MarshallUtil.unmarshallMap(input, HashMap::new);
+      entries = MarshalledEntryUtil.unmarshallMap(input, HashMap::new);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/commands/triangle/MultiKeyFunctionalBackupWriteCommand.java
+++ b/core/src/main/java/org/infinispan/commands/triangle/MultiKeyFunctionalBackupWriteCommand.java
@@ -16,6 +16,8 @@ import org.infinispan.commons.marshall.MarshallUtil;
 import org.infinispan.context.InvocationContextFactory;
 import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.interceptors.AsyncInterceptorChain;
+import org.infinispan.marshall.MarshalledEntryUtil;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.util.ByteString;
 
 /**
@@ -69,11 +71,11 @@ public class MultiKeyFunctionalBackupWriteCommand extends FunctionalBackupWriteC
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
       writeBase(output);
       writeFunctionAndParams(output);
       output.writeBoolean(writeOnly);
-      MarshallUtil.marshallCollection(keys, output);
+      MarshalledEntryUtil.marshallCollection(keys, entryFactory, output, MarshalledEntryUtil::writeKey);
    }
 
    @Override
@@ -81,7 +83,7 @@ public class MultiKeyFunctionalBackupWriteCommand extends FunctionalBackupWriteC
       readBase(input);
       readFunctionAndParams(input);
       writeOnly = input.readBoolean();
-      keys = MarshallUtil.unmarshallCollection(input, ArrayList::new);
+      keys = MarshallUtil.unmarshallCollection(input, ArrayList::new, MarshalledEntryUtil::readKey);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/commands/triangle/PutMapBackupWriteCommand.java
+++ b/core/src/main/java/org/infinispan/commands/triangle/PutMapBackupWriteCommand.java
@@ -9,9 +9,10 @@ import java.util.Map;
 
 import org.infinispan.commands.write.PutMapCommand;
 import org.infinispan.commands.write.WriteCommand;
-import org.infinispan.commons.marshall.MarshallUtil;
 import org.infinispan.context.InvocationContextFactory;
 import org.infinispan.interceptors.AsyncInterceptorChain;
+import org.infinispan.marshall.MarshalledEntryUtil;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.metadata.Metadata;
 import org.infinispan.notifications.cachelistener.CacheNotifier;
 import org.infinispan.util.ByteString;
@@ -54,17 +55,17 @@ public class PutMapBackupWriteCommand extends BackupWriteCommand {
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
       writeBase(output);
-      MarshallUtil.marshallMap(map, output);
-      output.writeObject(metadata);
+      MarshalledEntryUtil.marshallMap(map, entryFactory, output);
+      MarshalledEntryUtil.writeMetadata(metadata, entryFactory, output);
    }
 
    @Override
    public void readFrom(ObjectInput input) throws IOException, ClassNotFoundException {
       readBase(input);
-      map = MarshallUtil.unmarshallMap(input, HashMap::new);
-      metadata = (Metadata) input.readObject();
+      map = MarshalledEntryUtil.unmarshallMap(input, HashMap::new);
+      metadata = MarshalledEntryUtil.readMetadata(input);
    }
 
    public void setPutMapCommand(PutMapCommand command, Collection<Object> keys) {

--- a/core/src/main/java/org/infinispan/commands/tx/AbstractTransactionBoundaryCommand.java
+++ b/core/src/main/java/org/infinispan/commands/tx/AbstractTransactionBoundaryCommand.java
@@ -9,6 +9,7 @@ import org.infinispan.context.InvocationContext;
 import org.infinispan.context.InvocationContextFactory;
 import org.infinispan.context.impl.RemoteTxInvocationContext;
 import org.infinispan.interceptors.AsyncInterceptorChain;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.transaction.impl.RemoteTransaction;
 import org.infinispan.transaction.impl.TransactionTable;
@@ -109,7 +110,7 @@ public abstract class AbstractTransactionBoundaryCommand implements TransactionB
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
       output.writeObject(globalTx);
    }
 

--- a/core/src/main/java/org/infinispan/commands/tx/PrepareCommand.java
+++ b/core/src/main/java/org/infinispan/commands/tx/PrepareCommand.java
@@ -36,6 +36,7 @@ import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.FlagBitSets;
 import org.infinispan.context.impl.RemoteTxInvocationContext;
 import org.infinispan.context.impl.TxInvocationContext;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.notifications.cachelistener.CacheNotifier;
 import org.infinispan.transaction.impl.RemoteTransaction;
 import org.infinispan.transaction.xa.GlobalTransaction;
@@ -199,8 +200,8 @@ public class PrepareCommand extends AbstractTransactionBoundaryCommand implement
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
-      super.writeTo(output); //global tx
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
+      super.writeTo(output, entryFactory); //global tx
       output.writeBoolean(onePhaseCommit);
       output.writeBoolean(retriedCommand);
       MarshallUtil.marshallArray(modifications, output);

--- a/core/src/main/java/org/infinispan/commands/tx/VersionedCommitCommand.java
+++ b/core/src/main/java/org/infinispan/commands/tx/VersionedCommitCommand.java
@@ -6,6 +6,7 @@ import java.io.ObjectOutput;
 
 import org.infinispan.commons.marshall.MarshallUtil;
 import org.infinispan.container.versioning.EntryVersionsMap;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.transaction.xa.GlobalTransaction;
 import org.infinispan.util.ByteString;
 
@@ -46,8 +47,8 @@ public class VersionedCommitCommand extends CommitCommand {
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
-      super.writeTo(output); //write global tx
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
+      super.writeTo(output, entryFactory); //write global tx
       MarshallUtil.marshallMap(updatedVersions, output);
    }
 

--- a/core/src/main/java/org/infinispan/commands/tx/VersionedPrepareCommand.java
+++ b/core/src/main/java/org/infinispan/commands/tx/VersionedPrepareCommand.java
@@ -9,6 +9,7 @@ import java.util.List;
 import org.infinispan.commands.write.WriteCommand;
 import org.infinispan.commons.marshall.MarshallUtil;
 import org.infinispan.container.versioning.EntryVersionsMap;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.transaction.xa.GlobalTransaction;
 import org.infinispan.util.ByteString;
 
@@ -50,8 +51,8 @@ public class VersionedPrepareCommand extends PrepareCommand {
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
-      super.writeTo(output); //writes global tx, one phase, retried and mods.
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
+      super.writeTo(output, entryFactory); //writes global tx, one phase, retried and mods.
       MarshallUtil.marshallMap(versionsSeen, output);
    }
 

--- a/core/src/main/java/org/infinispan/commands/write/ApplyDeltaCommand.java
+++ b/core/src/main/java/org/infinispan/commands/write/ApplyDeltaCommand.java
@@ -9,6 +9,7 @@ import org.infinispan.atomic.Delta;
 import org.infinispan.commands.CommandInvocationId;
 import org.infinispan.commands.Visitor;
 import org.infinispan.context.InvocationContext;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 
 
 /**
@@ -59,7 +60,7 @@ public class ApplyDeltaCommand extends AbstractDataWriteCommand {
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
       throw new UnsupportedOperationException();
    }
 

--- a/core/src/main/java/org/infinispan/commands/write/BackupAckCommand.java
+++ b/core/src/main/java/org/infinispan/commands/write/BackupAckCommand.java
@@ -5,6 +5,7 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 
 import org.infinispan.commands.remote.BaseRpcCommand;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.util.ByteString;
 import org.infinispan.util.concurrent.CommandAckCollector;
 
@@ -57,7 +58,7 @@ public class BackupAckCommand extends BaseRpcCommand {
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
       output.writeLong(id);
       output.writeInt(topologyId);
    }

--- a/core/src/main/java/org/infinispan/commands/write/BackupMultiKeyAckCommand.java
+++ b/core/src/main/java/org/infinispan/commands/write/BackupMultiKeyAckCommand.java
@@ -5,6 +5,7 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 
 import org.infinispan.commands.remote.BaseRpcCommand;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.util.ByteString;
 import org.infinispan.util.concurrent.CommandAckCollector;
 
@@ -61,7 +62,7 @@ public class BackupMultiKeyAckCommand extends BaseRpcCommand {
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
       output.writeLong(id);
       output.writeInt(segment);
       output.writeInt(topologyId);

--- a/core/src/main/java/org/infinispan/commands/write/ClearCommand.java
+++ b/core/src/main/java/org/infinispan/commands/write/ClearCommand.java
@@ -12,6 +12,7 @@ import org.infinispan.commands.Visitor;
 import org.infinispan.container.DataContainer;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.FlagBitSets;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.notifications.cachelistener.CacheNotifier;
 
 /**
@@ -56,7 +57,7 @@ public class ClearCommand extends AbstractTopologyAffectedCommand implements Wri
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
       output.writeLong(FlagBitSets.copyWithoutRemotableFlags(getFlagsBitSet()));
    }
 

--- a/core/src/main/java/org/infinispan/commands/write/ExceptionAckCommand.java
+++ b/core/src/main/java/org/infinispan/commands/write/ExceptionAckCommand.java
@@ -6,6 +6,7 @@ import java.io.ObjectOutput;
 
 import org.infinispan.commands.remote.BaseRpcCommand;
 import org.infinispan.commons.CacheException;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.remoting.transport.ResponseCollectors;
 import org.infinispan.util.ByteString;
 import org.infinispan.util.concurrent.CommandAckCollector;
@@ -65,7 +66,7 @@ public class ExceptionAckCommand extends BaseRpcCommand {
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
       output.writeLong(id);
       output.writeObject(throwable);
       output.writeInt(topologyId);

--- a/core/src/main/java/org/infinispan/commands/write/InvalidateCommand.java
+++ b/core/src/main/java/org/infinispan/commands/write/InvalidateCommand.java
@@ -17,6 +17,8 @@ import org.infinispan.commons.util.Util;
 import org.infinispan.container.entries.MVCCEntry;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.FlagBitSets;
+import org.infinispan.marshall.MarshalledEntryUtil;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.notifications.cachelistener.CacheNotifier;
 import org.infinispan.util.concurrent.locks.RemoteLockCommand;
 import org.infinispan.util.logging.Log;
@@ -106,16 +108,16 @@ public class InvalidateCommand extends AbstractTopologyAffectedCommand implement
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
       CommandInvocationId.writeTo(output, commandInvocationId);
-      MarshallUtil.marshallArray(keys, output);
+      MarshalledEntryUtil.marshallArray(keys, entryFactory, output, MarshalledEntryUtil::writeKey);
       output.writeLong(getFlagsBitSet());
    }
 
    @Override
    public void readFrom(ObjectInput input) throws IOException, ClassNotFoundException {
       commandInvocationId = CommandInvocationId.readFrom(input);
-      keys = MarshallUtil.unmarshallArray(input, Util::objectArray);
+      keys = MarshallUtil.unmarshallArray(input, Util::objectArray, MarshalledEntryUtil::readKey);
       setFlagsBitSet(input.readLong());
    }
 

--- a/core/src/main/java/org/infinispan/commands/write/InvalidateL1Command.java
+++ b/core/src/main/java/org/infinispan/commands/write/InvalidateL1Command.java
@@ -14,6 +14,7 @@ import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.container.entries.MVCCEntry;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.distribution.DistributionManager;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.notifications.cachelistener.CacheNotifier;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.util.logging.Log;
@@ -104,8 +105,8 @@ public class InvalidateL1Command extends InvalidateCommand {
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
-      super.writeTo(output); //command invocation id + keys
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
+      super.writeTo(output, entryFactory); //command invocation id + keys
       output.writeObject(writeOrigin);
    }
 

--- a/core/src/main/java/org/infinispan/commands/write/InvalidateVersionsCommand.java
+++ b/core/src/main/java/org/infinispan/commands/write/InvalidateVersionsCommand.java
@@ -6,6 +6,8 @@ import org.infinispan.container.DataContainer;
 import org.infinispan.container.versioning.InequalVersionComparisonResult;
 import org.infinispan.container.versioning.SimpleClusteredVersion;
 import org.infinispan.distribution.DistributionManager;
+import org.infinispan.marshall.MarshalledEntryUtil;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.persistence.manager.OrderedUpdatesManager;
 import org.infinispan.scattered.BiasManager;
 import org.infinispan.statetransfer.StateTransferLock;
@@ -136,7 +138,7 @@ public class InvalidateVersionsCommand extends BaseRpcCommand {
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
       output.writeInt(topologyId);
       // TODO: topology ids are mostly the same - sort the arrays according to topologyIds and use compaction encoding
       output.writeInt(keys.length);
@@ -145,7 +147,7 @@ public class InvalidateVersionsCommand extends BaseRpcCommand {
             output.writeObject(null);
             break;
          } else {
-            output.writeObject(keys[i]);
+            MarshalledEntryUtil.writeKey(keys[i], entryFactory, output);
             output.writeInt(topologyIds[i]);
             output.writeLong(versions[i]);
          }
@@ -160,7 +162,7 @@ public class InvalidateVersionsCommand extends BaseRpcCommand {
       topologyIds = new int[keys.length];
       versions = new long[keys.length];
       for (int i = 0; i < keys.length; ++i) {
-         Object key = input.readObject();
+         Object key = MarshalledEntryUtil.readKey(input);
          if (key == null) {
             break;
          }

--- a/core/src/main/java/org/infinispan/factories/ComponentRegistry.java
+++ b/core/src/main/java/org/infinispan/factories/ComponentRegistry.java
@@ -1,6 +1,8 @@
 package org.infinispan.factories;
 
+import static org.infinispan.factories.KnownComponentNames.INTERNAL_MARSHALLER;
 import static org.infinispan.factories.KnownComponentNames.MODULE_COMMAND_INITIALIZERS;
+import static org.infinispan.factories.KnownComponentNames.USER_MARSHALLER;
 
 import java.lang.ref.WeakReference;
 import java.util.Collections;
@@ -12,6 +14,7 @@ import org.infinispan.commands.CommandsFactory;
 import org.infinispan.commands.module.ModuleCommandInitializer;
 import org.infinispan.commons.CacheConfigurationException;
 import org.infinispan.commons.CacheException;
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.commons.marshall.StreamingMarshaller;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.conflict.impl.InternalConflictManager;
@@ -290,10 +293,14 @@ public class ComponentRegistry extends AbstractComponentRegistry {
    }
 
    /**
-    * Caching shortcut for #getComponent(StreamingMarshaller.class, KnownComponentNames.CACHE_MARSHALLER);
+    * Caching shortcut for #getComponent(Marshaller.class, USER_MARSHALLER);
     */
-   public StreamingMarshaller getCacheMarshaller() {
-      return globalComponents.getComponent(StreamingMarshaller.class);
+   public Marshaller getUserMarshaller() {
+      return globalComponents.getComponent(Marshaller.class, USER_MARSHALLER);
+   }
+
+   public StreamingMarshaller getInternalMarshaller() {
+      return globalComponents.getComponent(StreamingMarshaller.class, INTERNAL_MARSHALLER);
    }
 
    /**

--- a/core/src/main/java/org/infinispan/factories/EncoderRegistryFactory.java
+++ b/core/src/main/java/org/infinispan/factories/EncoderRegistryFactory.java
@@ -1,5 +1,7 @@
 package org.infinispan.factories;
 
+import static org.infinispan.factories.KnownComponentNames.INTERNAL_MARSHALLER;
+
 import org.infinispan.commons.configuration.ClassWhiteList;
 import org.infinispan.commons.dataconversion.BinaryEncoder;
 import org.infinispan.commons.dataconversion.ByteArrayWrapper;
@@ -16,6 +18,7 @@ import org.infinispan.commons.dataconversion.UTF8Encoder;
 import org.infinispan.commons.marshall.JavaSerializationMarshaller;
 import org.infinispan.commons.marshall.StreamingMarshaller;
 import org.infinispan.commons.marshall.jboss.GenericJBossMarshaller;
+import org.infinispan.factories.annotations.ComponentName;
 import org.infinispan.factories.annotations.DefaultFactoryFor;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -30,7 +33,7 @@ import org.infinispan.marshall.core.EncoderRegistryImpl;
 @DefaultFactoryFor(classes = {EncoderRegistry.class})
 public class EncoderRegistryFactory extends AbstractComponentFactory implements AutoInstantiableFactory {
 
-   @Inject
+   @Inject @ComponentName(INTERNAL_MARSHALLER)
    private StreamingMarshaller globalMarshaller;
    @Inject
    private EmbeddedCacheManager embeddedCacheManager;

--- a/core/src/main/java/org/infinispan/factories/KnownComponentNames.java
+++ b/core/src/main/java/org/infinispan/factories/KnownComponentNames.java
@@ -32,13 +32,16 @@ public class KnownComponentNames {
    public static final String TIMEOUT_SCHEDULE_EXECUTOR = "org.infinispan.executors.timeout";
    public static final String CACHE_DEPENDENCY_GRAPH = "org.infinispan.CacheDependencyGraph";
 
+   public static final String INTERNAL_MARSHALLER= "org.infinispan.marshaller.internal";
+   public static final String USER_MARSHALLER = "org.infinispan.marshaller.user";
+
    // Please make sure this is kept up to date
    public static final Collection<String> ALL_KNOWN_COMPONENT_NAMES = Arrays.asList(
       ASYNC_TRANSPORT_EXECUTOR, ASYNC_NOTIFICATION_EXECUTOR, PERSISTENCE_EXECUTOR, ASYNC_OPERATIONS_EXECUTOR,
-      EXPIRATION_SCHEDULED_EXECUTOR,
+      EXPIRATION_SCHEDULED_EXECUTOR, INTERNAL_MARSHALLER,
       MODULE_COMMAND_INITIALIZERS, MODULE_COMMAND_FACTORIES, CLASS_LOADER,
       REMOTE_COMMAND_EXECUTOR, STATE_TRANSFER_EXECUTOR, TRANSACTION_VERSION_GENERATOR,
-      TIMEOUT_SCHEDULE_EXECUTOR
+      TIMEOUT_SCHEDULE_EXECUTOR, USER_MARSHALLER
    );
 
    private static final Map<String, Integer> DEFAULT_THREAD_COUNT = new HashMap<>(8);

--- a/core/src/main/java/org/infinispan/interceptors/impl/ClusteringInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/ClusteringInterceptor.java
@@ -10,6 +10,7 @@ import org.infinispan.container.impl.EntryFactory;
 import org.infinispan.container.impl.InternalDataContainer;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.factories.annotations.Inject;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.remoting.responses.CacheNotFoundResponse;
 import org.infinispan.remoting.responses.Response;
 import org.infinispan.remoting.responses.SuccessfulResponse;
@@ -33,6 +34,7 @@ public abstract class ClusteringInterceptor extends BaseRpcInterceptor {
    @Inject protected InternalDataContainer dataContainer;
    @Inject protected StateTransferManager stateTransferManager;
    @Inject protected DistributionManager distributionManager;
+   @Inject protected MarshalledEntryFactory marshalledEntryFactory;
 
    protected static Response getSingleResponse(Map<Address, Response> responseMap) {
       Iterator<Response> it = responseMap.values().iterator();

--- a/core/src/main/java/org/infinispan/interceptors/impl/IsMarshallableInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/IsMarshallableInterceptor.java
@@ -1,5 +1,7 @@
 package org.infinispan.interceptors.impl;
 
+import static org.infinispan.factories.KnownComponentNames.USER_MARSHALLER;
+
 import java.util.Map;
 
 import org.infinispan.commands.FlagAffectedCommand;
@@ -10,10 +12,11 @@ import org.infinispan.commands.write.PutKeyValueCommand;
 import org.infinispan.commands.write.PutMapCommand;
 import org.infinispan.commands.write.RemoveCommand;
 import org.infinispan.commands.write.ReplaceCommand;
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.commons.marshall.NotSerializableException;
-import org.infinispan.commons.marshall.StreamingMarshaller;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.FlagBitSets;
+import org.infinispan.factories.annotations.ComponentName;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
 import org.infinispan.interceptors.DDAsyncInterceptor;
@@ -31,7 +34,7 @@ import org.infinispan.interceptors.DDAsyncInterceptor;
  */
 public class IsMarshallableInterceptor extends DDAsyncInterceptor {
 
-   @Inject private StreamingMarshaller marshaller;
+   @Inject @ComponentName(USER_MARSHALLER) private Marshaller marshaller;
    private boolean usingAsyncStore;
 
    @Start

--- a/core/src/main/java/org/infinispan/interceptors/impl/TransactionalStoreInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/TransactionalStoreInterceptor.java
@@ -10,11 +10,11 @@ import org.infinispan.commands.tx.CommitCommand;
 import org.infinispan.commands.tx.PrepareCommand;
 import org.infinispan.commands.tx.RollbackCommand;
 import org.infinispan.commands.write.WriteCommand;
-import org.infinispan.commons.marshall.StreamingMarshaller;
 import org.infinispan.container.impl.InternalEntryFactory;
 import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.interceptors.DDAsyncInterceptor;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.persistence.manager.PersistenceManager;
 
 /**
@@ -27,14 +27,14 @@ import org.infinispan.persistence.manager.PersistenceManager;
 public class TransactionalStoreInterceptor extends DDAsyncInterceptor {
    @Inject private PersistenceManager persistenceManager;
    @Inject private InternalEntryFactory entryFactory;
-   @Inject private StreamingMarshaller marshaller;
+   @Inject private MarshalledEntryFactory marshalledEntryFactory;
 
    @Override
    public Object visitPrepareCommand(TxInvocationContext ctx, PrepareCommand command) throws Throwable {
       if (ctx.isOriginLocal()) {
          Transaction tx = ctx.getTransaction();
          TxBatchUpdater modBuilder = TxBatchUpdater.createTxStoreUpdater(
-               persistenceManager, entryFactory, marshaller, ctx.getCacheTransaction().getAffectedKeys());
+               persistenceManager, entryFactory, marshalledEntryFactory, ctx.getCacheTransaction().getAffectedKeys());
 
          List<WriteCommand> modifications = ctx.getCacheTransaction().getAllModifications();
          for (WriteCommand writeCommand : modifications) {

--- a/core/src/main/java/org/infinispan/manager/impl/ReplicableCommandManagerFunction.java
+++ b/core/src/main/java/org/infinispan/manager/impl/ReplicableCommandManagerFunction.java
@@ -9,6 +9,7 @@ import java.util.function.Function;
 import org.infinispan.commands.ReplicableCommand;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 
 /**
  * Replicable Command that runs the given Function passing the {@link EmbeddedCacheManager} as an argument
@@ -47,7 +48,7 @@ public class ReplicableCommandManagerFunction implements ReplicableCommand {
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
       output.writeObject(function);
    }
 

--- a/core/src/main/java/org/infinispan/manager/impl/ReplicableCommandRunnable.java
+++ b/core/src/main/java/org/infinispan/manager/impl/ReplicableCommandRunnable.java
@@ -6,6 +6,7 @@ import java.io.ObjectOutput;
 import java.util.concurrent.CompletableFuture;
 
 import org.infinispan.commands.ReplicableCommand;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.util.concurrent.CompletableFutures;
 
 /**
@@ -45,7 +46,7 @@ public class ReplicableCommandRunnable implements ReplicableCommand {
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
       output.writeObject(runnable);
    }
 

--- a/core/src/main/java/org/infinispan/marshall/MarshalledEntryUtil.java
+++ b/core/src/main/java/org/infinispan/marshall/MarshalledEntryUtil.java
@@ -1,0 +1,194 @@
+package org.infinispan.marshall;
+
+import static org.infinispan.commons.marshall.MarshallUtil.NULL_VALUE;
+import static org.infinispan.commons.marshall.MarshallUtil.marshallSize;
+import static org.infinispan.commons.marshall.MarshallUtil.unmarshallSize;
+import static org.infinispan.commons.util.CollectionFactory.computeCapacity;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+
+import org.infinispan.commons.marshall.MarshallUtil;
+import org.infinispan.marshall.core.MarshalledEntry;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
+import org.infinispan.marshall.core.MarshalledEntryImpl;
+import org.infinispan.metadata.Metadata;
+
+/**
+ * Util class for writing user key/values to the Object input/outputs used by the internal marshaller.
+ */
+public class MarshalledEntryUtil {
+
+   public static <K> void writeKey(K key, MarshalledEntryFactory factory, ObjectOutput out) throws IOException {
+      write(key, null, null, factory, out);
+   }
+
+   public static <V> void writeValue(V value, MarshalledEntryFactory factory, ObjectOutput out) throws IOException {
+      write(null, value, null, factory, out);
+   }
+
+   public static <K, V> void writeKeyValue(K key, V value, MarshalledEntryFactory factory, ObjectOutput out) throws IOException {
+      write(key, value, null, factory, out);
+   }
+
+   public static void writeMetadata(Metadata metadata, MarshalledEntryFactory factory, ObjectOutput out) throws IOException {
+      write(null, null, metadata, factory, out);
+   }
+
+   public static <K, V> void write(K key, V value, Metadata metadata, MarshalledEntryFactory factory, ObjectOutput out) throws IOException {
+      try {
+         out.writeObject(factory.newMarshalledEntry(key, value, metadata));
+      } catch (NullPointerException e) {
+         throw e;
+      }
+   }
+
+   public static <K, V> K readKey(ObjectInput in) throws ClassNotFoundException, IOException {
+      MarshalledEntry<K, V> entry = read(in);
+      return entry.getKey();
+   }
+
+   public static <K, V> V readValue(ObjectInput in) throws ClassNotFoundException, IOException {
+      MarshalledEntry<K, V> entry = read(in);
+      return entry.getValue();
+   }
+
+   public static Metadata readMetadata(ObjectInput in) throws ClassNotFoundException, IOException {
+      return read(in).metadata();
+   }
+
+   public static <K, V> MarshalledEntryImpl<K, V> read(ObjectInput in) throws ClassNotFoundException, IOException {
+      //noinspection unchecked
+      return (MarshalledEntryImpl<K, V>) in.readObject();
+   }
+
+   /**
+    * Marshall the {@code map} to the {@code ObjectOutput} using the user marshaller to serialize the key/values.
+    * <p>
+    * {@code null} maps are supported.
+    *
+    * @param map     {@link Map} to marshall.
+    * @param out     {@link ObjectOutput} to write. It must be non-null.
+    * @param factory {@link MarshalledEntryFactory} used to create the {@link org.infinispan.marshall.core.MarshalledEntry}
+    *                wrapper.
+    * @param <K>     Key type of the map.
+    * @param <V>     Value type of the map.
+    * @param <T>     Type of the {@link Map}.
+    * @throws IOException If any of the usual Input/Output related exceptions occur.
+    */
+   public static <K, V, T extends Map<K, V>> void marshallMap(T map, MarshalledEntryFactory factory, ObjectOutput out) throws IOException {
+      final int mapSize = map == null ? NULL_VALUE : map.size();
+      marshallSize(out, mapSize);
+      if (mapSize <= 0) return;
+
+      for (Map.Entry<K, V> entry : map.entrySet()) {
+         MarshalledEntry me = factory.newMarshalledEntry(entry.getKey(), entry.getValue(), null);
+         out.writeObject(me);
+      }
+   }
+
+   /**
+    * Unmarshall a {@link Map} which contains user entries wrapped as {@link MarshalledEntry}.
+    * <p>
+    * If the marshalled map is {@link null}, then the {@link MarshallUtil.MapBuilder} is not invoked.
+    *
+    * @param in      {@link ObjectInput} to read.
+    * @param builder {@link MarshallUtil.MapBuilder} to create the concrete {@link Map} implementation.
+    * @return The populated {@link Map} created by the {@link MarshallUtil.MapBuilder} or {@code null}.
+    * @throws IOException            If any of the usual Input/Output related exceptions occur.
+    * @throws ClassNotFoundException If the class of a serialized object cannot be found.
+    * @see #marshallMap(Map, MarshalledEntryFactory marshalledEntryFactory, ObjectOutput)
+    */
+   public static <K, V, T extends Map<K, V>> T unmarshallMap(ObjectInput in, MarshallUtil.MapBuilder<K, V, T> builder) throws IOException, ClassNotFoundException {
+      final int size = unmarshallSize(in);
+      if (size == NULL_VALUE) {
+         return null;
+      }
+      final T map = Objects.requireNonNull(builder, "MapBuilder must be non-null").build(computeCapacity(size));
+      for (int i = 0; i < size; i++) {
+         //noinspection unchecked
+         MarshalledEntryImpl<K, V> me = read(in);
+         map.put(me.getKey(), me.getValue());
+      }
+      return map;
+   }
+
+   /**
+    * Marshall a {@link Collection}.
+    * <p>
+    * This method supports {@code null} {@code collection}.
+    *
+    * @param collection {@link Collection} to marshal.
+    * @param factory    {@link MarshalledEntryFactory} to write.
+    * @param out        {@link ObjectOutput} to write.
+    * @param writer     {@link MarshalledElementWriter} that writes single element to the output.
+    * @param <E>        Collection's element type.
+    * @throws IOException If any of the usual Input/Output related exceptions occur.
+    */
+   public static <E> void marshallCollection(Collection<E> collection, MarshalledEntryFactory factory, ObjectOutput out, MarshalledElementWriter<E> writer) throws IOException {
+      final int size = collection == null ? NULL_VALUE : collection.size();
+      marshallSize(out, size);
+      if (size <= 0) {
+         return;
+      }
+      for (E e : collection) {
+         writer.writeTo(e, factory, out);
+      }
+   }
+
+   /**
+    * Marshall arrays.
+    * <p>
+    * This method supports {@code null} {@code array}.
+    *
+    * @param array   Array to marshall.
+    * @param factory {@link MarshalledEntryFactory} to write.
+    * @param out     {@link ObjectOutput} to write.
+    * @param writer  {@link MarshalledElementWriter} that writes single element to the output.
+    * @param <E>     Array type.
+    * @throws IOException If any of the usual Input/Output related exceptions occur.
+    */
+   public static <E> void marshallArray(E[] array, MarshalledEntryFactory factory, ObjectOutput out, MarshalledElementWriter<E> writer) throws IOException {
+      final int size = array == null ? NULL_VALUE : array.length;
+      marshallSize(out, size);
+      if (size <= 0) {
+         return;
+      }
+      for (int i = 0; i < size; ++i) {
+         writer.writeTo(array[i], factory, out);
+      }
+   }
+
+   /**
+    * Unmarshall arrays.
+    *
+    * @param in      {@link ObjectInput} to read.
+    * @param builder {@link MarshallUtil.ArrayBuilder} to build the array.
+    * @param <E>     Array type.
+    * @return The populated array.
+    * @throws IOException            If any of the usual Input/Output related exceptions occur.
+    * @throws ClassNotFoundException If the class of a serialized object cannot be found.
+    * @see #marshallArray(Object[], ObjectOutput).
+    */
+   public static <E> E[] unmarshallArray(ObjectInput in, MarshallUtil.ArrayBuilder<E> builder) throws IOException, ClassNotFoundException {
+      final int size = unmarshallSize(in);
+      if (size == NULL_VALUE) {
+         return null;
+      }
+      final E[] array = Objects.requireNonNull(builder, "ArrayBuilder must be non-null").build(size);
+      for (int i = 0; i < size; ++i) {
+         //noinspection unchecked
+         array[i] = (E) in.readObject();
+      }
+      return array;
+   }
+
+   @FunctionalInterface
+   public interface MarshalledElementWriter<E> {
+      void writeTo(E element, MarshalledEntryFactory factory, ObjectOutput out) throws IOException;
+   }
+}

--- a/core/src/main/java/org/infinispan/marshall/StreamingMarshallerWrapper.java
+++ b/core/src/main/java/org/infinispan/marshall/StreamingMarshallerWrapper.java
@@ -1,0 +1,114 @@
+package org.infinispan.marshall;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.io.OutputStream;
+
+import org.infinispan.commons.dataconversion.MediaType;
+import org.infinispan.commons.io.ByteBuffer;
+import org.infinispan.commons.marshall.BufferSizePredictor;
+import org.infinispan.commons.marshall.Marshaller;
+import org.infinispan.commons.marshall.StreamingMarshaller;
+
+/**
+ * A wrapper {@link StreamingMarshaller} implementation for {@link Marshaller} instances that throws {@link UnsupportedOperationException}
+ * for all methods that are not in the {@link Marshaller} interface.
+ * // TODO
+ * @author remerson@redhat.com
+ * @since 9.4
+ */
+public class StreamingMarshallerWrapper implements StreamingMarshaller {
+
+   private final Marshaller delegate;
+
+   public StreamingMarshallerWrapper(Marshaller delegate) {
+      this.delegate = delegate;
+   }
+
+   @Override
+   public ObjectOutput startObjectOutput(OutputStream os, boolean isReentrant, int estimatedSize) {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   public void finishObjectOutput(ObjectOutput oo) {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   public void objectToObjectStream(Object obj, ObjectOutput out) {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   public ObjectInput startObjectInput(InputStream is, boolean isReentrant) {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   public void finishObjectInput(ObjectInput oi) {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   public Object objectFromObjectStream(ObjectInput in) {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   public Object objectFromInputStream(InputStream is) {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   public void stop() {
+      // no-op
+   }
+
+   @Override
+   public void start() {
+      // no-op
+   }
+
+   @Override
+   public byte[] objectToByteBuffer(Object obj, int estimatedSize) throws IOException, InterruptedException {
+      return delegate.objectToByteBuffer(obj, estimatedSize);
+   }
+
+   @Override
+   public byte[] objectToByteBuffer(Object obj) throws IOException, InterruptedException {
+      return delegate.objectToByteBuffer(obj);
+   }
+
+   @Override
+   public Object objectFromByteBuffer(byte[] buf) throws IOException, ClassNotFoundException {
+      return delegate.objectFromByteBuffer(buf);
+   }
+
+   @Override
+   public Object objectFromByteBuffer(byte[] buf, int offset, int length) throws IOException, ClassNotFoundException {
+      return delegate.objectFromByteBuffer(buf, offset, length);
+   }
+
+   @Override
+   public ByteBuffer objectToBuffer(Object o) throws IOException, InterruptedException {
+      return delegate.objectToBuffer(o);
+   }
+
+   @Override
+   public boolean isMarshallable(Object o) throws Exception {
+      return delegate.isMarshallable(o);
+   }
+
+   @Override
+   public BufferSizePredictor getBufferSizePredictor(Object o) {
+      return delegate.getBufferSizePredictor(o);
+   }
+
+   @Override
+   public MediaType mediaType() {
+      return delegate.mediaType();
+   }
+}

--- a/core/src/main/java/org/infinispan/marshall/core/ExternalJbossMarshaller.java
+++ b/core/src/main/java/org/infinispan/marshall/core/ExternalJbossMarshaller.java
@@ -12,17 +12,17 @@ import org.infinispan.commons.marshall.BufferSizePredictor;
 import org.infinispan.commons.marshall.MarshallableTypeHints;
 import org.infinispan.commons.marshall.StreamingMarshaller;
 import org.infinispan.commons.marshall.jboss.ExtendedRiverUnmarshaller;
-import org.infinispan.configuration.global.GlobalConfiguration;
 import org.jboss.marshalling.ByteInput;
 import org.jboss.marshalling.ByteOutput;
+import org.jboss.marshalling.ClassResolver;
 
-final class ExternalJBossMarshaller implements StreamingMarshaller {
+final class ExternalJbossMarshaller implements StreamingMarshaller {
 
    final MarshallableTypeHints marshallableTypeHints = new MarshallableTypeHints();
    final JBossMarshaller marshaller;
 
-   ExternalJBossMarshaller(GlobalMarshaller marshaller, GlobalConfiguration globalCfg) {
-      this.marshaller = new JBossMarshaller(marshaller, globalCfg);
+   ExternalJbossMarshaller(GlobalMarshaller marshaller, ClassResolver classResolver) {
+      this.marshaller = new JBossMarshaller(marshaller, classResolver);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/marshall/core/MarshalledEntryFactory.java
+++ b/core/src/main/java/org/infinispan/marshall/core/MarshalledEntryFactory.java
@@ -1,7 +1,7 @@
 package org.infinispan.marshall.core;
 
 import org.infinispan.commons.io.ByteBuffer;
-import org.infinispan.metadata.InternalMetadata;
+import org.infinispan.metadata.Metadata;
 
 /**
  * Factory for {@link MarshalledEntry}.
@@ -15,5 +15,5 @@ public interface MarshalledEntryFactory<K,V> {
 
    MarshalledEntry<K,V> newMarshalledEntry(Object key, ByteBuffer valueBytes, ByteBuffer metadataBytes);
 
-   MarshalledEntry<K,V> newMarshalledEntry(Object key, Object value, InternalMetadata im);
+   MarshalledEntry<K,V> newMarshalledEntry(Object key, Object value, Metadata im);
 }

--- a/core/src/main/java/org/infinispan/marshall/core/MarshalledEntryFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/marshall/core/MarshalledEntryFactoryImpl.java
@@ -1,9 +1,12 @@
 package org.infinispan.marshall.core;
 
+import static org.infinispan.factories.KnownComponentNames.USER_MARSHALLER;
+
 import org.infinispan.commons.io.ByteBuffer;
-import org.infinispan.commons.marshall.StreamingMarshaller;
+import org.infinispan.commons.marshall.Marshaller;
+import org.infinispan.factories.annotations.ComponentName;
 import org.infinispan.factories.annotations.Inject;
-import org.infinispan.metadata.InternalMetadata;
+import org.infinispan.metadata.Metadata;
 
 /**
  * @author Mircea Markus
@@ -11,12 +14,12 @@ import org.infinispan.metadata.InternalMetadata;
  */
 public class MarshalledEntryFactoryImpl implements MarshalledEntryFactory {
 
-   @Inject private StreamingMarshaller marshaller;
+   @Inject @ComponentName(USER_MARSHALLER) private Marshaller marshaller;
 
    public MarshalledEntryFactoryImpl() {
    }
 
-   public MarshalledEntryFactoryImpl(StreamingMarshaller marshaller) {
+   public MarshalledEntryFactoryImpl(Marshaller marshaller) {
       this.marshaller = marshaller;
    }
 
@@ -31,7 +34,7 @@ public class MarshalledEntryFactoryImpl implements MarshalledEntryFactory {
    }
 
    @Override
-   public MarshalledEntry newMarshalledEntry(Object key, Object value, InternalMetadata im) {
+   public MarshalledEntry newMarshalledEntry(Object key, Object value, Metadata im) {
       return new MarshalledEntryImpl(key, value, im, marshaller);
    }
 }

--- a/core/src/main/java/org/infinispan/marshall/core/MarshalledEntryImpl.java
+++ b/core/src/main/java/org/infinispan/marshall/core/MarshalledEntryImpl.java
@@ -7,10 +7,10 @@ import java.util.Set;
 
 import org.infinispan.commons.io.ByteBuffer;
 import org.infinispan.commons.marshall.AbstractExternalizer;
-import org.infinispan.commons.marshall.StreamingMarshaller;
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.commons.util.Util;
 import org.infinispan.metadata.InternalMetadata;
-import org.infinispan.persistence.spi.PersistenceException;
+import org.infinispan.metadata.Metadata;
 
 /**
  * @author Mircea Markus
@@ -36,24 +36,24 @@ public class MarshalledEntryImpl<K,V> implements MarshalledEntry<K,V> {
    private ByteBuffer metadataBytes;
    private transient K key;
    private transient V value;
-   private transient InternalMetadata metadata;
-   private final transient StreamingMarshaller marshaller;
+   private transient Metadata metadata;
+   private volatile transient Marshaller marshaller;
 
-   public MarshalledEntryImpl(ByteBuffer key, ByteBuffer valueBytes, ByteBuffer metadataBytes, StreamingMarshaller marshaller) {
+   public MarshalledEntryImpl(ByteBuffer key, ByteBuffer valueBytes, ByteBuffer metadataBytes, Marshaller marshaller) {
       this.keyBytes = key;
       this.valueBytes = valueBytes;
       this.metadataBytes = metadataBytes;
       this.marshaller = marshaller;
    }
 
-   public MarshalledEntryImpl(K key, ByteBuffer valueBytes, ByteBuffer metadataBytes, StreamingMarshaller marshaller) {
+   public MarshalledEntryImpl(K key, ByteBuffer valueBytes, ByteBuffer metadataBytes, Marshaller marshaller) {
       this.key = key;
       this.valueBytes = valueBytes;
       this.metadataBytes = metadataBytes;
       this.marshaller = marshaller;
    }
 
-   public MarshalledEntryImpl(K key, V value, InternalMetadata im, StreamingMarshaller sm) {
+   public MarshalledEntryImpl(K key, V value, Metadata im, Marshaller sm) {
       this.key = key;
       this.value = value;
       this.metadata = im;
@@ -84,6 +84,13 @@ public class MarshalledEntryImpl<K,V> implements MarshalledEntry<K,V> {
 
    @Override
    public InternalMetadata getMetadata() {
+      Metadata metadata = metadata();
+      return metadata instanceof InternalMetadata ? (InternalMetadata) metadata : null;
+   }
+
+   // Internal method required so that command externalizers can make use of MarshalledEntryImpl to serialize
+   // user key/value/metadata via the User marshaller
+   public Metadata metadata() {
       if (metadata == null) {
          if (metadataBytes == null)
             return null;
@@ -129,7 +136,7 @@ public class MarshalledEntryImpl<K,V> implements MarshalledEntry<K,V> {
       try {
          return marshaller.objectToBuffer(obj);
       } catch (Exception e) {
-         throw new PersistenceException(e);
+         throw new MarshallingException(e);
       }
    }
 
@@ -138,7 +145,7 @@ public class MarshalledEntryImpl<K,V> implements MarshalledEntry<K,V> {
       try {
          return (T) marshaller.objectFromByteBuffer(buf.getBuf(), buf.getOffset(), buf.getLength());
       } catch (Exception e) {
-         throw new PersistenceException(e);
+         throw new MarshallingException(e);
       }
    }
 
@@ -190,10 +197,10 @@ public class MarshalledEntryImpl<K,V> implements MarshalledEntry<K,V> {
 
       private static final long serialVersionUID = -5291318076267612501L;
 
-      private final StreamingMarshaller marshaller;
+      private final Marshaller userMarshaller;
 
-      public Externalizer(StreamingMarshaller marshaller) {
-         this.marshaller = marshaller;
+      public Externalizer(Marshaller userMarshaller) {
+         this.userMarshaller = userMarshaller;
       }
 
       @Override
@@ -205,10 +212,10 @@ public class MarshalledEntryImpl<K,V> implements MarshalledEntry<K,V> {
 
       @Override
       public MarshalledEntryImpl readObject(ObjectInput input) throws IOException, ClassNotFoundException {
-            ByteBuffer keyBytes = (ByteBuffer) input.readObject();
-            ByteBuffer valueBytes = (ByteBuffer) input.readObject();
-            ByteBuffer metadataBytes = (ByteBuffer) input.readObject();
-            return new MarshalledEntryImpl(keyBytes, valueBytes, metadataBytes, marshaller);
+         ByteBuffer keyBytes = (ByteBuffer) input.readObject();
+         ByteBuffer valueBytes = (ByteBuffer) input.readObject();
+         ByteBuffer metadataBytes = (ByteBuffer) input.readObject();
+         return new MarshalledEntryImpl(keyBytes, valueBytes, metadataBytes, userMarshaller);
       }
 
       @Override

--- a/core/src/main/java/org/infinispan/marshall/core/MarshallingException.java
+++ b/core/src/main/java/org/infinispan/marshall/core/MarshallingException.java
@@ -1,0 +1,27 @@
+package org.infinispan.marshall.core;
+
+import org.infinispan.commons.CacheException;
+
+/**
+ * An exception thrown by a {@link MarshalledEntry} implementation if there are marshalling/unmarshalling data.
+ *
+ * @author Ryan Emerson
+ * @since 9.4
+ */
+public class MarshallingException extends CacheException {
+
+   public MarshallingException() {
+   }
+
+   public MarshallingException(String message) {
+      super(message);
+   }
+
+   public MarshallingException(String message, Throwable cause) {
+      super(message, cause);
+   }
+
+   public MarshallingException(Throwable cause) {
+      super(cause);
+   }
+}

--- a/core/src/main/java/org/infinispan/marshall/exts/ReplicableCommandExternalizer.java
+++ b/core/src/main/java/org/infinispan/marshall/exts/ReplicableCommandExternalizer.java
@@ -42,6 +42,7 @@ import org.infinispan.factories.GlobalComponentRegistry;
 import org.infinispan.manager.impl.ReplicableCommandManagerFunction;
 import org.infinispan.manager.impl.ReplicableCommandRunnable;
 import org.infinispan.marshall.core.Ids;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.topology.CacheTopologyControlCommand;
 import org.infinispan.topology.HeartBeatCommand;
 import org.infinispan.util.ByteString;
@@ -55,10 +56,13 @@ import org.infinispan.util.ByteString;
 public class ReplicableCommandExternalizer extends AbstractExternalizer<ReplicableCommand> {
    private final RemoteCommandsFactory cmdFactory;
    private final GlobalComponentRegistry globalComponentRegistry;
+   private final MarshalledEntryFactory entryFactory;
 
-   public ReplicableCommandExternalizer(RemoteCommandsFactory cmdFactory, GlobalComponentRegistry globalComponentRegistry) {
+   public ReplicableCommandExternalizer(RemoteCommandsFactory cmdFactory, GlobalComponentRegistry globalComponentRegistry,
+                                        MarshalledEntryFactory entryFactory) {
       this.cmdFactory = cmdFactory;
       this.globalComponentRegistry = globalComponentRegistry;
+      this.entryFactory = entryFactory;
    }
 
    @Override
@@ -68,7 +72,7 @@ public class ReplicableCommandExternalizer extends AbstractExternalizer<Replicab
    }
 
    protected void writeCommandParameters(ObjectOutput output, ReplicableCommand command) throws IOException {
-      command.writeTo(output);
+      command.writeTo(output, entryFactory);
       if (command instanceof TopologyAffectedCommand) {
          output.writeInt(((TopologyAffectedCommand) command).getTopologyId());
       }

--- a/core/src/main/java/org/infinispan/marshall/exts/TriangleAckExternalizer.java
+++ b/core/src/main/java/org/infinispan/marshall/exts/TriangleAckExternalizer.java
@@ -13,6 +13,7 @@ import org.infinispan.commands.write.BackupMultiKeyAckCommand;
 import org.infinispan.commands.write.ExceptionAckCommand;
 import org.infinispan.commons.marshall.AdvancedExternalizer;
 import org.infinispan.commons.util.Util;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.util.ByteString;
 
 /**
@@ -22,6 +23,12 @@ import org.infinispan.util.ByteString;
  * @since 9.0
  */
 public class TriangleAckExternalizer implements AdvancedExternalizer<CacheRpcCommand> {
+
+   private final MarshalledEntryFactory entryFactory;
+
+   public TriangleAckExternalizer(MarshalledEntryFactory entryFactory) {
+      this.entryFactory = entryFactory;
+   }
 
    public Set<Class<? extends CacheRpcCommand>> getTypeClasses() {
       //noinspection unchecked
@@ -35,7 +42,7 @@ public class TriangleAckExternalizer implements AdvancedExternalizer<CacheRpcCom
    public void writeObject(ObjectOutput output, CacheRpcCommand object) throws IOException {
       output.writeByte(object.getCommandId());
       ByteString.writeObject(output, object.getCacheName());
-      object.writeTo(output);
+      object.writeTo(output, entryFactory);
    }
 
    public CacheRpcCommand readObject(ObjectInput input) throws IOException, ClassNotFoundException {

--- a/core/src/main/java/org/infinispan/persistence/InitializationContextImpl.java
+++ b/core/src/main/java/org/infinispan/persistence/InitializationContextImpl.java
@@ -4,6 +4,7 @@ import java.util.concurrent.ExecutorService;
 
 import org.infinispan.Cache;
 import org.infinispan.commons.io.ByteBufferFactory;
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.commons.marshall.StreamingMarshaller;
 import org.infinispan.configuration.cache.StoreConfiguration;
 import org.infinispan.marshall.core.MarshalledEntryFactory;
@@ -18,14 +19,14 @@ public class InitializationContextImpl implements InitializationContext {
 
    private final StoreConfiguration configuration;
    private final Cache cache;
-   private final StreamingMarshaller marshaller;
+   private final Marshaller marshaller;
    private final TimeService timeService;
    private final ByteBufferFactory byteBufferFactory;
    private final MarshalledEntryFactory marshalledEntryFactory;
    private final ExecutorService executorService;
 
 
-   public InitializationContextImpl(StoreConfiguration configuration, Cache cache, StreamingMarshaller marshaller,
+   public InitializationContextImpl(StoreConfiguration configuration, Cache cache, Marshaller marshaller,
                                     TimeService timeService, ByteBufferFactory byteBufferFactory, MarshalledEntryFactory mef,
                                     ExecutorService executorService) {
       this.configuration = configuration;
@@ -49,6 +50,13 @@ public class InitializationContextImpl implements InitializationContext {
 
    @Override
    public StreamingMarshaller getMarshaller() {
+      if (marshaller instanceof StreamingMarshaller)
+         return (StreamingMarshaller) marshaller;
+      throw  new UnsupportedOperationException(String.format("Marshaller '%s' is not an instanceof StreamingMarshaller", marshaller.getClass().getName()));
+   }
+
+   @Override
+   public Marshaller getUserMarshaller() {
       return marshaller;
    }
 

--- a/core/src/main/java/org/infinispan/persistence/manager/PersistenceManagerImpl.java
+++ b/core/src/main/java/org/infinispan/persistence/manager/PersistenceManagerImpl.java
@@ -9,6 +9,7 @@ import static org.infinispan.context.Flag.SKIP_LOCKING;
 import static org.infinispan.context.Flag.SKIP_OWNERSHIP_CHECK;
 import static org.infinispan.context.Flag.SKIP_XSITE_BACKUP;
 import static org.infinispan.factories.KnownComponentNames.PERSISTENCE_EXECUTOR;
+import static org.infinispan.factories.KnownComponentNames.USER_MARSHALLER;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -38,7 +39,7 @@ import org.infinispan.AdvancedCache;
 import org.infinispan.commons.CacheException;
 import org.infinispan.commons.api.Lifecycle;
 import org.infinispan.commons.io.ByteBufferFactory;
-import org.infinispan.commons.marshall.StreamingMarshaller;
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.commons.util.IntSet;
 import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.AbstractSegmentedStoreConfiguration;
@@ -102,7 +103,7 @@ public class PersistenceManagerImpl implements PersistenceManager {
 
    @Inject private Configuration configuration;
    @Inject private AdvancedCache<Object, Object> cache;
-   @Inject private StreamingMarshaller m;
+   @Inject @ComponentName(USER_MARSHALLER) private Marshaller m;
    @Inject private TransactionManager transactionManager;
    @Inject private TimeService timeService;
    @Inject @ComponentName(PERSISTENCE_EXECUTOR)
@@ -1154,7 +1155,7 @@ public class PersistenceManagerImpl implements PersistenceManager {
       }
    }
 
-   public StreamingMarshaller getMarshaller() {
+   public Marshaller getMarshaller() {
       return m;
    }
 

--- a/core/src/main/java/org/infinispan/persistence/spi/InitializationContext.java
+++ b/core/src/main/java/org/infinispan/persistence/spi/InitializationContext.java
@@ -4,6 +4,7 @@ import java.util.concurrent.ExecutorService;
 
 import org.infinispan.Cache;
 import org.infinispan.commons.io.ByteBufferFactory;
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.commons.marshall.StreamingMarshaller;
 import org.infinispan.configuration.cache.StoreConfiguration;
 import org.infinispan.marshall.core.MarshalledEntryFactory;
@@ -24,7 +25,15 @@ public interface InitializationContext {
 
    Cache getCache();
 
+   /**
+    * @deprecated This method will be removed in the future and {@link #getUserMarshaller()}} should be used instead.
+    * @return the results of {@link #getUserMarshaller()} if the user marshaller implements the {@link StreamingMarshaller}
+    * interface, otherwise {@link UnsupportedOperationException};
+    */
+   @Deprecated
    StreamingMarshaller getMarshaller();
+
+   Marshaller getUserMarshaller();
 
    TimeService getTimeService();
 

--- a/core/src/main/java/org/infinispan/remoting/rpc/RpcManagerImpl.java
+++ b/core/src/main/java/org/infinispan/remoting/rpc/RpcManagerImpl.java
@@ -376,7 +376,6 @@ public class RpcManagerImpl implements RpcManager, JmxStatisticsExposer {
       // Set the topology id of the command, in case we don't have it yet
       setTopologyId(command);
       CacheRpcCommand cacheRpc = toCacheRpcCommand(command);
-
       try {
          t.sendToMany(destinations, cacheRpc, deliverOrder);
       } catch (Exception e) {

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
@@ -1,5 +1,6 @@
 package org.infinispan.remoting.transport.jgroups;
 
+import static org.infinispan.factories.KnownComponentNames.INTERNAL_MARSHALLER;
 import static org.infinispan.remoting.transport.jgroups.JGroupsAddressCache.fromJGroupsAddress;
 import static org.infinispan.util.logging.LogFactory.CLUSTER;
 
@@ -141,7 +142,7 @@ public class JGroupsTransport implements Transport {
    private static final byte SINGLE_MESSAGE = 2;
 
    @Inject protected GlobalConfiguration configuration;
-   @Inject protected StreamingMarshaller marshaller;
+   @Inject @ComponentName(INTERNAL_MARSHALLER) protected StreamingMarshaller marshaller;
    @Inject protected CacheManagerNotifier notifier;
    @Inject protected TimeService timeService;
    @Inject protected InboundInvocationHandler invocationHandler;

--- a/core/src/main/java/org/infinispan/statetransfer/StateRequestCommand.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateRequestCommand.java
@@ -13,6 +13,7 @@ import org.infinispan.commons.CacheException;
 import org.infinispan.commons.marshall.MarshallUtil;
 import org.infinispan.commons.util.IntSet;
 import org.infinispan.distexec.DistributedCallable;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.scattered.BiasManager;
 import org.infinispan.scattered.ScatteredStateProvider;
@@ -161,7 +162,7 @@ public class StateRequestCommand extends BaseRpcCommand implements TopologyAffec
 
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
       MarshallUtil.marshallEnum(type, output);
       switch (type) {
          case START_CONSISTENCY_CHECK:

--- a/core/src/main/java/org/infinispan/statetransfer/StateResponseCommand.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateResponseCommand.java
@@ -11,6 +11,7 @@ import org.infinispan.commands.TopologyAffectedCommand;
 import org.infinispan.commands.remote.BaseRpcCommand;
 import org.infinispan.commons.marshall.MarshallUtil;
 import org.infinispan.conflict.impl.StateReceiver;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.util.ByteString;
 import org.infinispan.util.concurrent.CompletableFutures;
@@ -125,7 +126,7 @@ public class StateResponseCommand extends BaseRpcCommand implements TopologyAffe
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
       output.writeObject(getOrigin());
       output.writeBoolean(pushTransfer);
       MarshallUtil.marshallCollection(stateChunks, output);

--- a/core/src/main/java/org/infinispan/statetransfer/TransactionInfo.java
+++ b/core/src/main/java/org/infinispan/statetransfer/TransactionInfo.java
@@ -81,6 +81,7 @@ public class TransactionInfo {
          output.writeObject(object.globalTransaction);
          output.writeInt(object.topologyId);
          MarshallUtil.marshallArray(object.modifications, output);
+         // TODO use MarshalledEntryFactory?
          MarshallUtil.marshallCollection(object.lockedKeys, output);
       }
 

--- a/core/src/main/java/org/infinispan/stream/impl/StreamIteratorCloseCommand.java
+++ b/core/src/main/java/org/infinispan/stream/impl/StreamIteratorCloseCommand.java
@@ -7,6 +7,7 @@ import java.util.concurrent.CompletableFuture;
 
 import org.infinispan.commands.remote.BaseRpcCommand;
 import org.infinispan.factories.annotations.Inject;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.util.ByteString;
 import org.infinispan.util.concurrent.CompletableFutures;
@@ -54,7 +55,7 @@ public class StreamIteratorCloseCommand extends BaseRpcCommand {
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
       output.writeObject(id);
    }
 

--- a/core/src/main/java/org/infinispan/stream/impl/StreamIteratorNextCommand.java
+++ b/core/src/main/java/org/infinispan/stream/impl/StreamIteratorNextCommand.java
@@ -9,6 +9,7 @@ import org.infinispan.commands.TopologyAffectedCommand;
 import org.infinispan.commands.remote.BaseRpcCommand;
 import org.infinispan.commons.io.UnsignedNumeric;
 import org.infinispan.factories.annotations.Inject;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.util.ByteString;
 
 /**
@@ -65,7 +66,7 @@ public class StreamIteratorNextCommand extends BaseRpcCommand implements Topolog
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
       output.writeObject(id);
       UnsignedNumeric.writeUnsignedLong(output, batchSize);
    }

--- a/core/src/main/java/org/infinispan/stream/impl/StreamIteratorRequestCommand.java
+++ b/core/src/main/java/org/infinispan/stream/impl/StreamIteratorRequestCommand.java
@@ -9,6 +9,7 @@ import java.util.concurrent.CompletableFuture;
 
 import org.infinispan.commons.marshall.MarshallUtil;
 import org.infinispan.commons.util.IntSet;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.stream.impl.intops.IntermediateOperation;
 import org.infinispan.util.ByteString;
@@ -61,8 +62,8 @@ public class StreamIteratorRequestCommand<K> extends StreamIteratorNextCommand {
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
-      super.writeTo(output);
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
+      super.writeTo(output, entryFactory);
       output.writeObject(getOrigin());
       output.writeBoolean(parallelStream);
       output.writeObject(segments);

--- a/core/src/main/java/org/infinispan/stream/impl/StreamRequestCommand.java
+++ b/core/src/main/java/org/infinispan/stream/impl/StreamRequestCommand.java
@@ -13,6 +13,7 @@ import org.infinispan.commons.marshall.MarshallUtil;
 import org.infinispan.commons.util.IntSet;
 import org.infinispan.commons.util.Util;
 import org.infinispan.factories.annotations.Inject;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.util.ByteString;
 import org.infinispan.util.concurrent.CompletableFutures;
@@ -116,7 +117,7 @@ public class StreamRequestCommand<K> extends BaseRpcCommand implements TopologyA
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
       output.writeObject(getOrigin());
       output.writeObject(id);
       output.writeBoolean(parallelStream);

--- a/core/src/main/java/org/infinispan/stream/impl/StreamResponseCommand.java
+++ b/core/src/main/java/org/infinispan/stream/impl/StreamResponseCommand.java
@@ -8,6 +8,7 @@ import java.util.concurrent.CompletableFuture;
 import org.infinispan.commands.remote.BaseRpcCommand;
 import org.infinispan.commons.util.IntSets;
 import org.infinispan.factories.annotations.Inject;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.util.ByteString;
 import org.infinispan.util.concurrent.CompletableFutures;
@@ -56,7 +57,7 @@ public class StreamResponseCommand<R> extends BaseRpcCommand {
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
       output.writeObject(getOrigin());
       output.writeObject(id);
       output.writeBoolean(complete);

--- a/core/src/main/java/org/infinispan/stream/impl/StreamSegmentResponseCommand.java
+++ b/core/src/main/java/org/infinispan/stream/impl/StreamSegmentResponseCommand.java
@@ -6,6 +6,7 @@ import java.io.ObjectOutput;
 import java.util.concurrent.CompletableFuture;
 
 import org.infinispan.commons.util.IntSet;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.util.ByteString;
 import org.infinispan.util.concurrent.CompletableFutures;
@@ -44,7 +45,7 @@ public class StreamSegmentResponseCommand<R> extends StreamResponseCommand<R> {
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
       output.writeObject(getOrigin());
       output.writeObject(id);
       output.writeBoolean(complete);

--- a/core/src/main/java/org/infinispan/topology/CacheTopologyControlCommand.java
+++ b/core/src/main/java/org/infinispan/topology/CacheTopologyControlCommand.java
@@ -12,6 +12,7 @@ import org.infinispan.commons.CacheException;
 import org.infinispan.commons.marshall.MarshallUtil;
 import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.factories.annotations.Inject;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.partitionhandling.AvailabilityMode;
 import org.infinispan.remoting.responses.ExceptionResponse;
 import org.infinispan.remoting.responses.SuccessfulResponse;
@@ -270,7 +271,7 @@ public class CacheTopologyControlCommand implements ReplicableCommand {
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
       MarshallUtil.marshallString(cacheName, output);
       MarshallUtil.marshallEnum(type, output);
       switch (type) {

--- a/core/src/main/java/org/infinispan/topology/HeartBeatCommand.java
+++ b/core/src/main/java/org/infinispan/topology/HeartBeatCommand.java
@@ -4,6 +4,7 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 
 import org.infinispan.commands.ReplicableCommand;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 
 /**
  * A hear-beat command used to ping members in {@link ClusterTopologyManagerImpl#confirmMembersAvailable()}.
@@ -33,7 +34,7 @@ public class HeartBeatCommand implements ReplicableCommand {
    }
 
    @Override
-   public void writeTo(ObjectOutput output){
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory){
       //nothing to write
    }
 

--- a/core/src/main/java/org/infinispan/xsite/SingleXSiteRpcCommand.java
+++ b/core/src/main/java/org/infinispan/xsite/SingleXSiteRpcCommand.java
@@ -6,6 +6,7 @@ import java.io.ObjectOutput;
 import java.util.concurrent.CompletableFuture;
 
 import org.infinispan.commands.VisitableCommand;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.util.ByteString;
 
 /**
@@ -48,7 +49,7 @@ public class SingleXSiteRpcCommand extends XSiteReplicateCommand {
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
       output.writeObject(command);
    }
 

--- a/core/src/main/java/org/infinispan/xsite/XSiteAdminCommand.java
+++ b/core/src/main/java/org/infinispan/xsite/XSiteAdminCommand.java
@@ -8,6 +8,7 @@ import java.util.concurrent.CompletableFuture;
 
 import org.infinispan.commands.remote.BaseRpcCommand;
 import org.infinispan.commons.marshall.MarshallUtil;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.util.ByteString;
 import org.infinispan.util.concurrent.CompletableFutures;
 
@@ -102,7 +103,7 @@ public class XSiteAdminCommand extends BaseRpcCommand {
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
       MarshallUtil.marshallEnum(adminOperation, output);
       switch (adminOperation) {
          case SITE_STATUS:

--- a/core/src/main/java/org/infinispan/xsite/statetransfer/XSiteStatePushCommand.java
+++ b/core/src/main/java/org/infinispan/xsite/statetransfer/XSiteStatePushCommand.java
@@ -6,6 +6,7 @@ import java.io.ObjectOutput;
 import java.util.concurrent.CompletableFuture;
 
 import org.infinispan.commons.marshall.MarshallUtil;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.util.ByteString;
 import org.infinispan.util.concurrent.CompletableFutures;
 import org.infinispan.xsite.BackupReceiver;
@@ -68,7 +69,7 @@ public class XSiteStatePushCommand extends XSiteReplicateCommand {
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
       output.writeLong(timeoutMillis);
       MarshallUtil.marshallArray(chunk, output);
    }

--- a/core/src/main/java/org/infinispan/xsite/statetransfer/XSiteStateTransferControlCommand.java
+++ b/core/src/main/java/org/infinispan/xsite/statetransfer/XSiteStateTransferControlCommand.java
@@ -7,6 +7,7 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 import org.infinispan.commons.marshall.MarshallUtil;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.util.ByteString;
 import org.infinispan.util.concurrent.CompletableFutures;
 import org.infinispan.xsite.BackupReceiver;
@@ -96,7 +97,7 @@ public class XSiteStateTransferControlCommand extends XSiteReplicateCommand {
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
       MarshallUtil.marshallEnum(control, output);
       switch (control) {
          case START_SEND:

--- a/core/src/test/java/org/infinispan/container/offheap/OffHeapSingleNodeTest.java
+++ b/core/src/test/java/org/infinispan/container/offheap/OffHeapSingleNodeTest.java
@@ -54,7 +54,7 @@ public class OffHeapSingleNodeTest extends OffHeapMultiNodeTest {
    public void testLockOnExecuteTask() throws InterruptedException, TimeoutException, BrokenBarrierException,
          ExecutionException, IOException {
       Cache<byte[], byte[]> cache = cache(0);
-      Marshaller marshaller = cache.getAdvancedCache().getComponentRegistry().getCacheMarshaller();
+      Marshaller marshaller = cache.getAdvancedCache().getComponentRegistry().getUserMarshaller();
       byte[] key = randomBytes(KEY_SIZE);
       WrappedBytes keyWB = new WrappedByteArray(marshaller.objectToByteBuffer(key));
       byte[] value = randomBytes(VALUE_SIZE);
@@ -110,7 +110,7 @@ public class OffHeapSingleNodeTest extends OffHeapMultiNodeTest {
 
       timeService.advance(20);
 
-      Marshaller marshaller = cache.getAdvancedCache().getComponentRegistry().getCacheMarshaller();
+      Marshaller marshaller = cache.getAdvancedCache().getComponentRegistry().getUserMarshaller();
 
       WrappedBytes keyWB = new WrappedByteArray(marshaller.objectToByteBuffer(key));
 

--- a/core/src/test/java/org/infinispan/dataconversion/DataConversionTest.java
+++ b/core/src/test/java/org/infinispan/dataconversion/DataConversionTest.java
@@ -75,7 +75,7 @@ public class DataConversionTest extends AbstractInfinispanTest {
             cm.getClassWhiteList().addClasses(Person.class);
             Cache<String, Person> cache = cm.getCache();
 
-            Marshaller marshaller = cache.getAdvancedCache().getComponentRegistry().getCacheMarshaller();
+            Marshaller marshaller = cache.getAdvancedCache().getComponentRegistry().getUserMarshaller();
 
             Person value = new Person();
             cache.put("1", value);

--- a/core/src/test/java/org/infinispan/jmx/ActivationAndPassivationInterceptorMBeanTest.java
+++ b/core/src/test/java/org/infinispan/jmx/ActivationAndPassivationInterceptorMBeanTest.java
@@ -13,7 +13,7 @@ import javax.management.Attribute;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
-import org.infinispan.commons.marshall.StreamingMarshaller;
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -87,8 +87,8 @@ public class ActivationAndPassivationInterceptorMBeanTest extends SingleCacheMan
       threadMBeanServer.setAttribute(activationInterceptorObjName, new Attribute("StatisticsEnabled", Boolean.TRUE));
    }
 
-   private StreamingMarshaller marshaller() {
-      return cache.getAdvancedCache().getComponentRegistry().getCacheMarshaller();
+   private Marshaller marshaller() {
+      return cache.getAdvancedCache().getComponentRegistry().getUserMarshaller();
    }
 
    public void testActivationOnGet(Method m) throws Exception {

--- a/core/src/test/java/org/infinispan/jmx/CacheLoaderAndCacheWriterInterceptorMBeanTest.java
+++ b/core/src/test/java/org/infinispan/jmx/CacheLoaderAndCacheWriterInterceptorMBeanTest.java
@@ -6,7 +6,7 @@ import static org.infinispan.test.TestingUtil.getCacheObjectName;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
-import org.infinispan.commons.marshall.StreamingMarshaller;
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.context.Flag;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -64,8 +64,8 @@ public class CacheLoaderAndCacheWriterInterceptorMBeanTest extends SingleCacheMa
       checkMBeanOperationParameterNaming(storeInterceptorObjName);
    }
 
-   private StreamingMarshaller marshaller() {
-      return cache.getAdvancedCache().getComponentRegistry().getCacheMarshaller();
+   private Marshaller marshaller() {
+      return cache.getAdvancedCache().getComponentRegistry().getUserMarshaller();
    }
 
    public void testPutKeyValue() throws Exception {

--- a/core/src/test/java/org/infinispan/marshall/TestObjectStreamMarshaller.java
+++ b/core/src/test/java/org/infinispan/marshall/TestObjectStreamMarshaller.java
@@ -36,7 +36,7 @@ public class TestObjectStreamMarshaller extends AbstractMarshaller implements St
 
    public TestObjectStreamMarshaller() {
       cacheManager = TestCacheManagerFactory.createCacheManager();
-      marshaller = cacheManager.getCache().getAdvancedCache().getComponentRegistry().getCacheMarshaller();
+      marshaller = cacheManager.getCache().getAdvancedCache().getComponentRegistry().getInternalMarshaller();
    }
 
    @Override

--- a/core/src/test/java/org/infinispan/marshall/VersionAwareMarshallerTest.java
+++ b/core/src/test/java/org/infinispan/marshall/VersionAwareMarshallerTest.java
@@ -81,6 +81,7 @@ import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.marshall.core.ExternalPojo;
 import org.infinispan.marshall.core.JBossMarshallingTest.CustomReadObjectMethod;
 import org.infinispan.marshall.core.JBossMarshallingTest.ObjectThatContainsACustomReadObjectMethod;
+import org.infinispan.marshall.core.MarshallingException;
 import org.infinispan.metadata.EmbeddedMetadata;
 import org.infinispan.remoting.MIMECacheEntry;
 import org.infinispan.remoting.responses.ExceptionResponse;
@@ -90,6 +91,7 @@ import org.infinispan.remoting.transport.Address;
 import org.infinispan.remoting.transport.jgroups.JGroupsAddress;
 import org.infinispan.statetransfer.StateRequestCommand;
 import org.infinispan.test.AbstractInfinispanTest;
+import org.infinispan.test.Exceptions;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.test.fwk.TestInternalCacheEntryFactory;
 import org.infinispan.transaction.xa.GlobalTransaction;
@@ -382,19 +384,11 @@ public class VersionAwareMarshallerTest extends AbstractInfinispanTest {
       assert rEntry.contentType.equals(entry.contentType);
    }
 
-   public void testNestedNonSerializable() throws Exception {
+   public void testNestedNonSerializable() {
       PutKeyValueCommand cmd = new PutKeyValueCommand(
             "k", new Object(), false, null, new EmbeddedMetadata.Builder().build(), 0,
             EnumUtil.EMPTY_BIT_SET, CommandInvocationId.generateId(null));
-      try {
-         marshaller.objectToByteBuffer(cmd);
-      } catch (NotSerializableException e) {
-         log.info("Log exception for output format verification", e);
-         TraceInformation inf = (TraceInformation) e.getCause();
-         if (inf != null) {
-            assert inf.toString().contains("in object java.lang.Object@");
-         }
-      }
+      Exceptions.expectException(MarshallingException.class, NotSerializableException.class, () -> marshaller.objectToByteBuffer(cmd));
    }
 
    public void testNonSerializable() throws Exception {

--- a/core/src/test/java/org/infinispan/persistence/BaseStoreTest.java
+++ b/core/src/test/java/org/infinispan/persistence/BaseStoreTest.java
@@ -19,14 +19,14 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import org.infinispan.commons.marshall.StreamingMarshaller;
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.commons.marshall.WrappedByteArray;
 import org.infinispan.commons.marshall.WrappedBytes;
 import org.infinispan.configuration.cache.Configuration;
-import org.infinispan.container.impl.InternalEntryFactory;
-import org.infinispan.container.impl.InternalEntryFactoryImpl;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.container.entries.InternalCacheValue;
+import org.infinispan.container.impl.InternalEntryFactory;
+import org.infinispan.container.impl.InternalEntryFactoryImpl;
 import org.infinispan.marshall.TestObjectStreamMarshaller;
 import org.infinispan.marshall.core.ExternalPojo;
 import org.infinispan.marshall.core.MarshalledEntry;
@@ -102,7 +102,7 @@ public abstract class BaseStoreTest extends AbstractInfinispanTest {
    /**
     * @return a mock marshaller for use with the cache store impls
     */
-   protected StreamingMarshaller getMarshaller() {
+   protected Marshaller getMarshaller() {
       return marshaller;
    }
 

--- a/core/src/test/java/org/infinispan/persistence/CacheLoaderFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/persistence/CacheLoaderFunctionalTest.java
@@ -23,7 +23,7 @@ import javax.transaction.TransactionManager;
 
 import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
-import org.infinispan.commons.marshall.StreamingMarshaller;
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.container.DataContainer;
@@ -69,7 +69,7 @@ public class CacheLoaderFunctionalTest extends AbstractInfinispanTest {
    TransactionManager tm;
    ConfigurationBuilder cfg;
    EmbeddedCacheManager cm;
-   StreamingMarshaller sm;
+   Marshaller marshaller;
 
    long lifespan = 60000000; // very large lifespan so nothing actually expires
 
@@ -82,7 +82,7 @@ public class CacheLoaderFunctionalTest extends AbstractInfinispanTest {
       store = TestingUtil.getFirstLoader(cache);
       writer = TestingUtil.getFirstLoader(cache);
       tm = TestingUtil.getTransactionManager(cache);
-      sm = cache.getAdvancedCache().getComponentRegistry().getCacheMarshaller();
+      marshaller = cache.getAdvancedCache().getComponentRegistry().getUserMarshaller();
    }
 
    public CacheLoaderFunctionalTest segmented(boolean segmented) {
@@ -296,7 +296,7 @@ public class CacheLoaderFunctionalTest extends AbstractInfinispanTest {
 
    public void testLoading() throws PersistenceException {
       assertNotInCacheAndStore("k1", "k2", "k3", "k4");
-      for (int i = 1; i < 5; i++) writer.write(new MarshalledEntryImpl("k" + i, "v" + i, null, sm));
+      for (int i = 1; i < 5; i++) writer.write(new MarshalledEntryImpl("k" + i, "v" + i, null, marshaller));
       for (int i = 1; i < 5; i++) assertEquals("v" + i, cache.get("k" + i));
       // make sure we have no stale locks!!
       assertNoLocks(cache);
@@ -495,8 +495,8 @@ public class CacheLoaderFunctionalTest extends AbstractInfinispanTest {
 
    public void testLoadingToMemory() throws PersistenceException {
       assertNotInCacheAndStore("k1", "k2");
-      store.write(new MarshalledEntryImpl("k1", "v1", null, sm));
-      store.write(new MarshalledEntryImpl("k2", "v2", null, sm));
+      store.write(new MarshalledEntryImpl("k1", "v1", null, marshaller));
+      store.write(new MarshalledEntryImpl("k2", "v2", null, marshaller));
 
       assertInStoreNotInCache("k1", "k2");
 
@@ -547,7 +547,7 @@ public class CacheLoaderFunctionalTest extends AbstractInfinispanTest {
          assertNull(cache.get("k1"));
 
          // Now simulate that someone else wrote to the store while during our tx
-         store.write(new MarshalledEntryImpl("k1", "v1", null, sm));
+         store.write(new MarshalledEntryImpl("k1", "v1", null, marshaller));
          IsolationLevel level = cache.getCacheConfiguration().locking().isolationLevel();
          switch(level) {
             case READ_COMMITTED:

--- a/core/src/test/java/org/infinispan/persistence/ClusterCacheLoaderTest.java
+++ b/core/src/test/java/org/infinispan/persistence/ClusterCacheLoaderTest.java
@@ -60,7 +60,7 @@ public class ClusterCacheLoaderTest extends MultipleCacheManagersTest {
 
       assertNull(cache1.get("key"));
       assertNull(cache2.get("key"));
-      writer.write(new MarshalledEntryImpl("key", "value", null, cache2.getAdvancedCache().getComponentRegistry().getCacheMarshaller()));
+      writer.write(new MarshalledEntryImpl("key", "value", null, cache2.getAdvancedCache().getComponentRegistry().getUserMarshaller()));
       assertEquals(((CacheLoader)writer).load("key").getValue(), "value");
       assertEquals(cache1.get("key"), "value");
    }

--- a/core/src/test/java/org/infinispan/persistence/ClusteredConditionalCommandTest.java
+++ b/core/src/test/java/org/infinispan/persistence/ClusteredConditionalCommandTest.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.infinispan.Cache;
-import org.infinispan.commons.marshall.StreamingMarshaller;
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.context.Flag;
@@ -27,8 +27,8 @@ import org.infinispan.marshall.core.MarshalledEntryImpl;
 import org.infinispan.persistence.dummy.DummyInMemoryStore;
 import org.infinispan.persistence.dummy.DummyInMemoryStoreConfigurationBuilder;
 import org.infinispan.test.MultipleCacheManagersTest;
-import org.infinispan.util.concurrent.IsolationLevel;
 import org.infinispan.test.fwk.InCacheMode;
+import org.infinispan.util.concurrent.IsolationLevel;
 import org.testng.annotations.Test;
 
 /**
@@ -79,7 +79,7 @@ public class ClusteredConditionalCommandTest extends MultipleCacheManagersTest {
       cacheHelper.cacheStore(ownership).write(marshalledEntry(key, value, cacheHelper.marshaller(ownership)));
    }
 
-   private static <K, V> MarshalledEntry<K, V> marshalledEntry(K key, V value, StreamingMarshaller marshaller) {
+   private static <K, V> MarshalledEntry<K, V> marshalledEntry(K key, V value, Marshaller marshaller) {
       return new MarshalledEntryImpl<>(key, value, null, marshaller);
    }
 
@@ -581,8 +581,8 @@ public class ClusteredConditionalCommandTest extends MultipleCacheManagersTest {
          return cache != null ? getFirstWriter(cache) : null;
       }
 
-      private StreamingMarshaller marshaller(Ownership ownership) {
-         return cacheEnumMap.get(ownership).getAdvancedCache().getComponentRegistry().getCacheMarshaller();
+      private Marshaller marshaller(Ownership ownership) {
+         return cacheEnumMap.get(ownership).getAdvancedCache().getComponentRegistry().getUserMarshaller();
       }
 
       protected long loads(Ownership ownership) {

--- a/core/src/test/java/org/infinispan/persistence/DummyInitializationContext.java
+++ b/core/src/test/java/org/infinispan/persistence/DummyInitializationContext.java
@@ -4,6 +4,7 @@ import java.util.concurrent.ExecutorService;
 
 import org.infinispan.Cache;
 import org.infinispan.commons.io.ByteBufferFactory;
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.commons.marshall.StreamingMarshaller;
 import org.infinispan.configuration.cache.StoreConfiguration;
 import org.infinispan.marshall.core.MarshalledEntryFactory;
@@ -17,7 +18,7 @@ import org.infinispan.util.TimeService;
 public class DummyInitializationContext implements InitializationContext {
    StoreConfiguration clc;
    Cache cache;
-   StreamingMarshaller marshaller;
+   Marshaller marshaller;
 
    ByteBufferFactory byteBufferFactory;
    MarshalledEntryFactory marshalledEntryFactory;
@@ -26,7 +27,7 @@ public class DummyInitializationContext implements InitializationContext {
    public DummyInitializationContext() {
    }
 
-   public DummyInitializationContext(StoreConfiguration clc, Cache cache, StreamingMarshaller marshaller,
+   public DummyInitializationContext(StoreConfiguration clc, Cache cache, Marshaller marshaller,
                                      ByteBufferFactory byteBufferFactory, MarshalledEntryFactory marshalledEntryFactory,
                                      ExecutorService executorService) {
       this.clc = clc;
@@ -49,6 +50,11 @@ public class DummyInitializationContext implements InitializationContext {
 
    @Override
    public StreamingMarshaller getMarshaller() {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   public Marshaller getUserMarshaller() {
       return marshaller;
    }
 

--- a/core/src/test/java/org/infinispan/persistence/LocalConditionalCommandTest.java
+++ b/core/src/test/java/org/infinispan/persistence/LocalConditionalCommandTest.java
@@ -4,7 +4,7 @@ import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertTrue;
 
 import org.infinispan.Cache;
-import org.infinispan.commons.marshall.StreamingMarshaller;
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.context.Flag;
@@ -64,11 +64,11 @@ public class LocalConditionalCommandTest extends SingleCacheManagerTest {
    }
 
    private static <K, V> void writeToStore(Cache<K, V> cache, K key, V value) {
-      TestingUtil.getFirstWriter(cache).write(marshalledEntry(key, value, cache.getAdvancedCache().getComponentRegistry().getCacheMarshaller()));
+      TestingUtil.getFirstWriter(cache).write(marshalledEntry(key, value, cache.getAdvancedCache().getComponentRegistry().getUserMarshaller()));
    }
 
-   private static <K, V> MarshalledEntry<K, V> marshalledEntry(K key, V value, StreamingMarshaller marshaller) {
-      return new MarshalledEntryImpl<>(key, value, null, marshaller);
+   private static <K, V> MarshalledEntry<K, V> marshalledEntry(K key, V value, Marshaller marshaller) {
+      return new MarshalledEntryImpl<>(key, value, null, (Marshaller) marshaller);
    }
 
    private static CacheLoaderInterceptor cacheLoaderInterceptor(Cache<?, ?> cache) {

--- a/core/src/test/java/org/infinispan/persistence/ParallelIterationTest.java
+++ b/core/src/test/java/org/infinispan/persistence/ParallelIterationTest.java
@@ -14,7 +14,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.infinispan.commons.marshall.StreamingMarshaller;
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -49,7 +49,7 @@ public abstract class ParallelIterationTest extends SingleCacheManagerTest {
    protected AdvancedCacheLoader<Object, Object> loader;
    protected AdvancedCacheWriter<Object, Object> writer;
    protected ExecutorService executor;
-   protected StreamingMarshaller sm;
+   protected Marshaller sm;
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {

--- a/core/src/test/java/org/infinispan/persistence/file/SingleFileStoreStressTest.java
+++ b/core/src/test/java/org/infinispan/persistence/file/SingleFileStoreStressTest.java
@@ -20,7 +20,7 @@ import java.util.concurrent.Future;
 import org.infinispan.Cache;
 import org.infinispan.commons.io.ByteBuffer;
 import org.infinispan.commons.io.ByteBufferImpl;
-import org.infinispan.commons.marshall.StreamingMarshaller;
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -67,7 +67,7 @@ public class SingleFileStoreStressTest extends SingleCacheManagerTest {
 
       Cache<String, String> cache = cacheManager.getCache(CACHE_NAME);
       final SingleFileStore store = TestingUtil.getFirstWriter(cache);
-      final StreamingMarshaller marshaller = TestingUtil.extractComponentRegistry(cache).getCacheMarshaller();
+      final Marshaller marshaller = TestingUtil.extractComponentRegistry(cache).getUserMarshaller();
       assertEquals(0, store.size());
 
       final List<String> keys = populateStore(5, 0, store, marshaller);
@@ -101,7 +101,7 @@ public class SingleFileStoreStressTest extends SingleCacheManagerTest {
 
       Cache<String, String> cache = cacheManager.getCache(CACHE_NAME);
       final SingleFileStore store = TestingUtil.getFirstWriter(cache);
-      final StreamingMarshaller marshaller = TestingUtil.extractComponentRegistry(cache).getCacheMarshaller();
+      final Marshaller marshaller = TestingUtil.extractComponentRegistry(cache).getUserMarshaller();
       assertEquals(0, store.size());
 
       final List<String> keys = new ArrayList<>(numberOfKeys);
@@ -133,13 +133,13 @@ public class SingleFileStoreStressTest extends SingleCacheManagerTest {
       clearFuture.get();
    }
 
-   public void testSpaceOptimization() throws ExecutionException, InterruptedException {
+   public void testSpaceOptimization() throws InterruptedException {
       final int numberOfKeys = 100;
       final int times = 10;
 
       Cache<String, String> cache = cacheManager.getCache(CACHE_NAME);
       final SingleFileStore store = TestingUtil.getFirstWriter(cache);
-      final StreamingMarshaller marshaller = TestingUtil.extractComponentRegistry(cache).getCacheMarshaller();
+      final Marshaller marshaller = TestingUtil.extractComponentRegistry(cache).getUserMarshaller();
       assertEquals(0, store.size());
 
       long [] fileSizesWithoutPurge = new long [times];
@@ -188,7 +188,7 @@ public class SingleFileStoreStressTest extends SingleCacheManagerTest {
 
       Cache<String, String> cache = cacheManager.getCache(CACHE_NAME);
       final SingleFileStore store = TestingUtil.getFirstWriter(cache);
-      final StreamingMarshaller marshaller = TestingUtil.extractComponentRegistry(cache).getCacheMarshaller();
+      final Marshaller marshaller = TestingUtil.extractComponentRegistry(cache).getUserMarshaller();
       assertEquals(0, store.size());
 
       // Write a few entries into the cache
@@ -236,7 +236,7 @@ public class SingleFileStoreStressTest extends SingleCacheManagerTest {
       assertTrue(String.format("Length1=%d, Length2=%d", length1, length2), length2 < length1);
    }
 
-   public List<String> populateStore(int numKeys, int numPadding, SingleFileStore store, StreamingMarshaller marshaller) {
+   public List<String> populateStore(int numKeys, int numPadding, SingleFileStore store, Marshaller marshaller) {
       final List<String> keys = new ArrayList<>(numKeys);
       for (int j = 0; j < numKeys; j++) {
          String key = "key" + j;
@@ -254,7 +254,7 @@ public class SingleFileStoreStressTest extends SingleCacheManagerTest {
 
       Cache<String, String> cache = cacheManager.getCache(CACHE_NAME);
       final SingleFileStore store = TestingUtil.getFirstWriter(cache);
-      final StreamingMarshaller marshaller = TestingUtil.extractComponentRegistry(cache).getCacheMarshaller();
+      final Marshaller marshaller = TestingUtil.extractComponentRegistry(cache).getUserMarshaller();
       assertEquals(0, store.size());
 
       final List<String> keys = new ArrayList<>(numberOfKeys);
@@ -283,7 +283,7 @@ public class SingleFileStoreStressTest extends SingleCacheManagerTest {
 
       Cache<String, String> cache = cacheManager.getCache(CACHE_NAME);
       final SingleFileStore store = TestingUtil.getFirstWriter(cache);
-      final StreamingMarshaller marshaller = TestingUtil.extractComponentRegistry(cache).getCacheMarshaller();
+      final Marshaller marshaller = TestingUtil.extractComponentRegistry(cache).getUserMarshaller();
       assertEquals(0, store.size());
 
       final List<String> keys = new ArrayList<>(numberOfKeys);
@@ -307,7 +307,7 @@ public class SingleFileStoreStressTest extends SingleCacheManagerTest {
    }
 
    private void populateStoreRandomValues(int numberOfKeys, SingleFileStore store,
-                                          StreamingMarshaller marshaller, List<String> keys) {
+                                          Marshaller marshaller, List<String> keys) {
       for (int j = 0; j < numberOfKeys; j++) {
          String key = "key" + j;
          String value = key + "_value_" + j + times(new Random().nextInt(10));
@@ -334,11 +334,11 @@ public class SingleFileStoreStressTest extends SingleCacheManagerTest {
 
    private class WriteTask implements Callable<Object> {
       final SingleFileStore store;
-      final StreamingMarshaller marshaller;
+      final Marshaller marshaller;
       final List<String> keys;
       final CountDownLatch stopLatch;
 
-      WriteTask(SingleFileStore store, StreamingMarshaller marshaller, List<String> keys, CountDownLatch stopLatch) {
+      WriteTask(SingleFileStore store, Marshaller marshaller, List<String> keys, CountDownLatch stopLatch) {
          this.store = store;
          this.marshaller = marshaller;
          this.keys = keys;

--- a/core/src/test/java/org/infinispan/remoting/TransportSenderExceptionHandlingTest.java
+++ b/core/src/test/java/org/infinispan/remoting/TransportSenderExceptionHandlingTest.java
@@ -16,6 +16,7 @@ import org.infinispan.context.InvocationContext;
 import org.infinispan.interceptors.base.CommandInterceptor;
 import org.infinispan.interceptors.locking.NonTransactionalLockingInterceptor;
 import org.infinispan.marshall.core.ExternalPojo;
+import org.infinispan.marshall.core.MarshallingException;
 import org.infinispan.notifications.Listener;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryCreated;
 import org.infinispan.notifications.cachelistener.event.CacheEntryEvent;
@@ -36,7 +37,7 @@ public class TransportSenderExceptionHandlingTest extends MultipleCacheManagersT
    public void testInvokeAndExceptionWhileUnmarshalling() throws Exception {
       Cache cache1 = cache(0, "replSync");
       Cache cache2 = cache(1, "replSync");
-      Exceptions.expectException(RemoteException.class, EOFException.class,
+      Exceptions.expectException(RemoteException.class, MarshallingException.class, EOFException.class,
                                  () -> cache1.put(key, new BrokenDeserializationPojo()));
    }
 

--- a/core/src/test/java/org/infinispan/remoting/rpc/CustomCacheRpcCommand.java
+++ b/core/src/test/java/org/infinispan/remoting/rpc/CustomCacheRpcCommand.java
@@ -9,6 +9,7 @@ import org.infinispan.commands.VisitableCommand;
 import org.infinispan.commands.Visitor;
 import org.infinispan.commands.remote.BaseRpcCommand;
 import org.infinispan.context.InvocationContext;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.util.ByteString;
 
 /**
@@ -52,7 +53,7 @@ public class CustomCacheRpcCommand extends BaseRpcCommand implements VisitableCo
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
       output.writeObject(arg);
    }
 

--- a/core/src/test/java/org/infinispan/remoting/rpc/CustomReplicableCommand.java
+++ b/core/src/test/java/org/infinispan/remoting/rpc/CustomReplicableCommand.java
@@ -8,6 +8,7 @@ import java.io.Serializable;
 import org.infinispan.commands.VisitableCommand;
 import org.infinispan.commands.Visitor;
 import org.infinispan.context.InvocationContext;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 
 /**
  * @author anistor@redhat.com
@@ -45,7 +46,7 @@ public class CustomReplicableCommand implements VisitableCommand, Serializable {
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
       output.writeObject(arg);
    }
 

--- a/core/src/test/java/org/infinispan/remoting/rpc/SleepingCacheRpcCommand.java
+++ b/core/src/test/java/org/infinispan/remoting/rpc/SleepingCacheRpcCommand.java
@@ -6,6 +6,7 @@ import java.io.ObjectOutput;
 
 import org.infinispan.commands.remote.BaseRpcCommand;
 import org.infinispan.context.InvocationContext;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.util.ByteString;
 
 /**
@@ -42,7 +43,7 @@ public class SleepingCacheRpcCommand extends BaseRpcCommand {
    }
 
    @Override
-   public void writeTo(ObjectOutput output) throws IOException {
+   public void writeTo(ObjectOutput output, MarshalledEntryFactory entryFactory) throws IOException {
       output.writeLong(sleepTime);
    }
 

--- a/core/src/test/java/org/infinispan/util/PersistenceMockUtil.java
+++ b/core/src/test/java/org/infinispan/util/PersistenceMockUtil.java
@@ -10,7 +10,7 @@ import java.util.Set;
 import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
 import org.infinispan.commons.io.ByteBufferFactoryImpl;
-import org.infinispan.commons.marshall.StreamingMarshaller;
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
@@ -33,11 +33,11 @@ import org.infinispan.util.concurrent.WithinThreadExecutor;
  */
 public class PersistenceMockUtil {
 
-   public static InitializationContext createContext(String cacheName, Configuration configuration, StreamingMarshaller marshaller) {
+   public static InitializationContext createContext(String cacheName, Configuration configuration, Marshaller marshaller) {
       return createContext(cacheName, configuration, marshaller, AbstractInfinispanTest.TIME_SERVICE);
    }
 
-   public static InitializationContext createContext(String cacheName, Configuration configuration, StreamingMarshaller marshaller, TimeService timeService) {
+   public static InitializationContext createContext(String cacheName, Configuration configuration, Marshaller marshaller, TimeService timeService) {
       Cache mockCache = mockCache(cacheName, configuration, timeService);
       return new InitializationContextImpl(configuration.persistence().stores().get(0), mockCache, marshaller,
                                            timeService, new ByteBufferFactoryImpl(), new MarshalledEntryFactoryImpl(marshaller),

--- a/extended-statistics/src/main/java/org/infinispan/stats/wrappers/ExtendedStatisticInterceptor.java
+++ b/extended-statistics/src/main/java/org/infinispan/stats/wrappers/ExtendedStatisticInterceptor.java
@@ -848,7 +848,7 @@ public class ExtendedStatisticInterceptor extends BaseCustomAsyncInterceptor {
 
    private void replaceRpcManager(ComponentRegistry componentRegistry) {
       RpcManager oldRpcManager = componentRegistry.getComponent(RpcManager.class);
-      StreamingMarshaller marshaller = componentRegistry.getCacheMarshaller();
+      StreamingMarshaller marshaller = componentRegistry.getInternalMarshaller();
       if (oldRpcManager == null) {
          //local mode
          return;

--- a/lucene/lucene-directory/src/main/java/org/infinispan/lucene/cacheloader/DirectoryLoaderAdaptor.java
+++ b/lucene/lucene-directory/src/main/java/org/infinispan/lucene/cacheloader/DirectoryLoaderAdaptor.java
@@ -9,7 +9,7 @@ import java.util.Set;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
-import org.infinispan.commons.marshall.StreamingMarshaller;
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.lucene.ChunkCacheKey;
 import org.infinispan.lucene.FileCacheKey;
 import org.infinispan.lucene.FileListCacheKey;
@@ -63,7 +63,7 @@ final class DirectoryLoaderAdaptor {
     * @param entriesCollector loaded entries are collected in this set
     * @param maxEntries to limit amount of entries loaded
     */
-   protected <K, V> void loadAllEntries(final Set<MarshalledEntry<K, V>> entriesCollector, final int maxEntries, StreamingMarshaller marshaller) {
+   protected <K, V> void loadAllEntries(final Set<MarshalledEntry<K, V>> entriesCollector, final int maxEntries, Marshaller marshaller) {
       int existingElements = entriesCollector.size();
       int toLoadElements = maxEntries - existingElements;
       if (toLoadElements <= 0) {

--- a/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/stringbased/JdbcStringBasedStore.java
+++ b/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/stringbased/JdbcStringBasedStore.java
@@ -90,7 +90,7 @@ public class JdbcStringBasedStore<K,V> implements AdvancedLoadWriteStore<K,V>, T
    private String cacheName;
    private ConnectionFactory connectionFactory;
    private MarshalledEntryFactory<K, V> marshalledEntryFactory;
-   private StreamingMarshaller marshaller;
+   private StreamingMarshaller marshaller; // TODO convert to Marshaller
    private TableManager tableManager;
    private TimeService timeService;
    private boolean isDistributedCache;

--- a/persistence/jdbc/src/test/java/org/infinispan/persistence/jdbc/stringbased/JdbcStringBasedStoreAltMapperTest.java
+++ b/persistence/jdbc/src/test/java/org/infinispan/persistence/jdbc/stringbased/JdbcStringBasedStoreAltMapperTest.java
@@ -7,7 +7,7 @@ import static org.testng.AssertJUnit.assertNull;
 import static org.testng.AssertJUnit.assertTrue;
 import static org.testng.AssertJUnit.fail;
 
-import org.infinispan.commons.marshall.StreamingMarshaller;
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.commons.util.ReflectionUtil;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.container.entries.InternalCacheEntry;
@@ -43,7 +43,7 @@ public class JdbcStringBasedStoreAltMapperTest extends AbstractInfinispanTest {
    protected TableManager tableManager;
    protected static final Person MIRCEA = new Person("Mircea", "Markus", 28);
    protected static final Person MANIK = new Person("Manik", "Surtani", 18);
-   protected StreamingMarshaller marshaller;
+   protected Marshaller marshaller;
 
    protected JdbcStringBasedStoreConfigurationBuilder createJdbcConfig(ConfigurationBuilder builder) {
       JdbcStringBasedStoreConfigurationBuilder storeBuilder = builder
@@ -76,7 +76,6 @@ public class JdbcStringBasedStoreAltMapperTest extends AbstractInfinispanTest {
    @AfterClass
    public void destroyStore() throws PersistenceException {
       cacheStore.stop();
-      marshaller.stop();
    }
 
    /**

--- a/persistence/jdbc/src/test/java/org/infinispan/persistence/jdbc/stringbased/JdbcStringBasedStoreVamAltMapperTest.java
+++ b/persistence/jdbc/src/test/java/org/infinispan/persistence/jdbc/stringbased/JdbcStringBasedStoreVamAltMapperTest.java
@@ -2,7 +2,7 @@ package org.infinispan.persistence.jdbc.stringbased;
 
 import static org.infinispan.test.TestingUtil.extractGlobalMarshaller;
 
-import org.infinispan.commons.marshall.StreamingMarshaller;
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.persistence.spi.PersistenceException;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
@@ -20,7 +20,7 @@ import org.testng.annotations.Test;
 public class JdbcStringBasedStoreVamAltMapperTest extends JdbcStringBasedStoreAltMapperTest {
 
    EmbeddedCacheManager cm;
-   StreamingMarshaller marshaller;
+   Marshaller marshaller;
 
    @BeforeClass
    @Override
@@ -38,7 +38,7 @@ public class JdbcStringBasedStoreVamAltMapperTest extends JdbcStringBasedStoreAl
       cm.stop();
    }
 
-   protected StreamingMarshaller getMarshaller() {
+   protected Marshaller getMarshaller() {
       return marshaller;
    }
 

--- a/persistence/jdbc/src/test/java/org/infinispan/persistence/jdbc/stringbased/JdbcStringBasedStoreVamTest.java
+++ b/persistence/jdbc/src/test/java/org/infinispan/persistence/jdbc/stringbased/JdbcStringBasedStoreVamTest.java
@@ -1,8 +1,8 @@
 package org.infinispan.persistence.jdbc.stringbased;
 
-import static org.infinispan.test.TestingUtil.extractGlobalMarshaller;
+import static org.infinispan.test.TestingUtil.extractUserMarshaller;
 
-import org.infinispan.commons.marshall.StreamingMarshaller;
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.persistence.spi.PersistenceException;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
@@ -20,12 +20,12 @@ import org.testng.annotations.Test;
 public class JdbcStringBasedStoreVamTest extends JdbcStringBasedStoreTest {
 
    EmbeddedCacheManager cm;
-   StreamingMarshaller marshaller;
+   Marshaller marshaller;
 
    @BeforeClass
    public void setUpClass() {
       cm = TestCacheManagerFactory.createCacheManager(false);
-      marshaller = extractGlobalMarshaller(cm.getCache().getCacheManager());
+      marshaller = extractUserMarshaller(cm.getCache().getCacheManager());
    }
 
    @AfterClass
@@ -34,7 +34,7 @@ public class JdbcStringBasedStoreVamTest extends JdbcStringBasedStoreTest {
    }
 
    @Override
-   protected StreamingMarshaller getMarshaller() {
+   protected Marshaller getMarshaller() {
       return marshaller;
    }
 

--- a/persistence/jpa/src/main/java/org/infinispan/persistence/jpa/JpaStore.java
+++ b/persistence/jpa/src/main/java/org/infinispan/persistence/jpa/JpaStore.java
@@ -35,7 +35,7 @@ import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.MySQLDialect;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.infinispan.commons.configuration.ConfiguredBy;
-import org.infinispan.commons.marshall.StreamingMarshaller;
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.commons.persistence.Store;
 import org.infinispan.commons.util.AbstractIterator;
 import org.infinispan.executors.ExecutorAllCompletionService;
@@ -72,7 +72,7 @@ public class JpaStore<K, V> implements AdvancedLoadWriteStore<K, V> {
    private JpaStoreConfiguration configuration;
    private EntityManagerFactory emf;
    private EntityManagerFactoryRegistry emfRegistry;
-   private StreamingMarshaller marshaller;
+   private Marshaller marshaller;
    private MarshalledEntryFactory marshallerEntryFactory;
    private TimeService timeService;
    private ExecutorService executorService;
@@ -84,7 +84,7 @@ public class JpaStore<K, V> implements AdvancedLoadWriteStore<K, V> {
       this.configuration = ctx.getConfiguration();
       this.emfRegistry = ctx.getCache().getAdvancedCache().getComponentRegistry().getGlobalComponentRegistry().getComponent(EntityManagerFactoryRegistry.class);
       this.marshallerEntryFactory = ctx.getMarshalledEntryFactory();
-      this.marshaller = ctx.getMarshaller();
+      this.marshaller = ctx.getUserMarshaller();
       this.timeService = ctx.getTimeService();
       this.executorService = ctx.getExecutor();
    }

--- a/persistence/jpa/src/test/java/org/infinispan/persistence/jpa/AbstractJpaStoreTest.java
+++ b/persistence/jpa/src/test/java/org/infinispan/persistence/jpa/AbstractJpaStoreTest.java
@@ -3,18 +3,15 @@ package org.infinispan.persistence.jpa;
 import static org.testng.Assert.assertTrue;
 import static org.testng.AssertJUnit.assertNotNull;
 
-import org.infinispan.commons.marshall.StreamingMarshaller;
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
-import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.marshall.core.MarshalledEntryFactoryImpl;
 import org.infinispan.marshall.core.MarshalledEntryImpl;
-import org.infinispan.metadata.impl.InternalMetadataImpl;
 import org.infinispan.persistence.InitializationContextImpl;
 import org.infinispan.persistence.jpa.configuration.JpaStoreConfigurationBuilder;
 import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
-import org.infinispan.test.fwk.TestInternalCacheEntryFactory;
 import org.infinispan.util.DefaultTimeService;
 import org.infinispan.util.concurrent.WithinThreadExecutor;
 import org.testng.annotations.AfterMethod;
@@ -38,7 +35,7 @@ public abstract class AbstractJpaStoreTest extends AbstractInfinispanTest {
 
    //protected TransactionFactory gtf = new TransactionFactory();
 
-   protected StreamingMarshaller marshaller;
+   protected Marshaller marshaller;
 
    protected AbstractJpaStoreTest() {
      // gtf.init(false, false, true, false);
@@ -72,7 +69,7 @@ public abstract class AbstractJpaStoreTest extends AbstractInfinispanTest {
    public void setUp() throws Exception {
       try {
          cm = createCacheManager();
-         marshaller = cm.getCache().getAdvancedCache().getComponentRegistry().getCacheMarshaller();
+         marshaller = cm.getCache().getAdvancedCache().getComponentRegistry().getUserMarshaller();
          cs = createCacheStore();
          cs.clear();
       } catch (Exception e) {
@@ -91,17 +88,12 @@ public abstract class AbstractJpaStoreTest extends AbstractInfinispanTest {
    /**
     * @return a mock marshaller for use with the cache store impls
     */
-   protected StreamingMarshaller getMarshaller() {
+   protected Marshaller getMarshaller() {
       return marshaller;
    }
 
    protected MarshalledEntryImpl createEntry(Object key, Object value) {
       return new MarshalledEntryImpl(key, value, null, getMarshaller());
-   }
-
-   protected MarshalledEntryImpl createEntry(Object key, Object value, long lifespan) {
-      InternalCacheEntry ice = TestInternalCacheEntryFactory.create(key, value, lifespan);
-      return new MarshalledEntryImpl(key, value, new InternalMetadataImpl(ice), getMarshaller());
    }
 
    protected MarshalledEntryImpl createEntry(TestObject obj) {

--- a/persistence/remote/src/test/java/org/infinispan/persistence/remote/RemoteStoreRawValuesTest.java
+++ b/persistence/remote/src/test/java/org/infinispan/persistence/remote/RemoteStoreRawValuesTest.java
@@ -5,7 +5,7 @@ import static org.testng.AssertJUnit.assertNull;
 import static org.testng.AssertJUnit.assertTrue;
 
 import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
-import org.infinispan.commons.marshall.StreamingMarshaller;
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.eviction.EvictionType;
@@ -69,8 +69,8 @@ public class RemoteStoreRawValuesTest extends BaseStoreTest {
    }
 
    @Override
-   protected StreamingMarshaller getMarshaller() {
-      return localCacheManager.getCache(REMOTE_CACHE).getAdvancedCache().getComponentRegistry().getCacheMarshaller();
+   protected Marshaller getMarshaller() {
+      return localCacheManager.getCache(REMOTE_CACHE).getAdvancedCache().getComponentRegistry().getUserMarshaller();
    }
 
    @Override

--- a/persistence/remote/src/test/java/org/infinispan/persistence/remote/RemoteStoreSSLTest.java
+++ b/persistence/remote/src/test/java/org/infinispan/persistence/remote/RemoteStoreSSLTest.java
@@ -5,7 +5,7 @@ import static org.testng.AssertJUnit.assertNull;
 import static org.testng.AssertJUnit.assertTrue;
 
 import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
-import org.infinispan.commons.marshall.StreamingMarshaller;
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.factories.GlobalComponentRegistry;
@@ -96,8 +96,8 @@ public class RemoteStoreSSLTest extends BaseStoreTest {
    }
 
    @Override
-   protected StreamingMarshaller getMarshaller() {
-      return localCacheManager.getCache(REMOTE_CACHE).getAdvancedCache().getComponentRegistry().getCacheMarshaller();
+   protected Marshaller getMarshaller() {
+      return localCacheManager.getCache(REMOTE_CACHE).getAdvancedCache().getComponentRegistry().getUserMarshaller();
    }
 
    @Override

--- a/persistence/remote/src/test/java/org/infinispan/persistence/remote/RemoteStoreTest.java
+++ b/persistence/remote/src/test/java/org/infinispan/persistence/remote/RemoteStoreTest.java
@@ -5,7 +5,7 @@ import static org.testng.AssertJUnit.assertNull;
 import static org.testng.AssertJUnit.assertTrue;
 
 import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
-import org.infinispan.commons.marshall.StreamingMarshaller;
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.eviction.EvictionType;
@@ -68,8 +68,8 @@ public class RemoteStoreTest extends BaseStoreTest {
    }
 
    @Override
-   protected StreamingMarshaller getMarshaller() {
-      return localCacheManager.getCache(REMOTE_CACHE).getAdvancedCache().getComponentRegistry().getCacheMarshaller();
+   protected Marshaller getMarshaller() {
+      return localCacheManager.getCache(REMOTE_CACHE).getAdvancedCache().getComponentRegistry().getUserMarshaller();
    }
 
    @Override

--- a/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/SoftIndexFileStore.java
+++ b/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/SoftIndexFileStore.java
@@ -10,7 +10,7 @@ import java.util.function.Predicate;
 
 import org.infinispan.commons.io.ByteBuffer;
 import org.infinispan.commons.io.ByteBufferFactory;
-import org.infinispan.commons.marshall.StreamingMarshaller;
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.commons.persistence.Store;
 import org.infinispan.commons.util.AbstractIterator;
 import org.infinispan.commons.util.CloseableIterator;
@@ -117,7 +117,7 @@ public class SoftIndexFileStore implements AdvancedLoadWriteStore {
    private LogAppender logAppender;
    private Index index;
    private Compactor compactor;
-   private StreamingMarshaller marshaller;
+   private Marshaller marshaller;
    private ByteBufferFactory byteBufferFactory;
    private MarshalledEntryFactory marshalledEntryFactory;
    private TimeService timeService;
@@ -126,7 +126,7 @@ public class SoftIndexFileStore implements AdvancedLoadWriteStore {
    @Override
    public void init(InitializationContext ctx) {
       configuration = ctx.getConfiguration();
-      marshaller = ctx.getMarshaller();
+      marshaller = ctx.getUserMarshaller();
       marshalledEntryFactory = ctx.getMarshalledEntryFactory();
       byteBufferFactory = ctx.getByteBufferFactory();
       timeService = ctx.getTimeService();

--- a/tools/src/main/java/org/infinispan/tools/store/migrator/file/SoftIndexFileStoreIterator.java
+++ b/tools/src/main/java/org/infinispan/tools/store/migrator/file/SoftIndexFileStoreIterator.java
@@ -7,7 +7,7 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 
 import org.infinispan.commons.CacheException;
-import org.infinispan.commons.marshall.StreamingMarshaller;
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.marshall.core.MarshalledEntry;
 import org.infinispan.marshall.core.MarshalledEntryImpl;
 import org.infinispan.persistence.sifs.EntryHeader;
@@ -20,7 +20,7 @@ import org.infinispan.tools.store.migrator.marshaller.SerializationConfigUtil;
 
 public class SoftIndexFileStoreIterator implements StoreIterator {
 
-   private final StreamingMarshaller marshaller;
+   private final Marshaller marshaller;
    private final String location;
 
    public SoftIndexFileStoreIterator(StoreProperties props) {

--- a/tools/src/main/java/org/infinispan/tools/store/migrator/rocksdb/RocksDBReader.java
+++ b/tools/src/main/java/org/infinispan/tools/store/migrator/rocksdb/RocksDBReader.java
@@ -8,7 +8,7 @@ import java.io.File;
 import java.util.Iterator;
 
 import org.infinispan.commons.CacheException;
-import org.infinispan.commons.marshall.StreamingMarshaller;
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.marshall.core.MarshalledEntry;
 import org.infinispan.persistence.spi.PersistenceException;
 import org.infinispan.tools.store.migrator.StoreIterator;
@@ -24,7 +24,7 @@ import org.rocksdb.RocksIterator;
 public class RocksDBReader implements StoreIterator {
 
    private final RocksDB db;
-   private final StreamingMarshaller marshaller;
+   private final Marshaller marshaller;
 
    public RocksDBReader(StoreProperties props) {
       props.required(LOCATION);

--- a/tools/src/test/java/org/infinispan/tools/store/migrator/marshaller/LegacyVersionAwareMarshallerTest.java
+++ b/tools/src/test/java/org/infinispan/tools/store/migrator/marshaller/LegacyVersionAwareMarshallerTest.java
@@ -69,7 +69,7 @@ public class ByteOutputGenerator {
 
       EmbeddedCacheManager manager = new DefaultCacheManager(globalConfig, config);
       ComponentRegistry registry = manager.getCache().getAdvancedCache().getComponentRegistry();
-      StreamingMarshaller marshaller = registry.getCacheMarshaller();
+      StreamingMarshaller marshaller = registry.getUserMarshaller();
 
       // Write to stores
       generateOutput(new CacheStoreOutput(manager.getCache("RocksDBReaderTest")));


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-7409

This is still very much a preview. I still need to rework the SerializationConfiguration so that custom marshallers have a way of performing initialisation/configuration of the user marshaller; I was considering a similar approach to store configuration. 

My approach of separating the two marshallers is as follows:
- All user key/values/metada are marshalled via a MarshalledEntryImpl object.
    - The global marshaller externalizers the MarshallEntryImpl object, but the user marshaller generates the bytes of the key/value/metadata
   - We can then still use the MarshalledEntryImpl externalizer ID to reduce the size of the payload for RPCs
- User marshallers only need to be able to marshall their types, plus potential metadata implementations
- RPC commands are now passed a MarshalledEntryFactory so that user values can be wrapped and marshalled for internal communication. 

In another branch I have a protostream based marshaller impl that works for our internal metadata classes and data structures, but still needs updating to handle test POJOs etc. 
