### PR TITLE
ISPN-9475 AbstractInfinispanTest mistakenly detects some test with params as duplicates

### DIFF
--- a/commons-test/src/main/java/org/infinispan/commons/test/PolarionJUnitXMLReporter.java
+++ b/commons-test/src/main/java/org/infinispan/commons/test/PolarionJUnitXMLReporter.java
@@ -275,7 +275,7 @@ public class PolarionJUnitXMLReporter implements IResultListener2, ISuiteListene
       }
       StringBuilder result = new StringBuilder();
       while (idx != -1) {
-         result.append(str.substring(start, idx));
+         result.append(str, start, idx);
          if (pattern.matcher(str.substring(idx)).matches()) {
             // do nothing it is an entity;
             result.append("&");
@@ -391,8 +391,8 @@ public class PolarionJUnitXMLReporter implements IResultListener2, ISuiteListene
       report.addComment("Environment variables");
       for (String key : System.getenv().keySet()) {
          Properties property = new Properties();
-         property.setProperty(XMLConstants.ATTR_NAME, key.toString());
-         property.setProperty(XMLConstants.ATTR_VALUE, System.getenv(key.toString()));
+         property.setProperty(XMLConstants.ATTR_NAME, key);
+         property.setProperty(XMLConstants.ATTR_VALUE, System.getenv(key));
          report.addEmptyElement(XMLConstants.PROPERTY, property);
       }
 
@@ -420,7 +420,7 @@ public class PolarionJUnitXMLReporter implements IResultListener2, ISuiteListene
          itrList.add(tr);
          m_allTests.put(key, itrList);
       } else {
-         ArrayList<ITestResult> itrList = new ArrayList<ITestResult>();
+         ArrayList<ITestResult> itrList = new ArrayList<>();
          itrList.add(tr);
          m_allTests.put(key, itrList);
       }

--- a/core/src/test/java/org/infinispan/api/APINonTxOffHeapTest.java
+++ b/core/src/test/java/org/infinispan/api/APINonTxOffHeapTest.java
@@ -34,6 +34,11 @@ public class APINonTxOffHeapTest extends APINonTxTest {
       return this;
    }
 
+   @Override
+   protected String parameters() {
+      return "[" + storageType + "]";
+   }
+
    @Factory
    public Object[] factory() {
       return new Object[]{
@@ -77,7 +82,7 @@ public class APINonTxOffHeapTest extends APINonTxTest {
       assertEquals("K", cache.getOrDefault("Not there", "K"));
    }
 
-   public void testMerge() throws Exception {
+   public void testMerge() {
       cache.put("A", "B");
 
       // replace
@@ -225,27 +230,4 @@ public class APINonTxOffHeapTest extends APINonTxTest {
          this.value = value;
       }
    }
-
-   static class FalseEqualsKey implements Serializable, ExternalPojo {
-      private static final long serialVersionUID = 1L;
-
-      final String name;
-      final int value;
-
-      FalseEqualsKey(String name, int value) {
-         this.name = name;
-         this.value = value;
-      }
-
-      @Override
-      public int hashCode() {
-         return 0;
-      }
-
-      @Override
-      public boolean equals(Object obj) {
-         return false;
-      }
-   }
-
 }

--- a/core/src/test/java/org/infinispan/container/offheap/OffHeapSingleNodeExpirationEvictionTest.java
+++ b/core/src/test/java/org/infinispan/container/offheap/OffHeapSingleNodeExpirationEvictionTest.java
@@ -20,6 +20,7 @@ import org.testng.annotations.Test;
  */
 @Test(groups = "functional", testName = "container.offheap.OffHeapSingleNodeExpirationEvictionTest")
 public class OffHeapSingleNodeExpirationEvictionTest extends OffHeapSingleNodeTest {
+
    private enum EXPIRE_TYPE {
       MORTAL,
       TRANSIENT,
@@ -37,6 +38,16 @@ public class OffHeapSingleNodeExpirationEvictionTest extends OffHeapSingleNodeTe
    private OffHeapSingleNodeExpirationEvictionTest eviction(boolean enable) {
       eviction = enable;
       return this;
+   }
+
+   @Override
+   protected String[] parameterNames() {
+      return concat(super.parameterNames(), "EXPIRE_TYPE", "eviction");
+   }
+
+   @Override
+   protected Object[] parameterValues() {
+      return concat(super.parameterValues(), expirationType, eviction);
    }
 
    @Override
@@ -79,8 +90,7 @@ public class OffHeapSingleNodeExpirationEvictionTest extends OffHeapSingleNodeTe
 
       DataConversion dataConversion = cache.getAdvancedCache().getKeyDataConversion();
 
-      CacheEntry<String, String> entry = cache.getAdvancedCache().getDataContainer().get(
-            dataConversion.toStorage("k"));
+      CacheEntry<String, String> entry = cache.getAdvancedCache().getDataContainer().get(dataConversion.toStorage("k"));
 
       assertNotNull(entry);
       long storedTime = TimeUnit.MINUTES.toMillis(10);

--- a/core/src/test/java/org/infinispan/manager/SingleClusterExecutorTest.java
+++ b/core/src/test/java/org/infinispan/manager/SingleClusterExecutorTest.java
@@ -33,13 +33,12 @@ public class SingleClusterExecutorTest extends AllClusterExecutorTest {
    }
 
    @Override
-   public String toString() {
-      return "SingleClusterExecutorTest{ local = " + local + "}";
+   protected String parameters() {
+      return "[" + local + "]";
    }
 
    @Factory
    public Object[] factory() {
-      System.currentTimeMillis();
       return new Object[] {
             new SingleClusterExecutorTest().executeLocal(true),
             new SingleClusterExecutorTest().executeLocal(false)

--- a/core/src/test/java/org/infinispan/persistence/file/SingleFileStoreTest.java
+++ b/core/src/test/java/org/infinispan/persistence/file/SingleFileStoreTest.java
@@ -25,6 +25,11 @@ public class SingleFileStoreTest extends BaseStoreTest {
    protected String tmpDirectory;
    protected StorageType storage;
 
+   @Override
+   protected String parameters() {
+      return "[" + storage + "]";
+   }
+
    @Factory
    public Object[] factory() {
       return new Object[]{
@@ -41,7 +46,7 @@ public class SingleFileStoreTest extends BaseStoreTest {
 
    @BeforeClass(alwaysRun = true)
    protected void setUpTempDir() {
-      tmpDirectory = TestingUtil.tmpDirectory(this.getClass());
+      tmpDirectory = TestingUtil.tmpDirectory(getClass());
    }
 
    @AfterClass(alwaysRun = true)
@@ -50,7 +55,7 @@ public class SingleFileStoreTest extends BaseStoreTest {
    }
 
    @Override
-   protected AdvancedLoadWriteStore createStore() throws Exception {
+   protected AdvancedLoadWriteStore createStore() {
       clearTempDir();
       SingleFileStore store = new SingleFileStore();
       ConfigurationBuilder configurationBuilder = TestCacheManagerFactory.getDefaultCacheConfiguration(false);

--- a/core/src/test/java/org/infinispan/test/AbstractInfinispanTest.java
+++ b/core/src/test/java/org/infinispan/test/AbstractInfinispanTest.java
@@ -29,6 +29,7 @@ import java.util.concurrent.locks.LockSupport;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
+
 import javax.transaction.TransactionManager;
 
 import org.infinispan.commons.api.BasicCache;
@@ -50,7 +51,6 @@ import org.jgroups.stack.Protocol;
 import org.testng.IMethodInstance;
 import org.testng.IMethodInterceptor;
 import org.testng.ITestContext;
-import org.testng.TestNGException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
@@ -68,6 +68,7 @@ import org.testng.internal.MethodInstance;
 @Listeners({ChainMethodInterceptor.class, TestNGLongTestsHook.class})
 @TestSelector(interceptors = AbstractInfinispanTest.OrderByInstance.class)
 public abstract class AbstractInfinispanTest {
+
    protected interface Condition {
       boolean isSatisfied() throws Exception;
    }
@@ -97,9 +98,8 @@ public abstract class AbstractInfinispanTest {
                String instanceName = ((AbstractInfinispanTest) instance).getTestName();
                Object otherInstance = instancesByName.putIfAbsent(instanceName, instance);
                if (otherInstance != null) {
-                  throw new TestNGException(
-                        "Duplicate test name: " + instanceName + ", classes " + instance.getClass().getName() +
-                              " and " + otherInstance.getClass().getName());
+                  System.err.printf("ERROR: Duplicate test name: %s, classes %s and %s", instanceName,
+                        instance.getClass().getName(), otherInstance.getClass().getName());
                }
                String parameters = ((AbstractInfinispanTest) instance).parameters();
                if (parameters != null) {
@@ -149,7 +149,6 @@ public abstract class AbstractInfinispanTest {
       String parameters = parameters();
       return parameters == null ? className : className + parameters;
    }
-
 
    protected void killSpawnedThreads() {
       List<Runnable> runnables = defaultExecutorService.shutdownNow();
@@ -537,6 +536,4 @@ public abstract class AbstractInfinispanTest {
          }
       }
    }
-
-
 }

--- a/core/src/test/java/org/infinispan/test/MultipleCacheManagersTest.java
+++ b/core/src/test/java/org/infinispan/test/MultipleCacheManagersTest.java
@@ -93,7 +93,7 @@ import org.testng.annotations.Factory;
 })
 public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
 
-   protected List<EmbeddedCacheManager> cacheManagers = Collections.synchronizedList(new ArrayList<EmbeddedCacheManager>());
+   protected List<EmbeddedCacheManager> cacheManagers = Collections.synchronizedList(new ArrayList<>());
    protected IdentityHashMap<Cache<?, ?>, ReplListener> listeners = new IdentityHashMap<>();
    // the cache mode set in configuration is shared in many tests, therefore we'll place the field,
    // fluent setter cacheMode(...) and parameters() to this class.
@@ -569,10 +569,6 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
             modifiers[mi].accept((MultipleCacheManagersTest) tests[i + j]);
          }
       }
-   }
-
-   public List<MultipleCacheManagersTest> expand() {
-      return new ArrayList<>();
    }
 
    private <Mode, A extends Annotation> Consumer<MultipleCacheManagersTest>[] getModifiers(Class<A> annotationClass, Function<A, Mode[]> methodRetriever, BiConsumer<MultipleCacheManagersTest, Mode> applier) {

--- a/query/src/test/java/org/infinispan/query/api/PutAllTest.java
+++ b/query/src/test/java/org/infinispan/query/api/PutAllTest.java
@@ -28,6 +28,11 @@ public class PutAllTest extends SingleCacheManagerTest {
 
    private StorageType storageType;
 
+   @Override
+   protected String parameters() {
+      return "[" + storageType + "]";
+   }
+
    @Factory
    public Object[] factory() {
       return new Object[] {

--- a/query/src/test/java/org/infinispan/query/blackbox/ClusteredCacheTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/ClusteredCacheTest.java
@@ -78,6 +78,16 @@ public class ClusteredCacheTest extends MultipleCacheManagersTest {
       cleanup = CleanupPhase.AFTER_METHOD;
    }
 
+   @Override
+   protected String[] parameterNames() {
+      return concat(super.parameterNames(), "StorageType");
+   }
+
+   @Override
+   protected Object[] parameterValues() {
+      return concat(super.parameterValues(), storageType);
+   }
+
    public Object[] factory() {
       return new Object[]{
             new ClusteredCacheTest().storageType(StorageType.OFF_HEAP),
@@ -684,7 +694,7 @@ public class ClusteredCacheTest extends MultipleCacheManagersTest {
             .buildQueryBuilderForClass(Person.class)
             .get();
       Query allQuery = queryBuilder.all().createQuery();
-      assertTrue(searchManager.getQuery(allQuery, Person.class).list().size() == 3);
+      assertEquals(3, searchManager.getQuery(allQuery, Person.class).list().size());
 
       String key = "newGoat";
       person4 = new Person(key, "eats something", 42);

--- a/query/src/test/java/org/infinispan/query/blackbox/ClusteredQueryTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/ClusteredQueryTest.java
@@ -64,6 +64,16 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
       };
    }
 
+   @Override
+   protected String[] parameterNames() {
+      return concat(super.parameterNames(), "StorageType");
+   }
+
+   @Override
+   protected Object[] parameterValues() {
+      return concat(super.parameterValues(), storageType);
+   }
+
    ClusteredQueryTest storageType(StorageType storageType) {
       this.storageType = storageType;
       return this;
@@ -71,7 +81,7 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
 
    @AfterMethod
    @Override
-   protected void clearContent() throws Throwable {
+   protected void clearContent() {
       // Leave it be
    }
 
@@ -108,7 +118,7 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
       StaticTestingErrorHandler.assertAllGood(cacheAMachine1, cacheAMachine2);
    }
 
-   public void testLazyOrdered() throws ParseException {
+   public void testLazyOrdered() {
       // applying sort
       SortField sortField = new SortField("age", Type.INT);
       Sort sort = new Sort(sortField);
@@ -129,7 +139,7 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
       StaticTestingErrorHandler.assertAllGood(cacheAMachine1, cacheAMachine2);
    }
 
-   public void testLazyNonOrdered() throws ParseException {
+   public void testLazyNonOrdered() {
       try (ResultIterator<Person> ignored = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.LAZY))) {
          assert cacheQuery.getResultSize() == 10 : cacheQuery.getResultSize();
       }
@@ -150,7 +160,7 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
       StaticTestingErrorHandler.assertAllGood(cacheAMachine1, cacheAMachine2);
    }
 
-   public void testEagerOrdered() throws ParseException {
+   public void testEagerOrdered() {
       // applying sort
       SortField sortField = new SortField("age", Type.INT);
       Sort sort = new Sort(sortField);
@@ -170,7 +180,7 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
    }
 
    @Test(expectedExceptions = NoSuchElementException.class, expectedExceptionsMessageRegExp = "Out of boundaries")
-   public void testIteratorNextOutOfBounds() throws Exception {
+   public void testIteratorNextOutOfBounds() {
       cacheQuery.maxResults(1);
       try (ResultIterator<Person> iterator = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.EAGER))) {
          assert iterator.hasNext();
@@ -183,7 +193,7 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
    }
 
    @Test(expectedExceptions = UnsupportedOperationException.class)
-   public void testIteratorRemove() throws Exception {
+   public void testIteratorRemove() {
       cacheQuery.maxResults(1);
       try (ResultIterator<Person> iterator = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.EAGER))) {
          assert iterator.hasNext();
@@ -192,7 +202,7 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
       StaticTestingErrorHandler.assertAllGood(cacheAMachine1, cacheAMachine2);
    }
 
-   public void testList() throws ParseException {
+   public void testList() {
       // applying sort
       SortField sortField = new SortField("age", Type.INT);
       Sort sort = new Sort(sortField);
@@ -209,11 +219,11 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
       StaticTestingErrorHandler.assertAllGood(cacheAMachine1, cacheAMachine2);
    }
 
-   public void testGetResultSizeList() throws ParseException {
+   public void testGetResultSizeList() {
       assertEquals(10, cacheQuery.getResultSize());
    }
 
-   public void testPagination() throws ParseException {
+   public void testPagination() {
       cacheQuery.firstResult(2);
       cacheQuery.maxResults(1);
 
@@ -231,7 +241,7 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
    }
 
    @Test
-   public void testPagination2() throws Exception {
+   public void testPagination2() {
       int[] pageSizes = new int[]{1, 5, 7, NUM_ENTRIES + 10};
 
       for (int pageSize : pageSizes) {
@@ -240,15 +250,15 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
       }
    }
 
-   private void testPaginationWithoutSort(int pageSize) throws ParseException {
+   private void testPaginationWithoutSort(int pageSize) {
       testPaginationInternal(pageSize, null);
    }
 
-   private void testPaginationWithSort(int pageSize, String field, Type type) throws ParseException {
+   private void testPaginationWithSort(int pageSize, String field, Type type) {
       testPaginationInternal(pageSize, new Sort(new SortField(field, type)));
    }
 
-   private void testPaginationInternal(int pageSize, Sort sort) throws ParseException {
+   private void testPaginationInternal(int pageSize, Sort sort) {
       CacheQuery<Person> paginationQuery = buildPaginationQuery(0, pageSize, sort);
 
       int idx = 0;
@@ -264,7 +274,7 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
       StaticTestingErrorHandler.assertAllGood(cacheAMachine1, cacheAMachine2);
    }
 
-   private CacheQuery<Person> buildPaginationQuery(int offset, int pageSize, Sort sort) throws ParseException {
+   private CacheQuery<Person> buildPaginationQuery(int offset, int pageSize, Sort sort) {
       CacheQuery<Person> clusteredQuery = Search.getSearchManager(cacheAMachine1)
             .getQuery(new MatchAllDocsQuery(), IndexedQueryMode.BROADCAST);
       clusteredQuery.firstResult(offset);
@@ -275,7 +285,7 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
       return clusteredQuery;
    }
 
-   public void testQueryAll() throws ParseException {
+   public void testQueryAll() {
       CacheQuery<Person> clusteredQuery = Search.getSearchManager(cacheAMachine1)
             .getQuery(new MatchAllDocsQuery(), IndexedQueryMode.BROADCAST, Person.class);
 
@@ -289,13 +299,13 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
       org.apache.lucene.search.Query query = queryParser.parse("name:name1~2");
 
       CacheQuery<Person> clusteredQuery = Search.getSearchManager(cacheAMachine1)
-            .getClusteredQuery(query, Person.class);
+            .getQuery(query, IndexedQueryMode.BROADCAST, Person.class);
 
       assertEquals(NUM_ENTRIES, clusteredQuery.list().size());
       StaticTestingErrorHandler.assertAllGood(cacheAMachine1, cacheAMachine2);
    }
 
-   public void testBroadcastIckleMatchAllQuery() throws Exception {
+   public void testBroadcastIckleMatchAllQuery() {
       CacheQuery<Person> everybody = Search.getSearchManager(cacheAMachine1)
             .getQuery(String.format("FROM %s", Person.class.getName()), IndexedQueryMode.BROADCAST, Person.class);
 
@@ -303,7 +313,7 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
       StaticTestingErrorHandler.assertAllGood(cacheAMachine1, cacheAMachine2);
    }
 
-   public void testBroadcastIckleTermQuery() throws Exception {
+   public void testBroadcastIckleTermQuery() {
       String targetName = "name2";
       CacheQuery<Person> singlePerson = Search.getSearchManager(cacheAMachine1)
             .getQuery(String.format("FROM %s p where p.name:'%s'", Person.class.getName(), targetName),
@@ -314,7 +324,7 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
       StaticTestingErrorHandler.assertAllGood(cacheAMachine1, cacheAMachine2);
    }
 
-   public void testBroadcastFuzzyIckle() throws Exception {
+   public void testBroadcastFuzzyIckle() {
       CacheQuery<Person> persons0to10 = Search.getSearchManager(cacheAMachine1)
             .getQuery(String.format("FROM %s p where p.name:'nome'~2", Person.class.getName()),
                   IndexedQueryMode.BROADCAST, Person.class);
@@ -324,7 +334,7 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
       StaticTestingErrorHandler.assertAllGood(cacheAMachine1, cacheAMachine2);
    }
 
-   public void testBroadcastNumericRangeQuery() throws Exception {
+   public void testBroadcastNumericRangeQuery() {
       CacheQuery<Person> infants = Search.getSearchManager(cacheAMachine1)
             .getQuery(String.format("FROM %s p where p.age between 0 and 5", Person.class.getName()),
                   IndexedQueryMode.BROADCAST, Person.class);
@@ -334,7 +344,7 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
       StaticTestingErrorHandler.assertAllGood(cacheAMachine1, cacheAMachine2);
    }
 
-   public void testBroadcastProjectionIckleQuery() throws Exception {
+   public void testBroadcastProjectionIckleQuery() {
       SearchManager sm = Search.getSearchManager(cacheAMachine2);
       CacheQuery<Object[]> onlyNames = sm.getQuery(
             String.format("Select p.name FROM %s p", Person.class.getName()), IndexedQueryMode.BROADCAST, Person.class
@@ -351,7 +361,7 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
       StaticTestingErrorHandler.assertAllGood(cacheAMachine1, cacheAMachine2);
    }
 
-   public void testBroadcastSortedIckleQuery() throws Exception {
+   public void testBroadcastSortedIckleQuery() {
       SearchManager sm = Search.getSearchManager(cacheAMachine2);
       CacheQuery<Person> theLastWillBeFirst = sm.getQuery(
             String.format("FROM %s p order by p.age desc", Person.class.getName()), IndexedQueryMode.BROADCAST, Person.class
@@ -363,7 +373,7 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
       StaticTestingErrorHandler.assertAllGood(cacheAMachine1, cacheAMachine2);
    }
 
-   public void testPaginatedIckleQuery() throws Exception {
+   public void testPaginatedIckleQuery() {
       SearchManager sm = Search.getSearchManager(cacheAMachine1);
       CacheQuery<Person> q = sm.getQuery(String.format("FROM %s p order by p.age", Person.class.getName()),
             IndexedQueryMode.BROADCAST, Person.class);
@@ -378,7 +388,7 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
       assertEquals("name14", results.get(9).getName());
    }
 
-   public void testPartialIckleQuery() throws Exception {
+   public void testPartialIckleQuery() {
       SearchManager searchManager1 = Search.getSearchManager(cacheAMachine1);
       SearchManager searchManager2 = Search.getSearchManager(cacheAMachine2);
       String query = String.format("FROM %s p", Person.class.getName());
@@ -404,7 +414,7 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
    }
 
    @Test(expectedExceptions = SearchException.class, expectedExceptionsMessageRegExp = ".*cannot be converted to an indexed Query")
-   public void testPreventHybridQuery() throws Exception {
+   public void testPreventHybridQuery() {
       CacheQuery<Person> hybridQuery = Search.getSearchManager(cacheAMachine1)
             .getQuery(String.format("FROM %s p where p.nonSearchableField = 'nothing'", Person.class.getName()),
                   IndexedQueryMode.BROADCAST, Person.class);
@@ -413,7 +423,7 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
    }
 
    @Test(expectedExceptions = SearchException.class, expectedExceptionsMessageRegExp = ".*cannot be converted to an indexed Query")
-   public void testPreventAggregationQueries() throws Exception {
+   public void testPreventAggregationQueries() {
       CacheQuery<Person> aggregationQuery = Search.getSearchManager(cacheAMachine1)
             .getQuery(String.format("FROM %s p where p.name:'name3' group by p.name", Person.class.getName()),
                   IndexedQueryMode.BROADCAST, Person.class);
@@ -422,7 +432,7 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
    }
 
    @Test
-   public void testBroadcastNativeInfinispanMatchAllQuery() throws Exception {
+   public void testBroadcastNativeInfinispanMatchAllQuery() {
       String q = String.format("FROM %s", Person.class.getName());
       Query partialResultQuery = Search.getQueryFactory(cacheAMachine1).create(q);
       Query fullResultQuery = Search.getQueryFactory(cacheAMachine2).create(q, IndexedQueryMode.BROADCAST);
@@ -434,7 +444,7 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
    }
 
    @Test
-   public void testBroadcastNativeInfinispanHybridQuery() throws Exception {
+   public void testBroadcastNativeInfinispanHybridQuery() {
       String q = "FROM " + Person.class.getName() + " where age >= 40 and nonSearchableField = 'na'";
       Query query = Search.getQueryFactory(cacheAMachine1).create(q, IndexedQueryMode.BROADCAST);
 
@@ -442,7 +452,7 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
    }
 
    @Test
-   public void testBroadcastNativeInfinispanFuzzyQuery() throws Exception {
+   public void testBroadcastNativeInfinispanFuzzyQuery() {
       String q = String.format("FROM %s p where p.name:'nome'~2", Person.class.getName());
 
       Query query = Search.getQueryFactory(cacheAMachine1).create(q, IndexedQueryMode.BROADCAST);
@@ -451,7 +461,7 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
    }
 
    @Test
-   public void testBroadcastSortedInfinispanQuery() throws Exception {
+   public void testBroadcastSortedInfinispanQuery() {
       QueryFactory queryFactory = Search.getQueryFactory(cacheAMachine1);
       Query sortedQuery = queryFactory.create("FROM " + Person.class.getName() + " p order by p.age desc",
             IndexedQueryMode.BROADCAST);
@@ -463,7 +473,7 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
    }
 
    @Test
-   public void testBroadcastAggregatedInfinispanQuery() throws Exception {
+   public void testBroadcastAggregatedInfinispanQuery() {
       QueryFactory queryFactory = Search.getQueryFactory(cacheAMachine2);
       Query hybridQuery = queryFactory.create("select name FROM " + Person.class.getName() + " WHERE name : 'na*' group by name",
             IndexedQueryMode.BROADCAST);
@@ -472,7 +482,7 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
    }
 
    @Test
-   public void testNonIndexedBroadcastInfinispanQuery() throws Exception {
+   public void testNonIndexedBroadcastInfinispanQuery() {
       QueryFactory queryFactory = Search.getQueryFactory(cacheAMachine2);
       Query slowQuery = queryFactory.create("FROM " + Person.class.getName() + " WHERE nonSearchableField LIKE 'na%'",
             IndexedQueryMode.BROADCAST);
@@ -492,5 +502,4 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
             .add(queryParser.parse("blurb1?"), Occur.SHOULD)
             .build();
    }
-
 }

--- a/query/src/test/java/org/infinispan/query/blackbox/LocalCacheStorageTypeTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/LocalCacheStorageTypeTest.java
@@ -19,6 +19,11 @@ public class LocalCacheStorageTypeTest extends LocalCacheTest {
 
    protected StorageType storageType;
 
+   @Override
+   protected String parameters() {
+      return "[" + storageType + "]";
+   }
+
    @Factory
    public Object[] factory() {
       return new Object[]{
@@ -48,5 +53,4 @@ public class LocalCacheStorageTypeTest extends LocalCacheTest {
       enhanceConfig(cfg);
       return TestCacheManagerFactory.createCacheManager(cfg);
    }
-
 }

--- a/tasks/scripting/src/test/java/org/infinispan/scripting/ScriptingDataStoresTest.java
+++ b/tasks/scripting/src/test/java/org/infinispan/scripting/ScriptingDataStoresTest.java
@@ -23,7 +23,13 @@ import org.testng.annotations.Test;
 public class ScriptingDataStoresTest extends AbstractScriptingTest {
 
    static final String CACHE_NAME = "script-exec";
+
    protected StorageType storageType;
+
+   @Override
+   protected String parameters() {
+      return "[" + storageType + "]";
+   }
 
    @Factory
    public Object[] factory() {


### PR DESCRIPTION
* the culprit is AbstractInfinispanTest
* after fixing this we find many tests were previously ignored by mistake and need params to be declared 
https://issues.jboss.org/browse/ISPN-9475