### PR TITLE
[9.4] ISPN-9599 DefaultCacheManager.getGlobalComponentRegistry should require ADMIN permission

### DIFF
--- a/core/src/test/java/org/infinispan/security/BaseAuthorizationTest.java
+++ b/core/src/test/java/org/infinispan/security/BaseAuthorizationTest.java
@@ -1,0 +1,85 @@
+package org.infinispan.security;
+
+import java.security.PrivilegedAction;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.security.auth.Subject;
+
+import org.infinispan.configuration.cache.AuthorizationConfigurationBuilder;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalAuthorizationConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.security.impl.IdentityRoleMapper;
+import org.infinispan.test.SingleCacheManagerTest;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.transaction.LockingMode;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
+public abstract class BaseAuthorizationTest extends SingleCacheManagerTest {
+
+   static final Log log = LogFactory.getLog(CacheAuthorizationTest.class);
+   static final Subject ADMIN;
+   static final Map<AuthorizationPermission, Subject> SUBJECTS;
+
+   static {
+      // Initialize one subject per permission
+      SUBJECTS = new HashMap<>(AuthorizationPermission.values().length);
+      for (AuthorizationPermission perm : AuthorizationPermission.values()) {
+         SUBJECTS.put(perm, TestingUtil.makeSubject(perm.toString() + "_user", perm.toString()));
+      }
+      ADMIN = SUBJECTS.get(AuthorizationPermission.ALL);
+   }
+
+   @Override
+   protected EmbeddedCacheManager createCacheManager() throws Exception {
+      final GlobalConfigurationBuilder global = new GlobalConfigurationBuilder();
+      GlobalAuthorizationConfigurationBuilder globalRoles = global.security().authorization().enable()
+            .principalRoleMapper(new IdentityRoleMapper());
+      final ConfigurationBuilder config = TestCacheManagerFactory.getDefaultCacheConfiguration(true);
+      config.transaction().lockingMode(LockingMode.PESSIMISTIC);
+      config.invocationBatching().enable();
+      AuthorizationConfigurationBuilder authConfig = config.security().authorization().enable();
+
+      for (AuthorizationPermission perm : AuthorizationPermission.values()) {
+         globalRoles.role(perm.toString()).permission(perm);
+         authConfig.role(perm.toString());
+      }
+      return Security.doAs(ADMIN, new PrivilegedAction<EmbeddedCacheManager>() {
+         @Override
+         public EmbeddedCacheManager run() {
+            return TestCacheManagerFactory.createCacheManager(global, config);
+         }
+      });
+   }
+
+   @Override
+   protected void setup() throws Exception {
+      cacheManager = createCacheManager();
+   }
+
+   @Override
+   protected void teardown() {
+      Security.doAs(ADMIN, new PrivilegedAction<Void>() {
+         @Override
+         public Void run() {
+            BaseAuthorizationTest.super.teardown();
+            return null;
+         }
+      });
+   }
+
+   @Override
+   protected void clearContent() {
+      Security.doAs(ADMIN, new PrivilegedAction<Void>() {
+         @Override
+         public Void run() {
+            cacheManager.getCache().clear();
+            return null;
+         }
+      });
+   }
+}

--- a/core/src/test/java/org/infinispan/security/CacheAuthorizationTest.java
+++ b/core/src/test/java/org/infinispan/security/CacheAuthorizationTest.java
@@ -4,92 +4,15 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.security.PrivilegedAction;
 import java.security.PrivilegedExceptionAction;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
-
-import javax.security.auth.Subject;
 
 import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
-import org.infinispan.configuration.cache.AuthorizationConfigurationBuilder;
-import org.infinispan.configuration.cache.ConfigurationBuilder;
-import org.infinispan.configuration.global.GlobalAuthorizationConfigurationBuilder;
-import org.infinispan.configuration.global.GlobalConfigurationBuilder;
-import org.infinispan.manager.EmbeddedCacheManager;
-import org.infinispan.security.impl.IdentityRoleMapper;
-import org.infinispan.test.SingleCacheManagerTest;
-import org.infinispan.test.TestingUtil;
-import org.infinispan.test.fwk.TestCacheManagerFactory;
-import org.infinispan.transaction.LockingMode;
-import org.infinispan.util.logging.Log;
-import org.infinispan.util.logging.LogFactory;
 import org.testng.annotations.Test;
 
 @Test(groups = {"functional", "smoke"}, testName = "security.CacheAuthorizationTest")
