### PR TITLE
Fix security chapter disappearance

### DIFF
--- a/documentation/src/main/asciidoc/user_guide/compatibility_mode.adoc
+++ b/documentation/src/main/asciidoc/user_guide/compatibility_mode.adoc
@@ -58,3 +58,4 @@ One concrete example of this marshaller logic can be found in the link:https://g
 
 === Code examples
 The best code examples available showing compatibility in action can be found in the link:https://github.com/infinispan/infinispan/tree/master/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility[{brandname} Compatibility Mode testsuite], but more will be developed in the near future.
+

--- a/documentation/src/main/asciidoc/user_guide/endpoint_interop.adoc
+++ b/documentation/src/main/asciidoc/user_guide/endpoint_interop.adoc
@@ -1,4 +1,4 @@
-==  Embedded/Remote Interoperability[[endpoint.interop]]
+== Embedded/Remote Interoperability[[endpoint.interop]]
 
 
 {brandname} offers the possibility to store and retrieve data in a local embedded way, and also remotely thanks to multiple endpoints offered.
@@ -173,3 +173,4 @@ WARNING: Entities must be visible to the server during startup!
 === Demos
 
 Please refer to https://github.com/infinispan-demos/endpoint-interop to try out the interoperability support using the {brandname} docker image.
+


### PR DESCRIPTION
It is currently hidden inside "Endpoint interoperability"