### PR TITLE
[9.4.x] ISPN-10532 org.antlr.runtime.RecognitionException class leaks from lo…

### DIFF
--- a/feature-pack/embedded-query/src/main/resources/modules/org/infinispan/objectfilter/slot/module.xml
+++ b/feature-pack/embedded-query/src/main/resources/modules/org/infinispan/objectfilter/slot/module.xml
@@ -7,8 +7,6 @@
 
    <dependencies>
       <module name="org.infinispan.query.dsl" slot="@infinispan.module.slot@"/>
-      <!-- TODO [anistor] We still need antlr-runtime because RecognitionException is used by the logger -->
-      <module name="org.antlr.antlr-runtime" slot="@infinispan.module.slot@"/>
       <module name="org.infinispan.protostream" slot="@infinispan.module.slot@"/>
       <module name="org.jboss.logging" slot="@infinispan.module.slot@"/>
    </dependencies>

--- a/object-filter/pom.xml
+++ b/object-filter/pom.xml
@@ -40,6 +40,8 @@
       <dependency>
          <groupId>org.antlr</groupId>
          <artifactId>antlr-runtime</artifactId>
+         <!--  This gets shaded, so we mark it optional in order not to propagate this dependency any further -->
+         <optional>true</optional>
       </dependency>
 
       <dependency>
@@ -54,11 +56,6 @@
          <scope>test</scope>
       </dependency>
    </dependencies>
-
-   <properties>
-      <intermediary_jar_name>intermediary-${project.build.finalName}</intermediary_jar_name>
-      <intermediary_jar_path>${project.build.directory}/${intermediary_jar_name}.jar</intermediary_jar_path>
-   </properties>
 
    <build>
       <plugins>
@@ -115,19 +112,21 @@
                      <goal>shade</goal>
                   </goals>
                   <configuration>
-                     <finalName>${intermediary_jar_name}</finalName>
+                     <finalName>${project.artifactId}-${project.version}</finalName>
                      <minimizeJar>true</minimizeJar>
                      <artifactSet>
                         <excludes>
                            <exclude>net.jcip:jcip-annotations:jar:</exclude>
                            <exclude>log4j:log4j:jar:</exclude>
                            <exclude>org.jboss.logging:jboss-logging:jar:</exclude>
+                           <exclude>org.infinispan:infinispan-query-dsl:jar:</exclude>
+                           <exclude>org.infinispan.protostream:protostream:jar:</exclude>
                         </excludes>
                      </artifactSet>
                      <relocations>
                         <relocation>
                            <pattern>org.antlr.runtime</pattern>
-                           <shadedPattern>org.infinipan.objectfilter.impl.antlr.runtime</shadedPattern>
+                           <shadedPattern>org.infinispan.objectfilter.impl.antlr.runtime</shadedPattern>
                         </relocation>
                      </relocations>
                   </configuration>

--- a/object-filter/src/main/java/org/infinispan/objectfilter/impl/logging/Log.java
+++ b/object-filter/src/main/java/org/infinispan/objectfilter/impl/logging/Log.java
@@ -2,7 +2,6 @@ package org.infinispan.objectfilter.impl.logging;
 
 import java.util.List;
 
-import org.antlr.runtime.RecognitionException;
 import org.infinispan.objectfilter.ParsingException;
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.annotations.Cause;
@@ -92,7 +91,7 @@ public interface Log extends BasicLogger {
    ParsingException getLeftSideMustBeAPropertyPath();
 
    @Message(id = 28525, value = "Invalid query: %s")
-   ParsingException getQuerySyntaxException(String query, @Cause RecognitionException cause);
+   ParsingException getQuerySyntaxException(String query, @Cause Throwable cause);
 
    @Message(id = 28526, value = "Invalid query: %s; Parser error messages: %s.")
    ParsingException getQuerySyntaxException(String query, List<?> parserErrorMessages);
@@ -102,5 +101,4 @@ public interface Log extends BasicLogger {
 
    @Message(id = 28528, value = "Error parsing content. Data not stored as protobuf?")
    ParsingException errorParsingProtobuf(@Cause Exception e);
-
 }


### PR DESCRIPTION
…gger interface of object-filter

* ensure ANTLR is properly shaded and mark it optional so users no longer need to depend on it
* now ANTLR runtime can be removed as a dependency from module.xml

https://issues.jboss.org/browse/ISPN-10532