### PR TITLE
ISPN-10879 Fix PersistenceIT random failures

### DIFF
--- a/server/runtime/src/test/java/org/infinispan/server/cli/CliIT.java
+++ b/server/runtime/src/test/java/org/infinispan/server/cli/CliIT.java
@@ -7,7 +7,7 @@ import org.infinispan.cli.CLI;
 import org.infinispan.server.test.AeshTestConnection;
 import org.infinispan.server.test.AeshTestShell;
 import org.infinispan.server.test.InfinispanServerRule;
-import org.infinispan.server.test.InfinispanServerTestConfiguration;
+import org.infinispan.server.test.InfinispanServerRuleConfigurationBuilder;
 import org.infinispan.server.test.InfinispanServerTestMethodRule;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -20,7 +20,7 @@ import org.junit.Test;
 public class CliIT {
 
    @ClassRule
-   public static InfinispanServerRule SERVERS = new InfinispanServerRule(new InfinispanServerTestConfiguration("configuration/ClusteredServerTest.xml"));
+   public static InfinispanServerRule SERVERS = new InfinispanServerRule(new InfinispanServerRuleConfigurationBuilder("configuration/ClusteredServerTest.xml"));
 
    @Rule
    public InfinispanServerTestMethodRule SERVER_TEST = new InfinispanServerTestMethodRule(SERVERS);

--- a/server/runtime/src/test/java/org/infinispan/server/extensions/ExtensionsIT.java
+++ b/server/runtime/src/test/java/org/infinispan/server/extensions/ExtensionsIT.java
@@ -1,7 +1,7 @@
 package org.infinispan.server.extensions;
 
 import org.infinispan.server.test.InfinispanServerRule;
-import org.infinispan.server.test.InfinispanServerTestConfiguration;
+import org.infinispan.server.test.InfinispanServerRuleConfigurationBuilder;
 import org.infinispan.server.test.ServerRunMode;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
@@ -20,9 +20,9 @@ public class ExtensionsIT {
 
    @ClassRule
    public static final InfinispanServerRule SERVERS = new InfinispanServerRule(
-         new InfinispanServerTestConfiguration("configuration/ClusteredServerTest.xml")
-               .runMode(ServerRunMode.CONTAINER)
+         new InfinispanServerRuleConfigurationBuilder("configuration/ClusteredServerTest.xml")
+               .serverRunMode(ServerRunMode.CONTAINER)
                .numServers(2)
-               .artifacts(HelloServerTask.artifact())
+               .archive(HelloServerTask.artifact())
    );
 }

--- a/server/runtime/src/test/java/org/infinispan/server/functional/ClusteredIT.java
+++ b/server/runtime/src/test/java/org/infinispan/server/functional/ClusteredIT.java
@@ -13,7 +13,7 @@ import org.infinispan.configuration.cache.Index;
 import org.infinispan.protostream.sampledomain.marshallers.MarshallerRegistration;
 import org.infinispan.query.remote.client.ProtobufMetadataManagerConstants;
 import org.infinispan.server.test.InfinispanServerRule;
-import org.infinispan.server.test.InfinispanServerTestConfiguration;
+import org.infinispan.server.test.InfinispanServerRuleConfigurationBuilder;
 import org.infinispan.server.test.InfinispanServerTestMethodRule;
 import org.infinispan.test.Exceptions;
 import org.junit.ClassRule;
@@ -44,7 +44,7 @@ public class ClusteredIT {
 
    @ClassRule
    public static final InfinispanServerRule SERVERS = new InfinispanServerRule(
-         new InfinispanServerTestConfiguration("configuration/ClusteredServerTest.xml")
+         new InfinispanServerRuleConfigurationBuilder("configuration/ClusteredServerTest.xml")
                .numServers(2)
    );
 

--- a/server/runtime/src/test/java/org/infinispan/server/functional/ShutdownRestIT.java
+++ b/server/runtime/src/test/java/org/infinispan/server/functional/ShutdownRestIT.java
@@ -8,7 +8,7 @@ import java.net.ConnectException;
 import org.infinispan.client.rest.RestClient;
 import org.infinispan.commons.util.Util;
 import org.infinispan.server.test.InfinispanServerRule;
-import org.infinispan.server.test.InfinispanServerTestConfiguration;
+import org.infinispan.server.test.InfinispanServerRuleConfigurationBuilder;
 import org.infinispan.server.test.InfinispanServerTestMethodRule;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -21,7 +21,7 @@ public class ShutdownRestIT {
 
    @ClassRule
    public static final InfinispanServerRule SERVER = new InfinispanServerRule(
-         new InfinispanServerTestConfiguration("configuration/ClusteredServerTest.xml").numServers(1));
+         new InfinispanServerRuleConfigurationBuilder("configuration/ClusteredServerTest.xml").numServers(1));
 
    @Rule
    public InfinispanServerTestMethodRule SERVER_TEST = new InfinispanServerTestMethodRule(SERVER);

--- a/server/runtime/src/test/java/org/infinispan/server/persistence/PersistenceIT.java
+++ b/server/runtime/src/test/java/org/infinispan/server/persistence/PersistenceIT.java
@@ -1,7 +1,7 @@
 package org.infinispan.server.persistence;
 
 import org.infinispan.server.test.InfinispanServerRule;
-import org.infinispan.server.test.InfinispanServerTestConfiguration;
+import org.infinispan.server.test.InfinispanServerRuleConfigurationBuilder;
 import org.infinispan.server.test.ServerRunMode;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
@@ -17,9 +17,11 @@ import org.junit.runners.Suite;
 })
 public class PersistenceIT {
 
-   protected static final Integer NUM_SERVERS = 1;
-
    @ClassRule
-   public static InfinispanServerRule SERVERS = new InfinispanServerRule(new InfinispanServerTestConfiguration("configuration/ClusteredServerTest.xml")
-         .numServers(NUM_SERVERS).runMode(ServerRunMode.CONTAINER).mavenArtifacts("com.h2database:h2:1.4.199", "mysql:mysql-connector-java:8.0.17", "org.postgresql:postgresql:jar:42.2.8"));
+   public static InfinispanServerRule SERVERS = new InfinispanServerRule(
+         new InfinispanServerRuleConfigurationBuilder("configuration/ClusteredServerTest.xml")
+            .numServers(1)
+            .serverRunMode(ServerRunMode.CONTAINER)
+            .mavenArtifacts(new String[] {"com.h2database:h2:1.4.199", "mysql:mysql-connector-java:8.0.17", "org.postgresql:postgresql:jar:42.2.8"})
+   );
 }

