### PR TITLE
ISPN-9588 Workaround for no JGroups view after coordinator leaving

### DIFF
--- a/commons-test/src/main/java/org/infinispan/commons/test/TestSuiteProgress.java
+++ b/commons-test/src/main/java/org/infinispan/commons/test/TestSuiteProgress.java
@@ -96,7 +96,7 @@ public class TestSuiteProgress {
          actualColor = color;
          actualReset = RESET;
       }
-      out.printf("%s[OK: %5s, KO: %5s, SKIP: %5s] %s%s%n", actualColor, succeeded.get(), failed.get(), skipped.get(), message, actualReset);
+      out.printf("%s[OK:%5s, KO:%3s, SKIP:%3s] %s%s%n", actualColor, succeeded.get(), failed.get(), skipped.get(), message, actualReset);
       if (t != null) {
          t.printStackTrace(out);
       }

--- a/core/src/test/java/org/infinispan/test/fwk/JGroupsConfigBuilder.java
+++ b/core/src/test/java/org/infinispan/test/fwk/JGroupsConfigBuilder.java
@@ -117,7 +117,8 @@ public class JGroupsConfigBuilder {
    }
 
    private static void removeMerge(JGroupsProtocolCfg jgroupsCfg) {
-      jgroupsCfg.removeProtocol(MERGE3);
+      // FIXME Dan: Workaround for ISPN-9588, uncomment once fixed
+//      jgroupsCfg.removeProtocol(MERGE3);
    }
 
    public static String getUdpConfig(String fullTestName, TransportFlags flags) {
@@ -146,8 +147,9 @@ public class JGroupsConfigBuilder {
     * protocols from the given JGroups stack.
     */
    private static void removeFailureDetection(JGroupsProtocolCfg jgroupsCfg) {
-      jgroupsCfg.removeProtocol(FD).removeProtocol(FD_SOCK).removeProtocol(FD_ALL).removeProtocol(FD_ALL2)
-            .removeProtocol(VERIFY_SUSPECT);
+      // FIXME Dan: Workaround for ISPN-9588, uncomment once fixed
+//      jgroupsCfg.removeProtocol(FD).removeProtocol(FD_SOCK).removeProtocol(FD_ALL).removeProtocol(FD_ALL2)
+//            .removeProtocol(VERIFY_SUSPECT);
    }
 
    private static void removeRelay2(JGroupsProtocolCfg jgroupsCfg) {


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-9588

This is just a workaround, please don't resolve the issue.
Since I've been exercising the long tests watcher I've made some small improvements in that area as well.