### PR TITLE
Fix MariaDB dialect discover

### DIFF
--- a/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/impl/table/TableManagerFactory.java
+++ b/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/impl/table/TableManagerFactory.java
@@ -130,6 +130,8 @@ public class TableManagerFactory {
 
       name = name.toLowerCase();
       if (name.contains("mysql")) {
+         type = DatabaseType.MARIA_DB;
+      } else if (name.contains("mariadb")) {
          type = DatabaseType.MYSQL;
       } else if (name.contains("postgres")) {
          type = DatabaseType.POSTGRES;


### PR DESCRIPTION
This modification avoid receive `Unable to guess database dialect from JDBC driver name.`