### PR TITLE
ISPN-10943 Handle thread pool queue rejection when invoking rxjava code

### DIFF
--- a/commons/src/main/java/org/infinispan/commons/util/concurrent/BlockingRejectedExecutionHandler.java
+++ b/commons/src/main/java/org/infinispan/commons/util/concurrent/BlockingRejectedExecutionHandler.java
@@ -14,7 +14,7 @@ import org.infinispan.commons.logging.LogFactory;
  * @author wburns
  * @since 10.1
  */
-public class BlockingRejectedExecutionHandler extends ThreadPoolExecutor.AbortPolicy {
+public class BlockingRejectedExecutionHandler implements RejectedExecutionHandler {
    private static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
    private static final boolean trace = log.isTraceEnabled();
 
@@ -35,7 +35,7 @@ public class BlockingRejectedExecutionHandler extends ThreadPoolExecutor.AbortPo
          if (trace) {
             log.tracef("Task %s was rejected from %s when submitted from non blocking thread", r, executor);
          }
-         super.rejectedExecution(r, executor);
+         throw new CacheBackpressureFullException();
       } else {
          r.run();
       }

--- a/commons/src/main/java/org/infinispan/commons/util/concurrent/CacheBackpressureFullException.java
+++ b/commons/src/main/java/org/infinispan/commons/util/concurrent/CacheBackpressureFullException.java
@@ -1,0 +1,11 @@
+package org.infinispan.commons.util.concurrent;
+
+import org.infinispan.commons.CacheException;
+
+/**
+ * A {@link CacheException} that is thrown when the backpressure has been filled an unable to process the request. This
+ * can be thrown during periods where too much concurrency was requested or the load from an external source is too
+ * high. This can be remedied by reducing the load or increasing the backpressure handling (usually buffering of some sort).
+ */
+public class CacheBackpressureFullException extends CacheException {
+}

--- a/core/src/test/java/org/infinispan/reactive/RxJavaPublisherTest.java
+++ b/core/src/test/java/org/infinispan/reactive/RxJavaPublisherTest.java
@@ -1,0 +1,26 @@
+package org.infinispan.reactive;
+
+import static org.testng.AssertJUnit.fail;
+
+import org.infinispan.commons.util.concurrent.CacheBackpressureFullException;
+import org.infinispan.test.Exceptions;
+import org.testng.annotations.Test;
+
+import io.reactivex.Flowable;
+import io.reactivex.schedulers.Schedulers;
+
+@Test(groups = "functional", testName = "reactive.RxJavaPublisherTest")
+public class RxJavaPublisherTest {
+   public void testExceptionHandling() throws InterruptedException {
+      try {
+         Flowable.just(new Object())
+               .subscribeOn(Schedulers.from(task -> {
+                  throw new CacheBackpressureFullException();
+               }))
+               .subscribe();
+         fail("The error should have been thrown from subscribe!");
+      } catch (NullPointerException e) {
+         Exceptions.assertException(CacheBackpressureFullException.class, e.getCause());
+      }
+   }
+}


### PR DESCRIPTION
* Use CacheBackpressureFullException instead of RejectedExecutionException

https://issues.jboss.org/browse/ISPN-10943