### PR TITLE
ISPN-10564 removing wildfly references

### DIFF
--- a/documentation/src/main/asciidoc/topics/con_server.adoc
+++ b/documentation/src/main/asciidoc/topics/con_server.adoc
@@ -1,8 +1,6 @@
 = {brandname} Server
 {brandname} Server is a standalone server which exposes any number of caches to clients over a variety of protocols, including HotRod, Memcached and REST.
 
-The server itself is built on top of the robust foundation provided by WildFly, therefore delegating services such as management, configuration, datasources, transactions, logging, security to the respective subsystems.
-
 Because {brandname} Server is closely tied to the latest releases of {brandname} and JGroups, the subsystems which control these components are different, in that they introduce new features and change some existing ones (e.g. cross-site replication, etc).
 
 For this reason, the configuration of these subsystems should use the {brandname} Server-specific schema, although for most use-cases the configuration is interchangeable.

--- a/documentation/src/main/asciidoc/topics/faq_content.adoc
+++ b/documentation/src/main/asciidoc/topics/faq_content.adoc
@@ -498,15 +498,6 @@ So, any work on the 2nd level cache will be done under a different transaction t
 ==== Is there a way to do a Bulk Get on a remote cache?
 There's no bulk get operation in Hot Rod, but the Java Hot Rod client has implemented via link:{javadocroot}/org/infinispan/client/hotrod/RemoteCache.html[RemoteCache] the getAsync() operation, which returns a link:{javadocroot}/org/infinispan/util/concurrent/NotifyingFuture.html[org.infinispan.util.concurrent.NotifyingFuture] (extends java.util.concurrent.Future). So, if you want to retrieve multiple keys in parallel, just call multiple times _getAsync()_ and when you need the values, just call _Future.get()_ , or attach a link:{javadocroot}/org/infinispan/util/concurrent/FutureListener.html[ _FutureListener_ ] to the _NotifyingFuture_ to get notified when the value is ready.
 
-==== What is the startServer.sh script used for? What is the startServer.bat script used for?
-These scripts were used to start {brandname} server instances in earlier
-{brandname} versions, but this is not the case any more since the {brandname}
-Server modules are built into a base Wildfly/EAP instance, allowing all server
-modules to interact with other base services provided by Wildfly/EAP, e.g.
-the web container for REST server. Check the dedicated {brandname} Server guide
-to find out more on how to start it.
-
-
 === Debugging questions
 
 ==== How can I get {brandname} to show the full byte array? The log only shows partial contents of byte arrays...

--- a/documentation/src/main/asciidoc/topics/integrations.adoc
+++ b/documentation/src/main/asciidoc/topics/integrations.adoc
@@ -274,7 +274,7 @@ section of the documentation.
 include::integrations_spring.adoc[]
 
 ifndef::productized[]
-==  {brandname} modules for WildFly / EAP
+= {brandname} modules for WildFly / EAP
 
 As the {brandname} modules shipped with link:http://wildfly.org/[WildFly] / link:https://www.redhat.com/en/technologies/jboss-middleware/application-platform[EAP] are tailored to its internal usage, it is recommend to install separate modules
 if you want to use {brandname} in your application that is deployed to WildFly / EAP. By installing these modules, it is possible to deploy user applications without packaging the {brandname} JARs within the deployments (WARs, EARs, etc), thus minimizing their size.
@@ -282,14 +282,14 @@ Also, there will be no conflict with WildFly / EAP's internal modules since the 
 endif::productized[]
 
 ifdef::productized[]
-==  {brandname} modules for EAP
+= {brandname} modules for EAP
 
 As the {brandname} modules shipped with link:https://www.redhat.com/en/technologies/jboss-middleware/application-platform[EAP] are tailored to its internal usage, it is recommend to install separate modules if you want to use {brandname} in your application that is deployed to EAP. By installing these modules, it is possible to deploy user applications without packaging the {brandname} JARs within the deployments (WARs, EARs, etc), thus minimizing their size.
 Also, there will be no conflict with EAP's internal modules since the slot will be different.
 endif::productized[]
 
 [[modules_installation_section]]
-=== Installation
+== Installation
 ifndef::productized[]
 The modules for WildFly / EAP are available in the link:http://infinispan.org/download/[downloads] section of our site.
 After extracting the zip, copy the contents of the `modules` directory to the `WILDFLY_HOME/modules` directory, so that
