### PR TITLE
[8.2] ISPN-9600 ReflectionUtil.invokeAccessibly should not be public

### DIFF
--- a/commons/src/main/java/org/infinispan/commons/util/SecurityActions.java
+++ b/commons/src/main/java/org/infinispan/commons/util/SecurityActions.java
@@ -1,12 +1,7 @@
 package org.infinispan.commons.util;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.util.Arrays;
-
-import org.infinispan.commons.CacheException;
 
 /**
  * Privileged actions for the package
@@ -82,22 +77,6 @@ final class SecurityActions {
       } else {
          return action.run();
       }
-   }
-
-   static Object invokeAccessibly(Object instance, Method method, Object[] parameters) {
-       return doPrivileged((PrivilegedAction<Object>) () -> {
-          try {
-             method.setAccessible(true);
-             return method.invoke(instance, parameters);
-          } catch (InvocationTargetException e) {
-             Throwable cause = e.getCause() != null ? e.getCause() : e;
-             throw new CacheException("Unable to invoke method " + method + " on object of type " + (instance == null ? "null" : instance.getClass().getSimpleName()) +
-                                            (parameters != null ? " with parameters " + Arrays.asList(parameters) : ""), cause);
-          } catch (Exception e) {
-             throw new CacheException("Unable to invoke method " + method + " on object of type " + (instance == null ? "null" : instance.getClass().getSimpleName()) +
-                   (parameters != null ? " with parameters " + Arrays.asList(parameters) : ""), e);
-          }
-       });
    }
 
    static ClassLoader[] getClassLoaders(ClassLoader appClassLoader) {

--- a/core/src/main/java/org/infinispan/distribution/group/GroupManagerImpl.java
+++ b/core/src/main/java/org/infinispan/distribution/group/GroupManagerImpl.java
@@ -1,6 +1,6 @@
 package org.infinispan.distribution.group;
 
-import static org.infinispan.commons.util.ReflectionUtil.invokeAccessibly;
+import static org.infinispan.commons.util.ReflectionUtil.invokeMethod;
 
 import org.infinispan.commons.util.CollectionFactory;
 import org.infinispan.commons.util.ReflectionUtil;
@@ -50,13 +50,15 @@ public class GroupManagerImpl implements GroupManager {
 
         @Override
         public String getGroup(Object instance) {
-            Object object;
             if (System.getSecurityManager() == null) {
-                object = invokeAccessibly(instance, method, Util.EMPTY_OBJECT_ARRAY);
+                method.setAccessible(true);
             } else {
-                object = AccessController.doPrivileged((PrivilegedAction<Object>) () -> invokeAccessibly(instance, method, Util.EMPTY_OBJECT_ARRAY));
+                AccessController.doPrivileged((PrivilegedAction<List<Method>>) () -> {
+                    method.setAccessible(true);
+                    return null;
+                });
             }
-            return String.class.cast(object);
+            return String.class.cast(invokeMethod(instance, method, Util.EMPTY_OBJECT_ARRAY));
         }
         
     }

--- a/core/src/main/java/org/infinispan/factories/SecurityActions.java
+++ b/core/src/main/java/org/infinispan/factories/SecurityActions.java
@@ -21,6 +21,14 @@ import org.infinispan.util.logging.LogFactory;
 final class SecurityActions {
    private static final Log log = LogFactory.getLog(SecurityActions.class);
 
+    static <T> T doPrivileged(PrivilegedAction<T> action) {
+      if (System.getSecurityManager() != null) {
+         return AccessController.doPrivileged(action);
+      } else {
+         return action.run();
+      }
+   }
+
    private static Field findFieldRecursively(Class<?> c, String fieldName) {
       Field f = null;
       try {


### PR DESCRIPTION
Hi @tristantarrant  as discussed, here is a backport of [ISPN-9600](https://github.com/johnpoth/infinispan/pull/new/ISPN-9600) to the 8.2.x branch. cc @danberindei 

`maven clean install` passes sucessfully (except for some previously failing tests described in https://github.com/infinispan/infinispan/pull/6492). 

Thanks!


(cherry picked from commit 7bdc2822ccf79127a488130239c49a5e944e3ca2)

Conflicts:
	commons/src/main/java/org/infinispan/commons/util/ReflectionUtil.java
	commons/src/main/java/org/infinispan/commons/util/SecurityActions.java
	core/src/main/java/org/infinispan/distribution/group/impl/GroupManagerImpl.java
	core/src/main/java/org/infinispan/factories/impl/BasicComponentRegistryImpl.java
	core/src/test/java/org/infinispan/test/TestingUtil.java