### PR TITLE
ISPN-10220 Create named lambdas to identify which test is running

### DIFF
--- a/commons-test/src/main/java/org/infinispan/commons/lambda/NamedLambdas.java
+++ b/commons-test/src/main/java/org/infinispan/commons/lambda/NamedLambdas.java
@@ -1,0 +1,77 @@
+package org.infinispan.commons.lambda;
+
+import java.util.function.BiConsumer;
+import java.util.function.Predicate;
+
+public class NamedLambdas {
+
+   public static <T, U> BiConsumer<T, U> of(String description, BiConsumer<T, U> consumer) {
+      return new NamedBiConsumer<>(description, consumer);
+   }
+
+   public static <T> Predicate<T> of(String description, Predicate<T> predicate) {
+      return new NamedPredicate(description, predicate);
+   }
+
+   private static class NamedPredicate<T> implements Predicate<T> {
+
+      private String description;
+      private Predicate<T> predicate;
+
+      public NamedPredicate(String description, Predicate<T> predicate) {
+         this.description = description;
+         this.predicate = predicate;
+      }
+
+      @Override
+      public boolean test(T t) {
+         return predicate.test(t);
+      }
+
+      @Override
+      public Predicate<T> and(Predicate<? super T> other) {
+         return predicate.and(other);
+      }
+
+      @Override
+      public Predicate<T> negate() {
+         return predicate.negate();
+      }
+
+      @Override
+      public Predicate<T> or(Predicate<? super T> other) {
+         return predicate.or(other);
+      }
+
+      @Override
+      public String toString() {
+         return this.description;
+      }
+   }
+
+   private static class NamedBiConsumer<T, U> implements BiConsumer<T, U> {
+
+      private String description;
+      private BiConsumer<T, U> biConsumer;
+
+      public NamedBiConsumer(String description, BiConsumer<T, U> biConsumer) {
+         this.description = description;
+         this.biConsumer = biConsumer;
+      }
+
+      @Override
+      public void accept(T t, U u) {
+         this.biConsumer.accept(t, u);
+      }
+
+      @Override
+      public BiConsumer<T, U> andThen(BiConsumer<? super T, ? super U> after) {
+         return this.biConsumer.andThen(after);
+      }
+
+      @Override
+      public String toString() {
+         return this.description;
+      }
+   }
+}

--- a/commons-test/src/main/java/org/infinispan/commons/test/PolarionJUnitXMLReporter.java
+++ b/commons-test/src/main/java/org/infinispan/commons/test/PolarionJUnitXMLReporter.java
@@ -343,7 +343,7 @@ public class PolarionJUnitXMLReporter implements IResultListener2, ISuiteListene
                .dataProvider();
          // Add parameters for methods that use a data provider only
          if (res.getParameters().length != 0 && (dataProviderName != null && !dataProviderName.isEmpty())) {
-            result.append("(").append(deepToStringParameters(res.getParameters()));
+            result.append("(").append(deepToStringParameters(res));
          }
          // Add number of invocations to method name
          if (res.getMethod().getConstructorOrMethod().getMethod().getAnnotation(Test.class).invocationCount() > 1) {
@@ -376,14 +376,16 @@ public class PolarionJUnitXMLReporter implements IResultListener2, ISuiteListene
       return result.toString();
    }
 
