### PR TITLE
ISPN-10310 State provider should not block while sending state

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/cache/Configurations.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/Configurations.java
@@ -95,6 +95,10 @@ public class Configurations {
       return globalConfiguration.transport().transport() != null;
    }
 
+   public static boolean isStateTransferStore(StoreConfiguration storeConfiguration) {
+      return !storeConfiguration.shared() && storeConfiguration.fetchPersistentState();
+   }
+
    static Set<Class<? extends StoreConfigurationBuilder<?, ?>>> lookupPersistenceBuilders() {
       Collection<ConfigurationParser> parsers = ServiceFinder.load(ConfigurationParser.class, Configurations.class.getClassLoader(), ParserRegistry.class.getClassLoader());
       Set<Class<? extends StoreConfigurationBuilder<?, ?>>> builders = new HashSet<>();

--- a/core/src/main/java/org/infinispan/configuration/cache/StateTransferConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/StateTransferConfigurationBuilder.java
@@ -96,7 +96,7 @@ public class StateTransferConfigurationBuilder extends
    public void validate() {
       int chunkSize = attributes.attribute(CHUNK_SIZE).get();
       if (chunkSize <= 0) {
-         throw log.invalidChunkSize(chunkSize);
+         throw CONFIG.invalidChunkSize(chunkSize);
       }
 
       if (clustering().cacheMode().isInvalidation()) {

--- a/core/src/main/java/org/infinispan/configuration/cache/StateTransferConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/StateTransferConfigurationBuilder.java
@@ -8,7 +8,6 @@ import static org.infinispan.util.logging.Log.CONFIG;
 
 import java.util.concurrent.TimeUnit;
 
-import org.infinispan.commons.CacheConfigurationException;
 import org.infinispan.commons.configuration.Builder;
 import org.infinispan.commons.configuration.ConfigurationBuilderInfo;
 import org.infinispan.commons.configuration.attributes.Attribute;
@@ -95,8 +94,9 @@ public class StateTransferConfigurationBuilder extends
 
    @Override
    public void validate() {
-      if (attributes.attribute(CHUNK_SIZE).get() <= 0) {
-         throw new CacheConfigurationException("chunkSize can not be <= 0");
+      int chunkSize = attributes.attribute(CHUNK_SIZE).get();
+      if (chunkSize <= 0) {
+         throw log.invalidChunkSize(chunkSize);
       }
 
       if (clustering().cacheMode().isInvalidation()) {

--- a/core/src/main/java/org/infinispan/configuration/cache/XSiteStateTransferConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/XSiteStateTransferConfigurationBuilder.java
@@ -35,7 +35,7 @@ public class XSiteStateTransferConfigurationBuilder extends AbstractConfiguratio
    public void validate() {
       int chunkSize = attributes.attribute(StateTransferConfiguration.CHUNK_SIZE).get();
       if (chunkSize <= 0) {
-         throw log.invalidChunkSize(chunkSize);
+         throw CONFIG.invalidChunkSize(chunkSize);
       }
       if (attributes.attribute(TIMEOUT).get() <= 0) {
          throw CONFIG.invalidXSiteStateTransferTimeout();

--- a/core/src/main/java/org/infinispan/configuration/cache/XSiteStateTransferConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/XSiteStateTransferConfigurationBuilder.java
@@ -33,6 +33,10 @@ public class XSiteStateTransferConfigurationBuilder extends AbstractConfiguratio
 
    @Override
    public void validate() {
+      int chunkSize = attributes.attribute(StateTransferConfiguration.CHUNK_SIZE).get();
+      if (chunkSize <= 0) {
+         throw log.invalidChunkSize(chunkSize);
+      }
       if (attributes.attribute(TIMEOUT).get() <= 0) {
          throw CONFIG.invalidXSiteStateTransferTimeout();
       }

--- a/core/src/main/java/org/infinispan/persistence/manager/PersistenceManager.java
+++ b/core/src/main/java/org/infinispan/persistence/manager/PersistenceManager.java
@@ -191,11 +191,6 @@ public interface PersistenceManager extends Lifecycle {
       return CompletionStages.join(loadFromAllStores(key, segment, localInvocation, includeStores));
    }
 
-   /**
-    * Returns the store one configured with fetch persistent state, or null if none exist.
-    */
-   AdvancedCacheLoader getStateTransferProvider();
-
    default CompletionStage<Integer> size() {
        return size(AccessMode.BOTH);
    }

--- a/core/src/main/java/org/infinispan/persistence/manager/PersistenceManagerImpl.java
+++ b/core/src/main/java/org/infinispan/persistence/manager/PersistenceManagerImpl.java
@@ -1014,22 +1014,6 @@ public class PersistenceManagerImpl implements PersistenceManager {
    }
 
    @Override
-   public AdvancedCacheLoader getStateTransferProvider() {
-      storesMutex.readLock().lock();
-      try {
-         checkStoreAvailability();
-         for (CacheLoader l : loaders) {
-            StoreConfiguration storeConfiguration = getStoreConfig(l);
-            if (storeConfiguration.fetchPersistentState() && !storeConfiguration.shared())
-               return (AdvancedCacheLoader) l;
-         }
-         return null;
-      } finally {
-         storesMutex.readLock().unlock();
-      }
-   }
-
-   @Override
    public CompletionStage<Integer> size(Predicate<? super StoreConfiguration> predicate) {
       assert !Thread.currentThread().getName().startsWith("persistence") : "Thread name is: " + Thread.currentThread().getName();
       storesMutex.readLock().lock();

--- a/core/src/main/java/org/infinispan/persistence/manager/PersistenceManagerStub.java
+++ b/core/src/main/java/org/infinispan/persistence/manager/PersistenceManagerStub.java
@@ -16,7 +16,6 @@ import org.infinispan.factories.annotations.Stop;
 import org.infinispan.factories.annotations.SurvivesRestarts;
 import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
-import org.infinispan.persistence.spi.AdvancedCacheLoader;
 import org.infinispan.persistence.spi.MarshallableEntry;
 import org.infinispan.persistence.spi.PersistenceException;
 import org.infinispan.persistence.support.BatchModification;
@@ -128,11 +127,6 @@ public class PersistenceManagerStub implements PersistenceManager {
    @Override
    public CompletionStage<Void> writeToAllNonTxStores(MarshallableEntry marshalledEntry, int segment, Predicate<? super StoreConfiguration> predicate, long flags) {
       return CompletableFutures.completedNull();
-   }
-
-   @Override
-   public AdvancedCacheLoader getStateTransferProvider() {
-      return null;
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/persistence/support/DelegatingPersistenceManager.java
+++ b/core/src/main/java/org/infinispan/persistence/support/DelegatingPersistenceManager.java
@@ -17,7 +17,6 @@ import org.infinispan.factories.annotations.Stop;
 import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
 import org.infinispan.persistence.manager.PersistenceManager;
-import org.infinispan.persistence.spi.AdvancedCacheLoader;
 import org.infinispan.persistence.spi.MarshallableEntry;
 import org.infinispan.persistence.spi.PersistenceException;
 import org.reactivestreams.Publisher;
@@ -134,11 +133,6 @@ public class DelegatingPersistenceManager implements PersistenceManager, Lifecyc
    public <K, V> CompletionStage<MarshallableEntry<K, V>> loadFromAllStores(Object key, boolean localInvocation,
                                                                             boolean includeStores) {
       return persistenceManager.loadFromAllStores(key, localInvocation, includeStores);
-   }
-
-   @Override
-   public AdvancedCacheLoader getStateTransferProvider() {
-      return persistenceManager.getStateTransferProvider();
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/scattered/ScatteredStateProvider.java
+++ b/core/src/main/java/org/infinispan/scattered/ScatteredStateProvider.java
@@ -11,6 +11,9 @@ import org.infinispan.statetransfer.StateProvider;
  */
 public interface ScatteredStateProvider extends StateProvider {
 
+   /**
+    * Start transferring keys and remote metadata for the given segments to the origin.
+    */
    void startKeysTransfer(IntSet segments, Address origin);
 
    /**

--- a/core/src/main/java/org/infinispan/statetransfer/StateProvider.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateProvider.java
@@ -3,6 +3,7 @@ package org.infinispan.statetransfer;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.infinispan.commons.util.IntSet;
 import org.infinispan.conflict.impl.StateReceiver;
@@ -36,11 +37,11 @@ public interface StateProvider {
     * StateRequestCommand of type StateRequestCommand.Type.GET_TRANSACTIONS.
     *
     * @param destination the address of the requester
-    * @param topologyId
-    * @param segments
-    * @return list transactions and locks for the given segments
+    * @param topologyId required topology before we can start collecting transactions
+    * @param segments only return transactions affecting these segments
+    * @return a {@code CompletionStage} that completes with the list transactions and locks for the given segments
     */
-   List<TransactionInfo> getTransactionsForSegments(Address destination, int topologyId, IntSet segments) throws InterruptedException;
+   CompletionStage<List<TransactionInfo>> getTransactionsForSegments(Address destination, int topologyId, IntSet segments);
 
    Collection<ClusterListenerReplicateCallable<Object, Object>> getClusterListenersToInstall();
 
@@ -50,13 +51,12 @@ public interface StateProvider {
     *
     * If the applyState field is set to false, then upon delivery at the destination the cache entries are processed
     * by a {@link StateReceiver} and are not applied to the local cache.
-    *
-    * @param destination the address of the requester
+    *  @param destination the address of the requester
     * @param topologyId
     * @param segments
     * @param applyState
     */
-   void startOutboundTransfer(Address destination, int topologyId, IntSet segments, boolean applyState) throws InterruptedException;
+   void startOutboundTransfer(Address destination, int topologyId, IntSet segments, boolean applyState);
 
    /**
     * Cancel sending of cache entries that belong to the given set of segments. This is invoked in response to a

--- a/core/src/main/java/org/infinispan/statetransfer/StateRequestCommand.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateRequestCommand.java
@@ -4,8 +4,8 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Collection;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.infinispan.commands.InitializableCommand;
 import org.infinispan.commands.TopologyAffectedCommand;
@@ -87,9 +87,9 @@ public class StateRequestCommand extends BaseRpcCommand implements Initializable
       try {
          switch (type) {
             case GET_TRANSACTIONS:
-               List<TransactionInfo> transactions =
-                     stateProvider.getTransactionsForSegments(getOrigin(), topologyId, segments);
-               return CompletableFuture.completedFuture(transactions);
+               CompletionStage transactionsStage =
+                  stateProvider.getTransactionsForSegments(getOrigin(), topologyId, segments);
+               return transactionsStage.toCompletableFuture();
 
             case START_CONSISTENCY_CHECK:
                stateProvider.startOutboundTransfer(getOrigin(), topologyId, segments, false);

--- a/core/src/main/java/org/infinispan/transaction/impl/AbstractCacheTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/impl/AbstractCacheTransaction.java
@@ -368,6 +368,14 @@ public abstract class AbstractCacheTransaction implements CacheTransaction {
    }
 
    @Override
+   public void forEachLock(Consumer<Object> consumer) {
+      Set<Object> locked = lockedKeys.get();
+      if (locked != null) {
+         locked.forEach(consumer);
+      }
+   }
+
+   @Override
    public synchronized void forEachBackupLock(Consumer<Object> consumer) {
       if (backupKeyLocks != null) {
          backupKeyLocks.keySet().forEach(consumer);

--- a/core/src/main/java/org/infinispan/transaction/xa/CacheTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/xa/CacheTransaction.java
@@ -147,6 +147,12 @@ public interface CacheTransaction {
    void removeBackupLock(Object key);
 
    /**
+    * Invokes the {@link Consumer} with each lock.
+    * @param consumer The backup lock {@link Consumer}
+    */
+   void forEachLock(Consumer<Object> consumer);
+
+   /**
     * Invokes the {@link Consumer} with each backup lock.
     * @param consumer The backup lock {@link Consumer}
     */

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -732,7 +732,7 @@ public interface Log extends BasicLogger {
 
    @LogMessage(level = WARN)
    @Message(value = "Failed loading keys from cache store", id = 194)
-   void failedLoadingKeysFromCacheStore(@Cause Exception e);
+   void failedLoadingKeysFromCacheStore(@Cause Throwable t);
 
    @LogMessage(level = ERROR)
    @Message(value = "Error during rebalance for cache %s on node %s, topology id = %d", id = 195)

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -1906,4 +1906,7 @@ public interface Log extends BasicLogger {
    @LogMessage(level = WARN)
    @Message(value = "The AdvancedExternalizer configuration has been deprecated and will be removed in the future", id = 560)
    void advancedExternalizerDeprecated();
+
+   @Message(value = "Chunk size must be positive, got %d", id = 561)
+   CacheConfigurationException invalidChunkSize(int chunkSize);
 }

--- a/core/src/main/java/org/infinispan/xsite/statetransfer/XSiteStateProviderImpl.java
+++ b/core/src/main/java/org/infinispan/xsite/statetransfer/XSiteStateProviderImpl.java
@@ -21,8 +21,8 @@ import org.infinispan.commands.CommandsFactory;
 import org.infinispan.commons.CacheException;
 import org.infinispan.configuration.cache.BackupConfiguration;
 import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.configuration.cache.Configurations;
 import org.infinispan.configuration.cache.XSiteStateTransferConfiguration;
-import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.container.impl.InternalDataContainer;
 import org.infinispan.factories.annotations.ComponentName;
 import org.infinispan.factories.annotations.Inject;
@@ -31,7 +31,7 @@ import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
 import org.infinispan.interceptors.locking.ClusteringDependentLogic;
 import org.infinispan.persistence.manager.PersistenceManager;
-import org.infinispan.persistence.spi.AdvancedCacheLoader;
+import org.infinispan.persistence.spi.MarshallableEntry;
 import org.infinispan.remoting.rpc.RpcManager;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.remoting.transport.RetryOnFailureXSiteCommand;
@@ -40,6 +40,7 @@ import org.infinispan.util.concurrent.CompletableFutures;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 import org.infinispan.xsite.XSiteBackup;
+import org.reactivestreams.Publisher;
 
 import io.reactivex.Flowable;
 
@@ -52,14 +53,13 @@ import io.reactivex.Flowable;
 @Scope(Scopes.NAMED_CACHE)
 public class XSiteStateProviderImpl implements XSiteStateProvider {
 
-   private static final int DEFAULT_CHUNK_SIZE = 1024;
    private static final Log log = LogFactory.getLog(XSiteStateProviderImpl.class);
    private static final boolean trace = log.isTraceEnabled();
    private static final boolean debug = log.isDebugEnabled();
 
    private final ConcurrentMap<String, StatePushTask> runningStateTransfer;
 
-   @Inject InternalDataContainer<?, ?> dataContainer;
+   @Inject InternalDataContainer<Object, Object> dataContainer;
    @Inject PersistenceManager persistenceManager;
    @Inject ClusteringDependentLogic clusteringDependentLogic;
    @Inject CommandsFactory commandsFactory;
@@ -159,7 +159,7 @@ public class XSiteStateProviderImpl implements XSiteStateProvider {
       if (sharedBuffer.size() == 0) {
          return;
       }
-      XSiteState[] privateBuffer = sharedBuffer.toArray(new XSiteState[sharedBuffer.size()]);
+      XSiteState[] privateBuffer = sharedBuffer.toArray(new XSiteState[0]);
 
       if (trace) {
          log.debugf("Sending chunk to site '%s'. Chunk contains %s", xSiteBackup.getSiteName(),
@@ -185,7 +185,7 @@ public class XSiteStateProviderImpl implements XSiteStateProvider {
       private volatile boolean canceled;
       private boolean error;
 
-      public StatePushTask(String siteName, Address origin, XSiteStateTransferConfiguration configuration, int minTopologyId) {
+      StatePushTask(String siteName, Address origin, XSiteStateTransferConfiguration configuration, int minTopologyId) {
          this.minTopologyId = minTopologyId;
          this.chunkSize = configuration.chunkSize();
          this.waitTime = configuration.waitTime();
@@ -206,91 +206,82 @@ public class XSiteStateProviderImpl implements XSiteStateProvider {
 
             CompletableFutures.await(stateTransferLock.topologyFuture(minTopologyId));
 
-            final List<XSiteState> chunk = new ArrayList<>(chunkSize <= 0 ? DEFAULT_CHUNK_SIZE : chunkSize);
+            final List<XSiteState> chunk = new ArrayList<>(chunkSize);
 
             if (debug) {
                log.debugf("[X-Site State Transfer - %s] start DataContainer iteration", xSiteBackup.getSiteName());
             }
 
-            for (InternalCacheEntry ice : dataContainer) {
-               if (canceled) {
-                  log.debugf("[X-Site State Transfer - %s] State transfer canceled!", xSiteBackup.getSiteName());
-                  return;
-               }
-               if (chunkSize > 0 && chunk.size() == chunkSize) {
-                  try {
-                     sendFromSharedBuffer(xSiteBackup, chunk, this);
-                  } catch (Throwable t) {
-                     error = true;
-                     log.unableToSendXSiteState(xSiteBackup.getSiteName(), t);
-                     return;
-                  }
-                  chunk.clear();
-               }
-               if (shouldSendKey(ice.getKey())) {
-                  if (trace) {
-                     log.tracef("Added key '%s' to current chunk", ice.getKey());
-                  }
-                  chunk.add(XSiteState.fromDataContainer(ice));
-               }
-            }
-
-            if (canceled) {
+            try {
+               Flowable.fromIterable(dataContainer)
+                       .filter(ice -> shouldSendKey(ice.getKey()))
+                       .map(ice -> {
+                          if (trace) {
+                             log.tracef("Added key '%s' to current chunk", ice.getKey());
+                          }
+                          return XSiteState.fromDataContainer(ice);
+                       })
+                       .buffer(chunkSize)
+                       .takeUntil(batch -> canceled)
+                       .blockingForEach(batch -> {
+                          try {
+                             // TODO Make non-blocking and use concatMapCompletable like OutboundTransferTask
+                             sendFromSharedBuffer(xSiteBackup, batch, this);
+                          } catch (Throwable t) {
+                             // This will terminate the flowable early
+                             throw new CacheException(t);
+                          }
+                       });
+            } catch (Throwable t) {
+               error = true;
+               log.unableToSendXSiteState(xSiteBackup.getSiteName(), t);
                return;
             }
-            if (chunk.size() > 0) {
-               try {
-                  sendFromSharedBuffer(xSiteBackup, chunk, this);
-               } catch (Throwable t) {
-                  error = true;
-                  log.unableToSendXSiteState(xSiteBackup.getSiteName(), t);
-                  return;
-               }
+            if (canceled) {
+               return;
             }
 
             if (debug) {
                log.debugf("[X-Site State Transfer - %s] finish DataContainer iteration", xSiteBackup.getSiteName());
             }
 
-            @SuppressWarnings("unchecked")
-            AdvancedCacheLoader<Object, Object> stProvider = persistenceManager.getStateTransferProvider();
-            if (stProvider != null) {
-               if (debug) {
-                  log.debugf("[X-Site State Transfer - %s] start Persistence iteration", xSiteBackup.getSiteName());
-               }
-               try {
-                  Flowable.fromPublisher(stProvider.entryPublisher(k -> shouldSendKey(k) && !dataContainer.containsKey(k), true, true))
-                        .map(XSiteState::fromCacheLoader)
-                        .takeUntil(l -> canceled)
-                        .buffer(chunkSize <= 0 ? Integer.MAX_VALUE : chunkSize)
-                        // We want the CacheException to be thrown to the catch block
-                        .blockingForEach(l -> {
-                           try {
-                              sendFromSharedBuffer(xSiteBackup, l, this);
-                           } catch (Throwable throwable) {
-                              // This will terminate the flowable early
-                              throw new CacheException(throwable);
-                           }
-                        });
+            if (debug) {
+               log.debugf("[X-Site State Transfer - %s] start Persistence iteration", xSiteBackup.getSiteName());
+            }
+            try {
+               Publisher<MarshallableEntry<Object, Object>> loaderPublisher =
+                  persistenceManager.publishEntries(k -> shouldSendKey(k) && !dataContainer.containsKey(k), true, true,
+                                                    Configurations::isStateTransferStore);
+               Flowable.fromPublisher(loaderPublisher)
+                       .map(XSiteState::fromCacheLoader)
+                       .takeUntil(l -> canceled)
+                       .buffer(chunkSize)
+                       // We want the CacheException to be thrown to the catch block
+                       .blockingForEach(l -> {
+                        try {
+                           // TODO Make non-blocking and use concatMapCompletable like OutboundTransferTask
+                           sendFromSharedBuffer(xSiteBackup, l, this);
+                        } catch (Throwable throwable) {
+                           // This will terminate the flowable early
+                           throw new CacheException(throwable);
+                        }
+                     });
 
-                  if (canceled) {
-                     log.debugf("[X-Site State Transfer - %s] State transfer canceled!", xSiteBackup.getSiteName());
-                     return;
-                  }
-               } catch (CacheException e) {
-                  error = true;
-                  log.failedLoadingKeysFromCacheStore(e);
-                  return;
-               } catch (Throwable t) {
-                  error = true;
-                  log.unableToSendXSiteState(xSiteBackup.getSiteName(), t);
+               if (canceled) {
+                  log.debugf("[X-Site State Transfer - %s] State transfer canceled!", xSiteBackup.getSiteName());
                   return;
                }
-               if (debug) {
-                  log.debugf("[X-Site State Transfer - %s] finish Persistence iteration", xSiteBackup.getSiteName());
-               }
-            } else if (debug) {
-               log.debugf("[X-Site State Transfer - %s] skip Persistence iteration", xSiteBackup.getSiteName());
+            } catch (CacheException e) {
+               error = true;
+               log.failedLoadingKeysFromCacheStore(e);
+               return;
+            } catch (Throwable t) {
+               error = true;
+               log.unableToSendXSiteState(xSiteBackup.getSiteName(), t);
+               return;
+            }
+            if (debug) {
+               log.debugf("[X-Site State Transfer - %s] finish Persistence iteration", xSiteBackup.getSiteName());
             }
          } catch (Throwable e) {
             error = true;

--- a/core/src/main/resources/schema/infinispan-config-10.0.xsd
+++ b/core/src/main/resources/schema/infinispan-config-10.0.xsd
@@ -1806,10 +1806,7 @@
         <xs:complexType>
           <xs:attribute name="chunk-size" type="xs:int" default="512">
             <xs:annotation>
-              <xs:documentation>
-                If &gt; 0, the state will be transferred in batches of {@code chunkSize} cache entries.
-                If &lt;= 0, the state will be transferred in all at once. Not recommended. Defaults to 512.
-              </xs:documentation>
+               <xs:documentation>The number of cache entries to batch in each transfer.</xs:documentation>
             </xs:annotation>
           </xs:attribute>
           <xs:attribute name="timeout" type="xs:long" default="1200000">

--- a/core/src/main/resources/schema/infinispan-config-10.0.xsd
+++ b/core/src/main/resources/schema/infinispan-config-10.0.xsd
@@ -1804,12 +1804,12 @@
           </xs:documentation>
         </xs:annotation>
         <xs:complexType>
-          <xs:attribute name="chunk-size" type="xs:int" default="512">
+          <xs:attribute name="chunk-size" type="xs:int" default="${XSiteStateTransfer.ChunkSize}">
             <xs:annotation>
                <xs:documentation>The number of cache entries to batch in each transfer.</xs:documentation>
             </xs:annotation>
           </xs:attribute>
-          <xs:attribute name="timeout" type="xs:long" default="1200000">
+          <xs:attribute name="timeout" type="xs:long" default="${XSiteStateTransfer.timeout}">
             <xs:annotation>
               <xs:documentation>
                 The time (in milliseconds) to wait for the backup site acknowledge the state chunk
@@ -1817,7 +1817,7 @@
               </xs:documentation>
             </xs:annotation>
           </xs:attribute>
-          <xs:attribute name="max-retries" type="xs:int" default="30">
+          <xs:attribute name="max-retries" type="xs:int" default="${XSiteStateTransfer.maxRetries}">
             <xs:annotation>
               <xs:documentation>
                 The maximum number of retries when a push state command fails. A value &lt;= 0 (zero) mean that
@@ -1825,7 +1825,7 @@
               </xs:documentation>
             </xs:annotation>
           </xs:attribute>
-          <xs:attribute name="wait-time" type="xs:long" default="2000">
+          <xs:attribute name="wait-time" type="xs:long" default="${XSiteStateTransfer.waitTime}">
             <xs:annotation>
               <xs:documentation>
                 The waiting time (in milliseconds) between each retry. The value should be &gt; 0 (zero). Default

--- a/core/src/test/java/org/infinispan/persistence/ClassLoaderManagerDisablingTest.java
+++ b/core/src/test/java/org/infinispan/persistence/ClassLoaderManagerDisablingTest.java
@@ -2,7 +2,6 @@ package org.infinispan.persistence;
 
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
-import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertNull;
 import static org.testng.AssertJUnit.assertTrue;
 
@@ -19,7 +18,6 @@ import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.persistence.dummy.DummyInMemoryStore;
 import org.infinispan.persistence.dummy.DummyInMemoryStoreConfigurationBuilder;
 import org.infinispan.persistence.manager.PersistenceManager;
-import org.infinispan.persistence.spi.AdvancedCacheLoader;
 import org.infinispan.persistence.spi.CacheLoader;
 import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.test.TestingUtil;
@@ -99,8 +97,8 @@ public class ClassLoaderManagerDisablingTest extends AbstractInfinispanTest {
          stores = pm.getStores(CacheLoader.class);
          assertEquals(1, stores.size());
 
-         AdvancedCacheLoader loader = pm.getStateTransferProvider();
-         assertNotNull(loader);
+         DummyInMemoryStore store = (DummyInMemoryStore) stores.iterator().next();
+         assertTrue(store.getConfiguration().fetchPersistentState());
       } finally {
          TestingUtil.killCacheManagers(cacheManager);
       }

--- a/core/src/test/java/org/infinispan/persistence/dummy/DummyInMemoryStore.java
+++ b/core/src/test/java/org/infinispan/persistence/dummy/DummyInMemoryStore.java
@@ -378,4 +378,8 @@ public class DummyInMemoryStore implements AdvancedLoadWriteStore, AdvancedCache
       if (!available)
          throw new PersistenceException();
    }
+
+   public DummyInMemoryStoreConfiguration getConfiguration() {
+      return configuration;
+   }
 }

--- a/core/src/test/java/org/infinispan/statetransfer/StaleTxWithCommitDuringStateTransferTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StaleTxWithCommitDuringStateTransferTest.java
@@ -1,14 +1,15 @@
 package org.infinispan.statetransfer;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.spy;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNull;
 import static org.testng.AssertJUnit.fail;
 
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeoutException;
 
@@ -24,6 +25,7 @@ import org.infinispan.distribution.MagicKey;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestDataSCI;
+import org.infinispan.test.TestException;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.CheckPoint;
 import org.infinispan.test.fwk.CleanupAfterMethod;
@@ -70,10 +72,16 @@ public class StaleTxWithCommitDuringStateTransferTest extends MultipleCacheManag
          Object[] arguments = invocation.getArguments();
          Address source = (Address) arguments[0];
          int topologyId = (Integer) arguments[1];
-         Object result = invocation.callRealMethod();
-         checkpoint.trigger("post_get_transactions_" + topologyId + "_from_" + source);
-         checkpoint.awaitStrict("resume_get_transactions_" + topologyId + "_from_" + source, 10, SECONDS);
-         return result;
+         CompletionStage<?> result = (CompletionStage<?>) invocation.callRealMethod();
+         return result.thenApply(transactions -> {
+            try {
+               checkpoint.trigger("post_get_transactions_" + topologyId + "_from_" + source);
+               checkpoint.awaitStrict("resume_get_transactions_" + topologyId + "_from_" + source, 10, SECONDS);
+               return transactions;
+            } catch (InterruptedException | TimeoutException e) {
+               throw new TestException(e);
+            }
+         });
       }).when(spyProvider).getTransactionsForSegments(any(Address.class), anyInt(), any());
       TestingUtil.replaceComponent(cache0, StateProvider.class, spyProvider, true);
 

--- a/core/src/test/java/org/infinispan/statetransfer/StateProviderTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateProviderTest.java
@@ -1,7 +1,7 @@
 package org.infinispan.statetransfer;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -9,16 +9,14 @@ import static org.mockito.Mockito.when;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertTrue;
-import static org.testng.AssertJUnit.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.infinispan.Cache;
 import org.infinispan.commands.CommandsFactory;
@@ -39,14 +37,11 @@ import org.infinispan.distribution.TestAddress;
 import org.infinispan.distribution.ch.KeyPartitioner;
 import org.infinispan.distribution.ch.impl.DefaultConsistentHash;
 import org.infinispan.distribution.ch.impl.DefaultConsistentHashFactory;
-import org.infinispan.distribution.ch.impl.HashFunctionPartitioner;
 import org.infinispan.notifications.cachelistener.cluster.ClusterCacheNotifier;
 import org.infinispan.persistence.manager.PersistenceManager;
-import org.infinispan.remoting.inboundhandler.DeliverOrder;
-import org.infinispan.remoting.rpc.ResponseMode;
 import org.infinispan.remoting.rpc.RpcManager;
-import org.infinispan.remoting.rpc.RpcOptionsBuilder;
 import org.infinispan.remoting.transport.Address;
+import org.infinispan.test.Exceptions;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.topology.CacheTopology;
 import org.infinispan.topology.PersistentUUID;
@@ -55,12 +50,14 @@ import org.infinispan.topology.PersistentUUIDManagerImpl;
 import org.infinispan.transaction.impl.TransactionOriginatorChecker;
 import org.infinispan.transaction.impl.TransactionTable;
 import org.infinispan.util.ByteString;
+import org.infinispan.util.concurrent.CompletionStages;
 import org.infinispan.util.concurrent.IsolationLevel;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
-import org.mockito.stubbing.Answer;
-import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import io.reactivex.Flowable;
 
 /**
  * Test for StateProviderImpl.
@@ -70,8 +67,10 @@ import org.testng.annotations.Test;
  */
 @Test(groups = "functional", testName = "statetransfer.StateProviderTest")
 public class StateProviderTest {
-
    private static final Log log = LogFactory.getLog(StateProviderTest.class);
+
+   // Number of segments must be a power of 2 for keyPartition4Segments to work
+   private static final int NUM_SEGMENTS = 4;
    private static final TestAddress A = new TestAddress(0, "A");
    private static final TestAddress B = new TestAddress(1, "B");
    private static final TestAddress C = new TestAddress(2, "C");
@@ -79,15 +78,14 @@ public class StateProviderTest {
    private static final TestAddress E = new TestAddress(4, "E");
    private static final TestAddress F = new TestAddress(5, "F");
    private static final TestAddress G = new TestAddress(6, "G");
-   private static final PersistentUUIDManager persistentUUIDManager = new PersistentUUIDManagerImpl();
 
+   private static final PersistentUUIDManager persistentUUIDManager = new PersistentUUIDManagerImpl();
    static {
       Arrays.asList(A, B, C, D, E, F, G).forEach(address -> persistentUUIDManager.addPersistentAddressMapping(address, PersistentUUID.randomUUID()));
    }
 
    private Configuration configuration;
 
-   private ExecutorService mockExecutorService;
    private Cache cache;
 
    private RpcManager rpcManager;
@@ -101,7 +99,7 @@ public class StateProviderTest {
    private LocalizedCacheTopology cacheTopology;
    private InternalEntryFactory ef;
 
-   @BeforeClass
+   @BeforeMethod
    public void setUp() {
       // create cache configuration
       ConfigurationBuilder cb = new ConfigurationBuilder();
@@ -112,7 +110,6 @@ public class StateProviderTest {
             .locking().isolationLevel(IsolationLevel.REPEATABLE_READ);
       configuration = cb.build();
 
-      mockExecutorService = mock(ExecutorService.class);
       cache = mock(Cache.class);
       when(cache.getName()).thenReturn("testCache");
 
@@ -128,9 +125,7 @@ public class StateProviderTest {
       when(distributionManager.getCacheTopology()).thenAnswer(invocation -> cacheTopology);
    }
 
-   public void test1() throws InterruptedException {
-      int numSegments = 4;
-
+   public void test1() {
       // create list of 6 members
       List<Address> members1 = Arrays.asList(A, B, C, D, E, F);
       List<Address> members2 = new ArrayList<>(members1);
@@ -139,26 +134,20 @@ public class StateProviderTest {
       members2.add(G);
 
       // create CHes
-      KeyPartitioner keyPartitioner = new HashFunctionPartitioner();
+      KeyPartitioner keyPartitioner = StateProviderTest::keyToSegment;
       DefaultConsistentHashFactory chf = new DefaultConsistentHashFactory();
-      DefaultConsistentHash ch1 = chf.create(MurmurHash3.getInstance(), 2, numSegments, members1, null);
+      DefaultConsistentHash ch1 = chf.create(MurmurHash3.getInstance(), 2, StateProviderTest.NUM_SEGMENTS, members1, null);
       DefaultConsistentHash ch2 = chf.updateMembers(ch1, members2, null);
 
       // create dependencies
-      when(mockExecutorService.submit(any(Runnable.class)))
-            .thenAnswer((Answer<Future<?>>) invocation -> null);
-
       when(rpcManager.getAddress()).thenReturn(A);
-      when(rpcManager.getRpcOptionsBuilder(any(ResponseMode.class))).thenAnswer(invocation -> {
-         Object[] args = invocation.getArguments();
-         return new RpcOptionsBuilder(10000, TimeUnit.MILLISECONDS, (ResponseMode) args[0], DeliverOrder.PER_SENDER);
-      });
+      when(rpcManager.invokeCommand(any(Address.class), any(), any(), any())).thenReturn(new CompletableFuture<>());
 
       // create state provider
       StateProviderImpl stateProvider = new StateProviderImpl();
-      TestingUtil.inject(stateProvider, mockExecutorService,
-                         configuration, rpcManager, commandsFactory, cacheNotifier, persistenceManager,
-                         dataContainer, transactionTable, stateTransferLock, distributionManager, ef, keyPartitioner, TransactionOriginatorChecker.LOCAL);
+      TestingUtil.inject(stateProvider, configuration, rpcManager, commandsFactory, cacheNotifier, persistenceManager,
+                         dataContainer, transactionTable, stateTransferLock, distributionManager, ef, keyPartitioner,
+                         TransactionOriginatorChecker.LOCAL);
       stateProvider.start();
 
       final List<InternalCacheEntry> cacheEntries = new ArrayList<>();
@@ -178,17 +167,21 @@ public class StateProviderTest {
 
       log.debug("ch1: " + ch1);
       IntSet segmentsToRequest = IntSets.from(ch1.getSegmentsForOwner(members1.get(0)));
-      List<TransactionInfo> transactions = stateProvider.getTransactionsForSegments(members1.get(0), 1, segmentsToRequest);
+      CompletionStage<List<TransactionInfo>> transactionsStage =
+         stateProvider.getTransactionsForSegments(members1.get(0), 1, segmentsToRequest);
+      List<TransactionInfo> transactions = CompletionStages.join(transactionsStage);
       assertEquals(0, transactions.size());
 
-      try {
-         stateProvider.getTransactionsForSegments(members1.get(0), 1, SmallIntSet.of(2, numSegments));
-         fail("IllegalArgumentException expected");
-      } catch (IllegalArgumentException e) {
-         // expected
-      }
+      CompletionStage<List<TransactionInfo>> transactionsStage2 =
+         stateProvider.getTransactionsForSegments(members1.get(0), 1,
+                                                  SmallIntSet.of(2, StateProviderTest.NUM_SEGMENTS));
+      Exceptions.expectExecutionException(IllegalArgumentException.class, transactionsStage2.toCompletableFuture());
 
       verifyNoMoreInteractions(stateTransferLock);
+
+      when(dataContainer.iterator(any())).thenReturn(cacheEntries.iterator());
+      when(persistenceManager.publishEntries(any(IntSet.class), any(), anyBoolean(), anyBoolean(), any()))
+         .thenReturn(Flowable.empty());
 
       stateProvider.startOutboundTransfer(F, 1, IntSets.immutableSet(0), true);
 
@@ -212,9 +205,7 @@ public class StateProviderTest {
       assertFalse(stateProvider.isStateTransferInProgress());
    }
 
-   public void test2() throws InterruptedException {
-      int numSegments = 4;
-
+   public void test2() {
       // create list of 6 members
       List<Address> members1 = Arrays.asList(A, B, C, D, E, F);
       List<Address> members2 = new ArrayList<>(members1);
@@ -223,49 +214,28 @@ public class StateProviderTest {
       members2.add(G);
 
       // create CHes
-      KeyPartitioner keyPartitioner = new HashFunctionPartitioner();
+      KeyPartitioner keyPartitioner = StateProviderTest::keyToSegment;
       DefaultConsistentHashFactory chf = new DefaultConsistentHashFactory();
-      DefaultConsistentHash ch1 = chf.create(MurmurHash3.getInstance(), 2, numSegments, members1, null);
+      DefaultConsistentHash ch1 = chf.create(MurmurHash3.getInstance(), 2, NUM_SEGMENTS, members1, null);
       //todo [anistor] it seems that address 6 is not used for un-owned segments
       DefaultConsistentHash ch2 = chf.updateMembers(ch1, members2, null);
 
-      when(commandsFactory.buildStateResponseCommand(any(Address.class), anyInt(), any(Collection.class), anyBoolean(), anyBoolean()))
+      // set up dependencies
+      when(commandsFactory.buildStateResponseCommand(any(Address.class), anyInt(), any(), anyBoolean(), anyBoolean()))
             .thenAnswer(invocation -> new StateResponseCommand(ByteString.fromString("testCache"),
                                                                (Address) invocation.getArguments()[0],
                                                                (Integer) invocation.getArguments()[1],
                                                                (Collection<StateChunk>) invocation.getArguments()[2],
                                                                true, false));
 
-      // create dependencies
       when(rpcManager.getAddress()).thenReturn(A);
-
-      //rpcManager.invokeRemotelyInFuture(Collections.singleton(destination), cmd, false, sendFuture, timeout);
-//      doAnswer(new Answer<Map<Address, Response>>() {
-//         @Override
-//         public Map<Address, Response> answer(InvocationOnMock invocation) {
-//            Collection<Address> recipients = (Collection<Address>) invocation.getArguments()[0];
-//            ReplicableCommand rpcCommand = (ReplicableCommand) invocation.getArguments()[1];
-//            if (rpcCommand instanceof StateResponseCommand) {
-//               Map<Address, Response> results = new HashMap<Address, Response>();
-//               TestingUtil.sleepThread(10000, "RpcManager mock interrupted during invokeRemotelyInFuture(..)");
-//               return results;
-//            }
-//            return Collections.emptyMap();
-//         }
-//      }).when(rpcManager).invokeRemotelyInFuture(any(Collection.class), any(ReplicableCommand.class), any(RpcOptions.class),
-//                                                 any(NotifyingNotifiableFuture.class));
-
-      when(rpcManager.getRpcOptionsBuilder(any(ResponseMode.class))).thenAnswer(invocation -> {
-         Object[] args = invocation.getArguments();
-         return new RpcOptionsBuilder(10000, TimeUnit.MILLISECONDS, (ResponseMode) args[0], DeliverOrder.PER_SENDER);
-      });
-
+      when(rpcManager.invokeCommand(any(Address.class), any(), any(), any())).thenReturn(new CompletableFuture<>());
 
       // create state provider
       StateProviderImpl stateProvider = new StateProviderImpl();
-      TestingUtil.inject(stateProvider, mockExecutorService,
-                         configuration, rpcManager, commandsFactory, cacheNotifier, persistenceManager,
-                         dataContainer, transactionTable, stateTransferLock, distributionManager, ef, keyPartitioner, TransactionOriginatorChecker.LOCAL);
+      TestingUtil.inject(stateProvider, configuration, rpcManager, commandsFactory, cacheNotifier, persistenceManager,
+                         dataContainer, transactionTable, stateTransferLock, distributionManager, ef, keyPartitioner,
+                         TransactionOriginatorChecker.LOCAL);
       stateProvider.start();
 
       final List<InternalCacheEntry> cacheEntries = new ArrayList<>();
@@ -277,7 +247,10 @@ public class StateProviderTest {
       cacheEntries.add(new ImmortalCacheEntry(key2, "value2"));
       cacheEntries.add(new ImmortalCacheEntry(key3, "value3"));
       cacheEntries.add(new ImmortalCacheEntry(key4, "value4"));
-      when(dataContainer.iterator()).thenAnswer(invocation -> cacheEntries.iterator());
+      when(dataContainer.iterator(any())).thenReturn(cacheEntries.iterator());
+      when(persistenceManager.publishEntries(any(IntSet.class), any(), anyBoolean(), anyBoolean(), any()))
+         .thenReturn(Flowable.empty());
+
       when(transactionTable.getLocalTransactions()).thenReturn(Collections.emptyList());
       when(transactionTable.getRemoteTransactions()).thenReturn(Collections.emptyList());
 
@@ -289,15 +262,15 @@ public class StateProviderTest {
 
       log.debug("ch1: " + ch1);
       IntSet segmentsToRequest = IntSets.from(ch1.getSegmentsForOwner(members1.get(0)));
-      List<TransactionInfo> transactions = stateProvider.getTransactionsForSegments(members1.get(0), 1, segmentsToRequest);
+      CompletionStage<List<TransactionInfo>> transactionsStage =
+         stateProvider.getTransactionsForSegments(members1.get(0), 1, segmentsToRequest);
+      List<TransactionInfo> transactions = CompletionStages.join(transactionsStage);
       assertEquals(0, transactions.size());
 
-      try {
-         stateProvider.getTransactionsForSegments(members1.get(0), 1, SmallIntSet.of(2, numSegments));
-         fail("IllegalArgumentException expected");
-      } catch (IllegalArgumentException e) {
-         // expected
-      }
+      CompletionStage<List<TransactionInfo>> transactionsStage2 =
+         stateProvider.getTransactionsForSegments(members1.get(0), 1,
+                                                  SmallIntSet.of(2, StateProviderTest.NUM_SEGMENTS));
+      Exceptions.expectExecutionException(IllegalArgumentException.class, transactionsStage2.toCompletableFuture());
 
       verifyNoMoreInteractions(stateTransferLock);
 
@@ -322,5 +295,9 @@ public class StateProviderTest {
       stateProvider.stop();
 
       assertFalse(stateProvider.isStateTransferInProgress());
+   }
+
+   private static int keyToSegment(Object k) {
+      return MurmurHash3.getInstance().hash(k) & (NUM_SEGMENTS - 1);
    }
 }

--- a/core/src/test/java/org/infinispan/tx/EntryWrappingInterceptorDoesNotBlockTest.java
+++ b/core/src/test/java/org/infinispan/tx/EntryWrappingInterceptorDoesNotBlockTest.java
@@ -119,7 +119,7 @@ public class EntryWrappingInterceptorDoesNotBlockTest extends MultipleCacheManag
       cache(0).addListener(new TopologyChangeListener(topologyChangeLatch));
       cache(2).addListener(new TopologyChangeListener(topologyChangeLatch));
       PrepareExpectingInterceptor prepareExpectingInterceptor = new PrepareExpectingInterceptor();
-      cache(2).getAdvancedCache().getAsyncInterceptorChain().addInterceptor(prepareExpectingInterceptor, 0);
+      TestingUtil.extractInterceptorChain(cache(2)).addInterceptor(prepareExpectingInterceptor, 0);
 
       tm(0).begin();
       for (int i = 0; i < keys.length; ++i) {
@@ -135,7 +135,7 @@ public class EntryWrappingInterceptorDoesNotBlockTest extends MultipleCacheManag
 
       // block sending segment 0 to node 2
       expectStateRequestCommand(crm2, StateRequestCommand.Type.GET_TRANSACTIONS).send().receiveAll();
-      expectStateRequestCommand(crm2, StateRequestCommand.Type.START_STATE_TRANSFER).send().receiveAll();
+      expectStateRequestCommand(crm2, StateRequestCommand.Type.START_STATE_TRANSFER).send().receiveAllAsync();
       ControlledRpcManager.BlockedRequest blockedStateResponse0 = crm0.expectCommand(StateResponseCommand.class);
       assertTrue(topologyChangeLatch.await(10, TimeUnit.SECONDS));
 
@@ -179,8 +179,7 @@ public class EntryWrappingInterceptorDoesNotBlockTest extends MultipleCacheManag
    }
 
    private ControlledRpcManager.BlockedRequest expectStateRequestCommand(ControlledRpcManager crm,
-                                                                         StateRequestCommand.Type type)
-      throws InterruptedException {
+                                                                         StateRequestCommand.Type type) {
       return crm.expectCommand(StateRequestCommand.class, c -> assertEquals(type, c.getType()));
    }
 

--- a/core/src/test/java/org/infinispan/util/ControlledRpcManager.java
+++ b/core/src/test/java/org/infinispan/util/ControlledRpcManager.java
@@ -601,6 +601,10 @@ public class ControlledRpcManager extends AbstractDelegatingRpcManager {
          expectAllResponses().receive();
       }
 
+      public void receiveAllAsync() {
+         expectAllResponsesAsync().thenAccept(BlockedResponseMap::receive);
+      }
+
       /**
        * Complete a request after expecting and receiving responses individually, e.g. with
        * {@link #expectResponse(Address)}.

--- a/documentation/src/main/asciidoc/topics/upgrading.adoc
+++ b/documentation/src/main/asciidoc/topics/upgrading.adoc
@@ -55,6 +55,10 @@ Several configuration elements and attributes that were deprecated since 9.0 hav
 * `deadlock-detection-spin` - always disabled
 * `write-skew` - enabled automatically
 
+The xsite state transfer chunk size (`<backup><state-transfer chunk-size="X"/></backup>`) can no longer be `&gt;= 0`,
+same as the regular state transfer chunk size.
+Previously a value &lt;= 0 would transfer the entire cache in a single batch, which is almost always a bad idea.
+
 == RemoteCache Changes
 
 === The getBulk methods have been removed

--- a/pom.xml
+++ b/pom.xml
@@ -4544,7 +4544,7 @@
             <executions>
                <execution>
                   <id>checkstyle</id>
-                  <phase>verify</phase>
+                  <phase>validate</phase>
                   <goals>
                      <goal>check</goal>
                   </goals>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-10310

Second part of the series, handling topology updates without blocking is still pending.
I have made some changes to XSiteStateProviderImpl to make it more like StateProviderImpl, but I did not make it non-blocking.