@@ -302,7 +302,7 @@ The modules for EAP are available from the link:https://access.redhat.com/downlo
 After extracting the zip, copy the contents of the `modules` directory to the `${EAP_HOME}/modules` directory. For example, the {brandname} core module should be under `${EAP_HOME}/modules/system/add-ons/{moduleprefix}/org/infinispan/core`.
 endif::productized[]
 
-=== Application Dependencies
+== Application Dependencies
 
 If you are using Maven to build your application, mark the {brandname} dependencies as _provided_ and configure your artifact archiver to generate the appropriate MANIFEST.MF file:
 
@@ -314,7 +314,7 @@ include::dependencies_maven/eap_dependencies.xml[]
 
 The next section illustrates the manifest entries for different types of {brandname}'s dependencies.
 
-==== {brandname} core
+=== {brandname} core
 
 In order expose only {brandname} core dependencies to your application, add the follow to the manifest:
 
@@ -325,7 +325,7 @@ Manifest-Version: 1.0
 Dependencies: org.infinispan:{infinispanslot} services
 ----
 
-==== Remote
+=== Remote
 
 If you need to connect to remote {brandname} servers via Hot Rod, including execution of remote queries, use the module `org.infinispan.remote` that exposes the needed dependencies conveniently:
 
@@ -336,7 +336,7 @@ Manifest-Version: 1.0
 Dependencies: org.infinispan.remote:{infinispanslot} services
 ----
 
-==== Embedded Query
+=== Embedded Query
 
 For embedded querying, including the {brandname} Query DSL, Lucene and Hibernate Search Queries, add the following:
 
@@ -347,7 +347,7 @@ Manifest-Version: 1.0
 Dependencies: org.infinispan:{infinispanslot} services, org.infinispan.query:{infinispanslot} services
 ----
 
-==== Lucene Directory
+=== Lucene Directory
 
 Lucene users who wants to simple use {brandname} as a _org.apache.lucene.store.Directory_ don't need to add the query module, the entry below is sufficient:
 
@@ -358,12 +358,12 @@ Manifest-Version: 1.0
 Dependencies: org.infinispan.lucene-directory:{infinispanslot}
 ----
 
-==== Hibernate Search directory provider for {brandname}
+=== Hibernate Search directory provider for {brandname}
 
 The Hibernate Search directory provider for {brandname} is also contained within the {brandname} modules zip. It is not necessary to add an entry to the manifest file since the Hibernate Search module already has an optional dependency to it.
 When choosing the {brandname} module zip to use, start by checking which Hibernate Search is in use, more details below.
 
-===== Usage with {wildflybrandname} Internal Hibernate Search Modules
+==== Usage with {wildflybrandname} Internal Hibernate Search Modules
 
 The Hibernate Search module present in {wildflybrandname}
 ifndef::productized[]
@@ -375,26 +375,26 @@ endif::productized[]
 has slot "5.5", which in turn has an optional dependency to `org.infinispan.hibernate-search.directory-provider:for-hibernatesearch-5.5`.
 This dependency will be available once the {brandname} modules are link:#modules_installation_section[installed].
 
-===== Usage with other Hibernate Search modules
+==== Usage with other Hibernate Search modules
 
 The module `org.hibernate.search:{infinispanslot}` distributed with {brandname} is to be used together with {brandname} Query only (querying data from caches), and should not be used by Hibernate ORM applications.
 To use a Hibernate Search with a different version that is present in {wildflybrandname}, please consult the link:https://docs.jboss.org/hibernate/search/5.6/reference/en-US/html_single/#search-configuration-deploy-on-wildfly[Hibernate Search documentation].
 
 Make sure that the chosen Hibernate Search optional slot for `org.infinispan.hibernate-search.directory-provider` matches the one distributed with {brandname}.
 
-==== Usage
+=== Usage
 There are two possible ways for your application to utilize {brandname} within {wildflybrandname}, embedded mode and server mode.
 
-==== Embedded Mode
+=== Embedded Mode
 All CacheManagers and cache instances are created in your application logic.  The lifecycle of your EmbeddedCacheManager
 is tightly coupled with your application's lifecycle, resulting in any manager instances created by your application being destroyed with your application.
 
-===== Server Mode
+==== Server Mode
 In server mode, it is possible for cache containers and caches to be created before runtime as part of {wildflybrandname}'s
 standalone/domain.xml configuration. This allows cache instances to be shared across multiple applications, with the
 lifecycle of the underlying cache container being independent of the deployed application.
 
