### PR TITLE
ISPN-10586 - Use ServerNG in the testsuite

### DIFF
--- a/integrationtests/wildfly-modules/pom.xml
+++ b/integrationtests/wildfly-modules/pom.xml
@@ -14,8 +14,8 @@
    <description>Integration tests - Wildfly Module Integration Tests</description>
 
    <properties>
-      <ispnserver.project.dir>${basedir}/../../server/integration/build</ispnserver.project.dir>
-      <server.build.dist>${ispnserver.project.dir}/target/${infinispan.brand.prefix}-${wildfly.brand.prefix}-server-${infinispan.brand.version}</server.build.dist>
+      <ispnserver.project.dir>${basedir}/../../server/runtime</ispnserver.project.dir>
+      <server.build.dist>${ispnserver.project.dir}/target/${infinispan.brand.prefix}-server-${infinispan.brand.version}</server.build.dist>
       <ispnserver.dist>${basedir}/target/infinispan-server</ispnserver.dist>
       <resources.dir>${basedir}/src/test/resources</resources.dir>
       <serverMemoryJvmArgs>-Xmx300m ${testjvm.commonArgs}</serverMemoryJvmArgs>
@@ -327,13 +327,14 @@
                   <goals>
                      <goal>run</goal>
                   </goals>
-                  <phase>generate-resources</phase>
+                  <phase>package</phase>
                   <configuration>
                      <skip>${skipTests}</skip>
                      <target>
                         <ant antfile="${basedir}/../../server/integration/src/main/ant/infinispan-server.xml" target="create-distro">
                            <property name="server.build.dist" value="${server.build.dist}" />
                            <property name="server.dist" value="${ispnserver.dist}" />
+                           <property name="ispn.config.file" value="${project.build.testOutputDirectory}/infinispan-custom.xml" />
                         </ant>
                      </target>
                   </configuration>
@@ -353,10 +354,9 @@
                         <ant antfile="${basedir}/../../server/integration/src/main/ant/infinispan-server.xml" target="start-server">
                            <property name="server.dist" value="${ispnserver.dist}" />
                            <property name="port.offset" value="0" />
-                           <property name="management.port" value="9990" />
                            <property name="hotrod.port" value="11222" />
                            <property name="jboss.node.name" value="ispn-server" />
-                           <property name="jboss.config.file" value="standalone.xml" />
+                           <property name="jboss.config.file" value="infinispan-custom.xml" />
                         </ant>
                      </target>
                   </configuration>

--- a/integrationtests/wildfly-modules/src/test/resources/infinispan-custom.xml
+++ b/integrationtests/wildfly-modules/src/test/resources/infinispan-custom.xml
@@ -1,0 +1,52 @@
+<infinispan
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="urn:infinispan:config:10.0 http://www.infinispan.org/schemas/infinispan-config-10.0.xsd
+                            urn:infinispan:server:10.0 http://www.infinispan.org/schemas/infinispan-server-10.0.xsd"
+        xmlns="urn:infinispan:config:10.0"
+        xmlns:server="urn:infinispan:server:10.0">
+
+    <cache-container default-cache="default" statistics="true">
+        <transport cluster="${infinispan.cluster.name}" stack="${infinispan.cluster.stack:tcp}"/>
+        <global-state />
+        <local-cache name="default" />
+    </cache-container>
+
+    <server xmlns="urn:infinispan:server:10.0">
+        <interfaces>
+            <interface name="public">
+                <inet-address value="${infinispan.bind.address:127.0.0.1}"/>
+            </interface>
+        </interfaces>
+
+        <socket-bindings default-interface="public" port-offset="${infinispan.socket.binding.port-offset:0}">
+            <socket-binding name="default" port="${infinispan.bind.port:11222}"/>
+            <socket-binding name="memcached" port="11221"/>
+        </socket-bindings>
+
+        <security>
+            <security-realms>
+                <security-realm name="default">
+                    <!-- Uncomment to enable TLS on the realm -->
+                    <!-- server-identities>
+                       <ssl>
+                          <keystore path="application.keystore" relative-to="infinispan.server.config.path"
+                                    keystore-password="password" alias="server" key-password="password"
+                                    generate-self-signed-certificate-host="localhost"/>
+                       </ssl>
+                    </server-identities-->
+                    <properties-realm groups-attribute="Roles">
+                        <user-properties path="users.properties" relative-to="infinispan.server.config.path" plain-text="true"/>
+                        <group-properties path="groups.properties" relative-to="infinispan.server.config.path" />
+                    </properties-realm>
+                </security-realm>
+            </security-realms>
+        </security>
+
+        <endpoints socket-binding="default" security-realm="default">
+            <hotrod-connector name="hotrod"/>
+            <rest-connector name="rest"/>
+            <!-- Uncomment to enable the memcached connector -->
+            <!-- memcached-connector socket-binding="memcached" / -->
+        </endpoints>
+    </server>
+</infinispan>

--- a/jcache/tck-runner/pom.xml
+++ b/jcache/tck-runner/pom.xml
@@ -31,8 +31,8 @@
       <remote.CacheEntryImpl>org.infinispan.jcache.JCacheEntry</remote.CacheEntryImpl>
       <remote.CacheInvocationContextImpl>org.infinispan.jcache.annotation.CacheKeyInvocationContextImpl</remote.CacheInvocationContextImpl>
 
