### PR TITLE
ISPN-9720 JDK11: An illegal reflective access operation has occurred

### DIFF
--- a/core/src/main/java/org/infinispan/marshall/exts/DoubleSummaryStatisticsExternalizer.java
+++ b/core/src/main/java/org/infinispan/marshall/exts/DoubleSummaryStatisticsExternalizer.java
@@ -3,6 +3,7 @@ package org.infinispan.marshall.exts;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.util.DoubleSummaryStatistics;
 import java.util.Set;
@@ -20,26 +21,40 @@ import org.infinispan.marshall.core.Ids;
  * @since 8.2
  */
 public class DoubleSummaryStatisticsExternalizer extends AbstractExternalizer<DoubleSummaryStatistics> {
+
+   private final static String CONSTRUCTOR_CALL_ERROR_MSG =
+           "Unable to create instance of %s via [%s] with parameters (%s, %s, %s, %s)";
+
    static final Field countField;
    static final Field sumField;
-   static final Field sumCompensationField;
-   static final Field simpleSumField;
    static final Field minField;
    static final Field maxField;
 
    static final boolean canSerialize;
+   static final Constructor<DoubleSummaryStatistics> constructor;
 
    static {
-      countField = SecurityActions.getField(DoubleSummaryStatistics.class, "count");
-      sumField = SecurityActions.getField(DoubleSummaryStatistics.class, "sum");
-      sumCompensationField = SecurityActions.getField(DoubleSummaryStatistics.class, "sumCompensation");
-      simpleSumField = SecurityActions.getField(DoubleSummaryStatistics.class, "simpleSum");
-      minField = SecurityActions.getField(DoubleSummaryStatistics.class, "min");
-      maxField = SecurityActions.getField(DoubleSummaryStatistics.class, "max");
+      constructor = SecurityActions.getConstructor(
+              DoubleSummaryStatistics.class, long.class, double.class, double.class, double.class);
 
-      // We can only properly serialize if all of the fields are non null
-      canSerialize = countField != null && sumField != null && sumCompensationField != null && simpleSumField != null
-              && minField != null && maxField != null;
+      if (constructor != null) {
+         // since JDK 10, *SummaryStatistics have parametrized constructors, so reflection can be avoided
+
+         countField = null;
+         sumField = null;
+         minField = null;
+         maxField = null;
+
+         canSerialize = true;
+      } else {
+         countField = SecurityActions.getField(DoubleSummaryStatistics.class, "count");
+         sumField = SecurityActions.getField(DoubleSummaryStatistics.class, "sum");
+         minField = SecurityActions.getField(DoubleSummaryStatistics.class, "min");
+         maxField = SecurityActions.getField(DoubleSummaryStatistics.class, "max");
+
+         // We can only properly serialize if all of the fields are non null
+         canSerialize = countField != null && sumField != null && minField != null && maxField != null;
+      }
    }
 
    @Override
@@ -56,33 +71,49 @@ public class DoubleSummaryStatisticsExternalizer extends AbstractExternalizer<Do
    @Override
    public void writeObject(ObjectOutput output, DoubleSummaryStatistics object) throws IOException {
       verifySerialization();
-      try {
-         output.writeLong(countField.getLong(object));
-         output.writeDouble(sumField.getDouble(object));
-         output.writeDouble(sumCompensationField.getDouble(object));
-         output.writeDouble(simpleSumField.getDouble(object));
-         output.writeDouble(minField.getDouble(object));
-         output.writeDouble(maxField.getDouble(object));
-      } catch (IllegalAccessException e) {
-         // This can't happen as we force accessibility in the getField
-         throw new IOException(e);
-      }
+      output.writeLong(object.getCount());
+      output.writeDouble(object.getSum());
+      // To stay backward compatible with older versions of infinispan, write 0s for the compensation and simpleSum
+      // fields. The API doesn't allow for obtaining nor setting values of these _implementation specific_ fields.
+      // This means precision can be lost.
+      output.writeDouble(0); // sumCompensation
+      output.writeDouble(0); // simpleSum
+      output.writeDouble(object.getMin());
+      output.writeDouble(object.getMax());
    }
 
    @Override
    public DoubleSummaryStatistics readObject(ObjectInput input) throws IOException, ClassNotFoundException {
       verifySerialization();
-      DoubleSummaryStatistics summaryStatistics = new DoubleSummaryStatistics();
-      try {
-         countField.setLong(summaryStatistics, input.readLong());
-         sumField.setDouble(summaryStatistics, input.readDouble());
-         sumCompensationField.setDouble(summaryStatistics, input.readDouble());
-         simpleSumField.setDouble(summaryStatistics, input.readDouble());
-         minField.setDouble(summaryStatistics, input.readDouble());
-         maxField.setDouble(summaryStatistics, input.readDouble());
-      } catch (IllegalAccessException e) {
-         // This can't happen as we force accessibility in the getField
-         throw new IOException(e);
+      final DoubleSummaryStatistics summaryStatistics;
+
+      final long count = input.readLong();
+      final double sum = input.readDouble();
+      final double sumCompensation = input.readDouble(); // ignored, see writeObject()
+      final double simpleSum = input.readDouble(); // ignored, see writeObject()
+      final double min = input.readDouble();
+      final double max = input.readDouble();
+
+      if (constructor != null) {
+         // JDK 10+, pass values to constructor
+         try {
+            summaryStatistics = constructor.newInstance(count, min, max, sum);
+         } catch (ReflectiveOperationException e) {
+            throw new IOException(String.format(CONSTRUCTOR_CALL_ERROR_MSG,
+                    DoubleSummaryStatistics.class, constructor.toString(), count, min, max, sum), e);
+         }
+      } else {
+         // JDK 9 or older, fall back to reflection
+         summaryStatistics = new DoubleSummaryStatistics();
+         try {
+            countField.setLong(summaryStatistics, count);
+            sumField.setDouble(summaryStatistics, sum);
+            minField.setDouble(summaryStatistics, min);
+            maxField.setDouble(summaryStatistics, max);
+         } catch (IllegalAccessException e) {
+            // This can't happen as we force accessibility in the getField
+            throw new IOException(e);
+         }
       }
       return summaryStatistics;
    }

--- a/core/src/main/java/org/infinispan/marshall/exts/LongSummaryStatisticsExternalizer.java
+++ b/core/src/main/java/org/infinispan/marshall/exts/LongSummaryStatisticsExternalizer.java
@@ -3,6 +3,7 @@ package org.infinispan.marshall.exts;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.util.LongSummaryStatistics;
 import java.util.Set;
@@ -26,15 +27,30 @@ public class LongSummaryStatisticsExternalizer extends AbstractExternalizer<Long
    static final Field maxField;
 
    static final boolean canSerialize;
+   static final Constructor<LongSummaryStatistics> constructor;
 
    static {
-      countField = SecurityActions.getField(LongSummaryStatistics.class, "count");
-      sumField = SecurityActions.getField(LongSummaryStatistics.class, "sum");
-      minField = SecurityActions.getField(LongSummaryStatistics.class, "min");
-      maxField = SecurityActions.getField(LongSummaryStatistics.class, "max");
+      constructor = SecurityActions
+              .getConstructor(LongSummaryStatistics.class, long.class, long.class, long.class, long.class);
 
-      // We can only properly serialize if all of the fields are non null
-      canSerialize = countField != null && sumField != null && minField != null && maxField != null;
+      if (constructor != null) {
+         // since JDK 10, *SummaryStatistics have parametrized constructors, so reflection can be avoided
+
+         countField = null;
+         sumField = null;
+         minField = null;
+         maxField = null;
+
+         canSerialize = true;
+      } else {
+         countField = SecurityActions.getField(LongSummaryStatistics.class, "count");
+         sumField = SecurityActions.getField(LongSummaryStatistics.class, "sum");
+         minField = SecurityActions.getField(LongSummaryStatistics.class, "min");
+         maxField = SecurityActions.getField(LongSummaryStatistics.class, "max");
+
+         // We can only properly serialize if all of the fields are non null
+         canSerialize = countField != null && sumField != null && minField != null && maxField != null;
+      }
    }
 
    @Override
@@ -51,29 +67,41 @@ public class LongSummaryStatisticsExternalizer extends AbstractExternalizer<Long
    @Override
    public void writeObject(ObjectOutput output, LongSummaryStatistics object) throws IOException {
       verifySerialization();
-      try {
-         output.writeLong(countField.getLong(object));
-         output.writeLong(sumField.getLong(object));
-         output.writeLong(minField.getLong(object));
-         output.writeLong(maxField.getLong(object));
-      } catch (IllegalAccessException e) {
-         // This can't happen as we force accessibility in the getField
-         throw new IOException(e);
-      }
+      output.writeLong(object.getCount());
+      output.writeLong(object.getSum());
+      output.writeLong(object.getMin());
+      output.writeLong(object.getMax());
    }
 
    @Override
    public LongSummaryStatistics readObject(ObjectInput input) throws IOException, ClassNotFoundException {
       verifySerialization();
-      LongSummaryStatistics summaryStatistics = new LongSummaryStatistics();
-      try {
-         countField.setLong(summaryStatistics, input.readLong());
-         sumField.setLong(summaryStatistics, input.readLong());
-         minField.setLong(summaryStatistics, input.readLong());
-         maxField.setLong(summaryStatistics, input.readLong());
-      } catch (IllegalAccessException e) {
-         // This can't happen as we force accessibility in the getField
-         throw new IOException(e);
+      final LongSummaryStatistics summaryStatistics;
+
+      final long count = input.readLong();
+      final long sum = input.readLong();
+      final long min = input.readLong();
+      final long max = input.readLong();
+
+      if (constructor != null) {
+         // JDK 10+, pass values to constructor
+         try {
+            summaryStatistics = constructor.newInstance(count, min, max, sum);
+         } catch (ReflectiveOperationException e) {
+            throw new IOException(e);
+         }
+      } else {
+         // JDK 9 or older, fall back to reflection
+         summaryStatistics = new LongSummaryStatistics();
+         try {
+            countField.setLong(summaryStatistics, count);
+            sumField.setLong(summaryStatistics, sum);
+            minField.setLong(summaryStatistics, min);
+            maxField.setLong(summaryStatistics, max);
+         } catch (IllegalAccessException e) {
+            // This can't happen as we force accessibility in the getField
+            throw new IOException(e);
+         }
       }
       return summaryStatistics;
    }

--- a/core/src/test/java/org/infinispan/marshall/exts/AbstractExternalizerTest.java
+++ b/core/src/test/java/org/infinispan/marshall/exts/AbstractExternalizerTest.java
@@ -1,0 +1,33 @@
+package org.infinispan.marshall.exts;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import org.infinispan.commons.marshall.AbstractExternalizer;
+
+public abstract class AbstractExternalizerTest<T> {
+
+    protected AbstractExternalizer<T> externalizer;
+
+    public AbstractExternalizerTest() {
+        this.externalizer = createExternalizer();
+    }
+
+    protected T deserialize(T object) throws IOException, ClassNotFoundException {
+        byte[] buffer;
+        final int byteArrayLength = 8 * 6; // 8 bytes (size of long/double) * 6 fields
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream(byteArrayLength)) {
+            try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+                externalizer.writeObject(oos, object);
+            }
+            buffer = baos.toByteArray();
+        }
+        ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(buffer));
+        return externalizer.readObject(ois);
+    }
+
+    abstract AbstractExternalizer<T> createExternalizer();
+}

