### PR TITLE
ISPN-9465 Cannot join cache after killing the only member 9.3.x

### DIFF
--- a/core/src/main/java/org/infinispan/topology/ClusterCacheStatus.java
+++ b/core/src/main/java/org/infinispan/topology/ClusterCacheStatus.java
@@ -516,7 +516,8 @@ public class ClusterCacheStatus implements AvailabilityStrategyContext {
          setCurrentTopology(null);
          setStableTopology(null);
          rebalanceConfirmationCollector = null;
-         // TODO Remove the cache from the cache status map in ClusterTopologyManagerImpl instead
+         status = ComponentStatus.INSTANTIATED;
+
          return;
       }
 

--- a/core/src/test/java/org/infinispan/distribution/rehash/RehashAfterPartitionMergeTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/RehashAfterPartitionMergeTest.java
@@ -27,8 +27,8 @@ public class RehashAfterPartitionMergeTest extends MultipleCacheManagersTest {
 
       c1 = caches.get(0);
       c2 = caches.get(1);
-      d1 = TestingUtil.getDiscardForCache(c1);
-      d2 = TestingUtil.getDiscardForCache(c2);
+      d1 = TestingUtil.getDiscardForCache(c1.getCacheManager());
+      d2 = TestingUtil.getDiscardForCache(c2.getCacheManager());
    }
 
    public void testCachePartition() {

--- a/core/src/test/java/org/infinispan/notifications/MergeViewTest.java
+++ b/core/src/test/java/org/infinispan/notifications/MergeViewTest.java
@@ -33,7 +33,7 @@ public class MergeViewTest extends MultipleCacheManagersTest {
       ml0 = new MergeListener();
       manager(0).addListener(ml0);
 
-      discard = TestingUtil.getDiscardForCache(cache(0));
+      discard = TestingUtil.getDiscardForCache(manager(0));
       discard.setDiscardAll(true);
 
       addClusterEnabledCacheManager(getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, true),

--- a/core/src/test/java/org/infinispan/partitionhandling/PartitionStressTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/PartitionStressTest.java
@@ -62,7 +62,7 @@ public class PartitionStressTest extends MultipleCacheManagersTest {
    public void testWriteDuringPartition() throws Exception {
       DISCARD[] discards = new DISCARD[NUM_NODES];
       for (int i = 0; i < NUM_NODES; i++) {
-         discards[i] = TestingUtil.getDiscardForCache(cache(i));
+         discards[i] = TestingUtil.getDiscardForCache(manager(i));
       }
 
       final List<Future<Object>> futures = new ArrayList<>(NUM_NODES);

--- a/core/src/test/java/org/infinispan/partitionhandling/ScatteredCrashInSequenceTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/ScatteredCrashInSequenceTest.java
@@ -111,8 +111,8 @@ public class ScatteredCrashInSequenceTest extends BasePartitionHandlingTest {
 
       StateSequencer ss = new StateSequencer().logicalThread("main", "st_begin", "check", "new_topology", /* "st_end",*/ "degraded");
 
-      DISCARD discard1 = TestingUtil.getDiscardForCache(cache(c1));
-      DISCARD discard2 = TestingUtil.getDiscardForCache(cache(c2));
+      DISCARD discard1 = TestingUtil.getDiscardForCache(manager(c1));
+      DISCARD discard2 = TestingUtil.getDiscardForCache(manager(c2));
 
       Cache coordinator = c1 == 0 ? cache(1) : cache(0);
       // This doesn't go through RpcManager, so we can't mock this and we can't mock ClusterTopologyManager either

--- a/core/src/test/java/org/infinispan/scattered/statetransfer/CrashJoinTest.java
+++ b/core/src/test/java/org/infinispan/scattered/statetransfer/CrashJoinTest.java
@@ -25,9 +25,9 @@ public class CrashJoinTest extends AbstractStateTransferTest {
    protected void createCacheManagers() throws Throwable {
       super.createCacheManagers();
 
-      d1 = TestingUtil.getDiscardForCache(c1);
-      d2 = TestingUtil.getDiscardForCache(c2);
-      d3 = TestingUtil.getDiscardForCache(c3);
+      d1 = TestingUtil.getDiscardForCache(c1.getCacheManager());
+      d2 = TestingUtil.getDiscardForCache(c2.getCacheManager());
+      d3 = TestingUtil.getDiscardForCache(c3.getCacheManager());
    }
 
    public void testNodeCrash() {

--- a/core/src/test/java/org/infinispan/statetransfer/ClusterTopologyManagerTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/ClusterTopologyManagerTest.java
@@ -10,7 +10,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -62,9 +61,9 @@ public class ClusterTopologyManagerTest extends MultipleCacheManagersTest {
       c1 = cache(0, CACHE_NAME);
       c2 = cache(1, CACHE_NAME);
       c3 = cache(2, CACHE_NAME);
-      d1 = TestingUtil.getDiscardForCache(c1);
-      d2 = TestingUtil.getDiscardForCache(c2);
-      d3 = TestingUtil.getDiscardForCache(c3);
+      d1 = TestingUtil.getDiscardForCache(c1.getCacheManager());
+      d2 = TestingUtil.getDiscardForCache(c2.getCacheManager());
+      d3 = TestingUtil.getDiscardForCache(c3.getCacheManager());
    }
 
    @Override
@@ -461,16 +460,5 @@ public class ClusterTopologyManagerTest extends MultipleCacheManagersTest {
       long endTime = System.currentTimeMillis();
       log.debugf("Recovery took %s", Util.prettyPrintTime(endTime - startTime));
       assert endTime - startTime < 30000 : "Recovery took too long: " + Util.prettyPrintTime(endTime - startTime);
-   }
-
-   public void testJoinerBecomesOnlyMember() {
-      // Keep only 2 nodes for this test
-      killMember(2, CACHE_NAME);
-      defineConfigurationOnAllManagers(OTHER_CACHE_NAME, new ConfigurationBuilder().read(manager(0).getDefaultCacheConfiguration()));
-
-      d2.setDiscardAll(true);
-      fork((Callable<Object>) () -> cache(1, OTHER_CACHE_NAME));
-      TestingUtil.blockUntilViewsReceived(30000, false, manager(1));
-      TestingUtil.waitForNoRebalance(cache(1, OTHER_CACHE_NAME));
    }
 }

--- a/core/src/test/java/org/infinispan/statetransfer/LeaveDuringStateTransferTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/LeaveDuringStateTransferTest.java
@@ -70,7 +70,7 @@ public class LeaveDuringStateTransferTest extends MultipleCacheManagersTest {
          // Block rebalance that could follow even if the previous rebalance was not completed
 
          log.debug("Isolating node " + cacheManagers.get(1));
-         TestingUtil.getDiscardForCache(cache(1)).setDiscardAll(true);
+         TestingUtil.getDiscardForCache(manager(1)).setDiscardAll(true);
          TestingUtil.blockUntilViewsReceived(60000, true, cacheManagers);
 
          log.debug("Waiting for topology update from view change");

--- a/core/src/test/java/org/infinispan/statetransfer/MergeDuringReplaceTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/MergeDuringReplaceTest.java
@@ -34,9 +34,9 @@ public class MergeDuringReplaceTest extends MultipleCacheManagersTest {
       ConfigurationBuilder defaultConfig = getDefaultClusteredCacheConfig(cacheMode, false);
       createClusteredCaches(3, defaultConfig, new TransportFlags().withFD(true).withMerge(true));
 
-      DISCARD d1 = TestingUtil.getDiscardForCache(cache(0));
-      DISCARD d2 = TestingUtil.getDiscardForCache(cache(1));
-      DISCARD d3 = TestingUtil.getDiscardForCache(cache(2));
+      DISCARD d1 = TestingUtil.getDiscardForCache(manager(0));
+      DISCARD d2 = TestingUtil.getDiscardForCache(manager(1));
+      DISCARD d3 = TestingUtil.getDiscardForCache(manager(2));
       discard = new DISCARD[]{d1, d2, d3};
    }
 

--- a/core/src/test/java/org/infinispan/statetransfer/StateTransferRestart2Test.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateTransferRestart2Test.java
@@ -79,7 +79,7 @@ public class StateTransferRestart2Test extends MultipleCacheManagersTest {
       assertEquals(numKeys, c0.entrySet().size());
       assertEquals(numKeys, c1.entrySet().size());
 
-      DISCARD d1 = TestingUtil.getDiscardForCache(c1);
+      DISCARD d1 = TestingUtil.getDiscardForCache(c1.getCacheManager());
       GlobalConfigurationBuilder gcb2 = new GlobalConfigurationBuilder();
       gcb2.transport().transport(new JGroupsTransport() {
          @Override

--- a/core/src/test/java/org/infinispan/statetransfer/StateTransferRestartTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateTransferRestartTest.java
@@ -112,7 +112,7 @@ public class StateTransferRestartTest extends MultipleCacheManagersTest {
          fork((Callable<Void>) () -> {
             log.info("KILLING the c1 cache");
             try {
-               DISCARD d3 = TestingUtil.getDiscardForCache(c1);
+               DISCARD d3 = TestingUtil.getDiscardForCache(c1.getCacheManager());
                d3.setDiscardAll(true);
                TestingUtil.killCacheManagers(manager(c1));
             } catch (Exception e) {

--- a/core/src/test/java/org/infinispan/stream/DistributedStreamIteratorTest.java
+++ b/core/src/test/java/org/infinispan/stream/DistributedStreamIteratorTest.java
@@ -399,7 +399,7 @@ public class DistributedStreamIteratorTest extends BaseClusteredStreamIteratorTe
 
       KeyPartitioner keyPartitioner = TestingUtil.extractComponent(cache0, KeyPartitioner.class);
       ConsistentHash ch = cache0.getAdvancedCache().getDistributionManager().getWriteConsistentHash();
-      Set<Integer> segmentsCache0 = ch.getSegmentsForOwner(cache0.getCacheManager().getAddress());
+      Set<Integer> segmentsCache0 = ch.getSegmentsForOwner(address(0));
 
       CacheStream<Map.Entry<Object, String>> stream = cache0.entrySet().stream();
       if (!rehashAware) stream = stream.disableRehashAware();

--- a/core/src/test/java/org/infinispan/test/TestingUtil.java
+++ b/core/src/test/java/org/infinispan/test/TestingUtil.java
@@ -1320,8 +1320,8 @@ public class TestingUtil {
       return values;
    }
 
-   public static DISCARD getDiscardForCache(Cache<?, ?> c) throws Exception {
-      JGroupsTransport jgt = (JGroupsTransport) TestingUtil.extractComponent(c, Transport.class);
+   public static DISCARD getDiscardForCache(EmbeddedCacheManager cacheManager) throws Exception {
+      JGroupsTransport jgt = (JGroupsTransport) TestingUtil.extractGlobalComponent(cacheManager, Transport.class);
       JChannel ch = jgt.getChannel();
       ProtocolStack ps = ch.getProtocolStack();
       DISCARD discard = new DISCARD();

--- a/core/src/test/java/org/infinispan/topology/AsymmetricClusterTest.java
+++ b/core/src/test/java/org/infinispan/topology/AsymmetricClusterTest.java
@@ -1,0 +1,74 @@
+package org.infinispan.topology;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.CleanupAfterMethod;
+import org.infinispan.test.fwk.TransportFlags;
+import org.jgroups.protocols.DISCARD;
+import org.testng.annotations.Test;
+
+@Test(groups = "functional", testName = "topology.AsymmetricClusterTest")
+@CleanupAfterMethod
+public class AsymmetricClusterTest extends MultipleCacheManagersTest {
+
+   public static final String CACHE_NAME = "testCache";
+   private ConfigurationBuilder localConfig;
+   private ConfigurationBuilder clusteredConfig;
+
+   DISCARD d1, d2;
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      localConfig = new ConfigurationBuilder();
+      clusteredConfig = new ConfigurationBuilder();
+      clusteredConfig.clustering().cacheMode(CacheMode.REPL_SYNC).stateTransfer().timeout(30, TimeUnit.SECONDS);
+
+      for (int i = 0; i < 2; i++) addClusterEnabledCacheManager(localConfig, new TransportFlags().withFD(true));
+
+      d1 = TestingUtil.getDiscardForCache(manager(0));
+      d2 = TestingUtil.getDiscardForCache(manager(1));
+   }
+
+   public void testCrashAndRestartOnlyMember() throws Exception {
+      testRestartOnlyMember(true);
+   }
+
+   public void testStopAndRestartOnlyMember() throws Exception {
+      testRestartOnlyMember(false);
+   }
+
+   private void testRestartOnlyMember(boolean crash) {
+      // The coordinator stays up throughout the test, but the cache only runs on node 1 and then 2
+      manager(1).defineConfiguration(CACHE_NAME, clusteredConfig.build());
+
+      manager(1).getCache(CACHE_NAME);
+
+      if (crash) {
+         d2.setDiscardAll(true);
+      }
+      manager(1).stop();
+
+      TestingUtil.blockUntilViewsReceived(30000, false, manager(0));
+
+      addClusterEnabledCacheManager(clusteredConfig, new TransportFlags().withFD(true));
+
+      manager(2).getCache(CACHE_NAME);
+   }
+
+   public void testCoordinatorCrashesDuringJoin() {
+      d2.setDiscardAll(true);
+
+      manager(1).defineConfiguration(CACHE_NAME, clusteredConfig.build());
+      fork((Callable<Object>) () -> cache(1, CACHE_NAME));
+
+      TestingUtil.blockUntilViewsReceived(30000, false, manager(0));
+      TestingUtil.blockUntilViewsReceived(30000, false, manager(1));
+
+      TestingUtil.waitForNoRebalance(cache(1, CACHE_NAME));
+   }
+}

--- a/lucene/lucene-directory/src/test/java/org/infinispan/lucene/profiling/DynamicTopologyStressTest.java
+++ b/lucene/lucene-directory/src/test/java/org/infinispan/lucene/profiling/DynamicTopologyStressTest.java
@@ -79,7 +79,7 @@ public class DynamicTopologyStressTest extends MultipleCacheManagersTest {
       for (int i = 0; i < READERS; i++) {
          readers[i] = addClusterEnabledCacheManager(cb, transportFlags);
          Cache<Object, Object> cache = readers[i].getCache();
-         discardPerNode[i] = TestingUtil.getDiscardForCache(cache);
+         discardPerNode[i] = TestingUtil.getDiscardForCache(readers[i]);
          TestingUtil.setDelayForCache(cache, 1, 1);
          TestingUtil.blockUntilViewReceived(cache, i + 1);
       }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-9465

When the last cache member leaves, the coordinator's ClusterCacheStatus
stays in state RUNNING, and the next join doesn't reinitialize the cache
topology.