### PR TITLE
ISPN-9517 State transfer times out if initiated with yet to be verified suspected member and reincarnated member

### DIFF
--- a/core/src/main/java/org/infinispan/topology/ClusterTopologyManagerImpl.java
+++ b/core/src/main/java/org/infinispan/topology/ClusterTopologyManagerImpl.java
@@ -522,7 +522,7 @@ public class ClusterTopologyManagerImpl implements ClusterTopologyManager {
    }
 
    private void confirmMembersAvailable() throws Exception {
-      transport.invokeRemotely(null, HeartBeatCommand.INSTANCE, ResponseMode.SYNCHRONOUS, getGlobalTimeout(), null, DeliverOrder.NONE, false);
+      transport.invokeRemotely(null, HeartBeatCommand.INSTANCE, ResponseMode.SYNCHRONOUS_IGNORE_LEAVERS, getGlobalTimeout(), null, DeliverOrder.NONE, false);
    }
 
    /**


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-9517

JGroups upgrade contains fix for https://issues.jboss.org/browse/JGRP-2286

Please cherry-pick into 9.3.x.