### PR TITLE
ISPN-10937 CleanupAfterMethod tests take a very long time

### DIFF
--- a/core/src/test/java/org/infinispan/partitionhandling/BasePartitionHandlingTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/BasePartitionHandlingTest.java
@@ -37,6 +37,7 @@ import org.infinispan.test.Exceptions;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestDataSCI;
 import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.TestResourceTracker;
 import org.infinispan.test.fwk.TransportFlags;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -165,7 +166,8 @@ public class BasePartitionHandlingTest extends MultipleCacheManagersTest {
 
    protected void enableDiscoveryProtocol(JChannel c) {
       try {
-         c.getProtocolStack().findProtocol(Discovery.class).start();
+         String defaultClusterName = TestResourceTracker.getCurrentTestName();
+         ((Discovery) c.getProtocolStack().findProtocol(Discovery.class)).setClusterName(defaultClusterName);
       } catch (Exception e) {
          throw new RuntimeException(e);
       }
@@ -299,6 +301,7 @@ public class BasePartitionHandlingTest extends MultipleCacheManagersTest {
          ArrayList<JChannel> view2 = new ArrayList<>(partition.channels);
          partition.channels.stream().filter(c -> !channels.contains(c)).forEach(c -> channels.add(c));
          installMergeView(view1, view2);
+         enableDiscovery();
          waitForPartitionToForm(waitForNoRebalance);
          List<Partition> tmp = new ArrayList<>(Arrays.asList(BasePartitionHandlingTest.this.partitions));
          if (!tmp.remove(partition)) throw new AssertionError();

--- a/core/src/test/resources/configs/xsite/bridge.xml
+++ b/core/src/test/resources/configs/xsite/bridge.xml
@@ -48,7 +48,10 @@
                    max_bytes="1M"
     />
     <pbcast.GMS print_local_addr="false"
-                join_timeout="${jgroups.join_timeout:2000}"/>
+                join_timeout="${jgroups.join_timeout:2000}"
+                max_join_attempts="1"
+                max_leave_attempts="1"
+    />
 
     <UFC_NB max_credits="3m"
          min_threshold="0.40"/>

--- a/core/src/test/resources/configs/xsite/xsite-inline-test.xml
+++ b/core/src/test/resources/configs/xsite/xsite-inline-test.xml
@@ -40,7 +40,10 @@
                         max_bytes="1M"
          />
          <pbcast.GMS print_local_addr="false"
-                     join_timeout="${jgroups.join_timeout:2000}"/>
+                     join_timeout="${jgroups.join_timeout:2000}"
+                     max_join_attempts="1"
+                     max_leave_attempts="1"
+         />
          <UFC_NB max_credits="3m"
               min_threshold="0.40"/>
          <MFC_NB max_credits="3m"

--- a/core/src/test/resources/stacks/tcp.xml
+++ b/core/src/test/resources/stacks/tcp.xml
@@ -61,7 +61,10 @@
                   max_bytes="1M"
    />
    <pbcast.GMS print_local_addr="false"
-               join_timeout="${jgroups.join_timeout:2000}"/>
+               join_timeout="${jgroups.join_timeout:2000}"
+               max_join_attempts="1"
+               max_leave_attempts="1"
+   />
    <tom.TOA/> <!-- the Total Order Anycast is only needed for total order transactions (in distributed mode)-->
 
    <UFC_NB max_credits="3m" min_threshold="0.40"/>

--- a/core/src/test/resources/stacks/udp.xml
+++ b/core/src/test/resources/stacks/udp.xml
@@ -51,7 +51,10 @@
                   max_bytes="1M"
    />
    <pbcast.GMS print_local_addr="false"
-               join_timeout="${jgroups.join_timeout:2000}"/>
+               join_timeout="${jgroups.join_timeout:2000}"
+               max_join_attempts="1"
+               max_leave_attempts="1"
+   />
    <tom.TOA/> <!-- the Total Order Anycast is only needed for total order transactions (in distributed mode)-->
 
    <UFC_NB max_credits="3m" min_threshold="0.40"/>

--- a/hibernate/cache-commons/src/test/resources/2lc-test-tcp.xml
+++ b/hibernate/cache-commons/src/test/resources/2lc-test-tcp.xml
@@ -47,7 +47,9 @@
                   max_bytes="1M"
    />
    <pbcast.GMS print_local_addr="false"
-               join_timeout="2000"
+               join_timeout="${jgroups.join_timeout:2000}"
+               max_join_attempts="1"
+               max_leave_attempts="1"
    />
 
     <!-- At this place we can react on DISCONNECTs immediatelly -->

--- a/tools/src/test/resources/udp.xml
+++ b/tools/src/test/resources/udp.xml
@@ -51,7 +51,10 @@
                   max_bytes="1M"
    />
    <pbcast.GMS print_local_addr="false"
-               join_timeout="${jgroups.join_timeout:2000}"/>
+               join_timeout="${jgroups.join_timeout:2000}"
+               max_join_attempts="1"
+               max_leave_attempts="1"
+   />
    <tom.TOA/> <!-- the Total Order Anycast is only needed for total order transactions (in distributed mode)-->
 
    <UFC_NB max_credits="3m" min_threshold="0.40"/>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-10937

Reduce GMS.max_join_attempts to work around JGRP-2398