### PR TITLE
ISPN-10224 Fix session fixation protection

### DIFF
--- a/spring/spring5/spring5-common/src/test/java/org/infinispan/spring/common/session/InfinispanSessionRepositoryTCK.java
+++ b/spring/spring5/spring5-common/src/test/java/org/infinispan/spring/common/session/InfinispanSessionRepositoryTCK.java
@@ -132,6 +132,29 @@ public abstract class InfinispanSessionRepositoryTCK extends AbstractInfinispanT
       assertTrue(numberOfNonExistingUsers == 0);
    }
 
+   @Test
+   public void testChangeSessionId() throws Exception {
+      //given
+      MapSession session = sessionRepository.createSession();
+
+      //when
+      String originalId = session.getId();
+      sessionRepository.save(session);
+      session.changeSessionId();
+      String newId = session.getId();
+      sessionRepository.save(session);
+
+      //then
+      assertNotNull(sessionRepository.findById(newId));
+      assertNull(sessionRepository.findById(originalId));
+
+      // Save again to test that the deletion doesn't fail when the session isn't in the repo
+      sessionRepository.save(session );
+
+      assertNotNull(sessionRepository.findById(newId));
+      assertNull(sessionRepository.findById(originalId));
+   }
+
    protected void addEmptySessionWithPrincipal(AbstractInfinispanSessionRepository sessionRepository, String principalName) {
       MapSession session = sessionRepository.createSession();
       session.setAttribute(PRINCIPAL_NAME_INDEX_NAME, principalName);


### PR DESCRIPTION
`org.infinispan.spring.common.session.AbstractInfinispanSessionRepository` implements the `save(MapSession)` method defined by `org.springframework.session.SessionRepository`. However, the implementation does not correctly handle when the session id changes. When `getId()` returns a different value from `getOriginalId()`, the original session should be deleted.

Note that Spring Session's [`MapSessionRepository.save`](https://github.com/spring-projects/spring-session/blob/master/spring-session-core/src/main/java/org/springframework/session/MapSessionRepository.java#L73) implementation has the correct behaviour.

I couldn't get the Maven build working, so I can't guarantee it compiles.

https://issues.jboss.org/browse/ISPN-10245