### PR TITLE
StoreTypeMultimapCacheTest - was Ignored and should work now

### DIFF
--- a/multimap/src/test/java/org/infinispan/multimap/impl/DistributedMultimapCacheTest.java
+++ b/multimap/src/test/java/org/infinispan/multimap/impl/DistributedMultimapCacheTest.java
@@ -26,9 +26,6 @@ import java.util.Map;
 import java.util.function.Predicate;
 
 import org.infinispan.Cache;
-import org.infinispan.commons.dataconversion.Encoder;
-import org.infinispan.commons.dataconversion.EncodingUtils;
-import org.infinispan.commons.dataconversion.Wrapper;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.container.DataContainer;
 import org.infinispan.container.entries.ImmortalCacheEntry;
@@ -509,9 +506,7 @@ public class DistributedMultimapCacheTest extends BaseDistFunctionalTest<String,
    @Override
    protected void assertOwnershipAndNonOwnership(Object key, boolean allowL1) {
       for (Cache cache : caches) {
-         Wrapper keyWrapper = cache.getAdvancedCache().getKeyWrapper();
-         Encoder keyEncoder = cache.getAdvancedCache().getKeyEncoder();
-         Object keyToBeChecked = keyEncoder != null && keyWrapper != null ? EncodingUtils.toStorage(key, keyEncoder, keyWrapper) : key;
+         Object keyToBeChecked = cache.getAdvancedCache().getKeyDataConversion().toStorage(key);
          DataContainer dc = cache.getAdvancedCache().getDataContainer();
          InternalCacheEntry ice = dc.get(keyToBeChecked);
          if (isOwner(cache, keyToBeChecked)) {

--- a/multimap/src/test/java/org/infinispan/multimap/impl/StoreTypeMultimapCacheTest.java
+++ b/multimap/src/test/java/org/infinispan/multimap/impl/StoreTypeMultimapCacheTest.java
@@ -13,16 +13,12 @@ import org.infinispan.multimap.api.embedded.EmbeddedMultimapCacheManagerFactory;
 import org.infinispan.multimap.api.embedded.MultimapCache;
 import org.infinispan.multimap.api.embedded.MultimapCacheManager;
 import org.infinispan.remoting.transport.Address;
-import org.infinispan.test.data.Person;
-import org.junit.Ignore;
 import org.testng.annotations.Test;
 
-//TODO: Integrate https://issues.jboss.org/browse/ISPN-7993 to make it pass
 @Test(groups = "functional", testName = "distribution.StoreTypeMultimapCacheTest")
-@Ignore
 public class StoreTypeMultimapCacheTest extends DistributedMultimapCacheTest {
 
-   protected Map<Address, MultimapCache<String, Person>> multimapCacheCluster = new HashMap<>();
+   protected Map<Address, MultimapCache<String, String>> multimapCacheCluster = new HashMap<>();
 
    protected StorageType storageType;
 
@@ -52,10 +48,9 @@ public class StoreTypeMultimapCacheTest extends DistributedMultimapCacheTest {
    @Override
    public Object[] factory() {
       List testsToRun = new ArrayList<>();
-      //TODO: Integrate https://issues.jboss.org/browse/ISPN-7993 to make it pass
-//      testsToRun.add(new StoreTypeMultimapCacheTest().storageType(StorageType.OFF_HEAP));
-//      testsToRun.add(new StoreTypeMultimapCacheTest().storageType(StorageType.OBJECT));
-//      testsToRun.add(new StoreTypeMultimapCacheTest().storageType(StorageType.BINARY));
+      testsToRun.add(new StoreTypeMultimapCacheTest().storageType(StorageType.OFF_HEAP));
+      testsToRun.add(new StoreTypeMultimapCacheTest().storageType(StorageType.OBJECT));
+      testsToRun.add(new StoreTypeMultimapCacheTest().storageType(StorageType.BINARY));
       return testsToRun.toArray();
    }
 


### PR DESCRIPTION
Looking at the  multimap module, I've realised there is a test ignored attending this issue to be integrated: (functional maps + data conversion)

https://issues.jboss.org/browse/ISPN-7993

The issue is integrated now so the test should pass
