### PR TITLE
[9.4.x] ISPN-10074 DefaultDataContainer executeTask() should ignore maxIdle

### DIFF
--- a/core/src/main/java/org/infinispan/container/impl/DefaultDataContainer.java
+++ b/core/src/main/java/org/infinispan/container/impl/DefaultDataContainer.java
@@ -249,10 +249,9 @@ public class DefaultDataContainer<K, V> extends AbstractInternalDataContainer<K,
       if (action == null)
          throw new IllegalArgumentException("No action specified");
 
-      long now = timeService.wallClockTime();
-      entries.forEach((K key, InternalCacheEntry<K, V> value) -> {
-         if (filter.accept(key) && !value.isExpired(now)) {
-            action.accept(key, value);
+      forEach(e -> {
+         if (filter.accept(e.getKey())) {
+            action.accept(e.getKey(), e);
          }
       });
       //TODO figure out the way how to do interruption better (during iteration)
@@ -270,9 +269,9 @@ public class DefaultDataContainer<K, V> extends AbstractInternalDataContainer<K,
          throw new IllegalArgumentException("No action specified");
 
       long now = timeService.wallClockTime();
-      entries.forEach((K key, InternalCacheEntry<K, V> value) -> {
-         if (filter.accept(key, value.getValue(), value.getMetadata()) && !value.isExpired(now)) {
-            action.accept(key, value);
+      forEach(e -> {
+         if (filter.accept(e.getKey(), e.getValue(), e.getMetadata())) {
+            action.accept(e.getKey(), e);
          }
       });
       //TODO figure out the way how to do interruption better (during iteration)

--- a/core/src/main/java/org/infinispan/expiration/impl/ClusterExpirationManager.java
+++ b/core/src/main/java/org/infinispan/expiration/impl/ClusterExpirationManager.java
@@ -214,17 +214,17 @@ public class ClusterExpirationManager<K, V> extends ExpirationManagerImpl<K, V> 
    public CompletableFuture<Boolean> entryExpiredInMemoryFromIteration(InternalCacheEntry<K, V> entry, long currentTime) {
       // We need to synchronize on the entry since {@link InternalCacheEntry} locks the entry when doing an update
       // so we can see both the new value and the metadata
-      boolean expiredTransient;
+      boolean expiredMortal;
       synchronized (entry) {
-         expiredTransient = ExpiryHelper.isExpiredTransient(entry.getMaxIdle(), entry.getLastUsed(), currentTime);
+         expiredMortal = ExpiryHelper.isExpiredMortal(entry.getLifespan(), entry.getCreated(), currentTime);
       }
-      if (expiredTransient) {
+      if (expiredMortal) {
+         // Lifespan was expired - but we don't want to take the hit of causing an expire command to be fired
+         return CompletableFutures.completedTrue();
+      } else {
          // Max idle expiration - we just return it (otherwise we would have to incur remote overhead)
          // This entry will be removed on next get or reaper running
          return CompletableFutures.completedFalse();
-      } else {
-         // Lifespan was expired - but we don't want to take the hit of causing an expire command to be fired
-         return CompletableFutures.completedTrue();
       }
    }
 

--- a/core/src/test/java/org/infinispan/expiration/impl/ExpirationFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/expiration/impl/ExpirationFunctionalTest.java
@@ -7,8 +7,10 @@ import static org.testng.AssertJUnit.assertNull;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.StorageType;
+import org.infinispan.expiration.ExpirationManager;
 import org.infinispan.filter.KeyFilter;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.SingleCacheManagerTest;
@@ -25,19 +27,29 @@ public class ExpirationFunctionalTest extends SingleCacheManagerTest {
    protected final int SIZE = 10;
    protected ControlledTimeService timeService = new ControlledTimeService();
    protected StorageType storage;
+   protected CacheMode cacheMode;
+   protected ExpirationManager expirationManager;
 
    @Factory
    public Object[] factory() {
       return new Object[]{
-            new ExpirationFunctionalTest().withStorage(StorageType.BINARY),
-            new ExpirationFunctionalTest().withStorage(StorageType.OBJECT),
-            new ExpirationFunctionalTest().withStorage(StorageType.OFF_HEAP)
+         new ExpirationFunctionalTest().cacheMode(CacheMode.LOCAL).withStorage(StorageType.BINARY),
+         new ExpirationFunctionalTest().cacheMode(CacheMode.LOCAL).withStorage(StorageType.OBJECT),
+         new ExpirationFunctionalTest().cacheMode(CacheMode.LOCAL).withStorage(StorageType.OFF_HEAP),
+         new ExpirationFunctionalTest().cacheMode(CacheMode.DIST_SYNC).withStorage(StorageType.BINARY),
+         new ExpirationFunctionalTest().cacheMode(CacheMode.DIST_SYNC).withStorage(StorageType.OBJECT),
+         new ExpirationFunctionalTest().cacheMode(CacheMode.DIST_SYNC).withStorage(StorageType.OFF_HEAP)
       };
+   }
+
+   protected ExpirationFunctionalTest cacheMode(CacheMode mode) {
+      this.cacheMode = mode;
+      return this;
    }
 
    @Override
    protected String parameters() {
-      return "[" + storage + "]";
+      return "[" + cacheMode + ", " + storage + "]";
    }
 
    protected EmbeddedCacheManager createCacheManager() throws Exception {
@@ -46,16 +58,21 @@ public class ExpirationFunctionalTest extends SingleCacheManagerTest {
       EmbeddedCacheManager cm = createCacheManager(builder);
       TestingUtil.replaceComponent(cm, TimeService.class, timeService, true);
       cache = cm.getCache();
+      expirationManager = cache.getAdvancedCache().getExpirationManager();
       afterCacheCreated(cm);
       return cm;
    }
 
    protected EmbeddedCacheManager createCacheManager(ConfigurationBuilder builder) {
-      return TestCacheManagerFactory.createCacheManager(builder);
+      if (builder.clustering().cacheMode().isClustered()) {
+         return TestCacheManagerFactory.createClusteredCacheManager(builder);
+      } else {
+         return TestCacheManagerFactory.createCacheManager(builder);
+      }
    }
 
    protected void configure(ConfigurationBuilder config) {
-      config
+      config.clustering().cacheMode(cacheMode)
             .expiration().disableReaper()
             .memory().storageType(storage);
    }
@@ -86,6 +103,12 @@ public class ExpirationFunctionalTest extends SingleCacheManagerTest {
          cache.put("key-" + i, "value-" + i,-1, null, 1, TimeUnit.MILLISECONDS);
       }
       timeService.advance(2);
+
+      if (cacheMode.isClustered()) {
+         assertEquals(SIZE, cache.size());
+         expirationManager.processExpiration();
+      }
+
       assertEquals(0, cache.size());
    }
 
@@ -121,10 +144,11 @@ public class ExpirationFunctionalTest extends SingleCacheManagerTest {
       }
       timeService.advance(2);
 
-      for (int i = 0; i < SIZE; i++) {
-         cache.getAdvancedCache().getDataContainer().executeTask(KeyFilter.ACCEPT_ALL_FILTER,
-               (k, ice) -> { throw new RuntimeException("No task should be executed on expired entry"); });
-      }
+      cache.getAdvancedCache().getDataContainer()
+           .executeTask(KeyFilter.ACCEPT_ALL_FILTER, (k, ice) -> {
+              throw new RuntimeException(
+                 "No task should be executed on expired entry");
+           });
    }
 
    public void testExpirationMaxIdleInExec() throws Exception {
@@ -133,17 +157,18 @@ public class ExpirationFunctionalTest extends SingleCacheManagerTest {
       }
       timeService.advance(2);
 
-      if (cache.getCacheConfiguration().clustering().cacheMode().isClustered()) {
+      if (cacheMode.isClustered()) {
          AtomicInteger invocationCount = new AtomicInteger();
          cache.getAdvancedCache().getDataContainer().executeTask(KeyFilter.ACCEPT_ALL_FILTER,
                (k, ice) -> invocationCount.incrementAndGet());
          assertEquals(SIZE, invocationCount.get());
-      } else {
-         cache.getAdvancedCache().getDataContainer().executeTask(KeyFilter.ACCEPT_ALL_FILTER,
-               (k, ice) -> {
-                  throw new RuntimeException("No task should be executed on expired entry");
-               });
+         expirationManager.processExpiration();
       }
+      cache.getAdvancedCache().getDataContainer()
+           .executeTask(KeyFilter.ACCEPT_ALL_FILTER, (k, ice) -> {
+              throw new RuntimeException(
+                 "No task should be executed on expired entry");
+           });
    }
 
    public void testExpiredEntriesCleared() {

--- a/core/src/test/java/org/infinispan/expiration/impl/ExpirationListenerFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/expiration/impl/ExpirationListenerFunctionalTest.java
@@ -4,6 +4,7 @@ import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertNotNull;
 
+import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.StorageType;
 import org.infinispan.expiration.ExpirationManager;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -22,9 +23,12 @@ public class ExpirationListenerFunctionalTest extends ExpirationFunctionalTest {
    @Override
    public Object[] factory() {
       return new Object[]{
-            new ExpirationListenerFunctionalTest().withStorage(StorageType.BINARY),
-            new ExpirationListenerFunctionalTest().withStorage(StorageType.OBJECT),
-            new ExpirationListenerFunctionalTest().withStorage(StorageType.OFF_HEAP)
+            new ExpirationListenerFunctionalTest().cacheMode(CacheMode.LOCAL).withStorage(StorageType.BINARY),
+            new ExpirationListenerFunctionalTest().cacheMode(CacheMode.LOCAL).withStorage(StorageType.OBJECT),
+            new ExpirationListenerFunctionalTest().cacheMode(CacheMode.LOCAL).withStorage(StorageType.OFF_HEAP),
+            new ExpirationListenerFunctionalTest().cacheMode(CacheMode.DIST_SYNC).withStorage(StorageType.BINARY),
+            new ExpirationListenerFunctionalTest().cacheMode(CacheMode.DIST_SYNC).withStorage(StorageType.OBJECT),
+            new ExpirationListenerFunctionalTest().cacheMode(CacheMode.DIST_SYNC).withStorage(StorageType.OFF_HEAP)
       };
    }
 

--- a/core/src/test/java/org/infinispan/expiration/impl/ExpirationSingleFileStoreDistListenerFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/expiration/impl/ExpirationSingleFileStoreDistListenerFunctionalTest.java
@@ -25,7 +25,7 @@ public class ExpirationSingleFileStoreDistListenerFunctionalTest extends Expirat
    public Object[] factory() {
       return new Object[]{
             // Test is for single file store with a listener in a dist cache and we don't care about memory storage types
-            new ExpirationSingleFileStoreDistListenerFunctionalTest(),
+            new ExpirationSingleFileStoreDistListenerFunctionalTest().cacheMode(CacheMode.DIST_SYNC),
       };
    }
 
@@ -39,7 +39,7 @@ public class ExpirationSingleFileStoreDistListenerFunctionalTest extends Expirat
       config
               // Prevent the reaper from running, reaperEnabled(false) doesn't work when a store is present
               .expiration().wakeUpInterval(Long.MAX_VALUE)
-              .clustering().cacheMode(CacheMode.DIST_SYNC)
+              .clustering().cacheMode(cacheMode)
               .persistence().addSingleFileStore().location(TestingUtil.tmpDirectory(this.getClass()));
    }
 

--- a/core/src/test/java/org/infinispan/expiration/impl/ExpirationSingleFileStoreListenerFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/expiration/impl/ExpirationSingleFileStoreListenerFunctionalTest.java
@@ -1,6 +1,7 @@
 package org.infinispan.expiration.impl;
 
 import org.infinispan.commons.util.Util;
+import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.test.TestingUtil;
 import org.testng.annotations.AfterClass;
@@ -15,7 +16,7 @@ public class ExpirationSingleFileStoreListenerFunctionalTest extends ExpirationS
    public Object[] factory() {
       return new Object[]{
             // Test is for single file store with a listener in a local cache and we don't care about memory storage types
-            new ExpirationSingleFileStoreListenerFunctionalTest(),
+            new ExpirationSingleFileStoreListenerFunctionalTest().cacheMode(CacheMode.LOCAL),
       };
    }
 

--- a/core/src/test/java/org/infinispan/expiration/impl/ExpirationStoreFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/expiration/impl/ExpirationStoreFunctionalTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.expiration.impl;
 
+import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.persistence.dummy.DummyInMemoryStoreConfigurationBuilder;
 import org.testng.annotations.Factory;
@@ -13,7 +14,7 @@ public class ExpirationStoreFunctionalTest extends ExpirationFunctionalTest {
    public Object[] factory() {
       return new Object[]{
             // Test is for dummy store and we don't care about memory storage types
-            new ExpirationStoreFunctionalTest(),
+            new ExpirationStoreFunctionalTest().cacheMode(CacheMode.LOCAL),
       };
    }
 

--- a/core/src/test/java/org/infinispan/expiration/impl/ExpirationStoreListenerFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/expiration/impl/ExpirationStoreListenerFunctionalTest.java
@@ -7,7 +7,7 @@ import static org.testng.AssertJUnit.assertNull;
 
 import java.util.concurrent.TimeUnit;
 
-import org.infinispan.expiration.ExpirationManager;
+import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.notifications.cachelistener.event.CacheEntryExpiredEvent;
 import org.infinispan.notifications.cachelistener.event.Event;
@@ -20,14 +20,13 @@ import org.testng.annotations.Test;
 @Test(groups = "functional", testName = "expiration.impl.ExpirationStoreListenerFunctionalTest")
 public class ExpirationStoreListenerFunctionalTest extends ExpirationStoreFunctionalTest {
    protected ExpiredCacheListener listener = new ExpiredCacheListener();
-   protected ExpirationManager manager;
 
    @Factory
    @Override
    public Object[] factory() {
       return new Object[]{
             // Test is for dummy store with a listener and we don't care about memory storage types
-            new ExpirationStoreListenerFunctionalTest(),
+            new ExpirationStoreListenerFunctionalTest().cacheMode(CacheMode.LOCAL),
       };
    }
 
@@ -39,7 +38,6 @@ public class ExpirationStoreListenerFunctionalTest extends ExpirationStoreFuncti
    @Override
    protected void afterCacheCreated(EmbeddedCacheManager cm) {
       cache.addListener(listener);
-      manager = cache.getAdvancedCache().getExpirationManager();
    }
 
    @AfterMethod
@@ -50,7 +48,7 @@ public class ExpirationStoreListenerFunctionalTest extends ExpirationStoreFuncti
    @Override
    public void testSimpleExpirationLifespan() throws Exception {
       super.testSimpleExpirationLifespan();
-      manager.processExpiration();
+      expirationManager.processExpiration();
       assertExpiredEvents(SIZE);
    }
 
@@ -61,7 +59,7 @@ public class ExpirationStoreListenerFunctionalTest extends ExpirationStoreFuncti
       }
       timeService.advance(2);
       // We have to process expiration for store and max idle
-      manager.processExpiration();
+      expirationManager.processExpiration();
       assertEquals(0, cache.size());
       assertExpiredEvents(SIZE);
    }
@@ -76,7 +74,7 @@ public class ExpirationStoreListenerFunctionalTest extends ExpirationStoreFuncti
       timeService.advance(11);
       assertNull(cache.get(key));
       // Stores do not expire entries on load, thus we need to purge them
-      manager.processExpiration();
+      expirationManager.processExpiration();
 
       assertEquals(1, listener.getInvocationCount());
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-10074

In clustered caches, maxIdle expiration should be ignored by
executeTask() and iterator(), and expired entries should be returned
until the purge thread removes them from the container.

Backport of #6799 