### PR TITLE
ISPN-9949 & ISPN-8826 Remove the implicit default cache

### DIFF
--- a/cdi/embedded/src/main/java/org/infinispan/cdi/embedded/InfinispanExtensionEmbedded.java
+++ b/cdi/embedded/src/main/java/org/infinispan/cdi/embedded/InfinispanExtensionEmbedded.java
@@ -215,7 +215,7 @@ public class InfinispanExtensionEmbedded implements Extension {
                public EmbeddedCacheManager create(Bean<EmbeddedCacheManager> bean,
                      CreationalContext<EmbeddedCacheManager> creationalContext) {
                   GlobalConfiguration globalConfiguration = new GlobalConfigurationBuilder().globalJmxStatistics()
-                        .cacheManagerName(CACHE_NAME).build();
+                        .cacheManagerName(CACHE_NAME).defaultCacheName("default").build();
                   @SuppressWarnings("unchecked")
                   Bean<Configuration> configurationBean = (Bean<Configuration>) beanManager
                         .resolve(beanManager.getBeans(Configuration.class));

--- a/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cache/DefaultCacheTest.java
+++ b/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cache/DefaultCacheTest.java
@@ -1,7 +1,6 @@
 package org.infinispan.cdi.embedded.test.cache;
 
 import static org.infinispan.cdi.embedded.test.testutil.Deployments.baseDeployment;
-import static org.infinispan.commons.api.BasicCacheContainer.DEFAULT_CACHE_NAME;
 import static org.testng.Assert.assertEquals;
 
 import javax.inject.Inject;
@@ -9,6 +8,7 @@ import javax.inject.Inject;
 import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
 import org.infinispan.cdi.embedded.test.DefaultTestEmbeddedCacheManagerProducer;
+import org.infinispan.test.fwk.TestResourceTracker;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
@@ -42,7 +42,7 @@ public class DefaultCacheTest extends Arquillian {
       cache.put("manik", "Sri Lankan");
       assertEquals(cache.get("pete"), "British");
       assertEquals(cache.get("manik"), "Sri Lankan");
-      assertEquals(cache.getName(), DEFAULT_CACHE_NAME);
+      assertEquals(cache.getName(), TestResourceTracker.getCurrentTestShortName());
       /*
        * Check that the advanced cache contains the same data as the simple
        * cache. As we can inject either Cache or AdvancedCache, this is double
@@ -51,6 +51,6 @@ public class DefaultCacheTest extends Arquillian {
        */
       assertEquals(advancedCache.get("pete"), "British");
       assertEquals(advancedCache.get("manik"), "Sri Lankan");
-      assertEquals(advancedCache.getName(), DEFAULT_CACHE_NAME);
+      assertEquals(advancedCache.getName(), TestResourceTracker.getCurrentTestShortName());
    }
 }

--- a/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cache/specific/Config.java
+++ b/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cache/specific/Config.java
@@ -7,6 +7,7 @@ import javax.enterprise.inject.Produces;
 import org.infinispan.cdi.embedded.ConfigureCache;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.TestingUtil;
@@ -59,9 +60,11 @@ public class Config {
    @ApplicationScoped
    @SuppressWarnings("unused")
    public EmbeddedCacheManager specificCacheManager() {
+      GlobalConfigurationBuilder global = new GlobalConfigurationBuilder();
+      global.defaultCacheName("default");
       ConfigurationBuilder builder = new ConfigurationBuilder();
       builder.memory().size(4000);
-      return new DefaultCacheManager(builder.build());
+      return new DefaultCacheManager(global.build(), builder.build());
    }
 
    /**

--- a/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cachemanager/DefaultConfigurationTest.java
+++ b/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cachemanager/DefaultConfigurationTest.java
@@ -1,7 +1,6 @@
 package org.infinispan.cdi.embedded.test.cachemanager;
 
 import static org.infinispan.cdi.embedded.test.testutil.Deployments.baseDeployment;
-import static org.infinispan.commons.api.BasicCacheContainer.DEFAULT_CACHE_NAME;
 import static org.testng.Assert.assertEquals;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -12,6 +11,7 @@ import org.infinispan.Cache;
 import org.infinispan.cdi.embedded.test.DefaultTestEmbeddedCacheManagerProducer;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.test.fwk.TestResourceTracker;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
@@ -37,7 +37,7 @@ public class DefaultConfigurationTest extends Arquillian {
 
    public void testDefaultConfiguration() {
       assertEquals(cache.getCacheConfiguration().memory().size(), 16);
-      assertEquals(cache.getName(), DEFAULT_CACHE_NAME);
+      assertEquals(cache.getName(), TestResourceTracker.getCurrentTestShortName());
    }
 
    /**

--- a/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cachemanager/registration/CacheRegistrationTest.java
+++ b/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cachemanager/registration/CacheRegistrationTest.java
@@ -3,6 +3,7 @@ package org.infinispan.cdi.embedded.test.cachemanager.registration;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
+import java.util.Arrays;
 import java.util.Set;
 
 import javax.inject.Inject;
@@ -11,6 +12,7 @@ import org.infinispan.Cache;
 import org.infinispan.cdi.embedded.test.DefaultTestEmbeddedCacheManagerProducer;
 import org.infinispan.cdi.embedded.test.testutil.Deployments;
 import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.test.fwk.TestResourceTracker;
 import org.infinispan.test.fwk.TestResourceTrackingListener;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
@@ -50,9 +52,8 @@ public class CacheRegistrationTest extends Arquillian {
 
       final Set<String> cacheNames = defaultCacheManager.getCacheConfigurationNames();
 
-      assertEquals(cacheNames.size(), 2);
-      assertTrue(cacheNames.contains("small"));
-      assertTrue(cacheNames.contains("large"));
+      assertEquals(cacheNames.size(), 3);
+      assertTrue(cacheNames.containsAll(Arrays.asList("small", "large", TestResourceTracker.getCurrentTestShortName())));
    }
 
    public void testCacheRegistrationInSpecificCacheManager() {
@@ -60,7 +61,7 @@ public class CacheRegistrationTest extends Arquillian {
       cache.put("foo", "bar");
       final Set<String> cacheNames = specificCacheManager.getCacheConfigurationNames();
 
-      assertEquals(cacheNames.size(), 1);
-      assertTrue(cacheNames.contains("very-large"));
+      assertEquals(cacheNames.size(), 2);
+      assertTrue(cacheNames.containsAll(Arrays.asList("very-large", TestResourceTracker.getCurrentTestShortName())));
    }
 }

--- a/cli/cli-interpreter/src/main/java/org/infinispan/cli/interpreter/Interpreter.java
+++ b/cli/cli-interpreter/src/main/java/org/infinispan/cli/interpreter/Interpreter.java
@@ -25,7 +25,6 @@ import org.infinispan.cli.interpreter.result.ResultKeys;
 import org.infinispan.cli.interpreter.session.Session;
 import org.infinispan.cli.interpreter.session.SessionImpl;
 import org.infinispan.cli.interpreter.statement.Statement;
-import org.infinispan.commons.api.BasicCacheContainer;
 import org.infinispan.commons.time.TimeService;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
@@ -176,7 +175,6 @@ public class Interpreter {
    @ManagedAttribute(description = "Retrieves a list of caches for the cache manager")
    public String[] getCacheNames() {
       Set<String> cacheNames = new HashSet<>(cacheManager.getCacheNames());
-      cacheNames.add(BasicCacheContainer.DEFAULT_CACHE_NAME);
       return cacheNames.toArray(new String[0]);
    }
 

--- a/cli/cli-interpreter/src/main/java/org/infinispan/cli/interpreter/session/SessionImpl.java
+++ b/cli/cli-interpreter/src/main/java/org/infinispan/cli/interpreter/session/SessionImpl.java
@@ -15,14 +15,13 @@ import org.infinispan.cli.interpreter.codec.NoneCodec;
 import org.infinispan.cli.interpreter.logging.Log;
 import org.infinispan.commands.CommandsFactory;
 import org.infinispan.commands.CreateCacheCommand;
-import org.infinispan.commons.api.BasicCacheContainer;
 import org.infinispan.commons.dataconversion.IdentityEncoder;
 import org.infinispan.commons.dataconversion.MediaType;
+import org.infinispan.commons.time.TimeService;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.remoting.rpc.RpcManager;
-import org.infinispan.commons.time.TimeService;
 import org.infinispan.util.logging.LogFactory;
 
 public class SessionImpl implements Session {
@@ -101,7 +100,7 @@ public class SessionImpl implements Session {
          }
       } else {
          configuration = cacheManager.getDefaultCacheConfiguration();
-         baseCacheName = BasicCacheContainer.DEFAULT_CACHE_NAME;
+         baseCacheName = cacheManager.getCacheManagerConfiguration().defaultCacheName().get();
       }
       if (cacheManager.cacheExists(cacheName)) {
          throw log.cacheAlreadyExists(cacheName);
@@ -113,7 +112,7 @@ public class SessionImpl implements Session {
 
          CreateCacheCommand ccc = factory.buildCreateCacheCommand(cacheName, baseCacheName);
          try {
-            rpc.invokeRemotely(null, ccc, rpc.getDefaultRpcOptions(true));
+            rpc.invokeRemotely(null, ccc, rpc.getSyncRpcOptions());
             ccc.init(cacheManager);
             ccc.invoke();
          } catch (Throwable e) {

--- a/cli/cli-interpreter/src/test/java/org/infinispan/cli/interpreter/GrantDenyTest.java
+++ b/cli/cli-interpreter/src/test/java/org/infinispan/cli/interpreter/GrantDenyTest.java
@@ -12,7 +12,6 @@ import java.util.Map;
 import javax.security.auth.Subject;
 
 import org.infinispan.cli.interpreter.result.ResultKeys;
-import org.infinispan.commons.api.BasicCacheContainer;
 import org.infinispan.configuration.cache.AuthorizationConfigurationBuilder;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalAuthorizationConfigurationBuilder;
@@ -94,7 +93,7 @@ public class GrantDenyTest extends SingleCacheManagerTest {
 
    public void testGrantDeny() throws Exception {
       Interpreter interpreter = getInterpreter();
-      String sessionId = interpreter.createSessionId(BasicCacheContainer.DEFAULT_CACHE_NAME);
+      String sessionId = interpreter.createSessionId(cacheManager.getCacheManagerConfiguration().defaultCacheName().get());
       execute(interpreter, sessionId, "grant reader to jack;");
       assertTrue(cpm.list("jack").contains("reader"));
       execute(interpreter, sessionId, "grant reader to jill;");

--- a/cli/cli-interpreter/src/test/java/org/infinispan/cli/interpreter/SiteStatementTest.java
+++ b/cli/cli-interpreter/src/test/java/org/infinispan/cli/interpreter/SiteStatementTest.java
@@ -13,7 +13,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.infinispan.Cache;
 import org.infinispan.cli.interpreter.result.ResultKeys;
-import org.infinispan.commons.api.BasicCacheContainer;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
@@ -132,12 +131,13 @@ public class SiteStatementTest extends AbstractTwoSitesTest {
       Interpreter lonInterpreter = interpreter(LON, 0);
       String lonCache = cache(LON, 0).getName();
       String lonSessionId = lonInterpreter.createSessionId(lonCache);
+      String defaultCacheName = site(0).cacheManagers().get(0).getCacheManagerConfiguration().defaultCacheName().get();
 
       assertInterpreterOutput(lonInterpreter, lonSessionId, format("site --offlineall %s;", NYC), (output, error) -> {
          assertEquals(null, error);
          String outFormat = "%s: %s";
-         if (!output.contains(format(outFormat, BasicCacheContainer.DEFAULT_CACHE_NAME, XSiteAdminOperations.SUCCESS))) {
-            fail(format("Cache '%s' should be present in the output: %s", BasicCacheContainer.DEFAULT_CACHE_NAME, output));
+         if (!output.contains(format(outFormat, defaultCacheName, XSiteAdminOperations.SUCCESS))) {
+            fail(format("Cache '%s' should be present in the output: %s", defaultCacheName, output));
          }
          if (!output.contains(format(outFormat, "another-cache", XSiteAdminOperations.SUCCESS))) {
             fail(format("Cache '%s' should be present in the output: %s", "another-cache", output));
@@ -152,8 +152,8 @@ public class SiteStatementTest extends AbstractTwoSitesTest {
       assertInterpreterOutput(lonInterpreter, lonSessionId, format("site --onlineall %s;", NYC), (output, error) -> {
          assertEquals(null, error);
          String outFormat = "%s: %s";
-         if (!output.contains(format(outFormat, BasicCacheContainer.DEFAULT_CACHE_NAME, XSiteAdminOperations.SUCCESS))) {
-            fail(format("Cache '%s' should be present in the output: %s", BasicCacheContainer.DEFAULT_CACHE_NAME, output));
+         if (!output.contains(format(outFormat, defaultCacheName, XSiteAdminOperations.SUCCESS))) {
+            fail(format("Cache '%s' should be present in the output: %s", defaultCacheName, output));
          }
          if (!output.contains(format(outFormat, "another-cache", XSiteAdminOperations.SUCCESS))) {
             fail(format("Cache '%s' should be present in the output: %s", "another-cache", output));
@@ -168,8 +168,8 @@ public class SiteStatementTest extends AbstractTwoSitesTest {
       assertInterpreterOutput(lonInterpreter, lonSessionId, format("site --pushall %s;", NYC), (output, error) -> {
          assertEquals(null, error);
          String outFormat = "%s: %s";
-         if (!output.contains(format(outFormat, BasicCacheContainer.DEFAULT_CACHE_NAME, XSiteAdminOperations.SUCCESS))) {
-            fail(format("Cache '%s' should be present in the output: %s", BasicCacheContainer.DEFAULT_CACHE_NAME, output));
+         if (!output.contains(format(outFormat, defaultCacheName, XSiteAdminOperations.SUCCESS))) {
+            fail(format("Cache '%s' should be present in the output: %s", defaultCacheName, output));
          }
          if (!output.contains(format(outFormat, "another-cache", XSiteAdminOperations.SUCCESS))) {
             fail(format("Cache '%s' should be present in the output: %s", "another-cache", output));
@@ -182,8 +182,8 @@ public class SiteStatementTest extends AbstractTwoSitesTest {
       assertInterpreterOutput(lonInterpreter, lonSessionId, format("site --cancelpushall %s;", NYC), (output, error) -> {
          assertEquals(null, error);
          String outFormat = "%s: %s";
-         if (!output.contains(format(outFormat, BasicCacheContainer.DEFAULT_CACHE_NAME, XSiteAdminOperations.SUCCESS))) {
-            fail(format("Cache '%s' should be present in the output: %s", BasicCacheContainer.DEFAULT_CACHE_NAME, output));
+         if (!output.contains(format(outFormat, defaultCacheName, XSiteAdminOperations.SUCCESS))) {
+            fail(format("Cache '%s' should be present in the output: %s", defaultCacheName, output));
          }
          if (!output.contains(format(outFormat, "another-cache", XSiteAdminOperations.SUCCESS))) {
             fail(format("Cache '%s' should be present in the output: %s", "another-cache", output));

--- a/cli/cli-interpreter/src/test/java/org/infinispan/cli/interpreter/UpgradeTest.java
+++ b/cli/cli-interpreter/src/test/java/org/infinispan/cli/interpreter/UpgradeTest.java
@@ -11,7 +11,6 @@ import org.infinispan.cli.interpreter.result.ResultKeys;
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
-import org.infinispan.commons.api.BasicCacheContainer;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.factories.GlobalComponentRegistry;
@@ -77,7 +76,7 @@ public class UpgradeTest extends AbstractInfinispanTest {
       }
 
       Interpreter targetInterpreter = getInterpreter(targetContainer);
-      String targetSessionId = targetInterpreter.createSessionId(BasicCacheContainer.DEFAULT_CACHE_NAME);
+      String targetSessionId = targetInterpreter.createSessionId(targetServer.getCacheManager().getCacheManagerConfiguration().defaultCacheName().get());
       Map<String, String> synchronizeResult = targetInterpreter.execute(targetSessionId, "upgrade --synchronize=hotrod;");
       checkNoErrors(synchronizeResult);
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
@@ -89,7 +89,6 @@ public class RemoteCacheManager implements RemoteCacheContainer, Closeable, Remo
 
    private static final Log log = LogFactory.getLog(RemoteCacheManager.class);
 
-   public static final String DEFAULT_CACHE_NAME = "___defaultcache";
    public static final String HOTROD_CLIENT_PROPERTIES = "hotrod-client.properties";
    public static final String JSON_STRING_ARRAY_ELEMENT_REGEX = "(?:\")([^\"]*)(?:\",?)";
 
@@ -415,8 +414,7 @@ public class RemoteCacheManager implements RemoteCacheContainer, Closeable, Remo
 
             PingResponse pingResponse = result.resolveStorage();
             // If ping not successful assume that the cache does not exist
-            // Default cache is always started, so don't do for it
-            if (!cacheName.equals(RemoteCacheManager.DEFAULT_CACHE_NAME) && pingResponse.isCacheNotFound()) {
+            if (pingResponse.isCacheNotFound()) {
                return null;
             }
 
@@ -487,9 +485,7 @@ public class RemoteCacheManager implements RemoteCacheContainer, Closeable, Remo
    }
 
    public static byte[] cacheNameBytes(String cacheName) {
-      return cacheName.equals(DEFAULT_CACHE_NAME)
-            ? HotRodConstants.DEFAULT_CACHE_NAME_BYTES
-            : cacheName.getBytes(HotRodConstants.HOTROD_STRING_CHARSET);
+      return cacheName.getBytes(HotRodConstants.HOTROD_STRING_CHARSET);
    }
 
    public static byte[] cacheNameBytes() {

--- a/commons/src/main/java/org/infinispan/commons/api/BasicCacheContainer.java
+++ b/commons/src/main/java/org/infinispan/commons/api/BasicCacheContainer.java
@@ -12,9 +12,6 @@ import java.util.Set;
  * @since 4.0
  */
 public interface BasicCacheContainer extends Lifecycle {
-   @Deprecated
-   String DEFAULT_CACHE_NAME = "___defaultcache";
-
    /**
     * Retrieves the default cache associated with this cache container.
     * <p/>

--- a/core/src/main/java/org/infinispan/cache/impl/AbstractDelegatingCache.java
+++ b/core/src/main/java/org/infinispan/cache/impl/AbstractDelegatingCache.java
@@ -15,7 +15,6 @@ import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
 import org.infinispan.CacheCollection;
 import org.infinispan.CacheSet;
-import org.infinispan.commons.api.BasicCacheContainer;
 import org.infinispan.configuration.format.PropertyFormatter;
 import org.infinispan.filter.KeyFilter;
 import org.infinispan.jmx.annotations.DataType;
@@ -94,8 +93,7 @@ public abstract class AbstractDelegatingCache<K, V> implements Cache<K, V> {
          displayType = DisplayType.SUMMARY
    )
    public String getCacheName() {
-      String name = getName().equals(BasicCacheContainer.DEFAULT_CACHE_NAME) ? "Default Cache" : getName();
-      return name + "(" + getCacheConfiguration().clustering().cacheMode().toString().toLowerCase() + ")";
+      return getName() + "(" + getCacheConfiguration().clustering().cacheMode().toString().toLowerCase() + ")";
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/cache/impl/CacheImpl.java
+++ b/core/src/main/java/org/infinispan/cache/impl/CacheImpl.java
@@ -66,7 +66,6 @@ import org.infinispan.commands.write.RemoveExpiredCommand;
 import org.infinispan.commands.write.ReplaceCommand;
 import org.infinispan.commands.write.ValueMatcher;
 import org.infinispan.commons.CacheException;
-import org.infinispan.commons.api.BasicCacheContainer;
 import org.infinispan.commons.dataconversion.Encoder;
 import org.infinispan.commons.dataconversion.IdentityEncoder;
 import org.infinispan.commons.dataconversion.IdentityWrapper;
@@ -1351,8 +1350,7 @@ public class CacheImpl<K, V> implements AdvancedCache<K, V> {
          displayType = DisplayType.SUMMARY
    )
    public String getCacheName() {
-      String name = getName().equals(BasicCacheContainer.DEFAULT_CACHE_NAME) ? "Default Cache" : getName();
-      return name + "(" + getCacheConfiguration().clustering().cacheMode().toString().toLowerCase() + ")";
+      return getName() + "(" + getCacheConfiguration().clustering().cacheMode().toString().toLowerCase() + ")";
    }
 
    /**

--- a/core/src/main/java/org/infinispan/cache/impl/SimpleCacheImpl.java
+++ b/core/src/main/java/org/infinispan/cache/impl/SimpleCacheImpl.java
@@ -36,7 +36,6 @@ import org.infinispan.LockedStream;
 import org.infinispan.Version;
 import org.infinispan.atomic.Delta;
 import org.infinispan.batch.BatchContainer;
-import org.infinispan.commons.api.BasicCacheContainer;
 import org.infinispan.commons.dataconversion.Encoder;
 import org.infinispan.commons.dataconversion.Wrapper;
 import org.infinispan.commons.time.TimeService;
@@ -678,8 +677,7 @@ public class SimpleCacheImpl<K, V> implements AdvancedCache<K, V> {
          displayType = DisplayType.SUMMARY
    )
    public String getCacheName() {
-      String name = getName().equals(BasicCacheContainer.DEFAULT_CACHE_NAME) ? "Default Cache" : getName();
-      return name + "(" + getCacheConfiguration().clustering().cacheMode().toString().toLowerCase() + ")";
+      return getName() + "(" + getCacheConfiguration().clustering().cacheMode().toString().toLowerCase() + ")";
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/configuration/ConfigurationManager.java
+++ b/core/src/main/java/org/infinispan/configuration/ConfigurationManager.java
@@ -13,7 +13,6 @@ import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.configuration.parsing.ConfigurationBuilderHolder;
-import org.infinispan.manager.CacheContainer;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -103,7 +102,7 @@ public class ConfigurationManager {
 
    public Collection<String> getDefinedCaches() {
       List<String> cacheNames = namedConfiguration.entrySet().stream()
-            .filter(entry -> !entry.getValue().isTemplate() && !entry.getKey().equals(CacheContainer.DEFAULT_CACHE_NAME))
+            .filter(entry -> !entry.getValue().isTemplate())
             .map(entry -> entry.getKey())
             .collect(Collectors.toList());
       return Collections.unmodifiableCollection(cacheNames);

--- a/core/src/main/java/org/infinispan/configuration/cache/BackupForBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/BackupForBuilder.java
@@ -5,7 +5,6 @@ import static org.infinispan.configuration.cache.BackupForConfiguration.REMOTE_S
 
 import java.lang.invoke.MethodHandles;
 
-import org.infinispan.commons.api.BasicCacheContainer;
 import org.infinispan.commons.configuration.Builder;
 import org.infinispan.commons.configuration.ConfigurationBuilderInfo;
 import org.infinispan.commons.configuration.attributes.AttributeSet;
@@ -57,9 +56,11 @@ public class BackupForBuilder extends AbstractConfigurationChildBuilder implemen
 
    /**
     * Use this method if the remote cache that backups in this cache is the default cache.
+    * @deprecated Use a named cache with {@link #remoteCache(String)} instead.
     */
+   @Deprecated
    public BackupForBuilder defaultRemoteCache() {
-      attributes.attribute(REMOTE_CACHE).set(BasicCacheContainer.DEFAULT_CACHE_NAME);
+      attributes.attribute(REMOTE_CACHE).set("");
       return this;
    }
 

--- a/core/src/main/java/org/infinispan/configuration/parsing/Parser.java
+++ b/core/src/main/java/org/infinispan/configuration/parsing/Parser.java
@@ -23,7 +23,6 @@ import java.util.function.Supplier;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 
-import org.infinispan.commons.api.BasicCacheContainer;
 import org.infinispan.commons.configuration.BuiltBy;
 import org.infinispan.commons.configuration.ConfiguredBy;
 import org.infinispan.commons.executors.BlockingThreadPoolExecutorFactory;
@@ -558,14 +557,10 @@ public class Parser implements ConfigurationParser {
    private void parseContainer(XMLExtendedStreamReader reader, ConfigurationBuilderHolder holder) throws XMLStreamException {
       holder.pushScope(ParserScope.CACHE_CONTAINER);
       GlobalConfigurationBuilder builder = holder.getGlobalConfigurationBuilder();
-      if (!reader.getSchema().since(9, 0)) {
-         builder.defaultCacheName(BasicCacheContainer.DEFAULT_CACHE_NAME);
-      }
       for (int i = 0; i < reader.getAttributeCount(); i++) {
          ParseUtils.requireNoNamespaceAttribute(reader, i);
          String value = reader.getAttributeValue(i);
          Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
-
          switch (attribute) {
             case NAME: {
                builder.globalJmxStatistics().cacheManagerName(value);

--- a/core/src/main/java/org/infinispan/interceptors/impl/InvocationContextInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/InvocationContextInterceptor.java
@@ -26,7 +26,6 @@ import org.infinispan.factories.annotations.Stop;
 import org.infinispan.interceptors.BaseAsyncInterceptor;
 import org.infinispan.interceptors.InvocationExceptionFunction;
 import org.infinispan.lifecycle.ComponentStatus;
-import org.infinispan.manager.CacheContainer;
 import org.infinispan.statetransfer.OutdatedTopologyException;
 import org.infinispan.transaction.WriteSkewException;
 import org.infinispan.transaction.impl.AbstractCacheTransaction;
@@ -150,10 +149,7 @@ public class InvocationContextInterceptor extends BaseAsyncInterceptor {
 
    private String getCacheNamePrefix() {
       String cacheName = componentRegistry.getCacheName();
-      String prefix = "Cache '" + cacheName + "'";
-      if (cacheName.equals(CacheContainer.DEFAULT_CACHE_NAME))
-         prefix = "Default cache";
-      return prefix;
+      return  "Cache '" + cacheName + "'";
    }
 
    /**

--- a/core/src/main/java/org/infinispan/security/Security.java
+++ b/core/src/main/java/org/infinispan/security/Security.java
@@ -8,7 +8,8 @@ import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.security.acl.Group;
-import java.util.Stack;
+import java.util.ArrayDeque;
+import java.util.Deque;
 
 import javax.security.auth.Subject;
 
@@ -30,7 +31,7 @@ public final class Security {
 
    private static final ThreadLocal<Boolean> PRIVILEGED = ThreadLocal.withInitial(() -> Boolean.FALSE);
 
-   private static final ThreadLocal<Stack<Subject>> SUBJECT = new ThreadLocal<>();
+   private static final ThreadLocal<Deque<Subject>> SUBJECT = new ThreadLocal<>();
 
    private static boolean isTrustedClass(Class<?> klass) {
       // TODO: implement a better way
@@ -76,9 +77,9 @@ public final class Security {
     * @see Subject#doAs(Subject, PrivilegedAction)
     */
    public static <T> T doAs(final Subject subject, final java.security.PrivilegedAction<T> action) {
-      Stack<Subject> stack = SUBJECT.get();
+      Deque<Subject> stack = SUBJECT.get();
       if (stack == null) {
-         stack = new Stack<>();
+         stack = new ArrayDeque<>();
          SUBJECT.set(stack);
       }
       stack.push(subject);
@@ -101,9 +102,9 @@ public final class Security {
    public static <T> T doAs(final Subject subject,
          final java.security.PrivilegedExceptionAction<T> action)
          throws java.security.PrivilegedActionException {
-      Stack<Subject> stack = SUBJECT.get();
+      Deque<Subject> stack = SUBJECT.get();
       if (stack == null) {
-         stack = new Stack<>();
+         stack = new ArrayDeque<>();
          SUBJECT.set(stack);
       }
       stack.push(subject);

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -933,6 +933,7 @@ public interface Log extends BasicLogger {
    @Message(value = "Error while processing prepare", id = 255)
    void errorProcessingPrepare(@Cause Throwable e);
 
+/*
    @LogMessage(level = ERROR)
    @Message(value = "Configurator SAXParse error", id = 256)
    void configuratorSAXParseError(@Cause Exception e);
@@ -944,6 +945,7 @@ public interface Log extends BasicLogger {
    @LogMessage(level = ERROR)
    @Message(value = "Configurator general error", id = 258)
    void configuratorError(@Cause Exception e);
+ */
 
    @LogMessage(level = ERROR)
    @Message(value = "Async store executor did not stop properly", id = 259)
@@ -1495,9 +1497,8 @@ public interface Log extends BasicLogger {
    @Message(value = "Direct usage of the ___defaultcache name to retrieve the default cache is deprecated", id = 434)
    void deprecatedDefaultCache();
 
-   @LogMessage(level = WARN)
    @Message(value = "Cache manager initialized with a default cache configuration but without a name for it. Set it in the GlobalConfiguration.", id = 435)
-   void defaultCacheConfigurationWithoutName();
+   CacheConfigurationException defaultCacheConfigurationWithoutName();
 
    @Message(value = "Cache '%s' has been requested, but no cache configuration exists with that name and no default cache has been set for this container", id = 436)
    CacheConfigurationException noSuchCacheConfiguration(String name);

--- a/core/src/main/java/org/infinispan/xsite/BackupReceiverRepositoryImpl.java
+++ b/core/src/main/java/org/infinispan/xsite/BackupReceiverRepositoryImpl.java
@@ -69,15 +69,6 @@ public class BackupReceiverRepositoryImpl implements BackupReceiverRepository {
       BackupReceiver backupManager = backupReceivers.get(toLookFor);
       if (backupManager != null) return backupManager;
 
-      //check the default cache first
-      Configuration dcc = cacheManager.getDefaultCacheConfiguration();
-      if (dcc != null && isBackupForRemoteCache(remoteSite, remoteCache, dcc, EmbeddedCacheManager.DEFAULT_CACHE_NAME)) {
-         Cache<Object, Object> cache = cacheManager.getCache();
-         backupReceivers.putIfAbsent(toLookFor, createBackupReceiver(cache));
-         toLookFor.setLocalCacheName(EmbeddedCacheManager.DEFAULT_CACHE_NAME);
-         return backupReceivers.get(toLookFor);
-      }
-
       Set<String> cacheNames = cacheManager.getCacheNames();
       for (String name : cacheNames) {
          Configuration cacheConfiguration = cacheManager.getCacheConfiguration(name);

--- a/core/src/test/java/org/infinispan/configuration/XmlFileParsingTest.java
+++ b/core/src/test/java/org/infinispan/configuration/XmlFileParsingTest.java
@@ -38,6 +38,7 @@ import org.infinispan.eviction.EvictionStrategy;
 import org.infinispan.eviction.EvictionType;
 import org.infinispan.factories.threads.DefaultThreadFactory;
 import org.infinispan.interceptors.FooInterceptor;
+import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.marshall.AdvancedExternalizerTest;
 import org.infinispan.marshall.TestObjectStreamMarshaller;
 import org.infinispan.persistence.spi.MarshallableEntry;
@@ -71,7 +72,7 @@ public class XmlFileParsingTest extends AbstractInfinispanTest {
       assertNamedCacheFile(holder, false);
    }
 
-   public void testNoNamedCaches() throws Exception {
+   public void testNoNamedCaches() {
       String config = TestingUtil.wrapXMLWithSchema(
             "<cache-container default-cache=\"default\">" +
             "   <transport cluster=\"demoCluster\"/>\n" +
@@ -99,7 +100,7 @@ public class XmlFileParsingTest extends AbstractInfinispanTest {
    }
 
    @Test(expectedExceptions=CacheConfigurationException.class)
-   public void testDuplicateCacheNames() throws Exception {
+   public void testDuplicateCacheNames() {
       String config = TestingUtil.wrapXMLWithSchema(
             "<cache-container default-cache=\"duplicatename\">" +
             "   <transport cluster=\"demoCluster\"/>\n" +
@@ -114,7 +115,7 @@ public class XmlFileParsingTest extends AbstractInfinispanTest {
       TestCacheManagerFactory.fromStream(is);
    }
 
-   public void testNoSchemaWithStuff() throws IOException {
+   public void testNoSchemaWithStuff() {
       String config = TestingUtil.wrapXMLWithSchema(
             "<cache-container default-cache=\"default\">" +
             "   <local-cache name=\"default\">\n" +
@@ -137,7 +138,7 @@ public class XmlFileParsingTest extends AbstractInfinispanTest {
 
    }
 
-   public void testCompatibility() throws Exception {
+   public void testCompatibility() {
       String config = TestingUtil.wrapXMLWithSchema(
             "<cache-container default-cache=\"default\">" +
             "   <local-cache name=\"default\">\n" +
@@ -192,7 +193,7 @@ public class XmlFileParsingTest extends AbstractInfinispanTest {
       });
    }
 
-   public void testOffHeap() throws Exception {
+   public void testOffHeap() {
       String config = TestingUtil.wrapXMLWithSchema(
             "<cache-container default-cache=\"default\">" +
             "   <local-cache name=\"default\">\n" +
@@ -297,7 +298,7 @@ public class XmlFileParsingTest extends AbstractInfinispanTest {
       public void stop() { }
    }
 
-   public void testStoreWithNoConfigureBy() throws IOException {
+   public void testStoreWithNoConfigureBy() {
       String config = TestingUtil.wrapXMLWithoutSchema(
             "<cache-container default-cache=\"default\">" +
             "   <local-cache name=\"default\">\n" +
@@ -324,7 +325,7 @@ public class XmlFileParsingTest extends AbstractInfinispanTest {
       });
    }
 
-   public void testCustomTransport() throws IOException {
+   public void testCustomTransport() {
       String config = TestingUtil.wrapXMLWithSchema(
             "<jgroups transport=\"org.infinispan.configuration.XmlFileParsingTest$CustomTransport\"/>\n" +
             "<cache-container default-cache=\"default\">\n" +
@@ -344,7 +345,7 @@ public class XmlFileParsingTest extends AbstractInfinispanTest {
       });
    }
 
-   public void testNoDefaultCache() throws Exception {
+   public void testNoDefaultCache() {
       String config = TestingUtil.wrapXMLWithSchema(
             "<cache-container>" +
             "   <transport cluster=\"demoCluster\"/>\n" +
@@ -354,7 +355,8 @@ public class XmlFileParsingTest extends AbstractInfinispanTest {
       );
 
       InputStream is = new ByteArrayInputStream(config.getBytes());
-      withCacheManager(new CacheManagerCallable(TestCacheManagerFactory.fromStream(is)) {
+      ConfigurationBuilderHolder holder = TestCacheManagerFactory.holderFromStream(is, false);
+      withCacheManager(new CacheManagerCallable(new DefaultCacheManager(holder, true)) {
 
          @Override
          public void call() {
@@ -368,7 +370,7 @@ public class XmlFileParsingTest extends AbstractInfinispanTest {
    }
 
    @Test(expectedExceptions = CacheConfigurationException.class, expectedExceptionsMessageRegExp = "ISPN000432:.*")
-   public void testNoDefaultCacheDeclaration() throws Exception {
+   public void testNoDefaultCacheDeclaration() {
       String config = TestingUtil.wrapXMLWithSchema(
             "<cache-container default-cache=\"non-existent\">" +
             "   <transport cluster=\"demoCluster\"/>\n" +
@@ -389,7 +391,7 @@ public class XmlFileParsingTest extends AbstractInfinispanTest {
    }
 
 
-   public void testWildcards() throws IOException {
+   public void testWildcards() {
       String config = TestingUtil.wrapXMLWithSchema(
             "<cache-container>" +
             "   <local-cache-configuration name=\"wildcache*\">\n" +
@@ -438,7 +440,7 @@ public class XmlFileParsingTest extends AbstractInfinispanTest {
    }
 
    @Test(expectedExceptions = CacheConfigurationException.class, expectedExceptionsMessageRegExp = "ISPN000484:.*")
-   public void testNoWildcardsInCacheName() throws Exception {
+   public void testNoWildcardsInCacheName() {
       String config = TestingUtil.wrapXMLWithSchema(
             "<cache-container>" +
             "   <transport cluster=\"demoCluster\"/>\n" +

--- a/core/src/test/java/org/infinispan/conflict/impl/MultipleCachesDuringConflictResolutionTest.java
+++ b/core/src/test/java/org/infinispan/conflict/impl/MultipleCachesDuringConflictResolutionTest.java
@@ -2,7 +2,6 @@ package org.infinispan.conflict.impl;
 
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.conflict.MergePolicy;
-import org.infinispan.manager.CacheContainer;
 import org.infinispan.partitionhandling.BasePartitionHandlingTest;
 import org.infinispan.partitionhandling.PartitionHandling;
 import org.infinispan.test.TestingUtil;
@@ -39,7 +38,6 @@ public class MultipleCachesDuringConflictResolutionTest extends BasePartitionHan
             .partitionHandling().whenSplit(PartitionHandling.ALLOW_READ_WRITES).mergePolicy(MergePolicy.PREFERRED_ALWAYS);
       String[] cacheNames = getCacheNames();
       createClusteredCaches(numMembersInCluster, dcc, new TransportFlags().withFD(true).withMerge(true), cacheNames);
-      waitForClusterToForm(CacheContainer.DEFAULT_CACHE_NAME);
       waitForClusterToForm(cacheNames);
    }
 

--- a/core/src/test/java/org/infinispan/distribution/InvalidationFailureTest.java
+++ b/core/src/test/java/org/infinispan/distribution/InvalidationFailureTest.java
@@ -4,7 +4,6 @@ import javax.transaction.Transaction;
 
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
-import org.infinispan.manager.CacheContainer;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.util.concurrent.IsolationLevel;
 import org.testng.annotations.Test;
@@ -23,11 +22,12 @@ public class InvalidationFailureTest extends MultipleCacheManagersTest {
       config.clustering().l1().enable().hash().numOwners(1);
       config.locking().isolationLevel(IsolationLevel.READ_COMMITTED);
       createCluster(config, 2);
+      final String cacheName = manager(0).getCacheManagerConfiguration().defaultCacheName().get();
       manager(0).defineConfiguration("second", config.build());
       manager(1).defineConfiguration("second", config.build());
-      manager(0).startCaches(CacheContainer.DEFAULT_CACHE_NAME, "second");
-      manager(1).startCaches(CacheContainer.DEFAULT_CACHE_NAME, "second");
-      waitForClusterToForm(CacheContainer.DEFAULT_CACHE_NAME, "second");
+      manager(0).startCaches(cacheName, "second");
+      manager(1).startCaches(cacheName, "second");
+      waitForClusterToForm(cacheName, "second");
       cache(0).put("k","v");
       cache(0,"second").put("k","v");
       assert cache(1).get("k").equals("v");

--- a/core/src/test/java/org/infinispan/distribution/rehash/NonTxBackupOwnerBecomingPrimaryOwnerTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/NonTxBackupOwnerBecomingPrimaryOwnerTest.java
@@ -17,17 +17,15 @@ import java.util.concurrent.TimeUnit;
 
 import org.infinispan.AdvancedCache;
 import org.infinispan.commands.FlagAffectedCommand;
-import org.infinispan.commons.api.BasicCacheContainer;
+import org.infinispan.commands.write.PutKeyValueCommand;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
-import org.infinispan.context.impl.FlagBitSets;
-import org.infinispan.commands.write.PutKeyValueCommand;
 import org.infinispan.context.InvocationContext;
+import org.infinispan.context.impl.FlagBitSets;
 import org.infinispan.distribution.BlockingInterceptor;
 import org.infinispan.interceptors.DDAsyncInterceptor;
 import org.infinispan.interceptors.distribution.TriangleDistributionInterceptor;
 import org.infinispan.interceptors.impl.EntryWrappingInterceptor;
-import org.infinispan.manager.CacheContainer;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.partitionhandling.AvailabilityMode;
 import org.infinispan.remoting.transport.Address;
@@ -52,8 +50,6 @@ import org.testng.annotations.Test;
 @Test(groups = "functional", testName = "distribution.rehash.NonTxBackupOwnerBecomingPrimaryOwnerTest")
 @CleanupAfterMethod
 public class NonTxBackupOwnerBecomingPrimaryOwnerTest extends MultipleCacheManagersTest {
-
-   private static final String CACHE_NAME = BasicCacheContainer.DEFAULT_CACHE_NAME;
 
    @Override
    protected void createCacheManagers() throws Throwable {
@@ -102,13 +98,14 @@ public class NonTxBackupOwnerBecomingPrimaryOwnerTest extends MultipleCacheManag
 
    protected void doTest(final TestWriteOperation op) throws Exception {
       final String key = "testkey";
+      final String cacheName = manager(0).getCacheManagerConfiguration().defaultCacheName().get();
       if (op.getPreviousValue() != null) {
-         cache(0, CACHE_NAME).put(key, op.getPreviousValue());
+         cache(0, cacheName).put(key, op.getPreviousValue());
       }
 
       CheckPoint checkPoint = new CheckPoint();
       LocalTopologyManager ltm0 = TestingUtil.extractGlobalComponent(manager(0), LocalTopologyManager.class);
-      int preJoinTopologyId = ltm0.getCacheTopology(CACHE_NAME).getTopologyId();
+      int preJoinTopologyId = ltm0.getCacheTopology(cacheName).getTopologyId();
 
       final AdvancedCache<Object, Object> cache0 = advancedCache(0);
       addBlockingLocalTopologyManager(manager(0), checkPoint, preJoinTopologyId);
@@ -144,7 +141,7 @@ public class NonTxBackupOwnerBecomingPrimaryOwnerTest extends MultipleCacheManag
             cache1.getRpcManager().getMembers().size() == 3 &&
             cache2.getRpcManager().getMembers().size() == 3);
 
-      CacheTopology duringJoinTopology = ltm0.getCacheTopology(CACHE_NAME);
+      CacheTopology duringJoinTopology = ltm0.getCacheTopology(cacheName);
       assertEquals(duringJoinTopologyId, duringJoinTopology.getTopologyId());
       assertNotNull(duringJoinTopology.getPendingCH());
       log.tracef("Rebalance started. Found key %s with current owners %s and pending owners %s", key,
@@ -191,7 +188,7 @@ public class NonTxBackupOwnerBecomingPrimaryOwnerTest extends MultipleCacheManag
       beforeCache1Barrier.await(10, TimeUnit.SECONDS);
 
       // Allow the retry to proceed on cache1
-      CacheTopology postJoinTopology = ltm0.getCacheTopology(CACHE_NAME);
+      CacheTopology postJoinTopology = ltm0.getCacheTopology(cacheName);
       if (postJoinTopology.getCurrentCH().locateOwners(key).contains(address(1))) {
          beforeCache1Barrier.await(10, TimeUnit.SECONDS);
          beforeCache1Barrier.await(10, TimeUnit.SECONDS);
@@ -253,7 +250,7 @@ public class NonTxBackupOwnerBecomingPrimaryOwnerTest extends MultipleCacheManag
                   10, TimeUnit.SECONDS);
          }
          return invocation.callRealMethod();
-      }).when(spyLtm).handleTopologyUpdate(eq(CacheContainer.DEFAULT_CACHE_NAME), any(CacheTopology.class),
+      }).when(spyLtm).handleTopologyUpdate(eq(TestingUtil.getDefaultCacheName(manager)), any(CacheTopology.class),
                                            any(AvailabilityMode.class), anyInt(), any(Address.class));
       TestingUtil.replaceComponent(manager, LocalTopologyManager.class, spyLtm, true);
    }

--- a/core/src/test/java/org/infinispan/distribution/rehash/StateResponseOrderingTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/StateResponseOrderingTest.java
@@ -20,7 +20,6 @@ import org.infinispan.conflict.impl.StateReceiver;
 import org.infinispan.container.entries.ImmortalCacheEntry;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.distribution.MagicKey;
-import org.infinispan.manager.CacheContainer;
 import org.infinispan.remoting.inboundhandler.DeliverOrder;
 import org.infinispan.remoting.inboundhandler.PerCacheInboundInvocationHandler;
 import org.infinispan.remoting.inboundhandler.Reply;
@@ -115,7 +114,8 @@ public class StateResponseOrderingTest extends MultipleCacheManagersTest {
       PerCacheInboundInvocationHandler handler = TestingUtil.extractComponent(cache(0), PerCacheInboundInvocationHandler.class);
       StateChunk stateChunk0 = new StateChunk(0, Arrays.asList(new ImmortalCacheEntry("k0", "v0")), true);
       StateChunk stateChunk1 = new StateChunk(1, Arrays.asList(new ImmortalCacheEntry("k0", "v0")), true);
-      StateResponseCommand stateResponseCommand = new StateResponseCommand(ByteString.fromString(CacheContainer.DEFAULT_CACHE_NAME),
+      String cacheName = manager(0).getCacheManagerConfiguration().defaultCacheName().get();
+      StateResponseCommand stateResponseCommand = new StateResponseCommand(ByteString.fromString(cacheName),
             address(1), initialTopologyId, Arrays.asList(stateChunk0, stateChunk1), true, false);
       // Call with preserveOrder = true to force the execution in the same thread
       stateResponseCommand.setOrigin(address(3));

--- a/core/src/test/java/org/infinispan/jmx/AbstractClusterMBeanTest.java
+++ b/core/src/test/java/org/infinispan/jmx/AbstractClusterMBeanTest.java
@@ -18,28 +18,23 @@ import org.infinispan.test.fwk.TransportFlags;
  */
 abstract class AbstractClusterMBeanTest extends MultipleCacheManagersTest {
 
-   final String cachename;
    final String jmxDomain;
    final String jmxDomain2;
 
    AbstractClusterMBeanTest(String clusterName) {
-      this.cachename = clusterName;
       this.jmxDomain = clusterName;
       this.jmxDomain2 = clusterName + "2";
    }
 
    @Override
    protected void createCacheManagers() throws Throwable {
-      ConfigurationBuilder defaultConfig = new ConfigurationBuilder();
-      CacheContainer c1 = createManager(defaultConfig);
-      CacheContainer c2 = createManager(defaultConfig);
-      CacheContainer c3 = createManager(defaultConfig);
-      registerCacheManager(c1, c2, c3);
-
       ConfigurationBuilder cb = new ConfigurationBuilder();
       cb.clustering().cacheMode(CacheMode.REPL_SYNC).jmxStatistics().enable();
-      defineConfigurationOnAllManagers(cachename, cb);
-      waitForClusterToForm(cachename);
+      CacheContainer c1 = createManager(cb);
+      CacheContainer c2 = createManager(cb);
+      CacheContainer c3 = createManager(cb);
+      registerCacheManager(c1, c2, c3);
+      waitForClusterToForm(getDefaultCacheName());
    }
 
    private CacheContainer createManager(ConfigurationBuilder builder) {

--- a/core/src/test/java/org/infinispan/jmx/ActivationAndPassivationInterceptorMBeanTest.java
+++ b/core/src/test/java/org/infinispan/jmx/ActivationAndPassivationInterceptorMBeanTest.java
@@ -39,10 +39,8 @@ public class ActivationAndPassivationInterceptorMBeanTest extends SingleCacheMan
 
    AdvancedLoadWriteStore loader;
    MBeanServer threadMBeanServer;
-   final ObjectName activationInterceptorObjName =
-         getCacheObjectName(JMX_DOMAIN, "___defaultcache(local)", "Activation");
-   final ObjectName passivationInterceptorObjName =
-         getCacheObjectName(JMX_DOMAIN, "___defaultcache(local)", "Passivation");
+   ObjectName activationInterceptorObjName;
+   ObjectName passivationInterceptorObjName;
 
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       GlobalConfigurationBuilder globalBuilder = new GlobalConfigurationBuilder();
@@ -68,7 +66,11 @@ public class ActivationAndPassivationInterceptorMBeanTest extends SingleCacheMan
    @Override
    protected void setup() throws Exception {
       super.setup();
-      loader = (AdvancedLoadWriteStore) TestingUtil.getFirstLoader(cache);
+      activationInterceptorObjName =
+            getCacheObjectName(JMX_DOMAIN, getDefaultCacheName() + "(local)", "Activation");
+      passivationInterceptorObjName =
+            getCacheObjectName(JMX_DOMAIN, getDefaultCacheName() + "(local)", "Passivation");
+      loader = TestingUtil.getFirstLoader(cache);
    }
 
    @AfterMethod

--- a/core/src/test/java/org/infinispan/jmx/CacheAvailabilityJmxTest.java
+++ b/core/src/test/java/org/infinispan/jmx/CacheAvailabilityJmxTest.java
@@ -5,6 +5,7 @@ import static org.testng.AssertJUnit.assertNull;
 import static org.testng.AssertJUnit.assertTrue;
 
 import java.util.Arrays;
+
 import javax.management.Attribute;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
@@ -14,7 +15,6 @@ import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.distribution.DistributionManager;
-import org.infinispan.manager.CacheContainer;
 import org.infinispan.partitionhandling.PartitionHandling;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
@@ -52,10 +52,11 @@ public class CacheAvailabilityJmxTest extends MultipleCacheManagersTest {
 
    public void testAvailabilityChange() throws Exception {
       final MBeanServer mBeanServer = PerThreadMBeanServerLookup.getThreadMBeanServer();
+      final String cacheName = manager(0).getCacheManagerConfiguration().defaultCacheName().get();
       String domain0 = manager(1).getCacheManagerConfiguration().globalJmxStatistics().domain();
-      final ObjectName cacheName0 = TestingUtil.getCacheObjectName(domain0, CacheContainer.DEFAULT_CACHE_NAME + "(dist_sync)");
+      final ObjectName cacheName0 = TestingUtil.getCacheObjectName(domain0, cacheName + "(dist_sync)");
       String domain1 = manager(1).getCacheManagerConfiguration().globalJmxStatistics().domain();
-      final ObjectName cacheName1 = TestingUtil.getCacheObjectName(domain1, CacheContainer.DEFAULT_CACHE_NAME + "(dist_sync)");
+      final ObjectName cacheName1 = TestingUtil.getCacheObjectName(domain1, cacheName + "(dist_sync)");
 
       // Check initial state
       DistributionManager dm0 = advancedCache(0).getDistributionManager();

--- a/core/src/test/java/org/infinispan/jmx/CacheConfigurationMBeanTest.java
+++ b/core/src/test/java/org/infinispan/jmx/CacheConfigurationMBeanTest.java
@@ -11,7 +11,6 @@ import org.infinispan.commons.jmx.PerThreadMBeanServerLookup;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.container.impl.DefaultDataContainer;
-import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
@@ -36,11 +35,11 @@ public class CacheConfigurationMBeanTest extends SingleCacheManagerTest {
       dcc.memory().size(1000);
       dcc.jmxStatistics().enable();
       server = PerThreadMBeanServerLookup.getThreadMBeanServer();
-      return new DefaultCacheManager(gcb.build(), dcc.build());
+      return TestCacheManagerFactory.createCacheManager(gcb, dcc, true);
    }
 
    public void testEvictionSize() throws Exception {
-      ObjectName defaultOn = getCacheObjectName(JMX_DOMAIN, "___defaultcache(local)", "Configuration");
+      ObjectName defaultOn = getCacheObjectName(JMX_DOMAIN, getDefaultCacheName() + "(local)", "Configuration");
       assertEquals(1000L, (long) server.getAttribute(defaultOn, "evictionSize"));
       assertEquals(1000, cache().getCacheConfiguration().memory().size());
       DefaultDataContainer<Object, Object> dataContainer = (DefaultDataContainer<Object, Object>) cache()

--- a/core/src/test/java/org/infinispan/jmx/CacheMBeanTest.java
+++ b/core/src/test/java/org/infinispan/jmx/CacheMBeanTest.java
@@ -44,12 +44,12 @@ public class CacheMBeanTest extends MultipleCacheManagersTest {
    }
 
    public void testJmxOperationMetadata() throws Exception {
-      ObjectName name = getCacheObjectName(JMX_DOMAIN);
+      ObjectName name = getCacheObjectName(JMX_DOMAIN, getDefaultCacheName() + "(local)");
       checkMBeanOperationParameterNaming(name);
    }
 
    public void testStartStopManagedOperations() throws Exception {
-      ObjectName defaultOn = getCacheObjectName(JMX_DOMAIN);
+      ObjectName defaultOn = getCacheObjectName(JMX_DOMAIN, getDefaultCacheName() + "(local)");
       ObjectName managerON = getCacheManagerObjectName(JMX_DOMAIN);
       server.invoke(managerON, "startCache", new Object[]{}, new String[]{});
       assert ComponentStatus.RUNNING.toString().equals(server.getAttribute(defaultOn, "CacheStatus"));
@@ -79,7 +79,7 @@ public class CacheMBeanTest extends MultipleCacheManagersTest {
 
    public void testManagerStopRemovesCacheMBean(Method m) throws Exception {
       final String otherJmxDomain = getMethodSpecificJmxDomain(m, JMX_DOMAIN);
-      ObjectName defaultOn = getCacheObjectName(otherJmxDomain);
+      ObjectName defaultOn = getCacheObjectName(otherJmxDomain, getDefaultCacheName() + "(local)");
       ObjectName galderOn = getCacheObjectName(otherJmxDomain, "galder(local)");
       ObjectName managerON = getCacheManagerObjectName(otherJmxDomain);
       EmbeddedCacheManager otherContainer = createCacheManagerEnforceJmxDomain(otherJmxDomain);
@@ -108,7 +108,7 @@ public class CacheMBeanTest extends MultipleCacheManagersTest {
    }
 
 
-   public void testDuplicateJmxDomainOnlyCacheExposesJmxStatistics() throws Exception {
+   public void testDuplicateJmxDomainOnlyCacheExposesJmxStatistics() {
       Exceptions.expectException(EmbeddedCacheManagerStartupException.class, JmxDomainConflictException.class,
                                  () -> createCacheManagerEnforceJmxDomain(JMX_DOMAIN, false, true, false));
    }
@@ -118,9 +118,9 @@ public class CacheMBeanTest extends MultipleCacheManagersTest {
       withCacheManager(new CacheManagerCallable(
             createCacheManagerEnforceJmxDomain(jmxDomain, false, false, true)) {
          @Override
-         public void call() throws Exception {
+         public void call() {
             cm.getCache();
-            ObjectName cacheObjectName = getCacheObjectName(jmxDomain);
+            ObjectName cacheObjectName = getCacheObjectName(jmxDomain, getDefaultCacheName() + "(local)");
             assertTrue(cacheObjectName + " should be registered",
                   server.isRegistered(cacheObjectName));
             TestingUtil.killCacheManagers(cm);

--- a/core/src/test/java/org/infinispan/jmx/CacheManagerMBeanTest.java
+++ b/core/src/test/java/org/infinispan/jmx/CacheManagerMBeanTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.jmx;
 
+import static java.lang.String.format;
 import static org.infinispan.factories.KnownComponentNames.TIMEOUT_SCHEDULE_EXECUTOR;
 import static org.infinispan.test.TestingUtil.checkMBeanOperationParameterNaming;
 import static org.infinispan.test.TestingUtil.existsObject;
@@ -57,8 +58,8 @@ public class CacheManagerMBeanTest extends SingleCacheManagerTest {
 
    public void testJmxOperations() throws Exception {
       assertEquals("1", server.getAttribute(name, "CreatedCacheCount"));
-      assertEquals("0", server.getAttribute(name, "DefinedCacheCount"));
-      assertEquals("[]", server.getAttribute(name, "DefinedCacheNames"));
+      assertEquals("1", server.getAttribute(name, "DefinedCacheCount"));
+      assertEquals(format("[%s(created)]", getDefaultCacheName()), server.getAttribute(name, "DefinedCacheNames"));
       assertEquals("1", server.getAttribute(name, "RunningCacheCount"));
 
       //now define some new caches
@@ -66,7 +67,7 @@ public class CacheManagerMBeanTest extends SingleCacheManagerTest {
       cacheManager.defineConfiguration("b", new ConfigurationBuilder().build());
       cacheManager.defineConfiguration("c", new ConfigurationBuilder().build());
       assertEquals("1", server.getAttribute(name, "CreatedCacheCount"));
-      assertEquals("3", server.getAttribute(name, "DefinedCacheCount"));
+      assertEquals("4", server.getAttribute(name, "DefinedCacheCount"));
       assertEquals("1", server.getAttribute(name, "RunningCacheCount"));
       String attribute = (String) server.getAttribute(name, "DefinedCacheConfigurationNames");
       String names[] = attribute.substring(1, attribute.length()-1).split(",");
@@ -78,7 +79,7 @@ public class CacheManagerMBeanTest extends SingleCacheManagerTest {
       server.invoke(name, "startCache", new Object[]{"a"}, new String[]{String.class.getName()});
       server.invoke(name, "startCache", new Object[]{"b"}, new String[]{String.class.getName()});
       assertEquals("3", server.getAttribute(name, "CreatedCacheCount"));
-      assertEquals("3", server.getAttribute(name, "DefinedCacheCount"));
+      assertEquals("4", server.getAttribute(name, "DefinedCacheCount"));
       assertEquals("3", server.getAttribute(name, "RunningCacheCount"));
       attribute = (String) server.getAttribute(name, "DefinedCacheNames");
       assertTrue(attribute.contains("a("));

--- a/core/src/test/java/org/infinispan/jmx/CacheOpsTest.java
+++ b/core/src/test/java/org/infinispan/jmx/CacheOpsTest.java
@@ -10,7 +10,6 @@ import javax.management.ObjectName;
 import org.infinispan.commons.jmx.PerThreadMBeanServerLookup;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
-import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
@@ -35,11 +34,11 @@ public class CacheOpsTest extends SingleCacheManagerTest {
       dcc.memory().size(1000);
       dcc.jmxStatistics().enable();
       server = PerThreadMBeanServerLookup.getThreadMBeanServer();
-      return new DefaultCacheManager(gcb.build(), dcc.build());
+      return TestCacheManagerFactory.createCacheManager(gcb, dcc, true);
    }
 
    public void testClear() throws Exception {
-      ObjectName defaultOn = getCacheObjectName(JMX_DOMAIN);
+      ObjectName defaultOn = getCacheObjectName(JMX_DOMAIN, getDefaultCacheName() + "(local)");
       tm().begin();
       cache().put("k","v");
       tm().commit();

--- a/core/src/test/java/org/infinispan/jmx/ClusterCacheStatsMBeanTest.java
+++ b/core/src/test/java/org/infinispan/jmx/ClusterCacheStatsMBeanTest.java
@@ -25,9 +25,9 @@ public class ClusterCacheStatsMBeanTest extends AbstractClusterMBeanTest {
    }
 
    public void testClusterStats() throws Exception {
-      Cache<String, Serializable> cache1 = manager(0).getCache(cachename);
+      Cache<String, Serializable> cache1 = manager(0).getCache();
       MBeanServer mBeanServer = PerThreadMBeanServerLookup.getThreadMBeanServer();
-      ObjectName clusterStats = getCacheObjectName(jmxDomain, cachename + "(repl_sync)", "ClusterCacheStats");
+      ObjectName clusterStats = getCacheObjectName(jmxDomain, getDefaultCacheName() + "(repl_sync)", "ClusterCacheStats");
 
       mBeanServer.setAttribute(clusterStats, new Attribute("StatisticsEnabled", false));
       assert !(boolean) mBeanServer.getAttribute(clusterStats, "StatisticsEnabled");

--- a/core/src/test/java/org/infinispan/jmx/ClusteredCacheMgmtInterceptorMBeanTest.java
+++ b/core/src/test/java/org/infinispan/jmx/ClusteredCacheMgmtInterceptorMBeanTest.java
@@ -48,8 +48,8 @@ public class ClusteredCacheMgmtInterceptorMBeanTest extends MultipleCacheManager
       Cache<String, String> cache2 = cache(1);
       cache1.put("k", "v");
       assertEquals("v", cache2.get("k"));
-      ObjectName stats1 = getCacheObjectName(JMX_1, "___defaultcache(repl_sync)", "Statistics");
-      ObjectName stats2 = getCacheObjectName(JMX_2, "___defaultcache(repl_sync)", "Statistics");
+      ObjectName stats1 = getCacheObjectName(JMX_1, getDefaultCacheName() + "(repl_sync)", "Statistics");
+      ObjectName stats2 = getCacheObjectName(JMX_2, getDefaultCacheName() + "(repl_sync)", "Statistics");
 
       MBeanServer mBeanServer = PerThreadMBeanServerLookup.getThreadMBeanServer();
       assertEquals((long) 1, mBeanServer.getAttribute(stats1, "Stores"));

--- a/core/src/test/java/org/infinispan/jmx/PerCacheInboundHandlerMBeanTest.java
+++ b/core/src/test/java/org/infinispan/jmx/PerCacheInboundHandlerMBeanTest.java
@@ -86,7 +86,7 @@ public class PerCacheInboundHandlerMBeanTest extends AbstractClusterMBeanTest {
 
       XSiteReplicateCommand command = mock(XSiteReplicateCommand.class);
       when(command.performInLocalSite(ArgumentMatchers.any(BackupReceiver.class))).thenReturn(null);
-      when(command.getCacheName()).thenReturn(ByteString.fromString(cachename));
+      when(command.getCacheName()).thenReturn(ByteString.fromString(getDefaultCacheName()));
 
       //check if it is collected
       Reply reply = response -> {
@@ -127,11 +127,11 @@ public class PerCacheInboundHandlerMBeanTest extends AbstractClusterMBeanTest {
 
 
    private ObjectName getObjectName() {
-      return getCacheObjectName(jmxDomain, cachename + "(repl_sync)", MBEAN_COMPONENT_NAME);
+      return getCacheObjectName(jmxDomain, getDefaultCacheName() + "(repl_sync)", MBEAN_COMPONENT_NAME);
    }
 
    private PerCacheInboundInvocationHandler getHandler() {
-      return cache(0, cachename).getAdvancedCache().getComponentRegistry().getPerCacheInboundInvocationHandler();
+      return cache(0).getAdvancedCache().getComponentRegistry().getPerCacheInboundInvocationHandler();
    }
 
 }

--- a/core/src/test/java/org/infinispan/jmx/RpcManagerMBeanTest.java
+++ b/core/src/test/java/org/infinispan/jmx/RpcManagerMBeanTest.java
@@ -64,16 +64,16 @@ public class RpcManagerMBeanTest extends AbstractClusterMBeanTest {
    }
 
    public void testJmxOperationMetadata() throws Exception {
-      ObjectName rpcManager = getCacheObjectName(jmxDomain, cachename + "(repl_sync)", "RpcManager");
+      ObjectName rpcManager = getCacheObjectName(jmxDomain, getDefaultCacheName() + "(repl_sync)", "RpcManager");
       checkMBeanOperationParameterNaming(rpcManager);
    }
 
    public void testEnableJmxStats() throws Exception {
-      Cache<String, String> cache1 = manager(0).getCache(cachename);
-      Cache cache2 = manager(1).getCache(cachename);
+      Cache<String, String> cache1 = manager(0).getCache();
+      Cache cache2 = manager(1).getCache();
       MBeanServer mBeanServer = PerThreadMBeanServerLookup.getThreadMBeanServer();
-      ObjectName rpcManager1 = getCacheObjectName(jmxDomain, cachename + "(repl_sync)", "RpcManager");
-      ObjectName rpcManager2 = getCacheObjectName(jmxDomain2, cachename + "(repl_sync)", "RpcManager");
+      ObjectName rpcManager1 = getCacheObjectName(jmxDomain, getDefaultCacheName() + "(repl_sync)", "RpcManager");
+      ObjectName rpcManager2 = getCacheObjectName(jmxDomain2, getDefaultCacheName() + "(repl_sync)", "RpcManager");
       assert mBeanServer.isRegistered(rpcManager1);
       assert mBeanServer.isRegistered(rpcManager2);
 
@@ -110,10 +110,10 @@ public class RpcManagerMBeanTest extends AbstractClusterMBeanTest {
 
    @Test(dependsOnMethods = "testEnableJmxStats")
    public void testSuccessRatio() throws Exception {
-      Cache<MagicKey, Serializable> cache1 = manager(0).getCache(cachename);
-      Cache cache2 = manager(1).getCache(cachename);
+      Cache<MagicKey, Serializable> cache1 = manager(0).getCache();
+      Cache cache2 = manager(1).getCache();
       MBeanServer mBeanServer = PerThreadMBeanServerLookup.getThreadMBeanServer();
-      ObjectName rpcManager1 = getCacheObjectName(jmxDomain, cachename + "(repl_sync)", "RpcManager");
+      ObjectName rpcManager1 = getCacheObjectName(jmxDomain, getDefaultCacheName() + "(repl_sync)", "RpcManager");
 
       // the previous test has reset the statistics
       assertEquals(mBeanServer.getAttribute(rpcManager1, "ReplicationCount"), (long) 0);
@@ -156,7 +156,7 @@ public class RpcManagerMBeanTest extends AbstractClusterMBeanTest {
    @Test(dependsOnMethods = "testEnableJmxStats")
    public void testXsiteStats() throws Exception {
       ControlledTimeService timeService = new ControlledTimeService();
-      RpcManagerImpl rpcManager = (RpcManagerImpl) extractComponent(cache(0, cachename), RpcManager.class);
+      RpcManagerImpl rpcManager = (RpcManagerImpl) extractComponent(cache(0), RpcManager.class);
       replaceField(timeService, "timeService", rpcManager, RpcManagerImpl.class);
       Transport originalTransport = rpcManager.getTransport();
 
@@ -216,7 +216,7 @@ public class RpcManagerMBeanTest extends AbstractClusterMBeanTest {
       asyncFutures.get(1).complete(null);
 
       MBeanServer mBeanServer = PerThreadMBeanServerLookup.getThreadMBeanServer();
-      ObjectName rpcManagerName = getCacheObjectName(jmxDomain, cachename + "(repl_sync)", "RpcManager");
+      ObjectName rpcManagerName = getCacheObjectName(jmxDomain, getDefaultCacheName() + "(repl_sync)", "RpcManager");
       assertEquals(mBeanServer.getAttribute(rpcManagerName, "SyncXSiteCount"), (long) 2);
       assertEquals(mBeanServer.getAttribute(rpcManagerName, "AsyncXSiteCount"), (long) 2);
       assertEquals(mBeanServer.getAttribute(rpcManagerName, "AsyncXSiteAcksCount"), (long) 2);

--- a/core/src/test/java/org/infinispan/manager/CacheDependencyTest.java
+++ b/core/src/test/java/org/infinispan/manager/CacheDependencyTest.java
@@ -1,6 +1,5 @@
 package org.infinispan.manager;
 
-import static org.infinispan.commons.api.BasicCacheContainer.DEFAULT_CACHE_NAME;
 import static org.testng.AssertJUnit.assertEquals;
 
 import java.util.ArrayList;
@@ -58,7 +57,7 @@ public class CacheDependencyTest extends SingleCacheManagerTest {
       cacheManager.stop();
 
       assertAllTerminated(cacheA, cacheB);
-      assertEquals(Arrays.asList("B", GlobalConfigurationManager.CONFIG_STATE_CACHE_NAME, DEFAULT_CACHE_NAME), listener.stopOrder);
+      assertEquals(Arrays.asList("B", getDefaultCacheName(), GlobalConfigurationManager.CONFIG_STATE_CACHE_NAME), listener.stopOrder);
    }
 
    @Test
@@ -102,7 +101,7 @@ public class CacheDependencyTest extends SingleCacheManagerTest {
       cacheManager.stop();
 
       assertAllTerminated(cacheA, cacheB, cacheC, cacheD);
-      assertEquals(Arrays.asList("A", "B", "D", "C", GlobalConfigurationManager.CONFIG_STATE_CACHE_NAME, DEFAULT_CACHE_NAME), listener.stopOrder);
+      assertEquals(Arrays.asList("A", "B", "D", "C", getDefaultCacheName(), GlobalConfigurationManager.CONFIG_STATE_CACHE_NAME), listener.stopOrder);
    }
 
    @Test
@@ -127,7 +126,7 @@ public class CacheDependencyTest extends SingleCacheManagerTest {
       cacheManager.stop();
 
       assertAllTerminated(cacheA, cacheB, cacheC);
-      assertEquals(Arrays.asList("A", "C", GlobalConfigurationManager.CONFIG_STATE_CACHE_NAME, DEFAULT_CACHE_NAME), listener.stopOrder);
+      assertEquals(Arrays.asList("A", "C", getDefaultCacheName(), GlobalConfigurationManager.CONFIG_STATE_CACHE_NAME), listener.stopOrder);
 
    }
 

--- a/core/src/test/java/org/infinispan/manager/CacheManagerTest.java
+++ b/core/src/test/java/org/infinispan/manager/CacheManagerTest.java
@@ -82,10 +82,10 @@ public class CacheManagerTest extends AbstractInfinispanTest {
 
       try {
          assertEquals(ComponentStatus.RUNNING, cm.getCache().getStatus());
-         assertTrue(cm.getCache().getName().equals(CacheContainer.DEFAULT_CACHE_NAME));
+         assertTrue(cm.getCache().getName().equals(TestingUtil.getDefaultCacheName(cm)));
 
-         expectException(IllegalArgumentException.class,
-                         () -> cm.defineConfiguration(CacheContainer.DEFAULT_CACHE_NAME,
+         expectException(CacheConfigurationException.class,
+                         () -> cm.defineConfiguration(TestingUtil.getDefaultCacheName(cm),
                                                       new ConfigurationBuilder().build()));
       } finally {
          TestingUtil.killCacheManagers(cm);
@@ -204,7 +204,7 @@ public class CacheManagerTest extends AbstractInfinispanTest {
          cm.defineConfiguration("three", new ConfigurationBuilder().build());
          cm.getCache("three");
          Set<String> cacheNames = cm.getCacheNames();
-         assertEquals(3, cacheNames.size());
+         assertEquals(4, cacheNames.size());
          assertTrue(cacheNames.contains("one"));
          assertTrue(cacheNames.contains("two"));
          assertTrue(cacheNames.contains("three"));

--- a/core/src/test/java/org/infinispan/marshall/VersionAwareMarshallerTest.java
+++ b/core/src/test/java/org/infinispan/marshall/VersionAwareMarshallerTest.java
@@ -29,7 +29,6 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.infinispan.Cache;
 import org.infinispan.commands.CommandInvocationId;
 import org.infinispan.commands.ReplicableCommand;
 import org.infinispan.commands.read.GetKeyValueCommand;
@@ -90,6 +89,7 @@ import org.infinispan.remoting.transport.Address;
 import org.infinispan.remoting.transport.jgroups.JGroupsAddress;
 import org.infinispan.statetransfer.StateRequestCommand;
 import org.infinispan.test.AbstractInfinispanTest;
+import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.test.fwk.TestInternalCacheEntryFactory;
 import org.infinispan.transaction.xa.GlobalTransaction;
@@ -216,7 +216,7 @@ public class VersionAwareMarshallerTest extends AbstractInfinispanTest {
    }
 
    public void testReplicableCommandsMarshalling() throws Exception {
-      ByteString cacheName = ByteString.fromString(EmbeddedCacheManager.DEFAULT_CACHE_NAME);
+      ByteString cacheName = ByteString.fromString(TestingUtil.getDefaultCacheName(cm));
       ClusteredGetCommand c2 = new ClusteredGetCommand("key", cacheName, 0, EnumUtil.EMPTY_BIT_SET);
       marshallAndAssertEquality(c2);
 
@@ -284,9 +284,7 @@ public class VersionAwareMarshallerTest extends AbstractInfinispanTest {
    }
 
    public void testStateTransferControlCommand() throws Exception {
-      Cache<Object,Object> cache = cm.getCache();
-
-      ByteString cacheName = ByteString.fromString(EmbeddedCacheManager.DEFAULT_CACHE_NAME);
+      ByteString cacheName = ByteString.fromString(TestingUtil.getDefaultCacheName(cm));
       ImmortalCacheEntry entry1 = (ImmortalCacheEntry) TestInternalCacheEntryFactory.create("key", "value", System.currentTimeMillis() - 1000, -1, System.currentTimeMillis(), -1);
       Collection<InternalCacheEntry> state = new ArrayList<>();
       state.add(entry1);

--- a/core/src/test/java/org/infinispan/partitionhandling/NumOwnersNodeCrashInSequenceTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/NumOwnersNodeCrashInSequenceTest.java
@@ -12,7 +12,6 @@ import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.distribution.MagicKey;
 import org.infinispan.distribution.ch.ConsistentHash;
-import org.infinispan.manager.CacheContainer;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.partitionhandling.impl.PartitionHandlingManager;
 import org.infinispan.remoting.transport.Address;
@@ -168,7 +167,7 @@ public class NumOwnersNodeCrashInSequenceTest extends MultipleCacheManagersTest 
       log.debug("Changing partition availability mode back to AVAILABLE");
       cchf.setOwnerIndexes(new int[][]{{a0, a1}, {a1, a0}, {a0, a1}, {a1, a0}});
       LocalTopologyManager ltm = TestingUtil.extractGlobalComponent(manager(a0), LocalTopologyManager.class);
-      ltm.setCacheAvailability(CacheContainer.DEFAULT_CACHE_NAME, AvailabilityMode.AVAILABLE);
+      ltm.setCacheAvailability(TestingUtil.getDefaultCacheName(manager(a0)), AvailabilityMode.AVAILABLE);
       TestingUtil.waitForNoRebalance(cache(a0), cache(a1));
       eventuallyEquals(AvailabilityMode.AVAILABLE, phm0::getAvailabilityMode);
    }

--- a/core/src/test/java/org/infinispan/scattered/stream/ScatteredStreamIteratorWithLoaderTest.java
+++ b/core/src/test/java/org/infinispan/scattered/stream/ScatteredStreamIteratorWithLoaderTest.java
@@ -10,6 +10,6 @@ import org.testng.annotations.Test;
 @Test(groups = "functional", testName = "scattered.stream.ScatteredStreamIteratorWithLoaderTest")
 public class ScatteredStreamIteratorWithLoaderTest extends BaseStreamIteratorWithLoaderTest {
    public ScatteredStreamIteratorWithLoaderTest() {
-      super(false, CacheMode.SCATTERED_SYNC, "ScatteredStreamIteratorWithLoaderTest");
+      super(false, CacheMode.SCATTERED_SYNC);
    }
 }

--- a/core/src/test/java/org/infinispan/statetransfer/ConcurrentStartForkChannelTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/ConcurrentStartForkChannelTest.java
@@ -12,12 +12,12 @@ import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
-import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.remoting.transport.jgroups.JGroupsTransport;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.infinispan.test.fwk.JGroupsConfigBuilder;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.test.fwk.TestResourceTracker;
 import org.infinispan.test.fwk.TransportFlags;
 import org.jgroups.JChannel;
@@ -135,7 +135,7 @@ public class ConcurrentStartForkChannelTest extends MultipleCacheManagersTest {
       gcb.transport().nodeName(channel.getName());
       gcb.transport().distributedSyncTimeout(30, TimeUnit.SECONDS);
 
-      EmbeddedCacheManager cm = new DefaultCacheManager(gcb.build(), cacheCfg.build(), false);
+      EmbeddedCacheManager cm = TestCacheManagerFactory.newDefaultCacheManager(false, gcb, cacheCfg, false);
       registerCacheManager(cm);
       return cm;
    }

--- a/core/src/test/java/org/infinispan/statetransfer/ForkChannelRestartTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/ForkChannelRestartTest.java
@@ -18,13 +18,13 @@ import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
-import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.partitionhandling.PartitionHandling;
 import org.infinispan.remoting.transport.jgroups.JGroupsTransport;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.infinispan.test.fwk.JGroupsConfigBuilder;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.test.fwk.TestResourceTracker;
 import org.infinispan.test.fwk.TransportFlags;
 import org.jgroups.JChannel;
@@ -113,7 +113,7 @@ public class ForkChannelRestartTest extends MultipleCacheManagersTest {
       gcb.transport().transport(new JGroupsTransport(fch));
       gcb.transport().distributedSyncTimeout(40, TimeUnit.SECONDS);
 
-      EmbeddedCacheManager cm = new DefaultCacheManager(gcb.build(), cacheCfg.build(), false);
+      EmbeddedCacheManager cm = TestCacheManagerFactory.newDefaultCacheManager(false, gcb, cacheCfg, false);
       registerCacheManager(cm);
       return cm;
    }

--- a/core/src/test/java/org/infinispan/stream/DistributedStreamIteratorWithLoaderTest.java
+++ b/core/src/test/java/org/infinispan/stream/DistributedStreamIteratorWithLoaderTest.java
@@ -13,6 +13,6 @@ import org.testng.annotations.Test;
 public class DistributedStreamIteratorWithLoaderTest extends BaseStreamIteratorWithLoaderTest {
 
    public DistributedStreamIteratorWithLoaderTest() {
-      super(false, CacheMode.DIST_SYNC, "DistributedStreamIteratorWithLoaderTest");
+      super(false, CacheMode.DIST_SYNC);
    }
 }

--- a/core/src/test/java/org/infinispan/stream/DistributedStreamIteratorWithStoreAsBinaryTest.java
+++ b/core/src/test/java/org/infinispan/stream/DistributedStreamIteratorWithStoreAsBinaryTest.java
@@ -8,8 +8,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
 
 import org.infinispan.Cache;
 import org.infinispan.configuration.cache.CacheMode;
@@ -35,7 +33,6 @@ import org.testng.annotations.Test;
 @Test(groups = "functional", testName = "stream.DistributedStreamIteratorWithStoreAsBinaryTest")
 @InCacheMode({ CacheMode.DIST_SYNC, CacheMode.SCATTERED_SYNC })
 public class DistributedStreamIteratorWithStoreAsBinaryTest extends MultipleCacheManagersTest {
-   protected final static String CACHE_NAME = "DistributedStreamIteratorWithStoreAsBinaryTest";
 
    @Override
    protected void createCacheManagers() throws Throwable {
@@ -43,14 +40,14 @@ public class DistributedStreamIteratorWithStoreAsBinaryTest extends MultipleCach
       builderUsed.clustering().cacheMode(cacheMode);
       builderUsed.clustering().hash().numOwners(1);
       builderUsed.memory().storageType(StorageType.BINARY);
-      createClusteredCaches(3, CACHE_NAME, builderUsed);
+      createClusteredCaches(3, builderUsed);
    }
 
    @Test
-   public void testFilterWithStoreAsBinary() throws InterruptedException, ExecutionException, TimeoutException {
-      Cache<MagicKey, String> cache0 = cache(0, CACHE_NAME);
-      Cache<MagicKey, String> cache1 = cache(1, CACHE_NAME);
-      Cache<MagicKey, String> cache2 = cache(2, CACHE_NAME);
+   public void testFilterWithStoreAsBinary() {
+      Cache<MagicKey, String> cache0 = cache(0);
+      Cache<MagicKey, String> cache1 = cache(1);
+      Cache<MagicKey, String> cache2 = cache(2);
 
       Map<MagicKey, String> originalValues = new HashMap<>();
       originalValues.put(new MagicKey(cache0), "cache0");
@@ -76,10 +73,10 @@ public class DistributedStreamIteratorWithStoreAsBinaryTest extends MultipleCach
    }
 
    @Test
-   public void testFilterWithStoreAsBinaryPartialKeys() throws InterruptedException, ExecutionException, TimeoutException {
-      Cache<MagicKey, String> cache0 = cache(0, CACHE_NAME);
-      Cache<MagicKey, String> cache1 = cache(1, CACHE_NAME);
-      Cache<MagicKey, String> cache2 = cache(2, CACHE_NAME);
+   public void testFilterWithStoreAsBinaryPartialKeys() {
+      Cache<MagicKey, String> cache0 = cache(0);
+      Cache<MagicKey, String> cache1 = cache(1);
+      Cache<MagicKey, String> cache2 = cache(2);
 
       MagicKey findKey = new MagicKey(cache1);
       Map<MagicKey, String> originalValues = new HashMap<>();

--- a/core/src/test/java/org/infinispan/stream/InvalidationStreamIteratorWithLoaderTest.java
+++ b/core/src/test/java/org/infinispan/stream/InvalidationStreamIteratorWithLoaderTest.java
@@ -14,6 +14,6 @@ import org.testng.annotations.Test;
 public class InvalidationStreamIteratorWithLoaderTest extends BaseStreamIteratorWithLoaderTest {
 
    public InvalidationStreamIteratorWithLoaderTest() {
-      super(false, CacheMode.INVALIDATION_SYNC, "InvalidationStreamIteratorWithLoaderTest");
+      super(false, CacheMode.INVALIDATION_SYNC);
    }
 }

--- a/core/src/test/java/org/infinispan/stream/LocalStreamIteratorWithLoaderTest.java
+++ b/core/src/test/java/org/infinispan/stream/LocalStreamIteratorWithLoaderTest.java
@@ -14,6 +14,6 @@ import org.testng.annotations.Test;
 public class LocalStreamIteratorWithLoaderTest extends BaseStreamIteratorWithLoaderTest {
 
    public LocalStreamIteratorWithLoaderTest() {
-      super(false, CacheMode.LOCAL, "LocalStreamIteratorWithLoaderTest");
+      super(false, CacheMode.LOCAL);
    }
 }

--- a/core/src/test/java/org/infinispan/stream/ReplicatedStreamIteratorWithLoaderTest.java
+++ b/core/src/test/java/org/infinispan/stream/ReplicatedStreamIteratorWithLoaderTest.java
@@ -14,6 +14,6 @@ import org.testng.annotations.Test;
 public class ReplicatedStreamIteratorWithLoaderTest extends BaseStreamIteratorWithLoaderTest {
 
    public ReplicatedStreamIteratorWithLoaderTest() {
-      super(false, CacheMode.REPL_SYNC, "ReplicatedStreamIteratorWithLoaderTest");
+      super(false, CacheMode.REPL_SYNC);
    }
 }

--- a/core/src/test/java/org/infinispan/test/AbstractCacheTest.java
+++ b/core/src/test/java/org/infinispan/test/AbstractCacheTest.java
@@ -18,7 +18,7 @@ import org.infinispan.test.fwk.TestCacheManagerFactory;
  *
  * @author Mircea.Markus@jboss.com
  */
-public class AbstractCacheTest extends AbstractInfinispanTest {
+public abstract class AbstractCacheTest extends AbstractInfinispanTest {
 
    public enum CleanupPhase {
       AFTER_METHOD, AFTER_TEST
@@ -83,5 +83,9 @@ public class AbstractCacheTest extends AbstractInfinispanTest {
 
    public EmbeddedCacheManager manager(Cache c) {
       return c.getCacheManager();
+   }
+
+   public String getDefaultCacheName() {
+      throw new UnsupportedOperationException();
    }
 }

--- a/core/src/test/java/org/infinispan/test/MultipleCacheManagersTest.java
+++ b/core/src/test/java/org/infinispan/test/MultipleCacheManagersTest.java
@@ -21,6 +21,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
+
 import javax.transaction.RollbackException;
 import javax.transaction.SystemException;
 import javax.transaction.Transaction;
@@ -1032,4 +1033,8 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
       }
    }
 
+   @Override
+   public String getDefaultCacheName() {
+      return cacheManagers.get(0).getCacheManagerConfiguration().defaultCacheName().get();
+   }
 }

--- a/core/src/test/java/org/infinispan/test/SingleCacheManagerTest.java
+++ b/core/src/test/java/org/infinispan/test/SingleCacheManagerTest.java
@@ -136,4 +136,9 @@ public abstract class SingleCacheManagerTest extends AbstractCacheTest {
          }
       });
    }
+
+   @Override
+   public String getDefaultCacheName() {
+      return cacheManager.getCacheManagerConfiguration().defaultCacheName().get();
+   }
 }

--- a/core/src/test/java/org/infinispan/test/TestingUtil.java
+++ b/core/src/test/java/org/infinispan/test/TestingUtil.java
@@ -1,7 +1,6 @@
 package org.infinispan.test;
 
 import static java.io.File.separator;
-import static org.infinispan.commons.api.BasicCacheContainer.DEFAULT_CACHE_NAME;
 import static org.infinispan.commons.util.Util.EMPTY_OBJECT_ARRAY;
 import static org.infinispan.persistence.manager.PersistenceManager.AccessMode.BOTH;
 import static org.testng.AssertJUnit.assertFalse;
@@ -439,10 +438,6 @@ public class TestingUtil {
 
    public static Set<String> getInternalAndUserCacheNames(EmbeddedCacheManager cacheManager) {
       Set<String> testCaches = new HashSet<>(cacheManager.getCacheNames());
-      if (cacheManager.isDefaultRunning()) {
-         String defaultCacheName = cacheManager.getCacheManagerConfiguration().defaultCacheName().orElse(CacheContainer.DEFAULT_CACHE_NAME);
-         testCaches.add(defaultCacheName);
-      }
       testCaches.addAll(getInternalCacheNames(cacheManager));
       return testCaches;
    }
@@ -891,7 +886,7 @@ public class TestingUtil {
       Set<String> running = new LinkedHashSet<>(getOrderedCacheNames(cacheContainer));
       extractGlobalComponent(cacheContainer, InternalCacheRegistry.class).filterPrivateCaches(running);
       running.addAll(cacheContainer.getCacheNames());
-      running.add(cacheContainer.getCacheManagerConfiguration().defaultCacheName().orElse(DEFAULT_CACHE_NAME));
+      cacheContainer.getCacheManagerConfiguration().defaultCacheName().ifPresent(n -> running.add(n));
 
       return running.stream()
               .map(s -> cacheContainer.getCache(s, false))
@@ -1429,10 +1424,6 @@ public class TestingUtil {
       }
    }
 
-   public static ObjectName getCacheObjectName(String jmxDomain) {
-      return getCacheObjectName(jmxDomain, DEFAULT_CACHE_NAME + "(local)");
-   }
-
    public static ObjectName getCacheObjectName(String jmxDomain, String cacheName) {
       return getCacheObjectName(jmxDomain, cacheName, "Cache");
    }
@@ -1593,6 +1584,10 @@ public class TestingUtil {
       } finally {
          TestingUtil.killCacheManagers(c.cms);
       }
+   }
+
+   public static String getDefaultCacheName(EmbeddedCacheManager cm) {
+      return cm.getCacheManagerConfiguration().defaultCacheName().get();
    }
 
 

--- a/core/src/test/java/org/infinispan/test/fwk/TEST_PING.java
+++ b/core/src/test/java/org/infinispan/test/fwk/TEST_PING.java
@@ -174,14 +174,7 @@ public class TEST_PING extends Discovery {
 
    private Map<Address, TEST_PING> getTestDiscoveries() {
       DiscoveryKey key = new DiscoveryKey(testName, cluster_name);
-      ConcurrentMap<Address, TEST_PING> discoveries = all.get(key);
-      if (discoveries == null) {
-         discoveries = new ConcurrentHashMap<Address, TEST_PING>();
-         ConcurrentMap<Address, TEST_PING> ret = all.putIfAbsent(key, discoveries);
-         if (ret != null)
-            discoveries = ret;
-      }
-      return discoveries;
+      return all.computeIfAbsent(key,  k -> new ConcurrentHashMap<>());
    }
 
    @Override

--- a/core/src/test/java/org/infinispan/test/fwk/TestCacheManagerFactory.java
+++ b/core/src/test/java/org/infinispan/test/fwk/TestCacheManagerFactory.java
@@ -7,9 +7,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.UUID;
 
-import javax.xml.stream.FactoryConfigurationError;
-import javax.xml.stream.XMLStreamException;
-
 import org.infinispan.commons.executors.BlockingThreadPoolExecutorFactory;
 import org.infinispan.commons.jmx.MBeanServerLookup;
 import org.infinispan.commons.jmx.PerThreadMBeanServerLookup;
@@ -103,20 +100,20 @@ public class TestCacheManagerFactory {
       }
    }
 
-   public static EmbeddedCacheManager fromStream(InputStream is) throws IOException {
+   public static EmbeddedCacheManager fromStream(InputStream is) {
       return fromStream(is, false);
    }
 
-   public static EmbeddedCacheManager fromStream(InputStream is, boolean keepJmxDomainName) throws IOException {
+   public static EmbeddedCacheManager fromStream(InputStream is, boolean keepJmxDomainName) {
       return fromStream(is, keepJmxDomainName, true);
    }
 
-   public static EmbeddedCacheManager fromStream(InputStream is, boolean keepJmxDomainName, boolean defaultParsersOnly) throws IOException {
+   public static EmbeddedCacheManager fromStream(InputStream is, boolean keepJmxDomainName, boolean defaultParsersOnly) {
       return fromStream(is, keepJmxDomainName, defaultParsersOnly, true);
    }
 
-   public static EmbeddedCacheManager fromStream(InputStream is, boolean keepJmxDomainName, boolean defaultParsersOnly, boolean start) throws IOException {
-      return createClusteredCacheManager(start, holderFromStream(is, defaultParsersOnly), keepJmxDomainName);
+   public static EmbeddedCacheManager fromStream(InputStream is, boolean keepJmxDomainName, boolean defaultParsersOnly, boolean start) {
+      return createClusteredCacheManager(start, holderFromStream(is, defaultParsersOnly), keepJmxDomainName, new TransportFlags());
    }
 
    public static ConfigurationBuilderHolder holderFromXml(String xmlFile) throws IOException {
@@ -455,10 +452,12 @@ public class TestCacheManagerFactory {
    }
 
    private static DefaultCacheManager newDefaultCacheManager(boolean start, GlobalConfigurationBuilder gc, ConfigurationBuilder c) {
-      amendDefaultCache(gc);
+      if (c != null) {
+         amendDefaultCache(gc);
+      }
       setNodeName(gc);
       GlobalConfiguration globalConfiguration = gc.build();
-      DefaultCacheManager defaultCacheManager = new DefaultCacheManager(globalConfiguration, c.build(globalConfiguration), start);
+      DefaultCacheManager defaultCacheManager = new DefaultCacheManager(globalConfiguration, c == null ? null : c.build(globalConfiguration), start);
       TestResourceTracker.addResource(new TestResourceTracker.CacheManagerCleaner(defaultCacheManager));
       return defaultCacheManager;
    }
@@ -469,18 +468,5 @@ public class TestCacheManagerFactory {
       DefaultCacheManager defaultCacheManager = new DefaultCacheManager(holder, start);
       TestResourceTracker.addResource(new TestResourceTracker.CacheManagerCleaner(defaultCacheManager));
       return defaultCacheManager;
-   }
-
-   public static ConfigurationBuilderHolder buildAggregateHolder(String... xmls)
-         throws XMLStreamException, FactoryConfigurationError {
-      ClassLoader cl = Thread.currentThread().getContextClassLoader();
-      ParserRegistry registry = new ParserRegistry(cl);
-
-      ConfigurationBuilderHolder holder = new ConfigurationBuilderHolder(cl);
-      for (String xml : xmls) {
-         registry.parse(new ByteArrayInputStream(xml.getBytes()), holder);
-      }
-
-      return holder;
    }
 }

--- a/core/src/test/java/org/infinispan/tx/DefaultEnlistmentModeTest.java
+++ b/core/src/test/java/org/infinispan/tx/DefaultEnlistmentModeTest.java
@@ -6,9 +6,7 @@ import static org.testng.AssertJUnit.assertFalse;
 import org.infinispan.Cache;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
-import org.infinispan.configuration.global.GlobalConfiguration;
-import org.infinispan.configuration.global.GlobalConfigurationBuilder;
-import org.infinispan.manager.DefaultCacheManager;
+import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.AbstractCacheTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
@@ -19,18 +17,18 @@ import org.testng.annotations.Test;
 @Test (groups = "functional", testName = "tx.DefaultEnlistmentModeTest")
 public class DefaultEnlistmentModeTest extends AbstractCacheTest {
 
-   private DefaultCacheManager dcm;
+   private EmbeddedCacheManager ecm;
 
    @AfterMethod
    protected void destroyCacheManager() {
-      TestingUtil.killCacheManagers(dcm);
+      TestingUtil.killCacheManagers(ecm);
    }
 
    public void testDefaultEnlistment() {
       ConfigurationBuilder builder = getLocalBuilder();
       builder.transaction().transactionMode(TransactionMode.TRANSACTIONAL);
-      dcm = new DefaultCacheManager(getGlobalConfig(), builder.build());
-      Cache<Object,Object> cache = dcm.getCache();
+      ecm = TestCacheManagerFactory.createCacheManager(builder);
+      Cache<Object,Object> cache = ecm.getCache();
       assertFalse(cache.getCacheConfiguration().transaction().useSynchronization());
       assertFalse(cache.getCacheConfiguration().transaction().recovery().enabled());
       cache.put("k", "v");
@@ -42,8 +40,8 @@ public class DefaultEnlistmentModeTest extends AbstractCacheTest {
       builder.transaction()
             .transactionMode(TransactionMode.TRANSACTIONAL)
             .useSynchronization(false);
-      dcm = new DefaultCacheManager(getGlobalConfig(), builder.build());
-      Cache<Object,Object> cache = dcm.getCache();
+      ecm =  TestCacheManagerFactory.createCacheManager(builder);
+      Cache<Object,Object> cache = ecm.getCache();
       assertFalse(cache.getCacheConfiguration().transaction().useSynchronization());
       assertFalse(cache.getCacheConfiguration().transaction().recovery().enabled());
       cache.put("k", "v");
@@ -56,8 +54,8 @@ public class DefaultEnlistmentModeTest extends AbstractCacheTest {
             .transactionMode(TransactionMode.TRANSACTIONAL)
             .useSynchronization(false)
             .recovery().disable();
-      dcm = new DefaultCacheManager(getGlobalConfig(), builder.build());
-      Cache<Object,Object> cache = dcm.getCache();
+      ecm = TestCacheManagerFactory.createCacheManager(builder);
+      Cache<Object,Object> cache = ecm.getCache();
       assertFalse(cache.getCacheConfiguration().transaction().useSynchronization());
       assertFalse(cache.getCacheConfiguration().transaction().recovery().enabled());
    }
@@ -68,7 +66,4 @@ public class DefaultEnlistmentModeTest extends AbstractCacheTest {
       return builder;
    }
 
-   private GlobalConfiguration getGlobalConfig() {
-      return new GlobalConfigurationBuilder().build();
-   }
 }

--- a/core/src/test/java/org/infinispan/tx/TransactionsSpanningReplicatedCachesTest.java
+++ b/core/src/test/java/org/infinispan/tx/TransactionsSpanningReplicatedCachesTest.java
@@ -12,7 +12,6 @@ import javax.transaction.TransactionManager;
 import org.infinispan.Cache;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
-import org.infinispan.manager.CacheContainer;
 import org.infinispan.remoting.rpc.RpcManagerImpl;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
@@ -42,7 +41,7 @@ public class TransactionsSpanningReplicatedCachesTest extends MultipleCacheManag
       startCache("c2");
       startCache("cache1");
       startCache("cache2");
-      startCache(CacheContainer.DEFAULT_CACHE_NAME);
+      startCache(getDefaultCacheName());
    }
 
    private void startCache(String c1) {

--- a/core/src/test/java/org/infinispan/tx/recovery/RecoveryWithCustomCacheDistTest.java
+++ b/core/src/test/java/org/infinispan/tx/recovery/RecoveryWithCustomCacheDistTest.java
@@ -2,7 +2,6 @@ package org.infinispan.tx.recovery;
 
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
-import org.infinispan.manager.CacheContainer;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.testng.annotations.Test;
 
@@ -31,8 +30,8 @@ public class RecoveryWithCustomCacheDistTest extends RecoveryWithDefaultCacheDis
       manager(0).defineConfiguration(CUSTOM_CACHE, recoveryCache.build());
       manager(1).defineConfiguration(CUSTOM_CACHE, recoveryCache.build());
 
-      manager(0).startCaches(CacheContainer.DEFAULT_CACHE_NAME, CUSTOM_CACHE);
-      manager(1).startCaches(CacheContainer.DEFAULT_CACHE_NAME, CUSTOM_CACHE);
+      manager(0).startCaches(getDefaultCacheName(), CUSTOM_CACHE);
+      manager(1).startCaches(getDefaultCacheName(), CUSTOM_CACHE);
       waitForClusterToForm(CUSTOM_CACHE);
 
       assert manager(0).getCacheNames().contains(CUSTOM_CACHE);

--- a/core/src/test/java/org/infinispan/util/BlockingLocalTopologyManager.java
+++ b/core/src/test/java/org/infinispan/util/BlockingLocalTopologyManager.java
@@ -9,7 +9,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
-import org.infinispan.manager.CacheContainer;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.test.TestException;
@@ -57,7 +56,7 @@ public class BlockingLocalTopologyManager extends AbstractControlledLocalTopolog
    }
 
    public static BlockingLocalTopologyManager replaceTopologyManagerDefaultCache(EmbeddedCacheManager cacheContainer) {
-      return replaceTopologyManager(cacheContainer, CacheContainer.DEFAULT_CACHE_NAME);
+      return replaceTopologyManager(cacheContainer, TestingUtil.getDefaultCacheName(cacheContainer));
    }
 
    public static void confirmTopologyUpdate(CacheTopology.Phase phase, BlockingLocalTopologyManager... topologyManagers)

--- a/core/src/test/java/org/infinispan/util/ThreadLocalLeakTest.java
+++ b/core/src/test/java/org/infinispan/util/ThreadLocalLeakTest.java
@@ -97,7 +97,7 @@ public class ThreadLocalLeakTest extends AbstractInfinispanTest {
 
    private Thread doStuffWithCache(ConfigurationBuilder builder) {
       GlobalConfigurationBuilder globalBuilder =
-            new GlobalConfigurationBuilder().nonClusteredDefault();
+            new GlobalConfigurationBuilder().nonClusteredDefault().defaultCacheName("leak");
       final EmbeddedCacheManager[] cm = {new DefaultCacheManager(globalBuilder.build(), builder.build(),
             true)};
       Thread forkedThread = null;

--- a/core/src/test/java/org/infinispan/util/mocks/ControlledCommandFactory.java
+++ b/core/src/test/java/org/infinispan/util/mocks/ControlledCommandFactory.java
@@ -85,7 +85,6 @@ import org.infinispan.encoding.DataConversion;
 import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.functional.EntryView;
 import org.infinispan.functional.impl.Params;
-import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.metadata.Metadata;
 import org.infinispan.notifications.cachelistener.cluster.ClusterEvent;
 import org.infinispan.notifications.cachelistener.cluster.MultiClusterEventCommand;
@@ -169,7 +168,7 @@ public class ControlledCommandFactory implements CommandsFactory {
 
       //hack: re-add the component registry to the GlobalComponentRegistry's "namedComponents" (CHM) in order to correctly publish it for
       // when it will be read by the InboundInvocationHandlder. InboundInvocationHandlder reads the value from the GlobalComponentRegistry.namedComponents before using it
-      componentRegistry.getGlobalComponentRegistry().registerNamedComponentRegistry(componentRegistry, EmbeddedCacheManager.DEFAULT_CACHE_NAME);
+      componentRegistry.getGlobalComponentRegistry().registerNamedComponentRegistry(componentRegistry, TestingUtil.getDefaultCacheName(cache.getCacheManager()));
       return ccf;
    }
 

--- a/core/src/test/java/org/infinispan/xsite/AbstractTwoSitesTest.java
+++ b/core/src/test/java/org/infinispan/xsite/AbstractTwoSitesTest.java
@@ -10,7 +10,6 @@ import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
-import org.infinispan.manager.CacheContainer;
 import org.infinispan.transaction.LockingMode;
 
 /**
@@ -52,13 +51,13 @@ public abstract class AbstractTwoSitesTest extends AbstractXSiteTest {
 
       if (!implicitBackupCache) {
          ConfigurationBuilder nycBackup = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false);
-         nycBackup.sites().backupFor().remoteSite(NYC).defaultRemoteCache();
+         nycBackup.sites().backupFor().remoteSite(NYC).remoteCache(getDefaultCacheName());
          startCache(LON, "nycBackup", nycBackup);
          ConfigurationBuilder lonBackup = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, isLonBackupTransactional);
-         lonBackup.sites().backupFor().remoteSite(LON).defaultRemoteCache();
+         lonBackup.sites().backupFor().remoteSite(LON).remoteCache(getDefaultCacheName());
          startCache(NYC, "lonBackup", lonBackup);
          Configuration lonBackupConfig = cache(NYC, "lonBackup", 0).getCacheConfiguration();
-         assertTrue(lonBackupConfig.sites().backupFor().isBackupFor(LON, CacheContainer.DEFAULT_CACHE_NAME));
+         assertTrue(lonBackupConfig.sites().backupFor().isBackupFor(LON, getDefaultCacheName()));
       }
       waitForSites(LON, NYC);
    }

--- a/core/src/test/java/org/infinispan/xsite/AbstractXSiteTest.java
+++ b/core/src/test/java/org/infinispan/xsite/AbstractXSiteTest.java
@@ -13,7 +13,6 @@ import java.util.concurrent.locks.LockSupport;
 
 import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
-import org.infinispan.commons.api.BasicCacheContainer;
 import org.infinispan.commons.api.Lifecycle;
 import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.configuration.cache.Configuration;
@@ -171,7 +170,7 @@ public abstract class AbstractXSiteTest extends AbstractCacheTest {
       TestSite site = site(siteName);
       for (EmbeddedCacheManager ecm : site.cacheManagers) {
          Configuration config = configurationBuilder.build();
-         ecm.defineConfiguration(cacheName, BasicCacheContainer.DEFAULT_CACHE_NAME, config);
+         ecm.defineConfiguration(cacheName, getDefaultCacheName(), config);
       }
       site.waitForClusterToForm(cacheName);
    }
@@ -340,4 +339,8 @@ public abstract class AbstractXSiteTest extends AbstractCacheTest {
       return cache.getAdvancedCache().getComponentRegistry().getComponent(TransactionTable.class);
    }
 
+   @Override
+   public String getDefaultCacheName() {
+      return site(0).cacheManagers.get(0).getCacheManagerConfiguration().defaultCacheName().get();
+   }
 }

--- a/core/src/test/java/org/infinispan/xsite/BackupCacheStoppedTest.java
+++ b/core/src/test/java/org/infinispan/xsite/BackupCacheStoppedTest.java
@@ -8,7 +8,6 @@ import org.infinispan.Cache;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.factories.GlobalComponentRegistry;
-import org.infinispan.manager.EmbeddedCacheManager;
 import org.testng.annotations.Test;
 
 /**
@@ -35,7 +34,7 @@ public class BackupCacheStoppedTest extends AbstractTwoSitesTest {
          @Override
          public boolean isSatisfied() throws Exception {
             BackupReceiverRepositoryImpl component = (BackupReceiverRepositoryImpl) gcr.getComponent(BackupReceiverRepository.class);
-            return component.get(site, EmbeddedCacheManager.DEFAULT_CACHE_NAME) == null;
+            return component.get(site, getDefaultCacheName()) == null;
          }
       });
 

--- a/core/src/test/java/org/infinispan/xsite/NonTxAsyncBackupTest.java
+++ b/core/src/test/java/org/infinispan/xsite/NonTxAsyncBackupTest.java
@@ -64,7 +64,7 @@ public class NonTxAsyncBackupTest extends AbstractTwoSitesTest {
       blockingInterceptor.reset();
    }
 
-   public void testSiteMasterPicked() throws NoSuchFieldException, IllegalAccessException {
+   public void testSiteMasterPicked() {
       for (TestSite testSite : sites) {
          for (EmbeddedCacheManager cacheManager : testSite.cacheManagers) {
             RELAY2 relay2 = getRELAY2(cacheManager);

--- a/core/src/test/java/org/infinispan/xsite/RollbackNoPrepareOptimisticTest.java
+++ b/core/src/test/java/org/infinispan/xsite/RollbackNoPrepareOptimisticTest.java
@@ -11,7 +11,6 @@ import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.factories.GlobalComponentRegistry;
-import org.infinispan.manager.CacheContainer;
 import org.testng.annotations.Test;
 
 @Test(groups = "xsite", testName = "xsite.RollbackNoPrepareOptimisticTest")
@@ -28,9 +27,9 @@ public class RollbackNoPrepareOptimisticTest extends AbstractTwoSitesTest {
       ComponentRegistry cr = backup(LON).getAdvancedCache().getComponentRegistry();
       GlobalComponentRegistry gcr = cr.getGlobalComponentRegistry();
       BackupReceiverRepositoryImpl brr = (BackupReceiverRepositoryImpl) gcr.getComponent(BackupReceiverRepository.class);
-      BackupReceiver backupCacheManager = brr.getBackupReceiver(LON, CacheContainer.DEFAULT_CACHE_NAME);
+      BackupReceiver backupCacheManager = brr.getBackupReceiver(LON, getDefaultCacheName());
       BackupReceiverWrapper brWrapper = new BackupReceiverWrapper(backupCacheManager);
-      brr.replace(LON, CacheContainer.DEFAULT_CACHE_NAME, brWrapper);
+      brr.replace(LON, getDefaultCacheName(), brWrapper);
 
       assertNull(brWrapper.received);
       cache(LON, 0).put(key, val);

--- a/documentation/src/main/asciidoc/upgrading/upgrading-content.adoc
+++ b/documentation/src/main/asciidoc/upgrading/upgrading-content.adoc
@@ -1,5 +1,9 @@
 == Upgrading from 9.4 to 10.0
 
+=== Removed the implicit default cache
+
+The default cache must now be named explicitly via the link:{javadocroot}/org/infinispan/configuration/global/GlobalConfigurationBuilder.html#defaultCacheName(java.lang.String)[GlobalConfigurationBuilder#defaultCacheName()] method.
+
 === Removed DistributedExecutor
 
 The previously deprecated DistributedExecutor is now removed. References should be updated to use ClusterExecutor.

--- a/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/AbstractQueryTest.java
+++ b/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/AbstractQueryTest.java
@@ -37,7 +37,7 @@ public abstract class AbstractQueryTest {
 
    protected static EmbeddedCacheManager createCacheManager() throws Exception {
       GlobalConfigurationBuilder gcfg = new GlobalConfigurationBuilder();
-
+      gcfg.defaultCacheName("default");
       ConfigurationBuilder cfg = new ConfigurationBuilder();
       cfg.transaction()
           .transactionMode(TransactionMode.TRANSACTIONAL)

--- a/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/IndexedEntityAutodetectTest.java
+++ b/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/IndexedEntityAutodetectTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 public class IndexedEntityAutodetectTest extends LocalCacheTest {
    protected static EmbeddedCacheManager createCacheManager() throws Exception {
       GlobalConfigurationBuilder gcfg = new GlobalConfigurationBuilder();
-
+      gcfg.defaultCacheName("default");
       // this configuration does not declare any indexed types on purpose, so they are autodetected
       ConfigurationBuilder cfg = new ConfigurationBuilder();
       cfg.transaction()

--- a/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/QueryDslConditionsTest.java
+++ b/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/QueryDslConditionsTest.java
@@ -77,7 +77,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
    protected static EmbeddedCacheManager createCacheManager() {
       GlobalConfigurationBuilder gcfg = new GlobalConfigurationBuilder();
-
+      gcfg.defaultCacheName("default");
       ConfigurationBuilder cfg = new ConfigurationBuilder();
       cfg.transaction()
             .transactionMode(TransactionMode.TRANSACTIONAL)

--- a/integrationtests/cdi-weld-se-it/src/test/java/org/infinispan/integrationtests/cdi/weld/Config.java
+++ b/integrationtests/cdi-weld-se-it/src/test/java/org/infinispan/integrationtests/cdi/weld/Config.java
@@ -5,6 +5,7 @@ import javax.enterprise.inject.Disposes;
 import javax.enterprise.inject.Produces;
 
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.TestingUtil;
@@ -20,9 +21,10 @@ public class Config {
    @Produces
    @ApplicationScoped
    public EmbeddedCacheManager defaultEmbeddedCacheManager() {
-      return new DefaultCacheManager(new ConfigurationBuilder()
-            .memory().size(100)
-            .build());
+      return new DefaultCacheManager(
+            new GlobalConfigurationBuilder().defaultCacheName("cdi").build(),
+            new ConfigurationBuilder().memory().size(100).build()
+      );
    }
 
    /**

--- a/integrationtests/cdi-weld-se-it/src/test/java/org/infinispan/integrationtests/cdi/weld/WeldStandaloneTest.java
+++ b/integrationtests/cdi-weld-se-it/src/test/java/org/infinispan/integrationtests/cdi/weld/WeldStandaloneTest.java
@@ -14,7 +14,7 @@ import org.testng.annotations.Test;
 @Test(groups="functional", testName="cdi.test.weld.WeldStandaloneTest")
 public class WeldStandaloneTest {
 
-   public void testWeldStandaloneInitialisation() throws Exception {
+   public void testWeldStandaloneInitialisation() {
       WeldContainer weld = null;
       try {
          //given

--- a/integrationtests/endpoints-interop-it/src/test/java/org/infinispan/it/endpoints/EndpointsCacheFactory.java
+++ b/integrationtests/endpoints-interop-it/src/test/java/org/infinispan/it/endpoints/EndpointsCacheFactory.java
@@ -20,7 +20,6 @@ import org.infinispan.Cache;
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
-import org.infinispan.commons.api.BasicCacheContainer;
 import org.infinispan.commons.dataconversion.Encoder;
 import org.infinispan.commons.dataconversion.IdentityEncoder;
 import org.infinispan.commons.dataconversion.MediaType;
@@ -78,11 +77,11 @@ public class EndpointsCacheFactory<K, V> {
    }
 
    EndpointsCacheFactory(CacheMode cacheMode, int numOwners, boolean l1Enable) {
-      this("", null, cacheMode, numOwners, l1Enable, null, null);
+      this("test", null, cacheMode, numOwners, l1Enable, null, null);
    }
 
    EndpointsCacheFactory(CacheMode cacheMode, int numOwners, boolean l1Enable, Encoder encoder) {
-      this("", null, cacheMode, numOwners, l1Enable, null, encoder);
+      this("test", null, cacheMode, numOwners, l1Enable, null, encoder);
    }
 
    EndpointsCacheFactory(String cacheName, Marshaller marshaller, CacheMode cacheMode) {
@@ -139,6 +138,7 @@ public class EndpointsCacheFactory<K, V> {
          globalBuilder = new GlobalConfigurationBuilder().nonClusteredDefault();
       }
       globalBuilder.addModule(PrivateGlobalConfigurationBuilder.class).serverMode(true);
+      globalBuilder.defaultCacheName(cacheName);
 
       org.infinispan.configuration.cache.ConfigurationBuilder builder =
             new org.infinispan.configuration.cache.ConfigurationBuilder();
@@ -157,12 +157,7 @@ public class EndpointsCacheFactory<K, V> {
             ? TestCacheManagerFactory.createClusteredCacheManager(globalBuilder, builder)
             : TestCacheManagerFactory.createCacheManager(globalBuilder, builder);
 
-      if (!cacheName.isEmpty())
-         cacheManager.defineConfiguration(cacheName, builder.build());
-
-      embeddedCache = cacheName.isEmpty()
-            ? cacheManager.getCache()
-            : cacheManager.getCache(cacheName);
+      embeddedCache = cacheManager.getCache(cacheName);
 
       EncoderRegistry encoderRegistry = embeddedCache.getAdvancedCache().getComponentRegistry().getGlobalComponentRegistry().getComponent(EncoderRegistry.class);
 
@@ -280,8 +275,7 @@ public class EndpointsCacheFactory<K, V> {
    }
 
    public String getRestUrl() {
-      String restCacheName = cacheName.isEmpty() ? BasicCacheContainer.DEFAULT_CACHE_NAME : cacheName;
-      return String.format("http://localhost:%s/rest/%s", restPort, restCacheName);
+      return String.format("http://localhost:%s/rest/%s", restPort, cacheName);
    }
 
    HotRodServer getHotrodServer() {

--- a/integrationtests/spring-boot-it/src/test/java/org/infinispan/integrationtests/spring/boot/session/AbstractSpringSessionTCK.java
+++ b/integrationtests/spring-boot-it/src/test/java/org/infinispan/integrationtests/spring/boot/session/AbstractSpringSessionTCK.java
@@ -24,7 +24,7 @@ public class AbstractSpringSessionTCK {
    private int port;
 
    @Test
-   public void testCreatingSessionWhenUsingREST() throws Exception {
+   public void testCreatingSessionWhenUsingREST() {
       assertNull(httpSessionListener.getCreatedSession());
       assertNull(httpSessionListener.getDestroyedSession());
 

--- a/integrationtests/spring-boot-it/src/test/java/org/infinispan/integrationtests/spring/boot/session/embedded/EmbeddedConfiguration.java
+++ b/integrationtests/spring-boot-it/src/test/java/org/infinispan/integrationtests/spring/boot/session/embedded/EmbeddedConfiguration.java
@@ -1,5 +1,6 @@
 package org.infinispan.integrationtests.spring.boot.session.embedded;
 
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.integrationtests.spring.boot.session.configuration.WebConfig;
 import org.infinispan.spring.embedded.provider.SpringEmbeddedCacheManagerFactoryBean;
@@ -19,6 +20,7 @@ public class EmbeddedConfiguration {
    public SpringEmbeddedCacheManagerFactoryBean springCacheManager() {
       SpringEmbeddedCacheManagerFactoryBean cacheManagerFactoryBean = new SpringEmbeddedCacheManagerFactoryBean();
       cacheManagerFactoryBean.addCustomGlobalConfiguration(new GlobalConfigurationBuilder().defaultCacheName("sessions"));
+      cacheManagerFactoryBean.addCustomCacheConfiguration(new ConfigurationBuilder());
       return cacheManagerFactoryBean;
    }
 

--- a/integrationtests/wildfly-modules/src/test/java/org/infinispan/test/integration/as/InfinispanCoreIT.java
+++ b/integrationtests/wildfly-modules/src/test/java/org/infinispan/test/integration/as/InfinispanCoreIT.java
@@ -54,6 +54,7 @@ public class InfinispanCoreIT {
    @Test
    public void testCacheManager() {
       GlobalConfigurationBuilder gcb = new GlobalConfigurationBuilder();
+      gcb.defaultCacheName("default");
 
       cm = new DefaultCacheManager(gcb.build(), new ConfigurationBuilder().build());
       Cache<String, String> cache = cm.getCache();

--- a/integrationtests/wildfly-modules/src/test/java/org/infinispan/test/integration/as/InfinispanStoreJdbcIT.java
+++ b/integrationtests/wildfly-modules/src/test/java/org/infinispan/test/integration/as/InfinispanStoreJdbcIT.java
@@ -58,7 +58,7 @@ public class InfinispanStoreJdbcIT {
    @Test
    public void testCacheManager() {
       GlobalConfigurationBuilder gcb = new GlobalConfigurationBuilder();
-
+      gcb.defaultCacheName("default");
       ConfigurationBuilder builder = new ConfigurationBuilder();
       builder.persistence().addStore(JdbcStringBasedStoreConfigurationBuilder.class)
             .table()

--- a/integrationtests/wildfly-modules/src/test/java/org/infinispan/test/integration/as/InfinispanStoreJpaIT.java
+++ b/integrationtests/wildfly-modules/src/test/java/org/infinispan/test/integration/as/InfinispanStoreJpaIT.java
@@ -64,7 +64,7 @@ public class InfinispanStoreJpaIT {
    @Test
    public void testCacheManager() {
       GlobalConfigurationBuilder gcb = new GlobalConfigurationBuilder();
-
+      gcb.defaultCacheName("default");
       ConfigurationBuilder builder = new ConfigurationBuilder();
       builder.persistence().addStore(JpaStoreConfigurationBuilder.class)
             .persistenceUnitName("org.infinispan.persistence.jpa")

--- a/integrationtests/wildfly-modules/src/test/java/org/infinispan/test/integration/as/InfinispanStoreRocksDBIT.java
+++ b/integrationtests/wildfly-modules/src/test/java/org/infinispan/test/integration/as/InfinispanStoreRocksDBIT.java
@@ -71,7 +71,7 @@ public class InfinispanStoreRocksDBIT {
    @Test
    public void testCacheManager() {
       GlobalConfigurationBuilder gcb = new GlobalConfigurationBuilder();
-
+      gcb.defaultCacheName("default");
       ConfigurationBuilder builder = new ConfigurationBuilder();
       builder.persistence()
             .addStore(RocksDBStoreConfigurationBuilder.class)

--- a/integrationtests/wildfly-modules/src/test/java/org/infinispan/test/integration/as/cdi/DuplicatedDomainsCdiIT.java
+++ b/integrationtests/wildfly-modules/src/test/java/org/infinispan/test/integration/as/cdi/DuplicatedDomainsCdiIT.java
@@ -5,7 +5,6 @@ import java.io.File;
 import javax.inject.Inject;
 
 import org.infinispan.AdvancedCache;
-import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.DefaultCacheManager;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -43,12 +42,12 @@ public class DuplicatedDomainsCdiIT {
    private AdvancedCache<Object, Object> greetingCache;
 
    /**
-    * Creates new {@link DefaultCacheManager} with default {@link org.infinispan.configuration.cache.Configuration}.
+    * Creates new {@link DefaultCacheManager}.
     * This test will fail if CDI Extension registers and won't set Cache Manager's name.
     */
    @Test
    public void testIfCreatingDefaultCacheManagerSucceeds() {
-      DefaultCacheManager cacheManager = new DefaultCacheManager(new ConfigurationBuilder().build());
+      DefaultCacheManager cacheManager = new DefaultCacheManager();
       cacheManager.stop();
    }
 }

--- a/lucene/lucene-directory/src/test/java/org/infinispan/lucene/configuration/NoLifespanValidationTest.java
+++ b/lucene/lucene-directory/src/test/java/org/infinispan/lucene/configuration/NoLifespanValidationTest.java
@@ -25,7 +25,7 @@ public class NoLifespanValidationTest extends SingleCacheManagerTest {
    }
 
    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp =
-         "ISPN(\\d)*: Lucene Directory for index 'testIndexAlpha' can not use Cache '___defaultcache': maximum lifespan enabled on the Cache configuration!")
+         "ISPN(\\d)*: Lucene Directory for index 'testIndexAlpha' can not use Cache 'NoLifespanValidationTest': maximum lifespan enabled on the Cache configuration!")
    public void failOnExpiry() {
       DirectoryBuilder.newDirectoryInstance(cache, cache, cache, "testIndexAlpha").create();
    }

--- a/lucene/lucene-directory/src/test/java/org/infinispan/lucene/configuration/NotIdleValidationTest.java
+++ b/lucene/lucene-directory/src/test/java/org/infinispan/lucene/configuration/NotIdleValidationTest.java
@@ -25,7 +25,7 @@ public class NotIdleValidationTest extends SingleCacheManagerTest {
    }
 
    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp =
-         "ISPN(\\d)*: Lucene Directory for index 'testIndexBeta' can not use Cache '___defaultcache': expiration idle time enabled on the Cache configuration!")
+         "ISPN(\\d)*: Lucene Directory for index 'testIndexBeta' can not use Cache 'NotIdleValidationTest': expiration idle time enabled on the Cache configuration!")
    public void failOnExpiry() {
       DirectoryBuilder.newDirectoryInstance(cache, cache, cache, "testIndexBeta").create();
    }

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/RemoteStore.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/RemoteStore.java
@@ -17,7 +17,6 @@ import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
 import org.infinispan.client.hotrod.configuration.ExhaustedAction;
 import org.infinispan.client.hotrod.impl.RemoteCacheImpl;
 import org.infinispan.client.hotrod.impl.operations.PingResponse;
-import org.infinispan.commons.api.BasicCacheContainer;
 import org.infinispan.commons.configuration.ClassWhiteList;
 import org.infinispan.commons.configuration.ConfiguredBy;
 import org.infinispan.commons.marshall.Marshaller;
@@ -112,7 +111,7 @@ public class RemoteStore<K, V> implements SegmentedAdvancedLoadWriteStore<K, V>,
       ConfigurationBuilder builder = buildRemoteConfiguration(configuration, marshaller);
       remoteCacheManager = new RemoteCacheManager(builder.build());
 
-      if (configuration.remoteCacheName().equals(BasicCacheContainer.DEFAULT_CACHE_NAME))
+      if (configuration.remoteCacheName().isEmpty())
          remoteCache = remoteCacheManager.getCache();
       else
          remoteCache = remoteCacheManager.getCache(configuration.remoteCacheName());

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/RemoteStoreConfiguration.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/RemoteStoreConfiguration.java
@@ -8,7 +8,6 @@ import java.util.List;
 import org.infinispan.client.hotrod.ProtocolVersion;
 import org.infinispan.client.hotrod.impl.ConfigurationProperties;
 import org.infinispan.client.hotrod.impl.transport.tcp.RoundRobinBalancingStrategy;
-import org.infinispan.commons.api.BasicCacheContainer;
 import org.infinispan.commons.configuration.BuiltBy;
 import org.infinispan.commons.configuration.ConfigurationFor;
 import org.infinispan.commons.configuration.ConfigurationInfo;
@@ -36,7 +35,7 @@ public class RemoteStoreConfiguration extends AbstractStoreConfiguration {
    static final AttributeDefinition<Integer> VALUE_SIZE_ESTIMATE = AttributeDefinition.builder("valueSizeEstimate", ConfigurationProperties.DEFAULT_VALUE_SIZE).immutable().build();
    static final AttributeDefinition<String> MARSHALLER = AttributeDefinition.builder("marshaller", null, String.class).immutable().build();
    static final AttributeDefinition<ProtocolVersion> PROTOCOL_VERSION = AttributeDefinition.builder("protocolVersion", ProtocolVersion.DEFAULT_PROTOCOL_VERSION).immutable().build();
-   static final AttributeDefinition<String> REMOTE_CACHE_NAME = AttributeDefinition.builder("remoteCacheName", BasicCacheContainer.DEFAULT_CACHE_NAME).immutable().xmlName("cache").build();
+   static final AttributeDefinition<String> REMOTE_CACHE_NAME = AttributeDefinition.builder("remoteCacheName", "").immutable().xmlName("cache").build();
    static final AttributeDefinition<List<RemoteServerConfiguration>> SERVERS = AttributeDefinition.builder("servers", null, (Class<List<RemoteServerConfiguration>>)(Class<?>)List.class)
          .initializer(ArrayList::new).autoPersist(false).build();
    static final AttributeDefinition<Long> SOCKET_TIMEOUT = AttributeDefinition.builder("socketTimeout", (long)ConfigurationProperties.DEFAULT_SO_TIMEOUT).build();

--- a/persistence/remote/src/test/java/org/infinispan/persistence/remote/RemoteStoreFunctionalTest.java
+++ b/persistence/remote/src/test/java/org/infinispan/persistence/remote/RemoteStoreFunctionalTest.java
@@ -5,7 +5,6 @@ import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheCon
 import org.infinispan.client.hotrod.ProtocolVersion;
 import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
 import org.infinispan.commons.CacheConfigurationException;
-import org.infinispan.commons.api.BasicCacheContainer;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.PersistenceConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -31,7 +30,7 @@ public class RemoteStoreFunctionalTest extends BaseStoreFunctionalTest {
       hrServer = HotRodClientTestingUtil.startHotRodServer(localCacheManager);
       persistence
          .addStore(RemoteStoreConfigurationBuilder.class)
-            .remoteCacheName(BasicCacheContainer.DEFAULT_CACHE_NAME)
+            .remoteCacheName("")
             .preload(preload)
             .addServer()
                .host("localhost")

--- a/persistence/remote/src/test/resources/remote-cl-config.xml
+++ b/persistence/remote/src/test/resources/remote-cl-config.xml
@@ -7,11 +7,11 @@
       xmlns:remote="urn:infinispan:config:store:remote:${infinispan.core.schema.version}" >
 
    <!-- Default cache named to preserve old default cache name -->
-   <cache-container default-cache="___defaultcache">
-      <local-cache name="___defaultcache">
+   <cache-container default-cache="RemoteStoreConfigTest">
+      <local-cache name="RemoteStoreConfigTest">
          <persistence passivation="false">
             <remote-store xmlns="urn:infinispan:config:store:remote:${infinispan.core.schema.version}"
-                          cache="___defaultcache" fetch-state="false" preload="false" purge="false" shared="true" singleton="false" read-only="false"
+                          cache="RemoteStoreConfigTest" fetch-state="false" preload="false" purge="false" shared="true" singleton="false" read-only="false"
                           hotrod-wrapping="false" raw-values="false" socket-timeout="60000"
                           tcp-no-delay="true" balancing-strategy="org.infinispan.client.hotrod.impl.transport.tcp.RoundRobinBalancingStrategy"
                           transport-factory="org.infinispan.client.hotrod.impl.transport.netty.ChannelFactory"

--- a/persistence/rest/src/test/java/org/infinispan/persistence/rest/RestCacheStoreFunctionalTest.java
+++ b/persistence/rest/src/test/java/org/infinispan/persistence/rest/RestCacheStoreFunctionalTest.java
@@ -1,6 +1,5 @@
 package org.infinispan.persistence.rest;
 
-import org.infinispan.commons.api.BasicCacheContainer;
 import org.infinispan.configuration.cache.PersistenceConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.persistence.BaseStoreFunctionalTest;
@@ -31,7 +30,7 @@ public class RestCacheStoreFunctionalTest extends BaseStoreFunctionalTest {
       loaders.addStore(RestStoreConfigurationBuilder.class)
             .host("localhost")
             .port(restServer.getPort())
-            .path("/rest/"+BasicCacheContainer.DEFAULT_CACHE_NAME)
+            .path("/rest/" + getDefaultCacheName())
             .preload(preload);
       return loaders;
    }

--- a/persistence/rest/src/test/java/org/infinispan/persistence/rest/RestStoreParallelIterationTest.java
+++ b/persistence/rest/src/test/java/org/infinispan/persistence/rest/RestStoreParallelIterationTest.java
@@ -3,7 +3,6 @@ package org.infinispan.persistence.rest;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
-import org.infinispan.commons.api.BasicCacheContainer;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.metadata.Metadata;
@@ -19,8 +18,8 @@ import org.testng.annotations.Test;
  * @author Mircea Markus
  * @since 6.0
  */
-@Test (groups = "functional", testName = "persistence.rest.RestStoreParallelIterationTest")
-public class RestStoreParallelIterationTest  extends ParallelIterationTest {
+@Test(groups = "functional", testName = "persistence.rest.RestStoreParallelIterationTest")
+public class RestStoreParallelIterationTest extends ParallelIterationTest {
 
    private EmbeddedCacheManager localCacheManager;
    private RestServer restServer;
@@ -34,7 +33,7 @@ public class RestStoreParallelIterationTest  extends ParallelIterationTest {
       cb.persistence().addStore(RestStoreConfigurationBuilder.class)
             .host("localhost")
             .port(restServer.getPort())
-            .path("/rest/"+ BasicCacheContainer.DEFAULT_CACHE_NAME)
+            .path("/rest/" + TestingUtil.getDefaultCacheName(localCacheManager))
             .preload(false);
    }
 

--- a/persistence/rest/src/test/java/org/infinispan/persistence/rest/configuration/RestCacheStoreConfigTest.java
+++ b/persistence/rest/src/test/java/org/infinispan/persistence/rest/configuration/RestCacheStoreConfigTest.java
@@ -5,6 +5,7 @@ import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertSame;
 
 import org.infinispan.Cache;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.persistence.rest.RestStore;
 import org.infinispan.persistence.spi.CacheLoader;
@@ -33,7 +34,8 @@ public class RestCacheStoreConfigTest extends AbstractInfinispanTest {
 
    @BeforeClass
    public void startUp() {
-      cacheManager = TestCacheManagerFactory.createServerModeCacheManager();
+      GlobalConfigurationBuilder global = new GlobalConfigurationBuilder().defaultCacheName("default");
+      cacheManager = TestCacheManagerFactory.createServerModeCacheManager(global);
       assertEquals(cacheManager.getCache().size(), 0);
       RestServerConfigurationBuilder restServerConfigurationBuilder = new RestServerConfigurationBuilder();
       restServerConfigurationBuilder.port(18212);

--- a/persistence/rest/src/test/java/org/infinispan/persistence/rest/configuration/XmlFileParsingTest.java
+++ b/persistence/rest/src/test/java/org/infinispan/persistence/rest/configuration/XmlFileParsingTest.java
@@ -31,7 +31,7 @@ public class XmlFileParsingTest extends AbstractInfinispanTest {
       RestStoreConfiguration store = (RestStoreConfiguration) cacheLoaders.get(0);
       assertFalse(store.appendCacheNameToPath());
       assertEquals("localhost", store.host());
-      assertEquals("/rest/___defaultcache/", store.path());
+      assertEquals("/rest/default/", store.path());
       assertEquals(18212, store.port());
       assertEquals(15000000, store.maxContentLength());
       ConnectionPoolConfiguration connectionPool = store.connectionPool();

--- a/persistence/rest/src/test/java/org/infinispan/persistence/rest/upgrade/RestUpgradeSynchronizerTest.java
+++ b/persistence/rest/src/test/java/org/infinispan/persistence/rest/upgrade/RestUpgradeSynchronizerTest.java
@@ -9,7 +9,6 @@ import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.httpclient.methods.PutMethod;
 import org.apache.commons.httpclient.methods.StringRequestEntity;
 import org.infinispan.Cache;
-import org.infinispan.commons.api.BasicCacheContainer;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.context.Flag;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -59,7 +58,7 @@ public class RestUpgradeSynchronizerTest extends AbstractInfinispanTest {
 
       ConfigurationBuilder targetConfigurationBuilder = TestCacheManagerFactory.getDefaultCacheConfiguration(false);
       targetConfigurationBuilder.persistence().addStore(RestStoreConfigurationBuilder.class).host("localhost").port(sourceServer.getPort())
-            .path("/rest/" + BasicCacheContainer.DEFAULT_CACHE_NAME).rawValues(true).locking().isolationLevel(IsolationLevel.NONE);
+            .path("/rest/" + TestingUtil.getDefaultCacheName(sourceContainer)).rawValues(true).locking().isolationLevel(IsolationLevel.NONE);
       targetConfigurationBuilder.encoding().key().mediaType(LEGACY_KEY_ENCODING);
 
       targetContainer = TestCacheManagerFactory.createServerModeCacheManager(targetConfigurationBuilder);
@@ -75,18 +74,18 @@ public class RestUpgradeSynchronizerTest extends AbstractInfinispanTest {
 
       for (char ch = 'A'; ch <= 'Z'; ch++) {
          String s = Character.toString(ch);
-         PutMethod put = new PutMethod(String.format("http://localhost:%d/rest/%s/%s", sourceServer.getPort(), BasicCacheContainer.DEFAULT_CACHE_NAME, s));
+         PutMethod put = new PutMethod(String.format("http://localhost:%d/rest/%s/%s", sourceServer.getPort(), TestingUtil.getDefaultCacheName(sourceContainer), s));
          put.setRequestEntity(new StringRequestEntity(s, "text/plain", "UTF-8"));
          assertEquals(HttpStatus.SC_OK, client.executeMethod(put));
       }
 
       // Read a newly inserted entry
-      GetMethod getInserted = new GetMethod(String.format("http://localhost:%d/rest/%s/A", sourceServer.getPort(), BasicCacheContainer.DEFAULT_CACHE_NAME));
+      GetMethod getInserted = new GetMethod(String.format("http://localhost:%d/rest/%s/A", sourceServer.getPort(), TestingUtil.getDefaultCacheName(sourceContainer)));
       assertEquals(HttpStatus.SC_OK, client.executeMethod(getInserted));
       assertEquals("A", getInserted.getResponseBodyAsString());
 
       // Verify access to some of the data from the new cluster
-      GetMethod get = new GetMethod(String.format("http://localhost:%d/rest/%s/A", targetServer.getPort(), BasicCacheContainer.DEFAULT_CACHE_NAME));
+      GetMethod get = new GetMethod(String.format("http://localhost:%d/rest/%s/A", targetServer.getPort(), TestingUtil.getDefaultCacheName(targetContainer)));
       assertEquals(HttpStatus.SC_OK, client.executeMethod(get));
       assertEquals("A", get.getResponseBodyAsString());
 

--- a/persistence/rest/src/test/resources/rest-cl-config.xml
+++ b/persistence/rest/src/test/resources/rest-cl-config.xml
@@ -10,7 +10,7 @@
          <persistence passivation="false">
             <rest-store xmlns="urn:infinispan:config:store:rest:${infinispan.core.schema.version}"
                         fetch-state="false" read-only="false" preload="false" purge="false" shared="true" raw-values="false"
-                        path="/rest/___defaultcache" append-cache-name-to-path="false"
+                        path="/rest/default" append-cache-name-to-path="false"
                         key-to-string-mapper="org.infinispan.persistence.keymappers.WrappedByteArrayOrPrimitiveMapper"
                         max-content-length="15000000">
                <remote-server host="localhost" port="18212" outbound-socket-binding="rest-server-1" />

--- a/query/src/test/java/org/infinispan/query/api/ManualIndexingTest.java
+++ b/query/src/test/java/org/infinispan/query/api/ManualIndexingTest.java
@@ -7,7 +7,6 @@ import java.util.List;
 
 import org.apache.lucene.search.Query;
 import org.infinispan.Cache;
-import org.infinispan.commons.api.BasicCacheContainer;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.query.CacheQuery;
 import org.infinispan.query.Search;
@@ -23,13 +22,6 @@ public class ManualIndexingTest extends MultipleCacheManagersTest {
    protected static final int NUM_NODES = 4;
    protected List<Cache<String, Car>> caches = new ArrayList<>(NUM_NODES);
 
-   protected static final String[] neededCacheNames = {
-         BasicCacheContainer.DEFAULT_CACHE_NAME,
-         "LuceneIndexesMetadata",
-         "LuceneIndexesData",
-         "LuceneIndexesLocking",
-   };
-
    @Override
    protected void createCacheManagers() throws Throwable {
       for (int i = 0; i < NUM_NODES; i++) {
@@ -38,7 +30,12 @@ public class ManualIndexingTest extends MultipleCacheManagersTest {
          Cache<String, Car> cache = cacheManager.getCache();
          caches.add(cache);
       }
-      waitForClusterToForm(neededCacheNames);
+      waitForClusterToForm(new String[] {
+            getDefaultCacheName(),
+            "LuceneIndexesMetadata",
+            "LuceneIndexesData",
+            "LuceneIndexesLocking",
+      });
    }
 
    public void testManualIndexing() throws Exception {

--- a/query/src/test/java/org/infinispan/query/distributed/AsyncMassIndexTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/AsyncMassIndexTest.java
@@ -9,7 +9,6 @@ import java.util.concurrent.CountDownLatch;
 
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.infinispan.Cache;
-import org.infinispan.commons.api.BasicCacheContainer;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.Index;
@@ -47,7 +46,7 @@ public class AsyncMassIndexTest extends MultipleCacheManagersTest {
 
       List<Cache<Integer, Transaction>> cacheList = createClusteredCaches(NUM_NODES, cacheCfg);
 
-      waitForClusterToForm(BasicCacheContainer.DEFAULT_CACHE_NAME);
+      waitForClusterToForm(getDefaultCacheName());
 
       for (Cache cache : cacheList) {
          caches.add(cache);

--- a/query/src/test/java/org/infinispan/query/distributed/OverlappingDistMassIndexTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/OverlappingDistMassIndexTest.java
@@ -8,7 +8,6 @@ import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.Indexed;
 import org.hibernate.search.annotations.IndexedEmbedded;
 import org.infinispan.Cache;
-import org.infinispan.commons.api.BasicCacheContainer;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.Index;
@@ -38,7 +37,7 @@ public class OverlappingDistMassIndexTest extends OverlappingIndexMassIndexTest 
 
       List<Cache<String, Object>> cacheList = createClusteredCaches(NUM_NODES, cacheCfg);
 
-      waitForClusterToForm(BasicCacheContainer.DEFAULT_CACHE_NAME);
+      waitForClusterToForm(getDefaultCacheName());
 
       for (Cache cache : cacheList) {
          caches.add(cache);

--- a/query/src/test/java/org/infinispan/query/distributed/OverlappingIndexMassIndexTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/OverlappingIndexMassIndexTest.java
@@ -7,7 +7,6 @@ import java.util.List;
 
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.infinispan.Cache;
-import org.infinispan.commons.api.BasicCacheContainer;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.Index;
@@ -44,7 +43,7 @@ public class OverlappingIndexMassIndexTest extends MultipleCacheManagersTest {
 
       List<Cache<String, Object>> cacheList = createClusteredCaches(NUM_NODES, cacheCfg);
 
-      waitForClusterToForm(BasicCacheContainer.DEFAULT_CACHE_NAME);
+      waitForClusterToForm(getDefaultCacheName());
 
       for (Cache cache : cacheList) {
          caches.add(cache);

--- a/query/src/test/java/org/infinispan/query/distributed/PerfTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/PerfTest.java
@@ -8,7 +8,6 @@ import org.apache.lucene.search.Query;
 import org.hibernate.search.query.dsl.QueryBuilder;
 import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
-import org.infinispan.commons.api.BasicCacheContainer;
 import org.infinispan.commons.util.Util;
 import org.infinispan.context.Flag;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -39,20 +38,18 @@ public class PerfTest extends MultipleCacheManagersTest {
    private static final int LOG_ON_EACH = 2000;
    private static final int NUMBER_OF_ITERATIONS = 50;
 
-   private static final String[] neededCacheNames = {
-         BasicCacheContainer.DEFAULT_CACHE_NAME,
-         "LuceneIndexesMetadata",
-         "LuceneIndexesData",
-         "LuceneIndexesLocking",
-   };
-
    @Override
    protected void createCacheManagers() throws Throwable {
       for (int i = 0; i < NUM_NODES; i++) {
          EmbeddedCacheManager cacheManager = TestCacheManagerFactory.fromXml("indexing-perf.xml");
          registerCacheManager(cacheManager);
       }
-      waitForClusterToForm(neededCacheNames);
+      waitForClusterToForm(new String[] {
+            getDefaultCacheName(),
+            "LuceneIndexesMetadata",
+            "LuceneIndexesData",
+            "LuceneIndexesLocking",
+      });
    }
 
    public void testIndexing() throws Exception {

--- a/query/src/test/java/org/infinispan/query/distributed/ReplRamMassIndexingTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/ReplRamMassIndexingTest.java
@@ -6,7 +6,6 @@ import static org.testng.Assert.assertNotNull;
 import java.util.List;
 
 import org.infinispan.Cache;
-import org.infinispan.commons.api.BasicCacheContainer;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.Index;
@@ -35,7 +34,7 @@ public class ReplRamMassIndexingTest extends DistributedMassIndexingTest {
       cacheCfg.clustering().stateTransfer().fetchInMemoryState(true);
       List<Cache<String, Car>> cacheList = createClusteredCaches(NUM_NODES, cacheCfg);
 
-      waitForClusterToForm(BasicCacheContainer.DEFAULT_CACHE_NAME);
+      waitForClusterToForm(getDefaultCacheName());
 
       for(Cache cache : cacheList) {
          caches.add(cache);

--- a/query/src/test/java/org/infinispan/query/distributed/ShardingMassIndexTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/ShardingMassIndexTest.java
@@ -7,7 +7,6 @@ import java.util.List;
 
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.infinispan.Cache;
-import org.infinispan.commons.api.BasicCacheContainer;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.Index;
@@ -47,7 +46,7 @@ public class ShardingMassIndexTest extends MultipleCacheManagersTest {
 
       List<Cache<Integer, Object>> cacheList = createClusteredCaches(NUM_NODES, cacheCfg);
 
-      waitForClusterToForm(BasicCacheContainer.DEFAULT_CACHE_NAME);
+      waitForClusterToForm(getDefaultCacheName());
 
       for (Cache cache : cacheList) {
          caches.add(cache);

--- a/server/core/src/main/java/org/infinispan/server/core/AbstractProtocolServer.java
+++ b/server/core/src/main/java/org/infinispan/server/core/AbstractProtocolServer.java
@@ -11,7 +11,6 @@ import javax.management.ObjectName;
 
 import org.infinispan.IllegalLifecycleStateException;
 import org.infinispan.commons.CacheException;
-import org.infinispan.commons.api.BasicCacheContainer;
 import org.infinispan.commons.jmx.JmxUtil;
 import org.infinispan.commons.logging.LogFactory;
 import org.infinispan.configuration.global.GlobalConfiguration;
@@ -224,14 +223,17 @@ public abstract class AbstractProtocolServer<A extends ProtocolServerConfigurati
    }
 
    protected void startDefaultCache() {
-      cacheManager.getCache(defaultCacheName());
+      String name = defaultCacheName();
+      if (name != null) {
+         cacheManager.getCache(name);
+      }
    }
 
    public String defaultCacheName() {
       if (configuration.defaultCacheName() != null) {
          return configuration.defaultCacheName();
       } else {
-         return cacheManager.getCacheManagerConfiguration().defaultCacheName().orElse(BasicCacheContainer.DEFAULT_CACHE_NAME);
+         return cacheManager.getCacheManagerConfiguration().defaultCacheName().orElse(null);
       }
    }
 

--- a/server/core/src/test/java/org/infinispan/server/core/AbstractProtocolServerTest.java
+++ b/server/core/src/test/java/org/infinispan/server/core/AbstractProtocolServerTest.java
@@ -1,10 +1,10 @@
 package org.infinispan.server.core;
 
-import org.infinispan.configuration.cache.ConfigurationBuilder;
-import org.infinispan.manager.DefaultCacheManager;
+import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.server.core.configuration.MockServerConfigurationBuilder;
 import org.infinispan.server.core.configuration.ProtocolServerConfiguration;
 import org.infinispan.test.AbstractInfinispanTest;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -50,7 +50,7 @@ public class AbstractProtocolServerTest extends AbstractInfinispanTest {
       MockServerConfigurationBuilder b = new MockServerConfigurationBuilder();
       b.startTransport(false);
       AbstractProtocolServer server = new MockProtocolServer();
-      DefaultCacheManager manager = new DefaultCacheManager(new ConfigurationBuilder().build());
+      EmbeddedCacheManager manager = TestCacheManagerFactory.createCacheManager();
       try {
          server.start(b.build(), manager);
          Assert.assertFalse(server.isTransportEnabled());

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/CacheRequestProcessor.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/CacheRequestProcessor.java
@@ -46,8 +46,10 @@ class CacheRequestProcessor extends BaseRequestProcessor {
    }
 
    void ping(HotRodHeader header, Subject subject) {
-      // we need to throw an exception when this cache is inaccessible
-      server.cache(server.getCacheInfo(header), header, subject);
+      // we need to throw an exception when this cache is inaccessible, but ignore the empty cache name if no default cache has been configured
+      if (!header.cacheName.isEmpty() || server.getCacheManager().getCacheManagerConfiguration().defaultCacheName().isPresent()) {
+         server.cache(server.getCacheInfo(header), header, subject);
+      }
       writeResponse(header, header.encoder().pingResponse(header, server, channel.alloc(), OperationStatus.Success));
    }
 

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/Encoder2x.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/Encoder2x.java
@@ -443,7 +443,10 @@ class Encoder2x implements VersionedEncoder {
          if (CounterModuleLifecycle.COUNTER_CACHE_NAME.equals(header.cacheName)) {
             cacheTopology = getCounterCacheTopology(server.getCacheManager());
             newTopology = getTopologyResponse(header.clientIntel, header.topologyId, addressCache, CacheMode.DIST_SYNC,
-                                              cacheTopology);
+                  cacheTopology);
+         } else if (header.cacheName.isEmpty() && !server.hasDefaultCache()) {
+            cacheTopology = null;
+            newTopology = Optional.empty();
          } else {
             HotRodServer.CacheInfo cacheInfo = server.getCacheInfo(header);
             Configuration configuration = cacheInfo.configuration;

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/TaskRequestProcessor.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/TaskRequestProcessor.java
@@ -27,11 +27,14 @@ public class TaskRequestProcessor extends BaseRequestProcessor {
    }
 
    public void exec(HotRodHeader header, Subject subject, String taskName, Map<String, byte[]> taskParams) {
-      AdvancedCache<byte[], byte[]> cache = server.cache(server.getCacheInfo(header), header, subject);
       TaskContext taskContext = new TaskContext()
-            .cache(cache)
             .parameters(taskParams)
             .subject(subject);
+      if (!header.cacheName.isEmpty() || server.hasDefaultCache()) {
+         AdvancedCache<byte[], byte[]> cache = server.cache(server.getCacheInfo(header), header, subject);
+         taskContext.cache(cache);
+      }
+
       // TODO: TaskManager API is already asynchronous, though we cannot be sure that it won't block anywhere
       taskManager.runTask(taskName, taskContext).whenComplete((result, throwable) -> handleExec(header, result, throwable));
    }

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodMergeTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodMergeTest.java
@@ -53,7 +53,7 @@ public class HotRodMergeTest extends BasePartitionHandlingTest {
       ConfigurationBuilder dcc = hotRodCacheConfiguration();
       dcc.clustering().cacheMode(cacheMode).hash().numOwners(1);
       dcc.clustering().partitionHandling().whenSplit(partitionHandling);
-      createClusteredCaches(numMembersInCluster, dcc, new TransportFlags().withFD(true).withMerge(true));
+      createClusteredCaches(numMembersInCluster, dcc, new TransportFlags().withFD(true).withMerge(true), "merge");
       waitForClusterToForm();
 
       // Allow servers for both instances to run in parallel
@@ -64,7 +64,7 @@ public class HotRodMergeTest extends BasePartitionHandlingTest {
          nextServerPort += 1;
       }
 
-      client = new HotRodClient("127.0.0.1", servers.get(0).getPort(), "", 60, (byte) 21);
+      client = new HotRodClient("127.0.0.1", servers.get(0).getPort(), "merge", 60, (byte) 21);
       TestingUtil.waitForNoRebalance(cache(0), cache(1));
    }
 

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodMergeTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodMergeTest.java
@@ -1,6 +1,5 @@
 package org.infinispan.server.hotrod;
 
-import static org.infinispan.commons.api.BasicCacheContainer.DEFAULT_CACHE_NAME;
 import static org.infinispan.server.hotrod.Constants.INTELLIGENCE_HASH_DISTRIBUTION_AWARE;
 import static org.infinispan.server.hotrod.OperationStatus.Success;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.assertHashTopology20Received;
@@ -146,7 +145,7 @@ public class HotRodMergeTest extends BasePartitionHandlingTest {
          if (resp.topologyResponse == null || (resp.topologyResponse.topologyId < expectedTopologyId)) {
             return false;
          }
-         assertHashTopology20Received(resp.topologyResponse, servers, DEFAULT_CACHE_NAME, expectedTopologyId);
+         assertHashTopology20Received(resp.topologyResponse, servers, getDefaultCacheName(), expectedTopologyId);
          return true;
       });
    }
@@ -154,7 +153,7 @@ public class HotRodMergeTest extends BasePartitionHandlingTest {
    private void expectCompleteTopology(HotRodClient c, int expectedTopologyId) {
       TestResponse resp = c.ping(INTELLIGENCE_HASH_DISTRIBUTION_AWARE, 0);
       assertStatus(resp, Success);
-      assertHashTopology20Received(resp.topologyResponse, servers, DEFAULT_CACHE_NAME, expectedTopologyId);
+      assertHashTopology20Received(resp.topologyResponse, servers, getDefaultCacheName(), expectedTopologyId);
    }
 
    private void eventuallyExpectPartialTopology(HotRodClient c, int expectedTopologyId) {
@@ -164,7 +163,7 @@ public class HotRodMergeTest extends BasePartitionHandlingTest {
          if (resp.topologyResponse == null || (resp.topologyResponse.topologyId < expectedTopologyId)) {
             return false;
          }
-         assertHashTopology20Received(resp.topologyResponse, Arrays.asList(servers.get(0)), DEFAULT_CACHE_NAME,
+         assertHashTopology20Received(resp.topologyResponse, Arrays.asList(servers.get(0)), getDefaultCacheName(),
                                       expectedTopologyId);
          return true;
       });
@@ -173,7 +172,7 @@ public class HotRodMergeTest extends BasePartitionHandlingTest {
    private void expectPartialTopology(HotRodClient c, int expectedTopologyId) {
       TestResponse resp = c.ping(INTELLIGENCE_HASH_DISTRIBUTION_AWARE, 0);
       assertStatus(resp, Success);
-      assertHashTopology20Received(resp.topologyResponse, Arrays.asList(servers.get(0)), DEFAULT_CACHE_NAME,
+      assertHashTopology20Received(resp.topologyResponse, Arrays.asList(servers.get(0)), getDefaultCacheName(),
                                    expectedTopologyId);
    }
 

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodNoDefaultCacheTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodNoDefaultCacheTest.java
@@ -1,0 +1,57 @@
+package org.infinispan.server.hotrod;
+
+import static org.infinispan.server.core.test.ServerTestingUtil.killServer;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.killClient;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.startHotRodServer;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
+
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.server.hotrod.test.HotRodClient;
+import org.infinispan.server.hotrod.test.TestErrorResponse;
+import org.infinispan.server.hotrod.test.TestResponse;
+import org.infinispan.test.SingleCacheManagerTest;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.Test;
+
+/**
+ * Tests stats operation against a Hot Rod server.
+ *
+ * @author Galder Zamarreño
+ * @since 4.1
+ */
+@Test(groups = "functional", testName = "server.hotrod.HotRodNoDefaultCacheTest")
+public class HotRodNoDefaultCacheTest extends SingleCacheManagerTest {
+
+   private HotRodServer server;
+   private HotRodClient client;
+
+   @Override
+   public EmbeddedCacheManager createCacheManager() {
+      EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(null);
+      return cm;
+   }
+
+   @Override
+   protected void setup() throws Exception {
+      // super() creates the default cache and we do not want that
+      cacheManager = createCacheManager();
+      server = startHotRodServer(cacheManager, (String)null);
+      client = new HotRodClient("127.0.0.1", server.getPort(), "", 60, HotRodVersion.HOTROD_21.getVersion());
+   }
+
+   @Override
+   protected void teardown() {
+      log.debug("Killing Hot Rod client and server");
+      killClient(client);
+      killServer(server);
+      super.teardown();
+   }
+
+   public void testNoDefault() {
+      TestResponse response = client.get("k1");
+      assertTrue(response instanceof TestErrorResponse);
+      TestErrorResponse error = (TestErrorResponse)response;
+      assertEquals("org.infinispan.server.hotrod.CacheNotFoundException: Default cache requested but not configured", error.msg);
+   }
+}

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodSingleNodeTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodSingleNodeTest.java
@@ -12,6 +12,7 @@ import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.server.hotrod.test.HotRodClient;
 import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.test.fwk.TestResourceTracker;
 
 
 /**
@@ -21,7 +22,7 @@ import org.infinispan.test.fwk.TestCacheManagerFactory;
  * @since 4.1
  */
 public abstract class HotRodSingleNodeTest extends SingleCacheManagerTest {
-   protected static final String cacheName = "HotRodCache";
+   protected String cacheName;
 
    protected HotRodServer hotRodServer;
    protected HotRodClient hotRodClient;
@@ -38,6 +39,7 @@ public abstract class HotRodSingleNodeTest extends SingleCacheManagerTest {
 
    @Override
    protected void setup() throws Exception {
+      cacheName = TestResourceTracker.getCurrentTestShortName();
       super.setup();
       hotRodServer = createStartHotRodServer(cacheManager);
       hotRodClient = connectClient();

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodStatsTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodStatsTest.java
@@ -30,7 +30,6 @@ public class HotRodStatsTest extends HotRodSingleNodeTest {
       ConfigurationBuilder cfg = hotRodCacheConfiguration();
       cfg.jmxStatistics().enable();
       EmbeddedCacheManager cm = TestCacheManagerFactory.createClusteredCacheManagerEnforceJmxDomain(jmxDomain(), cfg);
-      cm.defineConfiguration(cacheName, cm.getDefaultCacheConfiguration());
       return cm;
    }
 

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/logging/HotRodAccessLoggingTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/logging/HotRodAccessLoggingTest.java
@@ -37,7 +37,7 @@ public class HotRodAccessLoggingTest extends HotRodSingleNodeTest {
 
       server().getTransport().stop();
 
-      String logline = logAppender.getLog(0).toString();
+      String logline = logAppender.getLog(0);
       assertTrue(logline, logline.matches("^127\\.0\\.0\\.1 - \\[\\d+/\\w+/\\d+:\\d+:\\d+:\\d+ [+-]?\\w+\\] \"PUT /HotRodCache/\\[B0x6B6579 HOTROD/2\\.1\" OK \\d+ \\d+ \\d+$"));
    }
 }

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/logging/HotRodAccessLoggingTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/logging/HotRodAccessLoggingTest.java
@@ -38,6 +38,6 @@ public class HotRodAccessLoggingTest extends HotRodSingleNodeTest {
       server().getTransport().stop();
 
       String logline = logAppender.getLog(0);
-      assertTrue(logline, logline.matches("^127\\.0\\.0\\.1 - \\[\\d+/\\w+/\\d+:\\d+:\\d+:\\d+ [+-]?\\w+\\] \"PUT /HotRodCache/\\[B0x6B6579 HOTROD/2\\.1\" OK \\d+ \\d+ \\d+$"));
+      assertTrue(logline, logline.matches("^127\\.0\\.0\\.1 - \\[\\d+/\\w+/\\d+:\\d+:\\d+:\\d+ [+-]?\\w+\\] \"PUT /HotRodAccessLoggingTest/\\[B0x6B6579 HOTROD/2\\.1\" OK \\d+ \\d+ \\d+$"));
    }
 }

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/test/HotRodPipeTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/test/HotRodPipeTest.java
@@ -11,6 +11,15 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
+import org.infinispan.commons.util.Either;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.server.hotrod.HotRodServer;
+import org.infinispan.test.SingleCacheManagerTest;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.test.fwk.TestResourceTracker;
+import org.testng.annotations.Test;
+
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
@@ -26,15 +35,6 @@ import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.MessageToByteEncoder;
 import io.netty.handler.codec.ReplayingDecoder;
 import io.netty.util.concurrent.DefaultThreadFactory;
-import org.infinispan.commons.util.Either;
-import org.infinispan.configuration.global.GlobalConfigurationBuilder;
-import org.infinispan.manager.CacheContainer;
-import org.infinispan.manager.EmbeddedCacheManager;
-import org.infinispan.server.hotrod.HotRodServer;
-import org.infinispan.test.SingleCacheManagerTest;
-import org.infinispan.test.fwk.TestCacheManagerFactory;
-import org.infinispan.test.fwk.TestResourceTracker;
-import org.testng.annotations.Test;
 
 @Test(groups = "functional", testName = "server.hotrod.test.HotRodPipeTest")
 public class HotRodPipeTest extends SingleCacheManagerTest {
@@ -44,7 +44,6 @@ public class HotRodPipeTest extends SingleCacheManagerTest {
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       GlobalConfigurationBuilder gcb = new GlobalConfigurationBuilder();
-      gcb.defaultCacheName(CacheContainer.DEFAULT_CACHE_NAME);
       TestCacheManagerFactory.amendTransport(gcb);
       return TestCacheManagerFactory.createServerModeCacheManager(gcb);
    }

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/test/HotRodPipeTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/test/HotRodPipeTest.java
@@ -27,6 +27,8 @@ import io.netty.handler.codec.MessageToByteEncoder;
 import io.netty.handler.codec.ReplayingDecoder;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import org.infinispan.commons.util.Either;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.manager.CacheContainer;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.server.hotrod.HotRodServer;
 import org.infinispan.test.SingleCacheManagerTest;
@@ -41,7 +43,10 @@ public class HotRodPipeTest extends SingleCacheManagerTest {
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
-      return TestCacheManagerFactory.createCacheManager();
+      GlobalConfigurationBuilder gcb = new GlobalConfigurationBuilder();
+      gcb.defaultCacheName(CacheContainer.DEFAULT_CACHE_NAME);
+      TestCacheManagerFactory.amendTransport(gcb);
+      return TestCacheManagerFactory.createServerModeCacheManager(gcb);
    }
 
    @Override

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/test/HotRodTestingUtil.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/test/HotRodTestingUtil.java
@@ -474,6 +474,18 @@ public class HotRodTestingUtil {
       }
    }
 
+   public static GlobalConfigurationBuilder hotRodGlobalConfiguration(Class<?> klass) {
+      GlobalConfigurationBuilder globalConfigurationBuilder = new GlobalConfigurationBuilder();
+      globalConfigurationBuilder.defaultCacheName(klass.getSimpleName());
+      return globalConfigurationBuilder;
+   }
+
+   public static GlobalConfigurationBuilder hotRodClusteredGlobalConfiguration(Class<?> klass) {
+      GlobalConfigurationBuilder globalConfigurationBuilder = GlobalConfigurationBuilder.defaultClusteredBuilder();
+      globalConfigurationBuilder.defaultCacheName(klass.getSimpleName());
+      return globalConfigurationBuilder;
+   }
+
    public static ConfigurationBuilder hotRodCacheConfiguration() {
       return new ConfigurationBuilder();
    }

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/test/HotRodTestingUtil.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/test/HotRodTestingUtil.java
@@ -25,11 +25,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
-import io.netty.channel.Channel;
-import io.netty.channel.ChannelInitializer;
 import org.infinispan.Cache;
 import org.infinispan.commons.CacheException;
-import org.infinispan.commons.api.BasicCacheContainer;
 import org.infinispan.commons.logging.LogFactory;
 import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.Configuration;
@@ -57,6 +54,9 @@ import org.infinispan.server.hotrod.transport.SingleByteFrameDecoderChannelIniti
 import org.infinispan.server.hotrod.transport.TimeoutEnabledChannelInitializer;
 import org.infinispan.test.fwk.TestResourceTracker;
 import org.infinispan.util.KeyValuePair;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelInitializer;
 
 /**
  * Test utils for Hot Rod tests.
@@ -127,7 +127,7 @@ public class HotRodTestingUtil {
 
       builder.startTransport(false);
 
-      DefaultCacheManager cacheManager = new DefaultCacheManager(globalConfiguration.build(), cacheConfiguration);
+      DefaultCacheManager cacheManager = new DefaultCacheManager(globalConfiguration.build());
       for (String cache : definedCaches) {
          cacheManager.defineConfiguration(cache, cacheConfiguration);
       }
@@ -138,13 +138,16 @@ public class HotRodTestingUtil {
    public static HotRodServer startHotRodServer(EmbeddedCacheManager manager, int port, int idleTimeout,
                                                 String proxyHost, int proxyPort, long delay, String defaultCacheName) {
       HotRodServerConfigurationBuilder builder = new HotRodServerConfigurationBuilder();
-      builder.proxyHost(proxyHost).proxyPort(proxyPort).idleTimeout(idleTimeout).defaultCacheName(defaultCacheName);
+      builder.proxyHost(proxyHost).proxyPort(proxyPort).idleTimeout(idleTimeout);
+      if (defaultCacheName != null) {
+         builder.defaultCacheName(defaultCacheName);
+      }
       return startHotRodServer(manager, port, delay, builder);
    }
 
    public static HotRodServer startHotRodServer(EmbeddedCacheManager manager, int port, int idleTimeout,
                                                 String proxyHost, int proxyPort, long delay) {
-      return startHotRodServer(manager, port, idleTimeout, proxyHost, proxyPort, delay, BasicCacheContainer.DEFAULT_CACHE_NAME);
+      return startHotRodServer(manager, port, idleTimeout, proxyHost, proxyPort, delay, TestResourceTracker.getCurrentTestShortName());
    }
 
    public static HotRodServer startHotRodServer(EmbeddedCacheManager manager, int port, HotRodServerConfigurationBuilder builder) {

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/DefaultCacheContainer.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/DefaultCacheContainer.java
@@ -23,7 +23,6 @@
 package org.jboss.as.clustering.infinispan;
 
 import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.Set;
 
 import org.infinispan.AdvancedCache;
@@ -64,7 +63,7 @@ public class DefaultCacheContainer extends AbstractDelegatingEmbeddedCacheManage
 
     @Override
     public Configuration defineConfiguration(String cacheName, Configuration configuration) {
-        return this.cm.defineConfiguration(this.getCacheName(cacheName), configuration);
+        return this.cm.defineConfiguration(cacheName, configuration);
     }
 
     /**
@@ -82,7 +81,7 @@ public class DefaultCacheContainer extends AbstractDelegatingEmbeddedCacheManage
      */
     @Override
     public <K, V> Cache<K, V> getCache(String cacheName) {
-        return this.getCache(cacheName, true);
+        return cacheName == null ? this.getCache() : this.getCache(cacheName, true);
     }
 
     /**
@@ -91,7 +90,7 @@ public class DefaultCacheContainer extends AbstractDelegatingEmbeddedCacheManage
      */
     @Override
     public <K, V> Cache<K, V> getCache(String cacheName, boolean start) {
-        Cache<K, V> cache = this.cm.getCache(this.getCacheName(cacheName), start);
+        Cache<K, V> cache = this.cm.getCache(cacheName, start);
         return (cache != null) ? new DelegatingCache<>(cache) : null;
     }
 
@@ -121,7 +120,7 @@ public class DefaultCacheContainer extends AbstractDelegatingEmbeddedCacheManage
      */
     @Override
     public boolean isRunning(String cacheName) {
-        return this.cm.isRunning(this.getCacheName(cacheName));
+        return cacheName == null ? isDefaultRunning() : this.cm.isRunning(cacheName);
     }
 
     /**
@@ -130,7 +129,7 @@ public class DefaultCacheContainer extends AbstractDelegatingEmbeddedCacheManage
      */
     @Override
     public boolean cacheExists(String cacheName) {
-        return this.cm.cacheExists(this.getCacheName(cacheName));
+        return this.cm.cacheExists(cacheName);
     }
 
     /**
@@ -139,21 +138,13 @@ public class DefaultCacheContainer extends AbstractDelegatingEmbeddedCacheManage
      */
     @Override
     public void removeCache(String cacheName) {
-        this.cm.removeCache(this.getCacheName(cacheName));
+        this.cm.removeCache(cacheName);
     }
 
     @Override
     public EmbeddedCacheManager startCaches(String... names) {
-        Set<String> cacheNames = new LinkedHashSet<>();
-        for (String name: names) {
-            cacheNames.add(this.getCacheName(name));
-        }
-        this.cm.startCaches(cacheNames.toArray(new String[cacheNames.size()]));
+        this.cm.startCaches(names);
         return this;
-    }
-
-    private String getCacheName(String name) {
-        return ((name == null) || name.equals(CacheContainer.DEFAULT_CACHE_NAME)) ? this.defaultCache : name;
     }
 
     /**

--- a/server/integration/infinispan/src/test/java/org/jboss/as/clustering/infinispan/DefaultEmbeddedCacheManagerTest.java
+++ b/server/integration/infinispan/src/test/java/org/jboss/as/clustering/infinispan/DefaultEmbeddedCacheManagerTest.java
@@ -43,7 +43,6 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.lifecycle.ComponentStatus;
-import org.infinispan.manager.CacheContainer;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.remoting.transport.Address;
 import org.junit.After;
@@ -100,7 +99,7 @@ public class DefaultEmbeddedCacheManagerTest {
         assertEquals(result, otherCache);
         assertSame(this.subject, result.getCacheManager());
 
-        result = this.subject.getCache(CacheContainer.DEFAULT_CACHE_NAME);
+        result = this.subject.getCache();
 
         assertNotSame(defaultCache, result);
         assertEquals(result, defaultCache);
@@ -279,7 +278,7 @@ public class DefaultEmbeddedCacheManagerTest {
 
         assertTrue(result);
 
-        result = this.subject.isRunning(CacheContainer.DEFAULT_CACHE_NAME);
+        result = this.subject.isDefaultRunning();
 
         assertTrue(result);
 
@@ -301,7 +300,7 @@ public class DefaultEmbeddedCacheManagerTest {
     public void startCaches() {
         when(this.manager.startCaches("other", "default")).thenReturn(this.manager);
 
-        EmbeddedCacheManager result = this.subject.startCaches("other", CacheContainer.DEFAULT_CACHE_NAME);
+        EmbeddedCacheManager result = this.subject.startCaches("other", "default");
 
         assertSame(this.subject, result);
     }

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/security/HotRodSslEncryptionIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/security/HotRodSslEncryptionIT.java
@@ -52,26 +52,26 @@ public class HotRodSslEncryptionIT {
    }
 
    @Test
-   public void testViaDirectConfig() throws Exception {
+   public void testViaDirectConfig() {
       ConfigurationBuilder builder = new ConfigurationBuilder();
       String hostname = ispnServer.getHotrodEndpoint().getInetAddress().getHostName();
       builder.addServer().host(hostname).port(ispnServer.getHotrodEndpoint().getPort());
       builder.security().ssl().enable().trustStoreFileName(DEFAULT_TRUSTSTORE_PATH).trustStorePassword(DEFAULT_TRUSTSTORE_PASSWORD.toCharArray());
       remoteCacheManager = new RemoteCacheManager(builder.build());
-      remoteCache = remoteCacheManager.getCache(RemoteCacheManager.DEFAULT_CACHE_NAME);
+      remoteCache = remoteCacheManager.getCache();
       testPutGet(remoteCache);
       testSize(remoteCache);
    }
 
    @Test
-   public void testViaSslContextSetup() throws Exception {
+   public void testViaSslContextSetup() {
       ConfigurationBuilder builder = new ConfigurationBuilder();
       String hostname = ispnServer.getHotrodEndpoint().getInetAddress().getHostName();
       builder.addServer().host(hostname).port(ispnServer.getHotrodEndpoint().getPort());
       SSLContext cont = SslContextFactory.getContext(null, null, DEFAULT_TRUSTSTORE_PATH, DEFAULT_TRUSTSTORE_PASSWORD.toCharArray());
       builder.security().ssl().sslContext(cont).enable();
       remoteCacheManager = new RemoteCacheManager(builder.build());
-      remoteCache = remoteCacheManager.getCache(RemoteCacheManager.DEFAULT_CACHE_NAME);
+      remoteCache = remoteCacheManager.getCache();
       testPutGet(remoteCache);
       testSize(remoteCache);
    }

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/security/HotRodSslWithSniEncryptionIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/security/HotRodSslWithSniEncryptionIT.java
@@ -31,7 +31,7 @@ import org.junit.runner.RunWith;
  *
  * @author Sebastian Łaskawiec
  * @since 9.0
- * @see HotRodSniFunctionalTest
+ * @see HotRodSslWithSniEncryptionIT
  */
 @RunWith(Arquillian.class)
 @Category({Security.class})
@@ -52,25 +52,25 @@ public class HotRodSslWithSniEncryptionIT {
    }
 
    @Test
-   public void testUnauthorizedAccessToDefaultSSLContext() throws Exception {
+   public void testUnauthorizedAccessToDefaultSSLContext() {
       ConfigurationBuilder builder = new SecurityConfigurationHelper().withDefaultSsl();
       String hostname = ispnServer.getHotrodEndpoint().getInetAddress().getHostName();
       builder.addServer().host(hostname).port(ispnServer.getHotrodEndpoint().getPort());
       remoteCacheManager = new RemoteCacheManager(builder.build());
       try {
-         remoteCacheManager.getCache(RemoteCacheManager.DEFAULT_CACHE_NAME);
+         remoteCacheManager.getCache();
       } catch (TransportException e) {
          assertTrue(e.getCause() instanceof SSLHandshakeException);
       }
    }
 
    @Test
-   public void testAuthorizedAccessThroughSni() throws Exception {
+   public void testAuthorizedAccessThroughSni() {
       ConfigurationBuilder builder = new SecurityConfigurationHelper().withDefaultSsl().withSni("sni");
       String hostname = ispnServer.getHotrodEndpoint().getInetAddress().getHostName();
       builder.addServer().host(hostname).port(ispnServer.getHotrodEndpoint().getPort());
       remoteCacheManager = new RemoteCacheManager(builder.build());
-      remoteCache = remoteCacheManager.getCache(RemoteCacheManager.DEFAULT_CACHE_NAME);
+      remoteCache = remoteCacheManager.getCache();
       assertNotNull(remoteCache);
    }
 }

--- a/server/rest/src/main/java/org/infinispan/rest/cachemanager/RestCacheManager.java
+++ b/server/rest/src/main/java/org/infinispan/rest/cachemanager/RestCacheManager.java
@@ -8,7 +8,6 @@ import java.util.function.Predicate;
 
 import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
-import org.infinispan.commons.api.BasicCacheContainer;
 import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.context.Flag;
@@ -77,7 +76,7 @@ public class RestCacheManager<V> {
    }
 
    private void checkCacheAvailable(String cacheName) {
-      if (!BasicCacheContainer.DEFAULT_CACHE_NAME.equals(cacheName) && !instance.getCacheNames().contains(cacheName))
+      if (!instance.getCacheNames().contains(cacheName))
          throw logger.cacheNotFound(cacheName);
       if (icr.isPrivateCache(cacheName)) {
          throw logger.requestNotAllowedToInternalCaches(cacheName);

--- a/server/rest/src/test/java/org/infinispan/rest/helper/RestServerHelper.java
+++ b/server/rest/src/test/java/org/infinispan/rest/helper/RestServerHelper.java
@@ -1,9 +1,6 @@
 package org.infinispan.rest.helper;
 
 import org.infinispan.configuration.cache.ConfigurationBuilder;
-import org.infinispan.configuration.global.GlobalConfigurationBuilder;
-import org.infinispan.configuration.internal.PrivateGlobalConfigurationBuilder;
-import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.registry.InternalCacheRegistry;
 import org.infinispan.rest.RestServer;
@@ -11,6 +8,7 @@ import org.infinispan.rest.TestClass;
 import org.infinispan.rest.authentication.Authenticator;
 import org.infinispan.rest.authentication.impl.VoidAuthenticator;
 import org.infinispan.rest.configuration.RestServerConfigurationBuilder;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
 
 /**
  * A small utility class which helps managing REST server.
@@ -35,10 +33,7 @@ public class RestServerHelper {
    }
 
    public static RestServerHelper defaultRestServer(ConfigurationBuilder configuration, String... cachesDefined) {
-      GlobalConfigurationBuilder globalConfigurationBuilder = new GlobalConfigurationBuilder();
-      globalConfigurationBuilder.addModule(PrivateGlobalConfigurationBuilder.class).serverMode(true);
-      GlobalConfigurationBuilder globalConfiguration = globalConfigurationBuilder.nonClusteredDefault();
-      DefaultCacheManager cacheManager = new DefaultCacheManager(globalConfiguration.build(), configuration.build());
+      EmbeddedCacheManager cacheManager = TestCacheManagerFactory.createCacheManager(configuration);
       cacheManager.getClassWhiteList().addClasses(TestClass.class);
       for (String cacheConfiguration : cachesDefined) {
          cacheManager.defineConfiguration(cacheConfiguration, configuration.build());

--- a/server/router/src/test/java/org/infinispan/server/router/integration/ProtocolServerEndpointRouterTest.java
+++ b/server/router/src/test/java/org/infinispan/server/router/integration/ProtocolServerEndpointRouterTest.java
@@ -72,10 +72,10 @@ public class ProtocolServerEndpointRouterTest {
      * The router should match properly SNI based routes and connect clients to proper server instances.
      */
     @Test
-    public void shouldRouteToProperHotRodServerBasedOnSniHostName() throws Exception {
+    public void shouldRouteToProperHotRodServerBasedOnSniHostName() {
         //given
-        hotrodServer1 = HotRodTestingUtil.startHotRodServerWithoutTransport();
-        hotrodServer2 = HotRodTestingUtil.startHotRodServerWithoutTransport();
+        hotrodServer1 = HotRodTestingUtil.startHotRodServerWithoutTransport("default");
+        hotrodServer2 = HotRodTestingUtil.startHotRodServerWithoutTransport("default");
 
         HotRodServerRouteDestination hotrod1Destination = new HotRodServerRouteDestination("HotRod1", hotrodServer1);
         SniNettyRouteSource hotrod1Source = new SniNettyRouteSource("hotrod1", KEYSTORE_LOCATION_FOR_HOTROD_1, "secret".toCharArray());
@@ -105,12 +105,12 @@ public class ProtocolServerEndpointRouterTest {
         hotrod1Client = HotRodClientTestingUtil.createWithSni(routerIp, routerPort, "hotrod1", TRUSTSTORE_LOCATION_FOR_HOTROD_1, "secret".toCharArray());
         hotrod2Client = HotRodClientTestingUtil.createWithSni(routerIp, routerPort, "hotrod2", TRUSTSTORE_LOCATION_FOR_HOTROD_2, "secret".toCharArray());
 
-        hotrod1Client.getCache().put("test", "hotrod1");
-        hotrod2Client.getCache().put("test", "hotrod2");
+        hotrod1Client.getCache("default").put("test", "hotrod1");
+        hotrod2Client.getCache("default").put("test", "hotrod2");
 
         //then
-        Cache<String, String> hotrod1Cache = hotrodServer1.getCacheManager().getCache();
-        Cache<String, String> hotrod2Cache = hotrodServer2.getCacheManager().getCache();
+        Cache<String, String> hotrod1Cache = hotrodServer1.getCacheManager().getCache("default");
+        Cache<String, String> hotrod2Cache = hotrodServer2.getCacheManager().getCache("default");
         assertThat(hotrod1Cache.size()).isEqualTo(1);
         assertThat(hotrod2Cache.size()).isEqualTo(1);
         assertThat(hotrod1Cache.get("test")).isEqualTo("hotrod1");

--- a/server/router/src/test/java/org/infinispan/server/router/integration/RestEndpointRouterTest.java
+++ b/server/router/src/test/java/org/infinispan/server/router/integration/RestEndpointRouterTest.java
@@ -52,10 +52,10 @@ public class RestEndpointRouterTest {
      * The router should match requests based on path and redirect them to proper server.
      */
     @Test
-    public void shouldRouteToProperRestServerBasedOnPath() throws Exception {
+    public void shouldRouteToProperRestServerBasedOnPath() {
         //given
-        restServer1 = RestTestingUtil.createDefaultRestServer();
-        restServer2 = RestTestingUtil.createDefaultRestServer();
+        restServer1 = RestTestingUtil.createDefaultRestServer("default");
+        restServer2 = RestTestingUtil.createDefaultRestServer("default");
 
         RestServerRouteDestination rest1Destination = new RestServerRouteDestination("rest1", restServer1);
         RestRouteSource rest1Source = new RestRouteSource("rest1");
@@ -79,8 +79,8 @@ public class RestEndpointRouterTest {
         int port = router.getRouter(EndpointRouter.Protocol.REST).get().getPort();
 
         //when
-        RestClient rest1Client = new RestClient("http://127.0.0.1:" + port + "/rest/rest1");
-        RestClient rest2Client = new RestClient("http://127.0.0.1:" + port + "/rest/rest2");
+        RestClient rest1Client = new RestClient("http://127.0.0.1:" + port + "/rest/rest1").cache("default");
+        RestClient rest2Client = new RestClient("http://127.0.0.1:" + port + "/rest/rest2").cache("default");
         rest1Client.put("test", "rest1");
         rest2Client.put("test", "rest2");
         String valueReturnedFromRest1 = rest1Client.get("test");

--- a/server/router/src/test/java/org/infinispan/server/router/utils/RestClient.java
+++ b/server/router/src/test/java/org/infinispan/server/router/utils/RestClient.java
@@ -14,7 +14,7 @@ public class RestClient {
     private final HttpClient client = new DefaultHttpClient();
     // using URI won't do any good since we need to concatenate and there is no method to do this
     private final String baseUri;
-    private String cache = "___defaultcache";
+    private String cache;
 
     public RestClient(String uri) {
         this.baseUri = uri;

--- a/server/router/src/test/java/org/infinispan/server/router/utils/RestTestingUtil.java
+++ b/server/router/src/test/java/org/infinispan/server/router/utils/RestTestingUtil.java
@@ -23,7 +23,7 @@ public class RestTestingUtil {
     public static RestServer createRest(RestServerConfigurationBuilder configuration, GlobalConfigurationBuilder globalConfigurationBuilder, ConfigurationBuilder cacheConfigurationBuilder, String... definedCaches) {
         RestServer nettyRestServer = new RestServer();
         Configuration cacheConfiguration = cacheConfigurationBuilder.build();
-        DefaultCacheManager cacheManager = new DefaultCacheManager(globalConfigurationBuilder.build(), cacheConfiguration);
+        DefaultCacheManager cacheManager = new DefaultCacheManager(globalConfigurationBuilder.build());
         for (String cache : definedCaches) {
             cacheManager.defineConfiguration(cache, cacheConfiguration);
         }

--- a/server/runtime/src/test/java/org/infinispan/server/RestClient.java
+++ b/server/runtime/src/test/java/org/infinispan/server/RestClient.java
@@ -8,14 +8,13 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
-import org.infinispan.commons.api.BasicCacheContainer;
 
 public class RestClient {
 
    private final HttpClient client = HttpClientBuilder.create().build();
    // using URI won't do any good since we need to concatenate and there is no method to do this
    private final String baseUri;
-   private String cache = BasicCacheContainer.DEFAULT_CACHE_NAME;
+   private String cache;
 
    public RestClient(String uri) {
       this.baseUri = uri;

--- a/spring/spring5/spring5-embedded/src/main/java/org/infinispan/spring/embedded/AbstractEmbeddedCacheManagerFactory.java
+++ b/spring/spring5/spring5-embedded/src/main/java/org/infinispan/spring/embedded/AbstractEmbeddedCacheManagerFactory.java
@@ -58,11 +58,10 @@ public class AbstractEmbeddedCacheManagerFactory {
          }
 
          if (builder == null) {
-            if (logger.isDebugEnabled()) logger.debug("ConfigurationBuilder is null. Using default new instance.");
-            builder = new ConfigurationBuilder();
+            return new DefaultCacheManager(gcb.build());
+         } else {
+            return new DefaultCacheManager(gcb.build(), builder.build());
          }
-
-         return new DefaultCacheManager(gcb.build(), builder.build());
       }
    }
 

--- a/spring/spring5/spring5-embedded/src/main/java/org/infinispan/spring/embedded/session/configuration/EnableInfinispanEmbeddedHttpSession.java
+++ b/spring/spring5/spring5-embedded/src/main/java/org/infinispan/spring/embedded/session/configuration/EnableInfinispanEmbeddedHttpSession.java
@@ -41,7 +41,7 @@ import org.springframework.session.config.annotation.web.http.EnableSpringHttpSe
 @Configuration
 public @interface EnableInfinispanEmbeddedHttpSession {
 
-   public static final String DEFAULT_CACHE_NAME = "sessions";
+   String DEFAULT_CACHE_NAME = "sessions";
 
    /**
     * This is the session timeout in seconds. By default, it is set to 1800 seconds (30 minutes). This should be a

--- a/spring/spring5/spring5-embedded/src/test/java/org/infinispan/spring/embedded/provider/SpringEmbeddedCacheManagerFactoryBeanTest.java
+++ b/spring/spring5/spring5-embedded/src/test/java/org/infinispan/spring/embedded/provider/SpringEmbeddedCacheManagerFactoryBeanTest.java
@@ -109,7 +109,7 @@ public class SpringEmbeddedCacheManagerFactoryBeanTest extends AbstractInfinispa
       GlobalConfigurationBuilder builder = new GlobalConfigurationBuilder();
       builder.defaultCacheName("default");
       objectUnderTest = SpringEmbeddedCacheManagerFactoryBeanBuilder
-            .defaultBuilder().withGlobalConfiguration(builder).build();
+            .defaultBuilder().withGlobalConfiguration(builder).withConfigurationBuilder(new ConfigurationBuilder()).build();
 
       final SpringEmbeddedCacheManager springEmbeddedCacheManager = objectUnderTest.getObject();
       springEmbeddedCacheManager.getCache("default"); // Implicitly starts
@@ -170,7 +170,7 @@ public class SpringEmbeddedCacheManagerFactoryBeanTest extends AbstractInfinispa
       objectUnderTest = new SpringEmbeddedCacheManagerFactoryBean();
 
       GlobalConfigurationBuilder gcb = new GlobalConfigurationBuilder();
-
+      gcb.defaultCacheName("default");
       // Now prepare a cache configuration.
       ConfigurationBuilder builder = new ConfigurationBuilder();
       builder.transaction().transactionMode(TransactionMode.NON_TRANSACTIONAL);

--- a/spring/spring5/spring5-embedded/src/test/java/org/infinispan/spring/embedded/support/InfinispanEmbeddedCacheManagerFactoryBeanTest.java
+++ b/spring/spring5/spring5-embedded/src/test/java/org/infinispan/spring/embedded/support/InfinispanEmbeddedCacheManagerFactoryBeanTest.java
@@ -147,7 +147,8 @@ public class InfinispanEmbeddedCacheManagerFactoryBeanTest extends AbstractInfin
       objectUnderTest.afterPropertiesSet();
 
       final EmbeddedCacheManager embeddedCacheManager = objectUnderTest.getObject();
-      embeddedCacheManager.getCache(); // Implicitly starts EmbeddedCacheManager
+      embeddedCacheManager.defineConfiguration("cache", new ConfigurationBuilder().build());
+      embeddedCacheManager.getCache("cache"); // Implicitly starts EmbeddedCacheManager
       objectUnderTest.destroy();
 
       withCacheManager(new CacheManagerCallable(objectUnderTest.getObject()) {
@@ -167,6 +168,7 @@ public class InfinispanEmbeddedCacheManagerFactoryBeanTest extends AbstractInfin
       final InfinispanEmbeddedCacheManagerFactoryBean objectUnderTest = new InfinispanEmbeddedCacheManagerFactoryBean();
       try {
          GlobalConfigurationBuilder gcb = new GlobalConfigurationBuilder();
+         gcb.defaultCacheName("default");
 
          // Now prepare a cache configuration.
          ConfigurationBuilder builder = new ConfigurationBuilder();

--- a/tasks/scripting/src/test/java/org/infinispan/scripting/ScriptingDataStoresTest.java
+++ b/tasks/scripting/src/test/java/org/infinispan/scripting/ScriptingDataStoresTest.java
@@ -5,13 +5,12 @@ import static org.testng.AssertJUnit.assertEquals;
 
 import java.util.concurrent.TimeUnit;
 
-import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.StorageType;
-import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.tasks.TaskContext;
 import org.infinispan.test.fwk.CleanupAfterMethod;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 
@@ -52,8 +51,9 @@ public class ScriptingDataStoresTest extends AbstractScriptingTest {
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
-      Configuration conf = new ConfigurationBuilder().memory().storageType(storageType).build();
-      return new DefaultCacheManager(conf);
+      ConfigurationBuilder conf = new ConfigurationBuilder();
+      conf.memory().storageType(storageType);
+      return TestCacheManagerFactory.createCacheManager(conf);
    }
 
    @Override

--- a/tools/src/main/java/org/infinispan/tools/config/v6/Parser60.java
+++ b/tools/src/main/java/org/infinispan/tools/config/v6/Parser60.java
@@ -56,7 +56,6 @@ import org.infinispan.distribution.group.Grouper;
 import org.infinispan.factories.threads.DefaultThreadFactory;
 import org.infinispan.interceptors.base.CommandInterceptor;
 import org.infinispan.jmx.MBeanServerLookup;
-import org.infinispan.manager.CacheContainer;
 import org.infinispan.persistence.cluster.ClusterLoader;
 import org.infinispan.persistence.file.SingleFileStore;
 import org.infinispan.persistence.spi.CacheLoader;
@@ -79,6 +78,7 @@ import org.kohsuke.MetaInfServices;
 @Namespace(uri = "urn:infinispan:config:6.0", root = "infinispan")
 public class Parser60 implements ConfigurationParser {
    public static final String INFINISPAN_FACTORY = "infinispan-factory";
+   public static final String DEFAULT_CACHE_NAME = "___defaultcache";
 
    public Parser60() {
    }
@@ -137,7 +137,7 @@ public class Parser60 implements ConfigurationParser {
          builder = holder.newConfigurationBuilder(name);
       }
       // Apply old default inheritance semantics
-      ConfigurationBuilder defaultBuilder = holder.getNamedConfigurationBuilders().get(CacheContainer.DEFAULT_CACHE_NAME);
+      ConfigurationBuilder defaultBuilder = holder.getNamedConfigurationBuilders().get(DEFAULT_CACHE_NAME);
       if (defaultBuilder != null) {
          builder.read(defaultBuilder.build());
       }
@@ -148,9 +148,9 @@ public class Parser60 implements ConfigurationParser {
    private void parseDefaultCache(final XMLExtendedStreamReader reader, final ConfigurationBuilderHolder holder) throws XMLStreamException {
       ParseUtils.requireNoAttributes(reader);
       // Reuse the builder if it was made before
-      ConfigurationBuilder builder = holder.getNamedConfigurationBuilders().get(CacheContainer.DEFAULT_CACHE_NAME);
+      ConfigurationBuilder builder = holder.getNamedConfigurationBuilders().get(DEFAULT_CACHE_NAME);
       if (builder == null) {
-         holder.newConfigurationBuilder(CacheContainer.DEFAULT_CACHE_NAME);
+         holder.newConfigurationBuilder(DEFAULT_CACHE_NAME);
       }
       parseCache(reader, holder);
    }

--- a/tools/src/test/java/org/infinispan/tools/store/migrator/AbstractReaderTest.java
+++ b/tools/src/test/java/org/infinispan/tools/store/migrator/AbstractReaderTest.java
@@ -16,14 +16,12 @@ import java.util.Properties;
 import org.infinispan.Cache;
 import org.infinispan.commons.test.skip.SkipTestNG;
 import org.infinispan.commons.util.Features;
-import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
-import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.factories.DataContainerFactory;
-import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.AbstractInfinispanTest;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.tools.store.migrator.marshaller.MarshallerType;
 import org.testng.annotations.Test;
 
@@ -79,15 +77,13 @@ public abstract class AbstractReaderTest extends AbstractInfinispanTest {
       // Read from the legacy LevelDB store and populate the new RocksDBStore using latest marshaller
       new StoreMigrator(properties).run();
 
-      GlobalConfiguration globalConfig = new GlobalConfigurationBuilder()
-            .serialization().addAdvancedExternalizer(256, new TestUtil.TestObjectExternalizer())
-            .build();
+      GlobalConfigurationBuilder globalConfig = new GlobalConfigurationBuilder();
+      globalConfig.serialization().addAdvancedExternalizer(256, new TestUtil.TestObjectExternalizer());
 
-      Configuration config = getTargetCacheConfig().build();
 
       // Create a new cache instance, with the required externalizers, to ensure that the new RocksDbStore can be
       // loaded and contains all of the expected values.
-      EmbeddedCacheManager manager = new DefaultCacheManager(globalConfig, config);
+      EmbeddedCacheManager manager = TestCacheManagerFactory.createCacheManager(globalConfig, getTargetCacheConfig());
       try {
          Cache cache = manager.getCache(TEST_CACHE_NAME);
          for (String key : TestUtil.TEST_MAP.keySet()) {


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-9949
https://issues.jboss.org/browse/ISPN-8826

Every test now sets the default cache to be named after the test's short name.
Some commits in here will be removed when the corresponding PRs are merged.