### PR TITLE
[9.4.x] ISPN-10068 AllClusterExecutorTest.testExecutorTriConsumerTimeoutExcep…

### DIFF
--- a/core/src/test/java/org/infinispan/distribution/rehash/NonTxBackupOwnerBecomingPrimaryOwnerTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/NonTxBackupOwnerBecomingPrimaryOwnerTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.spy;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertNotNull;
-import static org.testng.AssertJUnit.assertTrue;
 
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -250,8 +249,8 @@ public class NonTxBackupOwnerBecomingPrimaryOwnerTest extends MultipleCacheManag
          // Ignore the first topology update on the joiner, which is with the topology before the join
          if (topology.getTopologyId() != currentTopologyId) {
             checkPoint.trigger("pre_topology_" + topology.getTopologyId() + "_on_" + manager.getAddress());
-            assertTrue(checkPoint.await("allow_topology_" + topology.getTopologyId() + "_on_" + manager.getAddress(),
-                  10, TimeUnit.SECONDS));
+            checkPoint.awaitStrict("allow_topology_" + topology.getTopologyId() + "_on_" + manager.getAddress(),
+                  10, TimeUnit.SECONDS);
          }
          return invocation.callRealMethod();
       }).when(spyLtm).handleTopologyUpdate(eq(CacheContainer.DEFAULT_CACHE_NAME), any(CacheTopology.class),

--- a/core/src/test/java/org/infinispan/distribution/rehash/NonTxPrimaryOwnerBecomingNonOwnerTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/NonTxPrimaryOwnerBecomingNonOwnerTest.java
@@ -211,7 +211,7 @@ public class NonTxPrimaryOwnerBecomingNonOwnerTest extends MultipleCacheManagers
          // Ignore the first topology update on the joiner, which is with the topology before the join
          if (topology.getTopologyId() != currentTopologyId) {
             checkPoint.trigger("pre_topology_" + topology.getTopologyId() + "_on_" + manager.getAddress());
-            checkPoint.await("allow_topology_" + topology.getTopologyId() + "_on_" + manager.getAddress(),
+            checkPoint.awaitStrict("allow_topology_" + topology.getTopologyId() + "_on_" + manager.getAddress(),
                   10, TimeUnit.SECONDS);
          }
          return invocation.callRealMethod();

--- a/core/src/test/java/org/infinispan/manager/AllClusterExecutorTest.java
+++ b/core/src/test/java/org/infinispan/manager/AllClusterExecutorTest.java
@@ -4,36 +4,31 @@ import static org.infinispan.test.TestingUtil.withCacheManagers;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertTrue;
-import static org.testng.AssertJUnit.fail;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Exchanger;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
-import org.infinispan.commons.CacheException;
 import org.infinispan.configuration.cache.CacheMode;
-import org.infinispan.factories.KnownComponentNames;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.test.Exceptions;
 import org.infinispan.test.MultiCacheManagerCallable;
 import org.infinispan.test.TestException;
-import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.CheckPoint;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.test.fwk.TestClassLocal;
+import org.infinispan.util.function.SerializableFunction;
 import org.infinispan.util.function.SerializableSupplier;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
 /**
@@ -43,6 +38,7 @@ import org.testng.annotations.Test;
 @Test(groups = {"functional", "smoke"}, testName = "manager.AllClusterExecutorTest")
 public class AllClusterExecutorTest extends AbstractInfinispanTest {
    static AtomicInteger atomicInteger = new AtomicInteger();
+   private TestClassLocal<CheckPoint> checkPoint = new TestClassLocal<>("checkpoint", this, CheckPoint::new, c -> {});
 
    ClusterExecutor executor(EmbeddedCacheManager cm) {
       return cm.executor();
@@ -231,17 +227,19 @@ public class AllClusterExecutorTest extends AbstractInfinispanTest {
          @Override
          public void call() throws InterruptedException, ExecutionException, TimeoutException {
             EmbeddedCacheManager cm1 = cms[0];
+            TestClassLocal<CheckPoint> checkPoint = AllClusterExecutorTest.this.checkPoint;
 
-            CompletableFuture<Void> future = executor(cm1).timeout(10, TimeUnit.MILLISECONDS).submit(() -> {
+            CompletableFuture<Void> future = executor(cm1).timeout(1, TimeUnit.MILLISECONDS).submit(() -> {
                try {
-                  Thread.sleep(1000);
-               } catch (InterruptedException e) {
-                  fail("Unexpected interrupt: " + e);
+                  checkPoint.get().awaitStrict("resume_remote_execution", 10, TimeUnit.SECONDS);
+               } catch (InterruptedException | TimeoutException e) {
+                  throw new TestException(e);
                }
             });
             // This fails when local node is invoked since timeout is not adhered to
-            Exceptions
-                  .expectExecutionException(org.infinispan.util.concurrent.TimeoutException.class, future);
+            Exceptions.expectExecutionException(org.infinispan.util.concurrent.TimeoutException.class, future);
+
+            checkPoint.get().trigger("resume_remote_execution");
          }
       });
    }
@@ -385,37 +383,36 @@ public class AllClusterExecutorTest extends AbstractInfinispanTest {
          @Override
          public void call() throws InterruptedException, ExecutionException, TimeoutException {
             EmbeddedCacheManager cm1 = cms[0];
+            TestClassLocal<CheckPoint> checkPoint = AllClusterExecutorTest.this.checkPoint;
+            SerializableFunction<EmbeddedCacheManager, Object> blockingFunction = m -> {
+               try {
+                  checkPoint.get().trigger("block_execution");
+                  checkPoint.get().awaitStrict("resume_execution", 10, TimeUnit.SECONDS);
+               } catch (InterruptedException | TimeoutException e) {
+                  throw new TestException(e);
+               }
+               return null;
+            };
 
-            ScheduledExecutorService stpe = Mockito.mock(ScheduledExecutorService.class);
+            CompletableFuture<Void> futureRemote =
+               executor(cm1).filterTargets(a -> !a.equals(cm1.getAddress()))
+                            .timeout(1, TimeUnit.MILLISECONDS)
+                            .submitConsumer(blockingFunction, (a, i, t) -> {
+                               log.tracef("Consumer invoked with %s, %s, %s", a, i, t);
+                            });
+            Exceptions.expectExecutionException(org.infinispan.util.concurrent.TimeoutException.class, futureRemote);
+            checkPoint.get().awaitStrict("block_execution", 10, TimeUnit.SECONDS);
+            checkPoint.get().trigger("resume_execution");
 
-            for (EmbeddedCacheManager cm : cms) {
-               TestingUtil.replaceComponent(cm, ScheduledExecutorService.class,
-                     KnownComponentNames.TIMEOUT_SCHEDULE_EXECUTOR, stpe, true);
-            }
-
-            // These are to make sure the call to the scheduled executor doesn't overlap with others, so these should
-            // be unique
-            long crazyNumber = 84129912895471L;
-            TimeUnit unit = TimeUnit.DAYS;
-
-            CompletableFuture<Void> future =
-                  executor(cm1).timeout(crazyNumber, unit).submitConsumer(m -> {
-                     ArgumentCaptor<Callable> argument = ArgumentCaptor.forClass(Callable.class);
-                     // This will be a mock as we replaced them all above
-                     ScheduledExecutorService innerStpe = m.getGlobalComponentRegistry().getComponent(
-                           ScheduledExecutorService.class, KnownComponentNames.TIMEOUT_SCHEDULE_EXECUTOR);
-
-                     Mockito.verify(innerStpe, Mockito.timeout(TimeUnit.SECONDS.toMillis(10)).atLeastOnce()).schedule(argument.capture(),
-                           Mockito.eq(crazyNumber), Mockito.eq(unit));
-                     // We run the timeout ourselves, which should cause the timeout exception to occur.
-                     try {
-                        argument.getValue().call();
-                     } catch (Exception e) {
-                        throw new CacheException(e);
-                     }
-                     return null;
-                  }, (a, i, t) -> log.tracef("Consumer invoked with %s, %s, %s", a, i, t));
-            Exceptions.expectExecutionException(org.infinispan.util.concurrent.TimeoutException.class, future);
+            CompletableFuture<Void> futureLocal =
+               executor(cm1).filterTargets(a -> a.equals(cm1.getAddress()))
+                            .timeout(1, TimeUnit.MILLISECONDS)
+                            .submitConsumer(blockingFunction, (a, i, t) -> {
+                               log.tracef("Consumer invoked with %s, %s, %s", a, i, t);
+                            });
+            Exceptions.expectExecutionException(org.infinispan.util.concurrent.TimeoutException.class, futureLocal);
+            checkPoint.get().awaitStrict("block_execution", 10, TimeUnit.SECONDS);
+            checkPoint.get().trigger("resume_execution");
          }
       });
    }

--- a/core/src/test/java/org/infinispan/partitionhandling/StreamDistPartitionHandlingTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/StreamDistPartitionHandlingTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.spy;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
-import static org.testng.AssertJUnit.assertTrue;
 import static org.testng.AssertJUnit.fail;
 
 import java.util.Map;
@@ -72,7 +71,7 @@ public class StreamDistPartitionHandlingTest extends BasePartitionHandlingTest {
       // Repl only checks for partition when first retrieving the entrySet, keySet or values
    }
 
-   public void testUsingIteratorButPartitionOccursBeforeRetrievingRemoteValues() throws InterruptedException {
+   public void testUsingIteratorButPartitionOccursBeforeRetrievingRemoteValues() throws Exception {
       Cache<MagicKey, String> cache0 = cache(0);
       // Make sure we have 1 entry in each - since onEach will then be invoked once on each node
       cache0.put(new MagicKey(cache(1), cache(2)), "not-local");
@@ -96,7 +95,7 @@ public class StreamDistPartitionHandlingTest extends BasePartitionHandlingTest {
          splitCluster(new int[]{0, 1}, new int[]{2, 3});
 
          // Wait until we have been notified before letting remote responses to arrive
-         assertTrue(partitionCP.await(Mocks.AFTER_INVOCATION, 10, TimeUnit.SECONDS));
+         partitionCP.awaitStrict(Mocks.AFTER_INVOCATION, 10, TimeUnit.SECONDS);
 
          // Afterwards let all the responses come in
          iteratorCP.triggerForever(Mocks.BEFORE_RELEASE);
@@ -137,7 +136,7 @@ public class StreamDistPartitionHandlingTest extends BasePartitionHandlingTest {
          });
 
          // Wait for all the responses to come back - we have to do this before splitting
-         assertTrue(iteratorCP.await(Mocks.AFTER_INVOCATION, numMembersInCluster - 1, 10, TimeUnit.SECONDS));
+         iteratorCP.awaitStrict(Mocks.AFTER_INVOCATION, numMembersInCluster - 1, 10, TimeUnit.SECONDS);
 
          CheckPoint partitionCP = new CheckPoint();
          // Now we replace the notifier so we know when the notifier was told of the partition change so we know

--- a/core/src/test/java/org/infinispan/stream/DistributedStreamRehashTest.java
+++ b/core/src/test/java/org/infinispan/stream/DistributedStreamRehashTest.java
@@ -6,7 +6,6 @@ import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.spy;
 import static org.testng.AssertJUnit.assertEquals;
-import static org.testng.AssertJUnit.assertTrue;
 
 import java.util.List;
 import java.util.Map;
@@ -115,7 +114,7 @@ public class DistributedStreamRehashTest extends MultipleCacheManagersTest {
             originator.entrySet().stream().collect(() -> Collectors.toList()));
 
       // Make sure we are up to sync
-      assertTrue(checkPoint.await(Mocks.AFTER_INVOCATION, 10, TimeUnit.SECONDS));
+      checkPoint.awaitStrict(Mocks.AFTER_INVOCATION, 10, TimeUnit.SECONDS);
 
       // Note that segment 2 doesn't map to the node1 anymore
       consistentHashFactory.setOwnerIndexes(new int[][]{{0, 1}, {0, 2}, {2, 1}, {1, 0}});

--- a/core/src/test/java/org/infinispan/test/fwk/CheckPoint.java
+++ b/core/src/test/java/org/infinispan/test/fwk/CheckPoint.java
@@ -38,7 +38,7 @@ public class CheckPoint {
       awaitStrict(event, 1, timeout, unit);
    }
 
-   public boolean await(String event, long timeout, TimeUnit unit) throws InterruptedException {
+   private boolean await(String event, long timeout, TimeUnit unit) throws InterruptedException {
       return await(event, 1, timeout, unit);
    }
 
@@ -49,7 +49,7 @@ public class CheckPoint {
       }
    }
 
-   public boolean await(String event, int count, long timeout, TimeUnit unit) throws InterruptedException {
+   private boolean await(String event, int count, long timeout, TimeUnit unit) throws InterruptedException {
       log.tracef("Waiting for event %s * %d", event, count);
       lock.lock();
       try {


### PR DESCRIPTION
…tion

https://issues.jboss.org/browse/ISPN-10086

* Replace scheduled executor mock with CheckPoint
* Replace CheckPoint.await() with CheckPoint.awaitStrict() everywhere

Backport of #6808 