### PR TITLE
 ISPN-10029 Invalidation locking is not clustered 

### DIFF
--- a/core/src/main/java/org/infinispan/commands/tx/PrepareCommand.java
+++ b/core/src/main/java/org/infinispan/commands/tx/PrepareCommand.java
@@ -26,6 +26,7 @@ import org.infinispan.commands.functional.WriteOnlyManyEntriesCommand;
 import org.infinispan.commands.write.ComputeCommand;
 import org.infinispan.commands.write.ComputeIfAbsentCommand;
 import org.infinispan.commands.write.DataWriteCommand;
+import org.infinispan.commands.write.InvalidateCommand;
 import org.infinispan.commands.write.PutKeyValueCommand;
 import org.infinispan.commands.write.PutMapCommand;
 import org.infinispan.commands.write.RemoveCommand;
@@ -159,6 +160,7 @@ public class PrepareCommand extends AbstractTransactionBoundaryCommand implement
                set.add(((DataWriteCommand) writeCommand).getKey());
                break;
             case PutMapCommand.COMMAND_ID:
+            case InvalidateCommand.COMMAND_ID:
             case ReadWriteManyCommand.COMMAND_ID:
             case ReadWriteManyEntriesCommand.COMMAND_ID:
             case WriteOnlyManyCommand.COMMAND_ID:

