### PR TITLE
ISPN-10346 InitialClusterSizeTest thread leak

### DIFF
--- a/core/src/main/java/org/infinispan/factories/impl/BasicComponentRegistryImpl.java
+++ b/core/src/main/java/org/infinispan/factories/impl/BasicComponentRegistryImpl.java
@@ -239,8 +239,9 @@ public class BasicComponentRegistryImpl implements BasicComponentRegistry {
       if (factoryRef == null) {
          factoryRef = tryAutoInstantiation(factoryName);
       }
-      // Don't start the factory's dependencies
-      return factoryRef != null ? factoryRef.wired() : null;
+      // Start the factory (and it's dependencies!) because some factories
+      // are responsible for stopping the components they create (e.g. NamedExecutorsFactory)
+      return factoryRef != null ? factoryRef.running() : null;
    }
 
    private void commitWrapperStateChange(ComponentWrapper wrapper, WrapperState expectedState, WrapperState newState) {

--- a/core/src/main/java/org/infinispan/util/concurrent/BlockingTaskAwareExecutorServiceImpl.java
+++ b/core/src/main/java/org/infinispan/util/concurrent/BlockingTaskAwareExecutorServiceImpl.java
@@ -126,6 +126,7 @@ public class BlockingTaskAwareExecutorServiceImpl extends AbstractExecutorServic
       } catch (RejectedExecutionException rejected) {
          //put it back!
          blockedTasks.offer(runnable);
+         checkForReadyTasks();
       }
    }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-10346

* BasicComponentRegistryImpl: Start factories before construct()
* BlockingTaskAwareExecutorServiceImpl: Release permit after rejection