### PR TITLE
ISPN-10788 Use logger to display JVM information on Server boot

### DIFF
--- a/server/runtime/src/main/java/org/infinispan/server/Bootstrap.java
+++ b/server/runtime/src/main/java/org/infinispan/server/Bootstrap.java
@@ -7,10 +7,14 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
 import java.nio.file.Paths;
 import java.util.Iterator;
 import java.util.Properties;
+import java.util.StringJoiner;
 import java.util.logging.LogManager;
+import java.util.logging.Logger;
 
 import org.infinispan.commons.util.Version;
 import org.infinispan.server.tool.Main;
@@ -88,7 +92,7 @@ public class Bootstrap extends Main {
 
    public void runInternal() {
       if (!serverRoot.isAbsolute()) {
-         serverRoot =  serverRoot.getAbsoluteFile();
+         serverRoot = serverRoot.getAbsoluteFile();
       }
       File confDir = new File(serverRoot, Server.DEFAULT_SERVER_CONFIG);
       if (configurationFile == null) {
@@ -105,6 +109,8 @@ public class Bootstrap extends Main {
          stdErr.printf("Could not load logging.properties: %s", e.getMessage());
          e.printStackTrace(stdErr);
       }
+
+      logJVMInformation();
 
       try {
          Runtime.getRuntime().addShutdownHook(new ShutdownHook(exitHandler));
@@ -139,5 +145,14 @@ public class Bootstrap extends Main {
       out.printf("%s Server %s (%s)\n", Version.getBrandName(), Version.getVersion(), Version.getCodename());
       out.println("Copyright (C) Red Hat Inc. and/or its affiliates and other contributors");
       out.println("License Apache License, v. 2.0. http://www.apache.org/licenses/LICENSE-2.0");
+   }
+
+   private void logJVMInformation() {
+      RuntimeMXBean runtimeMxBean = ManagementFactory.getRuntimeMXBean();
+      Logger logger = Logger.getLogger("BOOT");
+      logger.info("JVM " + runtimeMxBean.getVmName() + " " + runtimeMxBean.getVmVendor() + " " + runtimeMxBean.getVmVersion());
+      StringJoiner sj = new StringJoiner(" ");
+      runtimeMxBean.getInputArguments().forEach(s -> sj.add(s));
+      logger.info("JVM arguments = " + sj);
    }
 }

--- a/server/runtime/src/main/server/bin/common.bat
+++ b/server/runtime/src/main/server/bin/common.bat
@@ -67,11 +67,3 @@ if "%DEBUG_MODE%" == "true" (
      echo Debug already enabled in JAVA_OPTS, ignoring --debug argument
   )
 )
-
-rem Display our environment
-echo "========================================================================="
-echo "  Bootstrap Environment"
-echo "  ISPN_HOME: $ISPN_HOME"
-echo "  JAVA: $JAVA"
-echo "  JAVA_OPTS: $JAVA_OPTS"
-echo "========================================================================="

--- a/server/runtime/src/main/server/bin/common.sh
+++ b/server/runtime/src/main/server/bin/common.sh
@@ -267,11 +267,3 @@ CLASSPATH=
 for JAR in "$ISPN_HOME/boot"/*.jar; do
     CLASSPATH="$CLASSPATH:$JAR"
 done
-
-# Display our environment
-echo "========================================================================="
-echo "  Bootstrap Environment"
-echo "  ISPN_HOME: $ISPN_HOME"
-echo "  JAVA: $JAVA"
-echo "  JAVA_OPTS: $JAVA_OPTS"
-echo "========================================================================="


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-10788

@ryanemerson @diegolovison 
This is what it looks like
```
18:22:20,066 INFO  [BOOT] (main) JVM OpenJDK 64-Bit Server VM Ubuntu 11.0.5-ea+10-post-Ubuntu-0ubuntu1
18:22:20,083 INFO  [BOOT] (main) JVM arguments = -Xms64m -Xmx512m -XX:MetaspaceSize=32M -XX:MaxMetaspaceSize=64m -Djava.net.preferIPv4Stack=true -Djava.awt.headless=true -Dvisualvm.display.name=infinispan-server -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dinfinispan.server.home.path=/home/tst/Work/Infinispan/infinispan/server/runtime/target/infinispan-server-10.0.0-SNAPSHOT
18:22:20,129 INFO  [org.infinispan.SERVER] (main) ISPN080000: Infinispan Server starting
18:22:20,130 INFO  [org.infinispan.SERVER] (main) ISPN080017: Server configuration: /home/tst/Work/Infinispan/infinispan/server/runtime/target/infinispan-server-10.0.0-SNAPSHOT/server/conf/infinispan.xml
18:22:20,733 INFO  [org.infinispan.SERVER] (main) ISPN080027: Loaded extension 'query-dsl-filter-converter-factory'
18:22:20,733 INFO  [org.infinispan.SERVER] (main) ISPN080027: Loaded extension 'continuous-query-filter-converter-factory'
```