### PR TITLE
ISPN-9727 Ickle query ignores an IN clause if there is only one value

### DIFF
--- a/object-filter/src/main/java/org/infinispan/objectfilter/impl/syntax/parser/ExpressionBuilder.java
+++ b/object-filter/src/main/java/org/infinispan/objectfilter/impl/syntax/parser/ExpressionBuilder.java
@@ -90,7 +90,12 @@ final class ExpressionBuilder<TypeMetadata> {
          ComparisonExpr booleanExpr = new ComparisonExpr(valueExpr, new ConstantValueExpr(typedValue), ComparisonExpr.Type.EQUAL);
          children.add(booleanExpr);
       }
-      push(new OrExpr(children));
+      if (children.size() == 1) {
+         // simplify INs with just one clause by removing the wrapper boolean expression
+         push(children.get(0));
+      } else {
+         push(new OrExpr(children));
+      }
    }
 
    public void addLike(PropertyPath<?> propertyPath, Object patternValue, Character escapeCharacter) {

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/QueryDslConditionsTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/QueryDslConditionsTest.java
@@ -3068,4 +3068,20 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       List<User> list = qb.build().list();
       assertEquals(0, list.size());
    }
+
+   public void testSingleIN() {
+      QueryFactory qf = getQueryFactory();
+
+      Query q = qf.from(getModelFactory().getUserImplClass())
+            .having("surname").in("Man")
+            .and()
+            .having("gender").eq(User.Gender.MALE)
+            .build();
+
+      List<User> list = q.list();
+      assertEquals(1, list.size());
+      assertEquals(2, list.get(0).getId());
+      assertEquals("Man", list.get(0).getSurname());
+      assertEquals(User.Gender.MALE, list.get(0).getGender());
+   }
 }


### PR DESCRIPTION
* The boolean OR query around the single value has this side effect; this can be fixed
  by transforming an IN predicate with a single value into a simple equals right after parsing

https://issues.jboss.org/browse/ISPN-9727