### PR TITLE
[9.4] ISPN-9748 Default transport for the test suite should be the same

### DIFF
--- a/core/src/test/java/org/infinispan/test/fwk/JGroupsConfigBuilder.java
+++ b/core/src/test/java/org/infinispan/test/fwk/JGroupsConfigBuilder.java
@@ -74,7 +74,7 @@ public class JGroupsConfigBuilder {
    };
 
    static {
-      JGROUPS_STACK = LegacyKeySupportSystemProperties.getProperty("infinispan.test.jgroups.protocol", "protocol.stack", "tcp");
+      JGROUPS_STACK = LegacyKeySupportSystemProperties.getProperty("infinispan.test.jgroups.protocol", "protocol.stack", "udp");
       System.out.println("Transport protocol stack used = " + JGROUPS_STACK);
    }
 

--- a/integrationtests/osgi/pom.xml
+++ b/integrationtests/osgi/pom.xml
@@ -18,7 +18,6 @@
       <defaultTestGroup />
       <defaultExcludedTestGroup />
       <infinispan.test.parallel.threads>1</infinispan.test.parallel.threads>
-      <infinispan.test.jgroups.protocol>tcp</infinispan.test.jgroups.protocol>
       <forkJvmArgs>-Xmx500m -XX:HeapDumpPath=${user.dir}</forkJvmArgs>
       <target.tmp.dir>${project.build.directory}/tmp/</target.tmp.dir>
       <skipOSGiTests>${skipTests}</skipOSGiTests>

--- a/integrationtests/wildfly-modules/pom.xml
+++ b/integrationtests/wildfly-modules/pom.xml
@@ -21,8 +21,7 @@
       <resources.dir>${basedir}/src/test/resources</resources.dir>
       <serverMemoryJvmArgs>-Xmx300m ${testjvm.commonArgs}</serverMemoryJvmArgs>
       <jvm.x64.args />
-      <default.transport.stack>udp</default.transport.stack>
-      <transport.stack>-Djboss.default.jgroups.stack=${default.transport.stack}</transport.stack>
+      <transport.stack>-Djboss.default.jgroups.stack=${infinispan.test.jgroups.protocol}</transport.stack>
       <jvm.ip.stack>-Djava.net.preferIPv4Stack=true</jvm.ip.stack>
       <mcast.ip>234.99.54.14</mcast.ip>
       <jvm.ip.stack>-Djava.net.preferIPv4Stack=true -Djava.net.preferIPv6Addresses=false -Djboss.default.multicast.address=${mcast.ip}</jvm.ip.stack>

--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,8 @@
       <forkJvmArgs>-Xmx1G ${testjvm.commonArgs}</forkJvmArgs>
       <infinispan.module-suffix>-${project.artifactId}</infinispan.module-suffix>
       <ansi.strip/>
-      <infinispan.test.jgroups.protocol>tcp</infinispan.test.jgroups.protocol>
+      <default.transport.stack>udp</default.transport.stack>
+      <infinispan.test.jgroups.protocol>${default.transport.stack}</infinispan.test.jgroups.protocol>
       <infinispan.test.parallel.threads>8</infinispan.test.parallel.threads>
       <skipArtifactUpload>false</skipArtifactUpload>
       <upload.username>infinispan</upload.username>

--- a/server/integration/testsuite/README.txt
+++ b/server/integration/testsuite/README.txt
@@ -64,8 +64,8 @@ This is controlled by following profile
 
 Running client tests with TCP stack (UDP by default)
 ----------------------------------------------------
-Controlled by property default.transport.stack:
-  mvn clean verify -Psuite.client -Ddefault.transport.stack=tcp
+Controlled by property infinispan.test.jgroups.protocol:
+  mvn clean verify -Psuite.client -Dinfinispan.test.jgroups.protocol=tcp
 
 Client side logging
 -------------------

--- a/server/integration/testsuite/pom.xml
+++ b/server/integration/testsuite/pom.xml
@@ -301,8 +301,7 @@
 
         <serverMemoryJvmArgs>-Xmx300m ${testjvm.commonArgs}</serverMemoryJvmArgs>
         <jvm.x64.args />
