### PR TITLE
[9.4.x] ISPN-9745 Compatibility bundle modules don't have source jars

### DIFF
--- a/client/marshaller/kryo/kryo-marshaller-compatibility-bundle/src/test/resources/README.txt
+++ b/client/marshaller/kryo/kryo-marshaller-compatibility-bundle/src/test/resources/README.txt
@@ -1,0 +1,1 @@
+This file triggers the creation of a test-sources jar and keeps Nexus happy.

--- a/client/marshaller/protostuff/protostuff-marshaller-compatibility-bundle/src/test/resources/README.txt
+++ b/client/marshaller/protostuff/protostuff-marshaller-compatibility-bundle/src/test/resources/README.txt
@@ -1,0 +1,1 @@
+This file triggers the creation of a test-sources jar and keeps Nexus happy.


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-9745

Add dummy README.txt files to force the generation of test-source jars.