### PR TITLE
ISPN-9698 - unwrapping NullValue.NULL SpringCache methods that don't return ValueWrapper

### DIFF
--- a/spring/spring4/spring4-embedded/src/test/java/org/infinispan/spring/provider/SpringCacheTest.java
+++ b/spring/spring4/spring4-embedded/src/test/java/org/infinispan/spring/provider/SpringCacheTest.java
@@ -210,6 +210,18 @@ public class SpringCacheTest extends SingleCacheManagerTest {
       assertEquals("test", valueFromCache.get());
    }
 
+   @Test
+   public void testValueLoaderNullValuesAreUnwrapped() {
+      cache.put("null", null);
+      assertNull(cache.get("null", () -> "notnull"));
+   }
+
+   @Test
+   public void testNullValuesAreUnwrappedWithType() {
+      cache.put("null", null);
+      assertNull(cache.get("null", String.class));
+   }
+
    /*
     * In this test Thread 1 should exclusively block Cache#get method so that Thread 2 won't be able to
     * insert "thread2" string into the cache.


### PR DESCRIPTION
The JIRA issue only called out the `get(key, Callable<T> valueLoader)` variant but it also applies to the `get(key, Class<?> type)` variant. 

The valueLoader version was also not wrapping null values in NullValue.NULL if the valueLoader.call() returned null.