### PR TITLE
ISPN-10984 Scattered cache distributed streams stack overflow

### DIFF
--- a/core/src/main/java/org/infinispan/scattered/ScatteredVersionManager.java
+++ b/core/src/main/java/org/infinispan/scattered/ScatteredVersionManager.java
@@ -101,6 +101,9 @@ public interface ScatteredVersionManager<K> {
 
    void setValuesTransferTopology(int topologyId);
 
+   /**
+    * @return A {@code CompletableFuture} that completes when value transfer has finished for the given topology id.
+    */
    CompletableFuture<Void> valuesFuture(int topologyId);
 
    /**

--- a/core/src/test/java/org/infinispan/scattered/stream/ScatteredStreamIteratorTest.java
+++ b/core/src/test/java/org/infinispan/scattered/stream/ScatteredStreamIteratorTest.java
@@ -1,7 +1,22 @@
 package org.infinispan.scattered.stream;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
+
+import java.util.concurrent.TimeUnit;
+
+import org.infinispan.Cache;
 import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.scattered.ScatteredStateProvider;
+import org.infinispan.statetransfer.StateProvider;
 import org.infinispan.stream.DistributedStreamIteratorTest;
+import org.infinispan.test.Mocks;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.CheckPoint;
+import org.mockito.AdditionalAnswers;
+import org.mockito.stubbing.Answer;
 import org.testng.annotations.Test;
 
 /**
@@ -21,5 +36,30 @@ public class ScatteredStreamIteratorTest extends DistributedStreamIteratorTest {
    @Override
    public void waitUntilProcessingResults() {
       // Test is ignored until https://issues.jboss.org/browse/ISPN-10864 can be fixed
+   }
+
+   @Override
+   protected <K> void blockStateTransfer(Cache<?, ?> cache, CheckPoint checkPoint) {
+      // Scattered cache doesn't use StateProvider.startOutboundTransfer,
+      // so we block ScatteredStateProviderImpl.startKeysTransferInstead
+      StateProvider realObject = TestingUtil.extractComponent(cache, StateProvider.class);
+      Answer<?> forwardedAnswer = AdditionalAnswers.delegatesTo(realObject);
+      ScatteredStateProvider mock = mock(ScatteredStateProvider.class, withSettings().defaultAnswer(forwardedAnswer));
+      // TODO Replace with Mocks.blockingAnswer() once ISPN-10864 is fixed
+      doAnswer(invocation -> {
+         checkPoint.trigger(Mocks.BEFORE_INVOCATION);
+         // Scattered cache iteration blocks and waits for state transfer to fetch the values
+         // if a segment is owned in the pending CH, so we can't block forever
+         // Instead we just block for 2 seconds to verify ISPN-10984
+         checkPoint.peek(2, TimeUnit.SECONDS, Mocks.BEFORE_RELEASE);
+         try {
+            return forwardedAnswer.answer(invocation);
+         } finally {
+            checkPoint.trigger(Mocks.AFTER_INVOCATION);
+            checkPoint.awaitStrict(Mocks.AFTER_RELEASE, 20, TimeUnit.SECONDS);
+         }
+      }).when(mock)
+        .startKeysTransfer(any(), any());
+      TestingUtil.replaceComponent(cache, StateProvider.class, mock, true);
    }
 }

--- a/core/src/test/java/org/infinispan/stream/BaseSetupStreamIteratorTest.java
+++ b/core/src/test/java/org/infinispan/stream/BaseSetupStreamIteratorTest.java
@@ -35,6 +35,7 @@ import org.infinispan.remoting.transport.Address;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.test.fwk.TransportFlags;
 import org.infinispan.transaction.TransactionMode;
 import org.infinispan.util.BaseControlledConsistentHashFactory;
 import org.testng.annotations.Test;
@@ -47,6 +48,7 @@ import org.testng.annotations.Test;
  */
 @Test(groups = "functional", testName = "stream.BaseSetupStreamIteratorTest")
 public abstract class BaseSetupStreamIteratorTest extends MultipleCacheManagersTest {
+   public static final int NUM_NODES = 3;
    protected final String CACHE_NAME = "testCache";
    protected ConfigurationBuilder builderUsed;
    protected SerializationContextInitializer sci;
@@ -74,9 +76,9 @@ public abstract class BaseSetupStreamIteratorTest extends MultipleCacheManagersT
          builderUsed.transaction().transactionMode(TransactionMode.TRANSACTIONAL);
       }
       if (cacheMode.isClustered()) {
-         builderUsed.clustering().stateTransfer().chunkSize(50);
+         builderUsed.clustering().stateTransfer().chunkSize(5);
          enhanceConfiguration(builderUsed);
-         createClusteredCaches(3, CACHE_NAME, sci, builderUsed);
+         createClusteredCaches(NUM_NODES, CACHE_NAME, sci, builderUsed, new TransportFlags().withFD(true));
       } else {
          enhanceConfiguration(builderUsed);
          EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(sci, builderUsed);


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-10984

With awaitInitialTransfer disabled, publisher requests can arrive
during the initial state transfer, and in scattered caches
they would fail with StackOverflowError.
Publisher requests will still block for the initial transfer to end
because of ISPN-10864.