-        <default.transport.stack>udp</default.transport.stack>
-        <transport.stack>-Djboss.default.jgroups.stack=${default.transport.stack}</transport.stack>
+        <transport.stack>-Djboss.default.jgroups.stack=${infinispan.test.jgroups.protocol}</transport.stack>
 
         <jvm.ip.stack>-Djava.net.preferIPv4Stack=true</jvm.ip.stack>
         <node0.ip>127.0.0.1</node0.ip>
@@ -913,7 +912,7 @@
                             <goal>integration-test</goal>
                         </goals>
                         <configuration>
-                            <reportNameSuffix>localmode-${default.transport.stack}</reportNameSuffix>
+                            <reportNameSuffix>localmode-${infinispan.test.jgroups.protocol}</reportNameSuffix>
                             <groups>${groups.client.local}</groups>
                             <excludedGroups>${groups.unstable}</excludedGroups>
                             <systemPropertyVariables>
@@ -930,7 +929,7 @@
                             <goal>integration-test</goal>
                         </goals>
                         <configuration>
-                            <reportNameSuffix>localmode-${default.transport.stack}</reportNameSuffix>
+                            <reportNameSuffix>localmode-${infinispan.test.jgroups.protocol}</reportNameSuffix>
                             <groups>org.infinispan.server.test.category.MemcachedSingleNode</groups>
                             <excludedGroups>${groups.unstable}</excludedGroups>
                             <systemPropertyVariables>
@@ -947,7 +946,7 @@
                             <goal>integration-test</goal>
                         </goals>
                         <configuration>
-                            <reportNameSuffix>localmode-${default.transport.stack}</reportNameSuffix>
+                            <reportNameSuffix>localmode-${infinispan.test.jgroups.protocol}</reportNameSuffix>
                             <groups>${groups.client.local.domain}</groups>
                             <excludedGroups>${groups.unstable}</excludedGroups>
                             <systemPropertyVariables>
@@ -964,7 +963,7 @@
                             <goal>integration-test</goal>
                         </goals>
                         <configuration>
-                            <reportNameSuffix>distmode-${default.transport.stack}</reportNameSuffix>
+                            <reportNameSuffix>distmode-${infinispan.test.jgroups.protocol}</reportNameSuffix>
                             <groups>${groups.client.clustered}</groups>
                             <excludedGroups>${groups.unstable}</excludedGroups>
                             <systemPropertyVariables>
@@ -981,7 +980,7 @@
                             <goal>integration-test</goal>
                         </goals>
                         <configuration>
-                            <reportNameSuffix>distmode-${default.transport.stack}</reportNameSuffix>
+                            <reportNameSuffix>distmode-${infinispan.test.jgroups.protocol}</reportNameSuffix>
                             <groups>org.infinispan.server.test.category.MemcachedClustered</groups>
                             <excludedGroups>${groups.unstable}</excludedGroups>
                             <systemPropertyVariables>
@@ -998,7 +997,7 @@
                             <goal>integration-test</goal>
                         </goals>
                         <configuration>
-                            <reportNameSuffix>distmode-${default.transport.stack}</reportNameSuffix>
+                            <reportNameSuffix>distmode-${infinispan.test.jgroups.protocol}</reportNameSuffix>
                             <groups>${groups.client.clustered.domain}</groups>
                             <excludedGroups>${groups.unstable}</excludedGroups>
                             <systemPropertyVariables>
@@ -1015,7 +1014,7 @@
                             <goal>integration-test</goal>
                         </goals>
                         <configuration>
-                            <reportNameSuffix>replmode-${default.transport.stack}</reportNameSuffix>
+                            <reportNameSuffix>replmode-${infinispan.test.jgroups.protocol}</reportNameSuffix>
                             <groups>${groups.client.clustered}</groups>
                             <excludedGroups>${groups.unstable}</excludedGroups>
                             <systemPropertyVariables>
@@ -1032,7 +1031,7 @@
                             <goal>integration-test</goal>
                         </goals>
                         <configuration>
-                            <reportNameSuffix>replmode-${default.transport.stack}</reportNameSuffix>
+                            <reportNameSuffix>replmode-${infinispan.test.jgroups.protocol}</reportNameSuffix>
                             <groups>${groups.client.clustered.domain}</groups>
                             <excludedGroups>${groups.unstable}</excludedGroups>
                             <systemPropertyVariables>


### PR DESCRIPTION
Default transport for the test suite should be the same except if it was activated by another profile