### PR TITLE
ISPN-10161 - ThreadLeakChecker is blocking PolarionJUnitXMLReporter to generate the reports

### DIFF
--- a/commons-test/src/main/java/org/infinispan/commons/test/ThreadLeakChecker.java
+++ b/commons-test/src/main/java/org/infinispan/commons/test/ThreadLeakChecker.java
@@ -187,7 +187,7 @@ public class ThreadLeakChecker {
          // Use -Dinfinispan.test.parallel.threads=3 (or even less) to narrow down source tests
          // Set a conditional breakpoint in Thread.start with the name of the leaked thread
          // If the thread has the pattern of a particular component, set a conditional breakpoint in that component
-         throw new RuntimeException("Leaked threads: \n  " +
+         log.error("Leaked threads: \n  " +
                                     leaks.stream()
                                        .map(Object::toString)
                                        .collect(Collectors.joining(",\n  ")));


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-10161

ISPN-10161 - ThreadLeakChecker is blocking PolarionJUnitXMLReporter to generate the reports