### PR TITLE
ISPN-10085 Hibernate51 and Hibernate53 should not report the same test name

### DIFF
--- a/commons-test/src/main/java/org/infinispan/commons/test/PolarionJUnitXMLReporter.java
+++ b/commons-test/src/main/java/org/infinispan/commons/test/PolarionJUnitXMLReporter.java
@@ -296,22 +296,37 @@ public class PolarionJUnitXMLReporter implements IResultListener2, ISuiteListene
                   res.getMethod().getConstructorOrMethod().getMethod().getAnnotation(Test.class).invocationCount())
                   .append(" times");
          }
-         // JCache tests are a special case
-         if (getModuleSuffix().contains("jcache")) {
-            if (result.indexOf("(") == -1) {
-               result.append("(");
-            } else {
-               result.append(", ");
-            }
-            if (getModuleSuffix().contains("infinispan-jcache-remote")) {
+      }
+      // JCache tests are a special case
+      String moduleSuffix = getModuleSuffix();
+      if (moduleSuffix.contains("jcache") || moduleSuffix.contains("hibernate")) {
+         if (result.indexOf("(") == -1) {
+            result.append("(");
+         } else {
+            result.append(", ");
+         }
+
+         // module
+         if (moduleSuffix.contains("jcache")) {
+            if (moduleSuffix.contains("infinispan-jcache-remote")) {
                result.append("remote");
             } else {
                result.append("embedded");
             }
+         } else if (moduleSuffix.contains("hibernate")) {
+            if (moduleSuffix.endsWith("v51")) {
+               result.append("hibernate-51");
+            } else if (moduleSuffix.endsWith("v53")) {
+               result.append("hibernate-53");
+            } else {
+               throw new IllegalStateException("Cannot parse the hibernate submodule: " + moduleSuffix);
+            }
          }
-         if (result.indexOf("(") != -1) {
-            result.append(")");
-         }
+
+      }
+      // end
+      if (result.indexOf("(") != -1) {
+         result.append(")");
       }
       return result.toString();
    }

