### PR TITLE
ISPN-10624 Documentation Global security authorization should be enabled

### DIFF
--- a/documentation/src/main/asciidoc/topics/security.adoc
+++ b/documentation/src/main/asciidoc/topics/security.adoc
@@ -99,7 +99,7 @@ There are two levels of configuration: global and per-cache. The global configur
   GlobalConfigurationBuilder global = new GlobalConfigurationBuilder();
   global
      .security()
-        .authorization()
+        .authorization().enable()
            .principalRoleMapper(new IdentityRoleMapper())
            .role("admin")
               .permission(AuthorizationPermission.ALL)


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-10624
ISPN-10624 Documentation Global security authorization should be enabled if cache authorization enabled