### PR TITLE
[9.4] ISPN-10175 Long test killer doesn't kill the JVM on Windows

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -9,16 +9,16 @@ GOTO :EOF
 
 :CHECK_MVN
 
-IF EXIST %M2_HOME%\bin\mvn.bat GOTO :RUN_MVN
+IF EXIST %M2_HOME%\bin\mvn.cmd GOTO :RUN_MVN
 
-ECHO Cannot find the mvn.bat executable in %M2_HOME%\bin
+ECHO Cannot find the mvn.cmd executable in %M2_HOME%\bin
 GOTO :EOF
 
 :RUN_MVN
 SET GOAL=%1
 IF "%GOAL%"=="" SET GOAL="clean install"
 
-echo Running %M2_HOME%\bin\mvn.bat -s maven-settings.xml %GOAL% %2 %3 %4 %5 %6 %7 %8 %9
+echo Running %M2_HOME%\bin\mvn.cmd -s maven-settings.xml %GOAL% %2 %3 %4 %5 %6 %7 %8 %9
 
-%M2_HOME%\bin\mvn.bat -s maven-settings.xml %GOAL% %2 %3 %4 %5 %6 %7 %8 %9
+%M2_HOME%\bin\mvn.cmd -s maven-settings.xml %GOAL% %2 %3 %4 %5 %6 %7 %8 %9
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-10175

* Remove extra /pid argument from /taskkill
* Add /f argument to force kill
* Log more details when JVM kill fails
* Search for jstack with .exe extension on Windows
* Use mvn.cmd instead of mvn.bat

Backport of #6903 