### PR TITLE
ISPN-9484 Near cache invalidation should ignore created events and

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/near/NearCacheService.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/near/NearCacheService.java
@@ -10,7 +10,6 @@ import org.infinispan.client.hotrod.annotation.ClientCacheEntryRemoved;
 import org.infinispan.client.hotrod.annotation.ClientCacheFailover;
 import org.infinispan.client.hotrod.annotation.ClientListener;
 import org.infinispan.client.hotrod.configuration.NearCacheConfiguration;
-import org.infinispan.client.hotrod.event.ClientCacheEntryCreatedEvent;
 import org.infinispan.client.hotrod.event.ClientCacheEntryCustomEvent;
 import org.infinispan.client.hotrod.event.ClientCacheEntryModifiedEvent;
 import org.infinispan.client.hotrod.event.ClientCacheEntryRemovedEvent;
@@ -157,13 +156,6 @@ public class NearCacheService<K, V> implements NearCache<K, V> {
 
       private InvalidatedNearCacheListener(NearCache<K, V> cache) {
          this.cache = cache;
-      }
-
-      // TODO: Created events should not be fired by the server for near cache, see ISPN-5545
-      @ClientCacheEntryCreated
-      @SuppressWarnings("unused")
-      public void handleCreatedEvent(ClientCacheEntryCreatedEvent<K> event) {
-         invalidate(event.getKey());
       }
 
       @ClientCacheEntryModified

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientCustomEventsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientCustomEventsTest.java
@@ -72,6 +72,16 @@ public class ClientCustomEventsTest extends SingleHotRodServerTest {
       withClientListener(l, remote -> {});
    }
 
+   public void testNoConverterFactoryCustomEvents() {
+      NoConverterFactoryListener l = new NoConverterFactoryListener<>(remoteCacheManager.getCache());
+      withClientListener(l, remote -> {
+         l.expectNoEvents();
+         remote.put(1, "one");
+         // We don't get an event, since we don't have a converter and we only allow custom events
+         l.expectNoEvents();
+      });
+   }
+
    public void testParameterBasedConversion() {
       final DynamicCustomEventLogListener<Integer> l =
             new DynamicCustomEventLogListener<>(remoteCacheManager.getCache());
@@ -131,4 +141,8 @@ public class ClientCustomEventsTest extends SingleHotRodServerTest {
       public NonExistingConverterFactoryListener(RemoteCache<K, ?> r) { super(r); }
    }
 
+   @ClientListener
+   public static class NoConverterFactoryListener<K> extends CustomEventLogListener<K, Object> {
+      public NoConverterFactoryListener(RemoteCache<K, ?> r) { super(r); }
+   }
 }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/AssertsNearCache.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/AssertsNearCache.java
@@ -159,6 +159,14 @@ class AssertsNearCache<K, V> {
       return this;
    }
 
+   public AssertsNearCache<K, V> expectNearPreemptiveRemove(K key, AssertsNearCache<K, V>... affected) {
+      // Preemptive remove
+      MockRemoveEvent preemptiveRemove = pollEvent(events);
+      assertEquals(key, preemptiveRemove.key);
+      expectNoNearEvents();
+      return this;
+   }
+
    @SafeVarargs
    final AssertsNearCache<K, V> expectNearRemove(K key, AssertsNearCache<K, V>... affected) {
       expectLocalNearRemoveInClient(this, key);
@@ -187,11 +195,9 @@ class AssertsNearCache<K, V> {
    }
 
    private static <K, V> void expectLocalNearRemoveInClient(AssertsNearCache<K, V> client, K key) {
-      if (client.nearCacheMode.invalidated()) {
-         // Preemptive remove
-         MockRemoveEvent preemptiveRemove = pollEvent(client.events);
-         assertEquals(key, preemptiveRemove.key);
-      }
+      // Preemptive remove
+      MockRemoveEvent preemptiveRemove = pollEvent(client.events);
+      assertEquals(key, preemptiveRemove.key);
       // Remote event remove
       MockRemoveEvent remoteRemove = pollEvent(client.events);
       assertEquals(key, remoteRemove.key);
@@ -225,5 +231,4 @@ class AssertsNearCache<K, V> {
       assertEquals(value, get.value == null ? null : get.value.getValue());
       return get;
    }
-
 }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/ClusterInvalidatedNearCacheTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/ClusterInvalidatedNearCacheTest.java
@@ -69,7 +69,7 @@ public class ClusterInvalidatedNearCacheTest extends MultiHotRodServersTest {
    protected void expectNearCacheUpdates(AssertsNearCache<Integer, String> producer,
          Integer key, AssertsNearCache<Integer, String> consumer) {
       producer.get(key, null).expectNearGetNull(key);
-      producer.put(key, "v1").expectNearRemove(key, consumer);
+      producer.put(key, "v1").expectNearPreemptiveRemove(key, consumer);
       producer.get(key, "v1").expectNearGetNull(key).expectNearPutIfAbsent(key, "v1");
       producer.put(key, "v2").expectNearRemove(key, consumer);
       producer.get(key, "v2").expectNearGetNull(key).expectNearPutIfAbsent(key, "v2");

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/EvictInvalidatedNearCacheTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/EvictInvalidatedNearCacheTest.java
@@ -29,11 +29,11 @@ public class EvictInvalidatedNearCacheTest extends SingleHotRodServerTest {
 
    public void testEvictAfterReachingMax() {
       assertClient.expectNoNearEvents();
-      assertClient.put(1, "v1").expectNearRemove(1);
-      assertClient.put(2, "v1").expectNearRemove(2);
+      assertClient.put(1, "v1").expectNearPreemptiveRemove(1);
+      assertClient.put(2, "v1").expectNearPreemptiveRemove(2);
       assertClient.get(1, "v1").expectNearGetNull(1).expectNearPutIfAbsent(1, "v1");
       assertClient.get(2, "v1").expectNearGetNull(2).expectNearPutIfAbsent(2, "v1");
-      assertClient.put(3, "v1").expectNearRemove(3);
+      assertClient.put(3, "v1").expectNearPreemptiveRemove(3);
       assertClient.get(3, "v1").expectNearGetNull(3).expectNearPutIfAbsent(3, "v1");
       assertClient.get(2, "v1").expectNearGetValue(2, "v1");
       assertClient.get(3, "v1").expectNearGetValue(3, "v1");

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/InvalidatedFailoverNearCacheTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/InvalidatedFailoverNearCacheTest.java
@@ -55,11 +55,11 @@ public class InvalidatedFailoverNearCacheTest extends MultiHotRodServersTest {
    public void testNearCacheClearedUponFailover() {
       AssertsNearCache<Integer, String> stickyClient = createStickyAssertClient();
       try {
-         stickyClient.put(1, "v1").expectNearRemove(1, headClient(), tailClient());
+         stickyClient.put(1, "v1").expectNearPreemptiveRemove(1, headClient(), tailClient());
          stickyClient.get(1, "v1").expectNearGetNull(1).expectNearPutIfAbsent(1, "v1");
-         stickyClient.put(2, "v1").expectNearRemove(2, headClient(), tailClient());
+         stickyClient.put(2, "v1").expectNearPreemptiveRemove(2, headClient(), tailClient());
          stickyClient.get(2, "v1").expectNearGetNull(2).expectNearPutIfAbsent(2, "v1");
-         stickyClient.put(3, "v1").expectNearRemove(3, headClient(), tailClient());
+         stickyClient.put(3, "v1").expectNearPreemptiveRemove(3, headClient(), tailClient());
          stickyClient.get(3, "v1").expectNearGetNull(3).expectNearPutIfAbsent(3, "v1");
          findServerAndKill(stickyClient.manager, servers, cacheManagers);
          // The clear will be executed when the connection to the server is closed from the listener.

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/InvalidatedNearCacheTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/InvalidatedNearCacheTest.java
@@ -72,7 +72,7 @@ public class InvalidatedNearCacheTest extends SingleHotRodServerTest {
    public void testGetNearCache() {
       assertClient.expectNoNearEvents();
       assertClient.get(1, null).expectNearGetNull(1);
-      assertClient.put(1, "v1").expectNearRemove(1);
+      assertClient.put(1, "v1").expectNearPreemptiveRemove(1);
       assertClient.get(1, "v1").expectNearGetNull(1).expectNearPutIfAbsent(1, "v1");
       assertClient.get(1, "v1").expectNearGetValue(1, "v1");
       assertClient.remove(1).expectNearRemove(1);
@@ -82,7 +82,7 @@ public class InvalidatedNearCacheTest extends SingleHotRodServerTest {
    public void testGetAsyncNearCache() throws ExecutionException, InterruptedException {
       assertClient.expectNoNearEvents();
       assertClient.getAsync(1, null).expectNearGetNull(1);
-      assertClient.putAsync(1, "v1").expectNearRemove(1);
+      assertClient.putAsync(1, "v1").expectNearPreemptiveRemove(1);
       assertClient.getAsync(1, "v1").expectNearGetNull(1).expectNearPutIfAbsent(1, "v1");
       assertClient.getAsync(1, "v1").expectNearGetValue(1, "v1");
       assertClient.removeAsync(1).expectNearRemove(1);
@@ -92,7 +92,7 @@ public class InvalidatedNearCacheTest extends SingleHotRodServerTest {
    public void testGetVersionedNearCache() {
       assertClient.expectNoNearEvents();
       assertClient.getVersioned(1, null).expectNearGetNull(1);
-      assertClient.put(1, "v1").expectNearRemove(1);
+      assertClient.put(1, "v1").expectNearPreemptiveRemove(1);
       assertClient.getVersioned(1, "v1").expectNearGetNull(1).expectNearPutIfAbsent(1, "v1");
       assertClient.getVersioned(1, "v1").expectNearGetValueVersion(1, "v1");
       assertClient.remove(1).expectNearRemove(1);
@@ -102,7 +102,7 @@ public class InvalidatedNearCacheTest extends SingleHotRodServerTest {
    public void testGetWithMetadataNearCache() {
       assertClient.expectNoNearEvents();
       assertClient.getWithMetadata(1, null).expectNearGetNull(1);
-      assertClient.put(1, "v1").expectNearRemove(1);
+      assertClient.put(1, "v1").expectNearPreemptiveRemove(1);
       assertClient.getWithMetadata(1, "v1").expectNearGetNull(1).expectNearPutIfAbsent(1, "v1");
       assertClient.getWithMetadata(1, "v1").expectNearGetValueVersion(1, "v1");
       assertClient.remove(1).expectNearRemove(1);
@@ -112,7 +112,7 @@ public class InvalidatedNearCacheTest extends SingleHotRodServerTest {
    public void testGetWithMetadataAsyncNearCache() throws ExecutionException, InterruptedException {
       assertClient.expectNoNearEvents();
       assertClient.getWithMetadataAsync(1, null).expectNearGetNull(1);
-      assertClient.putAsync(1, "v1").expectNearRemove(1);
+      assertClient.putAsync(1, "v1").expectNearPreemptiveRemove(1);
       assertClient.getWithMetadataAsync(1, "v1").expectNearGetNull(1).expectNearPutIfAbsent(1, "v1");
       assertClient.getWithMetadataAsync(1, "v1").expectNearGetValueVersion(1, "v1");
       assertClient.removeAsync(1).expectNearRemove(1);
@@ -121,7 +121,7 @@ public class InvalidatedNearCacheTest extends SingleHotRodServerTest {
 
    public void testUpdateNearCache() {
       assertClient.expectNoNearEvents();
-      assertClient.put(1, "v1").expectNearRemove(1);
+      assertClient.put(1, "v1").expectNearPreemptiveRemove(1);
       assertClient.put(1, "v2").expectNearRemove(1);
       assertClient.get(1, "v2").expectNearGetNull(1).expectNearPutIfAbsent(1, "v2");
       assertClient.get(1, "v2").expectNearGetValue(1, "v2");
@@ -131,19 +131,19 @@ public class InvalidatedNearCacheTest extends SingleHotRodServerTest {
 
    public void testUpdateAsyncNearCache() throws ExecutionException, InterruptedException {
       assertClient.expectNoNearEvents();
-      assertClient.putAsync(1, "v1").expectNearRemove(1);
+      assertClient.putAsync(1, "v1").expectNearPreemptiveRemove(1);
       assertClient.putAsync(1, "v2").expectNearRemove(1);
       assertClient.getAsync(1, "v2").expectNearGetNull(1).expectNearPutIfAbsent(1, "v2");
       assertClient.getAsync(1, "v2").expectNearGetValue(1, "v2");
       assertClient.putAsync(1, "v3").expectNearRemove(1);
       assertClient.removeAsync(1).expectNearRemove(1);
-      assertClient.putAsync(1, "v4", 3, TimeUnit.MILLISECONDS).expectNearRemove(1);
-      assertClient.putAsync(1, "v5", 3, TimeUnit.MILLISECONDS, 3, TimeUnit.MILLISECONDS).expectNearRemove(1);
+      assertClient.putAsync(1, "v4", 3, TimeUnit.SECONDS).expectNearPreemptiveRemove(1);
+      assertClient.putAsync(1, "v5", 3, TimeUnit.SECONDS, 3, TimeUnit.SECONDS).expectNearRemove(1);
    }
 
    public void testGetUpdatesNearCache() {
       assertClient.expectNoNearEvents();
-      assertClient.put(1, "v1").expectNearRemove(1);
+      assertClient.put(1, "v1").expectNearPreemptiveRemove(1);
 
       final AssertsNearCache<Integer, String> newAsserts = createAssertClient();
       withRemoteCacheManager(new RemoteCacheManagerCallable(newAsserts.manager) {
@@ -157,7 +157,7 @@ public class InvalidatedNearCacheTest extends SingleHotRodServerTest {
 
    public void testGetAsyncUpdatesNearCache() throws ExecutionException, InterruptedException {
       assertClient.expectNoNearEvents();
-      assertClient.putAsync(1, "v1").expectNearRemove(1);
+      assertClient.putAsync(1, "v1").expectNearPreemptiveRemove(1);
 
       final AssertsNearCache<Integer, String> newAsserts = createAssertClient();
       withRemoteCacheManager(new RemoteCacheManagerCallable(newAsserts.manager) {

--- a/commons/src/main/java/org/infinispan/commons/marshall/Ids.java
+++ b/commons/src/main/java/org/infinispan/commons/marshall/Ids.java
@@ -201,6 +201,8 @@ public interface Ids {
    int STATS_ENVELOPE = 137;
    int BIAS_REVOCATION_RESPONSE = 138;
 
+   int KEY_VALUE_FILTER_CONVERTER_AS_CACHE_EVENT_FILTER_CONVERTER = 139;
+
    int COUNTER_CONFIGURATION = 2000; //from counter
    int COUNTER_STATE = 2001; //from counter
 }

--- a/core/src/main/java/org/infinispan/marshall/core/InternalExternalizers.java
+++ b/core/src/main/java/org/infinispan/marshall/core/InternalExternalizers.java
@@ -62,8 +62,9 @@ import org.infinispan.filter.KeyFilterAsKeyValueFilter;
 import org.infinispan.filter.KeyValueFilterAsKeyFilter;
 import org.infinispan.functional.impl.EntryViews;
 import org.infinispan.functional.impl.MetaParamsInternalMetadata;
-import org.infinispan.globalstate.ScopedState;
+import org.infinispan.functional.impl.StatsEnvelope;
 import org.infinispan.globalstate.ScopeFilter;
+import org.infinispan.globalstate.ScopedState;
 import org.infinispan.interceptors.distribution.VersionedResult;
 import org.infinispan.interceptors.distribution.VersionedResults;
 import org.infinispan.marshall.exts.CacheRpcCommandExternalizer;
@@ -90,9 +91,9 @@ import org.infinispan.notifications.cachelistener.filter.CacheEventFilterAsKeyVa
 import org.infinispan.notifications.cachelistener.filter.CacheEventFilterConverterAsKeyValueFilterConverter;
 import org.infinispan.notifications.cachelistener.filter.KeyFilterAsCacheEventFilter;
 import org.infinispan.notifications.cachelistener.filter.KeyValueFilterAsCacheEventFilter;
+import org.infinispan.notifications.cachelistener.filter.KeyValueFilterConverterAsCacheEventFilterConverter;
 import org.infinispan.partitionhandling.AvailabilityMode;
 import org.infinispan.remoting.MIMECacheEntry;
-import org.infinispan.functional.impl.StatsEnvelope;
 import org.infinispan.remoting.responses.BiasRevocationResponse;
 import org.infinispan.remoting.responses.CacheNotFoundResponse;
 import org.infinispan.remoting.responses.ExceptionResponse;
@@ -183,6 +184,7 @@ final class InternalExternalizers {
       addInternalExternalizer(new GlobalTransaction.Externalizer(), exts);
       addInternalExternalizer(new KeyFilterAsCacheEventFilter.Externalizer(), exts);
       addInternalExternalizer(new KeyFilterAsKeyValueFilter.Externalizer(), exts);
+      addInternalExternalizer(new KeyValueFilterConverterAsCacheEventFilterConverter.Externalizer(), exts);
       addInternalExternalizer(new KeyValueFilterAsCacheEventFilter.Externalizer(), exts);
       addInternalExternalizer(new KeyValueFilterAsKeyFilter.Externalizer(), exts); // TODO: Untested in core
       addInternalExternalizer(new ImmortalCacheEntry.Externalizer(), exts);

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/filter/KeyValueFilterConverterAsCacheEventFilterConverter.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/filter/KeyValueFilterConverterAsCacheEventFilterConverter.java
@@ -1,0 +1,71 @@
+package org.infinispan.notifications.cachelistener.filter;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.Collections;
+import java.util.Set;
+
+import org.infinispan.commons.marshall.AdvancedExternalizer;
+import org.infinispan.commons.marshall.Ids;
+import org.infinispan.factories.ComponentRegistry;
+import org.infinispan.factories.annotations.Inject;
+import org.infinispan.filter.KeyValueFilterConverter;
+import org.infinispan.metadata.Metadata;
+
+/**
+ * {@link CacheEventFilterConverter} that uses an underlying {@link KeyValueFilterConverter} to do the conversion and
+ * filtering. The new value and metadata are used as arguments to the underlying filter converter as it doesn't take
+ * both new and old.
+ * @author wburns
+ * @since 9.4
+ */
+public class KeyValueFilterConverterAsCacheEventFilterConverter<K, V, C> implements CacheEventFilterConverter<K, V, C> {
+   private final KeyValueFilterConverter<K, V, C> keyValueFilterConverter;
+
+   public KeyValueFilterConverterAsCacheEventFilterConverter(KeyValueFilterConverter<K, V, C> keyValueFilterConverter) {
+      this.keyValueFilterConverter = keyValueFilterConverter;
+   }
+
+   @Override
+   public C filterAndConvert(K key, V oldValue, Metadata oldMetadata, V newValue, Metadata newMetadata, EventType eventType) {
+      return keyValueFilterConverter.convert(key, newValue, newMetadata);
+   }
+
+   @Override
+   public C convert(K key, V oldValue, Metadata oldMetadata, V newValue, Metadata newMetadata, EventType eventType) {
+      return keyValueFilterConverter.convert(key, newValue, newMetadata);
+   }
+
+   @Override
+   public boolean accept(K key, V oldValue, Metadata oldMetadata, V newValue, Metadata newMetadata, EventType eventType) {
+      return keyValueFilterConverter.accept(key, newValue, newMetadata);
+   }
+
+   @Inject
+   protected void injectDependencies(ComponentRegistry cr) {
+      cr.wireDependencies(keyValueFilterConverter);
+   }
+
+   public static class Externalizer implements AdvancedExternalizer<KeyValueFilterConverterAsCacheEventFilterConverter> {
+      @Override
+      public void writeObject(ObjectOutput output, KeyValueFilterConverterAsCacheEventFilterConverter object) throws IOException {
+         output.writeObject(object.keyValueFilterConverter);
+      }
+
+      @Override
+      public KeyValueFilterConverterAsCacheEventFilterConverter readObject(ObjectInput input) throws IOException, ClassNotFoundException {
+         return new KeyValueFilterConverterAsCacheEventFilterConverter((KeyValueFilterConverter)input.readObject());
+      }
+
+      @Override
+      public Set<Class<? extends KeyValueFilterConverterAsCacheEventFilterConverter>> getTypeClasses() {
+         return Collections.singleton(KeyValueFilterConverterAsCacheEventFilterConverter.class);
+      }
+
+      @Override
+      public Integer getId() {
+         return Ids.KEY_VALUE_FILTER_CONVERTER_AS_CACHE_EVENT_FILTER_CONVERTER;
+      }
+   }
+}


### PR DESCRIPTION
should not contain values

* All listeners without filter or converter don't use value
* Near cache ignores create remote events

https://issues.jboss.org/browse/ISPN-9484