### PR TITLE
[9.4.x] ISPN-10029 Invalidation locking is not clustered

### DIFF
--- a/core/src/main/java/org/infinispan/commands/tx/PrepareCommand.java
+++ b/core/src/main/java/org/infinispan/commands/tx/PrepareCommand.java
@@ -25,6 +25,7 @@ import org.infinispan.commands.functional.WriteOnlyManyEntriesCommand;
 import org.infinispan.commands.write.ComputeCommand;
 import org.infinispan.commands.write.ComputeIfAbsentCommand;
 import org.infinispan.commands.write.DataWriteCommand;
+import org.infinispan.commands.write.InvalidateCommand;
 import org.infinispan.commands.write.PutKeyValueCommand;
 import org.infinispan.commands.write.PutMapCommand;
 import org.infinispan.commands.write.RemoveCommand;
@@ -152,6 +153,7 @@ public class PrepareCommand extends AbstractTransactionBoundaryCommand implement
                set.add(((DataWriteCommand) writeCommand).getKey());
                break;
             case PutMapCommand.COMMAND_ID:
+            case InvalidateCommand.COMMAND_ID:
             case ReadWriteManyCommand.COMMAND_ID:
             case ReadWriteManyEntriesCommand.COMMAND_ID:
             case WriteOnlyManyCommand.COMMAND_ID:

