### PR TITLE
ISPN-10407 Representation of the CacheManager configuration as JSON

### DIFF
--- a/commons/src/main/java/org/infinispan/commons/configuration/elements/DefaultElementDefinition.java
+++ b/commons/src/main/java/org/infinispan/commons/configuration/elements/DefaultElementDefinition.java
@@ -6,15 +6,25 @@ public class DefaultElementDefinition<C extends ConfigurationInfo> implements El
 
    private final String name;
    private final boolean isTopLevel;
+   private final boolean omitIfEmpty;
 
    public DefaultElementDefinition(String name, boolean isTopLevel) {
+      this(name, isTopLevel, true);
+   }
+
+   public DefaultElementDefinition(String name, boolean isTopLevel, boolean omitIfEmpty) {
       this.name = name;
       this.isTopLevel = isTopLevel;
+      this.omitIfEmpty = omitIfEmpty;
    }
 
    public DefaultElementDefinition(String name) {
-      this.name = name;
-      this.isTopLevel = true;
+      this(name, true, true);
+   }
+
+   @Override
+   public boolean omitIfEmpty() {
+      return omitIfEmpty;
    }
 
    @Override

--- a/commons/src/main/java/org/infinispan/commons/configuration/elements/ElementDefinition.java
+++ b/commons/src/main/java/org/infinispan/commons/configuration/elements/ElementDefinition.java
@@ -23,6 +23,10 @@ public interface ElementDefinition<C extends ConfigurationInfo> {
     */
    ElementOutput toExternalName(C configuration);
 
+   default boolean omitIfEmpty() {
+      return true;
+   }
+
    /**
     * @return true if the attributeName inside the element is not mapped to any {@link Attribute}, but
     * as a helper to identify the element when reading it back.

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -98,6 +98,11 @@
          <artifactId>hamcrest-core</artifactId>
          <scope>test</scope>
       </dependency>
+       <dependency>
+           <groupId>com.fasterxml.jackson.core</groupId>
+           <artifactId>jackson-databind</artifactId>
+           <scope>test</scope>
+       </dependency>
 
       <dependency>
          <groupId>org.apache.commons</groupId>

--- a/core/src/main/java/org/infinispan/configuration/cache/AuthorizationConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/AuthorizationConfiguration.java
@@ -8,7 +8,6 @@ import java.util.Set;
 import org.infinispan.commons.configuration.ConfigurationInfo;
 import org.infinispan.commons.configuration.attributes.Attribute;
 import org.infinispan.commons.configuration.attributes.AttributeDefinition;
-import org.infinispan.commons.configuration.attributes.AttributeInitializer;
 import org.infinispan.commons.configuration.attributes.AttributeSet;
 import org.infinispan.commons.configuration.elements.DefaultElementDefinition;
 import org.infinispan.commons.configuration.elements.ElementDefinition;
@@ -21,12 +20,7 @@ import org.infinispan.commons.configuration.elements.ElementDefinition;
  */
 public class AuthorizationConfiguration implements ConfigurationInfo {
    public static final AttributeDefinition<Boolean> ENABLED = AttributeDefinition.builder("enabled", false).immutable().build();
-   public static final AttributeDefinition<Set> ROLES = AttributeDefinition.builder("roles", null, Set.class).initializer(new AttributeInitializer<Set>() {
-      @Override
-      public Set initialize() {
-         return new HashSet<String>();
-      }
-   }).build();
+   public static final AttributeDefinition<Set> ROLES = AttributeDefinition.builder("roles", null, Set.class).initializer(HashSet::new).build();
 
    static final AttributeSet attributeDefinitionSet() {
       return new AttributeSet(AuthorizationConfiguration.class, ENABLED, ROLES);

--- a/core/src/main/java/org/infinispan/configuration/global/BoundedThreadPoolConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/global/BoundedThreadPoolConfiguration.java
@@ -1,0 +1,86 @@
+package org.infinispan.configuration.global;
+
+import org.infinispan.commons.configuration.ConfigurationInfo;
+import org.infinispan.commons.configuration.attributes.Attribute;
+import org.infinispan.commons.configuration.attributes.AttributeDefinition;
+import org.infinispan.commons.configuration.attributes.AttributeSet;
+import org.infinispan.commons.configuration.elements.DefaultElementDefinition;
+import org.infinispan.commons.configuration.elements.ElementDefinition;
+import org.infinispan.configuration.parsing.Element;
+
+/**
+ * @since 10.0
+ */
+class BoundedThreadPoolConfiguration implements ConfigurationInfo {
+   static final AttributeDefinition<String> NAME = AttributeDefinition.builder("name", null, String.class).build();
+   static final AttributeDefinition<String> THREAD_FACTORY = AttributeDefinition.builder("threadFactory", null, String.class).build();
+   static final AttributeDefinition<Integer> MAX_THREADS = AttributeDefinition.builder("maxThreads", null, Integer.class).build();
+   static final AttributeDefinition<Integer> CORE_THREADS = AttributeDefinition.builder("coreThreads", null, Integer.class).build();
+   static final AttributeDefinition<Long> KEEP_ALIVE_TIME = AttributeDefinition.builder("keepAliveTime", null, Long.class).build();
+   static final AttributeDefinition<Integer> QUEUE_LENGTH = AttributeDefinition.builder("queue-length", null, Integer.class).build();
+
+   private final AttributeSet attributes;
+   private final Attribute<String> name;
+   private final Attribute<String> threadFactory;
+   private final Attribute<Integer> maxThreads;
+   private final Attribute<Integer> coreThreads;
+   private final Attribute<Long> keepAliveTime;
+   private final Attribute<Integer> queueLength;
+
+   public static AttributeSet attributeDefinitionSet() {
+      return new AttributeSet(BoundedThreadPoolConfiguration.class, NAME, THREAD_FACTORY, MAX_THREADS, CORE_THREADS, KEEP_ALIVE_TIME, QUEUE_LENGTH);
+   }
+
+   static ElementDefinition ELEMENT_DEFINITION = new DefaultElementDefinition(Element.BLOCKING_BOUNDED_QUEUE_THREAD_POOL.getLocalName());
+
+   BoundedThreadPoolConfiguration(AttributeSet attributes) {
+      this.attributes = attributes.checkProtection();
+      this.name = attributes.attribute(NAME);
+      this.threadFactory = attributes.attribute(THREAD_FACTORY);
+      this.maxThreads = attributes.attribute(MAX_THREADS);
+      this.coreThreads = attributes.attribute(CORE_THREADS);
+      this.keepAliveTime = attributes.attribute(KEEP_ALIVE_TIME);
+      this.queueLength = attributes.attribute(QUEUE_LENGTH);
+   }
+
+   @Override
+   public ElementDefinition getElementDefinition() {
+      return ELEMENT_DEFINITION;
+   }
+
+   public AttributeSet attributes() {
+      return attributes;
+   }
+
+   public String name() {
+      return name.get();
+   }
+
+   public String threadFactory() {
+      return threadFactory.get();
+   }
+
+   public Integer getMaxThreads() {
+      return maxThreads.get();
+   }
+
+   public Integer getCoreThreads() {
+      return coreThreads.get();
+   }
+
+   public Long getKeepAliveTime() {
+      return keepAliveTime.get();
+   }
+
+   public Integer getQueueLength() {
+      return queueLength.get();
+   }
+
+   @Override
+   public String toString() {
+      return "BoundedThreadPoolConfiguration{" +
+            "attributes=" + attributes +
+            '}';
+   }
+
+}

--- a/core/src/main/java/org/infinispan/configuration/global/BoundedThreadPoolConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/global/BoundedThreadPoolConfigurationBuilder.java
@@ -1,0 +1,111 @@
+package org.infinispan.configuration.global;
+
+import static org.infinispan.configuration.global.BoundedThreadPoolConfiguration.CORE_THREADS;
+import static org.infinispan.configuration.global.BoundedThreadPoolConfiguration.KEEP_ALIVE_TIME;
+import static org.infinispan.configuration.global.BoundedThreadPoolConfiguration.MAX_THREADS;
+import static org.infinispan.configuration.global.BoundedThreadPoolConfiguration.QUEUE_LENGTH;
+import static org.infinispan.configuration.global.CachedThreadPoolConfiguration.NAME;
+import static org.infinispan.configuration.global.CachedThreadPoolConfiguration.THREAD_FACTORY;
+
+import org.infinispan.commons.configuration.Builder;
+import org.infinispan.commons.configuration.attributes.AttributeSet;
+import org.infinispan.commons.executors.BlockingThreadPoolExecutorFactory;
+import org.infinispan.factories.threads.DefaultThreadFactory;
+
+/*
+ * @since 10.0
+ */
+public class BoundedThreadPoolConfigurationBuilder extends AbstractGlobalConfigurationBuilder implements Builder<BoundedThreadPoolConfiguration>, ThreadPoolBuilderAdapter {
+   private final AttributeSet attributes;
+
+   BoundedThreadPoolConfigurationBuilder(GlobalConfigurationBuilder globalConfig, String name) {
+      super(globalConfig);
+      attributes = BoundedThreadPoolConfiguration.attributeDefinitionSet();
+      attributes.attribute(NAME).set(name);
+
+   }
+
+   public AttributeSet attributes() {
+      return attributes;
+   }
+
+   public BoundedThreadPoolConfigurationBuilder threadFactory(String threadFactory) {
+      attributes.attribute(THREAD_FACTORY).set(threadFactory);
+      return this;
+   }
+
+   public BoundedThreadPoolConfigurationBuilder maxThreads(Integer maxThreads) {
+      attributes.attribute(MAX_THREADS).set(maxThreads);
+      return this;
+   }
+
+   public Integer maxThreads() {
+      return attributes.attribute(MAX_THREADS).get();
+   }
+
+   public BoundedThreadPoolConfigurationBuilder coreThreads(Integer coreThreads) {
+      attributes.attribute(CORE_THREADS).set(coreThreads);
+      return this;
+   }
+
+   public Integer coreThreads() {
+      return attributes.attribute(CORE_THREADS).get();
+   }
+
+   public BoundedThreadPoolConfigurationBuilder keepAliveTime(Long keepAlive) {
+      attributes.attribute(KEEP_ALIVE_TIME).set(keepAlive);
+      return this;
+   }
+
+   public Long keepAliveTime() {
+      return attributes.attribute(KEEP_ALIVE_TIME).get();
+   }
+
+   public BoundedThreadPoolConfigurationBuilder queueLength(Integer queueLength) {
+      attributes.attribute(QUEUE_LENGTH).set(queueLength);
+      return this;
+   }
+
+   public Integer queueLength() {
+      return attributes.attribute(QUEUE_LENGTH).get();
+   }
+
+   public String name() {
+      return attributes.attribute(NAME).get();
+   }
+
+   @Override
+   public void validate() {
+   }
+
+   @Override
+   public BoundedThreadPoolConfiguration create() {
+      return new BoundedThreadPoolConfiguration(attributes.protect());
+   }
+
+   @Override
+   public BoundedThreadPoolConfigurationBuilder read(BoundedThreadPoolConfiguration template) {
+      attributes.read(template.attributes());
+      return this;
+   }
+
+   public String threadFactory() {
+      return attributes.attribute(THREAD_FACTORY).get();
+   }
+
+   @Override
+   public String toString() {
+      return "BoundedThreadPoolConfigurationBuilder{" +
+            "attributes=" + attributes +
+            '}';
+   }
+
+   @Override
+   public ThreadPoolConfiguration asThreadPoolConfigurationBuilder() {
+      ThreadPoolConfigurationBuilder builder = new ThreadPoolConfigurationBuilder(getGlobalConfig());
+      builder.threadPoolFactory(new BlockingThreadPoolExecutorFactory(maxThreads(), coreThreads(), queueLength(), keepAliveTime()));
+      DefaultThreadFactory threadFactory = getGlobalConfig().threads().getThreadFactory(threadFactory()).create().getThreadFactory();
+      builder.threadFactory(threadFactory);
+      return builder.create();
+   }
+}

--- a/core/src/main/java/org/infinispan/configuration/global/CacheContainerConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/global/CacheContainerConfiguration.java
@@ -1,0 +1,196 @@
+package org.infinispan.configuration.global;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.infinispan.commons.configuration.ConfigurationInfo;
+import org.infinispan.commons.configuration.attributes.Attribute;
+import org.infinispan.commons.configuration.attributes.AttributeDefinition;
+import org.infinispan.commons.configuration.attributes.AttributeSet;
+import org.infinispan.commons.configuration.elements.DefaultElementDefinition;
+import org.infinispan.commons.configuration.elements.ElementDefinition;
+import org.infinispan.commons.util.Features;
+import org.infinispan.configuration.parsing.Element;
+
+/*
+ * @since 10.0
+ */
+class CacheContainerConfiguration implements ConfigurationInfo {
+
+   private static final String ZERO_CAPACITY_NODE_FEATURE = "zero-capacity-node";
+
+   static final AttributeDefinition<String> DEFAULT_CACHE = AttributeDefinition.builder("defaultCache", null, String.class).immutable().build();
+   static final AttributeDefinition<String> NAME = AttributeDefinition.builder("name", "DefaultCacheManager").immutable().build();
+   public static final AttributeDefinition<Boolean> STATISTICS = AttributeDefinition.builder("statistics", false).immutable().build();
+   static final AttributeDefinition<Boolean> ZERO_CAPACITY_NODE = AttributeDefinition.builder("zeroCapacityNode", Boolean.FALSE).immutable().build();
+   static final AttributeDefinition<String> ASYNC_EXECUTOR = AttributeDefinition.builder("asyncExecutor", null, String.class).immutable().build();
+   static final AttributeDefinition<String> LISTENER_EXECUTOR = AttributeDefinition.builder("listenerExecutor", null, String.class).immutable().build();
+   static final AttributeDefinition<String> EXPIRATION_EXECUTOR = AttributeDefinition.builder("expirationExecutor", null, String.class).immutable().build();
+   static final AttributeDefinition<String> PERSISTENCE_EXECUTOR = AttributeDefinition.builder("persistenceExecutor", null, String.class).immutable().build();
+   static final AttributeDefinition<String> STATE_TRANSFER_EXECUTOR = AttributeDefinition.builder("stateTransferExecutor", null, String.class).immutable().build();
+
+   public static AttributeSet attributeDefinitionSet() {
+      return new AttributeSet(CacheContainerConfiguration.class, NAME, STATISTICS, ZERO_CAPACITY_NODE, DEFAULT_CACHE, ASYNC_EXECUTOR, LISTENER_EXECUTOR, EXPIRATION_EXECUTOR, PERSISTENCE_EXECUTOR, STATE_TRANSFER_EXECUTOR);
+   }
+
+   static ElementDefinition ELEMENT_DEFINITION = new DefaultElementDefinition(Element.CACHE_CONTAINER.getLocalName());
+
+   private final Attribute<String> defaultCache;
+   private final Attribute<String> name;
+   private final Attribute<Boolean> statistics;
+   private final Attribute<Boolean> zeroCapacityNode;
+   private final boolean zeroCapacityAvailable;
+
+   private final ThreadsConfiguration threads;
+   private final GlobalJmxStatisticsConfiguration globalJmxStatistics;
+   private final TransportConfiguration transport;
+   private final GlobalSecurityConfiguration security;
+   private final SerializationConfiguration serialization;
+   private final GlobalStateConfiguration globalState;
+   private final ShutdownConfiguration shutdown;
+   private final AttributeSet attributes;
+   private final List<ConfigurationInfo> children;
+
+   CacheContainerConfiguration(AttributeSet attributes,
+                               ThreadsConfiguration threadsConfiguration,
+                               GlobalJmxStatisticsConfiguration globalJmxStatistics,
+                               TransportConfiguration transport,
+                               GlobalSecurityConfiguration security,
+                               SerializationConfiguration serialization,
+                               GlobalStateConfiguration globalState,
+                               ShutdownConfiguration shutdown,
+                               Features features) {
+      this.attributes = attributes.checkProtection();
+      this.defaultCache = attributes.attribute(DEFAULT_CACHE);
+      this.name = attributes.attribute(NAME);
+      this.statistics = attributes.attribute(STATISTICS);
+      this.zeroCapacityNode = attributes.attribute(ZERO_CAPACITY_NODE);
+      this.threads = threadsConfiguration;
+      this.globalJmxStatistics = globalJmxStatistics;
+      this.globalState = globalState;
+      this.shutdown = shutdown;
+      this.security = security;
+      this.serialization = serialization;
+      this.transport = transport;
+      this.zeroCapacityAvailable = features.isAvailable(ZERO_CAPACITY_NODE_FEATURE);
+      this.children = Arrays.asList(shutdown, transport, security, serialization, globalJmxStatistics, globalState);
+   }
+
+   @Override
+   public ElementDefinition getElementDefinition() {
+      return ELEMENT_DEFINITION;
+   }
+
+   @Override
+   public List<ConfigurationInfo> subElements() {
+      return children;
+   }
+
+   public AttributeSet attributes() {
+      return attributes;
+   }
+
+   public String defaultCacheName() {
+      return defaultCache.get();
+   }
+
+   public String cacheManagerName() {
+      return name.get();
+   }
+
+   public boolean statistics() {
+      return statistics.get();
+   }
+
+   public boolean getZeroCapacityNode() {
+      return zeroCapacityAvailable & zeroCapacityNode.get();
+   }
+
+   public GlobalJmxStatisticsConfiguration globalJmxStatistics() {
+      return globalJmxStatistics;
+   }
+
+   public TransportConfiguration transport() {
+      return transport;
+   }
+
+   public GlobalSecurityConfiguration security() {
+      return security;
+   }
+
+   public SerializationConfiguration serialization() {
+      return serialization;
+   }
+
+   public ShutdownConfiguration shutdown() {
+      return shutdown;
+   }
+
+   public String asyncExecutor() {
+      return attributes.attribute(ASYNC_EXECUTOR).get();
+   }
+
+   public String listenerExecutor() {
+      return attributes.attribute(LISTENER_EXECUTOR).get();
+   }
+
+   public String expirationExecutor() {
+      return attributes.attribute(EXPIRATION_EXECUTOR).get();
+   }
+
+   public String persistenceExecutor() {
+      return attributes.attribute(PERSISTENCE_EXECUTOR).get();
+   }
+
+   public String stateTransferExecutor() {
+      return attributes.attribute(STATE_TRANSFER_EXECUTOR).get();
+   }
+
+
+   public GlobalStateConfiguration globalState() {
+      return globalState;
+   }
+
+   public boolean isClustered() {
+      return transport().transport() != null;
+   }
+
+   @Override
+   public String toString() {
+      return "CacheContainerConfiguration{" +
+            "zeroCapacityAvailable=" + zeroCapacityAvailable +
+            ", threads=" + threads +
+            ", globalJmxStatistics=" + globalJmxStatistics +
+            ", transport=" + transport +
+            ", security=" + security +
+            ", serialization=" + serialization +
+            ", globalState=" + globalState +
+            ", shutdown=" + shutdown +
+            ", attributes=" + attributes +
+            '}';
+   }
+
+   public ThreadsConfiguration threads() {
+      return threads;
+   }
+
+   public ThreadPoolConfiguration expirationThreadPool() {
+      return threads.expirationThreadPool();
+   }
+
+   public ThreadPoolConfiguration listenerThreadPool() {
+      return threads.listenerThreadPool();
+   }
+
+   public ThreadPoolConfiguration persistenceThreadPool() {
+      return threads.persistenceThreadPool();
+   }
+
+   public ThreadPoolConfiguration stateTransferThreadPool() {
+      return threads.stateTransferThreadPool();
+   }
+
+   public ThreadPoolConfiguration asyncThreadPool() {
+      return threads.asyncThreadPool();
+   }
+}

--- a/core/src/main/java/org/infinispan/configuration/global/CacheContainerConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/global/CacheContainerConfigurationBuilder.java
@@ -1,0 +1,234 @@
+package org.infinispan.configuration.global;
+
+import static org.infinispan.configuration.global.CacheContainerConfiguration.ASYNC_EXECUTOR;
+import static org.infinispan.configuration.global.CacheContainerConfiguration.DEFAULT_CACHE;
+import static org.infinispan.configuration.global.CacheContainerConfiguration.EXPIRATION_EXECUTOR;
+import static org.infinispan.configuration.global.CacheContainerConfiguration.LISTENER_EXECUTOR;
+import static org.infinispan.configuration.global.CacheContainerConfiguration.NAME;
+import static org.infinispan.configuration.global.CacheContainerConfiguration.PERSISTENCE_EXECUTOR;
+import static org.infinispan.configuration.global.CacheContainerConfiguration.STATE_TRANSFER_EXECUTOR;
+import static org.infinispan.configuration.global.CacheContainerConfiguration.STATISTICS;
+import static org.infinispan.configuration.global.CacheContainerConfiguration.ZERO_CAPACITY_NODE;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.infinispan.commons.CacheConfigurationException;
+import org.infinispan.commons.configuration.Builder;
+import org.infinispan.commons.configuration.attributes.Attribute;
+import org.infinispan.commons.configuration.attributes.AttributeSet;
+
+public class CacheContainerConfigurationBuilder extends AbstractGlobalConfigurationBuilder implements Builder<CacheContainerConfiguration> {
+
+   private final AttributeSet attributes;
+   private final GlobalJmxStatisticsConfigurationBuilder globalJmxStatistics;
+   private final GlobalStateConfigurationBuilder globalState;
+   private final TransportConfigurationBuilder transport;
+   private final GlobalSecurityConfigurationBuilder security;
+   private final SerializationConfigurationBuilder serialization;
+   private final ShutdownConfigurationBuilder shutdown;
+   private final ThreadsConfigurationBuilder threads;
+
+   CacheContainerConfigurationBuilder(GlobalConfigurationBuilder globalConfig) {
+      super(globalConfig);
+      this.attributes = CacheContainerConfiguration.attributeDefinitionSet();
+      this.globalJmxStatistics = new GlobalJmxStatisticsConfigurationBuilder(globalConfig);
+      this.globalState = new GlobalStateConfigurationBuilder(globalConfig);
+      this.threads = new ThreadsConfigurationBuilder(globalConfig);
+      this.transport = new TransportConfigurationBuilder(globalConfig, threads);
+      this.security = new GlobalSecurityConfigurationBuilder(globalConfig);
+      this.serialization = new SerializationConfigurationBuilder(globalConfig);
+      this.shutdown = new ShutdownConfigurationBuilder(globalConfig);
+   }
+
+   public CacheContainerConfigurationBuilder clusteredDefault() {
+      transport().
+            defaultTransport()
+            .clearProperties();
+      return this;
+   }
+
+   public CacheContainerConfigurationBuilder nonClusteredDefault() {
+      transport()
+            .transport(null)
+            .clearProperties();
+      return this;
+   }
+
+   public static GlobalConfigurationBuilder defaultClusteredBuilder() {
+      GlobalConfigurationBuilder builder = new GlobalConfigurationBuilder();
+      builder.transport().defaultTransport();
+      return builder;
+   }
+
+   public String defaultCacheName() {
+      return attributes.attribute(DEFAULT_CACHE).get();
+   }
+
+   @Override
+   public GlobalJmxStatisticsConfigurationBuilder globalJmxStatistics() {
+      return globalJmxStatistics;
+   }
+
+   @Override
+   public GlobalStateConfigurationBuilder globalState() {
+      return globalState;
+   }
+
+   @Override
+   public TransportConfigurationBuilder transport() {
+      return transport;
+   }
+
+   public ThreadsConfigurationBuilder threads() {
+      return threads;
+   }
+
+   @Override
+   public ThreadPoolConfigurationBuilder asyncThreadPool() {
+      return threads.asyncThreadPool();
+   }
+
+   @Override
+   public ThreadPoolConfigurationBuilder expirationThreadPool() {
+      return threads.expirationThreadPool();
+   }
+
+   @Override
+   public ThreadPoolConfigurationBuilder persistenceThreadPool() {
+      return threads.persistenceThreadPool();
+   }
+
+   @Override
+   public ThreadPoolConfigurationBuilder stateTransferThreadPool() {
+      return threads.stateTransferThreadPool();
+   }
+
+   @Override
+   public ThreadPoolConfigurationBuilder listenerThreadPool() {
+      return threads.listenerThreadPool();
+   }
+
+   @Override
+   public GlobalSecurityConfigurationBuilder security() {
+      return security;
+   }
+
+   @Override
+   public SerializationConfigurationBuilder serialization() {
+      return serialization;
+   }
+
+   @Override
+   public ShutdownConfigurationBuilder shutdown() {
+      return shutdown;
+   }
+
+   public CacheContainerConfigurationBuilder defaultCache(String defaultCacheName) {
+      attributes.attribute(DEFAULT_CACHE).set(defaultCacheName);
+      return this;
+   }
+
+   public CacheContainerConfigurationBuilder name(String cacheManagerName) {
+      attributes.attribute(NAME).set(cacheManagerName);
+      return this;
+   }
+
+   public String name() {
+      return attributes.attribute(NAME).get();
+   }
+
+   public CacheContainerConfigurationBuilder statistics(Boolean statistics) {
+      attributes.attribute(STATISTICS).set(statistics);
+      return this;
+   }
+
+   public boolean statistics() {
+      return attributes.attribute(STATISTICS).get();
+   }
+
+   CacheContainerConfigurationBuilder zeroCapacityNode(boolean zeroCapacityNode) {
+      attributes.attribute(ZERO_CAPACITY_NODE).set(zeroCapacityNode);
+      return this;
+   }
+
+   public CacheContainerConfigurationBuilder asyncExecutor(String name) {
+      attributes.attribute(ASYNC_EXECUTOR).set(name);
+      return this;
+   }
+
+   CacheContainerConfigurationBuilder listenerExecutor(String name) {
+      attributes.attribute(LISTENER_EXECUTOR).set(name);
+      return this;
+   }
+
+   CacheContainerConfigurationBuilder expirationExecutor(String name) {
+      attributes.attribute(EXPIRATION_EXECUTOR).set(name);
+      return this;
+   }
+
+   public CacheContainerConfigurationBuilder persistenceExecutor(String name) {
+      attributes.attribute(PERSISTENCE_EXECUTOR).set(name);
+      return this;
+   }
+
+   public CacheContainerConfigurationBuilder stateTransferExecutor(String name) {
+      attributes.attribute(STATE_TRANSFER_EXECUTOR).set(name);
+      return this;
+   }
+
+   public void validate() {
+      List<RuntimeException> validationExceptions = new ArrayList<>();
+      Arrays.asList(
+            globalJmxStatistics,
+            globalState,
+            transport,
+            security,
+            serialization,
+            shutdown,
+            threads
+      ).forEach(c -> {
+         try {
+            c.validate();
+         } catch (RuntimeException e) {
+            validationExceptions.add(e);
+         }
+      });
+      CacheConfigurationException.fromMultipleRuntimeExceptions(validationExceptions).ifPresent(e -> {
+         throw e;
+      });
+   }
+
+   @Override
+   public CacheContainerConfiguration create() {
+      Attribute<String> attribute = attributes.attribute(NAME);
+      if (!attribute.isModified()) {
+         name(attribute.getAttributeDefinition().getDefaultValue());
+      }
+      return new CacheContainerConfiguration(
+            attributes.protect(),
+            threads.create(),
+            globalJmxStatistics.create(),
+            transport.create(),
+            security.create(),
+            serialization.create(),
+            globalState.create(),
+            shutdown.create(),
+            getGlobalConfig().getFeatures()
+            );
+   }
+
+   @Override
+   public Builder<?> read(CacheContainerConfiguration template) {
+      attributes.read(template.attributes());
+      this.globalState.read(template.globalState());
+      this.globalJmxStatistics.read(template.globalJmxStatistics());
+      this.transport.read(template.transport());
+      this.security.read(template.security());
+      this.serialization.read(template.serialization());
+      this.shutdown.read(template.shutdown());
+      this.threads.read(template.threads());
+      return this;
+   }
+}

--- a/core/src/main/java/org/infinispan/configuration/global/CachedThreadPoolConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/global/CachedThreadPoolConfiguration.java
@@ -1,0 +1,56 @@
+package org.infinispan.configuration.global;
+
+import org.infinispan.commons.configuration.ConfigurationInfo;
+import org.infinispan.commons.configuration.attributes.Attribute;
+import org.infinispan.commons.configuration.attributes.AttributeDefinition;
+import org.infinispan.commons.configuration.attributes.AttributeSet;
+import org.infinispan.commons.configuration.elements.DefaultElementDefinition;
+import org.infinispan.commons.configuration.elements.ElementDefinition;
+import org.infinispan.configuration.parsing.Element;
+
+class CachedThreadPoolConfiguration implements ConfigurationInfo {
+   static final AttributeDefinition<String> NAME = AttributeDefinition.builder("name", null, String.class).build();
+   static final AttributeDefinition<String> THREAD_FACTORY = AttributeDefinition.builder("threadFactory", null, String.class).build();
+
+   private final AttributeSet attributes;
+   private final Attribute<String> name;
+   private final Attribute<String> threadFactory;
+
+   public static AttributeSet attributeDefinitionSet() {
+      return new AttributeSet(CachedThreadPoolConfiguration.class, NAME, THREAD_FACTORY);
+   }
+
+   private static ElementDefinition ELEMENT_DEFINITION = new DefaultElementDefinition(Element.CACHED_THREAD_POOL.getLocalName());
+
+   CachedThreadPoolConfiguration(AttributeSet attributes) {
+      this.attributes = attributes.checkProtection();
+      this.name = attributes.attribute(NAME);
+      this.threadFactory = attributes.attribute(THREAD_FACTORY);
+   }
+
+   @Override
+   public ElementDefinition getElementDefinition() {
+      return ELEMENT_DEFINITION;
+   }
+
+   public AttributeSet attributes() {
+      return attributes;
+   }
+
+   public String name() {
+      return name.get();
+   }
+
+   public String threadFactory() {
+      return threadFactory.get();
+   }
+
+
+   @Override
+   public String toString() {
+      return "CachedThreadPoolConfiguration{" +
+            "attributes=" + attributes +
+            '}';
+   }
+
+}

--- a/core/src/main/java/org/infinispan/configuration/global/CachedThreadPoolConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/global/CachedThreadPoolConfigurationBuilder.java
@@ -1,0 +1,71 @@
+package org.infinispan.configuration.global;
+
+import static org.infinispan.configuration.global.CachedThreadPoolConfiguration.NAME;
+import static org.infinispan.configuration.global.CachedThreadPoolConfiguration.THREAD_FACTORY;
+
+import org.infinispan.commons.configuration.Builder;
+import org.infinispan.commons.configuration.attributes.AttributeSet;
+import org.infinispan.commons.executors.CachedThreadPoolExecutorFactory;
+import org.infinispan.factories.threads.DefaultThreadFactory;
+
+/*
+ * @since 10.0
+ */
+public class CachedThreadPoolConfigurationBuilder extends AbstractGlobalConfigurationBuilder implements Builder<CachedThreadPoolConfiguration>, ThreadPoolBuilderAdapter {
+   private final AttributeSet attributes;
+
+   CachedThreadPoolConfigurationBuilder(GlobalConfigurationBuilder globalConfig, String name) {
+      super(globalConfig);
+      attributes = CachedThreadPoolConfiguration.attributeDefinitionSet();
+      attributes.attribute(NAME).set(name);
+   }
+
+   public AttributeSet attributes() {
+      return attributes;
+   }
+
+   public CachedThreadPoolConfigurationBuilder name(String name) {
+      attributes.attribute(NAME).set(name);
+      return this;
+   }
+
+   public CachedThreadPoolConfigurationBuilder threadFactory(String threadFactory) {
+      attributes.attribute(THREAD_FACTORY).set(threadFactory);
+      return this;
+   }
+
+   @Override
+   public void validate() {
+   }
+
+   @Override
+   public CachedThreadPoolConfiguration create() {
+      return new CachedThreadPoolConfiguration(attributes.protect());
+   }
+
+   @Override
+   public CachedThreadPoolConfigurationBuilder read(CachedThreadPoolConfiguration template) {
+      attributes.read(template.attributes());
+      return this;
+   }
+
+   @Override
+   public String toString() {
+      return "CachedThreadPoolConfigurationBuilder{" +
+            "attributes=" + attributes +
+            '}';
+   }
+
+   @Override
+   public ThreadPoolConfiguration asThreadPoolConfigurationBuilder() {
+      ThreadPoolConfigurationBuilder builder = new ThreadPoolConfigurationBuilder(getGlobalConfig());
+      builder.threadPoolFactory(CachedThreadPoolExecutorFactory.create());
+      DefaultThreadFactory threadFactory = getGlobalConfig().threads().getThreadFactory(threadFactory()).create().getThreadFactory();
+      builder.threadFactory(threadFactory);
+      return builder.create();
+   }
+
+   public String threadFactory() {
+      return attributes.attribute(ScheduledThreadPoolConfiguration.THREAD_FACTORY).get();
+   }
+}

--- a/core/src/main/java/org/infinispan/configuration/global/GlobalAuthorizationConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/global/GlobalAuthorizationConfiguration.java
@@ -1,11 +1,21 @@
 package org.infinispan.configuration.global;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
+import org.infinispan.commons.configuration.ConfigurationBuilderInfo;
+import org.infinispan.commons.configuration.ConfigurationInfo;
 import org.infinispan.commons.configuration.attributes.Attribute;
 import org.infinispan.commons.configuration.attributes.AttributeDefinition;
+import org.infinispan.commons.configuration.attributes.AttributeSerializer;
 import org.infinispan.commons.configuration.attributes.AttributeSet;
 import org.infinispan.commons.configuration.attributes.IdentityAttributeCopier;
+import org.infinispan.commons.configuration.elements.DefaultElementDefinition;
+import org.infinispan.commons.configuration.elements.ElementDefinition;
+import org.infinispan.configuration.parsing.Element;
 import org.infinispan.security.AuditLogger;
 import org.infinispan.security.PrincipalRoleMapper;
 import org.infinispan.security.Role;
@@ -17,42 +27,67 @@ import org.infinispan.security.impl.NullAuditLogger;
  * @author Tristan Tarrant
  * @since 7.0
  */
-public class GlobalAuthorizationConfiguration {
+public class GlobalAuthorizationConfiguration implements ConfigurationInfo {
    public static final AttributeDefinition<Boolean> ENABLED = AttributeDefinition.builder("enabled", false).immutable().build();
    public static final AttributeDefinition<AuditLogger> AUDIT_LOGGER = AttributeDefinition.builder("auditLogger", (AuditLogger)new NullAuditLogger()).copier(IdentityAttributeCopier.INSTANCE).immutable().build();
-   public static final AttributeDefinition<PrincipalRoleMapper> PRINCIPAL_ROLE_MAPPER = AttributeDefinition.builder("principalRoleMapper", null, PrincipalRoleMapper.class).immutable().build();
-   public static final AttributeDefinition<Map> ROLES = AttributeDefinition.builder("roles", null, Map.class).build();
+
+   public static final AttributeDefinition<Map<String, Role>> ROLES = AttributeDefinition.<Map<String, Role>>builder("roles", new HashMap<>())
+         .serializer(new AttributeSerializer<Map<String, Role>, GlobalAuthorizationConfiguration, ConfigurationBuilderInfo>() {
+            @Override
+            public Object getSerializationValue(Attribute<Map<String, Role>> attribute, GlobalAuthorizationConfiguration configurationElement) {
+               if (!configurationElement.enabled()) return null;
+               return attribute.get().entrySet().stream()
+                     .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getPermissions()));
+            }
+         }).build();
 
    static final AttributeSet attributeDefinitionSet() {
-      return new AttributeSet(GlobalAuthorizationConfiguration.class, ENABLED, AUDIT_LOGGER, PRINCIPAL_ROLE_MAPPER, ROLES);
+      return new AttributeSet(GlobalAuthorizationConfiguration.class, ENABLED, AUDIT_LOGGER, ROLES);
    }
+
+   private static ElementDefinition ELEMENT_DEFINITION = new DefaultElementDefinition(Element.AUTHORIZATION.getLocalName());
 
    private final Attribute<Boolean> enabled;
    private final Attribute<AuditLogger> auditLogger;
-   private final Attribute<PrincipalRoleMapper> principalRoleMapper;
-   private final Attribute<Map> roles;
+   private final Attribute<Map<String, Role>> roles;
+   private final PrincipalRoleMapperConfiguration roleMapperConfiguration;
 
    private final AttributeSet attributes;
+   private final List<ConfigurationInfo> subElements;
 
-   public GlobalAuthorizationConfiguration(AttributeSet attributes) {
+   public GlobalAuthorizationConfiguration(AttributeSet attributes, PrincipalRoleMapperConfiguration roleMapperConfiguration) {
       this.attributes = attributes.checkProtection();
-      enabled = attributes.attribute(ENABLED);
-      auditLogger = attributes.attribute(AUDIT_LOGGER);
-      principalRoleMapper = attributes.attribute(PRINCIPAL_ROLE_MAPPER);
-      roles = attributes.attribute(ROLES);
+      this.enabled = attributes.attribute(ENABLED);
+      this.auditLogger = attributes.attribute(AUDIT_LOGGER);
+      this.roles = attributes.attribute(ROLES);
+      this.roleMapperConfiguration = roleMapperConfiguration;
+      this.subElements = Collections.singletonList(roleMapperConfiguration);
+   }
+
+   @Override
+   public ElementDefinition getElementDefinition() {
+      return ELEMENT_DEFINITION;
+   }
+
+   @Override
+   public List<ConfigurationInfo> subElements() {
+      return subElements;
    }
 
    public boolean enabled() {
       return enabled.get();
    }
 
-
    public AuditLogger auditLogger() {
       return auditLogger.get();
    }
 
    public PrincipalRoleMapper principalRoleMapper() {
-      return principalRoleMapper.get();
+      return roleMapperConfiguration.roleMapper();
+   }
+
+   public PrincipalRoleMapperConfiguration roleMapperConfiguration() {
+      return roleMapperConfiguration;
    }
 
    public Map<String, Role> roles() {
@@ -65,31 +100,28 @@ public class GlobalAuthorizationConfiguration {
 
    @Override
    public String toString() {
-      return "GlobalAuthorizationConfiguration [attributes=" + attributes + "]";
+      return "GlobalAuthorizationConfiguration{" +
+            "roleMapperConfiguration=" + roleMapperConfiguration +
+            ", attributes=" + attributes +
+            '}';
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      GlobalAuthorizationConfiguration that = (GlobalAuthorizationConfiguration) o;
+
+      if (roleMapperConfiguration != null ? !roleMapperConfiguration.equals(that.roleMapperConfiguration) : that.roleMapperConfiguration != null)
+         return false;
+      return attributes != null ? attributes.equals(that.attributes) : that.attributes == null;
    }
 
    @Override
    public int hashCode() {
-      final int prime = 31;
-      int result = 1;
-      result = prime * result + ((attributes == null) ? 0 : attributes.hashCode());
+      int result = roleMapperConfiguration != null ? roleMapperConfiguration.hashCode() : 0;
+      result = 31 * result + (attributes != null ? attributes.hashCode() : 0);
       return result;
-   }
-
-   @Override
-   public boolean equals(Object obj) {
-      if (this == obj)
-         return true;
-      if (obj == null)
-         return false;
-      if (getClass() != obj.getClass())
-         return false;
-      GlobalAuthorizationConfiguration other = (GlobalAuthorizationConfiguration) obj;
-      if (attributes == null) {
-         if (other.attributes != null)
-            return false;
-      } else if (!attributes.equals(other.attributes))
-         return false;
-      return true;
    }
 }

--- a/core/src/main/java/org/infinispan/configuration/global/GlobalConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/global/GlobalConfiguration.java
@@ -1,5 +1,6 @@
 package org.infinispan.configuration.global;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -7,6 +8,9 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.infinispan.Version;
+import org.infinispan.commons.configuration.ConfigurationInfo;
+import org.infinispan.commons.configuration.elements.DefaultElementDefinition;
+import org.infinispan.commons.configuration.elements.ElementDefinition;
 import org.infinispan.commons.util.Features;
 import org.infinispan.factories.annotations.SurvivesRestarts;
 import org.infinispan.factories.scopes.Scope;
@@ -30,9 +34,7 @@ import org.infinispan.factories.scopes.Scopes;
  */
 @Scope(Scopes.GLOBAL)
 @SurvivesRestarts
-public class GlobalConfiguration {
-   private static final String ZERO_CAPACITY_NODE_FEATURE = "zero-capacity-node";
-
+public class GlobalConfiguration implements ConfigurationInfo {
 
    /**
     * Default replication version, from {@link org.infinispan.Version#getVersionShort}.
@@ -42,102 +44,109 @@ public class GlobalConfiguration {
    @Deprecated
    public static final short DEFAULT_MARSHALL_VERSION = Version.getVersionShort();
 
-   private final GlobalJmxStatisticsConfiguration globalJmxStatistics;
-   private final TransportConfiguration transport;
-   private final GlobalSecurityConfiguration security;
-   private final SerializationConfiguration serialization;
-   private final ShutdownConfiguration shutdown;
-   private final GlobalStateConfiguration globalState;
    private final Map<Class<?>, ?> modules;
    private final SiteConfiguration site;
    private final ClassLoader cl;
-   private final ThreadPoolConfiguration expirationThreadPool;
-   private final ThreadPoolConfiguration listenerThreadPool;
-   private final ThreadPoolConfiguration persistenceThreadPool;
-   private final ThreadPoolConfiguration stateTransferThreadPool;
-   private final ThreadPoolConfiguration asyncThreadPool;
-   private final Optional<String> defaultCacheName;
+   private final CacheContainerConfiguration cacheContainerConfiguration;
    private final Features features;
-   private final boolean zeroCapacityNode;
 
-   GlobalConfiguration(ThreadPoolConfiguration expirationThreadPool,
-                       ThreadPoolConfiguration listenerThreadPool,
-                       ThreadPoolConfiguration persistenceThreadPool,
-                       ThreadPoolConfiguration stateTransferThreadPool,
-                       ThreadPoolConfiguration asyncThreadPool,
-                       GlobalJmxStatisticsConfiguration globalJmxStatistics,
-                       TransportConfiguration transport, GlobalSecurityConfiguration security,
-                       SerializationConfiguration serialization, ShutdownConfiguration shutdown,
-                       GlobalStateConfiguration globalState,
+   private static ElementDefinition ELEMENT_DEFINITION = new DefaultElementDefinition("infinispan");
+
+   private List<ConfigurationInfo> subElements;
+
+   GlobalConfiguration(CacheContainerConfiguration cacheContainerConfiguration,
                        List<?> modules, SiteConfiguration site,
-                       Optional<String> defaultCacheName,
-                       ClassLoader cl, Features features,
-                       boolean zeroCapacityNode) {
-      this.expirationThreadPool = expirationThreadPool;
-      this.listenerThreadPool = listenerThreadPool;
-      this.persistenceThreadPool = persistenceThreadPool;
-      this.stateTransferThreadPool = stateTransferThreadPool;
-      this.asyncThreadPool = asyncThreadPool;
-      this.globalJmxStatistics = globalJmxStatistics;
-      this.transport = transport;
-      this.security = security;
-      this.serialization = serialization;
-      this.shutdown = shutdown;
-      this.globalState = globalState;
+                       ClassLoader cl, Features features) {
+      this.cacheContainerConfiguration = cacheContainerConfiguration;
       Map<Class<?>, Object> moduleMap = new HashMap<>();
       for (Object module : modules) {
          moduleMap.put(module.getClass(), module);
       }
       this.modules = Collections.unmodifiableMap(moduleMap);
       this.site = site;
-      this.defaultCacheName = defaultCacheName;
       this.cl = cl;
       this.features = features;
-      this.zeroCapacityNode = features.isAvailable(ZERO_CAPACITY_NODE_FEATURE) ? zeroCapacityNode : false;
+      JGroupsConfiguration jgroupsConfiguration = cacheContainerConfiguration.transport().jgroups();
+      ThreadsConfiguration threads = cacheContainerConfiguration.threads();
+      this.subElements = Arrays.asList(jgroupsConfiguration, threads, cacheContainerConfiguration);
+   }
+
+   @Override
+   public ElementDefinition getElementDefinition() {
+      return ELEMENT_DEFINITION;
+   }
+
+   @Override
+   public List<ConfigurationInfo> subElements() {
+      return subElements;
+   }
+
+   CacheContainerConfiguration cacheContainer() {
+      return cacheContainerConfiguration;
    }
 
    public ThreadPoolConfiguration expirationThreadPool() {
-      return expirationThreadPool;
+      return cacheContainerConfiguration.expirationThreadPool();
    }
 
    public ThreadPoolConfiguration listenerThreadPool() {
-      return listenerThreadPool;
+      return cacheContainerConfiguration.listenerThreadPool();
    }
 
    public ThreadPoolConfiguration persistenceThreadPool() {
-      return persistenceThreadPool;
+      return cacheContainerConfiguration.persistenceThreadPool();
    }
 
    public ThreadPoolConfiguration stateTransferThreadPool() {
-      return stateTransferThreadPool;
+      return cacheContainerConfiguration.stateTransferThreadPool();
    }
 
    public ThreadPoolConfiguration asyncThreadPool() {
-      return asyncThreadPool;
+      return cacheContainerConfiguration.asyncThreadPool();
    }
 
    public GlobalJmxStatisticsConfiguration globalJmxStatistics() {
-      return globalJmxStatistics;
+      return cacheContainerConfiguration.globalJmxStatistics();
    }
 
    public TransportConfiguration transport() {
-      return transport;
+      return cacheContainerConfiguration.transport();
    }
 
    public GlobalSecurityConfiguration security() {
-      return security;
+      return cacheContainerConfiguration.security();
    }
 
    public SerializationConfiguration serialization() {
-      return serialization;
+      return cacheContainerConfiguration.serialization();
    }
 
    public ShutdownConfiguration shutdown() {
-      return shutdown;
+      return cacheContainerConfiguration.shutdown();
    }
 
    public GlobalStateConfiguration globalState() {
-      return globalState;
+      return cacheContainerConfiguration.globalState();
+   }
+
+   public String asyncThreadPoolName() {
+      return cacheContainer().asyncExecutor();
+   }
+
+   public String listenerThreadPoolName() {
+      return cacheContainer().listenerExecutor();
+   }
+
+   public String expirationThreadPoolName() {
+      return cacheContainer().expirationExecutor();
+   }
+
+   public String persistenceThreadPoolName() {
+      return cacheContainer().persistenceExecutor();
+   }
+
+   public String stateTransferThreadPoolName() {
+      return cacheContainer().stateTransferExecutor();
    }
 
    @SuppressWarnings("unchecked")
@@ -161,7 +170,7 @@ public class GlobalConfiguration {
    }
 
    public Optional<String> defaultCacheName() {
-      return defaultCacheName;
+      return Optional.ofNullable(cacheContainerConfiguration.defaultCacheName());
    }
 
    public Features features() {
@@ -171,21 +180,9 @@ public class GlobalConfiguration {
    @Override
    public String toString() {
       return "GlobalConfiguration{" +
-            "listenerThreadPool=" + listenerThreadPool +
-            ", expirationThreadPool=" + expirationThreadPool +
-            ", persistenceThreadPool=" + persistenceThreadPool +
-            ", stateTransferThreadPool=" + stateTransferThreadPool +
-            ", globalJmxStatistics=" + globalJmxStatistics +
-            ", transport=" + transport +
-            ", security=" + security +
-            ", serialization=" + serialization +
-            ", shutdown=" + shutdown +
-            ", globalState=" + globalState +
             ", modules=" + modules +
             ", site=" + site +
-            ", defaultCacheName=" + defaultCacheName +
             ", cl=" + cl +
-            ", zeroCapacityNode=" + zeroCapacityNode +
             '}';
    }
 
@@ -200,6 +197,7 @@ public class GlobalConfiguration {
     * @return true or false
     */
    public boolean isZeroCapacityNode() {
-      return zeroCapacityNode;
+      return cacheContainerConfiguration.getZeroCapacityNode();
    }
+
 }

--- a/core/src/main/java/org/infinispan/configuration/global/GlobalJmxStatisticsConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/global/GlobalJmxStatisticsConfigurationBuilder.java
@@ -1,8 +1,6 @@
 package org.infinispan.configuration.global;
 
 import static org.infinispan.configuration.global.GlobalJmxStatisticsConfiguration.ALLOW_DUPLICATE_DOMAINS;
-import static org.infinispan.configuration.global.GlobalJmxStatisticsConfiguration.CACHE_MANAGER_NAME;
-import static org.infinispan.configuration.global.GlobalJmxStatisticsConfiguration.ENABLED;
 import static org.infinispan.configuration.global.GlobalJmxStatisticsConfiguration.JMX_DOMAIN;
 import static org.infinispan.configuration.global.GlobalJmxStatisticsConfiguration.MBEAN_SERVER_LOOKUP;
 import static org.infinispan.configuration.global.GlobalJmxStatisticsConfiguration.PROPERTIES;
@@ -11,9 +9,9 @@ import java.util.Properties;
 
 import org.infinispan.commons.configuration.Builder;
 import org.infinispan.commons.configuration.attributes.AttributeSet;
+import org.infinispan.commons.jmx.MBeanServerLookup;
 import org.infinispan.commons.jmx.PlatformMBeanServerLookup;
 import org.infinispan.commons.util.TypedProperties;
-import org.infinispan.commons.jmx.MBeanServerLookup;
 
 /**
  * Configures whether global statistics are gathered and reported via JMX for all caches under this cache manager.
@@ -73,9 +71,11 @@ public class GlobalJmxStatisticsConfigurationBuilder extends AbstractGlobalConfi
     * amongst other cache managers that might be running under the same JVM.
     *
     * @param cacheManagerName
+    * @Deprecated Use {@link GlobalConfigurationBuilder#cacheManagerName(String)} instead
     */
+   @Deprecated
    public GlobalJmxStatisticsConfigurationBuilder cacheManagerName(String cacheManagerName) {
-      attributes.attribute(CACHE_MANAGER_NAME).set(cacheManagerName);
+      getGlobalConfig().cacheContainer().name(cacheManagerName);
       return this;
    }
 
@@ -99,8 +99,12 @@ public class GlobalJmxStatisticsConfigurationBuilder extends AbstractGlobalConfi
       return this;
    }
 
+   /**
+    * Enables JMX statistics in the cache manager
+    * @deprecated Use {@link GlobalConfigurationBuilder#statistics(boolean)} instead
+    */
    public GlobalJmxStatisticsConfigurationBuilder enabled(boolean enabled) {
-      attributes.attribute(ENABLED).set(enabled);
+      getGlobalConfig().cacheContainer().statistics(enabled);
       return this;
    }
 
@@ -112,10 +116,10 @@ public class GlobalJmxStatisticsConfigurationBuilder extends AbstractGlobalConfi
    @Override
    public
    GlobalJmxStatisticsConfiguration create() {
-      if (attributes.attribute(ENABLED).get() && attributes.attribute(MBEAN_SERVER_LOOKUP).isNull()) {
+      if (getGlobalConfig().cacheContainer().statistics() && attributes.attribute(MBEAN_SERVER_LOOKUP).isNull()) {
          mBeanServerLookup(new PlatformMBeanServerLookup());
       }
-      return new GlobalJmxStatisticsConfiguration(attributes.protect());
+      return new GlobalJmxStatisticsConfiguration(attributes.protect(), getGlobalConfig().cacheContainer().name(), getGlobalConfig().cacheContainer().statistics());
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/configuration/global/GlobalSecurityConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/global/GlobalSecurityConfiguration.java
@@ -1,19 +1,40 @@
 package org.infinispan.configuration.global;
 
+import java.util.Collections;
+import java.util.List;
+
+import org.infinispan.commons.configuration.ConfigurationInfo;
+import org.infinispan.commons.configuration.elements.DefaultElementDefinition;
+import org.infinispan.commons.configuration.elements.ElementDefinition;
+import org.infinispan.configuration.parsing.Element;
+
 /**
  * GlobalSecurityConfiguration.
  *
  * @author Tristan Tarrant
  * @since 7.0
  */
-public class GlobalSecurityConfiguration {
+public class GlobalSecurityConfiguration implements ConfigurationInfo {
    private final GlobalAuthorizationConfiguration authorization;
    private final long securityCacheTimeout;
 
+   private static ElementDefinition ELEMENT_DEFINITION = new DefaultElementDefinition(Element.SECURITY.getLocalName());
+   private final List<ConfigurationInfo> subElements;
 
    GlobalSecurityConfiguration(GlobalAuthorizationConfiguration authorization, long securityCacheTimeout) {
       this.authorization = authorization;
       this.securityCacheTimeout = securityCacheTimeout;
+      this.subElements = Collections.singletonList(authorization);
+   }
+
+   @Override
+   public ElementDefinition getElementDefinition() {
+      return ELEMENT_DEFINITION;
+   }
+
+   @Override
+   public List<ConfigurationInfo> subElements() {
+      return subElements;
    }
 
    public GlobalAuthorizationConfiguration authorization() {

--- a/core/src/main/java/org/infinispan/configuration/global/GlobalStatePathConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/global/GlobalStatePathConfiguration.java
@@ -1,0 +1,65 @@
+package org.infinispan.configuration.global;
+
+import org.infinispan.commons.configuration.ConfigurationInfo;
+import org.infinispan.commons.configuration.attributes.Attribute;
+import org.infinispan.commons.configuration.attributes.AttributeDefinition;
+import org.infinispan.commons.configuration.attributes.AttributeSet;
+import org.infinispan.commons.configuration.elements.DefaultElementDefinition;
+import org.infinispan.commons.configuration.elements.ElementDefinition;
+import org.infinispan.configuration.parsing.ParseUtils;
+
+public class GlobalStatePathConfiguration implements ConfigurationInfo {
+
+   public static AttributeDefinition<String> PATH = AttributeDefinition.builder("path", null, String.class)
+         .initializer(() -> SecurityActions.getSystemProperty("user.dir"))
+         .immutable().build();
+
+   public static AttributeDefinition<String> RELATIVE_TO = AttributeDefinition.builder("relativeTo", null, String.class).immutable().build();
+
+   private final Attribute<String> path;
+   private final Attribute<String> relativeTo;
+   private final String elementName;
+   private final ElementDefinition elementDefinition;
+   private final String location;
+
+   public static AttributeSet attributeDefinitionSet() {
+      return new AttributeSet(GlobalStateConfiguration.class, PATH, RELATIVE_TO);
+   }
+
+   private final AttributeSet attributes;
+
+   public GlobalStatePathConfiguration(AttributeSet attributes, String elementName) {
+      this.attributes = attributes.checkProtection();
+      this.path = attributes.attribute(PATH);
+      this.relativeTo = attributes.attribute(RELATIVE_TO);
+      this.elementName = elementName;
+      this.location = ParseUtils.resolvePath(path.get(), relativeTo.get());
+      this.elementDefinition = new DefaultElementDefinition<>(elementName);
+   }
+
+   @Override
+   public ElementDefinition getElementDefinition() {
+      return elementDefinition;
+   }
+
+   @Override
+   public AttributeSet attributes() {
+      return attributes;
+   }
+
+   public String getLocation() {
+      return location;
+   }
+
+   public String path() {
+      return path.get();
+   }
+
+   public String relativeTo() {
+      return relativeTo.get();
+   }
+
+   String elementName() {
+      return elementName;
+   }
+}

--- a/core/src/main/java/org/infinispan/configuration/global/GlobalStatePathConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/global/GlobalStatePathConfigurationBuilder.java
@@ -1,0 +1,46 @@
+package org.infinispan.configuration.global;
+
+import org.infinispan.commons.configuration.Builder;
+import org.infinispan.commons.configuration.attributes.AttributeSet;
+import org.infinispan.configuration.parsing.ParseUtils;
+
+public class GlobalStatePathConfigurationBuilder extends AbstractGlobalConfigurationBuilder implements Builder<GlobalStatePathConfiguration> {
+
+   private final AttributeSet attributes;
+   private String elementName;
+   private String location;
+
+   GlobalStatePathConfigurationBuilder(GlobalConfigurationBuilder globalConfig, String elementName) {
+      super(globalConfig);
+      this.elementName = elementName;
+      attributes = GlobalStatePathConfiguration.attributeDefinitionSet();
+   }
+
+   public GlobalStatePathConfigurationBuilder location(String path, String relativeTo) {
+      location = ParseUtils.resolvePath(path, relativeTo);
+      attributes.attribute(GlobalStatePathConfiguration.PATH).set(path);
+      attributes.attribute(GlobalStatePathConfiguration.RELATIVE_TO).set(relativeTo);
+      return this;
+   }
+
+   public String getLocation() {
+      return location;
+   }
+
+   @Override
+   public void validate() {
+   }
+
+   @Override
+   public GlobalStatePathConfiguration create() {
+      return new GlobalStatePathConfiguration(attributes.protect(), elementName);
+   }
+
+   @Override
+   public GlobalStatePathConfigurationBuilder read(GlobalStatePathConfiguration template) {
+      attributes.read(template.attributes());
+      location = template.getLocation();
+      elementName = template.elementName();
+      return this;
+   }
+}

--- a/core/src/main/java/org/infinispan/configuration/global/GlobalStorageConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/global/GlobalStorageConfiguration.java
@@ -1,0 +1,82 @@
+package org.infinispan.configuration.global;
+
+import java.util.function.Supplier;
+
+import org.infinispan.commons.configuration.ConfigurationBuilderInfo;
+import org.infinispan.commons.configuration.ConfigurationInfo;
+import org.infinispan.commons.configuration.attributes.Attribute;
+import org.infinispan.commons.configuration.attributes.AttributeDefinition;
+import org.infinispan.commons.configuration.attributes.AttributeSerializer;
+import org.infinispan.commons.configuration.attributes.AttributeSet;
+import org.infinispan.commons.configuration.elements.DefaultElementDefinition;
+import org.infinispan.commons.configuration.elements.ElementDefinition;
+import org.infinispan.configuration.parsing.Element;
+import org.infinispan.globalstate.ConfigurationStorage;
+import org.infinispan.globalstate.LocalConfigurationStorage;
+
+
+/**
+ * @since 10.0
+ */
+public class GlobalStorageConfiguration implements ConfigurationInfo {
+   static final AttributeDefinition<Supplier<? extends LocalConfigurationStorage>> CONFIGURATION_STORAGE_SUPPLIER = AttributeDefinition
+         .supplierBuilder("class", LocalConfigurationStorage.class).autoPersist(false)
+         .serializer(new AttributeSerializer<Supplier<? extends LocalConfigurationStorage>, ConfigurationInfo, ConfigurationBuilderInfo>() {
+            @Override
+            public Object getSerializationValue(Attribute<Supplier<? extends LocalConfigurationStorage>> attribute, ConfigurationInfo configurationElement) {
+               Supplier<? extends LocalConfigurationStorage> supplier = attribute.get();
+               if (supplier == null) return null;
+               return supplier.get().getClass().getName();
+            }
+         })
+         .immutable().build();
+
+   private final ElementDefinition elementDefinition;
+   private final ConfigurationStorage storage;
+
+   public static AttributeSet attributeDefinitionSet() {
+      return new AttributeSet(GlobalStorageConfiguration.class, CONFIGURATION_STORAGE_SUPPLIER);
+   }
+
+   private final AttributeSet attributes;
+
+   GlobalStorageConfiguration(AttributeSet attributeSet, ConfigurationStorage storage) {
+      this.attributes = attributeSet;
+      this.storage = storage;
+      this.elementDefinition = getElementDefinition(storage);
+   }
+
+   @Override
+   public AttributeSet attributes() {
+      return attributes;
+   }
+
+   public ConfigurationStorage configurationStorage() {
+      return storage;
+   }
+
+   Supplier<? extends LocalConfigurationStorage> storageSupplier() {
+      return attributes.attribute(CONFIGURATION_STORAGE_SUPPLIER).get();
+   }
+
+   @Override
+   public ElementDefinition getElementDefinition() {
+      return elementDefinition;
+   }
+
+   private ElementDefinition getElementDefinition(ConfigurationStorage configurationStorage) {
+      switch (configurationStorage) {
+         case IMMUTABLE:
+            return new DefaultElementDefinition(Element.IMMUTABLE_CONFIGURATION_STORAGE.getLocalName(), true, false);
+         case VOLATILE:
+            return new DefaultElementDefinition(Element.VOLATILE_CONFIGURATION_STORAGE.getLocalName(), true, false);
+         case OVERLAY:
+            return new DefaultElementDefinition(Element.OVERLAY_CONFIGURATION_STORAGE.getLocalName(), true, false);
+         case MANAGED:
+            return new DefaultElementDefinition(Element.MANAGED_CONFIGURATION_STORAGE.getLocalName(), true, false);
+         case CUSTOM:
+            return new DefaultElementDefinition(Element.CUSTOM_CONFIGURATION_STORAGE.getLocalName(), true, false);
+      }
+      return null;
+   }
+}

--- a/core/src/main/java/org/infinispan/configuration/global/GlobalStorageConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/global/GlobalStorageConfigurationBuilder.java
@@ -1,0 +1,53 @@
+package org.infinispan.configuration.global;
+
+import static org.infinispan.configuration.global.GlobalStorageConfiguration.CONFIGURATION_STORAGE_SUPPLIER;
+
+import java.lang.invoke.MethodHandles;
+import java.util.function.Supplier;
+
+import org.infinispan.commons.configuration.Builder;
+import org.infinispan.commons.configuration.attributes.AttributeSet;
+import org.infinispan.globalstate.ConfigurationStorage;
+import org.infinispan.globalstate.LocalConfigurationStorage;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
+public class GlobalStorageConfigurationBuilder extends AbstractGlobalConfigurationBuilder implements Builder<GlobalStorageConfiguration> {
+   private static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
+
+   private final AttributeSet attributes;
+   private ConfigurationStorage storage = ConfigurationStorage.VOLATILE;
+
+   GlobalStorageConfigurationBuilder(GlobalConfigurationBuilder globalConfig) {
+      super(globalConfig);
+      attributes = GlobalStorageConfiguration.attributeDefinitionSet();
+   }
+
+   public GlobalStorageConfigurationBuilder supplier(Supplier<? extends LocalConfigurationStorage> configurationStorageSupplier) {
+      attributes.attribute(CONFIGURATION_STORAGE_SUPPLIER).set(configurationStorageSupplier);
+      return this;
+   }
+
+   public GlobalStorageConfigurationBuilder configurationStorage(ConfigurationStorage configurationStorage) {
+      storage = configurationStorage;
+      return this;
+   }
+
+   @Override
+   public void validate() {
+      if (storage.equals(ConfigurationStorage.CUSTOM) && attributes.attribute(CONFIGURATION_STORAGE_SUPPLIER).isNull()) {
+         throw log.customStorageStrategyNotSet();
+      }
+   }
+
+   @Override
+   public GlobalStorageConfiguration create() {
+      return new GlobalStorageConfiguration(attributes.protect(), storage);
+   }
+
+   @Override
+   public GlobalStorageConfigurationBuilder read(GlobalStorageConfiguration template) {
+      attributes.read(template.attributes());
+      return this;
+   }
+}

--- a/core/src/main/java/org/infinispan/configuration/global/JGroupsConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/global/JGroupsConfiguration.java
@@ -1,0 +1,84 @@
+package org.infinispan.configuration.global;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.infinispan.commons.configuration.ConfigurationInfo;
+import org.infinispan.commons.configuration.attributes.Attribute;
+import org.infinispan.commons.configuration.attributes.AttributeDefinition;
+import org.infinispan.commons.configuration.attributes.AttributeSet;
+import org.infinispan.commons.configuration.attributes.IdentityAttributeCopier;
+import org.infinispan.commons.configuration.elements.DefaultElementDefinition;
+import org.infinispan.commons.configuration.elements.ElementDefinition;
+import org.infinispan.configuration.parsing.Element;
+import org.infinispan.remoting.transport.Transport;
+
+/*
+ * @since 10.0
+ */
+public class JGroupsConfiguration implements ConfigurationInfo {
+
+   static final AttributeDefinition<Transport> TRANSPORT = AttributeDefinition
+         .builder("transport", null, Transport.class).copier(IdentityAttributeCopier.INSTANCE).immutable().build();
+
+   public static AttributeSet attributeDefinitionSet() {
+      return new AttributeSet(JGroupsConfiguration.class, TRANSPORT);
+   }
+
+   private static ElementDefinition ELEMENT_DEFINITION = new DefaultElementDefinition(Element.JGROUPS.getLocalName());
+
+   private final Attribute<Transport> transport;
+   private final List<StackFileConfiguration> stackFileConfigurations;
+   private final List<StackConfiguration> stackConfigurations;
+   private final AttributeSet attributes;
+   private final List<ConfigurationInfo> subElements = new ArrayList<>();
+
+   JGroupsConfiguration(AttributeSet attributes, List<StackFileConfiguration> stackFileConfigurations, List<StackConfiguration> stackConfigurations) {
+      this.attributes = attributes.checkProtection();
+      this.transport = attributes.attribute(TRANSPORT);
+      this.stackFileConfigurations = stackFileConfigurations;
+      this.stackConfigurations = stackConfigurations;
+      this.subElements.addAll(stackFileConfigurations);
+      this.subElements.addAll(stackConfigurations);
+   }
+
+   @Override
+   public List<ConfigurationInfo> subElements() {
+      return subElements;
+   }
+
+   @Override
+   public ElementDefinition getElementDefinition() {
+      return ELEMENT_DEFINITION;
+   }
+
+   public AttributeSet attributes() {
+      return attributes;
+   }
+
+   public Transport transport() {
+      return transport.get();
+   }
+
+   public List<StackFileConfiguration> stackFiles() {
+      return stackFileConfigurations;
+   }
+
+   public List<StackConfiguration> stacks() {
+      return stackConfigurations;
+   }
+
+   public boolean isClustered() {
+      return transport.get() != null;
+   }
+
+   @Override
+   public String toString() {
+      return "JGroupsConfiguration{" +
+            "transport=" + transport +
+            ", stackFileConfigurations=" + stackFileConfigurations +
+            ", stackConfigurations=" + stackConfigurations +
+            '}';
+   }
+
+}

--- a/core/src/main/java/org/infinispan/configuration/global/JGroupsConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/global/JGroupsConfigurationBuilder.java
@@ -1,0 +1,96 @@
+package org.infinispan.configuration.global;
+
+import static org.infinispan.configuration.global.JGroupsConfiguration.TRANSPORT;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.infinispan.commons.configuration.Builder;
+import org.infinispan.commons.configuration.attributes.AttributeSet;
+import org.infinispan.remoting.transport.Transport;
+import org.infinispan.remoting.transport.jgroups.JGroupsChannelConfigurator;
+
+/**
+ * @since 10.0
+ */
+public class JGroupsConfigurationBuilder extends AbstractGlobalConfigurationBuilder implements Builder<JGroupsConfiguration> {
+   private final AttributeSet attributes;
+
+   private List<StackConfigurationBuilder> stackConfigurationBuilders = new ArrayList<>();
+   private List<StackFileConfigurationBuilder> stackFileConfigurationBuilders = new ArrayList<>();
+   private Map<String, StackBuilder<?>> buildersByName = new HashMap<>();
+
+   JGroupsConfigurationBuilder(GlobalConfigurationBuilder globalConfig) {
+      super(globalConfig);
+      attributes = JGroupsConfiguration.attributeDefinitionSet();
+   }
+
+   @Override
+   public void validate() {
+      stackConfigurationBuilders.forEach(s -> validate());
+      stackFileConfigurationBuilders.forEach(s -> validate());
+   }
+
+   public StackConfigurationBuilder addStack(String name) {
+      StackConfigurationBuilder stackConfigurationBuilder = new StackConfigurationBuilder(name, this.getGlobalConfig());
+      buildersByName.put(name, stackConfigurationBuilder);
+      stackConfigurationBuilders.add(stackConfigurationBuilder);
+      return stackConfigurationBuilder;
+   }
+
+   public StackFileConfigurationBuilder addStackFile(String name) {
+      StackFileConfigurationBuilder stackFileConfigurationBuilder = new StackFileConfigurationBuilder(name, this.getGlobalConfig());
+      stackFileConfigurationBuilders.add(stackFileConfigurationBuilder);
+      buildersByName.put(name, stackFileConfigurationBuilder);
+      return stackFileConfigurationBuilder;
+   }
+
+   public JGroupsConfigurationBuilder transport(Transport transport) {
+      attributes.attribute(TRANSPORT).set(transport);
+      return this;
+   }
+
+   public JGroupsConfigurationBuilder clear() {
+      stackConfigurationBuilders = new ArrayList<>();
+      stackFileConfigurationBuilders = new ArrayList<>();
+      return this;
+   }
+
+   Transport jgroupsTransport() {
+      return attributes.attribute(TRANSPORT).get();
+   }
+
+   @Override
+   public JGroupsConfiguration create() {
+      List<StackFileConfiguration> stackFileConfigurations = stackFileConfigurationBuilders.stream()
+            .map(StackFileConfigurationBuilder::create).collect(Collectors.toList());
+      List<StackConfiguration> stackConfigurations = stackConfigurationBuilders.stream()
+            .map(StackConfigurationBuilder::create).collect(Collectors.toList());
+      return new JGroupsConfiguration(attributes.protect(), stackFileConfigurations, stackConfigurations);
+   }
+
+   @Override
+   public JGroupsConfigurationBuilder read(JGroupsConfiguration template) {
+      attributes.read(template.attributes());
+      template.stackFiles().forEach(s -> stackFileConfigurationBuilders.add(new StackFileConfigurationBuilder(s.name(), getGlobalConfig()).read(s)));
+      template.stacks().forEach(s -> stackConfigurationBuilders.add(new StackConfigurationBuilder(s.name(), getGlobalConfig()).read(s)));
+      return this;
+   }
+
+   public JGroupsChannelConfigurator getStack(String name) {
+      StackBuilder<?> stackBuilder = buildersByName.get(name);
+      return stackBuilder == null ? null : stackBuilder.getConfigurator(name);
+   }
+
+   @Override
+   public String toString() {
+      return "JGroupsConfigurationBuilder{" +
+            "attributes=" + attributes +
+            ", stackConfigurationBuilders=" + stackConfigurationBuilders +
+            ", stackFileConfigurationBuilders=" + stackFileConfigurationBuilders +
+            '}';
+   }
+}

--- a/core/src/main/java/org/infinispan/configuration/global/JGroupsProtocolConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/global/JGroupsProtocolConfiguration.java
@@ -1,0 +1,78 @@
+package org.infinispan.configuration.global;
+
+import org.infinispan.commons.configuration.ConfigurationInfo;
+import org.infinispan.commons.configuration.attributes.AsElementAttributeSerializer;
+import org.infinispan.commons.configuration.attributes.Attribute;
+import org.infinispan.commons.configuration.attributes.AttributeDefinition;
+import org.infinispan.commons.configuration.attributes.AttributeSet;
+import org.infinispan.commons.configuration.elements.ElementDefinition;
+import org.jgroups.conf.ProtocolConfiguration;
+
+/*
+ * @since 10.0
+ */
+public class JGroupsProtocolConfiguration implements ConfigurationInfo {
+
+   static final AttributeDefinition<ProtocolConfiguration> PROTOCOL_CONFIG = AttributeDefinition
+         .builder("protocolConfig", null, ProtocolConfiguration.class)
+         .immutable().serializer(new AsElementAttributeSerializer<ProtocolConfiguration, JGroupsProtocolConfiguration, JGroupsProtocolConfigurationBuilder>() {
+            @Override
+            public String getSerializationName(Attribute<ProtocolConfiguration> attribute, JGroupsProtocolConfiguration configurationElement) {
+               return attribute.get().getProtocolName();
+            }
+
+            @Override
+            public Object getSerializationValue(Attribute<ProtocolConfiguration> attribute, JGroupsProtocolConfiguration configurationElement) {
+               return attribute.get().getProperties();
+            }
+         }).build();
+
+   public static AttributeSet attributeDefinitionSet() {
+      return new AttributeSet(JGroupsProtocolConfiguration.class, PROTOCOL_CONFIG);
+   }
+
+   public static ElementDefinition ELEMENT_DEFINITION = new ElementDefinition<JGroupsProtocolConfiguration>() {
+      @Override
+      public boolean isTopLevel() {
+         return false;
+      }
+
+      @Override
+      public ElementOutput toExternalName(JGroupsProtocolConfiguration configuration) {
+         return new ElementOutput(configuration.protocolConfiguration().getProtocolName());
+      }
+
+      @Override
+      public boolean supports(String elementName) {
+         return true;
+      }
+   };
+
+   private final Attribute<ProtocolConfiguration> protocolConfiguration;
+   private final AttributeSet attributes;
+
+   JGroupsProtocolConfiguration(AttributeSet attributes) {
+      this.attributes = attributes.checkProtection();
+      this.protocolConfiguration = attributes.attribute(PROTOCOL_CONFIG);
+   }
+
+   @Override
+   public ElementDefinition getElementDefinition() {
+      return ELEMENT_DEFINITION;
+   }
+
+   public AttributeSet attributes() {
+      return attributes;
+   }
+
+   public ProtocolConfiguration protocolConfiguration() {
+      return protocolConfiguration.get();
+   }
+
+   @Override
+   public String toString() {
+      return "JGroupsProtocolConfiguration{" +
+            "attributes=" + attributes +
+            '}';
+   }
+}

--- a/core/src/main/java/org/infinispan/configuration/global/JGroupsProtocolConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/global/JGroupsProtocolConfigurationBuilder.java
@@ -1,0 +1,41 @@
+package org.infinispan.configuration.global;
+
+import static org.infinispan.configuration.global.JGroupsProtocolConfiguration.PROTOCOL_CONFIG;
+
+import org.infinispan.commons.configuration.Builder;
+import org.infinispan.commons.configuration.ConfigurationBuilderInfo;
+import org.infinispan.commons.configuration.attributes.AttributeSet;
+import org.jgroups.conf.ProtocolConfiguration;
+
+/**
+ * @since 10.0
+ */
+public class JGroupsProtocolConfigurationBuilder extends AbstractGlobalConfigurationBuilder implements Builder<JGroupsProtocolConfiguration>, ConfigurationBuilderInfo {
+   private final AttributeSet attributes;
+
+   JGroupsProtocolConfigurationBuilder(GlobalConfigurationBuilder globalConfig) {
+      super(globalConfig);
+      attributes = JGroupsProtocolConfiguration.attributeDefinitionSet();
+
+   }
+
+   public JGroupsProtocolConfigurationBuilder protocolConfig(ProtocolConfiguration protocolConfiguration) {
+      attributes.attribute(PROTOCOL_CONFIG).set(protocolConfiguration);
+      return this;
+   }
+
+   @Override
+   public void validate() {
+   }
+
+   @Override
+   public JGroupsProtocolConfiguration create() {
+      return new JGroupsProtocolConfiguration(attributes.protect());
+   }
+
+   @Override
+   public Builder<?> read(JGroupsProtocolConfiguration template) {
+      attributes.read(template.attributes());
+      return this;
+   }
+}

--- a/core/src/main/java/org/infinispan/configuration/global/PrincipalRoleMapperConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/global/PrincipalRoleMapperConfiguration.java
@@ -1,0 +1,73 @@
+package org.infinispan.configuration.global;
+
+import org.infinispan.commons.configuration.ConfigurationInfo;
+import org.infinispan.commons.configuration.attributes.AttributeDefinition;
+import org.infinispan.commons.configuration.attributes.AttributeSet;
+import org.infinispan.commons.configuration.elements.DefaultElementDefinition;
+import org.infinispan.commons.configuration.elements.ElementDefinition;
+import org.infinispan.configuration.parsing.Element;
+import org.infinispan.security.PrincipalRoleMapper;
+import org.infinispan.security.impl.ClusterRoleMapper;
+import org.infinispan.security.impl.CommonNameRoleMapper;
+import org.infinispan.security.impl.IdentityRoleMapper;
+
+/**
+ * @since 10.0
+ */
+public class PrincipalRoleMapperConfiguration implements ConfigurationInfo {
+
+   public static final AttributeDefinition<Class> CLASS = AttributeDefinition.builder("class", null, Class.class).immutable().build();
+
+   private final ElementDefinition elementDefinition;
+   private final PrincipalRoleMapper principalRoleMapper;
+
+   public static AttributeSet attributeDefinitionSet() {
+      return new AttributeSet(PrincipalRoleMapperConfiguration.class, CLASS);
+   }
+
+   private final AttributeSet attributes;
+
+   PrincipalRoleMapperConfiguration(AttributeSet attributeSet, PrincipalRoleMapper principalRoleMapper) {
+      this.attributes = attributeSet;
+      this.principalRoleMapper = principalRoleMapper;
+      this.elementDefinition = getElementDefinition(principalRoleMapper);
+   }
+
+   @Override
+   public AttributeSet attributes() {
+      return attributes;
+   }
+
+   public PrincipalRoleMapper roleMapper() {
+      return principalRoleMapper;
+   }
+
+   @Override
+   public ElementDefinition getElementDefinition() {
+      return elementDefinition;
+   }
+
+   static boolean isCustomMapper(PrincipalRoleMapper mapper) {
+      return !(mapper instanceof IdentityRoleMapper) &&
+            !(mapper instanceof CommonNameRoleMapper) &&
+            !(mapper instanceof ClusterRoleMapper);
+   }
+
+   private ElementDefinition getElementDefinition(PrincipalRoleMapper mapper) {
+      String elementName;
+      if (isCustomMapper(mapper)) {
+         elementName = Element.CUSTOM_ROLE_MAPPER.getLocalName();
+      } else {
+         if (mapper instanceof IdentityRoleMapper) {
+            elementName = Element.IDENTITY_ROLE_MAPPER.getLocalName();
+         } else if (mapper instanceof CommonNameRoleMapper) {
+            elementName = Element.COMMON_NAME_ROLE_MAPPER.getLocalName();
+         } else if (mapper instanceof ClusterRoleMapper) {
+            elementName = Element.CLUSTER_ROLE_MAPPER.getLocalName();
+         } else {
+            elementName = Element.CUSTOM_ROLE_MAPPER.getLocalName();
+         }
+      }
+      return new DefaultElementDefinition(elementName, true, false);
+   }
+}

--- a/core/src/main/java/org/infinispan/configuration/global/PrincipalRoleMapperConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/global/PrincipalRoleMapperConfigurationBuilder.java
@@ -1,0 +1,45 @@
+package org.infinispan.configuration.global;
+
+import static org.infinispan.configuration.global.PrincipalRoleMapperConfiguration.CLASS;
+
+import org.infinispan.commons.configuration.Builder;
+import org.infinispan.commons.configuration.attributes.AttributeSet;
+import org.infinispan.security.PrincipalRoleMapper;
+
+public class PrincipalRoleMapperConfigurationBuilder extends AbstractGlobalConfigurationBuilder implements Builder<PrincipalRoleMapperConfiguration> {
+   private final AttributeSet attributes;
+   private PrincipalRoleMapper principalRoleMapper;
+
+   PrincipalRoleMapperConfigurationBuilder(GlobalConfigurationBuilder globalConfig) {
+      super(globalConfig);
+      attributes = PrincipalRoleMapperConfiguration.attributeDefinitionSet();
+   }
+
+   public PrincipalRoleMapperConfigurationBuilder mapper(PrincipalRoleMapper principalRoleMapper) {
+      this.principalRoleMapper = principalRoleMapper;
+      return this;
+   }
+
+   @Override
+   public void validate() {
+      if (principalRoleMapper != null && PrincipalRoleMapperConfiguration.isCustomMapper(principalRoleMapper)) {
+         attributes.attribute(CLASS).set(principalRoleMapper.getClass());
+      }
+   }
+
+   @Override
+   public PrincipalRoleMapperConfiguration create() {
+      return new PrincipalRoleMapperConfiguration(attributes.protect(), principalRoleMapper);
+   }
+
+   @Override
+   public PrincipalRoleMapperConfigurationBuilder read(PrincipalRoleMapperConfiguration template) {
+      attributes.read(template.attributes());
+      this.principalRoleMapper = template.roleMapper();
+      return this;
+   }
+
+   public PrincipalRoleMapper mapper() {
+      return principalRoleMapper;
+   }
+}

--- a/core/src/main/java/org/infinispan/configuration/global/ScheduledThreadPoolConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/global/ScheduledThreadPoolConfiguration.java
@@ -1,0 +1,54 @@
+package org.infinispan.configuration.global;
+
+import org.infinispan.commons.configuration.ConfigurationInfo;
+import org.infinispan.commons.configuration.attributes.Attribute;
+import org.infinispan.commons.configuration.attributes.AttributeDefinition;
+import org.infinispan.commons.configuration.attributes.AttributeSet;
+import org.infinispan.commons.configuration.elements.DefaultElementDefinition;
+import org.infinispan.commons.configuration.elements.ElementDefinition;
+import org.infinispan.configuration.parsing.Element;
+
+class ScheduledThreadPoolConfiguration implements ConfigurationInfo {
+   static final AttributeDefinition<String> NAME = AttributeDefinition.builder("name", null, String.class).build();
+   static final AttributeDefinition<String> THREAD_FACTORY = AttributeDefinition.builder("threadFactory", null, String.class).build();
+
+   private final AttributeSet attributes;
+   private final Attribute<String> name;
+   private final Attribute<String> threadFactory;
+
+   public static AttributeSet attributeDefinitionSet() {
+      return new AttributeSet(ScheduledThreadPoolConfiguration.class, NAME, THREAD_FACTORY);
+   }
+
+   static final ElementDefinition ELEMENT_DEFINITION = new DefaultElementDefinition(Element.SCHEDULED_THREAD_POOL.getLocalName());
+
+   ScheduledThreadPoolConfiguration(AttributeSet attributes) {
+      this.attributes = attributes.checkProtection();
+      this.name = attributes.attribute(NAME);
+      this.threadFactory = attributes.attribute(THREAD_FACTORY);
+   }
+
+   @Override
+   public ElementDefinition getElementDefinition() {
+      return ELEMENT_DEFINITION;
+   }
+
+   public AttributeSet attributes() {
+      return attributes;
+   }
+
+   public String name() {
+      return name.get();
+   }
+
+   public String threadFactory() {
+      return threadFactory.get();
+   }
+
+   @Override
+   public String toString() {
+      return "ScheduledThreadPoolConfiguration{" +
+            "attributes=" + attributes +
+            '}';
+   }
+}

--- a/core/src/main/java/org/infinispan/configuration/global/ScheduledThreadPoolConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/global/ScheduledThreadPoolConfigurationBuilder.java
@@ -1,0 +1,67 @@
+package org.infinispan.configuration.global;
+
+
+import static org.infinispan.configuration.global.ScheduledThreadPoolConfiguration.NAME;
+import static org.infinispan.configuration.global.ScheduledThreadPoolConfiguration.THREAD_FACTORY;
+
+import org.infinispan.commons.configuration.Builder;
+import org.infinispan.commons.configuration.attributes.AttributeSet;
+import org.infinispan.commons.executors.ScheduledThreadPoolExecutorFactory;
+import org.infinispan.factories.threads.DefaultThreadFactory;
+
+/*
+ * @since 10.0
+ */
+public class ScheduledThreadPoolConfigurationBuilder extends AbstractGlobalConfigurationBuilder implements Builder<ScheduledThreadPoolConfiguration>, ThreadPoolBuilderAdapter {
+   private final AttributeSet attributes;
+
+   ScheduledThreadPoolConfigurationBuilder(GlobalConfigurationBuilder globalConfig, String name) {
+      super(globalConfig);
+      attributes = ScheduledThreadPoolConfiguration.attributeDefinitionSet();
+      attributes.attribute(NAME).set(name);
+   }
+
+   public AttributeSet attributes() {
+      return attributes;
+   }
+
+   public ScheduledThreadPoolConfigurationBuilder threadFactory(String threadFactory) {
+      attributes.attribute(THREAD_FACTORY).set(threadFactory);
+      return this;
+   }
+
+   public String threadFactory() {
+      return attributes.attribute(THREAD_FACTORY).get();
+   }
+
+   @Override
+   public void validate() {
+   }
+
+   @Override
+   public ScheduledThreadPoolConfiguration create() {
+      return new ScheduledThreadPoolConfiguration(attributes.protect());
+   }
+
+   @Override
+   public ScheduledThreadPoolConfigurationBuilder read(ScheduledThreadPoolConfiguration template) {
+      attributes.read(template.attributes());
+      return this;
+   }
+
+   @Override
+   public String toString() {
+      return "ScheduledThreadPoolConfigurationBuilder{" +
+            "attributes=" + attributes +
+            '}';
+   }
+
+   @Override
+   public ThreadPoolConfiguration asThreadPoolConfigurationBuilder() {
+      ThreadPoolConfigurationBuilder builder = new ThreadPoolConfigurationBuilder(getGlobalConfig());
+      builder.threadPoolFactory(ScheduledThreadPoolExecutorFactory.create());
+      DefaultThreadFactory threadFactory = getGlobalConfig().threads().getThreadFactory(threadFactory()).create().getThreadFactory();
+      builder.threadFactory(threadFactory);
+      return builder.create();
+   }
+}

--- a/core/src/main/java/org/infinispan/configuration/global/SerializationConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/global/SerializationConfiguration.java
@@ -1,36 +1,62 @@
 package org.infinispan.configuration.global;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.infinispan.Version;
+import org.infinispan.commons.configuration.ConfigurationBuilderInfo;
+import org.infinispan.commons.configuration.ConfigurationInfo;
+import org.infinispan.commons.configuration.attributes.Attribute;
 import org.infinispan.commons.configuration.attributes.AttributeDefinition;
+import org.infinispan.commons.configuration.attributes.AttributeSerializer;
 import org.infinispan.commons.configuration.attributes.AttributeSet;
+import org.infinispan.commons.configuration.attributes.CollectionAttributeCopier;
+import org.infinispan.commons.configuration.elements.DefaultElementDefinition;
+import org.infinispan.commons.configuration.elements.ElementDefinition;
 import org.infinispan.commons.marshall.AdvancedExternalizer;
 import org.infinispan.commons.marshall.Marshaller;
+import org.infinispan.configuration.parsing.Element;
 import org.jboss.marshalling.ClassResolver;
 
-public class SerializationConfiguration {
+public class SerializationConfiguration implements ConfigurationInfo {
    public static final AttributeDefinition<Marshaller> MARSHALLER = AttributeDefinition.builder("marshaller", null, Marshaller.class)
          .immutable().build();
-   public static final AttributeDefinition<Short> VERSION = AttributeDefinition.builder("version", Version.getMarshallVersion()).immutable().build();
+   public static final AttributeDefinition<Short> VERSION = AttributeDefinition.builder("version", Version.getMarshallVersion())
+         .serializer(new AttributeSerializer<Short, ConfigurationInfo, ConfigurationBuilderInfo>() {
+            @Override
+            public Object getSerializationValue(Attribute<Short> attribute, ConfigurationInfo configurationElement) {
+               return Version.decodeVersion(attribute.get());
+            }
+         })
+         .immutable().build();
    public static final AttributeDefinition<ClassResolver> CLASS_RESOLVER = AttributeDefinition.builder("classResolver", null, ClassResolver.class).immutable().build();
+   public static final AttributeDefinition<Map<Integer, AdvancedExternalizer<?>>> ADVANCED_EXTERNALIZERS = AttributeDefinition.builder("advancedExternalizer", null, (Class<Map<Integer, AdvancedExternalizer<?>>>) (Class<?>) Map.class)
+         .copier(CollectionAttributeCopier.INSTANCE)
+         .initializer(HashMap::new).immutable().build();
+
+   static ElementDefinition ELEMENT_DEFINITION = new DefaultElementDefinition(Element.SERIALIZATION.getLocalName());
 
    static AttributeSet attributeDefinitionSet() {
-      return new AttributeSet(SerializationConfiguration.class, MARSHALLER, VERSION, CLASS_RESOLVER);
+      return new AttributeSet(SerializationConfiguration.class, MARSHALLER, VERSION, CLASS_RESOLVER, ADVANCED_EXTERNALIZERS);
    }
 
-   private final Map<Integer, AdvancedExternalizer<?>> advancedExternalizers;
+   private final Attribute<Map<Integer, AdvancedExternalizer<?>>> advancedExternalizers;
    private final ClassResolver classResolver;
    private final Marshaller marshaller;
    private final short version;
    private final AttributeSet attributes;
 
-   SerializationConfiguration(AttributeSet attributes, Map<Integer, AdvancedExternalizer<?>> advancedExternalizers) {
+   SerializationConfiguration(AttributeSet attributes) {
       this.attributes = attributes.checkProtection();
       this.marshaller = attributes.attribute(MARSHALLER).get();
       this.version = attributes.attribute(VERSION).get();
       this.classResolver = attributes.attribute(CLASS_RESOLVER).get();
-      this.advancedExternalizers = advancedExternalizers;
+      this.advancedExternalizers = attributes.attribute(ADVANCED_EXTERNALIZERS);
+   }
+
+   @Override
+   public ElementDefinition getElementDefinition() {
+      return ELEMENT_DEFINITION;
    }
 
    public Marshaller marshaller() {
@@ -42,7 +68,7 @@ public class SerializationConfiguration {
    }
 
    public Map<Integer, AdvancedExternalizer<?>> advancedExternalizers() {
-      return advancedExternalizers;
+      return advancedExternalizers.get();
    }
 
    public ClassResolver classResolver() {
@@ -55,38 +81,23 @@ public class SerializationConfiguration {
 
    @Override
    public String toString() {
-      return "SerializationConfiguration [advancedExternalizers=" + advancedExternalizers + ", attributes=" + attributes + "]";
+      return "SerializationConfiguration{" +
+            "attributes=" + attributes +
+            '}';
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      SerializationConfiguration that = (SerializationConfiguration) o;
+
+      return attributes != null ? attributes.equals(that.attributes) : that.attributes == null;
    }
 
    @Override
    public int hashCode() {
-      final int prime = 31;
-      int result = 1;
-      result = prime * result + ((advancedExternalizers == null) ? 0 : advancedExternalizers.hashCode());
-      result = prime * result + ((attributes == null) ? 0 : attributes.hashCode());
-      return result;
+      return attributes != null ? attributes.hashCode() : 0;
    }
-
-   @Override
-   public boolean equals(Object obj) {
-      if (this == obj)
-         return true;
-      if (obj == null)
-         return false;
-      if (getClass() != obj.getClass())
-         return false;
-      SerializationConfiguration other = (SerializationConfiguration) obj;
-      if (advancedExternalizers == null) {
-         if (other.advancedExternalizers != null)
-            return false;
-      } else if (!advancedExternalizers.equals(other.advancedExternalizers))
-         return false;
-      if (attributes == null) {
-         if (other.attributes != null)
-            return false;
-      } else if (!attributes.equals(other.attributes))
-         return false;
-      return true;
-   }
-
 }

--- a/core/src/main/java/org/infinispan/configuration/global/SerializationConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/global/SerializationConfigurationBuilder.java
@@ -1,5 +1,6 @@
 package org.infinispan.configuration.global;
 
+import static org.infinispan.configuration.global.SerializationConfiguration.ADVANCED_EXTERNALIZERS;
 import static org.infinispan.configuration.global.SerializationConfiguration.CLASS_RESOLVER;
 import static org.infinispan.configuration.global.SerializationConfiguration.MARSHALLER;
 import static org.infinispan.configuration.global.SerializationConfiguration.VERSION;
@@ -134,7 +135,8 @@ public class SerializationConfigurationBuilder extends AbstractGlobalConfigurati
    @Override
    public
    SerializationConfiguration create() {
-      return new SerializationConfiguration(attributes.protect(), advancedExternalizers);
+      if (!advancedExternalizers.isEmpty()) attributes.attribute(ADVANCED_EXTERNALIZERS).set(advancedExternalizers);
+      return new SerializationConfiguration(attributes.protect());
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/configuration/global/ShutdownConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/global/ShutdownConfiguration.java
@@ -1,22 +1,64 @@
 package org.infinispan.configuration.global;
 
-public class ShutdownConfiguration {
+import java.util.Objects;
 
-   private final ShutdownHookBehavior hookBehavior;
+import org.infinispan.commons.configuration.ConfigurationInfo;
+import org.infinispan.commons.configuration.attributes.Attribute;
+import org.infinispan.commons.configuration.attributes.AttributeDefinition;
+import org.infinispan.commons.configuration.attributes.AttributeSet;
+import org.infinispan.commons.configuration.elements.DefaultElementDefinition;
+import org.infinispan.commons.configuration.elements.ElementDefinition;
+import org.infinispan.configuration.parsing.Element;
 
-   ShutdownConfiguration(ShutdownHookBehavior hookBehavior) {
-      this.hookBehavior = hookBehavior;
+public class ShutdownConfiguration implements ConfigurationInfo {
+   static final AttributeDefinition<ShutdownHookBehavior> HOOK_BEHAVIOR = AttributeDefinition.builder("shutdownHook", ShutdownHookBehavior.DEFAULT).immutable().build();
+
+   private final AttributeSet attributes;
+   private final Attribute<ShutdownHookBehavior> hookBehavior;
+
+   static AttributeSet attributeDefinitionSet() {
+      return new AttributeSet(ShutdownConfiguration.class, HOOK_BEHAVIOR);
+   }
+
+   static final ElementDefinition ELEMENT_DEFINITION = new DefaultElementDefinition(Element.SHUTDOWN.getLocalName(), false);
+
+   ShutdownConfiguration(AttributeSet attributes) {
+      this.attributes = attributes.checkProtection();
+      hookBehavior = attributes.attribute(HOOK_BEHAVIOR);
+   }
+
+   @Override
+   public ElementDefinition getElementDefinition() {
+      return ELEMENT_DEFINITION;
    }
 
    public ShutdownHookBehavior hookBehavior() {
-      return hookBehavior;
+      return hookBehavior.get();
    }
 
    @Override
    public String toString() {
       return "ShutdownConfiguration{" +
-            "hookBehavior=" + hookBehavior +
+            "attributes=" + attributes +
             '}';
    }
 
+   public AttributeSet attributes() {
+      return attributes;
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      ShutdownConfiguration that = (ShutdownConfiguration) o;
+
+      return Objects.equals(attributes, that.attributes);
+   }
+
+   @Override
+   public int hashCode() {
+      return attributes != null ? attributes.hashCode() : 0;
+   }
 }

--- a/core/src/main/java/org/infinispan/configuration/global/ShutdownConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/global/ShutdownConfigurationBuilder.java
@@ -1,18 +1,25 @@
 package org.infinispan.configuration.global;
 
+import static org.infinispan.configuration.global.ShutdownConfiguration.HOOK_BEHAVIOR;
+
 import org.infinispan.commons.configuration.Builder;
+import org.infinispan.commons.configuration.attributes.AttributeSet;
 
 public class ShutdownConfigurationBuilder extends AbstractGlobalConfigurationBuilder implements Builder<ShutdownConfiguration> {
-
-   private ShutdownHookBehavior shutdownHookBehavior = ShutdownHookBehavior.DEFAULT;
+   private final AttributeSet attributes;
 
    ShutdownConfigurationBuilder(GlobalConfigurationBuilder globalConfig) {
       super(globalConfig);
+      attributes = ShutdownConfiguration.attributeDefinitionSet();
    }
 
    public ShutdownConfigurationBuilder hookBehavior(ShutdownHookBehavior hookBehavior) {
-      this.shutdownHookBehavior = hookBehavior;
+      attributes.attribute(HOOK_BEHAVIOR).set(hookBehavior);
       return this;
+   }
+
+   public AttributeSet attributes() {
+      return attributes;
    }
 
    @Override
@@ -24,21 +31,20 @@ public class ShutdownConfigurationBuilder extends AbstractGlobalConfigurationBui
    @Override
    public
    ShutdownConfiguration create() {
-      return new ShutdownConfiguration(shutdownHookBehavior);
+      return new ShutdownConfiguration(attributes.protect());
    }
 
    @Override
    public
    ShutdownConfigurationBuilder read(ShutdownConfiguration template) {
-      this.shutdownHookBehavior = template.hookBehavior();
-
+      attributes.read(template.attributes());
       return this;
    }
 
    @Override
    public String toString() {
       return "ShutdownConfigurationBuilder{" +
-            "shutdownHookBehavior=" + shutdownHookBehavior +
+            "attributes=" + attributes +
             '}';
    }
 
@@ -49,14 +55,11 @@ public class ShutdownConfigurationBuilder extends AbstractGlobalConfigurationBui
 
       ShutdownConfigurationBuilder that = (ShutdownConfigurationBuilder) o;
 
-      if (shutdownHookBehavior != that.shutdownHookBehavior) return false;
-
-      return true;
+      return attributes.equals(that.attributes);
    }
 
    @Override
    public int hashCode() {
-      return shutdownHookBehavior != null ? shutdownHookBehavior.hashCode() : 0;
+      return attributes.hashCode();
    }
-
 }

--- a/core/src/main/java/org/infinispan/configuration/global/StackBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/global/StackBuilder.java
@@ -1,0 +1,10 @@
+package org.infinispan.configuration.global;
+
+import org.infinispan.commons.configuration.Builder;
+import org.infinispan.remoting.transport.jgroups.JGroupsChannelConfigurator;
+
+public interface StackBuilder<T> extends Builder<T> {
+
+   JGroupsChannelConfigurator getConfigurator(String stackName);
+
+}

--- a/core/src/main/java/org/infinispan/configuration/global/StackConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/global/StackConfiguration.java
@@ -1,0 +1,63 @@
+package org.infinispan.configuration.global;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.infinispan.commons.configuration.ConfigurationInfo;
+import org.infinispan.commons.configuration.attributes.Attribute;
+import org.infinispan.commons.configuration.attributes.AttributeDefinition;
+import org.infinispan.commons.configuration.attributes.AttributeSet;
+import org.infinispan.commons.configuration.elements.DefaultElementDefinition;
+import org.infinispan.commons.configuration.elements.ElementDefinition;
+import org.infinispan.configuration.parsing.Element;
+
+/*
+ * @since 10.0
+ */
+public class StackConfiguration implements ConfigurationInfo {
+   static final AttributeDefinition<String> NAME = AttributeDefinition.builder("name", null, String.class).build();
+
+   public static AttributeSet attributeDefinitionSet() {
+      return new AttributeSet(StackConfiguration.class, NAME);
+   }
+
+   private static final ElementDefinition ELEMENT_DEFINITION = new DefaultElementDefinition(Element.STACK.getLocalName());
+
+   private final Attribute<String> name;
+   private final List<JGroupsProtocolConfiguration> protocolConfigurations;
+   private final AttributeSet attributes;
+   private final List<ConfigurationInfo> subElements = new ArrayList<>();
+
+   StackConfiguration(AttributeSet attributes, List<JGroupsProtocolConfiguration> protocolConfigurations) {
+      this.attributes = attributes.checkProtection();
+      this.name = attributes.attribute(NAME);
+      this.protocolConfigurations = protocolConfigurations;
+      this.subElements.addAll(protocolConfigurations);
+   }
+
+   public AttributeSet attributes() {
+      return attributes;
+   }
+
+   @Override
+   public ElementDefinition getElementDefinition() {
+      return ELEMENT_DEFINITION;
+   }
+
+   @Override
+   public List<ConfigurationInfo> subElements() {
+      return subElements;
+   }
+
+   public String name() {
+      return name.get();
+   }
+
+   @Override
+   public String toString() {
+      return "StackConfiguration{" +
+            "protocolConfigurations=" + protocolConfigurations +
+            ", attributes=" + attributes +
+            '}';
+   }
+}

--- a/core/src/main/java/org/infinispan/configuration/global/StackConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/global/StackConfigurationBuilder.java
@@ -1,0 +1,77 @@
+package org.infinispan.configuration.global;
+
+import static org.infinispan.configuration.global.StackConfiguration.NAME;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.infinispan.commons.configuration.attributes.AttributeSet;
+import org.infinispan.remoting.transport.jgroups.EmbeddedJGroupsChannelConfigurator;
+import org.infinispan.remoting.transport.jgroups.JGroupsChannelConfigurator;
+
+/*
+ * @since 10.0
+ */
+public class StackConfigurationBuilder extends AbstractGlobalConfigurationBuilder implements StackBuilder<StackConfiguration> {
+   private final AttributeSet attributes;
+
+   private List<JGroupsProtocolConfigurationBuilder> protocols = new ArrayList<>();
+   private EmbeddedJGroupsChannelConfigurator configurator;
+
+   StackConfigurationBuilder(String name, GlobalConfigurationBuilder globalConfig) {
+      super(globalConfig);
+      attributes = StackConfiguration.attributeDefinitionSet();
+      attributes.attribute(NAME).set(name);
+   }
+
+   public AttributeSet attributes() {
+      return attributes;
+   }
+
+   public JGroupsProtocolConfigurationBuilder newProtocol() {
+      JGroupsProtocolConfigurationBuilder protocolConfigurationBuilder = new JGroupsProtocolConfigurationBuilder(getGlobalConfig());
+      this.protocols.add(protocolConfigurationBuilder);
+      return protocolConfigurationBuilder;
+   }
+
+   public StackConfigurationBuilder channelConfigurator(EmbeddedJGroupsChannelConfigurator configurator) {
+      this.configurator = configurator;
+      attributes.attribute(NAME).set(configurator.getName());
+      configurator.getProtocolStack().forEach(protocolConfiguration -> {
+         JGroupsProtocolConfigurationBuilder protocol = newProtocol();
+         protocol.protocolConfig(protocolConfiguration);
+      });
+      return this;
+   }
+
+   @Override
+   public void validate() {
+   }
+
+   @Override
+   public StackConfiguration create() {
+      List<JGroupsProtocolConfiguration> protocolConfigurations = protocols.stream()
+            .map(JGroupsProtocolConfigurationBuilder::create).collect(Collectors.toList());
+      return new StackConfiguration(attributes.protect(), protocolConfigurations);
+   }
+
+   @Override
+   public StackConfigurationBuilder read(StackConfiguration template) {
+      attributes.read(template.attributes());
+      return this;
+   }
+
+   @Override
+   public String toString() {
+      return "StackConfigurationBuilder{" +
+            "attributes=" + attributes +
+            ", protocols=" + protocols +
+            '}';
+   }
+
+   @Override
+   public JGroupsChannelConfigurator getConfigurator(String stackName) {
+      return configurator;
+   }
+}

--- a/core/src/main/java/org/infinispan/configuration/global/StackFileConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/global/StackFileConfiguration.java
@@ -1,0 +1,57 @@
+package org.infinispan.configuration.global;
+
+import org.infinispan.commons.configuration.ConfigurationInfo;
+import org.infinispan.commons.configuration.attributes.Attribute;
+import org.infinispan.commons.configuration.attributes.AttributeDefinition;
+import org.infinispan.commons.configuration.attributes.AttributeSet;
+import org.infinispan.commons.configuration.elements.DefaultElementDefinition;
+import org.infinispan.commons.configuration.elements.ElementDefinition;
+import org.infinispan.configuration.parsing.Element;
+
+/*
+ * @since 10.0
+ */
+public class StackFileConfiguration implements ConfigurationInfo {
+   static final AttributeDefinition<String> NAME = AttributeDefinition.builder("name", null, String.class).build();
+   static final AttributeDefinition<String> PATH = AttributeDefinition.builder("path", null, String.class).build();
+
+   public static AttributeSet attributeDefinitionSet() {
+      return new AttributeSet(StackFileConfiguration.class, NAME, PATH);
+   }
+
+   private static final ElementDefinition ELEMENT_DEFINITION = new DefaultElementDefinition(Element.STACK_FILE.getLocalName());
+
+   private final Attribute<String> name;
+   private final Attribute<String> path;
+   private final AttributeSet attributes;
+
+   StackFileConfiguration(AttributeSet attributes) {
+      this.attributes = attributes.checkProtection();
+      this.name = attributes.attribute(NAME);
+      this.path = attributes.attribute(PATH);
+   }
+
+   @Override
+   public ElementDefinition getElementDefinition() {
+      return ELEMENT_DEFINITION;
+   }
+
+   public AttributeSet attributes() {
+      return attributes;
+   }
+
+   public String name() {
+      return name.get();
+   }
+
+   public String path() {
+      return path.get();
+   }
+
+   @Override
+   public String toString() {
+      return "StackFileConfiguration{" +
+            "attributes=" + attributes +
+            '}';
+   }
+}

--- a/core/src/main/java/org/infinispan/configuration/global/StackFileConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/global/StackFileConfigurationBuilder.java
@@ -1,0 +1,69 @@
+package org.infinispan.configuration.global;
+
+import static org.infinispan.configuration.global.StackFileConfiguration.NAME;
+import static org.infinispan.configuration.global.StackFileConfiguration.PATH;
+
+import org.infinispan.commons.configuration.attributes.AttributeSet;
+import org.infinispan.remoting.transport.jgroups.FileJGroupsChannelConfigurator;
+import org.infinispan.remoting.transport.jgroups.JGroupsChannelConfigurator;
+
+/*
+ * @since 10.0
+ */
+public class StackFileConfigurationBuilder extends AbstractGlobalConfigurationBuilder implements StackBuilder<StackFileConfiguration> {
+   private final AttributeSet attributes;
+   private FileJGroupsChannelConfigurator configurator;
+
+   StackFileConfigurationBuilder(String name, GlobalConfigurationBuilder globalConfig) {
+      super(globalConfig);
+      attributes = StackFileConfiguration.attributeDefinitionSet();
+      attributes.attribute(NAME).set(name);
+   }
+
+   public AttributeSet attributes() {
+      return attributes;
+   }
+
+   public StackFileConfigurationBuilder path(String name) {
+      attributes.attribute(StackFileConfiguration.PATH).set(name);
+      return this;
+   }
+
+   public StackFileConfigurationBuilder fileChannelConfigurator(FileJGroupsChannelConfigurator configurator) {
+      this.configurator = configurator;
+      attributes.attribute(NAME).set(configurator.getName());
+      attributes.attribute(PATH).set(configurator.getPath());
+      return this;
+   }
+
+   public JGroupsChannelConfigurator getConfigurator() {
+      return configurator;
+   }
+
+   @Override
+   public void validate() {
+   }
+
+   @Override
+   public StackFileConfiguration create() {
+      return new StackFileConfiguration(attributes.protect());
+   }
+
+   @Override
+   public StackFileConfigurationBuilder read(StackFileConfiguration template) {
+      attributes.read(template.attributes());
+      return this;
+   }
+
+   @Override
+   public String toString() {
+      return "StackFileConfigurationBuilder{" +
+            "attributes=" + attributes +
+            '}';
+   }
+
+   @Override
+   public JGroupsChannelConfigurator getConfigurator(String stackName) {
+      return configurator;
+   }
+}

--- a/core/src/main/java/org/infinispan/configuration/global/TemporaryGlobalStatePathConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/global/TemporaryGlobalStatePathConfiguration.java
@@ -1,0 +1,59 @@
+package org.infinispan.configuration.global;
+
+import org.infinispan.commons.configuration.ConfigurationInfo;
+import org.infinispan.commons.configuration.attributes.Attribute;
+import org.infinispan.commons.configuration.attributes.AttributeDefinition;
+import org.infinispan.commons.configuration.attributes.AttributeSet;
+import org.infinispan.commons.configuration.elements.DefaultElementDefinition;
+import org.infinispan.commons.configuration.elements.ElementDefinition;
+import org.infinispan.configuration.parsing.Element;
+
+public class TemporaryGlobalStatePathConfiguration implements ConfigurationInfo {
+
+   public static final AttributeDefinition<String> PATH = AttributeDefinition.builder("path", null, String.class)
+         .initializer(() -> SecurityActions.getSystemProperty("java.io.tmpdir"))
+         .immutable().build();
+
+   public static final AttributeDefinition<String> RELATIVE_TO = AttributeDefinition.builder("relativeTo", null, String.class).immutable().build();
+
+   private final Attribute<String> path;
+   private final Attribute<String> relativeTo;
+   private final String location;
+
+   public static AttributeSet attributeDefinitionSet() {
+      return new AttributeSet(GlobalStateConfiguration.class, PATH, RELATIVE_TO);
+   }
+
+   static final ElementDefinition ELEMENT_DEFINITION = new DefaultElementDefinition(Element.TEMPORARY_LOCATION.getLocalName());
+
+   private final AttributeSet attributes;
+
+   public TemporaryGlobalStatePathConfiguration(AttributeSet attributes, String location) {
+      this.attributes = attributes.checkProtection();
+      this.path = attributes.attribute(PATH);
+      this.relativeTo = attributes.attribute(RELATIVE_TO);
+      this.location = location;
+   }
+
+   @Override
+   public ElementDefinition getElementDefinition() {
+      return ELEMENT_DEFINITION;
+   }
+
+   @Override
+   public AttributeSet attributes() {
+      return attributes;
+   }
+
+   public String getLocation() {
+      return location;
+   }
+
+   public String path() {
+      return path.get();
+   }
+
+   public String relativeTo() {
+      return relativeTo.get();
+   }
+}

--- a/core/src/main/java/org/infinispan/configuration/global/TemporaryGlobalStatePathConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/global/TemporaryGlobalStatePathConfigurationBuilder.java
@@ -1,0 +1,39 @@
+package org.infinispan.configuration.global;
+
+import org.infinispan.commons.configuration.Builder;
+import org.infinispan.commons.configuration.attributes.AttributeSet;
+import org.infinispan.configuration.parsing.ParseUtils;
+
+public class TemporaryGlobalStatePathConfigurationBuilder extends AbstractGlobalConfigurationBuilder implements Builder<TemporaryGlobalStatePathConfiguration> {
+
+   private final AttributeSet attributes;
+   private String location;
+
+   TemporaryGlobalStatePathConfigurationBuilder(GlobalConfigurationBuilder globalConfig) {
+      super(globalConfig);
+      attributes = TemporaryGlobalStatePathConfiguration.attributeDefinitionSet();
+   }
+
+   public TemporaryGlobalStatePathConfigurationBuilder location(String path, String relativeTo) {
+      attributes.attribute(GlobalStatePathConfiguration.PATH).set(path);
+      attributes.attribute(GlobalStatePathConfiguration.RELATIVE_TO).set(relativeTo);
+      this.location = ParseUtils.resolvePath(path, relativeTo);
+      return this;
+   }
+
+   @Override
+   public void validate() {
+   }
+
+   @Override
+   public TemporaryGlobalStatePathConfiguration create() {
+      return new TemporaryGlobalStatePathConfiguration(attributes.protect(), location);
+   }
+
+   @Override
+   public TemporaryGlobalStatePathConfigurationBuilder read(TemporaryGlobalStatePathConfiguration template) {
+      attributes.read(template.attributes());
+      location = template.getLocation();
+      return this;
+   }
+}

--- a/core/src/main/java/org/infinispan/configuration/global/ThreadFactoryConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/global/ThreadFactoryConfiguration.java
@@ -1,0 +1,92 @@
+package org.infinispan.configuration.global;
+
+import org.infinispan.commons.configuration.ConfigurationBuilderInfo;
+import org.infinispan.commons.configuration.ConfigurationInfo;
+import org.infinispan.commons.configuration.attributes.Attribute;
+import org.infinispan.commons.configuration.attributes.AttributeDefinition;
+import org.infinispan.commons.configuration.attributes.AttributeSerializer;
+import org.infinispan.commons.configuration.attributes.AttributeSet;
+import org.infinispan.commons.configuration.elements.DefaultElementDefinition;
+import org.infinispan.commons.configuration.elements.ElementDefinition;
+import org.infinispan.configuration.parsing.Element;
+import org.infinispan.factories.threads.DefaultThreadFactory;
+
+class ThreadFactoryConfiguration implements ConfigurationInfo {
+   static final AttributeDefinition<String> NAME = AttributeDefinition.builder("name", null, String.class).build();
+   static final AttributeDefinition<ThreadGroup> GROUP = AttributeDefinition.builder("groupName", null, ThreadGroup.class)
+         .serializer(new AttributeSerializer<ThreadGroup, ConfigurationInfo, ConfigurationBuilderInfo>() {
+            @Override
+            public Object getSerializationValue(Attribute<ThreadGroup> attribute, ConfigurationInfo configurationElement) {
+               return attribute.get().getName();
+            }
+         }).build();
+   static final AttributeDefinition<String> THREAD_NAME_PATTERN = AttributeDefinition.builder("threadNamePattern", null, String.class).build();
+   static final AttributeDefinition<Integer> PRIORITY = AttributeDefinition.builder("priority", null, Integer.class).build();
+
+   private final AttributeSet attributes;
+   private final Attribute<String> name;
+   private final Attribute<ThreadGroup> group;
+   private final Attribute<String> threadNamePattern;
+   private final Attribute<Integer> priority;
+   private final DefaultThreadFactory threadFactory;
+   private String nodeName;
+
+   static final ElementDefinition ELEMENT_DEFINITION = new DefaultElementDefinition(Element.THREAD_FACTORY.getLocalName());
+
+   public static AttributeSet attributeDefinitionSet() {
+      return new AttributeSet(ThreadFactoryConfiguration.class, NAME, GROUP, THREAD_NAME_PATTERN, PRIORITY);
+   }
+
+   ThreadFactoryConfiguration(AttributeSet attributes, String nodeName) {
+      this.attributes = attributes.checkProtection();
+      this.name = attributes.attribute(NAME);
+      this.group = attributes.attribute(GROUP);
+      this.threadNamePattern = attributes.attribute(THREAD_NAME_PATTERN);
+      this.priority = attributes.attribute(PRIORITY);
+      this.nodeName = nodeName;
+      this.threadFactory = new DefaultThreadFactory(name.get(), group.get(), priority.get(), threadNamePattern.get(), nodeName, null);
+   }
+
+   @Override
+   public ElementDefinition getElementDefinition() {
+      return ELEMENT_DEFINITION;
+
+   }
+
+   public DefaultThreadFactory getThreadFactory() {
+      return threadFactory;
+   }
+
+   public AttributeSet attributes() {
+      return attributes;
+   }
+
+   public Attribute<String> name() {
+      return name;
+   }
+
+   public Attribute<ThreadGroup> groupName() {
+      return group;
+   }
+
+   public Attribute<String> threadPattern() {
+      return threadNamePattern;
+   }
+
+   public Attribute<Integer> priority() {
+      return priority;
+   }
+
+   public String getNodeName() {
+      return nodeName;
+   }
+
+   @Override
+   public String toString() {
+      return "ThreadFactoryConfiguration{" +
+            "attributes=" + attributes +
+            ", nodeName='" + nodeName + '\'' +
+            '}';
+   }
+
+}

--- a/core/src/main/java/org/infinispan/configuration/global/ThreadFactoryConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/global/ThreadFactoryConfigurationBuilder.java
@@ -1,0 +1,89 @@
+package org.infinispan.configuration.global;
+
+import static org.infinispan.configuration.global.ThreadFactoryConfiguration.GROUP;
+import static org.infinispan.configuration.global.ThreadFactoryConfiguration.NAME;
+import static org.infinispan.configuration.global.ThreadFactoryConfiguration.PRIORITY;
+import static org.infinispan.configuration.global.ThreadFactoryConfiguration.THREAD_NAME_PATTERN;
+
+import org.infinispan.commons.configuration.Builder;
+import org.infinispan.commons.configuration.attributes.AttributeSet;
+
+/*
+ * @since 10.0
+ */
+public class ThreadFactoryConfigurationBuilder extends AbstractGlobalConfigurationBuilder implements Builder<ThreadFactoryConfiguration> {
+   private final AttributeSet attributes;
+   private String nodeName;
+
+   ThreadFactoryConfigurationBuilder(GlobalConfigurationBuilder globalConfig, String name) {
+      super(globalConfig);
+      attributes = ThreadFactoryConfiguration.attributeDefinitionSet();
+      attributes.attribute(NAME).set(name);
+   }
+
+   public AttributeSet attributes() {
+      return attributes;
+   }
+
+   public ThreadFactoryConfigurationBuilder groupName(ThreadGroup threadGroup) {
+      attributes.attribute(GROUP).set(threadGroup);
+      return this;
+   }
+
+   public ThreadFactoryConfigurationBuilder threadNamePattern(String threadNamePattern) {
+      attributes.attribute(THREAD_NAME_PATTERN).set(threadNamePattern);
+      return this;
+   }
+
+   public ThreadFactoryConfigurationBuilder priority(Integer priority) {
+      attributes.attribute(PRIORITY).set(priority);
+      return this;
+   }
+
+   public ThreadFactoryConfigurationBuilder nodeName(String nodeName) {
+      this.nodeName = nodeName;
+      return this;
+   }
+
+   public String name() {
+      return attributes.attribute(NAME).get();
+   }
+
+   public Integer priority() {
+      return attributes.attribute(PRIORITY).get();
+   }
+
+   public ThreadGroup group() {
+      return attributes.attribute(GROUP).get();
+   }
+
+   public String threadNamePattern() {
+      return attributes.attribute(THREAD_NAME_PATTERN).get();
+   }
+
+   public String nodeName() {
+      return nodeName;
+   }
+
+   @Override
+   public void validate() {
+   }
+
+   @Override
+   public ThreadFactoryConfiguration create() {
+      return new ThreadFactoryConfiguration(attributes.protect(), nodeName);
+   }
+
+   @Override
+   public ThreadFactoryConfigurationBuilder read(ThreadFactoryConfiguration template) {
+      attributes.read(template.attributes());
+      return this;
+   }
+
+   @Override
+   public String toString() {
+      return "ThreadFactoryConfigurationBuilder{" +
+            "attributes=" + attributes +
+            '}';
+   }
+}

--- a/core/src/main/java/org/infinispan/configuration/global/ThreadPoolBuilderAdapter.java
+++ b/core/src/main/java/org/infinispan/configuration/global/ThreadPoolBuilderAdapter.java
@@ -1,0 +1,7 @@
+package org.infinispan.configuration.global;
+
+public interface ThreadPoolBuilderAdapter {
+
+   ThreadPoolConfiguration asThreadPoolConfigurationBuilder();
+
+}

--- a/core/src/main/java/org/infinispan/configuration/global/ThreadsConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/global/ThreadsConfiguration.java
@@ -1,0 +1,126 @@
+package org.infinispan.configuration.global;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.infinispan.commons.configuration.ConfigurationInfo;
+import org.infinispan.commons.configuration.elements.DefaultElementDefinition;
+import org.infinispan.commons.configuration.elements.ElementDefinition;
+import org.infinispan.configuration.parsing.Element;
+
+public class ThreadsConfiguration implements ConfigurationInfo {
+
+   private final List<ThreadFactoryConfiguration> threadFactories = new ArrayList<>();
+   private final List<BoundedThreadPoolConfiguration> boundedThreadPools = new ArrayList<>();
+   private final List<CachedThreadPoolConfiguration> cachedThreadPools = new ArrayList<>();
+   private final List<ScheduledThreadPoolConfiguration> scheduledThreadPools = new ArrayList<>();
+   private final ThreadPoolConfiguration asyncThreadPool;
+   private final ThreadPoolConfiguration expirationThreadPool;
+   private final ThreadPoolConfiguration listenerThreadPool;
+   private final ThreadPoolConfiguration persistenceThreadPool;
+   private final ThreadPoolConfiguration remoteThreadPool;
+   private final ThreadPoolConfiguration stateTransferThreadPool;
+   private final ThreadPoolConfiguration transportThreadPool;
+
+   private static ElementDefinition ELEMENT_DEFINITION = new DefaultElementDefinition(Element.THREADS.getLocalName());
+   private final List<ConfigurationInfo> children = new ArrayList<>();
+
+   ThreadsConfiguration(List<ThreadFactoryConfiguration> threadFactories,
+                        List<BoundedThreadPoolConfiguration> boundedThreadPools,
+                        List<CachedThreadPoolConfiguration> cachedThreadPools,
+                        List<ScheduledThreadPoolConfiguration> scheduledThreadPools,
+                        ThreadPoolConfiguration asyncThreadPool,
+                        ThreadPoolConfiguration expirationThreadPool,
+                        ThreadPoolConfiguration listenerThreadPool,
+                        ThreadPoolConfiguration persistenceThreadPool,
+                        ThreadPoolConfiguration remoteThreadPool,
+                        ThreadPoolConfiguration stateTransferThreadPool,
+                        ThreadPoolConfiguration transportThreadPool) {
+      this.asyncThreadPool = asyncThreadPool;
+      this.expirationThreadPool = expirationThreadPool;
+      this.listenerThreadPool = listenerThreadPool;
+      this.persistenceThreadPool = persistenceThreadPool;
+      this.remoteThreadPool = remoteThreadPool;
+      this.stateTransferThreadPool = stateTransferThreadPool;
+      this.transportThreadPool = transportThreadPool;
+      this.threadFactories.addAll(threadFactories);
+      this.boundedThreadPools.addAll(boundedThreadPools);
+      this.cachedThreadPools.addAll(cachedThreadPools);
+      this.scheduledThreadPools.addAll(scheduledThreadPools);
+      children.addAll(threadFactories);
+      children.addAll(boundedThreadPools);
+      children.addAll(cachedThreadPools);
+      children.addAll(scheduledThreadPools);
+   }
+
+   @Override
+   public List<ConfigurationInfo> subElements() {
+      return children;
+   }
+
+   @Override
+   public ElementDefinition getElementDefinition() {
+      return ELEMENT_DEFINITION;
+   }
+
+   public ThreadPoolConfiguration asyncThreadPool() {
+      return asyncThreadPool;
+   }
+
+   public ThreadPoolConfiguration expirationThreadPool() {
+      return expirationThreadPool;
+   }
+
+   public ThreadPoolConfiguration listenerThreadPool() {
+      return listenerThreadPool;
+   }
+
+   public ThreadPoolConfiguration persistenceThreadPool() {
+      return persistenceThreadPool;
+   }
+
+   public ThreadPoolConfiguration remoteThreadPool() {
+      return remoteThreadPool;
+   }
+
+   public ThreadPoolConfiguration stateTransferThreadPool() {
+      return stateTransferThreadPool;
+   }
+
+   public ThreadPoolConfiguration transportThreadPool() {
+      return transportThreadPool;
+   }
+
+   public List<ThreadFactoryConfiguration> threadFactories() {
+      return threadFactories;
+   }
+
+   public List<BoundedThreadPoolConfiguration> boundedThreadPools() {
+      return boundedThreadPools;
+   }
+
+   public List<CachedThreadPoolConfiguration> cachedThreadPools() {
+      return cachedThreadPools;
+   }
+
+   public List<ScheduledThreadPoolConfiguration> scheduledThreadPools() {
+      return scheduledThreadPools;
+   }
+
+   @Override
+   public String toString() {
+      return "ThreadsConfiguration{" +
+            "threadFactories=" + threadFactories +
+            ", boundedThreadPools=" + boundedThreadPools +
+            ", cachedThreadPools=" + cachedThreadPools +
+            ", scheduledThreadPools=" + scheduledThreadPools +
+            ", asyncThreadPool=" + asyncThreadPool +
+            ", expirationThreadPool=" + expirationThreadPool +
+            ", listenerThreadPool=" + listenerThreadPool +
+            ", persistenceThreadPool=" + persistenceThreadPool +
+            ", remoteThreadPool=" + remoteThreadPool +
+            ", stateTransferThreadPool=" + stateTransferThreadPool +
+            ", transportThreadPool=" + transportThreadPool +
+            '}';
+   }
+}

--- a/core/src/main/java/org/infinispan/configuration/global/ThreadsConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/global/ThreadsConfigurationBuilder.java
@@ -1,0 +1,160 @@
+package org.infinispan.configuration.global;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.infinispan.commons.configuration.Builder;
+
+public class ThreadsConfigurationBuilder extends AbstractGlobalConfigurationBuilder implements Builder<ThreadsConfiguration> {
+
+   private final ThreadPoolConfigurationBuilder asyncThreadPool;
+   private final ThreadPoolConfigurationBuilder expirationThreadPool;
+   private final ThreadPoolConfigurationBuilder listenerThreadPool;
+   private final ThreadPoolConfigurationBuilder persistenceThreadPool;
+   private final ThreadPoolConfigurationBuilder remoteCommandThreadPool;
+   private final ThreadPoolConfigurationBuilder stateTransferThreadPool;
+   private final ThreadPoolConfigurationBuilder transportThreadPool;
+   private List<ThreadFactoryConfigurationBuilder> threadFactoryBuilders = new ArrayList<>();
+   private List<BoundedThreadPoolConfigurationBuilder> boundedThreadPoolBuilders = new ArrayList<>();
+   private List<ScheduledThreadPoolConfigurationBuilder> scheduledThreadPoolBuilders = new ArrayList<>();
+   private List<CachedThreadPoolConfigurationBuilder> cachedThreadPoolBuilders = new ArrayList<>();
+
+   private final Map<String, ThreadFactoryConfigurationBuilder> threadFactoryByName = new HashMap<>();
+   private final Map<String, ThreadPoolBuilderAdapter> threadPoolByName = new HashMap<>();
+
+   ThreadsConfigurationBuilder(GlobalConfigurationBuilder globalConfig) {
+      super(globalConfig);
+      this.asyncThreadPool = new ThreadPoolConfigurationBuilder(globalConfig);
+      this.expirationThreadPool = new ThreadPoolConfigurationBuilder(globalConfig);
+      this.listenerThreadPool = new ThreadPoolConfigurationBuilder(globalConfig);
+      this.persistenceThreadPool = new ThreadPoolConfigurationBuilder(globalConfig);
+      this.stateTransferThreadPool = new ThreadPoolConfigurationBuilder(globalConfig);
+      this.remoteCommandThreadPool = new ThreadPoolConfigurationBuilder(globalConfig);
+      this.transportThreadPool = new ThreadPoolConfigurationBuilder(globalConfig);
+   }
+
+   public ThreadFactoryConfigurationBuilder addThreadFactory(String name) {
+      ThreadFactoryConfigurationBuilder threadFactoryConfigurationBuilder = new ThreadFactoryConfigurationBuilder(getGlobalConfig(), name);
+      threadFactoryBuilders.add(threadFactoryConfigurationBuilder);
+      threadFactoryByName.put(name, threadFactoryConfigurationBuilder);
+      return threadFactoryConfigurationBuilder;
+   }
+
+   public BoundedThreadPoolConfigurationBuilder addBoundedThreadPool(String name) {
+      BoundedThreadPoolConfigurationBuilder configurationBuilder = new BoundedThreadPoolConfigurationBuilder(getGlobalConfig(), name);
+      boundedThreadPoolBuilders.add(configurationBuilder);
+      threadPoolByName.put(name, configurationBuilder);
+      return configurationBuilder;
+   }
+
+   public ScheduledThreadPoolConfigurationBuilder addScheduledThreadPool(String name) {
+      ScheduledThreadPoolConfigurationBuilder configurationBuilder = new ScheduledThreadPoolConfigurationBuilder(getGlobalConfig(), name);
+      scheduledThreadPoolBuilders.add(configurationBuilder);
+      threadPoolByName.put(name, configurationBuilder);
+      return configurationBuilder;
+   }
+
+   public CachedThreadPoolConfigurationBuilder addCachedThreadPool(String name) {
+      CachedThreadPoolConfigurationBuilder configurationBuilder = new CachedThreadPoolConfigurationBuilder(getGlobalConfig(), name);
+      cachedThreadPoolBuilders.add(configurationBuilder);
+      threadPoolByName.put(name, configurationBuilder);
+      return configurationBuilder;
+   }
+
+   @Override
+   public ThreadPoolConfigurationBuilder asyncThreadPool() {
+      return asyncThreadPool;
+   }
+
+   @Override
+   public ThreadPoolConfigurationBuilder expirationThreadPool() {
+      return expirationThreadPool;
+   }
+
+   @Override
+   public ThreadPoolConfigurationBuilder listenerThreadPool() {
+      return listenerThreadPool;
+   }
+
+   @Override
+   public ThreadPoolConfigurationBuilder persistenceThreadPool() {
+      return persistenceThreadPool;
+   }
+
+   public ThreadPoolConfigurationBuilder remoteCommandThreadPool() {
+      return remoteCommandThreadPool;
+   }
+
+   @Override
+   public ThreadPoolConfigurationBuilder stateTransferThreadPool() {
+      return stateTransferThreadPool;
+   }
+
+   public ThreadPoolConfigurationBuilder transportThreadPool() {
+      return transportThreadPool;
+   }
+
+   @Override
+   public void validate() {
+   }
+
+   @Override
+   public ThreadsConfigurationBuilder read(ThreadsConfiguration template) {
+      this.asyncThreadPool.read(template.asyncThreadPool());
+      this.expirationThreadPool.read(template.expirationThreadPool());
+      this.listenerThreadPool.read(template.listenerThreadPool());
+      this.persistenceThreadPool.read(template.persistenceThreadPool());
+      this.remoteCommandThreadPool.read(template.remoteThreadPool());
+      this.stateTransferThreadPool.read(template.stateTransferThreadPool());
+      this.transportThreadPool.read(template.transportThreadPool());
+
+      template.threadFactories().forEach(s -> threadFactoryBuilders.add(new ThreadFactoryConfigurationBuilder(getGlobalConfig(), s.name().get()).read(s)));
+      template.boundedThreadPools().forEach(s -> boundedThreadPoolBuilders.add(new BoundedThreadPoolConfigurationBuilder(getGlobalConfig(), s.name()).read(s)));
+      template.cachedThreadPools().forEach(s -> cachedThreadPoolBuilders.add(new CachedThreadPoolConfigurationBuilder(getGlobalConfig(), s.name()).read(s)));
+      template.scheduledThreadPools().forEach(s -> scheduledThreadPoolBuilders.add(new ScheduledThreadPoolConfigurationBuilder(getGlobalConfig(), s.name()).read(s)));
+      return this;
+   }
+
+   @Override
+   public ThreadsConfiguration create() {
+      List<ThreadFactoryConfiguration> threadFactoryConfigurations = threadFactoryBuilders
+            .stream().map(ThreadFactoryConfigurationBuilder::create).collect(Collectors.toList());
+
+      List<BoundedThreadPoolConfiguration> boundedThreadPoolConfigurations = boundedThreadPoolBuilders
+            .stream().map(BoundedThreadPoolConfigurationBuilder::create).collect(Collectors.toList());
+
+      List<ScheduledThreadPoolConfiguration> scheduledThreadPoolConfigurations = scheduledThreadPoolBuilders
+            .stream().map(ScheduledThreadPoolConfigurationBuilder::create).collect(Collectors.toList());
+
+      List<CachedThreadPoolConfiguration> cachedThreadPoolConfigurations = cachedThreadPoolBuilders
+            .stream().map(CachedThreadPoolConfigurationBuilder::create).collect(Collectors.toList());
+
+      return new ThreadsConfiguration(threadFactoryConfigurations, boundedThreadPoolConfigurations,
+            cachedThreadPoolConfigurations, scheduledThreadPoolConfigurations,
+            asyncThreadPool.create(),
+            expirationThreadPool.create(),
+            listenerThreadPool.create(),
+            persistenceThreadPool.create(),
+            remoteCommandThreadPool.create(),
+            stateTransferThreadPool.create(),
+            transportThreadPool.create());
+   }
+
+   public ThreadsConfigurationBuilder nodeName(String value) {
+      threadFactoryBuilders.forEach(tfb -> tfb.nodeName(value));
+      return this;
+   }
+
+   public ThreadFactoryConfigurationBuilder getThreadFactory(String threadFactoryName) {
+      return threadFactoryByName.get(threadFactoryName);
+   }
+
+   public ThreadPoolBuilderAdapter getThreadPool(String threadFactoryName) {
+      return threadPoolByName.get(threadFactoryName);
+   }
+
+
+}

--- a/core/src/main/java/org/infinispan/configuration/global/TransportConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/global/TransportConfigurationBuilder.java
@@ -1,16 +1,16 @@
 package org.infinispan.configuration.global;
 
-import static java.util.Arrays.asList;
 import static org.infinispan.configuration.global.TransportConfiguration.CLUSTER_NAME;
 import static org.infinispan.configuration.global.TransportConfiguration.DISTRIBUTED_SYNC_TIMEOUT;
 import static org.infinispan.configuration.global.TransportConfiguration.INITIAL_CLUSTER_SIZE;
 import static org.infinispan.configuration.global.TransportConfiguration.INITIAL_CLUSTER_TIMEOUT;
 import static org.infinispan.configuration.global.TransportConfiguration.MACHINE_ID;
 import static org.infinispan.configuration.global.TransportConfiguration.NODE_NAME;
-import static org.infinispan.configuration.global.TransportConfiguration.PROPERTIES;
 import static org.infinispan.configuration.global.TransportConfiguration.RACK_ID;
+import static org.infinispan.configuration.global.TransportConfiguration.REMOTE_EXECUTOR;
 import static org.infinispan.configuration.global.TransportConfiguration.SITE_ID;
-import static org.infinispan.configuration.global.TransportConfiguration.TRANSPORT;
+import static org.infinispan.configuration.global.TransportConfiguration.STACK;
+import static org.infinispan.configuration.global.TransportConfiguration.TRANSPORT_EXECUTOR;
 
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
@@ -33,15 +33,16 @@ public class TransportConfigurationBuilder extends AbstractGlobalConfigurationBu
    // Lazily instantiate this if the user doesn't request an alternate to avoid a hard dep on jgroups library
    public static final String DEFAULT_TRANSPORT = "org.infinispan.remoting.transport.jgroups.JGroupsTransport";
 
-   private final ThreadPoolConfigurationBuilder transportThreadPool;
-   private final ThreadPoolConfigurationBuilder remoteCommandThreadPool;
+   private final ThreadsConfigurationBuilder threads;
    private final AttributeSet attributes;
+   private final JGroupsConfigurationBuilder jgroupsConfigurationBuilder;
+   private TypedProperties typedProperties = new TypedProperties();
 
-   TransportConfigurationBuilder(GlobalConfigurationBuilder globalConfig) {
+   TransportConfigurationBuilder(GlobalConfigurationBuilder globalConfig, ThreadsConfigurationBuilder threads) {
       super(globalConfig);
-      attributes = TransportConfiguration.attributeSet();
-      transportThreadPool = new ThreadPoolConfigurationBuilder(globalConfig);
-      remoteCommandThreadPool = new ThreadPoolConfigurationBuilder(globalConfig);
+      this.threads = threads;
+      this.attributes = TransportConfiguration.attributeSet();
+      this.jgroupsConfigurationBuilder = new JGroupsConfigurationBuilder(globalConfig);
    }
 
    /**
@@ -130,7 +131,7 @@ public class TransportConfigurationBuilder extends AbstractGlobalConfigurationBu
     * @param transport transport instance
     */
    public TransportConfigurationBuilder transport(Transport transport) {
-      attributes.attribute(TRANSPORT).set(transport);
+      jgroupsConfigurationBuilder.transport(transport);
       return this;
    }
 
@@ -153,7 +154,7 @@ public class TransportConfigurationBuilder extends AbstractGlobalConfigurationBu
     * @return this TransportConfig
     */
    public TransportConfigurationBuilder withProperties(Properties properties) {
-      attributes.attribute(PROPERTIES).set(TypedProperties.toTypedProperties(properties));
+      this.typedProperties = TypedProperties.toTypedProperties(properties);
       return this;
    }
 
@@ -163,49 +164,50 @@ public class TransportConfigurationBuilder extends AbstractGlobalConfigurationBu
     * @return this TransportConfig
     */
    public TransportConfigurationBuilder clearProperties() {
-      attributes.attribute(PROPERTIES).set(new TypedProperties());
+      typedProperties.clear();
       return this;
    }
 
    public TransportConfigurationBuilder addProperty(String key, String value) {
-      TypedProperties properties = attributes.attribute(PROPERTIES).get();
-      properties.put(key, value);
-      attributes.attribute(PROPERTIES).set(properties);
+      typedProperties.put(key, value);
       return this;
    }
 
    public TransportConfigurationBuilder removeProperty(String key) {
-      TypedProperties properties = attributes.attribute(PROPERTIES).get();
-      properties.remove(key);
-      attributes.attribute(PROPERTIES).set(properties);
+      typedProperties.remove(key);
       return this;
    }
 
    public String getProperty(String key) {
-      return String.valueOf(attributes.attribute(PROPERTIES).get().get(key));
+      return String.valueOf(typedProperties.get(key));
    }
 
    public ThreadPoolConfigurationBuilder transportThreadPool() {
-      return transportThreadPool;
+      return threads.transportThreadPool();
    }
 
    public ThreadPoolConfigurationBuilder remoteCommandThreadPool() {
-      return remoteCommandThreadPool;
+      return threads.remoteCommandThreadPool();
    }
 
    @Override
    public
    void validate() {
-      asList(transportThreadPool, remoteCommandThreadPool).forEach(Builder::validate);
       if(attributes.attribute(CLUSTER_NAME).get() == null){
           throw new CacheConfigurationException("Transport clusterName cannot be null");
       }
    }
 
+   public JGroupsConfigurationBuilder jgroups() {
+      return jgroupsConfigurationBuilder;
+   }
+
    @Override
    public
    TransportConfiguration create() {
-      return new TransportConfiguration(attributes.protect(), transportThreadPool.create(), remoteCommandThreadPool.create());
+      if (typedProperties.containsKey("stack")) attributes.attribute(STACK).set(typedProperties.getProperty("stack"));
+      return new TransportConfiguration(attributes.protect(),
+            jgroupsConfigurationBuilder.create(), threads.transportThreadPool().create(), threads.remoteCommandThreadPool().create(), typedProperties);
    }
 
    public TransportConfigurationBuilder defaultTransport() {
@@ -214,12 +216,21 @@ public class TransportConfigurationBuilder extends AbstractGlobalConfigurationBu
       return this;
    }
 
+   public TransportConfigurationBuilder transportExecutor(String threadPoolName) {
+      attributes.attribute(TRANSPORT_EXECUTOR).set(threadPoolName);
+      return this;
+   }
+
+   public TransportConfigurationBuilder remoteExecutor(String threadPoolName) {
+      attributes.attribute(REMOTE_EXECUTOR).set(threadPoolName);
+      return this;
+   }
+
    @Override
    public
    TransportConfigurationBuilder read(TransportConfiguration template) {
       attributes.read(template.attributes());
-      this.remoteCommandThreadPool.read(template.remoteCommandThreadPool());
-      this.transportThreadPool.read(template.transportThreadPool());
+      this.jgroupsConfigurationBuilder.read(template.jgroups());
       if (template.transport() != null) {
          Transport transport = Util.getInstance(template.transport().getClass().getName(), template.transport().getClass().getClassLoader());
          transport(transport);
@@ -229,14 +240,16 @@ public class TransportConfigurationBuilder extends AbstractGlobalConfigurationBu
    }
 
    public Transport getTransport() {
-      return attributes.attribute(TRANSPORT).get();
+      return jgroupsConfigurationBuilder.jgroupsTransport();
    }
 
    @Override
    public String toString() {
-      return "TransportConfigurationBuilder [transportThreadPool=" + transportThreadPool + ", remoteCommandThreadPool="
-            + remoteCommandThreadPool + ", attributes=" + attributes
-            + "]";
+      return "TransportConfigurationBuilder{" +
+            "threads=" + threads +
+            ", attributes=" + attributes +
+            ", jgroupsConfigurationBuilder=" + jgroupsConfigurationBuilder +
+            ", typedProperties=" + typedProperties +
+            '}';
    }
-
 }

--- a/core/src/test/java/org/infinispan/configuration/serializer/AbstractConfigurationSerializerTest.java
+++ b/core/src/test/java/org/infinispan/configuration/serializer/AbstractConfigurationSerializerTest.java
@@ -52,9 +52,9 @@ public abstract class AbstractConfigurationSerializerTest extends AbstractInfini
       assertEquals(globalConfigurationBefore.sites().localSite(), globalConfigurationAfter.sites().localSite());
       assertEquals(globalConfigurationBefore.security().securityCacheTimeout(), globalConfigurationAfter.security().securityCacheTimeout());
       compareAttributeSets("Global", globalConfigurationBefore.globalState().attributes(), globalConfigurationAfter.globalState().attributes(), "localConfigurationStorage");
-      compareAttributeSets("Global", globalConfigurationBefore.globalJmxStatistics().attributes(), globalConfigurationAfter.globalJmxStatistics().attributes(), "mBeanServerLookup");
+      compareAttributeSets("Global", globalConfigurationBefore.globalJmxStatistics().attributes(), globalConfigurationAfter.globalJmxStatistics().attributes(), "mbeanServerLookup");
       compareAttributeSets("Global", globalConfigurationBefore.security().authorization().attributes(), globalConfigurationAfter.security().authorization().attributes());
-      compareAttributeSets("Global", globalConfigurationBefore.serialization().attributes(), globalConfigurationAfter.serialization().attributes(), "marshaller", "classResolver");
+      compareAttributeSets("Global", globalConfigurationBefore.serialization().attributes(), globalConfigurationAfter.serialization().attributes(), "marshaller", "classResolver", "advancedExternalizer");
       compareAttributeSets("Global", globalConfigurationBefore.transport().attributes(), globalConfigurationAfter.transport().attributes(), "transport", "properties");
       compareExtraGlobalConfiguration(globalConfigurationBefore, globalConfigurationAfter);
 

--- a/core/src/test/resources/configs/named-cache-test.xml
+++ b/core/src/test/resources/configs/named-cache-test.xml
@@ -28,6 +28,15 @@
                     async-executor="async">
       <transport stack="udp" cluster="infinispan-cluster" lock-timeout="50000" node-name="Jalapeno" machine="m1" rack="r1" site="s1"
                  executor="transport" remote-command-executor="remote" />
+      <security>
+         <authorization audit-logger="org.infinispan.security.impl.NullAuditLogger">
+            <identity-role-mapper/>
+            <role name="peasant" permissions="READ"/>
+            <role name="vavasour" permissions="READ WRITE"/>
+            <role name="vassal" permissions="READ WRITE LISTEN"/>
+            <role name="king" permissions="ALL"/>
+         </authorization>
+      </security>
       <serialization marshaller="org.infinispan.marshall.TestObjectStreamMarshaller" version="1.0">
          <advanced-externalizer id="1234" class="org.infinispan.marshall.AdvancedExternalizerTest$IdViaConfigObj$Externalizer"/>
          <advanced-externalizer class="org.infinispan.marshall.AdvancedExternalizerTest$IdViaAnnotationObj$Externalizer"/>

--- a/core/src/test/resources/configs/unified/10.0.xml
+++ b/core/src/test/resources/configs/unified/10.0.xml
@@ -72,7 +72,7 @@
       <stack name="xsite" extends="udp">
          <relay.RELAY2 site="LON" xmlns="urn:org:jgroups"/>
          <remote-sites default-stack="tcpgossip">
-            <remote-site name="NYC"/>
+            <remote-site name="NYC" stack="tcp"/>
          </remote-sites>
       </stack>
    </jgroups>
@@ -101,6 +101,15 @@
                     persistence-executor="infinispan-cached" module="org.infinispan" statistics="true" shutdown-hook="DONT_REGISTER" zero-capacity-node="false">
       <transport cluster="maximal-cluster" executor="infinispan-transport" remote-command-executor="infinispan-cached" lock-timeout="120000" stack="tcp" node-name="a-node" machine="a" rack="b" site="c"
                  initial-cluster-size="4" initial-cluster-timeout="30000" />
+      <security>
+         <authorization audit-logger="org.infinispan.security.impl.NullAuditLogger">
+            <identity-role-mapper/>
+            <role name="peasant" permissions="READ"/>
+            <role name="vavasour" permissions="READ WRITE"/>
+            <role name="vassal" permissions="READ WRITE LISTEN"/>
+            <role name="king" permissions="ALL"/>
+         </authorization>
+      </security>
       <serialization marshaller="org.infinispan.marshall.TestObjectStreamMarshaller" version="1.0">
          <advanced-externalizer class="org.infinispan.marshall.AdvancedExternalizerTest$IdViaConfigObj$Externalizer" id="9001" />
          <advanced-externalizer class="org.infinispan.marshall.AdvancedExternalizerTest$IdViaAnnotationObj$Externalizer" id="9002" />

--- a/integrationtests/security-it/src/test/java/org/infinispan/test/integration/security/utils/Deployments.java
+++ b/integrationtests/security-it/src/test/java/org/infinispan/test/integration/security/utils/Deployments.java
@@ -47,6 +47,7 @@ public final class Deployments {
                   new File("target/test-libs/reactive-streams.jar"),
                   new File("target/test-libs/jboss-marshalling.jar"),
                   new File("target/test-libs/jboss-marshalling-river.jar"),
+                  new File("target/test-libs/jgroups.jar"),
                   new File("target/test-libs/protostream.jar"),
                   new File("target/test-libs/wildfly-controller-client.jar"))
             .addPackage(Deployments.class.getPackage())


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-10407

Rearranges the ```GlobalConfiguration```  and associated builders to better reflect the configuration file structure, regarding attributes and elements. Also adds elements like ```jgroups``` and ```threads``` who are currently left out from the XML serialization.

All the changes should be backwards compatible