--- a/core/src/test/java/org/infinispan/marshall/exts/DoubleSummaryStatisticsExternalizerTest.java
+++ b/core/src/test/java/org/infinispan/marshall/exts/DoubleSummaryStatisticsExternalizerTest.java
@@ -1,0 +1,74 @@
+package org.infinispan.marshall.exts;
+
+import java.io.IOException;
+import java.util.DoubleSummaryStatistics;
+
+import org.infinispan.commons.marshall.AbstractExternalizer;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+@Test(groups = "unit", testName = "marshall.DoubleSummaryStatisticsExternalizerTest")
+public class DoubleSummaryStatisticsExternalizerTest extends AbstractExternalizerTest<DoubleSummaryStatistics> {
+
+    public void testFinite() throws Exception {
+        DoubleSummaryStatistics stats = new DoubleSummaryStatistics();
+        stats.accept(10.0/3);
+        stats.accept(-0.1);
+
+        DoubleSummaryStatistics deserialized = deserialize(stats);
+        assertStatsAreEqual(stats, deserialized);
+    }
+
+    public void testPositiveNegativeInfinites() throws Exception {
+        // In JDK 10+, we expect the externalizer to pass inner state values through constructor, instead of via
+        // reflection. The state of this statistics instance however doesn't pass constructor validations, so
+        // deserialization of this instance fails in JDK 10+.
+
+        DoubleSummaryStatistics stats = new DoubleSummaryStatistics();
+        stats.accept(Double.POSITIVE_INFINITY);
+        stats.accept(Double.NEGATIVE_INFINITY);
+
+        try {
+            DoubleSummaryStatistics deserialized = deserialize(stats);
+            assertStatsAreEqual(stats, deserialized);
+        } catch (IOException e) {
+            if (SecurityActions.getConstructor(DoubleSummaryStatistics.class,
+                    long.class, double.class, double.class, double.class) != null) {
+                // JDK 10+, ignore
+            } else {
+                throw e;
+            }
+        }
+    }
+
+    public void testNaN() throws Exception {
+        DoubleSummaryStatistics stats = new DoubleSummaryStatistics();
+        stats.accept(-1);
+        stats.accept(Double.NaN);
+
+        DoubleSummaryStatistics deserialized = deserialize(stats);
+        assertStatsAreEqual(stats, deserialized);
+    }
+
+    public void testInfinity() throws Exception {
+        DoubleSummaryStatistics stats = new DoubleSummaryStatistics();
+        stats.accept(Double.POSITIVE_INFINITY);
+        stats.accept(-1);
+
+        DoubleSummaryStatistics deserialized = deserialize(stats);
+        assertStatsAreEqual(stats, deserialized);
+    }
+
+    @Override
+    AbstractExternalizer<DoubleSummaryStatistics> createExternalizer() {
+        return new DoubleSummaryStatisticsExternalizer();
+    }
+
+    private void assertStatsAreEqual(DoubleSummaryStatistics original, DoubleSummaryStatistics deserialized) {
+        Assert.assertEquals(original.getCount(), deserialized.getCount());
+        Assert.assertEquals(original.getMin(), deserialized.getMin());
+        Assert.assertEquals(original.getMax(), deserialized.getMax());
+        Assert.assertEquals(original.getSum(), deserialized.getSum());
+        Assert.assertEquals(original.getAverage(), deserialized.getAverage());
+    }
+}

