### PR TITLE
ISPN-10774 kill-server Ant task kills clients too

### DIFF
--- a/server/runtime/src/main/ant/infinispan-server.xml
+++ b/server/runtime/src/main/ant/infinispan-server.xml
@@ -104,7 +104,7 @@
 
         <exec executable="bash" outputproperty="lsof.pid" resultproperty="lsof.result" failifexecutionfails="false" failonerror="false" osfamily="unix">
             <arg value="-c"/>
-            <arg value="lsof -t -i TCP:${hotrod.port}"/>
+            <arg value="lsof -t -i TCP:${hotrod.port} -s TCP:LISTEN"/>
             <redirector>
                 <outputfilterchain>
                     <prefixlines prefix=" "/>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-10774

Kill only the server process listening on the HotRod port,
not clients connected to it.