### PR TITLE
ISPN-10469 Allow custom bind_addr and bind_port UDP configuration

### DIFF
--- a/core/src/main/resources/default-configs/default-jgroups-udp.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-udp.xml
@@ -1,7 +1,9 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.0.xsd">
-   <UDP mcast_addr="${jgroups.mcast_addr:228.6.7.8}"
+   <UDP bind_addr="${jgroups.udp.address:SITE_LOCAL}"
+        bind_port="${jgroups.udp.port:0}"
+        mcast_addr="${jgroups.mcast_addr:228.6.7.8}"
         mcast_port="${jgroups.mcast_port:46655}"
         ucast_send_buf_size="1m"
         mcast_send_buf_size="1m"

--- a/core/src/test/resources/stacks/udp.xml
+++ b/core/src/test/resources/stacks/udp.xml
@@ -2,6 +2,8 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.0.xsd">
    <UDP
+         bind_addr="${jgroups.udp.address:SITE_LOCAL}"
+         bind_port="${jgroups.udp.port:0}"
          mcast_addr="${jgroups.udp.mcast_addr:228.6.7.8}"
          mcast_port="${jgroups.udp.mcast_port:46655}"
          tos="8"

--- a/tools/src/test/resources/udp.xml
+++ b/tools/src/test/resources/udp.xml
@@ -2,6 +2,8 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.0.xsd">
    <UDP
+         bind_addr="${jgroups.udp.address:SITE_LOCAL}"
+         bind_port="${jgroups.udp.port:0}"
          mcast_addr="${jgroups.udp.mcast_addr:228.6.7.8}"
          mcast_port="${jgroups.udp.mcast_port:46655}"
          tos="8"


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-10469

Following the TCP custom `bind_addr` and `bind_port` configuration.
Yes, we have different config attributes when compared with JGroups