### PR TITLE
ISPN-9067 Fix test node names

### DIFF
--- a/core/src/test/java/org/infinispan/statetransfer/ConcurrentStartTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/ConcurrentStartTest.java
@@ -18,7 +18,6 @@ import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.lifecycle.ComponentStatus;
-import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.remoting.inboundhandler.DeliverOrder;
 import org.infinispan.remoting.inboundhandler.InboundInvocationHandler;
@@ -117,8 +116,10 @@ public class ConcurrentStartTest extends MultipleCacheManagersTest {
       GlobalConfigurationBuilder gcb = new GlobalConfigurationBuilder();
       gcb.transport().defaultTransport();
       TestCacheManagerFactory.amendGlobalConfiguration(gcb, new TransportFlags().withPortRange(index));
-      EmbeddedCacheManager cm = new DefaultCacheManager(gcb.build(), false);
+      ConfigurationBuilder defaultCacheConfig = new ConfigurationBuilder();
+      EmbeddedCacheManager cm = TestCacheManagerFactory.newDefaultCacheManager(false, gcb, defaultCacheConfig, false);
       registerCacheManager(cm);
+
       Configuration replCfg = new ConfigurationBuilder().clustering().cacheMode(CacheMode.REPL_SYNC).build();
       cm.defineConfiguration(REPL_CACHE_NAME, replCfg);
       Configuration distCfg = new ConfigurationBuilder().clustering().cacheMode(CacheMode.DIST_SYNC).build();

--- a/core/src/test/java/org/infinispan/test/AbstractInfinispanTest.java
+++ b/core/src/test/java/org/infinispan/test/AbstractInfinispanTest.java
@@ -137,15 +137,7 @@ public abstract class AbstractInfinispanTest {
    }
 
    public String getTestName() {
-      // will qualified test name and parameters, thread names can be quite long when debugging
-      boolean shortTestName = Boolean.getBoolean("test.infinispan.shortTestName");
-      String className;
-      if (shortTestName) {
-         className = "Test";
-      } else {
-         className = getClass().getName();
-      }
-
+      String className = getClass().getName();
       String parameters = parameters();
       return parameters == null ? className : className + parameters;
    }

--- a/core/src/test/java/org/infinispan/test/MultipleCacheManagersTest.java
+++ b/core/src/test/java/org/infinispan/test/MultipleCacheManagersTest.java
@@ -1,6 +1,8 @@
 package org.infinispan.test;
 
 import static java.util.Arrays.asList;
+import static org.infinispan.test.fwk.TestResourceTracker.getCurrentTestShortName;
+import static org.testng.AssertJUnit.assertTrue;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
@@ -135,6 +137,13 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
          TestingUtil.clearContent(cacheManagers);
          TestingUtil.killCacheManagers(cacheManagers);
       }
+
+      for (EmbeddedCacheManager cm : cacheManagers) {
+         String nodeName = cm.getCacheManagerConfiguration().transport().nodeName();
+         assertTrue("Invalid node name for test " + getCurrentTestShortName() + ": " + nodeName,
+                    nodeName != null && nodeName.contains(getCurrentTestShortName()));
+      }
+
       cacheManagers.clear();
       listeners.clear();
    }

--- a/core/src/test/resources/configs/named-cache-test.xml
+++ b/core/src/test/resources/configs/named-cache-test.xml
@@ -11,7 +11,8 @@
    <threads>
       <thread-factory name="listener-factory" group-name="infinispan" thread-name-pattern="AsyncListenerThread"/>
       <thread-factory name="persistence-factory" group-name="infinispan" thread-name-pattern="PersistenceThread"/>
-      <thread-factory name="transport-factory" group-name="infinispan" thread-name-pattern="AsyncSerializationThread"/>
+      <thread-factory name="transport-factory" group-name="infinispan" thread-name-pattern="AsyncTransportThread"/>
+      <thread-factory name="async-factory" group-name="infinispan" thread-name-pattern="AsyncOperationsThread"/>
       <thread-factory name="remote-factory" group-name="infinispan" thread-name-pattern="RemoteCommandThread"/>
       <thread-factory name="expiration-factory" group-name="infinispan" thread-name-pattern="ExpirationThread"/>
       <thread-factory name="replication-queue-factory" group-name="infinispan" thread-name-pattern="ReplicationQueueThread"/>
