### PR TITLE
[9.3.x] ISPN-7863 Ickle lexer wrongly discards letter v as whitespace ruining…

### DIFF
--- a/object-filter/src/main/antlr3/org/infinispan/objectfilter/impl/ql/parse/IckleLexer.g
+++ b/object-filter/src/main/antlr3/org/infinispan/objectfilter/impl/ql/parse/IckleLexer.g
@@ -113,7 +113,7 @@ tokens {
 package org.infinispan.objectfilter.impl.ql.parse;
 }
 
-WS: (' ' | '\t' | '\v' | '\f' | EOL)+ { $channel = HIDDEN; };
+WS: (' ' | '\t' | '\u000B' | '\f' | EOL)+ { $channel = HIDDEN; };
 
 fragment NL: ('\r' | '\n') ;
 

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/QueryDslConditionsTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/QueryDslConditionsTest.java
@@ -3059,10 +3059,12 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       QueryBuilder qb = qf.from(getModelFactory().getUserImplClass());
       FilterConditionContext fcc = qb.having("name").eq("test");
-      for (int i = 0; i < 2000; i++) {
+      for (int i = 0; i < 1024; i++) {
          fcc = fcc.and().having("name").eq("test" + i);
       }
 
+      // This query is a boolean contradiction, so our smart query engine does not really execute it,
+      // it just returns 0 results and that is fine. We just wanted to check it is parsed correctly.
       List<User> list = qb.build().list();
       assertEquals(0, list.size());
    }

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/QueryStringTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/QueryStringTest.java
@@ -399,6 +399,14 @@ public class QueryStringTest extends AbstractQueryDslTest {
       assertEquals("testing 123", list.get(0).notIndexedField);
    }
 
+   /**
+    * See <a href="https://issues.jboss.org/browse/ISPN-7863">ISPN-7863</a>
+    */
+   public void testAliasContainingLetterV() {
+      Query q = createQueryFromString("from " + getModelFactory().getTransactionTypeName() + " vvvTestAlias where vvvTestAlias.description = 'Birthday present'");
+      assertEquals(1, q.list().size());
+   }
+
    protected Query createQueryFromString(String q) {
       return getQueryFactory().create(q);
    }


### PR DESCRIPTION
… parsing of identifiers containing v

* the \v in the WS definition should stand for vertical tab but this escape char
  is not recognized and is treated like letter v instead

https://issues.jboss.org/browse/ISPN-7863