### PR TITLE
[9.4.x] ISPN-9605 Prevent cache configuration that has L1 and exception based

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/cache/L1ConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/L1ConfigurationBuilder.java
@@ -10,6 +10,7 @@ import java.util.concurrent.TimeUnit;
 import org.infinispan.commons.configuration.Builder;
 import org.infinispan.commons.configuration.attributes.AttributeSet;
 import org.infinispan.configuration.global.GlobalConfiguration;
+import org.infinispan.eviction.EvictionStrategy;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 /**
@@ -102,6 +103,10 @@ public class L1ConfigurationBuilder extends AbstractClusteringConfigurationChild
          if (attributes.attribute(LIFESPAN).get() < 1)
             throw log.l1InvalidLifespan();
 
+         MemoryConfigurationBuilder memoryConfigurationBuilder = getClusteringBuilder().memory();
+         if (memoryConfigurationBuilder.evictionStrategy() == EvictionStrategy.EXCEPTION) {
+            throw log.l1NotValidWithExpirationEviction();
+         }
       }
    }
 

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -1233,6 +1233,9 @@ public interface Log extends BasicLogger {
    @Message(value = "Using a L1 lifespan of 0 or a negative value is meaningless", id = 351)
    CacheConfigurationException l1InvalidLifespan();
 
+   @Message(value = "Enabling the L1 cache is not supported when using EXCEPTION based eviction.", id = 352)
+   CacheConfigurationException l1NotValidWithExpirationEviction();
+
    @Message(value = "Cannot define both interceptor class (%s) and interceptor instance (%s)", id = 354)
    CacheConfigurationException interceptorClassAndInstanceDefined(String customInterceptorClassName, String customInterceptor);
 

--- a/core/src/test/java/org/infinispan/configuration/cache/L1ConfigurationBuilderTest.java
+++ b/core/src/test/java/org/infinispan/configuration/cache/L1ConfigurationBuilderTest.java
@@ -1,10 +1,14 @@
 package org.infinispan.configuration.cache;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 import java.util.concurrent.TimeUnit;
 
+import org.infinispan.commons.CacheConfigurationException;
+import org.infinispan.eviction.EvictionStrategy;
+import org.infinispan.transaction.*;
 import org.testng.annotations.Test;
 
 /**
@@ -24,5 +28,20 @@ public class L1ConfigurationBuilderTest {
       assertEquals(l1Config.cleanupTaskFrequency(), TimeUnit.MINUTES.toMillis(1));
       assertEquals(l1Config.invalidationThreshold(), 0);
       assertEquals(l1Config.lifespan(), TimeUnit.MINUTES.toMillis(10));
+   }
+
+   @Test(expectedExceptions = CacheConfigurationException.class)
+   public void testL1WithExceptionEviction() {
+      Configuration config = new ConfigurationBuilder()
+            .clustering()
+               .cacheMode(CacheMode.DIST_SYNC)
+               .l1().enable()
+            .memory()
+               .evictionStrategy(EvictionStrategy.EXCEPTION)
+               .size(10)
+            .transaction()
+               .transactionMode(org.infinispan.transaction.TransactionMode.TRANSACTIONAL)
+            .build();
+      assertNotNull(config);
    }
 }


### PR DESCRIPTION
eviction

https://issues.jboss.org/browse/ISPN-9297