### PR TITLE
ISPN-10049 Persistence Executor threads should use ProcessorInfo

### DIFF
--- a/core/src/main/java/org/infinispan/factories/KnownComponentNames.java
+++ b/core/src/main/java/org/infinispan/factories/KnownComponentNames.java
@@ -5,6 +5,8 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.infinispan.commons.util.ProcessorInfo;
+
 /**
  * Holder for known named component names.  To be used with {@link org.infinispan.factories.annotations.ComponentName}
  * annotation.
@@ -49,7 +51,7 @@ public class KnownComponentNames {
       DEFAULT_THREAD_COUNT.put(ASYNC_TRANSPORT_EXECUTOR, 25);
       DEFAULT_THREAD_COUNT.put(EXPIRATION_SCHEDULED_EXECUTOR, 1);
       // Persistence Executor default to # of CPUs
-      DEFAULT_THREAD_COUNT.put(PERSISTENCE_EXECUTOR, Runtime.getRuntime().availableProcessors());
+      DEFAULT_THREAD_COUNT.put(PERSISTENCE_EXECUTOR, ProcessorInfo.availableProcessors());
       DEFAULT_THREAD_COUNT.put(REMOTE_COMMAND_EXECUTOR, 200);
       DEFAULT_THREAD_COUNT.put(STATE_TRANSFER_EXECUTOR, 60);
       DEFAULT_THREAD_COUNT.put(ASYNC_OPERATIONS_EXECUTOR, 25);


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-10049