### PR TITLE
ISPN-10815 Javadoc missing jboss-marshalling dependency

### DIFF
--- a/javadoc/javadoc-all/pom.xml
+++ b/javadoc/javadoc-all/pom.xml
@@ -150,6 +150,11 @@
          <groupId>org.infinispan</groupId>
          <artifactId>infinispan-extended-statistics</artifactId>
       </dependency>
+
+      <dependency>
+         <groupId>org.infinispan</groupId>
+         <artifactId>infinispan-jboss-marshalling</artifactId>
+      </dependency>
       <!-- /javadoc-embedded dependencies -->
 
       <!-- javadoc-remote dependencies -->


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-10815

This fixes the master build.