### PR TITLE
ISPN-10500 Remove javassist 3.24.1-GA dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -465,7 +465,6 @@
       <versionx.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>1.0.0.Final</versionx.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>
       <versionx.org.hibernate.lucene-jbossmodules.lucene-jbossmodules>${version.lucene.featurepack}</versionx.org.hibernate.lucene-jbossmodules.lucene-jbossmodules>
       <versionx.org.jacoco.org.jacoco.agent>${version.jacoco}</versionx.org.jacoco.org.jacoco.agent>
-      <versionx.org.javassist.javassist>3.24.1-GA</versionx.org.javassist.javassist>
       <versionx.org.jboss.aesh.aesh>0.66.13</versionx.org.jboss.aesh.aesh>
       <versionx.org.jboss.arquillian.config.arquillian-config-api>${version.arquillian}</versionx.org.jboss.arquillian.config.arquillian-config-api>
       <versionx.org.jboss.arquillian.config.arquillian-config-impl-base>${version.arquillian}</versionx.org.jboss.arquillian.config.arquillian-config-impl-base>
@@ -2496,11 +2495,6 @@
             <version>${versionx.org.jacoco.org.jacoco.agent}</version>
             <scope>test</scope>
             <classifier>runtime</classifier>
-         </dependency>
-         <dependency>
-            <groupId>org.javassist</groupId>
-            <artifactId>javassist</artifactId>
-            <version>${versionx.org.javassist.javassist}</version>
          </dependency>
          <dependency>
             <groupId>org.jboss</groupId>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -103,11 +103,6 @@
       </dependency>
 
       <dependency>
-         <groupId>org.javassist</groupId>
-         <artifactId>javassist</artifactId>
-      </dependency>
-
-      <dependency>
          <groupId>org.testng</groupId>
          <artifactId>testng</artifactId>
          <scope>test</scope>


### PR DESCRIPTION
* this version is no longer used by any Infinispan module, but 3.23.1-GA is still used by hibernate-search so that one is kept

https://issues.jboss.org/browse/ISPN-10500