### PR TITLE
[9.4.x] ISPN-4075 State transfer should preserve the timestamps of entries

### DIFF
--- a/core/src/main/java/org/infinispan/commands/FlagAffectedCommand.java
+++ b/core/src/main/java/org/infinispan/commands/FlagAffectedCommand.java
@@ -98,4 +98,13 @@ public interface FlagAffectedCommand extends VisitableCommand {
    default boolean hasAnyFlag(long flagsBitSet) {
       return EnumUtil.containsAny(getFlagsBitSet(), flagsBitSet);
    }
+
+   /**
+    * Check whether all of the flags in the {@code flagsBitSet} parameter are present in the command.
+    *
+    * Should be used with the constants in {@link FlagBitSets}.
+    */
+   default boolean hasAllFlags(long flagBitSet) {
+      return EnumUtil.containsAll(getFlagsBitSet(), flagBitSet);
+   }
 }

--- a/core/src/main/java/org/infinispan/container/entries/ReadCommittedEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/ReadCommittedEntry.java
@@ -29,7 +29,7 @@ public class ReadCommittedEntry implements MVCCEntry {
 
    protected Object key;
    protected Object value;
-   protected long created, lastUsed;
+   protected long created = -1, lastUsed = -1;
    protected short flags = 0;
    protected Metadata metadata;
 
@@ -142,7 +142,7 @@ public class ReadCommittedEntry implements MVCCEntry {
          } else if (isRemoved()) {
             container.remove(segment, key);
          } else if (value != null) {
-            container.put(segment, key, value, metadata);
+            container.put(segment, key, value, metadata, created, lastUsed);
          }
       }
    }

--- a/core/src/main/java/org/infinispan/container/impl/AbstractDelegatingInternalDataContainer.java
+++ b/core/src/main/java/org/infinispan/container/impl/AbstractDelegatingInternalDataContainer.java
@@ -28,8 +28,8 @@ public abstract class AbstractDelegatingInternalDataContainer<K, V> extends Abst
    }
 
    @Override