--- a/core/src/main/java/org/infinispan/configuration/cache/PartitionHandlingConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/PartitionHandlingConfigurationBuilder.java
@@ -9,6 +9,9 @@ import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.conflict.EntryMergePolicy;
 import org.infinispan.conflict.MergePolicy;
 import org.infinispan.partitionhandling.PartitionHandling;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
 /**
  * Controls how the cache handles partitioning and/or multiple node failures.
  *
@@ -16,6 +19,7 @@ import org.infinispan.partitionhandling.PartitionHandling;
  * @since 7.0
  */
 public class PartitionHandlingConfigurationBuilder extends AbstractClusteringConfigurationChildBuilder implements Builder<PartitionHandlingConfiguration> {
+   private static final Log log = LogFactory.getLog(PartitionHandlingConfigurationBuilder.class);
 
    private final AttributeSet attributes;
 
@@ -48,6 +52,8 @@ public class PartitionHandlingConfigurationBuilder extends AbstractClusteringCon
 
    @Override
    public void validate() {
+      if (attributes.attribute(WHEN_SPLIT).get() != PartitionHandling.ALLOW_READ_WRITES && clustering().cacheMode().isInvalidation())
+         throw log.invalidationPartitionHandlingNotSuported();
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/factories/InterceptorChainFactory.java
+++ b/core/src/main/java/org/infinispan/factories/InterceptorChainFactory.java
@@ -144,16 +144,20 @@ public class InterceptorChainFactory extends AbstractNamedCacheComponentFactory 
          interceptorChain.appendInterceptor(createInterceptor(new CacheMgmtInterceptor(), CacheMgmtInterceptor.class), false);
       }
 
-      // load the state transfer lock interceptor
-      // the state transfer lock ensures that the cache member list is up-to-date
-      // so it's necessary even if state transfer is disabled
-      if (cacheMode.needsStateTransfer()) {
+      // the state transfer interceptor sets the topology id and retries on topology changes
+      // so it's necessary even if there is no state transfer
+      // the only exception is non-tx invalidation mode, which ignores lock owners
+      if (cacheMode.needsStateTransfer() || cacheMode.isInvalidation() && transactionMode.isTransactional()) {
          if (isTotalOrder) {
             interceptorChain.appendInterceptor(createInterceptor(new TotalOrderStateTransferInterceptor(),
                                                                  TotalOrderStateTransferInterceptor.class), false);
          } else {
-            interceptorChain.appendInterceptor(createInterceptor(new StateTransferInterceptor(), StateTransferInterceptor.class), false);
+            interceptorChain.appendInterceptor(
+               createInterceptor(new StateTransferInterceptor(), StateTransferInterceptor.class), false);
          }
+      }
+
+      if (cacheMode.needsStateTransfer()) {
          if (transactionMode.isTransactional()) {
             interceptorChain.appendInterceptor(createInterceptor(new TransactionSynchronizerInterceptor(), TransactionSynchronizerInterceptor.class), false);
          }

--- a/core/src/main/java/org/infinispan/interceptors/locking/PessimisticLockingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/locking/PessimisticLockingInterceptor.java
@@ -237,7 +237,7 @@ public class PessimisticLockingInterceptor extends AbstractTxLockingInterceptor 
          }
       } else {
          if (trace)
-            log.tracef("Don't need backup locks %s", needBackupLocks);
+            log.tracef("Don't need backup locks for key %s", key);
       }
       return needRemoteLock;
    }

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -979,8 +979,8 @@ public interface Log extends BasicLogger {
    void unableToCreateInterceptor(Class type, @Cause Exception e);
 
    @LogMessage(level = WARN)
-   @Message(value = "Unable to broadcast evicts as a part of the prepare phase. Rolling back.", id = 268)
-   void unableToRollbackEvictionsDuringPrepare(@Cause Throwable e);
+   @Message(value = "Unable to broadcast invalidations as a part of the prepare phase. Rolling back.", id = 268)
+   void unableToRollbackInvalidationsDuringPrepare(@Cause Throwable e);
 
    @LogMessage(level = WARN)
    @Message(value = "Cache used for Grid metadata should be synchronous.", id = 269)
@@ -1837,4 +1837,7 @@ public interface Log extends BasicLogger {
    @LogMessage(level = ERROR)
    @Message(value = "Error stopping module %s", id = 538)
    void moduleStopError(String module, @Cause Throwable t);
+
+   @Message(value = "Invalidation mode only supports when-split=ALLOW_READ_WRITES", id = 550)
+   CacheConfigurationException invalidationPartitionHandlingNotSuported();
 }

--- a/core/src/test/java/org/infinispan/invalidation/BaseInvalidationTest.java
+++ b/core/src/test/java/org/infinispan/invalidation/BaseInvalidationTest.java
@@ -6,26 +6,32 @@ import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertNull;
+import static org.testng.AssertJUnit.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
 import javax.transaction.RollbackException;
-import javax.transaction.Transaction;
 import javax.transaction.TransactionManager;
 
 import org.infinispan.AdvancedCache;
 import org.infinispan.api.mvcc.LockAssert;
 import org.infinispan.commands.write.ClearCommand;
 import org.infinispan.commands.write.InvalidateCommand;
+import org.infinispan.commons.tx.TransactionImpl;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.remoting.rpc.RpcManager;
 import org.infinispan.remoting.rpc.RpcManagerImpl;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.remoting.transport.Transport;
+import org.infinispan.test.Exceptions;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
+import org.infinispan.transaction.LockingMode;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
 import org.infinispan.util.concurrent.CompletableFutures;
 import org.infinispan.util.concurrent.locks.LockManager;
 import org.testng.annotations.Test;
@@ -48,7 +54,9 @@ public abstract class BaseInvalidationTest extends MultipleCacheManagersTest {
       if (isSync) {
          c = getDefaultClusteredCacheConfig(CacheMode.INVALIDATION_SYNC, true);
          c.clustering().stateTransfer().timeout(10000)
-               .locking().lockAcquisitionTimeout(TestingUtil.shortTimeoutMillis());
+          .transaction().transactionManagerLookup(new EmbeddedTransactionManagerLookup())
+          .transaction().lockingMode(LockingMode.OPTIMISTIC)
+          .locking().lockAcquisitionTimeout(TestingUtil.shortTimeoutMillis());
          defineConfigurationOnAllManagers("invalidationTx", c);
 
          waitForClusterToForm("invalidationTx");
@@ -119,10 +127,8 @@ public abstract class BaseInvalidationTest extends MultipleCacheManagersTest {
       assertNull("Should be null", cache1.get("key"));
       assertNull("Should be null", cache2.get("key"));
 
-      log.info("before...");
       replListener(cache2).expect(InvalidateCommand.class);
       cache1.put("key", "value");
-      log.info("after...");
       replListener(cache2).waitForRpc();
 
       assertEquals("value", cache1.get("key"));
@@ -130,15 +136,17 @@ public abstract class BaseInvalidationTest extends MultipleCacheManagersTest {
 
       // OK, here's the real test
       TransactionManager tm = TestingUtil.getTransactionManager(cache2);
-      replListener(cache1).expect(InvalidateCommand.class); // invalidates always happen outside of a tx
       tm.begin();
+
       // Remove an entry that doesn't exist in cache2
       cache2.remove("key");
+
+      replListener(cache1).expect(InvalidateCommand.class); // invalidates always happen outside of a tx
       tm.commit();
       replListener(cache1).waitForRpc();
 
-      assert cache1.get("key") == null;
-      assert cache2.get("key") == null;
+      assertNull(cache1.get("key"));
+      assertNull(cache2.get("key"));
    }
 
    public void testTxSyncUnableToInvalidate() throws Exception {
@@ -147,6 +155,11 @@ public abstract class BaseInvalidationTest extends MultipleCacheManagersTest {
       }
       AdvancedCache<String, String> cache1 = advancedCache(0,"invalidationTx");
       AdvancedCache<String, String> cache2 = advancedCache(1,"invalidationTx");
+      TransactionManager mgr1 = TestingUtil.getTransactionManager(cache1);
+      TransactionManager mgr2 = TestingUtil.getTransactionManager(cache2);
+      LockManager lm1 = TestingUtil.extractComponent(cache1, LockManager.class);
+      LockManager lm2 = TestingUtil.extractComponent(cache2, LockManager.class);
+
       replListener(cache2).expect(InvalidateCommand.class);
       cache1.put("key", "value");
       replListener(cache2).waitForRpc();
@@ -154,35 +167,32 @@ public abstract class BaseInvalidationTest extends MultipleCacheManagersTest {
       assertEquals("value", cache1.get("key"));
       assertNull(cache2.get("key"));
 
-      // start a tx that cacahe1 will have to send out an evict ...
-      TransactionManager mgr1 = TestingUtil.getTransactionManager(cache1);
-      TransactionManager mgr2 = TestingUtil.getTransactionManager(cache2);
-
+      TransactionImpl tx1 = null;
       mgr1.begin();
-      cache1.put("key", "value2");
-      Transaction tx1 = mgr1.suspend();
-      mgr2.begin();
-      cache2.put("key", "value3");
-      Transaction tx2 = mgr2.suspend();
-      mgr1.resume(tx1);
-      // this oughtta fail
       try {
+         cache1.put("key", "value2");
+         tx1 = (TransactionImpl) mgr1.suspend();
+
+         // Acquire the key lock for tx1 and hold it
          replListener(cache2).expect(InvalidateCommand.class);
-         mgr1.commit();
+         tx1.runPrepare();
          replListener(cache2).waitForRpc();
-      } catch (RollbackException roll) {
-         assert isSync : "isSync should be true";
+
+         mgr2.begin();
+         cache2.put("key", "value3");
+
+         // tx2 prepare fails because tx1 is holding the key lock
+         replListener(cache1).expect(InvalidateCommand.class);
+         Exceptions.expectException(RollbackException.class, mgr2::commit);
+         replListener(cache2).assertNoRpc();
+      } finally {
+         if (tx1 != null) {
+            tx1.runCommit(false);
+         }
       }
 
-      mgr2.resume(tx2);
-      replListener(cache1).expect(InvalidateCommand.class);
-      mgr2.commit();
-      if (!isSync) replListener(cache1).waitForRpc();
-
-      LockManager lm1 = TestingUtil.extractComponent(cache1, LockManager.class);
-      LockManager lm2 = TestingUtil.extractComponent(cache2, LockManager.class);
-      assert !lm1.isLocked("key");
-      assert !lm2.isLocked("key");
+      eventually(() -> !lm1.isLocked("key"));
+      eventually(() -> !lm2.isLocked("key"));
 
       LockAssert.assertNoLocks(cache1);
       LockAssert.assertNoLocks(cache2);
@@ -216,26 +226,29 @@ public abstract class BaseInvalidationTest extends MultipleCacheManagersTest {
    public void testPutIfAbsent() {
       AdvancedCache<String, String> cache1 = advancedCache(0,"invalidation");
       AdvancedCache<String, String> cache2 = advancedCache(1,"invalidation");
-      assert null == cache2.withFlags(CACHE_MODE_LOCAL).put("key", "value");
-      assert cache2.get("key").equals("value");
-      assert cache1.get("key") == null;
+      String putPrevious = cache2.withFlags(CACHE_MODE_LOCAL).put("key", "value");
+      assertNull(putPrevious);
+      assertEquals("value", cache2.get("key"));
+      assertNull(cache1.get("key"));
 
       replListener(cache2).expect(InvalidateCommand.class);
-      cache1.putIfAbsent("key", "value");
+      String putIfAbsentPrevious = cache1.putIfAbsent("key", "value");
+      assertNull(putIfAbsentPrevious);
       replListener(cache2).waitForRpc();
 
-      assert cache1.get("key").equals("value");
-      assert cache2.get("key") == null;
+      assertEquals("value", cache1.get("key"));
+      String value = cache2.get("key");
+      assertNull(value);
 
-      assert null == cache2.withFlags(CACHE_MODE_LOCAL).put("key", "value2");
+      assertNull(cache2.withFlags(CACHE_MODE_LOCAL).put("key", "value2"));
 
-      assert cache1.get("key").equals("value");
-      assert cache2.get("key").equals("value2");
+      assertEquals("value", cache1.get("key"));
+      assertEquals("value2", cache2.get("key"));
 
       cache1.putIfAbsent("key", "value3");
 
-      assert cache1.get("key").equals("value");
-      assert cache2.get("key").equals("value2"); // should not invalidate cache2!!
+      assertEquals("value", cache1.get("key"));
+      assertEquals("value2", cache2.get("key")); // should not invalidate cache2!!
    }
 
    public void testRemoveIfPresent() {
@@ -243,20 +256,20 @@ public abstract class BaseInvalidationTest extends MultipleCacheManagersTest {
       AdvancedCache<String, String> cache2 = advancedCache(1,"invalidation");
       cache1.withFlags(CACHE_MODE_LOCAL).put("key", "value1");
       cache2.withFlags(CACHE_MODE_LOCAL).put("key", "value2");
-      assert cache1.get("key").equals("value1");
-      assert cache2.get("key").equals("value2");
+      assertEquals("value1", cache1.get("key"));
+      assertEquals("value2", cache2.get("key"));
 
-      assert !cache1.remove("key", "value");
+      assertFalse(cache1.remove("key", "value"));
 
-      assert cache1.get("key").equals("value1") : "Should not remove";
-      assert cache2.get("key").equals("value2") : "Should not evict";
+      assertEquals("Should not remove", "value1", cache1.get("key"));
+      assertEquals("Should not evict", "value2", cache2.get("key"));
 
       replListener(cache2).expect(InvalidateCommand.class);
       cache1.remove("key", "value1");
       replListener(cache2).waitForRpc();
 
-      assert cache1.get("key") == null;
-      assert cache2.get("key") == null;
+      assertNull(cache1.get("key"));
+      assertNull(cache2.get("key"));
    }
 
    public void testClear() {
@@ -264,64 +277,66 @@ public abstract class BaseInvalidationTest extends MultipleCacheManagersTest {
       AdvancedCache<String, String> cache2 = advancedCache(1,"invalidation");
       cache1.withFlags(CACHE_MODE_LOCAL).put("key", "value1");
       cache2.withFlags(CACHE_MODE_LOCAL).put("key", "value2");
-      assert cache1.get("key").equals("value1");
-      assert cache2.get("key").equals("value2");
+      assertEquals("value1", cache1.get("key"));
+      assertEquals("value2", cache2.get("key"));
 
       replListener(cache2).expect(ClearCommand.class);
       cache1.clear();
       replListener(cache2).waitForRpc();
 
-      assert cache1.get("key") == null;
-      assert cache2.get("key") == null;
+      assertNull(cache1.get("key"));
+      assertNull(cache2.get("key"));
    }
 
    public void testReplace() {
       AdvancedCache<String, String> cache1 = advancedCache(0,"invalidation");
       AdvancedCache<String, String> cache2 = advancedCache(1,"invalidation");
       cache2.withFlags(CACHE_MODE_LOCAL).put("key", "value2");
-      assert cache1.get("key") == null;
-      assert cache2.get("key").equals("value2");
+      assertNull(cache1.get("key"));
+      assertEquals("value2", cache2.get("key"));
 
-      assert null == cache1.replace("key", "value1"); // should do nothing since there is nothing to replace on cache1
+      assertNull(cache1.replace("key", "value1")); // should do nothing since there is nothing to replace on cache1
 
-      assert cache1.get("key") == null;
-      assert cache2.get("key").equals("value2");
+      assertNull(cache1.get("key"));
+      assertEquals("value2", cache2.get("key"));
 
-      assert null == cache1.withFlags(CACHE_MODE_LOCAL).put("key", "valueN");
+      assertNull(cache1.withFlags(CACHE_MODE_LOCAL).put("key", "valueN"));
 
       replListener(cache2).expect(InvalidateCommand.class);
       cache1.replace("key", "value1");
       replListener(cache2).waitForRpc();
 
-      assert cache1.get("key").equals("value1");
-      assert cache2.get("key") == null;
+      assertEquals("value1", cache1.get("key"));
+      assertNull(cache2.get("key"));
    }
 
    public void testReplaceWithOldVal() {
       AdvancedCache<String, String> cache1 = advancedCache(0,"invalidation");
       AdvancedCache<String, String> cache2 = advancedCache(1,"invalidation");
       cache2.withFlags(CACHE_MODE_LOCAL).put("key", "value2");
-      assert cache1.get("key") == null;
-      assert cache2.get("key").equals("value2");
+      assertNull(cache1.get("key"));
+      assertEquals("value2", cache2.get("key"));
 
-      assert !cache1.replace("key", "valueOld", "value1"); // should do nothing since there is nothing to replace on cache1
+      assertFalse(
+         cache1.replace("key", "valueOld", "value1")); // should do nothing since there is nothing to replace on cache1
 
-      assert cache1.get("key") == null;
-      assert cache2.get("key").equals("value2");
+      assertNull(cache1.get("key"));
+      assertEquals("value2", cache2.get("key"));
 
-      assert null == cache1.withFlags(CACHE_MODE_LOCAL).put("key", "valueN");
+      assertNull(cache1.withFlags(CACHE_MODE_LOCAL).put("key", "valueN"));
 
-      assert !cache1.replace("key", "valueOld", "value1"); // should do nothing since there is nothing to replace on cache1
+      assertFalse(
+         cache1.replace("key", "valueOld", "value1")); // should do nothing since there is nothing to replace on cache1
 
-      assert cache1.get("key").equals("valueN");
-      assert cache2.get("key").equals("value2");
+      assertEquals("valueN", cache1.get("key"));
+      assertEquals("value2", cache2.get("key"));
 
       replListener(cache2).expect(InvalidateCommand.class);
-      assert cache1.replace("key", "valueN", "value1");
+      assertTrue(cache1.replace("key", "valueN", "value1"));
       replListener(cache2).waitForRpc();
 
-      assert cache1.get("key").equals("value1");
-      assert cache2.get("key") == null;
+      assertEquals("value1", cache1.get("key"));
+      assertNull(cache2.get("key"));
    }
 
    public void testLocalOnlyClear() {
@@ -329,14 +344,14 @@ public abstract class BaseInvalidationTest extends MultipleCacheManagersTest {
       AdvancedCache<String, String> cache2 = advancedCache(1,"invalidation");
       cache1.withFlags(CACHE_MODE_LOCAL).put("key", "value1");
       cache2.withFlags(CACHE_MODE_LOCAL).put("key", "value2");
-      assert cache1.get("key").equals("value1");
-      assert cache2.get("key").equals("value2");
+      assertEquals("value1", cache1.get("key"));
+      assertEquals("value2", cache2.get("key"));
 
       cache1.withFlags(CACHE_MODE_LOCAL).clear();
 
-      assert cache1.get("key") == null;
-      assert cache2.get("key") != null;
-      assert cache2.get("key").equals("value2");
+      assertNull(cache1.get("key"));
+      assertNotNull(cache2.get("key"));
+      assertEquals("value2", cache2.get("key"));
    }
 
    public void testPutForExternalRead() throws Exception {
@@ -346,9 +361,9 @@ public abstract class BaseInvalidationTest extends MultipleCacheManagersTest {
       Thread.sleep(500); // sleep so that async invalidation (result of PFER) is propagated
       cache2.putForExternalRead("key", "value2");
       Thread.sleep(500); // sleep so that async invalidation (result of PFER) is propagated
-      assert cache1.get("key") != null;
-      assert cache1.get("key").equals("value1");
-      assert cache2.get("key") != null;
-      assert cache2.get("key").equals("value2");
+      assertNotNull(cache1.get("key"));
+      assertEquals("value1", cache1.get("key"));
+      assertNotNull(cache2.get("key"));
+      assertEquals("value2", cache2.get("key"));
    }
 }

--- a/core/src/test/java/org/infinispan/invalidation/InvalidationSharedStoreTest.java
+++ b/core/src/test/java/org/infinispan/invalidation/InvalidationSharedStoreTest.java
@@ -1,0 +1,183 @@
+package org.infinispan.invalidation;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertNull;
+
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.infinispan.AdvancedCache;
+import org.infinispan.Cache;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.context.Flag;
+import org.infinispan.globalstate.ConfigurationStorage;
+import org.infinispan.persistence.dummy.DummyInMemoryStoreConfigurationBuilder;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.fwk.CheckPoint;
+import org.infinispan.transaction.LockingMode;
+import org.infinispan.transaction.TransactionMode;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
+import org.infinispan.transaction.tm.EmbeddedTransaction;
+import org.infinispan.util.concurrent.IsolationLevel;
+import org.testng.annotations.Test;
+
+/**
+ * Test that global locks protect the shared store with pessimistic and optimistic locking.
+ *
+ * <p>See ISPN-10029</p>
+ *
+ * @author Dan Berindei
+ */
+@Test(groups = "functional", testName = "invalidation.InvalidationSharedStoreTest")
+public class InvalidationSharedStoreTest extends MultipleCacheManagersTest {
+   private static final String KEY = "key";
+   private static final String VALUE1 = "value1";
+   private static final Object VALUE2 = "value2";
+   private static final String PESSIMISTIC_CACHE = "pessimistic";
+   private static final String OPTIMISTIC_CACHE = "optimistic";
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      GlobalConfigurationBuilder globalConfig1 = GlobalConfigurationBuilder.defaultClusteredBuilder();
+      globalConfig1.defaultCacheName("local")
+                  .globalState().configurationStorage(ConfigurationStorage.IMMUTABLE).disable();
+      GlobalConfigurationBuilder globalConfig2 = GlobalConfigurationBuilder.defaultClusteredBuilder();
+      globalConfig2.defaultCacheName("local")
+                   .globalState().configurationStorage(ConfigurationStorage.IMMUTABLE).disable();
+      ConfigurationBuilder localConfig = new ConfigurationBuilder();
+      addClusterEnabledCacheManager(globalConfig1, localConfig);
+      addClusterEnabledCacheManager(globalConfig2, localConfig);
+
+      defineCache(PESSIMISTIC_CACHE, LockingMode.PESSIMISTIC);
+      defineCache(OPTIMISTIC_CACHE, LockingMode.OPTIMISTIC);
+      waitForClusterToForm(PESSIMISTIC_CACHE, OPTIMISTIC_CACHE);
+   }
+
+   private void defineCache(String cacheName, LockingMode pessimistic) {
+      ConfigurationBuilder pessimisticConfig = buildConfig(TransactionMode.TRANSACTIONAL, pessimistic);
+      manager(0).defineConfiguration(cacheName, pessimisticConfig.build());
+      manager(1).defineConfiguration(cacheName, pessimisticConfig.build());
+   }
+
+   private ConfigurationBuilder buildConfig(TransactionMode transactionMode, LockingMode lockingMode) {
+      ConfigurationBuilder cacheConfig = new ConfigurationBuilder();
+      cacheConfig.clustering().cacheMode(CacheMode.INVALIDATION_SYNC)
+                 .stateTransfer().fetchInMemoryState(false)
+                 .transaction().transactionMode(transactionMode)
+                 .transactionManagerLookup(new EmbeddedTransactionManagerLookup())
+                 .lockingMode(lockingMode)
+                 .locking().isolationLevel(IsolationLevel.REPEATABLE_READ)
+                 .persistence().addStore(DummyInMemoryStoreConfigurationBuilder.class)
+                 .storeName(InvalidationSharedStoreTest.class.getName())
+                 .build();
+      return cacheConfig;
+   }
+
+   public void testPessimisticWriteAcquiresGlobalLock() throws Exception {
+      Future<Void> tx2Future;
+
+      Cache<Object, Object> cache1 = cache(0, PESSIMISTIC_CACHE);
+      tm(cache1).begin();
+      try {
+         Object initialValue = cache1.put(KEY, VALUE1);
+         assertNull(initialValue);
+
+         tx2Future = fork(() -> {
+            AdvancedCache<Object, Object> cache2 = advancedCache(1, PESSIMISTIC_CACHE);
+            tm(cache2).begin();
+            try {
+               Object value = cache2.put(KEY, VALUE2);
+               assertEquals(VALUE1, value);
+            } finally {
+               tm(cache2).commit();
+            }
+         });
+
+         Thread.sleep(10);
+         assertFalse(tx2Future.isDone());
+
+      } finally {
+         tm(cache1).commit();
+      }
+
+      tx2Future.get();
+      assertEquals(VALUE2, cache1.get(KEY));
+   }
+
+   public void testPessimisticForceWriteLockAcquiresGlobalLock() throws Exception {
+      Future<Void> tx2Future;
+
+      AdvancedCache<Object, Object> cache1 = advancedCache(0, PESSIMISTIC_CACHE);
+      tm(cache1).begin();
+      try {
+         Object initialValue = cache1.withFlags(Flag.FORCE_WRITE_LOCK).get(KEY);
+         assertNull(initialValue);
+
+         tx2Future = fork(() -> {
+            AdvancedCache<Object, Object> cache2 = advancedCache(1, PESSIMISTIC_CACHE);
+            tm(cache2).begin();
+            try {
+               Object value = cache2.withFlags(Flag.FORCE_WRITE_LOCK).get(KEY);
+               assertEquals(VALUE1, value);
+               cache2.withFlags(Flag.IGNORE_RETURN_VALUES).put(KEY, VALUE2);
+            } finally {
+               tm(cache2).commit();
+            }
+         });
+
+         Thread.sleep(10);
+         assertFalse(tx2Future.isDone());
+
+         cache1.put(KEY, VALUE1);
+      } finally {
+         tm(cache1).commit();
+      }
+
+      tx2Future.get();
+      assertEquals(VALUE2, cache1.get(KEY));
+   }
+
+   public void testOptimisticPrepareAcquiresGlobalLock() throws Exception {
+      CheckPoint checkPoint = new CheckPoint();
+      Future<Void> tx2Future;
+
+      Cache<Object, Object> cache1 = cache(0, OPTIMISTIC_CACHE);
+      tm(cache1).begin();
+      EmbeddedTransaction tx1 = null;
+      try {
+         Object initialValue = cache1.put(KEY, VALUE1);
+         assertNull(initialValue);
+         tx1 = (EmbeddedTransaction) tm(cache1).getTransaction();
+         tx1.runPrepare();
+
+         tx2Future = fork(() -> {
+            AdvancedCache<Object, Object> cache2 = advancedCache(1, OPTIMISTIC_CACHE);
+            tm(cache2).begin();
+            try {
+               assertNull(cache2.get(KEY));
+               checkPoint.trigger("tx2_read");
+
+               cache2.put(KEY, VALUE2);
+            } finally {
+               tm(cache2).commit();
+            }
+         });
+
+         checkPoint.awaitStrict("tx2_read", 10, TimeUnit.SECONDS);
+
+         Thread.sleep(10);
+         assertFalse(tx2Future.isDone());
+      } finally {
+         if (tx1 != null) {
+            tx1.runCommit(false);
+         }
+      }
+
+      // No WriteSkewException
+      tx2Future.get(30, TimeUnit.SECONDS);
+      assertEquals(VALUE2, cache1.get(KEY));
+   }
+}

--- a/core/src/test/java/org/infinispan/statetransfer/NonTxStateTransferInvalidationTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/NonTxStateTransferInvalidationTest.java
@@ -26,7 +26,7 @@ import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.testng.annotations.Test;
 
 /**
- * Test if state transfer happens properly on a non-tx invalidation cache.
+ * Test that state transfer does not transfer anything on a non-tx invalidation cache.
  *
  * @since 7.0
  */

--- a/core/src/test/java/org/infinispan/test/ReplListener.java
+++ b/core/src/test/java/org/infinispan/test/ReplListener.java
@@ -218,6 +218,15 @@ public class ReplListener {
       }
    }
 
+   public void assertNoRpc() {
+      debugf("Expecting no commands");
+      for (VisitableCommand command : loggedCommands) {
+         for (Predicate<VisitableCommand> expectation : expectedCommands) {
+            assertFalse("Shouldn't have matched command " + command, expectation.test(command));
+         }
+      }
+   }
+
    public Cache<?, ?> getCache() {
       return cache;
    }

--- a/documentation/src/main/asciidoc/user_guide/clustering.adoc
+++ b/documentation/src/main/asciidoc/user_guide/clustering.adoc
@@ -147,8 +147,19 @@ That means other nodes still see the stale value for a while after the write com
 the originator.
 
 Transactions can be used to batch the invalidation messages.
-They won't behave like regular transactions though, as locks are only acquired on the
-local node, and entries can be invalidated by other transactions at any time.
+Transactions acquire the key lock on the primary owner.
+To find more about how primary owners are assigned, please read the
+link:#key_ownership[Key Ownership] section.
+
+* With pessimistic locking, each write triggers a lock message, which is
+broadcast to all the nodes.
+During transaction commit, the originator broadcasts a one-phase prepare message
+(optionally fire-and-forget) which invalidates all affected keys and releases the locks.
+
+* With optimistic locking, the originator broadcasts a prepare message, a commit message,
+and an unlock message (optional).
+Either the one-phase prepare or the unlock message is fire-and-forget,
+and the last message always releases the locks.
 
 
 === Replicated Mode

--- a/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/NonTxInvalidationInterceptor.java
+++ b/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/NonTxInvalidationInterceptor.java
@@ -105,9 +105,6 @@ public class NonTxInvalidationInterceptor extends BaseInvalidationInterceptor {
             invalidateCommand = commandsFactory.buildInvalidateCommand(EnumUtil.EMPTY_BIT_SET, new Object[] {key });
 			}
 			invalidateCommand.setTopologyId(rpcManager.getTopologyId());
-			if (log.isDebugEnabled()) {
-				log.debug("Cache [" + rpcManager.getAddress() + "] replicating " + invalidateCommand);
-			}
 
 			if (isSynchronous(command)) {
 				return rpcManager.invokeCommandOnAll(invalidateCommand, VoidResponseCollector.ignoreLeavers(), syncRpcOptions)

--- a/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/TxInvalidationInterceptor.java
+++ b/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/TxInvalidationInterceptor.java
@@ -14,6 +14,7 @@ import java.util.Set;
 import java.util.concurrent.CompletionStage;
 
 import org.infinispan.commands.TopologyAffectedCommand;
+import org.infinispan.commands.tx.CommitCommand;
 import org.infinispan.hibernate.cache.commons.util.InfinispanMessageLogger;
 
 import org.infinispan.commands.AbstractVisitor;
@@ -62,6 +63,7 @@ public class TxInvalidationInterceptor extends BaseInvalidationInterceptor {
 
    private final InvocationSuccessFunction broadcastClearIfNotLocal = this::broadcastClearIfNotLocal;
    private final InvocationSuccessFunction broadcastInvalidateForPrepare = this::broadcastInvalidateForPrepare;
+   private final InvocationSuccessFunction handleCommit = this::handleCommit;
 
    @Override
 	public Object visitPutKeyValueCommand(InvocationContext ctx, PutKeyValueCommand command) {
@@ -113,8 +115,29 @@ public class TxInvalidationInterceptor extends BaseInvalidationInterceptor {
       return invokeNextThenApply(ctx, command, broadcastInvalidateForPrepare);
 	}
 
+   @Override
+   public Object visitCommitCommand(TxInvocationContext ctx, CommitCommand command) throws Throwable {
+      if (!shouldInvokeRemoteTxCommand(ctx)) {
+         return invokeNext(ctx, command);
+      }
+
+      return invokeNextThenApply(ctx, command, handleCommit);
+   }
+
+   private Object handleCommit(InvocationContext ctx, VisitableCommand command, Object ignored) {
+      try {
+         CompletionStage<Void> remoteInvocation =
+            rpcManager.invokeCommandOnAll(command, VoidResponseCollector.ignoreLeavers(),
+                                          rpcManager.getSyncRpcOptions());
+         return asyncValue(remoteInvocation);
+      } catch (Throwable t) {
+         throw t;
+      }
+   }
+
+
    private Object broadcastInvalidateForPrepare(InvocationContext rCtx, VisitableCommand rCommand, Object rv) throws Throwable {
-      log.tracef( "Entering InvalidationInterceptor's prepare phase.  Ctx flags are empty" );
+      log.tracef("Entering InvalidationInterceptor's prepare phase");
       // fetch the modifications before the transaction is committed (and thus removed from the txTable)
       TxInvocationContext txCtx = (TxInvocationContext) rCtx;
       if ( shouldInvokeRemoteTxCommand( txCtx ) ) {
@@ -123,8 +146,7 @@ public class TxInvalidationInterceptor extends BaseInvalidationInterceptor {
          }
 
          PrepareCommand prepareCmd = (PrepareCommand) rCommand;
-         List<WriteCommand> mods = Arrays.asList( prepareCmd.getModifications() );
-			CompletionStage<Void> completion = broadcastInvalidateForPrepare(mods, txCtx);
+         CompletionStage<Void> completion = broadcastInvalidateForPrepare(prepareCmd, txCtx);
 			if (completion != null) {
 				return asyncValue(completion);
 			} else {
@@ -167,14 +189,17 @@ public class TxInvalidationInterceptor extends BaseInvalidationInterceptor {
 			if (isLocalModeForced( writeCmd )) {
 				return rv;
 			}
-			CompletionStage<Void> completion = invalidateAcrossCluster(isSynchronous(writeCmd), keys, rCtx);
+         CompletionStage<Void> completion =
+            invalidateAcrossCluster(isSynchronous(writeCmd), keys, rCtx, true, rpcManager.getTopologyId());
 			return completion != null ? asyncValue(completion) : rv;
 		} );
 	}
 
-	private CompletionStage<Void> broadcastInvalidateForPrepare(List<WriteCommand> modifications, InvocationContext ctx) throws Throwable {
+   private CompletionStage<Void> broadcastInvalidateForPrepare(PrepareCommand prepareCmd, InvocationContext ctx)
+      throws Throwable {
 		// A prepare does not carry flags, so skip checking whether is local or not
 		if ( ctx.isInTxScope() ) {
+         List<WriteCommand> modifications = Arrays.asList(prepareCmd.getModifications());
 			if ( modifications.isEmpty() ) {
 				return null;
 			}
@@ -183,14 +208,16 @@ public class TxInvalidationInterceptor extends BaseInvalidationInterceptor {
 			filterVisitor.visitCollection( null, modifications );
 
 			if ( filterVisitor.containsPutForExternalRead ) {
-				log.debug( "Modification list contains a putForExternalRead operation.  Not invalidating." );
+            log.trace("Modification list contains a putForExternalRead operation.  Not invalidating.");
 			}
 			else if ( filterVisitor.containsLocalModeFlag ) {
-				log.debug( "Modification list contains a local mode flagged operation.  Not invalidating." );
+            log.trace("Modification list contains a local mode flagged operation.  Not invalidating.");
 			}
 			else {
 				try {
-					CompletionStage<Void> completion = invalidateAcrossCluster(defaultSynchronous, filterVisitor.result.toArray(), ctx);
+               CompletionStage<Void> completion =
+                  invalidateAcrossCluster(defaultSynchronous, filterVisitor.result.toArray(), ctx,
+                                          prepareCmd.isOnePhaseCommit(), prepareCmd.getTopologyId());
 					if (completion != null) {
 						return completion.exceptionally(t -> {
 							log.unableToRollbackInvalidationsDuringPrepare( t );
@@ -249,25 +276,19 @@ public class TxInvalidationInterceptor extends BaseInvalidationInterceptor {
 		}
 	}
 
-	private CompletionStage<Void> invalidateAcrossCluster(boolean synchronous, Object[] keys, InvocationContext ctx) {
+   private CompletionStage<Void> invalidateAcrossCluster(boolean synchronous, Object[] keys, InvocationContext ctx,
+                                                         boolean onePhaseCommit, int topologyId) {
 		// increment invalidations counter if statistics maintained
 		incrementInvalidations();
-		final InvalidateCommand invalidateCommand = commandsFactory.buildInvalidateCommand( EnumUtil.EMPTY_BIT_SET, keys );
-		if ( log.isDebugEnabled() ) {
-			log.debug( "Cache [" + rpcManager.getAddress() + "] replicating " + invalidateCommand );
-		}
 
+      InvalidateCommand invalidateCommand = commandsFactory.buildInvalidateCommand(EnumUtil.EMPTY_BIT_SET, keys);
 		TopologyAffectedCommand command = invalidateCommand;
 		if ( ctx.isInTxScope() ) {
 			TxInvocationContext txCtx = (TxInvocationContext) ctx;
-			// A Prepare command containing the invalidation command in its 'modifications' list is sent to the remote nodes
-			// so that the invalidation is executed in the same transaction and locks can be acquired and released properly.
-			// This is 1PC on purpose, as an optimisation, even if the current TX is 2PC.
-			// If the cache uses 2PC it's possible that the remotes will commit the invalidation and the originator rolls back,
-			// but this does not impact consistency and the speed benefit is worth it.
-			command = commandsFactory.buildPrepareCommand( txCtx.getGlobalTransaction(), Collections.<WriteCommand>singletonList( invalidateCommand ), true );
-		}
-		command.setTopologyId(rpcManager.getTopologyId());
+         command = commandsFactory.buildPrepareCommand(txCtx.getGlobalTransaction(),
+                                                       Collections.singletonList(invalidateCommand), onePhaseCommit);
+      }
+      command.setTopologyId(topologyId);
 		if (synchronous) {
 			return rpcManager.invokeCommandOnAll(command, VoidResponseCollector.ignoreLeavers(), syncRpcOptions);
 		} else {

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/cluster/NaturalIdInvalidationTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/cluster/NaturalIdInvalidationTest.java
@@ -6,6 +6,11 @@
  */
 package org.infinispan.test.hibernate.cache.commons.functional.cluster;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -14,30 +19,29 @@ import java.util.concurrent.TimeUnit;
 import org.hibernate.Criteria;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
+import org.hibernate.criterion.Restrictions;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.infinispan.Cache;
 import org.infinispan.commons.test.categories.Smoke;
 import org.infinispan.hibernate.cache.commons.InfinispanBaseRegion;
 import org.infinispan.hibernate.cache.commons.util.InfinispanMessageLogger;
-import org.hibernate.criterion.Restrictions;
+import org.infinispan.manager.CacheContainer;
+import org.infinispan.notifications.Listener;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryCreated;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryModified;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryRemoved;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryVisited;
+import org.infinispan.notifications.cachelistener.event.CacheEntryEvent;
+import org.infinispan.notifications.cachelistener.event.CacheEntryVisitedEvent;
 import org.infinispan.test.hibernate.cache.commons.functional.entities.Citizen;
 import org.infinispan.test.hibernate.cache.commons.functional.entities.NaturalIdOnManyToOne;
 import org.infinispan.test.hibernate.cache.commons.functional.entities.State;
-import org.infinispan.Cache;
-import org.infinispan.manager.CacheContainer;
-import org.infinispan.notifications.Listener;
-import org.infinispan.notifications.cachelistener.annotation.CacheEntryVisited;
-import org.infinispan.notifications.cachelistener.event.CacheEntryVisitedEvent;
 import org.infinispan.test.hibernate.cache.commons.util.TestSessionAccess;
 import org.jboss.util.collection.ConcurrentSet;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TestName;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * // TODO: Document this
@@ -265,6 +269,13 @@ public class NaturalIdInvalidationTest extends DualNodeTest {
 				visited.add(event.getKey().toString());
 			}
 		}
+
+		@CacheEntryCreated
+      @CacheEntryModified
+      @CacheEntryRemoved
+		public void nodeWritten(CacheEntryEvent event) {
+		   log.debug( event.toString() );
+      }
 	}
 
 }

--- a/hibernate/cache-v51/pom.xml
+++ b/hibernate/cache-v51/pom.xml
@@ -68,6 +68,7 @@
                   <jgroups.udp.enable_bundling>false</jgroups.udp.enable_bundling>
                   <jgroups.bind_addr>localhost</jgroups.bind_addr>
                   <hibernate.cache.infinispan.jgroups_cfg>2lc-test-tcp.xml</hibernate.cache.infinispan.jgroups_cfg>
+                  <infinispan.test.checkThreadLeaks>false</infinispan.test.checkThreadLeaks>
                </systemPropertyVariables>
             </configuration>
             <dependencies>

--- a/hibernate/cache-v53/pom.xml
+++ b/hibernate/cache-v53/pom.xml
@@ -91,6 +91,7 @@
                   <jgroups.udp.enable_bundling>false</jgroups.udp.enable_bundling>
                   <jgroups.bind_addr>localhost</jgroups.bind_addr>
                   <hibernate.cache.infinispan.jgroups_cfg>2lc-test-tcp.xml</hibernate.cache.infinispan.jgroups_cfg>
+                  <infinispan.test.checkThreadLeaks>false</infinispan.test.checkThreadLeaks>
                </systemPropertyVariables>
             </configuration>
             <dependencies>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-10029

The original fix didn't set the topology id in non-txt caches, only in tx caches.

Backport of https://github.com/infinispan/infinispan/pull/6886