### PR TITLE
ISPN-9912 preventing controlling the flow with NPE in LimitExpiryPoli…

### DIFF
--- a/jcache/commons/src/main/java/org/infinispan/jcache/Expiration.java
+++ b/jcache/commons/src/main/java/org/infinispan/jcache/Expiration.java
@@ -35,19 +35,22 @@ public class Expiration {
             try {
                return policy.getExpiryForCreation();
             } catch (Throwable t) {
+               log.getExpiryHasThrown(t);
                return getDefaultDuration();
             }
          case ACCESS:
             try {
                return policy.getExpiryForAccess();
             } catch (Throwable t) {
+               log.getExpiryHasThrown(t);
                // If an exception is thrown, leave expiration untouched
                return null;
             }
          case UPDATE:
             try {
                return policy.getExpiryForUpdate();
-            } catch (Exception e) {
+            } catch (Throwable t) {
+               log.getExpiryHasThrown(t);
                // If an exception is thrown, leave expiration untouched
                return null;
             }

--- a/jcache/commons/src/main/java/org/infinispan/jcache/logging/Log.java
+++ b/jcache/commons/src/main/java/org/infinispan/jcache/logging/Log.java
@@ -104,6 +104,10 @@ public interface Log extends BasicLogger {
    @Message(value = "Error closing %s", id = 21031)
    void errorClosingCloseable(Closeable closeable, @Cause Exception e);
 
+   @LogMessage(level = WARN)
+   @Message(value = "Exception while getting expiry duration. Fallback to default duration eternal.", id = 21032)
+   void getExpiryHasThrown(@Cause Throwable t);
+
    class LeakDescription extends Throwable {
 
       public LeakDescription() {

--- a/jcache/embedded/src/main/java/org/infinispan/jcache/embedded/LimitExpiryFactory.java
+++ b/jcache/embedded/src/main/java/org/infinispan/jcache/embedded/LimitExpiryFactory.java
@@ -38,6 +38,7 @@ public class LimitExpiryFactory implements Factory<ExpiryPolicy>, Serializable {
       @Override
       public Duration getExpiryForCreation() {
          Duration duration = expiryPolicy.getExpiryForCreation();
+         if (duration == null) return null;
          if (duration.isZero()) return duration;
          if (duration.isEternal()) return new Duration(TimeUnit.MILLISECONDS, min);
          long actualMin = Math.min(duration.getTimeUnit().toMillis(duration.getDurationAmount()), this.min);
@@ -47,6 +48,7 @@ public class LimitExpiryFactory implements Factory<ExpiryPolicy>, Serializable {
       @Override
       public Duration getExpiryForAccess() {
          Duration duration = expiryPolicy.getExpiryForAccess();
+         if (duration == null) return null;
          if (duration.isZero() || maxIdle < 0) return duration;
          if (duration.isEternal()) return new Duration(TimeUnit.MILLISECONDS, maxIdle);
          long actualMin = Math.min(duration.getTimeUnit().toMillis(duration.getDurationAmount()), this.maxIdle);
@@ -56,6 +58,7 @@ public class LimitExpiryFactory implements Factory<ExpiryPolicy>, Serializable {
       @Override
       public Duration getExpiryForUpdate() {
          Duration duration = expiryPolicy.getExpiryForUpdate();
+         if (duration == null) return null;
          if (duration.isZero()) return duration;
          if (duration.isEternal()) return new Duration(TimeUnit.MILLISECONDS, min);
          long actualMin = Math.min(duration.getTimeUnit().toMillis(duration.getDurationAmount()), this.min);

--- a/jcache/embedded/src/test/java/org/infinispan/jcache/LimitExpiryFactoryTest.java
+++ b/jcache/embedded/src/test/java/org/infinispan/jcache/LimitExpiryFactoryTest.java
@@ -1,0 +1,38 @@
+package org.infinispan.jcache.embedded;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.concurrent.TimeUnit;
+
+import javax.cache.expiry.Duration;
+import javax.cache.expiry.EternalExpiryPolicy;
+import javax.cache.expiry.ExpiryPolicy;
+
+import org.junit.Test;
+
+public class LimitExpiryFactoryTest {
+
+    @Test
+    public void getExpiryForAccess() {
+
+        ExpiryPolicy limitExpiryPolicy = new LimitExpiryFactory(EternalExpiryPolicy.factoryOf(), 0, 0).create();
+
+        assertEquals(null, limitExpiryPolicy.getExpiryForAccess());
+    }
+
+    @Test
+    public void getExpiryForCreation() {
+
+        ExpiryPolicy limitExpiryPolicy = new LimitExpiryFactory(EternalExpiryPolicy.factoryOf(), 0, 0).create();
+
+        assertEquals(new Duration(TimeUnit.MILLISECONDS, 0), limitExpiryPolicy.getExpiryForCreation());
+    }
+
+    @Test
+    public void getExpiryForUpdate() {
+
+        ExpiryPolicy limitExpiryPolicy = new LimitExpiryFactory(EternalExpiryPolicy.factoryOf(), 0, 0).create();
+
+        assertEquals(null, limitExpiryPolicy.getExpiryForUpdate());
+    }
+}


### PR DESCRIPTION
LimitExpiryPolicy creates unnecessary a NullPointerException, it could check the NULL, and return a NULL as result.
The NPE will be also catched by the caller* class, and it was handled as a NULL return value. 
(*: org.infinispan.jcache.Expiration.getExpiry(ExpiryPolicy, Operation))

LimitExpiryPolicy .getExpiryForAccess() and  getExpiryForUpdate() are affected. getExpiryForCreation() was also changed for "symmetry".

VisualVM sampling shows it costs 10% of a jcache.get() call. See the JIRA Issue for VisualVM Screenshot and the SSCCE was used for profiling (eg. with VisualVM).