### PR TITLE
ISPN-11035 XSiteResourceTest.testPushAllCaches random failures

### DIFF
--- a/client/rest-client/src/main/java/org/infinispan/client/rest/RestResponse.java
+++ b/client/rest-client/src/main/java/org/infinispan/client/rest/RestResponse.java
@@ -12,7 +12,7 @@ import org.infinispan.commons.util.Experimental;
  * @since 10.0
  **/
 @Experimental
-public interface RestResponse extends RestEntity {
+public interface RestResponse extends RestEntity, AutoCloseable {
    int getStatus();
 
    Map<String, List<String>> headers();

--- a/server/rest/src/main/java/org/infinispan/rest/resources/XSiteResource.java
+++ b/server/rest/src/main/java/org/infinispan/rest/resources/XSiteResource.java
@@ -123,8 +123,8 @@ public class XSiteResource implements ResourceHandler {
             SiteStatus status = e.getValue();
             if (status instanceof OnlineSiteStatus) return GlobalStatus.ONLINE;
             if (status instanceof OfflineSiteStatus) return GlobalStatus.OFFLINE;
-            if (status instanceof AbstractMixedSiteStatus) {
-               AbstractMixedSiteStatus mixedSiteStatus = (AbstractMixedSiteStatus) status;
+            if (status instanceof AbstractMixedSiteStatus<?>) {
+               AbstractMixedSiteStatus<?> mixedSiteStatus = (AbstractMixedSiteStatus<?>) status;
                return GlobalStatus.mixed(mixedSiteStatus.getOnline(), mixedSiteStatus.getOffline());
             }
             return GlobalStatus.UNKNOWN;
@@ -309,16 +309,16 @@ public class XSiteResource implements ResourceHandler {
       static final GlobalStatus UNKNOWN = new GlobalStatus("unknown", null, null);
 
       private String status;
-      private List online;
-      private List offline;
+      private List<?> online;
+      private List<?> offline;
 
-      GlobalStatus(String status, List online, List offline) {
+      GlobalStatus(String status, List<?> online, List<?> offline) {
          this.status = status;
          this.online = online;
          this.offline = offline;
       }
 
-      static GlobalStatus mixed(List online, List offline) {
+      static GlobalStatus mixed(List<?> online, List<?> offline) {
          return new GlobalStatus("mixed", online, offline);
       }
 
@@ -327,12 +327,12 @@ public class XSiteResource implements ResourceHandler {
       }
 
       @JsonInclude(NON_NULL)
-      public List getOnline() {
+      public List<?> getOnline() {
          return online;
       }
 
       @JsonInclude(NON_NULL)
-      public List getOffline() {
+      public List<?> getOffline() {
          return offline;
       }
    }

--- a/server/rest/src/test/java/org/infinispan/rest/helper/RestResponses.java
+++ b/server/rest/src/test/java/org/infinispan/rest/helper/RestResponses.java
@@ -1,0 +1,56 @@
+package org.infinispan.rest.helper;
+
+import static org.testng.AssertJUnit.assertEquals;
+
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+
+import org.infinispan.client.rest.RestResponse;
+import org.infinispan.test.Exceptions;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * A utility for managing {@link RestResponse}s in tests.
+ *
+ * @author Dan Berindei
+ * @since 10.1
+ */
+public class RestResponses {
+   private static final ObjectMapper MAPPER = new ObjectMapper();
+
+   public static void assertSuccessful(CompletionStage<RestResponse> responseStage) {
+      assertStatus(200, responseStage);
+   }
+
+   public static void assertNoContent(CompletionStage<RestResponse> responseStage) {
+      assertStatus(204, responseStage);
+   }
+
+   public static void assertStatus(int expectedStatus, CompletionStage<RestResponse> responseStage) {
+      int status = responseStatus(responseStage);
+      assertEquals(expectedStatus, status);
+   }
+
+   public static int responseStatus(CompletionStage<RestResponse> responseStage) {
+      try (RestResponse response = sync(responseStage)) {
+         return response.getStatus();
+      }
+   }
+
+   public static String responseBody(CompletionStage<RestResponse> responseStage) {
+      try (RestResponse response = sync(responseStage)) {
+         assertEquals(200, response.getStatus());
+         return response.getBody();
+      }
+   }
+
+   public static JsonNode jsonResponseBody(CompletionStage<RestResponse> responseCompletionStage) {
+      return Exceptions.unchecked(() -> MAPPER.readTree(responseBody(responseCompletionStage)));
+   }
+
+   private static <T> T sync(CompletionStage<T> stage) {
+      return Exceptions.unchecked(() -> stage.toCompletableFuture().get(10, TimeUnit.SECONDS));
+   }
+}

--- a/server/rest/src/test/java/org/infinispan/rest/resources/XSiteResourceTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/resources/XSiteResourceTest.java
@@ -1,5 +1,11 @@
 package org.infinispan.rest.resources;
 
+import static org.infinispan.rest.helper.RestResponses.assertNoContent;
+import static org.infinispan.rest.helper.RestResponses.assertStatus;
+import static org.infinispan.rest.helper.RestResponses.assertSuccessful;
+import static org.infinispan.rest.helper.RestResponses.jsonResponseBody;
+import static org.infinispan.rest.helper.RestResponses.responseBody;
+import static org.infinispan.rest.helper.RestResponses.responseStatus;
 import static org.infinispan.xsite.XSiteAdminOperations.OFFLINE;
 import static org.infinispan.xsite.XSiteAdminOperations.ONLINE;
 import static org.testng.Assert.assertTrue;
@@ -9,15 +15,12 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 
 import org.infinispan.client.rest.RestCacheClient;
 import org.infinispan.client.rest.RestCacheManagerClient;
 import org.infinispan.client.rest.RestClient;
-import org.infinispan.client.rest.RestResponse;
 import org.infinispan.client.rest.configuration.RestClientConfiguration;
 import org.infinispan.client.rest.configuration.RestClientConfigurationBuilder;
 import org.infinispan.configuration.cache.BackupConfiguration;
@@ -27,7 +30,6 @@ import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.remoting.transport.ControlledTransport;
 import org.infinispan.rest.helper.RestServerHelper;
-import org.infinispan.test.Exceptions;
 import org.infinispan.test.fwk.TestResourceTracker;
 import org.infinispan.xsite.AbstractMultipleSitesTest;
 import org.infinispan.xsite.statetransfer.XSiteStatePushCommand;
@@ -37,7 +39,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * @since 10.0
@@ -54,7 +55,6 @@ public class XSiteResourceTest extends AbstractMultipleSitesTest {
 
    private Map<String, RestServerHelper> restServerPerSite = new HashMap<>(2);
    private Map<String, RestClient> clientPerSite = new HashMap<>(2);
-   private final ObjectMapper MAPPER = new ObjectMapper();
 
    protected int defaultNumberOfSites() {
       return 3;
@@ -96,7 +96,7 @@ public class XSiteResourceTest extends AbstractMultipleSitesTest {
       return configurationBuilder;
    }
 
-   @AfterClass
+   @AfterClass(alwaysRun = true)
    public void clean() {
       restServerPerSite.values().forEach(RestServerHelper::stop);
       clientPerSite.values().forEach(cli -> {
@@ -107,10 +107,10 @@ public class XSiteResourceTest extends AbstractMultipleSitesTest {
       });
    }
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    public void cleanCache() {
-      sync(getCacheClient(LON).clear());
-      sync(getCacheClient(NYC).clear());
+      assertNoContent(getCacheClient(LON).clear());
+      assertNoContent(getCacheClient(NYC).clear());
    }
 
    @Override
@@ -119,7 +119,7 @@ public class XSiteResourceTest extends AbstractMultipleSitesTest {
    }
 
    @Test
-   public void testObtainBackupStatus() throws Exception {
+   public void testObtainBackupStatus() {
       assertEquals(ONLINE, getBackupStatus(LON, NYC));
       assertEquals(ONLINE, getBackupStatus(LON, SFO));
       assertEquals(ONLINE, getBackupStatus(NYC, LON));
@@ -129,54 +129,49 @@ public class XSiteResourceTest extends AbstractMultipleSitesTest {
    @Test
    public void testInvalidCache() {
       RestClient client = clientPerSite.get(LON);
-      RestResponse response = sync(client.cache("invalid-cache").xsiteBackups());
-      assertEquals(404, response.getStatus());
+      assertStatus(404, client.cache("invalid-cache").xsiteBackups());
    }
 
    @Test
    public void testInvalidSite() {
       RestClient client = clientPerSite.get(LON);
       RestCacheClient cache = client.cache(CACHE_1);
-      RestResponse response = sync(cache.backupStatus("invalid-site"));
-      assertEquals(404, response.getStatus());
+      assertStatus(404, cache.backupStatus("invalid-site"));
    }
 
    @Test
-   public void testOnlineOffline() throws Exception {
+   public void testOnlineOffline() {
       testOnlineOffline(LON, NYC);
       testOnlineOffline(NYC, LON);
    }
 
    @Test
-   public void testBackups() throws Exception {
+   public void testBackups() {
       RestCacheClient cache = getCacheClient(LON);
-      RestResponse response = sync(cache.xsiteBackups());
-      assertEquals(200, response.getStatus());
 
-      JsonNode status = MAPPER.readTree(response.getBody().toString());
+      JsonNode status = jsonResponseBody(cache.xsiteBackups());
       assertEquals(ONLINE, status.get(NYC).asText());
    }
 
    @Test
-   public void testPushState() throws Exception {
+   public void testPushState() {
       RestCacheClient cache = getCacheClient(LON);
       RestCacheClient backupCache = getCacheClient(NYC);
       String key = "key";
       String value = "value";
-      Function<String, Integer> keyOnBackup = k -> sync(backupCache.get(key)).getStatus();
+      Function<String, Integer> keyOnBackup = k -> responseStatus(backupCache.get(key));
 
       takeBackupOffline(LON, NYC);
       assertEquals(OFFLINE, getBackupStatus(LON, NYC));
       assertEquals(ONLINE, getBackupStatus(LON, SFO));
 
-      sync(cache.put(key, value));
+      assertNoContent(cache.put(key, value));
       assertEquals(404, (int) keyOnBackup.apply(key));
 
-      RestResponse response = sync(cache.pushSiteState(NYC));
-      assertEquals(200, response.getStatus());
-
-      eventually(() -> getBackupStatus(LON, NYC).equals(ONLINE));
-      eventually(() -> keyOnBackup.apply(key) == 200);
+      assertSuccessful(cache.pushSiteState(NYC));
+      assertEquals(ONLINE, getBackupStatus(LON, NYC));
+      eventuallyEquals("OK", () -> pushStateStatus(cache, NYC));
+      assertEquals(200, responseStatus(backupCache.get(key)));
    }
 
    @Test
@@ -189,8 +184,8 @@ public class XSiteResourceTest extends AbstractMultipleSitesTest {
       assertEquals(OFFLINE, getBackupStatus(LON, NYC));
 
       // Write in the cache
-      int entries = 500;
-      IntStream.range(0, entries).forEach(i -> sync(cache.put(String.valueOf(i), "value")));
+      int entries = 50;
+      IntStream.range(0, entries).forEach(i -> assertNoContent(cache.put(String.valueOf(i), "value")));
 
       // Backup should be empty
       assertEquals(entries, getCacheSize(cache));
@@ -199,44 +194,38 @@ public class XSiteResourceTest extends AbstractMultipleSitesTest {
       // Start state push
       ControlledTransport controllerTransport = ControlledTransport.replace(cache(LON, 0));
       controllerTransport.blockBefore(XSiteStatePushCommand.class);
-      sync(cache.pushSiteState(NYC));
+      assertSuccessful(cache.pushSiteState(NYC));
       controllerTransport.waitForCommandToBlock();
 
       // Cancel push
-      RestResponse response = sync(cache.cancelPushState(NYC));
-      assertEquals(200, response.getStatus());
+      assertSuccessful(cache.cancelPushState(NYC));
 
       controllerTransport.stopBlocking();
 
-      JsonNode status = MAPPER.readTree(sync(cache.pushStateStatus()).getBody());
+      JsonNode status = jsonResponseBody(cache.pushStateStatus());
       assertEquals("CANCELED", status.get(NYC).asText());
 
       // Clear status
-      response = sync(cache.clearPushStateStatus());
-      assertEquals(200, response.getStatus());
+      assertSuccessful(cache.clearPushStateStatus());
 
-      status = MAPPER.readTree(sync(cache.pushStateStatus()).getBody());
+      status = jsonResponseBody(cache.pushStateStatus());
       assertTrue(status.isEmpty());
 
-      response = sync(cache.cancelReceiveState(NYC));
-      assertEquals(200, response.getStatus());
+      assertSuccessful(cache.cancelReceiveState(NYC));
    }
 
    @Test
-   public void testTakeOfflineConfig() throws Exception {
+   public void testTakeOfflineConfig() {
       RestCacheClient cacheClient = getCacheClient(LON);
 
-      RestResponse response = sync(cacheClient.getXSiteTakeOfflineConfig(NYC));
-      JsonNode takeOfflineConfig = MAPPER.readTree(response.getBody());
+      JsonNode takeOfflineConfig = jsonResponseBody(cacheClient.getXSiteTakeOfflineConfig(NYC));
 
       assertEquals(0, takeOfflineConfig.get("after_failures").asInt());
       assertEquals(0, takeOfflineConfig.get("min_wait").asInt());
 
-      response = sync(cacheClient.updateXSiteTakeOfflineConfig(NYC, 5, 1000));
-      assertEquals(204, response.getStatus());
+      assertNoContent(cacheClient.updateXSiteTakeOfflineConfig(NYC, 5, 1000));
 
-      response = sync(cacheClient.getXSiteTakeOfflineConfig(NYC));
-      takeOfflineConfig = MAPPER.readTree(response.getBody());
+      takeOfflineConfig = jsonResponseBody(cacheClient.getXSiteTakeOfflineConfig(NYC));
 
       assertEquals(5, takeOfflineConfig.get("after_failures").asInt());
       assertEquals(1000, takeOfflineConfig.get("min_wait").asInt());
@@ -246,48 +235,46 @@ public class XSiteResourceTest extends AbstractMultipleSitesTest {
    public void testInvalidInputTakeOffline() {
       RestClient restClient = clientPerSite.get(LON);
       String url = String.format("/rest/v2/caches/%s/x-site/backups/%s/take-offline-config", CACHE_1, NYC);
-      RestResponse response = sync(restClient.raw().putValue(url, new HashMap<>(), "invalid", "application/json"));
-      assertEquals(400, response.getStatus());
+      assertStatus(400, restClient.raw().putValue(url, new HashMap<>(), "invalid", "application/json"));
    }
 
    @Test
-   public void testGetStatusAllCaches() throws Exception {
+   public void testGetStatusAllCaches() {
       RestClient restClient = clientPerSite.get(LON);
 
       assertAllSitesOnline(restClient);
 
-      sync(restClient.cache(CACHE_2).takeSiteOffline(NYC));
-      RestResponse response = sync(restClient.cacheManager(CACHE_MANAGER).backupStatuses());
-      JsonNode json = MAPPER.readTree(response.getBody());
+      assertSuccessful(restClient.cache(CACHE_2).takeSiteOffline(NYC));
+
+      JsonNode json = jsonResponseBody(restClient.cacheManager(CACHE_MANAGER).backupStatuses());
       assertEquals(json.get(NYC).get("status").asText(), "mixed");
       assertEquals(json.get(NYC).get("online").elements().next().asText(), CACHE_1);
       assertEquals(json.get(NYC).get("offline").elements().next().asText(), CACHE_2);
-      sync(restClient.cache(CACHE_2).bringSiteOnline(NYC));
+
+      assertSuccessful(restClient.cache(CACHE_2).bringSiteOnline(NYC));
 
       assertAllSitesOnline(restClient);
    }
 
 
    @Test
-   public void testBringAllCachesOnlineOffline() throws Exception {
+   public void testBringAllCachesOnlineOffline() {
       RestClient restClient = clientPerSite.get(LON);
       RestCacheManagerClient restCacheManagerClient = restClient.cacheManager(CACHE_MANAGER);
 
-      RestResponse response = sync(restCacheManagerClient.takeOffline(SFO));
-      assertEquals(200, response.getStatus());
+      assertSuccessful(restCacheManagerClient.takeOffline(SFO));
 
-      response = sync(restCacheManagerClient.backupStatuses());
-      JsonNode json = MAPPER.readTree(response.getBody());
+      JsonNode json = jsonResponseBody(restCacheManagerClient.backupStatuses());
       assertEquals(json.get(SFO).get("status").asText(), "offline");
 
-      sync(restCacheManagerClient.bringBackupOnline(SFO));
-      response = sync(restCacheManagerClient.backupStatuses());
-      json = MAPPER.readTree(response.getBody());
+      assertSuccessful(restCacheManagerClient.bringBackupOnline(SFO));
+
+      json = jsonResponseBody(restCacheManagerClient.backupStatuses());
       assertEquals(json.get(SFO).get("status").asText(), "online");
    }
 
    @Test
-   public void testPushAllCaches() throws Exception {
+   public void testPushAllCaches() {
       RestClient restClientLon = clientPerSite.get(LON);
       RestClient restClientSfo = clientPerSite.get(SFO);
 
@@ -298,17 +285,17 @@ public class XSiteResourceTest extends AbstractMultipleSitesTest {
       RestCacheClient cache2Sfo = restClientSfo.cache(CACHE_2);
 
       // Take SFO offline for all caches
-      sync(restClientLon.cacheManager(CACHE_MANAGER).takeOffline(SFO));
-      RestResponse statusResponse = sync(restClientLon.cacheManager(CACHE_MANAGER).backupStatuses());
-      assertEquals("offline", MAPPER.readTree(statusResponse.getBody()).get(SFO).get("status").asText());
+      assertSuccessful(restClientLon.cacheManager(CACHE_MANAGER).takeOffline(SFO));
+      JsonNode backupStatuses = jsonResponseBody(restClientLon.cacheManager(CACHE_MANAGER).backupStatuses());
+      assertEquals("offline", backupStatuses.get(SFO).get("status").asText());
 
       // Write to the caches
       int entries = 10;
       IntStream.range(0, entries).forEach(i -> {
          String key = String.valueOf(i);
          String value = "value";
-         sync(cache1Lon.put(key, value));
-         sync(cache2Lon.put(key, value));
+         assertNoContent(cache1Lon.put(key, value));
+         assertNoContent(cache2Lon.put(key, value));
       });
 
       // Backups should be empty
@@ -316,19 +303,23 @@ public class XSiteResourceTest extends AbstractMultipleSitesTest {
       assertEquals(0, getCacheSize(cache2Sfo));
 
       // Start state push
-      RestResponse response = sync(restClientLon.cacheManager(CACHE_MANAGER).pushSiteState(SFO));
-      assertEquals(200, response.getStatus());
+      assertSuccessful(restClientLon.cacheManager(CACHE_MANAGER).pushSiteState(SFO));
 
-      // Backups should eventually be online...
-      eventually(() -> {
-         RestResponse restResponse = sync(restClientLon.cacheManager(CACHE_MANAGER).backupStatuses());
-         String status = MAPPER.readTree(restResponse.getBody()).get(SFO).get("status").asText();
-         return "online".equals(status);
-      });
+      // Backups go online online immediately
+      assertEquals(ONLINE, getBackupStatus(LON, SFO));
+
+      // State push should eventually finish
+      eventuallyEquals("OK", () -> pushStateStatus(cache1Lon, SFO));
+      eventuallyEquals("OK", () -> pushStateStatus(cache2Lon, SFO));
 
       // ... and with state
       assertEquals(entries, getCacheSize(cache1Sfo));
       assertEquals(entries, getCacheSize(cache2Sfo));
+   }
+
+   private String pushStateStatus(RestCacheClient cacheClient, String siteName) {
+      JsonNode json = jsonResponseBody(cacheClient.pushStateStatus());
+      return json.get(siteName).asText();
    }
 
    @Test
@@ -336,35 +327,34 @@ public class XSiteResourceTest extends AbstractMultipleSitesTest {
       RestClient restClientLon = clientPerSite.get(LON);
       RestCacheClient cache1Lon = restClientLon.cache(CACHE_1);
       RestCacheClient cache2Lon = restClientLon.cache(CACHE_2);
-      sync(cache1Lon.put("k1", "v1"));
-      sync(cache2Lon.put("k2", "v2"));
+      assertNoContent(cache1Lon.put("k1", "v1"));
+      assertNoContent(cache2Lon.put("k2", "v2"));
 
       // Block before pushing state on both caches
       ControlledTransport controlledTransport = ControlledTransport.replace(cache(LON, CACHE_1, 0));
       controlledTransport.blockBefore(XSiteStatePushCommand.class);
 
       // Trigger a state push
-      sync(restClientLon.cacheManager(CACHE_MANAGER).pushSiteState(SFO));
+      assertSuccessful(restClientLon.cacheManager(CACHE_MANAGER).pushSiteState(SFO));
       controlledTransport.waitForCommandToBlock();
 
       // Cancel state push
-      RestResponse response = sync(restClientLon.cacheManager(CACHE_MANAGER).cancelPushState(SFO));
-      assertEquals(200, response.getStatus());
+      assertSuccessful(restClientLon.cacheManager(CACHE_MANAGER).cancelPushState(SFO));
       controlledTransport.stopBlocking();
 
       // Verify that push was cancelled for both caches
-      JsonNode pushStatusCache1 = MAPPER.readTree(sync(cache1Lon.pushStateStatus()).getBody());
-      JsonNode pushStatusCache2 = MAPPER.readTree(sync(cache2Lon.pushStateStatus()).getBody());
+      JsonNode pushStatusCache1 = jsonResponseBody(cache1Lon.pushStateStatus());
+      JsonNode pushStatusCache2 = jsonResponseBody(cache2Lon.pushStateStatus());
 
       assertEquals("CANCELED", pushStatusCache1.get(SFO).asText());
       assertEquals("CANCELED", pushStatusCache2.get(SFO).asText());
    }
 
    private int getCacheSize(RestCacheClient cacheClient) {
-      return Integer.parseInt(sync(cacheClient.size()).getBody());
+      return Integer.parseInt(responseBody(cacheClient.size()));
    }
 
-   private void testOnlineOffline(String site, String backup) throws Exception {
+   private void testOnlineOffline(String site, String backup) {
       takeBackupOffline(site, backup);
 
       String siteStatus = getBackupStatus(site, backup);
@@ -378,14 +368,12 @@ public class XSiteResourceTest extends AbstractMultipleSitesTest {
 
    private void takeBackupOffline(String site, String backup) {
       RestCacheClient client = getCacheClient(site);
-      RestResponse response = sync(client.takeSiteOffline(backup));
-      assertEquals(200, response.getStatus());
+      assertSuccessful(client.takeSiteOffline(backup));
    }
 
    private void bringBackupOnline(String site, String backup) {
       RestCacheClient client = getCacheClient(site);
-      RestResponse response = sync(client.bringSiteOnline(backup));
-      assertEquals(200, response.getStatus());
+      assertSuccessful(client.bringSiteOnline(backup));
    }
 
    private String getFirstCacheManagerAddress(String site) {
@@ -395,33 +383,27 @@ public class XSiteResourceTest extends AbstractMultipleSitesTest {
       return cacheManager.getAddress().toString();
    }
 
-   private String getBackupStatus(String site, String backup) throws Exception {
+   private String getBackupStatus(String site, String backup) {
       RestCacheClient cacheClient = getCacheClient(site);
-      RestResponse response = sync(cacheClient.backupStatus(backup));
-      assertEquals(200, response.getStatus());
-
-      JsonNode json = MAPPER.readTree(response.getBody());
       String cacheManagerAddress = getFirstCacheManagerAddress(site);
+
+      JsonNode json = jsonResponseBody(cacheClient.backupStatus(backup));
       return json.get(cacheManagerAddress).asText();
    }
 
-   private void assertAllSitesOnline(RestClient restClient, String... sites) throws Exception {
-      RestResponse response = sync(restClient.cacheManager(CACHE_MANAGER).backupStatuses());
-      assertEquals(200, response.getStatus());
-      JsonNode json = MAPPER.readTree(response.getBody());
+   private void assertAllSitesOnline(RestClient restClient, String... sites) {
+      JsonNode json = jsonResponseBody(restClient.cacheManager(CACHE_MANAGER).backupStatuses());
       Arrays.stream(sites).forEach(s -> assertEquals(json.get(s).get("status").asText(), "online"));
-   }
-
-   public static <T> T sync(CompletionStage<T> stage) {
-      return Exceptions.unchecked(() -> stage.toCompletableFuture().get(5, TimeUnit.SECONDS));
    }
 
    @Override
    protected void afterSitesCreated() {
       // LON backs-up to SFO, NYC
       ConfigurationBuilder builder = defaultConfigurationForSite(0);
-      builder.sites().addBackup().site(siteName(1)).strategy(BackupConfiguration.BackupStrategy.SYNC);
-      builder.sites().addBackup().site(siteName(2)).strategy(BackupConfiguration.BackupStrategy.SYNC);
+      builder.sites().addBackup().site(siteName(1)).strategy(BackupConfiguration.BackupStrategy.SYNC)
+             .stateTransfer().chunkSize(5);
+      builder.sites().addBackup().site(siteName(2)).strategy(BackupConfiguration.BackupStrategy.SYNC)
+             .stateTransfer().chunkSize(5);
       defineInSite(site(0), CACHE_1, builder.build());
       defineInSite(site(0), CACHE_2, builder.build());
       defineInSite(site(2), CACHE_1, builder.build());
@@ -433,8 +415,10 @@ public class XSiteResourceTest extends AbstractMultipleSitesTest {
 
       // NYC backs up to LON, SFO
       builder = defaultConfigurationForSite(1);
-      builder.sites().addBackup().site(siteName(0)).strategy(BackupConfiguration.BackupStrategy.SYNC);
-      builder.sites().addBackup().site(siteName(2)).strategy(BackupConfiguration.BackupStrategy.SYNC);
+      builder.sites().addBackup().site(siteName(0)).strategy(BackupConfiguration.BackupStrategy.SYNC)
+             .stateTransfer().chunkSize(5);
+      builder.sites().addBackup().site(siteName(2)).strategy(BackupConfiguration.BackupStrategy.SYNC)
+             .stateTransfer().chunkSize(5);
       defineInSite(site(1), CACHE_1, builder.build());
       defineInSite(site(1), CACHE_2, builder.build());
       site(1).waitForClusterToForm(CACHE_1);


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-11035

* Use push-state-status to wait for xsite state transfer end
* Add RestResponses with helper methods to close responses
* Reduce the number of entries in testCancelPushState
* Fix unchecked warnings