### PR TITLE
ISPN-11164 clustered max idle doc update

### DIFF
--- a/documentation/src/main/asciidoc/topics/eviction.adoc
+++ b/documentation/src/main/asciidoc/topics/eviction.adoc
@@ -48,7 +48,7 @@ on the cache. If passivation is enabled this will cause aa warning message to be
 emitted. This is the default strategy.
 
 .`MANUAL`
-This strategy is just like <b>NONE</b> except that it asssumes the user will be
+This strategy is just like <b>NONE</b> except that it assumes the user will be
 invoking evict directly. This way if passivation is enabled no warning message
 is logged.
 
@@ -209,46 +209,45 @@ can result in slower operation times.
 
 Maximum idle expiration has different behavior in local and clustered cache environments.
 
+[IMPORTANT]
+====
+Maximum idle expiration, `max-idle`, does not currently work with entries stored in off-heap memory.
+
+Likewise, `max-idle` does not work if caches use cache stores as a persistence layer.
+====
+
 [[expiration_maxidle_local]]
 ==== Local Max Idle
+In local cache mode, {brandname} expires entries with the `maxIdle` configuration when:
 
-In non-clustered cache environments, the `maxIdle` configuration expires entries when:
-
-* accessed directly (`Cache.get`).
-* iterated upon (`Cache.size`).
+* accessed directly (`Cache.get()`).
+* iterated upon (`Cache.size()`).
 * the expiration reaper thread runs.
 
 [[expiration_maxidle_clustered]]
 ==== Clustered Max Idle
+In clustered cache modes, when clients read entries that have `max-idle`
+expiration values, {brandname} sends touch commands to all owners. This ensures
+that the entries have the same relative access time across the cluster.
 
-In clustered environments, nodes in the cluster can have different access times
-for the same entry. Entries do not expire from the cache until they reach the
-maxium idle time for all owners across the cluster.
+When nodes detect that an entry reaches the maximum idle time, {brandname}
+removes it from the cache and does not return the entry to the client that
+requested it.
 
-When a node detects that an entry has reached the maximum idle time and is
-expired, the node gets the last time that the entry was accessed from the other
-owners in the cluster. If the other owners indicate that the entry is expired,
-that entry is not returned to the requester and removed from the cache.
+Before using clustered `max-idle`, you should review the following points:
 
-The following points apply to using the `maxIdle` configuration with clustered
-caches:
-
-* If one or more owner in the cluster detects that an entry is not expired,
-then a `Cache.get` operation returns the entry. The last access time for that
-entry is also updated to the current time.
-* When the expiration reaper finds entries that might be expired with the
-maximum idle time, all nodes update the last access time for those entries
-to the most recent access time before the `maxIdle` time. In this way, the
-reaper prevents invalid expiration of entries.
-* Clustered transactional caches do *not* remove entries that are expired
-with the maximum idle time on `Cache.get` operations. These expired entries
-are removed with the expiration reaper thread only, otherwise deadlocking
-can occur.
+* `Cache.get()` does not return until the touch commands complete. This synchronous behavior increases latency of client requests.
+* Clustered `max-idle` also updates the recent access count for eviction on all owners.
+//Scattered cache is community only
+ifndef::productized[]
+* With scattered cache mode, {brandname} sends touch commands to all nodes, not
+just primary and backup owners.
+endif::productized[]
 * Iteration across a clustered cache returns entries that might be expired
 with the maximum idle time. This behavior ensures performance because no
 remote invocations are performed during the iteration. However this does not
 refresh any expired entries, which are removed by the expiration reaper or
-when accessed directly (`Cache.get`).
+when accessed directly (`Cache.get()`).
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-11164

Needs backport to 9.4.x to hit downstream 7.3.5.