### PR TITLE
ISPN-9969 Configure statistics with the hotrod-client.properties

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/ConfigurationBuilder.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/ConfigurationBuilder.java
@@ -400,6 +400,8 @@ public class ConfigurationBuilder implements ConfigurationChildBuilder, Builder<
          ClusterConfigurationBuilder cluster = this.addCluster(entry.getKey());
          parseServers(entry.getValue(), (host, port) -> cluster.addClusterNode(host, port));
       });
+
+      statistics.withProperties(properties);
       return this;
    }
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/StatisticsConfigurationBuilder.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/StatisticsConfigurationBuilder.java
@@ -5,10 +5,16 @@ import static org.infinispan.client.hotrod.configuration.StatisticsConfiguration
 import static org.infinispan.client.hotrod.configuration.StatisticsConfiguration.JMX_ENABLED;
 import static org.infinispan.client.hotrod.configuration.StatisticsConfiguration.JMX_NAME;
 import static org.infinispan.client.hotrod.configuration.StatisticsConfiguration.MBEAN_SERVER_LOOKUP;
+import static org.infinispan.client.hotrod.impl.ConfigurationProperties.JMX;
+import static org.infinispan.client.hotrod.impl.ConfigurationProperties.STATISTICS;
 
+import java.util.Properties;
+
+import org.infinispan.client.hotrod.impl.ConfigurationProperties;
 import org.infinispan.commons.configuration.Builder;
 import org.infinispan.commons.configuration.attributes.AttributeSet;
 import org.infinispan.commons.jmx.MBeanServerLookup;
+import org.infinispan.commons.util.TypedProperties;
 
 /**
  * Configures client-side statistics
@@ -62,7 +68,8 @@ public class StatisticsConfigurationBuilder extends AbstractConfigurationChildBu
    }
 
    /**
-    * Sets the instance of the {@link org.infinispan.commons.jmx.MBeanServerLookup} class to be used to bound JMX MBeans to.
+    * Sets the instance of the {@link org.infinispan.commons.jmx.MBeanServerLookup} class to be used to bound JMX MBeans
+    * to.
     *
     * @param mBeanServerLookupInstance An instance of {@link org.infinispan.commons.jmx.MBeanServerLookup}
     */
