### PR TITLE
ISPN-10032 unclear lifespan expiration lifespan value (seconds or UnicTime)…

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCache.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCache.java
@@ -50,9 +50,7 @@ import org.infinispan.query.dsl.Query;
  * org.infinispan.Cache} cache, which allows specifying time values with any granularity (as defined by {@link
  * TimeUnit}), HotRod only supports seconds as time units. If a different time unit is used instead, HotRod will
  * transparently convert it to seconds, using {@link java.util.concurrent.TimeUnit#toSeconds(long)} method. This might
- * result in loss of precision for values specified as nanos or milliseconds. <br/> Another fundamental difference is in
- * the case of lifespan (naturally does NOT apply for max idle): If number of seconds is bigger than 30 days, this
- * number of seconds is treated as UNIX time and so, represents the number of seconds since 1/1/1970. <br/>
+ * result in loss of precision for values specified as nanos or milliseconds. <br/>
  *
  * <b>Note on default expiration values:</b> Due to limitations on the first
  * version of the protocol, it's not possible for clients to rely on default
@@ -64,6 +62,7 @@ import org.infinispan.query.dsl.Query;
  * values in each remote cache operation.
  *
  * @author Mircea.Markus@jboss.com
+ * @author WolfDieter.Fink@gmail.com
  * @since 4.1
  */
 public interface RemoteCache<K, V> extends BasicCache<K, V>, TransactionalCache {

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/HotRodServer.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/HotRodServer.java
@@ -105,12 +105,11 @@ import org.infinispan.util.KeyValuePair;
  * startup and shutdown.
  *
  * @author Galder Zamarreño
+ * @author WolfDieter.Fink@gmail.com
  * @since 4.1
  */
 public class HotRodServer extends AbstractProtocolServer<HotRodServerConfiguration> {
    private static final Log log = LogFactory.getLog(HotRodServer.class, Log.class);
-
-   private static final long MILLISECONDS_IN_30_DAYS = TimeUnit.DAYS.toMillis(30);
 
    public static final int LISTENERS_CHECK_INTERVAL = 10;
 
@@ -597,22 +596,16 @@ public class HotRodServer extends AbstractProtocolServer<HotRodServerConfigurati
    }
 
    /**
-    * Transforms lifespan pass as seconds into milliseconds following this rule (inspired by Memcached):
-    * <p>
-    * If lifespan is bigger than number of seconds in 30 days, then it is considered unix time. After converting it to
-    * milliseconds, we subtract the current time in and the result is returned.
-    * <p>
-    * Otherwise it's just considered number of seconds from now and it's returned in milliseconds unit.
+    * Transforms lifespan pass with TimeUnit into milliseconds
+    *
+    * @param duration lifespan passed with unit
+    * @param unit TimeUnit for the lifespan duration parameter
+    * @return lifespan in milliseconds
     */
    private static long toMillis(long duration, TimeUnitValue unit) {
       if (duration > 0) {
          long milliseconds = unit.toTimeUnit().toMillis(duration);
-         if (milliseconds > MILLISECONDS_IN_30_DAYS) {
-            long unixTimeExpiry = milliseconds - System.currentTimeMillis();
-            return unixTimeExpiry < 0 ? 0 : unixTimeExpiry;
-         } else {
-            return milliseconds;
-         }
+         return milliseconds;
       } else {
          return duration;
       }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-10032

removed conversion from seconds to UnitTime if  seconds>30days (2592000)
removed Javadoc which mention converting from seconds>30Days to Unix time 1/1/1970