### PR TITLE
Bump console version to 9.4.0.Final

### DIFF
--- a/build-configuration/bom/pom.xml
+++ b/build-configuration/bom/pom.xml
@@ -505,7 +505,7 @@
         <versionx.org.infinispan.infinispan-js-client>${version.infinispan}</versionx.org.infinispan.infinispan-js-client>
         <versionx.org.infinispan.infinispan-license>${version.infinispan}</versionx.org.infinispan.infinispan-license>
         <versionx.org.infinispan.infinispan-lucene-directory>${version.infinispan}</versionx.org.infinispan.infinispan-lucene-directory>
-        <versionx.org.infinispan.infinispan-management-console>9.4.0.Alpha1</versionx.org.infinispan.infinispan-management-console>
+        <versionx.org.infinispan.infinispan-management-console>${version.infinispan}</versionx.org.infinispan.infinispan-management-console>
         <versionx.org.infinispan.infinispan-marshaller-kryo-bundle>${version.infinispan}</versionx.org.infinispan.infinispan-marshaller-kryo-bundle>
         <versionx.org.infinispan.infinispan-marshaller-kryo>${version.infinispan}</versionx.org.infinispan.infinispan-marshaller-kryo>
         <versionx.org.infinispan.infinispan-marshaller-protostuff-bundle>${version.infinispan}</versionx.org.infinispan.infinispan-marshaller-protostuff-bundle>


### PR DESCRIPTION
Tried and tested locally to pull the 9.4.0.Final console. Also tested that the console actually loads and works as well. This one is gtg.