### PR TITLE
ISPN-9851 Formatting for Rolling Upgrades

### DIFF
--- a/documentation/src/main/asciidoc/user_guide/configuration.adoc
+++ b/documentation/src/main/asciidoc/user_guide/configuration.adoc
@@ -555,7 +555,7 @@ The `stack.combine` attribute determines the type of the operation:
 * `INSERT_AFTER`: inserts a protocol after another protocol identified by the `stack.position` attribute.
 * `REMOVE`: removes the protocol.
 
-====== Tuning JGroups settings
+===== Tuning JGroups settings
 The settings above can be further tuned without editing the XML files themselves.
 Passing in certain system properties to your JVM at startup can affect the behaviour of some of these settings.  The table below shows you which settings can be configured in this way.  E.g.,
 

--- a/documentation/src/main/asciidoc/user_guide/rolling_upgrades.adoc
+++ b/documentation/src/main/asciidoc/user_guide/rolling_upgrades.adoc
@@ -93,3 +93,5 @@ $ JDG_HOME/bin/cli.sh --connect controller=127.0.0.1:9990 -c "/subsystem=datagri
 ----
 +
 . Decommission the source cluster.
+
+//-


### PR DESCRIPTION
Needs backport to 9.4.x. Rolling upgrades formatting fix. Plus correct level sequence for tuning JGroups.