### PR TITLE
ISPN-11140 RemoteCache w/near-cache throws InstanceAlreadyExistsException following restart

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/InvalidatedNearRemoteCache.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/InvalidatedNearRemoteCache.java
@@ -124,11 +124,13 @@ public class InvalidatedNearRemoteCache<K, V> extends RemoteCacheImpl<K, V> {
 
    @Override
    public void start() {
+      super.start();
       nearcache.start(this);
    }
 
    @Override
    public void stop() {
       nearcache.stop(this);
+      super.stop();
    }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-11140