### PR TITLE
[9.3.x] ISPN-9725 Blackbox query tests are failing due to improper teardown that does not take store and index into account

### DIFF
--- a/query/src/test/java/org/infinispan/query/blackbox/ClusteredCacheFSDirectoryTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/ClusteredCacheFSDirectoryTest.java
@@ -1,5 +1,7 @@
 package org.infinispan.query.blackbox;
 
+import static org.testng.AssertJUnit.assertTrue;
+
 import java.io.File;
 
 import org.infinispan.commons.util.Util;
@@ -24,10 +26,10 @@ import org.testng.annotations.Test;
 @Test(groups = "functional", testName = "query.blackbox.ClusteredCacheFSDirectoryTest")
 public class ClusteredCacheFSDirectoryTest extends ClusteredCacheTest {
 
-   private final String TMP_DIR = TestingUtil.tmpDirectory(this.getClass());
+   private final String TMP_DIR = TestingUtil.tmpDirectory(getClass());
 
    @Override
-   protected void createCacheManagers() throws Exception {
+   protected void createCacheManagers() {
       addClusterEnabledCacheManager(buildCacheConfig("index1"));
       addClusterEnabledCacheManager(buildCacheConfig("index2"));
       waitForClusterToForm();
@@ -49,7 +51,9 @@ public class ClusteredCacheFSDirectoryTest extends ClusteredCacheTest {
 
    @BeforeMethod
    protected void setUpTempDir() {
-      new File(TMP_DIR).mkdirs();
+      Util.recursiveFileRemove(TMP_DIR);
+      boolean created = new File(TMP_DIR).mkdirs();
+      assertTrue(created);
    }
 
    @Override

--- a/query/src/test/java/org/infinispan/query/blackbox/LocalCacheAsyncCacheStoreTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/LocalCacheAsyncCacheStoreTest.java
@@ -23,7 +23,6 @@ public class LocalCacheAsyncCacheStoreTest extends LocalCacheTest {
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       cacheManager = TestCacheManagerFactory.fromXml("async-file-store-config.xml");
       cache = cacheManager.getCache("queryCache_lucenestore_async_filestore");
-
       return cacheManager;
    }
 

--- a/query/src/test/java/org/infinispan/query/blackbox/LocalCacheFSDirectoryTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/LocalCacheFSDirectoryTest.java
@@ -1,5 +1,7 @@
 package org.infinispan.query.blackbox;
 
+import static org.testng.AssertJUnit.assertTrue;
+
 import java.io.File;
 
 import org.infinispan.commons.util.Util;
@@ -22,25 +24,26 @@ import org.testng.annotations.Test;
 @Test(groups = "functional", testName = "query.blackbox.LocalCacheFSDirectoryTest")
 public class LocalCacheFSDirectoryTest extends LocalCacheTest {
 
-   private final String indexDirectory = TestingUtil.tmpDirectory(this.getClass());
+   private final String indexDirectory = TestingUtil.tmpDirectory(getClass());
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       ConfigurationBuilder cfg = getDefaultStandaloneCacheConfig(true);
       cfg.indexing().index(Index.ALL)
-         .addIndexedEntity(Person.class)
-         .addIndexedEntity(AnotherGrassEater.class)
-         .addProperty("default.directory_provider", "filesystem")
-         .addProperty("default.indexBase", indexDirectory)
-         .addProperty("error_handler", "org.infinispan.query.helper.StaticTestingErrorHandler")
-         .addProperty("lucene_version", "LUCENE_CURRENT");
+            .addIndexedEntity(Person.class)
+            .addIndexedEntity(AnotherGrassEater.class)
+            .addProperty("default.directory_provider", "filesystem")
+            .addProperty("default.indexBase", indexDirectory)
+            .addProperty("error_handler", "org.infinispan.query.helper.StaticTestingErrorHandler")
+            .addProperty("lucene_version", "LUCENE_CURRENT");
       return TestCacheManagerFactory.createCacheManager(cfg);
    }
 
    @Override
    protected void setup() throws Exception {
       Util.recursiveFileRemove(indexDirectory);
-      new File(indexDirectory).mkdirs();
+      boolean created = new File(indexDirectory).mkdirs();
+      assertTrue(created);
       super.setup();
    }
 

--- a/query/src/test/java/org/infinispan/query/blackbox/LocalCachePerfIspnDirConfTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/LocalCachePerfIspnDirConfTest.java
@@ -16,7 +16,6 @@ public class LocalCachePerfIspnDirConfTest extends LocalCacheTest {
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       cacheManager = TestCacheManagerFactory.fromXml("nrt-performance-writer-infinispandirectory.xml");
       cache = cacheManager.getCache("Indexed");
-
       return cacheManager;
    }
 }

--- a/query/src/test/java/org/infinispan/query/blackbox/LocalCachePerfProgrammaticConfTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/LocalCachePerfProgrammaticConfTest.java
@@ -1,5 +1,7 @@
 package org.infinispan.query.blackbox;
 
+import static org.testng.AssertJUnit.assertTrue;
+
 import java.io.File;
 
 import org.infinispan.commons.util.Util;
@@ -20,7 +22,7 @@ import org.testng.annotations.Test;
 @Test(groups = "functional", testName = "query.blackbox.LocalCachePerfProgrammaticConfTest")
 public class LocalCachePerfProgrammaticConfTest extends LocalCacheTest {
 
-   private final String indexDirectory = TestingUtil.tmpDirectory(this.getClass());
+   private final String indexDirectory = TestingUtil.tmpDirectory(getClass());
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
@@ -48,7 +50,8 @@ public class LocalCachePerfProgrammaticConfTest extends LocalCacheTest {
    @Override
    protected void setup() throws Exception {
       Util.recursiveFileRemove(indexDirectory);
-      new File(indexDirectory).mkdirs();
+      boolean created = new File(indexDirectory).mkdirs();
+      assertTrue(created);
       super.setup();
    }
 

--- a/query/src/test/java/org/infinispan/query/blackbox/LocalCachePerformantConfTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/LocalCachePerformantConfTest.java
@@ -17,14 +17,15 @@ import org.testng.annotations.Test;
 @Test(groups = "functional", testName = "query.blackbox.LocalCachePerformantConfTest")
 public class LocalCachePerformantConfTest extends LocalCacheTest {
 
-   /** the file constant needs to match what's defined in the configuration file **/
+   /**
+    * The file constant needs to match what's defined in the configuration file.
+    */
    private final String indexDirectory = System.getProperty("java.io.tmpdir") + File.separator + "LocalCachePerformantConfTest";
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       cacheManager = TestCacheManagerFactory.fromXml("testconfig-LocalCachePerformantConfTest.xml");
       cache = cacheManager.getCache("Indexed");
-
       return cacheManager;
    }
 

--- a/query/src/test/java/org/infinispan/query/blackbox/LocalCacheTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/LocalCacheTest.java
@@ -670,6 +670,16 @@ public class LocalCacheTest extends SingleCacheManagerTest {
       return TestCacheManagerFactory.createCacheManager(cfg);
    }
 
+   @Override
+   protected void teardown() {
+      if (cache != null) {
+         // a proper cache.clear() should ensure indexes and stores are cleared too if present
+         // this is better and more complete than the cleanup performed by the superclass
+         cache.clear();
+      }
+      super.teardown();
+   }
+
    protected void loadTestingData() {
       prepareTestingData();
 

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/QueryStringTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/QueryStringTest.java
@@ -403,7 +403,7 @@ public class QueryStringTest extends AbstractQueryDslTest {
     * See <a href="https://issues.jboss.org/browse/ISPN-7863">ISPN-7863</a>
     */
    public void testAliasContainingLetterV() {
-      Query q = createQueryFromString("from " + getModelFactory().getTransactionTypeName() + " vvvTestAlias where vvvTestAlias.description = 'Birthday present'");
+      Query q = createQueryFromString("from " + getModelFactory().getTransactionTypeName() + " vvv where vvv.description = 'Birthday present'");
       assertEquals(1, q.list().size());
    }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-9725 