### PR TITLE
ISPN-8616 DistAsyncFuncTest.testMergeFromNonOwner random failures

### DIFF
--- a/core/src/test/java/org/infinispan/distribution/DistSyncFuncTest.java
+++ b/core/src/test/java/org/infinispan/distribution/DistSyncFuncTest.java
@@ -269,12 +269,12 @@ public class DistSyncFuncTest extends BaseDistFunctionalTest<Object, String> {
       c1.getAdvancedCache().lockedStream().forEach((c, e) -> e.setValue(e.getValue() + "-changed"));
 
       for (int i = 0; i < size; i++) {
-         int offset = i;
          String key = "k" + i;
+         asyncWait(key, PutKeyValueCommand.class);
          Cache<Object, String>[] caches = getOwners(key);
          for (Cache<Object, String> cache : caches) {
-            eventuallyEquals("value" + offset + "-changed",
-                  () -> cache.getAdvancedCache().withFlags(Flag.CACHE_MODE_LOCAL).get("k" + offset));
+            assertEquals("value" + i + "-changed",
+                         cache.getAdvancedCache().withFlags(Flag.CACHE_MODE_LOCAL).get(key));
          }
       }
    }
@@ -291,12 +291,12 @@ public class DistSyncFuncTest extends BaseDistFunctionalTest<Object, String> {
       c1.getAdvancedCache().lockedStream().forEach((c, e) -> c.put(e.getKey(), e.getValue() + "-changed"));
 
       for (int i = 0; i < size; i++) {
-         int offset = i;
          String key = "k" + i;
+         asyncWait(key, PutKeyValueCommand.class);
          Cache<Object, String>[] caches = getOwners(key);
          for (Cache<Object, String> cache : caches) {
-            eventuallyEquals("value" + offset + "-changed",
-                  () -> cache.getAdvancedCache().withFlags(Flag.CACHE_MODE_LOCAL).get("k" + offset));
+            assertEquals("value" + i + "-changed",
+                  cache.getAdvancedCache().withFlags(Flag.CACHE_MODE_LOCAL).get(key));
          }
       }
    }

--- a/core/src/test/java/org/infinispan/test/ReplListener.java
+++ b/core/src/test/java/org/infinispan/test/ReplListener.java
@@ -162,11 +162,7 @@ public class ReplListener {
       }
    }
 
-   private void info(String str) {
-      log.debugf("[" + cache.getCacheManager().getAddress() + "] " + str);
-   }
-
-   private void infof(String format, Object... params) {
+   private void debugf(String format, Object... params) {
       log.debugf("[" + cache.getCacheManager().getAddress() + "] " + format, params);
    }
 
@@ -188,14 +184,14 @@ public class ReplListener {
       try {
          long remainingNanos = unit.toNanos(time);
          while (true) {
-            infof("Waiting for %d command(s)", expectedCommands.size());
+            debugf("Waiting for %d command(s)", expectedCommands.size());
             for (Iterator<VisitableCommand> itCommand = loggedCommands.iterator(); itCommand.hasNext(); ) {
                VisitableCommand command = itCommand.next();
                for (Iterator<Predicate<VisitableCommand>> itExpectation = expectedCommands.iterator();
                     itExpectation.hasNext(); ) {
                   Predicate<VisitableCommand> expectation = itExpectation.next();
                   if (expectation.test(command)) {
-                     infof("Matched command %s", command);
+                     debugf("Matched command %s", command);
                      itCommand.remove();
                      itExpectation.remove();
                      break;
@@ -259,13 +255,17 @@ public class ReplListener {
       @Override
       protected Object handleDefault(InvocationContext ctx, VisitableCommand cmd) throws Throwable {
          try {
-            // first pass up chain
+            if (!ctx.isOriginLocal() || (watchLocal && isPrimaryOwner(cmd))) {
+               debugf("Delaying command %s", cmd);
+               TestingUtil.sleepThread(5);
+            }
+            // pass up chain
             return invokeNextInterceptor(ctx, cmd);
          } finally {//make sure we do mark this command as received even in the case of exceptions(e.g. timeouts)
             if (!ctx.isOriginLocal() || (watchLocal && isPrimaryOwner(cmd))) {
                logCommand(cmd);
             } else {
-               infof("Not logging command (watchLocal=%b) %s", watchLocal, cmd);
+               debugf("Not logging command (watchLocal=%b) %s", watchLocal, cmd);
             }
          }
       }
@@ -286,7 +286,7 @@ public class ReplListener {
       private void logCommand(VisitableCommand cmd) {
          lock.lock();
          try {
-            infof("ReplListener saw command %s", cmd);
+            debugf("ReplListener saw command %s", cmd);
             loggedCommands.add(cmd);
             newCommandCondition.signalAll();
          } finally {


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-8816
https://issues.jboss.org/browse/ISPN-8298

* Wait for replication in locked stream tests
* Delay command execution to trigger random failures more often

Should fix ISPN-8298 as well, although the `ReplListener` approach still has the risk of asynchronous commands leaking from one test method to the next. I hope to have more time to switch to `ControlledRpcManager` in the future.