### PR TITLE
ISPN-9512 *TxPartitionAndMerge*Test tests hang during teardown

### DIFF
--- a/core/src/test/java/org/infinispan/test/fwk/TestCacheManagerFactory.java
+++ b/core/src/test/java/org/infinispan/test/fwk/TestCacheManagerFactory.java
@@ -42,8 +42,9 @@ import org.infinispan.util.logging.LogFactory;
  */
 public class TestCacheManagerFactory {
    private static final int NAMED_EXECUTORS_THREADS_NO_QUEUE = 6;
-   private static final int NAMED_EXECUTORS_THREADS_WITH_QUEUE = 4;
-   private static final int NAMED_EXECUTORS_QUEUE_SIZE = 10;
+   // Check *TxPartitionAndMerge*Test with taskset -c 1 before reducing the following 2
+   private static final int NAMED_EXECUTORS_THREADS_WITH_QUEUE = 6;
+   private static final int NAMED_EXECUTORS_QUEUE_SIZE = 20;
    private static final int NAMED_EXECUTORS_KEEP_ALIVE = 30000;
 
    private static final String MARSHALLER = LegacyKeySupportSystemProperties.getProperty(


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-9512

Restore the number of threads and queue in transport thread pool.