### PR TITLE
ISPN-8799 Limit the default number of shards in the AffinityIndexManager

### DIFF
--- a/query/src/test/java/org/infinispan/query/affinity/BaseAffinityTest.java
+++ b/query/src/test/java/org/infinispan/query/affinity/BaseAffinityTest.java
@@ -49,7 +49,7 @@ public abstract class BaseAffinityTest extends MultipleCacheManagersTest {
    private static final int DEFAULT_NUM_ENTRIES = 50;
    private static final int DEFAULT_NUM_SEGMENTS = 256;
    private static final int DEFAULT_NUM_OWNERS = 2;
-   private static final int DEFAULT_NUM_SHARDS = DEFAULT_NUM_SEGMENTS;
+   private static final int DEFAULT_NUM_SHARDS = AffinityShardIdentifierProvider.DEFAULT_NUMBER_SHARDS;
    private static final int DEFAULT_REMOTE_TIMEOUT_MINUTES = 1;
    private static final int DEFAULT_INDEXING_THREADS_PER_NODE = 3;
    private static final int DEFAULT_QUERYING_THREADS_PER_NODE = 10;


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-8799