### PR TITLE
ISPN-10090 Allow running TestNG tests without TestNGTestListener

### DIFF
--- a/commons-test/src/main/java/org/infinispan/commons/test/JUnitTestListener.java
+++ b/commons-test/src/main/java/org/infinispan/commons/test/JUnitTestListener.java
@@ -73,9 +73,10 @@ public class JUnitTestListener extends RunListener {
    public void testRunFinished(Result result) {
       try {
          // We don't use @RunWith(Suite.class) so we only have a single suite
-         ThreadLeakChecker.checkForLeaks(null);
+         ThreadLeakChecker.checkForLeaks();
       } catch (Throwable e) {
          progressLogger.configurationFailed("[ERROR]", e);
+         throw e;
       }
    }
 }

--- a/commons-test/src/main/java/org/infinispan/commons/test/RunningTestsRegistry.java
+++ b/commons-test/src/main/java/org/infinispan/commons/test/RunningTestsRegistry.java
@@ -66,7 +66,7 @@ class RunningTestsRegistry {
    private static List<String> collectChildProcesses(String testName) {
       try {
          System.err.printf(
-            "Test %s has been running for more than %d seconds. Interrupting the test thread and dumping " +
+            "[ERROR] Test %s has been running for more than %d seconds. Interrupting the test thread and dumping " +
             "threads of the test suite process and its children.\n",
             testName, MAX_TEST_SECONDS);
 
@@ -107,9 +107,10 @@ class RunningTestsRegistry {
 
    private static void dumpThreads(String safeTestName, List<String> pids) {
       try {
-         File jstackFile = new File(System.getProperty("java.home") + "/../bin/jstack");
+         String javaHome = System.getProperty("java.home");
+         File jstackFile = new File(javaHome, "bin/jstack");
          if (!jstackFile.canExecute()) {
-            jstackFile = new File(System.getProperty("java.home") + "/bin/jstack");
+            jstackFile = new File(javaHome, "../bin/jstack");
          }
          LocalDateTime now = LocalDateTime.now();
          if (jstackFile.canExecute() && !pids.isEmpty()) {
@@ -126,6 +127,7 @@ class RunningTestsRegistry {
          } else {
             File dumpFile = new File(String.format("threaddump-%1$s-%2$tY-%2$tm-%2$td.log",
                                                    safeTestName, now));
+            System.out.printf("Cannot find jstack in %s, programmatically dumping thread stacks of testsuite process to %s\n", javaHome, dumpFile.getAbsolutePath());
             ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
             try (PrintWriter writer = new PrintWriter(new FileWriter(dumpFile))) {
                // 2019-02-05 14:03:11

--- a/commons-test/src/main/java/org/infinispan/commons/test/TestNGSuiteChecksTest.java
+++ b/commons-test/src/main/java/org/infinispan/commons/test/TestNGSuiteChecksTest.java
@@ -42,7 +42,7 @@ public class TestNGSuiteChecksTest {
 
    @AfterSuite(alwaysRun = true)
    public void afterSuite() {
-      ThreadLeakChecker.checkForLeaks(TestNGSuiteChecksTest.class.getName());
+      ThreadLeakChecker.checkForLeaks();
    }
 
    private void checkAnnotations(List<String> errors, Set<Class> classes, Collection<ITestNGMethod> methods) {

--- a/commons-test/src/main/java/org/infinispan/commons/test/TestNGTestListener.java
+++ b/commons-test/src/main/java/org/infinispan/commons/test/TestNGTestListener.java
@@ -58,7 +58,9 @@ public class TestNGTestListener implements ITestListener, IConfigurationListener
 
    @Override
    public void onFinish(ITestContext context) {
-      ThreadLeakChecker.testFinished(context.getCurrentXmlTest().getXmlClasses().get(0).getName());
+      String testName = context.getCurrentXmlTest().getXmlClasses().get(0).getName();
+      // Mark the test as finished. The actual leak check is in TestNGSuiteChecksTest
+      ThreadLeakChecker.testFinished(testName);
    }
 
    private String testName(ITestResult res) {
@@ -82,6 +84,7 @@ public class TestNGTestListener implements ITestListener, IConfigurationListener
 
    @Override
    public void onFinish(ISuite suite) {
+      ThreadLeakChecker.checkForLeaks();
    }
 
    @Override

--- a/commons-test/src/main/java/org/infinispan/commons/test/ThreadLeakChecker.java
+++ b/commons-test/src/main/java/org/infinispan/commons/test/ThreadLeakChecker.java
@@ -147,23 +147,12 @@ public class ThreadLeakChecker {
    /**
     * Check for leaked threads.
     *
-    * <p>When running tests in parallel, this method will only perform the leak check if there are no running tests.</p>
-    *
-    * @param testName test that just ended, or {@code null} if running after all the tests (e.g. from {@code
-    * @AfterSuite} in TestNG)
+    * Assumes that no tests are running.
     */
-   public static void checkForLeaks(String testName) {
+   public static void checkForLeaks() {
       lock.lock();
       try {
-         if (testName == null) {
-            assert runningTests.isEmpty() : "Tests are still running: " + runningTests;
-         } else if (runningTests.size() > 1) {
-            return;
-         } else if (runningTests.size() == 1) {
-            assert runningTests.contains(testName) :
-               "Test " + runningTests + " is running, should have been " + testName;
-            testFinished(testName);
-         }
+         assert runningTests.isEmpty() : "Tests are still running: " + runningTests;
          performCheck();
       } finally {
          lock.unlock();
@@ -196,8 +185,8 @@ public class ThreadLeakChecker {
          // Use -Dinfinispan.test.parallel.threads=3 (or even less) to narrow down source tests
          // Set a conditional breakpoint in Thread.start with the name of the leaked thread
          // If the thread has the pattern of a particular component, set a conditional breakpoint in that component
-         throw new AssertionError("Leaked threads: \n  " +
-                                  leaks.stream()
+         throw new RuntimeException("Leaked threads: \n  " +
+                                    leaks.stream()
                                        .map(Object::toString)
                                        .collect(Collectors.joining(",\n  ")));
       }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -283,6 +283,12 @@
                   <version>${version.maven.surefire}</version>
                </dependency>
             </dependencies>
+            <configuration>
+               <dependenciesToScan>
+                  <!-- TestNGSuiteChecksTest -->
+                  <dependency>org.infinispan:infinispan-commons-test</dependency>
+               </dependenciesToScan>
+            </configuration>
          </plugin>
       </plugins>
    </build>
@@ -306,10 +312,6 @@
                         <exclude>**/DistSyncUnsafe*.java</exclude>
                         <exclude>**/TopologyAwareDist*.java</exclude>
                      </excludes>
-                     <dependenciesToScan>
-                        <!-- TestNGSuiteChecksTest -->
-                        <dependency>org.infinispan:infinispan-commons-test</dependency>
-                     </dependenciesToScan>
                   </configuration>
                </plugin>
             </plugins>

--- a/core/src/test/java/org/infinispan/test/AbstractInfinispanTest.java
+++ b/core/src/test/java/org/infinispan/test/AbstractInfinispanTest.java
@@ -35,7 +35,6 @@ import javax.transaction.TransactionManager;
 import org.infinispan.commons.api.BasicCache;
 import org.infinispan.commons.api.BasicCacheContainer;
 import org.infinispan.commons.test.TestNGLongTestsHook;
-import org.infinispan.commons.test.ThreadLeakChecker;
 import org.infinispan.functional.FunctionalMap;
 import org.infinispan.interceptors.AsyncInterceptor;
 import org.infinispan.partitionhandling.BasePartitionHandlingTest;
@@ -141,7 +140,6 @@ public abstract class AbstractInfinispanTest {
       killSpawnedThreads();
       nullOutFields();
       TestResourceTracker.testFinished(getTestName());
-      ThreadLeakChecker.checkForLeaks(getClass().getName());
    }
 
    public String getTestName() {

--- a/core/src/test/java/org/infinispan/test/fwk/TestResourceTrackingListener.java
+++ b/core/src/test/java/org/infinispan/test/fwk/TestResourceTrackingListener.java
@@ -1,6 +1,5 @@
 package org.infinispan.test.fwk;
 
-import org.infinispan.commons.test.ThreadLeakChecker;
 import org.infinispan.test.AbstractInfinispanTest;
 import org.testng.ITestContext;
 import org.testng.ITestListener;
@@ -44,6 +43,5 @@ public class TestResourceTrackingListener implements ITestListener {
    public void onFinish(ITestContext context) {
       Class testClass = context.getCurrentXmlTest().getXmlClasses().get(0).getSupportClass();
       TestResourceTracker.testFinished(testClass.getName());
-      ThreadLeakChecker.checkForLeaks(testClass.getName());
    }
 }

--- a/documentation/src/main/asciidoc/contributing/tests.adoc
+++ b/documentation/src/main/asciidoc/contributing/tests.adoc
@@ -2,11 +2,7 @@
 Tests are written using the link:http://testng.org/[TestNG] framework. 
 
 === Running the tests
-Before running the actual tests it is highly recommended to configure adjust suite's memory setting by updating the `MAVEN_OPTS` variables. E.g.
-
- $ export MAVEN_OPTS="-Xms512m -Xmx2048m"
-
-The default run executes all tests in the functional and unit groups. To just run the tests with txt and xml output the command is:
+The default run executes all tests in the functional, unit, xsite, and arquillian groups. To just run the tests with txt and xml output the command is:
 
  $ mvn test
 
@@ -25,6 +21,13 @@ Open up `/etc/security/limits.conf` and add the following lines replacing the us
  rhusar    soft    nproc     16384
  rhusar    hard    nproc     16384
 ----
+
+We recommend running the tests on a machine with at least 4GB of RAM.
+Tests run in a forked JVM, so `MAVEN_OPTS` does not affect them.
+However, you may need to reduce the Maven JVM's heap to run in 4GB of RAM
+by updating the `MAVEN_OPTS` environment variable, e.g.
+
+ $ export MAVEN_OPTS="-Xmx800m"
 
 ==== Specifying which tests to run
 A single test can be executed using the test property. 
@@ -49,7 +52,25 @@ To do this, simply use the `skipTests` property:
 
  $ mvn -DskipTests install
 
-Note that you should _never_ use `-Dmaven.test.skip=true` since modules' test classes depend on other module test classes, and this will cause compilation errors. 
+Note that you should _never_ use `-Dmaven.test.skip=true` since modules' test classes depend on other module test classes, and this will cause compilation errors.
+
+==== Debugging thread leaks
+The Infinispan test suite uses TestNG/JUnit test listeners to find and report thread leaks.
+In order to debug thread leaks in the IDE, please add this listener to your default TestNG run configuration:
+
+  org.infinispan.commons.test.TestNGTestListener
+
+If your IDE supports listeners in the JUnit run configuration (IntelliJ IDEA does not), add this listener:
+
+  org.infinispan.commons.test.JUnitTestListener
+
+If your IDE does not support listeners in the JUnit run configuration, you can always add the listener to your class:
+
+  @Listeners(org.infinispan.commons.test.JUnitTestListener.class)
+
+In order to make the leak report look like a test failure,
+modules using TestNG duplicate the check in a test, `TestNGSuiteChecksTest`.
+Including the test is not required to see the leak, but without it the failure looks more like a crash.
 
 ==== Running tests using `@Parameters`
 If you want to execute tests relying on TestNG's `@Parameters` from an IDE (such as Eclipse or IntelliJ IDEA), please read link:http://infinispan.blogspot.com/2009/06/executing-testng-tests-relying-on.html[this blog entry] . 

--- a/spring/spring5/spring5-common/src/test/java/org/infinispan/spring/common/InfinispanTestExecutionListener.java
+++ b/spring/spring5/spring5-common/src/test/java/org/infinispan/spring/common/InfinispanTestExecutionListener.java
@@ -19,7 +19,5 @@ public class InfinispanTestExecutionListener extends AbstractTestExecutionListen
    @Override
    public void afterTestClass(TestContext testContext) throws Exception {
       TestResourceTracker.testFinished(testContext.getTestClass().getName());
-      // Don't check for thread leaks here, the Spring listener that stops the application context will run later
-      // ThreadLeakChecker.checkForLeaks(testContext.getTestClass().getName());
    }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-10090

* Don't check for leaks in AbstractInfinispanTest
* Change listeners to crash if they detect a leak
  (and TestNGSuiteChecksTest didn't detect it first)
* Include TestNGSuiteChecksTest in default profile in core
* Log the file name when dumping threads programmatically (ISPN-10024)
