### PR TITLE
Added mandatory parameter in configuration example

### DIFF
--- a/documentation/src/main/asciidoc/topics/persistence_jdbc.adoc
+++ b/documentation/src/main/asciidoc/topics/persistence_jdbc.adoc
@@ -77,7 +77,7 @@ For detailed description of all the parameters used refer to the link:{javadocro
 ----
 <persistence>
    <string-keyed-jdbc-store xmlns="urn:infinispan:config:store:jdbc:9.2" shared="true" fetch-state="false" read-only="false" purge="false">
-      <connection-pool connection-url="jdbc:h2:mem:infinispan_string_based;DB_CLOSE_DELAY=-1" username="sa" driver="org.h2.Driver"/>
+      <connection-pool connection-url="jdbc:h2:mem:infinispan_string_based;DB_CLOSE_DELAY=-1" username="sa" password="pass" driver="org.h2.Driver"/>
       <string-keyed-table drop-on-exit="true" create-on-start="true" prefix="ISPN_STRING_TABLE">
          <id-column name="ID_COLUMN" type="VARCHAR(255)" />
          <data-column name="DATA_COLUMN" type="BINARY" />


### PR DESCRIPTION
Hi,

If the `password` attribute is not given, connection pool provider will try to connect to the db with a null password, which will throw an exception if a password exists for that db. I think it would be good idea to add this parameter in the example ,just as a precaution so that no one gets doubt.