### PR TITLE
ISPN-9801 ClusterTopologyManagerImpl hangs when restarting a FORK node

### DIFF
--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -740,8 +740,8 @@ public interface Log extends BasicLogger {
    void failedToRecoverClusterState(@Cause Throwable cause);
 
    @LogMessage(level = WARN)
-   @Message(value = "Error updating cluster member list", id = 197)
-   void errorUpdatingMembersList(@Cause Throwable cause);
+   @Message(value = "Error updating cluster member list for view %d, waiting for next view", id = 197)
+   void errorUpdatingMembersList(int viewId, @Cause Throwable cause);
 
    @LogMessage(level = INFO)
    @Message(value = "Unable to register MBeans for default cache", id = 198)

--- a/core/src/test/java/org/infinispan/scattered/statetransfer/CoordinatorStopTest.java
+++ b/core/src/test/java/org/infinispan/scattered/statetransfer/CoordinatorStopTest.java
@@ -207,6 +207,8 @@ public class CoordinatorStopTest extends MultipleCacheManagersTest {
       oteBarrier.await(10, TimeUnit.SECONDS);
 
       assertEquals("value", future.get());
+      ((DelayedViewJGroupsTransport) transport1.getDelegate()).assertUnblocked();
+      ((DelayedViewJGroupsTransport) manager(2).getTransport()).assertUnblocked();
    }
 
    private void assertOwners(BlockedTopology t, boolean current, int segmentId, Address... address) {

--- a/core/src/test/java/org/infinispan/statetransfer/ConcurrentStartChanelLookupTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/ConcurrentStartChanelLookupTest.java
@@ -104,7 +104,7 @@ public class ConcurrentStartChanelLookupTest extends MultipleCacheManagersTest {
    private EmbeddedCacheManager createCacheManager(String name1, JChannel ch1) {
       GlobalConfigurationBuilder gcb1 = new GlobalConfigurationBuilder();
       gcb1.transport().nodeName(ch1.getName()).distributedSyncTimeout(10, SECONDS);
-      CustomChannelLookup.registerChannel(gcb1, ch1, name1, false);
+      CustomChannelLookup.configureTransportWithChannel(gcb1, ch1, name1, false);
 
       ConfigurationBuilder replCfg = new ConfigurationBuilder();
       replCfg.clustering().cacheMode(CacheMode.REPL_SYNC);

--- a/core/src/test/java/org/infinispan/statetransfer/ConcurrentStartForkChannelTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/ConcurrentStartForkChannelTest.java
@@ -96,12 +96,7 @@ public class ConcurrentStartForkChannelTest extends MultipleCacheManagersTest {
    }
 
    private EmbeddedCacheManager createCacheManager(ConfigurationBuilder cacheCfg, String name,
-                                                   JChannel channel) throws
-         Exception {
-      GlobalConfigurationBuilder gcb = new GlobalConfigurationBuilder();
-      gcb.transport().nodeName(channel.getName());
-      gcb.transport().distributedSyncTimeout(30, TimeUnit.SECONDS);
-
+                                                   JChannel channel) throws Exception {
       FORK fork = new FORK();
       fork.setUnknownForkHandler(new UnknownForkHandler() {
          @Override
@@ -134,7 +129,11 @@ public class ConcurrentStartForkChannelTest extends MultipleCacheManagersTest {
       });
       channel.getProtocolStack().addProtocol(fork);
       ForkChannel fch = new ForkChannel(channel, "stack1", "channel1");
-      CustomChannelLookup.registerChannel(gcb, fch, name, true);
+
+      GlobalConfigurationBuilder gcb = new GlobalConfigurationBuilder();
+      gcb.transport().transport(new JGroupsTransport(fch));
+      gcb.transport().nodeName(channel.getName());
+      gcb.transport().distributedSyncTimeout(30, TimeUnit.SECONDS);
 
       EmbeddedCacheManager cm = new DefaultCacheManager(gcb.build(), cacheCfg.build(), false);
       registerCacheManager(cm);

--- a/core/src/test/java/org/infinispan/statetransfer/CustomChannelLookup.java
+++ b/core/src/test/java/org/infinispan/statetransfer/CustomChannelLookup.java
@@ -20,8 +20,8 @@ public class CustomChannelLookup implements JGroupsChannelLookup {
    private static final Map<String, JChannel> channelMap = CollectionFactory.makeConcurrentMap();
    private boolean connect;
 
-   public static void registerChannel(GlobalConfigurationBuilder gcb, JChannel channel, String nodeName,
-         boolean connect) {
+   public static void configureTransportWithChannel(GlobalConfigurationBuilder gcb, JChannel channel, String nodeName,
+                                                    boolean connect) {
       TransportConfigurationBuilder tcb = gcb.transport();
       tcb.defaultTransport();
       tcb.addProperty(JGroupsTransport.CHANNEL_LOOKUP, CustomChannelLookup.class.getName());

--- a/core/src/test/java/org/infinispan/statetransfer/ForkChannelRestartTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/ForkChannelRestartTest.java
@@ -1,0 +1,169 @@
+package org.infinispan.statetransfer;
+
+import static org.infinispan.test.TestingUtil.blockUntilViewsReceived;
+import static org.infinispan.test.TestingUtil.getDiscardForCache;
+import static org.infinispan.test.TestingUtil.installNewView;
+import static org.infinispan.test.TestingUtil.waitForNoRebalance;
+
+import java.io.ByteArrayInputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.infinispan.Cache;
+import org.infinispan.commons.util.Util;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.manager.DefaultCacheManager;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.partitionhandling.PartitionHandling;
+import org.infinispan.remoting.transport.jgroups.JGroupsTransport;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.fwk.CleanupAfterMethod;
+import org.infinispan.test.fwk.JGroupsConfigBuilder;
+import org.infinispan.test.fwk.TestResourceTracker;
+import org.infinispan.test.fwk.TransportFlags;
+import org.jgroups.JChannel;
+import org.jgroups.Message;
+import org.jgroups.blocks.RequestCorrelator;
+import org.jgroups.conf.ClassConfigurator;
+import org.jgroups.fork.ForkChannel;
+import org.jgroups.fork.UnknownForkHandler;
+import org.jgroups.protocols.FORK;
+import org.testng.annotations.Test;
+
+/**
+ * Tests restart of nodes using ForkChannels.
+ *
+ * @author Dan Berindei
+ * @since 10.0
+ */
+@Test(testName = "statetransfer.ForkChannelRestartTest", groups = "functional")
+@CleanupAfterMethod
+public class ForkChannelRestartTest extends MultipleCacheManagersTest {
+   private static final byte[] FORK_NOT_FOUND_BUFFER = Util.EMPTY_BYTE_ARRAY;
+   private static final String CACHE_NAME = "repl";
+   private static final int CLUSTER_SIZE = 3;
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      // The test method will create the cache managers
+   }
+
+   public void testRestart() throws Exception {
+      TestResourceTracker.testThreadStarted(this);
+
+      ConfigurationBuilder replCfg = new ConfigurationBuilder();
+      replCfg.clustering().cacheMode(CacheMode.REPL_SYNC).stateTransfer().timeout(30, TimeUnit.SECONDS);
+      replCfg.clustering().partitionHandling().whenSplit(PartitionHandling.DENY_READ_WRITES);
+
+      String[] names = new String[CLUSTER_SIZE + 1];
+      JChannel[] channels = new JChannel[CLUSTER_SIZE + 1];
+      EmbeddedCacheManager[] managers = new EmbeddedCacheManager[CLUSTER_SIZE + 1];
+      for (int i = 0; i < CLUSTER_SIZE; i++) {
+         configureManager(replCfg, names, channels, managers, i);
+      }
+      for (int i = 0; i < CLUSTER_SIZE; i++) {
+         managers[i].getCache(CACHE_NAME);
+      }
+
+      log.debugf("Cache managers created. Crashing manager %s but keeping the channel in the view", names[1]);
+      getDiscardForCache(managers[1]).setDiscardAll(true);
+      installNewView(managers[1]);
+      managers[1].stop();
+
+      configureManager(replCfg, names, channels, managers, CLUSTER_SIZE);
+      Future<Cache<Object, Object>> future = fork(() -> managers[CLUSTER_SIZE].getCache(CACHE_NAME));
+
+      Thread.sleep(1000);
+      log.debugf("Stopping channel %s", names[1]);
+      channels[1].close();
+
+      List<EmbeddedCacheManager> liveManagers = new ArrayList<>(Arrays.asList(managers));
+      liveManagers.remove(1);
+      blockUntilViewsReceived(10000, false, liveManagers);
+      waitForNoRebalance(liveManagers.stream().map(cm -> cm.getCache(CACHE_NAME)).collect(Collectors.toList()));
+      log.debug("Rebalance finished successfully");
+
+      future.get(10, TimeUnit.SECONDS);
+   }
+
+   private void configureManager(ConfigurationBuilder replCfg, String[] names,
+                                 JChannel[] channels,
+                                 EmbeddedCacheManager[] managers, int i) throws Exception {
+      // Create the ForkChannels
+      names[i] = TestResourceTracker.getNextNodeName();
+      channels[i] = createChannel(names[i], 0);
+
+      // Then start the managers
+      managers[i] = createCacheManager(replCfg, names[i], channels[i]);
+      managers[i].defineConfiguration(CACHE_NAME, replCfg.build());
+   }
+
+   private EmbeddedCacheManager createCacheManager(ConfigurationBuilder cacheCfg, String name,
+                                                   JChannel channel) throws Exception {
+      ForkChannel fch = new ForkChannel(channel, "stack1", "channel1");
+
+      GlobalConfigurationBuilder gcb = new GlobalConfigurationBuilder();
+      gcb.transport().nodeName(name);
+      gcb.transport().transport(new JGroupsTransport(fch));
+      gcb.transport().distributedSyncTimeout(40, TimeUnit.SECONDS);
+
+      EmbeddedCacheManager cm = new DefaultCacheManager(gcb.build(), cacheCfg.build(), false);
+      registerCacheManager(cm);
+      return cm;
+   }
+
+   private JChannel createChannel(String name, int portRange) throws Exception {
+      String configString =
+         JGroupsConfigBuilder.getJGroupsConfig(ForkChannelRestartTest.class.getName(),
+                                               new TransportFlags().withPortRange(portRange).withFD(true));
+
+      JChannel channel = new JChannel(new ByteArrayInputStream(configString.getBytes()));
+      TestResourceTracker.addResource(new TestResourceTracker.Cleaner<JChannel>(channel) {
+         @Override
+         public void close() {
+            ref.close();
+         }
+      });
+      channel.setName(name);
+      FORK fork = new FORK();
+      fork.setUnknownForkHandler(new UnknownForkHandler() {
+         @Override
+         public Object handleUnknownForkStack(Message message, String forkStackId) {
+            return handle(message);
+         }
+
+         @Override
+         public Object handleUnknownForkChannel(Message message, String forkChannelId) {
+            return handle(message);
+         }
+
+         private Object handle(Message message) {
+            short id = ClassConfigurator.getProtocolId(RequestCorrelator.class);
+            RequestCorrelator.Header requestHeader = message.getHeader(id);
+            if (requestHeader != null) {
+               log.debugf("Sending CacheNotFoundResponse reply from %s for %s", name, requestHeader);
+               short flags = JGroupsTransport.REPLY_FLAGS;
+               Message response = message.makeReply().setFlag(flags);
+
+               FORK.ForkHeader forkHeader = message.getHeader(FORK.ID);
+               response.putHeader(FORK.ID, forkHeader);
+               response.putHeader(id, new RequestCorrelator.Header(RequestCorrelator.Header.RSP, requestHeader.req_id, id));
+               response.setBuffer(FORK_NOT_FOUND_BUFFER);
+
+               fork.down(response);
+            }
+            return null;
+         }
+      });
+      channel.getProtocolStack().addProtocol(fork);
+      channel.connect("FORKISPN");
+      log.tracef("Channel %s connected: %s", channel, channel.getViewAsString());
+      return channel;
+   }
+}

--- a/core/src/test/java/org/infinispan/test/transport/DelayedViewJGroupsTransport.java
+++ b/core/src/test/java/org/infinispan/test/transport/DelayedViewJGroupsTransport.java
@@ -1,14 +1,19 @@
 package org.infinispan.test.transport;
 
+import java.lang.invoke.MethodHandles;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import org.infinispan.remoting.transport.jgroups.JGroupsTransport;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
 import org.jgroups.View;
 
 public final class DelayedViewJGroupsTransport extends JGroupsTransport {
+   private static Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
 
    private final CountDownLatch waitLatch;
+   private boolean unblocked;
 
    public DelayedViewJGroupsTransport(CountDownLatch waitLatch) {
       this.waitLatch = waitLatch;
@@ -19,11 +24,21 @@ public final class DelayedViewJGroupsTransport extends JGroupsTransport {
       // check if this is an event of node going down, and if so wait for a signal to apply new view
       if (waitLatch != null && getMembers().size() > newView.getMembers().size()) {
          try {
-            waitLatch.await(10, TimeUnit.SECONDS);
+            log.debugf("Delaying view %s", newView);
+            unblocked = waitLatch.await(10, TimeUnit.SECONDS);
+            if (unblocked) {
+               log.debugf("Unblocking view %s", newView);
+            } else {
+               log.errorf("Timed out waiting for view to be unblocked: %s", newView);
+            }
          } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
          }
       }
       super.receiveClusterView(newView);
+   }
+
+   public void assertUnblocked() {
+      assert unblocked;
    }
 }

--- a/core/src/test/java/org/infinispan/topology/ClusterCacheStatusTest.java
+++ b/core/src/test/java/org/infinispan/topology/ClusterCacheStatusTest.java
@@ -85,7 +85,8 @@ public class ClusterCacheStatusTest extends AbstractInfinispanTest {
       verifyStableTopologyUpdate();
 
       when(transport.getMembers()).thenReturn(singletonList(C));
-      status.doHandleClusterView();
+      when(transport.getViewId()).thenReturn(1);
+      status.doHandleClusterView(1);
 
       TestClusterCacheStatus cache = TestClusterCacheStatus.start(JOIN_INFO, C);
       cache.incrementIds(9, 2);


### PR DESCRIPTION
Backport of https://github.com/infinispan/infinispan/pull/6527

* ClusterTopologyManagerImpl should process new views while waiting
  for member hearbeats for a previous view
* Member availability check should ignore nodes that didn't join
  any cache
* Test doesn't reproduce the problem described in the issue,
  but it's still good to have
* Small changes in other tests