### PR TITLE
[9.4.x] ISPN-9871 ProtobufMetadataManagementInterceptor ClassCastException

### DIFF
--- a/core/src/main/java/org/infinispan/commands/write/PutKeyValueCommand.java
+++ b/core/src/main/java/org/infinispan/commands/write/PutKeyValueCommand.java
@@ -22,6 +22,10 @@ import org.infinispan.notifications.cachelistener.CacheNotifier;
 /**
  * Implements functionality defined by {@link org.infinispan.Cache#put(Object, Object)}
  *
+ * <p>Note: Since 9.4, when the flag {@link org.infinispan.context.Flag#PUT_FOR_STATE_TRANSFER} is set,
+ * the value is actually an {@code InternalCacheEntry} wrapping the value and the timestamps of the entry
+ * from the source node.</p>
+ *
  * @author Mircea.Markus@jboss.com
  * @since 4.0
  */

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/ProtobufMetadataManagerImpl.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/ProtobufMetadataManagerImpl.java
@@ -20,7 +20,7 @@ import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.factories.annotations.Inject;
-import org.infinispan.interceptors.locking.PessimisticLockingInterceptor;
+import org.infinispan.interceptors.impl.EntryWrappingInterceptor;
 import org.infinispan.jmx.annotations.MBean;
 import org.infinispan.jmx.annotations.ManagedAttribute;
 import org.infinispan.jmx.annotations.ManagedOperation;
@@ -116,7 +116,7 @@ public final class ProtobufMetadataManagerImpl implements ProtobufMetadataManage
             .encoding().key().mediaType(MediaType.APPLICATION_OBJECT_TYPE)
             .encoding().value().mediaType(MediaType.APPLICATION_OBJECT_TYPE)
             .customInterceptors().addInterceptor()
-            .interceptor(new ProtobufMetadataManagerInterceptor()).after(PessimisticLockingInterceptor.class);
+            .interceptor(new ProtobufMetadataManagerInterceptor()).after(EntryWrappingInterceptor.class);
       if (globalConfiguration.security().authorization().enabled()) {
          globalConfiguration.security().authorization().roles().put(SCHEMA_MANAGER_ROLE, new CacheRoleImpl(SCHEMA_MANAGER_ROLE, AuthorizationPermission.ALL));
          cfg.security().authorization().enable().role(SCHEMA_MANAGER_ROLE);

--- a/remote-query/remote-query-server/src/test/java/org/infinispan/query/remote/impl/ProtobufMetadataManagerInterceptorTest.java
+++ b/remote-query/remote-query-server/src/test/java/org/infinispan/query/remote/impl/ProtobufMetadataManagerInterceptorTest.java
@@ -17,6 +17,7 @@ import org.infinispan.functional.FunctionalMap;
 import org.infinispan.functional.impl.FunctionalMapImpl;
 import org.infinispan.functional.impl.ReadWriteMapImpl;
 import org.infinispan.interceptors.locking.PessimisticLockingInterceptor;
+import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.query.remote.client.ProtobufMetadataManagerConstants;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
@@ -302,6 +303,23 @@ public class ProtobufMetadataManagerInterceptorTest extends MultipleCacheManager
       assertTrue(cache0.isEmpty());
 
       assertNoTransactionsAndLocks();
+   }
+
+   /**
+    * State transfer is interesting because StateConsumerImpl uses PutKeyValueCommand with InternalCacheEntry values,
+    * in order to preserve timestamps.
+    */
+   public void testStateTransfer() {
+      cache(0).put("state.proto", "import \"test.proto\";");
+
+      EmbeddedCacheManager manager = addClusterEnabledCacheManager(makeCfg());
+      try {
+         Cache<Object, Object> cache = manager.getCache();
+         assertEquals("import \"test.proto\";", cache.get("state.proto"));
+         cache(0).remove("state.proto");
+      } finally {
+         killMember(2);
+      }
    }
 
    private void assertNoTransactionsAndLocks() {


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-9871

StateConsumerImpl uses PutKeyValueCommands with InternalCacheEntry
values in order to preserve timestamps, so read the value from the
context

Backport of https://github.com/infinispan/infinispan/pull/6602