### PR TITLE
ISPN-9667 DefaultCacheManager inconsistent status checks

### DIFF
--- a/core/src/main/java/org/infinispan/health/impl/ClusterHealthImpl.java
+++ b/core/src/main/java/org/infinispan/health/impl/ClusterHealthImpl.java
@@ -49,14 +49,15 @@ public class ClusterHealthImpl implements ClusterHealth {
 
    @Override
    public int getNumberOfNodes() {
-      return Optional.ofNullable(cacheManager.getTransport()).map(t -> t.getMembers().size()).orElse(1);
+      return Optional.ofNullable(cacheManager.getMembers()).orElse(Collections.emptyList())
+                     .size();
    }
 
    @Override
    public List<String> getNodeNames() {
-      return Optional.ofNullable(cacheManager.getTransport()).map(t -> t.getMembers()).orElse(Collections.emptyList())
-            .stream()
-            .map(member -> member.toString())
-            .collect(Collectors.toList());
+      return Optional.ofNullable(cacheManager.getMembers()).orElse(Collections.emptyList())
+                     .stream()
+                     .map(Object::toString)
+                     .collect(Collectors.toList());
    }
 }

--- a/core/src/test/java/org/infinispan/health/ClusterHealthImplTest.java
+++ b/core/src/test/java/org/infinispan/health/ClusterHealthImplTest.java
@@ -156,7 +156,7 @@ public class ClusterHealthImplTest extends AbstractInfinispanTest {
    public void testGetNumberOfNodesWithNullTransport() throws Exception {
       ClusterHealth clusterHealth = new ClusterHealthImpl(mockedCacheManager);
 
-      assertEquals(1, clusterHealth.getNumberOfNodes());
+      assertEquals(0, clusterHealth.getNumberOfNodes());
    }
 
    public void testGetNodeNamesWithNullTransport() throws Exception {

--- a/server/core/src/main/java/org/infinispan/server/core/transport/NettyTransportConnectionStats.java
+++ b/server/core/src/main/java/org/infinispan/server/core/transport/NettyTransportConnectionStats.java
@@ -62,8 +62,7 @@ class NettyTransportConnectionStats {
 
    private boolean needDistributedCalculation() {
       if (cacheManager != null) {
-         org.infinispan.remoting.transport.Transport transport = cacheManager.getTransport();
-         return transport != null && transport.getMembers().size() > 1;
+         return cacheManager.getMembers() != null && cacheManager.getMembers().size() > 1;
       }
       return false;
    }

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/AbstractCacheConfigurationService.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/AbstractCacheConfigurationService.java
@@ -70,7 +70,7 @@ public abstract class AbstractCacheConfigurationService implements Service<Confi
 
         EmbeddedCacheManager container = this.getCacheContainer();
         CacheMode mode = this.config.clustering().cacheMode();
-        if (mode.isClustered() && (container.getTransport() == null)) {
+        if (mode.isClustered() && (container.getCacheManagerConfiguration().transport().transport() == null)) {
             throw InfinispanMessages.MESSAGES.transportRequired(mode, this.name, container.getCacheManagerConfiguration().globalJmxStatistics().cacheManagerName());
         }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-9667

Previous fix was incomplete, because the getCache() returned null while stopping.

Cache the Transport so we can return the local address even while stopping.