### PR TITLE
ISPN-10019 Avoid transport exception when using clustered locks

### DIFF
--- a/counter/src/main/java/org/infinispan/counter/impl/CounterModuleLifecycle.java
+++ b/counter/src/main/java/org/infinispan/counter/impl/CounterModuleLifecycle.java
@@ -138,7 +138,7 @@ public class CounterModuleLifecycle implements ModuleLifecycle {
       InternalCacheRegistry internalCacheRegistry = bcr.getComponent(InternalCacheRegistry.class).running();
 
       CounterManagerConfiguration counterManagerConfiguration = extractConfiguration(gcr);
-      if (gcr.getGlobalConfiguration().transport().transport() != null) {
+      if (gcr.getGlobalConfiguration().isClustered()) {
          //only attempts to create the caches if the cache manager is clustered.
          registerCounterCache(internalCacheRegistry, counterManagerConfiguration);
       } else {

--- a/lock/src/main/java/org/infinispan/lock/EmbeddedClusteredLockManagerFactory.java
+++ b/lock/src/main/java/org/infinispan/lock/EmbeddedClusteredLockManagerFactory.java
@@ -2,8 +2,10 @@ package org.infinispan.lock;
 
 import static java.util.Objects.requireNonNull;
 
+import org.infinispan.commons.logging.LogFactory;
 import org.infinispan.commons.util.Experimental;
 import org.infinispan.lock.api.ClusteredLockManager;
+import org.infinispan.lock.logging.Log;
 import org.infinispan.manager.EmbeddedCacheManager;
 
 /**
@@ -15,11 +17,18 @@ import org.infinispan.manager.EmbeddedCacheManager;
 @Experimental
 public final class EmbeddedClusteredLockManagerFactory {
 
+   private static final Log log = LogFactory.getLog(EmbeddedClusteredLockManagerFactory.class, Log.class);
+
    private EmbeddedClusteredLockManagerFactory() {
    }
 
    public static ClusteredLockManager from(EmbeddedCacheManager cacheManager) {
-      return requireNonNull(cacheManager, "EmbeddedCacheManager can't be null.")
+      requireNonNull(cacheManager, "EmbeddedCacheManager can't be null.");
+
+      if (!cacheManager.getCacheManagerConfiguration().isClustered()) {
+         throw log.requireClustered();
+      }
+      return cacheManager
             .getGlobalComponentRegistry()
             .getComponent(ClusteredLockManager.class);
    }

--- a/lock/src/main/java/org/infinispan/lock/impl/ClusteredLockModuleLifecycle.java
+++ b/lock/src/main/java/org/infinispan/lock/impl/ClusteredLockModuleLifecycle.java
@@ -66,11 +66,14 @@ public class ClusteredLockModuleLifecycle implements ModuleLifecycle {
       ClusteredLockManagerConfiguration config = extractConfiguration(gcr);
       GlobalConfiguration globalConfig = gcr.getGlobalConfiguration();
 
-      internalCacheRegistry.registerInternalCache(CLUSTERED_LOCK_CACHE_NAME, createClusteredLockCacheConfiguration(config, globalConfig),
-            EnumSet.of(InternalCacheRegistry.Flag.EXCLUSIVE));
-
-      CompletableFuture<CacheHolder> future = startCaches(cacheManager);
-      registerClusteredLockManager(gcr, future, config);
+      if (globalConfig.isClustered()) {
+         internalCacheRegistry.registerInternalCache(CLUSTERED_LOCK_CACHE_NAME, createClusteredLockCacheConfiguration(config, globalConfig),
+               EnumSet.of(InternalCacheRegistry.Flag.EXCLUSIVE));
+         CompletableFuture<CacheHolder> future = startCaches(cacheManager);
+         registerClusteredLockManager(gcr, future, config);
+      } else {
+         log.configurationNotClustered();
+      }
    }
 
    private static ClusteredLockManagerConfiguration extractConfiguration(GlobalComponentRegistry globalComponentRegistry) {

--- a/lock/src/main/java/org/infinispan/lock/logging/Log.java
+++ b/lock/src/main/java/org/infinispan/lock/logging/Log.java
@@ -1,7 +1,10 @@
 package org.infinispan.lock.logging;
 
+import static org.jboss.logging.Logger.Level.INFO;
+
 import org.infinispan.lock.exception.ClusteredLockException;
 import org.jboss.logging.BasicLogger;
+import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 
@@ -37,4 +40,11 @@ public interface Log extends BasicLogger {
 
    @Message(value = "Invalid scope for tag <clustered-lock>. Expected CACHE_CONTAINER but was %s", id = 29007)
    ClusteredLockException invalidScope(String scope);
+
+   @Message(value = "Cannot create clustered locks when clustering is not enabled", id = 29008)
+   ClusteredLockException requireClustered();
+
+   @LogMessage(level = INFO)
+   @Message(value = "Configuration is not clustered, clustered locks are disabled", id = 29009)
+   void configurationNotClustered();
 }

--- a/lock/src/test/java/org/infinispan/lock/ClusteredLockWithoutClusterTest.java
+++ b/lock/src/test/java/org/infinispan/lock/ClusteredLockWithoutClusterTest.java
@@ -1,0 +1,26 @@
+package org.infinispan.lock;
+
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.lock.exception.ClusteredLockException;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.test.Exceptions;
+import org.infinispan.test.SingleCacheManagerTest;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.Test;
+
+@Test(groups = "functional", testName = "clusteredLock.ClusteredLockWithoutClusterTest")
+public class ClusteredLockWithoutClusterTest extends SingleCacheManagerTest {
+
+   @Override
+   protected EmbeddedCacheManager createCacheManager() {
+      ConfigurationBuilder c = getDefaultStandaloneCacheConfig(false);
+      EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(false);
+      cm.defineConfiguration("test", c.build());
+      cache = cm.getCache("test");
+      return cm;
+   }
+
+   public void testNeedsCluster() {
+      Exceptions.expectException(ClusteredLockException.class, () -> EmbeddedClusteredLockManagerFactory.from(cacheManager));
+   }
+}


### PR DESCRIPTION
Clustered locks work and are needed when we are in clustered mode. 
Log a message and avoid a transport error. More information in the issue

https://issues.jboss.org/browse/ISPN-10019

backport #6736 