### PR TITLE
ISPN-10271 Port 9993 for JMX over TLS

### DIFF
--- a/documentation/src/main/asciidoc/server_guide/management.adoc
+++ b/documentation/src/main/asciidoc/server_guide/management.adoc
@@ -72,7 +72,7 @@ ifndef::productized[]
 endif::productized[]
 ifdef::productized[]
 * `service:jmx:remote+http://hostname:9990` for plain connections through the management interface
-* `service:jmx:remote+https://hostname:9990` for TLS connections through the management interface (although this requires having the appropriate keys available)
+* `service:jmx:remote+https://hostname:9993` for TLS connections through the management interface (although this requires having the appropriate keys available)
 endif::productized[]
 
 The JMX subsystem registers a service with the Remoting endpoint so that remote access to JMX can be obtained over the exposed Remoting connector.


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-10271 

Reopening for correct port with JMX over TLS. Needs backport to 9.4.x.