### PR TITLE
ISPN-9863 Fix leak-related random failures

### DIFF
--- a/atomic-factory/pom.xml
+++ b/atomic-factory/pom.xml
@@ -62,6 +62,16 @@
                     </instructions>
                 </configuration>
             </plugin>
+           <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <configuration>
+                 <dependenciesToScan>
+                    <!-- TestNGSuiteChecksTest -->
+                    <dependency>org.infinispan:infinispan-commons-test</dependency>
+                 </dependenciesToScan>
+              </configuration>
+           </plugin>
         </plugins>
     </build>
 

--- a/cdi/embedded/pom.xml
+++ b/cdi/embedded/pom.xml
@@ -122,6 +122,10 @@
                     <forkCount>1</forkCount>
                     <parallel>none</parallel>
                     <groups>${defaultTestGroup}</groups>
+                   <dependenciesToScan>
+                      <!-- TestNGSuiteChecksTest -->
+                      <dependency>org.infinispan:infinispan-commons-test</dependency>
+                   </dependenciesToScan>
                 </configuration>
             </plugin>
         </plugins>

--- a/cdi/remote/pom.xml
+++ b/cdi/remote/pom.xml
@@ -147,6 +147,9 @@
                     <forkCount>1</forkCount>
                     <parallel>none</parallel>
                     <groups>${defaultTestGroup}</groups>
+                   <dependenciesToScan>
+                      <dependency>org.infinispan:infinispan-commons-test</dependency>
+                   </dependenciesToScan>
                 </configuration>
             </plugin>
         </plugins>

--- a/cdi/remote/src/test/java/org/infinispan/cdi/embedded/test/cachemanager/remote/DefaultCacheManagerOverrideTest.java
+++ b/cdi/remote/src/test/java/org/infinispan/cdi/embedded/test/cachemanager/remote/DefaultCacheManagerOverrideTest.java
@@ -59,7 +59,7 @@ public class DefaultCacheManagerOverrideTest extends Arquillian {
       return new RemoteCacheManager(clientBuilder.build());
    }
 
-   public void stopRemoteCacheManager(@Disposes RemoteCacheManager remoteCacheManager) {
+   static void stopRemoteCacheManager(@Disposes RemoteCacheManager remoteCacheManager) {
       remoteCacheManager.stop();
    }
 }

--- a/cli/cli-client/pom.xml
+++ b/cli/cli-client/pom.xml
@@ -75,6 +75,9 @@
                 <reuseForks>false</reuseForks>
                 <forkCount>1</forkCount>
                 <parallel>none</parallel>
+               <dependenciesToScan>
+                  <dependency>org.infinispan:infinispan-commons-test</dependency>
+               </dependenciesToScan>
             </configuration>
          </plugin>
          <plugin>

--- a/cli/cli-interpreter/pom.xml
+++ b/cli/cli-interpreter/pom.xml
@@ -144,6 +144,16 @@
                </instructions>
             </configuration>
          </plugin>
+           <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <configuration>
+                 <dependenciesToScan>
+                    <!-- TestNGSuiteChecksTest -->
+                    <dependency>org.infinispan:infinispan-commons-test</dependency>
+                 </dependenciesToScan>
+              </configuration>
+           </plugin>
       </plugins>
    </build>
 </project>

--- a/client/hotrod-client/pom.xml
+++ b/client/hotrod-client/pom.xml
@@ -201,6 +201,10 @@
                <systemPropertyVariables combine.self="append">
                   <infinispan.server.hotrod.workerThreads>3</infinispan.server.hotrod.workerThreads>
                </systemPropertyVariables>
+               <dependenciesToScan>
+                  <!-- TestNGSuiteChecksTest -->
+                  <dependency>org.infinispan:infinispan-commons-test</dependency>
+               </dependenciesToScan>
             </configuration>
          </plugin>
          <plugin>

--- a/client/marshaller/kryo/kryo-marshaller/pom.xml
+++ b/client/marshaller/kryo/kryo-marshaller/pom.xml
@@ -36,4 +36,19 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+   <build>
+      <plugins>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+               <dependenciesToScan>
+                  <!-- TestNGSuiteChecksTest -->
+                  <dependency>org.infinispan:infinispan-commons-test</dependency>
+               </dependenciesToScan>
+            </configuration>
+         </plugin>
+      </plugins>
+   </build>
 </project>

--- a/client/marshaller/protostuff/protostuff-marshaller/pom.xml
+++ b/client/marshaller/protostuff/protostuff-marshaller/pom.xml
@@ -38,4 +38,19 @@
             <type>test-jar</type>
         </dependency>
     </dependencies>
+
+   <build>
+      <plugins>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+               <dependenciesToScan>
+                  <!-- TestNGSuiteChecksTest -->
+                  <dependency>org.infinispan:infinispan-commons-test</dependency>
+               </dependenciesToScan>
+            </configuration>
+         </plugin>
+      </plugins>
+   </build>
 </project>

--- a/commons-test/src/main/java/org/infinispan/commons/test/TestNGSuiteChecksTest.java
+++ b/commons-test/src/main/java/org/infinispan/commons/test/TestNGSuiteChecksTest.java
@@ -1,0 +1,124 @@
+package org.infinispan.commons.test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.testng.ITestContext;
+import org.testng.ITestNGMethod;
+import org.testng.annotations.AfterSuite;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.Test;
+
+/**
+ * This test checks for thread leaks.
+ *
+ * The check must be in a configuration method, because TestNG doesn't report listener exceptions properly.
+ *
+ * @since 10.0
+ * @author Dan Berindei
+ */
+@Test(groups = {"unit", "smoke"}, testName = "test.fwk.TestNGSuiteChecksTest")
+public class TestNGSuiteChecksTest {
+   private static final Set<String> REQUIRED_GROUPS = new HashSet<>(
+      Arrays.asList("unit", "functional", "xsite", "arquillian", "stress", "profiling", "manual", "unstable"));
+   private static final Set<String> ALLOWED_GROUPS = new HashSet<>(
+      Arrays.asList("unit", "functional", "xsite", "arquillian", "stress", "profiling", "manual", "unstable",
+                    "smoke", "java10", "transaction"));
+
+   @BeforeSuite(alwaysRun = true)
+   public void beforeSuite(ITestContext context) {
+      List<String> errors = new ArrayList<>();
+      Set<Class> classes = new HashSet<>();
+      checkAnnotations(errors, classes, context.getSuite().getExcludedMethods());
+      checkAnnotations(errors, classes, context.getSuite().getAllMethods());
+      if (!errors.isEmpty()) {
+         throw new AssertionError(String.join("\n", errors));
+      }
+   }
+
+   @AfterSuite(alwaysRun = true)
+   public void afterSuite() {
+      ThreadLeakChecker.checkForLeaks(TestNGSuiteChecksTest.class.getName());
+   }
+
+   private void checkAnnotations(List<String> errors, Set<Class> classes, Collection<ITestNGMethod> methods) {
+      for (ITestNGMethod m : methods) {
+         checkMethodAnnotations(errors, m);
+         checkClassAnnotations(errors, classes, m);
+      }
+   }
+
+   private void checkMethodAnnotations(List<String> errors, ITestNGMethod m) {
+      if (!m.getEnabled())
+         return;
+
+      boolean hasRequiredGroup = false;
+      for (String g : m.getGroups()) {
+         if (!ALLOWED_GROUPS.contains(g)) {
+            errors.add(
+               "Method " + m.getConstructorOrMethod() +
+               " and/or its class has a @Test annotation with the wrong group: " +
+               g + ".\nAllowed groups are " + ALLOWED_GROUPS);
+            return;
+         }
+         if (REQUIRED_GROUPS.contains(g)) {
+            hasRequiredGroup = true;
+         }
+      }
+      if (!hasRequiredGroup) {
+         errors.add("Method " + m.getConstructorOrMethod() + " and/or its class don't have any required group." +
+                    "\nRequired groups are " + REQUIRED_GROUPS);
+         return;
+      }
+
+      // Some stress tests extend a functional test and change some parameters (e.g. number of operations)
+      // If the author forgets to override the test methods, they inherit the group from the base class
+      Class<?> testClass = m.getRealClass();
+      Class<?> declaringClass = m.getConstructorOrMethod().getDeclaringClass();
+      Test annotation = testClass.getAnnotation(Test.class);
+      if (testClass != declaringClass) {
+         if (!Arrays.equals(annotation.groups(), m.getGroups())) {
+            errors.add("Method " + m.getConstructorOrMethod() + " was inherited from class " + declaringClass +
+                       " with groups " + Arrays.toString(m.getGroups()) +
+                       ", but the test class has groups " + Arrays.toString(annotation.groups()));
+         }
+      }
+   }
+
+   private void checkClassAnnotations(List<String> errors, Set<Class> processedClasses, ITestNGMethod m) {
+      // Class of the test instance
+      Class<?> testClass = m.getTestClass().getRealClass();
+
+      // Check that the test instance's class matches the XmlTest's support class
+      // They can be different if a test inherits a @Factory method and doesn't override it
+      // Ignore multiple classes in the same XmlTest, which can happen when running from the IDE
+      // or when the testName is incorrect (handled below)
+      if (m.getXmlTest().getXmlClasses().size() == 1) {
+         Class xmlClass = m.getXmlTest().getXmlClasses().get(0).getSupportClass();
+         if (xmlClass != testClass && processedClasses.add(xmlClass)) {
+            errors.add("Class " + xmlClass.getName() + " must override the @Factory method from base class " +
+                       testClass.getName());
+            return;
+         }
+      }
+
+      if (!processedClasses.add(testClass))
+         return;
+
+      // Check that the testName in the @Test annotation is set and matches the test class
+      // All tests with the same testName or without a testName run in the same XmlTest
+      // which means they also run in the same thread, not in parallel
+      Test annotation = testClass.getAnnotation(Test.class);
+      if (annotation == null || annotation.testName().isEmpty()) {
+         errors.add("Class " + testClass.getName() + " does not have a testName");
+         return;
+      }
+      if (!annotation.testName().contains(testClass.getSimpleName())) {
+         errors.add("Class " + testClass.getName() + " has an invalid testName: " + annotation.testName());
+      }
+   }
+}

--- a/commons-test/src/main/java/org/infinispan/commons/test/TestNGTestListener.java
+++ b/commons-test/src/main/java/org/infinispan/commons/test/TestNGTestListener.java
@@ -1,11 +1,6 @@
 package org.infinispan.commons.test;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 
 import org.jboss.logging.Logger;
 import org.testng.IConfigurationListener2;
