### PR TITLE
Test query on bytes ProtoBuffer type field

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteNonIndexedQueryStringTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteNonIndexedQueryStringTest.java
@@ -138,6 +138,14 @@ public class RemoteNonIndexedQueryStringTest extends RemoteQueryStringTest {
       super.testFullTextRegexp2();
    }
 
+   @Override public void findMovieByViews_startsV() {
+      // Not applicable to non-indexed caches
+   }
+
+   @Override public void findMovieByRating_protoBytesTypeProperty() {
+      // Not applicable to non-indexed caches
+   }
+
    @Override
    public void testCustomFieldAnalyzer() {
       // Not applicable to non-indexed caches

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/testdomain/protobuf/Movie.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/testdomain/protobuf/Movie.java
@@ -1,0 +1,29 @@
+package org.infinispan.client.hotrod.query.testdomain.protobuf;
+
+/**
+ * @author Fabio Massimo Ercoli
+ * @since 9.4
+ */
+public class Movie {
+
+   public String id;
+   public Integer genre;
+   public Long releaseDate;
+   public String suitableForKids;
+   public String title;
+   public byte rating;
+   public Integer views;
+
+   public Movie() {
+   }
+
+   public Movie(String id, Integer genre, Long releaseDate, String suitableForKids, String title, byte rating, Integer views) {
+      this.id = id;
+      this.genre = genre;
+      this.releaseDate = releaseDate;
+      this.suitableForKids = suitableForKids;
+      this.title = title;
+      this.rating = rating;
+      this.views = views;
+   }
+}

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/testdomain/protobuf/marshallers/MovieMarshaller.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/testdomain/protobuf/marshallers/MovieMarshaller.java
@@ -1,0 +1,53 @@
+package org.infinispan.client.hotrod.query.testdomain.protobuf.marshallers;
+
+import java.io.IOException;
+
+import org.infinispan.client.hotrod.query.testdomain.protobuf.Movie;
+import org.infinispan.protostream.MessageMarshaller;
+
+/**
+ * @author Fabio Massimo Ercoli
+ * @since 9.4
+ */
+public class MovieMarshaller implements MessageMarshaller<Movie> {
+
+   public Movie readFrom(ProtoStreamReader reader) throws IOException {
+      String id = reader.readString("id");
+      Integer genre = reader.readInt("genre");
+      Long releaseDate = reader.readLong("releaseDate");
+      String suitableForKids = reader.readString("suitableForKids");
+      String title = reader.readString("title");
+      byte[] viewerRatings = reader.readBytes("rating");
+      Integer views = reader.readInt("views");
+
+      return new Movie(id, genre, releaseDate, suitableForKids, title, MovieMarshaller.toSingle(viewerRatings), views);
+   }
+
+   public void writeTo(ProtoStreamWriter writer, Movie movie) throws IOException {
+      writer.writeString("id", movie.id);
+      writer.writeInt("genre", movie.genre);
+      writer.writeLong("releaseDate", movie.releaseDate);
+      writer.writeString("suitableForKids", movie.suitableForKids);
+      writer.writeString("title", movie.title);
+      writer.writeBytes("rating", MovieMarshaller.toArray(movie.rating));
+      writer.writeInt("views", movie.views);
+   }
+
+   public Class<? extends Movie> getJavaClass() {
+      return Movie.class;
+   }
+
+   public String getTypeName() {
+      return "sample_bank_account.Movie";
+   }
+
+   public static byte[] toArray(byte single) {
+      byte[] array = new byte[1];
+      array[0] = single;
+      return array;
+   }
+
+   public static byte toSingle(byte[] array) {
+      return array[0];
+   }
+}


### PR DESCRIPTION
I'm trying to query filtering on Protocol Butters type property.
Test:  `findMovieByRating_protoBytesTypeProperty`.

I'm trying to query filtering on starting with 'v' property.
Test: `findMovieByViews_startsV`.

I'm definitely trying to do something wrong. thank you