### PR TITLE
ISPN-10395 Remove GAV from infinispan-bom and distribution pom

### DIFF
--- a/build-configuration/bom/pom.xml
+++ b/build-configuration/bom/pom.xml
@@ -135,11 +135,6 @@
             </dependency>
             <dependency>
                 <groupId>org.infinispan</groupId>
-                <artifactId>infinispan-cli</artifactId>
-                <version>${version.infinispan}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.infinispan</groupId>
                 <artifactId>infinispan-cli-client</artifactId>
                 <version>${version.infinispan}</version>
             </dependency>
@@ -280,11 +275,6 @@
             </dependency>
             <dependency>
                 <groupId>org.infinispan</groupId>
-                <artifactId>infinispan-jcache-tck-runner</artifactId>
-                <version>${version.infinispan}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.infinispan</groupId>
                 <artifactId>infinispan-lucene-directory</artifactId>
                 <version>${version.infinispan}</version>
             </dependency>
@@ -349,11 +339,6 @@
             <dependency>
                 <groupId>org.infinispan</groupId>
                 <artifactId>infinispan-query-dsl</artifactId>
-                <version>${version.infinispan}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.infinispan</groupId>
-                <artifactId>infinispan-remote</artifactId>
                 <version>${version.infinispan}</version>
             </dependency>
             <dependency>
@@ -429,16 +414,6 @@
             <dependency>
                 <groupId>org.infinispan.protostream</groupId>
                 <artifactId>protostream</artifactId>
-                <version>${version.protostream}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.infinispan.protostream</groupId>
-                <artifactId>sample-domain-definition</artifactId>
-                <version>${version.protostream}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.infinispan.protostream</groupId>
-                <artifactId>sample-domain-implementation</artifactId>
                 <version>${version.protostream}</version>
             </dependency>
             <dependency>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -64,20 +64,6 @@
 
       <dependency>
          <groupId>org.infinispan</groupId>
-         <artifactId>infinispan-javadoc-embedded</artifactId>
-         <version>${version.infinispan}</version>
-         <classifier>javadoc</classifier>
-      </dependency>
-
-      <dependency>
-         <groupId>org.infinispan</groupId>
-         <artifactId>infinispan-javadoc-remote</artifactId>
-         <version>${version.infinispan}</version>
-         <classifier>javadoc</classifier>
-      </dependency>
-
-      <dependency>
-         <groupId>org.infinispan</groupId>
          <artifactId>infinispan-javadoc-all</artifactId>
          <version>${version.infinispan}</version>
          <classifier>javadoc</classifier>

--- a/pom.xml
+++ b/pom.xml
@@ -2484,6 +2484,18 @@
             <scope>provided</scope>
          </dependency>
          <dependency>
+            <groupId>org.infinispan.protostream</groupId>
+            <artifactId>sample-domain-definition</artifactId>
+            <version>${version.protostream}</version>
+            <scope>test</scope>
+         </dependency>
+         <dependency>
+            <groupId>org.infinispan.protostream</groupId>
+            <artifactId>sample-domain-implementation</artifactId>
+            <version>${version.protostream}</version>
+            <scope>test</scope>
+         </dependency>
+         <dependency>
             <groupId>org.jacoco</groupId>
             <artifactId>org.jacoco.agent</artifactId>
             <version>${versionx.org.jacoco.org.jacoco.agent}</version>


### PR DESCRIPTION
Removed:
org.infinispan.protostream:sample-domain-definition
org.infinispan.protostream:sample-domain-implementation
org.infinispan:infinispan-jcache-tck-runner
org.infinispan:infinispan-remote
org.infinispan:infinispan-javadoc-embedded
org.infinispan:infinispan-javadoc-remote

See JIRA description for more info.
https://issues.jboss.org/browse/ISPN-10395