@@ -19,13 +20,16 @@
       <blocking-bounded-queue-thread-pool name="persistence" thread-factory="persistence-factory" max-threads="6" queue-length="10001"/>
       <blocking-bounded-queue-thread-pool name="state-transfer" thread-factory="persistence-factory" max-threads="20" queue-length="5" keepalive-time="60000"/>
       <blocking-bounded-queue-thread-pool name="transport" thread-factory="transport-factory" max-threads="25" queue-length="10000"/>
+      <blocking-bounded-queue-thread-pool name="async" thread-factory="async-factory" max-threads="5" core-threads="5" queue-length="10000"/>
       <blocking-bounded-queue-thread-pool name="remote" thread-factory="transport-factory" max-threads="30" core-threads="2" queue-length="10000" keepalive-time="10000"/>
       <scheduled-thread-pool name="expiration" thread-factory="expiration-factory" />
       <scheduled-thread-pool name="replication-queue" thread-factory="replication-queue-factory" />
    </threads>
 
    <cache-container default-cache="default" statistics="true" shutdown-hook="REGISTER"
-                    listener-executor="listener" persistence-executor="persistence" state-transfer-executor="state-transfer" expiration-executor="expiration">
+                    listener-executor="listener" persistence-executor="persistence"
+                    state-transfer-executor="state-transfer" expiration-executor="expiration"
+                    async-executor="async">
       <transport stack="udp" cluster="infinispan-cluster" lock-timeout="50000" node-name="Jalapeno" machine="m1" rack="r1" site="s1"
                  executor="transport" remote-command-executor="remote" />
       <serialization marshaller="org.infinispan.marshall.TestObjectStreamMarshaller" version="1.0">

--- a/core/src/test/resources/configs/string-property-replaced.xml
+++ b/core/src/test/resources/configs/string-property-replaced.xml
@@ -11,8 +11,8 @@
    <threads>
       <thread-factory name="listener-factory" group-name="infinispan" thread-name-pattern="AsyncListenerThread" priority="5"/>
       <thread-factory name="persistence-factory" group-name="infinispan" thread-name-pattern="PersistenceThread" priority="5"/>
-      <blocking-bounded-queue-thread-pool name="infinispan-listener" thread-factory="listener-factory" max-threads="${test.property.asyncListenerMaxThreads:5}"/>
-      <blocking-bounded-queue-thread-pool name="infinispan-persistence" thread-factory="persistence-factory" max-threads="${test.property.persistenceMaxThreads:5}"/>
+      <blocking-bounded-queue-thread-pool name="infinispan-listener" thread-factory="listener-factory" max-threads="${StringPropertyReplacementTest.asyncListenerMaxThreads:5}"/>
+      <blocking-bounded-queue-thread-pool name="infinispan-persistence" thread-factory="persistence-factory" max-threads="${StringPropertyReplacementTest.persistenceMaxThreads:5}"/>
    </threads>
 
    <jgroups>
@@ -23,8 +23,8 @@
       <transport stack="tcp"/>
       <replicated-cache name="default" mode="SYNC">
          <locking
-               isolation="${test.property.IsolationLevel:REPEATABLE_READ}"
-               acquire-timeout="${test.property.LockAcquisitionTimeout:15000}"
+               isolation="${StringPropertyReplacementTest.IsolationLevel:REPEATABLE_READ}"
+               acquire-timeout="${StringPropertyReplacementTest.LockAcquisitionTimeout:15000}"
                write-skew="false"
                concurrency-level="500"/>
          <transaction


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-9067

I had this lying around for a while...

* Only set the node name once
* Fail the test if a node doesn't have a proper name set
* Don't start the cache manager in the configuration parsing tests