### PR TITLE
ISPN-9778 XidImpl implementations can optimize some byte[] allocations

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/RecoveryOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/RecoveryOperation.java
@@ -51,9 +51,8 @@ public class RecoveryOperation extends RetryOnFailureOperation<Collection<Xid>> 
       for (int i = 0; i < size; ++i) {
          int formatId = SignedNumeric.decode(ByteBufUtil.readVInt(buf));
          byte[] globalId = ByteBufUtil.readArray(buf);
-         byte[] branchId = ByteBufUtil.readArray(buf);
          //the Xid class does't matter since it only compares the format-id, global-id and branch-id
-         xids.add(RemoteXid.create(formatId, globalId, branchId));
+         xids.add(RemoteXid.create(formatId, globalId));
       }
       complete(xids);
    }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/transaction/manager/RemoteXid.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/transaction/manager/RemoteXid.java
@@ -24,18 +24,16 @@ public final class RemoteXid extends XidImpl {
    //HRTX in hex
    private static final int FORMAT_ID = 0x48525458;
    private static final AtomicLong GLOBAL_ID_GENERATOR = new AtomicLong(1);
-   private static final AtomicLong BRANCH_QUALIFIER_GENERATOR = new AtomicLong(1);
 
-   private RemoteXid(int formatId, byte[] globalTransactionId, byte[] branchQualifier) {
-      super(formatId, globalTransactionId, branchQualifier);
+   private RemoteXid(int formatId, byte[] globalTransactionId) {
+      super(formatId, globalTransactionId);
    }
 
 
    public static RemoteXid create(UUID tmId) {
       long creationTime = System.currentTimeMillis();
       byte[] gid = create(tmId, creationTime, GLOBAL_ID_GENERATOR);
-      byte[] bid = create(tmId, creationTime, BRANCH_QUALIFIER_GENERATOR);
-      return new RemoteXid(FORMAT_ID, gid, bid);
+      return new RemoteXid(FORMAT_ID, gid);
    }
 
    private static void longToBytes(long val, byte[] array, int offset) {
@@ -57,12 +55,10 @@ public final class RemoteXid extends XidImpl {
 
    public void writeTo(ByteBuf byteBuf) {
       writeSignedVInt(byteBuf, FORMAT_ID);
-      byte[] rawData = rawData();
-      writeArray(byteBuf, rawData, globalIdOffset(), globalIdLength());
-      writeArray(byteBuf, rawData, branchQualifierOffset(), branchQualifierLength());
+      writeArray(byteBuf, rawData());
    }
 
    public int estimateSize() {
-      return estimateVIntSize(FORMAT_ID) + globalIdLength() + branchQualifierLength();
+      return estimateVIntSize(FORMAT_ID) + rawData().length;
    }
 }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/tx/RecoveryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/tx/RecoveryTest.java
@@ -237,7 +237,7 @@ public class RecoveryTest extends MultiHotRodServersTest {
    private static class DummyXid extends XidImpl {
 
       DummyXid(byte id) {
-         super(-1234, new byte[]{id}, new byte[]{id});
+         super(-1234, new byte[]{id});
       }
    }
 

--- a/commons/src/test/java/org/infinispan/commons/tx/XidUnitTest.java
+++ b/commons/src/test/java/org/infinispan/commons/tx/XidUnitTest.java
@@ -30,7 +30,7 @@ public class XidUnitTest {
       long seed = System.currentTimeMillis();
       log.infof("[testInvalidGlobalTransaction] seed: %s", seed);
       Random random = new Random(seed);
-      Xid xid = XidImpl.create(random.nextInt(), Util.EMPTY_BYTE_ARRAY, new byte[]{0});
+      Xid xid = XidImpl.create(random.nextInt(), Util.EMPTY_BYTE_ARRAY);
       log.debugf("Invalid XID: %s", xid);
    }
 
@@ -41,27 +41,7 @@ public class XidUnitTest {
       Random random = new Random(seed);
       byte[] globalTx = new byte[65]; //max is 64
       random.nextBytes(globalTx);
-      Xid xid = XidImpl.create(random.nextInt(), globalTx, new byte[]{0});
-      log.debugf("Invalid XID: %s", xid);
-   }
-
-   @Test(expected = IllegalArgumentException.class)
-   public void testInvalidBranch() {
-      long seed = System.currentTimeMillis();
-      log.infof("[testInvalidBranch] seed: %s", seed);
-      Random random = new Random(seed);
-      Xid xid = XidImpl.create(random.nextInt(), new byte[]{0}, Util.EMPTY_BYTE_ARRAY);
-      log.debugf("Invalid XID: %s", xid);
-   }
-
-   @Test(expected = IllegalArgumentException.class)
-   public void testInvalidBranch2() {
-      long seed = System.currentTimeMillis();
-      log.infof("[testInvalidBranch2] seed: %s", seed);
-      Random random = new Random(seed);
-      byte[] branch = new byte[65]; //max is 64
-      random.nextBytes(branch);
-      Xid xid = XidImpl.create(random.nextInt(), new byte[]{0}, branch);
+      Xid xid = XidImpl.create(random.nextInt(), globalTx);
       log.debugf("Invalid XID: %s", xid);
    }
 
@@ -73,17 +53,14 @@ public class XidUnitTest {
 
       int formatId = random.nextInt();
       byte[] tx = new byte[random.nextInt(64) + 1];
-      byte[] branch = new byte[random.nextInt(64) + 1];
       random.nextBytes(tx);
-      random.nextBytes(branch);
-      Xid xid = XidImpl.create(formatId, tx, branch);
+      Xid xid = XidImpl.create(formatId, tx);
       log.debugf("XID: %s", xid);
 
       Assert.assertEquals(formatId, xid.getFormatId());
       Assert.assertArrayEquals(tx, xid.getGlobalTransactionId());
-      Assert.assertArrayEquals(branch, xid.getBranchQualifier());
 
-      Xid sameXid = XidImpl.create(formatId, tx, branch);
+      Xid sameXid = XidImpl.create(formatId, tx);
       log.debugf("same XID: %s", sameXid);
       Assert.assertEquals(xid, sameXid);
    }
@@ -96,17 +73,14 @@ public class XidUnitTest {
       int formatId = random.nextInt();
 
       byte[] tx = new byte[Xid.MAXGTRIDSIZE];
-      byte[] branch = new byte[Xid.MAXBQUALSIZE];
       random.nextBytes(tx);
-      random.nextBytes(branch);
-      Xid xid = XidImpl.create(formatId, tx, branch);
+      Xid xid = XidImpl.create(formatId, tx);
 
       log.debugf("XID: %s", xid);
       Assert.assertEquals(formatId, xid.getFormatId());
       Assert.assertArrayEquals(tx, xid.getGlobalTransactionId());
-      Assert.assertArrayEquals(branch, xid.getBranchQualifier());
 
-      Xid sameXid = XidImpl.create(formatId, tx, branch);
+      Xid sameXid = XidImpl.create(formatId, tx);
       log.debugf("same XID: %s", sameXid);
       Assert.assertEquals(xid, sameXid);
    }
@@ -119,10 +93,8 @@ public class XidUnitTest {
 
       int formatId = random.nextInt();
       byte[] tx = new byte[random.nextInt(64) + 1];
-      byte[] branch = new byte[random.nextInt(64) + 1];
       random.nextBytes(tx);
-      random.nextBytes(branch);
-      XidImpl xid = XidImpl.create(formatId, tx, branch);
+      XidImpl xid = XidImpl.create(formatId, tx);
 
       log.debugf("XID: %s", xid);
 
@@ -155,10 +127,8 @@ public class XidUnitTest {
 
       int formatId = random.nextInt();
       byte[] tx = new byte[Xid.MAXGTRIDSIZE];
-      byte[] branch = new byte[Xid.MAXBQUALSIZE];
       random.nextBytes(tx);
-      random.nextBytes(branch);
-      XidImpl xid = XidImpl.create(formatId, tx, branch);
+      XidImpl xid = XidImpl.create(formatId, tx);
 
       log.debugf("XID: %s", xid);
 

--- a/core/src/main/java/org/infinispan/transaction/tm/EmbeddedXid.java
+++ b/core/src/main/java/org/infinispan/transaction/tm/EmbeddedXid.java
@@ -22,11 +22,9 @@ public final class EmbeddedXid extends XidImpl {
    //I would like ot use 0x4953504E (ISPN in hex) for the format, but keep it to 1 to be consistent with DummyXid.
    private static final int FORMAT = 1;
    private static final AtomicLong GLOBAL_ID_GENERATOR = new AtomicLong(1);
-   private static final AtomicLong BRANCH_QUALIFIER_GENERATOR = new AtomicLong(1);
 
    public EmbeddedXid(UUID transactionManagerId) {
-      super(FORMAT, create(transactionManagerId, GLOBAL_ID_GENERATOR),
-            create(transactionManagerId, BRANCH_QUALIFIER_GENERATOR));
+      super(FORMAT, create(transactionManagerId, GLOBAL_ID_GENERATOR));
 
    }
 

--- a/core/src/main/java/org/infinispan/transaction/xa/recovery/RecoveryAdminOperations.java
+++ b/core/src/main/java/org/infinispan/transaction/xa/recovery/RecoveryAdminOperations.java
@@ -69,9 +69,8 @@ public class RecoveryAdminOperations {
    @ManagedOperation(description = "Forces the commit of an in-doubt transaction", displayName="Force commit by Xid", name="forceCommit")
    public String forceCommit(
          @Parameter(name = "formatId", description = "The formatId of the transaction") int formatId,
-         @Parameter(name = "globalTxId", description = "The globalTxId of the transaction") byte[] globalTxId,
-         @Parameter(name = "branchQualifier", description = "The branchQualifier of the transaction") byte[] branchQualifier) {
-      return completeBasedOnXid(formatId, globalTxId, branchQualifier, true);
+         @Parameter(name = "globalTxId", description = "The globalTxId of the transaction") byte[] globalTxId) {
+      return completeBasedOnXid(formatId, globalTxId, true);
    }
 
    @ManagedOperation(description = "Forces the rollback of an in-doubt transaction", displayName="Force rollback by internal id")
@@ -82,17 +81,15 @@ public class RecoveryAdminOperations {
    @ManagedOperation(description = "Forces the rollback of an in-doubt transaction", displayName="Force rollback by Xid", name="forceRollback")
    public String forceRollback(
          @Parameter(name = "formatId", description = "The formatId of the transaction") int formatId,
-         @Parameter(name = "globalTxId", description = "The globalTxId of the transaction") byte[] globalTxId,
-         @Parameter(name = "branchQualifier", description = "The branchQualifier of the transaction") byte[] branchQualifier) {
-      return completeBasedOnXid(formatId, globalTxId, branchQualifier, false);
+         @Parameter(name = "globalTxId", description = "The globalTxId of the transaction") byte[] globalTxId) {
+      return completeBasedOnXid(formatId, globalTxId, false);
    }
 
    @ManagedOperation(description = "Removes recovery info for the given transaction.", displayName="Remove recovery info by Xid", name="forget")
    public String forget(
          @Parameter(name = "formatId", description = "The formatId of the transaction") int formatId,
-         @Parameter(name = "globalTxId", description = "The globalTxId of the transaction") byte[] globalTxId,
-         @Parameter(name = "branchQualifier", description = "The branchQualifier of the transaction") byte[] branchQualifier) {
-      recoveryManager.removeRecoveryInformation(null, XidImpl.create(formatId, globalTxId, branchQualifier), true, null, false);
+         @Parameter(name = "globalTxId", description = "The globalTxId of the transaction") byte[] globalTxId) {
+      recoveryManager.removeRecoveryInformation(null, XidImpl.create(formatId, globalTxId), true, null, false);
       return "Recovery info removed.";
    }
 
@@ -103,12 +100,12 @@ public class RecoveryAdminOperations {
    }
 
 
-   private String completeBasedOnXid(int formatId, byte[] globalTxId, byte[] branchQualifier, boolean commit) {
-      RecoveryManager.InDoubtTxInfo inDoubtTxInfo = lookupRecoveryInfo(formatId, globalTxId, branchQualifier);
+   private String completeBasedOnXid(int formatId, byte[] globalTxId, boolean commit) {
+      RecoveryManager.InDoubtTxInfo inDoubtTxInfo = lookupRecoveryInfo(formatId, globalTxId);
       if (inDoubtTxInfo != null) {
          return completeTransaction(inDoubtTxInfo.getXid(), inDoubtTxInfo, commit);
       } else {
-         return transactionNotFound(formatId, globalTxId, branchQualifier);
+         return transactionNotFound(formatId, globalTxId);
       }
    }
 
@@ -134,9 +131,9 @@ public class RecoveryAdminOperations {
       }
    }
 
-   private  RecoveryManager.InDoubtTxInfo lookupRecoveryInfo(int formatId, byte[] globalTxId, byte[] branchQualifier) {
+   private  RecoveryManager.InDoubtTxInfo lookupRecoveryInfo(int formatId, byte[] globalTxId) {
       Set<RecoveryManager.InDoubtTxInfo> info = getRecoveryInfoFromCluster();
-      Xid xid = XidImpl.create(formatId, globalTxId, branchQualifier);
+      Xid xid = XidImpl.create(formatId, globalTxId);
       for (RecoveryManager.InDoubtTxInfo i : info) {
          if (i.getXid().equals(xid)) {
             log.tracef("Found matching recovery info: %s", i);
@@ -163,8 +160,8 @@ public class RecoveryAdminOperations {
       return null;
    }
 
-   private String transactionNotFound(int formatId, byte[] globalTxId, byte[] branchQualifier) {
-      return "Transaction not found: " + XidImpl.printXid(formatId, globalTxId, branchQualifier);
+   private String transactionNotFound(int formatId, byte[] globalTxId) {
+      return "Transaction not found: " + XidImpl.printXid(formatId, globalTxId);
    }
 
    private String transactionNotFound(Long internalId) {

--- a/core/src/test/java/org/infinispan/tx/recovery/admin/ForgetTest.java
+++ b/core/src/test/java/org/infinispan/tx/recovery/admin/ForgetTest.java
@@ -57,7 +57,7 @@ public class ForgetTest extends AbstractRecoveryTest {
 
    public void testInternalIdOnSameNode() throws Exception {
       Xid xid = tx.getXid();
-      recoveryOps(0).forget(xid.getFormatId(), xid.getGlobalTransactionId(), xid.getBranchQualifier());
+      recoveryOps(0).forget(xid.getFormatId(), xid.getGlobalTransactionId());
       assertEquals(tt(1).getRemoteTxCount(), 0);//make sure tx has been removed
    }
 
@@ -95,7 +95,7 @@ public class ForgetTest extends AbstractRecoveryTest {
 
    private void forgetWithXid(int nodeIndex) {
       Xid xid = tx.getXid();
-      recoveryOps(nodeIndex).forget(xid.getFormatId(), xid.getGlobalTransactionId(), xid.getBranchQualifier());
+      recoveryOps(nodeIndex).forget(xid.getFormatId(), xid.getGlobalTransactionId());
       assertEquals(tt(1).getRemoteTxCount(), 0);//make sure tx has been removed
    }
 }

--- a/core/src/test/java/org/infinispan/tx/recovery/admin/SimpleCacheRecoveryAdminTest.java
+++ b/core/src/test/java/org/infinispan/tx/recovery/admin/SimpleCacheRecoveryAdminTest.java
@@ -176,8 +176,8 @@ public class SimpleCacheRecoveryAdminTest extends AbstractRecoveryTest {
    private String invokeForceWithXid(String methodName, int cacheIndex, Xid xid) {
       try {
          ObjectName recoveryAdmin = getRecoveryAdminObjectName(cacheIndex);
-         Object[] params = {xid.getFormatId(), xid.getGlobalTransactionId(), xid.getBranchQualifier()};
-         String[] signature = {int.class.getName(), byte[].class.getName(), byte[].class.getName()};
+         Object[] params = {xid.getFormatId(), xid.getGlobalTransactionId()};
+         String[] signature = {int.class.getName(), byte[].class.getName()};
          return threadMBeanServer.invoke(recoveryAdmin, methodName, params, signature).toString();
       } catch (Exception e) {
          throw new RuntimeException(e);

--- a/server/hotrod/src/main/resources/hotrod.gr
+++ b/server/hotrod/src/main/resources/hotrod.gr
@@ -221,17 +221,12 @@ chunkedValue returns ByteBuf
    : { chunkedValue = cacheProcessor.channel().alloc().buffer(); chunkLength = 1; } #chunkLength chunk
    ;
 
-xid returns XidImpl: xidFormat xidLength transactionId branchLength branchId { XidImpl.create(xidFormat, transactionId, branchId) };
+xid returns XidImpl: xidFormat xidLength transactionId { XidImpl.create(xidFormat, transactionId) };
 xidFormat: signedVInt;
 xidLength: byte;
 // in case xidLength == 0 we would get into loop as we couldn't progress reading 0 bytes from buffer
 transactionId returns byte[]
    :  { xidLength > 0 }? fixedArray[xidLength]
-   |  { org.infinispan.commons.util.Util.EMPTY_BYTE_ARRAY }
-   ;
-branchLength: byte;
-branchId returns byte[]
-   :  { branchLength > 0 }? fixedArray[branchLength]
    |  { org.infinispan.commons.util.Util.EMPTY_BYTE_ARRAY }
    ;
 

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/counter/response/RecoveryTestResponse.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/counter/response/RecoveryTestResponse.java
@@ -44,8 +44,7 @@ public class RecoveryTestResponse extends TestResponse {
       for (int i = 0; i < size; ++i) {
          int formatId = SignedNumeric.decode(VInt.read(buffer));
          byte[] globalId = readRangedBytes(buffer);
-         byte[] branchId = readRangedBytes(buffer);
-         xids.add(XidImpl.create(formatId, globalId, branchId));
+         xids.add(XidImpl.create(formatId, globalId));
       }
       return xids;
    }

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/test/RemoteTransaction.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/test/RemoteTransaction.java
@@ -36,7 +36,7 @@ public class RemoteTransaction {
    private RemoteTransaction(HotRodClient client) {
       this.client = client;
       byte[] gtxAndBrandId = intToBytes(ID_GENERATOR.incrementAndGet());
-      xid = XidImpl.create(FORMAT, gtxAndBrandId, gtxAndBrandId);
+      xid = XidImpl.create(FORMAT, gtxAndBrandId);
       txContext = new ConcurrentHashMap<>();
    }
 

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/tx/ServerConfigurationTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/tx/ServerConfigurationTest.java
@@ -125,7 +125,7 @@ public class ServerConfigurationTest extends HotRodMultiNodeTest {
       cacheManagers.forEach(cm -> cm.defineConfiguration(cacheName, builder.build()));
       waitForClusterToForm(cacheName);
       HotRodClient client = createClient(cacheName);
-      XidImpl xid = XidImpl.create(-1, new byte[]{2}, new byte[]{3});
+      XidImpl xid = XidImpl.create(-1, new byte[]{2});
       try {
          TestErrorResponse response = (TestErrorResponse) client.prepareTx(xid, false, Collections.emptyList());
          assertEquals(errorMsg, response.msg);
@@ -143,7 +143,7 @@ public class ServerConfigurationTest extends HotRodMultiNodeTest {
       cacheManagers.forEach(cm -> cm.defineConfiguration(cacheName, builder.build()));
       waitForClusterToForm(cacheName);
       HotRodClient client = createClient(cacheName);
-      XidImpl xid = XidImpl.create(-1, new byte[]{2}, new byte[]{3});
+      XidImpl xid = XidImpl.create(-1, new byte[]{2});
       try {
          TxResponse response = (TxResponse) client.prepareTx(xid, false, Collections.emptyList());
          assertEquals(XAResource.XA_RDONLY, response.xaCode);

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/tx/TxReaperAndRecoveryTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/tx/TxReaperAndRecoveryTest.java
@@ -446,7 +446,7 @@ public class TxReaperAndRecoveryTest extends HotRodMultiNodeTest {
    private static class DummyXid extends XidImpl {
 
       DummyXid(int id) {
-         super(-123456, new byte[]{(byte) id}, new byte[]{(byte) id});
+         super(-123456, new byte[]{(byte) id});
       }
    }
 


### PR DESCRIPTION
* Remove unneeded additional branch id
* Reuse byte[] in constructor for XidImpl

https://issues.jboss.org/browse/ISPN-9778