### PR TITLE
Should support the nextVersion feature in release

### DIFF
--- a/Jenkinsfile-release
+++ b/Jenkinsfile-release
@@ -71,6 +71,16 @@ pipeline {
                 sh "$MAVEN_HOME/bin/mvn -B -V scm:tag"
             }
         }
+
+        stage('Next version') {
+            when {
+                expression { params.nextVersion != '' }
+            }
+            steps {
+                sh "$MAVEN_HOME/bin/mvn -B -V versions:set -DnewVersion=${nextVersion}"
+                sh "$MAVEN_HOME/bin/mvn -B -V -Dmessage='next version ${nextVersion}' -DscmVersion=${branch} -DscmVersionType=branch scm:checkin"
+            }
+        }
     }
 
     post {


### PR DESCRIPTION
This change should allow specify the next version in the jenkins release, if such is specified during the build with parameters 