### PR TITLE
ISPN-9373 Fix FunctionalListenersTest

### DIFF
--- a/core/src/test/java/org/infinispan/functional/AbstractFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/functional/AbstractFunctionalTest.java
@@ -96,14 +96,14 @@ abstract class AbstractFunctionalTest extends MultipleCacheManagersTest {
    }
 
    @Override
-   @BeforeClass
+   @BeforeClass(alwaysRun = true)
    public void createBeforeClass() throws Throwable {
       super.createBeforeClass();
       if (cleanupAfterTest()) initMaps();
    }
 
    @Override
-   @BeforeMethod
+   @BeforeMethod(alwaysRun = true)
    public void createBeforeMethod() throws Throwable {
       super.createBeforeMethod();
       if (cleanupAfterMethod()) initMaps();


### PR DESCRIPTION
https://github.com/infinispan/infinispan/pull/6365 broke FunctionalListenersTest because TestNG simplified the inheritance of groups: if a method and its declaring class are both missing the `@Test(groups)`, they don't automatically use the derived class' groups.