### PR TITLE
ISPN-20259 Deprecate Total Order transactions

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/cache/TransactionConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/TransactionConfiguration.java
@@ -296,7 +296,9 @@ public class TransactionConfiguration implements Matchable<TransactionConfigurat
 
    /**
     * @return the transaction protocol in use (2PC or Total Order)
+    * @deprecated since 10.0. Total Order will be removed.
     */
+   @Deprecated
    public TransactionProtocol transactionProtocol() {
       return transactionProtocol.get();
    }

--- a/core/src/main/java/org/infinispan/configuration/cache/TransactionConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/TransactionConfigurationBuilder.java
@@ -266,6 +266,10 @@ public class TransactionConfigurationBuilder extends AbstractConfigurationChildB
       return this;
    }
 
+   /**
+    * @deprecated Since 10.0. Total Order will be removed.
+    */
+   @Deprecated
    public TransactionConfigurationBuilder transactionProtocol(TransactionProtocol transactionProtocol) {
       attributes.attribute(TRANSACTION_PROTOCOL).set(transactionProtocol);
       return this;

--- a/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderDistributionInterceptor.java
@@ -22,7 +22,9 @@ import org.infinispan.util.logging.LogFactory;
  * order based protocol is enabled
  *
  * @author Pedro Ruivo
+ * @deprecated since 10.0. Total Order will be removed.
  */
+@Deprecated
 public class TotalOrderDistributionInterceptor extends TxDistributionInterceptor {
 
    private static final Log log = LogFactory.getLog(TotalOrderDistributionInterceptor.class);

--- a/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderInterceptor.java
@@ -33,7 +33,9 @@ import org.infinispan.util.logging.LogFactory;
  *
  * @author Pedro Ruivo
  * @author Mircea.Markus@jboss.com
+ * @deprecated since 10.0. Total Order will be removed.
  */
+@Deprecated
 public class TotalOrderInterceptor extends DDAsyncInterceptor {
 
    private static final Log log = LogFactory.getLog(TotalOrderInterceptor.class);

--- a/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderStateTransferInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderStateTransferInterceptor.java
@@ -16,7 +16,9 @@ import org.infinispan.util.logging.LogFactory;
  * Synchronizes the incoming totally ordered transactions with the state transfer.
  *
  * @author Pedro Ruivo
+ * @deprecated since 10.0. Total Order will be removed.
  */
+@Deprecated
 public class TotalOrderStateTransferInterceptor extends BaseStateTransferInterceptor {
    private static final Log log = LogFactory.getLog(TotalOrderStateTransferInterceptor.class);
    private static final boolean trace = log.isTraceEnabled();

--- a/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderVersionedDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderVersionedDistributionInterceptor.java
@@ -24,7 +24,9 @@ import org.infinispan.util.logging.LogFactory;
  * (i.e., the write skew check passes in all keys owners)
  *
  * @author Pedro Ruivo
+ * @deprecated since 10.0. Total Order will be removed.
  */
+@Deprecated
 public class TotalOrderVersionedDistributionInterceptor extends VersionedDistributionInterceptor {
 
    private static final Log log = LogFactory.getLog(TotalOrderVersionedDistributionInterceptor.class);

--- a/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderVersionedEntryWrappingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderVersionedEntryWrappingInterceptor.java
@@ -27,7 +27,9 @@ import org.infinispan.util.logging.LogFactory;
  *
  * @author Mircea.Markus@jboss.com
  * @author Pedro Ruivo
+ * @deprecated @deprecated since 10.0. Total Order will be removed.
  */
+@Deprecated
 public class TotalOrderVersionedEntryWrappingInterceptor extends VersionedEntryWrappingInterceptor {
 
    private static final Log log = LogFactory.getLog(TotalOrderVersionedEntryWrappingInterceptor.class);

--- a/core/src/main/java/org/infinispan/remoting/inboundhandler/TotalOrderTxPerCacheInboundInvocationHandler.java
+++ b/core/src/main/java/org/infinispan/remoting/inboundhandler/TotalOrderTxPerCacheInboundInvocationHandler.java
@@ -27,7 +27,9 @@ import org.infinispan.util.logging.LogFactory;
  *
  * @author Pedro Ruivo
  * @since 7.1
+ * @deprecated since 10.0. Total Order will be removed.
  */
+@Deprecated
 public class TotalOrderTxPerCacheInboundInvocationHandler extends BasePerCacheInboundInvocationHandler {
 
    private static final Log log = LogFactory.getLog(TotalOrderTxPerCacheInboundInvocationHandler.class);

--- a/core/src/main/java/org/infinispan/transaction/TransactionProtocol.java
+++ b/core/src/main/java/org/infinispan/transaction/TransactionProtocol.java
@@ -5,7 +5,9 @@ package org.infinispan.transaction;
  *
  * @author Pedro Ruivo
  * @since 5.3
+ * @deprecated since 10.0. Total Order will be removed.
  */
+@Deprecated
 public enum TransactionProtocol {
    /**
     * uses the 2PC protocol

--- a/core/src/main/java/org/infinispan/transaction/impl/RemoteTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/impl/RemoteTransaction.java
@@ -142,7 +142,9 @@ public class RemoteTransaction extends AbstractCacheTransaction implements Clone
 
    /**
     * @return  get (or create if needed) the {@code TotalOrderRemoteTransactionState} associated to this remote transaction
+    * @deprecated since 10.0. Total Order will be removed.
     */
+   @Deprecated
    public final TotalOrderRemoteTransactionState getTransactionState() {
       if (transactionState != null) {
          return transactionState;

--- a/core/src/main/java/org/infinispan/transaction/impl/TotalOrderRemoteTransactionState.java
+++ b/core/src/main/java/org/infinispan/transaction/impl/TotalOrderRemoteTransactionState.java
@@ -16,7 +16,9 @@ import org.infinispan.util.logging.LogFactory;
  *
  * @author Pedro Ruivo
  * @since 5.3
+ * @deprecated since 10.0. Total Order will be removed.
  */
+@Deprecated
 public class TotalOrderRemoteTransactionState {
 
    private static final Log log = LogFactory.getLog(TotalOrderRemoteTransactionState.class);

--- a/core/src/main/java/org/infinispan/transaction/totalorder/TotalOrderLatch.java
+++ b/core/src/main/java/org/infinispan/transaction/totalorder/TotalOrderLatch.java
@@ -8,7 +8,9 @@ package org.infinispan.transaction.totalorder;
  *
  * @author Pedro Ruivo
  * @since 5.3
+ * @deprecated since 10.0. Total Order will be removed.
  */
+@Deprecated
 public interface TotalOrderLatch {
 
    /**

--- a/core/src/main/java/org/infinispan/transaction/totalorder/TotalOrderManager.java
+++ b/core/src/main/java/org/infinispan/transaction/totalorder/TotalOrderManager.java
@@ -38,8 +38,10 @@ import org.infinispan.util.logging.LogFactory;
  *
  * @author Pedro Ruivo
  * @since 5.3
+ * @deprecated since 10.0. Total Order will be removed.
  */
 @Scope(Scopes.NAMED_CACHE)
+@Deprecated
 public class TotalOrderManager {
 
    private static final Log log = LogFactory.getLog(TotalOrderManager.class);

--- a/core/src/main/resources/schema/infinispan-config-10.0.xsd
+++ b/core/src/main/resources/schema/infinispan-config-10.0.xsd
@@ -996,7 +996,7 @@
     <xs:attribute name="protocol" type="tns:transaction-protocol">
       <xs:annotation>
         <xs:documentation>
-          Configures the commit protocol to use.
+          (Deprecated, Total Order will be removed) Configures the commit protocol to use.
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>
@@ -2210,7 +2210,7 @@
   <xs:simpleType name="transaction-protocol">
     <xs:annotation>
       <xs:documentation>
-        Enumeration containing the available commit protocols
+        (Deprecated since 10.0. It is going to be removed) Enumeration containing the available commit protocols
       </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">

--- a/documentation/src/main/asciidoc/upgrading/upgrading-content.adoc
+++ b/documentation/src/main/asciidoc/upgrading/upgrading-content.adoc
@@ -1,5 +1,10 @@
 == Upgrading from 9.4 to 10.0
 
+=== Total Order transaction protocol is deprecated
+
+Total Order transaction protocol is going to be removed in a future release.
+Use the default protocol (2PC).
+
 === Removed AtomicMap and FineGrainedAtomicMap
 
 AtomicMapLookup, AtomicMap and FineGrainedAtomicMap have been removed. Please see FunctionalMaps or Cache#Merge for


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-10259

Deprecated the configuration and interceptors. There are other classes around (commands) that aren't deprecated (should they be?)