### PR TITLE
ISPN-10855 Run all test methods when the class isn't annotated @InCacheMode

### DIFF
--- a/core/src/test/java/org/infinispan/test/MultipleCacheManagersTest.java
+++ b/core/src/test/java/org/infinispan/test/MultipleCacheManagersTest.java
@@ -988,13 +988,13 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
 
       public boolean test(CM mode, IMethodInstance method) {
          // If both method and class have the annotation, method annotation has priority.
-         A clazzAnnotation = method.getInstance().getClass().getAnnotation(annotationClazz);
          A methodAnnotation = method.getMethod().getConstructorOrMethod().getMethod().getAnnotation(annotationClazz);
          if (methodAnnotation != null) {
             // If a method-level annotation contains current cache mode, run it, otherwise ignore that
             return Stream.of(modesRetriever.apply(methodAnnotation)).anyMatch(m -> modeChecker.test(m, mode));
          } else {
-            return clazzAnnotation != null;
+            // If there is no method-level annotation, always run it
+            return true;
          }
       }
    }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-10855

My initial commit for ISPN-10855 simplified the handling of `@InCacheMode` and `@InTransactionMode` annotations so you can't add a new cache mode just for one method, but I made a mistake and I skipped running all the test methods when the class wasn't annotated with `@InCacheMode` or `@InTransactionMode`.