### PR TITLE
ISPN-10363 LazyInitializingExecutorService is not thread-safe

### DIFF
--- a/core/src/main/java/org/infinispan/factories/NamedExecutorsFactory.java
+++ b/core/src/main/java/org/infinispan/factories/NamedExecutorsFactory.java
@@ -12,7 +12,6 @@ import static org.infinispan.factories.KnownComponentNames.getDefaultThreadPrio;
 import static org.infinispan.factories.KnownComponentNames.shortened;
 
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 
 import org.infinispan.commons.CacheConfigurationException;
@@ -25,9 +24,7 @@ import org.infinispan.executors.LazyInitializingBlockingTaskAwareExecutorService
 import org.infinispan.executors.LazyInitializingExecutorService;
 import org.infinispan.executors.LazyInitializingScheduledExecutorService;
 import org.infinispan.factories.annotations.DefaultFactoryFor;
-import org.infinispan.factories.annotations.Stop;
 import org.infinispan.factories.threads.DefaultThreadFactory;
-import org.infinispan.util.concurrent.BlockingTaskAwareExecutorService;
 
 /**
  * A factory that specifically knows how to create named executors.
@@ -39,98 +36,47 @@ import org.infinispan.util.concurrent.BlockingTaskAwareExecutorService;
 @DefaultFactoryFor(names = {ASYNC_TRANSPORT_EXECUTOR, ASYNC_NOTIFICATION_EXECUTOR, PERSISTENCE_EXECUTOR, ASYNC_OPERATIONS_EXECUTOR,
                              EXPIRATION_SCHEDULED_EXECUTOR, REMOTE_COMMAND_EXECUTOR, STATE_TRANSFER_EXECUTOR, TIMEOUT_SCHEDULE_EXECUTOR})
 public class NamedExecutorsFactory extends AbstractComponentFactory implements AutoInstantiableFactory {
-
-   private ExecutorService notificationExecutor;
-   private ExecutorService asyncTransportExecutor;
-   private ExecutorService persistenceExecutor;
-   private BlockingTaskAwareExecutorService remoteCommandsExecutor;
-   private ScheduledExecutorService expirationExecutor;
-   private ExecutorService stateTransferExecutor;
-   private ExecutorService asyncOperationsExecutor;
-   private ScheduledExecutorService timeoutExecutor;
-
    @Override
-   @SuppressWarnings("unchecked")
    public Object construct(String componentName) {
       try {
          // Construction happens only on startup of either CacheManager, or Cache, so
          // using synchronized protection does not have a great impact on app performance.
          if (componentName.equals(ASYNC_NOTIFICATION_EXECUTOR)) {
-            synchronized (this) {
-               if (notificationExecutor == null) {
-                  notificationExecutor = createExecutorService(
+            return createExecutorService(
                         globalConfiguration.listenerThreadPool(),
                         ASYNC_NOTIFICATION_EXECUTOR,
                         ExecutorServiceType.DEFAULT);
-               }
-            }
-            return notificationExecutor;
          } else if (componentName.equals(PERSISTENCE_EXECUTOR)) {
-            synchronized (this) {
-               if (persistenceExecutor == null) {
-                  persistenceExecutor = createExecutorService(
+            return createExecutorService(
                         globalConfiguration.persistenceThreadPool(),
                         PERSISTENCE_EXECUTOR,
                         ExecutorServiceType.DEFAULT);
-               }
-            }
-            return persistenceExecutor;
          } else if (componentName.equals(ASYNC_TRANSPORT_EXECUTOR)) {
-            synchronized (this) {
-               if (asyncTransportExecutor == null) {
-                  asyncTransportExecutor = createExecutorService(
+            return createExecutorService(
                         globalConfiguration.transport().transportThreadPool(),
                         ASYNC_TRANSPORT_EXECUTOR,
                         ExecutorServiceType.DEFAULT);
-               }
-            }
-            return asyncTransportExecutor;
          } else if (componentName.equals(EXPIRATION_SCHEDULED_EXECUTOR)) {
-            synchronized (this) {
-               if (expirationExecutor == null) {
-                  expirationExecutor = createExecutorService(
+            return createExecutorService(
                         globalConfiguration.expirationThreadPool(),
                         EXPIRATION_SCHEDULED_EXECUTOR,
                         ExecutorServiceType.SCHEDULED);
-               }
-            }
-            return expirationExecutor;
          } else if (componentName.equals(REMOTE_COMMAND_EXECUTOR)) {
-            synchronized (this) {
-               if (remoteCommandsExecutor == null) {
-                  remoteCommandsExecutor = createExecutorService(
+            return createExecutorService(
                         globalConfiguration.transport().remoteCommandThreadPool(),
                         REMOTE_COMMAND_EXECUTOR,
                         ExecutorServiceType.BLOCKING);
-               }
-            }
-            return remoteCommandsExecutor;
          } else if (componentName.equals(STATE_TRANSFER_EXECUTOR)) {
-            synchronized (this) {
-               if (stateTransferExecutor == null) {
-                  stateTransferExecutor = createExecutorService(
+            return createExecutorService(
                         globalConfiguration.stateTransferThreadPool(),
                         STATE_TRANSFER_EXECUTOR,
                         ExecutorServiceType.DEFAULT);
-               }
-            }
-            return stateTransferExecutor;
          } else if (componentName.equals(ASYNC_OPERATIONS_EXECUTOR)) {
-            synchronized (this) {
-               if (asyncOperationsExecutor == null) {
-                  asyncOperationsExecutor = createExecutorService(
+            return createExecutorService(
                         globalConfiguration.asyncThreadPool(),
                         ASYNC_OPERATIONS_EXECUTOR, ExecutorServiceType.DEFAULT);
-               }
-            }
-            return asyncOperationsExecutor;
          } else if (componentName.endsWith(TIMEOUT_SCHEDULE_EXECUTOR)) {
-            synchronized (this) {
-               if (timeoutExecutor == null) {
-                  timeoutExecutor = createExecutorService(null, TIMEOUT_SCHEDULE_EXECUTOR, ExecutorServiceType.SCHEDULED);
-               }
-            }
-            return timeoutExecutor;
+            return createExecutorService(null, TIMEOUT_SCHEDULE_EXECUTOR, ExecutorServiceType.SCHEDULED);
          } else {
             throw new CacheConfigurationException("Unknown named executor " + componentName);
          }
@@ -139,19 +85,6 @@ public class NamedExecutorsFactory extends AbstractComponentFactory implements A
       } catch (Exception e) {
          throw new CacheConfigurationException("Unable to instantiate ExecutorFactory for named component " + componentName, e);
       }
-   }
-
-   @Stop(priority = 999)
-   public void stop() {
-      // TODO Dan: awaitTermination()?
-      if (remoteCommandsExecutor != null) remoteCommandsExecutor.shutdownNow();
-      if (notificationExecutor != null) notificationExecutor.shutdownNow();
-      if (persistenceExecutor != null) persistenceExecutor.shutdownNow();
-      if (asyncTransportExecutor != null) asyncTransportExecutor.shutdownNow();
-      if (expirationExecutor != null) expirationExecutor.shutdownNow();
-      if (stateTransferExecutor != null) stateTransferExecutor.shutdownNow();
-      if (timeoutExecutor != null) timeoutExecutor.shutdownNow();
-      if (asyncOperationsExecutor != null) asyncOperationsExecutor.shutdownNow();
    }
 
    @SuppressWarnings("unchecked")

--- a/core/src/main/java/org/infinispan/util/concurrent/BlockingTaskAwareExecutorServiceImpl.java
+++ b/core/src/main/java/org/infinispan/util/concurrent/BlockingTaskAwareExecutorServiceImpl.java
@@ -66,6 +66,8 @@ public class BlockingTaskAwareExecutorServiceImpl extends AbstractExecutorServic
    @Override
    public void shutdown() {
       shutdown = true;
+      controllerThread.interrupt();
+      executorService.shutdown();
    }
 
    @Override


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-10363

* Remove cached executors from NamedExecutorFactory
* Move the @Stop methods to the executors themselves
* Don't allow lazy executors to start after stopping