### PR TITLE
ISPN-10940 JPA deleteBatch should not pass empty collection to Criter…

### DIFF
--- a/core/src/test/java/org/infinispan/persistence/BaseStoreTest.java
+++ b/core/src/test/java/org/infinispan/persistence/BaseStoreTest.java
@@ -579,6 +579,15 @@ public abstract class BaseStoreTest extends AbstractInfinispanTest {
       );
    }
 
+   public void testEmptyWriteAndDeleteBatchIterable() {
+      assertIsEmpty();
+      assertNull("should not be present in the store", cl.loadEntry(0));
+      cl.bulkUpdate(Flowable.empty());
+      assertEquals(0, cl.size());
+      cl.deleteBatch(Collections.emptyList());
+      assertEquals(0, cl.size());
+   }
+
    private <R> void testBatch(int numberOfEntries, Runnable createBatch) {
       assertIsEmpty();
       assertNull("should not be present in the store", cl.loadEntry(0));


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-10940

@wburns Unfortunately `testEmptyWriteAndDeleteBatchIterable` doesn't actually reproduce the issue with H2 as the issue is DB specific, however I figured it was good to have coverage of this scenario for all stores anyway.