### PR TITLE
ISPN-9798 Availability deadlock fixes

### DIFF
--- a/core/src/main/java/org/infinispan/persistence/manager/PersistenceManagerImpl.java
+++ b/core/src/main/java/org/infinispan/persistence/manager/PersistenceManagerImpl.java
@@ -27,7 +27,9 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -132,6 +134,7 @@ public class PersistenceManagerImpl implements PersistenceManager {
    private final List<TransactionalCacheWriter> txWriters = new ArrayList<>();
    private final Semaphore publisherSemaphore = new Semaphore(Integer.MAX_VALUE);
    private final ReadWriteLock storesMutex = new ReentrantReadWriteLock();
+   private final Lock availabilityMutex = new ReentrantLock();
    @GuardedBy("storesMutex")
    private final Map<Object, StoreStatus> storeStatuses = new HashMap<>();
    private AdvancedPurgeListener<Object, Object> advancedListener;
@@ -185,25 +188,32 @@ public class PersistenceManagerImpl implements PersistenceManager {
    }
 
    protected void pollStoreAvailability() {
-      storesMutex.writeLock().lock();
+      storesMutex.readLock().lock();
       try {
-         boolean availabilityChanged = false;
-         boolean failureDetected = false;
-         for (StoreStatus status : storeStatuses.values()) {
-            if (status.availabilityChanged())
-               availabilityChanged = true;
-            if (availabilityChanged && !status.availability && !failureDetected) {
-               failureDetected = true;
-               unavailableException = new StoreUnavailableException(String.format("Store %s is unavailable", status.store));
-               cacheNotifier.notifyPersistenceAvailabilityChanged(false);
+         // If the lock is not available, then it means that an availability check is in progress due to scheduled calls overlapping
+         if (availabilityMutex.tryLock()) {
+            try {
+               boolean availabilityChanged = false;
+               boolean failureDetected = false;
+               for (StoreStatus status : storeStatuses.values()) {
+                  if (status.availabilityChanged())
+                     availabilityChanged = true;
+                  if (availabilityChanged && !status.availability && !failureDetected) {
+                     failureDetected = true;
+                     unavailableException = new StoreUnavailableException(String.format("Store %s is unavailable", status.store));
+                     cacheNotifier.notifyPersistenceAvailabilityChanged(false);
+                  }
+               }
+               if (!failureDetected && availabilityChanged) {
+                  unavailableException = null;
+                  cacheNotifier.notifyPersistenceAvailabilityChanged(true);
+               }
+            } finally {
+               availabilityMutex.unlock();
             }
          }
-         if (!failureDetected && availabilityChanged) {
-            unavailableException = null;
-            cacheNotifier.notifyPersistenceAvailabilityChanged(true);
-         }
       } finally {
-         storesMutex.writeLock().unlock();
+         storesMutex.readLock().unlock();
       }
    }
 

--- a/core/src/main/java/org/infinispan/persistence/manager/PersistenceManagerImpl.java
+++ b/core/src/main/java/org/infinispan/persistence/manager/PersistenceManagerImpl.java
@@ -175,7 +175,8 @@ public class PersistenceManagerImpl implements PersistenceManager {
 
             // Now schedule the availability check
             long interval = configuration.persistence().availabilityInterval();
-            availabilityFuture = persistenceExecutor.scheduleAtFixedRate(this::pollStoreAvailability, interval, interval, TimeUnit.MILLISECONDS);
+            if (interval > 0)
+               availabilityFuture = persistenceExecutor.scheduleAtFixedRate(this::pollStoreAvailability, interval, interval, TimeUnit.MILLISECONDS);
          } finally {
             if (xaTx != null) {
                transactionManager.resume(xaTx);
@@ -356,7 +357,9 @@ public class PersistenceManagerImpl implements PersistenceManager {
          }
 
          if (noMoreStores) {
-            availabilityFuture.cancel(true);
+            if (availabilityFuture != null)
+               availabilityFuture.cancel(true);
+
             AsyncInterceptorChain chain = cache.wired().getAsyncInterceptorChain();
             AsyncInterceptor loaderInterceptor = chain.findInterceptorExtending(CacheLoaderInterceptor.class);
             if (loaderInterceptor == null) {

--- a/core/src/main/java/org/infinispan/persistence/manager/PersistenceManagerImpl.java
+++ b/core/src/main/java/org/infinispan/persistence/manager/PersistenceManagerImpl.java
@@ -27,9 +27,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -134,7 +132,6 @@ public class PersistenceManagerImpl implements PersistenceManager {
    private final List<TransactionalCacheWriter> txWriters = new ArrayList<>();
    private final Semaphore publisherSemaphore = new Semaphore(Integer.MAX_VALUE);
    private final ReadWriteLock storesMutex = new ReentrantReadWriteLock();
-   private final Lock availabilityMutex = new ReentrantLock();
    @GuardedBy("storesMutex")
    private final Map<Object, StoreStatus> storeStatuses = new HashMap<>();
    private AdvancedPurgeListener<Object, Object> advancedListener;
@@ -191,27 +188,20 @@ public class PersistenceManagerImpl implements PersistenceManager {
    protected void pollStoreAvailability() {
       storesMutex.readLock().lock();
       try {
-         // If the lock is not available, then it means that an availability check is in progress due to scheduled calls overlapping
-         if (availabilityMutex.tryLock()) {
-            try {
-               boolean availabilityChanged = false;
-               boolean failureDetected = false;
-               for (StoreStatus status : storeStatuses.values()) {
-                  if (status.availabilityChanged())
-                     availabilityChanged = true;
-                  if (availabilityChanged && !status.availability && !failureDetected) {
-                     failureDetected = true;
-                     unavailableException = new StoreUnavailableException(String.format("Store %s is unavailable", status.store));
-                     cacheNotifier.notifyPersistenceAvailabilityChanged(false);
-                  }
-               }
-               if (!failureDetected && availabilityChanged) {
-                  unavailableException = null;
-                  cacheNotifier.notifyPersistenceAvailabilityChanged(true);
-               }
-            } finally {
-               availabilityMutex.unlock();
+         boolean availabilityChanged = false;
+         boolean failureDetected = false;
+         for (StoreStatus status : storeStatuses.values()) {
+            if (status.availabilityChanged())
+               availabilityChanged = true;
+            if (availabilityChanged && !status.availability && !failureDetected) {
+               failureDetected = true;
+               unavailableException = new StoreUnavailableException(String.format("Store %s is unavailable", status.store));
+               cacheNotifier.notifyPersistenceAvailabilityChanged(false);
             }
+         }
+         if (!failureDetected && availabilityChanged) {
+            unavailableException = null;
+            cacheNotifier.notifyPersistenceAvailabilityChanged(true);
          }
       } finally {
          storesMutex.readLock().unlock();
@@ -1248,14 +1238,14 @@ public class PersistenceManagerImpl implements PersistenceManager {
    class StoreStatus {
       final Object store;
       final StoreConfiguration config;
-      volatile boolean availability = true;
+      boolean availability = true;
 
       StoreStatus(Object store, StoreConfiguration config) {
          this.store = store;
          this.config = config;
       }
 
-      boolean availabilityChanged() {
+      synchronized boolean availabilityChanged() {
          boolean oldAvailability = availability;
          try {
             if (store instanceof CacheWriter)


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-9798
https://issues.jboss.org/browse/ISPN-9800

As `checkStoreAvailability()` always utilises the volatile `unavailableException` to determine whether the PersistenceManager is available, we don't need to use the writeLock as the `storeStatuses` map is never updated, only the `StoreStatus` itself. ~~However, we do need to introduce a lock to prevent scheduled calls to `pollStoreAvailability` overlapping.~~