### PR TITLE
[9.4.x] ISPN-9599 Fix RestServer startup with security enabled

### DIFF
--- a/server/core/src/main/java/org/infinispan/server/core/AbstractProtocolServer.java
+++ b/server/core/src/main/java/org/infinispan/server/core/AbstractProtocolServer.java
@@ -138,7 +138,7 @@ public abstract class AbstractProtocolServer<A extends ProtocolServerConfigurati
    };
 
    protected void registerServerMBeans() {
-      GlobalConfiguration globalCfg = cacheManager.getCacheManagerConfiguration();
+      GlobalConfiguration globalCfg = SecurityActions.getCacheManagerConfiguration(cacheManager);
       GlobalJmxStatisticsConfiguration jmxConfig = globalCfg.globalJmxStatistics();
       mbeanServer = JmxUtil.lookupMBeanServer(jmxConfig.mbeanServerLookup(), jmxConfig.properties());
       String groupName = String.format("type=Server,name=%s", getQualifiedName());

--- a/server/core/src/main/java/org/infinispan/server/core/SecurityActions.java
+++ b/server/core/src/main/java/org/infinispan/server/core/SecurityActions.java
@@ -3,9 +3,11 @@ package org.infinispan.server.core;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
+import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.factories.GlobalComponentRegistry;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.security.Security;
+import org.infinispan.security.actions.GetCacheManagerConfigurationAction;
 import org.infinispan.security.actions.GetGlobalComponentRegistryAction;
 
 /**
@@ -27,5 +29,9 @@ final class SecurityActions {
 
    static GlobalComponentRegistry getGlobalComponentRegistry(EmbeddedCacheManager cacheManager) {
       return doPrivileged(new GetGlobalComponentRegistryAction(cacheManager));
+   }
+
+   public static GlobalConfiguration getCacheManagerConfiguration(EmbeddedCacheManager cacheManager) {
+      return doPrivileged(new GetCacheManagerConfigurationAction(cacheManager));
    }
 }

--- a/server/rest/src/main/java/org/infinispan/rest/cachemanager/RestCacheManager.java
+++ b/server/rest/src/main/java/org/infinispan/rest/cachemanager/RestCacheManager.java
@@ -47,7 +47,7 @@ public class RestCacheManager<V> {
       this.instance = instance;
       this.isCacheIgnored = isCacheIgnored;
       this.icr = SecurityActions.getGlobalComponentRegistry(instance).getComponent(InternalCacheRegistry.class);
-      this.allowInternalCacheAccess = instance.getCacheManagerConfiguration().security().authorization().enabled();
+      this.allowInternalCacheAccess = SecurityActions.getCacheManagerConfiguration(instance).security().authorization().enabled();
       removeCacheListener = new RemoveCacheListener();
       SecurityActions.addListener(instance, removeCacheListener);
    }

--- a/server/rest/src/main/java/org/infinispan/rest/cachemanager/SecurityActions.java
+++ b/server/rest/src/main/java/org/infinispan/rest/cachemanager/SecurityActions.java
@@ -6,6 +6,7 @@ import java.security.PrivilegedAction;
 import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
 import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.factories.ComponentRegistry;
@@ -18,6 +19,7 @@ import org.infinispan.security.actions.GetCacheComponentRegistryAction;
 import org.infinispan.security.actions.GetCacheConfigurationAction;
 import org.infinispan.security.actions.GetCacheDistributionManagerAction;
 import org.infinispan.security.actions.GetCacheEntryAction;
+import org.infinispan.security.actions.GetCacheManagerConfigurationAction;
 import org.infinispan.security.actions.GetGlobalComponentRegistryAction;
 import org.infinispan.security.actions.RemoveListenerAction;
 
@@ -67,5 +69,9 @@ final class SecurityActions {
    }
    static GlobalComponentRegistry getGlobalComponentRegistry(EmbeddedCacheManager cacheManager) {
       return doPrivileged(new GetGlobalComponentRegistryAction(cacheManager));
+   }
+
+   public static GlobalConfiguration getCacheManagerConfiguration(EmbeddedCacheManager cacheManager) {
+      return doPrivileged(new GetCacheManagerConfigurationAction(cacheManager));
    }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-9599

I forgot to backport these RestServer fixes to 9.4.x and RESTBasicSecurityIT is failing because of them.