### PR TITLE
ISPN-9500 ConcurrentSmallIntSet.clear() does not always set size to 0

### DIFF
--- a/commons/src/main/java/org/infinispan/commons/util/ConcurrentSmallIntSet.java
+++ b/commons/src/main/java/org/infinispan/commons/util/ConcurrentSmallIntSet.java
@@ -362,11 +362,7 @@ class ConcurrentSmallIntSet implements IntSet {
    public void clear() {
       for (int i = 0; i < array.length(); ++i) {
          int oldValue = array.getAndSet(i, 0);
-         int bitsSet = 0;
-         while (oldValue > 0) {
-            bitsSet += oldValue & 1;
-            oldValue >>= 1;
-         }
+         int bitsSet = Integer.bitCount(oldValue);
          if (bitsSet != 0) {
             currentSize.addAndGet(-bitsSet);
          }
@@ -393,7 +389,7 @@ class ConcurrentSmallIntSet implements IntSet {
       for (int i = 0; i < array.length(); ++i) {
          int value = array.get(i);
          int offset = 1;
-         while (value > 0) {
+         while (value != 0) {
             if ((value & 1) == 1) {
                if (index == size) {
                   size += (size >>> 1) + 1;
@@ -401,7 +397,7 @@ class ConcurrentSmallIntSet implements IntSet {
                }
                r[index++] = (i << ADDRESS_BITS_PER_INT) + offset - 1;
             }
-            value >>= 1;
+            value >>>= 1;
             offset += 1;
          }
       }
@@ -423,11 +419,11 @@ class ConcurrentSmallIntSet implements IntSet {
       for (int i = 0; i < array.length(); ++i) {
          int value = array.get(i);
          int offset = 1;
-         while (value > 0) {
+         while (value != 0) {
             if ((value & 1) == 1) {
                action.accept((i << ADDRESS_BITS_PER_INT) + offset - 1);
             }
-            value >>= 1;
+            value >>>= 1;
             offset += 1;
          }
       }
@@ -448,14 +444,14 @@ class ConcurrentSmallIntSet implements IntSet {
       for (int i = 0; i < array.length(); ++i) {
          int value = array.get(i);
          int offset = 1;
-         while (value > 0) {
+         while (value != 0) {
             if ((value & 1) == 1) {
                int ourValue = (i << ADDRESS_BITS_PER_INT) + offset - 1;
                if (filter.test(ourValue)) {
                   modified |= remove(ourValue);
                }
             }
-            value >>= 1;
+            value >>>= 1;
             offset += 1;
          }
       }

--- a/commons/src/test/java/org/infinispan/commons/util/MutableIntSetTest.java
+++ b/commons/src/test/java/org/infinispan/commons/util/MutableIntSetTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.PrimitiveIterator;
 import java.util.Set;
@@ -29,7 +30,7 @@ public class MutableIntSetTest {
    public static Object[] data() {
       return new Object[] {
             new SmallIntSet(),
-            new ConcurrentSmallIntSet(16),
+            new ConcurrentSmallIntSet(64),
       };
    }
 
@@ -92,6 +93,14 @@ public class MutableIntSetTest {
       intSet.add(4);
       int[] array = intSet.toIntArray();
       assertArrayEquals(new int[]{1, 4}, array);
+   }
+
+   @Test
+   public void testToIntArray64() throws Exception {
+      addRange64();
+
+      int[] array = intSet.toIntArray();
+      assertArrayEquals(new RangeSet(64).toIntArray(), array);
    }
 
    @Test
@@ -301,6 +310,23 @@ public class MutableIntSetTest {
    }
 
    @Test
+   public void testClear64() {
+      addRange64();
+
+      assertEquals(64, intSet.size());
+
+      intSet.clear();
+
+      assertEquals(0, intSet.size());
+   }
+
+   public void addRange64() {
+      for (int i = 0; i < 64; i++) {
+         intSet.add(i);
+      }
+   }
+
+   @Test
    public void testIntStream() throws Exception {
       intSet.add(1);
       intSet.add(4);
@@ -380,6 +406,17 @@ public class MutableIntSetTest {
    }
 
    @Test
+   public void testForEachPrimitive64() {
+      addRange64();
+
+      Set<Integer> results = new HashSet<>();
+
+      intSet.forEach((IntConsumer) results::add);
+
+      assertEquals(new RangeSet(64), results);
+   }
+
+   @Test
    public void testForEachObject() {
       intSet.add(0);
       intSet.add(4);
@@ -398,10 +435,22 @@ public class MutableIntSetTest {
       intSet.add(4);
       intSet.add(7);
 
-      assertFalse(intSet.removeIf((int i) -> i / 10 > 0));
+      assertFalse(intSet.removeIf((int i) -> i > 10));
       assertEquals(3, intSet.size());
-      assertTrue(intSet.removeIf((int i) -> i > 3));
-      assertEquals(CollectionFactory.makeSet((Object) 1), intSet);
+      assertTrue(intSet.removeIf((int i) -> true));
+      assertEquals(0, intSet.size());
+      assertEquals(Collections.emptySet(), intSet);
+   }
+
+   @Test
+   public void testRemoveIf64() {
+      addRange64();
+
+      assertFalse(intSet.removeIf((int i) -> i > 64));
+      assertEquals(64, intSet.size());
+      assertTrue(intSet.removeIf((int i) -> true));
+      assertEquals(0, intSet.size());
+      assertEquals(Collections.emptySet(), intSet);
    }
 
    @Test


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-9500

Fix the handling of negative values in clear() and several other
methods:
* toIntArray()
* forEach(IntConsumer)
* removeIf(IntPredicate)