### PR TITLE
ISPN-10425 Update Netty and RxJava2 to align with Quarkus dependencies

### DIFF
--- a/build-configuration/pom.xml
+++ b/build-configuration/pom.xml
@@ -196,7 +196,7 @@
       <version.mockito_dep.hamcrest>1.3</version.mockito_dep.hamcrest>
       <version.mockito_dep.objenesis>2.6</version.mockito_dep.objenesis>
       <version.net.bytebuddy>1.9.12</version.net.bytebuddy>
-      <version.netty>4.1.30.Final</version.netty>
+      <version.netty>4.1.34.Final</version.netty>
       <version.netty-conscrypt-optional>1.0.0</version.netty-conscrypt-optional>
       <version.netty.tcnative>2.0.17.Final</version.netty.tcnative>
       <version.netty-tcnative-boringssl-static>${version.netty.tcnative}</version.netty-tcnative-boringssl-static>
@@ -218,7 +218,7 @@
       <version.protostuff>1.6.0</version.protostuff>
       <version.reactivestreams>1.0.2</version.reactivestreams>
       <version.rocksdb>5.18.3</version.rocksdb>
-      <version.rxjava>2.2.5</version.rxjava>
+      <version.rxjava>2.2.9</version.rxjava>
       <version.slf4j>1.7.22</version.slf4j>
       <version.sonatype.plexus>1.4</version.sonatype.plexus>
       <version.spring.boot>2.1.5.RELEASE</version.spring.boot>

--- a/build-configuration/pom.xml
+++ b/build-configuration/pom.xml
@@ -198,7 +198,7 @@
       <version.net.bytebuddy>1.9.12</version.net.bytebuddy>
       <version.netty>4.1.34.Final</version.netty>
       <version.netty-conscrypt-optional>1.0.0</version.netty-conscrypt-optional>
-      <version.netty.tcnative>2.0.17.Final</version.netty.tcnative>
+      <version.netty.tcnative>2.0.23.Final</version.netty.tcnative>
       <version.netty-tcnative-boringssl-static>${version.netty.tcnative}</version.netty-tcnative-boringssl-static>
       <version.openjdk.jmh>1.12</version.openjdk.jmh>
       <version.ops4j.base>1.5.0</version.ops4j.base>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-10425