### PR TITLE
fixed default value of isolation level of document

### DIFF
--- a/documentation/src/main/asciidoc/glossary/glossary.asciidoc
+++ b/documentation/src/main/asciidoc/glossary/glossary.asciidoc
@@ -284,8 +284,6 @@ return different results, and this phenomenon is known as
 link:http://en.wikipedia.org/wiki/Isolation_level#Non-repeatable_reads[non-repeatable reads].
 This issue is avoided with +REPETEABLE_READ+ isolation level.
 
-By default, {brandname} uses +READ_COMMITTED+ as isolation level.
-
 == Relational Database Management System (RDBMS)
 A relational database management system (RDBMS) is a database management system
  that is based on the relational model. Many popular databases currently in use
@@ -326,6 +324,8 @@ Thread1: tx1.commit()
 Thread2:                                       cache.get("B") // returns 2
 Thread2:                                       tx2.commit()
 ----
+
+By default, {brandname} uses +REPEATABLE_READ+ as isolation level.
 
 == Representational State Transfer (ReST)
 ReST is a software architectural style that promotes accessing resources via a

--- a/documentation/src/main/asciidoc/user_guide/transactions.adoc
+++ b/documentation/src/main/asciidoc/user_guide/transactions.adoc
@@ -106,7 +106,7 @@ builder.versioning()
 
 
 * `isolation` - configures the isolation level. Check section <<tx:isolation-levels>> for more details.
-Default is `READ_COMMITTED`.
+Default is `REPEATABLE_READ`.
 * `write-skew` - enables the write skew check. Check section <<tx:write-skew>> for more details. Default is `false`.
 * `locking` - configures whether the cache uses optimistic or pessimistic locking. Check section <<tx:locking>> for more details.
 Default is `OPTIMISTIC`.


### PR DESCRIPTION
I think the default isolation level after Infinispan 9.0 is REPEATABLE READ, but the document is READ COMMITTED.

[Enable write-skew for optimistic + repeatable-read transactions](https://issues.jboss.org/browse/ISPN-7613)

https://github.com/infinispan/infinispan/blob/9.4.0.CR1/core/src/main/java/org/infinispan/configuration/cache/LockingConfiguration.java#L19