### PR TITLE
ISPN-9601 JMX cluster switching

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/package-info.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/package-info.java
@@ -136,6 +136,18 @@
  *          <td>Size of the thread pool</td>
  *       </tr>
  *       <tr>
+ *          <td><b>infinispan.client.hotrod.default_executor_factory.threadname_prefix</b></td>
+ *          <td>String</td>
+ *          <td>HotRod-client-async-pool</td>
+ *          <td>Prefix for the default executor thread names</td>
+ *       </tr>
+ *       <tr>
+ *          <td><b>infinispan.client.hotrod.default_executor_factory.threadname_suffix</b></td>
+ *          <td>String</td>
+ *          <td>(empty)</td>
+ *          <td>Suffix for the default executor thread names</td>
+ *       </tr>
+ *       <tr>
  *          <th colspan="4">Marshalling properties</th>
  *       </tr>
  *       <tr>

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/counter/operation/BaseCounterOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/counter/operation/BaseCounterOperation.java
@@ -14,6 +14,7 @@ import org.infinispan.client.hotrod.impl.transport.netty.ByteBufUtil;
 import org.infinispan.client.hotrod.impl.transport.netty.ChannelFactory;
 import org.infinispan.client.hotrod.logging.LogFactory;
 import org.infinispan.commons.logging.Log;
+import org.infinispan.commons.util.Util;
 import org.infinispan.counter.exception.CounterException;
 
 import io.netty.buffer.ByteBuf;