--- a/server/runtime/src/test/java/org/infinispan/server/resilience/GracefulShutdownRestartIT.java
+++ b/server/runtime/src/test/java/org/infinispan/server/resilience/GracefulShutdownRestartIT.java
@@ -12,7 +12,7 @@ import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.server.test.ContainerInfinispanServerDriver;
 import org.infinispan.server.test.InfinispanServerRule;
-import org.infinispan.server.test.InfinispanServerTestConfiguration;
+import org.infinispan.server.test.InfinispanServerRuleConfigurationBuilder;
 import org.infinispan.server.test.InfinispanServerTestMethodRule;
 import org.infinispan.server.test.ServerRunMode;
 import org.junit.ClassRule;
@@ -26,7 +26,7 @@ public class GracefulShutdownRestartIT {
 
    @ClassRule
    public static final InfinispanServerRule SERVER = new InfinispanServerRule(
-         new InfinispanServerTestConfiguration("configuration/ClusteredServerTest.xml").numServers(2).runMode(ServerRunMode.CONTAINER));
+         new InfinispanServerRuleConfigurationBuilder("configuration/ClusteredServerTest.xml").numServers(2).serverRunMode(ServerRunMode.CONTAINER));
 
    @Rule
    public InfinispanServerTestMethodRule SERVER_TEST = new InfinispanServerTestMethodRule(SERVER);

--- a/server/runtime/src/test/java/org/infinispan/server/resilience/ResilienceIT.java
+++ b/server/runtime/src/test/java/org/infinispan/server/resilience/ResilienceIT.java
@@ -9,7 +9,7 @@ import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
 import org.infinispan.commons.util.Eventually;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.server.test.InfinispanServerRule;
