### PR TITLE
ISPN-9403 Increase build timeout to work around slow CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 3, unit: 'HOURS')
+        timeout(time: 4, unit: 'HOURS')
     }
 
     stages {


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-9403

Workaround only, do not close the issue.