### PR TITLE
fix list notation for the description of Cache Passivation limitation

### DIFF
--- a/documentation/src/main/asciidoc/user_guide/persistence.adoc
+++ b/documentation/src/main/asciidoc/user_guide/persistence.adoc
@@ -145,9 +145,9 @@ configured is used and all others are ignored.
 
 Due to the unique nature of passivation, it is not supported with some other store configurations.
 
-# Transactional store - Passivation writes/removes entries from the store outside
+* Transactional store - Passivation writes/removes entries from the store outside
 the scope of the actual Infinispan commit boundaries.
-# Shared store - Shared store requires entries always being in the store for other
+* Shared store - Shared store requires entries always being in the store for other
 owners. Thus passivation makes no sense as we can't remove the entry from the store.
 
 ==== Cache Loader Behavior with Passivation Disabled vs Enabled


### PR DESCRIPTION
It is a description about the store described in the `Limitations` of the Persistence document, but is not it correct to write it in an unordered list?

For Infinispan's current User Guide, it seems to me that the table of contents and display are collapsed.

![image](https://user-images.githubusercontent.com/6071726/44663012-46631300-aa4a-11e8-9a0d-059a3567538e.png)