-import org.infinispan.server.test.InfinispanServerTestConfiguration;
+import org.infinispan.server.test.InfinispanServerRuleConfigurationBuilder;
 import org.infinispan.server.test.InfinispanServerTestMethodRule;
 import org.infinispan.server.test.ServerRunMode;
 import org.infinispan.server.test.category.Resilience;
@@ -27,7 +27,8 @@ import org.junit.experimental.categories.Category;
 public class ResilienceIT {
 
    @ClassRule
-   public static InfinispanServerRule SERVERS = new InfinispanServerRule(new InfinispanServerTestConfiguration("configuration/ClusteredServerTest.xml").runMode(ServerRunMode.CONTAINER));
+   public static InfinispanServerRule SERVERS = new InfinispanServerRule(new InfinispanServerRuleConfigurationBuilder("configuration/ClusteredServerTest.xml")
+         .serverRunMode(ServerRunMode.CONTAINER));
 
    @Rule
    public InfinispanServerTestMethodRule SERVER_TEST = new InfinispanServerTestMethodRule(SERVERS);

--- a/server/runtime/src/test/java/org/infinispan/server/security/AuthenticationCertIT.java
+++ b/server/runtime/src/test/java/org/infinispan/server/security/AuthenticationCertIT.java
@@ -9,7 +9,6 @@ import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
 import org.infinispan.client.hotrod.exceptions.TransportException;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.server.test.InfinispanServerRule;
-import org.infinispan.server.test.InfinispanServerTestConfiguration;
 import org.infinispan.server.test.InfinispanServerTestMethodRule;
 import org.infinispan.server.test.category.Security;
 import org.infinispan.test.Exceptions;
@@ -26,7 +25,7 @@ import org.junit.experimental.categories.Category;
 public class AuthenticationCertIT {
 
    @ClassRule
-   public static InfinispanServerRule SERVERS = new InfinispanServerRule(new InfinispanServerTestConfiguration("configuration/AuthenticationServerTrustTest.xml"));
+   public static InfinispanServerRule SERVERS = new InfinispanServerRule("configuration/AuthenticationServerTrustTest.xml");
 
    @Rule
    public InfinispanServerTestMethodRule SERVER_TEST = new InfinispanServerTestMethodRule(SERVERS);

--- a/server/runtime/src/test/java/org/infinispan/server/security/AuthenticationKeyCloakIT.java
+++ b/server/runtime/src/test/java/org/infinispan/server/security/AuthenticationKeyCloakIT.java
@@ -12,7 +12,7 @@ import org.infinispan.client.rest.RestResponse;
 import org.infinispan.client.rest.configuration.RestClientConfigurationBuilder;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.server.test.InfinispanServerRule;
-import org.infinispan.server.test.InfinispanServerTestConfiguration;
+import org.infinispan.server.test.InfinispanServerRuleConfigurationBuilder;
 import org.infinispan.server.test.InfinispanServerTestMethodRule;
 import org.infinispan.server.test.KeyCloakServerRule;
 import org.junit.ClassRule;
@@ -28,7 +28,7 @@ import org.wildfly.security.credential.BearerTokenCredential;
 public class AuthenticationKeyCloakIT {
 
    @ClassRule
-   public static InfinispanServerRule SERVERS = new InfinispanServerRule(new InfinispanServerTestConfiguration("configuration/AuthenticationKeyCloakTest.xml"));
+   public static InfinispanServerRule SERVERS = new InfinispanServerRule(new InfinispanServerRuleConfigurationBuilder("configuration/AuthenticationKeyCloakTest.xml"));
 
    @ClassRule
    public static KeyCloakServerRule KEYCLOAK = new KeyCloakServerRule("keycloak/infinispan-keycloak-realm.json");

--- a/server/runtime/src/test/java/org/infinispan/server/security/AuthenticationLDAPIT.java
+++ b/server/runtime/src/test/java/org/infinispan/server/security/AuthenticationLDAPIT.java
@@ -9,7 +9,7 @@ import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
 import org.infinispan.client.hotrod.exceptions.HotRodClientException;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.server.test.InfinispanServerRule;
-import org.infinispan.server.test.InfinispanServerTestConfiguration;
+import org.infinispan.server.test.InfinispanServerRuleConfigurationBuilder;
 import org.infinispan.server.test.InfinispanServerTestMethodRule;
 import org.infinispan.server.test.LdapServerRule;
 import org.infinispan.server.test.category.Security;
@@ -29,7 +29,7 @@ import org.junit.runners.Parameterized;
 @Category(Security.class)
 public class AuthenticationLDAPIT {
    @ClassRule
-   public static InfinispanServerRule SERVERS = new InfinispanServerRule(new InfinispanServerTestConfiguration("configuration/AuthenticationLDAPTest.xml"));
+   public static InfinispanServerRule SERVERS = new InfinispanServerRule(new InfinispanServerRuleConfigurationBuilder("configuration/AuthenticationLDAPTest.xml"));
 
    @ClassRule
    public static LdapServerRule LDAP = new LdapServerRule(SERVERS);

--- a/server/runtime/src/test/java/org/infinispan/server/security/AuthenticationTLSIT.java
+++ b/server/runtime/src/test/java/org/infinispan/server/security/AuthenticationTLSIT.java
@@ -9,7 +9,7 @@ import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
 import org.infinispan.client.hotrod.exceptions.HotRodClientException;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.server.test.InfinispanServerRule;
-import org.infinispan.server.test.InfinispanServerTestConfiguration;
+import org.infinispan.server.test.InfinispanServerRuleConfigurationBuilder;
 import org.infinispan.server.test.InfinispanServerTestMethodRule;
 import org.infinispan.server.test.category.Security;
 import org.junit.ClassRule;
@@ -29,7 +29,7 @@ import org.junit.runners.Parameterized;
 public class AuthenticationTLSIT {
 
    @ClassRule
-   public static InfinispanServerRule SERVERS = new InfinispanServerRule(new InfinispanServerTestConfiguration("configuration/AuthenticationServerTLSTest.xml"));
+   public static InfinispanServerRule SERVERS = new InfinispanServerRule(new InfinispanServerRuleConfigurationBuilder("configuration/AuthenticationServerTLSTest.xml"));
 
    @Rule
    public InfinispanServerTestMethodRule SERVER_TEST = new InfinispanServerTestMethodRule(SERVERS);

--- a/server/runtime/src/test/java/org/infinispan/server/security/AuthorizationLDAPIT.java
+++ b/server/runtime/src/test/java/org/infinispan/server/security/AuthorizationLDAPIT.java
@@ -11,7 +11,7 @@ import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
 import org.infinispan.client.hotrod.exceptions.HotRodClientException;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.server.test.InfinispanServerRule;
-import org.infinispan.server.test.InfinispanServerTestConfiguration;
+import org.infinispan.server.test.InfinispanServerRuleConfigurationBuilder;
 import org.infinispan.server.test.InfinispanServerTestMethodRule;
 import org.infinispan.server.test.LdapServerRule;
 import org.infinispan.server.test.category.Security;
@@ -29,7 +29,7 @@ import org.junit.experimental.categories.Category;
 @Category(Security.class)
 public class AuthorizationLDAPIT {
    @ClassRule
-   public static InfinispanServerRule SERVERS = new InfinispanServerRule(new InfinispanServerTestConfiguration("configuration/AuthorizationLDAPTest.xml"));
+   public static InfinispanServerRule SERVERS = new InfinispanServerRule(new InfinispanServerRuleConfigurationBuilder("configuration/AuthorizationLDAPTest.xml"));
 
    @ClassRule
    public static LdapServerRule LDAP = new LdapServerRule(SERVERS);

--- a/server/runtime/src/test/java/org/infinispan/server/security/authentication/AuthenticationIT.java
+++ b/server/runtime/src/test/java/org/infinispan/server/security/authentication/AuthenticationIT.java
@@ -1,7 +1,7 @@
 package org.infinispan.server.security.authentication;
 
 import org.infinispan.server.test.InfinispanServerRule;
-import org.infinispan.server.test.InfinispanServerTestConfiguration;
+import org.infinispan.server.test.InfinispanServerRuleConfigurationBuilder;
 import org.infinispan.server.test.category.Security;
 import org.junit.ClassRule;
 import org.junit.experimental.categories.Category;
@@ -18,5 +18,8 @@ import org.junit.runners.Suite;
 public class AuthenticationIT {
 
    @ClassRule
-   public static final InfinispanServerRule SERVERS = new InfinispanServerRule(new InfinispanServerTestConfiguration("configuration/AuthenticationServerTest.xml").numServers(2));
+   public static final InfinispanServerRule SERVERS = new InfinispanServerRule(
+         new InfinispanServerRuleConfigurationBuilder("configuration/AuthenticationServerTest.xml")
+               .numServers(2)
+   );
 }

--- a/server/runtime/src/test/java/org/infinispan/server/test/InfinispanServerRule.java
+++ b/server/runtime/src/test/java/org/infinispan/server/test/InfinispanServerRule.java
@@ -35,17 +35,21 @@ import net.spy.memcached.MemcachedClient;
  * @since 10.0
  **/
 public class InfinispanServerRule implements TestRule {
-   public static final Log log = LogFactory.getLog(InfinispanServerRule.class);
-   private final InfinispanServerTestConfiguration configuration;
-   private final InfinispanServerDriver serverDriver;
 
-   public InfinispanServerRule(InfinispanServerTestConfiguration configuration) {
-      this.configuration = configuration;
-      this.serverDriver = configuration.runMode().newDriver(configuration);
+   public static final Log log = LogFactory.getLog(InfinispanServerRule.class);
+
+   private final LazyInfinispanServerDriver lazyInfinispanServerDriver;
+
+   public InfinispanServerRule(String configurationFile) {
+      this.lazyInfinispanServerDriver = new LazyInfinispanServerDriver(new InfinispanServerRuleConfigurationBuilder(configurationFile));
+   }
+
+   public InfinispanServerRule(InfinispanServerRuleConfigurationBuilder configurationBuilder) {
+      this.lazyInfinispanServerDriver = new LazyInfinispanServerDriver(configurationBuilder);
    }
 
    public InfinispanServerDriver getServerDriver() {
-      return serverDriver;
+      return lazyInfinispanServerDriver.get();
    }
 
    @Override
@@ -59,17 +63,17 @@ public class InfinispanServerRule implements TestRule {
             if (!inSuite) {
                TestResourceTracker.testStarted(testName);
             }
-            boolean manageServer = serverDriver.getStatus() == ComponentStatus.INSTANTIATED;
+            boolean manageServer = getServerDriver().getStatus() == ComponentStatus.INSTANTIATED;
             try {
                if (manageServer) {
-                  serverDriver.before(testName);
+                  getServerDriver().before(testName);
                }
                InfinispanServerRule.this.before(testName);
                base.evaluate();
             } finally {
                InfinispanServerRule.this.after(testName);
                if (manageServer) {
-                  serverDriver.after(testName);
+                  getServerDriver().after(testName);
                }
                if (!inSuite) {
                   TestResourceTracker.testFinished(testName);
@@ -97,8 +101,8 @@ public class InfinispanServerRule implements TestRule {
     */
    RemoteCacheManager newHotRodClient(ConfigurationBuilder builder) {
       // Add all known server addresses
-      for (int i = 0; i < serverDriver.configuration.numServers(); i++) {
-         InetSocketAddress serverAddress = serverDriver.getServerSocket(i, 11222);
+      for (int i = 0; i < getServerDriver().configuration.numServers(); i++) {
+         InetSocketAddress serverAddress = getServerDriver().getServerSocket(i, 11222);
          builder.addServer().host(serverAddress.getHostName()).port(serverAddress.getPort());
       }
       RemoteCacheManager remoteCacheManager = new RemoteCacheManager(builder.build());
@@ -111,8 +115,8 @@ public class InfinispanServerRule implements TestRule {
 
    public RestClient newRestClient(RestClientConfigurationBuilder builder) {
       // Add all known server addresses
-      for (int i = 0; i < serverDriver.configuration.numServers(); i++) {
-         InetSocketAddress serverAddress = serverDriver.getServerSocket(i, 11222);
+      for (int i = 0; i < getServerDriver().configuration.numServers(); i++) {
+         InetSocketAddress serverAddress = getServerDriver().getServerSocket(i, 11222);
          builder.addServer().host(serverAddress.getHostName()).port(serverAddress.getPort());
       }
       return RestClient.forConfiguration(builder.build());
@@ -123,8 +127,8 @@ public class InfinispanServerRule implements TestRule {
     */
    CloseableMemcachedClient newMemcachedClient() {
       List<InetSocketAddress> addresses = new ArrayList<>();
-      for (int i = 0; i < serverDriver.configuration.numServers(); i++) {
-         InetSocketAddress unresolved = serverDriver.getServerSocket(i, 11221);
+      for (int i = 0; i < getServerDriver().configuration.numServers(); i++) {
+         InetSocketAddress unresolved = getServerDriver().getServerSocket(i, 11221);
          addresses.add(new InetSocketAddress(unresolved.getHostName(), unresolved.getPort()));
       }
       MemcachedClient memcachedClient = Exceptions.unchecked(() -> new MemcachedClient(addresses));

--- a/server/runtime/src/test/java/org/infinispan/server/test/InfinispanServerRuleConfigurationBuilder.java
+++ b/server/runtime/src/test/java/org/infinispan/server/test/InfinispanServerRuleConfigurationBuilder.java
@@ -1,0 +1,62 @@
+package org.infinispan.server.test;
+
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * {@link org.junit.ClassRule} constructors should be trivial and complex objects be initialized in the
+ * {@link org.junit.rules.TestRule#apply(Statement, Description)} method.
+ *
+ * @author Diego Lovison &lt;dlovison@redhat.com&gt;
+ * @since 10.0
+ **/
+public class InfinispanServerRuleConfigurationBuilder {
+
+   private final String configurationFile;
+   private String[] mavenArtifacts;
+   private Integer numServers;
+   private ServerRunMode serverRunMode;
+   private JavaArchive[] archive;
+
+   public InfinispanServerRuleConfigurationBuilder(String configurationFile) {
+      this.configurationFile = configurationFile;
+   }
+
+   public InfinispanServerRuleConfigurationBuilder mavenArtifacts(String... mavenArtifacts) {
+      this.mavenArtifacts = mavenArtifacts;
+      return this;
+   }
+
+   public InfinispanServerRuleConfigurationBuilder numServers(Integer numServers) {
+      this.numServers = numServers;
+      return this;
+   }
+
+   public InfinispanServerRuleConfigurationBuilder serverRunMode(ServerRunMode serverRunMode) {
+      this.serverRunMode = serverRunMode;
+      return this;
+   }
+
+   public InfinispanServerRuleConfigurationBuilder archive(JavaArchive... archive) {
+      this.archive = archive;
+      return this;
+   }
+
+   public InfinispanServerTestConfiguration build() {
+      InfinispanServerTestConfiguration configuration = new InfinispanServerTestConfiguration(this.configurationFile);
+      if (this.numServers != null) {
+         configuration.numServers(this.numServers);
+      }
+      if (this.serverRunMode != null) {
+         configuration.runMode(this.serverRunMode);
+      }
+      if (this.mavenArtifacts != null) {
+         configuration.mavenArtifacts(this.mavenArtifacts);
+      }
+      if (this.archive != null) {
+         configuration.artifacts(this.archive);
+      }
+      return configuration;
+   }
+}

--- a/server/runtime/src/test/java/org/infinispan/server/test/LazyInfinispanServerDriver.java
+++ b/server/runtime/src/test/java/org/infinispan/server/test/LazyInfinispanServerDriver.java
@@ -1,0 +1,29 @@
+package org.infinispan.server.test;
+
+import java.util.function.Supplier;
+
+public class LazyInfinispanServerDriver implements Supplier<InfinispanServerDriver> {
+
+   private final InfinispanServerRuleConfigurationBuilder configurationBuilder;
+
+   private InfinispanServerDriver serverDriver;
+
+   public LazyInfinispanServerDriver(InfinispanServerRuleConfigurationBuilder configurationBuilder) {
+      this.configurationBuilder = configurationBuilder;
+   }
+
+   @Override
+   public InfinispanServerDriver get() {
+      if (this.serverDriver == null) {
+         // if two threads have serverDriver == null,
+         synchronized (this) {
+            // this prevent two instance
+            if (this.serverDriver == null) {
+               final InfinispanServerTestConfiguration configuration = configurationBuilder.build();
+               this.serverDriver = configuration.runMode().newDriver(configuration);
+            }
+         }
+      }
+      return this.serverDriver;
+   }
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-10879

`ClassRule` constructors should be trivial and complex objects be initialized in the `TestRule#apply` method.