-   private String deepToStringParameters(Object[] parameters) {
+   private String deepToStringParameters(ITestResult res) {
+      Object[] parameters = res.getParameters();
       for (int i=0; i<parameters.length; i++) {
          Object parameter = parameters[i];
          if (parameter != null) {
             if (parameter instanceof Path) {
                parameters[i] = ((Path) parameter).getFileName().toString();
             } else if (parameter.getClass().getSimpleName().contains("$$Lambda$")) {
-               parameters[i] = "$$Lambda$";
+               res.setStatus(ITestResult.FAILURE);
+               res.setThrowable(new IllegalStateException("Cannot identify which test is running. Use NamedLambdas.of static method"));
             }
          }
       }

--- a/core/src/test/java/org/infinispan/manager/SingleClusterExecutorExecutionPolicyTest.java
+++ b/core/src/test/java/org/infinispan/manager/SingleClusterExecutorExecutionPolicyTest.java
@@ -11,6 +11,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 
+import org.infinispan.commons.lambda.NamedLambdas;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.configuration.global.TransportConfiguration;
 import org.infinispan.configuration.parsing.ConfigurationBuilderHolder;
@@ -41,24 +42,24 @@ public class SingleClusterExecutorExecutionPolicyTest extends MultipleCacheManag
    @DataProvider(name = "params")
    public Object[][] dataProvider() {
       return new Object[][] {
-            { ClusterExecutionPolicy.ALL, 0, 0, 0, (Predicate<String>) v -> true },
-            { ClusterExecutionPolicy.ALL, 2, 1, 1, (Predicate<String>) v -> true },
-            { ClusterExecutionPolicy.DIFFERENT_MACHINE, 1, 0, 1, (Predicate<String>) v -> !v.equals("101") },
-            { ClusterExecutionPolicy.DIFFERENT_MACHINE, 0, 1, 0, (Predicate<String>) v -> !v.equals("010") },
-            { ClusterExecutionPolicy.SAME_MACHINE, 2, 1, 1, (Predicate<String>) v -> v.equals("211") },
-            { ClusterExecutionPolicy.SAME_MACHINE, 0, 0, 1, (Predicate<String>) v -> v.equals("001") },
-            { ClusterExecutionPolicy.DIFFERENT_RACK, 2, 2, 0, (Predicate<String>) v -> !v.startsWith("22") },
-            { ClusterExecutionPolicy.DIFFERENT_RACK, 1, 0, 1, (Predicate<String>) v -> !v.startsWith("10") },
-            { ClusterExecutionPolicy.DIFFERENT_RACK, 0, 1, 0, (Predicate<String>) v -> !v.startsWith("01") },
-            { ClusterExecutionPolicy.SAME_RACK, 2, 1, 1, (Predicate<String>) v -> v.startsWith("21") },
-            { ClusterExecutionPolicy.SAME_RACK, 1, 0, 1, (Predicate<String>) v -> v.startsWith("10") },
-            { ClusterExecutionPolicy.SAME_RACK, 0, 2, 0, (Predicate<String>) v -> v.startsWith("02") },
-            { ClusterExecutionPolicy.DIFFERENT_SITE, 2, 0, 0, (Predicate<String>) v -> !v.startsWith("2") },
-            { ClusterExecutionPolicy.DIFFERENT_SITE, 1, 0, 1, (Predicate<String>) v -> !v.startsWith("1") },
-            { ClusterExecutionPolicy.DIFFERENT_SITE, 0, 1, 0, (Predicate<String>) v -> !v.startsWith("0") },
-            { ClusterExecutionPolicy.SAME_SITE, 2, 0, 1, (Predicate<String>) v -> v.startsWith("2") },
-            { ClusterExecutionPolicy.SAME_SITE, 1, 0, 0, (Predicate<String>) v -> v.startsWith("1") },
-            { ClusterExecutionPolicy.SAME_SITE, 0, 1, 0, (Predicate<String>) v -> v.startsWith("0") },
+            { ClusterExecutionPolicy.ALL, 0, 0, 0, NamedLambdas.of("all_0", (Predicate<String>) v -> true) },
+            { ClusterExecutionPolicy.ALL, 2, 1, 1, NamedLambdas.of("all_2", (Predicate<String>) v -> true) },
+            { ClusterExecutionPolicy.DIFFERENT_MACHINE, 1, 0, 1, NamedLambdas.of("diff_machine_1", (Predicate<String>) v -> !v.equals("101")) },
+            { ClusterExecutionPolicy.DIFFERENT_MACHINE, 0, 1, 0, NamedLambdas.of("diff_machine_0", (Predicate<String>) v -> !v.equals("010")) },
+            { ClusterExecutionPolicy.SAME_MACHINE, 2, 1, 1, NamedLambdas.of("same_machine_2", (Predicate<String>) v -> v.equals("211")) },
+            { ClusterExecutionPolicy.SAME_MACHINE, 0, 0, 1, NamedLambdas.of("same_machine_0", (Predicate<String>) v -> v.equals("001")) },
+            { ClusterExecutionPolicy.DIFFERENT_RACK, 2, 2, 0, NamedLambdas.of("diff_rack_2", (Predicate<String>) v -> !v.startsWith("22")) },
+            { ClusterExecutionPolicy.DIFFERENT_RACK, 1, 0, 1, NamedLambdas.of("diff_rack_1", (Predicate<String>) v -> !v.startsWith("10")) },
+            { ClusterExecutionPolicy.DIFFERENT_RACK, 0, 1, 0, NamedLambdas.of("diff_rack_0", (Predicate<String>) v -> !v.startsWith("01")) },
+            { ClusterExecutionPolicy.SAME_RACK, 2, 1, 1, NamedLambdas.of("same_rack_2", (Predicate<String>) v -> v.startsWith("21")) },
+            { ClusterExecutionPolicy.SAME_RACK, 1, 0, 1, NamedLambdas.of("same_rack_1", (Predicate<String>) v -> v.startsWith("10")) },
+            { ClusterExecutionPolicy.SAME_RACK, 0, 2, 0, NamedLambdas.of("same_rack_0", (Predicate<String>) v -> v.startsWith("02")) },
+            { ClusterExecutionPolicy.DIFFERENT_SITE, 2, 0, 0, NamedLambdas.of("diff_site_2", (Predicate<String>) v -> !v.startsWith("2")) },
+            { ClusterExecutionPolicy.DIFFERENT_SITE, 1, 0, 1, NamedLambdas.of("diff_site_1", (Predicate<String>) v -> !v.startsWith("1")) },
+            { ClusterExecutionPolicy.DIFFERENT_SITE, 0, 1, 0, NamedLambdas.of("diff_site_0", (Predicate<String>) v -> !v.startsWith("0")) },
+            { ClusterExecutionPolicy.SAME_SITE, 2, 0, 1, NamedLambdas.of("same_site_2", (Predicate<String>) v -> v.startsWith("2")) },
+            { ClusterExecutionPolicy.SAME_SITE, 1, 0, 0, NamedLambdas.of("same_site_1", (Predicate<String>) v -> v.startsWith("1")) },
+            { ClusterExecutionPolicy.SAME_SITE, 0, 1, 0, NamedLambdas.of("same_site_0", (Predicate<String>) v -> v.startsWith("0")) },
       };
    }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-10220

Now the lambda tests will be stored in the XML like:

```xml
  <testcase classname="org.infinispan.api.SimpleCacheTest" name="testLockedStreamActuallyLocks([functional-command, true])" time="0.001"/>
  <testcase classname="org.infinispan.api.SimpleCacheTest" name="testLockedStreamActuallyLocks([put-async, true])" time="0.001"/>
  <testcase classname="org.infinispan.api.SimpleCacheTest" name="testRetainAllMethodOfValuesCollection" time="0.001"/>
  <testcase classname="org.infinispan.api.SimpleCacheTest" name="testLockedStreamActuallyLocks([functional-command, false])" time="0.001"/>
```

If the test was not implemented with the named lambda we will have:

```xml
  <testcase classname="org.infinispan.api.SimpleCacheTest" name="testLockedStreamActuallyLocks([org.infinispan.api.APINonTxTest$$Lambda$266/0x00000008003df840@1fa88115, false])" time="0.001">
    <failure type="java.lang.IllegalStateException" message="Cannot identify what test is running">
      <![CDATA[java.lang.IllegalStateException: Cannot identify what test is running
at org.infinispan.commons.test.PolarionJUnitXMLReporter.deepToStringParameters(PolarionJUnitXMLReporter.java:388)
at org.infinispan.commons.test.PolarionJUnitXMLReporter.testName(PolarionJUnitXMLReporter.java:346)
at org.infinispan.commons.test.PolarionJUnitXMLReporter.createElement(PolarionJUnitXMLReporter.java:223)
at org.infinispan.commons.test.PolarionJUnitXMLReporter.createElementFromTestResults(PolarionJUnitXMLReporter.java:201)
at org.infinispan.commons.test.PolarionJUnitXMLReporter.generateReport(PolarionJUnitXMLReporter.java:188)
at org.infinispan.commons.test.PolarionJUnitXMLReporter.onFinish(PolarionJUnitXMLReporter.java:130)
... Removed 16 stack frames]]>
    </failure>
  </testcase> <!-- testLockedStreamActuallyLocks([org.infinispan.api.APINonTxTest$$Lambda$266/0x00000008003df840@1fa88115, false]) -->
```