### PR TITLE
ISPN-9755 Version dropdown doesn't work in the server guide

### DIFF
--- a/documentation/src/main/asciidoc/js/js.js
+++ b/documentation/src/main/asciidoc/js/js.js
@@ -1,5 +1,8 @@
+function addVersionsMenu()
 $(document).ready(function() {
-    var version = "{infinispanversion}.x";
+    var prefix = "/docs/"
+    var path = document.location.pathname;
+    var version = path.substring(prefix.length, path.indexOf("/", prefix.length));
     $.ajax({type: 'GET', dataType: 'xml', url: '../../versions.xml',
             success: function(xml) {
                 $('#toctitle').before('<select id="vchooser"></select>');
@@ -11,7 +14,7 @@ $(document).ready(function() {
                 });
                 $('#vchooser').change(function(e) {
                     if (this.value !== '')
-                        window.location.href = '../../' + this.value + '/user_guide/user_guide.html';
+                        window.location.href = path.replace(version, this.value);
                 });
             }
     });

--- a/documentation/src/main/asciidoc/server_guide/configuration.adoc
+++ b/documentation/src/main/asciidoc/server_guide/configuration.adoc
@@ -554,7 +554,7 @@ libraries are presented below:
 
 Add the protostuff marshaller dependency to your pom:
 
-[source,xml]
+[source,xml,subs="attributes"]
 ----
 <dependency>
   <groupId>org.infinispan</groupId>
@@ -580,7 +580,7 @@ file within your deployment jar.
 
 Add the kryo marshaller dependency to your pom:
 
-[source,xml]
+[source,xml,subs="attributes"]
 ----
 <dependency>
   <groupId>org.infinispan</groupId>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-9755

* Make the version dropdown work without the placeholder
* Add subs="attributes" to source blocks referencing the placeholder