### PR TITLE
ISPN-6162 Deprecate Query.getResultSize() method

### DIFF
--- a/query-dsl/src/main/java/org/infinispan/query/dsl/Query.java
+++ b/query-dsl/src/main/java/org/infinispan/query/dsl/Query.java
@@ -31,7 +31,9 @@ public interface Query extends PaginationContext<Query>, ParameterContext<Query>
     * Gets the total number of results matching the query, ignoring pagination (firstResult, maxResult).
     *
     * @return total number of results.
+    * @deprecated since 10.1. This will be removed with no direct replacement.
     */
+   @Deprecated
    int getResultSize(); //todo [anistor] this should probably be a long?
 
    /**


### PR DESCRIPTION
Please do not close the jira. This PR only deprecates the method in question.
https://issues.redhat.com/browse/ISPN-6162