### PR TITLE
ISPN-10866 Force Infinispan Wildfly extension to use jboss marshalling

### DIFF
--- a/wildfly/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerConfigurationBuilder.java
+++ b/wildfly/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerConfigurationBuilder.java
@@ -40,6 +40,7 @@ import org.infinispan.configuration.global.ShutdownHookBehavior;
 import org.infinispan.configuration.global.ThreadPoolConfiguration;
 import org.infinispan.configuration.internal.PrivateGlobalConfigurationBuilder;
 import org.infinispan.globalstate.LocalConfigurationStorage;
+import org.infinispan.jboss.marshalling.core.JBossUserMarshaller;
 import org.infinispan.marshall.core.Ids;
 import org.infinispan.security.AuditLogger;
 import org.infinispan.security.PrincipalRoleMapper;
@@ -152,7 +153,7 @@ public class CacheContainerConfigurationBuilder implements Builder<GlobalConfigu
 
         GlobalConfigurationBuilder builder = new GlobalConfigurationBuilder();
         ModuleLoader moduleLoader = this.loader.getValue();
-        builder.serialization().classResolver(ModularClassResolver.getInstance(moduleLoader));
+        builder.serialization().classResolver(ModularClassResolver.getInstance(moduleLoader)).marshaller(new JBossUserMarshaller());
         ClassLoader loader;
         try {
             loader = makeGlobalClassLoader(moduleLoader, module, modules);


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-10866

This is necessary as the wildfly `InfinispanExtension` does not allow serialization to be configured via the DMR or XML. Therefore, we default to the old behaviour of using jboss-marshalling.