### PR TITLE
ISPN-9807 SingleClusterExecutorTest.testExecutorTriConsumerTimeoutException

### DIFF
--- a/core/src/test/java/org/infinispan/manager/AllClusterExecutorTest.java
+++ b/core/src/test/java/org/infinispan/manager/AllClusterExecutorTest.java
@@ -386,7 +386,7 @@ public class AllClusterExecutorTest extends AbstractInfinispanTest {
          public void call() throws InterruptedException, ExecutionException, TimeoutException {
             EmbeddedCacheManager cm1 = cms[0];
 
-            ScheduledExecutorService stpe = Mockito.mock(ScheduledExecutorService.class);
+            ScheduledExecutorService stpe = Mockito.mock(ScheduledExecutorService.class, Mockito.RETURNS_DEEP_STUBS);
 
             for (EmbeddedCacheManager cm : cms) {
                TestingUtil.replaceComponent(cm, ScheduledExecutorService.class,


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-9807

I think this one doesn't need a separate PR for 9.4.x ;)