### PR TITLE
ISPN-8320 Javadoc comments contain malformed HTML

### DIFF
--- a/cdi/common/src/main/java/org/infinispan/cdi/common/util/AbstractImmutableBean.java
+++ b/cdi/common/src/main/java/org/infinispan/cdi/common/util/AbstractImmutableBean.java
@@ -21,7 +21,7 @@ import org.infinispan.commons.logging.LogFactory;
  * collections are defensively copied on instantiation. It uses the defaults
  * from the specification for properties if not specified.
  * </p>
- * <p/>
+ * <p>
  * <p>
  * This class does not provide any bean lifecycle operations
  * </p>

--- a/cdi/common/src/main/java/org/infinispan/cdi/common/util/Annotateds.java
+++ b/cdi/common/src/main/java/org/infinispan/cdi/common/util/Annotateds.java
@@ -21,16 +21,12 @@ import javax.enterprise.inject.spi.AnnotatedParameter;
 import javax.enterprise.inject.spi.AnnotatedType;
 
 /**
- * <p>
  * Utilities for working with {@link Annotated}s.
- * </p>
- * <p/>
  * <p>
  * Includes utilities to check the equality of and create unique id's for
  * <code>Annotated</code> instances.
- * </p>
  *
- * @author Stuart Douglas <stuart@baileyroberts.com.au>
+ * @author Stuart Douglas &lt;stuart@baileyroberts.com.au&gt;
  */
 public class Annotateds {
 
@@ -150,7 +146,7 @@ public class Annotateds {
      * Generates a deterministic signature for an {@link AnnotatedType}. Two
      * <code>AnnotatedType</code>s that have the same annotations and underlying
      * type will generate the same signature.
-     * <p/>
+     * <p>
      * This can be used to create a unique bean id for a passivation capable bean
      * that is added directly through the SPI.
      *

--- a/cdi/common/src/main/java/org/infinispan/cdi/common/util/BeanBuilder.java
+++ b/cdi/common/src/main/java/org/infinispan/cdi/common/util/BeanBuilder.java
@@ -22,13 +22,13 @@ import javax.inject.Named;
  * {@link PassivationCapable} beans, using
  * {@link Annotateds#createTypeId(AnnotatedType)} to generate the id.
  * </p>
- * <p/>
+ * <p>
  * <p>
  * The builder can read from an {@link AnnotatedType} and have any attribute
  * modified. This class is not thread-safe, but the bean created by calling
  * {@link #create()} is.
  * </p>
- * <p/>
+ * <p>
  * <p>
  * It is advised that a new bean builder is instantiated for each bean created.
  * </p>
@@ -73,12 +73,12 @@ public class BeanBuilder<T> {
      * Read the {@link AnnotatedType}, creating a bean from the class and it's
      * annotations.
      * </p>
-     * <p/>
+     * <p>
      * <p>
      * By default the bean lifecycle will wrap the result of calling
      * {@link BeanManager#createInjectionTarget(AnnotatedType)}.
      * </p>
-     * <p/>
+     * <p>
      * <p>
      * {@link BeanBuilder} does <em>not</em> support reading members of the class
      * to create producers or observer methods.

--- a/cdi/common/src/main/java/org/infinispan/cdi/common/util/BeanManagerProvider.java
+++ b/cdi/common/src/main/java/org/infinispan/cdi/common/util/BeanManagerProvider.java
@@ -23,10 +23,10 @@ import javax.naming.NamingException;
  * <p>This is really handy if you like to access CDI functionality
  * from places where no injection is available.</p>
  * <p>If a simple but manual bean-lookup is needed, it's easier to use the {@link BeanProvider}.</p>
- * <p/>
+ * <p>
  * <p>As soon as an application shuts down, the reference to the {@link BeanManager} will be removed.<p>
- * <p/>
- * <p>Usage:<p/>
+ * <p>
+ * <p>Usage:</p>
  * <pre>
  * BeanManager bm = BeanManagerProvider.getInstance().getBeanManager();
  *

--- a/cdi/common/src/main/java/org/infinispan/cdi/common/util/Contracts.java
+++ b/cdi/common/src/main/java/org/infinispan/cdi/common/util/Contracts.java
@@ -3,7 +3,7 @@ package org.infinispan.cdi.common.util;
 /**
  * An helper class providing useful assertion methods.
  *
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 public final class Contracts {
    /**

--- a/cdi/common/src/main/java/org/infinispan/cdi/common/util/ImmutableBean.java
+++ b/cdi/common/src/main/java/org/infinispan/cdi/common/util/ImmutableBean.java
@@ -16,7 +16,7 @@ import javax.enterprise.inject.spi.InjectionPoint;
  * collections are defensively copied on instantiation. It uses the defaults
  * from the specification for properties if not specified.
  * </p>
- * <p/>
+ * <p>
  * <p>
  * This bean delegates it's lifecycle to the callbacks on the provided
  * {@link ContextualLifecycle}.

--- a/cdi/common/src/main/java/org/infinispan/cdi/common/util/ImmutablePassivationCapableBean.java
+++ b/cdi/common/src/main/java/org/infinispan/cdi/common/util/ImmutablePassivationCapableBean.java
@@ -15,7 +15,7 @@ import javax.enterprise.inject.spi.PassivationCapable;
  * instantiation. It uses the defaults from the specification for properties if
  * not specified.
  * </p>
- * <p/>
+ * <p>
  * <p>
  * This bean delegates it's lifecycle to the callbacks on the provided
  * {@link ContextualLifecycle}.

--- a/cdi/common/src/main/java/org/infinispan/cdi/common/util/InjectableMethod.java
+++ b/cdi/common/src/main/java/org/infinispan/cdi/common/util/InjectableMethod.java
@@ -15,7 +15,7 @@ import javax.enterprise.inject.spi.InjectionPoint;
  * Allows an {@link AnnotatedMethod} to be injected using the CDI type safe
  * resolution rules.
  * </p>
- * <p/>
+ * <p>
  * <p>
  * {@link ParameterValueRedefiner} allows the default value to be overridden by
  * the caller of

--- a/cdi/common/src/main/java/org/infinispan/cdi/common/util/Reflections.java
+++ b/cdi/common/src/main/java/org/infinispan/cdi/common/util/Reflections.java
@@ -48,7 +48,7 @@ public class Reflections {
      * Perform a runtime cast. Similar to {@link Class#cast(Object)}, but useful
      * when you do not have a {@link Class} object for type you wish to cast to.
      * </p>
-     * <p/>
+     * <p>
      * <p>
      * {@link Class#cast(Object)} should be used if possible
      * </p>
@@ -109,13 +109,13 @@ public class Reflections {
      * Invoke the specified method on the provided instance, passing any additional
      * arguments included in this method as arguments to the specified method.
      * </p>
-     * <p/>
+     * <p>
      * <p>
      * This method attempts to set the accessible flag of the method in a
      * {@link PrivilegedAction} before invoking the method if the first argument
      * is true.
      * </p>
-     * <p/>
+     * <p>
      * <p>This method provides the same functionality and throws the same exceptions as
      * {@link Reflections#invokeMethod(boolean, Method, Class, Object, Object...)}, with the
      * expected return type set to {@link Object}.</p>
@@ -132,7 +132,7 @@ public class Reflections {
      * Invoke the specified method on the provided instance, passing any additional
      * arguments included in this method as arguments to the specified method.
      * </p>
-     * <p/>
+     * <p>
      * <p>This method provides the same functionality and throws the same exceptions as
      * {@link Reflections#invokeMethod(boolean, Method, Class, Object, Object...)}, with the
      * expected return type set to {@link Object} and honoring the accessibility of
@@ -150,13 +150,13 @@ public class Reflections {
      * Invoke the method on the instance, with any arguments specified, casting
      * the result of invoking the method to the expected return type.
      * </p>
-     * <p/>
+     * <p>
      * <p>
      * This method wraps {@link Method#invoke(Object, Object...)}, converting the
      * checked exceptions that {@link Method#invoke(Object, Object...)} specifies
      * to runtime exceptions.
      * </p>
-     * <p/>
+     * <p>
      * <p>
      * If instructed, this method attempts to set the accessible flag of the method in a
      * {@link PrivilegedAction} before invoking the method.
@@ -222,7 +222,7 @@ public class Reflections {
      * Get the value of the field, on the specified instance, casting the value
      * of the field to the expected type.
      * </p>
-     * <p/>
+     * <p>
      * <p>
      * This method wraps {@link Field#get(Object)}, converting the checked
      * exceptions that {@link Field#get(Object)} specifies to runtime exceptions.

--- a/cdi/common/src/main/java/org/infinispan/cdi/common/util/Synthetic.java
+++ b/cdi/common/src/main/java/org/infinispan/cdi/common/util/Synthetic.java
@@ -10,14 +10,10 @@ import javax.enterprise.util.AnnotationLiteral;
 import javax.inject.Qualifier;
 
 /**
- * <p>
  * A synthetic qualifier that can be used to replace other user-supplied
  * configuration at deployment.
- * </p>
- * <p/>
- * <p/>
  *
- * @author Stuart Douglas <stuart@baileyroberts.com.au>
+ * @author Stuart Douglas &lt;stuart@baileyroberts.com.au&gt;
  * @author Pete Muir
  */
 @Retention(RetentionPolicy.RUNTIME)
@@ -50,13 +46,9 @@ public @interface Synthetic {
     }
 
     /**
-     * <p>
-     * Provides a unique Synthetic qualifier for the specified namespace
-     * </p>
-     * <p/>
+     * Provides a unique Synthetic qualifier for the specified namespace.
      * <p>
      * {@link Provider} is thread safe.
-     * </p>
      *
      * @author Pete Muir
      */

--- a/cdi/common/src/main/java/org/infinispan/cdi/common/util/annotatedtypebuilder/AnnotatedTypeBuilder.java
+++ b/cdi/common/src/main/java/org/infinispan/cdi/common/util/annotatedtypebuilder/AnnotatedTypeBuilder.java
@@ -22,7 +22,7 @@ import org.infinispan.commons.logging.LogFactory;
 
 /**
  * <p> Class for constructing a new AnnotatedType. A new instance of builder
- * should be used for each annotated type. </p> <p/> <p> {@link
+ * should be used for each annotated type. </p> <p> <p> {@link
  * AnnotatedTypeBuilder} is not thread-safe. </p>
  *
  * @author Stuart Douglas

--- a/cdi/common/src/main/java/org/infinispan/cdi/common/util/annotatedtypebuilder/AnnotatedTypeImpl.java
+++ b/cdi/common/src/main/java/org/infinispan/cdi/common/util/annotatedtypebuilder/AnnotatedTypeImpl.java
@@ -32,7 +32,7 @@ class AnnotatedTypeImpl<X> extends AnnotatedImpl implements AnnotatedType<X> {
    /**
     * We make sure that there is a NewAnnotatedMember for every public
     * method/field/constructor
-    * <p/>
+    * <p>
     * If annotation have been added to other methods as well we add them to
     */
    AnnotatedTypeImpl(Class<X> clazz, AnnotationStore typeAnnotations, Map<Field, AnnotationStore> fieldAnnotations, Map<Method, AnnotationStore> methodAnnotations, Map<Method, Map<Integer, AnnotationStore>> methodParameterAnnotations, Map<Constructor<?>, AnnotationStore> constructorAnnotations, Map<Constructor<?>, Map<Integer, AnnotationStore>> constructorParameterAnnotations, Map<Field, Type> fieldTypes, Map<Method, Map<Integer, Type>> methodParameterTypes, Map<Constructor<?>, Map<Integer, Type>> constructorParameterTypes) {

--- a/cdi/common/src/main/java/org/infinispan/cdi/common/util/logging/Log.java
+++ b/cdi/common/src/main/java/org/infinispan/cdi/common/util/logging/Log.java
@@ -11,7 +11,7 @@ import org.jboss.logging.annotations.MessageLogger;
  * The JBoss Logging interface which defined the logging methods for the CDI integration. The id range for the CDI
  * integration is 17001-18000
  *
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 @MessageLogger(projectCode = "ISPN")
 public interface Log extends BasicLogger {

--- a/cdi/embedded/src/main/java/org/infinispan/cdi/embedded/AdvancedCacheProducer.java
+++ b/cdi/embedded/src/main/java/org/infinispan/cdi/embedded/AdvancedCacheProducer.java
@@ -23,7 +23,7 @@ import org.infinispan.manager.EmbeddedCacheManager;
  * mechanism provided by Seam Solder.
  *
  * @author Pete Muir
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 @ApplicationScoped
 public class AdvancedCacheProducer {

--- a/cdi/embedded/src/main/java/org/infinispan/cdi/embedded/ConfigureCache.java
+++ b/cdi/embedded/src/main/java/org/infinispan/cdi/embedded/ConfigureCache.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
  * This annotation is used to define a cache {@link Configuration}.
  *
  * @author Pete Muir
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 @Retention(RUNTIME)
 @Target({METHOD, FIELD, PARAMETER, TYPE})

--- a/cdi/embedded/src/main/java/org/infinispan/cdi/embedded/InfinispanExtensionEmbedded.java
+++ b/cdi/embedded/src/main/java/org/infinispan/cdi/embedded/InfinispanExtensionEmbedded.java
@@ -43,7 +43,7 @@ import org.infinispan.manager.EmbeddedCacheManager;
  * The Infinispan CDI extension for embedded caches
  *
  * @author Pete Muir
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 public class InfinispanExtensionEmbedded implements Extension {
 

--- a/cdi/embedded/src/main/java/org/infinispan/cdi/embedded/util/logging/EmbeddedLog.java
+++ b/cdi/embedded/src/main/java/org/infinispan/cdi/embedded/util/logging/EmbeddedLog.java
@@ -12,7 +12,7 @@ import org.jboss.logging.annotations.MessageLogger;
  * The JBoss Logging interface which defined the logging methods for the CDI integration. The id range for the CDI
  * integration is 17001-18000
  *
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 @MessageLogger(projectCode = "ISPN")
 public interface EmbeddedLog extends BasicLogger {

--- a/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cache/DefaultCacheTest.java
+++ b/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cache/DefaultCacheTest.java
@@ -18,7 +18,7 @@ import org.testng.annotations.Test;
  * Tests that the default cache is available and can be injected with no configuration.
  *
  * @author Pete Muir
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 @Test(groups = {"functional", "smoke"}, testName = "cdi.test.cache.embedded.DefaultCacheTest")
 public class DefaultCacheTest extends Arquillian {

--- a/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cache/configured/Config.java
+++ b/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cache/configured/Config.java
@@ -7,7 +7,7 @@ import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 
 /**
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 public class Config {
    /**

--- a/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cache/configured/ConfiguredCacheTest.java
+++ b/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cache/configured/ConfiguredCacheTest.java
@@ -16,7 +16,7 @@ import org.testng.annotations.Test;
  * Tests that the simple form of configuration works.
  *
  * @author Pete Muir
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  * @see Config
  */
 @Test(groups = {"functional", "smoke"}, testName = "cdi.test.cache.embedded.configured.ConfiguredCacheTest")

--- a/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cache/configured/Small.java
+++ b/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cache/configured/Small.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
 import javax.inject.Qualifier;
 
 /**
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 @Qualifier
 @Target({TYPE, METHOD, PARAMETER, FIELD})

--- a/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cache/configured/Tiny.java
+++ b/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cache/configured/Tiny.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
 import javax.inject.Qualifier;
 
 /**
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 @Qualifier
 @Target({TYPE, METHOD, PARAMETER, FIELD})

--- a/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cache/specific/Config.java
+++ b/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cache/specific/Config.java
@@ -12,7 +12,7 @@ import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.TestingUtil;
 
 /**
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 public class Config {
 

--- a/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cache/specific/Large.java
+++ b/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cache/specific/Large.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
 import javax.inject.Qualifier;
 
 /**
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 @Qualifier
 @Target({TYPE, METHOD, PARAMETER, FIELD})

--- a/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cache/specific/Small.java
+++ b/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cache/specific/Small.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
 import javax.inject.Qualifier;
 
 /**
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 @Qualifier
 @Target({TYPE, METHOD, PARAMETER, FIELD})

--- a/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cache/specific/SpecificCacheManagerTest.java
+++ b/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cache/specific/SpecificCacheManagerTest.java
@@ -19,7 +19,7 @@ import org.testng.annotations.Test;
 /**
  * Tests that a specific cache manager can be used for one or more caches.
  *
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  * @see Config
  */
 @Test(groups = "functional", testName = "cdi.test.cache.embedded.specific.SpecificCacheManagerTest")

--- a/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cachemanager/DefaultConfigurationTest.java
+++ b/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cachemanager/DefaultConfigurationTest.java
@@ -20,7 +20,7 @@ import org.testng.annotations.Test;
 /**
  * Tests that the default embedded cache configuration can be overridden.
  *
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 @Test(groups = "functional", testName = "cdi.test.cachemanager.embedded.DefaultConfigurationTest")
 public class DefaultConfigurationTest extends Arquillian {

--- a/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cachemanager/external/Config.java
+++ b/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cachemanager/external/Config.java
@@ -15,7 +15,7 @@ import org.infinispan.test.fwk.TestCacheManagerFactory;
  * Creates a number of caches, based on some external mechanism.
  *
  * @author Pete Muir
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 public class Config {
    /**

--- a/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cachemanager/programmatic/Config.java
+++ b/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cachemanager/programmatic/Config.java
@@ -16,7 +16,7 @@ import org.infinispan.test.fwk.TestCacheManagerFactory;
  * Creates a cache, based on some external mechanism.
  *
  * @author Pete Muir
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 public class Config {
 

--- a/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cachemanager/registration/CacheRegistrationTest.java
+++ b/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cachemanager/registration/CacheRegistrationTest.java
@@ -21,7 +21,7 @@ import org.testng.annotations.Test;
 /**
  * Tests that configured caches are registered in the corresponding cache manager.
  *
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 @Listeners(TestResourceTrackingListener.class)
 @Test(groups = "functional", testName = "cdi.test.cachemanager.embedded.registration.CacheRegistrationTest")

--- a/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cachemanager/registration/Config.java
+++ b/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cachemanager/registration/Config.java
@@ -10,7 +10,7 @@ import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 
 /**
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 public class Config {
    /**

--- a/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cachemanager/registration/Large.java
+++ b/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cachemanager/registration/Large.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
 import javax.inject.Qualifier;
 
 /**
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 @Qualifier
 @Target({TYPE, METHOD, PARAMETER, FIELD})

--- a/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cachemanager/registration/Small.java
+++ b/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cachemanager/registration/Small.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
 import javax.inject.Qualifier;
 
 /**
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 @Qualifier
 @Target({TYPE, METHOD, PARAMETER, FIELD})

--- a/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cachemanager/registration/VeryLarge.java
+++ b/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cachemanager/registration/VeryLarge.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
 import javax.inject.Qualifier;
 
 /**
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 @Qualifier
 @Target({TYPE, METHOD, PARAMETER, FIELD})

--- a/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cachemanager/xml/Config.java
+++ b/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cachemanager/xml/Config.java
@@ -17,7 +17,7 @@ import org.infinispan.test.fwk.TestCacheManagerFactory;
  * Creates a number of caches, based on some external mechanism.
  *
  * @author Pete Muir
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 public class Config {
    /**

--- a/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/event/Config.java
+++ b/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/event/Config.java
@@ -9,7 +9,7 @@ import org.infinispan.configuration.cache.Configuration;
  * Configures two default caches - we will use both caches to check that events for one don't spill over to the other.
  *
  * @author Pete Muir
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 public class Config {
    /**

--- a/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/testutil/Deployments.java
+++ b/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/testutil/Deployments.java
@@ -11,7 +11,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 /**
  * Arquillian deployment utility class.
  *
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 public final class Deployments {
    /**

--- a/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/util/ContractsTest.java
+++ b/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/util/ContractsTest.java
@@ -4,7 +4,7 @@ import org.infinispan.cdi.common.util.Contracts;
 import org.testng.annotations.Test;
 
 /**
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 @Test(groups = "unit", testName = "cdi.test.util.ContractsTest")
 public class ContractsTest {

--- a/cdi/remote/src/main/java/org/infinispan/cdi/remote/Remote.java
+++ b/cdi/remote/src/main/java/org/infinispan/cdi/remote/Remote.java
@@ -16,7 +16,7 @@ import javax.inject.Qualifier;
 /**
  * Qualifier used to specify which remote cache will be injected.
  *
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 @Target({METHOD, FIELD, PARAMETER, TYPE})
 @Retention(RUNTIME)

--- a/cdi/remote/src/main/java/org/infinispan/cdi/remote/RemoteCacheProducer.java
+++ b/cdi/remote/src/main/java/org/infinispan/cdi/remote/RemoteCacheProducer.java
@@ -19,7 +19,7 @@ import org.infinispan.client.hotrod.RemoteCacheManager;
 /**
  * The {@link RemoteCache} producer.
  *
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 @ApplicationScoped
 public class RemoteCacheProducer {

--- a/cdi/remote/src/main/java/org/infinispan/cdi/remote/logging/RemoteLog.java
+++ b/cdi/remote/src/main/java/org/infinispan/cdi/remote/logging/RemoteLog.java
@@ -11,7 +11,7 @@ import org.jboss.logging.annotations.MessageLogger;
  * The JBoss Logging interface which defined the logging methods for the CDI integration. The id range for the CDI
  * integration is 17001-18000
  *
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 @MessageLogger(projectCode = "ISPN")
 public interface RemoteLog extends BasicLogger {

--- a/cdi/remote/src/test/java/org/infinispan/cdi/embedded/test/Deployments.java
+++ b/cdi/remote/src/test/java/org/infinispan/cdi/embedded/test/Deployments.java
@@ -8,7 +8,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 /**
  * Arquillian deployment utility class.
  *
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 public final class Deployments {
    /**

--- a/cdi/remote/src/test/java/org/infinispan/cdi/embedded/test/cache/remote/DefaultCacheTest.java
+++ b/cdi/remote/src/test/java/org/infinispan/cdi/embedded/test/cache/remote/DefaultCacheTest.java
@@ -29,7 +29,7 @@ import org.testng.annotations.Test;
 /**
  * Tests the default cache injection.
  *
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 @Listeners(TestResourceTrackingListener.class)
 @Test(groups = "functional", testName = "cdi.test.cache.remote.DefaultCacheTest")

--- a/cdi/remote/src/test/java/org/infinispan/cdi/embedded/test/cache/remote/NamedCacheTest.java
+++ b/cdi/remote/src/test/java/org/infinispan/cdi/embedded/test/cache/remote/NamedCacheTest.java
@@ -27,7 +27,7 @@ import org.testng.annotations.Test;
 /**
  * Tests the named cache injection.
  *
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 @Listeners(TestResourceTrackingListener.class)
 @Test(groups = {"functional", "smoke"}, testName = "cdi.test.cache.remote.NamedCacheTest")

--- a/cdi/remote/src/test/java/org/infinispan/cdi/embedded/test/cache/remote/Small.java
+++ b/cdi/remote/src/test/java/org/infinispan/cdi/embedded/test/cache/remote/Small.java
@@ -15,7 +15,7 @@ import javax.inject.Qualifier;
 import org.infinispan.cdi.remote.Remote;
 
 /**
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 @Remote("small")
 @Qualifier

--- a/cdi/remote/src/test/java/org/infinispan/cdi/embedded/test/cache/remote/SpecificCacheManagerTest.java
+++ b/cdi/remote/src/test/java/org/infinispan/cdi/embedded/test/cache/remote/SpecificCacheManagerTest.java
@@ -26,7 +26,7 @@ import org.testng.annotations.Test;
 /**
  * Tests that the use of a specific cache manager for one cache.
  *
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 @Listeners(TestResourceTrackingListener.class)
 @Test(groups = "functional", testName = "cdi.test.cache.remote.SpecificCacheManagerTest")

--- a/cdi/remote/src/test/java/org/infinispan/cdi/embedded/test/cachemanager/remote/DefaultCacheManagerOverrideTest.java
+++ b/cdi/remote/src/test/java/org/infinispan/cdi/embedded/test/cachemanager/remote/DefaultCacheManagerOverrideTest.java
@@ -18,7 +18,7 @@ import org.testng.annotations.Test;
 /**
  * Tests that the default remote cache manager can be overridden.
  *
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 @Test(groups = "functional", testName = "cdi.test.cachemanager.remote.DefaultCacheManagerOverrideTest")
 public class DefaultCacheManagerOverrideTest extends Arquillian {

--- a/cdi/remote/src/test/java/org/infinispan/cdi/embedded/test/cachemanager/remote/DefaultCacheManagerTest.java
+++ b/cdi/remote/src/test/java/org/infinispan/cdi/embedded/test/cachemanager/remote/DefaultCacheManagerTest.java
@@ -16,7 +16,7 @@ import org.testng.annotations.Test;
 /**
  * Test the default remote cache manager injection.
  *
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 @Test(groups = "functional", testName = "cdi.test.cachemanager.remote.DefaultCacheManagerTest")
 public class DefaultCacheManagerTest extends Arquillian {

--- a/checkstyle/src/main/java/org/infinispan/checkstyle/filters/ExcludeTestPackages.java
+++ b/checkstyle/src/main/java/org/infinispan/checkstyle/filters/ExcludeTestPackages.java
@@ -14,7 +14,7 @@ import com.puppycrawl.tools.checkstyle.api.Filter;
  * <p>
  * A SuppressionFilter is too generic, and requires per-module configuration.
  *
- * @author Sanne Grinovero <sanne@hibernate.org>
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt;
  */
 public class ExcludeTestPackages implements Filter {
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/Flag.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/Flag.java
@@ -2,7 +2,7 @@ package org.infinispan.client.hotrod;
 
 /**
  * Defines all the flags available in the Hot Rod client that can influence the behavior of operations.
- * <p />
+ * <p>
  * Available flags:
  * <ul>
  *    <li>{@link #FORCE_RETURN_VALUE} - By default, previously existing values for {@link java.util.Map} operations are not
@@ -30,7 +30,7 @@ public enum Flag {
    /**
     * By default, previously existing values for {@link java.util.Map} operations are not returned. E.g. {@link RemoteCache#put(Object, Object)}
     * does <i>not</i> return the previous value associated with the key.
-    * <p />
+    * <p>
     * By applying this flag, this default behavior is overridden for the scope of a single invocation, and the previous
     * existing value is returned.
     */

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCache.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCache.java
@@ -18,22 +18,22 @@ import org.infinispan.query.dsl.Query;
  * Provides remote reference to a Hot Rod server/cluster. It implements {@link org.infinispan.Cache}, but given its
  * nature (remote) some operations are not supported. All these unsupported operations are being overridden within this
  * interface and documented as such.
- * <p/>
+ * <p>
  * <b>New operations</b>: besides the operations inherited from {@link org.infinispan.Cache}, RemoteCache also adds new
  * operations to optimize/reduce network traffic: e.g. versioned put operation.
- * <p/>
+ * <p>
  * <b>Concurrency</b>: implementors of this interface will support multi-threaded access, similar to the way {@link
  * org.infinispan.Cache} supports it.
- * <p/>
+ * <p>
  * <b>Return values</b>: previously existing values for certain {@link java.util.Map} operations are not returned, null
  * is returned instead. E.g. {@link java.util.Map#put(Object, Object)} returns the previous value associated to the
  * supplied key. In case of RemoteCache, this returns null.
- * <p/>
+ * <p>
  * <b>Synthetic operations</b>: aggregate operations are being implemented based on other Hot Rod operations. E.g. all
  * the {@link java.util.Map#putAll(java.util.Map)} is implemented through multiple individual puts. This means that the
  * these operations are not atomic and that they are costly, e.g. as the number of network round-trips is not one, but
  * the size of the added map. All these synthetic operations are documented as such.
- * <p/>
+ * <p>
  * <b>changing default behavior through {@link org.infinispan.client.hotrod.Flag}s</b>: it is possible to change the
  * default cache behaviour by using flags on an per invocation basis. E.g.
  * <pre>
@@ -45,7 +45,7 @@ import org.infinispan.query.dsl.Query;
  * would return (by default) <tt>null</tt>. This is in order to avoid fetching a possibly large object from the remote
  * server, which might not be needed. The flags as set by the {@link org.infinispan.client.hotrod.RemoteCache#withFlags(Flag...)}
  * operation only apply for the very next operation executed <b>by the same thread</b> on the RemoteCache.
- * <p/>
+ * <p>
  * <b><a href="http://community.jboss.org/wiki/Eviction">Eviction and expiration</a></b>: Unlike local {@link
  * org.infinispan.Cache} cache, which allows specifying time values with any granularity (as defined by {@link
  * TimeUnit}), HotRod only supports seconds as time units. If a different time unit is used instead, HotRod will
@@ -428,7 +428,7 @@ public interface RemoteCache<K, V> extends BasicCache<K, V>, TransactionalCache 
    /**
     * Applies one or more {@link Flag}s to the scope of a single invocation.  See the {@link Flag} enumeration to for
     * information on available flags.
-    * <p />
+    * <p>
     * Sample usage:
     * <pre>
     *    remoteCache.withFlags(Flag.FORCE_RETURN_VALUE).put("hello", "world");

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/RemoteCacheSupport.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/RemoteCacheSupport.java
@@ -11,7 +11,7 @@ import java.util.function.Function;
 import org.infinispan.client.hotrod.RemoteCache;
 
 /**
- * Purpose: keep all delegating and unsupported methods in one place -> readability.
+ * Purpose: keep all delegating and unsupported methods in one place for readability.
  *
  * @author Mircea.Markus@jboss.com
  * @since 4.1
@@ -84,7 +84,7 @@ public abstract class RemoteCacheSupport<K, V> implements RemoteCache<K, V> {
     * alter the signature even if it might look like unreachable code. Implementors should perform a put operation but
     * optimizing it as return values are not required.
     *
-    * @author Sanne Grinovero <sanne@infinispan.org> (C) 2011 Red Hat Inc.
+    * @author Sanne Grinovero &lt;sanne@infinispan.org&gt; (C) 2011 Red Hat Inc.
     * @since 5.0
     */
    protected abstract void set(K key, V value);
@@ -128,7 +128,6 @@ public abstract class RemoteCacheSupport<K, V> implements RemoteCache<K, V> {
    public V put(K key, V value, long lifespan, TimeUnit unit) {
       return put(key, value, lifespan, unit, defaultMaxIdleTime, MILLISECONDS);
    }
-
 
    @Override
    public CompletableFuture<V> putIfAbsentAsync(K key, V value) {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/consistenthash/ConsistentHashFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/consistenthash/ConsistentHashFactory.java
@@ -12,7 +12,7 @@ import org.infinispan.commons.util.Util;
  * <code>infinispan.client.hotrod.hash_function_impl.3=org.infinispan.client.hotrod.impl.consistenthash.SegmentConsistentHash</code>
  * or if using the {@link Configuration} API,
  * <code>configuration.consistentHashImpl(3, org.infinispan.client.hotrod.impl.consistenthash.SegmentConsistentHash.class);</code>
- * <p/>
+ * <p>
  *
  * <p>The defaults are:</p>
  * <ol>

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ConsistentHashPerformanceTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ConsistentHashPerformanceTest.java
@@ -16,7 +16,7 @@ import org.infinispan.commons.hash.MurmurHash3;
 import org.testng.annotations.Test;
 
 /**
- * @author Mircea Markus <mircea.markus@jboss.com> (C) 2011 Red Hat Inc.
+ * @author Mircea Markus &lt;mircea.markus@jboss.com&gt; (C) 2011 Red Hat Inc.
  * @since 5.1
  */
 @Test (groups = "profiling", testName = "client.hotrod.ConsistentHashPerformanceTest")

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ExpiryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ExpiryTest.java
@@ -17,7 +17,7 @@ import org.testng.annotations.Test;
 
 /**
  * This test verifies that an entry can be expired from the Hot Rod server
- * using the default expiry lifespan or maxIdle. </p>
+ * using the default expiry lifespan or maxIdle.
  *
  * @author Galder Zamarreño
  * @since 5.0
@@ -52,7 +52,7 @@ public class ExpiryTest extends MultiHotRodServersTest {
 
    public void testGlobalExpiryPutAll() {
       RemoteCache<Integer, String> cache0 = client(0).getCache();
-      Map<Integer, String> data = new HashMap<Integer, String>();
+      Map<Integer, String> data = new HashMap<>();
       data.put(2,"v0");
       Req.PUT_ALL.execute(cache0,data);
       expectCachedThenExpired(cache0, 2, "v0");
@@ -60,7 +60,7 @@ public class ExpiryTest extends MultiHotRodServersTest {
 
    public void testGlobalExpiryPutAllWithFlag() {
       RemoteCache<Integer, String> cache0 = client(0).<Integer, String>getCache().withFlags(Flag.SKIP_INDEXING);
-      Map<Integer, String> data = new HashMap<Integer, String>();
+      Map<Integer, String> data = new HashMap<>();
       data.put(3, "v0");
       Req.PUT_ALL.execute(cache0,data);
       expectCachedThenExpired(cache0, 3, "v0");

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/MixedExpiryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/MixedExpiryTest.java
@@ -20,7 +20,7 @@ import org.testng.annotations.Test;
 
 /**
  * This test verifies that an entry can be expired from the Hot Rod server
- * using the default expiry lifespan or maxIdle. </p>
+ * using the default expiry lifespan or maxIdle.
  *
  * @author William Burns
  * @since 8.0

--- a/commons/src/main/java/org/infinispan/commons/CacheException.java
+++ b/commons/src/main/java/org/infinispan/commons/CacheException.java
@@ -2,10 +2,10 @@ package org.infinispan.commons;
 
 /**
  * Thrown when operations on {@link Cache} fail unexpectedly.
- * <p/>
+ * <p>
  * Specific subclasses such as {@link org.infinispan.util.concurrent.TimeoutException} and {@link
  * org.infinispan.commons.CacheConfigurationException} have more specific uses.
- * <p/>
+ * <p>
  * Transactions: if a CacheException (including any subclasses) is thrown for an operation on a JTA transaction, then
  * the transaction is marked for rollback.
  *

--- a/commons/src/main/java/org/infinispan/commons/api/AsyncCache.java
+++ b/commons/src/main/java/org/infinispan/commons/api/AsyncCache.java
@@ -33,13 +33,13 @@ import java.util.function.Function;
  * completed successfully, but you have the added benefit that the three calls could happen in parallel.  This is
  * especially advantageous if the cache uses distribution and the three keys map to different cache instances in the
  * cluster.
- * <p/>
+ * <p>
  * Also, the use of async operations when within a transaction return your local value only, as expected.  A
  * {@link CompletableFuture} is still returned though for API consistency.
  *
  * These methods can have benefit over their sync versions even in LOCAL mode.
  *
- * <p/>
+ * <p>
  *
  * @author Mircea Markus
  * @author Manik Surtani

--- a/commons/src/main/java/org/infinispan/commons/api/BasicCache.java
+++ b/commons/src/main/java/org/infinispan/commons/api/BasicCache.java
@@ -9,24 +9,24 @@ import java.util.function.Function;
 /**
  * BasicCache provides the common building block for the two different types of caches that Infinispan provides:
  * embedded and remote.
- * <p/>
+ * <p>
  * For convenience, BasicCache extends {@link ConcurrentMap} and implements all methods accordingly, although methods like
  * {@link ConcurrentMap#keySet()}, {@link ConcurrentMap#values()} and {@link ConcurrentMap#entrySet()} are expensive
  * (prohibitively so when using a distributed cache) and frequent use of these methods is not recommended.
- * <p />
+ * <p>
  * Other methods such as {@link #size()} provide an approximation-only, and should not be relied on for an accurate picture
  * as to the size of the entire, distributed cache.  Remote nodes are <i>not</i> queried and in-fly transactions are not
  * taken into account, even if {@link #size()} is invoked from within such a transaction.
- * <p/>
+ * <p>
  * Also, like many {@link ConcurrentMap} implementations, BasicCache does not support the use of <tt>null</tt> keys or
  * values.
- * <p/>
+ * <p>
  * <h3>Unsupported operations</h3>
  * <p>{@link #containsValue(Object)}</p>
  *
  * Please see the <a href="http://www.jboss.org/infinispan/docs">Infinispan documentation</a> and/or the <a
  * href="https://docs.jboss.org/author/display/ISPN/Getting+Started+Guide#GettingStartedGuide-5minutetutorial">5 Minute Usage Tutorial</a> for more details.
- * <p/>
+ * <p>
  *
  * @author Mircea.Markus@jboss.com
  * @author Manik Surtani

--- a/commons/src/main/java/org/infinispan/commons/api/BasicCacheContainer.java
+++ b/commons/src/main/java/org/infinispan/commons/api/BasicCacheContainer.java
@@ -4,7 +4,6 @@ import java.util.Set;
 
 /**
  * <tt>BasicCacheContainer</tt> defines the methods used to obtain a {@link org.infinispan.api.BasicCache}.
- * <p/>
  *
  *
  * @see org.infinispan.manager.EmbeddedCacheManager
@@ -21,10 +20,10 @@ public interface BasicCacheContainer extends Lifecycle {
 
    /**
     * Retrieves the default cache associated with this cache container.
-    * <p/>
+    * <p>
     * As such, this method is always guaranteed to return the default cache, unless one has not been supplied to the
     * cache container.
-    * <p />
+    * <p>
     * <b>NB:</b> Shared caches are supported (and in fact encouraged) but if they are used it's the users responsibility to
     * ensure that <i>at least one</i> but <i>only one</i> caller calls stop() on the cache, and it does so with the awareness
     * that others may be using the cache.
@@ -36,13 +35,13 @@ public interface BasicCacheContainer extends Lifecycle {
    /**
     * Retrieves a named cache from the system.  If the cache has been previously created with the same name, the running
     * cache instance is returned.  Otherwise, this method attempts to create the cache first.
-    * <p/>
+    * <p>
     * In the case of a {@link org.infinispan.manager.EmbeddedCacheManager}: when creating a new cache, this method will
     * use the configuration passed in to the EmbeddedCacheManager on construction, as a template, and then optionally
     * apply any overrides previously defined for the named cache using the {@link EmbeddedCacheManager#defineConfiguration(String, org.infinispan.config.Configuration)}
     * or {@link EmbeddedCacheManager#defineConfiguration(String, String, org.infinispan.config.Configuration)}
     * methods, or declared in the configuration file.
-    * <p />
+    * <p>
     * <b>NB:</b> Shared caches are supported (and in fact encouraged) but if they are used it's the users responsibility to
     * ensure that <i>at least one</i> but <i>only one</i> caller calls stop() on the cache, and it does so with the awareness
     * that others may be using the cache.

--- a/commons/src/main/java/org/infinispan/commons/api/BatchingCache.java
+++ b/commons/src/main/java/org/infinispan/commons/api/BatchingCache.java
@@ -10,7 +10,6 @@ public interface BatchingCache {
    /**
     * Starts a batch.  All operations on the current client thread are performed as a part of this batch, with locks
     * held for the duration of the batch and any remote calls delayed till the end of the batch.
-    * <p/>
     *
     * @return true if a batch was successfully started; false if one was available and already running.
     */
@@ -19,7 +18,6 @@ public interface BatchingCache {
    /**
     * Completes a batch if one has been started using {@link #startBatch()}.  If no batch has been started, this is a
     * no-op.
-    * <p/>
     *
     * @param successful if true, the batch completes, otherwise the batch is aborted and changes are not committed.
     */

--- a/commons/src/main/java/org/infinispan/commons/io/ExposedByteArrayOutputStream.java
+++ b/commons/src/main/java/org/infinispan/commons/io/ExposedByteArrayOutputStream.java
@@ -14,7 +14,6 @@ import net.jcip.annotations.NotThreadSafe;
  * to help prevent an OutOfMemoryError during a resize of a large buffer. </p> <p> A version of this class was
  * originally created by Bela Ban as part of the JGroups library. </p> This class is not threadsafe as it will not
  * support concurrent readers and writers.
- * <p/>
  *
  * @author <a href="mailto://brian.stansberry@jboss.com">Brian Stansberry</a>
  * @since 4.0
@@ -112,7 +111,7 @@ public final class ExposedByteArrayOutputStream extends ByteArrayOutputStream im
    }
 
    /**
-    * Overriden only to avoid unneeded synchronization
+    * Overriden only to avoid unneeded synchronization.
     */
    @Override
    public final int size() {

--- a/commons/src/main/java/org/infinispan/commons/jmx/PlatformMBeanServerLookup.java
+++ b/commons/src/main/java/org/infinispan/commons/jmx/PlatformMBeanServerLookup.java
@@ -7,7 +7,7 @@ import javax.management.MBeanServer;
 
 /**
  * Default implementation for {@link MBeanServerLookup}, will return the platform MBean server.
- * <p/>
+ * <p>
  * Note: to enable platform MBeanServer the following system property should be passed to the Sun JVM:
  * <b>-Dcom.sun.management.jmxremote</b>.
  *

--- a/commons/src/main/java/org/infinispan/commons/logging/Log.java
+++ b/commons/src/main/java/org/infinispan/commons/logging/Log.java
@@ -22,32 +22,32 @@ import org.jboss.logging.annotations.MessageLogger;
 
 /**
  * Infinispan's log abstraction layer on top of JBoss Logging.
- * <p/>
+ * <p>
  * It contains explicit methods for all INFO or above levels so that they can
  * be internationalized. For the commons module, message ids ranging from 0901
  * to 1000 inclusively have been reserved.
- * <p/>
- * <code> Log log = LogFactory.getLog( getClass() ); </code> The above will get
- * you an instance of <tt>Log</tt>, which can be used to generate log messages
+ * <p>
+ * <code> Log log = LogFactory.getLog( getClass() ); </code>
+ * <p>
+ * The above will get you an instance of <tt>Log</tt>, which can be used to generate log messages
  * either via JBoss Logging which then can delegate to Log4J (if the libraries
  * are present) or (if not) the built-in JDK logger.
- * <p/>
+ * <p>
  * In addition to the 6 log levels available, this framework also supports
  * parameter interpolation, similar to the JDKs {@link String#format(String, Object...)}
  * method. What this means is, that the following block:
- * <code> if (log.isTraceEnabled()) { log.trace("This is a message " + message + " and some other value is " + value); }
+ * <p>
+ * <code> if (log.isTraceEnabled()) log.trace("This is a message " + message + " and some other value is " + value);
  * </code>
- * <p/>
+ * <p>
  * ... could be replaced with ...
- * <p/>
+ * <p>
  * <code> if (log.isTraceEnabled()) log.tracef("This is a message %s and some other value is %s", message, value);
  * </code>
- * <p/>
+ * <p>
  * This greatly enhances code readability.
- * <p/>
- * If you are passing a <tt>Throwable</tt>, note that this should be passed in
- * <i>before</i> the vararg parameter list.
- * <p/>
+ * <p>
+ * If you are passing a <tt>Throwable</tt>, note that this should be passed in <i>before</i> the vararg parameter list.
  *
  * @author Manik Surtani
  * @since 4.0
@@ -55,6 +55,7 @@ import org.jboss.logging.annotations.MessageLogger;
  */
 @MessageLogger(projectCode = "ISPN")
 public interface Log extends BasicLogger {
+
    @LogMessage(level = WARN)
    @Message(value = "Property %s could not be replaced as intended!", id = 901)
    void propertyCouldNotBeReplaced(String line);

--- a/commons/src/main/java/org/infinispan/commons/marshall/Externalizer.java
+++ b/commons/src/main/java/org/infinispan/commons/marshall/Externalizer.java
@@ -35,7 +35,7 @@ import java.io.Serializable;
  * It's common practice to include externalizer implementations within the
  * classes that they marshall/unmarshall as <code>public static classes</code>.
  * To make externalizer implementations easier to code and more typesafe, make
- * sure you define type <T> as the type of object that's being
+ * sure you define type &lt;T&gt; as the type of object that's being
  * marshalled/unmarshalled.
  *
  * Even though this way of defining externalizers is very user friendly, it has

--- a/commons/src/main/java/org/infinispan/commons/marshall/Marshaller.java
+++ b/commons/src/main/java/org/infinispan/commons/marshall/Marshaller.java
@@ -9,11 +9,11 @@ import net.jcip.annotations.ThreadSafe;
 
 /**
  * A marshaller is a class that is able to marshall and unmarshall objects efficiently.
- * <p/>
+ * <p>
  * This interface is used to marshall {@link org.infinispan.commands.ReplicableCommand}s, their parameters and their
  * response values, as well as any other arbitraty Object <--> byte[] conversions, such as those used in client/server
  * communications.
- * <p/>
+ * <p>
  * A single instance of any implementation is shared by multiple threads, so implementations <i>need</i> to be threadsafe,
  * and preferably immutable.
  *

--- a/commons/src/main/java/org/infinispan/commons/marshall/StreamingMarshaller.java
+++ b/commons/src/main/java/org/infinispan/commons/marshall/StreamingMarshaller.java
@@ -10,7 +10,7 @@ import net.jcip.annotations.ThreadSafe;
 
 /**
  * A specialization of {@link Marshaller} that supports streams.
- * <p/>
+ * <p>
  * A single instance of any implementation is shared by multiple threads, so implementations <i>need</i> to be threadsafe,
  * and preferably immutable.
  *
@@ -24,8 +24,8 @@ import net.jcip.annotations.ThreadSafe;
 public interface StreamingMarshaller extends Marshaller {
 
    /**
-    * <p>Create and open an ObjectOutput instance for the given output stream. This method should be used for opening data
-    * outputs when multiple objectToObjectStream() calls will be made before the stream is closed by calling finishObjectOutput().</p>
+    * Create and open an ObjectOutput instance for the given output stream. This method should be used for opening data
+    * outputs when multiple objectToObjectStream() calls will be made before the stream is closed by calling finishObjectOutput().
     *
     * <p>This method also takes a boolean that represents whether this particular call to startObjectOutput() is reentrant
     * or not. A call to startObjectOutput() should be marked reentrant whenever a 2nd or more calls to this method are made
@@ -41,7 +41,7 @@ public interface StreamingMarshaller extends Marshaller {
     * following, a 2nd call could occur so that MarshalledValue's raw byte array version is calculated and sent across.
     * This enables storing as binary on the receiver side which is performance gain. The StreamingMarshaller implementation could decide
     * that it needs a separate ObjectOutput or similar for the 2nd call since it's aim is only to get the raw byte array version
-    * and the close finish with it.</p>
+    * and the close finish with it.
     *
     * @param os output stream
     * @param isReentrant whether the call is reentrant or not.

--- a/commons/src/main/java/org/infinispan/commons/marshall/jboss/DefaultContextClassResolver.java
+++ b/commons/src/main/java/org/infinispan/commons/marshall/jboss/DefaultContextClassResolver.java
@@ -8,7 +8,7 @@ import org.jboss.marshalling.ContextClassResolver;
  * This class refines <code>ContextClassLoader</code> to add a default class loader.
  * The context class loader is only used when the default is <code>null</code>.
  *
- * @author Dan Berindei <dberinde@redhat.com>
+ * @author Dan Berindei &lt;dberinde@redhat.com&gt;
  * @since 4.2
  */
 public class DefaultContextClassResolver extends ContextClassResolver {

--- a/commons/src/main/java/org/infinispan/commons/util/Base64.java
+++ b/commons/src/main/java/org/infinispan/commons/util/Base64.java
@@ -5,7 +5,7 @@ import org.infinispan.commons.logging.LogFactory;
 
 // TODO Remove this class in Infinispan 10
 /**
- * Encodes and decodes to and from Base64 notation. <p/> <p> Change Log: </p>
+ * Encodes and decodes to and from Base64 notation. <p> <p> Change Log: </p>
  * <ul> <li>v2.1 - Cleaned up javadoc comments and unused variables and
  * methods. Added some convenience methods for reading and writing to and from
  * files.</li> <li>v2.0.2 - Now specifies UTF-8 encoding in places where the
@@ -29,7 +29,7 @@ import org.infinispan.commons.logging.LogFactory;
  * line breaks. Fixed bug in input stream where last buffer being read, if not
  * completely full, was not returned.</li> <li>v1.3.4 - Fixed when "improperly
  * padded stream" error was thrown at the wrong time.</li> <li>v1.3.3 - Fixed
- * I/O streams which were totally messed up.</li> </ul> <p/> <p> I am placing
+ * I/O streams which were totally messed up.</li> </ul> <p> <p> I am placing
  * this code in the Public Domain. Do with it as you will. This software comes
  * with no guarantees or warranties but with plenty of well-wishing instead!
  * Please visit <a href="http://iharder.net/base64">http://iharder.net/base64</a>

--- a/commons/src/main/java/org/infinispan/commons/util/EnumerationList.java
+++ b/commons/src/main/java/org/infinispan/commons/util/EnumerationList.java
@@ -6,31 +6,28 @@ import java.util.List;
 
 
 /**
- * An Enumeration -> List adaptor
+ * An {@link Enumeration} to {@link List} adapter.
  *
  * @author Pete Muir
  */
-public class EnumerationList<T> extends ForwardingList<T>
-{
+public class EnumerationList<T> extends ForwardingList<T> {
+
    // The enumeration as a list
-   private final List<T> list = new LinkedList<T>();
+   private final List<T> list = new LinkedList<>();
 
    /**
     * Constructor
     *
     * @param enumeration The enumeration
     */
-   public EnumerationList(Enumeration<T> enumeration)
-   {
-      while (enumeration.hasMoreElements())
-      {
+   public EnumerationList(Enumeration<T> enumeration) {
+      while (enumeration.hasMoreElements()) {
          list.add(enumeration.nextElement());
       }
    }
 
    @Override
-   protected List<T> delegate()
-   {
+   protected List<T> delegate() {
       return list;
    }
 }

--- a/commons/src/main/java/org/infinispan/commons/util/FastCopyHashMap.java
+++ b/commons/src/main/java/org/infinispan/commons/util/FastCopyHashMap.java
@@ -16,7 +16,7 @@ import org.infinispan.commons.logging.LogFactory;
 
 /**
  * A HashMap that is optimized for fast shallow copies.
- * <p/>
+ * <p>
  * Null keys are <i>not</i> supported.
  *
  * @author Jason T. Greene

--- a/commons/src/main/java/org/infinispan/commons/util/ImmutableListCopy.java
+++ b/commons/src/main/java/org/infinispan/commons/util/ImmutableListCopy.java
@@ -19,11 +19,10 @@ import net.jcip.annotations.Immutable;
 /**
  * A lightweight, read-only copy of a List.  Typically used in place of the common idiom: <code> return
  * Collections.unmodifiableList(new ArrayList( myInternalList )); </code>
- * <p/>
+ * <p>
  * a it is far more efficient than making a defensive copy and then wrapping the defensive copy in a read-only wrapper.
- * <p/>
+ * <p>
  * Also used whenever a read-only reference List is needed.
- * <p/>
  *
  * @author Manik Surtani (<a href="mailto:manik@jboss.org">manik@jboss.org</a>)
  * @since 4.0

--- a/commons/src/main/java/org/infinispan/commons/util/ReflectionUtil.java
+++ b/commons/src/main/java/org/infinispan/commons/util/ReflectionUtil.java
@@ -283,7 +283,7 @@ public class ReflectionUtil {
    /**
     * Inspects the class passed in for the class level annotation specified.  If the annotation is not available, this
     * method recursively inspects superclasses and interfaces until it finds the required annotation.
-    * <p/>
+    * <p>
     * Returns null if the annotation cannot be found.
     *
     * @param clazz class to inspect

--- a/commons/src/main/java/org/infinispan/commons/util/StringPropertyReplacer.java
+++ b/commons/src/main/java/org/infinispan/commons/util/StringPropertyReplacer.java
@@ -52,14 +52,14 @@ public class StringPropertyReplacer {
     * Go through the input string and replace any occurance of ${p} with the
     * System.getProperty(p) value. If there is no such property p defined, then
     * the ${p} reference will remain unchanged.
-    * <p/>
+    * <p>
     * If the property reference is of the form ${p:v} and there is no such
     * property p, then the default value v will be returned.
-    * <p/>
+    * <p>
     * If the property reference is of the form ${p1,p2} or ${p1,p2:v} then the
     * primary and the secondary properties will be tried in turn, before
     * returning either the unchanged input, or the default value.
-    * <p/>
+    * <p>
     * The property ${/} is replaced with System.getProperty("file.separator")
     * value and the property ${:} is replaced with System.getProperty("path.separator").
     *
@@ -75,14 +75,14 @@ public class StringPropertyReplacer {
     * Go through the input string and replace any occurance of ${p} with the
     * props.getProperty(p) value. If there is no such property p defined, then
     * the ${p} reference will remain unchanged.
-    * <p/>
+    * <p>
     * If the property reference is of the form ${p:v} and there is no such
     * property p, then the default value v will be returned.
-    * <p/>
+    * <p>
     * If the property reference is of the form ${p1,p2} or ${p1,p2:v} then the
     * primary and the secondary properties will be tried in turn, before
     * returning either the unchanged input, or the default value.
-    * <p/>
+    * <p>
     * The property ${/} is replaced with System.getProperty("file.separator")
     * value and the property ${:} is replaced with System.getProperty("path.separator").
     *
@@ -198,7 +198,7 @@ public class StringPropertyReplacer {
     * Try to resolve a "key" from the provided properties by checking if it is
     * actually a "key1,key2", in which case try first "key1", then "key2". If
     * all fails, return null.
-    * <p/>
+    * <p>
     * It also accepts "key1," and ",key2".
     *
     * @param key   the key to resolve

--- a/commons/src/main/java/org/infinispan/commons/util/Util.java
+++ b/commons/src/main/java/org/infinispan/commons/util/Util.java
@@ -218,7 +218,7 @@ public final class Util {
    /**
     * Instantiates a class by first attempting a static <i>factory method</i> named <tt>getInstance()</tt> on the class
     * and then falling back to an empty constructor.
-    * <p/>
+    * <p>
     * Any exceptions encountered are wrapped in a {@link CacheConfigurationException} and rethrown.
     *
     * @param clazz class to instantiate
@@ -262,7 +262,7 @@ public final class Util {
     * Instantiates a class based on the class name provided.  Instantiation is attempted via an appropriate, static
     * factory method named <tt>getInstance()</tt> first, and failing the existence of an appropriate factory, falls
     * back to an empty constructor.
-    * <p />
+    * <p>
     * Any exceptions encountered loading and instantiating the class is wrapped in a {@link CacheConfigurationException}.
     *
     * @param classname class to instantiate

--- a/commons/src/main/java/org/infinispan/commons/util/concurrent/ConcurrentHashSet.java
+++ b/commons/src/main/java/org/infinispan/commons/util/concurrent/ConcurrentHashSet.java
@@ -11,7 +11,7 @@ import org.infinispan.commons.util.CollectionFactory;
 /**
  * A simple Set implementation backed by a {@link java.util.concurrent.ConcurrentHashMap} to deal with the fact that the
  * JDK does not have a proper concurrent Set implementation that uses efficient lock striping.
- * <p/>
+ * <p>
  * Note that values are stored as keys in the underlying Map, with a static dummy object as value.
  *
  * @author <a href="mailto:manik@jboss.org">Manik Surtani</a>

--- a/commons/src/main/java/org/infinispan/commons/util/concurrent/ConcurrentWeakKeyHashMap.java
+++ b/commons/src/main/java/org/infinispan/commons/util/concurrent/ConcurrentWeakKeyHashMap.java
@@ -152,7 +152,7 @@ public final class ConcurrentWeakKeyHashMap<K, V> extends AbstractMap<K, V> impl
 
    /**
     * ConcurrentReferenceHashMap list entry. Note that this is never exported out as a user-visible Map.Entry.
-    * <p/>
+    * <p>
     * Because the value field is volatile, not final, it is legal wrt the Java Memory Model for an unsynchronized
     * reader to see null instead of initial value when read via a data race.  Although a reordering leading to this is
     * not likely to ever actually occur, the Segment.readValueUnderLock method is used as a backup in case a null
@@ -807,8 +807,8 @@ public final class ConcurrentWeakKeyHashMap<K, V> extends AbstractMap<K, V> impl
    /**
     * Returns the value to which the specified key is mapped, or {@code null} if this map contains no mapping for the
     * key.
-    * <p/>
-    * <p>More formally, if this map contains a mapping from a key {@code k} to a value {@code v} such that {@code
+    * <p>
+    * More formally, if this map contains a mapping from a key {@code k} to a value {@code v} such that {@code
     * key.equals(k)}, then this method returns {@code v}; otherwise it returns {@code null}.  (There can be at most one
     * such mapping.)
     *
@@ -912,8 +912,8 @@ public final class ConcurrentWeakKeyHashMap<K, V> extends AbstractMap<K, V> impl
 
    /**
     * Maps the specified key to the specified value in this table.  Neither the key nor the value can be null.
-    * <p/>
-    * <p>The value can be retrieved by calling the <tt>get</tt> method with a key that is equal to the original key.
+    * <p>
+    * The value can be retrieved by calling the <tt>get</tt> method with a key that is equal to the original key.
     *
     * @param key   key with which the specified value is to be associated
     * @param value value to be associated with the specified key
@@ -1033,7 +1033,7 @@ public final class ConcurrentWeakKeyHashMap<K, V> extends AbstractMap<K, V> impl
     * stale entries are automatically removed lazily, when blocking operations are required. However, there are some
     * cases where this operation should be performed eagerly, such as cleaning up old references to a ClassLoader in a
     * multi-classloader environment.
-    * <p/>
+    * <p>
     * Note: this method will acquire locks, one at a time, across all segments of this table, so if it is to be used,
     * it should be used sparingly.
     */
@@ -1049,8 +1049,8 @@ public final class ConcurrentWeakKeyHashMap<K, V> extends AbstractMap<K, V> impl
     * mapping from this map, via the <tt>Iterator.remove</tt>, <tt>Set.remove</tt>, <tt>removeAll</tt>,
     * <tt>retainAll</tt>, and <tt>clear</tt> operations.  It does not support the <tt>add</tt> or <tt>addAll</tt>
     * operations.
-    * <p/>
-    * <p>The view's <tt>iterator</tt> is a "weakly consistent" iterator that will never throw {@link
+    * <p>
+    * The view's <tt>iterator</tt> is a "weakly consistent" iterator that will never throw {@link
     * ConcurrentModificationException}, and guarantees to traverse elements as they existed upon construction of the
     * iterator, and may (but is not guaranteed to) reflect any modifications subsequent to construction.
     */
@@ -1066,8 +1066,8 @@ public final class ConcurrentWeakKeyHashMap<K, V> extends AbstractMap<K, V> impl
     * which removes the corresponding mapping from this map, via the <tt>Iterator.remove</tt>,
     * <tt>Collection.remove</tt>, <tt>removeAll</tt>, <tt>retainAll</tt>, and <tt>clear</tt> operations.  It does not
     * support the <tt>add</tt> or <tt>addAll</tt> operations.
-    * <p/>
-    * <p>The view's <tt>iterator</tt> is a "weakly consistent" iterator that will never throw {@link
+    * <p>
+    * The view's <tt>iterator</tt> is a "weakly consistent" iterator that will never throw {@link
     * ConcurrentModificationException}, and guarantees to traverse elements as they existed upon construction of the
     * iterator, and may (but is not guaranteed to) reflect any modifications subsequent to construction.
     */
@@ -1083,8 +1083,8 @@ public final class ConcurrentWeakKeyHashMap<K, V> extends AbstractMap<K, V> impl
     * mapping from the map, via the <tt>Iterator.remove</tt>, <tt>Set.remove</tt>, <tt>removeAll</tt>,
     * <tt>retainAll</tt>, and <tt>clear</tt> operations.  It does not support the <tt>add</tt> or <tt>addAll</tt>
     * operations.
-    * <p/>
-    * <p>The view's <tt>iterator</tt> is a "weakly consistent" iterator that will never throw {@link
+    * <p>
+    * The view's <tt>iterator</tt> is a "weakly consistent" iterator that will never throw {@link
     * ConcurrentModificationException}, and guarantees to traverse elements as they existed upon construction of the
     * iterator, and may (but is not guaranteed to) reflect any modifications subsequent to construction.
     */

--- a/commons/src/main/java/org/infinispan/multimap/api/BasicMultimapCache.java
+++ b/commons/src/main/java/org/infinispan/multimap/api/BasicMultimapCache.java
@@ -10,7 +10,7 @@ import org.infinispan.commons.util.Experimental;
  * provides: embedded and remote. <p> Please see the <a href="http://infinispan.org/documentation/">Infinispan
  * documentation</a> and/or the <a href="http://infinispan.org/docs/dev/getting_started/getting_started.html">5 Minute
  * Usage Tutorial</a> for more details on Infinispan.
- * <p/>
+ * <p>
  * <p> MutimapCache is a type of Infinispan Cache that maps keys to values, similar to {@link
  * org.infinispan.commons.api.AsyncCache} in which each key can contain multiple values.
  * <pre>

--- a/core/src/main/java/org/infinispan/AdvancedCache.java
+++ b/core/src/main/java/org/infinispan/AdvancedCache.java
@@ -61,10 +61,10 @@ public interface AdvancedCache<K, V> extends Cache<K, V>, TransactionalCache {
     *   cache.withFlags(Flag.FORCE_WRITE_LOCK).get(key);
     * </pre>
     * will invoke a cache.get() with a write lock forced.
-    * <p/>
+    * <p>
     * <b>Note</b> that for the flag to take effect, the cache operation <b>must</b> be invoked on the instance returned
     * by this method.
-    * <p/>
+    * <p>
     * As an alternative to setting this on every invocation, users could also consider using the {@link DecoratedCache}
     * wrapper, as this allows for more readable code.  E.g.:
     * <pre>
@@ -343,7 +343,7 @@ public interface AdvancedCache<K, V> extends Cache<K, V>, TransactionalCache {
     * Using this operation, users can call any {@link AdvancedCache} operation with a given {@link ClassLoader}. This
     * means that any {@link ClassLoader} happening as a result of the cache operation will be done using the {@link
     * ClassLoader} given. For example:
-    * <p/>
+    * <p>
     * When users store POJO instances in caches configured with {@link org.infinispan.configuration.cache.StoreAsBinaryConfiguration},
     * these instances are transformed into byte arrays. When these entries are read from the cache, a lazy unmarshalling
     * process happens where these byte arrays are transformed back into POJO instances. Using {@link
@@ -354,7 +354,7 @@ public interface AdvancedCache<K, V> extends Cache<K, V>, TransactionalCache {
     * </pre>
     * <b>Note</b> that for the flag to take effect, the cache operation <b>must</b> be invoked on the instance returned
     * by this method.
-    * <p/>
+    * <p>
     * As an alternative to setting this on every invocation, users could also consider using the {@link DecoratedCache}
     * wrapper, as this allows for more readable code.  E.g.:
     * <pre>
@@ -579,7 +579,7 @@ public interface AdvancedCache<K, V> extends Cache<K, V>, TransactionalCache {
     * Asynchronous version of {@link #put(Object, Object, Metadata)} which stores metadata alongside the value.  This
     * method does not block on remote calls, even if your cache mode is synchronous.  Has no benefit over {@link
     * #put(Object, Object, Metadata)} if used in LOCAL mode.
-    * <p/>
+    * <p>
     *
     * @param key      key to use
     * @param value    value to store
@@ -796,15 +796,15 @@ public interface AdvancedCache<K, V> extends Cache<K, V>, TransactionalCache {
 
    /**
     * It fetches all the keys which belong to the group.
-    * <p/>
+    * <p>
     * Semantically, it iterates over all the keys in memory and persistence, and performs a read operation in the keys
     * found. Multiple invocations inside a transaction ensures that all the keys previous read are returned and it may
     * return newly added keys to the group from other committed transactions (also known as phantom reads).
-    * <p/>
+    * <p>
     * The {@code map} returned is immutable and represents the group at the time of the invocation. If you want to add
     * or remove keys from a group use {@link #put(Object, Object)} and {@link #remove(Object)}. To remove all the keys
     * in the group use {@link #removeGroup(String)}.
-    * <p/>
+    * <p>
     * To improve performance you may use the {@code flag} {@link org.infinispan.context.Flag#SKIP_CACHE_LOAD} to avoid
     * fetching the key/value from persistence. However, you will get an inconsistent snapshot of the group.
     *
@@ -815,9 +815,9 @@ public interface AdvancedCache<K, V> extends Cache<K, V>, TransactionalCache {
 
    /**
     * It removes all the key which belongs to a group.
-    * <p/>
+    * <p>
     * Semantically, it fetches the most recent group keys/values and removes them.
-    * <p/>
+    * <p>
     * Note that, concurrent addition perform by other transactions/threads to the group may not be removed.
     *
     * @param groupName the group name.

--- a/core/src/main/java/org/infinispan/Cache.java
+++ b/core/src/main/java/org/infinispan/Cache.java
@@ -21,13 +21,13 @@ import org.infinispan.util.function.SerializableFunction;
 /**
  * The central interface of Infinispan.  A Cache provides a highly concurrent, optionally distributed data structure
  * with additional features such as:
- * <p/>
+ * <p>
  * <ul> <li>JTA transaction compatibility</li> <li>Eviction support for evicting entries from memory to prevent {@link
  * OutOfMemoryError}s</li> <li>Persisting entries to a {@link org.infinispan.persistence.spi.CacheLoader}, either when they are evicted as an overflow,
  * or all the time, to maintain persistent copies that would withstand server failure or restarts.</li> </ul>
- * <p/>
- * <p/>
- * <p/>
+ * <p>
+ * <p>
+ * <p>
  * For convenience, Cache extends {@link ConcurrentMap} and implements all methods accordingly.  Methods like
  * {@link #keySet()}, {@link #values()} and {@link #entrySet()} produce backing collections in that updates done to them
  * also update the original Cache instance.  Certain methods on these maps can be expensive however (prohibitively so
@@ -39,10 +39,10 @@ import org.infinispan.util.function.SerializableFunction;
  * context to prevent {@link OutOfMemoryError}s.  Please note all of these methods behavior can be controlled using
  * a {@link org.infinispan.context.Flag} to disable certain things such as taking into account the loader.  Please see
  * each method on this interface for more details.
- * <p />
+ * <p>
  * Also, like many {@link ConcurrentMap} implementations, Cache does not support the use of <tt>null</tt> keys or
  * values.
- * <p/>
+ * <p>
  * <h3>Asynchronous operations</h3> Cache also supports the use of "async" remote operations.  Note that these methods
  * only really make sense if you are using a clustered cache.  I.e., when used in LOCAL mode, these "async" operations
  * offer no benefit whatsoever.  These methods, such as {@link #putAsync(Object, Object)} offer the best of both worlds
@@ -64,10 +64,10 @@ import org.infinispan.util.function.SerializableFunction;
  * completed successfully, but you have the added benefit that the three calls could happen in parallel.  This is
  * especially advantageous if the cache uses distribution and the three keys map to different cache instances in the
  * cluster.
- * <p/>
+ * <p>
  * Also, the use of async operations when within a transaction return your local value only, as expected.  A
  * CompletableFuture is still returned though for API consistency.
- * <p/>
+ * <p>
  * <h3>Constructing a Cache</h3> An instance of the Cache is usually obtained by using a {@link org.infinispan.manager.CacheContainer}.
  * <pre>
  *   CacheManager cm = new DefaultCacheManager(); // optionally pass in a default configuration
@@ -75,10 +75,10 @@ import org.infinispan.util.function.SerializableFunction;
  * </pre>
  * See the {@link org.infinispan.manager.CacheContainer} interface for more details on providing specific configurations, using multiple caches
  * in the same JVM, etc.
- * <p/>
+ * <p>
  * Please see the <a href="http://www.jboss.org/infinispan/docs">Infinispan documentation</a> and/or the <a
  * href="http://www.jboss.org/community/wiki/5minutetutorialonInfinispan">5 Minute Usage Tutorial</a> for more details.
- * <p/>
+ * <p>
  *
  * @author Mircea.Markus@jboss.com
  * @author Manik Surtani
@@ -101,13 +101,13 @@ public interface Cache<K, V> extends BasicCache<K, V>, BatchingCache, FilteringL
     * that has an external representation in storage, where, concurrent modification and transactions are not a
     * consideration, and failure to put the data in the cache should be treated as a 'suboptimal outcome' rather than a
     * 'failing outcome'.
-    * <p/>
+    * <p>
     * An example of when this method is useful is when data is read from, for example, a legacy datastore, and is cached
     * before returning the data to the caller.  Subsequent calls would prefer to get the data from the cache and if the
     * data doesn't exist in the cache, fetch again from the legacy datastore.
-    * <p/>
+    * <p>
     * See <a href="http://jira.jboss.com/jira/browse/JBCACHE-848">JBCACHE-848</a> for details around this feature.
-    * <p/>
+    * <p>
     *
     * @param key   key with which the specified value is to be associated.
     * @param value value to be associated with the specified key.
@@ -145,11 +145,11 @@ public interface Cache<K, V> extends BasicCache<K, V>, BatchingCache, FilteringL
     * Evicts an entry from the memory of the cache.  Note that the entry is <i>not</i> removed from any configured cache
     * stores or any other caches in the cluster (if used in a clustered mode).  Use {@link #remove(Object)} to remove an
     * entry from the entire cache system.
-    * <p/>
+    * <p>
     * This method is designed to evict an entry from memory to free up memory used by the application.  This method uses
     * a 0 lock acquisition timeout so it does not block in attempting to acquire locks.  It behaves as a no-op if the
     * lock on the entry cannot be acquired <i>immediately</i>.
-    * <p/>
+    * <p>
     * Important: this method should not be called from within a transaction scope.
     *
     * @param key key to evict
@@ -171,27 +171,27 @@ public interface Cache<K, V> extends BasicCache<K, V>, BatchingCache, FilteringL
 
    /**
     * Returns a count of all elements in this cache and cache loader across the entire cluster.
-    * <p/>
+    * <p>
     * Only a subset of entries is held in memory at a time when using a loader or remote entries, to prevent possible
     * memory issues, however the loading of said entries can still be vary slow.
-    * <p/>
+    * <p>
     * If there are performance concerns then the {@link org.infinispan.context.Flag#SKIP_CACHE_LOAD} flag should be used to
     * avoid hitting the cache loader in case if this is not needed in the size calculation.
-    * <p/>
+    * <p>
     * Also if you want the local contents only you can use the {@link org.infinispan.context.Flag#CACHE_MODE_LOCAL} flag so
     * that other remote nodes are not queried for data.  However the loader will still be used unless the previously
     * mentioned {@link org.infinispan.context.Flag#SKIP_CACHE_LOAD} is also configured.
-    * <p/>
+    * <p>
     * If this method is used in a transactional context, note this method will not bring additional values into the
     * transaction context and thus objects that haven't yet been read will act in a
     * {@link org.infinispan.util.concurrent.IsolationLevel#READ_COMMITTED} behavior irrespective of the configured
     * isolation level.  However values that have been previously modified or read that are in the context will be
     * adhered to. e.g. any write modification or any previous read when using
     * {@link org.infinispan.util.concurrent.IsolationLevel#REPEATABLE_READ}
-    * <p/>
+    * <p>
     * This method should only be used for debugging purposes such as to verify that the cache contains all the keys
     * entered. Any other use involving execution of this method on a production system is not recommended.
-    * <p/>
+    * <p>
     *
     * @return the number of key-value mappings in this cache and cache loader across the entire cluster.
     */
@@ -203,7 +203,7 @@ public interface Cache<K, V> extends BasicCache<K, V>, BatchingCache, FilteringL
     * Modifications and changes to the cache will be reflected in the set and vice versa. When this method is called
     * nothing is actually queried as the backing set is just returned.  Invocation on the set itself is when the
     * various operations are ran.
-    * <p/>
+    * <p>
     * <h3>Unsupported Operations</h3>
     * Care should be taken when invoking {@link java.util.Set#toArray()}, {@link Set#toArray(Object[])},
     * {@link java.util.Set#size()}, {@link Set#retainAll(Collection)} and {@link java.util.Set#iterator()}
@@ -213,19 +213,19 @@ public interface Cache<K, V> extends BasicCache<K, V>, BatchingCache, FilteringL
     * cluster in the array.
     * Use involving execution of this method on a production system is not recommended as they can be quite expensive
     * operations
-    * <p/>
+    * <p>
     * <h3>Supported Flags</h3>
     * Note any flag configured for the cache will also be passed along to the backing set when it was created.  If
     * additional flags are configured on the cache they will not affect any existing backings sets.
-    * <p/>
+    * <p>
     * If there are performance concerns then the {@link org.infinispan.context.Flag#SKIP_CACHE_LOAD} flag should be used to
     * avoid hitting the cache store as this will cause all entries there to be read in (albeit in a batched form to
     * prevent {@link java.lang.OutOfMemoryError})
-    * <p/>
+    * <p>
     * Also if you want the local contents only you can use the {@link org.infinispan.context.Flag#CACHE_MODE_LOCAL} flag so
     * that other remote nodes are not queried for data.  However the loader will still be used unless the previously
     * mentioned {@link org.infinispan.context.Flag#SKIP_CACHE_LOAD} is also configured.
-    * <p/>
+    * <p>
     * <h3>Iterator Use</h3>
     * This class implements the {@link CloseableIteratorSet} interface which creates a
     * {@link org.infinispan.commons.util.CloseableIterator} instead of a regular one.  This means this iterator must be
@@ -246,7 +246,7 @@ public interface Cache<K, V> extends BasicCache<K, V>, BatchingCache, FilteringL
     * changes to the cache will be reflected in the set and vice versa. When this method is called nothing is actually
     * queried as the backing collection is just returned.  Invocation on the collection itself is when the various
     * operations are ran.
-    * <p/>
+    * <p>
     * Care should be taken when invoking {@link Collection#toArray()}, {@link Collection#toArray(Object[])},
     * {@link Collection#size()}, {@link Collection#retainAll(Collection)} and {@link Collection#iterator()}
     * methods as they will traverse the entire contents of the cluster including a configured
@@ -255,19 +255,19 @@ public interface Cache<K, V> extends BasicCache<K, V>, BatchingCache, FilteringL
     * cluster in the array.
     * Use involving execution of this method on a production system is not recommended as they can be quite expensive
     * operations
-    * <p/>
+    * <p>
     * * <h3>Supported Flags</h3>
     * Note any flag configured for the cache will also be passed along to the backing set when it was created.  If
     * additional flags are configured on the cache they will not affect any existing backings sets.
-    * <p/>
+    * <p>
     * If there are performance concerns then the {@link org.infinispan.context.Flag#SKIP_CACHE_LOAD} flag should be used to
     * avoid hitting the cache store as this will cause all entries there to be read in (albeit in a batched form to
     * prevent {@link java.lang.OutOfMemoryError})
-    * <p/>
+    * <p>
     * Also if you want the local contents only you can use the {@link org.infinispan.context.Flag#CACHE_MODE_LOCAL} flag so
     * that other remote nodes are not queried for data.  However the loader will still be used unless the previously
     * mentioned {@link org.infinispan.context.Flag#SKIP_CACHE_LOAD} is also configured.
-    * <p/>
+    * <p>
     * <h3>Iterator Use</h3>
     * <p>This class implements the {@link CloseableIteratorCollection} interface which creates a
     * {@link org.infinispan.commons.util.CloseableIterator} instead of a regular one.  This means this iterator must be
@@ -291,7 +291,7 @@ public interface Cache<K, V> extends BasicCache<K, V>, BatchingCache, FilteringL
     * Modifications and changes to the cache will be reflected in the set and vice versa. When this method is called
     * nothing is actually queried as the backing set is just returned.  Invocation on the set itself is when the
     * various operations are ran.
-    * <p/>
+    * <p>
     * Care should be taken when invoking {@link java.util.Set#toArray()}, {@link Set#toArray(Object[])},
     * {@link java.util.Set#size()}, {@link Set#retainAll(Collection)} and {@link java.util.Set#iterator()}
     * methods as they will traverse the entire contents of the cluster including a configured
@@ -300,19 +300,19 @@ public interface Cache<K, V> extends BasicCache<K, V>, BatchingCache, FilteringL
     * cluster in the array.
     * Use involving execution of this method on a production system is not recommended as they can be quite expensive
     * operations
-    * <p/>
+    * <p>
     * * <h3>Supported Flags</h3>
     * Note any flag configured for the cache will also be passed along to the backing set when it was created.  If
     * additional flags are configured on the cache they will not affect any existing backings sets.
-    * <p/>
+    * <p>
     * If there are performance concerns then the {@link org.infinispan.context.Flag#SKIP_CACHE_LOAD} flag should be used to
     * avoid hitting the cache store as this will cause all entries there to be read in (albeit in a batched form to
     * prevent {@link java.lang.OutOfMemoryError})
-    * <p/>
+    * <p>
     * Also if you want the local contents only you can use the {@link org.infinispan.context.Flag#CACHE_MODE_LOCAL} flag so
     * that other remote nodes are not queried for data.  However the loader will still be used unless the previously
     * mentioned {@link org.infinispan.context.Flag#SKIP_CACHE_LOAD} is also configured.
-    * <p/>
+    * <p>
     * <h3>Modifying or Adding Entries</h3>
     * An entry's value is supported to be modified by using the {@link java.util.Map.Entry#setValue(Object)} and it will update
     * the cache as well.  Also this backing set does allow addition of a new Map.Entry(s) via the
@@ -329,10 +329,10 @@ public interface Cache<K, V> extends BasicCache<K, V>, BatchingCache, FilteringL
 
    /**
     * Removes all mappings from the cache.
-    * <p/>
+    * <p>
     * <b>Note:</b> This should never be invoked in production unless you can guarantee no other invocations are ran
     * concurrently.
-    * <p/>
+    * <p>
     * If the cache is transactional, it will not interact with the transaction.
     */
    @Override

--- a/core/src/main/java/org/infinispan/affinity/KeyAffinityService.java
+++ b/core/src/main/java/org/infinispan/affinity/KeyAffinityService.java
@@ -6,9 +6,9 @@ import org.infinispan.remoting.transport.Address;
 /**
  * Defines a service that generates keys to be mapped to specific nodes in a distributed(vs. replicated) cluster.
  * The service is instantiated through through one of the factory methods from {@link org.infinispan.affinity.KeyAffinityServiceFactory}.
- * <p/>
+ * <p>
  * Sample usage:
- * <p/>
+ * <p>
  * <pre><code>
  *    Cache&lt;String, Long&gt; cache = getDistributedCache();
  *    KeyAffinityService&lt;String&gt; service = KeyAffinityServiceFactory.newKeyAffinityService(cache, 100);
@@ -19,11 +19,11 @@ import org.infinispan.remoting.transport.Address;
  *    //this will reside on the same node in the cluster
  *    cache.put(newCollocatedSession, someInfo);
  * </code></pre>
- * <p/>
+ * <p>
  * Uniqueness: the service does not guarantee that the generated keys are unique. It relies on an
  * {@link org.infinispan.affinity.KeyGenerator} for obtaining and distributing the generated keys. If key uniqueness is
  * needed that should be enforced in the generator.
- * <p/>
+ * <p>
  * The service might also drop key generated through the {@link org.infinispan.affinity.KeyGenerator}.
  *
  * @see org.infinispan.affinity.KeyAffinityServiceFactory

--- a/core/src/main/java/org/infinispan/cache/impl/CacheSupport.java
+++ b/core/src/main/java/org/infinispan/cache/impl/CacheSupport.java
@@ -36,7 +36,7 @@ public abstract class CacheSupport<K, V> implements BasicCache<K, V> {
     * alter the signature even if it might look like unreachable code. Implementors should perform a put operation but
     * optimizing it as return values are not required.
     *
-    * @author Sanne Grinovero <sanne@infinispan.org> (C) 2011 Red Hat Inc.
+    * @author Sanne Grinovero &lt;sanne@infinispan.org&gt; (C) 2011 Red Hat Inc.
     * @since 5.0
     */
    protected abstract void set(K key, V value);

--- a/core/src/main/java/org/infinispan/cache/impl/DecoratedCache.java
+++ b/core/src/main/java/org/infinispan/cache/impl/DecoratedCache.java
@@ -31,11 +31,11 @@ import org.infinispan.stream.impl.local.ValueCacheCollection;
 /**
  * A decorator to a cache, which can be built with a specific set of {@link Flag}s.  This
  * set of {@link Flag}s will be applied to all cache invocations made via this decorator.
- * <p/>
+ * <p>
  * In addition to cleaner and more readable code, this approach offers a performance benefit to using
  * {@link AdvancedCache#withFlags(Flag...)} API, thanks to
  * internal optimizations that can be made when the {@link Flag} set is unchanging.
- * <p/>
+ * <p>
  * Note that {@link DecoratedCache} must be the closest Delegate to the actual Cache implementation. All others
  * must delegate to this DecoratedCache.
  * @author Manik Surtani

--- a/core/src/main/java/org/infinispan/commands/CommandsFactory.java
+++ b/core/src/main/java/org/infinispan/commands/CommandsFactory.java
@@ -347,10 +347,9 @@ public interface CommandsFactory {
    /**
     * Initializes a {@link org.infinispan.commands.ReplicableCommand} read from a data stream with components specific
     * to the target cache instance.
-    * <p/>
+    * <p>
     * Implementations should also be deep, in that if the command contains other commands, these should be recursed
     * into.
-    * <p/>
     *
     * @param command command to initialize.  Cannot be null.
     * @param isRemote

--- a/core/src/main/java/org/infinispan/commands/CommandsFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/commands/CommandsFactoryImpl.java
@@ -158,7 +158,7 @@ import org.infinispan.xsite.statetransfer.XSiteStateTransferManager;
 /**
  * @author Mircea.Markus@jboss.com
  * @author Galder Zamarreño
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2011 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2011 Red Hat Inc.
  * @since 4.0
  */
 public class CommandsFactoryImpl implements CommandsFactory {

--- a/core/src/main/java/org/infinispan/commands/RemoteCommandsFactory.java
+++ b/core/src/main/java/org/infinispan/commands/RemoteCommandsFactory.java
@@ -86,7 +86,7 @@ import org.infinispan.xsite.statetransfer.XSiteStateTransferControlCommand;
  * Specifically used to create un-initialized {@link org.infinispan.commands.ReplicableCommand}s from a byte stream.
  * This is a {@link Scopes#GLOBAL} component and doesn't have knowledge of initializing a command by injecting
  * cache-specific components into it.
- * <p />
+ * <p>
  * Usually a second step to unmarshalling a command from a byte stream (after
  * creating an un-initialized version using this factory) is to pass the command though {@link CommandsFactory#initializeReplicableCommand(ReplicableCommand,boolean)}.
  *
@@ -104,10 +104,8 @@ public class RemoteCommandsFactory {
    /**
     * Creates an un-initialized command.  Un-initialized in the sense that parameters will be set, but any components
     * specific to the cache in question will not be set.
-    * <p/>
+    * <p>
     * You would typically set these parameters using {@link CommandsFactory#initializeReplicableCommand(ReplicableCommand,boolean)}
-    * <p/>
-    *
     *
     * @param id id of the command
     * @param type type of the command

--- a/core/src/main/java/org/infinispan/commands/ReplicableCommand.java
+++ b/core/src/main/java/org/infinispan/commands/ReplicableCommand.java
@@ -22,9 +22,8 @@ public interface ReplicableCommand {
    /**
     * Invoke the command asynchronously.
     * <p>
-    * <p>This method replaces {@link #perform(InvocationContext)} for remote execution.
+    * This method replaces {@link #perform(InvocationContext)} for remote execution.
     * The default implementation and {@link #perform(InvocationContext)} will be removed in future versions.
-    * </p>
     *
     * @since 9.0
     */
@@ -89,7 +88,7 @@ public interface ReplicableCommand {
    /**
     * If true, the command is processed asynchronously in a thread provided by an Infinispan thread pool. Otherwise,
     * the command is processed directly in the JGroups thread.
-    * <p/>
+    * <p>
     * This feature allows to avoid keep a JGroups thread busy that can originate discard of messages and
     * retransmissions. So, the commands that can block (waiting for some state, acquiring locks, etc.) should return
     * true.

--- a/core/src/main/java/org/infinispan/commands/control/LockControlCommand.java
+++ b/core/src/main/java/org/infinispan/commands/control/LockControlCommand.java
@@ -32,7 +32,7 @@ import org.infinispan.util.logging.LogFactory;
 
 /**
  * LockControlCommand is a command that enables distributed locking across infinispan nodes.
- * <p/>
+ * <p>
  * For more details refer to: https://jira.jboss.org/jira/browse/ISPN-70 https://jira.jboss.org/jira/browse/ISPN-48
  *
  * @author Vladimir Blagojevic (<a href="mailto:vblagoje@redhat.com">vblagoje@redhat.com</a>)

--- a/core/src/main/java/org/infinispan/commands/package-info.java
+++ b/core/src/main/java/org/infinispan/commands/package-info.java
@@ -2,11 +2,11 @@
  * Commands that operate on the cache, either locally or remotely.  This package contains the entire command object
  * model including interfaces and abstract classes.  Your starting point is probably {@link ReplicableCommand}, which
  * represents a command that can be used in RPC calls.
- * <p />
+ * <p>
  * A sub-interface, {@link VisitableCommand}, represents commands that can be visited using the <a href="http://en.wikipedia.org/wiki/Visitor_pattern">visitor pattern</a>.
  * Most commands that relate to public {@link Cache} API methods tend to be {@link VisitableCommand}s, and hence the
  * importance of this interface.
- * <p />
+ * <p>
  * The {@link Visitor} interface is capable of visiting {@link VisitableCommand}s, and a useful abstract implementation
  * of {@link Visitor} is {@link org.infinispan.interceptors.base.CommandInterceptor}, which allows you to create
  * interceptors that intercept command invocations adding aspects of behavior to a given invocation.

--- a/core/src/main/java/org/infinispan/commands/read/AbstractDataCommand.java
+++ b/core/src/main/java/org/infinispan/commands/read/AbstractDataCommand.java
@@ -11,7 +11,7 @@ import org.infinispan.context.Flag;
 
 /**
  * @author Mircea.Markus@jboss.com
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2011 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2011 Red Hat Inc.
  * @since 4.0
  */
 public abstract class AbstractDataCommand implements DataCommand, SegmentSpecificCommand {

--- a/core/src/main/java/org/infinispan/commands/read/GetCacheEntryCommand.java
+++ b/core/src/main/java/org/infinispan/commands/read/GetCacheEntryCommand.java
@@ -17,7 +17,7 @@ import org.infinispan.context.impl.FlagBitSets;
  * Used to fetch a full CacheEntry rather than just the value.
  * This functionality was originally incorporated into GetKeyValueCommand.
  *
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2014 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2014 Red Hat Inc.
  * @since 7.1
  */
 public final class GetCacheEntryCommand extends AbstractDataCommand {

--- a/core/src/main/java/org/infinispan/commands/remote/ClusteredGetCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/ClusteredGetCommand.java
@@ -27,7 +27,6 @@ import org.infinispan.util.logging.LogFactory;
 /**
  * Issues a remote get call.  This is not a {@link org.infinispan.commands.VisitableCommand} and hence not passed up the
  * interceptor chain.
- * <p/>
  *
  * @author Mircea.Markus@jboss.com
  * @since 4.0

--- a/core/src/main/java/org/infinispan/configuration/cache/StateTransferConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/StateTransferConfiguration.java
@@ -40,7 +40,7 @@ public class StateTransferConfiguration implements Matchable<StateTransferConfig
    /**
     * If {@code true}, the cache will fetch data from the neighboring caches when it starts up, so
     * the cache starts 'warm', although it will impact startup time.
-    * <p/>
+    * <p>
     * In distributed mode, state is transferred between running caches as well, as the ownership of
     * keys changes (e.g. because a cache left the cluster). Disabling this setting means a key will
     * sometimes have less than {@code numOwner} owners.

--- a/core/src/main/java/org/infinispan/configuration/cache/StateTransferConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/StateTransferConfigurationBuilder.java
@@ -35,7 +35,7 @@ public class StateTransferConfigurationBuilder extends
    /**
     * If {@code true}, the cache will fetch data from the neighboring caches when it starts up, so
     * the cache starts 'warm', although it will impact startup time.
-    * <p/>
+    * <p>
     * In distributed mode, state is transferred between running caches as well, as the ownership of
     * keys changes (e.g. because a cache left the cluster). Disabling this setting means a key will
     * sometimes have less than {@code numOwner} owners.

--- a/core/src/main/java/org/infinispan/configuration/cache/StoreAsBinaryConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/StoreAsBinaryConfiguration.java
@@ -10,10 +10,10 @@ import org.infinispan.commons.configuration.attributes.Matchable;
  * a serialized, binary format.  There are benefits to both approaches, but often if used in a clustered mode,
  * storing objects as binary means that the cost of serialization happens early on, and can be amortized.  Further,
  * deserialization costs are incurred lazily which improves throughput.
- * <p />
+ * <p>
  * It is possible to control this on a fine-grained basis: you can choose to just store keys or values as binary, or
  * both.
- * <p />
+ *
  * @see StoreAsBinaryConfigurationBuilder
  * @deprecated Use {@link MemoryConfiguration} instead
  */

--- a/core/src/main/java/org/infinispan/configuration/cache/StoreAsBinaryConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/StoreAsBinaryConfigurationBuilder.java
@@ -11,10 +11,10 @@ import org.infinispan.configuration.global.GlobalConfiguration;
  * a serialized, binary format.  There are benefits to both approaches, but often if used in a clustered mode,
  * storing objects as binary means that the cost of serialization happens early on, and can be amortized.  Further,
  * deserialization costs are incurred lazily which improves throughput.
- * <p />
+ * <p>
  * It is possible to control this on a fine-grained basis: you can choose to just store keys or values as binary, or
  * both.
- * <p />
+ *
  * @see StoreAsBinaryConfiguration
  * @deprecated Please use {@link MemoryConfigurationBuilder#storageType(StorageType)} method instead
  */

--- a/core/src/main/java/org/infinispan/configuration/cache/StoreConfigurationChildBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/StoreConfigurationChildBuilder.java
@@ -62,7 +62,7 @@ public interface StoreConfigurationChildBuilder<S> extends ConfigurationChildBui
     * database.) Setting this to true avoids multiple cache instances writing the same modification
     * multiple times. If enabled, only the node where the modification originated will write to the
     * cache store.
-    * <p/>
+    * <p>
     * If disabled, each individual cache reacts to a potential remote update by storing the data to
     * the cache store. Note that this could be useful if each individual node has its own cache
     * store - perhaps local on-disk.
@@ -73,12 +73,12 @@ public interface StoreConfigurationChildBuilder<S> extends ConfigurationChildBui
     * This setting should be set to true when the underlying cache store supports transactions and it is desirable for
     * the underlying store and the cache to remain synchronized. With this enabled any Exceptions thrown whilst writing
     * to the underlying store will result in both the store's and the cache's transaction rollingback.
-    * <p/>
+    * <p>
     * If enabled and this store is shared, then writes to this store will be performed at prepare time of the Infinispan Tx.
     * If an exception is encountered by the store during prepare time, then this will result in the global Tx being
     * rolledback along with this stores writes, otherwise writes to this store will be committed during the commit
     * phase of 2PC. If this is not enabled, then writes to the cache store are performed during the commit phase of a Tx.
-    *<p/>
+    * <p>
     * Note that this requires {@link #shared(boolean)} to be set to true.
     */
    S transactional(boolean b);

--- a/core/src/main/java/org/infinispan/configuration/cache/TransactionConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/TransactionConfiguration.java
@@ -241,13 +241,13 @@ public class TransactionConfiguration implements Matchable<TransactionConfigurat
     * offers less consistency guarantees. From Infinispan 5.1 onwards, mixed
     * access is no longer supported, so if you wanna speed up transactional
     * caches and you're ready to trade some consistency guarantees, you can
-    * enable use1PcForAutoCommitTransactions. <p/>
-    *
+    * enable use1PcForAutoCommitTransactions.
+    * <p>
     * What this configuration option does is force an induced transaction,
     * that has been started by Infinispan as a result of enabling autoCommit,
     * to commit in a single phase. So only 1 RPC instead of 2RPCs as in the
     * case of a full 2 Phase Commit (2PC).
-    * <p/>
+    * <p>
     * <b>N.B.</b> this option should NOT be used when modifying the
     * same key from multiple transactions as 1PC does not offer any consistency
     * guarantees under concurrent access.

--- a/core/src/main/java/org/infinispan/configuration/cache/TransactionConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/TransactionConfigurationBuilder.java
@@ -66,7 +66,7 @@ public class TransactionConfigurationBuilder extends AbstractConfigurationChildB
     * cache stop timeout. It is recommended that this value does not exceed the transaction timeout
     * because even if a new transaction was started just before the cache was stopped, this could
     * only last as long as the transaction timeout allows it.
-    * <p/>
+    * <p>
     * This configuration property may be adjusted at runtime
     */
    public TransactionConfigurationBuilder cacheStopTimeout(long l) {
@@ -80,7 +80,7 @@ public class TransactionConfigurationBuilder extends AbstractConfigurationChildB
     * cache stop timeout. It is recommended that this value does not exceed the transaction timeout
     * because even if a new transaction was started just before the cache was stopped, this could
     * only last as long as the transaction timeout allows it.
-    * <p/>
+    * <p>
     * This configuration property may be adjusted at runtime
     */
    public TransactionConfigurationBuilder cacheStopTimeout(long l, TimeUnit unit) {
@@ -215,8 +215,8 @@ public class TransactionConfigurationBuilder extends AbstractConfigurationChildB
     * offers less consistency guarantees. From Infinispan 5.1 onwards, mixed
     * access is no longer supported, so if you wanna speed up transactional
     * caches and you're ready to trade some consistency guarantees, you can
-    * enable use1PcForAutoCommitTransactions. <p/>
-    *
+    * enable use1PcForAutoCommitTransactions.
+    * <p>
     * What this configuration option does is force an induced transaction,
     * that has been started by Infinispan as a result of enabling autoCommit,
     * to commit in a single phase. So only 1 RPC instead of 2RPCs as in the

--- a/core/src/main/java/org/infinispan/configuration/cache/UnsafeConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/UnsafeConfiguration.java
@@ -11,10 +11,9 @@ import org.infinispan.commons.configuration.attributes.Matchable;
  *
  * Controls certain tuning parameters that may break some of Infinispan's public API contracts in
  * exchange for better performance in some cases.
- * <p />
+ * <p>
  * Use with care, only after thoroughly reading and understanding the documentation about a specific
  * feature.
- * <p />
  *
  * @see UnsafeConfigurationBuilder
  */

--- a/core/src/main/java/org/infinispan/configuration/cache/UnsafeConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/UnsafeConfigurationBuilder.java
@@ -11,9 +11,8 @@ import org.infinispan.configuration.global.GlobalConfiguration;
 /**
  * Controls certain tuning parameters that may break some of Infinispan's public API contracts in exchange for better
  * performance in some cases.
- * <p />
+ * <p>
  * Use with care, only after thoroughly reading and understanding the documentation about a specific feature.
- * <p />
  */
 public class UnsafeConfigurationBuilder extends AbstractConfigurationChildBuilder implements Builder<UnsafeConfiguration> {
 
@@ -28,11 +27,11 @@ public class UnsafeConfigurationBuilder extends AbstractConfigurationChildBuilde
    /**
     * Specify whether Infinispan is allowed to disregard the {@link Map} contract when providing return values for
     * {@link org.infinispan.Cache#put(Object, Object)} and {@link org.infinispan.Cache#remove(Object)} methods.
-    * <p />
+    * <p>
     * Providing return values can be expensive as they may entail a read from disk or across a network, and if the usage
     * of these methods never make use of these return values, allowing unreliable return values helps Infinispan
     * optimize away these remote calls or disk reads.
-    * <p />
+    *
     * @param allowUnreliableReturnValues if true, return values for the methods described above should not be relied on.
     */
    public UnsafeConfigurationBuilder unreliableReturnValues(boolean allowUnreliableReturnValues) {

--- a/core/src/main/java/org/infinispan/configuration/global/GlobalConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/global/GlobalConfiguration.java
@@ -13,9 +13,7 @@ import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
 
 /**
- * <p>
  * Configuration component that exposes the global configuration.
- * </p>
  *
  * @author Manik Surtani
  * @author Vladimir Blagojevic
@@ -26,7 +24,6 @@ import org.infinispan.factories.scopes.Scopes;
  * @since 5.1
  *
  * @see <a href="../../../config.html#ce_infinispan_global">Configuration reference</a>
- *
  */
 @Scope(Scopes.GLOBAL)
 @SurvivesRestarts

--- a/core/src/main/java/org/infinispan/container/DataContainer.java
+++ b/core/src/main/java/org/infinispan/container/DataContainer.java
@@ -49,7 +49,7 @@ public interface DataContainer<K, V> extends Iterable<InternalCacheEntry<K, V>> 
     * Retrieves a cache entry in the same way as {@link #get(Object)}} except that it does not update or reorder any of
     * the internal constructs. I.e., expiration does not happen, and in the case of the LRU container, the entry is not
     * moved to the end of the chain.
-    * <p/>
+    * <p>
     * This method should be used instead of {@link #get(Object)}} when called while iterating through the data container
     * using methods like {@link #iterator()} to avoid changing the underlying collection's order.
     *
@@ -61,7 +61,7 @@ public interface DataContainer<K, V> extends Iterable<InternalCacheEntry<K, V>> 
    /**
     * Puts an entry in the cache along with metadata adding information such lifespan of entry, max idle time, version
     * information...etc.
-    * <p/>
+    * <p>
     * The {@code key} must be activate by invoking {@link org.infinispan.eviction.ActivationManager#onUpdate(Object,
     * boolean)}.
     *
@@ -81,7 +81,7 @@ public interface DataContainer<K, V> extends Iterable<InternalCacheEntry<K, V>> 
 
    /**
     * Removes an entry from the cache
-    * <p/>
+    * <p>
     * The {@code key} must be activate by invoking {@link org.infinispan.eviction.ActivationManager#onRemove(Object,
     * boolean)}.
     *
@@ -150,7 +150,7 @@ public interface DataContainer<K, V> extends Iterable<InternalCacheEntry<K, V>> 
     * Returns a mutable set of immutable cache entries exposed as immutable Map.Entry instances. Clients of this method
     * such as Cache.entrySet() operation implementors are free to convert the set into an immutable set if needed, which
     * is the most common use case.
-    * <p/>
+    * <p>
     * If a client needs to iterate through a mutable set of mutable cache entries, it should iterate the container
     * itself rather than iterating through the return of entrySet().
     * <p>
@@ -169,7 +169,7 @@ public interface DataContainer<K, V> extends Iterable<InternalCacheEntry<K, V>> 
 
    /**
     * Atomically, it removes the key from {@code DataContainer} and passivates it to persistence.
-    * <p/>
+    * <p>
     * The passivation must be done by invoking the method {@link org.infinispan.eviction.PassivationManager#passivate(org.infinispan.container.entries.InternalCacheEntry)}.
     *
     * @param key The key to evict.
@@ -178,10 +178,10 @@ public interface DataContainer<K, V> extends Iterable<InternalCacheEntry<K, V>> 
 
    /**
     * Computes the new value for the key.
-    * <p/>
+    * <p>
     * See {@link org.infinispan.container.DataContainer.ComputeAction#compute(Object,
     * org.infinispan.container.entries.InternalCacheEntry, InternalEntryFactory)}.
-    * <p/>
+    * <p>
     * The {@code key} must be activate by invoking {@link org.infinispan.eviction.ActivationManager#onRemove(Object,
     * boolean)} or {@link org.infinispan.eviction.ActivationManager#onUpdate(Object, boolean)} depending if the value
     * returned by the {@link org.infinispan.container.DataContainer.ComputeAction} is null or not respectively.

--- a/core/src/main/java/org/infinispan/container/entries/InternalCacheEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/InternalCacheEntry.java
@@ -76,12 +76,11 @@ public interface InternalCacheEntry<K, V> extends CacheEntry<K, V>, Cloneable {
     * purpose of this is to provide a representation that does <i>not</i> have a reference to the key. This is useful in
     * situations where the key is already known or stored elsewhere, making serialization and deserialization more
     * efficient.
-    * <p/>
+    * <p>
     * Note that this should not be used to optimize memory overhead, since the saving of an additional reference to a
     * key (a single object reference) does not warrant the cost of constructing an InternalCacheValue.  This <i>only</i>
     * makes sense when marshalling is involved, since the cost of marshalling the key again can be sidestepped using an
     * InternalCacheValue if the key is already known/marshalled.
-    * <p/>
     *
     * @return a new InternalCacheValue encapsulating this InternalCacheEntry's value and expiration information.
     */

--- a/core/src/main/java/org/infinispan/container/entries/InternalCacheValue.java
+++ b/core/src/main/java/org/infinispan/container/entries/InternalCacheValue.java
@@ -6,14 +6,13 @@ import org.infinispan.metadata.Metadata;
  * A representation of an InternalCacheEntry that does not have a reference to the key.  This should be used if the key
  * is either not needed or available elsewhere as it is more efficient to marshall and unmarshall.  Probably most useful
  * in cache stores.
- * <p/>
+ * <p>
  * Note that this should not be used to optimize memory overhead, since the saving of an additional reference to a key
  * (a single object reference) does not warrant the cost of constructing an InternalCacheValue, where an existing
  * InternalCacheEntry is already referenced.
- * <p/>
+ * <p>
  * Use of this interface <i>only</i> makes sense when marshalling is involved, since the cost of marshalling the key
  * again can be sidestepped using an InternalCacheValue if the key is already known/marshalled.
- * <p/>
  *
  * @author Manik Surtani
  * @since 4.0

--- a/core/src/main/java/org/infinispan/container/impl/InternalEntryFactory.java
+++ b/core/src/main/java/org/infinispan/container/impl/InternalEntryFactory.java
@@ -115,7 +115,7 @@ public interface InternalEntryFactory {
    /**
     * Similar to {@link #update(org.infinispan.container.entries.InternalCacheEntry, org.infinispan.metadata.Metadata)}
     * but it also updates the {@link org.infinispan.container.entries.InternalCacheEntry} value.
-    * <p/>
+    * <p>
     * If the same internal cache entry is returned and if it is a mortal cache entry, the returned instance needs to be
     * reincarnated.
     *

--- a/core/src/main/java/org/infinispan/container/impl/package-info.java
+++ b/core/src/main/java/org/infinispan/container/impl/package-info.java
@@ -2,7 +2,7 @@
  * Data containers which store cache entries.  This package contains different implementations of
  * containers based on their performance and ordering characteristics, as well as the entries
  * that live in the containers.
- * <p />
+ * <p>
  * This package also contains the factory for creating entries, and is typically used by the {@link LockingInterceptor}
  * to wrap an entry and put it in a thread's {@link InvocationContext}
  */

--- a/core/src/main/java/org/infinispan/context/EntryLookup.java
+++ b/core/src/main/java/org/infinispan/context/EntryLookup.java
@@ -15,7 +15,6 @@ import org.infinispan.container.entries.CacheEntry;
 public interface EntryLookup {
    /**
     * Retrieves an entry from the collection of looked up entries in the current scope.
-    * <p/>
     *
     * @param key key to look up
     * @return an entry, or null if it cannot be found.
@@ -24,7 +23,7 @@ public interface EntryLookup {
 
    /**
     * Retrieves a map of entries looked up within the current scope.
-    * <p/>
+    * <p>
     * Note: The key inside the {@linkplain CacheEntry} may be {@code null} if the key does not exist in the cache.
     *
     * @return a map of looked up entries.
@@ -69,7 +68,6 @@ public interface EntryLookup {
 
    /**
     * Puts an entry in the registry of looked up entries in the current scope.
-    * <p/>
     *
     * @param key key to store
     * @param e   entry to store

--- a/core/src/main/java/org/infinispan/context/impl/ImmutableContext.java
+++ b/core/src/main/java/org/infinispan/context/impl/ImmutableContext.java
@@ -13,7 +13,7 @@ import org.infinispan.remoting.transport.Address;
  * This context is a non-context for operations such as eviction which are not related
  * to the method invocation which caused them.
  *
- * @author Sanne Grinovero <sanne@infinispan.org> (C) 2011 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@infinispan.org&gt; (C) 2011 Red Hat Inc.
  */
 public final class ImmutableContext implements InvocationContext {
 

--- a/core/src/main/java/org/infinispan/distribution/ch/impl/TopologyAwareSyncConsistentHashFactory.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/impl/TopologyAwareSyncConsistentHashFactory.java
@@ -19,10 +19,10 @@ import org.infinispan.remoting.transport.TopologyAwareAddress;
  * A {@link org.infinispan.distribution.ch.ConsistentHashFactory} implementation that guarantees caches
  * with the same members have the same consistent hash and also tries to distribute segments based on the
  * topology information in {@link org.infinispan.configuration.global.TransportConfiguration}.
- * <p/>
+ * <p>
  * It has a drawback compared to {@link org.infinispan.distribution.ch.impl.DefaultConsistentHashFactory}:
  * it can potentially move a lot more segments during a rebalance than strictly necessary.
- * <p/>
+ * <p>
  * It is not recommended using the {@code TopologyAwareSyncConsistentHashFactory} with a very small number
  * of segments. The distribution of segments to owners gets better with a higher number of segments, and is
  * especially bad when {@code numSegments &lt; numNodes}

--- a/core/src/main/java/org/infinispan/distribution/impl/DistributionManagerImpl.java
+++ b/core/src/main/java/org/infinispan/distribution/impl/DistributionManagerImpl.java
@@ -37,7 +37,7 @@ import org.infinispan.util.logging.LogFactory;
  * @author Vladimir Blagojevic
  * @author Mircea.Markus@jboss.com
  * @author Bela Ban
- * @author Dan Berindei <dan@infinispan.org>
+ * @author Dan Berindei &lt;dan@infinispan.org&gt;
  * @author anistor@redhat.com
  * @since 4.0
  */

--- a/core/src/main/java/org/infinispan/eviction/ActivationManager.java
+++ b/core/src/main/java/org/infinispan/eviction/ActivationManager.java
@@ -22,7 +22,7 @@ public interface ActivationManager {
 
    /**
     * Remove key and associated value from cache store and update the activation counter.
-    * <p/>
+    * <p>
     * The key is also removed from the shared configured stores.
     *
     * @param key      Key to activate

--- a/core/src/main/java/org/infinispan/eviction/EvictionManager.java
+++ b/core/src/main/java/org/infinispan/eviction/EvictionManager.java
@@ -10,9 +10,9 @@ import net.jcip.annotations.ThreadSafe;
 
 /**
  * Central component that deals with eviction of cache entries.
- * <p />
+ * <p>
  * This manager only controls notifications of when entries are evicted.
- * <p />
+ *
  * @author Manik Surtani
  * @since 4.0
  */

--- a/core/src/main/java/org/infinispan/expiration/ExpirationManager.java
+++ b/core/src/main/java/org/infinispan/expiration/ExpirationManager.java
@@ -11,13 +11,13 @@ import net.jcip.annotations.ThreadSafe;
 
 /**
  * Central component that deals with expiration of cache entries.
- * <p />
+ * <p>
  * Typically, {@link #processExpiration()} is called periodically by the expiration thread (which can be configured using
  * {@link ExpirationConfigurationBuilder#wakeUpInterval(long)} and {@link GlobalConfigurationBuilder#expirationThreadPool()}).
- * <p />
+ * <p>
  * If the expiration thread is disabled - by setting {@link ExpirationConfigurationBuilder#wakeUpInterval(long)} to <tt>0</tt> -
  * then this method could be called directly, perhaps by any other maintenance thread that runs periodically in the application.
- * <p />
+ *
  * @author William Burns
  * @since 7.2
  */

--- a/core/src/main/java/org/infinispan/factories/AbstractComponentFactory.java
+++ b/core/src/main/java/org/infinispan/factories/AbstractComponentFactory.java
@@ -11,11 +11,11 @@ import org.infinispan.util.logging.LogFactory;
 
 /**
  * Factory that creates components used internally within Infinispan, and also wires dependencies into the components.
- * <p/>
+ * <p>
  * The {@link InternalCacheFactory} is a special subclass of this, which bootstraps the construction of other
  * components. When this class is loaded, it maintains a static list of known default factories for known components,
  * which it then delegates to, when actually performing the construction.
- * <p/>
+ * <p>
  *
  * @author Manik Surtani (<a href="mailto:manik@jboss.org">manik@jboss.org</a>)
  * @see Inject

--- a/core/src/main/java/org/infinispan/factories/AbstractComponentRegistry.java
+++ b/core/src/main/java/org/infinispan/factories/AbstractComponentRegistry.java
@@ -28,22 +28,22 @@ import org.infinispan.util.logging.Log;
 /**
  * A registry where components which have been created are stored.  Components are stored as singletons, registered
  * under a specific name.
- * <p/>
+ * <p>
  * Components can be retrieved from the registry using {@link #getComponent(Class)}.
- * <p/>
+ * <p>
  * Components can be registered using {@link #registerComponent(Object, Class)}, which will cause any dependencies to be
  * wired in as well.  Components that need to be created as a result of wiring will be done using {@link
  * #getOrCreateComponent(Class)}, which will look up the default factory for the component type (factories annotated
  * with the appropriate {@link DefaultFactoryFor} annotation.
- * <p/>
+ * <p>
  * Default factories are treated as components too and will need to be wired before being used.
- * <p/>
+ * <p>
  * The registry can exist in one of several states, as defined by the {@link org.infinispan.lifecycle.ComponentStatus}
  * enumeration. In terms of the cache, state changes in the following manner: <ul> <li>INSTANTIATED - when first
  * constructed</li> <li>CONSTRUCTED - when created using the DefaultCacheFactory</li> <li>STARTED - when {@link
  * org.infinispan.Cache#start()} is called</li> <li>STOPPED - when {@link org.infinispan.Cache#stop()} is called</li>
  * </ul>
- * <p/>
+ * <p>
  * Cache configuration can only be changed and will only be re-injected if the cache is not in the {@link
  * org.infinispan.lifecycle.ComponentStatus#RUNNING} state.
  *
@@ -141,16 +141,15 @@ public abstract class AbstractComponentRegistry implements Lifecycle, Cloneable 
     * Retrieves a component if one exists, and if not, attempts to find a factory capable of constructing the component
     * (factories annotated with the {@link DefaultFactoryFor} annotation that is capable of creating the component
     * class).
-    * <p/>
+    * <p>
     * If an instance needs to be constructed, dependencies are then automatically wired into the instance, based on
     * methods on the component type annotated with {@link Inject}.
-    * <p/>
+    * <p>
     * Summing it up, component retrieval happens in the following order:<br /> 1.  Look for a component that has already
     * been created and registered. 2.  Look for an appropriate component that exists in the {@link Configuration} that
     * may be injected from an external system. 3.  Look for a class definition passed in to the {@link Configuration} -
     * such as an EvictionPolicy implementation 4.  Attempt to create it by looking for an appropriate factory (annotated
     * with {@link DefaultFactoryFor})
-    * <p/>
     *
     * @param componentClass type of component to be retrieved.  Should not be null.
     * @return a fully wired component instance, or null if one cannot be found or constructed.
@@ -270,7 +269,6 @@ public abstract class AbstractComponentRegistry implements Lifecycle, Cloneable 
     * Rewires components.  Used to rewire components in the CR if a cache has been stopped (moved to state TERMINATED),
     * which would (almost) empty the registry of components.  Rewiring will re-inject all dependencies so that the cache
     * can be started again.
-    * <p/>
     */
    public void rewire() {
       basicComponentRegistry.rewire();

--- a/core/src/main/java/org/infinispan/factories/AutoInstantiableFactory.java
+++ b/core/src/main/java/org/infinispan/factories/AutoInstantiableFactory.java
@@ -4,9 +4,8 @@ package org.infinispan.factories;
  * Component factories that implement this interface can be instantiated automatically by component registries when
  * looking up components.  Typically, most component factories will implement this.  One known exception is the {@link
  * org.infinispan.factories.BootstrapFactory}.
- * <p/>
+ * <p>
  * Anything implementing this interface should expose a public, no-arg constructor.
- * <p/>
  *
  * @author Manik Surtani
  * @since 4.0

--- a/core/src/main/java/org/infinispan/factories/InternalCacheFactory.java
+++ b/core/src/main/java/org/infinispan/factories/InternalCacheFactory.java
@@ -59,10 +59,9 @@ import org.infinispan.xsite.XSiteAdminOperations;
 /**
  * An internal factory for constructing Caches.  Used by the {@link org.infinispan.manager.DefaultCacheManager}, this is
  * not intended as public API.
- * <p/>
+ * <p>
  * This is a special instance of a {@link AbstractComponentFactory} which contains bootstrap information for the {@link
  * ComponentRegistry}.
- * <p/>
  *
  * @author <a href="mailto:manik@jboss.org">Manik Surtani (manik@jboss.org)</a>
  * @since 4.0

--- a/core/src/main/java/org/infinispan/factories/annotations/ComponentName.java
+++ b/core/src/main/java/org/infinispan/factories/annotations/ComponentName.java
@@ -6,7 +6,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Mechanism for specifying the name of components to retrieve
+ * Mechanism for specifying the name of components to retrieve.
  *
  * @author Manik Surtani
  * @since 4.0

--- a/core/src/main/java/org/infinispan/factories/annotations/Inject.java
+++ b/core/src/main/java/org/infinispan/factories/annotations/Inject.java
@@ -14,7 +14,7 @@ import org.infinispan.factories.ComponentRegistry;
  * to be constructed must be built using the {@link AbstractComponentFactory#construct(Class)} method, or if your object
  * that needs components injected into it already exists, it can be built using the {@link
  * ComponentRegistry#wireDependencies(Object)} method.
- * <p/>
+ * <p>
  * Usage example:
  * <pre>
  *       public class MyClass
@@ -22,21 +22,20 @@ import org.infinispan.factories.ComponentRegistry;
  *          private TransactionManager tm;
  *          private BuddyManager bm;
  *          private Notifier n;
- * <p/>
- *          &amp;Inject
+ *
+ *          &#064;Inject
  *          public void setTransactionManager(TransactionManager tm)
  *          {
  *             this.tm = tm;
  *          }
- * <p/>
- *          &amp;Inject
+ *
+ *          &#064;Inject
  *          public void injectMoreStuff(BuddyManager bm, Notifier n)
  *          {
  *             this.bm = bm;
  *             this.n = n;
  *          }
  *       }
- * <p/>
  * </pre>
  * and an instance of this class can be constructed and wired using
  * <pre>

--- a/core/src/main/java/org/infinispan/factories/annotations/PostStart.java
+++ b/core/src/main/java/org/infinispan/factories/annotations/PostStart.java
@@ -8,8 +8,7 @@ import java.lang.annotation.Target;
 
 /**
  * Method level annotation that indicates a (no-param) method to be called on a component after the
- * {@link org.infinispan.factories.ComponentRegistry} has been fully initialized
- * <p/>
+ * {@link org.infinispan.factories.ComponentRegistry} has been fully initialized.
  *
  * @author Tristan Tarrant
  * @since 9.2

--- a/core/src/main/java/org/infinispan/factories/annotations/Start.java
+++ b/core/src/main/java/org/infinispan/factories/annotations/Start.java
@@ -9,7 +9,6 @@ import java.lang.annotation.Target;
 /**
  * Method level annotation that indicates a (no-param) method to be called on a component registered in the
  * component registry when the registry starts.
- * <p/>
  *
  * @author Manik Surtani (<a href="mailto:manik@jboss.org">manik@jboss.org</a>)
  * @since 4.0

--- a/core/src/main/java/org/infinispan/factories/annotations/Stop.java
+++ b/core/src/main/java/org/infinispan/factories/annotations/Stop.java
@@ -9,7 +9,6 @@ import java.lang.annotation.Target;
 /**
  * Method level annotation that indicates a (no-param) method to be called on a component registered in the
  * component registry when the registry stops.
- * <p/>
  *
  * @author Manik Surtani (<a href="mailto:manik@jboss.org">manik@jboss.org</a>)
  * @since 4.0

--- a/core/src/main/java/org/infinispan/factories/components/ComponentMetadata.java
+++ b/core/src/main/java/org/infinispan/factories/components/ComponentMetadata.java
@@ -28,14 +28,14 @@ import org.infinispan.factories.scopes.Scopes;
  * {@link DefaultFactoryFor}, {@link ComponentName}, {@link Inject}, {@link Start} and {@link Stop} annotations.  Instead
  * of scanning for these annotations and working out dependency chains at runtime "on-demand", since Infinispan 5.1, this
  * process now happens offline, at build-time.
- * <p />
+ * <p>
  * When compiling Infinispan, components and their dependency chains are inspected and the information expressed by the
  * annotations above are denormalized and a series of {@link ComponentMetadata} objects are created and persisted in the
  * Infinispan jar.
- * <p />
+ * <p>
  * This metadata is then read in by the {@link ComponentMetadataRepo} at runtime, and used by the {@link ComponentRegistry}
  * and other factory-like classes to bootstrap an Infinispan node.
- * <p />
+ * <p>
  * Also see {@link ManageableComponentMetadata} for components that also expose JMX information.
 
  * @author Manik Surtani

--- a/core/src/main/java/org/infinispan/factories/components/ModuleMetadataFileFinder.java
+++ b/core/src/main/java/org/infinispan/factories/components/ModuleMetadataFileFinder.java
@@ -8,17 +8,17 @@ import org.infinispan.factories.annotations.Stop;
  * This interface should be implemented by all Infinispan modules that expect to have components using {@link Inject},
  * {@link Start} or {@link Stop} annotations.  The metadata file is generated at build time and packaged in the module's
  * corresponding jar file (see Infinispan's <pre>core</pre> module <pre>pom.xml</pre> for an example of this).
- * <p />
+ * <p>
  * Module component metadata is usually generated in a file titled <pre>${module-name}-component-metadata.dat</pre> and
  * typically resides in the root of the module's jar file.
- * <p />
+ * <p>
  * For example, Infinispan's Query Module would implement this interface to return <pre>infinispan-query-component-metadata.dat</pre>.
- * <p />
+ * <p>
  * Implementations of this interface are discovered using the JDK's {@link java.util.ServiceLoader} utility.  Which means
  * modules would also have to package a file called <pre>org.infinispan.factories.components.ModuleMetadataFileFinder</pre>
  * in the <pre>META-INF/services/</pre> folder in their jar, and this file would contain the fully qualified class name
  * of the module's implementation of this interface.
- * <p />
+ * <p>
  * Please see Infinispan's query module for an example of this.
  *
  * @author Manik Surtani

--- a/core/src/main/java/org/infinispan/interceptors/base/CommandInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/base/CommandInterceptor.java
@@ -30,20 +30,19 @@ import org.infinispan.util.logging.LogFactory;
 /**
  * This is the base class for all interceptors to extend, and implements the {@link Visitor} interface allowing it to
  * intercept invocations on {@link VisitableCommand}s.
- * <p/>
+ * <p>
  * Commands are either created by the {@link CacheImpl} (for invocations on the {@link Cache} public interface), or
  * by the {@link org.infinispan.remoting.inboundhandler.InboundInvocationHandler} for remotely originating invocations, and are passed up the interceptor chain
  * by using the {@link InterceptorChain} helper class.
- * <p/>
+ * <p>
  * When writing interceptors, authors can either override a specific visitXXX() method (such as {@link
  * #visitGetKeyValueCommand(InvocationContext, GetKeyValueCommand)}) or the more generic {@link
  * #handleDefault(InvocationContext, VisitableCommand)} which is the default behaviour of any visit method, as defined
  * in {@link AbstractVisitor#handleDefault(InvocationContext, VisitableCommand)}.
- * <p/>
+ * <p>
  * The preferred approach is to override the specific visitXXX() methods that are of interest rather than to override
  * {@link #handleDefault(InvocationContext, VisitableCommand)} and then write a series of if statements or a switch
  * block, if command-specific behaviour is needed.
- * <p/>
  *
  * @author Mircea.Markus@jboss.com
  * @see VisitableCommand

--- a/core/src/main/java/org/infinispan/interceptors/base/PrePostProcessingCommandInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/base/PrePostProcessingCommandInterceptor.java
@@ -20,16 +20,15 @@ import org.infinispan.interceptors.AsyncInterceptor;
 
 /**
  * This interceptor adds pre and post processing to each <tt>visitXXX()</tt> method.
- * <p/>
+ * <p>
  * For each <tt>visitXXX()</tt> method invoked, it will first call {@link #doBeforeCall(InvocationContext,
  * VisitableCommand)} and if this method returns true, it will proceed to invoking a <tt>handleXXX()</tt> method and
  * lastly, {@link #doAfterCall(InvocationContext, VisitableCommand)} in a <tt>finally</tt> block.  Note that the
  * <tt>doAfterCall()</tt> method is still invoked even if <tt>doBeforeCall()</tt> returns <tt>false</tt>.
- * <p/>
+ * <p>
  * Instead of overriding <tt>visitXXX()</tt> methods, implementations should override their <tt>handleXXX()</tt>
  * counterparts defined in this class instead, as well as the {@link #doAfterCall(InvocationContext ,VisitableCommand)}
  * method and optionally {@link #doBeforeCall(InvocationContext, VisitableCommand)}.
- * <p/>
  *
  * @author Mircea.Markus@jboss.com
  * @deprecated Since 9.0, please extend {@link AsyncInterceptor} instead.

--- a/core/src/main/java/org/infinispan/interceptors/distribution/BaseDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/BaseDistributionInterceptor.java
@@ -83,7 +83,7 @@ import net.jcip.annotations.GuardedBy;
  * @author Manik Surtani
  * @author Mircea.Markus@jboss.com
  * @author Pete Muir
- * @author Dan Berindei <dan@infinispan.org>
+ * @author Dan Berindei &lt;dan@infinispan.org&gt;
  */
 public abstract class BaseDistributionInterceptor extends ClusteringInterceptor {
    private static final Log log = LogFactory.getLog(BaseDistributionInterceptor.class);

--- a/core/src/main/java/org/infinispan/interceptors/impl/BaseStateTransferInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/BaseStateTransferInterceptor.java
@@ -42,7 +42,7 @@ import org.infinispan.util.logging.LogFactory;
 /**
  * A base class for a state transfer interceptor. It contains the base code to avoid duplicating in the two current
  * different implementations.
- * <p/>
+ * <p>
  * Also, it has some utilities methods with the most common logic.
  *
  * @author Pedro Ruivo

--- a/core/src/main/java/org/infinispan/interceptors/impl/InvalidationInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/InvalidationInterceptor.java
@@ -49,7 +49,7 @@ import org.infinispan.util.logging.LogFactory;
 /**
  * This interceptor acts as a replacement to the replication interceptor when the CacheImpl is configured with
  * ClusteredSyncMode as INVALIDATE.
- * <p/>
+ * <p>
  * The idea is that rather than replicating changes to all caches in a cluster when write methods are called, simply
  * broadcast an {@link InvalidateCommand} on the remote caches containing all keys modified.  This allows the remote
  * cache to look up the value in a shared cache loader which would have been updated with the changes.

--- a/core/src/main/java/org/infinispan/io/ExposedByteArrayOutputStream.java
+++ b/core/src/main/java/org/infinispan/io/ExposedByteArrayOutputStream.java
@@ -14,7 +14,6 @@ import net.jcip.annotations.NotThreadSafe;
  * to help prevent an OutOfMemoryError during a resize of a large buffer. </p> <p> A version of this class was
  * originally created by Bela Ban as part of the JGroups library. </p> This class is not threadsafe as it will not
  * support concurrent readers and writers.
- * <p/>
  *
  * @author <a href="mailto://brian.stansberry@jboss.com">Brian Stansberry</a>
  * @since 4.0

--- a/core/src/main/java/org/infinispan/jmx/PlatformMBeanServerLookup.java
+++ b/core/src/main/java/org/infinispan/jmx/PlatformMBeanServerLookup.java
@@ -7,7 +7,7 @@ import javax.management.MBeanServer;
 
 /**
  * Default implementation for {@link MBeanServerLookup}, will return the platform MBean server.
- * <p/>
+ * <p>
  * Note: to enable platform MBeanServer the following system property should be passed to the Sun JVM:
  * <b>-Dcom.sun.management.jmxremote</b>.
  *

--- a/core/src/main/java/org/infinispan/jmx/ResourceDMBean.java
+++ b/core/src/main/java/org/infinispan/jmx/ResourceDMBean.java
@@ -33,7 +33,7 @@ import org.infinispan.util.logging.LogFactory;
 /**
  * This class was entirely copied from JGroups 2.7 (same name there). Couldn't simply reuse it because JGroups does not
  * ship with MBean, ManagedAttribute and ManagedOperation.
- * <p/>
+ * <p>
  * The original JGroup's ResourceDMBean logic has been modified so that invoke() method checks whether the operation
  * called has been exposed as a {@link ManagedOperation}, otherwise the call fails. JGroups deviated from this logic on
  * purpose because they liked the fact that you could expose all class methods by simply annotating class with {@link

--- a/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
@@ -85,30 +85,30 @@ import org.infinispan.util.logging.LogFactory;
 /**
  * A <tt>CacheManager</tt> is the primary mechanism for retrieving a {@link Cache} instance, and is often used as a
  * starting point to using the {@link Cache}.
- * <p/>
+ * <p>
  * <tt>CacheManager</tt>s are heavyweight objects, and we foresee no more than one <tt>CacheManager</tt> being used per
  * JVM (unless specific configuration requirements require more than one; but either way, this would be a minimal and
  * finite number of instances).
- * <p/>
+ * <p>
  * Constructing a <tt>CacheManager</tt> is done via one of its constructors, which optionally take in a {@link
  * org.infinispan.configuration.cache.Configuration} or a path or URL to a configuration XML file.
- * <p/>
+ * <p>
  * Lifecycle - <tt>CacheManager</tt>s have a lifecycle (it implements {@link Lifecycle}) and the default constructors
  * also call {@link #start()}. Overloaded versions of the constructors are available, that do not start the
  * <tt>CacheManager</tt>, although it must be kept in mind that <tt>CacheManager</tt>s need to be started before they
  * can be used to create <tt>Cache</tt> instances.
- * <p/>
+ * <p>
  * Once constructed, <tt>CacheManager</tt>s should be made available to any component that requires a <tt>Cache</tt>,
  * via JNDI or via some other mechanism such as an IoC container.
- * <p/>
+ * <p>
  * You obtain <tt>Cache</tt> instances from the <tt>CacheManager</tt> by using one of the overloaded
  * <tt>getCache()</tt>, methods. Note that with <tt>getCache()</tt>, there is no guarantee that the instance you get is
  * brand-new and empty, since caches are named and shared. Because of this, the <tt>CacheManager</tt> also acts as a
  * repository of <tt>Cache</tt>s, and is an effective mechanism of looking up or creating <tt>Cache</tt>s on demand.
- * <p/>
+ * <p>
  * When the system shuts down, it should call {@link #stop()} on the <tt>CacheManager</tt>. This will ensure all caches
  * within its scope are properly stopped as well.
- * <p/>
+ * <p>
  * Sample usage:
  * <pre><code>
  *    CacheManager manager = CacheManager.getInstance("my-config-file.xml");
@@ -421,7 +421,7 @@ public class DefaultCacheManager implements EmbeddedCacheManager {
     * Retrieves the default cache associated with this cache manager. Note that the default cache does not need to be
     * explicitly created with {@link #createCache(String, String)} (String)} since it is automatically created lazily
     * when first used.
-    * <p/>
+    * <p>
     * As such, this method is always guaranteed to return the default cache.
     *
     * @return the default cache.
@@ -437,7 +437,7 @@ public class DefaultCacheManager implements EmbeddedCacheManager {
    /**
     * Retrieves a named cache from the system. If the cache has been previously created with the same name, the running
     * cache instance is returned. Otherwise, this method attempts to create the cache first.
-    * <p/>
+    * <p>
     * When creating a new cache, this method will use the configuration passed in to the CacheManager on construction,
     * as a template, and then optionally apply any overrides previously defined for the named cache using the {@link
     * #defineConfiguration(String, Configuration)} or {@link #defineConfiguration(String, String, Configuration)}

--- a/core/src/main/java/org/infinispan/manager/EmbeddedCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/EmbeddedCacheManager.java
@@ -23,19 +23,19 @@ import org.infinispan.stats.CacheContainerStats;
 
 /**
  * EmbeddedCacheManager is an CacheManager that runs in the same JVM as the client.
- * <p/>
+ * <p>
  * Constructing a <tt>EmbeddedCacheManager</tt> is done via one of its constructors, which optionally take in a {@link
  * org.infinispan.configuration.cache.Configuration} or a path or URL to a configuration XML file: see {@link org.infinispan.manager.DefaultCacheManager}.
- * <p/>
+ * <p>
  * Lifecycle - <tt>EmbeddedCacheManager</tt>s have a lifecycle (it implements {@link Lifecycle}) and
  * the default constructors also call {@link #start()}.  Overloaded versions of the constructors are available, that do
  * not start the <tt>CacheManager</tt>, although it must be kept in mind that <tt>CacheManager</tt>s need to be started
  * before they can be used to readWriteMap <tt>Cache</tt> instances.
- * <p/>
+ * <p>
  * Once constructed, <tt>EmbeddedCacheManager</tt>s should be made available to any component that requires a <tt>Cache</tt>,
  * via <a href="http://en.wikipedia.org/wiki/Java_Naming_and_Directory_Interface">JNDI</a> or via some other mechanism
  * such as an <a href="http://en.wikipedia.org/wiki/Dependency_injection">dependency injection</a> framework.
- * <p/>
+ * <p>
  *
  * @see org.infinispan.manager.DefaultCacheManager
  * @author Manik Surtani (<a href="mailto:manik@jboss.org">manik@jboss.org</a>)
@@ -49,13 +49,13 @@ public interface EmbeddedCacheManager extends CacheContainer, Listenable, Closea
 
    /**
     * Defines a named cache's configuration by using the provided configuration
-    * <p/>
+    * <p>
     * Unlike previous versions of Infinispan, this method does not build on an existing configuration (default or named).
     * If you want this behavior, then use {@link ConfigurationBuilder#read(org.infinispan.configuration.cache.Configuration)}.
-    * <p/>
+    * <p>
     * The other way to define named cache's configuration is declaratively, in the XML file passed in to the cache
     * manager.
-    * <p/>
+    * <p>
     * If this cache was already configured either declaritively or programmatically this method will throw a
     * {@link org.infinispan.commons.CacheConfigurationException}.
     * @param cacheName             name of cache whose configuration is being defined
@@ -67,13 +67,13 @@ public interface EmbeddedCacheManager extends CacheContainer, Listenable, Closea
    /**
     * Defines a named cache's configuration using by first reading the template configuration and then applying
     * the override afterwards to generate a configuration.
-    * <p/>
+    * <p>
     * The other way to define named cache's configuration is declaratively, in the XML file passed in to the cache
     * manager.
-    * <p/>
+    * <p>
     * If templateName is null or there isn't any named cache with that name, this methods works exactly like {@link
     * #defineConfiguration(String, Configuration)}.
-    * <p/>
+    * <p>
     * If this cache was already configured either declaratively or programmatically this method will throw a
     * {@link org.infinispan.commons.CacheConfigurationException}.
     * @param cacheName             name of cache whose configuration is being defined

--- a/core/src/main/java/org/infinispan/marshall/core/JBossMarshaller.java
+++ b/core/src/main/java/org/infinispan/marshall/core/JBossMarshaller.java
@@ -20,13 +20,13 @@ import org.jboss.marshalling.Unmarshaller;
  * A JBoss Marshalling based marshaller that is oriented at internal, embedded,
  * Infinispan usage. It uses of a custom object table for Infinispan based
  * Externalizer instances that are either internal or user defined.
- * <p />
+ * <p>
  * The reason why this is implemented specially in Infinispan rather than resorting to Java serialization or even the
  * more efficient JBoss serialization is that a lot of efficiency can be gained when a majority of the serialization
  * that occurs has to do with a small set of known types such as {@link org.infinispan.transaction.xa.GlobalTransaction} or
  * {@link org.infinispan.commands.ReplicableCommand}, and class type information can be replaced with simple magic
  * numbers.
- * <p/>
+ * <p>
  * Unknown types (typically user data) falls back to Java serialization.
  *
  * @author Galder Zamarreño

--- a/core/src/main/java/org/infinispan/notifications/ClassLoaderAwareFilteringListenable.java
+++ b/core/src/main/java/org/infinispan/notifications/ClassLoaderAwareFilteringListenable.java
@@ -18,9 +18,9 @@ public interface ClassLoaderAwareFilteringListenable<K, V> extends FilteringList
    /**
     * Adds a listener to the component.  Typically, listeners would need to be annotated with {@link org.infinispan.notifications.Listener} and
     * further to that, contain methods annotated appropriately, otherwise the listener will not be registered.
-    * <p/>
+    * <p>
     * See the {@link org.infinispan.notifications.Listener} annotation for more information.
-    * <p/>
+    * <p>
     *
     * @param listener must not be null.
     * @param classLoader class loader
@@ -33,7 +33,7 @@ public interface ClassLoaderAwareFilteringListenable<K, V> extends FilteringList
     * org.infinispan.notifications.cachelistener.filter.CacheEventFilter,
     * org.infinispan.notifications.cachelistener.filter.CacheEventConverter)}
     * for more details.
-    * <p/>
+    * <p>
     * @param listener must not be null.  The listener to callback on when an event is raised
     * @param filter The filter to apply for the entry to see if the event should be raised
     * @param converter The converter to convert the filtered entry to a new value

--- a/core/src/main/java/org/infinispan/notifications/FilteringListenable.java
+++ b/core/src/main/java/org/infinispan/notifications/FilteringListenable.java
@@ -21,9 +21,9 @@ public interface FilteringListenable<K, V> extends Listenable {
    /**
     * Adds a listener to the component.  Typically, listeners would need to be annotated with {@link org.infinispan.notifications.Listener} and
     * further to that, contain methods annotated appropriately, otherwise the listener will not be registered.
-    * <p/>
+    * <p>
     * See the {@link org.infinispan.notifications.Listener} annotation for more information.
-    * <p/>
+    * <p>
     *
     * @param listener must not be null.
     */
@@ -49,18 +49,18 @@ public interface FilteringListenable<K, V> extends Listenable {
    /**
     * Registers a listener limiting the cache-entry specific events only to
     * annotations that are passed in as parameter.
-    * <p/>
+    * <p>
     * For example, if the listener passed in contains callbacks for
     * {@link CacheEntryCreated} and {@link CacheEntryModified},
     * and filtered annotations contains only {@link CacheEntryCreated},
     * then the listener will be registered only for {@link CacheEntryCreated}
     * callbacks.
-    * <p/>
+    * <p>
     * Callback filtering only applies to {@link CacheEntryCreated},
     * {@link CacheEntryModified}, {@link CacheEntryRemoved}
     * and {@link CacheEntryExpired} annotations.
     * If the listener contains other annotations, these are preserved.
-    * <p/>
+    * <p>
     * This methods enables dynamic registration of listener interests at
     * runtime without the need to create several different listener classes.
     *

--- a/core/src/main/java/org/infinispan/notifications/Listenable.java
+++ b/core/src/main/java/org/infinispan/notifications/Listenable.java
@@ -13,9 +13,8 @@ public interface Listenable {
    /**
     * Adds a listener to the component.  Typically, listeners would need to be annotated with {@link Listener} and
     * further to that, contain methods annotated appropriately, otherwise the listener will not be registered.
-    * <p/>
+    * <p>
     * See the {@link Listener} annotation for more information.
-    * <p/>
     *
     * @param listener must not be null.
     */

--- a/core/src/main/java/org/infinispan/notifications/Listener.java
+++ b/core/src/main/java/org/infinispan/notifications/Listener.java
@@ -7,26 +7,26 @@ import java.lang.annotation.Target;
 
 /**
  * Class-level annotation used to annotate an object as being a valid cache listener.  Used with the {@link
- * org.infinispan.Cache#addListener(Object)} and related APIs. <p/> Note that even if a class is annotated with this
+ * org.infinispan.Cache#addListener(Object)} and related APIs. <p> Note that even if a class is annotated with this
  * annotation, it still needs method-level annotation (such as {@link org.infinispan.notifications.cachemanagerlistener.annotation.CacheStarted})
- * to actually receive notifications. <p/> Objects annotated with this annotation - listeners - can be attached to a
- * running {@link org.infinispan.Cache} so users can be notified of {@link org.infinispan.Cache} events. <p/> <p/> There can
+ * to actually receive notifications. <p> Objects annotated with this annotation - listeners - can be attached to a
+ * running {@link org.infinispan.Cache} so users can be notified of {@link org.infinispan.Cache} events. <p> There can
  * be multiple methods that are annotated to receive the same event, and a method may receive multiple events by using a
- * super type. </p> <p/> <h4>Delivery Semantics</h4> <p/> An event is delivered immediately after the respective
+ * super type. </p> <p> <h4>Delivery Semantics</h4> <p> An event is delivered immediately after the respective
  * operation, but before the underlying cache call returns. For this reason it is important to keep listener processing
- * logic short-lived. If a long running task needs to be performed, it's recommended to use another thread. </p> <p/>
- * <h4>Transactional Semantics</h4> <p/> Since the event is delivered during the actual cache call, the transactional
+ * logic short-lived. If a long running task needs to be performed, it's recommended to use another thread. </p> <p>
+ * <h4>Transactional Semantics</h4> <p> Since the event is delivered during the actual cache call, the transactional
  * outcome is not yet known. For this reason, <i>events are always delivered, even if the changes they represent are
  * discarded by their containing transaction</i>. For applications that must only process events that represent changes
  * in a completed transaction, {@link org.infinispan.notifications.cachelistener.event.TransactionalEvent#getGlobalTransaction()}
  * can be used, along with {@link org.infinispan.notifications.cachelistener.event.TransactionCompletedEvent#isTransactionSuccessful()}
  * to record events and later process them once the transaction has been successfully committed. Example 4 demonstrates
- * this. </p> <p/> <h4>Threading Semantics</h4> <p/> A listener implementation must be capable of handling concurrent
- * invocations. Local notifications reuse the calling thread; remote notifications reuse the network thread. </p> <p/>
+ * this. </p> <p> <h4>Threading Semantics</h4> <p> A listener implementation must be capable of handling concurrent
+ * invocations. Local notifications reuse the calling thread; remote notifications reuse the network thread. </p> <p>
  * Since notifications reuse the calling or network thread, it is important to realise that if your listener
  * implementation blocks or performs a long-running task, the original caller which triggered the cache event may block
  * until the listener callback completes.  It is therefore a good idea to use the listener to be notified of an event
- * but to perform any long running tasks in a separate thread so as not to block the original caller. </p> <p/> In
+ * but to perform any long running tasks in a separate thread so as not to block the original caller. </p> <p> In
  * addition, any locks acquired for the operation being performed will still be held for the callback.  This needs to be
  * kept in mind as locks may be held longer than necessary or intended to and may cause deadlocking in certain
  * situations.  See above paragraph on long-running tasks that should be run in a separate thread. </p> <b>Note</b>:
@@ -35,7 +35,7 @@ import java.lang.annotation.Target;
  * made in a <i>separate</i> thread, which will not cause any blocking on the caller or network thread.  The separate
  * thread is taken from a pool, which can be configured using {@link org.infinispan.config.GlobalConfiguration#setAsyncListenerExecutorProperties(java.util.Properties)}
  * and {@link org.infinispan.config.GlobalConfiguration#setAsyncListenerExecutorFactoryClass(String)}.
- * <p/>
+ * <p>
  * <b>Summary of Notification Annotations</b> <table border="1" cellpadding="1" cellspacing="1" summary="Summary of
  * notification annotations"> <tr> <th bgcolor="#CCCCFF" align="left">Annotation</th> <th bgcolor="#CCCCFF"
  * align="left">Event</th> <th bgcolor="#CCCCFF" align="left">Description</th> </tr> <tr> <td valign="top">{@link
@@ -72,9 +72,9 @@ import java.lang.annotation.Target;
  * org.infinispan.notifications.cachelistener.annotation.CacheEntryInvalidated}</td> <td valign=@"top">{@link
  * org.infinispan.notifications.cachelistener.event.CacheEntryInvalidatedEvent}</td> <td valign="top">A cache entry was
  * invalidated by a remote cache.  Only if cache mode is INVALIDATION_SYNC or INVALIDATION_ASYNC.</td> </tr>
- * <p/>
+ * <p>
  * </table>
- * <p/>
+ * <p>
  * <h4>Example 1 - Method receiving a single event</h4>
  * <pre>
  *    &#064;Listener
@@ -87,7 +87,7 @@ import java.lang.annotation.Target;
  *       }
  *    }
  * </pre>
- * <p/>
+ * <p>
  * <h4>Example 2 - Method receiving multiple events</h4>
  * <pre>
  *    &#064;Listener
@@ -104,7 +104,7 @@ import java.lang.annotation.Target;
  *       }
  *    }
  * </pre>
- * <p/>
+ * <p>
  * <h4>Example 3 - Multiple methods receiving the same event</h4>
  * <pre>
  *    &#064;Listener
@@ -115,7 +115,7 @@ import java.lang.annotation.Target;
  *       {
  *          System.out.println(&quot;Cache started&quot;);
  *       }
- * <p/>
+ *
  *       &#064;CacheStarted
  *       &#064;CacheStopped
  *       &#064;CacheBlocked
@@ -127,10 +127,10 @@ import java.lang.annotation.Target;
  *       }
  *    }
  * </pre>
- * <p/>
- * <p/>
+ * <p>
+ * <p>
  * <b>Example 4 - Processing only events with a committed transaction.</b>
- * <p/>
+ * <p>
  * <pre>
  *    &#064;Listener
  *    public class EventHandler

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/annotation/CacheEntriesEvicted.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/annotation/CacheEntriesEvicted.java
@@ -7,13 +7,12 @@ import java.lang.annotation.Target;
 
 /**
  * This annotation should be used on methods that need to be notified when cache entries are evicted.
- * <p/>
+ * <p>
  * Methods annotated with this annotation should be public and take in a single parameter, a {@link
  * org.infinispan.notifications.cachelistener.event.CacheEntriesEvictedEvent} otherwise an {@link
  * org.infinispan.notifications.IncorrectListenerException} will be thrown when registering your cache listener.
- * <p/>
- *  Locking: notification is performed WITH locks on the given key.
- * <p/>
+ * <p>
+ * Locking: notification is performed WITH locks on the given key.
  *
  * @author Manik Surtani
  * @author Galder Zamarreño

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/annotation/CacheEntryActivated.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/annotation/CacheEntryActivated.java
@@ -7,12 +7,13 @@ import java.lang.annotation.Target;
 
 /**
  * This annotation should be used on methods that need to be notified when a cache entry is activated.
- * <p/>
+ * <p>
  * Methods annotated with this annotation should be public and take in a single parameter, a {@link
  * org.infinispan.notifications.cachelistener.event.CacheEntryActivatedEvent} otherwise an {@link
  * org.infinispan.notifications.IncorrectListenerException} will be thrown when registering your cache listener.
+ * <p>
  * Locking: notification is performed WITH locks on the given key.
- * <p/>
+ * <p>
  * Any exceptions thrown by the listener will abort the call. Any other listeners not yet called will not be called,
  * and any transactions in progress will be rolled back.
  *

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/annotation/CacheEntryCreated.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/annotation/CacheEntryCreated.java
@@ -7,13 +7,13 @@ import java.lang.annotation.Target;
 
 /**
  * This annotation should be used on methods that need to be notified when a cache entry is created.
- * <p/>
+ * <p>
  * Methods annotated with this annotation should be public and take in a single parameter, a {@link
  * org.infinispan.notifications.cachelistener.event.CacheEntryCreatedEvent} otherwise an {@link
  * org.infinispan.notifications.IncorrectListenerException} will be thrown when registering your cache listener.
- * <p/>
+ * <p>
  * Locking: notification is performed WITH locks on the given key.
- * <p/>
+ * <p>
  * Any exceptions thrown by the listener will abort the call. Any other listeners not yet called will not be called,
  * and any transactions in progress will be rolled back.
  *

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/annotation/CacheEntryExpired.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/annotation/CacheEntryExpired.java
@@ -7,17 +7,18 @@ import java.lang.annotation.Target;
 
 /**
  * This annotation should be used on methods that need to be notified when a cache entry is expired
- * <p/>
+ * <p>
  * Methods annotated with this annotation should be public and take in a single parameter, a {@link
  * org.infinispan.notifications.cachelistener.event.CacheEntryExpiredEvent} otherwise an {@link
  * org.infinispan.notifications.IncorrectListenerException} will be thrown when registering your cache listener.
- * <p/>
- *  Locking: there is no guarantee as to whether the lock is acquired for this key, however there is internal
- *  guarantees to make sure these events are not out of order
- * <p/>
+ * <p>
+ * Locking: there is no guarantee as to whether the lock is acquired for this key, however there is internal
+ * guarantees to make sure these events are not out of order
+ * <p>
  * It is possible yet highly unlikely to receive this event right after a remove event even though the value
  * was previously removed.  This can happen in the case when an expired entry in a store (not present in memory) is
  * found by the reaper thread and a remove occurs at the same time.
+ *
  * @author William Burns
  * @see org.infinispan.notifications.Listener
  * @since 8.0

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/annotation/CacheEntryInvalidated.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/annotation/CacheEntryInvalidated.java
@@ -7,12 +7,12 @@ import java.lang.annotation.Target;
 
 /**
  * This annotation should be used on methods that need to be notified when a cache entry is invalidated.
- * <p/>
+ * <p>
  * Methods annotated with this annotation should be public and take in a single parameter, a {@link
  * org.infinispan.notifications.cachelistener.event.CacheEntryInvalidatedEvent} otherwise an {@link
  * org.infinispan.notifications.IncorrectListenerException} will be thrown when registering your cache listener.
- *  <p/>
- *  Locking: notification is performed WITH locks on the given key.
+ * <p>
+ * Locking: notification is performed WITH locks on the given key.
  * <p>
  * Any exceptions thrown by the listener will abort the call. Any other listeners not yet called will not be called,
  * and any transactions in progress will be rolled back.

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/annotation/CacheEntryLoaded.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/annotation/CacheEntryLoaded.java
@@ -13,15 +13,16 @@ import org.infinispan.persistence.spi.CacheLoader;
 /**
  * This annotation should be used on methods that need to be notified when a cache entry is loaded from a {@link
  * CacheLoader}.
- * <p/>
+ * <p>
  * Methods annotated with this annotation should be public and take in a single parameter, a {@link
  * CacheEntryLoadedEvent} otherwise an {@link IncorrectListenerException} will be thrown when registering your cache
  * listener.
- * <p/>
+ * <p>
  * Locking: notification is performed WITH locks on the given key.
- * <p/>
+ * <p>
  * Any exceptions thrown by the listener will abort the call. Any other listeners not yet called will not be called,
  * and any transactions in progress will be rolled back.
+ *
  * @author <a href="mailto:manik@jboss.org">Manik Surtani</a>
  * @see Listener
  * @since 4.0

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/annotation/CacheEntryModified.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/annotation/CacheEntryModified.java
@@ -7,15 +7,16 @@ import java.lang.annotation.Target;
 
 /**
  * This annotation should be used on methods that need to be notified when a cache entry has been modified.
- * <p/>
+ * <p>
  * Methods annotated with this annotation should be public and take in a single parameter, a {@link
  * org.infinispan.notifications.cachelistener.event.CacheEntryModifiedEvent} otherwise an {@link
  * org.infinispan.notifications.IncorrectListenerException} will be thrown when registering your cache listener.
- * <p/>
+ * <p>
  * Locking: notification is performed WITH locks on the given key.
- * <p/>
+ * <p>
  * Any exceptions thrown by the listener will abort the call. Any other listeners not yet called will not be called,
  * and any transactions in progress will be rolled back.
+ *
  * @author <a href="mailto:manik@jboss.org">Manik Surtani</a>
  * @see org.infinispan.notifications.Listener
  * @since 4.0

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/annotation/CacheEntryPassivated.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/annotation/CacheEntryPassivated.java
@@ -7,13 +7,13 @@ import java.lang.annotation.Target;
 
 /**
  * This annotation should be used on methods that need to be notified when cache entries are passivated.
- * <p/>
+ * <p>
  * Methods annotated with this annotation should accept a single parameter, a {@link
  * org.infinispan.notifications.cachelistener.event.CacheEntryPassivatedEvent} otherwise a {@link
  * org.infinispan.notifications.IncorrectListenerException} will be thrown when registering your listener.
- *  <p/>
- *  Locking: notification is performed WITH locks on the given key.
- * <p/>
+ * <p>
+ * Locking: notification is performed WITH locks on the given key.
+ * <p>
  * Any exceptions thrown by the listener will abort the call. Any other listeners not yet called will not be called,
  * and any transactions in progress will be rolled back.
  *

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/annotation/CacheEntryRemoved.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/annotation/CacheEntryRemoved.java
@@ -7,15 +7,16 @@ import java.lang.annotation.Target;
 
 /**
  * This annotation should be used on methods that need to be notified when a cache entry is removed from the cache.
- * <p/>
+ * <p>
  * Methods annotated with this annotation should accept a single parameter, a {@link
  * org.infinispan.notifications.cachelistener.event.CacheEntryRemovedEvent} otherwise a {@link
  * org.infinispan.notifications.IncorrectListenerException} will be thrown when registering your listener.
- *  <p/>
- *  Locking: notification is performed WITH locks on the given key.
- * <p/>
+ * <p>
+ * Locking: notification is performed WITH locks on the given key.
+ * <p>
  * Any exceptions thrown by the listener will abort the call. Any other listeners not yet called will not be called,
  * and any transactions in progress will be rolled back.
+ *
  * @author <a href="mailto:manik@jboss.org">Manik Surtani</a>
  * @see org.infinispan.notifications.Listener
  * @since 4.0

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/annotation/CacheEntryVisited.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/annotation/CacheEntryVisited.java
@@ -7,13 +7,13 @@ import java.lang.annotation.Target;
 
 /**
  * This annotation should be used on methods that need to be notified when a cache entry is visited.
- * <p/>
+ * <p>
  * Methods annotated with this annotation should accept a single parameter, a {@link
  * org.infinispan.notifications.cachelistener.event.CacheEntryVisitedEvent} otherwise a {@link
  * org.infinispan.notifications.IncorrectListenerException} will be thrown when registering your listener.
- *  <p/>
- *  Locking: notification is performed WITHOUT locks on the given key (unless {@link org.infinispan.context.Flag#FORCE_WRITE_LOCK} is used for this call).
- * <p/>
+ * <p>
+ * Locking: notification is performed WITHOUT locks on the given key (unless {@link org.infinispan.context.Flag#FORCE_WRITE_LOCK} is used for this call).
+ * <p>
  * Any exceptions thrown by the listener will abort the call. Any other listeners not yet called will not be called,
  * and any transactions in progress will be rolled back.
  *

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/annotation/DataRehashed.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/annotation/DataRehashed.java
@@ -14,13 +14,13 @@ import org.infinispan.notifications.cachelistener.event.Event;
  * A "rehash" (or "rebalance") is the interval during which nodes are transferring data between each
  * other. When the event with {@code pre = false} is fired all nodes have received all data; Some nodes can
  * still keep old data, though - old data cleanup is executed after this event is fired.
- * <p/>
+ * <p>
  * Methods annotated with this annotation should accept a single parameter, a {@link DataRehashedEvent} otherwise a
  * {@link IncorrectListenerException} will be thrown when registering your listener.
- * <p/>
+ * <p>
  * Note that methods marked with this annotation will be fired <i>before</i> and <i>after</i> rehashing takes place,
  * i.e., your method will be called twice, with {@link Event#isPre()} being set to <tt>true</tt> as well as <tt>false</tt>.
- * <p/>
+ * <p>
  * Any exceptions thrown by the listener will abort the call. Any other listeners not yet called will not be called,
  * and any transactions in progress will be rolled back.
  *

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/annotation/PartitionStatusChanged.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/annotation/PartitionStatusChanged.java
@@ -13,17 +13,16 @@ import org.infinispan.configuration.cache.CacheMode;
  * {@link org.infinispan.partitionhandling.impl.PartitionHandlingManager} changes due to a change in cluster topology.
  * This is only fired in a {@link CacheMode#DIST_SYNC}, {@link CacheMode#DIST_ASYNC}, {@link CacheMode#REPL_SYNC} or
  * {@link CacheMode#REPL_ASYNC} configured cache.
- * <p/>
+ * <p>
  * Methods annotated with this annotation should accept a single parameter, a
  * {@link org.infinispan.notifications.cachelistener.event.PartitionStatusChangedEvent} otherwise a
  * {@link org.infinispan.notifications.IncorrectListenerException} will be thrown when registering your listener.
- * <p/>
+ * <p>
  * Note that methods marked with this annotation will be fired <i>before</i> and <i>after</i> the updated
  * {@link org.infinispan.partitionhandling.AvailabilityMode}
  * is updated, i.e., your method will be called twice, with
  * {@link org.infinispan.notifications.cachelistener.event.Event#isPre()} being set to <tt>true</tt> as well
  * as <tt>false</tt>.
- * <p/>
  *
  * @author William Burns
  * @see org.infinispan.notifications.Listener

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/annotation/PersistenceAvailabilityChanged.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/annotation/PersistenceAvailabilityChanged.java
@@ -10,12 +10,12 @@ import java.lang.annotation.Target;
  * When Cache stores are configured, but the connection to at least one store is lost, the PersistenceManager becomes
  * unavailable. As a result, {@link org.infinispan.persistence.spi.StoreUnavailableException} is thrown on all read/write
  * operations that require the PersistenceManager until all stores become available again.
- * <p/>
+ * <p>
  * Methods that use this annotation should be public and take one parameter, {@link
  * org.infinispan.notifications.cachelistener.event.CacheEntryActivatedEvent}. Otherwise {@link
  * org.infinispan.notifications.IncorrectListenerException} is thrown when registering your cache listener.
  * Locking: notification is performed WITH locks on the given key.
- * <p/>
+ * <p>
  * If the listener throws any exceptions, the call aborts. No other listeners are called. Any transactions in progress
  * are rolled back.
  *

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/annotation/TopologyChanged.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/annotation/TopologyChanged.java
@@ -15,14 +15,13 @@ import org.infinispan.notifications.cachelistener.event.TopologyChangedEvent;
  * This annotation should be used on methods that need to be notified when the {@link ConsistentHash} implementation
  * in use by the {@link DistributionManager} changes due to a change in cluster topology.  This is only fired
  * in a {@link Configuration.CacheMode#DIST_SYNC} or {@link Configuration.CacheMode#DIST_ASYNC} configured cache.
- * <p/>
+ * <p>
  * Methods annotated with this annotation should accept a single parameter, a {@link TopologyChangedEvent} otherwise a
  * {@link IncorrectListenerException} will be thrown when registering your listener.
- * <p/>
+ * <p>
  * Note that methods marked with this annotation will be fired <i>before</i> and <i>after</i> the updated {@link ConsistentHash}
  * is installed, i.e., your method will be called twice, with {@link Event#isPre()} being set to <tt>true</tt> as well
  * as <tt>false</tt>.
- * <p/>
  *
  * @author Manik Surtani
  * @see org.infinispan.notifications.Listener

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/annotation/TransactionCompleted.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/annotation/TransactionCompleted.java
@@ -8,14 +8,14 @@ import java.lang.annotation.Target;
 /**
  * This annotation should be used on methods that need to be notified when the cache is called to participate in a
  * transaction and the transaction completes, either with a commit or a rollback.
- * <p/>
+ * <p>
  * Methods annotated with this annotation should accept a single parameter, a {@link
  * org.infinispan.notifications.cachelistener.event.TransactionCompletedEvent} otherwise a {@link
  * org.infinispan.notifications.IncorrectListenerException} will be thrown when registering your listener.
- * <p/>
+ * <p>
  * Note that methods marked with this annotation will only be fired <i>after the fact</i>, i.e., your method will never
  * be called with {@link org.infinispan.notifications.cachelistener.event.Event#isPre()} being set to <tt>true</tt>.
- * <p/>
+ * <p>
  * Any exceptions thrown by the listener will abort the call. Any other listeners not yet called will not be called,
  * and any transactions in progress will be rolled back.
  *

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/annotation/TransactionRegistered.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/annotation/TransactionRegistered.java
@@ -9,14 +9,14 @@ import java.lang.annotation.Target;
  * This annotation should be used on methods that need to be notified when the cache is called to participate in a
  * transaction and registers a {@link javax.transaction.Synchronization} with a registered {@link
  * javax.transaction.TransactionManager}.
- * <p/>
+ * <p>
  * Methods annotated with this annotation should accept a single parameter, a {@link
  * org.infinispan.notifications.cachelistener.event.TransactionRegisteredEvent} otherwise a {@link
  * org.infinispan.notifications.IncorrectListenerException} will be thrown when registering your listener.
- * <p/>
+ * <p>
  * Note that methods marked with this annotation will only be fired <i>after the fact</i>, i.e., your method will never
  * be called with {@link org.infinispan.notifications.cachelistener.event.Event#isPre()} being set to <tt>true</tt>.
- * <p/>
+ * <p>
  * Any exceptions thrown by the listener will abort the call. Any other listeners not yet called will not be called,
  * and any transactions in progress will be rolled back.
  *

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/event/CacheEntryExpiredEvent.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/event/CacheEntryExpiredEvent.java
@@ -3,7 +3,7 @@ package org.infinispan.notifications.cachelistener.event;
 /**
  * This event subtype is passed in to any method annotated with
  * {@link org.infinispan.notifications.cachelistener.annotation.CacheEntryExpired}.
- * <p />
+ * <p>
  * The {@link #getValue()} method returns the value of the entry before it expired.  Note this value may be null if
  * the entry expired from a cache store
  * <p>
@@ -12,6 +12,7 @@ package org.infinispan.notifications.cachelistener.event;
  * This event can be raised multiple times in sequence for a single expiration event if concurrent reads for the same
  * key occur on different nodes.  This should rarely happen though since this window is narrowed internally by the
  * cache.
+ *
  * @author William Burns
  * @since 8.0
  */
@@ -19,7 +20,7 @@ public interface CacheEntryExpiredEvent<K, V> extends CacheEntryEvent<K, V> {
 
    /**
     * Retrieves the value of the entry being expired.  Note this event is raised after the value has been expired.
-    * <p />
+    *
     * @return the value of the entry expired
     */
    @Override

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/event/CacheEntryModifiedEvent.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/event/CacheEntryModifiedEvent.java
@@ -2,12 +2,12 @@ package org.infinispan.notifications.cachelistener.event;
 
 /**
  * This event subtype is passed in to any method annotated with {@link org.infinispan.notifications.cachelistener.annotation.CacheEntryModified}
- * <p />
+ * <p>
  * The {@link #getValue()} method's behavior is specific to whether the callback is triggered before or after the event
  * in question.  For example, if <tt>event.isPre()</tt> is <tt>true</tt>, then <tt>event.getValue()</tt> would return the
  * <i>old</i> value, prior to modification.  If <tt>event.isPre()</tt> is <tt>false</tt>, then <tt>event.getValue()</tt>
  * would return new <i>new</i> value.  If the event is creating and inserting a new entry, the old value would be <tt>null</tt>.
- * <p />
+ *
  * @author Manik Surtani
  * @since 4.0
  */
@@ -15,7 +15,7 @@ public interface CacheEntryModifiedEvent<K, V> extends CacheEntryEvent<K, V> {
 
    /**
     * Retrieves the value of the entry being modified.
-    * <p />
+    *
     * @return the previous or new value of the entry, depending on whether isPre() is true or false.
     */
    V getValue();

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/event/CacheEntryPassivatedEvent.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/event/CacheEntryPassivatedEvent.java
@@ -11,7 +11,7 @@ package org.infinispan.notifications.cachelistener.event;
 public interface CacheEntryPassivatedEvent<K, V> extends CacheEntryEvent<K, V> {
    /**
     * Retrieves the value of the entry being passivated.
-    * <p />
+    *
     * @return the value of the entry being passivated, if <tt>isPre()</tt> is <tt>true</tt>.  <tt>null</tt> otherwise.
     */
    V getValue();

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/event/CacheEntryRemovedEvent.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/event/CacheEntryRemovedEvent.java
@@ -2,7 +2,7 @@ package org.infinispan.notifications.cachelistener.event;
 
 /**
  * This event subtype is passed in to any method annotated with {@link org.infinispan.notifications.cachelistener.annotation.CacheEntryRemoved}.
- * <p />
+ * <p>
  * The {@link #getValue()} method would return the <i>old</i> value prior to deletion, if <tt>isPre()</tt> is <tt>true</tt>.
  * If <tt>isPre()</tt> is <tt>false</tt>, {@link #getValue()} will return <tt>null</tt>.
  *
@@ -13,7 +13,7 @@ public interface CacheEntryRemovedEvent<K, V> extends CacheEntryEvent<K, V> {
 
    /**
     * Retrieves the value of the entry being deleted.
-    * <p />
+    *
     * @return the value of the entry being deleted, if <tt>isPre()</tt> is <tt>true</tt>.  <tt>null</tt> otherwise.
     */
    V getValue();

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/event/TransactionCompletedEvent.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/event/TransactionCompletedEvent.java
@@ -2,7 +2,7 @@ package org.infinispan.notifications.cachelistener.event;
 
 /**
  * This event is passed in to any method annotated with {@link org.infinispan.notifications.cachelistener.annotation.TransactionCompleted}.
- * <p/>
+ * <p>
  * Note that this event is only delivered <i>after the fact</i>, i.e., you will never see an instance of this event with
  * {@link #isPre()} being set to <tt>true</tt>.
  *

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/event/TransactionRegisteredEvent.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/event/TransactionRegisteredEvent.java
@@ -2,7 +2,7 @@ package org.infinispan.notifications.cachelistener.event;
 
 /**
  * This event is passed in to any method annotated with {@link org.infinispan.notifications.cachelistener.annotation.TransactionRegistered}.
- * <p/>
+ * <p>
  * Note that this event is only delivered <i>after the fact</i>, i.e., you will never see an instance of this event with
  * {@link #isPre()} being set to <tt>true</tt>.
  *

--- a/core/src/main/java/org/infinispan/notifications/cachemanagerlistener/annotation/CacheStarted.java
+++ b/core/src/main/java/org/infinispan/notifications/cachemanagerlistener/annotation/CacheStarted.java
@@ -7,11 +7,11 @@ import java.lang.annotation.Target;
 
 /**
  * This annotation should be used on methods that need to be notified when a cache is started.
- * <p/>
+ * <p>
  * Methods annotated with this annotation should accept a single parameter, a {@link
  * org.infinispan.notifications.cachemanagerlistener.event.CacheStartedEvent} otherwise a {@link
  * org.infinispan.notifications.IncorrectListenerException} will be thrown when registering your listener.
- * <p/>
+ * <p>
  * Any exceptions thrown by the listener will abort the call. Any other listeners not yet called will not be called,
  * and any transactions in progress will be rolled back.
  *

--- a/core/src/main/java/org/infinispan/notifications/cachemanagerlistener/annotation/CacheStopped.java
+++ b/core/src/main/java/org/infinispan/notifications/cachemanagerlistener/annotation/CacheStopped.java
@@ -7,11 +7,11 @@ import java.lang.annotation.Target;
 
 /**
  * This annotation should be used on methods that need to be notified when a cache is stopped.
- * <p/>
+ * <p>
  * Methods annotated with this annotation should accept a single parameter, a {@link
  * org.infinispan.notifications.cachemanagerlistener.event.CacheStoppedEvent} otherwise a {@link
  * org.infinispan.notifications.IncorrectListenerException} will be thrown when registering your listener.
- * <p/>
+ * <p>
  * Any exceptions thrown by the listener will abort the call. Any other listeners not yet called will not be called,
  * and any transactions in progress will be rolled back.
  *

--- a/core/src/main/java/org/infinispan/notifications/cachemanagerlistener/annotation/Merged.java
+++ b/core/src/main/java/org/infinispan/notifications/cachemanagerlistener/annotation/Merged.java
@@ -8,11 +8,11 @@ import java.lang.annotation.Target;
 /**
  * This annotation should be used on methods that need to be notified when the cache is used in a cluster and the
  * cluster topology experiences a merge event after a cluster split.
- * <p/>
+ * <p>
  * Methods annotated with this annotation should accept a single parameter, a {@link
  * org.infinispan.notifications.cachemanagerlistener.event.MergeEvent} otherwise a {@link
  * org.infinispan.notifications.IncorrectListenerException} will be thrown when registering your listener.
- * <p/>
+ * <p>
  * Any exceptions thrown by the listener will abort the call. Any other listeners not yet called will not be called,
  * and any transactions in progress will be rolled back.
  *

--- a/core/src/main/java/org/infinispan/notifications/cachemanagerlistener/annotation/ViewChanged.java
+++ b/core/src/main/java/org/infinispan/notifications/cachemanagerlistener/annotation/ViewChanged.java
@@ -8,11 +8,11 @@ import java.lang.annotation.Target;
 /**
  * This annotation should be used on methods that need to be notified when the cache is used in a cluster and the
  * cluster topology changes (i.e., a member joins or leaves the cluster).
- * <p/>
+ * <p>
  * Methods annotated with this annotation should accept a single parameter, a {@link
  * org.infinispan.notifications.cachemanagerlistener.event.ViewChangedEvent} otherwise a {@link
  * org.infinispan.notifications.IncorrectListenerException} will be thrown when registering your listener.
- * <p/>
+ * <p>
  * Any exceptions thrown by the listener will abort the call. Any other listeners not yet called will not be called,
  * and any transactions in progress will be rolled back.
  *

--- a/core/src/main/java/org/infinispan/partitionhandling/impl/PartitionHandlingManager.java
+++ b/core/src/main/java/org/infinispan/partitionhandling/impl/PartitionHandlingManager.java
@@ -32,7 +32,7 @@ public interface PartitionHandlingManager {
 
    /**
     * Adds a partially aborted transaction.
-    * <p/>
+    * <p>
     * The transaction should be registered when it is not sure if the abort happens successfully in all the affected
     * nodes.
     *
@@ -46,7 +46,7 @@ public interface PartitionHandlingManager {
 
    /**
     * Adds a partially committed transaction.
-    * <p/>
+    * <p>
     * The transaction is committed in the second phase and it is register if it is not sure that the transaction was
     * committed successfully in all the affected nodes.
     *
@@ -61,7 +61,7 @@ public interface PartitionHandlingManager {
 
    /**
     * Adds a partially committed transaction.
-    * <p/>
+    * <p>
     * The transaction is committed in one phase and it is register if it is not sure that the transaction was committed
     * successfully in all the affected nodes.
     *
@@ -76,7 +76,7 @@ public interface PartitionHandlingManager {
 
    /**
     * It checks if the transaction resources (for example locks) can be released.
-    * <p/>
+    * <p>
     * The transaction resource can't be released when the transaction is partially committed.
     *
     * @param globalTransaction the transaction.
@@ -91,7 +91,7 @@ public interface PartitionHandlingManager {
 
    /**
     * It checks if the transaction can be aborted when the originator leaves the cluster.
-    * <p/>
+    * <p>
     * The only case in which it is not possible to abort is when partition handling is enabled and the originator didn't
     * leave gracefully. The transaction will complete when the partition heals.
     *
@@ -102,7 +102,7 @@ public interface PartitionHandlingManager {
 
    /**
     * Notifies the {@link PartitionHandlingManager} that the cache topology was update.
-    * <p/>
+    * <p>
     * It detects when the partition is merged and tries to complete all the partially completed transactions.
     *
     * @param cacheTopology the new cache topology.

--- a/core/src/main/java/org/infinispan/persistence/async/AsyncCacheWriter.java
+++ b/core/src/main/java/org/infinispan/persistence/async/AsyncCacheWriter.java
@@ -42,21 +42,20 @@ import net.jcip.annotations.GuardedBy;
 /**
  * The AsyncCacheWriter is a delegating CacheStore that buffers changes and writes them asynchronously to
  * the underlying CacheStore.
- * <p/>
+ * <p>
  * Read operations are done synchronously, taking into account the current state of buffered changes.
- * <p/>
+ * <p>
  * There is no provision for exception handling for problems encountered with the underlying store
  * during a write operation, and the exception is just logged.
- * <p/>
+ * <p>
  * When configuring the loader, use the following element:
- * <p/>
+ * <p>
  * <code> &lt;async enabled="true" /&gt; </code>
- * <p/>
+ * <p>
  * to define whether cache loader operations are to be asynchronous. If not specified, a cache loader operation is
  * assumed synchronous and this decorator is not applied.
- * <p/>
+ * <p>
  * Write operations affecting same key are now coalesced so that only the final state is actually stored.
- * <p/>
  *
  * @author Manik Surtani
  * @author Galder Zamarreño

--- a/core/src/main/java/org/infinispan/persistence/async/BufferLock.java
+++ b/core/src/main/java/org/infinispan/persistence/async/BufferLock.java
@@ -4,14 +4,14 @@ import java.util.concurrent.locks.AbstractQueuedSynchronizer;
 
 /**
  * A custom reader-writer-lock combined with a bounded buffer size counter.
- * <p/>
+ * <p>
  * Supports multiple concurrent writers and a single exclusive reader. This ensures that no more
  * data is being written to the current state when the AsyncStoreCoordinator thread hands the
  * data off to the back-end store.
- * <p/>
+ * <p>
  * Additionally, {@link #writeLock(int)} blocks if the buffer is full, and {@link #readLock()}
  * blocks if no data is available.
- * <p/>
+ * <p>
  * This lock implementation is <em>not</em> reentrant!
  *
  *  @author Karsten Blees

--- a/core/src/main/java/org/infinispan/persistence/file/SingleFileStore.java
+++ b/core/src/main/java/org/infinispan/persistence/file/SingleFileStore.java
@@ -40,11 +40,11 @@ import io.reactivex.Flowable;
  * A filesystem-based implementation of a {@link org.infinispan.persistence.spi.AdvancedLoadWriteStore}. This file store
  * stores cache values in a single file <tt>&lt;location&gt;/&lt;cache name&gt;.dat</tt>,
  * keys and file positions are kept in memory.
- * <p/>
+ * <p>
  * Note: this CacheStore implementation keeps keys and file positions in memory!
  * The current implementation needs about 100 bytes per cache entry, plus the
  * memory for the key objects.
- * <p/>
+ * <p>
  * So, the space taken by this cache store is both the space in the file
  * itself plus the in-memory index with the keys and their file positions.
  * With this in mind and to avoid the cache store leading to
@@ -56,7 +56,7 @@ import io.reactivex.Flowable;
  * is used as a cache where loss of data in the cache store does not lead to
  * data loss, and data can be recomputed or re-queried from the original data
  * source.
- * <p/>
+ * <p>
  * This class is fully thread safe, yet allows for concurrent load / store
  * of individual cache entries.
  *
@@ -306,7 +306,7 @@ public class SingleFileStore<K, V> implements AdvancedLoadWriteStore<K, V> {
 
    /**
     * Frees the space of the specified file entry (for reuse by allocate).
-    * <p/>
+    * <p>
     * Note: Caller must hold the {@code resizeLock} in shared mode.
     */
    private void free(FileEntry fe) throws IOException {
@@ -722,7 +722,7 @@ public class SingleFileStore<K, V> implements AdvancedLoadWriteStore<K, V> {
 
    /**
     * Helper class to represent an entry in the cache file.
-    * <p/>
+    * <p>
     * The format of a FileEntry on disk is as follows:
     * <ul>
     * <li>4 bytes: {@link #size}</li>

--- a/core/src/main/java/org/infinispan/persistence/keymappers/TwoWayKey2StringMapper.java
+++ b/core/src/main/java/org/infinispan/persistence/keymappers/TwoWayKey2StringMapper.java
@@ -4,7 +4,7 @@ package org.infinispan.persistence.keymappers;
  * Extends {@link Key2StringMapper} and allows a bidirectional transformation between keys and Strings.  Note that the
  * object instance created by {@link #getKeyMapping(String)} is guaranteed to be <i>equal</i> to the original object
  * used to generate the String, but not necessarily the same object reference.
- * <p />
+ * <p>
  * The following condition should be satisfied by implementations of this interface:
  * <code>
  *   assert key.equals(mapper.getKeyMapping(mapper.getStringMapping(key)));
@@ -16,7 +16,8 @@ package org.infinispan.persistence.keymappers;
  */
 public interface TwoWayKey2StringMapper extends Key2StringMapper {
    /**
-    * Maps a String back to its original key
+    * Maps a String back to its original key.
+    *
     * @param stringKey string representation of a key
     * @return an object instance that is <i>equal</i> to the original object used to create the key mapping.
     */

--- a/core/src/main/java/org/infinispan/persistence/support/SingletonCacheWriter.java
+++ b/core/src/main/java/org/infinispan/persistence/support/SingletonCacheWriter.java
@@ -30,14 +30,14 @@ import org.infinispan.util.logging.LogFactory;
 /**
  * SingletonStore is a delegating cache store used for situations when only one instance should interact with the
  * underlying store. The coordinator of the cluster will be responsible for the underlying CacheStore.
- * <p/>
+ * <p>
  * SingletonStore is a simply facade to a real CacheStore implementation. It always delegates reads to the real
  * CacheStore.
- * <p/>
+ * <p>
  * Writes are delegated <i>only if</i> this SingletonStore is currently the coordinator. This avoids having all stores in
  * a cluster writing the same data to the same underlying store. Although not incorrect (e.g. a DB will just discard
  * additional INSERTs for the same key, and throw an exception), this will avoid a lot of redundant work.
- * <p/>
+ * <p>
  * Whenever the current coordinator dies (or leaves), the second in line will take over. That SingletonStore will then
  * pass writes through to its underlying CacheStore. Optionally, when a new coordinator takes over the Singleton, it can
  * push the in-memory state to the cache cacheStore, within a time constraint.

--- a/core/src/main/java/org/infinispan/remoting/inboundhandler/DefaultTopologyRunnable.java
+++ b/core/src/main/java/org/infinispan/remoting/inboundhandler/DefaultTopologyRunnable.java
@@ -8,7 +8,7 @@ import org.infinispan.remoting.responses.Response;
 
 /**
  * The default {@link Runnable} for the remote commands receives.
- * <p/>
+ * <p>
  * It checks the command topology and ensures that the topology higher or equal is installed in this node.
  *
  * @author Pedro Ruivo

--- a/core/src/main/java/org/infinispan/remoting/inboundhandler/GlobalInboundInvocationHandler.java
+++ b/core/src/main/java/org/infinispan/remoting/inboundhandler/GlobalInboundInvocationHandler.java
@@ -33,11 +33,11 @@ import org.infinispan.xsite.XSiteReplicateCommand;
 /**
  * {@link org.infinispan.remoting.inboundhandler.InboundInvocationHandler} implementation that handles all the {@link
  * org.infinispan.commands.ReplicableCommand}.
- * <p/>
+ * <p>
  * This component handles the {@link org.infinispan.commands.ReplicableCommand} from local and remote site. The remote
  * site {@link org.infinispan.commands.ReplicableCommand} are sent to the {@link org.infinispan.xsite.BackupReceiver} to
  * be handled.
- * <p/>
+ * <p>
  * Also, the non-{@link org.infinispan.commands.remote.CacheRpcCommand} are processed directly and the {@link
  * org.infinispan.commands.remote.CacheRpcCommand} are processed in the cache's {@link
  * org.infinispan.remoting.inboundhandler.PerCacheInboundInvocationHandler} implementation.

--- a/core/src/main/java/org/infinispan/remoting/inboundhandler/action/Action.java
+++ b/core/src/main/java/org/infinispan/remoting/inboundhandler/action/Action.java
@@ -10,9 +10,9 @@ public interface Action {
 
    /**
     * It checks this action.
-    * <p/>
+    * <p>
     * When {@link ActionStatus#READY} or {@link ActionStatus#CANCELED} are final states.
-    * <p/>
+    * <p>
     * This method should be thread safe and idempotent since it can be invoked multiple times by multiples threads.
     *
     * @param state the current state.

--- a/core/src/main/java/org/infinispan/remoting/inboundhandler/action/ActionState.java
+++ b/core/src/main/java/org/infinispan/remoting/inboundhandler/action/ActionState.java
@@ -6,7 +6,7 @@ import org.infinispan.commands.ReplicableCommand;
 
 /**
  * The state used by an {@link Action}.
- * <p/>
+ * <p>
  * It is shared among them.
  *
  * @author Pedro Ruivo

--- a/core/src/main/java/org/infinispan/remoting/inboundhandler/action/BaseLockingAction.java
+++ b/core/src/main/java/org/infinispan/remoting/inboundhandler/action/BaseLockingAction.java
@@ -13,7 +13,7 @@ import org.infinispan.util.concurrent.locks.RemoteLockCommand;
 
 /**
  * A base {@link Action} implementation for locking.
- * <p/>
+ * <p>
  * This contains the basic steps for lock acquisition: try to acquire, check when it is available and acquired (or not).
  *
  * @author Pedro Ruivo

--- a/core/src/main/java/org/infinispan/remoting/inboundhandler/action/CheckTopologyAction.java
+++ b/core/src/main/java/org/infinispan/remoting/inboundhandler/action/CheckTopologyAction.java
@@ -4,7 +4,7 @@ import org.infinispan.remoting.inboundhandler.BasePerCacheInboundInvocationHandl
 
 /**
  * An {@link Action} implementation that checks if the command topology id is valid.
- * <p/>
+ * <p>
  * The command topology id is valid when it is higher or equal thant the first topology as member for this node.
  *
  * @author Pedro Ruivo

--- a/core/src/main/java/org/infinispan/remoting/inboundhandler/action/DefaultReadyAction.java
+++ b/core/src/main/java/org/infinispan/remoting/inboundhandler/action/DefaultReadyAction.java
@@ -8,7 +8,7 @@ import org.infinispan.commons.util.InfinispanCollections;
 
 /**
  * A list of {@link Action} to be executed to check when it is ready.
- * <p/>
+ * <p>
  * If an {@link Action} is canceled, then the remaining {@link Action} are not invoked.
  *
  * @author Pedro Ruivo

--- a/core/src/main/java/org/infinispan/remoting/inboundhandler/action/LockAction.java
+++ b/core/src/main/java/org/infinispan/remoting/inboundhandler/action/LockAction.java
@@ -15,7 +15,7 @@ import org.infinispan.util.concurrent.locks.TransactionalRemoteLockCommand;
 
 /**
  * An {@link Action} implementation that acquire the locks.
- * <p/>
+ * <p>
  * It returns {@link ActionStatus#READY} when the locks are available to acquired or the acquisition failed (timeout or
  * deadlock).
  *

--- a/core/src/main/java/org/infinispan/remoting/inboundhandler/action/PendingTxAction.java
+++ b/core/src/main/java/org/infinispan/remoting/inboundhandler/action/PendingTxAction.java
@@ -16,7 +16,7 @@ import org.infinispan.util.concurrent.locks.TransactionalRemoteLockCommand;
 
 /**
  * An {@link Action} implementation that check for older topology transactions.
- * <p/>
+ * <p>
  * This action is ready when no older topology transactions exists or is canceled when the timeout occurs.
  *
  * @author Pedro Ruivo

--- a/core/src/main/java/org/infinispan/remoting/rpc/RpcManager.java
+++ b/core/src/main/java/org/infinispan/remoting/rpc/RpcManager.java
@@ -196,7 +196,7 @@ public interface RpcManager {
 
    /**
     * Creates a new {@link org.infinispan.remoting.rpc.RpcOptionsBuilder}.
-    * <p/>
+    * <p>
     * The {@link org.infinispan.remoting.rpc.RpcOptionsBuilder} is configured with the {@link org.infinispan.remoting.rpc.ResponseMode} and with
     * {@link org.infinispan.remoting.inboundhandler.DeliverOrder#NONE} if the {@link
     * org.infinispan.remoting.rpc.ResponseMode} is synchronous otherwise, with {@link
@@ -224,7 +224,7 @@ public interface RpcManager {
 
    /**
     * Creates a new {@link org.infinispan.remoting.rpc.RpcOptionsBuilder}.
-    * <p/>
+    * <p>
     * The {@link org.infinispan.remoting.rpc.RpcOptionsBuilder} is configured with {@link
     * org.infinispan.remoting.inboundhandler.DeliverOrder#NONE} if the {@param sync} is {@code true} otherwise, with
     * {@link org.infinispan.remoting.inboundhandler.DeliverOrder#PER_SENDER}.

--- a/core/src/main/java/org/infinispan/statetransfer/StateTransferManager.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateTransferManager.java
@@ -17,7 +17,7 @@ import org.infinispan.topology.CacheTopology;
 /**
  * A component that manages the state transfer when the topology of the cluster changes.
  *
- * @author Dan Berindei <dan@infinispan.org>
+ * @author Dan Berindei &lt;dan@infinispan.org&gt;
  * @author Mircea Markus
  * @author anistor@redhat.com
  * @since 5.1

--- a/core/src/main/java/org/infinispan/statetransfer/TransactionSynchronizerInterceptor.java
+++ b/core/src/main/java/org/infinispan/statetransfer/TransactionSynchronizerInterceptor.java
@@ -15,7 +15,7 @@ import org.infinispan.util.logging.LogFactory;
  * With the Non-Blocking State Transfer (NBST) in place it is possible for a transactional command to be forwarded
  * multiple times, concurrently to the same node. This interceptor makes sure that for any given transaction, the
  * interceptor chain, post {@link StateTransferInterceptor}, would only allows a single thread to amend a transaction.
- * </p>
+ * <p>
  * E.g. of when this situation might occur:
  * <ul>
  * <li>1) Node A broadcasts PrepareCommand to nodes B, C </li>
@@ -24,7 +24,7 @@ import org.infinispan.util.logging.LogFactory;
  * <li>4) Both B and C forward the command to node D</li>
  * <li>5) D executes the two commands in parallel and finds out that A has left, therefore executing RollbackCommand></li>
  * </ul>
- * <p/>
+ * <p>
  * This interceptor must placed after the logic that handles command forwarding ({@link StateTransferInterceptor}),
  * otherwise we can end up in deadlocks when a command is forwarded in a loop to the same cache: e.g. A->B->C->A. This
  * scenario is possible when we have chained topology changes (see <a href="https://issues.jboss.org/browse/ISPN-2578">ISPN-2578</a>).

--- a/core/src/main/java/org/infinispan/topology/CacheTopology.java
+++ b/core/src/main/java/org/infinispan/topology/CacheTopology.java
@@ -17,9 +17,9 @@ import org.infinispan.util.logging.LogFactory;
 
 /**
  * The status of a cache from a distribution/state transfer point of view.
- * <p/>
+ * <p>
  * The pending CH can be {@code null} if we don't have a state transfer in progress.
- * <p/>
+ * <p>
  * The {@code topologyId} is incremented every time the topology changes (e.g. a member leaves, state transfer
  * starts or ends).
  * The {@code rebalanceId} is not modified when the consistent hashes are updated without requiring state

--- a/core/src/main/java/org/infinispan/topology/LocalTopologyManager.java
+++ b/core/src/main/java/org/infinispan/topology/LocalTopologyManager.java
@@ -77,7 +77,7 @@ public interface LocalTopologyManager {
 
    /**
     * Checks if the cache defined by {@code cacheName} is using total order.
-    * <p/>
+    * <p>
     * If this component is not running or the {@code cacheName} is not defined, it returns {@code false}.
     *
     * @return {@code true} if the cache is using the total order protocol, {@code false} otherwise.

--- a/core/src/main/java/org/infinispan/transaction/impl/TransactionTable.java
+++ b/core/src/main/java/org/infinispan/transaction/impl/TransactionTable.java
@@ -575,7 +575,7 @@ public class TransactionTable implements org.infinispan.transaction.TransactionT
     * This method calculates the minimum topology ID known by the current node.  This method is only used in a clustered
     * cache, and only invoked when either a topology change is detected, or a transaction whose topology ID is not the same as
     * the current topology ID.
-    * <p/>
+    * <p>
     * This method is guarded by minTopologyRecalculationLock to prevent concurrent updates to the minimum topology ID field.
     *
     * @param idOfRemovedTransaction the topology ID associated with the transaction that triggered this recalculation, or -1

--- a/core/src/main/java/org/infinispan/transaction/tm/DummyNoXaXid.java
+++ b/core/src/main/java/org/infinispan/transaction/tm/DummyNoXaXid.java
@@ -8,7 +8,7 @@ import javax.transaction.xa.Xid;
  * Xid to be used when no XAResource enlistment takes place. This is more efficient both creation and memory wise than
  * {@link DummyXid}.
  *
- * @author Mircea Markus <mircea.markus@jboss.com> (C) 2011 Red Hat Inc.
+ * @author Mircea Markus &lt;mircea.markus@jboss.com&gt; (C) 2011 Red Hat Inc.
  * @since 5.1
  * @deprecated it will be removed and {@link EmbeddedXid} would be used instead.
  */

--- a/core/src/main/java/org/infinispan/transaction/tm/DummyTransactionManager.java
+++ b/core/src/main/java/org/infinispan/transaction/tm/DummyTransactionManager.java
@@ -6,8 +6,6 @@ import javax.transaction.xa.XAResource;
  * Simple transaction manager implementation that maintains transaction state in memory only.
  *
  * @author bela
- *         <p/>
- *         Date: May 15, 2003 Time: 4:11:37 PM
  * @since 4.0
  * @deprecated use {@link EmbeddedTransactionManager}
  */

--- a/core/src/main/java/org/infinispan/transaction/tm/DummyUserTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/tm/DummyUserTransaction.java
@@ -11,8 +11,6 @@ import javax.transaction.UserTransaction;
 
 /**
  * @author bela
- *         <p/>
- *         Date: May 15, 2003 Time: 4:20:17 PM
  * @since 4.0
  * @deprecated use {@link EmbeddedUserTransaction}
  */

--- a/core/src/main/java/org/infinispan/transaction/totalorder/TotalOrderManager.java
+++ b/core/src/main/java/org/infinispan/transaction/totalorder/TotalOrderManager.java
@@ -19,7 +19,7 @@ import org.infinispan.util.logging.LogFactory;
 /**
  * This class behaves as a synchronization point between incoming transactions (totally ordered) and between incoming
  * transactions and state transfer.
- * <p/>
+ * <p>
  * Main functions:
  * <ul>
  *    <li>

--- a/core/src/main/java/org/infinispan/transaction/xa/CacheTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/xa/CacheTransaction.java
@@ -86,7 +86,7 @@ public interface CacheTransaction {
     * Checks if this transaction holds a lock on the given key and then waits until the transaction completes or until
     * the timeout expires and returns <code>true</code> if the transaction is complete or <code>false</code> otherwise.
     * If the key is not locked or if the transaction is already completed it returns <code>true</code> immediately.
-    * <p/>
+    * <p>
     * This method is subject to spurious returns in a way similar to {@link java.lang.Object#wait()}. It can sometimes return
     * before the specified time has elapsed and without guaranteeing that this transaction is complete. The caller is
     * responsible to call the method again if transaction completion was not reached and the time budget was not spent.
@@ -140,7 +140,7 @@ public interface CacheTransaction {
    /**
     * Sets the version read for this key. The version is only set at the first time, i.e. multiple invocation of this
     * method will not change the state.
-    * <p/>
+    * <p>
     * Note: used in Repeatable Read + Write Skew + Clustering + Versioning.
     */
    void addVersionRead(Object key, EntryVersion version);
@@ -148,7 +148,7 @@ public interface CacheTransaction {
    /**
     * Sets the version read fr this key, replacing the old version if it exists, i.e each invocation updates the version
     * of the key. This method is used when a remote get is performed for the key.
-    * <p/>
+    * <p>
     * Note: used in Repeatable Read + Write Skew + Clustering + Versioning.
     * @deprecated since 9.0
     */

--- a/core/src/main/java/org/infinispan/util/AbstractControlledLocalTopologyManager.java
+++ b/core/src/main/java/org/infinispan/util/AbstractControlledLocalTopologyManager.java
@@ -16,7 +16,7 @@ import org.infinispan.topology.RebalancingStatus;
 
 /**
  * Class to be extended to allow some control over the local topology manager when testing Infinispan.
- * <p/>
+ * <p>
  * Note: create before/after method lazily when need.
  *
  * @author Pedro Ruivo

--- a/core/src/main/java/org/infinispan/util/concurrent/BlockingRunnable.java
+++ b/core/src/main/java/org/infinispan/util/concurrent/BlockingRunnable.java
@@ -3,11 +3,11 @@ package org.infinispan.util.concurrent;
 /**
  * A special Runnable (for the particular case of Total Order) that is only sent to a thread when it is ready to be
  * executed without blocking the thread
- * <p/>
+ * <p>
  * Use case: - in Total Order, when the prepare is delivered, the runnable blocks waiting for the previous conflicting
  * transactions to be finished. In a normal executor service, this will take a thread and that thread will be blocked.
  * This way, the runnable waits on the queue and not in the Thread
- * <p/>
+ * <p>
  * Used in {@code org.infinispan.util.concurrent.BlockingTaskAwareExecutorService}
  *
  * @author Pedro Ruivo

--- a/core/src/main/java/org/infinispan/util/concurrent/BlockingTaskAwareExecutorService.java
+++ b/core/src/main/java/org/infinispan/util/concurrent/BlockingTaskAwareExecutorService.java
@@ -5,7 +5,7 @@ import java.util.concurrent.ExecutorService;
 /**
  * Executor service that is aware of {@code BlockingRunnable} and only dispatch the runnable to a thread when it has low
  * (or no) probability of blocking the thread.
- * <p/>
+ * <p>
  * However, it is not aware of the changes in the state so you must invoke {@link #checkForReadyTasks()} to notify
  * this that some runnable may be ready to be processed.
  *

--- a/core/src/main/java/org/infinispan/util/concurrent/IsolationLevel.java
+++ b/core/src/main/java/org/infinispan/util/concurrent/IsolationLevel.java
@@ -3,9 +3,9 @@ package org.infinispan.util.concurrent;
 /**
  * Various transaction isolation levels as an enumerated class.  Note that Infinispan
  * supports only {@link #READ_COMMITTED} and {@link #REPEATABLE_READ}, upgrading where possible.
- * <p/>
+ * <p>
  * Also note that Infinispan defaults to {@link #READ_COMMITTED}.
- * <p/>
+ * <p>
  *
  * @author (various)
  * @see <a href="http://infinispan.org/docs/stable/user_guide/user_guide.html#isolation_levels">Isolation levels</a>

--- a/core/src/main/java/org/infinispan/util/concurrent/ReclosableLatch.java
+++ b/core/src/main/java/org/infinispan/util/concurrent/ReclosableLatch.java
@@ -5,7 +5,7 @@ import java.util.concurrent.locks.AbstractQueuedSynchronizer;
 
 /**
  * A thread gate, that uses an {@link java.util.concurrent.locks.AbstractQueuedSynchronizer}.
- * <p/>
+ * <p>
  * This implementation allows you to create a latch with a default state (open or closed), and repeatedly open or close
  * the latch.
  *

--- a/core/src/main/java/org/infinispan/util/concurrent/SynchronizedRestarter.java
+++ b/core/src/main/java/org/infinispan/util/concurrent/SynchronizedRestarter.java
@@ -10,10 +10,10 @@ import org.infinispan.commons.util.concurrent.ConcurrentHashSet;
  * A class that handles restarts of components via multiple threads.  Specifically, if a component needs to be restarted
  * and several threads may demand a restart but only one thread should be allowed to restart the component, then use
  * this class.
- * <p/>
+ * <p>
  * What this class guarantees is that several threads may come in while a component is being restarted, but they will
  * block until the restart is complete.
- * <p/>
+ * <p>
  * This is different from other techniques in that: <ul> <li>A simple compare-and-swap to check whether another thread
  * is already performing a restart will result in the requesting thread returning immediately and potentially attempting
  * to use the resource being restarted.</li> <li>A synchronized method or use of a lock would result in the thread

--- a/core/src/main/java/org/infinispan/util/concurrent/locks/StripedLock.java
+++ b/core/src/main/java/org/infinispan/util/concurrent/locks/StripedLock.java
@@ -13,13 +13,13 @@ import net.jcip.annotations.ThreadSafe;
 /**
  * A simple implementation of lock striping, using cache entry keys to lock on, primarily used to help make {@link
  * org.infinispan.persistence.spi.CacheLoader} implemtations thread safe.
- * <p/>
+ * <p>
  * Backed by a set of {@link java.util.concurrent.locks.ReentrantReadWriteLock} instances, and using the key hashcodes
  * to determine buckets.
- * <p/>
+ * <p>
  * Since buckets are used, it doesn't matter that the key in question is not removed from the lock map when no longer in
  * use, since the key is not referenced in this class.  Rather, the hash code is used.
- * <p/>
+ * <p>
  *
  * @author <a href="mailto:manik@jboss.org">Manik Surtani</a>
  * @author Mircea.Markus@jboss.com

--- a/core/src/main/java/org/infinispan/util/concurrent/locks/impl/InfinispanLock.java
+++ b/core/src/main/java/org/infinispan/util/concurrent/locks/impl/InfinispanLock.java
@@ -30,11 +30,11 @@ import org.infinispan.util.logging.LogFactory;
 
 /**
  * A special lock for Infinispan cache.
- * <p/>
+ * <p>
  * The main different with the traditional {@link java.util.concurrent.locks.Lock} is allowing to use any object as lock
  * owner. It is possible to use a {@link Thread} as lock owner that makes similar to {@link
  * java.util.concurrent.locks.Lock}.
- * <p/>
+ * <p>
  * In addition, it has an asynchronous interface. {@link #acquire(Object, long, TimeUnit)}  will not acquire the lock
  * immediately (except if it is free) but will return a {@link ExtendedLockPromise}. This promise allow to test if the
  * lock is acquired asynchronously and cancel the lock acquisition, without any blocking.
@@ -102,10 +102,10 @@ public class InfinispanLock {
 
    /**
     * It tries to acquire this lock.
-    * <p/>
+    * <p>
     * If it is invoked multiple times with the same owner, the same {@link ExtendedLockPromise} is returned until it has
     * timed-out or {@link #release(Object)}  is invoked.
-    * <p/>
+    * <p>
     * If the lock is free, it is immediately acquired, otherwise the lock owner is queued.
     *
     * @param lockOwner the lock owner who needs to acquire the lock.
@@ -151,7 +151,7 @@ public class InfinispanLock {
 
    /**
     * It tries to release the lock held by {@code lockOwner}.
-    * <p/>
+    * <p>
     * If the lock is not acquired (is waiting or timed out/deadlocked) by {@code lockOwner}, its {@link
     * ExtendedLockPromise} is canceled. If {@code lockOwner} is the current lock owner, the lock is released and the
     * next lock owner available will acquire the lock. If the {@code lockOwner} never tried to acquire the lock, this
@@ -197,7 +197,7 @@ public class InfinispanLock {
 
    /**
     * It checks if the lock is acquired.
-    * <p/>
+    * <p>
     * A {@code false} return value does not mean the lock is free since it may have queued lock owners.
     *
     * @return {@code true} if the lock is acquired.
@@ -223,7 +223,7 @@ public class InfinispanLock {
 
    /**
     * It tests if the lock has the lock owner.
-    * <p/>
+    * <p>
     * It return {@code true} if the lock owner is the current lock owner or it in the queue.
     *
     * @param lockOwner the lock owner to test.

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -70,32 +70,32 @@ import org.jgroups.View;
 
 /**
  * Infinispan's log abstraction layer on top of JBoss Logging.
- * <p/>
+ * <p>
  * It contains explicit methods for all INFO or above levels so that they can
  * be internationalized. For the core module, message ids ranging from 0001
  * to 0900 inclusively have been reserved.
- * <p/>
+ * <p>
  * <code> Log log = LogFactory.getLog( getClass() ); </code> The above will get
  * you an instance of <tt>Log</tt>, which can be used to generate log messages
  * either via JBoss Logging which then can delegate to Log4J (if the libraries
  * are present) or (if not) the built-in JDK logger.
- * <p/>
+ * <p>
  * In addition to the 6 log levels available, this framework also supports
  * parameter interpolation, similar to the JDKs {@link String#format(String, Object...)}
  * method. What this means is, that the following block:
  * <code> if (log.isTraceEnabled()) { log.trace("This is a message " + message + " and some other value is " + value); }
  * </code>
- * <p/>
+ * <p>
  * ... could be replaced with ...
- * <p/>
+ * <p>
  * <code> if (log.isTraceEnabled()) log.tracef("This is a message %s and some other value is %s", message, value);
  * </code>
- * <p/>
+ * <p>
  * This greatly enhances code readability.
- * <p/>
+ * <p>
  * If you are passing a <tt>Throwable</tt>, note that this should be passed in
  * <i>before</i> the vararg parameter list.
- * <p/>
+ * <p>
  *
  * @author Manik Surtani
  * @private

--- a/core/src/main/java/org/infinispan/util/stream/Streams.java
+++ b/core/src/main/java/org/infinispan/util/stream/Streams.java
@@ -11,8 +11,8 @@ import org.infinispan.util.logging.LogFactory;
 
 /**
  * A collection of stream related utility methods.
- * <p/>
- * <p>Exceptions that are thrown and not explicitly declared are ignored.
+ * <p>
+ * Exceptions that are thrown and not explicitly declared are ignored.
  *
  * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
  * @since 4.2

--- a/core/src/main/java/org/infinispan/xsite/BackupReceiverRepository.java
+++ b/core/src/main/java/org/infinispan/xsite/BackupReceiverRepository.java
@@ -15,7 +15,7 @@ public interface BackupReceiverRepository {
    /**
     * Returns the local cache associated defined as backup for the provided remote (site, cache) combo, or throws an
     * exception if no such site is defined.
-    * <p/>
+    * <p>
     * Also starts the cache if not already stated; that is because the cache is needed for update after when this method
     * is invoked.
     */

--- a/core/src/main/java/org/infinispan/xsite/BackupReceiverRepositoryImpl.java
+++ b/core/src/main/java/org/infinispan/xsite/BackupReceiverRepositoryImpl.java
@@ -56,7 +56,7 @@ public class BackupReceiverRepositoryImpl implements BackupReceiverRepository {
    /**
     * Returns the local cache defined as backup for the provided remote (site, cache) combo, or throws an
     * exception if no such site is defined.
-    * <p/>
+    * <p>
     * Also starts the cache if not already started; that is because the cache is needed for update after this method
     * is invoked.
     */

--- a/core/src/main/java/org/infinispan/xsite/CustomFailurePolicy.java
+++ b/core/src/main/java/org/infinispan/xsite/CustomFailurePolicy.java
@@ -14,10 +14,10 @@ import org.infinispan.Cache;
  * allowed to throw instances of {@link BackupFailureException} to signal that they want the intra-site operation to
  * fail as well. If handle methods don't throw any exception then the operation will succeed in the local cluster. For
  * convenience, there is a support implementation of this class: {@link AbstractCustomFailurePolicy}
- * <p/>
+ * <p>
  * Lifecycle: the same instance is invoked during the lifecycle of a cache so it is allowed to hold state between
  * invocations.
- * <p/>
+ * <p>
  * Threadsafety: instances of this class might be invoked from different threads and they should be synchronized.
  *
  * @author Mircea Markus

--- a/core/src/main/java/org/infinispan/xsite/OfflineStatus.java
+++ b/core/src/main/java/org/infinispan/xsite/OfflineStatus.java
@@ -14,10 +14,10 @@ import net.jcip.annotations.ThreadSafe;
 
 /**
  * Keeps state needed for knowing when a site needs to be taken offline.
- * <p/>
+ * <p>
  * Thread safety: This class is updated from multiple threads so the access to it is synchronized by object's intrinsic
  * lock.
- * <p/>
+ * <p>
  * Impl detail: As this class's state changes constantly, the equals and hashCode haven't been overridden. This
  * shouldn't affect performance significantly as the number of site backups should be relatively small (1-3).
  *

--- a/core/src/main/java/org/infinispan/xsite/statetransfer/XSiteStateTransferManager.java
+++ b/core/src/main/java/org/infinispan/xsite/statetransfer/XSiteStateTransferManager.java
@@ -79,7 +79,7 @@ public interface XSiteStateTransferManager {
 
    /**
     * Sets the cluster to normal state.
-    * <p/>
+    * <p>
     * The main use for this method is when the link between the sites is broken and the receiver site keeps it state
     * transfer state forever.
     *
@@ -90,7 +90,7 @@ public interface XSiteStateTransferManager {
 
    /**
     * Makes this node the coordinator for the state transfer to the site name.
-    * <p/>
+    * <p>
     * This method is invoked when the coordinator dies and this node receives a late start state transfer request.
     *
     * @param siteName the site name.

--- a/core/src/test/java/org/infinispan/api/ConditionalOperationsConcurrentStressTest.java
+++ b/core/src/test/java/org/infinispan/api/ConditionalOperationsConcurrentStressTest.java
@@ -8,7 +8,7 @@ import org.testng.annotations.Test;
  * Verifies the atomic semantic of Infinispan's implementations of java.util.concurrent.ConcurrentMap'
  * conditional operations.
  *
- * @author Sanne Grinovero <sanne@infinispan.org> (C) 2012 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@infinispan.org&gt; (C) 2012 Red Hat Inc.
  * @author William Burns
  * @see java.util.concurrent.ConcurrentMap#replace(Object, Object, Object)
  * @since 7.0

--- a/core/src/test/java/org/infinispan/api/ConditionalOperationsConcurrentTest.java
+++ b/core/src/test/java/org/infinispan/api/ConditionalOperationsConcurrentTest.java
@@ -36,7 +36,7 @@ import org.testng.annotations.Test;
  * Verifies the atomic semantic of Infinispan's implementations of java.util.concurrent.ConcurrentMap'
  * conditional operations.
  *
- * @author Sanne Grinovero <sanne@infinispan.org> (C) 2012 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@infinispan.org&gt; (C) 2012 Red Hat Inc.
  * @see java.util.concurrent.ConcurrentMap#replace(Object, Object, Object)
  * @since 5.2
  */

--- a/core/src/test/java/org/infinispan/api/NonDuplicateModificationTest.java
+++ b/core/src/test/java/org/infinispan/api/NonDuplicateModificationTest.java
@@ -18,7 +18,7 @@ import org.testng.annotations.Test;
 /**
  * Data inconsistency can happen in non-transactional caches. the tests replicates this scenario: assuming N1 and N2 are
  * owners of key K. N2 is the primary owner
- * <p/>
+ * <p>
  * <ul>
  *    <li>N1 tries to update K. it forwards the command to N2.</li>
  *    <li>N2 acquires the lock, and forwards back to N1 (that applies the modification).</li>

--- a/core/src/test/java/org/infinispan/api/flags/DecoratedCacheTest.java
+++ b/core/src/test/java/org/infinispan/api/flags/DecoratedCacheTest.java
@@ -10,7 +10,7 @@ import org.infinispan.context.Flag;
 import org.testng.annotations.Test;
 
 /**
- * @author Sanne Grinovero <sanne@infinispan.org> (C) 2011 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@infinispan.org&gt; (C) 2011 Red Hat Inc.
  */
 @Test(groups = "functional", testName = "api.flags.DecoratedCacheTest")
 public class DecoratedCacheTest {

--- a/core/src/test/java/org/infinispan/api/flags/FlagsEnabledTest.java
+++ b/core/src/test/java/org/infinispan/api/flags/FlagsEnabledTest.java
@@ -28,7 +28,7 @@ import org.infinispan.util.concurrent.IsolationLevel;
 import org.testng.annotations.Test;
 
 /**
- * @author Sanne Grinovero <sanne@infinispan.org> (C) 2011 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@infinispan.org&gt; (C) 2011 Red Hat Inc.
  */
 @Test(groups = "functional", testName = "api.flags.FlagsEnabledTest")
 @CleanupAfterMethod

--- a/core/src/test/java/org/infinispan/distribution/DistStoreTxDisjointSetTest.java
+++ b/core/src/test/java/org/infinispan/distribution/DistStoreTxDisjointSetTest.java
@@ -17,7 +17,7 @@ import org.testng.annotations.Test;
 
 /**
  * This tests the access pattern where a Tx touches multiple keys such that: K1: {A, B} K2: {A, C}
- * <p/>
+ * <p>
  * The tx starts and runs on A, and the TX must succeed even though each node only gets a subset of data.  Particularly,
  * needs to be checked when using a cache store.
  */

--- a/core/src/test/java/org/infinispan/distribution/DistSyncStoreNotSharedTest.java
+++ b/core/src/test/java/org/infinispan/distribution/DistSyncStoreNotSharedTest.java
@@ -29,7 +29,7 @@ import org.testng.annotations.Test;
  * DistSyncSharedTest.
  *
  * @author Galder Zamarreño
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2011 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2011 Red Hat Inc.
  * @since 4.0
  */
 @Test(groups = "functional", testName = "distribution.DistSyncStoreNotSharedTest")

--- a/core/src/test/java/org/infinispan/distribution/IllegalMonitorTest.java
+++ b/core/src/test/java/org/infinispan/distribution/IllegalMonitorTest.java
@@ -13,7 +13,7 @@ import org.testng.annotations.Test;
  * This is by design, so that we don't have to keep track of them:
  * @see org.infinispan.util.concurrent.locks.LockManager#possiblyLocked(org.infinispan.container.entries.CacheEntry)
  *
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2011 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2011 Red Hat Inc.
  * @since 5.0
  */
 @Test(groups = "functional", testName = IllegalMonitorTest.TEST_NAME)

--- a/core/src/test/java/org/infinispan/distribution/TestTopologyAwareAddress.java
+++ b/core/src/test/java/org/infinispan/distribution/TestTopologyAwareAddress.java
@@ -6,7 +6,7 @@ import org.infinispan.remoting.transport.TopologyAwareAddress;
  * Mock TopologyAwareAddress to be used in tests.
  * We only care about the addressNum for equality, so we don't override compareTo(), equals() and hashCode().
  *
- * @author Dan Berindei <dberinde@redhat.com>
+ * @author Dan Berindei &lt;dberinde@redhat.com&gt;
  * @since 5.0
  */
 public class TestTopologyAwareAddress extends TestAddress implements TopologyAwareAddress {

--- a/core/src/test/java/org/infinispan/distribution/groups/StateTransferGetGroupKeysTest.java
+++ b/core/src/test/java/org/infinispan/distribution/groups/StateTransferGetGroupKeysTest.java
@@ -29,7 +29,7 @@ import org.testng.annotations.Test;
 
 /**
  * It tests the grouping advanced interface during the state transfer.
- * <p/>
+ * <p>
  * Note: no tests were added for {@link org.infinispan.AdvancedCache#removeGroup(String)} because internally it uses the
  * {@link org.infinispan.commands.write.RemoveCommand}. If the implementation changes, the new tests must be added to
  * this class.

--- a/core/src/test/java/org/infinispan/distribution/rehash/DataLossOnJoinOneOwnerTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/DataLossOnJoinOneOwnerTest.java
@@ -11,7 +11,7 @@ import org.testng.annotations.Test;
 
 /**
  * Tests data loss during state transfer when a single data owner is configured.
- * @author Sanne Grinovero <sanne@infinispan.org> (C) 2011 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@infinispan.org&gt; (C) 2011 Red Hat Inc.
  * @author Alex Heneveld
  * @author Manik Surtani
  */

--- a/core/src/test/java/org/infinispan/distribution/rehash/OngoingTransactionsAndJoinTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/OngoingTransactionsAndJoinTest.java
@@ -39,7 +39,7 @@ import org.testng.annotations.Test;
 
 /**
  * This tests the following scenario:
- * <p/>
+ * <p>
  * 1 node exists.  Transactions running.  Some complete, some in prepare, some in commit. New node joins, rehash occurs.
  * Test that the new node is the owner and receives this state.
  */

--- a/core/src/test/java/org/infinispan/eviction/impl/ExpensiveEvictionTest.java
+++ b/core/src/test/java/org/infinispan/eviction/impl/ExpensiveEvictionTest.java
@@ -9,7 +9,7 @@ import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.testng.annotations.Test;
 
 /**
- * @author Sanne Grinovero <sanne@infinispan.org> (C) 2011 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@infinispan.org&gt; (C) 2011 Red Hat Inc.
  */
 @Test(groups = "profiling", testName = "eviction.ExpensiveEvictionTest")
 public class ExpensiveEvictionTest extends SingleCacheManagerTest {

--- a/core/src/test/java/org/infinispan/lock/L1LockTest.java
+++ b/core/src/test/java/org/infinispan/lock/L1LockTest.java
@@ -9,7 +9,7 @@ import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
 import org.testng.annotations.Test;
 
 /**
- * @author Mircea Markus <mircea.markus@jboss.com> (C) 2011 Red Hat Inc.
+ * @author Mircea Markus &lt;mircea.markus@jboss.com&gt; (C) 2011 Red Hat Inc.
  * @since 5.1
  */
 @Test(groups = "functional", testName = "lock.L1LockTest")

--- a/core/src/test/java/org/infinispan/notifications/DistListenerTest.java
+++ b/core/src/test/java/org/infinispan/notifications/DistListenerTest.java
@@ -23,7 +23,7 @@ import static org.testng.AssertJUnit.assertEquals;
  * as DIST: all key owners and the node which is performing the operation will receive
  * a notification.
  *
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2011 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2011 Red Hat Inc.
  * @since 5.0
  */
 @Test(groups = "functional", testName = "notifications.DistListenerTest")

--- a/core/src/test/java/org/infinispan/persistence/ClusteredConditionalCommandPassivationTest.java
+++ b/core/src/test/java/org/infinispan/persistence/ClusteredConditionalCommandPassivationTest.java
@@ -7,7 +7,7 @@ import org.testng.annotations.Test;
 /**
  * Tests if the conditional commands correctly fetch the value from cache loader even with the skip cache load/store
  * flags.
- * <p/>
+ * <p>
  * The configuration used is a non-tx distributed cache with passivation.
  *
  * @author Pedro Ruivo

--- a/core/src/test/java/org/infinispan/persistence/ClusteredConditionalCommandTest.java
+++ b/core/src/test/java/org/infinispan/persistence/ClusteredConditionalCommandTest.java
@@ -35,7 +35,7 @@ import org.testng.annotations.Test;
 /**
  * Tests if the conditional commands correctly fetch the value from cache loader even with the skip cache load/store
  * flags.
- * <p/>
+ * <p>
  * The configuration used is a non-tx distributed cache without passivation.
  *
  * @author Pedro Ruivo

--- a/core/src/test/java/org/infinispan/persistence/ClusteredTxConditionalCommandPassivationTest.java
+++ b/core/src/test/java/org/infinispan/persistence/ClusteredTxConditionalCommandPassivationTest.java
@@ -9,7 +9,7 @@ import org.testng.annotations.Test;
 /**
  * Tests if the conditional commands correctly fetch the value from cache loader even with the skip cache load/store
  * flags.
- * <p/>
+ * <p>
  * The configuration used is a tx distributed cache with passivation.
  *
  * @author Pedro Ruivo

--- a/core/src/test/java/org/infinispan/persistence/ClusteredTxConditionalCommandTest.java
+++ b/core/src/test/java/org/infinispan/persistence/ClusteredTxConditionalCommandTest.java
@@ -9,7 +9,7 @@ import org.testng.annotations.Test;
 /**
  * Tests if the conditional commands correctly fetch the value from cache loader even with the skip cache load/store
  * flags.
- * <p/>
+ * <p>
  * The configuration used is a tx distributed cache without passivation.
  *
  * @author Pedro Ruivo

--- a/core/src/test/java/org/infinispan/persistence/LocalConditionalCommandPassivationTest.java
+++ b/core/src/test/java/org/infinispan/persistence/LocalConditionalCommandPassivationTest.java
@@ -5,7 +5,7 @@ import org.testng.annotations.Test;
 /**
  * Tests if the conditional commands correctly fetch the value from cache loader even with the skip cache load/store
  * flags.
- * <p/>
+ * <p>
  * The configuration used is a non-tx non-clustered cache with passivation.
  *
  * @author Pedro Ruivo

--- a/core/src/test/java/org/infinispan/persistence/LocalConditionalCommandTest.java
+++ b/core/src/test/java/org/infinispan/persistence/LocalConditionalCommandTest.java
@@ -23,7 +23,7 @@ import org.testng.annotations.Test;
 /**
  * Tests if the conditional commands correctly fetch the value from cache loader even with the skip cache load/store
  * flags.
- * <p/>
+ * <p>
  * The configuration used is a non-tx non-clustered cache without passivation.
  *
  * @author Pedro Ruivo

--- a/core/src/test/java/org/infinispan/persistence/LocalTxConditionalCommandPassivationTest.java
+++ b/core/src/test/java/org/infinispan/persistence/LocalTxConditionalCommandPassivationTest.java
@@ -5,7 +5,7 @@ import org.testng.annotations.Test;
 /**
  * Tests if the conditional commands correctly fetch the value from cache loader even with the skip cache load/store
  * flags.
- * <p/>
+ * <p>
  * The configuration used is a tx non-clustered cache with passivation.
  *
  * @author Pedro Ruivo

--- a/core/src/test/java/org/infinispan/persistence/LocalTxConditionalCommandTest.java
+++ b/core/src/test/java/org/infinispan/persistence/LocalTxConditionalCommandTest.java
@@ -5,7 +5,7 @@ import org.testng.annotations.Test;
 /**
  * Tests if the conditional commands correctly fetch the value from cache loader even with the skip cache load/store
  * flags.
- * <p/>
+ * <p>
  * The configuration used is a tx non-clustered cache with passivation.
  *
  * @author Pedro Ruivo

--- a/core/src/test/java/org/infinispan/profiling/ProfileTest.java
+++ b/core/src/test/java/org/infinispan/profiling/ProfileTest.java
@@ -12,12 +12,11 @@ import org.testng.annotations.Test;
 
 /**
  * Test to use with a profiler to profile replication.  To be used in conjunction with ProfileSlaveTest.
- * <p/>
+ * <p>
  * Typical usage pattern:
- * <p/>
+ * <p>
  * 1.  Start a single test method in ProfileSlaveTest.  This will block until you kill it. 2.  Start the corresponding
  * test in this class, with the same name, in a different JVM, and attached to a profiler. 3.  Profile away!
- * <p/>
  *
  * @author Manik Surtani (<a href="mailto:manik@jboss.org">manik@jboss.org</a>)
  */

--- a/core/src/test/java/org/infinispan/remoting/MessageSentToLeaverTest.java
+++ b/core/src/test/java/org/infinispan/remoting/MessageSentToLeaverTest.java
@@ -24,7 +24,7 @@ import org.testng.annotations.Test;
 /**
  * Test that CommandAwareRpcManager detects members who left the cluster and throws an exception.
  *
- * @author Dan Berindei <dan@infinispan.org>
+ * @author Dan Berindei &lt;dan@infinispan.org&gt;
  */
 @Test (testName = "remoting.MessageSentToLeaverTest", groups = "functional")
 public class MessageSentToLeaverTest extends AbstractInfinispanTest {

--- a/core/src/test/java/org/infinispan/replication/FlagsReplicationTest.java
+++ b/core/src/test/java/org/infinispan/replication/FlagsReplicationTest.java
@@ -17,7 +17,7 @@ import javax.transaction.Transaction;
 /**
  * Verifies the Flags affect both local and remote nodes.
  *
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2011 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2011 Red Hat Inc.
  * @since 4.2.1
  */
 @Test(groups = "functional", testName = FlagsReplicationTest.TEST_NAME)

--- a/core/src/test/java/org/infinispan/replication/SyncLockingTest.java
+++ b/core/src/test/java/org/infinispan/replication/SyncLockingTest.java
@@ -20,8 +20,8 @@ import org.infinispan.transaction.tm.EmbeddedTransactionManager;
 import org.testng.annotations.Test;
 
 /**
- * Tests for lock API
- * <p/>
+ * Tests for lock API.
+ * <p>
  * Introduce lock() API methods https://jira.jboss.org/jira/browse/ISPN-48
  *
  * @author Manik Surtani

--- a/core/src/test/java/org/infinispan/replication/SyncPessimisticLockingTest.java
+++ b/core/src/test/java/org/infinispan/replication/SyncPessimisticLockingTest.java
@@ -26,8 +26,8 @@ import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
 import org.testng.annotations.Test;
 
 /**
- * Tests for implicit locking
- * <p/>
+ * Tests for implicit locking.
+ * <p>
  * Transparent eager locking for transactions https://jira.jboss.org/jira/browse/ISPN-70
  *
  * @author Vladimir Blagojevic

--- a/core/src/test/java/org/infinispan/statetransfer/ReplStateTransferCacheLoaderTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/ReplStateTransferCacheLoaderTest.java
@@ -21,7 +21,7 @@ import org.testng.annotations.Test;
 
 /**
  * Short test to reproduce the scenario from ISPN-2712/MODE-1754 (https://issues.jboss.org/browse/MODE-2712, https://issues.jboss.org/browse/MODE-1754).
- * <p/>
+ * <p>
  * This test passes on 5.1.x but fails on 5.2.0 without the fix.
  *
  * @author anistor@redhat.com

--- a/core/src/test/java/org/infinispan/stress/MapStressTest.java
+++ b/core/src/test/java/org/infinispan/stress/MapStressTest.java
@@ -30,7 +30,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
  * Stress test different maps for container implementations
  *
  * @author Manik Surtani
- * @author Dan Berindei <dberinde@redhat.com>
+ * @author Dan Berindei &lt;dberinde@redhat.com&gt;
  * @since 4.0
  */
 @Test(testName = "stress.MapStressTest", groups = "profiling")

--- a/core/src/test/java/org/infinispan/test/MultipleCacheManagersTest.java
+++ b/core/src/test/java/org/infinispan/test/MultipleCacheManagersTest.java
@@ -73,15 +73,13 @@ import org.testng.annotations.Factory;
  * class</i>, you could set the <tt>cleanup</tt> field to {@link MultipleCacheManagersTest.CleanupPhase#AFTER_METHOD} in
  * your test's constructor.  E.g.:
  * <pre>
- * <p/>
  * public void MyTest extends MultipleCacheManagersTest {
  *    public MyTest() {
  *       cleanup =  CleanupPhase.AFTER_METHOD;
  *    }
  * }
- * <p/>
  * </pre>
- * <p/>
+ * <p>
  * Note that this will cause {@link #createCacheManagers()}  to be called before each method.
  *
  * @author Mircea.Markus@jboss.com

--- a/core/src/test/java/org/infinispan/test/ReplListener.java
+++ b/core/src/test/java/org/infinispan/test/ReplListener.java
@@ -65,7 +65,7 @@ public class ReplListener {
    /**
     * As {@link #ReplListener(org.infinispan.Cache)} except that you can optionally configure whether command recording
     * is eager (false by default).
-    * <p/>
+    * <p>
     * If <tt>recordCommandsEagerly</tt> is true, then commands are recorded from the moment the listener is attached to
     * the cache, even before {@link #expect(Class[])} is invoked.  As such, when {@link #expect(Class[])} is called, the
     * list of commands to wait for will take into account commands already seen thanks to eager recording.

--- a/core/src/test/java/org/infinispan/test/ValueFuture.java
+++ b/core/src/test/java/org/infinispan/test/ValueFuture.java
@@ -9,7 +9,7 @@ import java.util.concurrent.TimeoutException;
 /**
  * A simple <code>Future</code> implementation whose <code>get()</code> method blocks until another thread calls <code>set()</code>.
  *
- * @author Dan Berindei <dberinde@redhat.com>
+ * @author Dan Berindei &lt;dberinde@redhat.com&gt;
  * @since 5.0
  */
 public class ValueFuture<V> implements Future<V> {

--- a/core/src/test/java/org/infinispan/test/concurrent/GlobalComponentSequencerAction.java
+++ b/core/src/test/java/org/infinispan/test/concurrent/GlobalComponentSequencerAction.java
@@ -32,7 +32,7 @@ public class GlobalComponentSequencerAction<T> {
 
    /**
     * Set up a list of sequencer states before interceptor {@code interceptorClass} is called.
-    * <p/>
+    * <p>
     * Each invocation accepted by {@code matcher} will enter/exit the next state from the list, and does nothing after the list is exhausted.
     */
    public GlobalComponentSequencerAction<T> before(String state1, String... additionalStates) {
@@ -60,7 +60,7 @@ public class GlobalComponentSequencerAction<T> {
 
    /**
     * Set up a list of sequencer states after interceptor {@code interceptorClass} has returned.
-    * <p/>
+    * <p>
     * Each invocation accepted by {@code matcher} will enter/exit the next state from the list, and does nothing after the list is exhausted.
     */
    public GlobalComponentSequencerAction<T> after(String state1, String... additionalStates) {

--- a/core/src/test/java/org/infinispan/test/concurrent/InboundRpcSequencerAction.java
+++ b/core/src/test/java/org/infinispan/test/concurrent/InboundRpcSequencerAction.java
@@ -33,7 +33,7 @@ public class InboundRpcSequencerAction {
 
    /**
     * Set up a list of sequencer states before interceptor {@code interceptorClass} is called.
-    * <p/>
+    * <p>
     * Each invocation accepted by {@code matcher} will enter/exit the next state from the list, and does nothing after the list is exhausted.
     */
    public InboundRpcSequencerAction before(String state1, String... additionalStates) {
@@ -51,7 +51,7 @@ public class InboundRpcSequencerAction {
 
    /**
     * Set up a list of sequencer states after interceptor {@code interceptorClass} has returned.
-    * <p/>
+    * <p>
     * Each invocation accepted by {@code matcher} will enter/exit the next state from the list, and does nothing after the list is exhausted.
     */
    public InboundRpcSequencerAction after(String state1, String... additionalStates) {

--- a/core/src/test/java/org/infinispan/test/concurrent/InterceptorSequencerAction.java
+++ b/core/src/test/java/org/infinispan/test/concurrent/InterceptorSequencerAction.java
@@ -51,7 +51,7 @@ public class InterceptorSequencerAction {
 
    /**
     * Set up a list of sequencer states after interceptor {@code interceptorClass} has returned.
-    * <p/>
+    * <p>
     * Each invocation accepted by {@code matcher} will enter/exit the next state from the list, and does nothing after the list is exhausted.
     */
    public InterceptorSequencerAction after(String state1, String... additionalStates) {

--- a/core/src/test/java/org/infinispan/test/concurrent/OutboundRpcSequencerAction.java
+++ b/core/src/test/java/org/infinispan/test/concurrent/OutboundRpcSequencerAction.java
@@ -35,7 +35,7 @@ public class OutboundRpcSequencerAction {
 
    /**
     * Set up a list of sequencer states before interceptor {@code interceptorClass} is called.
-    * <p/>
+    * <p>
     * Each invocation accepted by {@code matcher} will enter/exit the next state from the list, and does nothing after the list is exhausted.
     */
    public OutboundRpcSequencerAction before(String state1, String... additionalStates) {
@@ -55,7 +55,7 @@ public class OutboundRpcSequencerAction {
 
    /**
     * Set up a list of sequencer states after interceptor {@code interceptorClass} has returned.
-    * <p/>
+    * <p>
     * Each invocation accepted by {@code matcher} will enter/exit the next state from the list, and does nothing after the list is exhausted.
     */
    public OutboundRpcSequencerAction after(String state1, String... additionalStates) {

--- a/core/src/test/java/org/infinispan/test/concurrent/StateSequencer.java
+++ b/core/src/test/java/org/infinispan/test/concurrent/StateSequencer.java
@@ -24,7 +24,7 @@ import net.jcip.annotations.GuardedBy;
 
 /**
  * Defines a set of logical threads, each with a list of states, and a partial ordering between states.
- * <p/>
+ * <p>
  * <p>Logical threads are defined with {@link #logicalThread(String, String, String...)}. States in a logical thread are implicitly
  * ordered - they must be entered in the order in which they were defined.</p>
  * <p>The ordering between states in different logical threads can be defined with {@link #order(String, String, String...)}</p>
@@ -56,7 +56,7 @@ public class StateSequencer {
 
    /**
     * Define a logical thread.
-    * <p/>
+    * <p>
     * States in a logical thread are implicitly ordered - they must be entered in the order in which they were defined.
     */
    public StateSequencer logicalThread(String threadName, String initialState, String... additionalStates) {
@@ -191,7 +191,7 @@ public class StateSequencer {
 
    /**
     * Define an action for a state.
-    * <p/>
+    * <p>
     * States that depend on another state with an associated action can only be entered after the action has finished.
     */
    public StateSequencer action(String stateName, Callable<Object> action) {

--- a/core/src/test/java/org/infinispan/test/concurrent/StateSequencerUtil.java
+++ b/core/src/test/java/org/infinispan/test/concurrent/StateSequencerUtil.java
@@ -93,7 +93,7 @@ public class StateSequencerUtil {
 
    /**
     * Advance to the every state in the {@code states} list, in the given order, but only if {@code condition} is true.
-    * <p/>
+    * <p>
     * Does nothing if {@code states} is {@code null} or empty.
     */
    public static void advanceMultiple(StateSequencer stateSequencer, boolean condition, List<String> states)

--- a/core/src/test/java/org/infinispan/test/jndi/DummyContext.java
+++ b/core/src/test/java/org/infinispan/test/jndi/DummyContext.java
@@ -104,7 +104,7 @@ public class DummyContext implements Context {
    /**
     * Binds a name to an object, overwriting any existing binding. All intermediate contexts and the target context
     * (that named by all but terminal atomic component of the name) must already exist.
-    * <p/>
+    * <p>
     * <p> If the object is a <tt>DirContext</tt>, any existing attributes associated with the name are replaced with
     * those of the object. Otherwise, any existing attributes associated with the name remain unchanged.
     *
@@ -138,10 +138,10 @@ public class DummyContext implements Context {
    /**
     * Unbinds the named object. Removes the terminal atomic name in <code>name</code> from the target context--that
     * named by all but the terminal atomic part of <code>name</code>.
-    * <p/>
+    * <p>
     * <p> This method is idempotent. It succeeds even if the terminal atomic name is not bound in the target context,
     * but throws <tt>NameNotFoundException</tt> if any of the intermediate contexts do not exist.
-    * <p/>
+    * <p>
     * <p> Any attributes associated with the name are removed. Intermediate contexts are not changed.
     *
     * @param name the name to unbind; may not be empty
@@ -205,7 +205,7 @@ public class DummyContext implements Context {
    /**
     * Enumerates the names bound in the named context, along with the class names of objects bound to them. The contents
     * of any subcontexts are not included.
-    * <p/>
+    * <p>
     * <p> If a binding is added to or removed from this context, its effect on an enumeration previously returned is
     * undefined.
     *
@@ -237,7 +237,7 @@ public class DummyContext implements Context {
    /**
     * Enumerates the names bound in the named context, along with the objects bound to them. The contents of any
     * subcontexts are not included.
-    * <p/>
+    * <p>
     * <p> If a binding is added to or removed from this context, its effect on an enumeration previously returned is
     * undefined.
     *
@@ -269,10 +269,10 @@ public class DummyContext implements Context {
    /**
     * Destroys the named context and removes it from the namespace. Any attributes associated with the name are also
     * removed. Intermediate contexts are not destroyed.
-    * <p/>
+    * <p>
     * <p> This method is idempotent. It succeeds even if the terminal atomic name is not bound in the target context,
     * but throws <tt>NameNotFoundException</tt> if any of the intermediate contexts do not exist.
-    * <p/>
+    * <p>
     * <p> In a federated naming system, a context from one naming system may be bound to a name in another.  One can
     * subsequently look up and perform operations on the foreign context using a composite name.  However, an attempt
     * destroy the context using this composite name will fail with <tt>NotContextException</tt>, because the foreign
@@ -402,7 +402,7 @@ public class DummyContext implements Context {
     * returns the composition of the two names using the syntax appropriate for the naming system(s) involved.  That is,
     * if <code>name</code> names an object relative to this context, the result is the name of the same object, but
     * relative to the ancestor context.  None of the names may be null.
-    * <p/>
+    * <p>
     * For example, if this context is named "wiz.com" relative to the initial context, then
     * <pre>
     *    composeName("east", "wiz.com")   </pre>
@@ -472,7 +472,7 @@ public class DummyContext implements Context {
    /**
     * Retrieves the environment in effect for this context. See class description for more details on environment
     * properties.
-    * <p/>
+    * <p>
     * <p> The caller should not make any changes to the object returned: their effect on the context is undefined. The
     * environment of this context may be changed using <tt>addToEnvironment()</tt> and
     * <tt>removeFromEnvironment()</tt>.
@@ -489,7 +489,7 @@ public class DummyContext implements Context {
    /**
     * Closes this context. This method releases this context's resources immediately, instead of waiting for them to be
     * released automatically by the garbage collector.
-    * <p/>
+    * <p>
     * <p> This method is idempotent:  invoking it on a context that has already been closed has no effect.  Invoking any
     * other method on a closed context is not allowed, and results in undefined behaviour.
     *
@@ -500,7 +500,7 @@ public class DummyContext implements Context {
 
    /**
     * Retrieves the full name of this context within its own namespace.
-    * <p/>
+    * <p>
     * <p> Many naming services have a notion of a "full name" for objects in their respective namespaces.  For example,
     * an LDAP entry has a distinguished name, and a DNS record has a fully qualified name. This method allows the client
     * application to retrieve this name. The string returned by this method is not a JNDI composite name and should not

--- a/core/src/test/java/org/infinispan/test/jndi/DummyContextFactory.java
+++ b/core/src/test/java/org/infinispan/test/jndi/DummyContextFactory.java
@@ -12,7 +12,7 @@ public class DummyContextFactory implements InitialContextFactory {
    /**
     * Creates an Initial Context for beginning name resolution. Special requirements of this context are supplied using
     * <code>environment</code>.
-    * <p/>
+    * <p>
     * The environment parameter is owned by the caller. The implementation will not modify the object or keep a
     * reference to it, although it may keep a reference to a clone or copy.
     *

--- a/core/src/test/java/org/infinispan/tx/BatchingAndEnlistmentTest.java
+++ b/core/src/test/java/org/infinispan/tx/BatchingAndEnlistmentTest.java
@@ -16,7 +16,7 @@ import org.infinispan.transaction.tm.EmbeddedTransaction;
 import org.testng.annotations.Test;
 
 /**
- * @author Mircea Markus <mircea.markus@jboss.com> (C) 2011 Red Hat Inc.
+ * @author Mircea Markus &lt;mircea.markus@jboss.com&gt; (C) 2011 Red Hat Inc.
  * @since 5.1
  */
 @Test (groups = "functional", testName = "tx.BatchingAndEnlistmentTest")

--- a/core/src/test/java/org/infinispan/tx/ExceptionDuringGetTest.java
+++ b/core/src/test/java/org/infinispan/tx/ExceptionDuringGetTest.java
@@ -12,7 +12,7 @@ import org.infinispan.transaction.LockingMode;
 import org.testng.annotations.Test;
 
 /**
- * @author Mircea Markus <mircea.markus@jboss.com> (C) 2011 Red Hat Inc.
+ * @author Mircea Markus &lt;mircea.markus@jboss.com&gt; (C) 2011 Red Hat Inc.
  * @since 5.1
  */
 @Test (groups = "functional", testName = "tx.ExceptionDuringGetTest")

--- a/core/src/test/java/org/infinispan/tx/LockReleaseWithNoWriteTest.java
+++ b/core/src/test/java/org/infinispan/tx/LockReleaseWithNoWriteTest.java
@@ -13,7 +13,7 @@ import org.infinispan.transaction.LockingMode;
 import org.testng.annotations.Test;
 
 /**
- * @author Mircea Markus <mircea.markus@jboss.com> (C) 2011 Red Hat Inc.
+ * @author Mircea Markus &lt;mircea.markus@jboss.com&gt; (C) 2011 Red Hat Inc.
  * @since 5.1
  */
 @Test (groups = "functional", testName = "tx.LockReleaseWithNoWriteTest")

--- a/core/src/test/java/org/infinispan/tx/RemoteTxNotCreatedOnGetTest.java
+++ b/core/src/test/java/org/infinispan/tx/RemoteTxNotCreatedOnGetTest.java
@@ -10,7 +10,7 @@ import org.infinispan.transaction.impl.TransactionTable;
 import org.testng.annotations.Test;
 
 /**
- * @author Mircea Markus <mircea.markus@jboss.com> (C) 2011 Red Hat Inc.
+ * @author Mircea Markus &lt;mircea.markus@jboss.com&gt; (C) 2011 Red Hat Inc.
  * @since 5.1
  */
 @Test(groups = "functional", testName = "tx.RemoteTxNotCreatedOnGetTest")

--- a/core/src/test/java/org/infinispan/tx/StaleLockAfterTxAbortTest.java
+++ b/core/src/test/java/org/infinispan/tx/StaleLockAfterTxAbortTest.java
@@ -17,7 +17,7 @@ import org.testng.annotations.Test;
 
 /**
  * This tests the following pattern:
- * <p/>
+ * <p>
  * Thread T1 holds lock for key K. TX1 attempts to lock a key K.  Waits for lock. TM times out the tx and aborts the tx
  * (calls XA.end, XA.rollback). T1 releases lock. Wait a few seconds. Make sure there are no stale locks (i.e., when the
  * thread for TX1 wakes up and gets the lock on K, it then releases and aborts).

--- a/core/src/test/java/org/infinispan/tx/recovery/RecoveryDummyTransactionManagerLookup.java
+++ b/core/src/test/java/org/infinispan/tx/recovery/RecoveryDummyTransactionManagerLookup.java
@@ -7,7 +7,7 @@ import org.infinispan.commons.tx.lookup.TransactionManagerLookup;
 import org.infinispan.transaction.tm.DummyTransactionManager;
 
 /**
- * @author Mircea Markus <mircea.markus@jboss.com> (C) 2011 Red Hat Inc.
+ * @author Mircea Markus &lt;mircea.markus@jboss.com&gt; (C) 2011 Red Hat Inc.
  * @since 5.1
  * @deprecated use {@link EmbeddedTransactionManagerLookup}
  */

--- a/core/src/test/java/org/infinispan/tx/totalorder/statetransfer/DistTotalOrderVersionedStateTransferTest.java
+++ b/core/src/test/java/org/infinispan/tx/totalorder/statetransfer/DistTotalOrderVersionedStateTransferTest.java
@@ -6,7 +6,7 @@ import org.infinispan.transaction.TransactionProtocol;
 import org.testng.annotations.Test;
 
 /**
- * @author Mircea Markus <mircea.markus@jboss.com> (C) 2011 Red Hat Inc.
+ * @author Mircea Markus &lt;mircea.markus@jboss.com&gt; (C) 2011 Red Hat Inc.
  * @since 5.3
  */
 @Test(groups = "functional", testName = "tx.totalorder.statetransfer.DistTotalOrderVersionedStateTransferTest")

--- a/core/src/test/java/org/infinispan/tx/totalorder/statetransfer/TotalOrderStateTransferFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/tx/totalorder/statetransfer/TotalOrderStateTransferFunctionalTest.java
@@ -10,7 +10,7 @@ import org.infinispan.util.concurrent.IsolationLevel;
 import org.testng.annotations.Test;
 
 /**
- * @author Mircea Markus <mircea.markus@jboss.com> (C) 2011 Red Hat Inc.
+ * @author Mircea Markus &lt;mircea.markus@jboss.com&gt; (C) 2011 Red Hat Inc.
  * @since 5.3
  */
 @Test(groups = "unstable", testName = "tx.totalorder.statetransfer.TotalOrderStateTransferFunctionalTest", description = "JGRP-2233")

--- a/core/src/test/java/org/infinispan/tx/totalorder/writeskew/TotalOrderWriteSkewTest.java
+++ b/core/src/test/java/org/infinispan/tx/totalorder/writeskew/TotalOrderWriteSkewTest.java
@@ -11,7 +11,7 @@ import org.infinispan.transaction.TransactionProtocol;
 import org.testng.annotations.Test;
 
 /**
- * @author Mircea Markus <mircea.markus@jboss.com> (C) 2011 Red Hat Inc.
+ * @author Mircea Markus &lt;mircea.markus@jboss.com&gt; (C) 2011 Red Hat Inc.
  * @since 5.3
  */
 @Test(groups = "functional", testName = "tx.totalorder.writeskew.TotalOrderWriteSkewTest")

--- a/extended-statistics/src/main/java/org/infinispan/stats/percentiles/ReservoirSampler.java
+++ b/extended-statistics/src/main/java/org/infinispan/stats/percentiles/ReservoirSampler.java
@@ -6,7 +6,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Keeps the sample for percentile calculations.
- * <p/>
+ * <p>
  * Please check <a href="http://en.wikipedia.org/wiki/Reservoir_sampling for more details">this</a> for more details
  *
  * @author Roberto Palmieri

--- a/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/AccessDelegate.java
+++ b/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/AccessDelegate.java
@@ -11,7 +11,7 @@ import org.hibernate.cache.spi.access.SoftLock;
 
 /**
  * Defines the strategy for access to entity or collection data in a Infinispan instance.
- * <p/>
+ * <p>
  * The intent of this class is to encapsulate common code and serve as a delegate for
  * {@link org.hibernate.cache.spi.access.EntityRegionAccessStrategy}
  * and {@link org.hibernate.cache.spi.access.CollectionRegionAccessStrategy} implementations.

--- a/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/PutFromLoadValidator.java
+++ b/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/PutFromLoadValidator.java
@@ -47,7 +47,7 @@ import org.infinispan.util.ByteString;
  * <p>
  * The expected usage of this class by a thread that read the cache and did
  * not find data is:
- * <p/>
+ * <p>
  * <ol>
  * <li> Call {@link #registerPendingPut(Object, Object, long)}</li>
  * <li> Read the database</li>
@@ -57,12 +57,12 @@ import org.infinispan.util.ByteString;
  * <li> then call {@link #releasePutFromLoadLock(Object, Lock)}</li>
  * </ol>
  * </p>
- * <p/>
+ * <p>
  * <p>
  * The expected usage by a thread that is taking an action such that any pending
  * <code>putFromLoad</code> may have stale data and should not cache it is to either
  * call
- * <p/>
+ * <p>
  * <ul>
  * <li> {@link #beginInvalidatingKey(Object, Object)} (for a single key invalidation)</li>
  * <li>or {@link #beginInvalidatingRegion()} followed by {@link #endInvalidatingRegion()}
@@ -71,7 +71,7 @@ import org.infinispan.util.ByteString;
  * After transaction commit (when the DB is updated) {@link #endInvalidatingKey(Object, Object)} should
  * be called in order to allow further attempts to cache entry.
  * </p>
- * <p/>
+ * <p>
  * <p>
  * This class also supports the concept of "naked puts", which are calls to
  * {@link #acquirePutFromLoadLock(Object, Object, long)} without a preceding {@link #registerPendingPut(Object, Object, long)}.
@@ -667,7 +667,7 @@ public class PutFromLoadValidator {
 	/**
 	 * Lazy-initialization map for PendingPut. Optimized for the expected usual case where only a
 	 * single put is pending for a given key.
-	 * <p/>
+	 * <p>
 	 * This class is NOT THREAD SAFE. All operations on it must be performed with the lock held.
 	 */
 	private class PendingPutMap extends Lock {

--- a/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/TxInvalidationInterceptor.java
+++ b/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/TxInvalidationInterceptor.java
@@ -45,7 +45,7 @@ import org.infinispan.util.logging.LogFactory;
 /**
  * This interceptor acts as a replacement to the replication interceptor when the CacheImpl is configured with
  * ClusteredSyncMode as INVALIDATE.
- * <p/>
+ * <p>
  * The idea is that rather than replicating changes to all caches in a cluster when write methods are called, simply
  * broadcast an {@link InvalidateCommand} on the remote caches containing all keys modified.  This allows the remote
  * cache to look up the value in a shared cache loader which would have been updated with the changes.

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/AbstractGeneralDataRegionTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/AbstractGeneralDataRegionTest.java
@@ -177,7 +177,7 @@ public abstract class AbstractGeneralDataRegionTest extends AbstractRegionImplTe
 
 	/**
 	 * Test method for {@link QueryResultsRegion#evictAll()}.
-	 * <p/>
+	 * <p>
 	 * FIXME add testing of the "immediately without regard for transaction isolation" bit in the
 	 * CollectionRegionAccessStrategy API.
 	 */

--- a/hibernate/cache-v51/src/main/java/org/infinispan/hibernate/cache/v51/impl/BaseRegion.java
+++ b/hibernate/cache-v51/src/main/java/org/infinispan/hibernate/cache/v51/impl/BaseRegion.java
@@ -89,7 +89,7 @@ public abstract class BaseRegion implements Region, InfinispanBaseRegion {
 
 	/**
 	 * {@inheritDoc}
-	 * <p/>
+	 * <p>
 	 * Not supported; returns -1
 	 */
 	@Override
@@ -99,7 +99,7 @@ public abstract class BaseRegion implements Region, InfinispanBaseRegion {
 
 	/**
 	 * {@inheritDoc}
-	 * <p/>
+	 * <p>
 	 * Not supported; returns -1
 	 */
 	@Override

--- a/hibernate/cache-v51/src/main/java/org/infinispan/hibernate/cache/v51/naturalid/NaturalIdRegionImpl.java
+++ b/hibernate/cache-v51/src/main/java/org/infinispan/hibernate/cache/v51/naturalid/NaturalIdRegionImpl.java
@@ -20,9 +20,9 @@ import org.infinispan.hibernate.cache.v51.impl.BaseTransactionalDataRegion;
 import javax.transaction.TransactionManager;
 
 /**
- * Natural ID cache region
+ * Natural ID cache region.
  *
- * @author Strong Liu <stliu@hibernate.org>
+ * @author Strong Liu &lt;stliu@hibernate.org&gt;
  * @author Galder Zamarreño
  */
 public class NaturalIdRegionImpl extends BaseTransactionalDataRegion

--- a/hibernate/cache-v51/src/main/java/org/infinispan/hibernate/cache/v51/naturalid/ReadWriteAccess.java
+++ b/hibernate/cache-v51/src/main/java/org/infinispan/hibernate/cache/v51/naturalid/ReadWriteAccess.java
@@ -12,7 +12,7 @@ import org.hibernate.cache.spi.access.SoftLock;
 import org.hibernate.engine.spi.SessionImplementor;
 
 /**
- * @author Strong Liu <stliu@hibernate.org>
+ * @author Strong Liu &lt;stliu@hibernate.org&gt;
  */
 class ReadWriteAccess extends ReadOnlyAccess {
 

--- a/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/SimpleFacetingTest.java
+++ b/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/SimpleFacetingTest.java
@@ -20,7 +20,7 @@ import org.junit.Test;
  * Copy of SimpleFacetingTest for testing uber-jars
  *
  * @author Jiri Holusa (jholusa@redhat.com)
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2011 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2011 Red Hat Inc.
  * @author Hardy Ferentschik
  */
 public class SimpleFacetingTest extends AbstractQueryTest {

--- a/integrationtests/as-lucene-directory/src/test/java/org/infinispan/test/integration/as/VersionTestHelper.java
+++ b/integrationtests/as-lucene-directory/src/test/java/org/infinispan/test/integration/as/VersionTestHelper.java
@@ -13,7 +13,7 @@ import org.jboss.shrinkwrap.descriptor.api.spec.se.manifest.ManifestDescriptor;
 
 /**
  * Helper class for integration testing of the generated JBoss Modules.
- * <p/>
+ * <p>
  * The slot version is set as a property in the parent pom, and passed to the JVM of Arquillian as a system property of
  * the Maven maven-failsafe-plugin.
  * Loading it as a Properties makes these settings available to tests run withing the IDE as well.

--- a/integrationtests/as-lucene-directory/src/test/java/org/infinispan/test/integration/as/jms/SearchNewEntityJmsMasterSlave.java
+++ b/integrationtests/as-lucene-directory/src/test/java/org/infinispan/test/integration/as/jms/SearchNewEntityJmsMasterSlave.java
@@ -23,10 +23,10 @@ import org.junit.Test;
 /**
  * In a JMS Master/Slave configuration, every node should be able to find entities created by some other nodes after the
  * synchronization succeed.
- * <p/>
+ * <p>
  * Search dependencies are not added to the archives.
  *
- * @author Davide D'Alto <davide@hibernate.org>
+ * @author Davide D'Alto &lt;davide@hibernate.org&gt;
  */
 public abstract class SearchNewEntityJmsMasterSlave {
 

--- a/integrationtests/as-lucene-directory/src/test/java/org/infinispan/test/integration/as/jms/infinispan/SearchNewEntityJmsMasterSlaveAndInfinispan.java
+++ b/integrationtests/as-lucene-directory/src/test/java/org/infinispan/test/integration/as/jms/infinispan/SearchNewEntityJmsMasterSlaveAndInfinispan.java
@@ -17,10 +17,10 @@ import org.junit.Test;
 
 /**
  * Test that the JMS backend can be used at the same time with Infinispan.
- * <p/>
+ * <p>
  * Search dependencies are not added to the archives.
  *
- * @author Davide D'Alto <davide@hibernate.org>
+ * @author Davide D'Alto &lt;davide@hibernate.org&gt;
  */
 public abstract class SearchNewEntityJmsMasterSlaveAndInfinispan {
 

--- a/integrationtests/as-lucene-directory/src/test/java/org/infinispan/test/integration/as/wildfly/util/Resources.java
+++ b/integrationtests/as-lucene-directory/src/test/java/org/infinispan/test/integration/as/wildfly/util/Resources.java
@@ -9,9 +9,8 @@ import org.hibernate.search.jpa.Search;
 
 /**
  * This class uses CDI to alias Java EE resources, such as the persistence context, to CDI beans
- * <p/>
+ * <p>
  * <p> Example injection on a managed bean field: </p>
- * <p/>
  * <pre>
  * &#064;Inject
  * private EntityManager em;

--- a/integrationtests/cdi-jcache-it/src/test/java/org/infinispan/integrationtests/cdijcache/Deployments.java
+++ b/integrationtests/cdi-jcache-it/src/test/java/org/infinispan/integrationtests/cdijcache/Deployments.java
@@ -12,7 +12,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 /**
  * Arquillian deployment utility class.
  *
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 public final class Deployments {
    /**

--- a/integrationtests/cdi-jcache-it/src/test/java/org/infinispan/integrationtests/cdijcache/interceptor/CachePutInterceptorTest.java
+++ b/integrationtests/cdi-jcache-it/src/test/java/org/infinispan/integrationtests/cdijcache/interceptor/CachePutInterceptorTest.java
@@ -27,7 +27,7 @@ import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
 /**
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  * @see javax.cache.annotation.CachePut
  */
 @Listeners(TestResourceTrackingListener.class)

--- a/integrationtests/cdi-jcache-it/src/test/java/org/infinispan/integrationtests/cdijcache/interceptor/CacheRemoveAllInterceptorTest.java
+++ b/integrationtests/cdi-jcache-it/src/test/java/org/infinispan/integrationtests/cdijcache/interceptor/CacheRemoveAllInterceptorTest.java
@@ -23,7 +23,7 @@ import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
 /**
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  * @see javax.cache.annotation.CacheRemoveAll
  */
 @Test(groups = "functional", testName = "cdi.test.interceptor.CacheRemoveAllInterceptorTest")

--- a/integrationtests/cdi-jcache-it/src/test/java/org/infinispan/integrationtests/cdijcache/interceptor/CacheRemoveEntryInterceptorTest.java
+++ b/integrationtests/cdi-jcache-it/src/test/java/org/infinispan/integrationtests/cdijcache/interceptor/CacheRemoveEntryInterceptorTest.java
@@ -27,7 +27,7 @@ import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
 /**
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  * @see javax.cache.annotation.CacheRemove
  */
 @Listeners(TestResourceTrackingListener.class)

--- a/integrationtests/cdi-jcache-it/src/test/java/org/infinispan/integrationtests/cdijcache/interceptor/config/Config.java
+++ b/integrationtests/cdi-jcache-it/src/test/java/org/infinispan/integrationtests/cdijcache/interceptor/config/Config.java
@@ -14,7 +14,7 @@ import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
 /**
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 public class Config {
 

--- a/integrationtests/cdi-jcache-it/src/test/java/org/infinispan/integrationtests/cdijcache/interceptor/config/Custom.java
+++ b/integrationtests/cdi-jcache-it/src/test/java/org/infinispan/integrationtests/cdijcache/interceptor/config/Custom.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
 import javax.inject.Qualifier;
 
 /**
- * @author @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 @Qualifier
 @Target({TYPE, METHOD, PARAMETER, FIELD})

--- a/integrationtests/cdi-jcache-it/src/test/java/org/infinispan/integrationtests/cdijcache/interceptor/config/Small.java
+++ b/integrationtests/cdi-jcache-it/src/test/java/org/infinispan/integrationtests/cdijcache/interceptor/config/Small.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
 import javax.inject.Qualifier;
 
 /**
- * @author @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 @Qualifier
 @Target({TYPE, METHOD, PARAMETER, FIELD})

--- a/integrationtests/cdi-jcache-it/src/test/java/org/infinispan/integrationtests/cdijcache/interceptor/service/CachePutService.java
+++ b/integrationtests/cdi-jcache-it/src/test/java/org/infinispan/integrationtests/cdijcache/interceptor/service/CachePutService.java
@@ -5,7 +5,7 @@ import javax.cache.annotation.CachePut;
 import javax.cache.annotation.CacheValue;
 
 /**
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 public class CachePutService {
 

--- a/integrationtests/cdi-jcache-it/src/test/java/org/infinispan/integrationtests/cdijcache/interceptor/service/CacheRemoveAllService.java
+++ b/integrationtests/cdi-jcache-it/src/test/java/org/infinispan/integrationtests/cdijcache/interceptor/service/CacheRemoveAllService.java
@@ -3,7 +3,7 @@ package org.infinispan.integrationtests.cdijcache.interceptor.service;
 import javax.cache.annotation.CacheRemoveAll;
 
 /**
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 public class CacheRemoveAllService {
 

--- a/integrationtests/cdi-jcache-it/src/test/java/org/infinispan/integrationtests/cdijcache/interceptor/service/CacheRemoveEntryService.java
+++ b/integrationtests/cdi-jcache-it/src/test/java/org/infinispan/integrationtests/cdijcache/interceptor/service/CacheRemoveEntryService.java
@@ -6,7 +6,7 @@ import javax.cache.annotation.CacheKey;
 import javax.cache.annotation.CacheRemove;
 
 /**
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 public class CacheRemoveEntryService {
 

--- a/integrationtests/cdi-jcache-it/src/test/java/org/infinispan/integrationtests/cdijcache/interceptor/service/CacheResultService.java
+++ b/integrationtests/cdi-jcache-it/src/test/java/org/infinispan/integrationtests/cdijcache/interceptor/service/CacheResultService.java
@@ -4,7 +4,7 @@ import javax.cache.annotation.CacheKey;
 import javax.cache.annotation.CacheResult;
 
 /**
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 public class CacheResultService {
 

--- a/integrationtests/cdi-jcache-it/src/test/java/org/infinispan/integrationtests/cdijcache/interceptor/service/CustomCacheKey.java
+++ b/integrationtests/cdi-jcache-it/src/test/java/org/infinispan/integrationtests/cdijcache/interceptor/service/CustomCacheKey.java
@@ -5,7 +5,7 @@ import java.lang.reflect.Method;
 import javax.cache.annotation.GeneratedCacheKey;
 
 /**
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  * @author Galder Zamarreño
  */
 public class CustomCacheKey implements GeneratedCacheKey {

--- a/integrationtests/cdi-jcache-it/src/test/java/org/infinispan/integrationtests/cdijcache/interceptor/service/CustomCacheKeyGenerator.java
+++ b/integrationtests/cdi-jcache-it/src/test/java/org/infinispan/integrationtests/cdijcache/interceptor/service/CustomCacheKeyGenerator.java
@@ -7,7 +7,7 @@ import javax.cache.annotation.CacheKeyInvocationContext;
 import javax.cache.annotation.GeneratedCacheKey;
 
 /**
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 public class CustomCacheKeyGenerator implements CacheKeyGenerator {
 

--- a/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/util/IspnKarafOptions.java
+++ b/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/util/IspnKarafOptions.java
@@ -273,7 +273,7 @@ public class IspnKarafOptions {
     * PAX URL needs to know the location of the local maven repo to resolve mvn: URLs. When running the tests on the CI
     * machine TeamCity passes a custom local repo location using -Dmaven.repo.local to isolate the build targets and PAX
     * URL is not aware there's a custom repo to be used and tries to load from the default local repo location.
-    * <p/>
+    * <p>
     * This option will pass the location specified using -Dmaven.repo.local to the appropriate system property of the
     * container.
     *

--- a/integrationtests/wildfly-modules/src/test/java/org/infinispan/test/integration/as/cdi/Config.java
+++ b/integrationtests/wildfly-modules/src/test/java/org/infinispan/test/integration/as/cdi/Config.java
@@ -13,7 +13,7 @@ import org.infinispan.manager.DefaultCacheManager;
 /**
  * This is the configuration class.
  *
- * @author Kevin Pollet <pollet.kevin@gmail.com> (C) 2011
+ * @author Kevin Pollet &lt;pollet.kevin@gmail.com&gt; (C) 2011
  * @author Galder Zamarreño
  */
 public class Config {

--- a/integrationtests/wildfly-modules/src/test/java/org/infinispan/test/integration/as/cdi/GreetingCache.java
+++ b/integrationtests/wildfly-modules/src/test/java/org/infinispan/test/integration/as/cdi/GreetingCache.java
@@ -13,7 +13,7 @@ import javax.inject.Qualifier;
  *
  * <p>This qualifier will be associated to the greeting cache in the {@link Config} class.</p>
  *
- * @author Kevin Pollet <pollet.kevin@gmail.com> (C) 2011
+ * @author Kevin Pollet &lt;pollet.kevin@gmail.com&gt; (C) 2011
  */
 @Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)

--- a/integrationtests/wildfly-modules/src/test/java/org/infinispan/test/integration/as/cdi/GreetingCacheManager.java
+++ b/integrationtests/wildfly-modules/src/test/java/org/infinispan/test/integration/as/cdi/GreetingCacheManager.java
@@ -17,7 +17,7 @@ import org.infinispan.eviction.EvictionType;
  *
  * <p>This manager is used to collect informations on the greeting cache and to clear it's content if needed.</p>
  *
- * @author Kevin Pollet <pollet.kevin@gmail.com> (C) 2011
+ * @author Kevin Pollet &lt;pollet.kevin@gmail.com&gt; (C) 2011
  * @see javax.cache.annotation.CacheRemoveAll
  */
 @Named

--- a/integrationtests/wildfly-modules/src/test/java/org/infinispan/test/integration/as/cdi/GreetingCacheManagerIT.java
+++ b/integrationtests/wildfly-modules/src/test/java/org/infinispan/test/integration/as/cdi/GreetingCacheManagerIT.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
- * @author Kevin Pollet <pollet.kevin@gmail.com> (C) 2011
+ * @author Kevin Pollet &lt;pollet.kevin@gmail.com&gt; (C) 2011
  */
 @RunWith(Arquillian.class)
 public class GreetingCacheManagerIT {

--- a/integrationtests/wildfly-modules/src/test/java/org/infinispan/test/integration/as/cdi/GreetingService.java
+++ b/integrationtests/wildfly-modules/src/test/java/org/infinispan/test/integration/as/cdi/GreetingService.java
@@ -9,7 +9,7 @@ import javax.cache.annotation.CacheResult;
  * the {@linkplain javax.cache.annotation.CacheKey CacheKey} will be the name). If this method has been already called
  * with the same name the cached value will be returned and this method will not be called.</p>
  *
- * @author Kevin Pollet <pollet.kevin@gmail.com> (C) 2011
+ * @author Kevin Pollet &lt;pollet.kevin@gmail.com&gt; (C) 2011
  * @see CacheResult
  */
 public class GreetingService {

--- a/integrationtests/wildfly-modules/src/test/java/org/infinispan/test/integration/as/cdi/GreetingServiceIT.java
+++ b/integrationtests/wildfly-modules/src/test/java/org/infinispan/test/integration/as/cdi/GreetingServiceIT.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
- * @author Kevin Pollet <pollet.kevin@gmail.com> (C) 2011
+ * @author Kevin Pollet &lt;pollet.kevin@gmail.com&gt; (C) 2011
  */
 @RunWith(Arquillian.class)
 public class GreetingServiceIT {

--- a/jcache/embedded/src/main/java/org/infinispan/jcache/annotation/AbstractCachePutInterceptor.java
+++ b/jcache/embedded/src/main/java/org/infinispan/jcache/annotation/AbstractCachePutInterceptor.java
@@ -15,7 +15,7 @@ import org.infinispan.jcache.logging.Log;
 /**
  * Base {@link javax.cache.annotation.CachePut} interceptor implementation.
  *
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  * @author Galder Zamarreño
  */
 public abstract class AbstractCachePutInterceptor implements Serializable {

--- a/jcache/embedded/src/main/java/org/infinispan/jcache/annotation/AbstractCacheRemoveAllInterceptor.java
+++ b/jcache/embedded/src/main/java/org/infinispan/jcache/annotation/AbstractCacheRemoveAllInterceptor.java
@@ -20,7 +20,7 @@ import org.infinispan.jcache.logging.Log;
  * specifying a afterInvocation attribute value of false. If afterInvocation is true and the annotated method throws an
  * exception, the removeAll will not happen.</p>
  *
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 public abstract class AbstractCacheRemoveAllInterceptor implements Serializable {
    protected final boolean trace = getLog().isTraceEnabled();

--- a/jcache/embedded/src/main/java/org/infinispan/jcache/annotation/AbstractCacheRemoveEntryInterceptor.java
+++ b/jcache/embedded/src/main/java/org/infinispan/jcache/annotation/AbstractCacheRemoveEntryInterceptor.java
@@ -22,7 +22,7 @@ import org.infinispan.jcache.logging.Log;
  * attribute value of false. If afterInvocation is true and the annotated method throws an exception the remove will not
  * happen.</p>
  *
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  * @author Galder Zamarreño
  */
 public abstract class AbstractCacheRemoveEntryInterceptor implements Serializable {

--- a/jcache/embedded/src/main/java/org/infinispan/jcache/annotation/AbstractCacheResultInterceptor.java
+++ b/jcache/embedded/src/main/java/org/infinispan/jcache/annotation/AbstractCacheResultInterceptor.java
@@ -29,7 +29,7 @@ import org.infinispan.jcache.logging.Log;
  * value put into the cache. The cache is not checked for the key before method body invocation, skipping steps 2 and 3
  * from the list above. This can be used for annotating methods that do a cache.put() with no other consequences.</p>
  *
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  * @author Galder Zamarreño
  */
 public abstract class AbstractCacheResultInterceptor implements Serializable {

--- a/jcache/embedded/src/main/java/org/infinispan/jcache/annotation/AggregatedParameterMetaData.java
+++ b/jcache/embedded/src/main/java/org/infinispan/jcache/annotation/AggregatedParameterMetaData.java
@@ -7,7 +7,7 @@ import java.util.List;
 /**
  * Contains all parameters metadata for a method annotated with a cache annotation.
  *
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  * @author Galder Zamarreño
  */
 public class AggregatedParameterMetaData {

--- a/jcache/embedded/src/main/java/org/infinispan/jcache/annotation/CacheInvocationParameterImpl.java
+++ b/jcache/embedded/src/main/java/org/infinispan/jcache/annotation/CacheInvocationParameterImpl.java
@@ -8,7 +8,7 @@ import javax.cache.annotation.CacheInvocationParameter;
 /**
  * The {@link javax.cache.annotation.CacheInvocationParameter} implementation.
  *
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  * @author Galder Zamarreño
  */
 public class CacheInvocationParameterImpl implements CacheInvocationParameter {

--- a/jcache/embedded/src/main/java/org/infinispan/jcache/annotation/CacheKeyInvocationContextFactory.java
+++ b/jcache/embedded/src/main/java/org/infinispan/jcache/annotation/CacheKeyInvocationContextFactory.java
@@ -31,7 +31,7 @@ import org.infinispan.commons.util.CollectionFactory;
 import org.infinispan.jcache.logging.Log;
 
 /**
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  * @author Galder Zamarreño
  */
 @ApplicationScoped

--- a/jcache/embedded/src/main/java/org/infinispan/jcache/annotation/CacheKeyInvocationContextImpl.java
+++ b/jcache/embedded/src/main/java/org/infinispan/jcache/annotation/CacheKeyInvocationContextImpl.java
@@ -20,7 +20,7 @@ import org.infinispan.jcache.logging.Log;
 /**
  * The {@link javax.cache.annotation.CacheKeyInvocationContext} implementation.
  *
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 public class CacheKeyInvocationContextImpl<A extends Annotation> implements CacheKeyInvocationContext<A> {
 

--- a/jcache/embedded/src/main/java/org/infinispan/jcache/annotation/CacheLookupHelper.java
+++ b/jcache/embedded/src/main/java/org/infinispan/jcache/annotation/CacheLookupHelper.java
@@ -17,7 +17,7 @@ import org.infinispan.jcache.logging.Log;
 /**
  * An helper class providing useful methods for cache lookup.
  *
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 public final class CacheLookupHelper {
 

--- a/jcache/embedded/src/main/java/org/infinispan/jcache/annotation/CachePutInterceptor.java
+++ b/jcache/embedded/src/main/java/org/infinispan/jcache/annotation/CachePutInterceptor.java
@@ -12,7 +12,7 @@ import org.infinispan.jcache.logging.Log;
 /**
  * {@link javax.cache.annotation.CachePut} interceptor implementation.
  *
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  * @author Galder Zamarreño
  */
 @Interceptor

--- a/jcache/embedded/src/main/java/org/infinispan/jcache/annotation/CacheRemoveAllInterceptor.java
+++ b/jcache/embedded/src/main/java/org/infinispan/jcache/annotation/CacheRemoveAllInterceptor.java
@@ -18,7 +18,7 @@ import org.infinispan.jcache.logging.Log;
  * specifying a afterInvocation attribute value of false. If afterInvocation is true and the annotated method throws an
  * exception, the removeAll will not happen.</p>
  *
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 @Interceptor
 @CacheRemoveAll

--- a/jcache/embedded/src/main/java/org/infinispan/jcache/annotation/CacheRemoveEntryInterceptor.java
+++ b/jcache/embedded/src/main/java/org/infinispan/jcache/annotation/CacheRemoveEntryInterceptor.java
@@ -19,7 +19,7 @@ import org.infinispan.jcache.logging.Log;
  * attribute value of false. If afterInvocation is true and the annotated method throws an exception the remove will not
  * happen.</p>
  *
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  * @author Galder Zamarreño
  */
 @Interceptor

--- a/jcache/embedded/src/main/java/org/infinispan/jcache/annotation/CacheResultInterceptor.java
+++ b/jcache/embedded/src/main/java/org/infinispan/jcache/annotation/CacheResultInterceptor.java
@@ -26,7 +26,7 @@ import org.infinispan.jcache.logging.Log;
  * value put into the cache. The cache is not checked for the key before method body invocation, skipping steps 2 and 3
  * from the list above. This can be used for annotating methods that do a cache.put() with no other consequences.</p>
  *
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  * @author Galder Zamarreño
  */
 @Interceptor

--- a/jcache/embedded/src/main/java/org/infinispan/jcache/annotation/CollectionsHelper.java
+++ b/jcache/embedded/src/main/java/org/infinispan/jcache/annotation/CollectionsHelper.java
@@ -8,7 +8,7 @@ import java.util.Set;
 /**
  * An helper class providing useful methods to work with JDK collections.
  *
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 public final class CollectionsHelper {
    /**

--- a/jcache/embedded/src/main/java/org/infinispan/jcache/annotation/Contracts.java
+++ b/jcache/embedded/src/main/java/org/infinispan/jcache/annotation/Contracts.java
@@ -3,7 +3,7 @@ package org.infinispan.jcache.annotation;
 /**
  * An helper class providing useful assertion methods.
  *
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 public final class Contracts {
    /**

--- a/jcache/embedded/src/main/java/org/infinispan/jcache/annotation/DefaultCacheKey.java
+++ b/jcache/embedded/src/main/java/org/infinispan/jcache/annotation/DefaultCacheKey.java
@@ -9,7 +9,7 @@ import javax.cache.annotation.GeneratedCacheKey;
 /**
  * Default {@link javax.cache.annotation.GeneratedCacheKey} implementation.
  *
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  * @author Galder Zamarreño
  */
 public class DefaultCacheKey implements GeneratedCacheKey {

--- a/jcache/embedded/src/main/java/org/infinispan/jcache/annotation/DefaultCacheKeyGenerator.java
+++ b/jcache/embedded/src/main/java/org/infinispan/jcache/annotation/DefaultCacheKeyGenerator.java
@@ -15,7 +15,7 @@ import javax.enterprise.context.ApplicationScoped;
  * By default all key parameters of the intercepted method compose the
  * {@link javax.cache.annotation.CacheKey}.
  *
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  * @author Galder Zamarreño
  */
 @ApplicationScoped

--- a/jcache/embedded/src/main/java/org/infinispan/jcache/annotation/DefaultCacheResolver.java
+++ b/jcache/embedded/src/main/java/org/infinispan/jcache/annotation/DefaultCacheResolver.java
@@ -16,7 +16,7 @@ import javax.enterprise.context.ApplicationScoped;
  * Default {@link javax.cache.annotation.CacheResolver} implementation for
  * standalone environments, where no Cache/CacheManagers are injected via CDI.
  *
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  * @author Galder Zamarreño
  */
 @ApplicationScoped

--- a/jcache/embedded/src/main/java/org/infinispan/jcache/annotation/MethodMetaData.java
+++ b/jcache/embedded/src/main/java/org/infinispan/jcache/annotation/MethodMetaData.java
@@ -12,7 +12,7 @@ import javax.cache.annotation.CacheKeyGenerator;
 /**
  * Metadata associated to a method annotated with a cache annotation.
  *
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 public class MethodMetaData<A extends Annotation> {
 

--- a/jcache/embedded/src/main/java/org/infinispan/jcache/annotation/ParameterMetaData.java
+++ b/jcache/embedded/src/main/java/org/infinispan/jcache/annotation/ParameterMetaData.java
@@ -9,7 +9,7 @@ import java.util.Set;
 /**
  * Contains the metadata for a parameter of a method annotated with A JCACHE annotation.
  *
- * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
 public class ParameterMetaData {
 

--- a/jcache/embedded/src/main/java/org/infinispan/jcache/embedded/RICacheStatistics.java
+++ b/jcache/embedded/src/main/java/org/infinispan/jcache/embedded/RICacheStatistics.java
@@ -31,7 +31,7 @@ public class RICacheStatistics implements CacheStatisticsMXBean, Serializable {
 
    /**
     * {@inheritDoc}
-    * <p/>
+    * <p>
     * Statistics will also automatically be cleared if internal counters
     * overflow.
     */
@@ -87,7 +87,7 @@ public class RICacheStatistics implements CacheStatisticsMXBean, Serializable {
    /**
     * The total number of requests to the cache. This will be equal to the sum
     * of the hits and misses.
-    * <p/>
+    * <p>
     * A "get" is an operation that returns the current or previous value.
     *
     * @return the number of hits
@@ -100,7 +100,7 @@ public class RICacheStatistics implements CacheStatisticsMXBean, Serializable {
 
    /**
     * The total number of puts to the cache.
-    * <p/>
+    * <p>
     * A put is counted even if it is immediately evicted. A replace includes a
     * put and remove.
     *
@@ -114,7 +114,7 @@ public class RICacheStatistics implements CacheStatisticsMXBean, Serializable {
    /**
     * The total number of removals from the cache. This does not include
     * evictions, where the cache itself initiates the removal to make space.
-    * <p/>
+    * <p>
     *
     * @return the number of removals
     */
@@ -134,7 +134,7 @@ public class RICacheStatistics implements CacheStatisticsMXBean, Serializable {
 
    /**
     * The mean time to execute gets.
-    * <p/>
+    * <p>
     * In a read-through cache the time taken to load an entry on miss is not included in get time.
     *
     * @return the time in µs

--- a/lucene/directory-provider/src/main/java/org/infinispan/hibernate/search/impl/AsyncDeleteExecutorService.java
+++ b/lucene/directory-provider/src/main/java/org/infinispan/hibernate/search/impl/AsyncDeleteExecutorService.java
@@ -11,7 +11,7 @@ import org.hibernate.search.engine.service.spi.Service;
  * write operations when Infinispan is running in clustered mode. This is implemented as a Service so that integrations
  * can inject a different managed threadpool, and we can share the same executor among multiple IndexManagers.
  *
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2014 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2014 Red Hat Inc.
  */
 public interface AsyncDeleteExecutorService extends Service {
 

--- a/lucene/directory-provider/src/main/java/org/infinispan/hibernate/search/impl/DefaultAsyncDeleteExecutor.java
+++ b/lucene/directory-provider/src/main/java/org/infinispan/hibernate/search/impl/DefaultAsyncDeleteExecutor.java
@@ -15,7 +15,7 @@ import org.kohsuke.MetaInfServices;
 /**
  * A shared service used among all InfinispanDirectoryProvider instances to delete segments asynchronously.
  *
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2014 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2014 Red Hat Inc.
  */
 @MetaInfServices(AsyncDeleteExecutorService.class)
 public class DefaultAsyncDeleteExecutor implements AsyncDeleteExecutorService, Startable, Stoppable {

--- a/lucene/directory-provider/src/main/java/org/infinispan/hibernate/search/spi/InfinispanIntegration.java
+++ b/lucene/directory-provider/src/main/java/org/infinispan/hibernate/search/spi/InfinispanIntegration.java
@@ -5,7 +5,7 @@ import java.util.Properties;
 /**
  * Configuration constants for the Infinispan integration
  *
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2012 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2012 Red Hat Inc.
  */
 public class InfinispanIntegration {
 
@@ -45,10 +45,10 @@ public class InfinispanIntegration {
 
    /**
     * Configuration attribute to control if the writes to Index Metadata should be performed asynchronously.
-    * <p/>
+    * <p>
     * Defaults to {@code false} if the backend is configured as synchronous and defaults to {@code true} if the backend
     * is configured as asynchronous.
-    * <p/>
+    * <p>
     * Setting this to {@code true} might improve performance but is highly experimental.
     */
    public static final String WRITE_METADATA_ASYNC = "write_metadata_async";

--- a/lucene/directory-provider/src/main/java/org/infinispan/hibernate/search/util/configuration/impl/ConfigurationParseHelper.java
+++ b/lucene/directory-provider/src/main/java/org/infinispan/hibernate/search/util/configuration/impl/ConfigurationParseHelper.java
@@ -12,7 +12,7 @@ import org.infinispan.hibernate.search.logging.Log;
  *
  * @author Sanne Grinovero
  * @author Steve Ebersole
- * @author Emmanuel Bernard <emmanuel@hibernate.org>
+ * @author Emmanuel Bernard &lt;emmanuel@hibernate.org&gt;
  * @author Hardy Ferentschik
  */
 public class ConfigurationParseHelper {

--- a/lucene/directory-provider/src/test/java/org/infinispan/hibernate/search/AsyncLiveRunningTest.java
+++ b/lucene/directory-provider/src/test/java/org/infinispan/hibernate/search/AsyncLiveRunningTest.java
@@ -27,14 +27,14 @@ import org.junit.Test;
  * In this test we initially start a master node which will stay alive for the full test duration and constantly
  * indexing new entities, focusing on the configurtion using async indexing and exclusive lock ownership on the primary
  * node.
- * <p/>
+ * <p>
  * After that we add and remove additional new nodes, still making more index changes checking that each node is always
  * able to see changes - although the purpose here is to test async indexing so the visibility on these changes might
  * be slightly delayed.
  * This results in a very stressfull test as the cluster topology is changed frequently, but since it uses replication
  * it doesn't need to perform rehashing.
  *
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2017 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2017 Red Hat Inc.
  */
 public class AsyncLiveRunningTest {
 

--- a/lucene/directory-provider/src/test/java/org/infinispan/hibernate/search/AsyncMetadataConfigurationTest.java
+++ b/lucene/directory-provider/src/test/java/org/infinispan/hibernate/search/AsyncMetadataConfigurationTest.java
@@ -17,7 +17,7 @@ import org.junit.runner.RunWith;
  * Verifies the {@link org.infinispan.hibernate.search.spi.InfinispanIntegration#WRITE_METADATA_ASYNC} setting is
  * correctly applied to the Infinispan directory.
  *
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2014 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2014 Red Hat Inc.
  * @author Gunnar Morling
  * @since 5.0
  */

--- a/lucene/directory-provider/src/test/java/org/infinispan/hibernate/search/ClusterSharedConnectionProvider.java
+++ b/lucene/directory-provider/src/test/java/org/infinispan/hibernate/search/ClusterSharedConnectionProvider.java
@@ -7,7 +7,7 @@ import org.h2.jdbcx.JdbcConnectionPool;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 
 /**
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2011 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2011 Red Hat Inc.
  */
 public class ClusterSharedConnectionProvider implements ConnectionProvider {
 

--- a/lucene/directory-provider/src/test/java/org/infinispan/hibernate/search/ClusterTestHelper.java
+++ b/lucene/directory-provider/src/test/java/org/infinispan/hibernate/search/ClusterTestHelper.java
@@ -19,7 +19,7 @@ import org.infinispan.remoting.transport.Address;
  * Helpers to setup several instances of Hibernate Search using clustering to connect the index, and sharing the same H2
  * database instance.
  *
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2011 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2011 Red Hat Inc.
  */
 public final class ClusterTestHelper {
 

--- a/lucene/directory-provider/src/test/java/org/infinispan/hibernate/search/InfinispanLockFactoryOptionsTest.java
+++ b/lucene/directory-provider/src/test/java/org/infinispan/hibernate/search/InfinispanLockFactoryOptionsTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
  * Verifies the locking_strategy option is being applied as expected, even if the DirectoryProvider is set to
  * Infinispan.
  *
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2014 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2014 Red Hat Inc.
  */
 public class InfinispanLockFactoryOptionsTest {
 

--- a/lucene/directory-provider/src/test/java/org/infinispan/hibernate/search/LiveRunningTest.java
+++ b/lucene/directory-provider/src/test/java/org/infinispan/hibernate/search/LiveRunningTest.java
@@ -27,12 +27,12 @@ import org.junit.experimental.categories.Category;
 /**
  * In this test we initially start a master node which will stay alive for the full test duration and constantly
  * indexing new entities.
- * <p/>
+ * <p>
  * After that we add and remove additional new nodes, still making more index changes checking that each node is always
  * able to see changes as soon as committed by the main node; this results in a very stressfull test as the cluster
  * topology is changed at each step (though it doesn't rehash as it's replicating).
  *
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2011 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2011 Red Hat Inc.
  */
 public class LiveRunningTest {
 

--- a/lucene/directory-provider/src/test/java/org/infinispan/hibernate/search/StoredIndexTest.java
+++ b/lucene/directory-provider/src/test/java/org/infinispan/hibernate/search/StoredIndexTest.java
@@ -22,7 +22,7 @@ import org.junit.rules.TemporaryFolder;
  * Verifies we're able to start from an existing index in Infinispan, stored in a CacheLoader. Requires a persistent
  * database so that we can shutdown the SessionFactory and start over again (simulated via a custom H2 service)
  *
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2012 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2012 Red Hat Inc.
  */
 public class StoredIndexTest {
 

--- a/lucene/lucene-directory/src/main/java/org/infinispan/lucene/impl/DirectoryExtensions.java
+++ b/lucene/lucene-directory/src/main/java/org/infinispan/lucene/impl/DirectoryExtensions.java
@@ -6,7 +6,7 @@ import org.infinispan.Cache;
  * Some additional methods we add to our Directory implementations,
  * mostly for reporting and testing reasons.
  *
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2013 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2013 Red Hat Inc.
  */
 public interface DirectoryExtensions {
 

--- a/lucene/lucene-directory/src/main/java/org/infinispan/lucene/impl/SlicedBufferIndexInput.java
+++ b/lucene/lucene-directory/src/main/java/org/infinispan/lucene/impl/SlicedBufferIndexInput.java
@@ -9,7 +9,7 @@ import org.apache.lucene.store.IndexInput;
  * The buffer is not copied to avoid copy operations as the slice is expected to have a lifespan shorter than the buffer itself,
  * so there would be no benefit in having a smaller copy in heap.
  *
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2014 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2014 Red Hat Inc.
  * @since 7.0
  */
 final class SlicedBufferIndexInput extends IndexInput {

--- a/lucene/lucene-directory/src/main/java/org/infinispan/lucene/impl/SlicingInfinispanIndexInput.java
+++ b/lucene/lucene-directory/src/main/java/org/infinispan/lucene/impl/SlicingInfinispanIndexInput.java
@@ -8,7 +8,7 @@ import org.apache.lucene.store.IndexInput;
  * Wraps an InfinispanIndexInput to expose only a slice of it.
  * Such slices are dependent on the parent IndexInput and will not handle readlocks.
  *
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2014 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2014 Red Hat Inc.
  * @since 7.0
  */
 final class SlicingInfinispanIndexInput extends IndexInput {

--- a/lucene/lucene-directory/src/test/java/org/infinispan/lucene/SkipIndexingGuaranteed.java
+++ b/lucene/lucene-directory/src/test/java/org/infinispan/lucene/SkipIndexingGuaranteed.java
@@ -17,7 +17,7 @@ import org.infinispan.interceptors.base.CommandInterceptor;
  * Using SKIP_INDEXING is much lighter than having Infinispan Query need to use class reflection and attempt to reconfigure the Search engine
  * dynamically.
  *
- * @author Sanne Grinovero <sanne@infinispan.org> (C) 2012 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@infinispan.org&gt; (C) 2012 Red Hat Inc.
  * @since 5.2
  */
 public class SkipIndexingGuaranteed extends CommandInterceptor {

--- a/lucene/lucene-directory/src/test/java/org/infinispan/lucene/cacheloader/CacheLoaderAPITest.java
+++ b/lucene/lucene-directory/src/test/java/org/infinispan/lucene/cacheloader/CacheLoaderAPITest.java
@@ -29,7 +29,7 @@ import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
 
 /**
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2013 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2013 Red Hat Inc.
  * @since 5.2
  */
 @Test(groups = "functional", testName = "lucene.cachestore.CacheLoaderAPITest")

--- a/lucene/lucene-directory/src/test/java/org/infinispan/lucene/profiling/DynamicTopologyStressTest.java
+++ b/lucene/lucene-directory/src/test/java/org/infinispan/lucene/profiling/DynamicTopologyStressTest.java
@@ -35,7 +35,7 @@ import org.jgroups.protocols.DISCARD;
 import org.testng.annotations.Test;
 
 /**
- * @author Sanne Grinovero <sanne@infinispan.org> (C) 2011 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@infinispan.org&gt; (C) 2011 Red Hat Inc.
  */
 @SuppressWarnings("deprecation")
 @Test(groups = "profiling", testName = "lucene.profiling.DynamicTopologyStressTest", sequential = true)

--- a/object-filter/src/main/java/org/infinispan/objectfilter/FilterCallback.java
+++ b/object-filter/src/main/java/org/infinispan/objectfilter/FilterCallback.java
@@ -7,7 +7,7 @@ package org.infinispan.objectfilter;
  * if specified) and the 'order by' projections (optional, if specified). The 'order by' projection is an array of
  * {@link java.lang.Comparable} that can be compared using the {@link java.util.Comparator} provided by {@link
  * FilterSubscription#getComparator()}.
- * <p/>
+ * <p>
  * Implementations of this interface are provided by the subscriber and must written is such a way that they can be
  * invoked from multiple threads simultaneously.
  *

--- a/object-filter/src/main/java/org/infinispan/objectfilter/impl/ql/JoinType.java
+++ b/object-filter/src/main/java/org/infinispan/objectfilter/impl/ql/JoinType.java
@@ -17,7 +17,7 @@ package org.infinispan.objectfilter.impl.ql;
 
 /**
  * Represents a canonical join type.
- * <p/>
+ * <p>
  * Note that currently HQL really only supports inner and left outer joins
  * (though cross joins can also be achieved).  This is because joins in HQL
  * are always defined in relation to a mapped association.  However, when we

--- a/object-filter/src/main/java/org/infinispan/objectfilter/impl/syntax/parser/ExpressionBuilder.java
+++ b/object-filter/src/main/java/org/infinispan/objectfilter/impl/syntax/parser/ExpressionBuilder.java
@@ -29,7 +29,7 @@ import org.jboss.logging.Logger;
 
 /**
  * Builder for the creation of WHERE/HAVING clause filters targeting a single entity.
- * <p/>
+ * <p>
  * Implemented as a stack of {@link LazyBooleanExpr}s which allows to add elements to the constructed query in a
  * uniform manner while traversing through the original query parse tree.
  *

--- a/object-filter/src/main/java/org/infinispan/objectfilter/impl/util/IntervalTree.java
+++ b/object-filter/src/main/java/org/infinispan/objectfilter/impl/util/IntervalTree.java
@@ -6,7 +6,7 @@ import java.util.List;
 /**
  * An Interval tree is an ordered tree data structure to hold Intervals. Specifically, it allows one to efficiently find
  * all Intervals that contain any given value in O(log n) time (see http://en.wikipedia.org/wiki/Interval_tree).
- * <p/>
+ * <p>
  * The implementation is based on red-black trees (http://en.wikipedia.org/wiki/Red–black_tree). Additions and removals
  * are efficient and require only minimal rebalancing of the tree as opposed to other implementation approaches that
  * perform a full rebuild after insertion. Duplicate intervals are not stored but are coped for.

--- a/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/stringbased/JdbcStringBasedStore.java
+++ b/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/stringbased/JdbcStringBasedStore.java
@@ -57,20 +57,20 @@ import io.reactivex.Flowable;
  * This cache store will store each entry within a row in the table. This assures a finer grained granularity for all
  * operation, and better performance. In order to be able to store non-string keys, it relies on an {@link
  * org.infinispan.persistence.keymappers.Key2StringMapper}.
- * <p/>
+ * <p>
  * Note that only the keys are stored as strings, the values are still saved as binary data. Using a character
  * data type for the value column will result in unmarshalling errors.
- * <p/>
+ * <p>
  * The actual storage table is defined through configuration {@link org.infinispan.persistence.jdbc.configuration.JdbcStringBasedStoreConfiguration}.
  * The table can be created/dropped on-the-fly, at deployment time. For more details consult javadoc for {@link
  * org.infinispan.persistence.jdbc.configuration.JdbcStringBasedStoreConfiguration}.
- * <p/>
+ * <p>
  * <b>Preload</b>.In order to support preload functionality the store needs to read the string keys from the database and transform them
  * into the corresponding key objects. {@link org.infinispan.persistence.keymappers.Key2StringMapper} only supports
  * key to string transformation(one way); in order to be able to use preload one needs to specify an
  * {@link org.infinispan.persistence.keymappers.TwoWayKey2StringMapper}, which extends {@link org.infinispan.persistence.keymappers.Key2StringMapper} and
  * allows bidirectional transformation.
- * <p/>
+ * <p>
  * <b>Rehashing</b>. When a node leaves/joins, Infinispan moves around persistent state as part of rehashing process.
  * For this it needs access to the underlaying key objects, so if distribution is used, the mapper needs to be an
  * {@link org.infinispan.persistence.keymappers.TwoWayKey2StringMapper} otherwise the cache won't start (same constraint as with preloading).

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/RemoteStore.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/RemoteStore.java
@@ -58,10 +58,10 @@ import net.jcip.annotations.ThreadSafe;
  * cluster is achieved through the java HotRod client: this assures fault tolerance and smart dispatching of calls to
  * the nodes that have the highest chance of containing the given key. This cache store supports both preloading
  * and <b>fetchPersistentState</b>.
- * <p/>
+ * <p>
  * Purging elements is not possible, as HotRod does not support the fetching of all remote keys (this would be a
  * very costly operation as well). Purging takes place at the remote end (infinispan cluster).
- * <p/>
+ * <p>
  *
  * @author Mircea.Markus@jboss.com
  * @see org.infinispan.persistence.remote.configuration.RemoteStoreConfiguration

--- a/query-dsl/src/main/java/org/infinispan/query/dsl/FilterConditionContext.java
+++ b/query-dsl/src/main/java/org/infinispan/query/dsl/FilterConditionContext.java
@@ -12,7 +12,7 @@ public interface FilterConditionContext {
    /**
     * Creates a new context and connects it with the current one using boolean AND. The new context is added after the
     * current one. The two conditions are not grouped so operator precedence in the resulting condition might change.
-    * <p/>
+    * <p>
     * The effect is: a AND b
     *
     * @return the new context
@@ -22,7 +22,7 @@ public interface FilterConditionContext {
    /**
     * Connects a given context with the current one using boolean AND. The new context is added after the current one
     * and is grouped. Operator precedence will be unaffected due to grouping.
-    * <p/>
+    * <p>
     * The effect is: a AND (b)
     *
     * @param rightCondition the second condition
@@ -33,7 +33,7 @@ public interface FilterConditionContext {
    /**
     * Creates a new context and connects it with the current one using boolean OR. The new context is added after the
     * current one.
-    * <p/>
+    * <p>
     * The effect is: a OR b
     *
     * @return the new context
@@ -43,7 +43,7 @@ public interface FilterConditionContext {
    /**
     * Connects a given context with the current one using boolean OR. The new context is added after the current one and
     * is grouped.
-    * <p/>
+    * <p>
     * The effect is: a OR (b)
     *
     * @param rightCondition the second condition

--- a/query/src/main/java/org/infinispan/query/CacheQuery.java
+++ b/query/src/main/java/org/infinispan/query/CacheQuery.java
@@ -12,7 +12,6 @@ import org.hibernate.search.query.engine.spi.FacetManager;
 /**
  * A cache-query is what will be returned when the getQuery() method is run on {@link org.infinispan.query.impl.SearchManagerImpl}. This object can
  * have methods such as list, setFirstResult,setMaxResults, setFetchSize, getResultSize and setSort.
- * <p/>
  *
  * @author Manik Surtani
  * @author Navin Surtani
@@ -96,10 +95,10 @@ public interface CacheQuery<E> extends Iterable<E> {
    /**
     * Defines the Lucene field names projected and returned in a query result
     * Each field is converted back to it's object representation, an Object[] being returned for each "row"
-    * <p/>
+    * <p>
     * A projectable field must be stored in the Lucene index and use a {@link org.hibernate.search.bridge.TwoWayFieldBridge}
     * Unless notified in their JavaDoc, all built-in bridges are two-way. All @DocumentId fields are projectable by design.
-    * <p/>
+    * <p>
     * If the projected field is not a projectable field, null is returned in the object[]
     *
     * @param fields the projected field names

--- a/query/src/main/java/org/infinispan/query/MassIndexer.java
+++ b/query/src/main/java/org/infinispan/query/MassIndexer.java
@@ -14,7 +14,7 @@ import org.infinispan.jmx.annotations.ManagedOperation;
  * While reindexing is being performed queries should not be executed as they
  * will very likely miss many or all results.
  *
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2012 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2012 Red Hat Inc.
  */
 @MBean(objectName = "MassIndexer",
       description = "Component that rebuilds the index from the cached data")

--- a/query/src/main/java/org/infinispan/query/backend/IndexModificationStrategy.java
+++ b/query/src/main/java/org/infinispan/query/backend/IndexModificationStrategy.java
@@ -13,7 +13,7 @@ import org.infinispan.remoting.rpc.RpcManager;
 /**
  * Defines for which events the Query Interceptor will generate indexing events.
  *
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2014 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2014 Red Hat Inc.
  * @since 7.0
  */
 public enum IndexModificationStrategy {

--- a/query/src/main/java/org/infinispan/query/clustered/ClusteredCacheQueryImpl.java
+++ b/query/src/main/java/org/infinispan/query/clustered/ClusteredCacheQueryImpl.java
@@ -25,7 +25,7 @@ import org.infinispan.remoting.transport.Address;
 /**
  * An extension of CacheQueryImpl used for distributed queries.
  *
- * @author Israel Lacerra <israeldl@gmail.com>
+ * @author Israel Lacerra &lt;israeldl@gmail.com&gt;
  * @since 5.1
  */
 public final class ClusteredCacheQueryImpl<E> extends CacheQueryImpl<E> {

--- a/query/src/main/java/org/infinispan/query/clustered/ClusteredQueryInvoker.java
+++ b/query/src/main/java/org/infinispan/query/clustered/ClusteredQueryInvoker.java
@@ -21,8 +21,8 @@ import org.infinispan.remoting.transport.Address;
 /**
  * Invoke a ClusteredQueryCommand on the cluster, including on own node.
  *
- * @author Israel Lacerra <israeldl@gmail.com>
- * @author Sanne Grinovero <sanne@infinispan.org> (C) 2011 Red Hat Inc.
+ * @author Israel Lacerra &lt;israeldl@gmail.com&gt;
+ * @author Sanne Grinovero &lt;sanne@infinispan.org&gt; (C) 2011 Red Hat Inc.
  * @since 5.1
  */
 final class ClusteredQueryInvoker {

--- a/query/src/main/java/org/infinispan/query/clustered/DistributedIterator.java
+++ b/query/src/main/java/org/infinispan/query/clustered/DistributedIterator.java
@@ -18,7 +18,7 @@ import org.infinispan.util.logging.LogFactory;
 /**
  * Iterates on a distributed query.
  *
- * @author Israel Lacerra <israeldl@gmail.com>
+ * @author Israel Lacerra &lt;israeldl@gmail.com&gt;
  * @author <a href="mailto:mluksa@redhat.com">Marko Luksa</a>
  * @author Sanne Grinovero
  * @since 5.1

--- a/query/src/main/java/org/infinispan/query/clustered/DistributedLazyIterator.java
+++ b/query/src/main/java/org/infinispan/query/clustered/DistributedLazyIterator.java
@@ -12,7 +12,7 @@ import org.infinispan.util.logging.LogFactory;
 /**
  * Lazily iterates on a distributed query.
  *
- * @author Israel Lacerra <israeldl@gmail.com>
+ * @author Israel Lacerra &lt;israeldl@gmail.com&gt;
  * @since 5.1
  */
 final class DistributedLazyIterator<E> extends DistributedIterator<E> {

--- a/query/src/main/java/org/infinispan/query/clustered/NodeTopDocs.java
+++ b/query/src/main/java/org/infinispan/query/clustered/NodeTopDocs.java
@@ -15,7 +15,7 @@ import org.infinispan.remoting.transport.Address;
 /**
  * A TopDocs with an array with keys of each result.
  *
- * @author Israel Lacerra <israeldl@gmail.com>
+ * @author Israel Lacerra &lt;israeldl@gmail.com&gt;
  * @since 5.1
  */
 public final class NodeTopDocs {

--- a/query/src/main/java/org/infinispan/query/clustered/QueryResponse.java
+++ b/query/src/main/java/org/infinispan/query/clustered/QueryResponse.java
@@ -12,7 +12,7 @@ import org.infinispan.query.impl.externalizers.ExternalizerIds;
 /**
  * The response for a {@link ClusteredQueryCommand}.
  *
- * @author Israel Lacerra <israeldl@gmail.com>
+ * @author Israel Lacerra &lt;israeldl@gmail.com&gt;
  * @since 5.1
  */
 public final class QueryResponse {

--- a/query/src/main/java/org/infinispan/query/clustered/commandworkers/QueryBox.java
+++ b/query/src/main/java/org/infinispan/query/clustered/commandworkers/QueryBox.java
@@ -16,7 +16,7 @@ import org.infinispan.commons.util.CollectionFactory;
  *
  * EVICTION: NOT IMPLEMENTED!
  *
- * @author Israel Lacerra <israeldl@gmail.com>
+ * @author Israel Lacerra &lt;israeldl@gmail.com&gt;
  * @since 5.1
  */
 public final class QueryBox {

--- a/query/src/main/java/org/infinispan/query/impl/CacheQueryImpl.java
+++ b/query/src/main/java/org/infinispan/query/impl/CacheQueryImpl.java
@@ -24,7 +24,6 @@ import org.infinispan.query.backend.KeyTransformationHandler;
 
 /**
  * Implementation class of the CacheQuery interface.
- * <p/>
  *
  * @author Navin Surtani
  * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2011 Red Hat Inc.

--- a/query/src/main/java/org/infinispan/query/impl/CommandFactory.java
+++ b/query/src/main/java/org/infinispan/query/impl/CommandFactory.java
@@ -15,7 +15,7 @@ import org.infinispan.util.ByteString;
 /**
 * Remote commands factory implementation.
 *
-* @author Israel Lacerra <israeldl@gmail.com>
+* @author Israel Lacerra &lt;israeldl@gmail.com&gt;
 * @since 5.1
 */
 final class CommandFactory implements ModuleCommandFactory {

--- a/query/src/main/java/org/infinispan/query/impl/EagerIterator.java
+++ b/query/src/main/java/org/infinispan/query/impl/EagerIterator.java
@@ -10,7 +10,6 @@ import net.jcip.annotations.NotThreadSafe;
  * This is the implementation class for the interface ResultIterator. It is what is
  * returned when the {@link org.infinispan.query.CacheQuery#iterator()} using
  * a {@link org.infinispan.query.FetchOptions.FetchMode#EAGER}.
- * <p/>
  *
  * @author Navin Surtani
  * @author Marko Luksa

--- a/query/src/main/java/org/infinispan/query/impl/ModuleCommandIds.java
+++ b/query/src/main/java/org/infinispan/query/impl/ModuleCommandIds.java
@@ -5,7 +5,7 @@ package org.infinispan.query.impl;
  * are unique all numbers are defined here, and should stay in the range 100-119
  * which is the reserved range for this module.
  *
- * @author Sanne Grinovero <sanne@infinispan.org> (C) 2011 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@infinispan.org&gt; (C) 2011 Red Hat Inc.
  */
 public interface ModuleCommandIds {
 

--- a/query/src/main/java/org/infinispan/query/indexmanager/ClusteredSwitchingBackend.java
+++ b/query/src/main/java/org/infinispan/query/indexmanager/ClusteredSwitchingBackend.java
@@ -50,7 +50,7 @@ import net.jcip.annotations.GuardedBy;
  * although if the buffer for postponed operations gets filled too quickly,
  * we'll both speed up the lock acquisition and apply backpressure to the clients.
  *
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2014 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2014 Red Hat Inc.
  * @since 7.0
  */
 @Listener

--- a/query/src/main/java/org/infinispan/query/indexmanager/IndexLockController.java
+++ b/query/src/main/java/org/infinispan/query/indexmanager/IndexLockController.java
@@ -3,7 +3,7 @@ package org.infinispan.query.indexmanager;
 /**
  * Interface to control the Lucene index's write lock.
  *
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2014 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2014 Red Hat Inc.
  * @since 7.0
  */
 interface IndexLockController {

--- a/query/src/main/java/org/infinispan/query/indexmanager/IndexManagerBasedLockController.java
+++ b/query/src/main/java/org/infinispan/query/indexmanager/IndexManagerBasedLockController.java
@@ -21,7 +21,7 @@ import org.infinispan.util.logging.LogFactory;
  * Rather than wrapping the Directory or the LockManager directly, we need to wrap the IndexManager
  * as the Directory initialization is deferred.
  *
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2014 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2014 Red Hat Inc.
  * @since 7.0
  */
 final class IndexManagerBasedLockController implements IndexLockController {

--- a/query/src/main/java/org/infinispan/query/indexmanager/IndexUpdateCommand.java
+++ b/query/src/main/java/org/infinispan/query/indexmanager/IndexUpdateCommand.java
@@ -14,8 +14,7 @@ import org.infinispan.util.ByteString;
 import org.infinispan.util.concurrent.CompletableFutures;
 
 /**
- * Custom RPC command containing an index update request for the
- * Master IndexManager of a specific cache & index.
+ * Custom RPC command containing an index update request for the Master IndexManager of a specific cache and index.
  *
  * @author Sanne Grinovero
  */

--- a/query/src/main/java/org/infinispan/query/indexmanager/IndexingBackend.java
+++ b/query/src/main/java/org/infinispan/query/indexmanager/IndexingBackend.java
@@ -12,7 +12,7 @@ import org.hibernate.search.indexes.spi.IndexManager;
  * respects this contract.
  *
  * @see ClusteredSwitchingBackend
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2014 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2014 Red Hat Inc.
  * @since 7.0
  */
 interface IndexingBackend {

--- a/query/src/main/java/org/infinispan/query/indexmanager/InfinispanBackendQueueProcessor.java
+++ b/query/src/main/java/org/infinispan/query/indexmanager/InfinispanBackendQueueProcessor.java
@@ -26,7 +26,7 @@ import org.infinispan.util.logging.LogFactory;
  * Adaptor to implement the Hibernate Search contract of a BackendQueueProcessor
  * while delegating to the cluster-aware components of Infinispan Query.
  *
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2014 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2014 Red Hat Inc.
  * @since 7.0
  */
 final class InfinispanBackendQueueProcessor extends WorkspaceHolder {

--- a/query/src/main/java/org/infinispan/query/indexmanager/InfinispanIndexManager.java
+++ b/query/src/main/java/org/infinispan/query/indexmanager/InfinispanIndexManager.java
@@ -13,7 +13,7 @@ import org.infinispan.util.logging.LogFactory;
 /**
  * A custom IndexManager to store indexes in the grid itself.
  *
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2012 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2012 Red Hat Inc.
  */
 public class InfinispanIndexManager extends DirectoryBasedIndexManager {
 

--- a/query/src/main/java/org/infinispan/query/indexmanager/LazyInitializableBackend.java
+++ b/query/src/main/java/org/infinispan/query/indexmanager/LazyInitializableBackend.java
@@ -3,7 +3,7 @@ package org.infinispan.query.indexmanager;
 /**
  * Some SwitchingBackend implementations need to expose additional transition methods.
  *
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2014 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2014 Red Hat Inc.
  * @since 7.0
  */
 interface LazyInitializableBackend extends SwitchingBackend {

--- a/query/src/main/java/org/infinispan/query/indexmanager/LazyInitializingBackend.java
+++ b/query/src/main/java/org/infinispan/query/indexmanager/LazyInitializingBackend.java
@@ -12,7 +12,7 @@ import org.hibernate.search.indexes.spi.IndexManager;
  * operations to the new backend.
  * Which backed is being selected depends on the cluster state.
  *
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2014 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2014 Red Hat Inc.
  * @since 7.0
  */
 public class LazyInitializingBackend implements IndexingBackend {

--- a/query/src/main/java/org/infinispan/query/indexmanager/LocalBackendFactory.java
+++ b/query/src/main/java/org/infinispan/query/indexmanager/LocalBackendFactory.java
@@ -3,7 +3,7 @@ package org.infinispan.query.indexmanager;
 /**
  * Used to postpone creation of Local only IndexingBackend instances.
  *
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2014 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2014 Red Hat Inc.
  * @since 7.0
  */
 interface LocalBackendFactory {

--- a/query/src/main/java/org/infinispan/query/indexmanager/LocalIndexingBackend.java
+++ b/query/src/main/java/org/infinispan/query/indexmanager/LocalIndexingBackend.java
@@ -14,7 +14,7 @@ import org.infinispan.util.logging.LogFactory;
  * Normally this will be the "lucene" backend, writing to the index.
  *
  * @see org.hibernate.search.backend.impl.lucene.WorkspaceHolder
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2014 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2014 Red Hat Inc.
  * @since 7.0
  */
 final class LocalIndexingBackend implements IndexingBackend {

--- a/query/src/main/java/org/infinispan/query/indexmanager/LocalOnlyBackend.java
+++ b/query/src/main/java/org/infinispan/query/indexmanager/LocalOnlyBackend.java
@@ -5,7 +5,7 @@ package org.infinispan.query.indexmanager;
  * to be used for non-clustered caches: much simpler as we have no
  * states nor transitions to manage.
  *
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2014 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2014 Red Hat Inc.
  * @since 7.0
  */
 public class LocalOnlyBackend implements SwitchingBackend {

--- a/query/src/main/java/org/infinispan/query/indexmanager/LockAcquiringBackend.java
+++ b/query/src/main/java/org/infinispan/query/indexmanager/LockAcquiringBackend.java
@@ -22,7 +22,7 @@ import org.infinispan.util.logging.LogFactory;
  * trigger more backpressure when it's filled (although filling it should not
  * be possible as the current implementation steals the locks aggressively).
  *
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2014 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2014 Red Hat Inc.
  * @since 7.0
  */
 public class LockAcquiringBackend implements IndexingBackend {

--- a/query/src/main/java/org/infinispan/query/indexmanager/LuceneWorkIdTransformer.java
+++ b/query/src/main/java/org/infinispan/query/indexmanager/LuceneWorkIdTransformer.java
@@ -4,7 +4,7 @@ import org.hibernate.search.backend.LuceneWork;
 import org.infinispan.query.backend.KeyTransformationHandler;
 
 /**
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2012 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2012 Red Hat Inc.
  */
 interface LuceneWorkIdTransformer<T extends LuceneWork> {
 

--- a/query/src/main/java/org/infinispan/query/indexmanager/LuceneWorkTransformationVisitor.java
+++ b/query/src/main/java/org/infinispan/query/indexmanager/LuceneWorkTransformationVisitor.java
@@ -18,7 +18,7 @@ import org.infinispan.query.backend.KeyTransformationHandler;
  * our custom keyTransformers. LuceneWork instances are immutable, so we have to replace them
  * with new instances iff an id transformation is needed.
  *
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2012 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2012 Red Hat Inc.
  */
 public class LuceneWorkTransformationVisitor implements IndexWorkVisitor<KeyTransformationHandler, LuceneWork> {
 

--- a/query/src/main/java/org/infinispan/query/indexmanager/RemoteIndexingBackend.java
+++ b/query/src/main/java/org/infinispan/query/indexmanager/RemoteIndexingBackend.java
@@ -22,7 +22,7 @@ import org.infinispan.util.logging.LogFactory;
  * The IndexingBackend which forwards all operations to a different node
  * using Infinispan's custom commands.
  *
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2014 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2014 Red Hat Inc.
  * @since 7.0
  */
 final class RemoteIndexingBackend implements IndexingBackend {

--- a/query/src/main/java/org/infinispan/query/indexmanager/SimpleLocalBackendFactory.java
+++ b/query/src/main/java/org/infinispan/query/indexmanager/SimpleLocalBackendFactory.java
@@ -9,7 +9,7 @@ import org.hibernate.search.spi.WorkerBuildContext;
 /**
  * Factory of local backends to simplify lazy initialization.
  *
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2014 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2014 Red Hat Inc.
  * @since 7.0
  */
 class SimpleLocalBackendFactory implements LocalBackendFactory {

--- a/query/src/main/java/org/infinispan/query/indexmanager/SwitchingBackend.java
+++ b/query/src/main/java/org/infinispan/query/indexmanager/SwitchingBackend.java
@@ -4,7 +4,7 @@ package org.infinispan.query.indexmanager;
  * Defines the strategy contract to be plugging into an InfinispanBackendQueueProcessor
  *
  * @see InfinispanBackendQueueProcessor
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2014 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2014 Red Hat Inc.
  * @since 7.0
  */
 public interface SwitchingBackend {

--- a/query/src/test/java/org/infinispan/query/analysis/AnalyzerTest.java
+++ b/query/src/test/java/org/infinispan/query/analysis/AnalyzerTest.java
@@ -25,7 +25,7 @@ import org.testng.annotations.Test;
  * Copied and adapted from Hibernate Search
  * org.hibernate.search.test.analyzer.solr.SolrAnalyzerTest
  *
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2012 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2012 Red Hat Inc.
  * @author Emmanuel Bernard
  * @author Hardy Ferentschik
  */

--- a/query/src/test/java/org/infinispan/query/blackbox/ClusteredQueryMultipleCachesTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/ClusteredQueryMultipleCachesTest.java
@@ -12,7 +12,7 @@ import org.testng.annotations.Test;
  * Tests for testing clustered queries functionality on multiple cache instances
  * (In these tests we have two caches in each CacheManager)
  *
- * @author Israel Lacerra <israeldl@gmail.com>
+ * @author Israel Lacerra &lt;israeldl@gmail.com&gt;
  * @since 5.2
  */
 @Test(groups = "functional", testName = "query.blackbox.ClusteredQueryMultipleCachesTest")

--- a/query/src/test/java/org/infinispan/query/blackbox/ClusteredQueryTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/ClusteredQueryTest.java
@@ -42,7 +42,7 @@ import org.testng.annotations.Test;
 
 /**
  * ClusteredQueryTest.
- * @author Israel Lacerra <israeldl@gmail.com>
+ * @author Israel Lacerra &lt;israeldl@gmail.com&gt;
  * @since 5.1
  */
 @Test(groups = "functional", testName = "query.blackbox.ClusteredQueryTest")

--- a/query/src/test/java/org/infinispan/query/config/MultipleCachesTest.java
+++ b/query/src/test/java/org/infinispan/query/config/MultipleCachesTest.java
@@ -26,7 +26,7 @@ import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.testng.annotations.Test;
 
 /**
- * @author Sanne Grinovero <sanne@infinispan.org> (C) 2011 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@infinispan.org&gt; (C) 2011 Red Hat Inc.
  */
 @Test(groups = "unit", testName = "query.config.MultipleCachesTest")
 public class MultipleCachesTest extends SingleCacheManagerTest {

--- a/query/src/test/java/org/infinispan/query/distributed/MultiNodeReplicatedTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/MultiNodeReplicatedTest.java
@@ -6,7 +6,7 @@ import org.testng.annotations.Test;
  * Similar to MultiNodeDistributedTest, but using a replicated configuration both for
  * the indexed cache and for the storage of the index data.
  *
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2012 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2012 Red Hat Inc.
  */
 @Test(groups = "functional", testName = "query.distributed.MultiNodeReplicatedTest")
 public class MultiNodeReplicatedTest extends MultiNodeDistributedTest {

--- a/query/src/test/java/org/infinispan/query/distributed/NonSerializableKeyType.java
+++ b/query/src/test/java/org/infinispan/query/distributed/NonSerializableKeyType.java
@@ -10,7 +10,7 @@ import org.infinispan.query.Transformable;
 import org.infinispan.query.Transformer;
 
 /**
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2012 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2012 Red Hat Inc.
  */
 @SerializeWith(NonSerializableKeyType.CustomExternalizer.class)
 @Transformable(transformer = NonSerializableKeyType.CustomTransformer.class)

--- a/query/src/test/java/org/infinispan/query/dynamicexample/DynamicPropertiesEntity.java
+++ b/query/src/test/java/org/infinispan/query/dynamicexample/DynamicPropertiesEntity.java
@@ -10,12 +10,12 @@ import org.hibernate.search.annotations.Indexed;
 import org.hibernate.search.annotations.Store;
 
 /**
- * @author Sanne Grinovero <sanne@infinispan.org> (C) 2011 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@infinispan.org&gt; (C) 2011 Red Hat Inc.
  */
 @Indexed
 public class DynamicPropertiesEntity {
 
-   private final Map<String,String> properties = new HashMap<String, String>();
+   private final Map<String,String> properties = new HashMap<>();
 
    @Field(analyze=Analyze.YES, store=Store.YES)
    @FieldBridge(impl=StringKeyedMapBridge.class)

--- a/query/src/test/java/org/infinispan/query/dynamicexample/DynamicPropertiesTest.java
+++ b/query/src/test/java/org/infinispan/query/dynamicexample/DynamicPropertiesTest.java
@@ -15,7 +15,7 @@ import org.infinispan.transaction.TransactionMode;
 import org.testng.annotations.Test;
 
 /**
- * @author Sanne Grinovero <sanne@infinispan.org> (C) 2011 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@infinispan.org&gt; (C) 2011 Red Hat Inc.
  */
 @Test(groups = "functional", testName = "query.dynamicexample.DynamicPropertiesTest")
 public class DynamicPropertiesTest extends SingleCacheManagerTest {

--- a/query/src/test/java/org/infinispan/query/dynamicexample/StringKeyedMapBridge.java
+++ b/query/src/test/java/org/infinispan/query/dynamicexample/StringKeyedMapBridge.java
@@ -7,7 +7,7 @@ import org.hibernate.search.bridge.FieldBridge;
 import org.hibernate.search.bridge.LuceneOptions;
 
 /**
- * @author Sanne Grinovero <sanne@infinispan.org> (C) 2011 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@infinispan.org&gt; (C) 2011 Red Hat Inc.
  */
 public class StringKeyedMapBridge implements FieldBridge {
 

--- a/query/src/test/java/org/infinispan/query/indexedembedded/BooksExampleTest.java
+++ b/query/src/test/java/org/infinispan/query/indexedembedded/BooksExampleTest.java
@@ -14,7 +14,7 @@ import org.infinispan.transaction.TransactionMode;
 import org.testng.annotations.Test;
 
 /**
- * @author Sanne Grinovero <sanne@infinispan.org> (C) 2011 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@infinispan.org&gt; (C) 2011 Red Hat Inc.
  */
 @Test(groups = "functional", testName = "query.indexedembedded.BooksExampleTest")
 public class BooksExampleTest extends SingleCacheManagerTest {

--- a/query/src/test/java/org/infinispan/query/indexedembedded/City.java
+++ b/query/src/test/java/org/infinispan/query/indexedembedded/City.java
@@ -5,7 +5,7 @@ import java.io.Serializable;
 import org.hibernate.search.annotations.Field;
 
 /**
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2011 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2011 Red Hat Inc.
  */
 public class City implements Serializable {
 

--- a/query/src/test/java/org/infinispan/query/indexedembedded/CollectionsIndexingTest.java
+++ b/query/src/test/java/org/infinispan/query/indexedembedded/CollectionsIndexingTest.java
@@ -22,7 +22,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /**
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2011 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2011 Red Hat Inc.
  */
 @Test(groups = "functional", testName = "query.indexedembedded.CollectionsIndexingTest")
 public class CollectionsIndexingTest extends SingleCacheManagerTest {

--- a/query/src/test/java/org/infinispan/query/indexedembedded/Country.java
+++ b/query/src/test/java/org/infinispan/query/indexedembedded/Country.java
@@ -10,7 +10,7 @@ import org.hibernate.search.annotations.IndexedEmbedded;
 import org.infinispan.marshall.core.ExternalPojo;
 
 /**
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2011 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2011 Red Hat Inc.
  */
 @Indexed
 public class Country implements Serializable, ExternalPojo {

--- a/query/src/test/java/org/infinispan/query/persistence/EntryActivatingTest.java
+++ b/query/src/test/java/org/infinispan/query/persistence/EntryActivatingTest.java
@@ -29,7 +29,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /**
- * @author Sanne Grinovero <sanne@infinispan.org> (C) 2011 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@infinispan.org&gt; (C) 2011 Red Hat Inc.
  */
 @Test(groups = "functional", testName = "query.persistence.EntryActivatingTest")
 public class EntryActivatingTest extends AbstractInfinispanTest {

--- a/query/src/test/java/org/infinispan/query/queries/faceting/SimpleFacetingTest.java
+++ b/query/src/test/java/org/infinispan/query/queries/faceting/SimpleFacetingTest.java
@@ -21,7 +21,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /**
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2011 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2011 Red Hat Inc.
  * @author Hardy Ferentschik
  */
 @Test(groups = {"functional"}, testName = "query.queries.faceting.SimpleFacetingTest")
@@ -58,7 +58,7 @@ public class SimpleFacetingTest extends SingleCacheManagerTest {
       cache.clear();
    }
 
-   public void testFaceting() throws Exception {
+   public void testFaceting() {
       QueryBuilder queryBuilder = qf.buildQueryBuilderForClass(Car.class).get();
 
       FacetingRequest request = queryBuilder.facet()

--- a/query/src/test/java/org/infinispan/query/tx/NonLocalIndexingTest.java
+++ b/query/src/test/java/org/infinispan/query/tx/NonLocalIndexingTest.java
@@ -25,7 +25,7 @@ import org.testng.annotations.Test;
  * transactions enabled.
  * See also ISPN-2467 and subclasses.
  *
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2012 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2012 Red Hat Inc.
  */
 @Test(groups = "functional", testName = "query.tx.NonLocalIndexingTest")
 public class NonLocalIndexingTest extends MultipleCacheManagersTest {

--- a/query/src/test/java/org/infinispan/query/tx/NonLocalTransactionalIndexingTest.java
+++ b/query/src/test/java/org/infinispan/query/tx/NonLocalTransactionalIndexingTest.java
@@ -7,7 +7,7 @@ import org.testng.annotations.Test;
  * transactions enabled.
  * See also ISPN-2467 and subclasses.
  *
- * @author Sanne Grinovero <sanne@hibernate.org> (C) 2012 Red Hat Inc.
+ * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2012 Red Hat Inc.
  */
 @Test(groups = "functional", testName = "query.tx.NonLocalTransactionalIndexingTest")
 public class NonLocalTransactionalIndexingTest extends NonLocalIndexingTest {

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/ExternalizerIds.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/ExternalizerIds.java
@@ -3,7 +3,7 @@ package org.infinispan.query.remote.impl;
 /**
  * Identifiers used by the Marshaller to delegate to specialized Externalizers. For details, read
  * http://infinispan.org/docs/9.0.x/user_guide/user_guide.html#_preassigned_externalizer_id_ranges
- * <p/>
+ * <p>
  * The range reserved for the Infinispan Remote Query module is from 1700 to 1799.
  *
  * @author anistor@redhat.com

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/indexing/IndexingMetadata.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/indexing/IndexingMetadata.java
@@ -21,9 +21,9 @@ import org.infinispan.protostream.descriptors.Option;
  * {@literal @}Field) that behave very similarly to the identically named Hibernate Search annotations and which can be
  * directly added to your Protobuf schema files in the documentation comments of your message type definitions as
  * demonstrated in the example below:
- * <p/>
+ * <p>
  * <b>Example:</b>
- * <p/>
+ * <p>
  * <pre>
  * /**
  *  * This message type is indexed, but not all of its fields are.

--- a/server/integration/cli/src/main/java/org/infinispan/server/cli/handlers/ContainerCommandHandler.java
+++ b/server/integration/cli/src/main/java/org/infinispan/server/cli/handlers/ContainerCommandHandler.java
@@ -14,7 +14,7 @@ import org.jboss.as.cli.operation.OperationFormatException;
 
 /**
  * {@link CommandHandler} implementation with the {@code container} command logic.
- * <p/>
+ * <p>
  * The {@code container} command changes the container in which the Infinispan CLI command are
  * executed against. The command is only executed in the client.
  *

--- a/server/integration/cli/src/main/java/org/infinispan/server/cli/handlers/NoArgumentsCliCommandHandler.java
+++ b/server/integration/cli/src/main/java/org/infinispan/server/cli/handlers/NoArgumentsCliCommandHandler.java
@@ -12,10 +12,10 @@ import org.jboss.dmr.ModelNode;
 /**
  * It represents the no-arg Infinispan CLI command. It should be used as a base class for other commands
  * with arguments Infinispan CLI command.
- * <p/>
+ * <p>
  * The Infinispan CLI command is only available when connected and the prefix contains the
  * {@code cache-container}.
- * <p/>
+ * <p>
  * The commands are sent to the Infinispan interpreted to be processed and the result is printed.
  *
  * @author Pedro Ruivo

--- a/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/subsystem/RestService.java
+++ b/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/subsystem/RestService.java
@@ -49,9 +49,9 @@ import io.netty.handler.codec.http.cors.CorsConfig;
 
 
 /**
- * A service which starts the REST web application
+ * A service which starts the REST web application.
  *
- * @author Tristan Tarrant <ttarrant@redhat.com>
+ * @author Tristan Tarrant &lt;ttarrant@redhat.com&gt;
  * @since 6.0
  */
 public class RestService implements Service<RestServer>, EncryptableService {

--- a/server/integration/infinispan/src/main/java/org/infinispan/server/infinispan/task/ServerTaskRegistry.java
+++ b/server/integration/infinispan/src/main/java/org/infinispan/server/infinispan/task/ServerTaskRegistry.java
@@ -6,27 +6,25 @@ import org.infinispan.tasks.ServerTask;
 import org.infinispan.tasks.Task;
 
 /**
- * Server task registry.
- * Stores server tasks that can be executed via {@link org.infinispan.tasks.TaskManager}
+ * Server task registry. Stores server tasks that can be executed via {@link org.infinispan.tasks.TaskManager}
  *
- * <p/>
- * Author: Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
- * Date: 1/22/16
- * Time: 4:03 PM
+ * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
  */
 public interface ServerTaskRegistry {
+
    /**
     * Lists the registered server tasks.
+    *
     * @return a list of server tasks
     */
    List<Task> getTasks();
 
    /**
-    * Returns a {@link ServerTaskWrapper} for a task with given name.
-    * ServerTaskWrapper wraps {@link ServerTask} to make it compatible with {@link Task}
+    * Returns a {@link ServerTaskWrapper} for a task with given name. ServerTaskWrapper wraps {@link ServerTask} to make
+    * it compatible with {@link Task}
     *
     * @param taskName task name (as returned by {@link ServerTask#getName()})
-    * @param <T> type of return value of the task
+    * @param <T>      type of return value of the task
     * @return server task wrapper for task of given name
     */
    <T> ServerTaskWrapper<T> getTask(String taskName);
@@ -41,13 +39,15 @@ public interface ServerTaskRegistry {
 
    /**
     * Register a ServerTask in the registry
+    *
     * @param task server task to register
-    * @param <T> type of the return value of the task
+    * @param <T>  type of the return value of the task
     */
    <T> void addDeployedTask(ServerTask<T> task);
 
    /**
     * Unregister server task with given name
+    *
     * @param name name of the task
     */
    void removeDeployedTask(String name);

--- a/server/integration/infinispan/src/main/java/org/infinispan/server/infinispan/task/ServerTaskRegistryImpl.java
+++ b/server/integration/infinispan/src/main/java/org/infinispan/server/infinispan/task/ServerTaskRegistryImpl.java
@@ -17,9 +17,7 @@ import org.infinispan.tasks.Task;
 import org.infinispan.tasks.TaskManager;
 
 /**
- * Author: Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
- * Date: 1/20/16
- * Time: 12:53 PM
+ * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
  */
 @Scope(Scopes.GLOBAL)
 public class ServerTaskRegistryImpl implements ServerTaskRegistry {

--- a/server/integration/infinispan/src/main/java/org/infinispan/server/infinispan/task/ServerTaskRunner.java
+++ b/server/integration/infinispan/src/main/java/org/infinispan/server/infinispan/task/ServerTaskRunner.java
@@ -5,8 +5,8 @@ import java.util.concurrent.CompletableFuture;
 import org.infinispan.tasks.TaskContext;
 
 /**
- * Used by ServerTaskEngine to executed ServerTasks
- * <p/>
+ * Used by ServerTaskEngine to executed ServerTasks.
+ * <p>
  * Author: Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
  * Date: 1/28/16
  * Time: 9:33 AM

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/AbstractRemoteCacheIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/AbstractRemoteCacheIT.java
@@ -67,7 +67,7 @@ import org.junit.Test;
  * Tests for HotRod client and its RemoteCache API. Subclasses must provide a
  * way to get the list of remote HotRod servers and to assert the cache is
  * empty.
- * <p/>
+ * <p>
  * Subclasses may be used in Client-Server mode or Hybrid mode where HotRod
  * server runs as a library deployed in an application server.
  *

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/AbstractRemoteCacheManagerIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/AbstractRemoteCacheManagerIT.java
@@ -41,7 +41,7 @@ import io.netty.channel.Channel;
 /**
  * Tests for HotRod client and its RemoteCacheManager API. Subclasses must provide
  * a way to get the list of remote HotRod servers.
- * <p/>
+ * <p>
  * Subclasses may be used in Client-Server mode or Hybrid mode where HotRod server
  * runs as a library deployed in an application server.
  *

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/memcached/AbstractMemcachedClusteredIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/memcached/AbstractMemcachedClusteredIT.java
@@ -14,7 +14,7 @@ import org.junit.Test;
 /**
  * Tests for Memcached endpoint. Subclasses must provide a way to get the list of remote
  * infinispan servers.
- * <p/>
+ * <p>
  * Subclasses may be used in Client-Server mode or Hybrid mode where Memcached server
  * runs as a library deployed in an application server.
  *

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/memcached/AbstractMemcachedLocalIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/memcached/AbstractMemcachedLocalIT.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 /**
  * Tests for Memcached endpoint. Subclasses must provide a way to get the list of remote
  * infinispan servers.
- * <p/>
+ * <p>
  * Subclasses may be used in Client-Server mode or Hybrid mode where Memcached server
  * runs as a library deployed in an application server.
  *

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/cs/remote/RemoteCacheStoreIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/cs/remote/RemoteCacheStoreIT.java
@@ -26,12 +26,12 @@ import org.junit.runner.RunWith;
 
 /**
  * Tests remote cache store under the following circumstances:
- * <p/>
+ * <p>
  * passivation == true --cache entries should get to the remote cache store only when evicted
  * preload == false --after server restart, entries should be be preloaded to the cache
  * purge == false --all entries should remain in the cache store after server restart
  * (must be false so that we can test preload)
- * <p/>
+ * <p>
  * Other attributes like singleton, shared, fetch-state do not make sense in single node cluster.
  *
  * @author <a href="mailto:mgencur@redhat.com">Martin Gencur</a>

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/jmx/management/JmxManagementIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/jmx/management/JmxManagementIT.java
@@ -34,10 +34,10 @@ import org.junit.runner.RunWith;
 
 /**
  * Test that JMX statistics/operations are available for an Infinispan server instance.
- * <p/>
+ * <p>
  * TODO: operations/attributes of Transactions MBean  - Transactions are only available in embedded mode (to be impl.
  * for HotRod later: ISPN-375)
- * <p/>
+ * <p>
  * operations/attributes of RecoveryAdmin MBean - the same as above
  *
  * @author <a href="mailto:mgencur@redhat.com">Martin Gencur</a>

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/security/rest/RESTCertSecurityIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/security/rest/RESTCertSecurityIT.java
@@ -45,18 +45,18 @@ import org.junit.runner.RunWith;
 /**
  * Tests CLIENT-CERT security for REST endpoint as is configured via "auth-method" attribute on "rest-connector" element
  * in datagrid subsystem.
- * <p/>
+ * <p>
  * In order to configure CLIENT-CERT security, we add a new security-domain in the security subsystem
  * and a new https connector in the web subsystem. This is done via XSL transformations.
- * <p/>
+ * <p>
  * Client authenticates himself with client.keystore file. Server contains ca.jks file in security subsystem as a
  * truststore and keystore_server.jks file in the REST connector as a certificate file. How to create and inspect those files
  * is described e.g. at http://docs.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html
- * <p/>
+ * <p>
  * Password for all the files is the same: "secret" The user is allowed to connect to the secured REST endpoint with
  * "client1" alias cos the server has this alias registered in its truststore. There's also another alias "test2" which is
  * not signed by the CA, and therefore won't be accepted.
- * <p/>
+ * <p>
  * The REST endpoint requires users to be in "REST" role which is defined in roles.properties.
  *
  * @author <a href="mailto:mgencur@redhat.com">Martin Gencur</a>

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/util/osgi/KarafTestSupport.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/util/osgi/KarafTestSupport.java
@@ -64,7 +64,7 @@ public class KarafTestSupport {
 
     /**
      * Make available system properties that are configured for the test, to the test container.
-     * <p>Note:</p> If not obvious the container runs in in forked mode and thus system properties passed
+     * <p><b>Note:</b> If not obvious the container runs in in forked mode and thus system properties passed
      * form command line or surefire plugin are not available to the container without an approach like this.
      */
     public static Option copySystemProperty(String propertyName) {

--- a/spring/spring4/spring4-embedded/src/main/java/org/infinispan/spring/provider/ContainerEmbeddedCacheManagerFactoryBean.java
+++ b/spring/spring4/spring4-embedded/src/main/java/org/infinispan/spring/provider/ContainerEmbeddedCacheManagerFactoryBean.java
@@ -7,7 +7,7 @@ import org.springframework.util.Assert;
 
 /**
  * {@link FactoryBean} for creating a {@link CacheManager} for a pre-defined {@link org.infinispan.manager.CacheContainer}.
- * <p/>
+ * <p>
  * Useful when the cache container is defined outside the application (e.g. provided by the application server)
  *
  * @author Marius Bogoevici

--- a/spring/spring4/spring4-remote/src/main/java/org/infinispan/spring/provider/ContainerRemoteCacheManagerFactoryBean.java
+++ b/spring/spring4/spring4-remote/src/main/java/org/infinispan/spring/provider/ContainerRemoteCacheManagerFactoryBean.java
@@ -7,7 +7,7 @@ import org.springframework.util.Assert;
 
 /**
  * {@link FactoryBean} for creating a {@link CacheManager} for a pre-defined {@link org.infinispan.manager.CacheContainer}.
- * <p/>
+ * <p>
  * Useful when the cache container is defined outside the application (e.g. provided by the application server)
  *
  * @author Marius Bogoevici

--- a/tasks/api/src/main/java/org/infinispan/tasks/ServerTask.java
+++ b/tasks/api/src/main/java/org/infinispan/tasks/ServerTask.java
@@ -12,9 +12,7 @@ import java.util.concurrent.Callable;
  * {@link org.infinispan.manager.EmbeddedCacheManager}, {@link org.infinispan.Cache},
  * {@link org.infinispan.commons.marshall.Marshaller} and parameters.
  *
- *
- * <p/>
- * Author: Michal Szynkiewicz <michal.l.szynkiewicz@gmail.com>
+ * @author Michal Szynkiewicz &lt;michal.l.szynkiewicz@gmail.com&gt;
  */
 public interface ServerTask<V> extends Callable<V>, Task {
    /**

--- a/tree/src/main/java/org/infinispan/tree/package-info.java
+++ b/tree/src/main/java/org/infinispan/tree/package-info.java
@@ -1,7 +1,7 @@
 /**
  * TreeCache API.  For usage, see the TreeCache and
  * TreeCacheFactory classes and their javadocs.
- * <p />
+ * <p>
  * This package is intended as a compatibility layer between JBoss Cache and Infinispan, and also
  * as an API for when a tree structure is useful.  In general though, this will not perform as
  * well as the core Infinispan API.

--- a/tree/src/test/java/org/infinispan/profiling/TreeProfileTest.java
+++ b/tree/src/test/java/org/infinispan/profiling/TreeProfileTest.java
@@ -27,13 +27,12 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 /**
- * * Test to use with a profiler to profile replication.  To be used in conjunction with ProfileSlaveTest.
- * <p/>
+ * Test to use with a profiler to profile replication.  To be used in conjunction with ProfileSlaveTest.
+ * <p>
  * Typical usage pattern:
- * <p/>
+ * <p>
  * 1.  Start a single test method in ProfileSlaveTest.  This will block until you kill it. 2.  Start the corresponding
  * test in this class, with the same name, in a different JVM, and attached to a profiler. 3.  Profile away!
- * <p/>
  *
  * @author Manik Surtani (<a href="mailto:manik@jboss.org">manik@jboss.org</a>)
  * @author Navin Surtani (<a href="mailto:nsurtani@redhat.com">nsurtani@redhat.com</a>)


### PR DESCRIPTION
* running Javadoc results in many warnings
* some author's email addresses contain < > which should be encoded as html entities
* some chars like ```&``` need to be encoded as html entities
* self closing ```<p/>``` tags are not allowed in javadocs

Many files were changed but since most of it was done with replace in all java files this should not cause much pain to validate.
Automatically replacing ```* <p/>``` with ```* <p>``` in all java files solved 99% of the issues. A handful of ```<p/>```embedded in text were solved manually. Email addresses were all solved with replace.

This still solves only some of the malformed javadoc problems, many more to go, so please keep the jira open.