### PR TITLE
ISPN-10624 Documentation Global security authorization should be enabled

### DIFF
--- a/documentation/src/main/asciidoc/user_guide/security.adoc
+++ b/documentation/src/main/asciidoc/user_guide/security.adoc
@@ -101,7 +101,7 @@ There are two levels of configuration: global and per-cache. The global configur
   GlobalConfigurationBuilder global = new GlobalConfigurationBuilder();
   global
      .security()
-        .authorization()
+        .authorization().enable()
            .principalRoleMapper(new IdentityRoleMapper())
            .role("admin")
               .permission(AuthorizationPermission.ALL)


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-10624
Documentation Global security authorization should be enabled if cache authorization enabled