### PR TITLE
ISPN-10963 Remove blocking queue from RocksDBStore

### DIFF
--- a/persistence/rocksdb/src/main/java/org/infinispan/persistence/rocksdb/configuration/RocksDBExpirationConfiguration.java
+++ b/persistence/rocksdb/src/main/java/org/infinispan/persistence/rocksdb/configuration/RocksDBExpirationConfiguration.java
@@ -47,6 +47,10 @@ public class RocksDBExpirationConfiguration implements ConfigurationInfo {
       return expiredLocation.get();
    }
 
+   /**
+    * @deprecated Since 10.1, there is no more queue in {@link org.infinispan.persistence.rocksdb.RocksDBStore}
+    */
+   @Deprecated
    int expiryQueueSize() {
       return expiryQueueSize.get();
    }

--- a/persistence/rocksdb/src/main/java/org/infinispan/persistence/rocksdb/configuration/RocksDBExpirationConfigurationBuilder.java
+++ b/persistence/rocksdb/src/main/java/org/infinispan/persistence/rocksdb/configuration/RocksDBExpirationConfigurationBuilder.java
@@ -34,7 +34,10 @@ public class RocksDBExpirationConfigurationBuilder implements Builder<RocksDBExp
       return this;
    }
 
-
+   /**
+    * @deprecated Since 10.1, there is no more queue in {@link org.infinispan.persistence.rocksdb.RocksDBStore}
+    */
+   @Deprecated
    RocksDBExpirationConfigurationBuilder expiryQueueSize(int expiryQueueSize) {
       attributes.attribute(EXPIRY_QUEUE_SIZE).set(expiryQueueSize);
       return this;

--- a/persistence/rocksdb/src/main/java/org/infinispan/persistence/rocksdb/configuration/RocksDBStoreConfiguration.java
+++ b/persistence/rocksdb/src/main/java/org/infinispan/persistence/rocksdb/configuration/RocksDBStoreConfiguration.java
@@ -97,6 +97,10 @@ public class RocksDBStoreConfiguration extends AbstractStoreConfiguration implem
       return cacheSize.get();
    }
 
+   /**
+    * @deprecated There is no more queue in {@link org.infinispan.persistence.rocksdb.RocksDBStore}
+    */
+   @Deprecated
    public int expiryQueueSize() {
       return expiration.expiryQueueSize();
    }

--- a/persistence/rocksdb/src/main/java/org/infinispan/persistence/rocksdb/configuration/RocksDBStoreConfigurationBuilder.java
+++ b/persistence/rocksdb/src/main/java/org/infinispan/persistence/rocksdb/configuration/RocksDBStoreConfigurationBuilder.java
@@ -24,10 +24,14 @@ import org.infinispan.configuration.cache.PersistenceConfigurationBuilder;
 public class RocksDBStoreConfigurationBuilder extends AbstractStoreConfigurationBuilder<RocksDBStoreConfiguration, RocksDBStoreConfigurationBuilder>
       implements ConfigurationBuilderInfo {
 
-   RocksDBExpirationConfigurationBuilder expiration = new RocksDBExpirationConfigurationBuilder();
+   protected RocksDBExpirationConfigurationBuilder expiration = new RocksDBExpirationConfigurationBuilder();
 
    public RocksDBStoreConfigurationBuilder(PersistenceConfigurationBuilder builder) {
-      super(builder, RocksDBStoreConfiguration.attributeDefinitionSet());
+      this(builder, RocksDBStoreConfiguration.attributeDefinitionSet());
+   }
+
+   public RocksDBStoreConfigurationBuilder(PersistenceConfigurationBuilder builder, AttributeSet attributeSet) {
+      super(builder, attributeSet);
    }
 
    @Override
@@ -65,6 +69,10 @@ public class RocksDBStoreConfigurationBuilder extends AbstractStoreConfiguration
       return self();
    }
 
+   /**
+    * @deprecated Since 10.1, there is no more queue in {@link org.infinispan.persistence.rocksdb.RocksDBStore}
+    */
+   @Deprecated
    public RocksDBStoreConfigurationBuilder expiryQueueSize(int expiryQueueSize) {
       expiration.expiryQueueSize(expiryQueueSize);
       return self();

--- a/persistence/rocksdb/src/main/java/org/infinispan/persistence/rocksdb/configuration/RocksDBStoreConfigurationParser.java
+++ b/persistence/rocksdb/src/main/java/org/infinispan/persistence/rocksdb/configuration/RocksDBStoreConfigurationParser.java
@@ -1,5 +1,7 @@
 package org.infinispan.persistence.rocksdb.configuration;
 
+import static org.infinispan.util.logging.Log.CONFIG;
+
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 
@@ -64,15 +66,15 @@ public class RocksDBStoreConfigurationParser implements ConfigurationParser {
                break;
             }
             case CLEAR_THRESHOLD: {
-               builder.clearThreshold(Integer.valueOf(value));
+               builder.clearThreshold(Integer.parseInt(value));
                break;
             }
             case BLOCK_SIZE: {
-               builder.blockSize(Integer.valueOf(value));
+               builder.blockSize(Integer.parseInt(value));
                break;
             }
             case CACHE_SIZE: {
-               builder.cacheSize(Long.valueOf(value));
+               builder.cacheSize(Long.parseLong(value));
                break;
             }
             default: {
@@ -113,7 +115,7 @@ public class RocksDBStoreConfigurationParser implements ConfigurationParser {
                break;
             }
             case QUEUE_SIZE: {
-               builder.expiryQueueSize(Integer.valueOf(value));
+               CONFIG.ignoreXmlAttribute(attribute, reader.getLocation().getLineNumber(), reader.getLocation().getColumnNumber());
                break;
             }
             default:

--- a/persistence/rocksdb/src/main/resources/schema/infinispan-cachestore-rocksdb-config-10.1.xsd
+++ b/persistence/rocksdb/src/main/resources/schema/infinispan-cachestore-rocksdb-config-10.1.xsd
@@ -67,7 +67,7 @@
     </xs:attribute>
     <xs:attribute name="queue-size" type="xs:integer" default="${RocksDBStore.expiryQueueSize}">
       <xs:annotation>
-        <xs:documentation>Expired entry queue size.</xs:documentation>
+        <xs:documentation>Deprecated. The expiration queue is no longer used since 10.1</xs:documentation>
       </xs:annotation>
     </xs:attribute>
   </xs:complexType>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-10963

When we have the following running on infinispan/master:
```java
      cacheManager.defineConfiguration("weather", new ConfigurationBuilder()
         .persistence()
            .addStore(RocksDBStoreConfigurationBuilder.class)
            .location("target/data")
            .expiredLocation("target/expired")
         .expiration().lifespan(5, TimeUnit.SECONDS)
         .build());
      cache = cacheManager.getCache("weather");

      int max = 10001;
      for (int i=0; i<max; i++) {
         cache.put(UUID.randomUUID().toString(), UUID.randomUUID().toString());
      }
```
The test took 60478ms. The max could be the following but not 10001

- 9999 = 1773 ms
- 10000 = 1797 ms

The ms values are from my local laptop not running in the perf lab. It just "show the problem".

The other changes are allowing we create a custom RocksDBStore that can use Statistics, Cache.