@@ -84,5 +91,15 @@ public class StatisticsConfigurationBuilder extends AbstractConfigurationChildBu
    public Builder<?> read(StatisticsConfiguration template) {
       this.attributes.read(template.attributes());
       return this;
+   }
+
+   @Override
+   public ConfigurationBuilder withProperties(Properties properties) {
+      TypedProperties typed = TypedProperties.toTypedProperties(properties);
+      enabled(typed.getBooleanProperty(STATISTICS, ENABLED.getDefaultValue()));
+      jmxEnabled(typed.getBooleanProperty(JMX, JMX_ENABLED.getDefaultValue()));
+      jmxDomain(typed.getProperty(ConfigurationProperties.JMX_DOMAIN, JMX_DOMAIN.getDefaultValue()));
+      jmxName(typed.getProperty(ConfigurationProperties.JMX_NAME, JMX_NAME.getDefaultValue()));
+      return builder;
    }
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/package-info.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/package-info.java
@@ -367,6 +367,33 @@
  *          <td>Relates to {@link org.infinispan.client.hotrod.configuration.ClusterConfigurationBuilder#addCluster(java.lang.String)} and
  *          {@link org.infinispan.client.hotrod.configuration.ClusterConfigurationBuilder#addClusterNode(java.lang.String, int)}</td>
  *       </tr>
+ *        <tr>
+ *           <th colspan="4">Statistics properties</th>
+ *        </tr>
+ *        <tr>
+ *           <td><b>infinispan.client.hotrod.statistics</b></td>
+ *           <td>Boolean</td>
+ *           <td>Default value {@link org.infinispan.client.hotrod.configuration.StatisticsConfiguration#ENABLED}</td>
+ *           <td>Relates to {@link org.infinispan.client.hotrod.configuration.StatisticsConfigurationBuilder#enabled(boolean)}</td>
+ *        </tr>
+ *        <tr>
+ *           <td><b>infinispan.client.hotrod.jmx</b></td>
+ *           <td>Boolean</td>
+ *           <td>Default value {@link org.infinispan.client.hotrod.configuration.StatisticsConfiguration#JMX_ENABLED}</td>
+ *           <td>Relates to {@link org.infinispan.client.hotrod.configuration.StatisticsConfigurationBuilder#jmxEnabled(boolean)}</td>
+ *        </tr>
+ *        <tr>
+ *           <td><b>infinispan.client.hotrod.jmx_name</b></td>
+ *           <td>String</td>
+ *           <td>Default value {@link org.infinispan.client.hotrod.configuration.StatisticsConfiguration#JMX_NAME}</td>
+ *           <td>Relates to {@link org.infinispan.client.hotrod.configuration.StatisticsConfigurationBuilder#jmxName(java.lang.String)}</td>
+ *        </tr>
+ *        <tr>
+ *           <td><b>infinispan.client.hotrod.jmx_domain</b></td>
+ *           <td>String</td>
+ *           <td>Default value {@link org.infinispan.client.hotrod.configuration.StatisticsConfiguration#JMX_DOMAIN}</td>
+ *           <td>Relates to {@link org.infinispan.client.hotrod.configuration.StatisticsConfigurationBuilder#jmxDomain(java.lang.String)}</td>
+ *        </tr>
  *    </tbody>
  * </table>
  *

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/ConfigurationProperties.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/ConfigurationProperties.java
@@ -79,7 +79,11 @@ public class ConfigurationProperties {
          Pattern.compile('^' + ConfigurationProperties.SASL_PROPERTIES_PREFIX + '.');
    public static final String JAVA_SERIAL_WHITELIST = ICH + "java_serial_whitelist";
    public static final String BATCH_SIZE = ICH + "batch_size";
+   // Statistics properties
    public static final String STATISTICS = ICH + "statistics";
+   public static final String JMX = ICH + "jmx";
+   public static final String JMX_NAME = ICH + "jmx_name";
+   public static final String JMX_DOMAIN = ICH + "jmx_domain";
    // Transaction properties
    public static final String TRANSACTION_MANAGER_LOOKUP = ICH + "transaction.transaction_manager_lookup";
    public static final String TRANSACTION_MODE = ICH + "transaction.transaction_mode";
@@ -407,6 +411,30 @@ public class ConfigurationProperties {
 
    public boolean isStatistics() {
       return props.getBooleanProperty(STATISTICS, StatisticsConfiguration.ENABLED.getDefaultValue());
+   }
+
+   public void setJmx(boolean jmx) {
+      props.setProperty(JMX, jmx);
+   }
+
+   public boolean isJmx() {
+      return props.getBooleanProperty(JMX, StatisticsConfiguration.JMX_ENABLED.getDefaultValue());
+   }
+
+   public void setJmxName(String jmxName) {
+      props.setProperty(JMX_NAME, jmxName);
+   }
+
+   public void getJmxName() {
+      props.getProperty(JMX_NAME);
+   }
+
+   public void setJmxDomain(String jmxDomain) {
+      props.setProperty(JMX_DOMAIN, jmxDomain);
+   }
+
+   public void getJmxDomain() {
+      props.getProperty(JMX_DOMAIN);
    }
 
    public String getTransactionManagerLookup() {

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/configuration/ConfigurationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/configuration/ConfigurationTest.java
@@ -13,6 +13,9 @@ import static org.infinispan.client.hotrod.impl.ConfigurationProperties.CONNECTI
 import static org.infinispan.client.hotrod.impl.ConfigurationProperties.CONNECTION_POOL_MIN_IDLE;
 import static org.infinispan.client.hotrod.impl.ConfigurationProperties.CONNECT_TIMEOUT;
 import static org.infinispan.client.hotrod.impl.ConfigurationProperties.HASH_FUNCTION_PREFIX;
+import static org.infinispan.client.hotrod.impl.ConfigurationProperties.JMX;
+import static org.infinispan.client.hotrod.impl.ConfigurationProperties.JMX_DOMAIN;
+import static org.infinispan.client.hotrod.impl.ConfigurationProperties.JMX_NAME;
 import static org.infinispan.client.hotrod.impl.ConfigurationProperties.KEY_SIZE_ESTIMATE;
 import static org.infinispan.client.hotrod.impl.ConfigurationProperties.KEY_STORE_CERTIFICATE_PASSWORD;
 import static org.infinispan.client.hotrod.impl.ConfigurationProperties.KEY_STORE_FILE_NAME;
@@ -31,6 +34,7 @@ import static org.infinispan.client.hotrod.impl.ConfigurationProperties.SNI_HOST
 import static org.infinispan.client.hotrod.impl.ConfigurationProperties.SO_TIMEOUT;
 import static org.infinispan.client.hotrod.impl.ConfigurationProperties.SSL_CONTEXT;
 import static org.infinispan.client.hotrod.impl.ConfigurationProperties.SSL_PROTOCOL;
+import static org.infinispan.client.hotrod.impl.ConfigurationProperties.STATISTICS;
 import static org.infinispan.client.hotrod.impl.ConfigurationProperties.TCP_KEEP_ALIVE;
 import static org.infinispan.client.hotrod.impl.ConfigurationProperties.TCP_NO_DELAY;
 import static org.infinispan.client.hotrod.impl.ConfigurationProperties.TRUST_STORE_FILE_NAME;
@@ -169,6 +173,7 @@ public class ConfigurationTest {
 
       ConfigurationBuilder builder = new ConfigurationBuilder();
       builder
+            .statistics().enable().jmxEnable().jmxDomain("jmxInfinispanDomain").jmxName("jmxInfinispan")
             .addServer()
             .host("host1")
             .port(11222)
@@ -287,6 +292,10 @@ public class ConfigurationTest {
       p.setProperty(NEAR_CACHE_NAME_PATTERN, "near.*");
       p.setProperty(CLUSTER_PROPERTIES_PREFIX + ".siteA", "hostA1:11222; hostA2:11223");
       p.setProperty(CLUSTER_PROPERTIES_PREFIX + ".siteB", "hostB1:11222; hostB2:11223");
+      p.setProperty(STATISTICS, "true");
+      p.setProperty(JMX, "true");
+      p.setProperty(JMX_NAME, "jmxInfinispan");
+      p.setProperty(JMX_DOMAIN, "jmxInfinispanDomain");
 
       Configuration configuration = builder.withProperties(p).build();
       validateConfiguration(configuration);
@@ -572,6 +581,10 @@ public class ConfigurationTest {
       assertEquals(11222, configuration.clusters().get(1).getCluster().get(0).port());
       assertEquals("hostB2", configuration.clusters().get(1).getCluster().get(1).host());
       assertEquals(11223, configuration.clusters().get(1).getCluster().get(1).port());
+      assertTrue(configuration.statistics().enabled());
+      assertTrue(configuration.statistics().jmxEnabled());
+      assertEquals("jmxInfinispan", configuration.statistics().jmxName());
+      assertEquals("jmxInfinispanDomain", configuration.statistics().jmxDomain());
    }
 
    private void validateSSLContextConfiguration(Configuration configuration) {


### PR DESCRIPTION
Statistics options can't be configured with properties. For spring-boot infinispan integration with actuator, this should be possible.

https://issues.jboss.org/browse/ISPN-9969

backport https://github.com/infinispan/infinispan/pull/6684