--- a/core/src/test/java/org/infinispan/marshall/exts/IntSummaryStatisticsExternalizerTest.java
+++ b/core/src/test/java/org/infinispan/marshall/exts/IntSummaryStatisticsExternalizerTest.java
@@ -1,0 +1,33 @@
+package org.infinispan.marshall.exts;
+
+import java.util.IntSummaryStatistics;
+
+import org.infinispan.commons.marshall.AbstractExternalizer;
+import org.testng.annotations.Test;
+import org.testng.Assert;
+
+@Test(groups = "unit", testName = "marshall.IntSummaryStatisticsExternalizerTest")
+public class IntSummaryStatisticsExternalizerTest extends AbstractExternalizerTest<IntSummaryStatistics> {
+
+    public void test() throws Exception {
+        IntSummaryStatistics stats = new IntSummaryStatistics();
+        stats.accept(1);
+        stats.accept(-Integer.MAX_VALUE);
+
+        IntSummaryStatistics deserialized = deserialize(stats);
+        assertStatsAreEqual(stats, deserialized);
+    }
+
+    @Override
+    AbstractExternalizer<IntSummaryStatistics> createExternalizer() {
+        return new IntSummaryStatisticsExternalizer();
+    }
+
+    private void assertStatsAreEqual(IntSummaryStatistics original, IntSummaryStatistics deserialized) {
+        Assert.assertEquals(original.getCount(), deserialized.getCount());
+        Assert.assertEquals(original.getMin(), deserialized.getMin());
+        Assert.assertEquals(original.getMax(), deserialized.getMax());
+        Assert.assertEquals(original.getSum(), deserialized.getSum());
+        Assert.assertEquals(original.getAverage(), deserialized.getAverage());
+    }
+}

