### PR TITLE
ISPN-10376 Optimize operation to get keys from a cache

### DIFF
--- a/documentation/src/main/asciidoc/topics/rest_api_v2.adoc
+++ b/documentation/src/main/asciidoc/topics/rest_api_v2.adoc
@@ -286,6 +286,25 @@ include::rest_examples/delete_v2_caches.adoc[]
 {brandname} deletes all data and removes the cache named `cacheName` from the
 cluster.
 
+[[rest_v2_get_keys]]
+=== Retrieving cache keys
+
+To obtain all the keys from the cache in JSON format, invoke a `GET` request:
+
+[source,options="nowrap",subs=attributes+]
+----
+include::rest_examples/get_v2_keys.adoc[]
+----
+
+.Request Parameters
+|===
+|Parameter |Required or Optional |Value
+
+|`batch-size`
+|OPTIONAL
+|Specifies the internal batch size when retrieving the keys. The default value is 1000.
+|===
+
 [[rest_v2_clear_cache]]
 === Clearing Caches
 

--- a/documentation/src/main/asciidoc/topics/rest_examples/get_v2_keys.adoc
+++ b/documentation/src/main/asciidoc/topics/rest_examples/get_v2_keys.adoc
@@ -1,0 +1,1 @@
+GET /rest/v2/caches/{cacheName}?action=keys

--- a/server/rest/src/main/java/org/infinispan/rest/CacheInputStream.java
+++ b/server/rest/src/main/java/org/infinispan/rest/CacheInputStream.java
@@ -1,0 +1,80 @@
+package org.infinispan.rest;
+
+import java.io.InputStream;
+import java.util.Iterator;
+import java.util.stream.Stream;
+
+import org.infinispan.CacheStream;
+
+/**
+ * An {@link InputStream} that reads from a {@link CacheStream} of byte[] and produces a JSON output.
+ *
+ * @since 10.0
+ */
+public class CacheInputStream extends InputStream {
+   private enum State {BEGIN, START_ITEM, ITEM, END_ITEM, SEPARATOR, END, EOF}
+
+   private static final char STREAM_OPEN_CHAR = '[';
+   private static final char DATA_ENCLOSING_CHAR = '\"';
+   private static final char SEPARATOR = ',';
+   private static final char STREAM_CLOSE_CHAR = ']';
+
+   private final Iterator<?> iterator;
+   private final Stream<?> stream;
+   private final int batchSize;
+
+   private byte[] currentEntry;
+   private int cursor = 0;
+
+   private State state = State.BEGIN;
+
+   public CacheInputStream(CacheStream<?> stream, int batchSize) {
+      this.batchSize = batchSize;
+      this.stream = stream.distributedBatchSize(batchSize);
+      this.iterator = stream.iterator();
+   }
+
+   @Override
+   public int available() {
+      return currentEntry == null ? 0 : currentEntry.length - cursor * batchSize;
+   }
+
+   @Override
+   public synchronized int read() {
+      boolean hasNext = iterator.hasNext();
+      switch (state) {
+         case BEGIN:
+            state = hasNext ? State.START_ITEM : State.END;
+            return STREAM_OPEN_CHAR;
+         case START_ITEM:
+            state = State.ITEM;
+            return DATA_ENCLOSING_CHAR;
+         case END_ITEM:
+            state = hasNext ? State.SEPARATOR : State.END;
+            return DATA_ENCLOSING_CHAR;
+         case SEPARATOR:
+            state = State.START_ITEM;
+            return SEPARATOR;
+         case END:
+            state = State.EOF;
+            stream.close();
+            return STREAM_CLOSE_CHAR;
+         case ITEM:
+            if (currentEntry == null) {
+               if (hasNext) {
+                  currentEntry = (byte[]) iterator.next();
+               }
+            }
+            int c = currentEntry == null || cursor == currentEntry.length ? -1 : currentEntry[cursor++] & 0xff;
+
+            if (c != -1) return c;
+
+            state = State.END_ITEM;
+            currentEntry = null;
+            cursor = 0;
+            return read();
+         default:
+            return -1;
+      }
+   }
+}

--- a/server/rest/src/main/java/org/infinispan/rest/NettyRestResponse.java
+++ b/server/rest/src/main/java/org/infinispan/rest/NettyRestResponse.java
@@ -4,6 +4,7 @@ import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 
 import java.io.File;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -72,7 +73,7 @@ public class NettyRestResponse implements RestResponse {
       @Override
       public NettyRestResponse build() {
          HttpResponse response;
-         if (entity instanceof File) {
+         if (entity instanceof File || entity instanceof InputStream) {
             response = new DefaultHttpResponse(HTTP_1_1, OK);
          } else {
             response = new DefaultFullHttpResponse(HTTP_1_1, OK, Unpooled.buffer());

--- a/server/rest/src/main/java/org/infinispan/rest/logging/Log.java
+++ b/server/rest/src/main/java/org/infinispan/rest/logging/Log.java
@@ -81,4 +81,5 @@ public interface Log extends BasicLogger {
 
    @Message(value = "Cannot register path '%s' for invocation '%s', since it conflicts with already registered path '%s'", id = 12019)
    RegistrationException duplicateResource(String candidate, Invocation invocation, String existingPath);
+
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-10376

Uses HTTP chunked + KeepAlive + CacheStreams to stream the keys to the client efficiently