-public class CacheAuthorizationTest extends SingleCacheManagerTest {
-   static final Log log = LogFactory.getLog(CacheAuthorizationTest.class);
-   static final Subject ADMIN;
-   static final Map<AuthorizationPermission, Subject> SUBJECTS;
-
-   static {
-      // Initialize one subject per permission
-      SUBJECTS = new HashMap<>(AuthorizationPermission.values().length);
-      for (AuthorizationPermission perm : AuthorizationPermission.values()) {
-         SUBJECTS.put(perm, TestingUtil.makeSubject(perm.toString() + "_user", perm.toString()));
-      }
-      ADMIN = SUBJECTS.get(AuthorizationPermission.ALL);
-   }
-
-   @Override
-   protected EmbeddedCacheManager createCacheManager() throws Exception {
-      final GlobalConfigurationBuilder global = new GlobalConfigurationBuilder();
-      GlobalAuthorizationConfigurationBuilder globalRoles = global.security().authorization().enable()
-            .principalRoleMapper(new IdentityRoleMapper());
-      final ConfigurationBuilder config = TestCacheManagerFactory.getDefaultCacheConfiguration(true);
-      config.transaction().lockingMode(LockingMode.PESSIMISTIC);
-      config.invocationBatching().enable();
-      AuthorizationConfigurationBuilder authConfig = config.security().authorization().enable();
-
-      for (AuthorizationPermission perm : AuthorizationPermission.values()) {
-         globalRoles.role(perm.toString()).permission(perm);
-         authConfig.role(perm.toString());
-      }
-      return Security.doAs(ADMIN, new PrivilegedAction<EmbeddedCacheManager>() {
-         @Override
-         public EmbeddedCacheManager run() {
-            return TestCacheManagerFactory.createCacheManager(global, config);
-         }
-      });
-   }
-
-   @Override
-   protected void setup() throws Exception {
-      cacheManager = createCacheManager();
-   }
-
-   @Override
-   protected void teardown() {
-      Security.doAs(ADMIN, new PrivilegedAction<Void>() {
-         @Override
-         public Void run() {
-            CacheAuthorizationTest.super.teardown();
-            return null;
-         }
-      });
-   }
-
-   @Override
-   protected void clearContent() {
-      Security.doAs(ADMIN, new PrivilegedAction<Void>() {
-         @Override
-         public Void run() {
-            cacheManager.getCache().clear();
-            return null;
-         }
-      });
-   }
+public class CacheAuthorizationTest extends BaseAuthorizationTest {
 
    public void testAllCombinations() throws Exception {
       Method[] allMethods = SecureCache.class.getMethods();

--- a/core/src/test/java/org/infinispan/security/CacheManagerAuthorizationTest.java
+++ b/core/src/test/java/org/infinispan/security/CacheManagerAuthorizationTest.java
@@ -1,0 +1,42 @@
+package org.infinispan.security;
+
+import static org.testng.Assert.assertTrue;
+
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.security.auth.Subject;
+
+import org.infinispan.test.Exceptions;
+import org.testng.annotations.Test;
+
+@Test(groups = {"functional", "smoke"}, testName = "security.CacheManagerAuthorizationTest")
+public class CacheManagerAuthorizationTest extends BaseAuthorizationTest {
+
+   public void testAdminCombinations() throws Exception {
+      List<Runnable> calls = Arrays.asList(
+            () -> cacheManager.getGlobalComponentRegistry(),
+            () -> cacheManager.getCacheManagerConfiguration());
+
+      for (final AuthorizationPermission perm : AuthorizationPermission.values()) {
+         for (Runnable fn : calls) {
+
+            PrivilegedExceptionAction<Boolean> action = () -> {
+               fn.run();
+               return true;
+            };
+
+            // only admin must work
+            Subject subject = SUBJECTS.get(perm);
+            if (perm.implies(AuthorizationPermission.ADMIN)) {
+               assertTrue(Security.doAs(subject, action));
+            } else {
+               Exceptions.expectException(PrivilegedActionException.class, SecurityException.class,
+                     () -> Security.doAs(subject, action));
+            }
+         }
+      }
+   }
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-9599
ISPN-9599 DefaultCacheManager.getGlobalComponentRegistry should require ADMIN permission