### PR TITLE
ISPN-9908 Cache startup failure with server hinting and insufficient …

### DIFF
--- a/core/src/main/java/org/infinispan/distribution/ch/impl/OwnershipStatistics.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/impl/OwnershipStatistics.java
@@ -25,6 +25,9 @@ public class OwnershipStatistics {
       for (int i = 0; i < nodes.size(); i++) {
          this.nodes.put(nodes.get(i), i);
       }
+      if (this.nodes.size() != nodes.size()) {
+         throw new IllegalArgumentException("Nodes are not distinct: " + nodes);
+      }
       this.primaryOwned = new int[nodes.size()];
       this.owned = new int[nodes.size()];
    }

--- a/core/src/main/java/org/infinispan/distribution/topologyaware/TopologyInfo.java
+++ b/core/src/main/java/org/infinispan/distribution/topologyaware/TopologyInfo.java
@@ -1,208 +1,319 @@
 package org.infinispan.distribution.topologyaware;
 
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
+import java.util.ListIterator;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
+import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.remoting.transport.TopologyAwareAddress;
 
 
 /**
- * This class holds the topology hierarchy of a cache's members.
+ * This class holds the topology hierarchy of a cache's members and estimates for owned segments.
  *
  * @author Dan Berindei
  * @since 5.2
  */
 public class TopologyInfo {
-   private final Map<String, Site> allSites = new HashMap<String, Site>();
-   private List<Rack> allRacks = new ArrayList<Rack>();
-   private List<Machine> allMachines = new ArrayList<Machine>();
-   private List<Address> sortedNodes;
-   private Map<Address, Float> capacityFactors;
-   private Map<Address, Float> maxSegments;
+   private final int numSegments;
+   private final int numOwners;
+   private final Cluster cluster = new Cluster();
+   private final List<Rack> allRacks = new ArrayList<>();
+   private final List<Machine> allMachines = new ArrayList<>();
+   private final List<Node> allNodes = new ArrayList<>();
+   private final Map<Address, Node> addressMap = new HashMap<>();
 
-   public TopologyInfo(Collection<Address> members, Map<Address, Float> capacityFactors) {
-      this.capacityFactors = capacityFactors;
-      this.sortedNodes = sortMembers(members, capacityFactors);
+   public TopologyInfo(ConsistentHash ch) {
+      this(ch.getNumSegments(), ch.getNumOwners(), ch.getMembers(), ch.getCapacityFactors());
+   }
 
-      // This way, all the nodes collections at the site/rack/machine levels will be sorted
-      for (Address node : sortedNodes) {
-         if (capacityFactors == null || capacityFactors.get(node) != 0.0) {
-            addTopology(node);
+   public TopologyInfo(int numSegments, int numOwners, Collection<Address> members,
+                       Map<Address, Float> capacityFactors) {
+      this.numOwners = Math.min(numOwners, members.size());
+      this.numSegments = numSegments;
+
+      // This way, all the nodes collections at the id/rack/machine levels will be sorted
+      for (Address node : members) {
+         float capacityFactor = capacityFactors != null ? capacityFactors.get(node) : 1f;
+         if (capacityFactor != 0f) {
+            addNode(node, capacityFactor);
          }
+      }
+
+      if (cluster.totalCapacity == 0)
+         throw new IllegalArgumentException("At least one node should have non-zero capacity");
+
+      // Sort all location lists descending by capacity factor and add them to the global collections
+      // splitExpectedOwnedSegments needs location lists to be sorted
+      Collections.sort(cluster.sites);
+      for (Site site : cluster.sites) {
+         Collections.sort(site.racks);
+         for (Rack rack : site.racks) {
+            allRacks.add(rack);
+            Collections.sort(rack.machines);
+            for (Machine machine : rack.machines) {
+               allMachines.add(machine);
+               Collections.sort(machine.nodes);
+               for (Node node : machine.nodes) {
+                  allNodes.add(node);
+                  addressMap.put(node.address, node);
+               }
+            }
+         }
+      }
+
+      computeExpectedSegments();
+   }
+
+   public int getDistinctLocationsCount(TopologyLevel level) {
+      switch (level) {
+         case NODE:
+            return allNodes.size();
+         case MACHINE:
+            return allMachines.size();
+         case RACK:
+            return allRacks.size();
+         case SITE:
+            return cluster.sites.size();
+         default:
+            throw new IllegalArgumentException("Unknown level: " + level);
       }
    }
 
-   private List<Address> sortMembers(Collection<Address> members, final Map<Address, Float> capacityFactors) {
-      List<Address> sortedList = new ArrayList<Address>(members);
-      Collections.sort(sortedList, new Comparator<Address>() {
-         @Override
-         public int compare(Address o1, Address o2) {
-            // Sort descending by capacity factor and ascending by address (UUID)
-            int capacityComparison = capacityFactors != null ? capacityFactors.get(o1).compareTo(capacityFactors.get(o2)) : 0;
-            return capacityComparison != 0 ? -capacityComparison : o1.compareTo(o2);
-         }
-      });
-      return sortedList;
+   public int getDistinctLocationsCount(TopologyLevel level, Collection<Address> addresses) {
+      Set<Object> locations = new HashSet<>();
+      for (Address address : addresses) {
+         locations.add(getLocationId(level, address));
+      }
+      return locations.size();
    }
 
-   private void addTopology(Address node) {
-      TopologyAwareAddress taNode = (TopologyAwareAddress) node;
-      String siteId = taNode.getSiteId();
-      String rackId = taNode.getRackId();
-      String machineId = taNode.getMachineId();
+   public boolean duplicateLocation(TopologyLevel level, Collection<Address> addresses, Address candidate, boolean excludeCandidate) {
+      Object newLocationId = getLocationId(level, candidate);
+      for (Address address : addresses) {
+         if (!excludeCandidate || !address.equals(candidate)) {
+            if (newLocationId.equals(getLocationId(level, address)))
+               return true;
+         }
+      }
+      return false;
+   }
 
-      Site site = allSites.get(siteId);
-      if (site == null) {
-         site = new Site(siteId);
-         allSites.put(siteId, site);
+   public Object getLocationId(TopologyLevel level, Address address) {
+      Node node = addressMap.get(address);
+      Object locationId;
+      switch (level) {
+         case SITE:
+            locationId = node.machine.rack.site;
+            break;
+         case RACK:
+            locationId = node.machine.rack;
+            break;
+         case MACHINE:
+            locationId = node.machine;
+            break;
+         case NODE:
+            locationId = node;
+            break;
+         default:
+            throw new IllegalStateException("Unexpected value: " + level);
       }
-      Rack rack = site.racks.get(rackId);
-      if (rack == null) {
-         rack = new Rack(siteId, rackId);
-         site.racks.put(rackId, rack);
-         allRacks.add(rack);
-      }
-      Machine machine = rack.machines.get(machineId);
-      if (machine == null) {
-         machine = new Machine(siteId, rackId, machineId);
-         rack.machines.put(machineId, machine);
-         allMachines.add(machine);
-      }
-      machine.nodes.add(node);
-      rack.nodes.add(node);
-      site.nodes.add(node);
+      return locationId;
+   }
+
+   private void addNode(Address address, float capacityFactor) {
+      TopologyAwareAddress taa = (TopologyAwareAddress) address;
+      String siteId = taa.getSiteId();
+      String rackId = taa.getRackId();
+      String machineId = taa.getMachineId();
+
+      cluster.addNode(siteId, rackId, machineId, address, capacityFactor);
    }
 
    public Collection<Address> getSiteNodes(String site) {
-      return allSites.get(site).nodes;
+      Collection<Address> addresses = new ArrayList<>();
+      cluster.getSite(site).collectNodes(addresses);
+      return addresses;
    }
 
    public Collection<Address> getRackNodes(String site, String rack) {
-      return allSites.get(site).racks.get(rack).nodes;
+      Collection<Address> addresses = new ArrayList<>();
+      cluster.getSite(site).getRack(rack).collectNodes(addresses);
+      return addresses;
    }
 
    public Collection<Address> getMachineNodes(String site, String rack, String machine) {
-      return allSites.get(site).racks.get(rack).machines.get(machine).nodes;
+      Collection<Address> addresses = new ArrayList<>();
+      cluster.getSite(site).getRack(rack).getMachine(machine).collectNodes(addresses);
+      return addresses;
    }
 
-   public Set<String> getAllSites() {
-      return allSites.keySet();
+   public Collection<String> getAllSites() {
+      return cluster.getChildNames();
    }
 
-   public Set<String> getSiteRacks(String site) {
-      return allSites.get(site).racks.keySet();
+   public Collection<String> getSiteRacks(String site) {
+      return cluster.getSite(site).getChildNames();
    }
 
-   public Set<String> getRackMachines(String site, String rack) {
-      return allSites.get(site).racks.get(rack).machines.keySet();
-   }
-
-   public int getAllSitesCount() {
-      return allSites.size();
-   }
-
-   public int getAllRacksCount() {
-      return allRacks.size();
-   }
-
-   public int getAllMachinesCount() {
-      return allMachines.size();
-   }
-
-   public int getAllNodesCount() {
-      return sortedNodes.size();
-   }
-
-   public int getDistinctLocationsCount(TopologyLevel level, int numOwners) {
-      switch (level) {
-         case NODE:
-            return Math.min(numOwners, getAllNodesCount());
-         case MACHINE:
-            return Math.min(numOwners, getAllMachinesCount());
-         case RACK:
-            return Math.min(numOwners, getAllRacksCount());
-         case SITE:
-            return Math.min(numOwners, getAllSitesCount());
-         default:
-            throw new IllegalArgumentException("Unexpected topology level: " + level);
-      }
+   public Collection<String> getRackMachines(String site, String rack) {
+      return cluster.getSite(site).getRack(rack).getChildNames();
    }
 
    @Override
    public String toString() {
+      DecimalFormat df = new DecimalFormat("0", DecimalFormatSymbols.getInstance(Locale.ENGLISH));
+      df.setMaximumFractionDigits(2);
       StringBuilder sb = new StringBuilder("TopologyInfo{\n");
-      for (Map.Entry<String, Site> site : allSites.entrySet()) {
-         String siteId = site.getKey();
-         sb.append(String.format("%s: {", siteId));
-         for (Map.Entry<String, Rack> rack : site.getValue().racks.entrySet()) {
-            String rackId = rack.getKey();
-            sb.append(String.format("%s: {", rackId));
-            for (Map.Entry<String, Machine> machine : rack.getValue().machines.entrySet()) {
-               String machineId = machine.getKey();
-               sb.append(String.format("%s: {", machineId));
-               for (Address node : machine.getValue().nodes) {
-                  sb.append(node);
-                  sb.append(", ");
+      sb.append(formatLocation(df, cluster, ""));
+      for (Site site : cluster.sites) {
+         sb.append(formatLocation(df, site, "  "));
+         for (Rack rack : site.racks) {
+            sb.append(formatLocation(df, rack, "    "));
+            for (Machine machine : rack.machines) {
+               sb.append(formatLocation(df, machine, "      "));
+               for (Node node : machine.nodes) {
+                  sb.append(formatLocation(df, node, "        "));
                }
-               sb.setLength(sb.length() - 2);
-               sb.append("}, ");
             }
-            sb.setLength(sb.length() - 3);
-            sb.append("}, ");
          }
-         sb.setLength(sb.length() - 3);
-         sb.append("}, ");
       }
-      sb.setLength(sb.length() - 3);
-      sb.append('}');
+      sb.append("}");
       return sb.toString();
    }
 
+   public String formatLocation(DecimalFormat df, Location location, String prefix) {
+      return String.format("%s%s * %s: %s+%s \n", prefix, location.getName(), df.format(location.totalCapacity),
+                           df.format(location.expectedPrimarySegments),
+                           df.format(location.getExpectedBackupSegments()));
+   }
+
+   private void computeExpectedSegments() {
+      // Primary owners are allocated strictly based on capacity factors
+      // But for backup owners we first try to put an owner on each site, on every rack, and on every machine
+      // If there are too few nodes, each node will hold all the segments
+      // If there are too few machines, each machine will hold all the segments, and some will have duplicates
+      // The same if there are too few racks or sites
+
+      splitPrimarySegments();
+
+      splitExpectedOwnedSegments(cluster.getChildren(), numSegments * numOwners,
+                                 cluster.totalCapacity);
+   }
+
+   private void splitPrimarySegments() {
+      // Round down, the actual segment allocation is allowed to add extra segments
+      for (Node node : allNodes) {
+         float fraction = node.totalCapacity / cluster.totalCapacity;
+         node.addPrimarySegments(numSegments * fraction);
+      }
+   }
+
    /**
-    * The nodes collection must be sorted in descending order by their capacity.
+    * Split totalOwnedSegments segments into the given locations recursively.
+    *
+    * @param locations List of locations of the same level, sorted descending by capacity factor
     */
-   private double computeMaxSegmentsForNode(int numSegments, double numCopies, Collection<Address> nodes,
-                                           Address node) {
-      if (capacityFactors == null) {
-         if (nodes.size() < numCopies) {
-            return numSegments;
-         } else {
-            // The number of segment copies on each node should be the same
-            return numCopies * numSegments / nodes.size();
-         }
+   private void splitExpectedOwnedSegments(Collection<? extends Location> locations, float totalOwnedSegments,
+                                           float totalCapacity) {
+      float remainingCapacity = totalCapacity;
+      float remainingOwned = totalOwnedSegments;
+
+      // First pass, assign expected owned segments for locations with too little capacity
+      // We know we can do it without a loop because locations are ordered descending by capacity
+      List<Location> remainingLocations = new ArrayList<>(locations);
+      for (ListIterator<Location> it = remainingLocations.listIterator(locations.size()); it.hasPrevious(); ) {
+         Location location = it.previous();
+
+         if (remainingOwned < numSegments * remainingLocations.size())
+            break;
+
+         // We don't have enough locations, so each location must own at least numSegments segments
+         int minOwned = numSegments;
+         float locationOwned = remainingOwned * location.totalCapacity / remainingCapacity;
+         if (locationOwned > minOwned)
+            break;
+
+         splitExpectedOwnedSegments2(location.getChildren(), minOwned, location.totalCapacity);
+         remainingCapacity -= location.totalCapacity;
+         remainingOwned -= location.expectedOwnedSegments;
+         it.remove();
       }
 
-      Float nodeCapacityFactor = capacityFactors.get(node);
-      if (nodeCapacityFactor == 0)
-         return 0;
+      // Second pass, assign expected owned segments for locations with too much capacity
+      // We know we can do it without a loop because locations are ordered descending by capacity
+      for (Iterator<? extends Location> it = remainingLocations.iterator(); it.hasNext(); ) {
+         Location location = it.next();
 
-      double remainingCapacity = computeTotalCapacity(nodes, capacityFactors);
-      double remainingCopies = numCopies * numSegments;
-      for (Address a : nodes) {
-         float capacityFactor = capacityFactors.get(a);
-         double nodeSegments = capacityFactor / remainingCapacity * remainingCopies;
-         if (nodeSegments > numSegments) {
-            nodeSegments = numSegments;
-            remainingCapacity -= capacityFactor;
-            remainingCopies -= nodeSegments;
-            if (node.equals(a))
-               return nodeSegments;
-         } else {
-            // All the nodes from now on will have less than numSegments segments, so we can stop the iteration
-            if (!node.equals(a)) {
-               nodeSegments = nodeCapacityFactor / remainingCapacity * remainingCopies;
-            }
-            return nodeSegments;
+         float maxOwned = computeMaxOwned(remainingOwned, remainingLocations.size());
+
+         float locationOwned = remainingOwned * location.totalCapacity / remainingCapacity;
+         if (locationOwned < maxOwned)
+            break;
+
+         splitExpectedOwnedSegments2(location.getChildren(), maxOwned, location.totalCapacity);
+         remainingCapacity -= location.totalCapacity;
+         remainingOwned -= maxOwned;
+         it.remove();
+      }
+
+      // If there were exactly numSegments segments per location, we're finished here
+      if (remainingLocations.isEmpty())
+         return;
+
+      // Third pass: If more than numSegments segments per location, split segments between their children
+      // Else spread remaining segments based only on the capacity, rounding down
+      if (remainingLocations.size() * numSegments < remainingOwned) {
+         List<Location> childrenLocations = new ArrayList<>(remainingLocations.size() * 2);
+         for (Location location : remainingLocations) {
+            childrenLocations.addAll(location.getChildren());
+         }
+         Collections.sort(childrenLocations);
+         splitExpectedOwnedSegments2(childrenLocations, remainingOwned, remainingCapacity);
+      } else {
+         // The allocation algorithm can assign more segments to nodes, so it's ok to miss some segments here
+         float fraction = remainingOwned / remainingCapacity;
+         for (Location location : remainingLocations) {
+            float locationOwned = location.totalCapacity * fraction;
+            splitExpectedOwnedSegments2(location.getChildren(), locationOwned, location.totalCapacity);
          }
       }
-      throw new IllegalStateException("The nodes collection does not include " + node);
+   }
+
+   private float computeMaxOwned(float remainingOwned, int locationsCount) {
+      float maxOwned;
+      if (remainingOwned < numSegments) {
+         // We already have enough owners on siblings of the parent location
+         maxOwned = remainingOwned;
+      } else if (remainingOwned < numSegments * locationsCount) {
+         // We have enough locations to so we don't put more than numSegments segments in any of them
+         maxOwned = numSegments;
+      } else {
+         // We don't have enough locations, so each location gets at least numSegments
+         maxOwned = remainingOwned - numSegments * (locationsCount - 1);
+      }
+      return maxOwned;
+   }
+
+   private void splitExpectedOwnedSegments2(Collection<? extends Location> locations,
+                                            float totalOwnedSegments, float totalCapacity) {
+      Location first = locations.iterator().next();
+      if (locations.size() == 1 && first instanceof Node) {
+         ((Node) first).addOwnedSegments(totalOwnedSegments);
+      } else {
+         splitExpectedOwnedSegments(locations, totalOwnedSegments, totalCapacity);
+      }
    }
 
    public float computeTotalCapacity(Collection<Address> nodes, Map<Address, Float> capacityFactors) {
@@ -216,132 +327,241 @@ public class TopologyInfo {
       return totalCapacity;
    }
 
-   private double computeMaxSegmentsForMachine(int numSegments, double numCopies, Collection<Machine> machines,
-                                              Machine machine, Address node) {
-      // The number of segment copies on each machine should be the same, except where not possible
-      double copiesPerMachine = numCopies / machines.size();
-      if (machine.nodes.size() <= copiesPerMachine) {
-         copiesPerMachine = 1;
-      } else {
-         int fullMachines = 0;
-         for (Machine m : machines) {
-            if (m.nodes.size() <= copiesPerMachine) {
-               fullMachines++;
-            }
+   public float getExpectedPrimarySegments(Address address) {
+      Node node = addressMap.get(address);
+      return node != null ? node.expectedPrimarySegments : 0;
+   }
+
+   public float getExpectedOwnedSegments(Address address) {
+      Node node = addressMap.get(address);
+      return node != null ? node.expectedOwnedSegments : 0;
+   }
+
+   /**
+    * Base class for locations.
+    *
+    * <p>Implements Comparable, but locations with equal capacity are equal, so they can't be used as map keys.</p>
+    */
+   static abstract class Location implements Comparable<Location> {
+      float totalCapacity;
+      int nodeCount;
+      float expectedPrimarySegments;
+      float expectedOwnedSegments;
+
+      abstract Collection<? extends Location> getChildren();
+
+      abstract String getName();
+
+      float getCapacityPerNode() {
+         return totalCapacity / nodeCount;
+      }
+
+      float getExpectedBackupSegments() {
+         return expectedOwnedSegments - expectedPrimarySegments;
+      }
+
+      void collectNodes(Collection<Address> addressCollection) {
+         for (Location location : getChildren()) {
+            location.collectNodes(addressCollection);
          }
-         copiesPerMachine = (numCopies - fullMachines) / (machines.size() - fullMachines);
       }
-      return computeMaxSegmentsForNode(numSegments, copiesPerMachine, machine.nodes, node);
-   }
 
-   private double computeMaxSegmentsForRack(int numSegments, double numCopies, Collection<Rack> racks, Rack rack,
-                                           Machine machine, Address node) {
-      // Not enough racks to have an owner in each rack.
-      // The number of segment copies on each Rack should be the same, except where not possible
-      double copiesPerRack = numCopies / racks.size();
-      if (rack.machines.size() <= copiesPerRack) {
-         copiesPerRack = 1;
-      } else {
-         int fullRacks = 0;
-         for (Rack m : racks) {
-            if (m.machines.size() <= copiesPerRack) {
-               fullRacks++;
-            }
+      public Collection<String> getChildNames() {
+         Collection<String> names = new ArrayList<>();
+         for (Location location : getChildren()) {
+            names.add(location.getName());
          }
-         copiesPerRack = (numCopies - fullRacks) / (racks.size() - fullRacks);
+         return names;
       }
-      if (copiesPerRack <= 1) {
-         return computeMaxSegmentsForNode(numSegments, copiesPerRack, rack.nodes, node);
-      } else {
-         return computeMaxSegmentsForMachine(numSegments, copiesPerRack, rack.machines.values(), machine, node);
+
+      @Override
+      public int compareTo(Location o) {
+         // Sort descending by total capacity, ignore everything else
+         return Float.compare(o.totalCapacity, totalCapacity);
+      }
+
+      @Override
+      public String toString() {
+         return getName() + " * " + totalCapacity + ": " + expectedPrimarySegments + "+" + getExpectedBackupSegments();
       }
    }
 
-   private double computeMaxSegmentsForSite(int numSegments, double numCopies, Collection<Site> sites,
-                                           Site site, Rack rack, Machine machine, Address node) {
-      // Not enough allSites to have an owner in each site.
-      // The number of segment copies on each Site should be the same, except where not possible
-      double copiesPerSite = numCopies / sites.size();
-      if (site.racks.size() <= copiesPerSite) {
-         copiesPerSite = 1;
-      } else {
-         int fullSites = 0;
-         for (Site s : sites) {
-            if (s.racks.size() <= copiesPerSite) {
-               fullSites++;
-            }
+   private static class Cluster extends Location {
+      final List<Site> sites = new ArrayList<>();
+      final Map<String, Site> siteMap = new HashMap<>();
+
+      void addNode(String siteId, String rackId, String machineId, Address address, float capacityFactor) {
+         Site site = siteMap.get(siteId);
+         if (site == null) {
+            site = new Site(this, siteId);
+            sites.add(site);
+            siteMap.put(siteId, site);
          }
-         // need to compute for racks if there are enough racks in total
-         copiesPerSite = (numCopies - fullSites) / (sites.size() - fullSites);
+         site.addNode(rackId, machineId, address, capacityFactor);
+         totalCapacity += capacityFactor;
+         nodeCount++;
       }
-      if (copiesPerSite <= 1) {
-         return computeMaxSegmentsForNode(numSegments, copiesPerSite, site.nodes, node);
-      } else {
-         return computeMaxSegmentsForRack(numSegments, copiesPerSite, site.racks.values(), rack, machine, node);
+
+      Site getSite(String siteId) {
+         return siteMap.get(siteId);
+      }
+
+      @Override
+      Collection<Site> getChildren() {
+         return sites;
+      }
+
+      @Override
+      String getName() {
+         return "cluster";
       }
    }
 
+   private static class Site extends Location {
+      final Cluster cluster;
+      final String siteId;
 
-   public int computeExpectedSegments(int numSegments, int numOwners, Address node) {
-      if (capacityFactors != null && capacityFactors.get(node) == 0.0)
-         return 0;
+      final List<Rack> racks = new ArrayList<>();
+      final Map<String, Rack> rackMap = new HashMap<>();
 
-      TopologyAwareAddress taa = (TopologyAwareAddress) node;
-      String siteId = taa.getSiteId();
-      String rackId = taa.getRackId();
-      String machineId = taa.getMachineId();
-
-      Site site = allSites.get(siteId);
-      Rack rack = site.racks.get(rackId);
-      Machine machine = rack.machines.get(machineId);
-
-      double maxSegments;
-      if (numOwners == 1) {
-         maxSegments = computeMaxSegmentsForNode(numSegments, numOwners, sortedNodes, node);
-      } else if (getAllNodesCount() <= numOwners) {
-         maxSegments = numSegments;
-      } else if (getAllMachinesCount() <= numOwners) {
-         maxSegments = computeMaxSegmentsForMachine(numSegments, numOwners, allMachines, machine, node);
-      } else if (getAllRacksCount() <= numOwners) {
-         maxSegments = computeMaxSegmentsForRack(numSegments, numOwners, allRacks, rack, machine, node);
-      } else {
-         maxSegments = computeMaxSegmentsForSite(numSegments, numOwners, allSites.values(), site, rack, machine, node);
+      Site(Cluster cluster, String siteId) {
+         this.cluster = cluster;
+         this.siteId = siteId;
       }
-      return (int) Math.round(maxSegments);
+
+      void addNode(String rackId, String machineId, Address address, float capacityFactor) {
+         Rack rack = rackMap.get(rackId);
+         if (rack == null) {
+            rack = new Rack(this, rackId);
+            racks.add(rack);
+            rackMap.put(rackId, rack);
+         }
+         rack.addNode(machineId, address, capacityFactor);
+         totalCapacity += capacityFactor;
+         nodeCount++;
+      }
+
+      Rack getRack(String rackId) {
+         return rackMap.get(rackId);
+      }
+
+      @Override
+      Collection<Rack> getChildren() {
+         return racks;
+      }
+
+      @Override
+      String getName() {
+         return siteId;
+      }
    }
 
-   private static class Site {
-      String site;
-      Map<String, Rack> racks = new HashMap<String, Rack>();
-      List<Address> nodes = new ArrayList<Address>();
+   private static class Rack extends Location {
+      final Site site;
+      final String rackId;
 
-      private Site(String site) {
+      final List<Machine> machines = new ArrayList<>();
+      final Map<String, Machine> machineMap = new HashMap<>();
+
+      Rack(Site site, String rackId) {
          this.site = site;
+         this.rackId = rackId;
+      }
+
+      void addNode(String machineId, Address address, float capacityFactor) {
+         Machine machine = machineMap.get(machineId);
+         if (machine == null) {
+            machine = new Machine(this, machineId);
+            machines.add(machine);
+            machineMap.put(machineId, machine);
+         }
+         machine.addNode(address, capacityFactor);
+         totalCapacity += capacityFactor;
+         nodeCount++;
+      }
+
+      Machine getMachine(String machineId) {
+         return machineMap.get(machineId);
+      }
+
+      @Override
+      Collection<Machine> getChildren() {
+         return machines;
+      }
+
+      @Override
+      String getName() {
+         return rackId;
       }
    }
 
-   private static class Rack {
-      String site;
-      String rack;
-      Map<String, Machine> machines = new HashMap<String, Machine>();
-      List<Address> nodes = new ArrayList<Address>();
+   private static class Machine extends Location {
+      final Rack rack;
+      final String machineId;
 
-      private Rack(String site, String rack) {
-         this.site = site;
+      final List<Node> nodes = new ArrayList<>();
+
+      Machine(Rack rack, String machineId) {
          this.rack = rack;
+         this.machineId = machineId;
+      }
+
+      void addNode(Address address, float capacityFactor) {
+         nodes.add(new Node(this, address, capacityFactor));
+         totalCapacity += capacityFactor;
+         nodeCount++;
+      }
+
+      @Override
+      Collection<Node> getChildren() {
+         return nodes;
+      }
+
+      @Override
+      String getName() {
+         return machineId;
       }
    }
 
-   private static class Machine {
-      String site;
-      String rack;
-      String machine;
-      List<Address> nodes = new ArrayList<Address>();
+   private static class Node extends Location {
+      final Machine machine;
+      final Address address;
 
-      private Machine(String site, String rack, String machine) {
-         this.site = site;
-         this.rack = rack;
+      Node(Machine machine, Address address, float capacityFactor) {
          this.machine = machine;
+         this.address = address;
+         this.totalCapacity = capacityFactor;
+      }
+
+      @Override
+      Collection<Node> getChildren() {
+         return Collections.singletonList(this);
+      }
+
+      @Override
+      void collectNodes(Collection<Address> addressCollection) {
+         addressCollection.add(address);
+      }
+
+      @Override
+      String getName() {
+         return address.toString();
+      }
+
+      void addPrimarySegments(float segments) {
+         expectedPrimarySegments += segments;
+         machine.expectedPrimarySegments += segments;
+         machine.rack.expectedPrimarySegments += segments;
+         machine.rack.site.expectedPrimarySegments += segments;
+         machine.rack.site.cluster.expectedPrimarySegments += segments;
+      }
+
+      void addOwnedSegments(float segments) {
+         expectedOwnedSegments += segments;
+         machine.expectedOwnedSegments += segments;
+         machine.rack.expectedOwnedSegments += segments;
+         machine.rack.site.expectedOwnedSegments += segments;
+         machine.rack.site.cluster.expectedOwnedSegments += segments;
       }
    }
 }

--- a/core/src/test/java/org/infinispan/distribution/topologyaware/TopologyAwareSyncConsistentHashFactoryTest.java
+++ b/core/src/test/java/org/infinispan/distribution/topologyaware/TopologyAwareSyncConsistentHashFactoryTest.java
@@ -34,16 +34,18 @@ public class TopologyAwareSyncConsistentHashFactoryTest extends TopologyAwareCon
    }
 
    @Override
-   protected void assertDistribution(int numOwners, List<Address> currentMembers) {
+   protected void assertDistribution(List<Address> currentMembers, int numOwners, int numSegments) {
       TopologyAwareOwnershipStatistics stats = new TopologyAwareOwnershipStatistics(ch);
       log.tracef("Ownership stats: " + stats);
       for (Address node : currentMembers) {
-         int maxPrimarySegments = stats.computeExpectedSegments(numSegments, 1, node);
-         int maxSegments = stats.computeExpectedSegments(numSegments, numOwners, node);
-         assertTrue(0.65 * maxPrimarySegments <= stats.getPrimaryOwned(node));
-         assertTrue(stats.getPrimaryOwned(node) <= 1.2 * maxPrimarySegments);
-         assertTrue(0.65 * maxSegments <= stats.getOwned(node));
-         assertTrue(stats.getOwned(node) <= 1.2 * maxSegments);
+         float expectedPrimarySegments = stats.computeExpectedPrimarySegments(node);
+         float expectedOwnedSegments = stats.computeExpectedOwnedSegments(node);
+         int primaryOwned = stats.getPrimaryOwned(node);
+         int owned = stats.getOwned(node);
+         assertTrue(Math.floor(0.7 * expectedPrimarySegments) <= primaryOwned);
+         assertTrue(primaryOwned <= Math.ceil(1.2 * expectedPrimarySegments));
+         assertTrue(Math.floor(0.7 * expectedOwnedSegments) <= owned);
+         assertTrue(owned <= Math.ceil(1.2 * expectedOwnedSegments));
       }
    }
 }


### PR DESCRIPTION
…segments

https://issues.jboss.org/browse/ISPN-9908

* Precompute maximum owned segments
* Round up the number of allowed primary segments
* Allow backup owners which don't have any primary segment

I have another local branch with a more ambitious rewrite of the [TA]SCHF algorithm, but it needs lots more work.