### PR TITLE
ISPN-10059 Off-heap clustered cache cannot start with segmentation di…

### DIFF
--- a/commons-test/src/main/java/org/infinispan/commons/test/RunningTestsRegistry.java
+++ b/commons-test/src/main/java/org/infinispan/commons/test/RunningTestsRegistry.java
@@ -41,7 +41,9 @@ class RunningTestsRegistry {
 
    static void unregisterThreadWithTest() {
       ScheduledFuture<?> killTask = scheduledTasks.remove(Thread.currentThread());
-      killTask.cancel(false);
+      if (killTask != null) {
+         killTask.cancel(false);
+      }
    }
 
    static void registerThreadWithTest(String testName, String simpleName) {

--- a/commons-test/src/main/java/org/infinispan/commons/test/TestNGTestListener.java
+++ b/commons-test/src/main/java/org/infinispan/commons/test/TestNGTestListener.java
@@ -40,6 +40,8 @@ public class TestNGTestListener implements ITestListener, IConfigurationListener
 
    @Override
    public void onTestSkipped(ITestResult result) {
+      // Unregister thread in case the method threw a SkipException
+      RunningTestsRegistry.unregisterThreadWithTest();
       progressLogger.testIgnored(testName(result));
    }
 
@@ -105,7 +107,8 @@ public class TestNGTestListener implements ITestListener, IConfigurationListener
 
    @Override
    public void onConfigurationSkip(ITestResult testResult) {
-      // beforeConfiguration didn't run, no need to unregister thread
+      // Unregister thread in case the configuration method threw a SkipException
+      RunningTestsRegistry.unregisterThreadWithTest();
       if (testResult.getThrowable() != null) {
          progressLogger.testIgnored(testName(testResult));
       }

--- a/core/src/main/java/org/infinispan/container/impl/DefaultDataContainer.java
+++ b/core/src/main/java/org/infinispan/container/impl/DefaultDataContainer.java
@@ -1,10 +1,8 @@
 package org.infinispan.container.impl;
 
 import java.lang.invoke.MethodHandles;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.Spliterator;
@@ -240,26 +238,7 @@ public class DefaultDataContainer<K, V> extends AbstractInternalDataContainer<K,
 
    @Override
    public void removeSegments(IntSet segments) {
-      if (!segments.isEmpty()) {
-         List<InternalCacheEntry<K, V>> removedEntries;
-         if (!listeners.isEmpty()) {
-            removedEntries = new ArrayList<>(entries.size());
-         } else {
-            removedEntries = null;
-         }
-         Iterator<InternalCacheEntry<K, V>> iter = iteratorIncludingExpired(segments);
-         while (iter.hasNext()) {
-            InternalCacheEntry<K, V> ice = iter.next();
-            if (removedEntries != null) {
-               removedEntries.add(ice);
-            }
-            iter.remove();
-         }
-         if (removedEntries != null) {
-            List<InternalCacheEntry<K, V>> unmod = Collections.unmodifiableList(removedEntries);
-            listeners.forEach(c -> c.accept(unmod));
-         }
-      }
+      InternalDataContainerAdapter.removeSegmentEntries(this, segments, listeners, keyPartitioner);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/container/offheap/BoundedOffHeapDataContainer.java
+++ b/core/src/main/java/org/infinispan/container/offheap/BoundedOffHeapDataContainer.java
@@ -1,16 +1,34 @@
 package org.infinispan.container.offheap;
 
+import java.util.Iterator;
+import java.util.List;
+import java.util.Spliterator;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
+
 import org.infinispan.commons.marshall.WrappedBytes;
+import org.infinispan.commons.util.FilterIterator;
+import org.infinispan.commons.util.FilterSpliterator;
+import org.infinispan.commons.util.IntSet;
 import org.infinispan.commons.util.IntSets;
 import org.infinispan.container.entries.InternalCacheEntry;
+import org.infinispan.container.impl.InternalDataContainerAdapter;
+import org.infinispan.distribution.ch.KeyPartitioner;
 import org.infinispan.eviction.EvictionType;
+import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
+import org.infinispan.metadata.Metadata;
 
 /**
  * @author wburns
  * @since 9.4
  */
 public class BoundedOffHeapDataContainer extends SegmentedBoundedOffHeapDataContainer {
+   @Inject KeyPartitioner keyPartitioner;
+
+   protected final List<Consumer<Iterable<InternalCacheEntry<WrappedBytes, WrappedBytes>>>> listeners =
+      new CopyOnWriteArrayList<>();
+
    public BoundedOffHeapDataContainer(int addressCount, long maxSize, EvictionType type) {
       super(addressCount, 1, maxSize, type);
    }
@@ -56,5 +74,89 @@ public class BoundedOffHeapDataContainer extends SegmentedBoundedOffHeapDataCont
    @Override
    public void evict(WrappedBytes key) {
       super.evict(0, key);
+   }
+
+   @Override
+   public void put(WrappedBytes key, WrappedBytes value, Metadata metadata) {
+      super.put(0, key, value, metadata, -1, -1);
+   }
+
+   @Override
+   public boolean containsKey(int segment, Object k) {
+      return super.containsKey(0, k);
+   }
+
+   @Override
+   public InternalCacheEntry<WrappedBytes, WrappedBytes> peek(int segment, Object k) {
+      return super.peek(0, k);
+   }
+
+   @Override
+   public InternalCacheEntry<WrappedBytes, WrappedBytes> get(int segment, Object k) {
+      return super.get(0, k);
+   }
+
+   @Override
+   public InternalCacheEntry<WrappedBytes, WrappedBytes> compute(int segment, WrappedBytes key,
+                                                                 ComputeAction<WrappedBytes, WrappedBytes> action) {
+      return super.compute(0, key, action);
+   }
+
+   @Override
+   public InternalCacheEntry<WrappedBytes, WrappedBytes> remove(int segment, Object k) {
+      return super.remove(0, k);
+   }
+
+   @Override
+   public void evict(int segment, WrappedBytes key) {
+      super.evict(0, key);
+   }
+
+   @Override
+   public void put(int segment, WrappedBytes key, WrappedBytes value, Metadata metadata, long createdTimestamp,
+                   long lastUseTimestamp) {
+      super.put(0, key, value, metadata, createdTimestamp, lastUseTimestamp);
+   }
+
+   @Override
+   public Spliterator<InternalCacheEntry<WrappedBytes, WrappedBytes>> spliterator(IntSet segments) {
+      return new FilterSpliterator<>(spliterator(), ice -> segments.contains(keyPartitioner.getSegment(ice.getKey())));
+   }
+
+   @Override
+   public Spliterator<InternalCacheEntry<WrappedBytes, WrappedBytes>> spliteratorIncludingExpired(IntSet segments) {
+      return new FilterSpliterator<>(spliteratorIncludingExpired(),
+                                     ice -> segments.contains(keyPartitioner.getSegment(ice.getKey())));
+   }
+
+   @Override
+   public Iterator<InternalCacheEntry<WrappedBytes, WrappedBytes>> iterator(IntSet segments) {
+      return new FilterIterator<>(iterator(), ice -> segments.contains(keyPartitioner.getSegment(ice.getKey())));
+   }
+
+   @Override
+   public Iterator<InternalCacheEntry<WrappedBytes, WrappedBytes>> iteratorIncludingExpired(IntSet segments) {
+      return new FilterIterator<>(iteratorIncludingExpired(),
+                                  ice -> segments.contains(keyPartitioner.getSegment(ice.getKey())));
+   }
+
+   @Override
+   public void addRemovalListener(Consumer<Iterable<InternalCacheEntry<WrappedBytes, WrappedBytes>>> listener) {
+      listeners.add(listener);
+   }
+
+   @Override
+   public void removeRemovalListener(Object listener) {
+      listeners.remove(listener);
+   }
+
+   @Override
+   public void addSegments(IntSet segments) {
+      // Don't have to do anything here
+   }
+
+   @Override
+   public void removeSegments(IntSet segments) {
+      InternalDataContainerAdapter.removeSegmentEntries(super.delegate(), segments, listeners, keyPartitioner);
    }
 }

--- a/core/src/main/java/org/infinispan/container/offheap/OffHeapDataContainer.java
+++ b/core/src/main/java/org/infinispan/container/offheap/OffHeapDataContainer.java
@@ -13,6 +13,7 @@ import org.infinispan.commons.util.ProcessorInfo;
 import org.infinispan.commons.util.Util;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.container.impl.AbstractInternalDataContainer;
+import org.infinispan.container.impl.InternalDataContainerAdapter;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
 import org.infinispan.factories.annotations.Stop;
@@ -110,12 +111,12 @@ public class OffHeapDataContainer extends AbstractInternalDataContainer<WrappedB
 
    @Override
    public void addSegments(IntSet segments) {
-      throw new UnsupportedOperationException("Container is not segmented");
+      // Don't have to do anything here
    }
 
    @Override
    public void removeSegments(IntSet segments) {
-      throw new UnsupportedOperationException("Container is not segmented");
+      InternalDataContainerAdapter.removeSegmentEntries(this, segments, listeners, keyPartitioner);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/topology/ClusterTopologyManagerImpl.java
+++ b/core/src/main/java/org/infinispan/topology/ClusterTopologyManagerImpl.java
@@ -151,6 +151,7 @@ public class ClusterTopologyManagerImpl implements ClusterTopologyManager {
                if (i == 0 || !(e instanceof TimeoutException)) {
                   log.errorReadingRebalancingStatus(coordinator, e);
                   response = SuccessfulResponse.create(Boolean.TRUE);
+                  break;
                }
                log.debug("Timed out waiting for rebalancing status from coordinator, trying again");
             }

--- a/core/src/test/java/org/infinispan/container/impl/DefaultSegmentedDataContainerTest.java
+++ b/core/src/test/java/org/infinispan/container/impl/DefaultSegmentedDataContainerTest.java
@@ -6,10 +6,12 @@ import static org.testng.AssertJUnit.assertTrue;
 import java.util.Set;
 
 import org.infinispan.Cache;
+import org.infinispan.commons.util.Features;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.container.DataContainer;
 import org.infinispan.distribution.DistributionManager;
+import org.infinispan.factories.DataContainerFactory;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
@@ -33,7 +35,14 @@ public class DefaultSegmentedDataContainerTest extends MultipleCacheManagersTest
    public void ensureOldMapsRemoved() {
       for (Cache<Object, Object> cache : caches(CACHE_NAME)) {
          DataContainer dc = TestingUtil.extractComponent(cache, InternalDataContainer.class);
-         assertTrue(dc instanceof DefaultSegmentedDataContainer);
+
+         boolean segmentationAvailable = new Features().isAvailable(DataContainerFactory.SEGMENTATION_FEATURE);
+         if (!segmentationAvailable) {
+            assertEquals(DefaultDataContainer.class, dc.getClass());
+            return;
+         }
+
+         assertEquals(DefaultSegmentedDataContainer.class, dc.getClass());
 
          DefaultSegmentedDataContainer segmentedDataContainer = (DefaultSegmentedDataContainer) dc;
 

--- a/core/src/test/java/org/infinispan/container/offheap/OffHeapMultiNodeTest.java
+++ b/core/src/test/java/org/infinispan/container/offheap/OffHeapMultiNodeTest.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.infinispan.commons.marshall.WrappedByteArray;
@@ -27,6 +28,7 @@ public class OffHeapMultiNodeTest extends MultipleCacheManagersTest {
    protected void createCacheManagers() throws Throwable {
       ConfigurationBuilder dcc = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false);
       dcc.memory().storageType(StorageType.OFF_HEAP);
+      dcc.clustering().stateTransfer().timeout(10, TimeUnit.SECONDS);
       createCluster(dcc, 4);
       waitForClusterToForm();
    }

--- a/core/src/test/java/org/infinispan/distribution/BaseDistStoreTest.java
+++ b/core/src/test/java/org/infinispan/distribution/BaseDistStoreTest.java
@@ -5,8 +5,11 @@ import static org.testng.AssertJUnit.assertEquals;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.infinispan.Cache;
+import org.infinispan.commons.test.skip.SkipTestNG;
+import org.infinispan.commons.util.Features;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.StoreConfigurationBuilder;
+import org.infinispan.factories.DataContainerFactory;
 import org.infinispan.persistence.dummy.DummyInMemoryStore;
 import org.infinispan.persistence.dummy.DummyInMemoryStoreConfigurationBuilder;
 import org.infinispan.persistence.spi.AdvancedLoadWriteStore;
@@ -51,6 +54,9 @@ public abstract class BaseDistStoreTest<K, V, C extends BaseDistStoreTest> exten
 
    @Override
    protected ConfigurationBuilder buildConfiguration() {
+      boolean segmentationAvailable = new Features().isAvailable(DataContainerFactory.SEGMENTATION_FEATURE);
+      SkipTestNG.skipIf(segmented && !segmentationAvailable, "Segmentation is disabled");
+
       ConfigurationBuilder cfg = super.buildConfiguration();
       StoreConfigurationBuilder<?, ?> storeConfigurationBuilder;
       if (shared) {

--- a/core/src/test/java/org/infinispan/factories/DataContainerFactoryTest.java
+++ b/core/src/test/java/org/infinispan/factories/DataContainerFactoryTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 import static org.testng.AssertJUnit.assertEquals;
-import static org.testng.AssertJUnit.assertTrue;
 
 import org.infinispan.commons.util.Features;
 import org.infinispan.configuration.cache.CacheMode;
@@ -58,8 +57,13 @@ public class DataContainerFactoryTest extends AbstractInfinispanTest {
       dataContainerFactory.configuration = new ConfigurationBuilder().clustering().cacheMode(CacheMode.DIST_ASYNC)
             .memory().storageType(StorageType.OFF_HEAP).build();
 
-      assertTrue(dataContainerFactory.globalConfiguration.features().isAvailable(DataContainerFactory.SEGMENTATION_FEATURE));
-      assertEquals(DefaultSegmentedDataContainer.class, dataContainerFactory.construct(COMPONENT_NAME).getClass());
+      boolean segmentationAvailable = new Features().isAvailable(DataContainerFactory.SEGMENTATION_FEATURE);
+      Object component = dataContainerFactory.construct(COMPONENT_NAME);
+      if (segmentationAvailable) {
+         assertEquals(DefaultSegmentedDataContainer.class, component.getClass());
+      } else {
+         assertEquals(OffHeapDataContainer.class, component.getClass());
+      }
    }
 
    @Test
@@ -75,7 +79,13 @@ public class DataContainerFactoryTest extends AbstractInfinispanTest {
             .l1().enable()
             .memory().storageType(StorageType.OFF_HEAP).build();
 
-      assertEquals(L1SegmentedDataContainer.class, this.dataContainerFactory.construct(COMPONENT_NAME).getClass());
+      boolean segmentationAvailable = new Features().isAvailable(DataContainerFactory.SEGMENTATION_FEATURE);
+      Object component = dataContainerFactory.construct(COMPONENT_NAME);
+      if (segmentationAvailable) {
+         assertEquals(L1SegmentedDataContainer.class, component.getClass());
+      } else {
+         assertEquals(OffHeapDataContainer.class, component.getClass());
+      }
    }
 
    @Test
@@ -83,7 +93,13 @@ public class DataContainerFactoryTest extends AbstractInfinispanTest {
       dataContainerFactory.configuration = new ConfigurationBuilder().clustering()
             .cacheMode(CacheMode.DIST_ASYNC).build();
 
-      assertEquals(DefaultSegmentedDataContainer.class, this.dataContainerFactory.construct(COMPONENT_NAME).getClass());
+      boolean segmentationAvailable = new Features().isAvailable(DataContainerFactory.SEGMENTATION_FEATURE);
+      Object component = dataContainerFactory.construct(COMPONENT_NAME);
+      if (segmentationAvailable) {
+         assertEquals(DefaultSegmentedDataContainer.class, component.getClass());
+      } else {
+         assertEquals(DefaultDataContainer.class, component.getClass());
+      }
    }
 
    @Test
@@ -92,7 +108,13 @@ public class DataContainerFactoryTest extends AbstractInfinispanTest {
             .cacheMode(CacheMode.DIST_ASYNC)
             .l1().enable().build();
 
-      assertEquals(L1SegmentedDataContainer.class, this.dataContainerFactory.construct(COMPONENT_NAME).getClass());
+      boolean segmentationAvailable = new Features().isAvailable(DataContainerFactory.SEGMENTATION_FEATURE);
+      Object component = dataContainerFactory.construct(COMPONENT_NAME);
+      if (segmentationAvailable) {
+         assertEquals(L1SegmentedDataContainer.class, component.getClass());
+      } else {
+         assertEquals(DefaultDataContainer.class, component.getClass());
+      }
    }
 
    @Test
@@ -109,7 +131,13 @@ public class DataContainerFactoryTest extends AbstractInfinispanTest {
             .memory().evictionStrategy(EvictionStrategy.REMOVE).size(1000)
             .clustering().cacheMode(CacheMode.DIST_ASYNC).build();
 
-      assertEquals(BoundedSegmentedDataContainer.class, this.dataContainerFactory.construct(COMPONENT_NAME).getClass());
+      boolean segmentationAvailable = new Features().isAvailable(DataContainerFactory.SEGMENTATION_FEATURE);
+      Object component = dataContainerFactory.construct(COMPONENT_NAME);
+      if (segmentationAvailable) {
+         assertEquals(BoundedSegmentedDataContainer.class, component.getClass());
+      } else {
+         assertEquals(DefaultDataContainer.class, component.getClass());
+      }
    }
 
    @Test
@@ -127,8 +155,13 @@ public class DataContainerFactoryTest extends AbstractInfinispanTest {
             .memory().storageType(StorageType.OFF_HEAP).evictionStrategy(EvictionStrategy.REMOVE).size(1000)
             .clustering().cacheMode(CacheMode.DIST_ASYNC).build();
 
-      assertEquals(SegmentedBoundedOffHeapDataContainer.class, this.dataContainerFactory.construct(
-         COMPONENT_NAME).getClass());
+      boolean segmentationAvailable = new Features().isAvailable(DataContainerFactory.SEGMENTATION_FEATURE);
+      Object component = dataContainerFactory.construct(COMPONENT_NAME);
+      if (segmentationAvailable) {
+         assertEquals(SegmentedBoundedOffHeapDataContainer.class, component.getClass());
+      } else {
+         assertEquals(BoundedOffHeapDataContainer.class, component.getClass());
+      }
    }
 
    @Test

--- a/core/src/test/java/org/infinispan/persistence/CacheLoaderFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/persistence/CacheLoaderFunctionalTest.java
@@ -15,7 +15,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-
 import javax.transaction.NotSupportedException;
 import javax.transaction.SystemException;
 import javax.transaction.Transaction;
@@ -23,11 +22,14 @@ import javax.transaction.TransactionManager;
 
 import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
+import org.infinispan.commons.test.skip.SkipTestNG;
+import org.infinispan.commons.util.Features;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.container.DataContainer;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.context.Flag;
+import org.infinispan.factories.DataContainerFactory;
 import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.marshall.persistence.impl.MarshalledEntryUtil;
@@ -73,6 +75,9 @@ public class CacheLoaderFunctionalTest extends AbstractInfinispanTest {
 
    @BeforeMethod(alwaysRun = true)
    public void setUp() {
+      boolean segmentationAvailable = new Features().isAvailable(DataContainerFactory.SEGMENTATION_FEATURE);
+      SkipTestNG.skipIf(segmented && !segmentationAvailable, "Segmentation is disabled");
+
       cfg = getConfiguration();
       configure(cfg);
       cm = TestCacheManagerFactory.createCacheManager(cfg);
@@ -122,7 +127,9 @@ public class CacheLoaderFunctionalTest extends AbstractInfinispanTest {
 
    @AfterMethod(alwaysRun = true)
    public void tearDown() throws PersistenceException {
-      writer.clear();
+      if (writer != null) {
+         writer.clear();
+      }
       TestingUtil.killCacheManagers(cm);
       cache = null;
       cm = null;


### PR DESCRIPTION
…sabled

https://issues.jboss.org/browse/ISPN-10059

* Implement addSegments/removeSegments in OffHeapDataContainer
* Use the InternalDataContainerAdapter implementation in all
  non-segmented InternalDataContainer implementations
* Only retry the join request on failure