### PR TITLE
ISPN-10804 JCache tck-runner does not run interception tests

### DIFF
--- a/jcache/tck-runner-embedded/pom.xml
+++ b/jcache/tck-runner-embedded/pom.xml
@@ -109,6 +109,8 @@
                   <javax.cache.Cache.Entry>${embedded.CacheEntryImpl}</javax.cache.Cache.Entry>
                   <jgroups.join_timeout>2000</jgroups.join_timeout>
                   <infinispan.module-suffix>-${project.artifactId}-embedded</infinispan.module-suffix>
+                  <!-- Apply our beans.xml to the TCK beans -->
+                  <org.jboss.weld.se.archive.isolation>false</org.jboss.weld.se.archive.isolation>
 
                   <javax.management.builder.initial>${tck.mbean.builder}</javax.management.builder.initial>
                   <org.jsr107.tck.management.agentId>${tck.mbean.server}</org.jsr107.tck.management.agentId>

--- a/jcache/tck-runner-embedded/src/test/resources/META-INF/beans.xml
+++ b/jcache/tck-runner-embedded/src/test/resources/META-INF/beans.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       version="1.2" bean-discovery-mode="annotated">
+
+    <interceptors>
+        <class>org.infinispan.jcache.annotation.CacheResultInterceptor</class>
+        <class>org.infinispan.jcache.annotation.CachePutInterceptor</class>
+        <class>org.infinispan.jcache.annotation.CacheRemoveEntryInterceptor</class>
+        <class>org.infinispan.jcache.annotation.CacheRemoveAllInterceptor</class>
+    </interceptors>
+
+</beans>


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-10804

Define system property `org.jboss.weld.se.archive.isolation`
to get the CDI 1.0 behaviour or applying the interceptors
fro any beans.xml to all the beans in the application.