-      <ispnserver.project.dir>${basedir}/../../server/integration/build</ispnserver.project.dir>
-      <server.build.dist>${ispnserver.project.dir}/target/${infinispan.brand.prefix}-${wildfly.brand.prefix}-server-${infinispan.brand.version}</server.build.dist>
+      <ispnserver.project.dir>${basedir}/../../server/runtime</ispnserver.project.dir>
+      <server.build.dist>${ispnserver.project.dir}/target/${infinispan.brand.prefix}-server-${infinispan.brand.version}</server.build.dist>
       <ispnserver.dist>${basedir}/target/infinispan-server</ispnserver.dist>
       <server.dir.parent>${project.build.directory}</server.dir.parent>
       <server.dir.name>infinispan-${wildfly.brand.prefix}-server-${project.version}</server.dir.name>
@@ -175,10 +175,9 @@
                         <ant antfile="${basedir}/../../server/integration/src/main/ant/infinispan-server.xml" target="start-server">
                            <property name="server.dist" value="${ispnserver.dist}" />
                            <property name="port.offset" value="0" />
-                           <property name="management.port" value="9990" />
                            <property name="hotrod.port" value="11222" />
                            <property name="jboss.node.name" value="ispn-server" />
-                           <property name="jboss.config.file" value="standalone.xml" />
+                           <property name="jboss.config.file" value="infinispan.xml" />
                            <property name="server.jvm.args" value="${server.jvm.args}" />
                         </ant>
                      </target>

--- a/server/integration/src/main/ant/infinispan-server.xml
+++ b/server/integration/src/main/ant/infinispan-server.xml
@@ -16,6 +16,7 @@
         <copy todir="${server.dist}">
             <fileset dir="${server.build.dist}"/>
         </copy>
+        <copy file="${ispn.config.file}" todir="${server.dist}/server/conf" if:set="ispn.config.file" />
         <!-- It happens when you do not specify namespaces in the XSLT templates for the newly added nodes
              then the IBM jdk transformation is adding empty namespace there - not possible to influence this
              behaviour by any environmental property - this is a bit workaround for it -->
@@ -36,18 +37,18 @@
         <exec dir="${server.dist}/bin" executable="chmod" osfamily="unix">
             <arg value="+x"/>
             <arg value="../bin"/>
-            <arg value="standalone.sh"/>
+            <arg value="server.sh"/>
         </exec>
         <exec executable="sh" osfamily="unix" spawn="true">
             <arg value="-c"/>
-            <arg value="${server.dist}/bin/standalone.sh -c ${jboss.config.file} > ${server.dist}/console.log"/>
+            <arg value="${server.dist}/bin/server.sh -c ${jboss.config.file} > ${server.dist}/console.log"/>
             <env key="JAVA_OPTS" value="${server.jvm.args} -Djboss.socket.binding.port-offset=${port.offset} -Djboss.node.name=${jboss.node.name}"/>
             <env key="JBOSS_HOME" value="${server.dist}"/>
             <env key="JAVA" value="${server.jvm}/bin/java"/>
         </exec>
         <exec executable="cmd" osfamily="windows" spawn="true">
             <arg value="/c"/>
-            <arg value="${server.dist}/bin/standalone.bat -c ${jboss.config.file} > ${server.dist}/console.log"/>
+            <arg value="${server.dist}/bin/server.bat -c ${jboss.config.file} > ${server.dist}/console.log"/>
             <env key="JAVA_OPTS" value="${server.jvm.args} -Djboss.socket.binding.port-offset=${port.offset} -Djboss.node.name=${jboss.node.name}"/>
             <env key="JBOSS_HOME" value="${server.dist}"/>
             <env key="JAVA" value="${server.jvm}/bin/java"/>
@@ -56,7 +57,6 @@
         <echo>Waiting for Infinispan server to start</echo>
         <waitfor timeoutproperty="server.timeout" maxwait="30" maxwaitunit="second" checkevery="1" checkeveryunit="second">
             <and>
-                <socket server="127.0.0.1" port="${management.port}"/>
                 <socket server="127.0.0.1" port="${hotrod.port}"/>
             </and>
         </waitfor>
@@ -104,8 +104,7 @@
 
         <exec executable="bash" outputproperty="lsof.pid" resultproperty="lsof.result" failifexecutionfails="false" failonerror="false" osfamily="unix">
             <arg value="-c"/>
-            <!-- Sometimes the server opens the management port but not the hotrod port -->
-            <arg value="lsof -t -i TCP:${management.port} -i TCP:${hotrod.port}"/>
+            <arg value="lsof -t -i TCP:${hotrod.port}"/>
             <redirector>
                 <outputfilterchain>
                     <prefixlines prefix=" "/>


### PR DESCRIPTION
Replaced Infinispan Wildfly Server with ServerNG in JCache remote tests and WildFly modules integration tests.
For Wildfly modules integration tests added custom infinispan configuration file for defining default cache as it is used by tests.
