### PR TITLE
ISPN-10114 Server managed transactional cache configuration cannot be persisted to global state

### DIFF
--- a/feature-pack/server/src/main/resources/modules/org/infinispan/extension/slot/module.xml
+++ b/feature-pack/server/src/main/resources/modules/org/infinispan/extension/slot/module.xml
@@ -55,6 +55,7 @@
       <module name="org.jboss.msc"/>
       <module name="org.jboss.staxmapper"/>
       <module name="org.jboss.threads"/>
+      <module name="org.wildfly.transaction.client"/>
    </dependencies>
 </module>
 

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/TransactionManagerProvider.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/TransactionManagerProvider.java
@@ -25,24 +25,15 @@ package org.jboss.as.clustering.infinispan;
 import javax.transaction.TransactionManager;
 
 import org.infinispan.commons.tx.lookup.TransactionManagerLookup;
+import org.wildfly.transaction.client.ContextTransactionManager;
 
 /**
  * @author Paul Ferraro
  */
 public class TransactionManagerProvider implements TransactionManagerLookup {
 
-    private final TransactionManager tm;
-
-    public TransactionManagerProvider(TransactionManager tm) {
-        this.tm = tm;
-    }
-
-    /**
-     * {@inheritDoc}
-     * @see TransactionManagerLookup#getTransactionManager()
-     */
     @Override
     public TransactionManager getTransactionManager() {
-        return this.tm;
+        return ContextTransactionManager.getInstance();
     }
 }

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheConfigurationAdd.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheConfigurationAdd.java
@@ -84,7 +84,6 @@ import org.infinispan.persistence.spi.CacheLoader;
 import org.infinispan.server.infinispan.spi.service.CacheContainerServiceName;
 import org.infinispan.server.infinispan.spi.service.CacheServiceName;
 import org.infinispan.transaction.LockingMode;
-import org.infinispan.transaction.tm.BatchModeTransactionManager;
 import org.infinispan.util.concurrent.IsolationLevel;
 import org.jboss.as.clustering.infinispan.InfinispanMessages;
 import org.jboss.as.clustering.infinispan.cs.configuration.DeployedStoreConfigurationBuilder;
@@ -277,9 +276,7 @@ public abstract class CacheConfigurationAdd extends AbstractAddStepHandler imple
                     Configuration.class,
                     cacheConfigurationDependencies.getTemplateConfigurationInjector());
         }
-        if (config.invocationBatching().enabled()) {
-            cacheConfigurationDependencies.getTransactionManagerInjector().inject(BatchModeTransactionManager.getInstance());
-        } else if (config.transaction().transactionMode() == org.infinispan.transaction.TransactionMode.TRANSACTIONAL) {
+        if (!config.invocationBatching().enabled() && config.transaction().transactionMode() == org.infinispan.transaction.TransactionMode.TRANSACTIONAL) {
             configBuilder.addDependency(
                     TxnServices.JBOSS_TXN_TRANSACTION_MANAGER,
                     TransactionManager.class,

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheConfigurationService.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheConfigurationService.java
@@ -74,7 +74,7 @@ public class CacheConfigurationService extends AbstractCacheConfigurationService
         builder.jmxStatistics().enabled(this.dependencies.getCacheContainer().getCacheManagerConfiguration().globalJmxStatistics().enabled());
         TransactionManager tm = this.dependencies.getTransactionManager();
         if (tm != null) {
-            builder.transaction().transactionManagerLookup(new TransactionManagerProvider(tm));
+            builder.transaction().transactionManagerLookup(new TransactionManagerProvider());
         }
         TransactionSynchronizationRegistry tsr = this.dependencies.getTransactionSynchronizationRegistry();
         if (tsr != null) {


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-10114

Needs backporting to 9.4.x.