-   public void put(int segment, K k, V v, Metadata metadata) {
-      delegate().put(segment, k, v, metadata);
+   public void put(int segment, K k, V v, Metadata metadata, long createdTimestamp, long lastUseTimestamp) {
+      delegate().put(segment, k, v, metadata, createdTimestamp, lastUseTimestamp);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/container/impl/EntryFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/container/impl/EntryFactoryImpl.java
@@ -264,8 +264,8 @@ public class EntryFactoryImpl implements EntryFactory {
       }
 
       if (trace) log.tracef("Creating new entry for key %s", toStr(key));
+      MVCCEntry mvccEntry;
       if (useRepeatableRead) {
-         MVCCEntry mvccEntry;
          if (useVersioning) {
             if (metadata == null) {
                metadata = new EmbeddedMetadata.Builder().version(versionGenerator.nonExistingVersion()).build();
@@ -274,9 +274,13 @@ public class EntryFactoryImpl implements EntryFactory {
          } else {
             mvccEntry = new RepeatableReadEntry(key, value, metadata);
          }
-         return mvccEntry;
       } else {
-         return new ReadCommittedEntry(key, value, metadata);
+         mvccEntry = new ReadCommittedEntry(key, value, metadata);
       }
+      if (cacheEntry != null) {
+         mvccEntry.setCreated(cacheEntry.getCreated());
+         mvccEntry.setLastUsed(cacheEntry.getLastUsed());
+      }
+      return mvccEntry;
    }
 }

--- a/core/src/main/java/org/infinispan/container/impl/InternalDataContainer.java
+++ b/core/src/main/java/org/infinispan/container/impl/InternalDataContainer.java
@@ -47,12 +47,19 @@ public interface InternalDataContainer<K, V> extends DataContainer<K, V> {
    /**
     * Same as {@link DataContainer#put(Object, Object, Metadata)} except that the segment of the key can provided to
     * write/lookup entries without calculating the segment for the given key.
+    *
+    * <p>Note: The timestamps ignored if the entry already exists in the data container.</p>
+    *
     * @param segment segment for the key
     * @param k key under which to store entry
     * @param v value to store
     * @param metadata metadata of the entry
+    * @param createdTimestamp creation timestamp, or {@code -1} to use the current time
+    * @param lastUseTimestamp last use timestamp, or {@code -1} to use the current time
+    *
+    * @since 10.0
     */
-   void put(int segment, K k, V v, Metadata metadata);
+   void put(int segment, K k, V v, Metadata metadata, long createdTimestamp, long lastUseTimestamp);
 
    /**
     * Same as {@link DataContainer#containsKey(Object)}  except that the segment of the key can provided to

--- a/core/src/main/java/org/infinispan/container/impl/InternalDataContainerAdapter.java
+++ b/core/src/main/java/org/infinispan/container/impl/InternalDataContainerAdapter.java
@@ -55,7 +55,7 @@ public class InternalDataContainerAdapter<K, V> extends AbstractDelegatingDataCo
    }
 
    @Override
-   public void put(int segment, K k, V v, Metadata metadata) {
+   public void put(int segment, K k, V v, Metadata metadata, long createdTimestamp, long lastUseTimestamp) {
       put(k, v, metadata);
    }
 

--- a/core/src/main/java/org/infinispan/container/offheap/SegmentedBoundedOffHeapDataContainer.java
+++ b/core/src/main/java/org/infinispan/container/offheap/SegmentedBoundedOffHeapDataContainer.java
@@ -97,8 +97,8 @@ public class SegmentedBoundedOffHeapDataContainer extends AbstractDelegatingInte
    }
 
    @Override
-   public void put(int segment, WrappedBytes wrappedBytes, WrappedBytes wrappedBytes2, Metadata metadata) {
-      super.put(segment, wrappedBytes, wrappedBytes2, metadata);
+   public void put(int segment, WrappedBytes key, WrappedBytes value, Metadata metadata, long createdTimestamp, long lastUseTimestamp) {
+      super.put(segment, key, value, metadata, createdTimestamp, lastUseTimestamp);
       // The following is called outside of the write lock specifically - since we may not have to evict and even
       // if we did it would quite possibly need a different lock
       ensureSize();

--- a/core/src/main/java/org/infinispan/interceptors/distribution/ScatteredDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/ScatteredDistributionInterceptor.java
@@ -714,6 +714,8 @@ public class ScatteredDistributionInterceptor extends ClusteringInterceptor {
             Metadata entryMetadata = command.getMetadata() == null ? value.getMetadata()
                : command.getMetadata().builder().version(value.getMetadata().version()).build();
             cacheEntry.setMetadata(entryMetadata);
+            cacheEntry.setCreated(value.getCreated());
+            cacheEntry.setLastUsed(value.getLastUsed());
             valueMap.put(key, value.getValue());
          }
          command.setMap(valueMap);

--- a/core/src/main/java/org/infinispan/interceptors/impl/PrefetchInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/PrefetchInterceptor.java
@@ -282,7 +282,7 @@ public class PrefetchInterceptor<K, V> extends DDAsyncInterceptor {
       // from the main comman d correct.
       entryFactory.wrapExternalEntry(ctx, dataCommand.getKey(), maxValue.toInternalCacheEntry(dataCommand.getKey()), true, true);
       PutKeyValueCommand putKeyValueCommand = commandsFactory.buildPutKeyValueCommand(
-            dataCommand.getKey(), maxValue.getValue(), dataCommand.getSegment(), maxValue.getMetadata(), STATE_TRANSFER_FLAGS);
+            dataCommand.getKey(), maxValue.toInternalCacheEntry(dataCommand.getKey()), dataCommand.getSegment(), maxValue.getMetadata(), STATE_TRANSFER_FLAGS);
       putKeyValueCommand.setTopologyId(dataCommand.getTopologyId());
       return invokeNext(ctx, putKeyValueCommand);
    }

--- a/core/src/main/java/org/infinispan/scattered/impl/ScatteredStateConsumerImpl.java
+++ b/core/src/main/java/org/infinispan/scattered/impl/ScatteredStateConsumerImpl.java
@@ -508,7 +508,7 @@ public class ScatteredStateConsumerImpl extends StateConsumerImpl {
             // the GetAllCommand. We'll just avoid NPEs here: data is lost as > 1 nodes have left.
             continue;
          }
-         PutKeyValueCommand put = commandsFactory.buildPutKeyValueCommand(key, icv.getValue(),
+         PutKeyValueCommand put = commandsFactory.buildPutKeyValueCommand(key, icv.toInternalCacheEntry(key),
                keyPartitioner.getSegment(key), icv.getMetadata(), STATE_TRANSFER_FLAGS);
          try {
             interceptorChain.invoke(icf.createSingleKeyNonTxInvocationContext(), put);

--- a/core/src/main/java/org/infinispan/statetransfer/StateConsumerImpl.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateConsumerImpl.java
@@ -641,7 +641,8 @@ public class StateConsumerImpl implements StateConsumer {
                ctx = icf.createSingleKeyNonTxInvocationContext();
             }
 
-            PutKeyValueCommand put = commandsFactory.buildPutKeyValueCommand(e.getKey(), e.getValue(), segmentId,
+            // CallInterceptor knows PUT_FOR_STATE_TRANSFER values are actually InternalCacheEntries
+            PutKeyValueCommand put = commandsFactory.buildPutKeyValueCommand(e.getKey(), e, segmentId,
                   e.getMetadata(), STATE_TRANSFER_FLAGS);
             ctx.setLockOwner(put.getKeyLockOwner());
             interceptorChain.invoke(ctx, put);

--- a/core/src/test/java/org/infinispan/statetransfer/StateTransferTimestampsTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateTransferTimestampsTest.java
@@ -1,0 +1,81 @@
+package org.infinispan.statetransfer;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertNull;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNotNull;
+
+import org.infinispan.AdvancedCache;
+import org.infinispan.commons.time.TimeService;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.container.entries.CacheEntry;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.util.ControlledTimeService;
+import org.testng.annotations.Test;
+
+/**
+ * Tests concurrent startup of replicated and distributed caches
+ *
+ * @author Dan Berindei
+ * @since 10.0
+ */
+@Test(testName = "statetransfer.StateTransferTimestampsTest", groups = "functional")
+public class StateTransferTimestampsTest extends MultipleCacheManagersTest {
+   public static final String CACHE_NAME = "cache";
+   private ControlledTimeService timeService;
+
+   @Override
+   public Object[] factory() {
+      return new Object[]{
+         // No need to test DIST_SYNC, it's exactly the same as REPL_SYNC
+         new StateTransferTimestampsTest().cacheMode(CacheMode.REPL_SYNC),
+         new StateTransferTimestampsTest().cacheMode(CacheMode.SCATTERED_SYNC),
+      };
+   }
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      createCluster(new ConfigurationBuilder(), 2);
+
+      timeService = new ControlledTimeService();
+      ConfigurationBuilder replConfig = new ConfigurationBuilder();
+      replConfig.clustering().cacheMode(cacheMode).hash().numSegments(4);
+      for (EmbeddedCacheManager manager : managers()) {
+         TestingUtil.replaceComponent(manager, TimeService.class, timeService, true);
+         manager.defineConfiguration(CACHE_NAME, replConfig.build());
+      }
+   }
+
+   public void testStateTransfer() {
+      // Insert a key on node 0
+      AdvancedCache<Object, Object> cache0 = advancedCache(0, CACHE_NAME);
+      cache0.put("lifespan", "value", 2, SECONDS);
+      cache0.put("maxidle", "value", 10, SECONDS, 2, SECONDS);
+      long created = timeService.wallClockTime();
+
+      // Advance the time service and start node 1 triggering state transfer
+      timeService.advance(SECONDS.toMillis(1));
+      AdvancedCache<Object, Object> cache1 = advancedCache(1, CACHE_NAME);
+
+      // Check the timestamps on node 1
+      long accessed = timeService.wallClockTime();
+      CacheEntry<Object, Object> lifespanEntry = cache1.getCacheEntry("lifespan");
+      assertEquals(created, lifespanEntry.getCreated());
+      assertEquals(-1, lifespanEntry.getLastUsed());
+      CacheEntry<Object, Object> maxidleEntry = cache1.getCacheEntry("maxidle");
+      assertEquals(created, maxidleEntry.getCreated());
+      assertEquals(accessed, maxidleEntry.getLastUsed());
+
+      // Advance the time service to expire the lifespan entry
+      timeService.advance(SECONDS.toMillis(2));
+      assertNull(cache1.getCacheEntry("lifespan"));
+      assertNotNull(cache1.getCacheEntry("maxidle"));
+
+      // Advance the time service a final time to expire the maxidle entry
+      timeService.advance(SECONDS.toMillis(3));
+      assertNull(cache1.getCacheEntry("maxidle"));
+   }
+}

--- a/tasks/scripting/src/main/java/org/infinispan/scripting/impl/ScriptingInterceptor.java
+++ b/tasks/scripting/src/main/java/org/infinispan/scripting/impl/ScriptingInterceptor.java
@@ -4,7 +4,9 @@ import org.infinispan.commands.write.ClearCommand;
 import org.infinispan.commands.write.PutKeyValueCommand;
 import org.infinispan.commands.write.RemoveCommand;
 import org.infinispan.commands.write.ReplaceCommand;
+import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.context.InvocationContext;
+import org.infinispan.context.impl.FlagBitSets;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.interceptors.BaseCustomAsyncInterceptor;
 import org.infinispan.scripting.ScriptingManager;
@@ -28,7 +30,12 @@ public final class ScriptingInterceptor extends BaseCustomAsyncInterceptor {
    @Override
    public Object visitPutKeyValueCommand(InvocationContext ctx, PutKeyValueCommand command) throws Throwable {
       String name = (String) command.getKey();
-      String script = (String) command.getValue();
+      String script;
+      if (command.hasAllFlags(FlagBitSets.PUT_FOR_STATE_TRANSFER | FlagBitSets.CACHE_MODE_LOCAL)) {
+         script = (String) ((InternalCacheEntry) command.getValue()).getValue();
+      } else {
+         script = (String) command.getValue();
+      }
       command.setMetadata(scriptingManager.compileScript(name, script));
       return invokeNext(ctx, command);
    }


### PR DESCRIPTION
Backport of https://github.com/infinispan/infinispan/pull/6525
https://issues.jboss.org/browse/ISPN-4075

* Use PutKeyValueCommand with InternalCacheEntry as value to pass the
  created and last use timestamps
* Scattered caches also use PutMapCommand with InternalCacheValue values
* Always copy the timestamps when copying entries
* Ignore -1 timestamp values and use current time instead