### PR TITLE
ISPN-10204 Add 'java.se' module to server integration testsuite

### DIFF
--- a/server/integration/testsuite/pom.xml
+++ b/server/integration/testsuite/pom.xml
@@ -1534,5 +1534,14 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>jigsaw</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <properties>
+                <testjvm.jigsawArgs>--add-modules java.se</testjvm.jigsawArgs>
+            </properties>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-10204

Prevents `ModuleNotFoundException: java.se` when executing the server testsuite. This does not seem to occur on the CI, but always happens on my local machine. Issuing a PR to see what happens on CI with the changes.
