### PR TITLE
ISPN-10925 CacheMgmtInterceptor.visitComputeCommand uses millis to up…

### DIFF
--- a/core/src/main/java/org/infinispan/interceptors/impl/CacheMgmtInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/CacheMgmtInterceptor.java
@@ -191,9 +191,9 @@ public final class CacheMgmtInterceptor extends JmxStatsCommandInterceptor {
          if (rv == null && rCommand.isSuccessful()) {
             increaseRemoveMisses();
          } else if (rCommand.isSuccessful()) {
-            long intervalMilliseconds = timeService.timeDuration(start, TimeUnit.MILLISECONDS);
+            long intervalNanos = timeService.timeDuration(start, TimeUnit.NANOSECONDS);
             StripeB stripe = counters.stripeForCurrentThread();
-            counters.add(StripeB.storeTimesFieldUpdater, stripe, intervalMilliseconds);
+            counters.add(StripeB.storeTimesFieldUpdater, stripe, intervalNanos);
             counters.increment(StripeB.storesFieldUpdater, stripe);
          }
       });


### PR DESCRIPTION
…date store time stats which are in nanos

https://issues.jboss.org/browse/ISPN-10925