### PR TITLE
ISPN-10718 Ensure protobuf metadata cache is predictably started when…

### DIFF
--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/ProtobufMetadataManager.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/ProtobufMetadataManager.java
@@ -8,8 +8,10 @@ import org.infinispan.protostream.BaseMarshaller;
 import org.infinispan.query.remote.client.ProtobufMetadataManagerMBean;
 
 /**
- * A clustered repository of protobuf definition files. All protobuf types and their marshallers must be registered with
- * this repository before being used.
+ * A clustered persistent and replicated repository of protobuf definition files. All protobuf types and their
+ * marshallers must be registered with this repository before being used.
+ * <p>
+ * ProtobufMetadataManager is backed by an internal replicated cache named ___protobuf_metadata.
  *
  * @author anistor@redhat.com
  * @since 8.0

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/ProtobufMetadataManagerInterceptor.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/ProtobufMetadataManagerInterceptor.java
@@ -1,5 +1,8 @@
 package org.infinispan.query.remote.impl;
 
+import static org.infinispan.query.remote.client.ProtobufMetadataManagerConstants.ERRORS_KEY_SUFFIX;
+import static org.infinispan.query.remote.client.ProtobufMetadataManagerConstants.PROTO_KEY_SUFFIX;
+
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
@@ -57,7 +60,7 @@ import org.infinispan.query.remote.impl.logging.Log;
  * @author anistor@redhat.com
  * @since 7.0
  */
-final class ProtobufMetadataManagerInterceptor extends BaseCustomAsyncInterceptor implements ProtobufMetadataManagerConstants {
+final class ProtobufMetadataManagerInterceptor extends BaseCustomAsyncInterceptor {
 
    private static final Log log = LogFactory.getLog(ProtobufMetadataManagerInterceptor.class, Log.class);
 

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/SecurityActions.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/SecurityActions.java
@@ -53,8 +53,7 @@ final class SecurityActions {
       return doPrivileged(new GetSerializationContextAction(cacheManager));
    }
 
-   static void addCacheDependency(EmbeddedCacheManager cacheManager, String dependantCacheName,
-                                  String protobufMetadataCacheName) {
-      doPrivileged(new AddCacheDependencyAction(cacheManager, dependantCacheName, protobufMetadataCacheName));
+   static void addCacheDependency(EmbeddedCacheManager cacheManager, String from, String to) {
+      doPrivileged(new AddCacheDependencyAction(cacheManager, from, to));
    }
 }

--- a/remote-query/remote-query-server/src/test/java/org/infinispan/query/remote/impl/ProtobufMetadataCachePreserveStateAcrossRestartsTest.java
+++ b/remote-query/remote-query-server/src/test/java/org/infinispan/query/remote/impl/ProtobufMetadataCachePreserveStateAcrossRestartsTest.java
@@ -34,7 +34,7 @@ public class ProtobufMetadataCachePreserveStateAcrossRestartsTest extends Abstra
       TestingUtil.withCacheManagers(new MultiCacheManagerCallable(createCacheManager(persistentStateLocation1),
                                                                   createCacheManager(persistentStateLocation2)) {
          @Override
-         public void call() throws Exception {
+         public void call() {
             Cache<String, String> protobufMetadaCache = cms[0].getCache(ProtobufMetadataManagerConstants.PROTOBUF_METADATA_CACHE_NAME);
             protobufMetadaCache.put("testA.proto", "package A;");
             protobufMetadaCache.put("testB.proto", "import \"testB.proto\";\npackage B;");
@@ -44,7 +44,7 @@ public class ProtobufMetadataCachePreserveStateAcrossRestartsTest extends Abstra
       TestingUtil.withCacheManagers(new MultiCacheManagerCallable(createCacheManager(persistentStateLocation1),
                                                                   createCacheManager(persistentStateLocation2)) {
          @Override
-         public void call() throws Exception {
+         public void call() {
             Cache<String, String> protobufMetadaCache = cms[0].getCache(ProtobufMetadataManagerConstants.PROTOBUF_METADATA_CACHE_NAME);
             assertTrue(protobufMetadaCache.containsKey("testA.proto"));
             assertTrue(protobufMetadaCache.containsKey("testB.proto"));

--- a/remote-query/remote-query-server/src/test/java/org/infinispan/query/remote/impl/ProtobufMetadataCacheStartedTest.java
+++ b/remote-query/remote-query-server/src/test/java/org/infinispan/query/remote/impl/ProtobufMetadataCacheStartedTest.java
@@ -1,6 +1,5 @@
 package org.infinispan.query.remote.impl;
 
-import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertTrue;
 
 import org.infinispan.commons.util.Util;
@@ -20,12 +19,11 @@ public class ProtobufMetadataCacheStartedTest extends AbstractInfinispanTest {
    protected EmbeddedCacheManager createCacheManager(String persistentStateLocation) throws Exception {
       GlobalConfigurationBuilder global = new GlobalConfigurationBuilder().clusteredDefault();
       global.globalState().enable().persistentLocation(persistentStateLocation);
-      EmbeddedCacheManager cacheManager = TestCacheManagerFactory.createClusteredCacheManager(global, new ConfigurationBuilder());
-      return cacheManager;
+      return TestCacheManagerFactory.createClusteredCacheManager(global, new ConfigurationBuilder());
    }
 
    public void testMetadataCacheStarted() throws Exception {
-      String persistentStateLocation = TestingUtil.tmpDirectory(this.getClass());
+      String persistentStateLocation = TestingUtil.tmpDirectory(getClass());
       Util.recursiveFileRemove(persistentStateLocation);
 
       final String persistentStateLocation1 = persistentStateLocation + "/1";
@@ -33,13 +31,9 @@ public class ProtobufMetadataCacheStartedTest extends AbstractInfinispanTest {
       TestingUtil.withCacheManagers(new MultiCacheManagerCallable(createCacheManager(persistentStateLocation1),
                                                                   createCacheManager(persistentStateLocation2)) {
          @Override
-         public void call() throws Exception {
-            assertFalse(cms[0].isRunning(ProtobufMetadataManagerConstants.PROTOBUF_METADATA_CACHE_NAME));
-            cms[0].getCache();
+         public void call() {
             assertTrue(cms[0].isRunning(ProtobufMetadataManagerConstants.PROTOBUF_METADATA_CACHE_NAME));
 
-            assertFalse(cms[1].isRunning(ProtobufMetadataManagerConstants.PROTOBUF_METADATA_CACHE_NAME));
-            cms[1].getCache();
             assertTrue(cms[1].isRunning(ProtobufMetadataManagerConstants.PROTOBUF_METADATA_CACHE_NAME));
          }
       });


### PR DESCRIPTION
… the cache manager has finished initializing

* move creation of protobuf metadata cache config into ProtobufMetadataManagerImpl for
  better encapsulation; hide the insertion of the interceptor; this does not belong in the ModuleLifecycle
* protobuf metadata cache should be always already running before first cache is started rather than
  being started accidentaly in addCacheDependency (see ProtobufMetadataCacheStartedTest)
* ProtobufMetadataManagerMBean should be registered only after protobuf metadata cache is started
* remote-query-server module depends on query

https://issues.jboss.org/browse/ISPN-10718