### PR TITLE
ISPN-10818 Remote-query 9.4.x backwards compatibility

### DIFF
--- a/core/src/main/java/org/infinispan/marshall/protostream/impl/marshallers/UUIDMarshaller.java
+++ b/core/src/main/java/org/infinispan/marshall/protostream/impl/marshallers/UUIDMarshaller.java
@@ -5,7 +5,7 @@ import java.util.UUID;
 
 import org.infinispan.protostream.MessageMarshaller;
 
-public class UUIDMarshaller implements MessageMarshaller<UUID> {
+public final class UUIDMarshaller implements MessageMarshaller<UUID> {
 
    private final String typeName;
 
@@ -30,7 +30,7 @@ public class UUIDMarshaller implements MessageMarshaller<UUID> {
    }
 
    @Override
-   public Class<? extends UUID> getJavaClass() {
+   public Class<UUID> getJavaClass() {
       return UUID.class;
    }
 

--- a/remote-query/remote-query-client/src/main/java/org/infinispan/query/remote/client/impl/MarshallerRegistration.java
+++ b/remote-query/remote-query-client/src/main/java/org/infinispan/query/remote/client/impl/MarshallerRegistration.java
@@ -1,7 +1,5 @@
 package org.infinispan.query.remote.client.impl;
 
-import java.io.IOException;
-
 import org.infinispan.protostream.FileDescriptorSource;
 import org.infinispan.protostream.SerializationContext;
 import org.infinispan.protostream.SerializationContextInitializer;
@@ -21,10 +19,14 @@ public final class MarshallerRegistration implements SerializationContextInitial
    }
 
    @Override
-   public String getProtoFileName() { return QUERY_PROTO_RES; }
+   public String getProtoFileName() {
+      return QUERY_PROTO_RES;
+   }
 
    @Override
-   public String getProtoFile() { return FileDescriptorSource.getResourceAsString(getClass(), QUERY_PROTO_RES); }
+   public String getProtoFile() {
+      return FileDescriptorSource.getResourceAsString(getClass(), QUERY_PROTO_RES);
+   }
 
    @Override
    public void registerSchema(SerializationContext serCtx) {
@@ -46,7 +48,6 @@ public final class MarshallerRegistration implements SerializationContextInitial
     *
     * @param ctx the serialization context
     * @throws org.infinispan.protostream.DescriptorParserException if a proto definition file fails to parse correctly
-    * @throws IOException if proto file registration fails
     */
    public static void init(SerializationContext ctx) {
       INSTANCE.registerSchema(ctx);

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/ProtobufMetadataManagerImpl.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/ProtobufMetadataManagerImpl.java
@@ -16,6 +16,7 @@ import org.infinispan.commons.CacheException;
 import org.infinispan.commons.dataconversion.IdentityEncoder;
 import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.commons.logging.LogFactory;
+import org.infinispan.commons.marshall.ProtoStreamMarshaller;
 import org.infinispan.commons.util.ServiceFinder;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
@@ -78,8 +79,15 @@ public final class ProtobufMetadataManagerImpl implements ProtobufMetadataManage
 
    public ProtobufMetadataManagerImpl() {
       Configuration.Builder protostreamCfgBuilder = Configuration.builder();
+
+      // Configure a TypeId mapper to support 9.x legacy. the values above 1000000 were used for WrappedMessage and remote query objects
+      protostreamCfgBuilder.wrappingConfig()
+            .wrappedMessageTypeIdMapper(ProtoStreamMarshaller.getLegacyWrappedMessageTypeIdMapper());
+
       IndexingMetadata.configure(protostreamCfgBuilder);
+
       serCtx = ProtobufUtil.newSerializationContext(protostreamCfgBuilder.build());
+
       try {
          MarshallerRegistration.init(serCtx);
       } catch (DescriptorParserException e) {

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/indexing/WrappedMessageTagHandler.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/indexing/WrappedMessageTagHandler.java
@@ -4,6 +4,7 @@ import org.infinispan.commons.logging.LogFactory;
 import org.infinispan.protostream.SerializationContext;
 import org.infinispan.protostream.TagHandler;
 import org.infinispan.protostream.WrappedMessage;
+import org.infinispan.protostream.WrappedMessageTypeIdMapper;
 import org.infinispan.protostream.descriptors.Descriptor;
 import org.infinispan.protostream.descriptors.FieldDescriptor;
 import org.infinispan.protostream.descriptors.GenericDescriptor;
@@ -23,6 +24,7 @@ class WrappedMessageTagHandler implements TagHandler {
 
    protected final ProtobufValueWrapper valueWrapper;
    protected final SerializationContext serCtx;
+   protected final WrappedMessageTypeIdMapper wrappedMessageTypeIdMapper;
 
    protected GenericDescriptor descriptor;
    protected byte[] messageBytes;
@@ -32,6 +34,7 @@ class WrappedMessageTagHandler implements TagHandler {
    WrappedMessageTagHandler(ProtobufValueWrapper valueWrapper, SerializationContext serCtx) {
       this.valueWrapper = valueWrapper;
       this.serCtx = serCtx;
+      this.wrappedMessageTypeIdMapper = serCtx.getConfiguration().wrappingConfig().wrappedMessageTypeIdMapper();
    }
 
    @Override
@@ -69,6 +72,9 @@ class WrappedMessageTagHandler implements TagHandler {
          }
          case WrappedMessage.WRAPPED_DESCRIPTOR_TYPE_ID: {
             Integer typeId = (Integer) value;
+            if (wrappedMessageTypeIdMapper != null) {
+               typeId = wrappedMessageTypeIdMapper.mapTypeIdIn(typeId, serCtx);
+            }
             descriptor = serCtx.getDescriptorByTypeId(typeId);
             break;
          }


### PR DESCRIPTION
….infinispan.commons.marshall.ProtoStreamTypeIds

also updates protostream to get WrappedMessageTypeMapper support for legacy TypeIds

https://issues.jboss.org/browse/ISPN-10663

