### PR TITLE
ISPN-10589 REST Resources allow for ambiguous paths

### DIFF
--- a/documentation/src/main/asciidoc/topics/rest_api_v2.adoc
+++ b/documentation/src/main/asciidoc/topics/rest_api_v2.adoc
@@ -298,6 +298,16 @@ request with the `?action=size` parameter:
 include::rest_examples/get_v2_size.adoc[]
 ----
 
+[[rest_v2_cache_stats]]
+=== Getting Cache Statistics
+
+To obtain runtime statistics of a cache invoke a `GET` request:
+
+[source,options="nowrap",subs=attributes+]
+----
+include::rest_examples/get_v2_stats.adoc[]
+----
+
 [[rest_v2_query_cache]]
 === Querying Caches
 

--- a/documentation/src/main/asciidoc/topics/rest_examples/get_v2_configuration.adoc
+++ b/documentation/src/main/asciidoc/topics/rest_examples/get_v2_configuration.adoc
@@ -1,1 +1,1 @@
-GET /rest/v2/configurations/{name}
+GET /rest/v2/caches/{name}?action=config

--- a/documentation/src/main/asciidoc/topics/rest_examples/get_v2_stats.adoc
+++ b/documentation/src/main/asciidoc/topics/rest_examples/get_v2_stats.adoc
@@ -1,0 +1,1 @@
+GET /rest/v2/caches/{cacheName}?action=stats

--- a/server/rest/src/main/java/org/infinispan/rest/InvocationHelper.java
+++ b/server/rest/src/main/java/org/infinispan/rest/InvocationHelper.java
@@ -81,4 +81,8 @@ public class InvocationHelper {
    public void stop() {
       scheduledExecutor.shutdown();
    }
+
+   public String getContext() {
+      return configuration.contextPath();
+   }
 }

--- a/server/rest/src/main/java/org/infinispan/rest/RestRequestHandler.java
+++ b/server/rest/src/main/java/org/infinispan/rest/RestRequestHandler.java
@@ -2,7 +2,6 @@ package org.infinispan.rest;
 
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
-import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static io.netty.handler.codec.http.HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE;
 import static io.netty.handler.codec.http.HttpResponseStatus.UNAUTHORIZED;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
@@ -77,9 +76,6 @@ public class RestRequestHandler extends BaseHttpRequestHandler {
          return;
       }
 
-      if (!restRequest.getContext().equals(this.context)) {
-         sendResponse(ctx, request, new NettyRestResponse.Builder().status(NOT_FOUND).build());
-      }
 
       LookupResult invocationLookup = restServer.getRestDispatcher().lookupInvocation(restRequest);
 

--- a/server/rest/src/main/java/org/infinispan/rest/RestServer.java
+++ b/server/rest/src/main/java/org/infinispan/rest/RestServer.java
@@ -106,19 +106,20 @@ public class RestServer extends AbstractProtocolServer<RestServerConfiguration> 
             (EmbeddedCounterManager) EmbeddedCounterManagerFactory.asCounterManager(cacheManager),
             configuration, server, getExecutor());
 
-      ResourceManager resourceManager = new ResourceManagerImpl(configuration.contextPath());
-
-      resourceManager.registerResource(new CacheResource(invocationHelper));
-      resourceManager.registerResource(new CacheResourceV2(invocationHelper));
-      resourceManager.registerResource(new SplashResource());
-      resourceManager.registerResource(new CounterResource(invocationHelper));
-      resourceManager.registerResource(new CacheManagerResource(invocationHelper));
+      String restContext = configuration.contextPath();
+      String staticContext = "/";
+      ResourceManager resourceManager = new ResourceManagerImpl();
+      resourceManager.registerResource(staticContext, new SplashResource());
+      resourceManager.registerResource(restContext, new CacheResource(invocationHelper));
+      resourceManager.registerResource(restContext, new CacheResourceV2(invocationHelper));
+      resourceManager.registerResource(restContext, new CounterResource(invocationHelper));
+      resourceManager.registerResource(restContext, new CacheManagerResource(invocationHelper));
       Path staticResources = configuration.staticResources();
       if (staticResources != null) {
-         resourceManager.registerResource(new StaticFileResource(staticResources, "static"));
+         resourceManager.registerResource(staticContext, new StaticFileResource(staticResources, "static"));
       }
       if (server != null) {
-         resourceManager.registerResource(new ServerResource(invocationHelper));
+         resourceManager.registerResource(restContext, new ServerResource(invocationHelper));
       }
       this.restDispatcher = new RestDispatcherImpl(resourceManager);
    }

