### PR TITLE
JDG-2953 ISPN-10303  config-converter.bat script contains wrong transaction library

### DIFF
--- a/distribution/src/main/release/all/bin/config-converter.bat
+++ b/distribution/src/main/release/all/bin/config-converter.bat
@@ -7,7 +7,7 @@ set ISPN_HOME="%ISPN_HOME%.."
 set CP=
 for %%i in (%ISPN_HOME%\*.jar) do call :append_to_cp %%i
 for %%i in (%ISPN_HOME%\modules\tools\*.jar) do call :append_to_cp %%i
-for %%i in (%ISPN_HOME%\lib\jboss-transactions-api*.jar) do call :append_to_cp %%i
+for %%i in (%ISPN_HOME%\lib\jboss-transaction-api*.jar) do call :append_to_cp %%i
 rem echo libs: %CP%
 
 java -classpath "%CP%" org.infinispan.tools.config.ConfigurationConverter %*


### PR DESCRIPTION
Fix for : https://issues.jboss.org/browse/JDG-2953
Upstream: https://issues.jboss.org/browse/ISPN-10303