@@ -29,7 +30,7 @@ import io.netty.channel.ChannelHandlerContext;
 abstract class BaseCounterOperation<T> extends RetryOnFailureOperation<T> {
 
    private static final Log commonsLog = LogFactory.getLog(BaseCounterOperation.class, Log.class);
-   private static final byte[] EMPTY_CACHE_NAME = new byte[0];
+   private static final byte[] EMPTY_CACHE_NAME = Util.EMPTY_BYTE_ARRAY;
    private static final byte[] COUNTER_CACHE_NAME = RemoteCacheManager.cacheNameBytes("org.infinispan.counter");
    private final String counterName;
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/ConfigurationProperties.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/ConfigurationProperties.java
@@ -33,6 +33,8 @@ public class ConfigurationProperties {
    public static final String ASYNC_EXECUTOR_FACTORY = ICH + "async_executor_factory";
    public static final String CLIENT_INTELLIGENCE = ICH + "client_intelligence";
    public static final String DEFAULT_EXECUTOR_FACTORY_POOL_SIZE = ICH + "default_executor_factory.pool_size";
+   public static final String DEFAULT_EXECUTOR_FACTORY_THREADNAME_PREFIX = ICH + "default_executor_factory.threadname_prefix";
+   public static final String DEFAULT_EXECUTOR_FACTORY_THREADNAME_SUFFIX = ICH + "default_executor_factory.threadname_suffix";
    public static final String TCP_NO_DELAY = ICH + "tcp_no_delay";
    public static final String TCP_KEEP_ALIVE = ICH + "tcp_keep_alive";
    @Deprecated
@@ -149,6 +151,22 @@ public class ConfigurationProperties {
 
    public void setDefaultExecutorFactoryPoolSize(int poolSize) {
       props.setProperty(DEFAULT_EXECUTOR_FACTORY_POOL_SIZE, poolSize);
+   }
+
+   public String getDefaultExecutorFactoryThreadNamePrefix() {
+      return props.getProperty(DEFAULT_EXECUTOR_FACTORY_THREADNAME_PREFIX, DefaultAsyncExecutorFactory.THREAD_NAME);
+   }
+
+   public void setDefaultExecutorFactoryThreadNamePrefix(String threadNamePrefix) {
+      props.setProperty(DEFAULT_EXECUTOR_FACTORY_THREADNAME_PREFIX, threadNamePrefix);
+   }
+
+   public String getDefaultExecutorFactoryThreadNameSuffix() {
+      return props.getProperty(DEFAULT_EXECUTOR_FACTORY_THREADNAME_SUFFIX, "");
+   }
+
+   public void setDefaultExecutorFactoryThreadNameSuffix(String threadNameSuffix) {
+      props.setProperty(DEFAULT_EXECUTOR_FACTORY_THREADNAME_SUFFIX, threadNameSuffix);
    }
 
    public boolean getTcpNoDelay() {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/RemoteCacheImpl.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/RemoteCacheImpl.java
@@ -507,7 +507,7 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
 
    private byte[][] marshallParams(Object[] params) {
       if (params == null)
-         return new byte[0][];
+         return org.infinispan.commons.util.Util.EMPTY_BYTE_ARRAY_ARRAY;
 
       byte[][] marshalledParams = new byte[params.length][];
       for (int i = 0; i < marshalledParams.length; i++) {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/TopologyInfo.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/TopologyInfo.java
@@ -34,7 +34,6 @@ public final class TopologyInfo {
 
    private static final Log log = LogFactory.getLog(TopologyInfo.class, Log.class);
    private static final boolean trace = log.isTraceEnabled();
-   private static final WrappedByteArray EMPTY_BYTES = new WrappedByteArray(new byte[0]);
 
    private Map<WrappedByteArray, Collection<SocketAddress>> servers = new ConcurrentHashMap<>();
    private Map<WrappedByteArray, ConsistentHash> consistentHashes = new ConcurrentHashMap<>();
@@ -43,8 +42,8 @@ public final class TopologyInfo {
    private final ConsistentHashFactory hashFactory = new ConsistentHashFactory();
 
    public TopologyInfo(AtomicInteger topologyId, Collection<SocketAddress> initialServers, Configuration configuration) {
-      this.topologyIds.put(EMPTY_BYTES, topologyId);
-      this.servers.put(EMPTY_BYTES, initialServers);
+      this.topologyIds.put(WrappedByteArray.EMPTY_BYTES, topologyId);
+      this.servers.put(WrappedByteArray.EMPTY_BYTES, initialServers);
       this.hashFactory.init(configuration);
    }
 
@@ -63,7 +62,7 @@ public final class TopologyInfo {
    }
 
    public Collection<SocketAddress> getServers(WrappedByteArray cacheName) {
-      return servers.computeIfAbsent(cacheName, k -> servers.get(EMPTY_BYTES));
+      return servers.computeIfAbsent(cacheName, k -> servers.get(WrappedByteArray.EMPTY_BYTES));
    }
 
    public Collection<SocketAddress> getServers() {
@@ -136,7 +135,7 @@ public final class TopologyInfo {
       // here would get out of sync with balancer.
       WrappedByteArray wrappedCacheName;
       if (cacheName == null || cacheName.length == 0) {
-         wrappedCacheName = EMPTY_BYTES;
+         wrappedCacheName = WrappedByteArray.EMPTY_BYTES;
       } else {
          wrappedCacheName = new WrappedByteArray(cacheName);
       }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/async/DefaultAsyncExecutorFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/async/DefaultAsyncExecutorFactory.java
@@ -14,7 +14,8 @@ import org.infinispan.client.hotrod.logging.LogFactory;
 import org.infinispan.commons.executors.ExecutorFactory;
 
 /**
- * Default implementation for {@link org.infinispan.commons.executors.ExecutorFactory} based on an {@link ThreadPoolExecutor}.
+ * Default implementation for {@link org.infinispan.commons.executors.ExecutorFactory} based on an {@link
+ * ThreadPoolExecutor}.
  *
  * @author Mircea.Markus@jboss.com
  * @since 4.1
@@ -27,17 +28,19 @@ public class DefaultAsyncExecutorFactory implements ExecutorFactory {
    @Override
    public ThreadPoolExecutor getExecutor(Properties p) {
       ConfigurationProperties cp = new ConfigurationProperties(p);
-       ThreadFactory tf = r -> {
-           Thread th = new Thread(r, THREAD_NAME + "-" + counter.getAndIncrement());
-           th.setDaemon(true);
-           return th;
-       };
+      final String threadNamePrefix = cp.getDefaultExecutorFactoryThreadNamePrefix();
+      final String threadNameSuffix = cp.getDefaultExecutorFactoryThreadNameSuffix();
+      ThreadFactory tf = r -> {
+         Thread th = new Thread(r, threadNamePrefix + "-" + counter.getAndIncrement() + threadNameSuffix);
+         th.setDaemon(true);
+         return th;
+      };
 
       return new ThreadPoolExecutor(cp.getDefaultExecutorFactoryPoolSize(), cp.getDefaultExecutorFactoryPoolSize(),
             0L, TimeUnit.MILLISECONDS, new SynchronousQueue<>(), tf, (r, executor) -> {
-            int poolSize = cp.getDefaultExecutorFactoryPoolSize();
-            log.cannotCreateAsyncThread(poolSize);
-            throw new RejectedExecutionException("Too few threads: " + poolSize);
-         });
+         int poolSize = cp.getDefaultExecutorFactoryPoolSize();
+         log.cannotCreateAsyncThread(poolSize);
+         throw new RejectedExecutionException("Too few threads: " + poolSize);
+      });
    }
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/ChannelFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/ChannelFactory.java
@@ -48,6 +48,7 @@ import org.infinispan.client.hotrod.logging.LogFactory;
 import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.commons.marshall.WrappedByteArray;
 import org.infinispan.commons.util.ProcessorInfo;
+import org.infinispan.commons.util.Util;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
@@ -324,7 +325,7 @@ public class ChannelFactory {
    private void updateServers(Collection<SocketAddress> newServers) {
       lock.writeLock().lock();
       try {
-         Collection<SocketAddress> servers = updateTopologyInfo(null, newServers, true);
+         Collection<SocketAddress> servers = updateTopologyInfo(Util.EMPTY_BYTE_ARRAY, newServers, true);
          if (!servers.isEmpty()) {
             for (FailoverRequestBalancingStrategy balancer : balancers.values())
                balancer.setServers(servers);
@@ -492,7 +493,7 @@ public class ChannelFactory {
                }
             } else {
                // One successful response is enough to be able to switch to this cluster
-               log.tracef("Ping to server %s succeeded");
+               log.tracef("Ping to server %s succeeded", server);
                allFuture.complete(true);
             }
          });

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/jmx/RemoteCacheManagerMXBean.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/jmx/RemoteCacheManagerMXBean.java
@@ -11,4 +11,23 @@ public interface RemoteCacheManagerMXBean {
    int getConnectionCount();
 
    int getIdleConnectionCount();
+
+   /**
+    * Switch remote cache manager to a different cluster, previously
+    * declared via configuration. If the switch was completed successfully,
+    * this method returns {@code true}, otherwise it returns {@code false}.
+    *
+    * @param clusterName name of the cluster to which to switch to
+    * @return {@code true} if the cluster was switched, {@code false} otherwise
+    */
+   boolean switchToCluster(String clusterName);
+
+   /**
+    * Switch remote cache manager to a the default cluster, previously
+    * declared via configuration. If the switch was completed successfully,
+    * this method returns {@code true}, otherwise it returns {@code false}.
+    *
+    * @return {@code true} if the cluster was switched, {@code false} otherwise
+    */
+   boolean switchToDefaultCluster();
 }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ConsistentHashV2Test.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ConsistentHashV2Test.java
@@ -12,6 +12,7 @@ import java.util.Set;
 
 import org.infinispan.client.hotrod.impl.consistenthash.ConsistentHashV2;
 import org.infinispan.commons.hash.Hash;
+import org.infinispan.commons.util.Util;
 import org.testng.annotations.Test;
 
 /**
@@ -50,51 +51,51 @@ public class ConsistentHashV2Test {
    public void simpleTest() {
       setUp(1);
       hash.value = 0;
-      assert v1.getServer(new byte[0]).equals(a1);
+      assert v1.getServer(Util.EMPTY_BYTE_ARRAY).equals(a1);
       hash.value = 1;
-      assert v1.getServer(new byte[0]).equals(a2);
+      assert v1.getServer(Util.EMPTY_BYTE_ARRAY).equals(a2);
       hash.value = 1001;
-      assert v1.getServer(new byte[0]).equals(a3);
+      assert v1.getServer(Util.EMPTY_BYTE_ARRAY).equals(a3);
       hash.value = 2001;
-      assertEquals(v1.getServer(new byte[0]), a4);
+      assertEquals(v1.getServer(Util.EMPTY_BYTE_ARRAY), a4);
       hash.value = 3001;
-      assert v1.getServer(new byte[0]).equals(a1);
+      assert v1.getServer(Util.EMPTY_BYTE_ARRAY).equals(a1);
    }
 
    public void numOwners2Test() {
       setUp(2);
       hash.value = 0;
-      assert list(a1, a2).contains(v1.getServer(new byte[0]));
+      assert list(a1, a2).contains(v1.getServer(Util.EMPTY_BYTE_ARRAY));
 
       hash.value = 1;
-      assert list(a2, a3).contains(v1.getServer(new byte[0]));
+      assert list(a2, a3).contains(v1.getServer(Util.EMPTY_BYTE_ARRAY));
 
       hash.value = 1001;
-      assert list(a3, a4).contains(v1.getServer(new byte[0]));
+      assert list(a3, a4).contains(v1.getServer(Util.EMPTY_BYTE_ARRAY));
 
       hash.value = 2001;
-      assert list(a4, a1).contains(v1.getServer(new byte[0]));
+      assert list(a4, a1).contains(v1.getServer(Util.EMPTY_BYTE_ARRAY));
 
       hash.value = 3001;
-      assert list(a1, a2).contains(v1.getServer(new byte[0]));
+      assert list(a1, a2).contains(v1.getServer(Util.EMPTY_BYTE_ARRAY));
    }
 
    public void numOwners3Test() {
       setUp(3);
       hash.value = 0;
-      assert list(a1, a2, a3).contains(v1.getServer(new byte[0]));
+      assert list(a1, a2, a3).contains(v1.getServer(Util.EMPTY_BYTE_ARRAY));
 
       hash.value = 1;
-      assert list(a2, a3, a4).contains(v1.getServer(new byte[0]));
+      assert list(a2, a3, a4).contains(v1.getServer(Util.EMPTY_BYTE_ARRAY));
 
       hash.value = 1001;
-      assert list(a3, a4, a1).contains(v1.getServer(new byte[0]));
+      assert list(a3, a4, a1).contains(v1.getServer(Util.EMPTY_BYTE_ARRAY));
 
       hash.value = 2001;
-      assert list(a4, a1, a2).contains(v1.getServer(new byte[0]));
+      assert list(a4, a1, a2).contains(v1.getServer(Util.EMPTY_BYTE_ARRAY));
 
       hash.value = 3001;
-      assert list(a1, a2, a3).contains(v1.getServer(new byte[0]));
+      assert list(a1, a2, a3).contains(v1.getServer(Util.EMPTY_BYTE_ARRAY));
    }
 
    //now a bit more extreme...
@@ -104,19 +105,19 @@ public class ConsistentHashV2Test {
       List<InetSocketAddress> list = list(a1, a2, a3, a4);
 
       hash.value = 0;
-      assert list.contains(v1.getServer(new byte[0]));
+      assert list.contains(v1.getServer(Util.EMPTY_BYTE_ARRAY));
 
       hash.value = 1;
-      assert list.contains(v1.getServer(new byte[0]));
+      assert list.contains(v1.getServer(Util.EMPTY_BYTE_ARRAY));
 
       hash.value = 1001;
-      assert list.contains(v1.getServer(new byte[0]));
+      assert list.contains(v1.getServer(Util.EMPTY_BYTE_ARRAY));
 
       hash.value = 2001;
-      assert list.contains(v1.getServer(new byte[0]));
+      assert list.contains(v1.getServer(Util.EMPTY_BYTE_ARRAY));
 
       hash.value = 3001;
-      assert list.contains(v1.getServer(new byte[0]));
+      assert list.contains(v1.getServer(Util.EMPTY_BYTE_ARRAY));
    }
 
    private List<InetSocketAddress> list(InetSocketAddress... a) {
@@ -126,7 +127,7 @@ public class ConsistentHashV2Test {
 
    public void testCorrectHash() {
       hash.value = 1;
-      v1.getServer(new byte[0]);
+      v1.getServer(Util.EMPTY_BYTE_ARRAY);
    }
 
    public static class DummyHash implements Hash {

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HotRodClientJmxTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HotRodClientJmxTest.java
@@ -2,6 +2,8 @@ package org.infinispan.client.hotrod;
 
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killRemoteCacheManager;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
+import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.remoteCacheManagerObjectName;
+import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.remoteCacheObjectName;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNull;
@@ -17,10 +19,9 @@ import java.util.Set;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
-import org.infinispan.client.hotrod.configuration.StatisticsConfiguration;
 import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
-import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.commons.jmx.PerThreadMBeanServerLookup;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.CacheContainer;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.server.hotrod.HotRodServer;
@@ -133,16 +134,6 @@ public class HotRodClientJmxTest extends AbstractInfinispanTest {
 
       assertNull(remoteCache.streaming().get("t"));
       assertEquals(6l, mbeanServer.getAttribute(objectName, "RemoteHits"));
-   }
-
-   private static ObjectName remoteCacheManagerObjectName(RemoteCacheManager rcm) throws Exception {
-      StatisticsConfiguration cfg = rcm.getConfiguration().statistics();
-      return new ObjectName(String.format("%s:type=HotRodClient,name=%s", cfg.jmxDomain(), cfg.jmxName()));
-   }
-
-   private static ObjectName remoteCacheObjectName(RemoteCacheManager rcm, String cacheName) throws Exception {
-      StatisticsConfiguration cfg = rcm.getConfiguration().statistics();
-      return new ObjectName(String.format("%s:type=HotRodClient,name=%s,cache=%s", cfg.jmxDomain(), cfg.jmxName(), cacheName));
    }
 
 }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HotRodClientNearCacheJmxTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HotRodClientNearCacheJmxTest.java
@@ -2,6 +2,7 @@ package org.infinispan.client.hotrod;
 
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killRemoteCacheManager;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
+import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.remoteCacheObjectName;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
 import static org.testng.AssertJUnit.assertEquals;
 
@@ -11,7 +12,6 @@ import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
 import org.infinispan.client.hotrod.configuration.NearCacheMode;
-import org.infinispan.client.hotrod.configuration.StatisticsConfiguration;
 import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
 import org.infinispan.commons.jmx.PerThreadMBeanServerLookup;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
@@ -90,10 +90,4 @@ public class HotRodClientNearCacheJmxTest extends AbstractInfinispanTest {
       remoteCache[1].put("a", "b"); // cause an invalidation from the other client
       eventually(() -> ((Long)mbeanServer.getAttribute(objectName, "NearCacheInvalidations")).longValue() == 1, 1000);
    }
-
-   private static ObjectName remoteCacheObjectName(RemoteCacheManager rcm, String cacheName) throws Exception {
-      StatisticsConfiguration cfg = rcm.getConfiguration().statistics();
-      return new ObjectName(String.format("%s:type=HotRodClient,name=%s,cache=%s", cfg.jmxDomain(), cfg.jmxName(), cacheName));
-   }
-
 }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/test/HotRodClientTestingUtil.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/test/HotRodClientTestingUtil.java
@@ -12,11 +12,14 @@ import java.util.Map;
 import java.util.Random;
 import java.util.function.Consumer;
 
+import javax.management.ObjectName;
+
 import org.infinispan.Cache;
 import org.infinispan.client.hotrod.FailoverRequestBalancingStrategy;
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
+import org.infinispan.client.hotrod.configuration.StatisticsConfiguration;
 import org.infinispan.client.hotrod.event.RemoteCacheSupplier;
 import org.infinispan.client.hotrod.impl.protocol.HotRodConstants;
 import org.infinispan.client.hotrod.impl.transaction.TransactionTable;
@@ -358,6 +361,16 @@ public class HotRodClientTestingUtil {
          log.tracef("Pending Transactions in %s: %s", cacheManager, txs.keySet());
          AssertJUnit.assertEquals(0, txs.size());
       }
+   }
+
+   public static ObjectName remoteCacheManagerObjectName(RemoteCacheManager rcm) throws Exception {
+      StatisticsConfiguration cfg = rcm.getConfiguration().statistics();
+      return new ObjectName(String.format("%s:type=HotRodClient,name=%s", cfg.jmxDomain(), cfg.jmxName()));
+   }
+
+   public static ObjectName remoteCacheObjectName(RemoteCacheManager rcm, String cacheName) throws Exception {
+      StatisticsConfiguration cfg = rcm.getConfiguration().statistics();
+      return new ObjectName(String.format("%s:type=HotRodClient,name=%s,cache=%s", cfg.jmxDomain(), cfg.jmxName(), cacheName));
    }
 
 }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/xsite/SiteManualSwitchTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/xsite/SiteManualSwitchTest.java
@@ -1,18 +1,26 @@
 package org.infinispan.client.hotrod.xsite;
 
+import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.remoteCacheManagerObjectName;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNull;
 import static org.testng.AssertJUnit.assertTrue;
 
 import java.util.Optional;
 
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
+import org.infinispan.commons.jmx.PerThreadMBeanServerLookup;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
-@Test(groups = "unstable", testName = "client.hotrod.xsite.SiteManualSwitchTest",
-   description = "Disabled for random failure, tracked by ISPN-9064")
+@Test(groups = "functional", testName = "client.hotrod.xsite.SiteManualSwitchTest")
 public class SiteManualSwitchTest extends AbstractHotRodSiteFailoverTest {
+   RemoteCacheManager clientA;
+   RemoteCacheManager clientB;
 
    @Override
    protected void createSites() {
@@ -20,15 +28,19 @@ public class SiteManualSwitchTest extends AbstractHotRodSiteFailoverTest {
       addHitCountInterceptors();
    }
 
+   @AfterMethod(alwaysRun = true)
+   public void killClients() {
+      HotRodClientTestingUtil.killRemoteCacheManagers(clientA, clientB);
+   }
+
    public void testManualClusterSwitch() {
-      RemoteCacheManager clientA = client(SITE_A, Optional.of(SITE_B));
-      RemoteCacheManager clientB = client(SITE_B, Optional.empty());
+      clientA = client(SITE_A, Optional.of(SITE_B));
+      clientB = client(SITE_B, Optional.empty());
 
       RemoteCache<Integer, String> cacheA = clientA.getCache();
       RemoteCache<Integer, String> cacheB = clientB.getCache();
 
       assertNoHits();
-
       assertSingleSiteHit(SITE_A, SITE_B, () -> assertNull(cacheA.put(1, "v1")));
       assertSingleSiteHit(SITE_A, SITE_B, () -> assertEquals("v1", cacheA.get(1)));
       assertSingleSiteHit(SITE_B, SITE_A, () -> assertNull(cacheB.put(2, "v2")));
@@ -43,10 +55,40 @@ public class SiteManualSwitchTest extends AbstractHotRodSiteFailoverTest {
       assertSingleSiteHit(SITE_A, SITE_B, () -> assertEquals("v4", cacheA.get(4)));
    }
 
+   @Test(enabled = false)
+   public void testManualClusterSwitchViaJMX() throws Exception {
+      clientA = client(SITE_A, Optional.of(SITE_B));
+      clientB = client(SITE_B, Optional.empty());
+
+      MBeanServer mbeanServer = PerThreadMBeanServerLookup.getThreadMBeanServer();
+      ObjectName objectName = remoteCacheManagerObjectName(clientA);
+
+      RemoteCache<Integer, String> cacheA = clientA.getCache();
+      RemoteCache<Integer, String> cacheB = clientB.getCache();
+
+      assertNoHits();
+
+      assertSingleSiteHit(SITE_A, SITE_B, () -> assertNull(cacheA.put(1, "v1")));
+      assertSingleSiteHit(SITE_A, SITE_B, () -> assertEquals("v1", cacheA.get(1)));
+      assertSingleSiteHit(SITE_B, SITE_A, () -> assertNull(cacheB.put(2, "v2")));
+      assertSingleSiteHit(SITE_B, SITE_A, () -> assertEquals("v2", cacheB.get(2)));
+
+      Object switched = mbeanServer.invoke(objectName, "switchToCluster", new Object[]{SITE_B}, new String[]{String.class.getName()});
+      assertEquals(Boolean.TRUE, switched);
+      assertSingleSiteHit(SITE_B, SITE_A, () -> assertNull(cacheA.put(3, "v3")));
+      assertSingleSiteHit(SITE_B, SITE_A, () -> assertEquals("v3", cacheA.get(3)));
+
+      switched = mbeanServer.invoke(objectName, "switchToDefaultCluster", new Object[]{}, new String[]{});
+      assertEquals(Boolean.TRUE, switched);
+      assertSingleSiteHit(SITE_A, SITE_B, () -> assertNull(cacheA.put(4, "v4")));
+      assertSingleSiteHit(SITE_A, SITE_B, () -> assertEquals("v4", cacheA.get(4)));
+   }
+
    private void assertSingleSiteHit(String siteHit, String siteNotHit, Runnable r) {
       r.run();
       assertSiteHit(siteHit, 1);
       assertSiteNotHit(siteNotHit);
+      resetHitCounters();
    }
 
 }

--- a/commons/src/main/java/org/infinispan/commons/marshall/WrappedByteArray.java
+++ b/commons/src/main/java/org/infinispan/commons/marshall/WrappedByteArray.java
@@ -15,6 +15,7 @@ import org.infinispan.commons.util.Util;
  * @since 9.0
  */
 public class WrappedByteArray implements WrappedBytes {
+   public static final WrappedByteArray EMPTY_BYTES = new WrappedByteArray(Util.EMPTY_BYTE_ARRAY);
    private final byte[] bytes;
    private transient int hashCode;
    private transient boolean initializedHashCode;

--- a/commons/src/main/java/org/infinispan/commons/util/Util.java
+++ b/commons/src/main/java/org/infinispan/commons/util/Util.java
@@ -64,6 +64,7 @@ public final class Util {
    public static final Object[] EMPTY_OBJECT_ARRAY = new Object[0];
    public static final String[] EMPTY_STRING_ARRAY = new String[0];
    public static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
+   public static final byte[][] EMPTY_BYTE_ARRAY_ARRAY = new byte[0][];
 
    private static final Log log = LogFactory.getLog(Util.class);
 

--- a/commons/src/test/java/org/infinispan/commons/tx/XidUnitTest.java
+++ b/commons/src/test/java/org/infinispan/commons/tx/XidUnitTest.java
@@ -13,6 +13,7 @@ import javax.transaction.xa.Xid;
 
 import org.infinispan.commons.logging.Log;
 import org.infinispan.commons.logging.LogFactory;
+import org.infinispan.commons.util.Util;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -29,7 +30,7 @@ public class XidUnitTest {
       long seed = System.currentTimeMillis();
       log.infof("[testInvalidGlobalTransaction] seed: %s", seed);
       Random random = new Random(seed);
-      Xid xid = XidImpl.create(random.nextInt(), new byte[0], new byte[]{0});
+      Xid xid = XidImpl.create(random.nextInt(), Util.EMPTY_BYTE_ARRAY, new byte[]{0});
       log.debugf("Invalid XID: %s", xid);
    }
 
@@ -49,7 +50,7 @@ public class XidUnitTest {
       long seed = System.currentTimeMillis();
       log.infof("[testInvalidBranch] seed: %s", seed);
       Random random = new Random(seed);
-      Xid xid = XidImpl.create(random.nextInt(), new byte[]{0}, new byte[0]);
+      Xid xid = XidImpl.create(random.nextInt(), new byte[]{0}, Util.EMPTY_BYTE_ARRAY);
       log.debugf("Invalid XID: %s", xid);
    }
 

--- a/commons/src/test/java/org/infinispan/commons/util/MarshallUtilTest.java
+++ b/commons/src/test/java/org/infinispan/commons/util/MarshallUtilTest.java
@@ -171,7 +171,7 @@ public class MarshallUtilTest {
       Assert.assertEquals(0, io.buffer.size());
       io.reset();
 
-      byte[] array = new byte[0];
+      byte[] array = Util.EMPTY_BYTE_ARRAY;
       MarshallUtil.marshallByteArray(array, io);
       Assert.assertTrue(Arrays.equals(array, MarshallUtil.unmarshallByteArray(io)));
       Assert.assertEquals(0, io.buffer.size());

--- a/core/src/main/java/org/infinispan/container/offheap/OffHeapEntryFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/container/offheap/OffHeapEntryFactoryImpl.java
@@ -6,6 +6,7 @@ import org.infinispan.commons.CacheException;
 import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.commons.marshall.WrappedByteArray;
 import org.infinispan.commons.marshall.WrappedBytes;
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.container.impl.InternalEntryFactory;
 import org.infinispan.container.entries.ExpiryHelper;
@@ -25,7 +26,6 @@ import org.infinispan.commons.time.TimeService;
  */
 public class OffHeapEntryFactoryImpl implements OffHeapEntryFactory {
    private static final OffHeapMemory MEMORY = OffHeapMemory.INSTANCE;
-   private static final byte[] EMPTY_BYTES = new byte[0];
 
    @Inject private Marshaller marshaller;
    @Inject private OffHeapMemoryAllocator allocator;
@@ -81,7 +81,7 @@ public class OffHeapEntryFactoryImpl implements OffHeapEntryFactory {
             }
          } else {
             type = 0;
-            versionBytes = EMPTY_BYTES;
+            versionBytes = Util.EMPTY_BYTE_ARRAY;
          }
 
          long lifespan = metadata.lifespan();
@@ -269,7 +269,7 @@ public class OffHeapEntryFactoryImpl implements OffHeapEntryFactory {
       byte[] metadataBytes;
       switch (metadataType) {
          case IMMORTAL:
-            metadataBytes = EMPTY_BYTES;
+            metadataBytes = Util.EMPTY_BYTE_ARRAY;
             break;
          case MORTAL:
             metadataBytes = new byte[16];

--- a/core/src/main/java/org/infinispan/util/ByteString.java
+++ b/core/src/main/java/org/infinispan/util/ByteString.java
@@ -7,6 +7,8 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
+import org.infinispan.commons.util.Util;
+
 /**
  * A simple class which encapsulates a byte[] representation of a String using a predefined encoding (currently UTF-8).
  * This avoids repeated invocation of the expensive {@link ObjectOutput#writeUTF(String)} on marshalling
@@ -16,7 +18,7 @@ import java.util.Arrays;
  */
 public class ByteString {
    private static final Charset CHARSET = StandardCharsets.UTF_8;
-   private static final ByteString EMPTY = new ByteString(new byte[0]);
+   private static final ByteString EMPTY = new ByteString(Util.EMPTY_BYTE_ARRAY);
    private final byte[] b;
    private String s;
    private final transient int hash;

--- a/core/src/test/java/org/infinispan/statetransfer/ConcurrentStartForkChannelTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/ConcurrentStartForkChannelTest.java
@@ -8,6 +8,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import org.infinispan.Cache;
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
@@ -39,7 +40,7 @@ import org.testng.annotations.Test;
 @CleanupAfterMethod
 public class ConcurrentStartForkChannelTest extends MultipleCacheManagersTest {
 
-   public static final byte[] FORK_NOT_FOUND_BUFFER = new byte[0];
+   public static final byte[] FORK_NOT_FOUND_BUFFER = Util.EMPTY_BYTE_ARRAY;
    public static final String CACHE_NAME = "repl";
 
    @Override

--- a/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/util/CustomPaxExamRunner.java
+++ b/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/util/CustomPaxExamRunner.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 
+import org.infinispan.commons.util.Util;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.Description;
 import org.junit.runner.notification.RunListener;
@@ -39,7 +40,7 @@ public class CustomPaxExamRunner extends PaxExam {
          // Replace System.in so that KarafJavaRunner's can't steal master commands from surefire's CommandReader
          savedIn = System.in;
 
-         System.setIn(new ByteArrayInputStream(new byte[0]));
+         System.setIn(new ByteArrayInputStream(Util.EMPTY_BYTE_ARRAY));
       }
       return klass;
    }

--- a/lucene/lucene-directory/src/main/java/org/infinispan/lucene/impl/SingleChunkIndexInput.java
+++ b/lucene/lucene-directory/src/main/java/org/infinispan/lucene/impl/SingleChunkIndexInput.java
@@ -3,6 +3,7 @@ package org.infinispan.lucene.impl;
 import java.io.IOException;
 
 import org.apache.lucene.store.IndexInput;
+import org.infinispan.commons.util.Util;
 import org.infinispan.lucene.ChunkCacheKey;
 
 /**
@@ -25,7 +26,7 @@ public final class SingleChunkIndexInput extends IndexInput {
       ChunkCacheKey key = new ChunkCacheKey(iic.fileKey.getIndexName(), iic.fileKey.getFileName(), 0, iic.fileMetadata.getBufferSize(), iic.affinitySegmentId);
       byte[] b = (byte[]) iic.chunksCache.get(key);
       if (b == null) {
-         buffer = new byte[0];
+         buffer = Util.EMPTY_BYTE_ARRAY;
       }
       else {
          buffer = b;

--- a/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/IndexNode.java
+++ b/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/IndexNode.java
@@ -14,6 +14,7 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.infinispan.commons.time.TimeService;
+import org.infinispan.commons.util.Util;
 import org.infinispan.util.logging.LogFactory;
 
 /**
@@ -626,8 +627,8 @@ class IndexNode {
          } else {
             overwriteHook.setOverwritten(true, oldLeafNode.file, oldLeafNode.offset);
             if (keyParts.length <= 1) {
-               newPrefix = new byte[0];
-               newKeyParts = new byte[0][];
+               newPrefix = Util.EMPTY_BYTE_ARRAY;
+               newKeyParts = Util.EMPTY_BYTE_ARRAY_ARRAY;
             } else {
                newPrefix = prefix;
                newKeyParts = new byte[keyParts.length - 1][];
@@ -758,7 +759,7 @@ class IndexNode {
       } else {
          System.arraycopy(keyParts, childFrom, newKeyParts, 0, childTo - childFrom);
       }
-      byte[] newPrefix = childFrom == childTo ? new byte[0] : concat(prefix, newPrefixExtension);
+      byte[] newPrefix = childFrom == childTo ? Util.EMPTY_BYTE_ARRAY : concat(prefix, newPrefixExtension);
       if (innerNodes != null) {
          InnerNode[] newInnerNodes = new InnerNode[childTo - childFrom + 1];
          System.arraycopy(innerNodes, childFrom, newInnerNodes, 0, childTo - childFrom + 1);
@@ -798,7 +799,7 @@ class IndexNode {
    }
 
    private static byte[] substring(byte[] key, int begin, int end) {
-      if (end <= begin) return new byte[0];
+      if (end <= begin) return Util.EMPTY_BYTE_ARRAY;
       byte[] sub = new byte[end - begin];
       System.arraycopy(key, begin, sub, 0, end - begin);
       return sub;
@@ -874,11 +875,11 @@ class IndexNode {
    }
 
    public static IndexNode emptyWithLeaves(Index.Segment segment) {
-      return new IndexNode(segment, new byte[0], new byte[0][], LeafNode.EMPTY_ARRAY);
+      return new IndexNode(segment, Util.EMPTY_BYTE_ARRAY, Util.EMPTY_BYTE_ARRAY_ARRAY, LeafNode.EMPTY_ARRAY);
    }
 
    private static IndexNode emptyWithInnerNodes(Index.Segment segment) {
-      return new IndexNode(segment, new byte[0], new byte[0][], new InnerNode[]{ new InnerNode(-1L, (short) -1) });
+      return new IndexNode(segment, Util.EMPTY_BYTE_ARRAY, Util.EMPTY_BYTE_ARRAY_ARRAY, new InnerNode[]{ new InnerNode(-1L, (short) -1) });
    }
 
    public static class OverwriteHook {

--- a/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/SoftIndexFileStore.java
+++ b/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/SoftIndexFileStore.java
@@ -14,6 +14,7 @@ import org.infinispan.commons.marshall.StreamingMarshaller;
 import org.infinispan.commons.persistence.Store;
 import org.infinispan.commons.util.AbstractIterator;
 import org.infinispan.commons.util.CloseableIterator;
+import org.infinispan.commons.util.Util;
 import org.infinispan.marshall.core.MarshalledEntry;
 import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.metadata.InternalMetadata;
@@ -106,7 +107,6 @@ public class SoftIndexFileStore implements AdvancedLoadWriteStore {
 
    private static final Log log = LogFactory.getLog(SoftIndexFileStore.class, Log.class);
    private static final boolean trace = log.isTraceEnabled();
-   private static final byte[] EMPTY_BYTES = new byte[0];
 
    private SoftIndexFileStoreConfiguration configuration;
    private boolean started = false;
@@ -541,7 +541,7 @@ public class SoftIndexFileStore implements AdvancedLoadWriteStore {
                if (serializedValue != null && (filter == null || filter.test(key)) && !isSeqIdOld(seqId, key, serializedKey)) {
                   return marshalledEntryFactory.newMarshalledEntry(key,
                         // EMPTY_BYTES is used to symbolize when fetchValue is false but there was an entry
-                        serializedValue != EMPTY_BYTES ? marshaller.objectFromByteBuffer(serializedValue) : null,
+                        serializedValue != Util.EMPTY_BYTE_ARRAY ? marshaller.objectFromByteBuffer(serializedValue) : null,
                         serializedMetadata == null ? null : (InternalMetadata) marshaller.objectFromByteBuffer(serializedMetadata));
                }
                return null;
@@ -593,7 +593,7 @@ public class SoftIndexFileStore implements AdvancedLoadWriteStore {
                      } else if (fetchValue) {
                         serializedValue = EntryRecord.readValue(handle, header, innerOffset);
                      } else {
-                        serializedValue = EMPTY_BYTES;
+                        serializedValue = Util.EMPTY_BYTE_ARRAY;
                      }
                   } else {
                      offsetOrNegation = ~innerOffset;

--- a/remote-query/remote-query-client/src/test/java/org/infinispan/query/remote/client/BaseProtoStreamMarshallerTest.java
+++ b/remote-query/remote-query-client/src/test/java/org/infinispan/query/remote/client/BaseProtoStreamMarshallerTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import org.infinispan.commons.util.Util;
 import org.infinispan.protostream.ProtobufUtil;
 import org.infinispan.protostream.SerializationContext;
 import org.infinispan.protostream.config.Configuration;
@@ -31,7 +32,7 @@ public class BaseProtoStreamMarshallerTest {
       roundtrip(true);
 //      roundtrip(new Date(0));
 //      roundtrip(Instant.now());
-      roundtrip(new byte[0]);
+      roundtrip(Util.EMPTY_BYTE_ARRAY);
    }
 
    private void roundtrip(Object in) throws Exception {

--- a/server/core/src/main/java/org/infinispan/server/core/security/external/ExternalSaslServer.java
+++ b/server/core/src/main/java/org/infinispan/server/core/security/external/ExternalSaslServer.java
@@ -12,12 +12,13 @@ import javax.security.sasl.AuthorizeCallback;
 import javax.security.sasl.SaslException;
 import javax.security.sasl.SaslServer;
 
+import org.infinispan.commons.util.Util;
+
 final class ExternalSaslServer implements SaslServer {
    private final AtomicBoolean complete = new AtomicBoolean();
    private String authorizationID;
    private final Principal peerPrincipal;
    private final CallbackHandler callbackHandler;
-   private static final byte[] EMPTY = new byte[0];
 
    ExternalSaslServer(final CallbackHandler callbackHandler, final Principal peerPrincipal) {
       this.callbackHandler = callbackHandler;
@@ -49,7 +50,7 @@ final class ExternalSaslServer implements SaslServer {
          throw new SaslException("EXTERNAL: " + peerPrincipal.getName() + " is not authorized to act as " + userName);
       }
 
-      return EMPTY;
+      return Util.EMPTY_BYTE_ARRAY;
    }
 
    private static void handleCallback(CallbackHandler handler, Callback callback) throws SaslException {

--- a/server/core/src/main/java/org/infinispan/server/core/transport/ExtendedByteBuf.java
+++ b/server/core/src/main/java/org/infinispan/server/core/transport/ExtendedByteBuf.java
@@ -1,5 +1,7 @@
 package org.infinispan.server.core.transport;
 
+import org.infinispan.commons.util.Util;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.util.CharsetUtil;
@@ -45,7 +47,7 @@ public class ExtendedByteBuf {
          bf.readBytes(array);
          return array;
       } else {
-         return new byte[0];
+         return Util.EMPTY_BYTE_ARRAY;
       }
    }
 

--- a/server/core/src/test/java/org/infinispan/server/core/dataconversion/JsonTranscoderTest.java
+++ b/server/core/src/test/java/org/infinispan/server/core/dataconversion/JsonTranscoderTest.java
@@ -17,6 +17,7 @@ import java.util.Collections;
 
 import org.infinispan.commons.configuration.ClassWhiteList;
 import org.infinispan.commons.dataconversion.MediaType;
+import org.infinispan.commons.util.Util;
 import org.infinispan.test.data.Address;
 import org.infinispan.test.data.Person;
 import org.infinispan.test.dataconversion.AbstractTranscoderTest;
@@ -62,7 +63,7 @@ public class JsonTranscoderTest extends AbstractTranscoderTest {
 
    @Test
    public void testEmptyContent() {
-      byte[] empty = new byte[0];
+      byte[] empty = Util.EMPTY_BYTE_ARRAY;
       assertArrayEquals(empty, (byte[]) transcoder.transcode(empty, APPLICATION_JSON, APPLICATION_JSON.withCharset(US_ASCII)));
       assertArrayEquals(empty, (byte[]) transcoder.transcode(empty, APPLICATION_UNKNOWN, APPLICATION_JSON));
       assertArrayEquals(empty, (byte[]) transcoder.transcode(empty, APPLICATION_OCTET_STREAM, APPLICATION_JSON));

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/HotRodServer.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/HotRodServer.java
@@ -45,6 +45,7 @@ import org.infinispan.commons.marshall.WrappedByteArray;
 import org.infinispan.commons.util.CollectionFactory;
 import org.infinispan.commons.util.SaslUtils;
 import org.infinispan.commons.util.ServiceFinder;
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
@@ -194,7 +195,7 @@ public class HotRodServer extends AbstractProtocolServer<HotRodServerConfigurati
 
       public static ToEmptyBytesKeyValueFilterConverter INSTANCE = new ToEmptyBytesKeyValueFilterConverter();
 
-      static final byte[] bytes = new byte[0];
+      static final byte[] bytes = Util.EMPTY_BYTE_ARRAY;
 
       @Override
       public Object filterAndConvert(Object key, Object value, Metadata metadata) {

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/iteration/DefaultIterationManager.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/iteration/DefaultIterationManager.java
@@ -121,7 +121,7 @@ public class DefaultIterationManager implements IterationManager {
          filteredStream = stream.segmentCompletionListener(segmentListener);
       } else {
          KeyValueFilterConverterFactory factory = getFactory(filterConverterFactory);
-         KeyValuePair<KeyValueFilterConverter, Boolean> filter = buildFilter(factory, filterConverterParams.toArray(new byte[0][]), unmarshaller);
+         KeyValuePair<KeyValueFilterConverter, Boolean> filter = buildFilter(factory, filterConverterParams.toArray(Util.EMPTY_BYTE_ARRAY_ARRAY), unmarshaller);
          KeyValueFilterConverter customFilter = filter.getKey();
          MediaType filterMediaType = customFilter.format();
 

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/transport/ExtendedByteBuf.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/transport/ExtendedByteBuf.java
@@ -49,7 +49,7 @@ public class ExtendedByteBuf {
          bf.readBytes(array);
          return array;
       } else {
-         return new byte[0];
+         return Util.EMPTY_BYTE_ARRAY;
       }
    }
 

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/test/HotRodClient.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/test/HotRodClient.java
@@ -255,7 +255,7 @@ public class HotRodClient {
    }
 
    public TestResponse removeIfUnmodified(byte[] k, long dataVersion, int flags) {
-      return execute(0xA0, (byte) 0x0D, defaultCacheName, k, 0, 0, new byte[0], dataVersion, flags);
+      return execute(0xA0, (byte) 0x0D, defaultCacheName, k, 0, 0, Util.EMPTY_BYTE_ARRAY, dataVersion, flags);
    }
 
    public TestResponse execute(int magic, byte code, String name, byte[] k, int lifespan, int maxIdle,
@@ -404,7 +404,7 @@ public class HotRodClient {
    }
 
    public TestAuthResponse auth(SaslClient sc) throws SaslException {
-      byte[] saslResponse = sc.hasInitialResponse() ? sc.evaluateChallenge(new byte[0]) : new byte[0];
+      byte[] saslResponse = sc.hasInitialResponse() ? sc.evaluateChallenge(Util.EMPTY_BYTE_ARRAY) : Util.EMPTY_BYTE_ARRAY;
       ClientHandler handler = (ClientHandler) ch.pipeline().last();
       AuthOp op = new AuthOp(0xA0, protocolVersion, (byte) 0x23, defaultCacheName, (byte) 1, 0, sc.getMechanismName(), saslResponse);
       writeOp(op);
@@ -584,7 +584,7 @@ class Encoder extends MessageToByteEncoder<Object> {
             return;
          }
          if (protocolVersion < 20)
-            writeRangedBytes(new byte[0], buffer); // transaction id
+            writeRangedBytes(Util.EMPTY_BYTE_ARRAY, buffer); // transaction id
          if (op.code != 0x13 && op.code != 0x15
                && op.code != 0x17 && op.code != 0x19
                && op.code != 0x1D && op.code != 0x1F

--- a/server/memcached/src/main/java/org/infinispan/server/memcached/MemcachedDecoder.java
+++ b/server/memcached/src/main/java/org/infinispan/server/memcached/MemcachedDecoder.java
@@ -55,6 +55,7 @@ import org.infinispan.Version;
 import org.infinispan.commons.CacheException;
 import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.commons.logging.LogFactory;
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.container.versioning.EntryVersion;
@@ -257,7 +258,7 @@ public class MemcachedDecoder extends ReplayingDecoder<MemcachedDecoderState> {
          rawValue = new byte[params.valueLength];
          checkpoint(MemcachedDecoderState.DECODE_VALUE);
       } else if (params.valueLength == 0) {
-         rawValue = new byte[0];
+         rawValue = Util.EMPTY_BYTE_ARRAY;
          decodeValue(ctx, buffer, state);
       } else {
          decodeValue(ctx, buffer, state);


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-9601
https://issues.jboss.org/browse/ISPN-9602

Introduces thread name prefix/suffix for the client async pool.

Let's see if https://issues.jboss.org/browse/ISPN-9064 is also resolved