### PR TITLE
ISPN-10534 SerializationContext ProtoStreamMarshaller.getSerializatio…

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/marshall/MarshallerUtil.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/marshall/MarshallerUtil.java
@@ -32,14 +32,19 @@ public final class MarshallerUtil {
     * configured on the provided {@link RemoteCacheManager}.
     *
     * @return the associated {@link SerializationContext}
-    * @throws HotRodClientException if the cache manager is not configured to use a {@link ProtoStreamMarshaller}
+    * @throws HotRodClientException if the cache manager is not started or is not configured to use a {@link ProtoStreamMarshaller}
     */
    public static SerializationContext getSerializationContext(RemoteCacheManager remoteCacheManager) {
       Marshaller marshaller = remoteCacheManager.getMarshaller();
       if (marshaller instanceof ProtoStreamMarshaller) {
          return ((ProtoStreamMarshaller) marshaller).getSerializationContext();
       }
-      throw new HotRodClientException("The cache manager must be configured with a ProtoStreamMarshaller");
+
+      if (marshaller == null) {
+         throw new HotRodClientException("The cache manager must be configured with a ProtoStreamMarshaller and must be started before attempting to retrieve the ProtoStream SerializationContext");
+      }
+
+      throw new HotRodClientException("The cache manager is not configured with a ProtoStreamMarshaller");
    }
 
    @SuppressWarnings("unchecked")

--- a/commons/src/main/java/org/infinispan/commons/marshall/ProtoStreamMarshaller.java
+++ b/commons/src/main/java/org/infinispan/commons/marshall/ProtoStreamMarshaller.java
@@ -10,14 +10,14 @@ import org.infinispan.protostream.SerializationContext;
 
 /**
  * Provides the starting point for implementing a {@link org.infinispan.commons.marshall.Marshaller} that uses Protobuf
- * encoding. Subclasses must implement just a single {@link #getSerializationContext} lookup method.
+ * encoding.
  *
  * @author anistor@redhat.com
  * @since 6.0
  */
 public class ProtoStreamMarshaller extends AbstractMarshaller {
 
-   protected final SerializationContext serializationContext;
+   private final SerializationContext serializationContext;
 
    public ProtoStreamMarshaller() {
       this(ProtobufUtil.newSerializationContext());

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/HotRodCustomMarshallerIteratorIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/HotRodCustomMarshallerIteratorIT.java
@@ -167,7 +167,7 @@ public class HotRodCustomMarshallerIteratorIT {
       // Iteration with parametrised filter
       entryMap = iteratorToMap(remoteCache.retrieveEntries(PARAM_FILTER_CONVERTER_FACTORY_NAME, new Object[]{3}, null, 10));
       assertEquals(10, entryMap.size());
-      assertTrue(entryMap.get(2).equals("Use"));
+      assertEquals("Use", entryMap.get(2));
    }
 
    private Map<Object, Object> iteratorToMap(CloseableIterator<Entry<Object, Object>> iterator) {


### PR DESCRIPTION
…nContext fails with unclear message

* fix MarshallerUtil.getSerializationContext to distinguish between null marshaller and wrong type of marshaller

https://issues.jboss.org/browse/ISPN-10534