### PR TITLE
ISPN-9496 Some xsite tests hang during teardown

### DIFF
--- a/commons-test/src/main/java/org/infinispan/commons/test/RunningTestsRegistry.java
+++ b/commons-test/src/main/java/org/infinispan/commons/test/RunningTestsRegistry.java
@@ -81,7 +81,7 @@ class RunningTestsRegistry {
             }
 
             File dumpFile =
-               new File(String.format("threaddump-%1$s-%2$tY-%2$tm-%2$td-%3$s.txt", safeTestName, new Date(), pid));
+               new File(String.format("threaddump-%1$s-%2$tY-%2$tm-%2$td-%3$s.log", safeTestName, new Date(), pid));
             System.out.printf("Dumping thread stacks of process %s to %s\n", pid, dumpFile.getAbsolutePath());
             Process jstack = new ProcessBuilder()
                .command(System.getProperty("java.home") + "/../bin/jstack", pid)
@@ -122,7 +122,8 @@ class RunningTestsRegistry {
             System.out.printf("Killed processes %s\n", String.join(" ", pids));
          }
       } catch (Exception e) {
-         System.err.println("Error dumping thread stacks/interrupting threads/killing processes:" + e);
+         System.err.println("Error dumping thread stacks/interrupting threads/killing processes:");
+         e.printStackTrace(System.err);
       }
    }
 }

--- a/core/src/test/java/org/infinispan/xsite/AbstractXSiteTest.java
+++ b/core/src/test/java/org/infinispan/xsite/AbstractXSiteTest.java
@@ -227,7 +227,7 @@ public abstract class AbstractXSiteTest extends AbstractCacheTest {
       }
 
       private TransportFlags transportFlags() {
-         return new TransportFlags().withPortRange(siteIndex).withSiteName(siteName);
+         return new TransportFlags().withPortRange(siteIndex).withSiteName(siteName).withFD(true);
       }
 
       protected <K, V> List<Cache<K, V>> createClusteredCaches(int numMembersInCluster, String cacheName,


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-9496

Enable FD only in xsite tests