--- a/server/rest/src/main/java/org/infinispan/rest/framework/ResourceManager.java
+++ b/server/rest/src/main/java/org/infinispan/rest/framework/ResourceManager.java
@@ -7,7 +7,7 @@ package org.infinispan.rest.framework;
  */
 public interface ResourceManager {
 
-   void registerResource(ResourceHandler handler) throws RegistrationException;
+   void registerResource(String context, ResourceHandler handler) throws RegistrationException;
 
    LookupResult lookupResource(Method method, String path, String action);
 

--- a/server/rest/src/main/java/org/infinispan/rest/framework/impl/InvocationImpl.java
+++ b/server/rest/src/main/java/org/infinispan/rest/framework/impl/InvocationImpl.java
@@ -123,4 +123,15 @@ public class InvocationImpl implements Invocation {
       }
    }
 
+   @Override
+   public String toString() {
+      return "InvocationImpl{" +
+            "methods=" + methods +
+            ", paths=" + paths +
+            ", handler=" + handler +
+            ", action='" + action + '\'' +
+            ", name='" + name + '\'' +
+            ", anonymous=" + anonymous +
+            '}';
+   }
 }

--- a/server/rest/src/main/java/org/infinispan/rest/logging/Log.java
+++ b/server/rest/src/main/java/org/infinispan/rest/logging/Log.java
@@ -7,6 +7,7 @@ import static org.jboss.logging.Logger.Level.WARN;
 import org.infinispan.commons.CacheConfigurationException;
 import org.infinispan.commons.dataconversion.EncodingException;
 import org.infinispan.rest.cachemanager.exceptions.CacheUnavailableException;
+import org.infinispan.rest.framework.Invocation;
 import org.infinispan.rest.framework.Method;
 import org.infinispan.rest.framework.RegistrationException;
 import org.infinispan.rest.operations.exceptions.NoCacheFoundException;
