### PR TITLE
ISPN-10262 Deprecate custom interceptors configuration

### DIFF
--- a/core/src/main/java/org/infinispan/AdvancedCache.java
+++ b/core/src/main/java/org/infinispan/AdvancedCache.java
@@ -18,7 +18,6 @@ import org.infinispan.cache.impl.DecoratedCache;
 import org.infinispan.commons.api.TransactionalCache;
 import org.infinispan.commons.dataconversion.Encoder;
 import org.infinispan.commons.dataconversion.Wrapper;
-import org.infinispan.commons.util.Experimental;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.PartitionHandlingConfiguration;
 import org.infinispan.container.DataContainer;
@@ -191,12 +190,10 @@ public interface AdvancedCache<K, V> extends Cache<K, V>, TransactionalCache {
 
    /**
     * Allows the modification of the interceptor chain.
-    * <p>
-    * Experimental: The ability to modify the interceptors at runtime may be removed in future versions.
     *
-    * @since 9.0
+    * @deprecated Since 10.0, will be removed without a replacement
     */
-   @Experimental
+   @Deprecated
    AsyncInterceptorChain getAsyncInterceptorChain();
 
    /**

--- a/core/src/main/java/org/infinispan/cache/impl/AbstractDelegatingAdvancedCache.java
+++ b/core/src/main/java/org/infinispan/cache/impl/AbstractDelegatingAdvancedCache.java
@@ -70,6 +70,10 @@ public class AbstractDelegatingAdvancedCache<K, V> extends AbstractDelegatingCac
       cache.getAsyncInterceptorChain().addInterceptor(i, position);
    }
 
+   /**
+    * @deprecated Since 10.0, will be removed without a replacement
+    */
+   @Deprecated
    @Override
    public AsyncInterceptorChain getAsyncInterceptorChain() {
       return cache.getAsyncInterceptorChain();

--- a/core/src/main/java/org/infinispan/cache/impl/CacheImpl.java
+++ b/core/src/main/java/org/infinispan/cache/impl/CacheImpl.java
@@ -1161,6 +1161,10 @@ public class CacheImpl<K, V> implements AdvancedCache<K, V> {
       invoker.addInterceptor(i, position);
    }
 
+   /**
+    * @deprecated Since 10.0, will be removed without a replacement
+    */
+   @Deprecated
    @Override
    public AsyncInterceptorChain getAsyncInterceptorChain() {
       return invoker;

--- a/core/src/main/java/org/infinispan/cache/impl/SimpleCacheImpl.java
+++ b/core/src/main/java/org/infinispan/cache/impl/SimpleCacheImpl.java
@@ -1194,6 +1194,10 @@ public class SimpleCacheImpl<K, V> implements AdvancedCache<K, V> {
       throw log.interceptorStackNotSupported();
    }
 
+   /**
+    * @deprecated Since 10.0, will be removed without a replacement
+    */
+   @Deprecated
    @Override
    public AsyncInterceptorChain getAsyncInterceptorChain() {
       return EmptyAsyncInterceptorChain.INSTANCE;

--- a/core/src/main/java/org/infinispan/configuration/cache/AbstractConfigurationChildBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/AbstractConfigurationChildBuilder.java
@@ -27,6 +27,10 @@ abstract class AbstractConfigurationChildBuilder implements ConfigurationChildBu
       return builder.clustering();
    }
 
+   /**
+    * @deprecated Since 10.0, custom interceptors support will be removed and only modules will be able to define interceptors
+    */
+   @Deprecated
    @Override
    public CustomInterceptorsConfigurationBuilder customInterceptors() {
       return builder.customInterceptors();

--- a/core/src/main/java/org/infinispan/configuration/cache/AbstractCustomInterceptorsConfigurationChildBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/AbstractCustomInterceptorsConfigurationChildBuilder.java
@@ -1,5 +1,9 @@
 package org.infinispan.configuration.cache;
 
+/**
+ * @deprecated Since 10.0, custom interceptors support will be removed and only modules will be able to define interceptors
+ */
+@Deprecated
 public abstract class AbstractCustomInterceptorsConfigurationChildBuilder extends AbstractConfigurationChildBuilder {
 
    private final CustomInterceptorsConfigurationBuilder customInterceptorsBuilder;

--- a/core/src/main/java/org/infinispan/configuration/cache/Configuration.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/Configuration.java
@@ -139,6 +139,10 @@ public class Configuration implements BasicConfiguration, Matchable<Configuratio
       return clusteringConfiguration;
    }
 
+   /**
+    * @deprecated Since 10.0, custom interceptors support will be removed and only modules will be able to define interceptors
+    */
+   @Deprecated
    public CustomInterceptorsConfiguration customInterceptors() {
       return customInterceptorsConfiguration;
    }

--- a/core/src/main/java/org/infinispan/configuration/cache/ConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/ConfigurationBuilder.java
@@ -111,6 +111,10 @@ public class ConfigurationBuilder implements ConfigurationChildBuilder, Configur
       return clustering;
    }
 
+   /**
+    * @deprecated Since 10.0, custom interceptors support will be removed and only modules will be able to define interceptors
+    */
+   @Deprecated
    @Override
    public CustomInterceptorsConfigurationBuilder customInterceptors() {
       return customInterceptors;

--- a/core/src/main/java/org/infinispan/configuration/cache/ConfigurationChildBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/ConfigurationChildBuilder.java
@@ -10,6 +10,10 @@ public interface ConfigurationChildBuilder {
 
    ClusteringConfigurationBuilder clustering();
 
+   /**
+    * @deprecated Since 10.0, custom interceptors support will be removed and only modules will be able to define interceptors
+    */
+   @Deprecated
    CustomInterceptorsConfigurationBuilder customInterceptors();
 
    DataContainerConfigurationBuilder dataContainer();

--- a/core/src/main/java/org/infinispan/configuration/cache/CustomInterceptorsConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/CustomInterceptorsConfiguration.java
@@ -15,7 +15,9 @@ import org.infinispan.commons.configuration.elements.ElementDefinition;
  * Configures custom interceptors to be added to the cache.
  *
  * @author pmuir
+ * @deprecated Since 10.0, custom interceptors support will be removed and only modules will be able to define interceptors
  */
+@Deprecated
 public class CustomInterceptorsConfiguration implements Matchable<CustomInterceptorsConfiguration>, ConfigurationInfo {
 
    static final ElementDefinition ELEMENT_DEFINITION = new DefaultElementDefinition(CUSTOM_INTERCEPTORS.getLocalName());

--- a/core/src/main/java/org/infinispan/configuration/cache/CustomInterceptorsConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/CustomInterceptorsConfigurationBuilder.java
@@ -14,8 +14,9 @@ import org.infinispan.configuration.parsing.Element;
  * Configures custom interceptors to be added to the cache.
  *
  * @author pmuir
- *
+ * @deprecated Since 10.0, custom interceptors support will be removed and only modules will be able to define interceptors
  */
+@Deprecated
 public class CustomInterceptorsConfigurationBuilder extends AbstractConfigurationChildBuilder implements Builder<CustomInterceptorsConfiguration>, ConfigurationBuilderInfo {
 
    private List<InterceptorConfigurationBuilder> interceptorBuilders = new LinkedList<>();
@@ -26,7 +27,9 @@ public class CustomInterceptorsConfigurationBuilder extends AbstractConfiguratio
 
    /**
     * Adds a new custom interceptor definition, to be added to the cache when the cache is started.
+    * @deprecated Since 10.0, custom interceptors support will be removed and only modules will be able to define interceptors
     */
+   @Deprecated
    public InterceptorConfigurationBuilder addInterceptor() {
       InterceptorConfigurationBuilder builder = new InterceptorConfigurationBuilder(this);
       this.interceptorBuilders.add(builder);

--- a/core/src/main/java/org/infinispan/configuration/cache/InterceptorConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/InterceptorConfigurationBuilder.java
@@ -28,7 +28,10 @@ import org.infinispan.util.logging.LogFactory;
 
 /**
  * This builder defines details of a specific custom interceptor.
+ *
+ * @deprecated Since 10.0, custom interceptors support will be removed and only modules will be able to define interceptors
  */
+@Deprecated
 public class InterceptorConfigurationBuilder extends AbstractCustomInterceptorsConfigurationChildBuilder implements Builder<InterceptorConfiguration>, ConfigurationBuilderInfo {
    private static final Log log = LogFactory.getLog(InterceptorConfigurationBuilder.class);
    private final AttributeSet attributes;

--- a/core/src/main/java/org/infinispan/configuration/parsing/Parser.java
+++ b/core/src/main/java/org/infinispan/configuration/parsing/Parser.java
@@ -1396,6 +1396,7 @@ public class Parser implements ConfigurationParser {
             break;
          }
          case CUSTOM_INTERCEPTORS: {
+            log.customInterceptorsDeprecated();
             this.parseCustomInterceptors(reader, holder);
             break;
          }

--- a/core/src/main/java/org/infinispan/security/impl/SecureCacheImpl.java
+++ b/core/src/main/java/org/infinispan/security/impl/SecureCacheImpl.java
@@ -248,6 +248,10 @@ public final class SecureCacheImpl<K, V> implements SecureCache<K, V> {
       delegate.addInterceptor(i, position);
    }
 
+   /**
+    * @deprecated Since 10.0, will be removed without a replacement
+    */
+   @Deprecated
    @Override
    public AsyncInterceptorChain getAsyncInterceptorChain() {
       authzManager.checkPermission(subject, AuthorizationPermission.ADMIN);

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -1867,4 +1867,8 @@ public interface Log extends BasicLogger {
 
    @Message(value = "Invalidation mode only supports when-split=ALLOW_READ_WRITES", id = 550)
    CacheConfigurationException invalidationPartitionHandlingNotSuported();
+
+   @LogMessage(level = WARN)
+   @Message(value = "The custom interceptors configuration has been deprecated and will be ignored in the future", id = 551)
+   void customInterceptorsDeprecated();
 }

--- a/core/src/main/resources/schema/infinispan-config-10.0.xsd
+++ b/core/src/main/resources/schema/infinispan-config-10.0.xsd
@@ -850,7 +850,8 @@
       </xs:element>
       <xs:element name="custom-interceptors" type="tns:custom-interceptors" minOccurs="0">
         <xs:annotation>
-          <xs:documentation>Configures custom interceptors to be added to the cache.</xs:documentation>
+          <xs:documentation>Deprecated since 10.0, will be removed without a replacement.
+             Configures custom interceptors to be added to the cache.</xs:documentation>
         </xs:annotation>
       </xs:element>
       <xs:element name="security" type="tns:cache-security" minOccurs="0">
@@ -1195,6 +1196,7 @@
   <xs:complexType name="custom-interceptors">
     <xs:sequence>
       <xs:element name="interceptor" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>Deprecated since 10.0, will be removed without a replacement.</xs:annotation>
         <xs:complexType>
           <xs:sequence>
             <xs:element name="property" type="tns:property" minOccurs="0"/>

--- a/core/src/test/java/org/infinispan/functional/decorators/FunctionalAdvancedCache.java
+++ b/core/src/test/java/org/infinispan/functional/decorators/FunctionalAdvancedCache.java
@@ -293,6 +293,10 @@ public final class FunctionalAdvancedCache<K, V> implements AdvancedCache<K, V> 
       cache.addInterceptor(i, position);
    }
 
+   /**
+    * @deprecated Since 10.0, will be removed without a replacement
+    */
+   @Deprecated
    @Override
    public AsyncInterceptorChain getAsyncInterceptorChain() {
       return cache.getAsyncInterceptorChain();

--- a/core/src/test/java/org/infinispan/test/TestingUtil.java
+++ b/core/src/test/java/org/infinispan/test/TestingUtil.java
@@ -1027,6 +1027,10 @@ public class TestingUtil {
       return cm.getGlobalComponentRegistry().getComponent(PersistenceMarshaller.class, KnownComponentNames.PERSISTENCE_MARSHALLER);
    }
 
+   public static AsyncInterceptorChain extractInterceptorChain(Cache cache) {
+      return extractComponent(cache, AsyncInterceptorChain.class);
+   }
+
    /**
     * Add a hook to cache startup sequence that will allow to replace existing component with a mock.
     * @param cacheContainer

--- a/tasks/scripting/src/main/java/org/infinispan/scripting/impl/LifecycleCallbacks.java
+++ b/tasks/scripting/src/main/java/org/infinispan/scripting/impl/LifecycleCallbacks.java
@@ -1,13 +1,27 @@
 package org.infinispan.scripting.impl;
 
+import static org.infinispan.commons.dataconversion.MediaType.APPLICATION_OBJECT_TYPE;
+import static org.infinispan.scripting.ScriptingManager.SCRIPT_CACHE;
+import static org.infinispan.scripting.ScriptingManager.SCRIPT_MANAGER_ROLE;
+
+import java.util.EnumSet;
+
+import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfiguration;
+import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.factories.GlobalComponentRegistry;
-import org.infinispan.factories.annotations.InfinispanModule;
 import org.infinispan.factories.KnownComponentNames;
+import org.infinispan.factories.annotations.InfinispanModule;
 import org.infinispan.factories.impl.BasicComponentRegistry;
+import org.infinispan.interceptors.AsyncInterceptorChain;
+import org.infinispan.interceptors.impl.CacheMgmtInterceptor;
 import org.infinispan.lifecycle.ModuleLifecycle;
 import org.infinispan.marshall.persistence.PersistenceMarshaller;
+import org.infinispan.registry.InternalCacheRegistry;
 import org.infinispan.scripting.ScriptingManager;
+import org.infinispan.security.AuthorizationPermission;
+import org.infinispan.security.impl.CacheRoleImpl;
 
 /**
  * LifecycleCallbacks.
@@ -26,5 +40,37 @@ public class LifecycleCallbacks implements ModuleLifecycle {
       BasicComponentRegistry bcr = gcr.getComponent(BasicComponentRegistry.class);
       PersistenceMarshaller persistenceMarshaller = bcr.getComponent(KnownComponentNames.PERSISTENCE_MARSHALLER, PersistenceMarshaller.class).wired();
       persistenceMarshaller.register(new PersistenceContextInitializerImpl());
+
+      InternalCacheRegistry internalCacheRegistry = bcr.getComponent(InternalCacheRegistry.class).wired();
+      internalCacheRegistry.registerInternalCache(SCRIPT_CACHE, getScriptCacheConfiguration(gc).build(),
+                                                  EnumSet.of(InternalCacheRegistry.Flag.USER,
+                                                             InternalCacheRegistry.Flag.PROTECTED,
+                                                             InternalCacheRegistry.Flag.PERSISTENT,
+                                                             InternalCacheRegistry.Flag.GLOBAL));
+   }
+
+   @Override
+   public void cacheStarting(ComponentRegistry cr, Configuration configuration, String cacheName) {
+      if (SCRIPT_CACHE.equals(cacheName)) {
+         BasicComponentRegistry bcr = cr.getComponent(BasicComponentRegistry.class);
+         ScriptingInterceptor scriptingInterceptor = new ScriptingInterceptor();
+         bcr.registerComponent(ScriptingInterceptor.class, scriptingInterceptor, true);
+         bcr.addDynamicDependency(AsyncInterceptorChain.class.getName(), ScriptingInterceptor.class.getName());
+         bcr.getComponent(AsyncInterceptorChain.class).wired()
+            .addInterceptorAfter(scriptingInterceptor, CacheMgmtInterceptor.class);
+      }
+   }
+
+   private ConfigurationBuilder getScriptCacheConfiguration(GlobalConfiguration globalConfiguration) {
+      ConfigurationBuilder cfg = new ConfigurationBuilder();
+      cfg.encoding().key().mediaType(APPLICATION_OBJECT_TYPE);
+      cfg.encoding().value().mediaType(APPLICATION_OBJECT_TYPE);
+      if (globalConfiguration.security().authorization().enabled()) {
+         globalConfiguration.security().authorization().roles()
+                            .put(SCRIPT_MANAGER_ROLE,
+                                 new CacheRoleImpl(SCRIPT_MANAGER_ROLE, AuthorizationPermission.ALL));
+         cfg.security().authorization().enable().role(SCRIPT_MANAGER_ROLE);
+      }
+      return cfg;
    }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-10262

ISPN-10262 Deprecate custom interceptors configuration

* Deprecate the custom interceptors configuration
* Warn at startup if custom interceptors are present
* Deprecate AdvancedCache.getAsyncInterceptorChain() 
* Replace interceptors configuration with direct AsyncInterceptorChain
  manipulation in all the modules.