### PR TITLE
[9.4.x] ISPN-10984 Scattered cache distributed streams stack overflow

### DIFF
--- a/core/src/main/java/org/infinispan/scattered/ScatteredVersionManager.java
+++ b/core/src/main/java/org/infinispan/scattered/ScatteredVersionManager.java
@@ -101,6 +101,9 @@ public interface ScatteredVersionManager<K> {
 
    void setValuesTransferTopology(int topologyId);
 
+   /**
+    * @return A {@code CompletableFuture} that completes when value transfer has finished for the given topology id.
+    */
    CompletableFuture<Void> valuesFuture(int topologyId);
 
    /**

--- a/core/src/main/java/org/infinispan/scattered/impl/ScatteredVersionManagerImpl.java
+++ b/core/src/main/java/org/infinispan/scattered/impl/ScatteredVersionManagerImpl.java
@@ -50,6 +50,7 @@ import org.infinispan.util.logging.LogFactory;
 import org.reactivestreams.Publisher;
 
 import io.reactivex.Flowable;
+import net.jcip.annotations.GuardedBy;
 
 /**
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
@@ -87,9 +88,14 @@ public class ScatteredVersionManagerImpl<K> implements ScatteredVersionManager<K
    private ReadWriteLock removedKeysLock = new ReentrantReadWriteLock();
    private ConcurrentMap<K, InvalidationInfo> removedKeys;
 
+   // Whether we are currently transferring values
    private volatile boolean transferringValues = false;
+   // The last topology for which we finished transferring values
    private volatile int valuesTopology = -1;
-   private CompletableFuture<Void> valuesFuture = CompletableFutures.completedNull();
+   // This future is completed when the current (or next, if transferringValues == false) value transfer finishes
+   // Should be completed and replaced with another future atomically, or valuesFuture() will enter an infinite loop
+   @GuardedBy("valuesLock")
+   private CompletableFuture<Void> valuesFuture = new CompletableFuture<>();
    private final Object valuesLock = new Object();
 
    @Start(priority = 15) // before StateConsumerImpl and StateTransferManagerImpl
@@ -296,7 +302,7 @@ public class ScatteredVersionManagerImpl<K> implements ScatteredVersionManager<K
                case KEY_TRANSFER:
                   blockedFutures.get(i).completeExceptionally(new CacheException("Failed to request versions"));
                   log.warnf("Stopped applying state for segment %d in topology %d but the segment is in state %s", i, topologyId, state);
-                  // no break
+                  // fall through
                case VALUE_TRANSFER:
                   if (segmentStates.compareAndSet(i, state, SegmentState.OWNED)) {
                      break LOOP;

--- a/core/src/test/java/org/infinispan/scattered/stream/ScatteredStreamIteratorTest.java
+++ b/core/src/test/java/org/infinispan/scattered/stream/ScatteredStreamIteratorTest.java
@@ -1,7 +1,22 @@
 package org.infinispan.scattered.stream;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
+
+import java.util.concurrent.TimeUnit;
+
+import org.infinispan.Cache;
 import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.scattered.ScatteredStateProvider;
+import org.infinispan.statetransfer.StateProvider;
 import org.infinispan.stream.DistributedStreamIteratorTest;
+import org.infinispan.test.Mocks;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.CheckPoint;
+import org.mockito.AdditionalAnswers;
+import org.mockito.stubbing.Answer;
 import org.testng.annotations.Test;
 
 /**
@@ -11,5 +26,30 @@ import org.testng.annotations.Test;
 public class ScatteredStreamIteratorTest extends DistributedStreamIteratorTest {
    public ScatteredStreamIteratorTest() {
       super(false, CacheMode.SCATTERED_SYNC);
+   }
+
+   @Override
+   protected void blockStateTransfer(Cache<?, ?> cache, CheckPoint checkPoint) {
+      // Scattered cache doesn't use StateProvider.startOutboundTransfer,
+      // so we block ScatteredStateProviderImpl.startKeysTransferInstead
+      StateProvider realObject = TestingUtil.extractComponent(cache, StateProvider.class);
+      Answer<?> forwardedAnswer = AdditionalAnswers.delegatesTo(realObject);
+      ScatteredStateProvider mock = mock(ScatteredStateProvider.class, withSettings().defaultAnswer(forwardedAnswer));
+      // TODO Replace with Mocks.blockingAnswer() once ISPN-10864 is fixed
+      doAnswer(invocation -> {
+         checkPoint.trigger(Mocks.BEFORE_INVOCATION);
+         // Scattered cache iteration blocks and waits for state transfer to fetch the values
+         // if a segment is owned in the pending CH, so we can't block forever
+         // Instead we just block for 2 seconds to verify ISPN-10984
+         checkPoint.peek(2, TimeUnit.SECONDS, Mocks.BEFORE_RELEASE);
+         try {
+            return forwardedAnswer.answer(invocation);
+         } finally {
+            checkPoint.trigger(Mocks.AFTER_INVOCATION);
+            checkPoint.awaitStrict(Mocks.AFTER_RELEASE, 20, TimeUnit.SECONDS);
+         }
+      }).when(mock)
+        .startKeysTransfer(any(), any());
+      TestingUtil.replaceComponent(cache, StateProvider.class, mock, true);
    }
 }

--- a/core/src/test/java/org/infinispan/stream/BaseSetupStreamIteratorTest.java
+++ b/core/src/test/java/org/infinispan/stream/BaseSetupStreamIteratorTest.java
@@ -32,6 +32,7 @@ import org.infinispan.stream.impl.ClusterStreamManager;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.test.fwk.TransportFlags;
 import org.infinispan.transaction.TransactionMode;
 import org.infinispan.util.BaseControlledConsistentHashFactory;
 import org.testng.annotations.Test;
@@ -44,6 +45,7 @@ import org.testng.annotations.Test;
  */
 @Test(groups = "functional", testName = "stream.BaseSetupStreamIteratorTest")
 public abstract class BaseSetupStreamIteratorTest extends MultipleCacheManagersTest {
+   public static final int NUM_NODES = 3;
    protected final String CACHE_NAME = "testCache";
    protected ConfigurationBuilder builderUsed;
 
@@ -69,9 +71,9 @@ public abstract class BaseSetupStreamIteratorTest extends MultipleCacheManagersT
          builderUsed.transaction().transactionMode(TransactionMode.TRANSACTIONAL);
       }
       if (cacheMode.isClustered()) {
-         builderUsed.clustering().stateTransfer().chunkSize(50);
+         builderUsed.clustering().stateTransfer().chunkSize(5);
          enhanceConfiguration(builderUsed);
-         createClusteredCaches(3, CACHE_NAME, builderUsed);
+         createClusteredCaches(NUM_NODES, CACHE_NAME, builderUsed, new TransportFlags().withFD(true));
       } else {
          enhanceConfiguration(builderUsed);
          EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(builderUsed);

--- a/core/src/test/java/org/infinispan/stream/DistributedStreamIteratorTest.java
+++ b/core/src/test/java/org/infinispan/stream/DistributedStreamIteratorTest.java
@@ -1,6 +1,8 @@
 package org.infinispan.stream;
 
-import static org.mockito.Matchers.any;
+import static org.infinispan.test.Exceptions.unchecked;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.doAnswer;
@@ -10,13 +12,12 @@ import static org.mockito.Mockito.withSettings;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertTrue;
-import static org.testng.AssertJUnit.fail;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -24,22 +25,25 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.IntStream;
 
 import org.infinispan.Cache;
 import org.infinispan.CacheStream;
 import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.container.impl.InternalDataContainer;
 import org.infinispan.context.Flag;
 import org.infinispan.distribution.MagicKey;
 import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.distribution.ch.KeyPartitioner;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.statetransfer.StateProvider;
 import org.infinispan.stream.impl.ClusterStreamManager;
 import org.infinispan.stream.impl.IteratorHandler;
 import org.infinispan.stream.impl.LocalStreamManager;
 import org.infinispan.test.Mocks;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.CheckPoint;
+import org.infinispan.test.fwk.TransportFlags;
 import org.mockito.AdditionalAnswers;
 import org.mockito.stubbing.Answer;
 import org.testng.annotations.Test;
@@ -67,7 +71,54 @@ public class DistributedStreamIteratorTest extends BaseClusteredStreamIteratorTe
    }
 
    @Test
-   public void verifyNodeLeavesBeforeGettingData() throws TimeoutException, InterruptedException, ExecutionException {
+   public void testIterationDuringInitialTransfer() throws Exception {
+      Map<Object, String> values = putValueInEachCache(3);
+
+      // Go back to 2 caches, because we assign all 3 segments to the first 3 nodes
+      // And we need the joiner to request some state in order to block it
+      killMember(2, CACHE_NAME);
+
+      Cache<Object, String> cache0 = cache(0, CACHE_NAME);
+
+      CheckPoint checkPoint = new CheckPoint();
+      checkPoint.triggerForever(Mocks.AFTER_RELEASE);
+      blockStateTransfer(cache0, checkPoint);
+
+      EmbeddedCacheManager joinerManager =
+            addClusterEnabledCacheManager(new ConfigurationBuilder(), new TransportFlags().withFD(true));
+      ConfigurationBuilder builderNoAwaitInitialTransfer = new ConfigurationBuilder();
+      builderNoAwaitInitialTransfer.read(builderUsed.build());
+      builderNoAwaitInitialTransfer.clustering().stateTransfer().awaitInitialTransfer(false);
+
+      joinerManager.defineConfiguration(CACHE_NAME, builderNoAwaitInitialTransfer.build());
+      Cache<String, String> joinerCache = joinerManager.getCache(CACHE_NAME, true);
+
+      // Not required, but it should make the logs clearer
+      checkPoint.awaitStrict(Mocks.BEFORE_INVOCATION, 10, TimeUnit.SECONDS);
+
+      Set<String> iteratorValues = new HashSet<>();
+      try {
+         Iterator<String> iter = joinerCache.entrySet().stream().map(Map.Entry::getValue).iterator();
+         // On NodeA, LocalStreamManagerImpl.handleSuspectSegmentsBeforeStream() suspects segments 1 and 2
+         // Even though the current phase is READ_OLD_WRITE_ALL and it's still the primary owner
+         // As a workaround we only wait for 1 value before we unblock state transfer
+         iteratorValues.add(iter.next());
+         checkPoint.trigger(Mocks.BEFORE_RELEASE, 2);
+
+         while (iter.hasNext()) {
+            iteratorValues.add(iter.next());
+         }
+      } finally {
+         checkPoint.triggerForever(Mocks.BEFORE_RELEASE);
+      }
+
+      for (Map.Entry<Object, String> entry : values.entrySet()) {
+         assertTrue("Entry wasn't found:" + entry, iteratorValues.contains(entry.getValue()));
+      }
+   }
+
+   @Test
+   public void verifyNodeLeavesBeforeGettingData() throws Exception {
       Map<Object, String> values = putValueInEachCache(3);
 
       Cache<Object, String> cache0 = cache(0, CACHE_NAME);
@@ -77,7 +128,7 @@ public class DistributedStreamIteratorTest extends BaseClusteredStreamIteratorTe
       checkPoint.triggerForever(Mocks.AFTER_RELEASE);
       waitUntilSendingResponse(cache1, checkPoint);
 
-      final BlockingQueue<String> returnQueue = new ArrayBlockingQueue<>(10);
+      final BlockingQueue<String> returnQueue = new LinkedBlockingQueue<>();
       Future<Void> future = fork(() -> {
          Iterator<String> iter = cache0.entrySet().stream().map(Map.Entry::getValue).iterator();
          while (iter.hasNext()) {
@@ -112,8 +163,8 @@ public class DistributedStreamIteratorTest extends BaseClusteredStreamIteratorTe
 
       Map<Object, String> values = new HashMap<>();
       int chunkSize = cache0.getCacheConfiguration().clustering().stateTransfer().chunkSize();
-      // Now insert 10 more values than the chunk size into the node we will kill
-      for (int i = 0; i < chunkSize + 10; ++i) {
+      // Now insert 2 more values than the chunk size into the node we will kill
+      for (int i = 0; i < chunkSize + 2; ++i) {
          MagicKey key = new MagicKey(cache1);
          cache1.put(key, key.toString());
          values.put(key, key.toString());
@@ -157,7 +208,7 @@ public class DistributedStreamIteratorTest extends BaseClusteredStreamIteratorTe
       Cache<Object, String> cache1 = cache(1, CACHE_NAME);
 
       Map<Object, String> values = new HashMap<>();
-      for (int i = 0; i < 501; ++i) {
+      for (int i = 0; i < 9; ++i) {
          MagicKey key = new MagicKey(cache1);
          cache1.put(key, key.toString());
          values.put(key, key.toString());
@@ -166,8 +217,10 @@ public class DistributedStreamIteratorTest extends BaseClusteredStreamIteratorTe
       CheckPoint checkPoint = new CheckPoint();
       checkPoint.triggerForever(Mocks.AFTER_RELEASE);
 
-      Mocks.blockingMock(checkPoint, ClusterStreamManager.class, cache0,
-            (stub, m) -> stub.when(m).remoteIterationPublisher(anyBoolean(), any(), any(), any(), anyBoolean(), anyBoolean(), any()));
+      Mocks.blockingMock(checkPoint, ClusterStreamManager.class, cache0, (stub, m) -> {
+               stub.when(m).remoteIterationPublisher(anyBoolean(), any(), any(), any(), anyBoolean(), anyBoolean(),
+                                                     any());
+            });
 
       final BlockingQueue<Map.Entry<Object, String>> returnQueue = new LinkedBlockingQueue<>();
       Future<Void> future = fork(() -> {
@@ -209,15 +262,14 @@ public class DistributedStreamIteratorTest extends BaseClusteredStreamIteratorTe
                   log.errorf("Segment %d, extra %s", segment, ans);
                }
             }
+            assertEquals(entry.getValue().size(), answerForSegment.size());
          }
          assertEquals("Segment " + segment + " had a mismatch", entry.getValue(), answerForSegment);
       }
    }
 
    @Test
-   public void testNodeLeavesWhileIteratingOverContainerCausingRehashToLoseValues() throws TimeoutException,
-                                                                                           InterruptedException,
-                                                                                           ExecutionException {
+   public void testNodeLeavesWhileIteratingOverContainerCausingRehashToLoseValues() throws Exception {
       Cache<Object, String> cache0 = cache(0, CACHE_NAME);
       Cache<Object, String> cache1 = cache(1, CACHE_NAME);
       Cache<Object, String> cache2 = cache(2, CACHE_NAME);
@@ -281,29 +333,19 @@ public class DistributedStreamIteratorTest extends BaseClusteredStreamIteratorTe
       Cache<Object, String> cache2 = cache(2, CACHE_NAME);
 
       Map<Object, String> values = new HashMap<>();
-      for (int i = 0; i < 501; ++i) {
-         switch (i % 3) {
-            case 0:
-               MagicKey key = new MagicKey(cache0);
-               cache0.put(key, key.toString());
-               values.put(key, key.toString());
-               break;
-            case 1:
-               // Force it so only cache0 has it's primary owned keys
-               key = magicKey(cache1, cache2);
-               // write from backup so that the test works on scattered cache, too
-               cache2.put(key, key.toString());
-               break;
-            case 2:
-               // Force it so only cache0 has it's primary owned keys
-               key = magicKey(cache2, cache1);
-               // write from backup so that the test works on scattered cache, too
-               cache1.put(key, key.toString());
-               break;
-            default:
-               fail("Unexpected switch case!");
-         }
-      }
+      MagicKey key1 = new MagicKey(cache0);
+      cache0.put(key1, key1.toString());
+      values.put(key1, key1.toString());
+
+      // Force it so only cache0 has it's primary owned keys
+      MagicKey key2 = magicKey(cache1, cache2);
+      // write from backup so that the test works on scattered cache, too
+      cache2.put(key2, key2.toString());
+
+      // Force it so only cache0 has it's primary owned keys
+      MagicKey key3 = magicKey(cache2, cache1);
+      // write from backup so that the test works on scattered cache, too
+      cache1.put(key3, key3.toString());
 
       int count = 0;
       Iterator<Map.Entry<Object, String>> iter = cache0.getAdvancedCache().withFlags(Flag.CACHE_MODE_LOCAL).entrySet().
@@ -385,12 +427,12 @@ public class DistributedStreamIteratorTest extends BaseClusteredStreamIteratorTe
       testStayLocalIfAllSegmentsPresentLocally(false);
    }
 
-   private void testStayLocalIfAllSegmentsPresentLocally(boolean rehashAware) throws Exception {
+   private void testStayLocalIfAllSegmentsPresentLocally(boolean rehashAware) {
       Cache<Object, String> cache0 = cache(0, CACHE_NAME);
 
-      ClusterStreamManager clusterStreamManager = replaceWithSpy(cache0);
+      ClusterStreamManager<?, ?> clusterStreamManager = replaceWithSpy(cache0);
 
-      IntStream.rangeClosed(0, 499).boxed().forEach(i -> cache0.put(i, i.toString()));
+      putValueInEachCache(3);
 
       KeyPartitioner keyPartitioner = TestingUtil.extractComponent(cache0, KeyPartitioner.class);
       ConsistentHash ch = cache0.getAdvancedCache().getDistributionManager().getWriteConsistentHash();
@@ -408,17 +450,25 @@ public class DistributedStreamIteratorTest extends BaseClusteredStreamIteratorTe
       verifyZeroInteractions(clusterStreamManager);
    }
 
-   protected <K> void waitUntilSendingResponse(final Cache<?, ?> cache, final CheckPoint checkPoint) {
-      Mocks.blockingMock(checkPoint, LocalStreamManager.class, cache,
-            (stub, m) -> stub.when(m).startIterator(any(), any(), any(), any(), any(), anyBoolean(), anyBoolean(), any(), anyLong()));
+   protected void waitUntilSendingResponse(final Cache<?, ?> cache, final CheckPoint checkPoint) {
+      Mocks.blockingMock(checkPoint, LocalStreamManager.class, cache, (stub, m) -> {
+                            stub.when(m).startIterator(any(), any(), any(), any(), any(), anyBoolean(), anyBoolean(),
+                                                       any(), anyLong());
+                         });
+   }
+
+   protected void blockStateTransfer(final Cache<?, ?> cache, final CheckPoint checkPoint) {
+      Mocks.blockingMock(checkPoint, StateProvider.class, cache, (stub, stateProvider) -> unchecked(() -> {
+                            stub.when(stateProvider).startOutboundTransfer(any(), anyInt(), any(), anyBoolean());
+                         }));
    }
 
    protected void waitUntilDataContainerWillBeIteratedOn(final Cache<?, ?> cache, final CheckPoint checkPoint) {
-      InternalDataContainer dataContainer = TestingUtil.extractComponent(cache, InternalDataContainer.class);
+      InternalDataContainer<?, ?> dataContainer = TestingUtil.extractComponent(cache, InternalDataContainer.class);
       final Answer<Object> forwardedAnswer = AdditionalAnswers.delegatesTo(dataContainer);
-      InternalDataContainer mockContainer = mock(InternalDataContainer.class, withSettings().defaultAnswer(forwardedAnswer));
+      InternalDataContainer<?, ?> mockContainer = mock(InternalDataContainer.class, withSettings().defaultAnswer(forwardedAnswer));
       final AtomicInteger invocationCount = new AtomicInteger();
-      Answer blockingAnswer = invocation -> {
+      Answer<?> blockingAnswer = invocation -> {
          boolean waiting = false;
          if (invocationCount.getAndIncrement() == 0) {
             waiting = true;

--- a/core/src/test/java/org/infinispan/test/Mocks.java
+++ b/core/src/test/java/org/infinispan/test/Mocks.java
@@ -108,9 +108,9 @@ public class Mocks {
     * @return the original object to put back into the cache
     */
    public static <Mock> Mock blockingMock(final CheckPoint checkPoint, Class<? extends Mock> classToMock,
-         Cache<?, ?> cache, Function<? super Mock, Answer> answerFunction, BiConsumer<? super Stubber, ? super Mock> mockStubConsumer) {
+         Cache<?, ?> cache, Function<? super Mock, Answer<?>> answerFunction, BiConsumer<? super Stubber, ? super Mock> mockStubConsumer) {
       Mock realObject = TestingUtil.extractComponent(cache, classToMock);
-      Answer forwardedAnswer = answerFunction.apply(realObject);
+      Answer<?> forwardedAnswer = answerFunction.apply(realObject);
       Mock mock = mock(classToMock, withSettings().extraInterfaces(ClusterCacheNotifier.class).defaultAnswer(forwardedAnswer));
       mockStubConsumer.accept(doAnswer(blockingAnswer(forwardedAnswer, checkPoint)), mock);
       TestingUtil.replaceComponent(cache, classToMock, mock, true);


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-10984

With awaitInitialTransfer disabled, publisher requests can arrive
during the initial state transfer, and in scattered caches
they would fail with StackOverflowError.
Publisher requests will still block for the initial transfer to end
because of ISPN-10864.