### PR TITLE
ISPN-9509 OffHeapConcurentMap can throw exception during shutdown

### DIFF
--- a/core/src/main/java/org/infinispan/container/impl/DefaultSegmentedDataContainer.java
+++ b/core/src/main/java/org/infinispan/container/impl/DefaultSegmentedDataContainer.java
@@ -65,7 +65,8 @@ public class DefaultSegmentedDataContainer<K, V> extends AbstractInternalDataCon
       shouldStopSegments = cache.getCacheConfiguration().clustering().cacheMode().isDistributed();
    }
 
-   @Stop(priority = 999)
+   // Priority has to be higher than the clear priority - which is currently 999
+   @Stop(priority = 9999)
    public void stop() {
       for (int i = 0; i < maps.length(); ++i) {
          stopMap(i, false);

--- a/core/src/main/java/org/infinispan/container/offheap/OffHeapDataContainer.java
+++ b/core/src/main/java/org/infinispan/container/offheap/OffHeapDataContainer.java
@@ -44,7 +44,8 @@ public class OffHeapDataContainer extends AbstractInternalDataContainer<WrappedB
       map.start();
    }
 
-   @Stop
+   // Priority has to be higher than the clear priority - which is currently 999
+   @Stop(priority = 9999)
    public void stop() {
       map.stop();
    }


### PR DESCRIPTION
* Make sure stop occurs after clear on shutdown

https://issues.jboss.org/browse/ISPN-9509