### PR TITLE
[9.4.x] ISPN-4075 State transfer should preserve the timestamps of entries

### DIFF
--- a/core/src/main/java/org/infinispan/commands/write/PutMapCommand.java
+++ b/core/src/main/java/org/infinispan/commands/write/PutMapCommand.java
@@ -27,6 +27,11 @@ import org.infinispan.notifications.cachelistener.CacheNotifier;
 import org.infinispan.util.concurrent.locks.RemoteLockCommand;
 
 /**
+ * A command writing multiple key/value pairs with the same metadata.
+ *
+ * <p>Note: In scattered caches, push state transfer uses {@code PutMapCommand} but wraps the values in
+ * {@code InternalCacheValue} instances in order to preserve the original metadata and timestamps.</p>
+ *
  * @author Mircea.Markus@jboss.com
  * @since 4.0
  */

--- a/core/src/main/java/org/infinispan/interceptors/impl/PrefetchInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/PrefetchInterceptor.java
@@ -82,6 +82,7 @@ import org.infinispan.interceptors.DDAsyncInterceptor;
 import org.infinispan.interceptors.InvocationStage;
 import org.infinispan.interceptors.InvocationSuccessFunction;
 import org.infinispan.metadata.Metadata;
+import org.infinispan.metadata.impl.InternalMetadataImpl;
 import org.infinispan.remoting.responses.Response;
 import org.infinispan.remoting.responses.SuccessfulResponse;
 import org.infinispan.remoting.rpc.RpcManager;
@@ -282,7 +283,7 @@ public class PrefetchInterceptor<K, V> extends DDAsyncInterceptor {
       // from the main comman d correct.
       entryFactory.wrapExternalEntry(ctx, dataCommand.getKey(), maxValue.toInternalCacheEntry(dataCommand.getKey()), true, true);
       PutKeyValueCommand putKeyValueCommand = commandsFactory.buildPutKeyValueCommand(
-            dataCommand.getKey(), maxValue.toInternalCacheEntry(dataCommand.getKey()), dataCommand.getSegment(), maxValue.getMetadata(), STATE_TRANSFER_FLAGS);
+         dataCommand.getKey(), maxValue.getValue(), dataCommand.getSegment(), new InternalMetadataImpl(maxValue), STATE_TRANSFER_FLAGS);
       putKeyValueCommand.setTopologyId(dataCommand.getTopologyId());
       return invokeNext(ctx, putKeyValueCommand);
    }

--- a/core/src/main/java/org/infinispan/metadata/impl/InternalMetadataImpl.java
+++ b/core/src/main/java/org/infinispan/metadata/impl/InternalMetadataImpl.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import org.infinispan.commons.marshall.AbstractExternalizer;
 import org.infinispan.commons.util.Util;
 import org.infinispan.container.entries.InternalCacheEntry;
+import org.infinispan.container.entries.InternalCacheValue;
 import org.infinispan.container.versioning.EntryVersion;
 import org.infinispan.marshall.core.Ids;
 import org.infinispan.metadata.InternalMetadata;
