### PR TITLE
[9.4] ISPN-10066 (addendum) ClusteredStatsFailureTest now uses awaitStrict

### DIFF
--- a/core/src/test/java/org/infinispan/stats/ClusteredStatsFailureTest.java
+++ b/core/src/test/java/org/infinispan/stats/ClusteredStatsFailureTest.java
@@ -2,7 +2,6 @@ package org.infinispan.stats;
 
 
 import static org.testng.AssertJUnit.assertEquals;
-import static org.testng.AssertJUnit.assertTrue;
 
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.ExecutionException;
@@ -66,7 +65,7 @@ public class ClusteredStatsFailureTest extends MultipleCacheManagersTest {
 
       Future<Void> future = fork(this::refreshClusterStats);
 
-      assertTrue(checkPoint.await(Mocks.BEFORE_INVOCATION, 10, TimeUnit.SECONDS));
+      checkPoint.awaitStrict(Mocks.BEFORE_INVOCATION, 10, TimeUnit.SECONDS);
 
       TestingUtil.killCacheManagers(manager(2));
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-10066