--- a/commons-test/src/main/java/org/infinispan/commons/test/TestNGTestListener.java
+++ b/commons-test/src/main/java/org/infinispan/commons/test/TestNGTestListener.java
@@ -65,7 +65,14 @@ public class TestNGTestListener implements ITestListener, IConfigurationListener
 
    private String testName(ITestResult res) {
       StringBuilder result = new StringBuilder();
-      result.append(res.getInstanceName()).append(".").append(res.getMethod().getMethodName());
+      // We prefer using the instance name, in case it's customized,
+      // but when running JUnit tests, TestNG sets the instance name to `methodName(className)`
+      if (res.getInstanceName().contains(res.getMethod().getMethodName())) {
+         result.append(res.getTestClass().getName());
+      } else {
+         result.append(res.getInstanceName());
+      }
+      result.append(".").append(res.getMethod().getMethodName());
       if (res.getMethod().getConstructorOrMethod().getMethod().isAnnotationPresent(Test.class)) {
          String dataProviderName = res.getMethod().getConstructorOrMethod().getMethod().getAnnotation(Test.class)
                .dataProvider();

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/AbstractGeneralDataRegionTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/AbstractGeneralDataRegionTest.java
@@ -40,10 +40,10 @@ import org.infinispan.test.hibernate.cache.commons.util.TestRegionFactory;
 import org.infinispan.test.hibernate.cache.commons.util.TestRegionFactoryProvider;
 import org.infinispan.test.hibernate.cache.commons.util.TestSessionAccess;
 import org.infinispan.test.hibernate.cache.commons.util.TestSessionAccess.TestRegion;
+import org.junit.Assume;
 import org.junit.Test;
 
 import org.infinispan.AdvancedCache;
-import org.junit.experimental.categories.Category;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -118,8 +118,10 @@ public abstract class AbstractGeneralDataRegionTest extends AbstractRegionImplTe
    }
 
 	@Test
-   @Category(TestDisabledIn53.class) // per-key eviction is not supported in 5.3
 	public void testEvict() throws Exception {
+		Assume.assumeFalse("Per-key eviction is not supported in 5.3",
+								 org.hibernate.Version.getVersionString().startsWith("5.3"));
+
 		withSessionFactoriesAndRegions(2, ((sessionFactories, regions) -> {
 			InfinispanBaseRegion localRegion = regions.get(0);
          TestRegion testLocalRegion = TEST_SESSION_ACCESS.fromRegion(localRegion);

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/TestDisabledIn53.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/TestDisabledIn53.java
@@ -1,8 +1,0 @@
-package org.infinispan.test.hibernate.cache.commons;
-
-/**
- * Inteface for JUnit's {@link org.junit.experimental.categories.Category} saying that this test
- * should not run in Hibernate 5.3 module.
- */
-public interface TestDisabledIn53 {
-}

--- a/hibernate/cache-v51/pom.xml
+++ b/hibernate/cache-v51/pom.xml
@@ -43,39 +43,6 @@
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-               <parallel>none</parallel>
-               <groups combine.self="override">${defaultJUnitGroups}</groups>
-               <excludedGroups combine.self="override">${defaultExcludedJUnitGroups}</excludedGroups>
-               <dependenciesToScan>
-                  <dependency>${project.groupId}:infinispan-hibernate-cache-commons</dependency>
-               </dependenciesToScan>
-               <properties>
-                  <usedefaultlisteners>false</usedefaultlisteners>
-                  <listener>${junitListener}</listener>
-               </properties>
-               <systemPropertyVariables>
-                  <java.net.preferIPv4Stack>true</java.net.preferIPv4Stack>
-                  <jgroups.ping.timeout>500</jgroups.ping.timeout>
-                  <jgroups.ping.num_initial_members>1</jgroups.ping.num_initial_members>
-                  <jgroups.udp.enable_bundling>false</jgroups.udp.enable_bundling>
-                  <jgroups.bind_addr>localhost</jgroups.bind_addr>
-                  <hibernate.cache.infinispan.jgroups_cfg>2lc-test-tcp.xml</hibernate.cache.infinispan.jgroups_cfg>
-                  <infinispan.test.checkThreadLeaks>false</infinispan.test.checkThreadLeaks>
-               </systemPropertyVariables>
-               <disableXmlReport>false</disableXmlReport>
-            </configuration>
-            <dependencies>
-               <dependency>
-                  <groupId>org.apache.maven.surefire</groupId>
-                  <artifactId>surefire-junit47</artifactId>
-                  <version>${version.maven.surefire}</version>
-               </dependency>
-            </dependencies>
-         </plugin>
-         <plugin>
             <groupId>org.apache.felix</groupId>
             <artifactId>maven-bundle-plugin</artifactId>
             <configuration>

--- a/hibernate/cache-v53/pom.xml
+++ b/hibernate/cache-v53/pom.xml
@@ -70,39 +70,6 @@
             </configuration>
          </plugin>
          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-               <parallel>none</parallel>
-               <groups combine.self="override">${defaultJUnitGroups}</groups>
-               <excludedGroups combine.self="override">${defaultExcludedJUnitGroups},org.infinispan.test.hibernate.cache.commons.TestDisabledIn53</excludedGroups>
-               <dependenciesToScan>
-                  <dependency>${project.groupId}:infinispan-hibernate-cache-commons</dependency>
-               </dependenciesToScan>
-               <properties>
-                  <usedefaultlisteners>false</usedefaultlisteners>
-                  <listener>${junitListener}</listener>
-               </properties>
-               <systemPropertyVariables>
-                  <java.net.preferIPv4Stack>true</java.net.preferIPv4Stack>
-                  <jgroups.ping.timeout>500</jgroups.ping.timeout>
-                  <jgroups.ping.num_initial_members>1</jgroups.ping.num_initial_members>
-                  <jgroups.udp.enable_bundling>false</jgroups.udp.enable_bundling>
-                  <jgroups.bind_addr>localhost</jgroups.bind_addr>
-                  <hibernate.cache.infinispan.jgroups_cfg>2lc-test-tcp.xml</hibernate.cache.infinispan.jgroups_cfg>
-                  <infinispan.test.checkThreadLeaks>false</infinispan.test.checkThreadLeaks>
-               </systemPropertyVariables>
-               <disableXmlReport>false</disableXmlReport>
-            </configuration>
-            <dependencies>
-               <dependency>
-                  <groupId>org.apache.maven.surefire</groupId>
-                  <artifactId>surefire-junit47</artifactId>
-                  <version>${version.maven.surefire}</version>
-               </dependency>
-            </dependencies>
-         </plugin>
-         <plugin>
             <groupId>org.apache.felix</groupId>
             <artifactId>maven-bundle-plugin</artifactId>
             <configuration>

--- a/hibernate/pom.xml
+++ b/hibernate/pom.xml
@@ -90,6 +90,11 @@
          <artifactId>h2</artifactId>
          <scope>test</scope>
       </dependency>
+      <dependency>
+         <groupId>org.testng</groupId>
+         <artifactId>testng</artifactId>
+         <scope>test</scope>
+      </dependency>
    </dependencies>
 
    <build>
@@ -104,6 +109,27 @@
             </plugin>
          </plugins>
       </pluginManagement>
+      <plugins>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+               <dependenciesToScan>
+                  <dependency>${project.groupId}:infinispan-hibernate-cache-commons</dependency>
+               </dependenciesToScan>
+                <argLine>${forkJvmArgs} ${testjvm.jigsawArgs} -Djdk.attach.allowAttachSelf=true</argLine>
+               <systemPropertyVariables>
+                  <java.net.preferIPv4Stack>true</java.net.preferIPv4Stack>
+                  <jgroups.ping.timeout>500</jgroups.ping.timeout>
+                  <jgroups.ping.num_initial_members>1</jgroups.ping.num_initial_members>
+                  <jgroups.udp.enable_bundling>false</jgroups.udp.enable_bundling>
+                  <jgroups.bind_addr>localhost</jgroups.bind_addr>
+                  <hibernate.cache.infinispan.jgroups_cfg>2lc-test-tcp.xml</hibernate.cache.infinispan.jgroups_cfg>
+                  <infinispan.test.checkThreadLeaks>false</infinispan.test.checkThreadLeaks>
+               </systemPropertyVariables>
+            </configuration>
+         </plugin>
+      </plugins>
    </build>
 
    <profiles>


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-10085

Replaces #7707, adds 2 commits:

* Properly exclude Hibernate 5.1-only tests in 5.3
* Shorten JUnit test names in TestNGTestListener 