--- a/core/src/main/java/org/infinispan/configuration/cache/PartitionHandlingConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/PartitionHandlingConfigurationBuilder.java
@@ -11,6 +11,9 @@ import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.conflict.EntryMergePolicy;
 import org.infinispan.conflict.MergePolicy;
 import org.infinispan.partitionhandling.PartitionHandling;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
 /**
  * Controls how the cache handles partitioning and/or multiple node failures.
  *
@@ -18,6 +21,7 @@ import org.infinispan.partitionhandling.PartitionHandling;
  * @since 7.0
  */
 public class PartitionHandlingConfigurationBuilder extends AbstractClusteringConfigurationChildBuilder implements Builder<PartitionHandlingConfiguration>, ConfigurationBuilderInfo {
+   private static final Log log = LogFactory.getLog(PartitionHandlingConfigurationBuilder.class);
 
    private final AttributeSet attributes;
 
@@ -55,6 +59,8 @@ public class PartitionHandlingConfigurationBuilder extends AbstractClusteringCon
 
    @Override
    public void validate() {
+      if (attributes.attribute(WHEN_SPLIT).get() != PartitionHandling.ALLOW_READ_WRITES && clustering().cacheMode().isInvalidation())
+         throw log.invalidationPartitionHandlingNotSuported();
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/factories/InterceptorChainFactory.java
+++ b/core/src/main/java/org/infinispan/factories/InterceptorChainFactory.java
@@ -144,16 +144,20 @@ public class InterceptorChainFactory extends AbstractNamedCacheComponentFactory 
          interceptorChain.appendInterceptor(createInterceptor(new CacheMgmtInterceptor(), CacheMgmtInterceptor.class), false);
       }
 
-      // load the state transfer lock interceptor
-      // the state transfer lock ensures that the cache member list is up-to-date
-      // so it's necessary even if state transfer is disabled
-      if (cacheMode.needsStateTransfer()) {
+      // the state transfer interceptor sets the topology id and retries on topology changes
+      // so it's necessary even if there is no state transfer
+      // the only exception is non-tx invalidation mode, which ignores lock owners
+      if (cacheMode.needsStateTransfer() || cacheMode.isInvalidation() && transactionMode.isTransactional()) {
          if (isTotalOrder) {
             interceptorChain.appendInterceptor(createInterceptor(new TotalOrderStateTransferInterceptor(),
                                                                  TotalOrderStateTransferInterceptor.class), false);
          } else {
-            interceptorChain.appendInterceptor(createInterceptor(new StateTransferInterceptor(), StateTransferInterceptor.class), false);
+            interceptorChain.appendInterceptor(
+               createInterceptor(new StateTransferInterceptor(), StateTransferInterceptor.class), false);
          }
+      }
+
+      if (cacheMode.needsStateTransfer()) {
          if (transactionMode.isTransactional()) {
             interceptorChain.appendInterceptor(createInterceptor(new TransactionSynchronizerInterceptor(), TransactionSynchronizerInterceptor.class), false);
          }

--- a/core/src/main/java/org/infinispan/interceptors/locking/PessimisticLockingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/locking/PessimisticLockingInterceptor.java
@@ -237,7 +237,7 @@ public class PessimisticLockingInterceptor extends AbstractTxLockingInterceptor 
          }
       } else {
          if (trace)
-            log.tracef("Don't need backup locks %s", needBackupLocks);
+            log.tracef("Don't need backup locks for key %s", key);
       }
       return needRemoteLock;
    }

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -974,8 +974,8 @@ public interface Log extends BasicLogger {
    void unableToCreateInterceptor(Class type, @Cause Exception e);
 
    @LogMessage(level = WARN)
-   @Message(value = "Unable to broadcast evicts as a part of the prepare phase. Rolling back.", id = 268)
-   void unableToRollbackEvictionsDuringPrepare(@Cause Throwable e);
+   @Message(value = "Unable to broadcast invalidations as a part of the prepare phase. Rolling back.", id = 268)
+   void unableToRollbackInvalidationsDuringPrepare(@Cause Throwable e);
 
    @LogMessage(level = WARN)
    @Message(value = "Cache used for Grid metadata should be synchronous.", id = 269)
@@ -1865,4 +1865,7 @@ public interface Log extends BasicLogger {
 
    @Message(value = "A store cannot be shared when utilised with a local cache.", id = 549)
    CacheConfigurationException sharedStoreWithLocalCache();
+
+   @Message(value = "Invalidation mode only supports when-split=ALLOW_READ_WRITES", id = 550)
+   CacheConfigurationException invalidationPartitionHandlingNotSuported();
 }

--- a/core/src/test/java/org/infinispan/invalidation/InvalidationSharedStoreTest.java
+++ b/core/src/test/java/org/infinispan/invalidation/InvalidationSharedStoreTest.java
@@ -1,0 +1,183 @@
+package org.infinispan.invalidation;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertNull;
+
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.infinispan.AdvancedCache;
+import org.infinispan.Cache;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.context.Flag;
+import org.infinispan.globalstate.ConfigurationStorage;
+import org.infinispan.persistence.dummy.DummyInMemoryStoreConfigurationBuilder;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.fwk.CheckPoint;
+import org.infinispan.transaction.LockingMode;
+import org.infinispan.transaction.TransactionMode;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
+import org.infinispan.transaction.tm.EmbeddedTransaction;
+import org.infinispan.util.concurrent.IsolationLevel;
+import org.testng.annotations.Test;
+
+/**
+ * Test that global locks protect the shared store with pessimistic and optimistic locking.
+ *
+ * <p>See ISPN-10029</p>
+ *
+ * @author Dan Berindei
+ */
+@Test(groups = "functional", testName = "invalidation.InvalidationSharedStoreTest")
+public class InvalidationSharedStoreTest extends MultipleCacheManagersTest {
+   private static final String KEY = "key";
+   private static final String VALUE1 = "value1";
+   private static final Object VALUE2 = "value2";
+   private static final String PESSIMISTIC_CACHE = "pessimistic";
+   private static final String OPTIMISTIC_CACHE = "optimistic";
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      GlobalConfigurationBuilder globalConfig1 = GlobalConfigurationBuilder.defaultClusteredBuilder();
+      globalConfig1.defaultCacheName("local")
+                  .globalState().configurationStorage(ConfigurationStorage.IMMUTABLE).disable();
+      GlobalConfigurationBuilder globalConfig2 = GlobalConfigurationBuilder.defaultClusteredBuilder();
+      globalConfig2.defaultCacheName("local")
+                   .globalState().configurationStorage(ConfigurationStorage.IMMUTABLE).disable();
+      ConfigurationBuilder localConfig = new ConfigurationBuilder();
+      addClusterEnabledCacheManager(globalConfig1, localConfig);
+      addClusterEnabledCacheManager(globalConfig2, localConfig);
+
+      defineCache(PESSIMISTIC_CACHE, LockingMode.PESSIMISTIC);
+      defineCache(OPTIMISTIC_CACHE, LockingMode.OPTIMISTIC);
+      waitForClusterToForm(PESSIMISTIC_CACHE, OPTIMISTIC_CACHE);
+   }
+
+   private void defineCache(String cacheName, LockingMode pessimistic) {
+      ConfigurationBuilder pessimisticConfig = buildConfig(TransactionMode.TRANSACTIONAL, pessimistic);
+      manager(0).defineConfiguration(cacheName, pessimisticConfig.build());
+      manager(1).defineConfiguration(cacheName, pessimisticConfig.build());
+   }
+
+   private ConfigurationBuilder buildConfig(TransactionMode transactionMode, LockingMode lockingMode) {
+      ConfigurationBuilder cacheConfig = new ConfigurationBuilder();
+      cacheConfig.clustering().cacheMode(CacheMode.INVALIDATION_SYNC)
+                 .stateTransfer().fetchInMemoryState(false)
+                 .transaction().transactionMode(transactionMode)
+                 .transactionManagerLookup(new EmbeddedTransactionManagerLookup())
+                 .lockingMode(lockingMode)
+                 .locking().isolationLevel(IsolationLevel.REPEATABLE_READ)
+                 .persistence().addStore(DummyInMemoryStoreConfigurationBuilder.class)
+                 .storeName(InvalidationSharedStoreTest.class.getName())
+                 .build();
+      return cacheConfig;
+   }
+
+   public void testPessimisticWriteAcquiresGlobalLock() throws Exception {
+      Future<Void> tx2Future;
+
+      Cache<Object, Object> cache1 = cache(0, PESSIMISTIC_CACHE);
+      tm(cache1).begin();
+      try {
+         Object initialValue = cache1.put(KEY, VALUE1);
+         assertNull(initialValue);
+
+         tx2Future = fork(() -> {
+            AdvancedCache<Object, Object> cache2 = advancedCache(1, PESSIMISTIC_CACHE);
+            tm(cache2).begin();
+            try {
+               Object value = cache2.put(KEY, VALUE2);
+               assertEquals(VALUE1, value);
+            } finally {
+               tm(cache2).commit();
+            }
+         });
+
+         Thread.sleep(10);
+         assertFalse(tx2Future.isDone());
+
+      } finally {
+         tm(cache1).commit();
+      }
+
+      tx2Future.get();
+      assertEquals(VALUE2, cache1.get(KEY));
+   }
+
+   public void testPessimisticForceWriteLockAcquiresGlobalLock() throws Exception {
+      Future<Void> tx2Future;
+
+      AdvancedCache<Object, Object> cache1 = advancedCache(0, PESSIMISTIC_CACHE);
+      tm(cache1).begin();
+      try {
+         Object initialValue = cache1.withFlags(Flag.FORCE_WRITE_LOCK).get(KEY);
+         assertNull(initialValue);
+
+         tx2Future = fork(() -> {
+            AdvancedCache<Object, Object> cache2 = advancedCache(1, PESSIMISTIC_CACHE);
+            tm(cache2).begin();
+            try {
+               Object value = cache2.withFlags(Flag.FORCE_WRITE_LOCK).get(KEY);
+               assertEquals(VALUE1, value);
+               cache2.withFlags(Flag.IGNORE_RETURN_VALUES).put(KEY, VALUE2);
+            } finally {
+               tm(cache2).commit();
+            }
+         });
+
+         Thread.sleep(10);
+         assertFalse(tx2Future.isDone());
+
+         cache1.put(KEY, VALUE1);
+      } finally {
+         tm(cache1).commit();
+      }
+
+      tx2Future.get();
+      assertEquals(VALUE2, cache1.get(KEY));
+   }
+
+   public void testOptimisticPrepareAcquiresGlobalLock() throws Exception {
+      CheckPoint checkPoint = new CheckPoint();
+      Future<Void> tx2Future;
+
+      Cache<Object, Object> cache1 = cache(0, OPTIMISTIC_CACHE);
+      tm(cache1).begin();
+      EmbeddedTransaction tx1 = null;
+      try {
+         Object initialValue = cache1.put(KEY, VALUE1);
+         assertNull(initialValue);
+         tx1 = (EmbeddedTransaction) tm(cache1).getTransaction();
+         tx1.runPrepare();
+
+         tx2Future = fork(() -> {
+            AdvancedCache<Object, Object> cache2 = advancedCache(1, OPTIMISTIC_CACHE);
+            tm(cache2).begin();
+            try {
+               assertNull(cache2.get(KEY));
+               checkPoint.trigger("tx2_read");
+
+               cache2.put(KEY, VALUE2);
+            } finally {
+               tm(cache2).commit();
+            }
+         });
+
+         checkPoint.awaitStrict("tx2_read", 10, TimeUnit.SECONDS);
+
+         Thread.sleep(10);
+         assertFalse(tx2Future.isDone());
+      } finally {
+         if (tx1 != null) {
+            tx1.runCommit(false);
+         }
+      }
+
+      // No WriteSkewException
+      tx2Future.get(30, TimeUnit.SECONDS);
+      assertEquals(VALUE2, cache1.get(KEY));
+   }
+}

--- a/core/src/test/java/org/infinispan/statetransfer/NonTxStateTransferInvalidationTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/NonTxStateTransferInvalidationTest.java
@@ -26,7 +26,7 @@ import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.testng.annotations.Test;
 
 /**
- * Test if state transfer happens properly on a non-tx invalidation cache.
+ * Test that state transfer does not transfer anything on a non-tx invalidation cache.
  *
  * @since 7.0
  */


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-10029

* Lock tx keys on the primary owner
* Keep locking non-tx keys only on the originator
* InvalidationSharedStoreTest tests that global locks protect
  the shared store with pessimistic and optimistic locking
* Require partition handling to be disabled in invalidation mode