### PR TITLE
ISPN-10202 SASL refactor to ease Elytron integration

### DIFF
--- a/build-configuration/pom.xml
+++ b/build-configuration/pom.xml
@@ -208,6 +208,7 @@
       <version.org.wildfly>${appserver.version}</version.org.wildfly>
       <version.org.wildfly.arquillian>2.1.1.Final</version.org.wildfly.arquillian>
       <version.org.wildfly.core>6.0.2.Final</version.org.wildfly.core>
+      <version.org.wildfly.elytron>1.8.0.Final</version.org.wildfly.elytron>
       <version.osgi>4.3.1</version.osgi>
       <version.pax.exam>4.11.0</version.pax.exam>
       <version.picketbox>5.0.3.Final</version.picketbox>

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/AbstractAuthenticationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/AbstractAuthenticationTest.java
@@ -36,7 +36,7 @@ public abstract class AbstractAuthenticationTest extends SingleCacheManagerTest 
 
    ConfigurationBuilder initServerAndClient(Map<String, String> mechProperties) {
       hotrodServer = new HotRodServer();
-      HotRodServerConfigurationBuilder serverBuilder = HotRodTestingUtil.getDefaultHotRodConfiguration();
+      HotRodServerConfigurationBuilder serverBuilder = HotRodTestingUtil.getDefaultHotRodConfiguration().defaultCacheName(this.getClass().getSimpleName());
       serverBuilder.authentication()
          .enable()
          .serverName("localhost")

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/AsymmetricRoutingTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/AsymmetricRoutingTest.java
@@ -4,6 +4,7 @@ import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killRemo
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
 import static org.infinispan.distribution.DistributionTestHelper.isFirstOwner;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodClusteredGlobalConfiguration;
 import static org.infinispan.test.TestingUtil.blockUntilCacheStatusAchieved;
 import static org.infinispan.test.TestingUtil.blockUntilViewReceived;
 import static org.testng.AssertJUnit.assertEquals;
@@ -79,7 +80,7 @@ public class AsymmetricRoutingTest extends HitsAwareCacheManagersTest {
    }
 
    private HotRodServer addHotRodServer() {
-      EmbeddedCacheManager cm = addClusterEnabledCacheManager(defaultBuilder);
+      EmbeddedCacheManager cm = addClusterEnabledCacheManager(hotRodClusteredGlobalConfiguration(this.getClass()), defaultBuilder);
       cm.defineConfiguration(DIST_ONE_CACHE_NAME, distOneBuilder.build());
       cm.defineConfiguration(DIST_TWO_CACHE_NAME, distTwoBuilder.build());
       HotRodServer server = HotRodClientTestingUtil.startHotRodServer(cm);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/AuthenticationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/AuthenticationTest.java
@@ -1,6 +1,7 @@
 package org.infinispan.client.hotrod;
 
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
 import static org.testng.AssertJUnit.assertEquals;
 
 import java.util.Collections;
@@ -31,7 +32,7 @@ public class AuthenticationTest extends AbstractAuthenticationTest {
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
-      cacheManager = TestCacheManagerFactory.createCacheManager(hotRodCacheConfiguration());
+      cacheManager = TestCacheManagerFactory.createCacheManager(hotRodGlobalConfiguration(this.getClass()), hotRodCacheConfiguration());
       cacheManager.getCache();
 
       return cacheManager;

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/BaseGetAllTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/BaseGetAllTest.java
@@ -3,6 +3,7 @@ package org.infinispan.client.hotrod;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killRemoteCacheManager;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodClusteredGlobalConfiguration;
 import static org.testng.AssertJUnit.assertEquals;
 
 import java.util.HashMap;
@@ -42,7 +43,7 @@ public abstract class BaseGetAllTest extends MultipleCacheManagersTest {
       final int numServers = numberOfHotRodServers();
       hotrodServers = new HotRodServer[numServers];
 
-      createCluster(hotRodCacheConfiguration(clusterConfig()), numberOfHotRodServers());
+      createCluster(hotRodClusteredGlobalConfiguration(this.getClass()), hotRodCacheConfiguration(clusterConfig()), numberOfHotRodServers());
 
       for (int i = 0; i < numServers; i++) {
          EmbeddedCacheManager cm = cacheManagers.get(i);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/BulkOperationsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/BulkOperationsTest.java
@@ -3,6 +3,7 @@ package org.infinispan.client.hotrod;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killRemoteCacheManager;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodClusteredGlobalConfiguration;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertNotNull;
@@ -125,7 +126,7 @@ public class BulkOperationsTest extends MultipleCacheManagersTest {
       final int numServers = numberOfHotRodServers();
       hotrodServers = new HotRodServer[numServers];
 
-      createCluster(hotRodCacheConfiguration(clusterConfig()), numberOfHotRodServers());
+      createCluster(hotRodClusteredGlobalConfiguration(this.getClass()), hotRodCacheConfiguration(clusterConfig()), numberOfHotRodServers());
 
       timeService = new ControlledTimeService();
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/CSAIntegrationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/CSAIntegrationTest.java
@@ -4,6 +4,7 @@ import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killRemo
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.assertHotRodEquals;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodClusteredGlobalConfiguration;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.marshall;
 import static org.infinispan.test.TestingUtil.blockUntilCacheStatusAchieved;
 import static org.infinispan.test.TestingUtil.blockUntilViewReceived;
@@ -65,9 +66,9 @@ public class CSAIntegrationTest extends HitsAwareCacheManagersTest {
             getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false));
       builder.clustering().hash().numOwners(1);
       builder.unsafe().unreliableReturnValues(true);
-      addClusterEnabledCacheManager(builder);
-      addClusterEnabledCacheManager(builder);
-      addClusterEnabledCacheManager(builder);
+      addClusterEnabledCacheManager(hotRodClusteredGlobalConfiguration(this.getClass()), builder);
+      addClusterEnabledCacheManager(hotRodClusteredGlobalConfiguration(this.getClass()), builder);
+      addClusterEnabledCacheManager(hotRodClusteredGlobalConfiguration(this.getClass()), builder);
 
       hotRodServer1 = HotRodClientTestingUtil.startHotRodServer(manager(0));
       addr2hrServer.put(InetSocketAddress.createUnresolved(hotRodServer1.getHost(), hotRodServer1.getPort()), hotRodServer1);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/CacheContainerTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/CacheContainerTest.java
@@ -3,6 +3,7 @@ package org.infinispan.client.hotrod;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killRemoteCacheManager;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
 import static org.infinispan.test.TestingUtil.killCacheManagers;
 
 import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
@@ -28,7 +29,7 @@ public class CacheContainerTest extends SingleCacheManagerTest {
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
-      cacheManager = TestCacheManagerFactory.createCacheManager(
+      cacheManager = TestCacheManagerFactory.createCacheManager(hotRodGlobalConfiguration(this.getClass()),
             hotRodCacheConfiguration());
       cacheManager.defineConfiguration(CACHE_NAME, hotRodCacheConfiguration().build());
       hotrodServer = HotRodClientTestingUtil.startHotRodServer(cacheManager);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/CacheManagerNotStartedTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/CacheManagerNotStartedTest.java
@@ -3,6 +3,7 @@ package org.infinispan.client.hotrod;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killRemoteCacheManager;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
 
 import java.util.HashMap;
 
@@ -31,7 +32,7 @@ public class CacheManagerNotStartedTest extends SingleCacheManagerTest {
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       cacheManager = TestCacheManagerFactory
-            .createCacheManager(hotRodCacheConfiguration());
+            .createCacheManager(hotRodGlobalConfiguration(this.getClass()), hotRodCacheConfiguration());
       cacheManager.defineConfiguration(CACHE_NAME, hotRodCacheConfiguration().build());
       return cacheManager;
    }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/CacheManagerStoppedTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/CacheManagerStoppedTest.java
@@ -3,6 +3,7 @@ package org.infinispan.client.hotrod;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killRemoteCacheManager;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
 import static org.infinispan.test.TestingUtil.killCacheManagers;
 
 import java.util.HashMap;
@@ -31,7 +32,7 @@ public class CacheManagerStoppedTest extends SingleCacheManagerTest {
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
-      cacheManager = TestCacheManagerFactory.createCacheManager(hotRodCacheConfiguration());
+      cacheManager = TestCacheManagerFactory.createCacheManager(hotRodGlobalConfiguration(this.getClass()), hotRodCacheConfiguration());
       cacheManager.defineConfiguration(CACHE_NAME, hotRodCacheConfiguration().build());
       cacheManager.getCache(CACHE_NAME);
       hotrodServer = HotRodClientTestingUtil.startHotRodServer(cacheManager);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ClientSocketReadTimeoutTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ClientSocketReadTimeoutTest.java
@@ -3,6 +3,7 @@ package org.infinispan.client.hotrod;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killRemoteCacheManager;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
 import static org.infinispan.test.TestingUtil.k;
 import static org.infinispan.test.TestingUtil.v;
 
@@ -41,7 +42,7 @@ public class ClientSocketReadTimeoutTest extends SingleCacheManagerTest {
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       barrier = new CyclicBarrier(2);
-      cacheManager = TestCacheManagerFactory.createCacheManager(hotRodCacheConfiguration());
+      cacheManager = TestCacheManagerFactory.createCacheManager(hotRodGlobalConfiguration(this.getClass()), hotRodCacheConfiguration());
       BlockingInterceptor<PutKeyValueCommand> blockingInterceptor =
          new BlockingInterceptor<>(barrier, PutKeyValueCommand.class, true, true);
       cacheManager.getCache().getAdvancedCache().getAsyncInterceptorChain()

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ConsistentHashV2IntegrationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ConsistentHashV2IntegrationTest.java
@@ -2,6 +2,7 @@ package org.infinispan.client.hotrod;
 
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodClusteredGlobalConfiguration;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertTrue;
 
@@ -47,10 +48,10 @@ public class ConsistentHashV2IntegrationTest extends MultipleCacheManagersTest {
    protected void createCacheManagers() throws Throwable {
       ConfigurationBuilder builder = buildConfiguration();
 
-      addClusterEnabledCacheManager(builder);
-      addClusterEnabledCacheManager(builder);
-      addClusterEnabledCacheManager(builder);
-      addClusterEnabledCacheManager(builder);
+      addClusterEnabledCacheManager(hotRodClusteredGlobalConfiguration(this.getClass()), builder);
+      addClusterEnabledCacheManager(hotRodClusteredGlobalConfiguration(this.getClass()), builder);
+      addClusterEnabledCacheManager(hotRodClusteredGlobalConfiguration(this.getClass()), builder);
+      addClusterEnabledCacheManager(hotRodClusteredGlobalConfiguration(this.getClass()), builder);
 
       hotRodServer1 = HotRodClientTestingUtil.startHotRodServer(manager(0));
       hotRodServer2 = HotRodClientTestingUtil.startHotRodServer(manager(1));
@@ -138,7 +139,7 @@ public class ConsistentHashV2IntegrationTest extends MultipleCacheManagersTest {
 
       final int topologyIdBeforeJoin = channelFactory.getTopologyId(new byte[]{});
       log.tracef("Starting test with client topology id %d", topologyIdBeforeJoin);
-      EmbeddedCacheManager cm5 = addClusterEnabledCacheManager(buildConfiguration());
+      EmbeddedCacheManager cm5 = addClusterEnabledCacheManager(hotRodClusteredGlobalConfiguration(this.getClass()), buildConfiguration());
       HotRodServer hotRodServer5 = HotRodClientTestingUtil.startHotRodServer(cm5);
 
       // Rebalancing to include the joiner will increment the topology id by 2

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/DefaultExpirationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/DefaultExpirationTest.java
@@ -2,6 +2,7 @@ package org.infinispan.client.hotrod;
 
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.assertHotRodEquals;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertTrue;
@@ -33,7 +34,7 @@ public class DefaultExpirationTest extends SingleCacheManagerTest {
       ConfigurationBuilder builder = hotRodCacheConfiguration(
             getDefaultStandaloneCacheConfig(false));
       builder.expiration().lifespan(3, TimeUnit.SECONDS).maxIdle(2, TimeUnit.SECONDS);
-      return TestCacheManagerFactory.createCacheManager(builder);
+      return TestCacheManagerFactory.createCacheManager(hotRodGlobalConfiguration(this.getClass()), builder);
    }
 
    @Override

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/DroppedConnectionsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/DroppedConnectionsTest.java
@@ -1,6 +1,7 @@
 package org.infinispan.client.hotrod;
 
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNotSame;
 
@@ -33,7 +34,7 @@ public class DroppedConnectionsTest extends SingleCacheManagerTest {
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
-      cacheManager = TestCacheManagerFactory.createCacheManager(
+      cacheManager = TestCacheManagerFactory.createCacheManager(hotRodGlobalConfiguration(this.getClass()),
             hotRodCacheConfiguration(getDefaultStandaloneCacheConfig(false)));
       hotRodServer = HotRodClientTestingUtil.startHotRodServer(cacheManager);
 
@@ -48,7 +49,7 @@ public class DroppedConnectionsTest extends SingleCacheManagerTest {
 
       remoteCacheManager = new InternalRemoteCacheManager(clientBuilder.build());
       rc = remoteCacheManager.getCache();
-      channelFactory = ((InternalRemoteCacheManager) remoteCacheManager).getChannelFactory();
+      channelFactory = remoteCacheManager.getChannelFactory();
       return cacheManager;
    }
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ForceReturnValuesIdentityTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ForceReturnValuesIdentityTest.java
@@ -10,6 +10,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertNotSame;
@@ -25,7 +26,7 @@ public class ForceReturnValuesIdentityTest extends SingleCacheManagerTest {
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
-      cacheManager = TestCacheManagerFactory.createCacheManager(hotRodCacheConfiguration());
+      cacheManager = TestCacheManagerFactory.createCacheManager(hotRodGlobalConfiguration(this.getClass()), hotRodCacheConfiguration());
       cache = cacheManager.getCache();
 
       hotRodServer = HotRodClientTestingUtil.startHotRodServer(cacheManager);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ForceReturnValuesTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ForceReturnValuesTest.java
@@ -9,6 +9,7 @@ import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
 
 @Test(testName = "client.hotrod.ForceReturnValuesTest", groups = "functional")
 @CleanupAfterMethod
@@ -18,7 +19,7 @@ public class ForceReturnValuesTest extends SingleCacheManagerTest {
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
-      cacheManager = TestCacheManagerFactory.createCacheManager(hotRodCacheConfiguration());
+      cacheManager = TestCacheManagerFactory.createCacheManager(hotRodGlobalConfiguration(this.getClass()), hotRodCacheConfiguration());
       cache = cacheManager.getCache();
 
       hotRodServer = HotRodClientTestingUtil.startHotRodServer(cacheManager);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HeavyLoadConnectionPoolingTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HeavyLoadConnectionPoolingTest.java
@@ -3,6 +3,7 @@ package org.infinispan.client.hotrod;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killRemoteCacheManager;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -41,7 +42,7 @@ public class HeavyLoadConnectionPoolingTest extends SingleCacheManagerTest {
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
-      cacheManager = TestCacheManagerFactory.createCacheManager(hotRodCacheConfiguration());
+      cacheManager = TestCacheManagerFactory.createCacheManager(hotRodGlobalConfiguration(this.getClass()), hotRodCacheConfiguration());
       cache = cacheManager.getCache();
 
       // make sure all operations take at least 100 msecs

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HitsAwareCacheManagersTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HitsAwareCacheManagersTest.java
@@ -1,6 +1,7 @@
 package org.infinispan.client.hotrod;
 
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodClusteredGlobalConfiguration;
 import static org.infinispan.test.TestingUtil.blockUntilCacheStatusAchieved;
 import static org.infinispan.test.TestingUtil.blockUntilViewReceived;
 import static org.infinispan.test.TestingUtil.killCacheManagers;
@@ -82,7 +83,7 @@ public abstract class HitsAwareCacheManagersTest extends MultipleCacheManagersTe
    }
 
    protected HotRodServer addHotRodServer(ConfigurationBuilder builder) {
-      EmbeddedCacheManager cm = addClusterEnabledCacheManager(builder);
+      EmbeddedCacheManager cm = addClusterEnabledCacheManager(hotRodClusteredGlobalConfiguration(this.getClass()), builder);
       HotRodServer server = HotRodClientTestingUtil.startHotRodServer(cm);
       InetSocketAddress addr = new InetSocketAddress(server.getHost(), server.getPort());
       addr2hrServer.put(addr, server);
@@ -90,7 +91,7 @@ public abstract class HitsAwareCacheManagersTest extends MultipleCacheManagersTe
    }
 
    protected HotRodServer addHotRodServer(ConfigurationBuilder builder, int port) {
-      EmbeddedCacheManager cm = addClusterEnabledCacheManager(builder);
+      EmbeddedCacheManager cm = addClusterEnabledCacheManager(hotRodClusteredGlobalConfiguration(this.getClass()), builder);
       HotRodServer server = HotRodTestingUtil.startHotRodServer(
          cm, port, new HotRodServerConfigurationBuilder());
       InetSocketAddress addr = new InetSocketAddress(server.getHost(), server.getPort());

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HotRodClientJmxTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HotRodClientJmxTest.java
@@ -5,6 +5,7 @@ import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServ
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.remoteCacheManagerObjectName;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.remoteCacheObjectName;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNull;
 
@@ -46,7 +47,7 @@ public class HotRodClientJmxTest extends AbstractInfinispanTest {
       ConfigurationBuilder cfg = hotRodCacheConfiguration();
       cfg.jmxStatistics().enable();
       cacheContainer = TestCacheManagerFactory
-            .createClusteredCacheManagerEnforceJmxDomain(getClass().getSimpleName(), cfg);
+            .createClusteredCacheManagerEnforceJmxDomain(getClass().getSimpleName(), hotRodGlobalConfiguration(this.getClass()), cfg);
 
       hotrodServer = HotRodClientTestingUtil.startHotRodServer((EmbeddedCacheManager) cacheContainer);
       startTime = System.currentTimeMillis();

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HotRodClientNearCacheJmxTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HotRodClientNearCacheJmxTest.java
@@ -4,6 +4,7 @@ import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killRemo
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.remoteCacheObjectName;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
 import static org.testng.AssertJUnit.assertEquals;
 
 import java.lang.invoke.MethodHandles;
@@ -37,7 +38,7 @@ public class HotRodClientNearCacheJmxTest extends AbstractInfinispanTest {
       ConfigurationBuilder cfg = hotRodCacheConfiguration();
       cfg.jmxStatistics().enable();
       cacheContainer = TestCacheManagerFactory
-            .createClusteredCacheManagerEnforceJmxDomain(getClass().getSimpleName(), cfg);
+            .createClusteredCacheManagerEnforceJmxDomain(getClass().getSimpleName(), hotRodGlobalConfiguration(this.getClass()), cfg);
 
       hotrodServer = HotRodClientTestingUtil.startHotRodServer((EmbeddedCacheManager) cacheContainer);
       rcms = new RemoteCacheManager[2];

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HotRodIntegrationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HotRodIntegrationTest.java
@@ -2,6 +2,7 @@ package org.infinispan.client.hotrod;
 
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.assertHotRodEquals;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
 import static org.infinispan.test.TestingUtil.k;
 import static org.infinispan.test.TestingUtil.v;
 import static org.testng.AssertJUnit.assertEquals;
@@ -51,7 +52,7 @@ public class HotRodIntegrationTest extends SingleCacheManagerTest {
       ConfigurationBuilder builder = hotRodCacheConfiguration(
             getDefaultStandaloneCacheConfig(false));
       EmbeddedCacheManager cm = TestCacheManagerFactory
-            .createCacheManager(hotRodCacheConfiguration());
+            .createCacheManager(hotRodGlobalConfiguration(this.getClass()), hotRodCacheConfiguration());
       cm.defineConfiguration(CACHE_NAME, builder.build());
       cm.getCache(CACHE_NAME);
       return cm;

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HotRodServerStartStopTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HotRodServerStartStopTest.java
@@ -3,6 +3,7 @@ package org.infinispan.client.hotrod;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killRemoteCacheManager;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodClusteredGlobalConfiguration;
 import static org.testng.AssertJUnit.assertEquals;
 
 import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
@@ -31,8 +32,8 @@ public class HotRodServerStartStopTest extends MultipleCacheManagersTest {
    protected void createCacheManagers() throws Throwable {
       ConfigurationBuilder builder = hotRodCacheConfiguration(
             getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false));
-      addClusterEnabledCacheManager(builder);
-      addClusterEnabledCacheManager(builder);
+      addClusterEnabledCacheManager(hotRodClusteredGlobalConfiguration(this.getClass()), builder);
+      addClusterEnabledCacheManager(hotRodClusteredGlobalConfiguration(this.getClass()), builder);
 
       hotRodServer1 = HotRodClientTestingUtil.startHotRodServer(manager(0));
       hotRodServer2 = HotRodClientTestingUtil.startHotRodServer(manager(1));

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HotRodStatisticsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HotRodStatisticsTest.java
@@ -3,6 +3,7 @@ package org.infinispan.client.hotrod;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killRemoteCacheManager;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodClusteredGlobalConfiguration;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertTrue;
@@ -39,7 +40,7 @@ public class HotRodStatisticsTest extends AbstractInfinispanTest {
       ConfigurationBuilder cfg = hotRodCacheConfiguration();
       cfg.jmxStatistics().enable();
       cacheContainer = TestCacheManagerFactory
-            .createClusteredCacheManagerEnforceJmxDomain(getClass().getSimpleName(), cfg);
+            .createClusteredCacheManagerEnforceJmxDomain(getClass().getSimpleName(), hotRodClusteredGlobalConfiguration(this.getClass()), cfg);
 
       hotrodServer = HotRodClientTestingUtil.startHotRodServer((EmbeddedCacheManager) cacheContainer);
       startTime = System.currentTimeMillis();

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/LockingTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/LockingTest.java
@@ -3,6 +3,7 @@ package org.infinispan.client.hotrod;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killRemoteCacheManager;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
 import static org.infinispan.test.TestingUtil.orTimeout;
 
 import java.util.concurrent.Callable;
@@ -57,7 +58,7 @@ public class LockingTest extends SingleCacheManagerTest {
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       ConfigurationBuilder builder = hotRodCacheConfiguration();
       builder.locking().lockAcquisitionTimeout(100, TimeUnit.MILLISECONDS);
-      EmbeddedCacheManager cacheManager = TestCacheManagerFactory.createCacheManager(builder);
+      EmbeddedCacheManager cacheManager = TestCacheManagerFactory.createCacheManager(hotRodGlobalConfiguration(this.getClass()), builder);
       for (CacheName cacheName : CacheName.values()) {
          cacheName.configure(builder);
          cacheManager.defineConfiguration(cacheName.name(), builder.build());

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/MillisecondExpirationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/MillisecondExpirationTest.java
@@ -1,6 +1,7 @@
 package org.infinispan.client.hotrod;
 
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
 import static org.testng.AssertJUnit.assertFalse;
 
 import java.util.concurrent.TimeUnit;
@@ -21,7 +22,7 @@ public class MillisecondExpirationTest extends DefaultExpirationTest {
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       ConfigurationBuilder builder = hotRodCacheConfiguration(
             getDefaultStandaloneCacheConfig(false));
-      return TestCacheManagerFactory.createCacheManager(builder);
+      return TestCacheManagerFactory.createCacheManager(hotRodGlobalConfiguration(this.getClass()), builder);
    }
 
    @Test

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/MultipleCacheTopologyChangeTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/MultipleCacheTopologyChangeTest.java
@@ -4,6 +4,7 @@ import static java.util.Arrays.stream;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.startHotRodServer;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodClusteredGlobalConfiguration;
 import static org.infinispan.test.TestingUtil.killCacheManagers;
 import static org.infinispan.test.fwk.TestCacheManagerFactory.createClusteredCacheManager;
 import static org.testng.AssertJUnit.assertTrue;
@@ -84,7 +85,7 @@ public class MultipleCacheTopologyChangeTest extends MultipleCacheManagersTest {
       }
 
       public void start() {
-         cacheManager = createClusteredCacheManager(hotRodCacheConfiguration(getConfigurationBuilder()));
+         cacheManager = createClusteredCacheManager(hotRodClusteredGlobalConfiguration(this.getClass()), hotRodCacheConfiguration(getConfigurationBuilder()));
          registerCacheManager(cacheManager);
          stream(cacheNames).forEach(cacheName -> {
             cacheManager.defineConfiguration(cacheName, getConfigurationBuilder().build());

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/RemoteCacheManagerExtendedTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/RemoteCacheManagerExtendedTest.java
@@ -1,6 +1,7 @@
 package org.infinispan.client.hotrod;
 
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
 import static org.testng.AssertJUnit.assertTrue;
 
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
@@ -30,7 +31,7 @@ public class RemoteCacheManagerExtendedTest extends SingleCacheManagerTest {
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
-      return TestCacheManagerFactory.createCacheManager(hotRodCacheConfiguration());
+      return TestCacheManagerFactory.createCacheManager(hotRodGlobalConfiguration(this.getClass()), hotRodCacheConfiguration());
    }
 
    @Override

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/RemoteCacheManagerTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/RemoteCacheManagerTest.java
@@ -1,6 +1,7 @@
 package org.infinispan.client.hotrod;
 
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertTrue;
 
@@ -26,7 +27,7 @@ public class RemoteCacheManagerTest extends SingleCacheManagerTest {
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
-      return TestCacheManagerFactory.createCacheManager(hotRodCacheConfiguration());
+      return TestCacheManagerFactory.createCacheManager(hotRodGlobalConfiguration(this.getClass()), hotRodCacheConfiguration());
    }
 
    @Override

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ReplTopologyChangeTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ReplTopologyChangeTest.java
@@ -3,6 +3,7 @@ package org.infinispan.client.hotrod;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killRemoteCacheManager;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodClusteredGlobalConfiguration;
 import static org.testng.AssertJUnit.assertEquals;
 
 import java.net.InetSocketAddress;
@@ -57,8 +58,8 @@ public class ReplTopologyChangeTest extends MultipleCacheManagersTest {
    @Override
    protected void createCacheManagers() throws Throwable {
       config = hotRodCacheConfiguration(getDefaultClusteredCacheConfig(getCacheMode(), false));
-      CacheContainer cm1 = TestCacheManagerFactory.createClusteredCacheManager(config);
-      CacheContainer cm2 = TestCacheManagerFactory.createClusteredCacheManager(config);
+      CacheContainer cm1 = TestCacheManagerFactory.createClusteredCacheManager(hotRodClusteredGlobalConfiguration(this.getClass()), config);
+      CacheContainer cm2 = TestCacheManagerFactory.createClusteredCacheManager(hotRodClusteredGlobalConfiguration(this.getClass()), config);
       registerCacheManager(cm1);
       registerCacheManager(cm2);
       waitForClusterToForm();
@@ -93,7 +94,7 @@ public class ReplTopologyChangeTest extends MultipleCacheManagersTest {
 
    @Test(dependsOnMethods = "testTwoMembers")
    public void testAddNewServer() {
-      CacheContainer cm3 = TestCacheManagerFactory.createClusteredCacheManager(config);
+      CacheContainer cm3 = TestCacheManagerFactory.createClusteredCacheManager(hotRodClusteredGlobalConfiguration(this.getClass()), config);
       registerCacheManager(cm3);
       hotRodServer3 = HotRodClientTestingUtil.startHotRodServer(manager(2));
       manager(2).getCache();

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/RoundRobinBalancingIntegrationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/RoundRobinBalancingIntegrationTest.java
@@ -3,6 +3,7 @@ package org.infinispan.client.hotrod;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killRemoteCacheManager;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
 import static org.testng.AssertJUnit.assertEquals;
 
 import java.net.InetSocketAddress;
@@ -50,9 +51,9 @@ public class RoundRobinBalancingIntegrationTest extends MultipleCacheManagersTes
 
    @Override
    protected void createCacheManagers() throws Throwable {
-      c1 = TestCacheManagerFactory.createCacheManager(hotRodCacheConfiguration()).getCache();
-      c2 = TestCacheManagerFactory.createCacheManager(hotRodCacheConfiguration()).getCache();
-      c3 = TestCacheManagerFactory.createCacheManager(hotRodCacheConfiguration()).getCache();
+      c1 = TestCacheManagerFactory.createCacheManager(hotRodGlobalConfiguration(this.getClass()), hotRodCacheConfiguration()).getCache();
+      c2 = TestCacheManagerFactory.createCacheManager(hotRodGlobalConfiguration(this.getClass()), hotRodCacheConfiguration()).getCache();
+      c3 = TestCacheManagerFactory.createCacheManager(hotRodGlobalConfiguration(this.getClass()), hotRodCacheConfiguration()).getCache();
       registerCacheManager(c1.getCacheManager(), c2.getCacheManager(), c3.getCacheManager());
 
       hotRodServer1 = HotRodClientTestingUtil.startHotRodServer(c1.getCacheManager());
@@ -104,7 +105,7 @@ public class RoundRobinBalancingIntegrationTest extends MultipleCacheManagersTes
 
    @Test(dependsOnMethods = "testRoundRobinLoadBalancing")
    public void testAddNewHotrodServer() {
-      c4 = TestCacheManagerFactory.createCacheManager(
+      c4 = TestCacheManagerFactory.createCacheManager(hotRodGlobalConfiguration(this.getClass()),
             hotRodCacheConfiguration()).getCache();
       hotRodServer4 = HotRodClientTestingUtil.startHotRodServer(c4.getCacheManager());
       registerCacheManager(c4.getCacheManager());
@@ -218,7 +219,7 @@ public class RoundRobinBalancingIntegrationTest extends MultipleCacheManagersTes
    }
 
    private RoundRobinBalancingStrategy getBalancer() {
-      ChannelFactory channelFactory = ((InternalRemoteCacheManager) remoteCacheManager).getChannelFactory();
+      ChannelFactory channelFactory = remoteCacheManager.getChannelFactory();
       return (RoundRobinBalancingStrategy) channelFactory.getBalancer(HotRodConstants.DEFAULT_CACHE_NAME_BYTES);
    }
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/SecureExecTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/SecureExecTest.java
@@ -44,6 +44,7 @@ public class SecureExecTest extends AbstractAuthenticationTest {
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       GlobalConfigurationBuilder global = new GlobalConfigurationBuilder();
+      global.defaultCacheName(this.getClass().getSimpleName());
       GlobalAuthorizationConfigurationBuilder globalRoles = global.security().authorization().enable().principalRoleMapper(new IdentityRoleMapper());
       globalRoles
             .role("admin")

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ServerErrorTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ServerErrorTest.java
@@ -3,12 +3,12 @@ package org.infinispan.client.hotrod;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killRemoteCacheManager;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.unmarshall;
 import static org.infinispan.test.TestingUtil.k;
 import static org.infinispan.test.TestingUtil.v;
 
 import java.lang.reflect.Method;
-import java.util.Properties;
 
 import org.infinispan.client.hotrod.exceptions.HotRodClientException;
 import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
@@ -39,7 +39,7 @@ public class ServerErrorTest extends SingleCacheManagerTest {
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       cacheManager = TestCacheManagerFactory
-            .createCacheManager(hotRodCacheConfiguration());
+            .createCacheManager(hotRodGlobalConfiguration(this.getClass()), hotRodCacheConfiguration());
       hotrodServer = HotRodClientTestingUtil.startHotRodServer(cacheManager);
 
       remoteCacheManager = getRemoteCacheManager();
@@ -49,7 +49,6 @@ public class ServerErrorTest extends SingleCacheManagerTest {
    }
 
    protected RemoteCacheManager getRemoteCacheManager() {
-      Properties config = new Properties();
       org.infinispan.client.hotrod.configuration.ConfigurationBuilder clientBuilder =
             HotRodClientTestingUtil.newRemoteConfigurationBuilder();
       clientBuilder.addServer().host("localhost").port(hotrodServer.getPort());

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ServerRestartTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ServerRestartTest.java
@@ -3,6 +3,7 @@ package org.infinispan.client.hotrod;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killRemoteCacheManager;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
 
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
 import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
@@ -32,7 +33,7 @@ public class ServerRestartTest extends SingleCacheManagerTest {
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
-      return TestCacheManagerFactory.createCacheManager(
+      return TestCacheManagerFactory.createCacheManager(hotRodGlobalConfiguration(this.getClass()),
             hotRodCacheConfiguration());
    }
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ServerShutdownTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ServerShutdownTest.java
@@ -3,6 +3,7 @@ package org.infinispan.client.hotrod;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.withRemoteCacheManager;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
 import static org.infinispan.test.TestingUtil.withCacheManager;
 import static org.testng.AssertJUnit.assertEquals;
 
@@ -24,6 +25,7 @@ public class ServerShutdownTest extends AbstractInfinispanTest {
    public void testServerShutdownWithConnectedClient() {
       withCacheManager(new CacheManagerCallable(
             TestCacheManagerFactory.createCacheManager(
+                  hotRodGlobalConfiguration(this.getClass()),
                   hotRodCacheConfiguration())) {
          @Override
          public void call() {
@@ -51,6 +53,7 @@ public class ServerShutdownTest extends AbstractInfinispanTest {
    public void testServerShutdownWithoutConnectedClient() {
       withCacheManager(new CacheManagerCallable(
             TestCacheManagerFactory.createCacheManager(
+                  hotRodGlobalConfiguration(this.getClass()),
                   hotRodCacheConfiguration())) {
          @Override
          public void call() {

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/SkipCacheLoadFlagTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/SkipCacheLoadFlagTest.java
@@ -3,6 +3,7 @@ package org.infinispan.client.hotrod;
 import static org.infinispan.client.hotrod.Flag.FORCE_RETURN_VALUE;
 import static org.infinispan.client.hotrod.Flag.SKIP_CACHE_LOAD;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -87,7 +88,7 @@ public class SkipCacheLoadFlagTest extends SingleCacheManagerTest {
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
-      cacheManager = TestCacheManagerFactory.createCacheManager(hotRodCacheConfiguration());
+      cacheManager = TestCacheManagerFactory.createCacheManager(hotRodGlobalConfiguration(this.getClass()), hotRodCacheConfiguration());
       cache = cacheManager.getCache();
 
       hotRodServer = HotRodClientTestingUtil.startHotRodServer(cacheManager);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/SkipIndexingFlagTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/SkipIndexingFlagTest.java
@@ -3,6 +3,7 @@ package org.infinispan.client.hotrod;
 import static org.infinispan.client.hotrod.Flag.FORCE_RETURN_VALUE;
 import static org.infinispan.client.hotrod.Flag.SKIP_INDEXING;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -89,7 +90,7 @@ public class SkipIndexingFlagTest extends SingleCacheManagerTest {
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
-      cacheManager = TestCacheManagerFactory.createCacheManager(hotRodCacheConfiguration());
+      cacheManager = TestCacheManagerFactory.createCacheManager(hotRodGlobalConfiguration(this.getClass()), hotRodCacheConfiguration());
       cache = cacheManager.getCache();
 
       hotRodServer = HotRodClientTestingUtil.startHotRodServer(cacheManager);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/SocketTimeoutErrorTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/SocketTimeoutErrorTest.java
@@ -1,6 +1,7 @@
 package org.infinispan.client.hotrod;
 
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
 import static org.infinispan.test.TestingUtil.k;
 import static org.testng.AssertJUnit.assertEquals;
 
@@ -42,7 +43,7 @@ public class SocketTimeoutErrorTest extends SingleHotRodServerTest {
       ConfigurationBuilder builder = new ConfigurationBuilder();
       builder.customInterceptors().addInterceptor().interceptor(
             new TimeoutInducingInterceptor()).after(EntryWrappingInterceptor.class);
-      return TestCacheManagerFactory.createCacheManager(hotRodCacheConfiguration(builder));
+      return TestCacheManagerFactory.createCacheManager(hotRodGlobalConfiguration(this.getClass()), hotRodCacheConfiguration(builder));
    }
 
    @Override

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/SslAuthenticationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/SslAuthenticationTest.java
@@ -1,6 +1,7 @@
 package org.infinispan.client.hotrod;
 
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
 import static org.testng.AssertJUnit.assertEquals;
 
 import java.security.PrivilegedAction;
@@ -46,8 +47,8 @@ public class SslAuthenticationTest extends SingleCacheManagerTest {
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
-      GlobalConfigurationBuilder global = new GlobalConfigurationBuilder();
-      global
+      GlobalConfigurationBuilder global = hotRodGlobalConfiguration(this.getClass());
+            global
          .security()
             .authorization()
                .enable()

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/SslTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/SslTest.java
@@ -1,6 +1,7 @@
 package org.infinispan.client.hotrod;
 
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
 import static org.testng.AssertJUnit.assertEquals;
 
 import java.io.IOException;
@@ -42,7 +43,7 @@ public class SslTest extends SingleCacheManagerTest {
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
-      cacheManager = TestCacheManagerFactory.createCacheManager(hotRodCacheConfiguration());
+      cacheManager = TestCacheManagerFactory.createCacheManager(hotRodGlobalConfiguration(this.getClass()), hotRodCacheConfiguration());
       cacheManager.getCache();
 
       return cacheManager;

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/StreamingOpsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/StreamingOpsTest.java
@@ -1,6 +1,7 @@
 package org.infinispan.client.hotrod;
 
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertNull;
@@ -46,7 +47,7 @@ public class StreamingOpsTest extends SingleCacheManagerTest {
       ConfigurationBuilder builder = hotRodCacheConfiguration(
             getDefaultStandaloneCacheConfig(false));
       EmbeddedCacheManager cm = TestCacheManagerFactory
-            .createCacheManager(hotRodCacheConfiguration());
+            .createCacheManager(hotRodGlobalConfiguration(this.getClass()), hotRodCacheConfiguration());
       cm.defineConfiguration(CACHE_NAME, builder.build());
       cm.getCache(CACHE_NAME);
       return cm;

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientClusterEventsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientClusterEventsTest.java
@@ -2,6 +2,7 @@ package org.infinispan.client.hotrod.event;
 
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.withClientListener;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodClusteredGlobalConfiguration;
 
 import org.infinispan.client.hotrod.event.CustomEventLogListener.CustomEvent;
 import org.infinispan.client.hotrod.event.CustomEventLogListener.FilterConverterFactory;
@@ -36,7 +37,7 @@ public class ClientClusterEventsTest extends MultiHotRodServersTest {
    }
 
    protected HotRodServer addHotRodServer(ConfigurationBuilder builder) {
-      EmbeddedCacheManager cm = addClusterEnabledCacheManager(builder);
+      EmbeddedCacheManager cm = addClusterEnabledCacheManager(hotRodClusteredGlobalConfiguration(this.getClass()), builder);
       HotRodServerConfigurationBuilder serverBuilder = new HotRodServerConfigurationBuilder();
       HotRodServer server = HotRodClientTestingUtil.startHotRodServer(cm, serverBuilder);
       server.addCacheEventConverterFactory("static-converter-factory", new StaticConverterFactory());

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientClusterExpirationEventsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientClusterExpirationEventsTest.java
@@ -2,6 +2,7 @@ package org.infinispan.client.hotrod.event;
 
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.withClientListener;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodClusteredGlobalConfiguration;
 import static org.testng.AssertJUnit.assertNull;
 
 import java.util.concurrent.TimeUnit;
@@ -48,7 +49,7 @@ public class ClientClusterExpirationEventsTest extends MultiHotRodServersTest {
    }
 
    protected HotRodServer addHotRodServer(ConfigurationBuilder builder) {
-      EmbeddedCacheManager cm = addClusterEnabledCacheManager(builder);
+      EmbeddedCacheManager cm = addClusterEnabledCacheManager(hotRodClusteredGlobalConfiguration(this.getClass()), builder);
       HotRodServerConfigurationBuilder serverBuilder = new HotRodServerConfigurationBuilder();
       HotRodServer server = HotRodClientTestingUtil.startHotRodServer(cm, serverBuilder);
       server.addCacheEventConverterFactory("static-converter-factory", new StaticConverterFactory());

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/EventSocketTimeoutTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/EventSocketTimeoutTest.java
@@ -2,6 +2,7 @@ package org.infinispan.client.hotrod.event;
 
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.withClientListener;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
 import static org.testng.AssertJUnit.assertTrue;
 
 import java.net.SocketTimeoutException;
@@ -28,7 +29,7 @@ public class EventSocketTimeoutTest extends SingleHotRodServerTest {
       ConfigurationBuilder builder = new ConfigurationBuilder();
       builder.customInterceptors().addInterceptor().interceptor(
          new TimeoutInducingInterceptor()).after(EntryWrappingInterceptor.class);
-      return TestCacheManagerFactory.createCacheManager(hotRodCacheConfiguration(builder));
+      return TestCacheManagerFactory.createCacheManager(hotRodGlobalConfiguration(this.getClass()), hotRodCacheConfiguration(builder));
    }
 
    @Override

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/JsonKeyValueRawEventsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/JsonKeyValueRawEventsTest.java
@@ -2,6 +2,7 @@ package org.infinispan.client.hotrod.event;
 
 import static org.infinispan.commons.dataconversion.MediaType.APPLICATION_JBOSS_MARSHALLING_TYPE;
 import static org.infinispan.commons.dataconversion.MediaType.APPLICATION_JSON;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
 import static org.testng.Assert.assertEquals;
 import static org.testng.AssertJUnit.assertNotNull;
 
@@ -41,7 +42,7 @@ public class JsonKeyValueRawEventsTest extends SingleHotRodServerTest {
       ConfigurationBuilder builder = new ConfigurationBuilder();
       builder.encoding().key().mediaType(APPLICATION_JBOSS_MARSHALLING_TYPE);
       builder.encoding().value().mediaType(APPLICATION_JBOSS_MARSHALLING_TYPE);
-      EmbeddedCacheManager cacheManager = TestCacheManagerFactory.createCacheManager(builder);
+      EmbeddedCacheManager cacheManager = TestCacheManagerFactory.createCacheManager(hotRodGlobalConfiguration(this.getClass()), builder);
       cacheManager.getClassWhiteList().addRegexps(".*");
       return cacheManager;
    }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/SingleServerObjectStorageRemoteIteratorTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/SingleServerObjectStorageRemoteIteratorTest.java
@@ -1,6 +1,8 @@
 package org.infinispan.client.hotrod.impl.iteration;
 
 
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
+
 import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -26,7 +28,7 @@ public class SingleServerObjectStorageRemoteIteratorTest extends SingleServerRem
       ConfigurationBuilder cb = HotRodTestingUtil.hotRodCacheConfiguration();
       cb.encoding().key().mediaType(MediaType.APPLICATION_OBJECT_TYPE);
       cb.encoding().value().mediaType(MediaType.APPLICATION_OBJECT_TYPE);
-      EmbeddedCacheManager cacheManager = TestCacheManagerFactory.createServerModeCacheManager(cb);
+      EmbeddedCacheManager cacheManager = TestCacheManagerFactory.createServerModeCacheManager(hotRodGlobalConfiguration(this.getClass()), cb);
       cacheManager.getClassWhiteList().addClasses(AccountHS.class, Account.Currency.class, LimitsHS.class);
       return cacheManager;
    }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/EmbeddedRemoteInteropQueryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/EmbeddedRemoteInteropQueryTest.java
@@ -3,6 +3,7 @@ package org.infinispan.client.hotrod.marshall;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killRemoteCacheManager;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertNull;
@@ -81,7 +82,7 @@ public class EmbeddedRemoteInteropQueryTest extends SingleCacheManagerTest {
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       org.infinispan.configuration.cache.ConfigurationBuilder builder = createConfigBuilder();
 
-      cacheManager = TestCacheManagerFactory.createServerModeCacheManager(builder);
+      cacheManager = TestCacheManagerFactory.createServerModeCacheManager(hotRodGlobalConfiguration(this.getClass()), builder);
       cache = cacheManager.getCache();
 
       embeddedCache = cache.getAdvancedCache().withEncoding(IdentityEncoder.class);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/PrimitiveEmbeddedRemoteInteropTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/PrimitiveEmbeddedRemoteInteropTest.java
@@ -3,6 +3,7 @@ package org.infinispan.client.hotrod.marshall;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killRemoteCacheManager;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertTrue;
 
@@ -38,7 +39,7 @@ public class PrimitiveEmbeddedRemoteInteropTest extends SingleCacheManagerTest {
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       org.infinispan.configuration.cache.ConfigurationBuilder builder = createConfigBuilder();
 
-      cacheManager = TestCacheManagerFactory.createServerModeCacheManager(builder);
+      cacheManager = TestCacheManagerFactory.createServerModeCacheManager(hotRodGlobalConfiguration(this.getClass()), builder);
       cache = cacheManager.getCache();
 
       embeddedCache = cache.getAdvancedCache().withEncoding(IdentityEncoder.class);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/PrimitiveProtoStreamMarshallerTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/PrimitiveProtoStreamMarshallerTest.java
@@ -3,6 +3,7 @@ package org.infinispan.client.hotrod.marshall;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killRemoteCacheManager;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertTrue;
@@ -33,7 +34,7 @@ public class PrimitiveProtoStreamMarshallerTest extends SingleCacheManagerTest {
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
-      cacheManager = TestCacheManagerFactory.createCacheManager(hotRodCacheConfiguration());
+      cacheManager = TestCacheManagerFactory.createCacheManager(hotRodGlobalConfiguration(this.getClass()), hotRodCacheConfiguration());
       cache = cacheManager.getCache();
 
       hotRodServer = HotRodClientTestingUtil.startHotRodServer(cacheManager);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/ProtoStreamMarshallerTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/ProtoStreamMarshallerTest.java
@@ -3,6 +3,7 @@ package org.infinispan.client.hotrod.marshall;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killRemoteCacheManager;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertTrue;
@@ -43,7 +44,7 @@ public class ProtoStreamMarshallerTest extends SingleCacheManagerTest {
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
-      cacheManager = TestCacheManagerFactory.createCacheManager(hotRodCacheConfiguration());
+      cacheManager = TestCacheManagerFactory.createCacheManager(hotRodGlobalConfiguration(this.getClass()), hotRodCacheConfiguration());
       cache = cacheManager.getCache();
 
       hotRodServer = HotRodClientTestingUtil.startHotRodServer(cacheManager);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/ProtoStreamMarshallerWithAnnotationsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/ProtoStreamMarshallerWithAnnotationsTest.java
@@ -3,6 +3,7 @@ package org.infinispan.client.hotrod.marshall;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killRemoteCacheManager;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertTrue;
@@ -71,7 +72,7 @@ public class ProtoStreamMarshallerWithAnnotationsTest extends SingleCacheManager
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
-      cacheManager = TestCacheManagerFactory.createCacheManager(hotRodCacheConfiguration());
+      cacheManager = TestCacheManagerFactory.createCacheManager(hotRodGlobalConfiguration(this.getClass()), hotRodCacheConfiguration());
       cache = cacheManager.getCache();
 
       hotRodServer = HotRodClientTestingUtil.startHotRodServer(cacheManager);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/BuiltInAnalyzersTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/BuiltInAnalyzersTest.java
@@ -1,6 +1,7 @@
 package org.infinispan.client.hotrod.query;
 
 
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
 import static org.testng.AssertJUnit.assertEquals;
 
 import org.infinispan.client.hotrod.RemoteCache;
@@ -38,7 +39,7 @@ public class BuiltInAnalyzersTest extends SingleHotRodServerTest {
             .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
 
-      return TestCacheManagerFactory.createServerModeCacheManager(builder);
+      return TestCacheManagerFactory.createServerModeCacheManager(hotRodGlobalConfiguration(this.getClass()), builder);
    }
 
    @BeforeClass

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/HotRodQueryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/HotRodQueryTest.java
@@ -2,6 +2,7 @@ package org.infinispan.client.hotrod.query;
 
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killRemoteCacheManager;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertNotNull;
@@ -19,12 +20,12 @@ import org.infinispan.client.hotrod.query.testdomain.protobuf.AddressPB;
 import org.infinispan.client.hotrod.query.testdomain.protobuf.UserPB;
 import org.infinispan.client.hotrod.query.testdomain.protobuf.marshallers.MarshallerRegistration;
 import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
+import org.infinispan.commons.jmx.PerThreadMBeanServerLookup;
 import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.Index;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.configuration.internal.PrivateGlobalConfigurationBuilder;
-import org.infinispan.commons.jmx.PerThreadMBeanServerLookup;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.query.dsl.Query;
 import org.infinispan.query.dsl.QueryFactory;
@@ -55,7 +56,7 @@ public class HotRodQueryTest extends SingleCacheManagerTest {
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
-      GlobalConfigurationBuilder gcb = new GlobalConfigurationBuilder().nonClusteredDefault();
+      GlobalConfigurationBuilder gcb = hotRodGlobalConfiguration(this.getClass());
       gcb.globalJmxStatistics()
             .enable()
             .jmxDomain(getClass().getSimpleName())

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/JBMARRemoteQueryDslConditionsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/JBMARRemoteQueryDslConditionsTest.java
@@ -3,6 +3,7 @@ package org.infinispan.client.hotrod.query;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killRemoteCacheManager;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodClusteredGlobalConfiguration;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertNotNull;
@@ -67,7 +68,7 @@ public class JBMARRemoteQueryDslConditionsTest extends QueryDslConditionsTest {
    @Override
    protected void createCacheManagers() throws Throwable {
       ConfigurationBuilder cfg = getConfigurationBuilder();
-      createClusteredCaches(1, cfg, true);
+      createClusteredCaches(1, hotRodClusteredGlobalConfiguration(this.getClass()), cfg, true);
 
       cache = manager(0).getCache();
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryDisableIndexingTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryDisableIndexingTest.java
@@ -3,6 +3,7 @@ package org.infinispan.client.hotrod.query;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killRemoteCacheManager;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertTrue;
@@ -100,7 +101,7 @@ public class RemoteQueryDisableIndexingTest extends AbstractQueryDslTest {
    @Override
    protected void createCacheManagers() throws Throwable {
       ConfigurationBuilder cfg = getConfigurationBuilder();
-      createClusteredCaches(getNodesCount(), cfg, true);
+      createClusteredCaches(getNodesCount(), hotRodGlobalConfiguration(this.getClass()), cfg, true);
 
       cache = manager(0).getCache();
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryDslConditionsIspnDirTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryDslConditionsIspnDirTest.java
@@ -1,5 +1,7 @@
 package org.infinispan.client.hotrod.query;
 
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
+
 import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.marshall.ProtoStreamMarshaller;
 import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
@@ -21,7 +23,7 @@ public class RemoteQueryDslConditionsIspnDirTest extends RemoteQueryDslCondition
    @Override
    protected void createCacheManagers() throws Throwable {
       ConfigurationBuilder defaultCacheConfiguration = new ConfigurationBuilder();
-      createClusteredCaches(1, defaultCacheConfiguration, true);
+      createClusteredCaches(1, hotRodGlobalConfiguration(this.getClass()), defaultCacheConfiguration, true);
 
       ConfigurationBuilder cfg = getConfigurationBuilder();
       manager(0).defineConfiguration(TEST_CACHE_NAME, cfg.build());

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryDslConditionsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryDslConditionsTest.java
@@ -9,6 +9,7 @@ import static org.infinispan.query.dsl.Expression.min;
 import static org.infinispan.query.dsl.Expression.param;
 import static org.infinispan.query.dsl.Expression.sum;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertTrue;
@@ -97,7 +98,7 @@ public class RemoteQueryDslConditionsTest extends QueryDslConditionsTest {
    @Override
    protected void createCacheManagers() throws Throwable {
       ConfigurationBuilder cfg = getConfigurationBuilder();
-      createClusteredCaches(1, cfg, true);
+      createClusteredCaches(1, hotRodGlobalConfiguration(this.getClass()), cfg, true);
 
       cache = manager(0).getCache();
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryJmxTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryJmxTest.java
@@ -2,6 +2,7 @@ package org.infinispan.client.hotrod.query;
 
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killRemoteCacheManager;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertNotNull;
@@ -27,12 +28,12 @@ import org.infinispan.client.hotrod.query.testdomain.protobuf.AddressPB;
 import org.infinispan.client.hotrod.query.testdomain.protobuf.UserPB;
 import org.infinispan.client.hotrod.query.testdomain.protobuf.marshallers.MarshallerRegistration;
 import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
+import org.infinispan.commons.jmx.PerThreadMBeanServerLookup;
 import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.Index;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.configuration.internal.PrivateGlobalConfigurationBuilder;
-import org.infinispan.commons.jmx.PerThreadMBeanServerLookup;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.query.dsl.Query;
 import org.infinispan.query.dsl.QueryFactory;
@@ -67,7 +68,7 @@ public class RemoteQueryJmxTest extends SingleCacheManagerTest {
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
-      GlobalConfigurationBuilder gcb = new GlobalConfigurationBuilder().nonClusteredDefault();
+      GlobalConfigurationBuilder gcb = hotRodGlobalConfiguration(this.getClass());
       gcb.globalJmxStatistics()
             .enable()
             .jmxDomain(jmxDomain)

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryProtostreamAnnotationsDisableIndexingTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryProtostreamAnnotationsDisableIndexingTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.client.hotrod.query;
 
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertNotNull;
@@ -90,7 +91,7 @@ public class RemoteQueryProtostreamAnnotationsDisableIndexingTest extends Single
             .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
 
-      return TestCacheManagerFactory.createServerModeCacheManager(builder);
+      return TestCacheManagerFactory.createServerModeCacheManager(hotRodGlobalConfiguration(this.getClass()), builder);
    }
 
    @Override

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryStringTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryStringTest.java
@@ -3,6 +3,7 @@ package org.infinispan.client.hotrod.query;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killRemoteCacheManager;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodClusteredGlobalConfiguration;
 import static org.testng.AssertJUnit.assertEquals;
 
 import java.io.IOException;
@@ -107,7 +108,7 @@ public class RemoteQueryStringTest extends QueryStringTest {
    @Override
    protected void createCacheManagers() throws Throwable {
       ConfigurationBuilder cfg = getConfigurationBuilder();
-      createClusteredCaches(getNodesCount(), cfg, true);
+      createClusteredCaches(getNodesCount(), hotRodClusteredGlobalConfiguration(this.getClass()), cfg, true);
 
       cache = manager(0).getCache();
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryWithProtostreamAnnotationsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryWithProtostreamAnnotationsTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.client.hotrod.query;
 
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertNotNull;
@@ -134,7 +135,7 @@ public class RemoteQueryWithProtostreamAnnotationsTest extends SingleHotRodServe
             .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
 
-      return TestCacheManagerFactory.createServerModeCacheManager(builder);
+      return TestCacheManagerFactory.createServerModeCacheManager(hotRodGlobalConfiguration(this.getClass()), builder);
    }
 
    @Override

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/AbstractRetryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/AbstractRetryTest.java
@@ -2,6 +2,7 @@ package org.infinispan.client.hotrod.retry;
 
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.getLoadBalancer;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodClusteredGlobalConfiguration;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.marshall;
 
 import java.net.SocketAddress;
@@ -45,9 +46,9 @@ public abstract class AbstractRetryTest extends HitsAwareCacheManagersTest {
    @Override
    protected void createCacheManagers() throws Throwable {
       config = hotRodCacheConfiguration(getCacheConfig());
-      EmbeddedCacheManager cm1 = TestCacheManagerFactory.createClusteredCacheManager(config);
-      EmbeddedCacheManager cm2 = TestCacheManagerFactory.createClusteredCacheManager(config);
-      EmbeddedCacheManager cm3 = TestCacheManagerFactory.createClusteredCacheManager(config);
+      EmbeddedCacheManager cm1 = TestCacheManagerFactory.createClusteredCacheManager(hotRodClusteredGlobalConfiguration(this.getClass()), config);
+      EmbeddedCacheManager cm2 = TestCacheManagerFactory.createClusteredCacheManager(hotRodClusteredGlobalConfiguration(this.getClass()), config);
+      EmbeddedCacheManager cm3 = TestCacheManagerFactory.createClusteredCacheManager(hotRodClusteredGlobalConfiguration(this.getClass()), config);
       registerCacheManager(cm1);
       registerCacheManager(cm2);
       registerCacheManager(cm3);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/test/HotRodClientTestingUtil.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/test/HotRodClientTestingUtil.java
@@ -3,6 +3,7 @@ package org.infinispan.client.hotrod.test;
 import static org.infinispan.client.hotrod.impl.ConfigurationProperties.DEFAULT_EXECUTOR_FACTORY_THREADNAME_PREFIX;
 import static org.infinispan.distribution.DistributionTestHelper.isFirstOwner;
 import static org.infinispan.server.core.test.ServerTestingUtil.findFreePort;
+import static org.testng.AssertJUnit.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -10,6 +11,7 @@ import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Random;
 import java.util.function.Consumer;
 
@@ -61,7 +63,11 @@ public class HotRodClientTestingUtil {
    }
 
    public static HotRodServer startHotRodServer(EmbeddedCacheManager cacheManager) {
-      return startHotRodServer(cacheManager, new HotRodServerConfigurationBuilder());
+      Optional<String> cacheName = cacheManager.getCacheManagerConfiguration().defaultCacheName();
+      assertTrue(cacheName.isPresent());
+      HotRodServerConfigurationBuilder serverBuilder = new HotRodServerConfigurationBuilder();
+      serverBuilder.defaultCacheName(cacheName.get());
+      return startHotRodServer(cacheManager, serverBuilder);
    }
 
    /**

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/test/MultiHotRodServersTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/test/MultiHotRodServersTest.java
@@ -109,6 +109,7 @@ public abstract class MultiHotRodServersTest extends MultipleCacheManagersTest {
       GlobalConfigurationBuilder globalConfigurationBuilder = new GlobalConfigurationBuilder();
       globalConfigurationBuilder.addModule(PrivateGlobalConfigurationBuilder.class).serverMode(true);
       globalConfigurationBuilder.transport().defaultTransport();
+      globalConfigurationBuilder.defaultCacheName(this.getClass().getSimpleName());
       return globalConfigurationBuilder;
    }
 
@@ -116,7 +117,10 @@ public abstract class MultiHotRodServersTest extends MultipleCacheManagersTest {
       GlobalConfigurationBuilder globalConfigurationBuilder = getServerModeGlobalConfigurationBuilder();
 
       EmbeddedCacheManager cm = addClusterEnabledCacheManager(globalConfigurationBuilder, builder);
-      HotRodServer server = HotRodTestingUtil.startHotRodServer(cm, port, new HotRodServerConfigurationBuilder());
+      HotRodServerConfigurationBuilder serverBuilder = new HotRodServerConfigurationBuilder();
+      serverBuilder.defaultCacheName(globalConfigurationBuilder.defaultCacheName().get());
+
+      HotRodServer server = HotRodTestingUtil.startHotRodServer(cm, port, serverBuilder);
       servers.add(server);
       return server;
    }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/test/SingleHotRodServerTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/test/SingleHotRodServerTest.java
@@ -3,9 +3,11 @@ package org.infinispan.client.hotrod.test;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killRemoteCacheManager;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
 
 import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.server.hotrod.HotRodServer;
 import org.infinispan.test.SingleCacheManagerTest;
@@ -21,7 +23,9 @@ public abstract class SingleHotRodServerTest extends SingleCacheManagerTest {
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
-      return TestCacheManagerFactory.createCacheManager(hotRodCacheConfiguration());
+      GlobalConfigurationBuilder globalConfigurationBuilder = hotRodGlobalConfiguration(this.getClass());
+      globalConfigurationBuilder.defaultCacheName(this.getClass().getSimpleName());
+      return TestCacheManagerFactory.createCacheManager(globalConfigurationBuilder, hotRodCacheConfiguration());
    }
 
    @Override

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/transcoding/DataFormatTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/transcoding/DataFormatTest.java
@@ -6,6 +6,7 @@ import static org.infinispan.commons.dataconversion.MediaType.APPLICATION_JBOSS_
 import static org.infinispan.commons.dataconversion.MediaType.APPLICATION_JSON;
 import static org.infinispan.commons.dataconversion.MediaType.TEXT_PLAIN;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodGlobalConfiguration;
 import static org.infinispan.test.fwk.TestCacheManagerFactory.createServerModeCacheManager;
 import static org.testng.Assert.assertTrue;
 import static org.testng.AssertJUnit.assertEquals;
@@ -43,7 +44,6 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.marshall.core.ExternallyMarshallable;
 import org.infinispan.server.hotrod.HotRodServer;
-import org.infinispan.server.hotrod.configuration.HotRodServerConfigurationBuilder;
 import org.testng.annotations.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -73,7 +73,7 @@ public class DataFormatTest extends SingleHotRodServerTest {
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
-      cacheManager = createServerModeCacheManager(hotRodCacheConfiguration());
+      cacheManager = createServerModeCacheManager(hotRodGlobalConfiguration(this.getClass()), hotRodCacheConfiguration());
       ConfigurationBuilder builder = buildCacheConfig();
 
       cacheManager.defineConfiguration(CACHE_NAME, hotRodCacheConfiguration(builder).build());
@@ -82,7 +82,7 @@ public class DataFormatTest extends SingleHotRodServerTest {
 
    @Override
    protected HotRodServer createHotRodServer() {
-      HotRodServer server = HotRodClientTestingUtil.startHotRodServer(cacheManager, new HotRodServerConfigurationBuilder());
+      HotRodServer server = HotRodClientTestingUtil.startHotRodServer(cacheManager);
       server.addCacheEventFilterFactory("static-filter-factory", new EventLogListener.StaticCacheEventFilterFactory(42));
       server.addCacheEventFilterFactory("raw-static-filter-factory", new EventLogListener.RawStaticCacheEventFilterFactory());
       return server;

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/xsite/AbstractHotRodSiteFailoverTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/xsite/AbstractHotRodSiteFailoverTest.java
@@ -1,6 +1,7 @@
 package org.infinispan.client.hotrod.xsite;
 
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodClusteredGlobalConfiguration;
 import static org.testng.AssertJUnit.assertEquals;
 
 import java.util.Collection;
@@ -104,7 +105,7 @@ abstract class AbstractHotRodSiteFailoverTest extends AbstractXSiteTest {
       BackupConfigurationBuilder backup = builder.sites().addBackup();
       backup.site(backupSiteName).strategy(BackupStrategy.SYNC);
 
-      GlobalConfigurationBuilder globalBuilder = GlobalConfigurationBuilder.defaultClusteredBuilder();
+      GlobalConfigurationBuilder globalBuilder = hotRodClusteredGlobalConfiguration(this.getClass());
       globalBuilder.site().localSite(siteName);
       TestSite site = createSite(siteName, NODES_PER_SITE, globalBuilder, builder);
       Collection<EmbeddedCacheManager> cacheManagers = site.cacheManagers();

--- a/core/src/main/java/org/infinispan/security/Security.java
+++ b/core/src/main/java/org/infinispan/security/Security.java
@@ -8,7 +8,8 @@ import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.security.acl.Group;
-import java.util.Stack;
+import java.util.ArrayDeque;
+import java.util.Deque;
 
 import javax.security.auth.Subject;
 
@@ -30,7 +31,7 @@ public final class Security {
 
    private static final ThreadLocal<Boolean> PRIVILEGED = ThreadLocal.withInitial(() -> Boolean.FALSE);
 
-   private static final ThreadLocal<Stack<Subject>> SUBJECT = new ThreadLocal<>();
+   private static final ThreadLocal<Deque<Subject>> SUBJECT = new ThreadLocal<>();
 
    private static boolean isTrustedClass(Class<?> klass) {
       // TODO: implement a better way
@@ -76,9 +77,9 @@ public final class Security {
     * @see Subject#doAs(Subject, PrivilegedAction)
     */
    public static <T> T doAs(final Subject subject, final java.security.PrivilegedAction<T> action) {
-      Stack<Subject> stack = SUBJECT.get();
+      Deque<Subject> stack = SUBJECT.get();
       if (stack == null) {
-         stack = new Stack<>();
+         stack = new ArrayDeque<>();
          SUBJECT.set(stack);
       }
       stack.push(subject);
@@ -101,9 +102,9 @@ public final class Security {
    public static <T> T doAs(final Subject subject,
          final java.security.PrivilegedExceptionAction<T> action)
          throws java.security.PrivilegedActionException {
-      Stack<Subject> stack = SUBJECT.get();
+      Deque<Subject> stack = SUBJECT.get();
       if (stack == null) {
-         stack = new Stack<>();
+         stack = new ArrayDeque<>();
          SUBJECT.set(stack);
       }
       stack.push(subject);

--- a/core/src/test/java/org/infinispan/test/fwk/TEST_PING.java
+++ b/core/src/test/java/org/infinispan/test/fwk/TEST_PING.java
@@ -174,14 +174,7 @@ public class TEST_PING extends Discovery {
 
    private Map<Address, TEST_PING> getTestDiscoveries() {
       DiscoveryKey key = new DiscoveryKey(testName, cluster_name);
-      ConcurrentMap<Address, TEST_PING> discoveries = all.get(key);
-      if (discoveries == null) {
-         discoveries = new ConcurrentHashMap<Address, TEST_PING>();
-         ConcurrentMap<Address, TEST_PING> ret = all.putIfAbsent(key, discoveries);
-         if (ret != null)
-            discoveries = ret;
-      }
-      return discoveries;
+      return all.computeIfAbsent(key,  k -> new ConcurrentHashMap<>());
    }
 
    @Override

--- a/core/src/test/java/org/infinispan/test/fwk/TestCacheManagerFactory.java
+++ b/core/src/test/java/org/infinispan/test/fwk/TestCacheManagerFactory.java
@@ -321,23 +321,31 @@ public class TestCacheManagerFactory {
    }
 
    public static EmbeddedCacheManager createClusteredCacheManagerEnforceJmxDomain(String cacheManagerName, String jmxDomain, boolean allowDuplicateDomains) {
-      return createClusteredCacheManagerEnforceJmxDomain(cacheManagerName, jmxDomain, true, allowDuplicateDomains, new ConfigurationBuilder(), new PerThreadMBeanServerLookup());
+      return createClusteredCacheManagerEnforceJmxDomain(cacheManagerName, jmxDomain, true, allowDuplicateDomains, GlobalConfigurationBuilder.defaultClusteredBuilder(), new ConfigurationBuilder(), new PerThreadMBeanServerLookup());
    }
 
    public static EmbeddedCacheManager createClusteredCacheManagerEnforceJmxDomain(String jmxDomain, ConfigurationBuilder builder) {
       return createClusteredCacheManagerEnforceJmxDomain(jmxDomain, true, false, builder);
    }
 
-   public static EmbeddedCacheManager createClusteredCacheManagerEnforceJmxDomain(
-         String jmxDomain, boolean exposeGlobalJmx, boolean allowDuplicateDomains, ConfigurationBuilder builder) {
-      return createClusteredCacheManagerEnforceJmxDomain(null, jmxDomain,
-            exposeGlobalJmx, allowDuplicateDomains, builder, new PerThreadMBeanServerLookup());
+   public static EmbeddedCacheManager createClusteredCacheManagerEnforceJmxDomain(String cacheManagerName, String jmxDomain, boolean exposeGlobalJmx, boolean allowDuplicateDomains, ConfigurationBuilder builder, MBeanServerLookup mBeanServerLookup) {
+      return createClusteredCacheManagerEnforceJmxDomain(cacheManagerName, jmxDomain, exposeGlobalJmx, allowDuplicateDomains, GlobalConfigurationBuilder.defaultClusteredBuilder(), builder, mBeanServerLookup);
+   }
+
+   public static EmbeddedCacheManager createClusteredCacheManagerEnforceJmxDomain(String jmxDomain, GlobalConfigurationBuilder globalBuilder, ConfigurationBuilder builder) {
+      return createClusteredCacheManagerEnforceJmxDomain(null, jmxDomain, true, false, globalBuilder, builder, new PerThreadMBeanServerLookup());
    }
 
    public static EmbeddedCacheManager createClusteredCacheManagerEnforceJmxDomain(
-         String cacheManagerName, String jmxDomain, boolean exposeGlobalJmx, boolean allowDuplicateDomains, ConfigurationBuilder builder,
+         String jmxDomain, boolean exposeGlobalJmx, boolean allowDuplicateDomains, ConfigurationBuilder builder) {
+      return createClusteredCacheManagerEnforceJmxDomain(null, jmxDomain,
+            exposeGlobalJmx, allowDuplicateDomains, GlobalConfigurationBuilder.defaultClusteredBuilder(), builder, new PerThreadMBeanServerLookup());
+   }
+
+   public static EmbeddedCacheManager createClusteredCacheManagerEnforceJmxDomain(
+         String cacheManagerName, String jmxDomain, boolean exposeGlobalJmx, boolean allowDuplicateDomains, GlobalConfigurationBuilder globalBuilder, ConfigurationBuilder builder,
          MBeanServerLookup mBeanServerLookup) {
-      GlobalConfigurationBuilder globalBuilder = GlobalConfigurationBuilder.defaultClusteredBuilder();
+
       amendGlobalConfiguration(globalBuilder, new TransportFlags());
       globalBuilder.globalJmxStatistics()
             .jmxDomain(jmxDomain)
@@ -466,5 +474,4 @@ public class TestCacheManagerFactory {
 
       return holder;
    }
-
 }

--- a/pom.xml
+++ b/pom.xml
@@ -725,7 +725,7 @@
       <versionx.org.wildfly.legacy.test.wildfly-legacy-spi>3.0.0.Final</versionx.org.wildfly.legacy.test.wildfly-legacy-spi>
       <versionx.org.wildfly.legacy.test.wildfly-legacy-versions>3.0.0.Final</versionx.org.wildfly.legacy.test.wildfly-legacy-versions>
       <versionx.org.wildfly.security.elytron-web.undertow-server>1.1.0.Final</versionx.org.wildfly.security.elytron-web.undertow-server>
-      <versionx.org.wildfly.security.wildfly-elytron>1.3.3.Final</versionx.org.wildfly.security.wildfly-elytron>
+      <versionx.org.wildfly.security.wildfly-elytron>${version.org.wildfly.elytron}</versionx.org.wildfly.security.wildfly-elytron>
       <versionx.org.wildfly.security.wildfly-security-manager>1.1.2.Final</versionx.org.wildfly.security.wildfly-security-manager>
       <versionx.org.wildfly.transaction.wildfly-transaction-client>1.1.2.Final</versionx.org.wildfly.transaction.wildfly-transaction-client>
       <versionx.org.wildfly.wildfly-clustering-common>${version.org.wildfly}</versionx.org.wildfly.wildfly-clustering-common>

--- a/server/core/src/main/java/org/infinispan/server/core/AbstractProtocolServer.java
+++ b/server/core/src/main/java/org/infinispan/server/core/AbstractProtocolServer.java
@@ -11,7 +11,6 @@ import javax.management.ObjectName;
 
 import org.infinispan.IllegalLifecycleStateException;
 import org.infinispan.commons.CacheException;
-import org.infinispan.commons.api.BasicCacheContainer;
 import org.infinispan.commons.jmx.JmxUtil;
 import org.infinispan.commons.logging.LogFactory;
 import org.infinispan.configuration.global.GlobalConfiguration;
@@ -224,14 +223,17 @@ public abstract class AbstractProtocolServer<A extends ProtocolServerConfigurati
    }
 
    protected void startDefaultCache() {
-      cacheManager.getCache(defaultCacheName());
+      String name = defaultCacheName();
+      if (name != null) {
+         cacheManager.getCache(name);
+      }
    }
 
    public String defaultCacheName() {
       if (configuration.defaultCacheName() != null) {
          return configuration.defaultCacheName();
       } else {
-         return cacheManager.getCacheManagerConfiguration().defaultCacheName().orElse(BasicCacheContainer.DEFAULT_CACHE_NAME);
+         return cacheManager.getCacheManagerConfiguration().defaultCacheName().orElse(null);
       }
    }
 

--- a/server/core/src/main/java/org/infinispan/server/core/admin/AdminOperationsHandler.java
+++ b/server/core/src/main/java/org/infinispan/server/core/admin/AdminOperationsHandler.java
@@ -9,7 +9,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
 import org.infinispan.commons.CacheException;
-import org.infinispan.commons.util.Util;
 import org.infinispan.security.Security;
 import org.infinispan.tasks.Task;
 import org.infinispan.tasks.TaskContext;
@@ -24,10 +23,9 @@ import org.infinispan.tasks.spi.TaskEngine;
 public abstract class AdminOperationsHandler implements TaskEngine {
    final Map<String, AdminServerTask> tasks;
 
-   protected AdminOperationsHandler(Class<? extends AdminServerTask>... taskClasses) {
-      this.tasks = new HashMap<>(taskClasses.length);
-      for(Class<? extends AdminServerTask> taskClass : taskClasses) {
-         AdminServerTask<?> task = Util.getInstance(taskClass);
+   protected AdminOperationsHandler(AdminServerTask<?>... tasks) {
+      this.tasks = new HashMap<>(tasks.length);
+      for (AdminServerTask<?> task : tasks) {
          this.tasks.put(task.getName(), task);
       }
    }

--- a/server/core/src/main/java/org/infinispan/server/core/admin/embeddedserver/EmbeddedServerAdminOperationHandler.java
+++ b/server/core/src/main/java/org/infinispan/server/core/admin/embeddedserver/EmbeddedServerAdminOperationHandler.java
@@ -12,11 +12,11 @@ public class EmbeddedServerAdminOperationHandler extends AdminOperationsHandler 
 
    public EmbeddedServerAdminOperationHandler() {
       super(
-            CacheCreateTask.class,
-            CacheGetOrCreateTask.class,
-            CacheNamesTask.class,
-            CacheRemoveTask.class,
-            CacheReindexTask.class
+            new CacheCreateTask(),
+            new CacheGetOrCreateTask(),
+            new CacheNamesTask(),
+            new CacheRemoveTask(),
+            new CacheReindexTask()
       );
    }
 }

--- a/server/core/src/main/java/org/infinispan/server/core/security/AuthorizingCallbackHandler.java
+++ b/server/core/src/main/java/org/infinispan/server/core/security/AuthorizingCallbackHandler.java
@@ -14,6 +14,6 @@ import javax.security.auth.callback.CallbackHandler;
  */
 public interface AuthorizingCallbackHandler extends CallbackHandler {
 
-    public SubjectUserInfo getSubjectUserInfo(Collection<Principal> principals);
+    SubjectUserInfo getSubjectUserInfo(Collection<Principal> principals);
 
 }

--- a/server/core/src/main/java/org/infinispan/server/core/security/ServerAuthenticationProvider.java
+++ b/server/core/src/main/java/org/infinispan/server/core/security/ServerAuthenticationProvider.java
@@ -1,6 +1,16 @@
 package org.infinispan.server.core.security;
 
+import java.security.Principal;
 import java.util.Map;
+import java.util.Set;
+
+import javax.security.auth.x500.X500Principal;
+import javax.security.sasl.SaslException;
+import javax.security.sasl.SaslServer;
+import javax.security.sasl.SaslServerFactory;
+
+import org.infinispan.commons.util.SaslUtils;
+import org.infinispan.server.core.security.external.ExternalSaslServerFactory;
 
 
 /**
@@ -11,18 +21,75 @@ public interface ServerAuthenticationProvider {
 
    /**
     * Get a callback handler for the given mechanism name.
-    *
+    * <p>
     * This method is called each time a mechanism is selected for the connection and the resulting
-    * AuthorizingCallbackHandler will be cached and used multiple times for this connection,
-    * AuthorizingCallbackHandler should either be thread safe or the ServerAuthenticationProvider
-    * should provide a new instance each time called.
+    * AuthorizingCallbackHandler will be cached and used multiple times for this connection, AuthorizingCallbackHandler
+    * should either be thread safe or the ServerAuthenticationProvider should provide a new instance each time called.
     *
-    * @param mechanismName
-    *           the SASL mechanism to get a callback handler for
-    * @param mechanismProperties
-    *           the mechanism properties that might need to be adjusted to support the specific mechanism / callbackhandler combination
+    * @param mechanismName       the SASL mechanism to get a callback handler for
+    * @param mechanismProperties the mechanism properties that might need to be adjusted to support the specific
+    *                            mechanism / callbackhandler combination
     * @return the callback handler or {@code null} if the mechanism is not supported
+    * @deprecated This method will no longer be invoked directly. Implement the
+    * {@link #createSaslServer(String, Set, String, String, Map)} method instead.
     */
-   AuthorizingCallbackHandler getCallbackHandler(String mechanismName, Map<String, String> mechanismProperties);
+   @Deprecated
+   default AuthorizingCallbackHandler getCallbackHandler(String mechanismName, Map<String, String> mechanismProperties) {
+      return null;
+   }
 
+   /**
+    * Create a SaslServer, to be used for a single authentication session, for the specified mechanismName. On
+    * completion of the SASL authentication exchange, the SaslServer <b>MUST</b> provide a non-read-only negotiated
+    * {@link javax.security.auth.Subject} when {@link SaslServer#getNegotiatedProperty(String)} is invoked with the
+    * {@link SubjectSaslServer#SUBJECT} property. The default implementation of this method will
+    *
+    * @param mechanism  The non-null IANA-registered name of a SASL mechanism. (e.g. "GSSAPI", "CRAM-MD5").
+    * @param principals Any principals which can be obtained before the authentication (e.g. TLS peer, remote network
+    *                   address). Can be empty.
+    * @param protocol   The non-null string name of the protocol for which the authentication is being performed (e.g.,
+    *                   "ldap").
+    * @param serverName The fully qualified host name of the server to authenticate to, or null if the server is not
+    *                   bound to any specific host name. If the mechanism does not allow an unbound server, a {@code
+    *                   SaslException} will be thrown.
+    * @param props      The possibly null set of properties used to select the SASL mechanism and to configure the
+    *                   authentication exchange of the selected mechanism. See the {@code Sasl} class for a list of
+    *                   standard properties. Other, possibly mechanism-specific, properties can be included. Properties
+    *                   not relevant to the selected mechanism are ignored, including any map entries with non-String
+    *                   keys.
+    * @return an instance of SaslServer (or null if it cannot be created)
+    */
+   default SaslServer createSaslServer(String mechanism, Set<Principal> principals, String protocol, String serverName, Map<String, String> props) throws SaslException {
+      AuthorizingCallbackHandler callbackHandler = getCallbackHandler(mechanism, props);
+
+      if ("EXTERNAL".equals(mechanism)) {
+         // Find the X500Principal among the supplied principals
+         for(Principal principal : principals) {
+            if (principal instanceof X500Principal) {
+               ExternalSaslServerFactory factory = new ExternalSaslServerFactory((X500Principal) principal);
+               SaslServer saslServer = factory.createSaslServer(mechanism, protocol, serverName, props, callbacks -> {
+                  if (callbackHandler != null) {
+                     callbackHandler.handle(callbacks);
+                  }
+               });
+               return new SubjectSaslServer(saslServer, principals, callbackHandler);
+            }
+         }
+         throw new IllegalStateException("EXTERNAL mech requires X500Principal");
+      } else {
+         for (SaslServerFactory factory : SaslUtils.getSaslServerFactories()) {
+            if (factory != null) {
+               SaslServer saslServer = factory.createSaslServer(mechanism, protocol, serverName, props, callbacks -> {
+                  if (callbackHandler != null) {
+                     callbackHandler.handle(callbacks);
+                  }
+               });
+               if (saslServer != null) {
+                  return new SubjectSaslServer(saslServer, principals, callbackHandler);
+               }
+            }
+         }
+      }
+      return null;
+   }
 }

--- a/server/core/src/main/java/org/infinispan/server/core/security/SubjectSaslServer.java
+++ b/server/core/src/main/java/org/infinispan/server/core/security/SubjectSaslServer.java
@@ -1,0 +1,76 @@
+package org.infinispan.server.core.security;
+
+import java.security.Principal;
+import java.util.Set;
+
+import javax.security.auth.Subject;
+import javax.security.sasl.SaslException;
+import javax.security.sasl.SaslServer;
+
+/**
+ * A {@link SaslServer} which, when complete, can return a negotiated property named {@link #SUBJECT} which contains a
+ * populated {@link Subject} representing the authenticated user.
+ *
+ * @author Tristan Tarrant &lt;tristan@infinispan.org&gt;
+ * @since 10.0
+ **/
+public class SubjectSaslServer implements SaslServer {
+   public static final String SUBJECT = "org.infinispan.security.Subject";
+   final SaslServer delegate;
+   private final AuthorizingCallbackHandler callbackHandler;
+   private final Set<Principal> principals;
+
+   public SubjectSaslServer(SaslServer delegate, Set<Principal> principals, AuthorizingCallbackHandler callbackHandler) {
+      this.delegate = delegate;
+      this.principals = principals;
+      this.callbackHandler = callbackHandler;
+   }
+
+   @Override
+   public String getMechanismName() {
+      return delegate.getMechanismName();
+   }
+
+   @Override
+   public byte[] evaluateResponse(byte[] response) throws SaslException {
+      return delegate.evaluateResponse(response);
+   }
+
+   @Override
+   public boolean isComplete() {
+      return delegate.isComplete();
+   }
+
+   @Override
+   public String getAuthorizationID() {
+      return delegate.getAuthorizationID();
+   }
+
+   @Override
+   public byte[] unwrap(byte[] incoming, int offset, int len) throws SaslException {
+      return delegate.unwrap(incoming, offset, len);
+   }
+
+   @Override
+   public byte[] wrap(byte[] outgoing, int offset, int len) throws SaslException {
+      return delegate.wrap(outgoing, offset, len);
+   }
+
+   @Override
+   public Object getNegotiatedProperty(String propName) {
+      if (SUBJECT.equals(propName)) {
+         if (isComplete()) {
+            return callbackHandler.getSubjectUserInfo(principals).getSubject();
+         } else {
+            throw new IllegalStateException("Authentication is not complete");
+         }
+      } else {
+         return delegate.getNegotiatedProperty(propName);
+      }
+   }
+
+   @Override
+   public void dispose() throws SaslException {
+      delegate.dispose();
+   }
+}

--- a/server/core/src/main/java/org/infinispan/server/core/security/external/ExternalSaslServerFactory.java
+++ b/server/core/src/main/java/org/infinispan/server/core/security/external/ExternalSaslServerFactory.java
@@ -1,10 +1,9 @@
 package org.infinispan.server.core.security.external;
 
-import java.security.Principal;
 import java.util.Map;
 
 import javax.security.auth.callback.CallbackHandler;
-import javax.security.sasl.SaslException;
+import javax.security.auth.x500.X500Principal;
 import javax.security.sasl.SaslServer;
 import javax.security.sasl.SaslServerFactory;
 
@@ -12,14 +11,14 @@ public final class ExternalSaslServerFactory implements SaslServerFactory {
 
    public static final String[] NAMES = new String[]{"EXTERNAL"};
 
-   private final Principal peerPrincipal;
+   private final X500Principal peerPrincipal;
 
-   public ExternalSaslServerFactory(final Principal peerPrincipal) {
+   public ExternalSaslServerFactory(final X500Principal peerPrincipal) {
       this.peerPrincipal = peerPrincipal;
    }
 
    public SaslServer createSaslServer(final String mechanism, final String protocol, final String serverName,
-                                      final Map<String, ?> props, final CallbackHandler cbh) throws SaslException {
+                                      final Map<String, ?> props, final CallbackHandler cbh) {
       return new ExternalSaslServer(cbh, peerPrincipal);
    }
 

--- a/server/core/src/main/java/org/infinispan/server/core/security/simple/SimpleGroupPrincipal.java
+++ b/server/core/src/main/java/org/infinispan/server/core/security/simple/SimpleGroupPrincipal.java
@@ -4,8 +4,6 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.security.Principal;
-import java.security.acl.Group;
-import java.util.Enumeration;
 
 import org.infinispan.commons.marshall.SerializeWith;
 
@@ -16,7 +14,7 @@ import org.infinispan.commons.marshall.SerializeWith;
  * @since 7.0
  */
 @SerializeWith(SimpleGroupPrincipal.Externalizer.class)
-public class SimpleGroupPrincipal implements Group {
+public class SimpleGroupPrincipal implements Principal {
 
    final String name;
 
@@ -27,26 +25,6 @@ public class SimpleGroupPrincipal implements Group {
    @Override
    public String getName() {
       return name;
-   }
-
-   @Override
-   public boolean addMember(Principal user) {
-      throw new UnsupportedOperationException();
-   }
-
-   @Override
-   public boolean removeMember(Principal user) {
-      throw new UnsupportedOperationException();
-   }
-
-   @Override
-   public boolean isMember(Principal member) {
-      throw new UnsupportedOperationException();
-   }
-
-   @Override
-   public Enumeration<? extends Principal> members() {
-      throw new UnsupportedOperationException();
    }
 
    @Override

--- a/server/core/src/main/java/org/infinispan/server/core/security/simple/SimpleServerAuthenticationProvider.java
+++ b/server/core/src/main/java/org/infinispan/server/core/security/simple/SimpleServerAuthenticationProvider.java
@@ -14,6 +14,7 @@ import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.sasl.AuthenticationException;
 import javax.security.sasl.AuthorizeCallback;
 import javax.security.sasl.RealmCallback;
+import javax.security.sasl.RealmChoiceCallback;
 
 import org.infinispan.server.core.security.AuthorizingCallbackHandler;
 import org.infinispan.server.core.security.ServerAuthenticationProvider;
@@ -27,7 +28,7 @@ import org.infinispan.server.core.security.SubjectUserInfo;
  */
 public final class SimpleServerAuthenticationProvider implements ServerAuthenticationProvider {
 
-   private final Map<String, Map<String, Entry>> map = new HashMap<String, Map<String, Entry>>();
+   private final Map<String, Map<String, Entry>> map = new HashMap<>();
 
    /**
     * {@inheritDoc}
@@ -58,6 +59,9 @@ public final class SimpleServerAuthenticationProvider implements ServerAuthentic
                      realmName = defaultRealm.toLowerCase().trim();
                      realmCallback.setText(realmName);
                   }
+               } else if (callback instanceof RealmChoiceCallback) {
+                  final RealmChoiceCallback realmChoiceCallback = (RealmChoiceCallback) callback;
+                  realmChoiceCallback.setSelectedIndex(realmChoiceCallback.getDefaultChoice());
                } else if (callback instanceof PasswordCallback) {
                   final PasswordCallback passwordCallback = (PasswordCallback) callback;
                   // retrieve the record based on user and realm (if any)

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/Authentication.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/Authentication.java
@@ -4,8 +4,8 @@ import java.net.InetSocketAddress;
 import java.security.Principal;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.Executor;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
@@ -13,13 +13,11 @@ import javax.security.auth.Subject;
 import javax.security.sasl.Sasl;
 import javax.security.sasl.SaslException;
 import javax.security.sasl.SaslServer;
-import javax.security.sasl.SaslServerFactory;
 
 import org.infinispan.commons.logging.LogFactory;
-import org.infinispan.server.core.security.AuthorizingCallbackHandler;
 import org.infinispan.server.core.security.InetAddressPrincipal;
 import org.infinispan.server.core.security.ServerAuthenticationProvider;
-import org.infinispan.server.core.security.external.ExternalSaslServerFactory;
+import org.infinispan.server.core.security.SubjectSaslServer;
 import org.infinispan.server.core.security.simple.SimpleUserPrincipal;
 import org.infinispan.server.core.transport.SaslQopHandler;
 import org.infinispan.server.hotrod.configuration.AuthenticationConfiguration;
@@ -39,6 +37,7 @@ import io.netty.handler.ssl.SslHandler;
  */
 public class Authentication extends BaseRequestProcessor {
    private final static Log log = LogFactory.getLog(Authentication.class, Log.class);
+   public static final String HOTROD_SASL_PROTOCOL = "hotrod";
 
    private final HotRodServerConfiguration serverConfig;
    private final AuthenticationConfiguration authenticationConfig;
@@ -46,7 +45,6 @@ public class Authentication extends BaseRequestProcessor {
    private final boolean requireAuthentication;
 
    private SaslServer saslServer;
-   private AuthorizingCallbackHandler callbackHandler;
    private Subject subject = ANONYMOUS;
 
    private final static Subject ANONYMOUS = new Subject();
@@ -79,104 +77,84 @@ public class Authentication extends BaseRequestProcessor {
             try {
                authInternal(header, mech, response);
             } catch (Throwable t) {
+               disposeSaslServer();
                writeException(header, t);
             }
          });
       }
    }
 
-   private void authInternal(HotRodHeader header, String mech, byte[] response) {
+   private void authInternal(HotRodHeader header, String mech, byte[] response) throws Throwable {
       if (saslServer == null) {
-         ServerAuthenticationProvider sap = authenticationConfig.serverAuthenticationProvider();
-         callbackHandler = sap.getCallbackHandler(mech, authenticationConfig.mechProperties());
-         final SaslServerFactory ssf;
-         if ("EXTERNAL".equals(mech)) {
-            SslHandler sslHandler = channel.pipeline().get(SslHandler.class);
-            try {
-               if (sslHandler != null)
-                  ssf = new ExternalSaslServerFactory(sslHandler.engine().getSession().getPeerPrincipal());
-               else {
-                  writeException(header, log.externalMechNotAllowedWithoutSSLClientCert());
-                  return;
-               }
-            } catch (SSLPeerUnverifiedException e) {
-               writeException(header, log.externalMechNotAllowedWithoutSSLClientCert());
-               return;
-            }
-         } else {
-            ssf = server.getSaslServerFactory(mech);
-         }
-         if (authenticationConfig.serverSubject() != null) {
-            try {
-               saslServer = Subject.doAs(authenticationConfig.serverSubject(), (PrivilegedExceptionAction<SaslServer>) () ->
-                     ssf.createSaslServer(mech, "hotrod", authenticationConfig.serverName(),
-                           authenticationConfig.mechProperties(), callbackHandler));
-            } catch (PrivilegedActionException e) {
-               writeException(header, e.getCause());
-               return;
-            }
-         } else {
-            try {
-               saslServer = ssf.createSaslServer(mech, "hotrod", authenticationConfig.serverName(),
-                     authenticationConfig.mechProperties(), callbackHandler);
-            } catch (SaslException e) {
-               writeException(header, e);
-               return;
-            }
-         }
+         saslServer = createSaslServer(mech);
       }
-      byte[] serverChallenge;
-      try {
-         serverChallenge = saslServer.evaluateResponse(response);
-      } catch (SaslException e) {
-         dispose(saslServer);
-         writeException(header, e);
-         return;
-      }
-
+      byte[] serverChallenge = saslServer.evaluateResponse(response);
       if (saslServer.isComplete()) {
-         // Obtaining the subject might be expensive, so do it before sending the final server response, otherwise the
-         // client might send another operation before this is complete
-         List<Principal> extraPrincipals = new ArrayList<>();
-         String id = normalizeAuthorizationId(saslServer.getAuthorizationID());
-         extraPrincipals.add(new SimpleUserPrincipal(id));
-         extraPrincipals.add(new InetAddressPrincipal(((InetSocketAddress) channel.remoteAddress()).getAddress()));
-         SslHandler sslHandler = (SslHandler) channel.pipeline().get("ssl");
-         try {
-            if (sslHandler != null)
-               extraPrincipals.add(sslHandler.engine().getSession().getPeerPrincipal());
-         } catch (SSLPeerUnverifiedException e) {
-            // Ignore any SSLPeerUnverifiedExceptions
-         }
-         subject = callbackHandler.getSubjectUserInfo(extraPrincipals).getSubject();
-      }
-
-      if (saslServer.isComplete()) {
-         // Finally we setup the QOP handler if required
-         String qop = (String) saslServer.getNegotiatedProperty(Sasl.QOP);
-         if ("auth-int".equals(qop) || "auth-conf".equals(qop)) {
-            channel.eventLoop().submit(() -> {
-               writeResponse(header, header.encoder().authResponse(header, server, channel.alloc(), serverChallenge));
-               SaslQopHandler qopHandler = new SaslQopHandler(saslServer);
-               channel.pipeline().addBefore("decoder", "saslQop", qopHandler);
-            });
-         } else {
-            writeResponse(header, header.encoder().authResponse(header, server, channel.alloc(), serverChallenge));
-            dispose(saslServer);
-            callbackHandler = null;
-            saslServer = null;
-         }
+         authComplete(header, serverChallenge);
       } else {
          // Write the server challenge
          writeResponse(header, header.encoder().authResponse(header, server, channel.alloc(), serverChallenge));
       }
    }
 
-   private void dispose(SaslServer server) {
+   private void authComplete(HotRodHeader header, byte[] serverChallenge) {
+      // Obtaining the subject might be expensive, so do it before sending the final server challenge, otherwise the
+      // client might send another operation before this is complete
+      subject = (Subject) saslServer.getNegotiatedProperty(SubjectSaslServer.SUBJECT);
+      String id = normalizeAuthorizationId(saslServer.getAuthorizationID());
+      subject.getPrincipals().add(new SimpleUserPrincipal(id));
+      // Finally we setup the QOP handler if required
+      String qop = (String) saslServer.getNegotiatedProperty(Sasl.QOP);
+      if ("auth-int".equals(qop) || "auth-conf".equals(qop)) {
+         channel.eventLoop().submit(() -> {
+            writeResponse(header, header.encoder().authResponse(header, server, channel.alloc(), serverChallenge));
+            SaslQopHandler qopHandler = new SaslQopHandler(saslServer);
+            channel.pipeline().addBefore("decoder", "saslQop", qopHandler);
+         });
+      } else {
+         // Send the final server challenge
+         writeResponse(header, header.encoder().authResponse(header, server, channel.alloc(), serverChallenge));
+         disposeSaslServer();
+         saslServer = null;
+      }
+   }
+
+   private SaslServer createSaslServer(String mech) throws Throwable {
+      ServerAuthenticationProvider sap = authenticationConfig.serverAuthenticationProvider();
+      Set<Principal> principals = new HashSet<>();
+      principals.add(new InetAddressPrincipal(((InetSocketAddress) channel.remoteAddress()).getAddress()));
+      SslHandler sslHandler = channel.pipeline().get(SslHandler.class);
+      if (sslHandler != null) {
+         try {
+            principals.add(sslHandler.engine().getSession().getPeerPrincipal());
+         } catch (SSLPeerUnverifiedException e) {
+            if ("EXTERNAL".equals(mech)) {
+               throw log.externalMechNotAllowedWithoutSSLClientCert();
+            }
+         }
+      }
+      if (authenticationConfig.serverSubject() != null) {
+         try {
+            return Subject.doAs(authenticationConfig.serverSubject(), (PrivilegedExceptionAction<SaslServer>) () ->
+                  sap.createSaslServer(mech, principals, HOTROD_SASL_PROTOCOL, authenticationConfig.serverName(),
+                        authenticationConfig.mechProperties()));
+         } catch (PrivilegedActionException e) {
+            throw e.getCause();
+         }
+      } else {
+         return sap.createSaslServer(mech, principals, HOTROD_SASL_PROTOCOL, authenticationConfig.serverName(),
+               authenticationConfig.mechProperties());
+      }
+   }
+
+   private void disposeSaslServer() {
       try {
-         server.dispose();
+         if (saslServer != null)
+            saslServer.dispose();
       } catch (SaslException e) {
          log.debug("Exception while disposing SaslServer", e);
+      } finally {
+         saslServer = null;
       }
    }
 

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/CacheRequestProcessor.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/CacheRequestProcessor.java
@@ -46,8 +46,10 @@ class CacheRequestProcessor extends BaseRequestProcessor {
    }
 
    void ping(HotRodHeader header, Subject subject) {
-      // we need to throw an exception when this cache is inaccessible
-      server.cache(server.getCacheInfo(header), header, subject);
+      // we need to throw an exception when this cache is inaccessible, but ignore the empty cache name if no default cache has been configured
+      if (!header.cacheName.isEmpty() || server.getCacheManager().getCacheManagerConfiguration().defaultCacheName().isPresent()) {
+         server.cache(server.getCacheInfo(header), header, subject);
+      }
       writeResponse(header, header.encoder().pingResponse(header, server, channel.alloc(), OperationStatus.Success));
    }
 

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/DefaultSaslServerFactoryFactory.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/DefaultSaslServerFactoryFactory.java
@@ -1,0 +1,39 @@
+package org.infinispan.server.hotrod;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+import javax.security.sasl.SaslServerFactory;
+
+import org.infinispan.commons.util.SaslUtils;
+
+/**
+ * Meta-factory for available {@link SaslServerFactory}
+ *
+ * @author Tristan Tarrant &lt;tristan@infinispan.org&gt;
+ * @since 10.0
+ **/
+public class DefaultSaslServerFactoryFactory implements BiFunction<String, Map<String, ?>, SaslServerFactory> {
+   private final SaslServerFactory factories[];
+
+   public DefaultSaslServerFactoryFactory() {
+      List<SaslServerFactory> factories = new ArrayList<>(SaslUtils.getSaslServerFactories(this.getClass().getClassLoader(), true));
+      this.factories = factories.toArray(new SaslServerFactory[0]);
+   }
+
+   @Override
+   public SaslServerFactory apply(String mechanism, Map<String, ?> mechProps) {
+      for (SaslServerFactory factory : factories) {
+         if (factory != null) {
+            String[] mechs = factory.getMechanismNames(mechProps);
+            for(String mech : mechs) {
+               if (mech.equals(mechanism))
+                  return factory;
+            }
+         }
+      }
+      return null;
+   }
+}

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/Encoder2x.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/Encoder2x.java
@@ -443,7 +443,10 @@ class Encoder2x implements VersionedEncoder {
          if (CounterModuleLifecycle.COUNTER_CACHE_NAME.equals(header.cacheName)) {
             cacheTopology = getCounterCacheTopology(server.getCacheManager());
             newTopology = getTopologyResponse(header.clientIntel, header.topologyId, addressCache, CacheMode.DIST_SYNC,
-                                              cacheTopology);
+                  cacheTopology);
+         } else if (header.cacheName.isEmpty() && !server.hasDefaultCache()) {
+            cacheTopology = null;
+            newTopology = Optional.empty();
          } else {
             HotRodServer.CacheInfo cacheInfo = server.getCacheInfo(header);
             Configuration configuration = cacheInfo.configuration;

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/HotRodServer.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/HotRodServer.java
@@ -13,7 +13,6 @@ import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.EnumSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -27,7 +26,6 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 
 import javax.security.auth.Subject;
-import javax.security.sasl.SaslServerFactory;
 
 import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
@@ -38,7 +36,6 @@ import org.infinispan.commons.marshall.Externalizer;
 import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.commons.marshall.SerializeWith;
 import org.infinispan.commons.marshall.WrappedByteArray;
-import org.infinispan.commons.util.SaslUtils;
 import org.infinispan.commons.util.ServiceFinder;
 import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.CacheMode;
@@ -114,17 +111,12 @@ public class HotRodServer extends AbstractProtocolServer<HotRodServerConfigurati
 
    public static final int LISTENERS_CHECK_INTERVAL = 10;
 
-
-   public HotRodServer() {
-      super("HotRod");
-   }
-
+   private boolean hasDefaultCache;
    private Address clusterAddress;
    private ServerAddress address;
    private Cache<Address, ServerAddress> addressCache;
    private final Map<String, CacheInfo> knownCaches = new ConcurrentHashMap<>();
    private QueryFacade queryFacade;
-   private Map<String, SaslServerFactory> saslMechFactories = new ConcurrentHashMap<>(4, 0.9f, 16);
    private ClientListenerRegistry clientListenerRegistry;
    private Marshaller marshaller;
    private ClusterExecutor clusterExecutor;
@@ -135,6 +127,14 @@ public class HotRodServer extends AbstractProtocolServer<HotRodServerConfigurati
    private ClientCounterManagerNotificationManager clientCounterNotificationManager;
    private HotRodAccessLogging accessLogging = new HotRodAccessLogging();
    private ScheduledExecutorService scheduledExecutor;
+
+   public HotRodServer() {
+      super("HotRod");
+   }
+
+   public boolean hasDefaultCache() {
+      return hasDefaultCache;
+   }
 
    public ServerAddress getAddress() {
       return address;
@@ -224,9 +224,7 @@ public class HotRodServer extends AbstractProtocolServer<HotRodServerConfigurati
       this.configuration = configuration;
       this.cacheManager = cacheManager;
       this.iterationManager = new DefaultIterationManager(cacheManager.getGlobalComponentRegistry().getTimeService());
-
-      // populate the sasl factories based on the required mechs
-      setupSasl();
+      this.hasDefaultCache = cacheManager.getCacheManagerConfiguration().defaultCacheName().isPresent();
 
       // Initialize query-specific stuff
       List<QueryFacade> queryFacades = loadQueryFacades();
@@ -301,7 +299,9 @@ public class HotRodServer extends AbstractProtocolServer<HotRodServerConfigurati
 
    @Override
    protected void startDefaultCache() {
-      getCacheInfo("", (byte) 0, 0, false);
+      if (hasDefaultCache) {
+         getCacheInfo("", (byte) 0, 0, false);
+      }
    }
 
    private void preStartCaches() {
@@ -426,8 +426,10 @@ public class HotRodServer extends AbstractProtocolServer<HotRodServerConfigurati
          keep = false;
       } else if (!cacheName.isEmpty() && !cacheManager.getCacheNames().contains(cacheName)) {
          throw new CacheNotFoundException(
-            String.format("Cache with name '%s' not found amongst the configured caches", cacheName),
-            hotRodVersion, messageId);
+               String.format("Cache with name '%s' not found amongst the configured caches", cacheName),
+               hotRodVersion, messageId);
+      } else if (cacheName.isEmpty() && !hasDefaultCache) {
+         throw new CacheNotFoundException("Default cache requested but not configured", hotRodVersion, messageId);
       } else {
          keep = true;
       }
@@ -458,27 +460,6 @@ public class HotRodServer extends AbstractProtocolServer<HotRodServerConfigurati
       ComponentRegistry cr = SecurityActions.getCacheComponentRegistry(cache.getAdvancedCache());
       RollingUpgradeManager migrationManager = cr.getComponent(RollingUpgradeManager.class);
       if (migrationManager != null) migrationManager.addSourceMigrator(new HotRodSourceMigrator(cache));
-   }
-
-   private void setupSasl() {
-      if (configuration.authentication().enabled()) {
-         Iterator<SaslServerFactory> saslFactories = SaslUtils.getSaslServerFactories(this.getClass().getClassLoader(), true);
-         while (saslFactories.hasNext()) {
-            SaslServerFactory saslFactory = saslFactories.next();
-            String[] saslFactoryMechs = saslFactory.getMechanismNames(configuration.authentication().mechProperties());
-            for (String supportedMech : saslFactoryMechs) {
-               for (String mech : configuration.authentication().allowedMechs()) {
-                  if (supportedMech.equals(mech)) {
-                     saslMechFactories.putIfAbsent(mech, saslFactory);
-                  }
-               }
-            }
-         }
-      }
-   }
-
-   SaslServerFactory getSaslServerFactory(String mech) {
-      return saslMechFactories.get(mech);
    }
 
    public Cache<Address, ServerAddress> getAddressCache() {

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/TaskRequestProcessor.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/TaskRequestProcessor.java
@@ -27,11 +27,14 @@ public class TaskRequestProcessor extends BaseRequestProcessor {
    }
 
    public void exec(HotRodHeader header, Subject subject, String taskName, Map<String, byte[]> taskParams) {
-      AdvancedCache<byte[], byte[]> cache = server.cache(server.getCacheInfo(header), header, subject);
       TaskContext taskContext = new TaskContext()
-            .cache(cache)
             .parameters(taskParams)
             .subject(subject);
+      if (!header.cacheName.isEmpty() || server.hasDefaultCache()) {
+         AdvancedCache<byte[], byte[]> cache = server.cache(server.getCacheInfo(header), header, subject);
+         taskContext.cache(cache);
+      }
+
       // TODO: TaskManager API is already asynchronous, though we cannot be sure that it won't block anywhere
       taskManager.runTask(taskName, taskContext).whenComplete((result, throwable) -> handleExec(header, result, throwable));
    }

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/configuration/AuthenticationConfiguration.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/configuration/AuthenticationConfiguration.java
@@ -57,8 +57,13 @@ public class AuthenticationConfiguration {
 
    @Override
    public String toString() {
-      return "AuthenticationConfiguration [enabled=" + enabled + ", allowedMechs=" + allowedMechs
-            + ", serverAuthenticationProvider=" + serverAuthenticationProvider + ", mechProperties=" + mechProperties
-            + ", serverName=" + serverName + ", serverSubject=" + serverSubject + "]";
+      return "AuthenticationConfiguration[" +
+            "enabled=" + enabled +
+            ", allowedMechs=" + allowedMechs +
+            ", serverAuthenticationProvider=" + serverAuthenticationProvider +
+            ", mechProperties=" + mechProperties +
+            ", serverName='" + serverName + '\'' +
+            ", serverSubject=" + serverSubject +
+            ']';
    }
 }

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/configuration/AuthenticationConfigurationBuilder.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/configuration/AuthenticationConfigurationBuilder.java
@@ -2,10 +2,10 @@ package org.infinispan.server.hotrod.configuration;
 
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiFunction;
 
 import javax.security.auth.Subject;
 import javax.security.sasl.SaslServerFactory;
@@ -15,6 +15,7 @@ import org.infinispan.commons.logging.LogFactory;
 import org.infinispan.commons.util.SaslUtils;
 import org.infinispan.server.core.security.ServerAuthenticationProvider;
 import org.infinispan.server.core.security.external.ExternalSaslServerFactory;
+import org.infinispan.server.hotrod.DefaultSaslServerFactoryFactory;
 import org.infinispan.server.hotrod.logging.Log;
 
 /**
@@ -31,6 +32,7 @@ public class AuthenticationConfigurationBuilder extends AbstractHotRodServerChil
    private Map<String, String> mechProperties = new HashMap<String, String>();
    private String serverName;
    private Subject serverSubject;
+   private BiFunction<String, Map<String, ?>, SaslServerFactory> saslFactoryFactory = new DefaultSaslServerFactoryFactory();
 
    AuthenticationConfigurationBuilder(HotRodServerChildConfigurationBuilder builder) {
       super(builder);
@@ -89,8 +91,7 @@ public class AuthenticationConfigurationBuilder extends AbstractHotRodServerChil
          }
          Set<String> allMechs = new LinkedHashSet<String>();
          Collections.addAll(allMechs, ExternalSaslServerFactory.NAMES);
-         for (Iterator<SaslServerFactory> factories = SaslUtils.getSaslServerFactories(this.getClass().getClassLoader(), true); factories.hasNext(); ) {
-            SaslServerFactory factory = factories.next();
+         for (SaslServerFactory factory : SaslUtils.getSaslServerFactories(this.getClass().getClassLoader(), true)) {
             for (String mech : factory.getMechanismNames(mechProperties)) {
                allMechs.add(mech);
             }

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodMergeTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodMergeTest.java
@@ -53,7 +53,7 @@ public class HotRodMergeTest extends BasePartitionHandlingTest {
       ConfigurationBuilder dcc = hotRodCacheConfiguration();
       dcc.clustering().cacheMode(cacheMode).hash().numOwners(1);
       dcc.clustering().partitionHandling().whenSplit(partitionHandling);
-      createClusteredCaches(numMembersInCluster, dcc, new TransportFlags().withFD(true).withMerge(true));
+      createClusteredCaches(numMembersInCluster, dcc, new TransportFlags().withFD(true).withMerge(true), "merge");
       waitForClusterToForm();
 
       // Allow servers for both instances to run in parallel
@@ -64,7 +64,7 @@ public class HotRodMergeTest extends BasePartitionHandlingTest {
          nextServerPort += 1;
       }
 
-      client = new HotRodClient("127.0.0.1", servers.get(0).getPort(), "", 60, (byte) 21);
+      client = new HotRodClient("127.0.0.1", servers.get(0).getPort(), "merge", 60, (byte) 21);
       TestingUtil.waitForNoRebalance(cache(0), cache(1));
    }
 

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/logging/HotRodAccessLoggingTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/logging/HotRodAccessLoggingTest.java
@@ -37,7 +37,7 @@ public class HotRodAccessLoggingTest extends HotRodSingleNodeTest {
 
       server().getTransport().stop();
 
-      String logline = logAppender.getLog(0).toString();
+      String logline = logAppender.getLog(0);
       assertTrue(logline, logline.matches("^127\\.0\\.0\\.1 - \\[\\d+/\\w+/\\d+:\\d+:\\d+:\\d+ [+-]?\\w+\\] \"PUT /HotRodCache/\\[B0x6B6579 HOTROD/2\\.1\" OK \\d+ \\d+ \\d+$"));
    }
 }

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/test/HotRodPipeTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/test/HotRodPipeTest.java
@@ -27,6 +27,8 @@ import io.netty.handler.codec.MessageToByteEncoder;
 import io.netty.handler.codec.ReplayingDecoder;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import org.infinispan.commons.util.Either;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.manager.CacheContainer;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.server.hotrod.HotRodServer;
 import org.infinispan.test.SingleCacheManagerTest;
@@ -41,7 +43,10 @@ public class HotRodPipeTest extends SingleCacheManagerTest {
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
-      return TestCacheManagerFactory.createCacheManager();
+      GlobalConfigurationBuilder gcb = new GlobalConfigurationBuilder();
+      gcb.defaultCacheName(CacheContainer.DEFAULT_CACHE_NAME);
+      TestCacheManagerFactory.amendTransport(gcb);
+      return TestCacheManagerFactory.createServerModeCacheManager(gcb);
    }
 
    @Override

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/test/HotRodTestingUtil.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/test/HotRodTestingUtil.java
@@ -474,6 +474,18 @@ public class HotRodTestingUtil {
       }
    }
 
+   public static GlobalConfigurationBuilder hotRodGlobalConfiguration(Class<?> klass) {
+      GlobalConfigurationBuilder globalConfigurationBuilder = new GlobalConfigurationBuilder();
+      globalConfigurationBuilder.defaultCacheName(klass.getSimpleName());
+      return globalConfigurationBuilder;
+   }
+
+   public static GlobalConfigurationBuilder hotRodClusteredGlobalConfiguration(Class<?> klass) {
+      GlobalConfigurationBuilder globalConfigurationBuilder = GlobalConfigurationBuilder.defaultClusteredBuilder();
+      globalConfigurationBuilder.defaultCacheName(klass.getSimpleName());
+      return globalConfigurationBuilder;
+   }
+
    public static ConfigurationBuilder hotRodCacheConfiguration() {
       return new ConfigurationBuilder();
    }

--- a/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/subsystem/EndpointServerAuthenticationProvider.java
+++ b/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/subsystem/EndpointServerAuthenticationProvider.java
@@ -84,7 +84,7 @@ public class EndpointServerAuthenticationProvider implements ServerAuthenticatio
       }
 
       @Override
-      public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+      public void handle(Callback[] callbacks) {
          for (Callback callback : callbacks) {
             if (callback instanceof AvailableRealmsCallback) {
                ((AvailableRealmsCallback) callback).setRealmNames(realm.getName());


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-10202

The reason of many changes in the HR client testsuite are because the default cache is no longer created by default.