@@ -31,6 +32,10 @@ public class InternalMetadataImpl implements InternalMetadata {
 
    public InternalMetadataImpl(InternalCacheEntry ice) {
       this(ice.getMetadata(), ice.getCreated(), ice.getLastUsed());
+   }
+
+   public InternalMetadataImpl(InternalCacheValue icv) {
+      this(icv.getMetadata(), icv.getCreated(), icv.getLastUsed());
    }
 
    public InternalMetadataImpl(Metadata actual, long created, long lastUsed) {

--- a/core/src/main/java/org/infinispan/scattered/impl/ScatteredStateConsumerImpl.java
+++ b/core/src/main/java/org/infinispan/scattered/impl/ScatteredStateConsumerImpl.java
@@ -38,6 +38,7 @@ import org.infinispan.factories.annotations.Inject;
 import org.infinispan.filter.CollectionKeyFilter;
 import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.metadata.InternalMetadata;
+import org.infinispan.metadata.impl.InternalMetadataImpl;
 import org.infinispan.persistence.spi.AdvancedCacheLoader;
 import org.infinispan.remoting.responses.Response;
 import org.infinispan.remoting.responses.SuccessfulResponse;
@@ -508,8 +509,11 @@ public class ScatteredStateConsumerImpl extends StateConsumerImpl {
             // the GetAllCommand. We'll just avoid NPEs here: data is lost as > 1 nodes have left.
             continue;
          }
-         PutKeyValueCommand put = commandsFactory.buildPutKeyValueCommand(key, icv.toInternalCacheEntry(key),
-               keyPartitioner.getSegment(key), icv.getMetadata(), STATE_TRANSFER_FLAGS);
+         // CallInterceptor will preserve the timestamps if the metadata is an InternalMetadataImpl instance
+         InternalMetadataImpl metadata = new InternalMetadataImpl(icv);
+         PutKeyValueCommand put = commandsFactory.buildPutKeyValueCommand(key, icv.getValue(),
+                                                                          keyPartitioner.getSegment(key), metadata,
+                                                                          STATE_TRANSFER_FLAGS);
          try {
             interceptorChain.invoke(icf.createSingleKeyNonTxInvocationContext(), put);
          } catch (Exception e) {

--- a/core/src/main/java/org/infinispan/statetransfer/StateConsumerImpl.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateConsumerImpl.java
@@ -65,6 +65,7 @@ import org.infinispan.factories.annotations.Start;
 import org.infinispan.factories.annotations.Stop;
 import org.infinispan.factories.impl.ComponentRef;
 import org.infinispan.interceptors.AsyncInterceptorChain;
+import org.infinispan.metadata.impl.InternalMetadataImpl;
 import org.infinispan.notifications.cachelistener.CacheNotifier;
 import org.infinispan.persistence.manager.PersistenceManager;
 import org.infinispan.remoting.inboundhandler.DeliverOrder;
@@ -641,9 +642,10 @@ public class StateConsumerImpl implements StateConsumer {
                ctx = icf.createSingleKeyNonTxInvocationContext();
             }
 
-            // CallInterceptor knows PUT_FOR_STATE_TRANSFER values are actually InternalCacheEntries
-            PutKeyValueCommand put = commandsFactory.buildPutKeyValueCommand(e.getKey(), e, segmentId,
-                  e.getMetadata(), STATE_TRANSFER_FLAGS);
+            // CallInterceptor will preserve the timestamps if the metadata is an InternalMetadataImpl instance
+            InternalMetadataImpl metadata = new InternalMetadataImpl(e);
+            PutKeyValueCommand put = commandsFactory.buildPutKeyValueCommand(e.getKey(), e.getValue(), segmentId,
+                                                                             metadata, STATE_TRANSFER_FLAGS);
             ctx.setLockOwner(put.getKeyLockOwner());
             interceptorChain.invoke(ctx, put);
 

--- a/tasks/scripting/src/main/java/org/infinispan/scripting/impl/ScriptingInterceptor.java
+++ b/tasks/scripting/src/main/java/org/infinispan/scripting/impl/ScriptingInterceptor.java
@@ -4,9 +4,7 @@ import org.infinispan.commands.write.ClearCommand;
 import org.infinispan.commands.write.PutKeyValueCommand;
 import org.infinispan.commands.write.RemoveCommand;
 import org.infinispan.commands.write.ReplaceCommand;
-import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.context.InvocationContext;
-import org.infinispan.context.impl.FlagBitSets;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.interceptors.BaseCustomAsyncInterceptor;
 import org.infinispan.scripting.ScriptingManager;
@@ -30,12 +28,7 @@ public final class ScriptingInterceptor extends BaseCustomAsyncInterceptor {
    @Override
    public Object visitPutKeyValueCommand(InvocationContext ctx, PutKeyValueCommand command) throws Throwable {
       String name = (String) command.getKey();
-      String script;
-      if (command.hasAllFlags(FlagBitSets.PUT_FOR_STATE_TRANSFER | FlagBitSets.CACHE_MODE_LOCAL)) {
-         script = (String) ((InternalCacheEntry) command.getValue()).getValue();
-      } else {
-         script = (String) command.getValue();
-      }
+      String script = (String) command.getValue();
       command.setMetadata(scriptingManager.compileScript(name, script));
       return invokeNext(ctx, command);
    }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-4075

Use InternalMetadataImpl to store the timestamps instead of an
InternalCacheEntry in PutKeyValueCommand.

Backport of #6629 