### PR TITLE
ISPN-10230 Fix ExceptionInCommandTest

### DIFF
--- a/core/src/test/java/org/infinispan/tx/exception/ExceptionInCommandTest.java
+++ b/core/src/test/java/org/infinispan/tx/exception/ExceptionInCommandTest.java
@@ -22,7 +22,9 @@ public class ExceptionInCommandTest extends MultipleCacheManagersTest {
    public void testPutThrowsLocalException() throws Exception {
       tm(0).begin();
       try {
-         cache(0).computeIfAbsent("k", (k) -> new RuntimeException());
+         cache(0).computeIfAbsent("k", (k) -> {
+            throw new RuntimeException();
+         });
          assert false;
       } catch (RuntimeException e) {
          assert tx(0).getStatus() == Status.STATUS_MARKED_ROLLBACK;


### PR DESCRIPTION
The test returns a RuntimeException instead of throwing it.