### PR TITLE
ISPN-9708 Expose the executor services through JMX

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
@@ -200,7 +200,7 @@ public class RemoteCacheManager implements RemoteCacheContainer, Closeable, Remo
    private void unregisterMBean() {
       try {
          StatisticsConfiguration configuration = this.configuration.statistics();
-         if (configuration.jmxEnabled()) {
+         if (configuration.jmxEnabled() && mbeanObjectName != null) {
             MBeanServer mbeanServer = configuration.mbeanServerLookup().getMBeanServer();
             JmxUtil.unregisterMBean(mbeanObjectName, mbeanServer);
          }

--- a/core/src/main/java/org/infinispan/executors/LazyInitializingBlockingTaskAwareExecutorService.java
+++ b/core/src/main/java/org/infinispan/executors/LazyInitializingBlockingTaskAwareExecutorService.java
@@ -23,13 +23,12 @@ import org.infinispan.util.concurrent.BlockingTaskAwareExecutorServiceImpl;
  * @author Pedro Ruivo
  * @since 5.3
  */
-public final class LazyInitializingBlockingTaskAwareExecutorService implements BlockingTaskAwareExecutorService {
+public final class LazyInitializingBlockingTaskAwareExecutorService extends ManageableExecutorService<BlockingTaskAwareExecutorService> implements BlockingTaskAwareExecutorService {
 
    private final ThreadPoolExecutorFactory<ExecutorService> executorFactory;
    private final ThreadFactory threadFactory;
    private final TimeService timeService;
    private final String controllerThreadName;
-   private volatile BlockingTaskAwareExecutorService delegate;
 
    public LazyInitializingBlockingTaskAwareExecutorService(ThreadPoolExecutorFactory<ExecutorService> executorFactory,
                                                            ThreadFactory threadFactory,
@@ -43,104 +42,104 @@ public final class LazyInitializingBlockingTaskAwareExecutorService implements B
    @Override
    public void execute(BlockingRunnable runnable) {
       initIfNeeded();
-      delegate.execute(runnable);
+      executor.execute(runnable);
    }
 
    @Override
    public void checkForReadyTasks() {
-      if (delegate != null) {
-         delegate.checkForReadyTasks();
+      if (executor != null) {
+         executor.checkForReadyTasks();
       }
    }
 
    @Override
    public void shutdown() {
-      if (delegate != null) delegate.shutdown();
+      if (executor != null) executor.shutdown();
    }
 
    @Override
    public List<Runnable> shutdownNow() {
-      if (delegate == null)
+      if (executor == null)
          return Collections.emptyList();
       else
-         return delegate.shutdownNow();
+         return executor.shutdownNow();
    }
 
    @Override
    public boolean isShutdown() {
-      return delegate == null || delegate.isShutdown();
+      return executor == null || executor.isShutdown();
    }
 
    @Override
    public boolean isTerminated() {
-      return delegate == null || delegate.isTerminated();
+      return executor == null || executor.isTerminated();
    }
 
    @Override
    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
-      if (delegate == null)
+      if (executor == null)
          return true;
       else
-         return delegate.awaitTermination(timeout, unit);
+         return executor.awaitTermination(timeout, unit);
    }
 
    @Override
    public <T> Future<T> submit(Callable<T> task) {
       initIfNeeded();
-      return delegate.submit(task);
+      return executor.submit(task);
    }
 
    @Override
    public <T> Future<T> submit(Runnable task, T result) {
       initIfNeeded();
-      return delegate.submit(task, result);
+      return executor.submit(task, result);
    }
 
    @Override
    public Future<?> submit(Runnable task) {
       initIfNeeded();
-      return delegate.submit(task);
+      return executor.submit(task);
    }
 
    @Override
    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
       initIfNeeded();
-      return delegate.invokeAll(tasks);
+      return executor.invokeAll(tasks);
    }
 
    @Override
    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException {
       initIfNeeded();
-      return delegate.invokeAll(tasks, timeout, unit);
+      return executor.invokeAll(tasks, timeout, unit);
    }
 
    @Override
    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
       initIfNeeded();
-      return delegate.invokeAny(tasks);
+      return executor.invokeAny(tasks);
    }
 
    @Override
    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
       initIfNeeded();
-      return delegate.invokeAny(tasks, timeout, unit);
+      return executor.invokeAny(tasks, timeout, unit);
    }
 
    @Override
    public void execute(Runnable command) {
       initIfNeeded();
-      delegate.execute(command);
+      executor.execute(command);
    }
 
    public BlockingTaskAwareExecutorService getExecutorService() {
-      return delegate;
+      return executor;
    }
 
    private void initIfNeeded() {
-      if (delegate == null) {
+      if (executor == null) {
          synchronized (this) {
-            if (delegate == null) {
-               delegate = new BlockingTaskAwareExecutorServiceImpl(controllerThreadName ,
+            if (executor == null) {
+               executor = new BlockingTaskAwareExecutorServiceImpl(controllerThreadName ,
                                                                    executorFactory.createExecutor(threadFactory),
                                                                    timeService);
             }

--- a/core/src/main/java/org/infinispan/executors/LazyInitializingExecutorService.java
+++ b/core/src/main/java/org/infinispan/executors/LazyInitializingExecutorService.java
@@ -20,9 +20,7 @@ import org.infinispan.commons.executors.ThreadPoolExecutorFactory;
  * @author Manik Surtani
  * @since 5.1
  */
-public final class LazyInitializingExecutorService implements ExecutorService {
-
-   private volatile ExecutorService delegate;
+public final class LazyInitializingExecutorService extends ManageableExecutorService<ExecutorService> implements ExecutorService {
    private final ThreadPoolExecutorFactory<ExecutorService> executorFactory;
    private final ThreadFactory threadFactory;
 
@@ -33,10 +31,10 @@ public final class LazyInitializingExecutorService implements ExecutorService {
    }
 
    private void initIfNeeded() {
-      if (delegate == null) {
+      if (executor == null) {
          synchronized (this) {
-            if (delegate == null) {
-               delegate = executorFactory.createExecutor(threadFactory);
+            if (executor == null) {
+               executor = executorFactory.createExecutor(threadFactory);
             }
          }
       }
@@ -44,80 +42,80 @@ public final class LazyInitializingExecutorService implements ExecutorService {
 
    @Override
    public void shutdown() {
-      if (delegate != null) delegate.shutdown();
+      if (executor != null) executor.shutdown();
    }
 
    @Override
    public List<Runnable> shutdownNow() {
-      if (delegate == null)
+      if (executor == null)
          return Collections.emptyList();
       else
-         return delegate.shutdownNow();
+         return executor.shutdownNow();
    }
 
    @Override
    public boolean isShutdown() {
-      return delegate == null || delegate.isShutdown();
+      return executor == null || executor.isShutdown();
    }
 
    @Override
    public boolean isTerminated() {
-      return delegate == null || delegate.isTerminated();
+      return executor == null || executor.isTerminated();
    }
 
    @Override
    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
-      if (delegate == null)
+      if (executor == null)
          return true;
       else
-         return delegate.awaitTermination(timeout, unit);
+         return executor.awaitTermination(timeout, unit);
    }
 
    @Override
    public <T> Future<T> submit(Callable<T> task) {
       initIfNeeded();
-      return delegate.submit(task);
+      return executor.submit(task);
    }
 
    @Override
    public <T> Future<T> submit(Runnable task, T result) {
       initIfNeeded();
-      return delegate.submit(task, result);
+      return executor.submit(task, result);
    }
 
    @Override
    public Future<?> submit(Runnable task) {
       initIfNeeded();
-      return delegate.submit(task);
+      return executor.submit(task);
    }
 
    @Override
    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
       initIfNeeded();
-      return delegate.invokeAll(tasks);
+      return executor.invokeAll(tasks);
    }
 
    @Override
    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException {
       initIfNeeded();
-      return delegate.invokeAll(tasks, timeout, unit);
+      return executor.invokeAll(tasks, timeout, unit);
    }
 
    @Override
    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
       initIfNeeded();
-      return delegate.invokeAny(tasks);
+      return executor.invokeAny(tasks);
    }
 
    @Override
    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
       initIfNeeded();
-      return delegate.invokeAny(tasks, timeout, unit);
+      return executor.invokeAny(tasks, timeout, unit);
    }
 
    @Override
    public void execute(Runnable command) {
       initIfNeeded();
-      delegate.execute(command);
+      executor.execute(command);
    }
 }

--- a/core/src/main/java/org/infinispan/executors/LazyInitializingScheduledExecutorService.java
+++ b/core/src/main/java/org/infinispan/executors/LazyInitializingScheduledExecutorService.java
@@ -21,9 +21,7 @@ import org.infinispan.commons.executors.ThreadPoolExecutorFactory;
  * @author Manik Surtani
  * @since 5.1
  */
-public class LazyInitializingScheduledExecutorService implements ScheduledExecutorService {
-
-   private volatile ScheduledExecutorService delegate;
+public class LazyInitializingScheduledExecutorService extends ManageableExecutorService<ScheduledExecutorService> implements ScheduledExecutorService {
    private final ThreadPoolExecutorFactory<ScheduledExecutorService> executorFactory;
    private final ThreadFactory threadFactory;
 
@@ -34,10 +32,10 @@ public class LazyInitializingScheduledExecutorService implements ScheduledExecut
    }
 
    private void initIfNeeded() {
-      if (delegate == null) {
+      if (executor == null) {
          synchronized (this) {
-            if (delegate == null) {
-               delegate = executorFactory.createExecutor(threadFactory);
+            if (executor == null) {
+               executor = executorFactory.createExecutor(threadFactory);
             }
          }
       }
@@ -45,105 +43,105 @@ public class LazyInitializingScheduledExecutorService implements ScheduledExecut
 
    @Override
    public void shutdown() {
-      if (delegate != null) delegate.shutdown();
+      if (executor != null) executor.shutdown();
    }
 
    @Override
    public List<Runnable> shutdownNow() {
-      if (delegate == null)
+      if (executor == null)
          return Collections.emptyList();
       else
-         return delegate.shutdownNow();
+         return executor.shutdownNow();
    }
 
    @Override
    public boolean isShutdown() {
-      return delegate == null || delegate.isShutdown();
+      return executor == null || executor.isShutdown();
    }
 
    @Override
    public boolean isTerminated() {
-      return delegate == null || delegate.isTerminated();
+      return executor == null || executor.isTerminated();
    }
 
    @Override
    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
-      if (delegate == null)
+      if (executor == null)
          return true;
       else
-         return delegate.awaitTermination(timeout, unit);
+         return executor.awaitTermination(timeout, unit);
 
    }
 
    @Override
    public <T> Future<T> submit(Callable<T> task) {
       initIfNeeded();
-      return delegate.submit(task);
+      return executor.submit(task);
    }
 
    @Override
    public <T> Future<T> submit(Runnable task, T result) {
       initIfNeeded();
-      return delegate.submit(task, result);
+      return executor.submit(task, result);
    }
 
    @Override
    public Future<?> submit(Runnable task) {
       initIfNeeded();
-      return delegate.submit(task);
+      return executor.submit(task);
    }
 
    @Override
    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
       initIfNeeded();
-      return delegate.invokeAll(tasks);
+      return executor.invokeAll(tasks);
    }
 
    @Override
    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException {
       initIfNeeded();
-      return delegate.invokeAll(tasks, timeout, unit);
+      return executor.invokeAll(tasks, timeout, unit);
    }
 
    @Override
    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
       initIfNeeded();
-      return delegate.invokeAny(tasks);
+      return executor.invokeAny(tasks);
    }
 
    @Override
    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
       initIfNeeded();
-      return delegate.invokeAny(tasks, timeout, unit);
+      return executor.invokeAny(tasks, timeout, unit);
    }
 
    @Override
    public void execute(Runnable command) {
       initIfNeeded();
-      delegate.execute(command);
+      executor.execute(command);
    }
 
    @Override
    public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
       initIfNeeded();
-      return delegate.schedule(command, delay, unit);
+      return executor.schedule(command, delay, unit);
    }
 
    @Override
    public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
       initIfNeeded();
-      return delegate.schedule(callable, delay, unit);
+      return executor.schedule(callable, delay, unit);
    }
 
    @Override
    public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
       initIfNeeded();
-      return delegate.scheduleAtFixedRate(command, initialDelay, period, unit);
+      return executor.scheduleAtFixedRate(command, initialDelay, period, unit);
    }
 
    @Override
    public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
       initIfNeeded();
-      return delegate.scheduleWithFixedDelay(command, initialDelay, delay, unit);
+      return executor.scheduleWithFixedDelay(command, initialDelay, delay, unit);
    }
 }

--- a/core/src/main/java/org/infinispan/executors/ManageableExecutorService.java
+++ b/core/src/main/java/org/infinispan/executors/ManageableExecutorService.java
@@ -1,0 +1,129 @@
+package org.infinispan.executors;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.infinispan.factories.scopes.Scope;
+import org.infinispan.factories.scopes.Scopes;
+import org.infinispan.jmx.annotations.DataType;
+import org.infinispan.jmx.annotations.DisplayType;
+import org.infinispan.jmx.annotations.MBean;
+import org.infinispan.jmx.annotations.ManagedAttribute;
+
+/**
+ * @author Tristan Tarrant &lt;tristan@infinispan.org&gt;
+ * @since 10.0
+ **/
+@MBean
+@Scope(Scopes.GLOBAL)
+public abstract class ManageableExecutorService<T extends ExecutorService> {
+
+   protected T executor;
+
+   @ManagedAttribute(
+         description = "Returns the number of threads in this executor.",
+         displayName = "Number of executor threads",
+         dataType = DataType.TRAIT,
+         displayType = DisplayType.SUMMARY
+   )
+   int getPoolSize() {
+      if (executor instanceof ThreadPoolExecutor) {
+         return ((ThreadPoolExecutor) executor).getPoolSize();
+      } else {
+         return -1;
+      }
+   }
+
+   @ManagedAttribute(
+         description = "Returns the number of active executor threads.",
+         displayName = "Number of active executor threads",
+         dataType = DataType.TRAIT,
+         displayType = DisplayType.SUMMARY
+   )
+   int getActiveCount() {
+      if (executor instanceof ThreadPoolExecutor) {
+         return ((ThreadPoolExecutor) executor).getActiveCount();
+      } else {
+         return -1;
+      }
+   }
+
+   @ManagedAttribute(
+         description = "Returns the maximum number of executor threads.",
+         displayName = "Maximum number of executor threads",
+         dataType = DataType.TRAIT,
+         displayType = DisplayType.SUMMARY,
+         writable = true
+   )
+   int getMaximumPoolSize() {
+      if (executor instanceof ThreadPoolExecutor) {
+         return ((ThreadPoolExecutor) executor).getMaximumPoolSize();
+      } else {
+         return -1;
+      }
+   }
+
+   void setMaximumPoolSize(int maximumPoolSize) {
+      if (executor instanceof ThreadPoolExecutor) {
+         ((ThreadPoolExecutor) executor).setMaximumPoolSize(maximumPoolSize);
+         if (!(((ThreadPoolExecutor)executor).getQueue() instanceof SynchronousQueue)) {
+            ((ThreadPoolExecutor) executor).setCorePoolSize(maximumPoolSize);
+         }
+      } else {
+         throw new UnsupportedOperationException();
+      }
+   }
+
+   @ManagedAttribute(
+         description = "Returns the largest ever number of executor threads.",
+         displayName = "Largest number of executor threads",
+         dataType = DataType.TRAIT,
+         displayType = DisplayType.SUMMARY
+   )
+   public int getLargestPoolSize() {
+      if (executor instanceof ThreadPoolExecutor) {
+         return ((ThreadPoolExecutor) executor).getLargestPoolSize();
+      } else {
+         return -1;
+      }
+   }
+
+   @ManagedAttribute(
+         description = "Returns the number of elements in this executor's queue.",
+         displayName = "Elements in the queue",
+         dataType = DataType.TRAIT,
+         displayType = DisplayType.SUMMARY
+   )
+   public int getQueueSize() {
+      if (executor instanceof ThreadPoolExecutor) {
+         return ((ThreadPoolExecutor) executor).getQueue().size();
+      } else {
+         return -1;
+      }
+   }
+
+   @ManagedAttribute(
+         description = "Returns the keep-alive time for this pool's threads",
+         displayName = "Keep-alive for pooled threads",
+         dataType = DataType.TRAIT,
+         displayType = DisplayType.SUMMARY
+   )
+   public long getKeepAliveTime() {
+      if (executor instanceof ThreadPoolExecutor) {
+         return ((ThreadPoolExecutor) executor).getKeepAliveTime(TimeUnit.MILLISECONDS);
+      } else {
+         return -1;
+      }
+   }
+
+   public void setKeepAliveTime(long milliseconds) {
+      if (executor instanceof ThreadPoolExecutor) {
+         ((ThreadPoolExecutor) executor).setKeepAliveTime(milliseconds, TimeUnit.MILLISECONDS);
+      } else {
+         throw new UnsupportedOperationException();
+      }
+   }
+
+}

--- a/core/src/main/java/org/infinispan/jmx/AbstractJmxRegistration.java
+++ b/core/src/main/java/org/infinispan/jmx/AbstractJmxRegistration.java
@@ -54,7 +54,7 @@ public abstract class AbstractJmxRegistration {
       for (ComponentRef<?> component : components) {
          Object instance = component.wired();
 
-         ResourceDMBean resourceDMBean = getResourceDMBean(instance);
+         ResourceDMBean resourceDMBean = getResourceDMBean(instance, component.getName());
          if (resourceDMBean != null) {
             resourceDMBeans.add(resourceDMBean);
          }
@@ -63,6 +63,10 @@ public abstract class AbstractJmxRegistration {
    }
 
    protected ResourceDMBean getResourceDMBean(Object instance) {
+      return getResourceDMBean(instance, null);
+   }
+
+   protected ResourceDMBean getResourceDMBean(Object instance, String componentName) {
       ComponentMetadata md = instance != null ?
                              componentMetadataRepo.getComponentMetadata(instance.getClass()) : null;
       if (md == null || !md.isManageable())
@@ -70,7 +74,7 @@ public abstract class AbstractJmxRegistration {
 
       ResourceDMBean resourceDMBean;
       try {
-         resourceDMBean = new ResourceDMBean(instance, md.toManageableComponentMetadata());
+         resourceDMBean = new ResourceDMBean(instance, md.toManageableComponentMetadata(), componentName);
       } catch (NoSuchFieldException | ClassNotFoundException e) {
          throw new CacheConfigurationException(e);
       }

--- a/core/src/main/java/org/infinispan/jmx/ResourceDMBean.java
+++ b/core/src/main/java/org/infinispan/jmx/ResourceDMBean.java
@@ -55,18 +55,23 @@ public class ResourceDMBean implements DynamicMBean {
    private final MBeanAttributeInfo[] attInfos;
    private final HashMap<String, InvokableMBeanAttributeInfo> atts = new HashMap<String, InvokableMBeanAttributeInfo>(2);
    private final ManageableComponentMetadata mBeanMetadata;
+   private final String name;
 
    private static final Map<String, Field> FIELD_CACHE = CollectionFactory.makeConcurrentMap(64);
    private static final Map<String, Method> METHOD_CACHE = CollectionFactory.makeConcurrentMap(64);
 
    public ResourceDMBean(Object instance, ManageableComponentMetadata mBeanMetadata) throws NoSuchFieldException, ClassNotFoundException {
+      this(instance, mBeanMetadata, null);
+   }
 
+   public ResourceDMBean(Object instance, ManageableComponentMetadata mBeanMetadata, String name) throws NoSuchFieldException, ClassNotFoundException {
       if (instance == null)
          throw new NullPointerException("Cannot make an MBean wrapper for null instance");
 
       this.obj = instance;
       this.objectClass = instance.getClass();
       this.mBeanMetadata = mBeanMetadata;
+      this.name = name;
 
       // Load up all fields.
       int i = 0;
@@ -402,6 +407,12 @@ public class ResourceDMBean implements DynamicMBean {
 
    public String getObjectName() {
       String s = mBeanMetadata.getJmxObjectName();
-      return (s != null && s.trim().length() > 0) ? s : objectClass.getSimpleName();
+      if (s != null && s.trim().length() > 0) {
+         return s;
+      } else if (name != null) {
+         return name;
+      } else {
+          return objectClass.getSimpleName();
+      }
    }
 }

--- a/core/src/test/java/org/infinispan/jmx/CacheManagerMBeanTest.java
+++ b/core/src/test/java/org/infinispan/jmx/CacheManagerMBeanTest.java
@@ -132,4 +132,14 @@ public class CacheManagerMBeanTest extends SingleCacheManagerTest {
       assertFalse(existsObject(cacheMBean));
    }
 
+   public void testExecutorMBeans() throws Exception {
+      ObjectName executor = getCacheManagerObjectName(JMX_DOMAIN, "DefaultCacheManager", "org.infinispan.executors.timeout");
+      assertTrue(existsObject(executor));
+      assertEquals(-1, server.getAttribute(executor, "PoolSize"));
+      executor = getCacheManagerObjectName(JMX_DOMAIN, "DefaultCacheManager", "org.infinispan.executors.notification");
+      assertTrue(existsObject(executor));
+      assertEquals(-1, server.getAttribute(executor, "PoolSize"));
+
+   }
+
 }

--- a/server/core/src/main/java/org/infinispan/server/core/transport/NettyChannelInitializer.java
+++ b/server/core/src/main/java/org/infinispan/server/core/transport/NettyChannelInitializer.java
@@ -38,7 +38,7 @@ public class NettyChannelInitializer<A extends ProtocolServerConfiguration> impl
 
    @Override
    public void initializeChannel(Channel ch) throws Exception {
-   ChannelPipeline pipeline = ch.pipeline();
+      ChannelPipeline pipeline = ch.pipeline();
       if(transport != null) {
          pipeline.addLast("stats", new StatsChannelHandler(transport));
       }

--- a/server/core/src/main/java/org/infinispan/server/core/transport/NettyTransport.java
+++ b/server/core/src/main/java/org/infinispan/server/core/transport/NettyTransport.java
@@ -3,6 +3,7 @@ package org.infinispan.server.core.transport;
 import java.net.InetSocketAddress;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.infinispan.commons.CacheException;
 import org.infinispan.commons.logging.LogFactory;
@@ -29,6 +30,7 @@ import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.ImmediateEventExecutor;
+import io.netty.util.concurrent.SingleThreadEventExecutor;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import io.netty.util.internal.logging.Log4J2LoggerFactory;
 
@@ -195,8 +197,10 @@ public class NettyTransport implements Transport {
    }
 
    @Override
-   public int getNumberWorkerThreads() {
-      return configuration.workerThreads();
+   public int getPendingTasks() {
+      AtomicInteger count = new AtomicInteger(0);
+      ioGroup.forEach(ee -> count.addAndGet(((SingleThreadEventExecutor)ee).pendingTasks()));
+      return count.get();
    }
 
    @Override

--- a/server/core/src/main/java/org/infinispan/server/core/transport/Transport.java
+++ b/server/core/src/main/java/org/infinispan/server/core/transport/Transport.java
@@ -64,20 +64,20 @@ public interface Transport {
    int getNumberIOThreads();
 
    @ManagedAttribute(
-         description = "Returns the number of slave threads.",
-         displayName = "Number of slave threads",
-         dataType = DataType.TRAIT,
-         displayType = DisplayType.SUMMARY
-   )
-   int getNumberWorkerThreads();
-
-   @ManagedAttribute(
          description = "Returns the idle timeout.",
          displayName = "Idle timeout",
          dataType = DataType.TRAIT,
          displayType = DisplayType.SUMMARY
    )
    int getIdleTimeout();
+
+   @ManagedAttribute(
+         description = "Returns the number of pending tasks.",
+         displayName = "Pending tasks",
+         dataType = DataType.MEASUREMENT,
+         displayType = DisplayType.SUMMARY
+   )
+   int getPendingTasks();
 
    @ManagedAttribute(
          description = "Returns whether TCP no delay was configured or not.",

--- a/server/core/src/main/java/org/infinispan/server/core/utils/ManageableThreadPoolExecutorService.java
+++ b/server/core/src/main/java/org/infinispan/server/core/utils/ManageableThreadPoolExecutorService.java
@@ -1,0 +1,16 @@
+package org.infinispan.server.core.utils;
+
+import java.util.concurrent.ThreadPoolExecutor;
+
+import org.infinispan.executors.ManageableExecutorService;
+
+/**
+ * @author Tristan Tarrant &lt;tristan@infinispan.org&gt;
+ * @since 10.0
+ **/
+public class ManageableThreadPoolExecutorService extends ManageableExecutorService<ThreadPoolExecutor> {
+
+   public ManageableThreadPoolExecutorService(ThreadPoolExecutor threadPoolExecutor) {
+      this.executor = threadPoolExecutor;
+   }
+}

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/BaseDecoder.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/BaseDecoder.java
@@ -41,6 +41,10 @@ abstract class BaseDecoder extends ByteToMessageDecoder {
       this.server = server;
    }
 
+   public Executor getExecutor() {
+      return executor;
+   }
+
    @Override
    public void handlerAdded(ChannelHandlerContext ctx) {
       auth = new Authentication(ctx.channel(), server);

--- a/server/memcached/src/main/java/org/infinispan/server/memcached/MemcachedServer.java
+++ b/server/memcached/src/main/java/org/infinispan/server/memcached/MemcachedServer.java
@@ -76,6 +76,8 @@ public class MemcachedServer extends AbstractProtocolServer<MemcachedServerConfi
 
    @Override
    public int getWorkerThreads() {
-      return Integer.getInteger("infinispan.server.memcached.workerThreads", configuration.workerThreads());
+      // Unused for now, so just return the smallest possible valid value
+      return 1;
    }
+
 }

--- a/server/rest/src/main/java/org/infinispan/rest/RestServer.java
+++ b/server/rest/src/main/java/org/infinispan/rest/RestServer.java
@@ -92,6 +92,7 @@ public class RestServer extends AbstractProtocolServer<RestServerConfiguration> 
 
    @Override
    public int getWorkerThreads() {
-      return Integer.getInteger("infinispan.server.rest.workerThreads", configuration.workerThreads());
+      // Unused for now, so just return the smallest possible valid value
+      return 1;
    }
 }

--- a/server/router/src/main/java/org/infinispan/server/router/router/impl/singleport/SinglePortEndpointRouter.java
+++ b/server/router/src/main/java/org/infinispan/server/router/router/impl/singleport/SinglePortEndpointRouter.java
@@ -95,7 +95,7 @@ public class SinglePortEndpointRouter extends AbstractProtocolServer<SinglePortR
 
    @Override
    public int getWorkerThreads() {
-      return configuration.workerThreads();
+      return 1;
    }
 
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-9708

This adds MBeans for all global executors (notifications, timeout, async, etc) as well as for the worker executors associated with the protocol servers. Since only the Hot Rod server uses the worker executor, I am setting the maximum pool size for REST and Memcached to 1 (as 0 is not a valid argument).