### PR TITLE
ISPN-9756 Improve ETag generation in the REST server

### DIFF
--- a/core/src/main/java/org/infinispan/container/versioning/LongEntryVersion.java
+++ b/core/src/main/java/org/infinispan/container/versioning/LongEntryVersion.java
@@ -1,0 +1,9 @@
+package org.infinispan.container.versioning;
+
+/**
+ * @since 10.0
+ */
+public interface LongEntryVersion extends IncrementableEntryVersion {
+
+   long getVersion();
+}

--- a/core/src/main/java/org/infinispan/container/versioning/NumericVersion.java
+++ b/core/src/main/java/org/infinispan/container/versioning/NumericVersion.java
@@ -15,7 +15,7 @@ import org.infinispan.marshall.core.Ids;
  * @author Galder Zamarreño
  * @since 5.3
  */
-public class NumericVersion implements IncrementableEntryVersion {
+public class NumericVersion implements LongEntryVersion {
 
    private final long version;
 

--- a/core/src/main/java/org/infinispan/container/versioning/SimpleClusteredVersion.java
+++ b/core/src/main/java/org/infinispan/container/versioning/SimpleClusteredVersion.java
@@ -18,7 +18,7 @@ import net.jcip.annotations.Immutable;
  * @since 5.1
  */
 @Immutable
-public class SimpleClusteredVersion implements IncrementableEntryVersion {
+public class SimpleClusteredVersion implements LongEntryVersion {
    /**
     * The cache topology id in which it was first created.
     */

--- a/server/rest/src/main/java/org/infinispan/rest/NettyRestResponse.java
+++ b/server/rest/src/main/java/org/infinispan/rest/NettyRestResponse.java
@@ -104,7 +104,7 @@ public class NettyRestResponse implements RestResponse {
 
       @Override
       public Builder eTag(String tag) {
-         response.headers().set(HttpHeaderNames.ETAG, tag);
+         if (tag != null) response.headers().set(HttpHeaderNames.ETAG, tag);
          return this;
       }
 

--- a/server/rest/src/main/java/org/infinispan/rest/operations/CacheOperationsHelper.java
+++ b/server/rest/src/main/java/org/infinispan/rest/operations/CacheOperationsHelper.java
@@ -11,6 +11,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.container.entries.InternalCacheEntry;
+import org.infinispan.container.versioning.NumericVersion;
 import org.infinispan.metadata.EmbeddedMetadata;
 import org.infinispan.metadata.Metadata;
 import org.infinispan.rest.CacheControl;
@@ -22,7 +23,7 @@ public class CacheOperationsHelper {
    private CacheOperationsHelper() {
    }
 
-   public static Metadata createMetadata(Configuration cfg, Long ttl, Long idleTime) {
+   public static Metadata createMetadata(long version, Configuration cfg, Long ttl, Long idleTime) {
       EmbeddedMetadata.Builder metadata = new EmbeddedMetadata.Builder();
 
       if (ttl != null) {
@@ -36,7 +37,7 @@ public class CacheOperationsHelper {
       } else {
          metadata.lifespan(cfg.expiration().lifespan(), TimeUnit.MILLISECONDS);
       }
-
+      metadata.version(new NumericVersion(version));
       if (idleTime != null) {
          if (idleTime < 0) {
             metadata.maxIdle(-1);


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-9756

This is just a preview to see the effects on the performance. I'm afraid the VersionGenerators available are not sufficient to be used as Etags, since they are  based on transient attributes such as memory only atomic integers, view Ids, etc. Once the server is restarted, it is possible that a change in an entry will not result in different version for the entry.

Ideally we should use something that uses time as part of the calculation and needs no coordination cluster wide, such as https://blog.twitter.com/engineering/en_us/a/2010/announcing-snowflake.html