@@ -67,7 +68,7 @@ public interface Log extends BasicLogger {
    CacheConfigurationException illegalCompressionLevel(int compressionLevel);
 
    @Message(value = "Cannot register invocation '%s': resource already registered for method '%s' at the destination path '/%s'", id = 12015)
-   RegistrationException duplicateResource(String invocationName, Method method, String existingPath);
+   RegistrationException duplicateResourceMethod(String invocationName, Method method, String existingPath);
 
    @LogMessage(level = WARN)
    @Message(value = "Header '%s' will be ignored, expecting a number but got '%s'", id = 12016)
@@ -78,4 +79,7 @@ public interface Log extends BasicLogger {
 
    @Message(value = "Cannot register invocation with path '%s': '*' is only allowed at the end", id = 12018)
    RegistrationException invalidPath(String path);
+
+   @Message(value = "Cannot register path '%s' for invocation '%s', since it conflicts with already registered path '%s'", id = 12019)
+   RegistrationException duplicateResource(String candidate, Invocation invocation, String existingPath);
 }

--- a/server/rest/src/main/java/org/infinispan/rest/resources/CacheResourceV2.java
+++ b/server/rest/src/main/java/org/infinispan/rest/resources/CacheResourceV2.java
@@ -51,8 +51,8 @@ public class CacheResourceV2 extends CacheResource {
             .invocation().method(DELETE).path("/v2/caches/{cacheName}/{cacheKey}").handleWith(this::deleteCacheValue)
 
             // Info and statistics
-            .invocation().methods(GET, HEAD).path("/v2/caches/{cacheName}/config").handleWith(this::getCacheConfig)
-            .invocation().methods(GET).path("/v2/caches/{cacheName}/stats").handleWith(this::getCacheStats)
+            .invocation().methods(GET, HEAD).path("/v2/caches/{cacheName}").withAction("config").handleWith(this::getCacheConfig)
+            .invocation().methods(GET).path("/v2/caches/{cacheName}").withAction("stats").handleWith(this::getCacheStats)
 
             // Cache lifecycle
             .invocation().methods(POST).path("/v2/caches/{cacheName}").handleWith(this::createCache)

--- a/server/rest/src/main/resources/index.html
+++ b/server/rest/src/main/resources/index.html
@@ -7,13 +7,13 @@
     <meta content="noindex" name="robots"/>
     <meta content="no-cache" http-equiv="cache-control"/>
     <meta content="no-cache" http-equiv="pragma"/>
-    <link href="rest/favicon.png" rel="Shortcut Icon"/>
-    <link href="rest/css.css" rel="stylesheet"/>
+    <link href="favicon.png" rel="Shortcut Icon"/>
+    <link href="css.css" rel="stylesheet"/>
     <title>Infinispan Server</title>
 </head>
 <body>
 <p align="center">
-    <a href="https://www.infinispan.org"><img src="rest/banner.png" border="0"/></a>
+    <a href="https://www.infinispan.org"><img src="banner.png" border="0"/></a>
 </p>
 <div class="main">
     <h1>Welcome to Infinispan Server</h1>

--- a/server/rest/src/test/java/org/infinispan/rest/framework/RestDispatcherTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/framework/RestDispatcherTest.java
@@ -29,20 +29,24 @@ public class RestDispatcherTest {
 
    @Test
    public void testDispatch() {
-      ResourceManagerImpl manager = new ResourceManagerImpl("ctx");
-      manager.registerResource(new RootResource());
-      manager.registerResource(new CounterResource());
-      manager.registerResource(new MemoryResource());
-      manager.registerResource(new EchoResource());
-      manager.registerResource(new FileResource());
+      ResourceManagerImpl manager = new ResourceManagerImpl();
+      manager.registerResource("/", new RootResource());
+      manager.registerResource("ctx", new CounterResource());
+      manager.registerResource("ctx", new MemoryResource());
+      manager.registerResource("ctx", new EchoResource());
+      manager.registerResource("ctx", new FileResource());
 
       RestDispatcherImpl restDispatcher = new RestDispatcherImpl(manager);
 
-      RestRequest restRequest = new SimpleRequest.Builder().setMethod(GET).setPath("/ctx/").build();
+      RestRequest restRequest = new SimpleRequest.Builder().setMethod(GET).setPath("/").build();
       CompletionStage<RestResponse> response = restDispatcher.dispatch(restRequest);
       assertEquals("Hello World!", join(response).getEntity().toString());
 
-      restRequest = new SimpleRequest.Builder().setMethod(POST).setPath("/ctx/counters/counter1").build();
+      restRequest = new SimpleRequest.Builder().setMethod(GET).setPath("/image.gif").build();
+      response = restDispatcher.dispatch(restRequest);
+      assertEquals("Hello World!", join(response).getEntity().toString());
+
+      restRequest = new SimpleRequest.Builder().setMethod(POST).setPath("//ctx/counters/counter1").build();
       response = restDispatcher.dispatch(restRequest);
       assertEquals(200, join(response).getStatus());
 
@@ -50,7 +54,7 @@ public class RestDispatcherTest {
       response = restDispatcher.dispatch(restRequest);
       assertEquals(200, join(response).getStatus());
 
-      restRequest = new SimpleRequest.Builder().setMethod(GET).setPath("/ctx/counters/counter1").build();
+      restRequest = new SimpleRequest.Builder().setMethod(GET).setPath("/ctx/counters//counter1").build();
       response = restDispatcher.dispatch(restRequest);
       assertEquals("counter1->1", join(response).getEntity().toString());
 
@@ -200,7 +204,7 @@ public class RestDispatcherTest {
       @Override
       public Invocations getInvocations() {
          return new Invocations.Builder()
-               .invocation().method(GET).path("/").handleWith(this::serveStaticResource)
+               .invocation().method(GET).path("/").path("/image.gif").handleWith(this::serveStaticResource)
                .create();
       }
 

--- a/server/rest/src/test/java/org/infinispan/rest/resources/BaseCacheResourceTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/resources/BaseCacheResourceTest.java
@@ -747,7 +747,7 @@ public abstract class BaseCacheResourceTest extends AbstractRestResourceTest {
    public void shouldServeHtmlFile() throws Exception {
       //when
       ContentResponse response = client
-            .newRequest(String.format("http://localhost:%d/rest", restServer().getPort()))
+            .newRequest(String.format("http://localhost:%d/", restServer().getPort()))
             .method(HttpMethod.GET)
             .send();
 
@@ -761,7 +761,7 @@ public abstract class BaseCacheResourceTest extends AbstractRestResourceTest {
    public void shouldServeBannerFile() throws Exception {
       //when
       ContentResponse response = client
-            .newRequest(String.format("http://localhost:%d/rest/banner.png", restServer().getPort()))
+            .newRequest(String.format("http://localhost:%d/banner.png", restServer().getPort()))
             .method(HttpMethod.GET)
             .send();
 

--- a/server/rest/src/test/java/org/infinispan/rest/resources/CacheV2ResourceTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/resources/CacheV2ResourceTest.java
@@ -66,13 +66,13 @@ public class CacheV2ResourceTest extends AbstractRestResourceTest {
             .method(HttpMethod.POST).content(new StringContentProvider(json)).send();
       ResponseAssertion.assertThat(response).isOk();
 
-      response = client.newRequest(url + "cache1/config").method(HttpMethod.GET).send();
+      response = client.newRequest(url + "cache1?action=config").method(HttpMethod.GET).send();
       ResponseAssertion.assertThat(response).isOk();
       ResponseAssertion.assertThat(response).bodyNotEmpty();
       String cache1Cfg = response.getContentAsString();
 
 
-      response = client.newRequest(url + "cache2/config").method(HttpMethod.GET).send();
+      response = client.newRequest(url + "cache2?action=config").method(HttpMethod.GET).send();
       ResponseAssertion.assertThat(response).isOk();
       ResponseAssertion.assertThat(response).bodyNotEmpty();
       String cache2Cfg = response.getContentAsString();
@@ -82,7 +82,7 @@ public class CacheV2ResourceTest extends AbstractRestResourceTest {
       response = client.newRequest(url + "cache1").method(HttpMethod.DELETE).send();
       ResponseAssertion.assertThat(response).isOk();
 
-      response = client.newRequest(url + "cache1/config").method(HttpMethod.GET).send();
+      response = client.newRequest(url + "cache1?action=config").method(HttpMethod.GET).send();
       ResponseAssertion.assertThat(response).isNotFound();
    }
 
@@ -103,7 +103,7 @@ public class CacheV2ResourceTest extends AbstractRestResourceTest {
       putStringValueInCache("statCache", "key1", "data");
       putStringValueInCache("statCache", "key2", "data");
 
-      response = client.newRequest(cacheURL + "/stats").send();
+      response = client.newRequest(cacheURL + "?action=stats").send();
       ResponseAssertion.assertThat(response).isOk();
 
       JsonNode jsonNode = objectMapper.readTree(response.getContent());
@@ -112,7 +112,7 @@ public class CacheV2ResourceTest extends AbstractRestResourceTest {
 
       response = client.newRequest(cacheURL + "?action=clear").send();
       ResponseAssertion.assertThat(response).isOk();
-      response = client.newRequest(cacheURL + "/stats").send();
+      response = client.newRequest(cacheURL + "?action=stats").send();
       ResponseAssertion.assertThat(response).isOk();
       assertEquals(objectMapper.readTree(response.getContent()).get("currentNumberOfEntries").asInt(), 0);
    }

--- a/server/rest/src/test/java/org/infinispan/rest/resources/StaticResourceTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/resources/StaticResourceTest.java
@@ -32,7 +32,7 @@ public class StaticResourceTest extends AbstractRestResourceTest {
    }
 
    private ContentResponse call(String path) throws InterruptedException, ExecutionException, TimeoutException {
-      String url = String.format("http://localhost:%d/rest/static/%s", restServer().getPort(), path);
+      String url = String.format("http://localhost:%d/static%s", restServer().getPort(), path);
       client.getContentDecoderFactories().clear();
       return client.newRequest(url).method(GET).send();
    }
@@ -45,13 +45,13 @@ public class StaticResourceTest extends AbstractRestResourceTest {
       response = call("");
       assertResponse(response, "index.html", "<h1>Hello</h1>", TEXT_HTML);
 
-      response = call("index.html");
+      response = call("/index.html");
       assertResponse(response, "index.html", "<h1>Hello</h1>", TEXT_HTML);
 
-      response = call("xml/file.xml");
+      response = call("/xml/file.xml");
       assertResponse(response, "xml/file.xml", "<distributed-cache", MediaType.fromString("text/xml"), APPLICATION_XML);
 
-      response = call("other/text/file.txt");
+      response = call("/other/text/file.txt");
       assertResponse(response, "other/text/file.txt", "This is a text file", TEXT_PLAIN);
    }
 
@@ -76,7 +76,7 @@ public class StaticResourceTest extends AbstractRestResourceTest {
    @Test
    public void testCacheHeaders() throws InterruptedException, ExecutionException, TimeoutException {
       ContentResponse response;
-      String url = String.format("http://localhost:%d/rest/static/index.html", restServer().getPort());
+      String url = String.format("http://localhost:%d/static/index.html", restServer().getPort());
       long lastModified = getTestFile("static-test/index.html").lastModified();
 
       response = client.newRequest(url).method(GET).header("If-Modified-Since", DateUtils.toRFC1123(lastModified)).send();


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-10589

* Improved validation during registration of REST resources to detect ambiguous paths
* Fixed path errors: cache stats/config conflicting with operations involving keys and splash screen conflicting with rest v1 API
* Moved Splash screen and static resources from ```/rest``` to ```/```
