### PR TITLE
ISPN-11555 Remove ClusteredQuery from the API

### DIFF
--- a/query/src/main/java/org/infinispan/query/SearchManager.java
+++ b/query/src/main/java/org/infinispan/query/SearchManager.java
@@ -49,15 +49,6 @@ public interface SearchManager {
    EntityContext buildQueryBuilderForClass(Class<?> entityType);
 
    /**
-    * @param luceneQuery
-    * @param classes
-    * @return
-    * @deprecated since 9.2, to be removed in 10.0; equivalent to {@code getQuery(luceneQuery, IndexedQueryMode.BROADCAST, classes)}
-    */
-   @Deprecated
-   <E> CacheQuery<E> getClusteredQuery(Query luceneQuery, Class<?>... classes);
-
-   /**
     * The MassIndexer can be used to rebuild the Lucene indexes from the entries stored in Infinispan.
     *
     * @return the MassIndexer component

--- a/query/src/main/java/org/infinispan/query/impl/SearchManagerImpl.java
+++ b/query/src/main/java/org/infinispan/query/impl/SearchManagerImpl.java
@@ -107,12 +107,6 @@ public final class SearchManagerImpl implements SearchManagerImplementor {
    }
 
    @Override
-   @Deprecated
-   public <E> CacheQuery<E> getClusteredQuery(Query luceneQuery, Class<?>... classes) {
-      return getQuery(luceneQuery, IndexedQueryMode.BROADCAST, classes);
-   }
-
-   @Override
    public void registerKeyTransformer(Class<?> keyClass, Class<? extends Transformer> transformerClass) {
       keyTransformationHandler.registerTransformer(keyClass, transformerClass);
    }


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-11155

From now on, there is no "Clustered Query" anymore. Let's erase this term from the collective mindset. If you are temped to say "Clustered Query", just say "Query". :smile: