### PR TITLE
ISPN-9556 The netty server module depends on the log4j and sun.jdk mo…

### DIFF
--- a/feature-pack/client/src/main/resources/modules/io/netty/slot/module.xml
+++ b/feature-pack/client/src/main/resources/modules/io/netty/slot/module.xml
@@ -17,5 +17,7 @@
     <dependencies>
         <module name="javax.api"/>
         <module name="org.javassist" optional="true"/>
+        <module name="org.apache.log4j"/>
+        <module name="sun.jdk"/>
     </dependencies>
 </module>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-9556