-====== Configuration
+===== Configuration
 To enable server mode, make the following additions to your {wildflybrandname} configuration in `standalone/domain.xml`:
 
 . Add the {brandname} extensions to your `<extensions>` section.
@@ -452,7 +452,7 @@ You do not neet to define a JGroups transport for local cache configurations. Th
 include::config_examples/wfly_jgroups.xml[]
 ----
 
-===== Accessing Containers and Caches
+==== Accessing Containers and Caches
 Once a container has been defined in your server's configuration, it is possible to inject an instance of a CacheContainer
 or Cache into your application using the `@Resource` JNDI lookup. A container is accessed using the following string
 `java:jboss/datagrid-infinispan/container/<container_name>` and similarly a cache is
@@ -466,9 +466,9 @@ called "infinispan_container" and the distributed cache "namedCache" into an app
 include::code_examples/ExampleApplicationInjectCache.java[]
 ----
 
-=== Troubleshooting
+== Troubleshooting
 
-==== Enable logging
+=== Enable logging
 
 Enabling trace on `org.jboss.modules` can be useful to debug issues like `LinkageError` and `ClassNotFoundException`.
 To enable it at runtime using the {wildflybrandname} CLI:
@@ -478,7 +478,7 @@ bin/jboss-cli.sh -c '/subsystem=logging/logger=org.jboss.modules:add'
 bin/jboss-cli.sh -c '/subsystem=logging/logger=org.jboss.modules:write-attribute(name=level,value=TRACE)'
 ----
 
-==== Print dependency tree
+=== Print dependency tree
 
 The following command can be used to print all dependencies for a certain module. For example, to obtain the tree for the module `org.infinispan:{infinispanslot}`, execute from `WILDFLY_HOME`:
 

--- a/documentation/src/main/asciidoc/topics/security_server.adoc
+++ b/documentation/src/main/asciidoc/topics/security_server.adoc
@@ -26,19 +26,14 @@ An example invocation for adding a user to the ApplicationRealm with an initial 
 +./bin/add-user.sh -a -u myuser -p "qwer1234!" -ro supervisor,reader,writer+
 
 It is also possible to authenticate/authorize against alternative sources, such as LDAP, JAAS, etc.
-Refer to the link:{wildflydocroot}/Security%20Realms[WildFly security realms guide] on how to configure the Security Realms.
+
 Bear in mind that the choice of authentication mechanism you select for the protocols limits the type of authentication sources, since the credentials must be in a format supported by the algorithm itself (e.g. pre-digested passwords for the digest algorithm)
 
 == Security Audit
 
 The {brandname} subsystem security audit by default sends audit logs to the audit manager configured at the server level.
-Refer to the link:{wildflydocroot}/Security%20subsystem%20configuration[WildFly security subsystem guide] on how to configure the server audit manager.
-Alternatively you can also set your custom audit logger by using the same configuration as for embedded mode.
-ifndef::productized[]
-Refer to the link:../user_guide/user_guide.html#Security_chapter[Security] chapter in the user guide for details.
-endif::productized[]
 
-//-
+Alternatively you can also set your custom audit logger by using the same configuration as for embedded mode.
 
 [[security_hotrod_auth]]
 == Hot Rod authentication

--- a/documentation/src/main/asciidoc/topics/server_tasks.adoc
+++ b/documentation/src/main/asciidoc/topics/server_tasks.adoc
@@ -73,24 +73,7 @@ example.HelloTask
 ----
 
 With jar packaged, the next step is to push the jar to the {brandname} Server.
-The server is powered by WildFly Application Server, so if using Maven
-https://docs.jboss.org/wildfly/plugins/maven/latest/index.html[Wildfly's Maven plugin]
-can be used for this:
-
-[source,xml,options="nowrap",subs=attributes+]
-----
-include::dependencies_maven/wildfly_maven_plugin.xml[]
-----
-
-Then call the following from command line:
-
-[source, bash]
-----
-$ mvn package wildfly:deploy
-----
-
-Alternative ways of deployment jar files to Wildfly Application Server are explained
-https://docs.jboss.org/author/display/WFLY10/Application+deployment[here].
+//dnaro: Need to provide example to push the JAR without using Wildfly.
 
 Executing the task can be done using the following code:
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-10564

Removes references to WildFly from 10.x documentation. Keeps WildFly modules and integrations topics (Hibernate L2C). 

Sections on getting server health via CLI and REST will be updated as part of https://issues.jboss.org/browse/ISPN-10642 