### PR TITLE
ISPN-10165 - Fix rolling upgrades tests according to latest changes

### DIFF
--- a/server/integration/src/main/ant/infinispan-server.xml
+++ b/server/integration/src/main/ant/infinispan-server.xml
@@ -51,7 +51,7 @@
             <env key="JAVA" value="${server.jvm}/bin/java"/>
         </exec>
         <echo>Waiting for Infinispan server to start</echo>
-        <waitfor maxwait="15" maxwaitunit="second" checkevery="1" checkeveryunit="second">
+        <waitfor maxwait="30" maxwaitunit="second" checkevery="1" checkeveryunit="second">
             <and>
                 <socket server="127.0.0.1" port="${management.port}"/>
                 <socket server="127.0.0.1" port="${hotrod.port}"/>
@@ -188,5 +188,5 @@
         </exec>
     </target>
 
-    <target name="kill-server" depends="-do.kinit, -do.ps, -do.lsof, -do.jps, -do.cmd"/>
+    <target name="kill-server" depends="-do.kinit, -do.lsof, -do.cmd"/>
 </project>

--- a/server/integration/testsuite/pom.xml
+++ b/server/integration/testsuite/pom.xml
@@ -1339,6 +1339,7 @@
                                             <property name="hotrod.port" value="11522" />
                                         </ant>
                                         <ant antfile="${basedir}/../src/main/ant/infinispan-server.xml" target="start-server">
+                                            <property name="server.jvm" value="${server.old.jvm}" />
                                             <property name="server.dist" value="${server3.old.dist}" />
                                             <property name="port.offset" value="300" />
                                             <property name="management.port" value="10290" />

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/rollingupgrades/HotRodRollingUpgradesDistIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/rollingupgrades/HotRodRollingUpgradesDistIT.java
@@ -34,7 +34,7 @@ public class HotRodRollingUpgradesDistIT extends AbstractHotRodRollingUpgradesIT
         MBeanServerConnectionProvider provider1;
 
         // Target nodes
-        final int managementPortServer2 = 10090;
+        final int managementPortServer2 = 10390;
         MBeanServerConnectionProvider provider2;
 
         try {
@@ -50,7 +50,7 @@ public class HotRodRollingUpgradesDistIT extends AbstractHotRodRollingUpgradesIT
             builder3.addServer()
                     .host("127.0.0.1")
                     .port(11422)
-                    .version(ProtocolVersion.PROTOCOL_VERSION_25);
+                    .version(ProtocolVersion.parseVersion(System.getProperty("hotrod.protocol.version")));
 
             RemoteCacheManager rcm3 = new RemoteCacheManager(builder3.build());
             final RemoteCache<String, String> c3 = rcm3.getCache("default");
@@ -59,7 +59,7 @@ public class HotRodRollingUpgradesDistIT extends AbstractHotRodRollingUpgradesIT
             builder4.addServer()
                     .host("127.0.0.1")
                     .port(11522)
-                    .version(ProtocolVersion.PROTOCOL_VERSION_25);
+                    .version(ProtocolVersion.parseVersion(System.getProperty("hotrod.protocol.version")));
 
             RemoteCacheManager rcm4 = new RemoteCacheManager(builder4.build());
             final RemoteCache<String, String> c4 = rcm4.getCache("default");

--- a/server/integration/testsuite/src/test/resources/arquillian.xml
+++ b/server/integration/testsuite/src/test/resources/arquillian.xml
@@ -1300,11 +1300,11 @@
                 <property name="serverConfig">testsuite/clustered-hotrod-rolling-upgrade.xml</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1
                     -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
-                    -Djboss.socket.binding.port-offset=100 -Dremote.destination.port=11522
+                    -Djboss.socket.binding.port-offset=400 -Dremote.destination.port=11522
                     -Djgroups.join_timeout=2000
                 </property>
-                <property name="managementPort">10090</property>
-                <property name="waitForPorts">11311 11322 8180</property>
+                <property name="managementPort">10390</property>
+                <property name="waitForPorts">11611 11622 8480</property>
                 <property name="jmxDomain">${server.jmx.domain}</property>
             </configuration>
         </container>

--- a/server/integration/testsuite/src/test/resources/config/parts/rolling-upgrades-server-endpoint-9.4.xml
+++ b/server/integration/testsuite/src/test/resources/config/parts/rolling-upgrades-server-endpoint-9.4.xml
@@ -2,6 +2,5 @@
             <hotrod-connector socket-binding="hotrod" cache-container="clustered-new">
                 <topology-state-transfer lazy-retrieval="false" lock-timeout="1000" replication-timeout="5000"/>
             </hotrod-connector>
-            <memcached-connector socket-binding="memcached" cache-container="clustered-new"/>
             <rest-connector socket-binding="rest" cache-container="clustered-new"/>
         </subsystem>


### PR DESCRIPTION
Fixed the configuration, as while the rolling upgrades tests running the servers were messed up.
