### PR TITLE
ISPN-9369 Non-tx query cache results should be cached regardless of tx outcome

### DIFF
--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/ReadOnlyTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/ReadOnlyTest.java
@@ -100,7 +100,7 @@ public class ReadOnlyTest extends SingleNodeTest {
       final Statistics stats = sessionFactory().getStatistics();
       stats.clear();
 
-      final Item item = new Item("query-cache-rollback", "Querying caching on rollback");
+      final Item item = new Item("query-cache-rb", "Querying caching on RB");
       withTxSession(s -> s.persist(item));
 
       // Delay added to guarantee that query cache results won't be considered

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/stress/CorrectnessTestCase.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/stress/CorrectnessTestCase.java
@@ -90,6 +90,7 @@ import org.hibernate.testing.BeforeClassOnce;
 import org.hibernate.testing.jta.JtaAwareConnectionProviderImpl;
 import org.hibernate.testing.jta.TestingJtaPlatformImpl;
 import org.hibernate.testing.junit4.CustomParameterized;
+import org.infinispan.test.hibernate.cache.commons.util.InducedException;
 import org.infinispan.test.hibernate.cache.commons.util.TestConfigurationHook;
 import org.infinispan.test.hibernate.cache.commons.stress.entities.Address;
 import org.infinispan.test.hibernate.cache.commons.stress.entities.Family;
@@ -296,12 +297,6 @@ public abstract class CorrectnessTestCase {
       }
 
       return metadata;
-   }
-
-   public static class InducedException extends Exception {
-      public InducedException(String message) {
-         super(message);
-      }
    }
 
    public static class FailureInducingInterceptor extends BaseCustomInterceptor {

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/util/InducedException.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/util/InducedException.java
@@ -1,0 +1,7 @@
+package org.infinispan.test.hibernate.cache.commons.util;
+
+public class InducedException extends Exception {
+   public InducedException(String message) {
+      super(message);
+   }
+}

--- a/hibernate/cache-v51/src/main/java/org/infinispan/hibernate/cache/v51/query/QueryResultsRegionImpl.java
+++ b/hibernate/cache-v51/src/main/java/org/infinispan/hibernate/cache/v51/query/QueryResultsRegionImpl.java
@@ -170,9 +170,7 @@ public final class QueryResultsRegionImpl extends BaseTransactionalDataRegion im
 
       @Override
       protected void invoke(boolean success) {
-         if (success) {
-            putCache.put(key, value);
-         }
+         putCache.put(key, value);
       }
    }
 }

--- a/hibernate/cache-v53/src/main/java/org/infinispan/hibernate/cache/v53/impl/QueryResultsRegionImpl.java
+++ b/hibernate/cache-v53/src/main/java/org/infinispan/hibernate/cache/v53/impl/QueryResultsRegionImpl.java
@@ -102,11 +102,7 @@ public final class QueryResultsRegionImpl extends BaseRegionImpl implements Quer
       @Override
       public CompletableFuture<Object> invoke(boolean success) {
          transactionContext.remove(session);
-         if (success) {
-            return putCache.putAsync(key, value);
-         } else {
-            return null;
-         }
+         return putCache.putAsync(key, value);
       }
    }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-9369