### PR TITLE
ISPN-9395 Failures in karaf-maven-plugin on Windows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4307,7 +4307,8 @@
                <version>${version.karaf-maven-plugin}</version>
                <configuration>
                   <descriptors>
-                     <descriptor>file://${project.build.directory}/classes/features.xml</descriptor>
+                     <!--On Windows we need /// or C: is interpreted as a host name -->
+                     <descriptor>file:///${project.build.directory}/classes/features.xml</descriptor>
                      <!-- ideally, those profiles should be referenced in the features file -->
                      <descriptor>mvn:org.apache.karaf.features/framework/${version.karaf}/xml/features</descriptor>
                      <descriptor>mvn:org.apache.karaf.features/enterprise/${version.karaf}/xml/features</descriptor>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-9395

Fix file:/// URL to have 3 slashes, otherwise C: is interpreted
as a host name

For testing see
https://ci.infinispan.org/job/InfinispanAlternateBuilds/job/InfinispanWindows/