### PR TITLE
ISPN-10085 - Hibernate51 and Hibernate53 should not report the same test name

### DIFF
--- a/hibernate/cache-v51/pom.xml
+++ b/hibernate/cache-v51/pom.xml
@@ -44,38 +44,6 @@
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-               <parallel>none</parallel>
-               <groups combine.self="override">${defaultJUnitGroups}</groups>
-               <excludedGroups combine.self="override">${defaultExcludedJUnitGroups}</excludedGroups>
-               <dependenciesToScan>
-                  <dependency>${project.groupId}:infinispan-hibernate-cache-commons</dependency>
-               </dependenciesToScan>
-               <properties>
-                  <usedefaultlisteners>false</usedefaultlisteners>
-                  <listener>${junitListener}</listener>
-               </properties>
-               <systemPropertyVariables>
-                  <java.net.preferIPv4Stack>true</java.net.preferIPv4Stack>
-                  <jgroups.ping.timeout>500</jgroups.ping.timeout>
-                  <jgroups.ping.num_initial_members>1</jgroups.ping.num_initial_members>
-                  <jgroups.udp.enable_bundling>false</jgroups.udp.enable_bundling>
-                  <jgroups.bind_addr>localhost</jgroups.bind_addr>
-                  <hibernate.cache.infinispan.jgroups_cfg>2lc-test-tcp.xml</hibernate.cache.infinispan.jgroups_cfg>
-                  <infinispan.test.checkThreadLeaks>false</infinispan.test.checkThreadLeaks>
-               </systemPropertyVariables>
-            </configuration>
-            <dependencies>
-               <dependency>
-                  <groupId>org.apache.maven.surefire</groupId>
-                  <artifactId>surefire-junit47</artifactId>
-                  <version>${version.maven.surefire}</version>
-               </dependency>
-            </dependencies>
-         </plugin>
-         <plugin>
             <groupId>org.apache.felix</groupId>
             <artifactId>maven-bundle-plugin</artifactId>
             <configuration>

--- a/hibernate/cache-v53/pom.xml
+++ b/hibernate/cache-v53/pom.xml
@@ -71,38 +71,6 @@
             </configuration>
          </plugin>
          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-               <parallel>none</parallel>
-               <groups combine.self="override">${defaultJUnitGroups}</groups>
-               <excludedGroups combine.self="override">${defaultExcludedJUnitGroups},org.infinispan.test.hibernate.cache.commons.TestDisabledIn53</excludedGroups>
-               <dependenciesToScan>
-                  <dependency>${project.groupId}:infinispan-hibernate-cache-commons</dependency>
-               </dependenciesToScan>
-               <properties>
-                  <usedefaultlisteners>false</usedefaultlisteners>
-                  <listener>${junitListener}</listener>
-               </properties>
-               <systemPropertyVariables>
-                  <java.net.preferIPv4Stack>true</java.net.preferIPv4Stack>
-                  <jgroups.ping.timeout>500</jgroups.ping.timeout>
-                  <jgroups.ping.num_initial_members>1</jgroups.ping.num_initial_members>
-                  <jgroups.udp.enable_bundling>false</jgroups.udp.enable_bundling>
-                  <jgroups.bind_addr>localhost</jgroups.bind_addr>
-                  <hibernate.cache.infinispan.jgroups_cfg>2lc-test-tcp.xml</hibernate.cache.infinispan.jgroups_cfg>
-                  <infinispan.test.checkThreadLeaks>false</infinispan.test.checkThreadLeaks>
-               </systemPropertyVariables>
-            </configuration>
-            <dependencies>
-               <dependency>
-                  <groupId>org.apache.maven.surefire</groupId>
-                  <artifactId>surefire-junit47</artifactId>
-                  <version>${version.maven.surefire}</version>
-               </dependency>
-            </dependencies>
-         </plugin>
-         <plugin>
             <groupId>org.apache.felix</groupId>
             <artifactId>maven-bundle-plugin</artifactId>
             <configuration>

--- a/hibernate/pom.xml
+++ b/hibernate/pom.xml
@@ -83,6 +83,11 @@
          <artifactId>h2</artifactId>
          <scope>test</scope>
       </dependency>
+      <dependency>
+         <groupId>org.testng</groupId>
+         <artifactId>testng</artifactId>
+         <scope>test</scope>
+      </dependency>
    </dependencies>
 
    <build>
@@ -93,6 +98,22 @@
                <artifactId>maven-checkstyle-plugin</artifactId>
                <configuration>
                   <configLocation>checkstyle-hibernate-cache.xml</configLocation>
+               </configuration>
+            </plugin>
+            <plugin>
+               <groupId>org.apache.maven.plugins</groupId>
+               <artifactId>maven-surefire-plugin</artifactId>
+               <configuration>
+                  <dependenciesToScan>
+                     <dependency>${project.groupId}:infinispan-hibernate-cache-commons</dependency>
+                  </dependenciesToScan>
+                  <argLine>${forkJvmArgs} ${testjvm.jigsawArgs} -Djdk.attach.allowAttachSelf=true</argLine>
+                  <systemPropertyVariables>
+                     <jgroups.ping.timeout>500</jgroups.ping.timeout>
+                     <jgroups.ping.num_initial_members>1</jgroups.ping.num_initial_members>
+                     <jgroups.udp.enable_bundling>false</jgroups.udp.enable_bundling>
+                     <hibernate.cache.infinispan.jgroups_cfg>2lc-test-tcp.xml</hibernate.cache.infinispan.jgroups_cfg>
+                  </systemPropertyVariables>
                </configuration>
             </plugin>
          </plugins>


### PR DESCRIPTION
I decided to remove the entire surefire configuration after generating the effective maven pom and applying only what was different

https://issues.jboss.org/browse/ISPN-10085