--- a/core/src/test/java/org/infinispan/marshall/exts/LongSummaryStatisticsExternalizerTest.java
+++ b/core/src/test/java/org/infinispan/marshall/exts/LongSummaryStatisticsExternalizerTest.java
@@ -1,0 +1,33 @@
+package org.infinispan.marshall.exts;
+
+import java.util.LongSummaryStatistics;
+
+import org.infinispan.commons.marshall.AbstractExternalizer;
+import org.testng.annotations.Test;
+import org.testng.Assert;
+
+@Test(groups = "unit", testName = "marshall.LongSummaryStatisticsExternalizerTest")
+public class LongSummaryStatisticsExternalizerTest extends AbstractExternalizerTest<LongSummaryStatistics> {
+
+    public void test() throws Exception {
+        LongSummaryStatistics stats = new LongSummaryStatistics();
+        stats.accept(1);
+        stats.accept(-Long.MAX_VALUE);
+
+        LongSummaryStatistics deserialized = deserialize(stats);
+        assertStatsAreEqual(stats, deserialized);
+    }
+
+    @Override
+    AbstractExternalizer<LongSummaryStatistics> createExternalizer() {
+        return new LongSummaryStatisticsExternalizer();
+    }
+
+    private void assertStatsAreEqual(LongSummaryStatistics original, LongSummaryStatistics deserialized) {
+        Assert.assertEquals(original.getCount(), deserialized.getCount());
+        Assert.assertEquals(original.getMin(), deserialized.getMin());
+        Assert.assertEquals(original.getMax(), deserialized.getMax());
+        Assert.assertEquals(original.getSum(), deserialized.getSum());
+        Assert.assertEquals(original.getAverage(), deserialized.getAverage());
+    }
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-9720
https://issues.jboss.org/browse/WFLY-11355

Upstream PR: https://github.com/infinispan/infinispan/pull/6426

This is to avoid illegal access warnings on JDK 10+. Three classes were changed, which used reflection to access private fields in JDK types:
* IntSummaryStatisticsExternalizer
* LongSummaryStatisticsExternalizer
* DoubleSummaryStatisticsExternalizer (see bellow for details on this one)

Since JDK 10, relevant JDK types ([Int|Long|Double]SummaryStatistics) have gotten new parametrized constructors, so reflective access to set their inner state is no longer necessary.

The `DoubleSummaryStatistics` case is however somewhat problematic - except for `sum`, `count`, `min` and `max` fields (that are accessible by public API), the externalizer used to also access and serialize `sumCompensation` and `simpleSum` fields, which are technically implementation specific fields (i.e. do not have to exist in all JDKs) and are not accessible by the API. The purpose of those fields is to improve precision of the summation. *This change omits those fields during (de)serialization, which may lead to lower precision of deserialized instance compared to the original instance.*