@@ -13,20 +8,13 @@ import org.testng.ISuite;
 import org.testng.ISuiteListener;
 import org.testng.ITestContext;
 import org.testng.ITestListener;
-import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
-import org.testng.TestNGException;
 import org.testng.annotations.Test;
 
 /**
  * Logs TestNG test progress.
  */
 public class TestNGTestListener implements ITestListener, IConfigurationListener2, ISuiteListener {
-   private static final Set<String> REQUIRED_GROUPS = new HashSet<>(
-      Arrays.asList("unit", "functional", "xsite", "arquillian", "stress", "profiling", "manual", "unstable"));
-   private static final Set<String> ALLOWED_GROUPS = new HashSet<>(
-      Arrays.asList("unit", "functional", "xsite", "arquillian", "stress", "profiling", "manual", "unstable",
-                    "smoke", "java10", "transaction"));
    private static final Logger log = Logger.getLogger(TestNGTestListener.class);
 
    private final TestSuiteProgress progressLogger;
@@ -62,11 +50,13 @@ public class TestNGTestListener implements ITestListener, IConfigurationListener
 
    @Override
    public void onStart(ITestContext context) {
-      Thread.currentThread().setName("before-" + context.getName());
+      Thread.currentThread().setName("testng-" + context.getName());
+      ThreadLeakChecker.testStarted(context.getCurrentXmlTest().getXmlClasses().get(0).getName());
    }
 
    @Override
    public void onFinish(ITestContext context) {
+      ThreadLeakChecker.testFinished(context.getCurrentXmlTest().getXmlClasses().get(0).getName());
    }
 
    private String testName(ITestResult res) {
@@ -85,94 +75,11 @@ public class TestNGTestListener implements ITestListener, IConfigurationListener
 
    @Override
    public void onStart(ISuite suite) {
-      List<String> errors = new ArrayList<>();
-      Set<Class> classes = new HashSet<>();
-      checkAnnotations(errors, classes, suite.getExcludedMethods());
-      checkAnnotations(errors, classes, suite.getAllMethods());
-      if (!errors.isEmpty()) {
-         throw new TestNGException(String.join("\n", errors));
-      }
+      ThreadLeakChecker.saveInitialThreads();
    }
 
    @Override
    public void onFinish(ISuite suite) {
-   }
-
-   private void checkAnnotations(List<String> errors, Set<Class> classes, Collection<ITestNGMethod> methods) {
-      for (ITestNGMethod m : methods) {
-         checkMethodAnnotations(errors, m);
-         checkClassAnnotations(errors, classes, m);
-      }
-   }
-
-   private void checkMethodAnnotations(List<String> errors, ITestNGMethod m) {
-      if (!m.getEnabled())
-         return;
-
-      boolean hasRequiredGroup = false;
-      for (String g : m.getGroups()) {
-         if (!ALLOWED_GROUPS.contains(g)) {
-            errors.add(
-               "Method " + m.getConstructorOrMethod() +
-               " and/or its class has a @Test annotation with the wrong group: " +
-               g + ".\nAllowed groups are " + ALLOWED_GROUPS);
-            return;
-         }
-         if (REQUIRED_GROUPS.contains(g)) {
-            hasRequiredGroup = true;
-         }
-      }
-      if (!hasRequiredGroup) {
-         errors.add("Method " + m.getConstructorOrMethod() + " and/or its class don't have any required group." +
-                    "\nRequired groups are " + REQUIRED_GROUPS);
-         return;
-      }
-
-      // Some stress tests extend a functional test and change some parameters (e.g. number of operations)
-      // If the author forgets to override the test methods, they inherit the group from the base class
-      Class<?> testClass = m.getRealClass();
-      Class<?> declaringClass = m.getConstructorOrMethod().getDeclaringClass();
-      Test annotation = testClass.getAnnotation(Test.class);
-      if (testClass != declaringClass) {
-         if (!Arrays.equals(annotation.groups(), m.getGroups())) {
-            errors.add("Method " + m.getConstructorOrMethod() + " was inherited from class " + declaringClass +
-                       " with groups " + Arrays.toString(m.getGroups()) +
-                       ", but the test class has groups " + Arrays.toString(annotation.groups()));
-         }
-      }
-   }
-
-   private void checkClassAnnotations(List<String> errors, Set<Class> processedClasses, ITestNGMethod m) {
-      // Class of the test instance
-      Class<?> testClass = m.getTestClass().getRealClass();
-
-      // Check that the test instance's class matches the XmlTest's support class
-      // They can be different if a test inherits a @Factory method and doesn't override it
-      // Ignore multiple classes in the same XmlTest, which can happen when running from the IDE
-      // or when the testName is incorrect (handled below)
-      if (m.getXmlTest().getXmlClasses().size() == 1) {
-         Class xmlClass = m.getXmlTest().getXmlClasses().get(0).getSupportClass();
-         if (xmlClass != testClass && processedClasses.add(xmlClass)) {
-            errors.add("Class " + xmlClass.getName() + " must override the @Factory method from base class " +
-                       testClass.getName());
-            return;
-         }
-      }
-
-      if (!processedClasses.add(testClass))
-         return;
-
-      // Check that the testName in the @Test annotation is set and matches the test class
-      // All tests with the same testName or without a testName run in the same XmlTest
-      // which means they also run in the same thread, not in parallel
-      Test annotation = testClass.getAnnotation(Test.class);
-      if (annotation == null || annotation.testName().isEmpty()) {
-         errors.add("Class " + testClass.getName() + " does not have a testName");
-         return;
-      }
-      if (!annotation.testName().contains(testClass.getSimpleName())) {
-         errors.add("Class " + testClass.getName() + " has an invalid testName: " + annotation.testName());
-      }
    }
 
    @Override

--- a/commons-test/src/main/java/org/infinispan/commons/test/ThreadLeakChecker.java
+++ b/commons-test/src/main/java/org/infinispan/commons/test/ThreadLeakChecker.java
@@ -56,7 +56,15 @@ public class ThreadLeakChecker {
                       "|Hibernate Search sync consumer thread for index" +
                       // Reader thread sometimes stays alive for 20s after stop (JGRP-2328)
                       "|NioConnection.Reader" +
+                      // java.lang.ProcessHandleImpl
+                      "|process reaper" +
+                      // Arquillian uses the static default XNIO worker
+                      "|XNIO-1 " +
+                      // org.apache.mina.transport.socket.nio.NioDatagramAcceptor.DEFAULT_RECYCLER
+                      "|ExpiringMapExpirer" +
                       ").*");
+   private static final String ARQUILLIAN_CONSOLE_CONSUMER =
+      "org.jboss.as.arquillian.container.managed.ManagedDeployableContainer$ConsoleConsumer";
 
    private static Logger log = Logger.getLogger(ThreadLeakChecker.class);
    private static volatile long lastUpdate = 0;
@@ -65,11 +73,24 @@ public class ThreadLeakChecker {
    private static final Map<Thread, LeakInfo> runningThreads = new ConcurrentHashMap<>();
    private static final Lock lock = new ReentrantLock();
 
+   /**
+    * A test class has started, and we should consider it as a potential owner for new threads.
+    */
    public static void testStarted(String testName) {
-      runningTests.add(testName);
+      lock.lock();
+      try {
+         runningTests.add(testName);
+      } finally {
+         lock.unlock();
+      }
+   }
 
-      // Save the system threads in order to ignore them
-      if (lastUpdate == 0) {
+   /**
+    * Save the system threads in order to ignore them
+    */
+   public static void saveInitialThreads() {
+      lock.lock();
+      try {
          Set<Thread> currentThreads = getThreadsSnapshot();
          for (Thread thread : currentThreads) {
             LeakInfo leakInfo = new LeakInfo(thread, Collections.emptyList());
@@ -77,43 +98,74 @@ public class ThreadLeakChecker {
             runningThreads.putIfAbsent(thread, leakInfo);
          }
          lastUpdate = System.nanoTime();
+      } finally {
+         lock.unlock();
       }
    }
 
+   /**
+    * A test class has finished, and we should not consider it a potential owner for new threads any more.
+    */
    public static void testFinished(String testName) {
-      finishedTests.add(testName);
-
       lock.lock();
       try {
-         // Available owners are tests that were running at any point since the last check
-         List<String> availableOwners = new ArrayList<>(runningTests);
-         List<String> testsJustFinished = drain(finishedTests);
+         finishedTests.add(testName);
 
          // Only update threads once per second, unless this is the last test
          // or the test suite runs on a single thread
-         boolean noTestsRunning = runningTests.size() == testsJustFinished.size();
-         if (noTestsRunning && (System.nanoTime() - lastUpdate < TimeUnit.SECONDS.toNanos(1)))
+         boolean noRunningTest = runningTests.size() <= finishedTests.size();
+         if (!noRunningTest && (System.nanoTime() - lastUpdate < TimeUnit.SECONDS.toNanos(1)))
             return;
 
          lastUpdate = System.nanoTime();
-         // Only update running tests once for each running threads update
-         runningTests.removeAll(testsJustFinished);
-         // Update the thread ownership information
-         Set<Thread> currentThreads = getThreadsSnapshot();
-         runningThreads.keySet().retainAll(currentThreads);
-         for (Thread thread : currentThreads) {
-            runningThreads.putIfAbsent(thread, new LeakInfo(thread, availableOwners));
-         }
 
-         if (runningTests.isEmpty()) {
-            performCheck();
+         // Available owners are tests that were running at any point since the last check
+         List<String> availableOwners = new ArrayList<>(runningTests);
+         runningTests.removeAll(finishedTests);
+         finishedTests.clear();
+         updateThreadOwnership(availableOwners);
+      } finally {
+         lock.unlock();
+      }
+   }
+
+   public static void updateThreadOwnership(List<String> availableOwners) {
+      // Update the thread ownership information
+      Set<Thread> currentThreads = getThreadsSnapshot();
+      runningThreads.keySet().retainAll(currentThreads);
+      for (Thread thread : currentThreads) {
+         runningThreads.putIfAbsent(thread, new LeakInfo(thread, availableOwners));
+      }
+   }
+
+   /**
+    * Check for leaked threads.
+    *
+    * <p>When running tests in parallel, this method will only perform the leak check if there are no running tests.</p>
+    *
+    * @param testName test that just ended, or {@code null} if running after all the tests (e.g. from {@code
+    * @AfterSuite} in TestNG)
+    */
+   public static void checkForLeaks(String testName) {
+      lock.lock();
+      try {
+         if (testName == null) {
+            assert runningTests.isEmpty() : "Tests are still running: " + runningTests;
+         } else if (runningTests.size() > 1) {
+            return;
+         } else if (runningTests.size() == 1) {
+            assert runningTests.contains(testName) :
+               "Test " + runningTests + " is running, should have been " + testName;
+            testFinished(testName);
          }
+         performCheck();
       } finally {
          lock.unlock();
       }
    }
 
    private static void performCheck() {
+      updateThreadOwnership(Collections.singletonList("UNKNOWN"));
       List<LeakInfo> leaks = computeLeaks();
 
       if (!leaks.isEmpty()) {
@@ -125,17 +177,13 @@ public class ThreadLeakChecker {
             Thread.currentThread().interrupt();
          }
          // Update the thread ownership information
-         Set<Thread> currentThreads = getThreadsSnapshot();
-         runningThreads.keySet().retainAll(currentThreads);
-         for (Thread thread : currentThreads) {
-            runningThreads.putIfAbsent(thread, new LeakInfo(thread, Collections.singletonList("ERROR")));
-         }
+         updateThreadOwnership(Collections.singletonList("UNKNOWN"));
          leaks = computeLeaks();
       }
 
       if (!leaks.isEmpty()) {
          for (LeakInfo leakInfo : leaks) {
-            logLeakedThread(leakInfo.thread);
+            log.warnf("Possible leaked thread:\n%s", prettyPringStacktrace(leakInfo.thread));
             leakInfo.reported = true;
          }
          // Strategies for debugging test suite thread leaks
@@ -162,15 +210,29 @@ public class ThreadLeakChecker {
    private static boolean ignore(LeakInfo leakInfo) {
       // System threads (running before the first test) have no potential owners
       String threadName = leakInfo.thread.getName();
-      return leakInfo.potentialOwnerTests.isEmpty() || IGNORED_THREADS_REGEX.matcher(threadName).matches();
+      if (leakInfo.potentialOwnerTests.isEmpty())
+         return true;
+      if (IGNORED_THREADS_REGEX.matcher(threadName).matches())
+         return true;
+
+      // Special check for Arquillian, because it uses an unnamed thread to read from the container console
+      if (leakInfo.thread.getName().startsWith("Thread-")) {
+         StackTraceElement[] s = leakInfo.thread.getStackTrace();
+         for (StackTraceElement ste : s) {
+            if (ste.getClassName().equals(ARQUILLIAN_CONSOLE_CONSUMER)) {
+               return true;
+            }
+         }
+   }
+         return false;
    }
 
-   private static void logLeakedThread(Thread thread) {
-      StringBuilder sb = new StringBuilder();
+   public static String prettyPringStacktrace(Thread thread) {
       // "management I/O-2" #55 prio=5 os_prio=0 tid=0x00007fe6a8134000 nid=0x7f9d runnable
       // [0x00007fe64e4db000]
       //    java.lang.Thread.State:RUNNABLE
-      sb.append(String.format("Possible leaked thread:\n\"%s\" %sprio=%d tid=0x%x nid=NA %s\n", thread.getName(),
+      StringBuilder sb = new StringBuilder();
+      sb.append(String.format("\"%s\" %sprio=%d tid=0x%x nid=NA %s\n", thread.getName(),
                               thread.isDaemon() ? "daemon " : "", thread.getPriority(), thread.getId(),
                               thread.getState().toString().toLowerCase()));
       sb.append("   java.lang.Thread.State: ").append(thread.getState()).append('\n');
@@ -178,7 +240,7 @@ public class ThreadLeakChecker {
       for (StackTraceElement ste : s) {
          sb.append("\t").append(ste).append('\n');
       }
-      log.warn(sb);
+      return sb.toString();
    }
 
    private static <T> List<T> drain(BlockingQueue<T> blockingQueue) {

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -294,6 +294,10 @@
                         <exclude>**/DistSyncUnsafe*.java</exclude>
                         <exclude>**/TopologyAwareDist*.java</exclude>
                      </excludes>
+                     <dependenciesToScan>
+                        <!-- TestNGSuiteChecksTest -->
+                        <dependency>org.infinispan:infinispan-commons-test</dependency>
+                     </dependenciesToScan>
                   </configuration>
                </plugin>
             </plugins>

--- a/core/src/test/java/org/infinispan/test/AbstractInfinispanTest.java
+++ b/core/src/test/java/org/infinispan/test/AbstractInfinispanTest.java
@@ -35,6 +35,7 @@ import javax.transaction.TransactionManager;
 import org.infinispan.commons.api.BasicCache;
 import org.infinispan.commons.api.BasicCacheContainer;
 import org.infinispan.commons.test.TestNGLongTestsHook;
+import org.infinispan.commons.test.ThreadLeakChecker;
 import org.infinispan.functional.FunctionalMap;
 import org.infinispan.interceptors.AsyncInterceptor;
 import org.infinispan.partitionhandling.BasePartitionHandlingTest;
@@ -140,6 +141,7 @@ public abstract class AbstractInfinispanTest {
       killSpawnedThreads();
       nullOutFields();
       TestResourceTracker.testFinished(getTestName());
+      ThreadLeakChecker.checkForLeaks(getClass().getName());
    }
 
    public String getTestName() {

--- a/core/src/test/java/org/infinispan/test/Exceptions.java
+++ b/core/src/test/java/org/infinispan/test/Exceptions.java
@@ -34,6 +34,9 @@ public class Exceptions {
       }
    }
 
+   /**
+    * Expect an exception of class {@code exceptionClass} or its subclasses.
+    */
    public static void assertExceptionNonStrict(Class<? extends Throwable> exceptionClass, Throwable t) {
       if (t == null) {
          throw new AssertionError("Should have thrown an " + exceptionClass, null);
@@ -175,7 +178,7 @@ public class Exceptions {
       assertException(wrapperExceptionClass, exceptionClass, t.getCause().getCause());
    }
 
-   private static Throwable extractException(ExceptionRunnable runnable) {
+   public static Throwable extractException(ExceptionRunnable runnable) {
       Throwable exception = null;
       try {
          runnable.run();

--- a/core/src/test/java/org/infinispan/test/TestingUtil.java
+++ b/core/src/test/java/org/infinispan/test/TestingUtil.java
@@ -1246,7 +1246,7 @@ public class TestingUtil {
     * @param componentType        component type of which to replace
     * @param replacementComponent new instance
     * @param rewire               if true, ComponentRegistry.rewire() is called after replacing.
-    * @param stopBeforeWire       stops the lifecycle component before rewiring (this will cause it to be started
+    * @param stopBeforeWire       stops the new component before wiring (the registry will start it again)
     * @return the original component that was replaced
     */
    public static <T extends Lifecycle> T replaceComponent(Cache<?, ?> cache, Class<T> componentType, T replacementComponent, boolean rewire,

--- a/core/src/test/java/org/infinispan/test/fwk/TestResourceTracker.java
+++ b/core/src/test/java/org/infinispan/test/fwk/TestResourceTracker.java
@@ -9,7 +9,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.infinispan.commons.test.ThreadLeakChecker;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.security.Security;
 import org.infinispan.test.AbstractInfinispanTest;
@@ -95,7 +94,6 @@ public class TestResourceTracker {
       }
       setThreadTestName(testName);
       Thread.currentThread().setName(getNextTestThreadName());
-      ThreadLeakChecker.testStarted(testName);
    }
 
    /**
@@ -109,7 +107,6 @@ public class TestResourceTracker {
                ", should have been " + testName);
       }
       setThreadTestName(null);
-      ThreadLeakChecker.testFinished(testName);
    }
 
    /**

--- a/core/src/test/java/org/infinispan/test/fwk/TestResourceTrackingListener.java
+++ b/core/src/test/java/org/infinispan/test/fwk/TestResourceTrackingListener.java
@@ -1,5 +1,6 @@
 package org.infinispan.test.fwk;
 
+import org.infinispan.commons.test.ThreadLeakChecker;
 import org.infinispan.test.AbstractInfinispanTest;
 import org.testng.ITestContext;
 import org.testng.ITestListener;
@@ -43,5 +44,6 @@ public class TestResourceTrackingListener implements ITestListener {
    public void onFinish(ITestContext context) {
       Class testClass = context.getCurrentXmlTest().getXmlClasses().get(0).getSupportClass();
       TestResourceTracker.testFinished(testClass.getName());
+      ThreadLeakChecker.checkForLeaks(getClass().getName());
    }
 }

--- a/counter/pom.xml
+++ b/counter/pom.xml
@@ -40,6 +40,16 @@
                     </instructions>
                 </configuration>
             </plugin>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+               <dependenciesToScan>
+                  <!-- TestNGSuiteChecksTest -->
+                  <dependency>org.infinispan:infinispan-commons-test</dependency>
+               </dependenciesToScan>
+            </configuration>
+         </plugin>
         </plugins>
     </build>
 

--- a/extended-statistics/pom.xml
+++ b/extended-statistics/pom.xml
@@ -77,6 +77,16 @@
                     </execution>
                 </executions>
             </plugin>
+           <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <configuration>
+                 <dependenciesToScan>
+                    <!-- TestNGSuiteChecksTest -->
+                    <dependency>org.infinispan:infinispan-commons-test</dependency>
+                 </dependenciesToScan>
+              </configuration>
+           </plugin>
         </plugins>
     </build>
 </project>

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/util/InfinispanTestingSetup.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/util/InfinispanTestingSetup.java
@@ -6,6 +6,7 @@
  */
 package org.infinispan.test.hibernate.cache.commons.util;
 
+import org.infinispan.commons.test.ThreadLeakChecker;
 import org.infinispan.test.fwk.TestResourceTracker;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -39,10 +40,12 @@ public final class InfinispanTestingSetup implements TestRule {
             @Override
             public void evaluate() throws Throwable {
                 TestResourceTracker.testStarted( testName );
+                ThreadLeakChecker.testStarted( testName );
                 try {
                     base.evaluate();
                 } finally {
                     TestResourceTracker.testFinished( testName );
+                    ThreadLeakChecker.testFinished( testName );
                 }
             }
         };

--- a/integrationtests/all-embedded-it/pom.xml
+++ b/integrationtests/all-embedded-it/pom.xml
@@ -130,6 +130,11 @@
                     </systemPropertyVariables>
                     <trimStackTrace>false</trimStackTrace>
                     <argLine>${forkJvmArgs} ${testjvm.jigsawArgs}</argLine>
+                   <properties>
+                      <!-- Deactivate the default listeners which may cause OOME. Jenkins uses the surefire generated XML file. -->
+                      <usedefaultlisteners>false</usedefaultlisteners>
+                      <listener>${junitListener}</listener>
+                   </properties>
                 </configuration>
                 <dependencies>
                     <dependency>

--- a/integrationtests/all-embedded-query-it/pom.xml
+++ b/integrationtests/all-embedded-query-it/pom.xml
@@ -92,6 +92,11 @@
                     </systemPropertyVariables>
                     <trimStackTrace>false</trimStackTrace>
                     <argLine>${forkJvmArgs} ${testjvm.jigsawArgs}</argLine>
+                    <properties>
+                       <!-- Deactivate the default listeners which may cause OOME. Jenkins uses the surefire generated XML file. -->
+                       <usedefaultlisteners>false</usedefaultlisteners>
+                       <listener>${junitListener}</listener>
+                   </properties>
                 </configuration>
                 <dependencies>
                     <dependency>

--- a/integrationtests/cdi-jcache-it/pom.xml
+++ b/integrationtests/cdi-jcache-it/pom.xml
@@ -90,6 +90,10 @@
                <forkCount>1</forkCount>
                <parallel>none</parallel>
                <groups>${defaultTestGroup}</groups>
+               <dependenciesToScan>
+                  <!-- TestNGSuiteChecksTest -->
+                  <dependency>org.infinispan:infinispan-commons-test</dependency>
+               </dependenciesToScan>
             </configuration>
          </plugin>
       </plugins>

--- a/integrationtests/cdi-jcache-it/src/test/java/org/infinispan/integrationtests/cdijcache/interceptor/CacheResultInterceptorConcurrencyTest.java
+++ b/integrationtests/cdi-jcache-it/src/test/java/org/infinispan/integrationtests/cdijcache/interceptor/CacheResultInterceptorConcurrencyTest.java
@@ -10,15 +10,20 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import javax.cache.Caching;
+import javax.cache.spi.CachingProvider;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.inject.Inject;
 
 import org.infinispan.cdi.embedded.test.DefaultTestEmbeddedCacheManagerProducer;
 import org.infinispan.integrationtests.cdijcache.interceptor.config.Config;
 import org.infinispan.integrationtests.cdijcache.interceptor.service.CacheResultService;
+import org.infinispan.test.fwk.TestResourceTrackingListener;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
 /**
@@ -27,6 +32,7 @@ import org.testng.annotations.Test;
  * @author Sebastian Laskawiec
  * @see javax.cache.annotation.CacheResult
  */
+@Listeners(TestResourceTrackingListener.class)
 @Test(groups = "functional", testName = "cdi.test.interceptor.CacheResultInterceptorConcurrencyTest", description = "https://issues.jboss.org/browse/ISPN-4563")
 public class CacheResultInterceptorConcurrencyTest extends Arquillian {
 
@@ -46,7 +52,13 @@ public class CacheResultInterceptorConcurrencyTest extends Arquillian {
    @Inject
    private BeanManager beanManager;
 
-   private static final int NUMBER_OF_THREADS = 100;
+   private static final int NUMBER_OF_THREADS = 10;
+
+   @AfterClass(alwaysRun = true)
+   public void stopDefaultCacheManager() {
+      CachingProvider provider = Caching.getCachingProvider();
+      provider.close(provider.getDefaultURI(), provider.getDefaultClassLoader());
+   }
 
    public void testConcurrentAccessToCache() throws Exception {
 

--- a/integrationtests/cdi-weld-se-it/pom.xml
+++ b/integrationtests/cdi-weld-se-it/pom.xml
@@ -47,4 +47,19 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+   <build>
+      <plugins>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+               <dependenciesToScan>
+                  <!-- TestNGSuiteChecksTest -->
+                  <dependency>org.infinispan:infinispan-commons-test</dependency>
+               </dependenciesToScan>
+            </configuration>
+         </plugin>
+      </plugins>
+   </build>
 </project>

--- a/integrationtests/endpoints-interop-it/pom.xml
+++ b/integrationtests/endpoints-interop-it/pom.xml
@@ -104,4 +104,18 @@
       </dependency>
    </dependencies>
 
+   <build>
+      <plugins>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+               <dependenciesToScan>
+                  <!-- TestNGSuiteChecksTest -->
+                  <dependency>org.infinispan:infinispan-commons-test</dependency>
+               </dependenciesToScan>
+            </configuration>
+         </plugin>
+      </plugins>
+   </build>
 </project>

--- a/integrationtests/security-manager-it/pom.xml
+++ b/integrationtests/security-manager-it/pom.xml
@@ -64,6 +64,10 @@
                   <listener>${testNGListeners}</listener>
                </properties>
                <argLine>${forkJvmArgs} ${testjvm.jigsawArgs}</argLine>
+               <dependenciesToScan>
+                  <!-- TestNGSuiteChecksTest -->
+                  <dependency>org.infinispan:infinispan-commons-test</dependency>
+               </dependenciesToScan>
             </configuration>
          </plugin>
       </plugins>

--- a/integrationtests/spring-boot-it/pom.xml
+++ b/integrationtests/spring-boot-it/pom.xml
@@ -133,6 +133,11 @@
                        <AsyncLogger.ThreadNameStrategy>UNCACHED</AsyncLogger.ThreadNameStrategy>
                     </systemPropertyVariables>
                     <trimStackTrace>false</trimStackTrace>
+                    <properties>
+                       <!-- Deactivate the default listeners which may cause OOME. Jenkins uses the surefire generated XML file. -->
+                       <usedefaultlisteners>false</usedefaultlisteners>
+                       <listener>${junitListener}</listener>
+                    </properties>
                     <argLine>${forkJvmArgs} ${testjvm.jigsawArgs}</argLine>
                 </configuration>
                 <dependencies>

--- a/jcache/embedded/pom.xml
+++ b/jcache/embedded/pom.xml
@@ -122,6 +122,10 @@
             <configuration>
                <parallel>none</parallel>
                <groups>${defaultTestGroup}</groups>
+               <dependenciesToScan>
+                  <!-- TestNGSuiteChecksTest -->
+                  <dependency>org.infinispan:infinispan-commons-test</dependency>
+               </dependenciesToScan>
             </configuration>
          </plugin>
 

--- a/jcache/embedded/src/test/java/org/infinispan/jcache/LimitExpiryFactoryTest.java
+++ b/jcache/embedded/src/test/java/org/infinispan/jcache/LimitExpiryFactoryTest.java
@@ -11,6 +11,12 @@ import javax.cache.expiry.ExpiryPolicy;
 import org.infinispan.jcache.embedded.LimitExpiryFactory;
 import org.testng.annotations.Test;
 
+/**
+ * Test preventing controlling the flow with NPE in LimitExpiryPolicy methods
+ *
+ * <p>See ISPN-9912</p>
+ */
+@Test(groups = "unit", testName = "jcache.LimitExpiryFactoryTest")
 public class LimitExpiryFactoryTest {
 
     @Test

--- a/jcache/remote/pom.xml
+++ b/jcache/remote/pom.xml
@@ -104,6 +104,10 @@
                <systemPropertyVariables>
                   <infinispan.jcache.mgmt.lookup.skip>true</infinispan.jcache.mgmt.lookup.skip>
                </systemPropertyVariables>
+               <dependenciesToScan>
+                  <!-- TestNGSuiteChecksTest -->
+                  <dependency>org.infinispan:infinispan-commons-test</dependency>
+               </dependenciesToScan>
             </configuration>
          </plugin>
       </plugins>

--- a/lock/pom.xml
+++ b/lock/pom.xml
@@ -41,6 +41,17 @@
                     </instructions>
                 </configuration>
             </plugin>
+
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+               <dependenciesToScan>
+                  <!-- TestNGSuiteChecksTest -->
+                  <dependency>org.infinispan:infinispan-commons-test</dependency>
+               </dependenciesToScan>
+            </configuration>
+         </plugin>
         </plugins>
     </build>
 

--- a/lucene/directory-provider/pom.xml
+++ b/lucene/directory-provider/pom.xml
@@ -154,6 +154,11 @@
                        <AsyncLogger.ThreadNameStrategy>UNCACHED</AsyncLogger.ThreadNameStrategy>
                     </systemPropertyVariables>
                     <trimStackTrace>false</trimStackTrace>
+                    <properties>
+                       <!-- Deactivate the default listeners which may cause OOME. Jenkins uses the surefire generated XML file. -->
+                       <usedefaultlisteners>false</usedefaultlisteners>
+                       <listener>${junitListener}</listener>
+                    </properties>
                 </configuration>
                 <dependencies>
                     <dependency>

--- a/lucene/lucene-directory/pom.xml
+++ b/lucene/lucene-directory/pom.xml
@@ -71,6 +71,17 @@
                     </instructions>
                 </configuration>
             </plugin>
+
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+               <dependenciesToScan>
+                  <!-- TestNGSuiteChecksTest -->
+                  <dependency>org.infinispan:infinispan-commons-test</dependency>
+               </dependenciesToScan>
+            </configuration>
+         </plugin>
         </plugins>
     </build>
 

--- a/multimap/pom.xml
+++ b/multimap/pom.xml
@@ -67,6 +67,16 @@
                     </instructions>
                 </configuration>
             </plugin>
+           <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <configuration>
+                 <dependenciesToScan>
+                    <!-- TestNGSuiteChecksTest -->
+                    <dependency>org.infinispan:infinispan-commons-test</dependency>
+                 </dependenciesToScan>
+              </configuration>
+           </plugin>
         </plugins>
     </build>
 </project>

--- a/object-filter/pom.xml
+++ b/object-filter/pom.xml
@@ -86,6 +86,11 @@
                   <AsyncLogger.ThreadNameStrategy>UNCACHED</AsyncLogger.ThreadNameStrategy>
                </systemPropertyVariables>
                <trimStackTrace>false</trimStackTrace>
+               <properties>
+                  <!-- Deactivate the default listeners which may cause OOME. Jenkins uses the surefire generated XML file. -->
+                  <usedefaultlisteners>false</usedefaultlisteners>
+                  <listener>${junitListener}</listener>
+               </properties>
                <argLine>-Xmx512m</argLine>
             </configuration>
             <dependencies>

--- a/persistence/jdbc/pom.xml
+++ b/persistence/jdbc/pom.xml
@@ -179,6 +179,16 @@
                </features>
             </configuration>
          </plugin>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+               <dependenciesToScan>
+                  <!-- TestNGSuiteChecksTest -->
+                  <dependency>org.infinispan:infinispan-commons-test</dependency>
+               </dependenciesToScan>
+            </configuration>
+         </plugin>
       </plugins>
    </build>
 

--- a/persistence/jdbc/src/test/java/org/infinispan/persistence/jdbc/ManagedConnectionFactoryTest.java
+++ b/persistence/jdbc/src/test/java/org/infinispan/persistence/jdbc/ManagedConnectionFactoryTest.java
@@ -24,7 +24,7 @@ import org.testng.annotations.Test;
 /**
  * @author Mircea.Markus@jboss.com
  */
-@Test(groups = "functional", testName = "persistence.jdbc.ManagedConnectionFactoryTest")
+@Test(groups = "functional")
 public abstract class ManagedConnectionFactoryTest extends BaseStoreTest {
 
    private DummyDataSource ds;
@@ -41,7 +41,7 @@ public abstract class ManagedConnectionFactoryTest extends BaseStoreTest {
 
    public abstract String getDatasourceLocation();
 
-   @AfterClass
+   @AfterClass(alwaysRun = true)
    public void destroyDatasourceAndUnbind() throws NamingException {
       InitialContext ic = new InitialContext();
       ic.unbind(getDatasourceLocation());

--- a/persistence/jdbc/src/test/java/org/infinispan/persistence/jdbc/TableManagerTest.java
+++ b/persistence/jdbc/src/test/java/org/infinispan/persistence/jdbc/TableManagerTest.java
@@ -19,6 +19,7 @@ import org.infinispan.persistence.jdbc.impl.table.TableManager;
 import org.infinispan.persistence.jdbc.impl.table.TableManagerFactory;
 import org.infinispan.persistence.jdbc.impl.table.TableName;
 import org.infinispan.persistence.spi.PersistenceException;
+import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.test.fwk.UnitTestDatabaseManager;
 import org.testng.annotations.AfterClass;
@@ -32,7 +33,7 @@ import org.testng.annotations.Test;
  * @author Ryan Emerson
  */
 @Test(groups = "functional", testName = "persistence.jdbc.TableManagerTest")
-public class TableManagerTest {
+public class TableManagerTest extends AbstractInfinispanTest {
    ConnectionFactory connectionFactory;
    Connection connection;
    TableManager tableManager;
@@ -66,9 +67,10 @@ public class TableManagerTest {
       tableManager.setCacheName("aName");
    }
 
-   @AfterClass
+   @AfterClass(alwaysRun = true)
    public void closeConnection() throws SQLException {
       connection.close();
+      connectionFactory.stop();
    }
 
    public void testConnectionLeakGuessDialect() throws Exception {

--- a/persistence/jpa/pom.xml
+++ b/persistence/jpa/pom.xml
@@ -111,6 +111,10 @@
             <configuration>
                <!-- Tests against single database cannot be executed in paralllel -->
                <threadCount>1</threadCount>
+               <dependenciesToScan>
+                  <!-- TestNGSuiteChecksTest -->
+                  <dependency>org.infinispan:infinispan-commons-test</dependency>
+               </dependenciesToScan>
             </configuration>
          </plugin>
          <plugin>

--- a/persistence/remote/pom.xml
+++ b/persistence/remote/pom.xml
@@ -436,6 +436,16 @@
                </features>
             </configuration>
          </plugin>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+               <dependenciesToScan>
+                  <!-- TestNGSuiteChecksTest -->
+                  <dependency>org.infinispan:infinispan-commons-test</dependency>
+               </dependenciesToScan>
+            </configuration>
+         </plugin>
       </plugins>
    </build>
 </project>

--- a/persistence/rest/pom.xml
+++ b/persistence/rest/pom.xml
@@ -137,6 +137,16 @@
                </execution>
             </executions>
          </plugin>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+               <dependenciesToScan>
+                  <!-- TestNGSuiteChecksTest -->
+                  <dependency>org.infinispan:infinispan-commons-test</dependency>
+               </dependenciesToScan>
+            </configuration>
+         </plugin>
       </plugins>
    </build>
 </project>

--- a/persistence/rocksdb/pom.xml
+++ b/persistence/rocksdb/pom.xml
@@ -149,6 +149,16 @@
                </features>
             </configuration>
          </plugin>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+               <dependenciesToScan>
+                  <!-- TestNGSuiteChecksTest -->
+                  <dependency>org.infinispan:infinispan-commons-test</dependency>
+               </dependenciesToScan>
+            </configuration>
+         </plugin>
       </plugins>
    </build>
 </project>

--- a/persistence/soft-index/pom.xml
+++ b/persistence/soft-index/pom.xml
@@ -97,6 +97,16 @@
                </execution>
             </executions>
          </plugin>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+               <dependenciesToScan>
+                  <!-- TestNGSuiteChecksTest -->
+                  <dependency>org.infinispan:infinispan-commons-test</dependency>
+               </dependenciesToScan>
+            </configuration>
+         </plugin>
       </plugins>
    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -5304,24 +5304,6 @@
          </properties>
       </profile>
       <profile>
-         <id>fail-all-tests</id>
-         <properties>
-            <testNGListener>
-               org.infinispan.commons.test.TestNGTestListener,org.infinispan.test.fwk.FailAllTestNGHook
-            </testNGListener>
-            <infinispan.test.jgroups.protocol>tcp</infinispan.test.jgroups.protocol>
-         </properties>
-      </profile>
-      <profile>
-         <id>fail-all-tests-setup</id>
-         <properties>
-            <testNGListener>
-               org.infinispan.commons.test.TestNGTestListener,org.infinispan.test.fwk.FailAllSetupTestNGHook
-            </testNGListener>
-            <infinispan.test.jgroups.protocol>tcp</infinispan.test.jgroups.protocol>
-         </properties>
-      </profile>
-      <profile>
          <id>customForkJvmArgs</id>
          <activation>
             <activeByDefault>false</activeByDefault>

--- a/query-dsl/pom.xml
+++ b/query-dsl/pom.xml
@@ -59,6 +59,11 @@
                   <AsyncLogger.ThreadNameStrategy>UNCACHED</AsyncLogger.ThreadNameStrategy>
                </systemPropertyVariables>
                <trimStackTrace>false</trimStackTrace>
+               <properties>
+                  <!-- Deactivate the default listeners which may cause OOME. Jenkins uses the surefire generated XML file. -->
+                  <usedefaultlisteners>false</usedefaultlisteners>
+                  <listener>${junitListener}</listener>
+               </properties>
                <argLine>-Xmx768m</argLine>
             </configuration>
          </plugin>

--- a/query/pom.xml
+++ b/query/pom.xml
@@ -238,6 +238,10 @@
                         <include>**/QueryDslConditionsTest.java</include>
                         <include>**/QueryStringTest.java</include>
                      </includes>
+                     <dependenciesToScan>
+                        <!-- TestNGSuiteChecksTest -->
+                        <dependency>org.infinispan:infinispan-commons-test</dependency>
+                     </dependenciesToScan>
                   </configuration>
                </plugin>
             </plugins>

--- a/remote-query/remote-query-client/pom.xml
+++ b/remote-query/remote-query-client/pom.xml
@@ -70,6 +70,12 @@
                        see https://issues.apache.org/jira/browse/LOG4J2-2052 -->
                   <AsyncLogger.ThreadNameStrategy>UNCACHED</AsyncLogger.ThreadNameStrategy>
                </systemPropertyVariables>
+               <trimStackTrace>false</trimStackTrace>
+               <properties>
+                  <!-- Deactivate the default listeners which may cause OOME. Jenkins uses the surefire generated XML file. -->
+                  <usedefaultlisteners>false</usedefaultlisteners>
+                  <listener>${junitListener}</listener>
+               </properties>
             </configuration>
             <dependencies>
                <dependency>

--- a/remote-query/remote-query-server/pom.xml
+++ b/remote-query/remote-query-server/pom.xml
@@ -117,6 +117,16 @@
                </instructions>
             </configuration>
          </plugin>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+               <dependenciesToScan>
+                  <!-- TestNGSuiteChecksTest -->
+                  <dependency>org.infinispan:infinispan-commons-test</dependency>
+               </dependenciesToScan>
+            </configuration>
+         </plugin>
       </plugins>
    </build>
 </project>

--- a/server/core/pom.xml
+++ b/server/core/pom.xml
@@ -121,6 +121,16 @@
                </instructions>
             </configuration>
          </plugin>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+               <dependenciesToScan>
+                  <!-- TestNGSuiteChecksTest -->
+                  <dependency>org.infinispan:infinispan-commons-test</dependency>
+               </dependenciesToScan>
+            </configuration>
+         </plugin>
       </plugins>
    </build>
 </project>

--- a/server/hotrod/pom.xml
+++ b/server/hotrod/pom.xml
@@ -242,6 +242,16 @@
                </execution>
             </executions>
          </plugin>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+               <dependenciesToScan>
+                  <!-- TestNGSuiteChecksTest -->
+                  <dependency>org.infinispan:infinispan-commons-test</dependency>
+               </dependenciesToScan>
+            </configuration>
+         </plugin>
       </plugins>
       <resources>
          <resource>

--- a/server/integration/commons/pom.xml
+++ b/server/integration/commons/pom.xml
@@ -109,6 +109,11 @@
                        <AsyncLogger.ThreadNameStrategy>UNCACHED</AsyncLogger.ThreadNameStrategy>
                     </systemPropertyVariables>
                     <trimStackTrace>false</trimStackTrace>
+                    <properties>
+                       <!-- Deactivate the default listeners which may cause OOME. Jenkins uses the surefire generated XML file. -->
+                       <usedefaultlisteners>false</usedefaultlisteners>
+                       <listener>${junitListener}</listener>
+                    </properties>
                     <argLine>${forkJvmArgs} ${testjvm.jigsawArgs}</argLine>
                 </configuration>
                 <dependencies>

--- a/server/integration/endpoint/pom.xml
+++ b/server/integration/endpoint/pom.xml
@@ -135,6 +135,11 @@
                   <AsyncLogger.ThreadNameStrategy>UNCACHED</AsyncLogger.ThreadNameStrategy>
                </systemPropertyVariables>
                <trimStackTrace>false</trimStackTrace>
+               <properties>
+                  <!-- Deactivate the default listeners which may cause OOME. Jenkins uses the surefire generated XML file. -->
+                  <usedefaultlisteners>false</usedefaultlisteners>
+                  <listener>${junitListener}</listener>
+               </properties>
                <argLine>${forkJvmArgs} ${testjvm.jigsawArgs}</argLine>
             </configuration>
             <dependencies>

--- a/server/integration/event-logger/pom.xml
+++ b/server/integration/event-logger/pom.xml
@@ -77,6 +77,10 @@
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <useManifestOnlyJar>false</useManifestOnlyJar>
                     <parallel>none</parallel>
+                   <dependenciesToScan>
+                      <!-- TestNGSuiteChecksTest -->
+                      <dependency>org.infinispan:infinispan-commons-test</dependency>
+                   </dependenciesToScan>
                 </configuration>
             </plugin>
         </plugins>

--- a/server/integration/infinispan/pom.xml
+++ b/server/integration/infinispan/pom.xml
@@ -263,6 +263,11 @@
                        <AsyncLogger.ThreadNameStrategy>UNCACHED</AsyncLogger.ThreadNameStrategy>
                     </systemPropertyVariables>
                     <trimStackTrace>false</trimStackTrace>
+                    <properties>
+                       <!-- Deactivate the default listeners which may cause OOME. Jenkins uses the surefire generated XML file. -->
+                       <usedefaultlisteners>false</usedefaultlisteners>
+                       <listener>${junitListener}</listener>
+                    </properties>
                     <argLine>${forkJvmArgs} ${testjvm.jigsawArgs} -Djdk.attach.allowAttachSelf=true</argLine>
                 </configuration>
                 <dependencies>

--- a/server/integration/jgroups/pom.xml
+++ b/server/integration/jgroups/pom.xml
@@ -143,6 +143,11 @@
                        <AsyncLogger.ThreadNameStrategy>UNCACHED</AsyncLogger.ThreadNameStrategy>
                     </systemPropertyVariables>
                     <trimStackTrace>false</trimStackTrace>
+                    <properties>
+                       <!-- Deactivate the default listeners which may cause OOME. Jenkins uses the surefire generated XML file. -->
+                       <usedefaultlisteners>false</usedefaultlisteners>
+                       <listener>${junitListener}</listener>
+                    </properties>
                     <argLine>${forkJvmArgs} ${testjvm.jigsawArgs} -Djdk.attach.allowAttachSelf=true</argLine>
                 </configuration>
                 <dependencies>

--- a/server/memcached/pom.xml
+++ b/server/memcached/pom.xml
@@ -64,6 +64,16 @@
                </instructions>
             </configuration>
          </plugin>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+               <dependenciesToScan>
+                  <!-- TestNGSuiteChecksTest -->
+                  <dependency>org.infinispan:infinispan-commons-test</dependency>
+               </dependenciesToScan>
+            </configuration>
+         </plugin>
       </plugins>
    </build>
 </project>

--- a/server/rest/pom.xml
+++ b/server/rest/pom.xml
@@ -173,6 +173,16 @@
                   </execution>
               </executions>
           </plugin>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+               <dependenciesToScan>
+                  <!-- TestNGSuiteChecksTest -->
+                  <dependency>org.infinispan:infinispan-commons-test</dependency>
+               </dependenciesToScan>
+            </configuration>
+         </plugin>
       </plugins>
    </build>
 </project>

--- a/server/router/pom.xml
+++ b/server/router/pom.xml
@@ -217,6 +217,12 @@
                             see https://issues.apache.org/jira/browse/LOG4J2-2052 -->
                        <AsyncLogger.ThreadNameStrategy>UNCACHED</AsyncLogger.ThreadNameStrategy>
                     </systemPropertyVariables>
+                    <trimStackTrace>false</trimStackTrace>
+                    <properties>
+                        <!-- Deactivate the default listeners which may cause OOME. Jenkins uses the surefire generated XML file. -->
+                        <usedefaultlisteners>false</usedefaultlisteners>
+                        <listener>${junitListener}</listener>
+                    </properties>
                     <argLine>${forkJvmArgs} ${testjvm.jigsawArgs}</argLine>
                 </configuration>
                 <dependencies>

--- a/spring/spring5/spring5-common/pom.xml
+++ b/spring/spring5/spring5-common/pom.xml
@@ -27,6 +27,11 @@
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-commons</artifactId>
         </dependency>
+       <dependency>
+          <groupId>org.infinispan</groupId>
+          <artifactId>infinispan-commons-test</artifactId>
+          <scope>test</scope>
+       </dependency>
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-core</artifactId>

--- a/spring/spring5/spring5-common/src/test/java/org/infinispan/spring/common/InfinispanTestExecutionListener.java
+++ b/spring/spring5/spring5-common/src/test/java/org/infinispan/spring/common/InfinispanTestExecutionListener.java
@@ -1,7 +1,6 @@
 package org.infinispan.spring.common;
 
 import org.infinispan.test.fwk.TestResourceTracker;
-import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.support.AbstractTestExecutionListener;
 
@@ -19,9 +18,8 @@ public class InfinispanTestExecutionListener extends AbstractTestExecutionListen
 
    @Override
    public void afterTestClass(TestContext testContext) throws Exception {
-      // The Spring listener that stops the application context will run later
-      // So we stop it explicitly before running the thread leak check
-      ((ConfigurableApplicationContext)testContext.getApplicationContext()).close();
       TestResourceTracker.testFinished(testContext.getTestClass().getName());
+      // Don't check for thread leaks here, the Spring listener that stops the application context will run later
+      // ThreadLeakChecker.checkForLeaks(testContext.getTestClass().getName());
    }
 }

--- a/spring/spring5/spring5-embedded/pom.xml
+++ b/spring/spring5/spring5-embedded/pom.xml
@@ -133,6 +133,16 @@
                     </instructions>
                 </configuration>
             </plugin>
+           <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <configuration>
+                 <dependenciesToScan>
+                    <!-- TestNGSuiteChecksTest -->
+                    <dependency>org.infinispan:infinispan-commons-test</dependency>
+                 </dependenciesToScan>
+              </configuration>
+           </plugin>
         </plugins>
     </build>
 

--- a/spring/spring5/spring5-embedded/src/test/java/org/infinispan/spring/embedded/config/CacheLoaderNotFoundTest.java
+++ b/spring/spring5/spring5-embedded/src/test/java/org/infinispan/spring/embedded/config/CacheLoaderNotFoundTest.java
@@ -2,10 +2,13 @@ package org.infinispan.spring.embedded.config;
 
 import static org.testng.AssertJUnit.fail;
 
+import org.infinispan.spring.common.InfinispanTestExecutionListener;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cache.CacheManager;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
@@ -19,6 +22,8 @@ import org.testng.annotations.Test;
  */
 @Test(groups = "functional", testName = "spring.config.embedded.CacheLoaderNotFoundTest")
 @ContextConfiguration
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@TestExecutionListeners(InfinispanTestExecutionListener.class)
 public class CacheLoaderNotFoundTest extends AbstractTestNGSpringContextTests {
 
    @Autowired

--- a/spring/spring5/spring5-embedded/src/test/java/org/infinispan/spring/embedded/config/InfinispanContainerCacheManagerDefinitionTest.java
+++ b/spring/spring5/spring5-embedded/src/test/java/org/infinispan/spring/embedded/config/InfinispanContainerCacheManagerDefinitionTest.java
@@ -1,10 +1,13 @@
 package org.infinispan.spring.embedded.config;
 
 
+import org.infinispan.spring.common.InfinispanTestExecutionListener;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cache.CacheManager;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -14,6 +17,8 @@ import org.testng.annotations.Test;
  */
 @Test(groups = "functional", testName = "spring.config.embedded.InfinispanContainerCacheManagerDefinitionTest")
 @ContextConfiguration
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@TestExecutionListeners(InfinispanTestExecutionListener.class)
 public class InfinispanContainerCacheManagerDefinitionTest extends AbstractTestNGSpringContextTests {
 
    @Autowired

--- a/spring/spring5/spring5-embedded/src/test/java/org/infinispan/spring/embedded/config/InfinispanEmbeddedCacheManagerDefinitionTest.java
+++ b/spring/spring5/spring5-embedded/src/test/java/org/infinispan/spring/embedded/config/InfinispanEmbeddedCacheManagerDefinitionTest.java
@@ -1,10 +1,13 @@
 package org.infinispan.spring.embedded.config;
 
 
+import org.infinispan.spring.common.InfinispanTestExecutionListener;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cache.CacheManager;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -15,6 +18,8 @@ import org.testng.annotations.Test;
 
 @Test(groups = {"functional", "smoke"}, testName = "spring.config.embedded.InfinispanEmbeddedCacheManagerDefinitionTest")
 @ContextConfiguration
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@TestExecutionListeners(InfinispanTestExecutionListener.class)
 public class InfinispanEmbeddedCacheManagerDefinitionTest extends AbstractTestNGSpringContextTests {
 
    @Autowired

--- a/spring/spring5/spring5-embedded/src/test/java/org/infinispan/spring/embedded/config/NonTransactionalCacheTest.java
+++ b/spring/spring5/spring5-embedded/src/test/java/org/infinispan/spring/embedded/config/NonTransactionalCacheTest.java
@@ -4,8 +4,11 @@ import static org.testng.AssertJUnit.assertEquals;
 
 import javax.annotation.Resource;
 
+import org.infinispan.spring.common.InfinispanTestExecutionListener;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
 import org.testng.annotations.Test;
 
@@ -17,6 +20,8 @@ import org.testng.annotations.Test;
  */
 @Test(groups = {"functional", "smoke"}, testName = "spring.embedded.config.NonTransactionalCacheTest")
 @ContextConfiguration
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@TestExecutionListeners(InfinispanTestExecutionListener.class)
 public class NonTransactionalCacheTest extends AbstractTestNGSpringContextTests {
 
    public interface ICachedMock {

--- a/spring/spring5/spring5-embedded/src/test/java/org/infinispan/spring/embedded/provider/SpringEmbeddedCacheManagerFactoryBeanTest.java
+++ b/spring/spring5/spring5-embedded/src/test/java/org/infinispan/spring/embedded/provider/SpringEmbeddedCacheManagerFactoryBeanTest.java
@@ -11,8 +11,9 @@ import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.spring.embedded.builders.SpringEmbeddedCacheManagerFactoryBeanBuilder;
 import org.infinispan.spring.common.provider.SpringCache;
+import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.transaction.TransactionMode;
-import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
 /**
@@ -25,7 +26,7 @@ import org.testng.annotations.Test;
  *
  */
 @Test(testName = "spring.embedded.provider.SpringEmbeddedCacheManagerFactoryBeanTest", groups = "unit")
-public class SpringEmbeddedCacheManagerFactoryBeanTest {
+public class SpringEmbeddedCacheManagerFactoryBeanTest extends AbstractInfinispanTest {
 
    private static final String CACHE_NAME_FROM_CONFIGURATION_FILE = "asyncCache";
 
@@ -33,7 +34,7 @@ public class SpringEmbeddedCacheManagerFactoryBeanTest {
 
    private SpringEmbeddedCacheManagerFactoryBean objectUnderTest;
 
-   @AfterClass(alwaysRun = true)
+   @AfterMethod(alwaysRun = true)
    public void closeCacheManager() throws Exception {
       if(objectUnderTest != null) {
          objectUnderTest.destroy();
@@ -166,8 +167,7 @@ public class SpringEmbeddedCacheManagerFactoryBeanTest {
    @Test
    public void testIfSpringEmbeddedCacheManagerFactoryBeanAllowesOverridingConfigurationWithEmptyInputStream()
          throws Exception {
-      objectUnderTest = SpringEmbeddedCacheManagerFactoryBeanBuilder
-            .defaultBuilder().build();
+      objectUnderTest = new SpringEmbeddedCacheManagerFactoryBean();
 
       GlobalConfigurationBuilder gcb = new GlobalConfigurationBuilder();
 

--- a/spring/spring5/spring5-embedded/src/test/java/org/infinispan/spring/embedded/provider/sample/SampleEmbeddedCacheTest.java
+++ b/spring/spring5/spring5-embedded/src/test/java/org/infinispan/spring/embedded/provider/sample/SampleEmbeddedCacheTest.java
@@ -1,11 +1,14 @@
 package org.infinispan.spring.embedded.provider.sample;
 
+import org.infinispan.spring.common.InfinispanTestExecutionListener;
 import org.infinispan.spring.embedded.provider.SpringEmbeddedCacheManager;
 import org.infinispan.spring.embedded.provider.sample.service.CachedBookService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cache.CacheManager;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
 import org.testng.annotations.Test;
 
 /**
@@ -15,6 +18,8 @@ import org.testng.annotations.Test;
  */
 @Test(testName = "spring.embedded.provider.SampleEmbeddedCacheTest", groups = "functional", sequential = true)
 @ContextConfiguration(locations = "classpath:/org/infinispan/spring/embedded/provider/sample/SampleEmbeddedCacheTestConfig.xml")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@TestExecutionListeners(InfinispanTestExecutionListener.class)
 public class SampleEmbeddedCacheTest extends AbstractTestTemplateJsr107 {
 
    @Qualifier(value = "cachedBookServiceImpl")

--- a/spring/spring5/spring5-embedded/src/test/java/org/infinispan/spring/embedded/provider/sample/SampleJavaConfigurationTest.java
+++ b/spring/spring5/spring5-embedded/src/test/java/org/infinispan/spring/embedded/provider/sample/SampleJavaConfigurationTest.java
@@ -3,6 +3,7 @@ package org.infinispan.spring.embedded.provider.sample;
 import javax.sql.DataSource;
 
 import org.apache.commons.dbcp.BasicDataSource;
+import org.infinispan.spring.common.InfinispanTestExecutionListener;
 import org.infinispan.spring.embedded.builders.SpringEmbeddedCacheManagerFactoryBeanBuilder;
 import org.infinispan.spring.embedded.provider.SpringEmbeddedCacheManager;
 import org.infinispan.spring.embedded.provider.sample.service.CachedBookService;
@@ -18,7 +19,9 @@ import org.springframework.core.io.Resource;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.jdbc.datasource.init.DataSourceInitializer;
 import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.testng.annotations.Test;
@@ -30,6 +33,8 @@ import org.testng.annotations.Test;
  */
 @Test(testName = "spring.embedded.provider.SampleJavaConfigurationTest", groups = "functional", sequential = true)
 @ContextConfiguration(classes = SampleJavaConfigurationTest.ContextConfiguration.class, loader = AnnotationConfigContextLoader.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@TestExecutionListeners(InfinispanTestExecutionListener.class)
 public class SampleJavaConfigurationTest extends AbstractTestTemplateJsr107 {
 
    @Autowired(required = true)
@@ -71,7 +76,7 @@ public class SampleJavaConfigurationTest extends AbstractTestTemplateJsr107 {
          return new CachedBookServiceImpl();
       }
 
-      @Bean
+      @Bean(destroyMethod = "stop")
       public SpringEmbeddedCacheManager cacheManager() throws Exception {
          return SpringEmbeddedCacheManagerFactoryBeanBuilder
                .defaultBuilder()

--- a/spring/spring5/spring5-embedded/src/test/java/org/infinispan/spring/embedded/provider/sample/SampleTransactionIntegrationTest.java
+++ b/spring/spring5/spring5-embedded/src/test/java/org/infinispan/spring/embedded/provider/sample/SampleTransactionIntegrationTest.java
@@ -8,12 +8,15 @@ import javax.transaction.TransactionManager;
 
 import org.infinispan.Cache;
 import org.infinispan.commons.api.BasicCache;
+import org.infinispan.spring.common.InfinispanTestExecutionListener;
 import org.infinispan.spring.embedded.provider.sample.entity.Book;
 import org.infinispan.spring.embedded.provider.sample.service.CachedTransactionBookService;
 import org.infinispan.spring.embedded.provider.SpringEmbeddedCacheManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.testng.AbstractTransactionalTestNGSpringContextTests;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
@@ -25,6 +28,8 @@ import org.testng.annotations.Test;
  */
 @Test(testName = "spring.embedded.provider.SampleTransactionIntegrationTest", groups = "functional", sequential = true)
 @ContextConfiguration(locations = "classpath:/org/infinispan/spring/embedded/provider/sample/SampleTransactionIntegrationTestConfig.xml")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@TestExecutionListeners(InfinispanTestExecutionListener.class)
 public class SampleTransactionIntegrationTest extends AbstractTransactionalTestNGSpringContextTests {
 
    @Qualifier(value = "cachedTransactionBookServiceImpl")

--- a/spring/spring5/spring5-embedded/src/test/java/org/infinispan/spring/embedded/provider/sample/SampleXmlConfigurationTest.java
+++ b/spring/spring5/spring5-embedded/src/test/java/org/infinispan/spring/embedded/provider/sample/SampleXmlConfigurationTest.java
@@ -1,11 +1,14 @@
 package org.infinispan.spring.embedded.provider.sample;
 
+import org.infinispan.spring.common.InfinispanTestExecutionListener;
 import org.infinispan.spring.embedded.provider.sample.service.CachedBookService;
 import org.infinispan.spring.embedded.provider.SpringEmbeddedCacheManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cache.CacheManager;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
 import org.testng.annotations.Test;
 
 /**
@@ -15,6 +18,8 @@ import org.testng.annotations.Test;
  */
 @Test(testName = "spring.embedded.provider.SampleXmlConfigurationTest", groups = "functional", sequential = true)
 @ContextConfiguration(locations = "classpath:/org/infinispan/spring/embedded/provider/sample/SampleXmlConfigurationTestConfig.xml")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@TestExecutionListeners(InfinispanTestExecutionListener.class)
 public class SampleXmlConfigurationTest extends AbstractTestTemplate {
 
    @Qualifier(value = "cachedBookServiceImpl")

--- a/spring/spring5/spring5-remote/pom.xml
+++ b/spring/spring5/spring5-remote/pom.xml
@@ -138,6 +138,16 @@
                     </instructions>
                 </configuration>
             </plugin>
+           <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <configuration>
+                 <dependenciesToScan>
+                    <!-- TestNGSuiteChecksTest -->
+                    <dependency>org.infinispan:infinispan-commons-test</dependency>
+                 </dependenciesToScan>
+              </configuration>
+           </plugin>
         </plugins>
     </build>
 

--- a/spring/spring5/spring5-remote/src/test/java/org/infinispan/spring/remote/config/InfinispanRemoteCacheManagerDefinitionTest.java
+++ b/spring/spring5/spring5-remote/src/test/java/org/infinispan/spring/remote/config/InfinispanRemoteCacheManagerDefinitionTest.java
@@ -5,6 +5,7 @@ import org.infinispan.spring.common.InfinispanTestExecutionListener;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cache.CacheManager;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
@@ -17,6 +18,7 @@ import org.testng.annotations.Test;
 
 @Test(groups = {"functional", "smoke"}, testName = "spring.config.InfinispanRemoteCacheManagerDefinitionTest")
 @ContextConfiguration
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @TestExecutionListeners(InfinispanTestExecutionListener.class)
 public class InfinispanRemoteCacheManagerDefinitionTest extends AbstractTestNGSpringContextTests {
 

--- a/spring/spring5/spring5-remote/src/test/java/org/infinispan/spring/remote/provider/SpringRemoteCacheManagerFactoryBeanContextTest.java
+++ b/spring/spring5/spring5-remote/src/test/java/org/infinispan/spring/remote/provider/SpringRemoteCacheManagerFactoryBeanContextTest.java
@@ -3,9 +3,11 @@ package org.infinispan.spring.remote.provider;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNotNull;
 
+import org.infinispan.spring.common.InfinispanTestExecutionListener;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
 import org.testng.annotations.Test;
 
@@ -20,8 +22,8 @@ import org.testng.annotations.Test;
 @Test(testName = "spring.provider.SpringRemoteCacheManagerFactoryBeanContextTest", groups = "unit")
 @DirtiesContext(classMode = ClassMode.AFTER_CLASS)
 @ContextConfiguration("classpath:/org/infinispan/spring/remote/provider/SpringRemoteCacheManagerFactoryBeanContextTest.xml")
-public class SpringRemoteCacheManagerFactoryBeanContextTest extends
-                                                            AbstractTestNGSpringContextTests {
+@TestExecutionListeners(InfinispanTestExecutionListener.class)
+public class SpringRemoteCacheManagerFactoryBeanContextTest extends AbstractTestNGSpringContextTests {
 
    private static final String SPRING_REMOTE_CACHE_MANAGER_WITH_DEFAULT_CONFIGURATION_BEAN_NAME = "springRemoteCacheManagerWithDefaultConfiguration";
 

--- a/spring/spring5/spring5-remote/src/test/java/org/infinispan/spring/remote/provider/sample/AbstractTestTemplate.java
+++ b/spring/spring5/spring5-remote/src/test/java/org/infinispan/spring/remote/provider/sample/AbstractTestTemplate.java
@@ -4,14 +4,12 @@ import java.lang.invoke.MethodHandles;
 import java.util.Random;
 
 import org.infinispan.commons.api.BasicCache;
-import org.infinispan.spring.common.InfinispanTestExecutionListener;
 import org.infinispan.spring.remote.provider.sample.entity.Book;
 import org.infinispan.spring.remote.provider.sample.service.CachedBookService;
 import org.infinispan.spring.remote.provider.sample.service.CachedBookServiceImpl;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 import org.springframework.cache.CacheManager;
-import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.testng.AbstractTransactionalTestNGSpringContextTests;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
@@ -27,7 +25,6 @@ import org.testng.annotations.Test;
  * @author Matej Cimbora (mcimbora@redhat.com)
  */
 @Test(groups = "functional")
-@TestExecutionListeners(InfinispanTestExecutionListener.class)
 public abstract class AbstractTestTemplate extends AbstractTransactionalTestNGSpringContextTests {
 
    protected static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());

--- a/spring/spring5/spring5-remote/src/test/java/org/infinispan/spring/remote/provider/sample/SampleRemoteCacheTest.java
+++ b/spring/spring5/spring5-remote/src/test/java/org/infinispan/spring/remote/provider/sample/SampleRemoteCacheTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.spring.remote.provider.sample;
 
+import org.infinispan.spring.common.InfinispanTestExecutionListener;
 import org.infinispan.spring.remote.provider.SpringRemoteCacheManager;
 import org.infinispan.spring.remote.provider.sample.service.CachedBookService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -7,6 +8,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cache.CacheManager;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
 import org.testng.annotations.Test;
 
 /**
@@ -17,6 +19,7 @@ import org.testng.annotations.Test;
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @Test(testName = "spring.provider.SampleRemoteCacheTest", groups = "functional", sequential = true)
 @ContextConfiguration(locations = "classpath:/org/infinispan/spring/remote/provider/sample/SampleRemoteCacheTestConfig.xml")
+@TestExecutionListeners(InfinispanTestExecutionListener.class)
 public class SampleRemoteCacheTest extends AbstractTestTemplateJsr107 {
 
    @Qualifier(value = "cachedBookServiceImpl")

--- a/spring/spring5/spring5-remote/src/test/java/org/infinispan/spring/remote/support/InfinispanNamedRemoteCacheFactoryBeanContextTest.java
+++ b/spring/spring5/spring5-remote/src/test/java/org/infinispan/spring/remote/support/InfinispanNamedRemoteCacheFactoryBeanContextTest.java
@@ -3,9 +3,11 @@ package org.infinispan.spring.remote.support;
 import static org.testng.AssertJUnit.assertNotNull;
 
 import org.infinispan.Cache;
+import org.infinispan.spring.common.InfinispanTestExecutionListener;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
 
 /**
@@ -18,10 +20,9 @@ import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
  */
 @DirtiesContext(classMode = ClassMode.AFTER_CLASS)
 @ContextConfiguration("classpath:/org/infinispan/spring/remote/support/InfinispanNamedRemoteCacheFactoryBeanContextTest.xml")
-// @Test(testName = "spring.support.remote.InfinispanNamedRemoteCacheFactoryBeanContextTest", groups
-// = "functional")
-public class InfinispanNamedRemoteCacheFactoryBeanContextTest extends
-                                                              AbstractTestNGSpringContextTests {
+//@Test(testName = "spring.support.remote.InfinispanNamedRemoteCacheFactoryBeanContextTest", groups = "functional")
+@TestExecutionListeners(InfinispanTestExecutionListener.class)
+public class InfinispanNamedRemoteCacheFactoryBeanContextTest extends AbstractTestNGSpringContextTests {
 
    private static final String INFINISPAN_NAMED_REMOTE_CACHE_WITHOUT_FURTHER_CONFIGURATION_BEAN_NAME = "infinispanNamedRemoteCacheWithoutFurtherConfiguration";
 

--- a/spring/spring5/spring5-remote/src/test/java/org/infinispan/spring/remote/support/InfinispanRemoteCacheManagerFactoryBeanContextTest.java
+++ b/spring/spring5/spring5-remote/src/test/java/org/infinispan/spring/remote/support/InfinispanRemoteCacheManagerFactoryBeanContextTest.java
@@ -3,9 +3,11 @@ package org.infinispan.spring.remote.support;
 import static org.testng.AssertJUnit.assertNotNull;
 
 import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.spring.common.InfinispanTestExecutionListener;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
 import org.testng.annotations.Test;
 
@@ -20,8 +22,8 @@ import org.testng.annotations.Test;
 @DirtiesContext(classMode = ClassMode.AFTER_CLASS)
 @ContextConfiguration("classpath:/org/infinispan/spring/remote/support/InfinispanRemoteCacheManagerFactoryBeanContextTest.xml")
 @Test(testName = "spring.support.remote.InfinispanRemoteCacheManagerFactoryBeanContextTest", groups = "unit")
-public class InfinispanRemoteCacheManagerFactoryBeanContextTest extends
-                                                                AbstractTestNGSpringContextTests {
+@TestExecutionListeners(InfinispanTestExecutionListener.class)
+public class InfinispanRemoteCacheManagerFactoryBeanContextTest extends AbstractTestNGSpringContextTests {
 
    private static final String INFINISPAN_REMOTE_CACHE_MANAGER_WITH_DEFAULT_CONFIGURATION_BEAN_NAME = "infinispanRemoteCacheManagerWithDefaultConfiguration";
 

--- a/spring/spring5/spring5-remote/src/test/java/org/infinispan/spring/remote/support/InfinispanRemoteCacheManagerFactoryBeanTest.java
+++ b/spring/spring5/spring5-remote/src/test/java/org/infinispan/spring/remote/support/InfinispanRemoteCacheManagerFactoryBeanTest.java
@@ -28,6 +28,7 @@ import org.infinispan.commons.executors.ExecutorFactory;
 import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.spring.remote.AbstractRemoteCacheManagerFactory;
 import org.infinispan.spring.remote.AssertionUtils;
+import org.infinispan.test.AbstractInfinispanTest;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.testng.annotations.Test;
@@ -41,7 +42,7 @@ import org.testng.annotations.Test;
  *
  */
 @Test(testName = "spring.remote.support.InfinispanRemoteCacheManagerFactoryBeanTest", groups = "unit")
-public class InfinispanRemoteCacheManagerFactoryBeanTest {
+public class InfinispanRemoteCacheManagerFactoryBeanTest extends AbstractInfinispanTest {
 
    private static final Resource HOTROD_CLIENT_PROPERTIES_LOCATION = new ClassPathResource(
          "hotrod-client.properties", InfinispanRemoteCacheManagerFactoryBeanTest.class);
@@ -116,12 +117,14 @@ public class InfinispanRemoteCacheManagerFactoryBeanTest {
       objectUnderTest.afterPropertiesSet();
 
       final RemoteCacheManager remoteCacheManager = objectUnderTest.getObject();
+      RemoteCacheManager remoteCacheManager2 = new RemoteCacheManager();
       AssertionUtils.assertPropertiesSubset(
               "The configuration properties used by the RemoteCacheManager returned by getObject() should be equal "
                       + "to RemoteCacheManager's default settings since neither property 'configurationProperties' "
                       + "nor property 'configurationPropertiesFileLocation' has been set. However, those two are not equal.",
-              new RemoteCacheManager().getConfiguration().properties(), remoteCacheManager.getConfiguration().properties());
+              remoteCacheManager2.getConfiguration().properties(), remoteCacheManager.getConfiguration().properties());
       objectUnderTest.destroy();
+      remoteCacheManager2.stop();
    }
 
    /**

--- a/tasks/manager/pom.xml
+++ b/tasks/manager/pom.xml
@@ -72,6 +72,16 @@
                </instructions>
             </configuration>
          </plugin>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+               <dependenciesToScan>
+                  <!-- TestNGSuiteChecksTest -->
+                  <dependency>org.infinispan:infinispan-commons-test</dependency>
+               </dependenciesToScan>
+            </configuration>
+         </plugin>
       </plugins>
    </build>
 </project>

--- a/tasks/scripting/pom.xml
+++ b/tasks/scripting/pom.xml
@@ -72,6 +72,16 @@
                </instructions>
             </configuration>
          </plugin>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+               <dependenciesToScan>
+                  <!-- TestNGSuiteChecksTest -->
+                  <dependency>org.infinispan:infinispan-commons-test</dependency>
+               </dependenciesToScan>
+            </configuration>
+         </plugin>
       </plugins>
    </build>
 </project>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -175,6 +175,16 @@
                </instructions>
             </configuration>
          </plugin>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+               <dependenciesToScan>
+                  <!-- TestNGSuiteChecksTest -->
+                  <dependency>org.infinispan:infinispan-commons-test</dependency>
+               </dependenciesToScan>
+            </configuration>
+         </plugin>
       </plugins>
    </build>
 </project>

--- a/tree/pom.xml
+++ b/tree/pom.xml
@@ -80,6 +80,16 @@
                </instructions>
             </configuration>
          </plugin>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+               <dependenciesToScan>
+                  <!-- TestNGSuiteChecksTest -->
+                  <dependency>org.infinispan:infinispan-commons-test</dependency>
+               </dependenciesToScan>
+            </configuration>
+         </plugin>
       </plugins>
    </build>
 </project>


### PR DESCRIPTION
Update for ISPN-9863 because it wasn't always catching leaks in the spring5 modules, depending on whether the last test to run called `TestResourceTracker` or not.

* Don't require tests to extend AbstractInfinispanTest
* TestNG modules check for thread leaks by running ThreadLeakCheckTest
  from the commons-test module
* JUnit modules check for thread leaks explicitly
  or in JUnitTestListener