### PR TITLE
ISPN-10061 ThreadLeakChecker states that "ClassCache Reaper" is leake…

### DIFF
--- a/commons-test/src/main/java/org/infinispan/commons/test/ThreadLeakChecker.java
+++ b/commons-test/src/main/java/org/infinispan/commons/test/ThreadLeakChecker.java
@@ -68,6 +68,8 @@ public class ThreadLeakChecker {
                       "|Reference Reaper" +
                       // jboss-remoting
                       "|remoting-jmx client" +
+                      // IBM JRE specific
+                      "|ClassCache Reaper" +
                       ").*");
    private static final String ARQUILLIAN_CONSOLE_CONSUMER =
       "org.jboss.as.arquillian.container.managed.ManagedDeployableContainer$ConsoleConsumer";


### PR DESCRIPTION
…d - is an IBM system thread

* Ignore ClassCache Reaper thread

https://issues.jboss.org/browse/ISPN-10061