### PR TITLE
[9.4.x] ISPN-11170 Infinispan directory does not work with pre-declared indexed entities when sharing user cache and data cache

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/EmbeddedRemoteInteropQueryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/EmbeddedRemoteInteropQueryTest.java
@@ -124,9 +124,13 @@ public class EmbeddedRemoteInteropQueryTest extends SingleCacheManagerTest {
       org.infinispan.configuration.cache.ConfigurationBuilder builder = hotRodCacheConfiguration();
       builder.encoding().key().mediaType(MediaType.APPLICATION_OBJECT_TYPE);
       builder.encoding().value().mediaType(MediaType.APPLICATION_OBJECT_TYPE);
-      builder.indexing().index(Index.ALL)
-            .addProperty("default.directory_provider", "local-heap")
-            .addProperty("lucene_version", "LUCENE_CURRENT");
+      builder.indexing()
+             .index(Index.ALL)
+             .addIndexedEntity(UserHS.class)
+             .addIndexedEntity(AccountHS.class)
+             .addIndexedEntity(TransactionHS.class)
+             .addProperty("default.directory_provider", "local-heap")
+             .addProperty("lucene_version", "LUCENE_CURRENT");
       return builder;
    }
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/CompleteShutdownDistRetryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/CompleteShutdownDistRetryTest.java
@@ -2,6 +2,7 @@ package org.infinispan.client.hotrod.retry;
 
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
 import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNull;
 import static org.testng.AssertJUnit.fail;
 
 import java.net.SocketAddress;
@@ -51,8 +52,8 @@ public class CompleteShutdownDistRetryTest extends HitsAwareCacheManagersTest {
 
       killServer();
       killServer();
-      assertEquals(null, client.get(keys.get(0))); // data gone
-      assertEquals(null, client.get(keys.get(1))); // data gone
+      assertNull(client.get(keys.get(0))); // data gone
+      assertNull(client.get(keys.get(1))); // data gone
 
       resetStats();
       assertEquals("two", client.get(keys.get(2)));
@@ -90,7 +91,7 @@ public class CompleteShutdownDistRetryTest extends HitsAwareCacheManagersTest {
    }
 
    private List<byte[]> genKeys() {
-      List<byte[]> keys = new ArrayList<byte[]>();
+      List<byte[]> keys = new ArrayList<>();
       for (Map.Entry<SocketAddress, HotRodServer> entry : addr2hrServer.entrySet()) {
          keys.add(HotRodClientTestingUtil.getKeyForServer(entry.getValue()));
       }
@@ -98,9 +99,7 @@ public class CompleteShutdownDistRetryTest extends HitsAwareCacheManagersTest {
    }
 
    private List<SocketAddress> getSocketAddressList() {
-      List<SocketAddress> addrs = new ArrayList<SocketAddress>();
-      addrs.addAll(addr2hrServer.keySet());
-      return addrs;
+      return new ArrayList<>(addr2hrServer.keySet());
    }
 
    private ConfigurationBuilder getConfiguration() {
@@ -108,5 +107,4 @@ public class CompleteShutdownDistRetryTest extends HitsAwareCacheManagersTest {
       builder.clustering().hash().numOwners(1);
       return hotRodCacheConfiguration(builder);
    }
-
 }

--- a/integrationtests/wildfly-modules/src/test/resources/dynamic-indexing-distribution.xml
+++ b/integrationtests/wildfly-modules/src/test/resources/dynamic-indexing-distribution.xml
@@ -16,7 +16,10 @@
          <state-transfer timeout="480000" enabled="true" />
          <eviction max-entries="-1" strategy="NONE" />
          <expiration max-idle="-1" />
-            <indexing index="LOCAL">
+            <indexing index="PRIMARY_OWNER">
+               <indexed-entities>
+                  <indexed-entity>org.infinispan.test.integration.as.query.Book</indexed-entity>
+               </indexed-entities>
                <!-- Use our custom IndexManager; TODO autoinject by default? -->
                <property name="hibernate.search.default.indexmanager">org.infinispan.query.indexmanager.InfinispanIndexManager</property>
                <!-- specify the managed index is to be shared across the nodes -->

--- a/integrationtests/wildfly-modules/src/test/resources/elasticsearch-indexing.xml
+++ b/integrationtests/wildfly-modules/src/test/resources/elasticsearch-indexing.xml
@@ -13,7 +13,10 @@
             <state-transfer timeout="480000" enabled="true"/>
             <eviction max-entries="-1" strategy="NONE"/>
             <expiration max-idle="-1"/>
-            <indexing index="LOCAL">
+            <indexing index="PRIMARY_OWNER">
+                <indexed-entities>
+                    <indexed-entity>org.infinispan.test.integration.as.query.Book</indexed-entity>
+                </indexed-entities>
                 <property name="default.indexmanager">elasticsearch</property>
                 <property name="default.elasticsearch.refresh_after_write">true</property>
                 <property name="default.elasticsearch.required_index_status">yellow</property>

--- a/query/pom.xml
+++ b/query/pom.xml
@@ -109,6 +109,12 @@
       </dependency>
 
       <dependency>
+         <groupId>org.antlr</groupId>
+         <artifactId>antlr-runtime</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
          <groupId>org.testng</groupId>
          <artifactId>testng</artifactId>
          <scope>test</scope>

--- a/query/src/main/java/org/infinispan/query/backend/SearchableCacheConfiguration.java
+++ b/query/src/main/java/org/infinispan/query/backend/SearchableCacheConfiguration.java
@@ -1,10 +1,7 @@
 package org.infinispan.query.backend;
 
 import static org.hibernate.search.cfg.Environment.INDEX_MANAGER_IMPL_NAME;
-import static org.infinispan.query.impl.IndexPropertyInspector.getDataCacheName;
-import static org.infinispan.query.impl.IndexPropertyInspector.getLockingCacheName;
-import static org.infinispan.query.impl.IndexPropertyInspector.getMetadataCacheName;
-import static org.infinispan.query.impl.IndexPropertyInspector.hasInfinispanDirectory;
+import static org.infinispan.query.impl.IndexPropertyInspector.isInfinispanDirectoryInternalCache;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -52,7 +49,7 @@ public final class SearchableCacheConfiguration extends SearchConfigurationBase 
 
    private static final Log log = LogFactory.getLog(SearchableCacheConfiguration.class, Log.class);
 
-   private final Map<String, Class<?>> classes;
+   private final Map<String, Class<?>> classes = new HashMap<>();
    private final Properties properties;
    private final SearchMapping searchMapping;
    private final Map<Class<? extends Service>, Object> providedServices;
@@ -72,15 +69,7 @@ public final class SearchableCacheConfiguration extends SearchConfigurationBase 
          this.properties.put(Environment.ERROR_HANDLER, new AffinityErrorHandler(configuredErrorHandler));
       }
 
-      Cache cache = cr.getComponent(Cache.class);
-
-      boolean isInfinispanDirectoryInternalCache = false;
-      if (hasInfinispanDirectory(properties) && (cache.getName().equals(getDataCacheName(properties))
-            || cache.getName().equals(getMetadataCacheName(properties))
-            || cache.getName().equals(getLockingCacheName(properties)))) {
-         // Infinispan Directory causes runtime circular dependencies so we need to postpone creation of indexes until all components are initialised
-         isInfinispanDirectoryInternalCache = true;
-      }
+      Cache<?, ?> cache = cr.getComponent(Cache.class);
 
       LuceneAnalysisDefinitionProvider analyzerDefProvider = analyzerDefProviders != null && !analyzerDefProviders.isEmpty() ?
             builder -> {
@@ -100,16 +89,6 @@ public final class SearchableCacheConfiguration extends SearchConfigurationBase 
       services.put(LuceneAnalysisDefinitionSourceService.class, loopService);
       this.providedServices = Collections.unmodifiableMap(services);
 
-      classes = new HashMap<>();
-      if (!isInfinispanDirectoryInternalCache) {
-         for (Class<?> c : indexedEntities) {
-            if (log.isDebugEnabled()) {
-               log.debugf("Found configured class mapping for Hibernate Search: %s", c.getName());
-            }
-            classes.put(c.getName(), c);
-         }
-      }
-
       //deal with programmatic mapping:
       SearchMapping searchMapping = SearchMappingHelper.extractSearchMapping(this);
       if (programmaticSearchMappingProviders != null && !programmaticSearchMappingProviders.isEmpty()) {
@@ -125,14 +104,25 @@ public final class SearchableCacheConfiguration extends SearchConfigurationBase 
       }
       this.searchMapping = searchMapping;
 
-      //if we have a SearchMapping then we can predict at least those entities specified in the mapping
-      //and avoid further SearchFactory rebuilds triggered by new entity discovery during cache events
-      if (!isInfinispanDirectoryInternalCache && this.searchMapping != null) {
-         for (Class<?> c : this.searchMapping.getMappedEntities()) {
+      // Infinispan Directory causes runtime circular dependencies so we need to postpone creation of indexes for
+      // classes until all components and other involved caches are initialised (see LifecycleManager.cacheStarted)
+      if (!isInfinispanDirectoryInternalCache(cache.getName(), properties)) {
+         for (Class<?> c : indexedEntities) {
             if (log.isDebugEnabled()) {
-               log.debugf("Found programmatically configured class mapping for Hibernate Search: %s", c.getName());
+               log.debugf("Found configured class mapping for Hibernate Search: %s", c.getName());
             }
             classes.put(c.getName(), c);
+         }
+
+         //if we have a SearchMapping then we can predict at least those entities specified in the mapping
+         //and avoid further SearchFactory rebuilds triggered by new entity discovery during cache events
+         if (searchMapping != null) {
+            for (Class<?> c : searchMapping.getMappedEntities()) {
+               if (log.isDebugEnabled()) {
+                  log.debugf("Found programmatically configured class mapping for Hibernate Search: %s", c.getName());
+               }
+               classes.put(c.getName(), c);
+            }
          }
       }
    }

--- a/query/src/main/java/org/infinispan/query/impl/IndexPropertyInspector.java
+++ b/query/src/main/java/org/infinispan/query/impl/IndexPropertyInspector.java
@@ -15,7 +15,7 @@ import org.infinispan.query.affinity.AffinityIndexManager;
 import org.infinispan.query.indexmanager.InfinispanIndexManager;
 
 /**
- * Extract useful information from indexing configuration
+ * Extract useful information from indexing configuration, mostly related to Infinispan Index Manager.
  *
  * @author gustavonalle
  * @since 7.0
@@ -35,6 +35,13 @@ public final class IndexPropertyInspector {
 
    public static String getMetadataCacheName(Properties properties) {
       return getPropertyFor(METADATA_CACHENAME, properties, DEFAULT_INDEXESMETADATA_CACHENAME);
+   }
+
+   public static boolean isInfinispanDirectoryInternalCache(String cacheName, Properties properties) {
+      return hasInfinispanDirectory(properties)
+            && (cacheName.equals(getDataCacheName(properties))
+            || cacheName.equals(getMetadataCacheName(properties))
+            || cacheName.equals(getLockingCacheName(properties)));
    }
 
    public static boolean hasInfinispanDirectory(Properties properties) {

--- a/query/src/test/java/org/infinispan/query/backend/AsyncBackendTest.java
+++ b/query/src/test/java/org/infinispan/query/backend/AsyncBackendTest.java
@@ -1,9 +1,12 @@
 package org.infinispan.query.backend;
 
-import static org.infinispan.test.TestingUtil.replaceComponent;
+import static org.infinispan.test.TestingUtil.replaceField;
 import static org.infinispan.test.TestingUtil.withCacheManagers;
-import static org.mockito.Matchers.anyCollection;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -15,9 +18,11 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.Index;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.query.indexmanager.IndexUpdateCommand;
+import org.infinispan.query.indexmanager.InfinispanIndexManager;
 import org.infinispan.query.test.Person;
+import org.infinispan.remoting.rpc.ResponseMode;
 import org.infinispan.remoting.rpc.RpcManager;
-import org.infinispan.remoting.rpc.RpcOptions;
+import org.infinispan.remoting.rpc.RpcManagerImpl;
 import org.infinispan.remoting.transport.Transport;
 import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.test.MultiCacheManagerCallable;
@@ -37,18 +42,18 @@ public class AsyncBackendTest extends AbstractInfinispanTest {
    @Test
    public void testWithEnablingAsync() {
       test(getBaseConfigPlus("default.worker.execution", "async"),
-           rpcManager -> calledIndexAsynchronously(rpcManager, "person"));
+           transport -> calledIndexAsynchronously(transport, "person"));
    }
 
    @Test
    public void testWithEnablingAsyncForDifferentIndex() {
       test(getBaseConfigPlus("cat.worker.execution", "async"),
-           rpcManager -> calledIndexSynchronously(rpcManager, "person"));
+           transport -> calledIndexSynchronously(transport, "person"));
    }
 
    @Test
    public void testWithDefaultSettings() {
-      test(getBaseConfig(), rpcManager -> calledIndexSynchronously(rpcManager, "person"));
+      test(getBaseConfig(), transport -> calledIndexSynchronously(transport, "person"));
    }
 
    @Test
@@ -57,9 +62,9 @@ public class AsyncBackendTest extends AbstractInfinispanTest {
             "default.sharding_strategy.nbr_of_shards", "2",
             "person.0.worker.execution", "async"
       );
-      test(cfg, rpcManager -> {
-         calledIndexAsynchronously(rpcManager, "person.0");
-         calledIndexSynchronously(rpcManager, "person.1");
+      test(cfg, transport -> {
+         calledIndexAsynchronously(transport, "person.0");
+         calledIndexSynchronously(transport, "person.1");
       });
    }
 
@@ -69,7 +74,7 @@ public class AsyncBackendTest extends AbstractInfinispanTest {
             "default.worker.execution", "async",
             "person.worker.execution", "sync"
       );
-      test(cfg, rpcManager -> calledIndexSynchronously(rpcManager, "person"));
+      test(cfg, transport -> calledIndexSynchronously(transport, "person"));
    }
 
    @Test
@@ -80,18 +85,20 @@ public class AsyncBackendTest extends AbstractInfinispanTest {
             "person.worker.execution", "async",
             "person.1.worker.execution", "sync"
       );
-      test(cfg, rpcManager -> {
-         calledIndexAsynchronously(rpcManager, "person.0");
-         calledIndexSynchronously(rpcManager, "person.1");
-         calledIndexAsynchronously(rpcManager, "person.2");
+      test(cfg, transport -> {
+         calledIndexAsynchronously(transport, "person.0");
+         calledIndexSynchronously(transport, "person.1");
+         calledIndexAsynchronously(transport, "person.2");
       });
    }
 
    private ConfigurationBuilder getBaseConfig() {
       ConfigurationBuilder cfg = new ConfigurationBuilder();
-      cfg.clustering().cacheMode(CacheMode.REPL_SYNC).indexing().index(Index.ALL)
-            .addProperty("default.indexmanager", "org.infinispan.query.indexmanager.InfinispanIndexManager")
-            .addProperty("lucene_version", "LUCENE_CURRENT");
+      cfg.clustering().cacheMode(CacheMode.REPL_SYNC)
+         .indexing().index(Index.ALL)
+         .addIndexedEntity(Person.class)
+         .addProperty("default.indexmanager", InfinispanIndexManager.class.getName())
+         .addProperty("lucene_version", "LUCENE_CURRENT");
       return cfg;
    }
 
@@ -104,21 +111,19 @@ public class AsyncBackendTest extends AbstractInfinispanTest {
       return cfg;
    }
 
-   @SuppressWarnings("unchecked")
-   private void calledIndexSynchronously(RpcManager rpcManager, String indexName) {
-      assertIndexCall(rpcManager, indexName, true);
+   private void calledIndexSynchronously(Transport transport, String indexName) throws Exception {
+      assertIndexCall(transport, indexName, true);
    }
 
-   @SuppressWarnings("unchecked")
-   private void calledIndexAsynchronously(RpcManager rpcManager, String indexName) {
-      assertIndexCall(rpcManager, indexName, false);
+   private void calledIndexAsynchronously(Transport transport, String indexName) throws Exception {
+      assertIndexCall(transport, indexName, false);
    }
 
-   @SuppressWarnings("unchecked")
-   private void assertIndexCall(RpcManager rpcManager, String indexName, boolean sync) {
+   private void assertIndexCall(Transport transport, String indexName, boolean sync) throws Exception {
       ArgumentCaptor<IndexUpdateCommand> argument = ArgumentCaptor.forClass(IndexUpdateCommand.class);
-      RpcOptions rpcOptions = rpcManager.getDefaultRpcOptions(sync);
-      verify(rpcManager, atLeastOnce()).invokeRemotely(anyCollection(), argument.capture(), eq(rpcOptions));
+      verify(transport, atLeastOnce()).invokeRemotelyAsync(anyCollection(), argument.capture(),
+                                                           eq(sync ? ResponseMode.SYNCHRONOUS : ResponseMode.ASYNCHRONOUS),
+                                                           anyLong(), any(), any(), anyBoolean());
       boolean indexCalled = false;
       for (IndexUpdateCommand updateCommand : argument.getAllValues()) {
          indexCalled |= updateCommand.getIndexName().equals(indexName);
@@ -127,21 +132,21 @@ public class AsyncBackendTest extends AbstractInfinispanTest {
    }
 
    private interface Assertion {
-      void doAssertion(RpcManager rpcManager);
+      void doAssertion(Transport transport) throws Exception;
    }
 
-   private void test(ConfigurationBuilder cfg, final Assertion assertion) {
+   private void test(ConfigurationBuilder cfg, Assertion assertion) {
       withCacheManagers(new MultiCacheManagerCallable(
             TestCacheManagerFactory.createClusteredCacheManager(cfg),
             TestCacheManagerFactory.createClusteredCacheManager(cfg)) {
          @Override
-         public void call() {
+         public void call() throws Exception {
             EmbeddedCacheManager slave = isMaster(cms[0].getCache()) ? cms[1] : cms[0];
-            RpcManager wireTappedRpcManager = spyOnTransport(slave.getCache());
+            Transport wireTappedTransport = spyOnTransport(slave.getCache());
             slave.getCache().put(1, new Person("person1", "blurb1", 20));
             slave.getCache().put(2, new Person("person2", "blurb2", 27));
             slave.getCache().put(3, new Person("person3", "blurb3", 56));
-            assertion.doAssertion(wireTappedRpcManager);
+            assertion.doAssertion(wireTappedTransport);
          }
       });
    }
@@ -151,10 +156,10 @@ public class AsyncBackendTest extends AbstractInfinispanTest {
       return transport.getCoordinator().equals(transport.getAddress());
    }
 
-   private RpcManager spyOnTransport(Cache<?, ?> cache) {
-      RpcManager rpcManager = spy(cache.getAdvancedCache().getRpcManager());
-      replaceComponent(cache, RpcManager.class, rpcManager, false);
-      return rpcManager;
+   private Transport spyOnTransport(Cache<?, ?> cache) {
+      RpcManager rpcManager = cache.getAdvancedCache().getRpcManager();
+      Transport transport = spy(rpcManager.getTransport());
+      replaceField(transport, "t", rpcManager, RpcManagerImpl.class);
+      return transport;
    }
-
 }

--- a/query/src/test/java/org/infinispan/query/backend/IndexCacheStopTest.java
+++ b/query/src/test/java/org/infinispan/query/backend/IndexCacheStopTest.java
@@ -18,6 +18,7 @@ import org.infinispan.manager.CacheContainer;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.query.CacheQuery;
 import org.infinispan.query.Search;
+import org.infinispan.query.indexmanager.InfinispanIndexManager;
 import org.infinispan.query.test.AnotherGrassEater;
 import org.infinispan.query.test.Person;
 import org.infinispan.test.AbstractInfinispanTest;
@@ -80,7 +81,6 @@ public class IndexCacheStopTest extends AbstractInfinispanTest {
       assertEquals(cacheManager.getStatus(), ComponentStatus.TERMINATED);
    }
 
-
    @Test
    public void testIndexingWithCustomLock() throws CyclicDependencyException {
       EmbeddedCacheManager cacheManager = createClusteredCacheManager();
@@ -98,7 +98,7 @@ public class IndexCacheStopTest extends AbstractInfinispanTest {
    }
 
    @Test
-   public void testIndexingOnCacheItself() throws CyclicDependencyException {
+   public void testIndexingOnCacheItself() {
       EmbeddedCacheManager cacheManager = createClusteredCacheManager();
       cacheManager.defineConfiguration("single", getIndexedConfigWithCustomCaches("single", "single", "single").build());
       startAndIndexData("single", cacheManager);
@@ -118,7 +118,7 @@ public class IndexCacheStopTest extends AbstractInfinispanTest {
    }
 
    @Test
-   public void testIndexingMultipleDirectoriesOnSameCache() throws CyclicDependencyException {
+   public void testIndexingMultipleDirectoriesOnSameCache() {
       EmbeddedCacheManager cacheManager = createClusteredCacheManager();
       cacheManager.defineConfiguration("cacheA", getIndexedConfigWithCustomCaches("single", "single", "single").build());
       cacheManager.defineConfiguration("cacheB", getIndexedConfigWithCustomCaches("single", "single", "single").build());
@@ -130,7 +130,7 @@ public class IndexCacheStopTest extends AbstractInfinispanTest {
    }
 
    @Test
-   public void testIndexingHierarchically() throws CyclicDependencyException {
+   public void testIndexingHierarchically() {
       EmbeddedCacheManager cacheManager = createClusteredCacheManager();
       cacheManager.defineConfiguration("cacheC", getIndexedConfigWithCustomCaches("cacheB", "cacheB", "cacheB").build());
       cacheManager.defineConfiguration("cacheB", getIndexedConfigWithCustomCaches("cacheA", "cacheA", "cacheA").build());
@@ -144,7 +144,7 @@ public class IndexCacheStopTest extends AbstractInfinispanTest {
    }
 
    @Test
-   public void testStartAndStopWithEmptyCache() throws CyclicDependencyException {
+   public void testStartAndStopWithEmptyCache() {
       EmbeddedCacheManager cacheManager = createClusteredCacheManager(getIndexedConfig());
       cacheManager.getCache();
       cacheManager.stop();
@@ -191,38 +191,35 @@ public class IndexCacheStopTest extends AbstractInfinispanTest {
 
    private ConfigurationBuilder getIndexedConfig() {
       ConfigurationBuilder cfg = getBaseConfig();
-      cfg.indexing().index(Index.ALL)
-              .addIndexedEntity(Person.class)
-              .addIndexedEntity(AnotherGrassEater.class)
-              .addProperty("default.directory_provider", "infinispan")
-              .addProperty("lucene_version", "LUCENE_CURRENT");
+      cfg.indexing()
+         .index(Index.ALL)
+         .addIndexedEntity(Person.class)
+         .addIndexedEntity(AnotherGrassEater.class)
+         .addProperty("default.directory_provider", "infinispan")
+         .addProperty("lucene_version", "LUCENE_CURRENT");
       return cfg;
    }
 
    private ConfigurationBuilder getIndexedConfigWithCustomCaches(String lockCache, String metadataCache, String dataCache) {
       ConfigurationBuilder cfg = getIndexedConfig();
-      cfg.indexing().index(Index.ALL)
-            .addProperty("default.locking_cachename", lockCache)
-            .addProperty("default.data_cachename", dataCache)
-            .addProperty("default.metadata_cachename", metadataCache)
-            .addProperty("lucene_version", "LUCENE_CURRENT");
+      cfg.indexing()
+         .addProperty("default.locking_cachename", lockCache)
+         .addProperty("default.data_cachename", dataCache)
+         .addProperty("default.metadata_cachename", metadataCache);
       return cfg;
    }
 
    private ConfigurationBuilder getIndexedConfigWithInfinispanIndexManager() {
       ConfigurationBuilder cfg = getIndexedConfig();
-      cfg.indexing().index(Index.ALL)
-              .addProperty("default.indexmanager", "org.infinispan.query.indexmanager.InfinispanIndexManager")
-              .addProperty("lucene_version", "LUCENE_CURRENT");
+      cfg.indexing()
+         .addProperty("default.indexmanager", InfinispanIndexManager.class.getName());
       return cfg;
    }
 
    private ConfigurationBuilder getIndexedConfigWithCustomLock() {
       ConfigurationBuilder cfg = getIndexedConfig();
-      cfg.indexing().index(Index.ALL)
-              .addProperty("default.locking_strategy", "none")
-              .addProperty("lucene_version", "LUCENE_CURRENT");
+      cfg.indexing()
+         .addProperty("default.locking_strategy", "none");
       return cfg;
    }
-
 }

--- a/query/src/test/java/org/infinispan/query/backend/IndexCacheStopTest.java
+++ b/query/src/test/java/org/infinispan/query/backend/IndexCacheStopTest.java
@@ -108,6 +108,16 @@ public class IndexCacheStopTest extends AbstractInfinispanTest {
    }
 
    @Test
+   public void testIndexingWithUserCacheAsDataCache() {
+      EmbeddedCacheManager cacheManager = createClusteredCacheManager();
+      cacheManager.defineConfiguration("single", getIndexedConfigWithCustomCaches("locking", "metadata", "single").build());
+      startAndIndexData("single", cacheManager);
+      cacheManager.stop();
+
+      assertEquals(cacheManager.getStatus(), ComponentStatus.TERMINATED);
+   }
+
+   @Test
    public void testIndexingMultipleDirectoriesOnSameCache() throws CyclicDependencyException {
       EmbeddedCacheManager cacheManager = createClusteredCacheManager();
       cacheManager.defineConfiguration("cacheA", getIndexedConfigWithCustomCaches("single", "single", "single").build());

--- a/query/src/test/java/org/infinispan/query/blackbox/ClusteredCacheWithAffinityIndexManagerTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/ClusteredCacheWithAffinityIndexManagerTest.java
@@ -8,6 +8,7 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.Index;
 import org.infinispan.distribution.ch.impl.AffinityPartitioner;
 import org.infinispan.query.affinity.AffinityIndexManager;
+import org.infinispan.query.helper.StaticTestingErrorHandler;
 import org.infinispan.query.test.Person;
 import org.testng.annotations.Test;
 
@@ -26,12 +27,11 @@ public class ClusteredCacheWithAffinityIndexManagerTest extends ClusteredCacheTe
               .index(Index.PRIMARY_OWNER)
               .addIndexedEntity(Person.class)
               .addProperty("default.indexmanager", AffinityIndexManager.class.getName())
-              .addProperty("error_handler", "org.infinispan.query.helper.StaticTestingErrorHandler")
+              .addProperty("error_handler", StaticTestingErrorHandler.class.getName())
               .addProperty("lucene_version", "LUCENE_CURRENT");
       enhanceConfig(cacheCfg);
       List<Cache<Object, Person>> caches = createClusteredCaches(2, cacheCfg);
       cache1 = caches.get(0);
       cache2 = caches.get(1);
    }
-
 }

--- a/query/src/test/java/org/infinispan/query/blackbox/SearchFactoryShutdownTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/SearchFactoryShutdownTest.java
@@ -1,5 +1,8 @@
 package org.infinispan.query.blackbox;
 
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertTrue;
+
 import org.hibernate.search.spi.SearchIntegrator;
 import org.infinispan.Cache;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
@@ -16,7 +19,7 @@ import org.testng.annotations.Test;
  * Ensures the search factory is properly shut down.
  *
  * @author Manik Surtani
- * @version 4.2
+ * @since 4.2
  */
 @Test(testName = "query.blackbox.SearchFactoryShutdownTest", groups = "functional")
 public class SearchFactoryShutdownTest extends AbstractInfinispanTest {
@@ -38,15 +41,14 @@ public class SearchFactoryShutdownTest extends AbstractInfinispanTest {
          Cache<?, ?> cache = cc.getCache();
          SearchIntegrator sfi = TestingUtil.extractComponent(cache, SearchIntegrator.class);
 
-         assert ! sfi.isStopped();
+         assertFalse(sfi.isStopped());
 
          cc.stop();
 
-         assert sfi.isStopped();
+         assertTrue(sfi.isStopped());
       } finally {
          // proper cleanup for exceptional execution
          TestingUtil.killCacheManagers(cc);
       }
    }
-
 }

--- a/query/src/test/java/org/infinispan/query/config/DefaultCacheInheritancePreventedTest.java
+++ b/query/src/test/java/org/infinispan/query/config/DefaultCacheInheritancePreventedTest.java
@@ -36,7 +36,7 @@ public class DefaultCacheInheritancePreventedTest extends AbstractInfinispanTest
             assertIndexingEnabled(cm.getCache("simple"), true, IndexModificationStrategy.ALL);
             assertIndexingEnabled(cm.getCache("not-searchable"), false, null);
             assertIndexingEnabled(cm.getCache("memory-searchable"), true, IndexModificationStrategy.ALL);
-            assertIndexingEnabled(cm.getCache("disk-searchable"), true, IndexModificationStrategy.LOCAL_ONLY);
+            assertIndexingEnabled(cm.getCache("disk-searchable"), true, IndexModificationStrategy.PRIMARY_OWNER);
          }
       });
    }
@@ -50,7 +50,7 @@ public class DefaultCacheInheritancePreventedTest extends AbstractInfinispanTest
             assertIndexingEnabled(cm.getCache(), false, null);
             assertIndexingEnabled(cm.getCache("simple"), false, null);
             assertIndexingEnabled(cm.getCache("memory-searchable"), true, IndexModificationStrategy.ALL);
-            assertIndexingEnabled(cm.getCache("disk-searchable"), true, IndexModificationStrategy.LOCAL_ONLY);
+            assertIndexingEnabled(cm.getCache("disk-searchable"), true, IndexModificationStrategy.PRIMARY_OWNER);
          }
       });
    }

--- a/query/src/test/java/org/infinispan/query/config/MultipleCachesTest.java
+++ b/query/src/test/java/org/infinispan/query/config/MultipleCachesTest.java
@@ -40,8 +40,11 @@ public class MultipleCachesTest extends SingleCacheManagerTest {
             "   </local-cache>\n" +
             "   <local-cache name=\"indexingenabled\">\n" +
             "      <indexing index=\"LOCAL\" >\n" +
-            "            <property name=\"default.directory_provider\">local-heap</property>\n" +
-            "            <property name=\"lucene_version\">LUCENE_CURRENT</property>\n" +
+            "         <indexed-entities>\n" +
+            "            <indexed-entity>org.infinispan.query.test.Person</indexed-entity>\n" +
+            "         </indexed-entities>\n" +
+            "         <property name=\"default.directory_provider\">local-heap</property>\n" +
+            "         <property name=\"lucene_version\">LUCENE_CURRENT</property>\n" +
             "      </indexing>\n" +
             "   </local-cache>\n" +
             "</cache-container>"

--- a/query/src/test/java/org/infinispan/query/config/QueryParsingTest.java
+++ b/query/src/test/java/org/infinispan/query/config/QueryParsingTest.java
@@ -9,6 +9,7 @@ import java.util.Map;
 
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.cache.Index;
 import org.infinispan.configuration.parsing.ConfigurationBuilderHolder;
 import org.infinispan.configuration.parsing.ParserRegistry;
 import org.infinispan.query.affinity.AffinityIndexManager;
@@ -48,7 +49,7 @@ public class QueryParsingTest extends AbstractInfinispanTest {
 
       Configuration affinity = namedConfigurations.get("dist-with-affinity").build();
       assertTrue(affinity.indexing().index().isEnabled());
-      assertTrue(affinity.indexing().index().isPrimaryOwner());
+      assertEquals(affinity.indexing().index(), Index.PRIMARY_OWNER);
       assertEquals(affinity.indexing().properties().getProperty("default.indexmanager"), AffinityIndexManager.class.getName());
    }
 
@@ -60,7 +61,7 @@ public class QueryParsingTest extends AbstractInfinispanTest {
 
       assertEquals(defaultConfiguration.indexing().properties().size(), 2);
       assertTrue(defaultConfiguration.indexing().index().isEnabled());
-      assertEquals(defaultConfiguration.indexing().properties().getProperty("hibernate.search.default.directory_provider"), "someDefault");
+      assertEquals(defaultConfiguration.indexing().properties().getProperty("hibernate.search.default.directory_provider"), "local-heap");
 
       Configuration nonSearchableCfg = namedConfigurations.get("not-searchable").build();
       assertFalse(nonSearchableCfg.indexing().index().isEnabled());
@@ -71,13 +72,13 @@ public class QueryParsingTest extends AbstractInfinispanTest {
 
       Configuration memoryCfg = namedConfigurations.get("memory-searchable").build();
       assertTrue(memoryCfg.indexing().index().isEnabled());
-      assertFalse(memoryCfg.indexing().index().isLocalOnly());
+      assertEquals(memoryCfg.indexing().index(), Index.ALL);
       assertEquals(memoryCfg.indexing().properties().size(), 2);
       assertEquals(memoryCfg.indexing().properties().getProperty("hibernate.search.default.directory_provider"), "local-heap");
 
       Configuration diskCfg = namedConfigurations.get("disk-searchable").build();
       assertTrue(diskCfg.indexing().index().isEnabled());
-      assertTrue(diskCfg.indexing().index().isLocalOnly());
+      assertEquals(diskCfg.indexing().index(), Index.PRIMARY_OWNER);
       assertEquals(diskCfg.indexing().properties().size(), 3);
       assertEquals(diskCfg.indexing().properties().getProperty("hibernate.search.default.directory_provider"), "filesystem");
       assertEquals(diskCfg.indexing().properties().getProperty("hibernate.search.cats.exclusive_index_use"), "true");

--- a/query/src/test/java/org/infinispan/query/distributed/SecureMassIndexingTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/SecureMassIndexingTest.java
@@ -28,17 +28,17 @@ public class SecureMassIndexingTest extends DistributedMassIndexingTest {
 
    @AfterMethod
    @Override
-   protected void clearContent() throws Throwable {
-      runAs(ADMIN, () -> super.clearContent());
+   protected void clearContent() {
+      runAs(ADMIN, super::clearContent);
    }
 
    @Override
-   public void testPartiallyReindex() throws Exception {
+   public void testPartiallyReindex() {
       runAs(ADMIN, super::testPartiallyReindex);
    }
 
    @Override
-   public void testReindexing() throws Exception {
+   public void testReindexing() {
       runAs(ADMIN, super::testReindexing);
    }
 
@@ -47,18 +47,14 @@ public class SecureMassIndexingTest extends DistributedMassIndexingTest {
    }
 
    private void runAs(Subject subject, TestExecution execution) {
-      Security.doAs(subject, new PrivilegedAction<Void>() {
-         @Override
-         public Void run() {
-            try {
-               execution.apply();
-            } catch (Throwable e) {
-               e.printStackTrace();
-               Assert.fail();
-            }
-            return null;
+      Security.doAs(subject, (PrivilegedAction<Void>) () -> {
+         try {
+            execution.apply();
+         } catch (Throwable e) {
+            e.printStackTrace();
+            Assert.fail();
          }
+         return null;
       });
    }
-
 }

--- a/query/src/test/java/org/infinispan/query/indexedembedded/City.java
+++ b/query/src/test/java/org/infinispan/query/indexedembedded/City.java
@@ -9,6 +9,6 @@ import org.hibernate.search.annotations.Field;
  */
 public class City implements Serializable {
 
-   public @Field String name;
-
+   @Field
+   public String name;
 }

--- a/query/src/test/java/org/infinispan/query/indexedembedded/CollectionsIndexingTest.java
+++ b/query/src/test/java/org/infinispan/query/indexedembedded/CollectionsIndexingTest.java
@@ -1,11 +1,10 @@
 package org.infinispan.query.indexedembedded;
 
 import static org.testng.AssertJUnit.assertEquals;
-import static org.testng.AssertJUnit.assertTrue;
+import static org.testng.AssertJUnit.assertSame;
 
 import java.util.List;
 
-import org.apache.lucene.queryparser.classic.ParseException;
 import org.apache.lucene.queryparser.classic.QueryParser;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
@@ -27,7 +26,7 @@ import org.testng.annotations.Test;
 @Test(groups = "functional", testName = "query.indexedembedded.CollectionsIndexingTest")
 public class CollectionsIndexingTest extends SingleCacheManagerTest {
 
-   private SearchManager qf;
+   private SearchManager searchManager;
 
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       ConfigurationBuilder cfg = getDefaultStandaloneCacheConfig(true);
@@ -41,8 +40,8 @@ public class CollectionsIndexingTest extends SingleCacheManagerTest {
    }
 
    @BeforeClass
-   public void prepareSearchFactory() throws Exception {
-      qf = Search.getSearchManager(cache);
+   public void prepareSearchManager() {
+      searchManager = Search.getSearchManager(cache);
    }
 
    @AfterMethod
@@ -51,41 +50,41 @@ public class CollectionsIndexingTest extends SingleCacheManagerTest {
    }
 
    @Test
-   public void searchOnEmptyIndex() throws ParseException {
+   public void searchOnEmptyIndex() throws Exception {
       QueryParser queryParser = TestQueryHelperFactory.createQueryParser("countryName");
       Query query = queryParser.parse("Italy");
-      List<Object> list = qf.getQuery(query, Country.class, City.class).list();
+      List<?> list = searchManager.getQuery(query, Country.class, City.class).list();
       assertEquals(0, list.size());
    }
 
    @Test
-   public void searchOnAllTypes() throws ParseException {
+   public void searchOnAllTypes() throws Exception {
       QueryParser queryParser = TestQueryHelperFactory.createQueryParser("countryName");
       Query query = queryParser.parse("Italy");
       Country italy = new Country();
       italy.countryName = "Italy";
       cache.put("IT", italy);
-      List<Object> list = qf.getQuery(query, Country.class, City.class).list();
+      List<?> list = searchManager.getQuery(query, Country.class, City.class).list();
       assertEquals(1, list.size());
-      list = qf.getQuery(query).list();
+      list = searchManager.getQuery(query).list();
       assertEquals(1, list.size());
-      list = qf.getQuery(new MatchAllDocsQuery()).list();
+      list = searchManager.getQuery(new MatchAllDocsQuery()).list();
       assertEquals(1, list.size());
    }
 
    @Test
-   public void searchOnSimpleField() throws ParseException {
+   public void searchOnSimpleField() throws Exception {
       QueryParser queryParser = TestQueryHelperFactory.createQueryParser("countryName");
       Query query = queryParser.parse("Italy");
       Country italy = new Country();
       italy.countryName = "Italy";
       cache.put("IT", italy);
-      List<Object> list = qf.getQuery(query, Country.class, City.class).list();
+      List<?> list = searchManager.getQuery(query, Country.class, City.class).list();
       assertEquals(1, list.size());
    }
 
    @Test
-   public void searchOnEmbeddedField() throws ParseException {
+   public void searchOnEmbeddedField() throws Exception {
       QueryParser queryParser = TestQueryHelperFactory.createQueryParser("cities.name");
       Query query = queryParser.parse("Newcastle");
 
@@ -102,9 +101,8 @@ public class CollectionsIndexingTest extends SingleCacheManagerTest {
       cache.put("UK", uk);
       cache.put("UK", uk);
       cache.put("UK", uk);
-      List<Object> list = qf.getQuery(query, Country.class, City.class).list();
+      List<?> list = searchManager.getQuery(query, Country.class, City.class).list();
       assertEquals(1, list.size());
-      assertTrue(uk == list.get(0));
+      assertSame(uk, list.get(0));
    }
-
 }

--- a/query/src/test/java/org/infinispan/query/jmx/QueryMBeanTest.java
+++ b/query/src/test/java/org/infinispan/query/jmx/QueryMBeanTest.java
@@ -24,6 +24,7 @@ import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.query.CacheQuery;
 import org.infinispan.query.Search;
 import org.infinispan.query.SearchManager;
+import org.infinispan.query.helper.StaticTestingErrorHandler;
 import org.infinispan.query.test.AnotherGrassEater;
 import org.infinispan.query.test.Person;
 import org.infinispan.test.SingleCacheManagerTest;
@@ -52,9 +53,11 @@ public class QueryMBeanTest extends SingleCacheManagerTest {
 
       ConfigurationBuilder builder = getDefaultStandaloneCacheConfig(true);
       builder.indexing().index(Index.ALL)
-            .addProperty("default.directory_provider", "local-heap")
-            .addProperty("error_handler", "org.infinispan.query.helper.StaticTestingErrorHandler")
-            .addProperty("lucene_version", "LUCENE_CURRENT");
+             .addIndexedEntity(Person.class)
+             .addIndexedEntity(AnotherGrassEater.class)
+             .addProperty("default.directory_provider", "local-heap")
+             .addProperty("error_handler", StaticTestingErrorHandler.class.getName())
+             .addProperty("lucene_version", "LUCENE_CURRENT");
 
       cm.defineConfiguration(CACHE_NAME, builder.build());
       return cm;
@@ -100,7 +103,7 @@ public class QueryMBeanTest extends SingleCacheManagerTest {
             person.setBlurb("value " + i);
             person.setNonIndexedField("i: " + i);
 
-            cache.put("key" + i, person);
+            cache.put(person.getName(), person);
          }
 
          // after adding more classes and reconfiguring the SearchFactory it might happen isStatisticsEnabled is reset, so we check again
@@ -120,7 +123,7 @@ public class QueryMBeanTest extends SingleCacheManagerTest {
                                        new Object[]{Person.class.getName()},
                                        new String[]{String.class.getName()}));
 
-         assertEquals(1, searchManager.getStatistics().indexedEntitiesCount().size());
+         assertEquals(2, searchManager.getStatistics().indexedEntitiesCount().size());
 
          // add more test data
          AnotherGrassEater anotherGrassEater = new AnotherGrassEater("Another grass-eater", "Eats grass");

--- a/query/src/test/java/org/infinispan/query/partitionhandling/HybridQueryTest.java
+++ b/query/src/test/java/org/infinispan/query/partitionhandling/HybridQueryTest.java
@@ -1,4 +1,4 @@
-package org.infinispan.query.partition;
+package org.infinispan.query.partitionhandling;
 
 import org.infinispan.query.test.Person;
 import org.testng.annotations.Test;
@@ -11,6 +11,6 @@ public class HybridQueryTest extends SharedIndexTest {
 
    @Override
    protected String getQuery() {
-      return "From " + Person.class.getName() + " p where p.age >= 0 and p.nonIndexedField = 'Pe'";
+      return "from " + Person.class.getName() + " p where p.age >= 0 and p.nonIndexedField = 'Pe'";
    }
 }

--- a/query/src/test/java/org/infinispan/query/partitionhandling/NonIndexedQuery.java
+++ b/query/src/test/java/org/infinispan/query/partitionhandling/NonIndexedQuery.java
@@ -1,6 +1,4 @@
-package org.infinispan.query.partition;
-
-import java.util.List;
+package org.infinispan.query.partitionhandling;
 
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -20,10 +18,10 @@ public class NonIndexedQuery extends SharedIndexTest {
 
    @Override
    protected String getQuery() {
-      return "From " + Person.class.getName() + " p where p.nonIndexedField = 'Pe'";
+      return "from " + Person.class.getName() + " p where p.nonIndexedField = 'Pe'";
    }
 
    @Override
-   protected void postConfigure(List<EmbeddedCacheManager> cacheManagers) {
+   protected void amendCacheManagerBeforeStart(EmbeddedCacheManager cm) {
    }
 }

--- a/query/src/test/java/org/infinispan/query/partitionhandling/NonSharedIndexTest.java
+++ b/query/src/test/java/org/infinispan/query/partitionhandling/NonSharedIndexTest.java
@@ -1,11 +1,10 @@
-package org.infinispan.query.partition;
-
-import java.util.List;
+package org.infinispan.query.partitionhandling;
 
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.Index;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.query.dsl.IndexedQueryMode;
+import org.infinispan.query.test.Person;
 import org.testng.annotations.Test;
 
 /**
@@ -17,9 +16,11 @@ public class NonSharedIndexTest extends SharedIndexTest {
    @Override
    protected ConfigurationBuilder cacheConfiguration() {
       ConfigurationBuilder configurationBuilder = new ConfigurationBuilder();
-      configurationBuilder.indexing().index(Index.PRIMARY_OWNER)
-            .addProperty("default.directory_provider", "local-heap")
-            .addProperty("lucene_version", "LUCENE_CURRENT");
+      configurationBuilder.indexing()
+                          .index(Index.PRIMARY_OWNER)
+                          .addIndexedEntity(Person.class)
+                          .addProperty("default.directory_provider", "local-heap")
+                          .addProperty("lucene_version", "LUCENE_CURRENT");
       return configurationBuilder;
    }
 
@@ -29,6 +30,6 @@ public class NonSharedIndexTest extends SharedIndexTest {
    }
 
    @Override
-   protected void postConfigure(List<EmbeddedCacheManager> cacheManagers) {
+   protected void amendCacheManagerBeforeStart(EmbeddedCacheManager cm) {
    }
 }

--- a/query/src/test/java/org/infinispan/query/partitionhandling/NonSharedIndexWithLocalCachesTest.java
+++ b/query/src/test/java/org/infinispan/query/partitionhandling/NonSharedIndexWithLocalCachesTest.java
@@ -1,15 +1,14 @@
-package org.infinispan.query.partition;
+package org.infinispan.query.partitionhandling;
 
 import static org.infinispan.hibernate.search.spi.InfinispanIntegration.DEFAULT_INDEXESDATA_CACHENAME;
 import static org.infinispan.hibernate.search.spi.InfinispanIntegration.DEFAULT_INDEXESMETADATA_CACHENAME;
 import static org.infinispan.hibernate.search.spi.InfinispanIntegration.DEFAULT_LOCKING_CACHENAME;
 
-import java.util.List;
-
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.Index;
 import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.query.test.Person;
 import org.testng.annotations.Test;
 
 /**
@@ -22,22 +21,19 @@ public class NonSharedIndexWithLocalCachesTest extends NonSharedIndexTest {
    protected ConfigurationBuilder cacheConfiguration() {
       ConfigurationBuilder configurationBuilder = new ConfigurationBuilder();
       configurationBuilder.indexing()
-            .index(Index.PRIMARY_OWNER)
-            .addProperty("default.indexmanager", "near-real-time")
-            .addProperty("default.directory_provider", "infinispan");
+                          .index(Index.PRIMARY_OWNER)
+                          .addIndexedEntity(Person.class)
+                          .addProperty("default.indexmanager", "near-real-time")
+                          .addProperty("default.directory_provider", "infinispan");
       return configurationBuilder;
    }
 
-   protected void postConfigure(List<EmbeddedCacheManager> cacheManagers) {
-      ConfigurationBuilder builder = new ConfigurationBuilder();
-      builder.indexing().index(Index.NONE);
-      Configuration configuration = builder.build();
+   @Override
+   protected void amendCacheManagerBeforeStart(EmbeddedCacheManager cm) {
+      Configuration configuration = new ConfigurationBuilder().indexing().index(Index.NONE).build();
 
-      cacheManagers.forEach(cm -> {
-         cm.defineConfiguration(DEFAULT_LOCKING_CACHENAME, configuration);
-         cm.defineConfiguration(DEFAULT_INDEXESDATA_CACHENAME, configuration);
-         cm.defineConfiguration(DEFAULT_INDEXESMETADATA_CACHENAME, configuration);
-      });
+      cm.defineConfiguration(DEFAULT_LOCKING_CACHENAME, configuration);
+      cm.defineConfiguration(DEFAULT_INDEXESDATA_CACHENAME, configuration);
+      cm.defineConfiguration(DEFAULT_INDEXESMETADATA_CACHENAME, configuration);
    }
-
 }

--- a/query/src/test/java/org/infinispan/query/partitionhandling/SharedIndexTest.java
+++ b/query/src/test/java/org/infinispan/query/partitionhandling/SharedIndexTest.java
@@ -1,4 +1,4 @@
-package org.infinispan.query.partition;
+package org.infinispan.query.partitionhandling;
 
 import static org.infinispan.hibernate.search.spi.InfinispanIntegration.DEFAULT_INDEXESDATA_CACHENAME;
 import static org.infinispan.hibernate.search.spi.InfinispanIntegration.DEFAULT_INDEXESMETADATA_CACHENAME;
@@ -6,7 +6,6 @@ import static org.infinispan.hibernate.search.spi.InfinispanIntegration.DEFAULT_
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
-import java.util.List;
 import java.util.stream.IntStream;
 
 import org.infinispan.Cache;
@@ -43,35 +42,27 @@ public class SharedIndexTest extends BasePartitionHandlingTest {
    protected ConfigurationBuilder cacheConfiguration() {
       ConfigurationBuilder configurationBuilder = new ConfigurationBuilder();
       configurationBuilder.indexing()
-            .index(Index.PRIMARY_OWNER)
-            .addProperty("default.indexmanager", InfinispanIndexManager.class.getName());
+                          .index(Index.PRIMARY_OWNER)
+                          .addIndexedEntity(Person.class)
+                          .addProperty("default.indexmanager", InfinispanIndexManager.class.getName());
       return configurationBuilder;
    }
 
    @Override
-   protected void createCacheManagers() throws Throwable {
-      super.createCacheManagers();
-      postConfigure(cacheManagers);
-   }
-
-   protected void postConfigure(List<EmbeddedCacheManager> cacheManagers) {
-      ConfigurationBuilder replBuilder = new ConfigurationBuilder();
-      replBuilder.clustering().cacheMode(CacheMode.REPL_SYNC).partitionHandling()
+   protected void amendCacheManagerBeforeStart(EmbeddedCacheManager cm) {
+      Configuration replConfig = new ConfigurationBuilder()
+            .clustering().cacheMode(CacheMode.REPL_SYNC).partitionHandling()
             .whenSplit(PartitionHandling.DENY_READ_WRITES)
-            .indexing().index(Index.NONE);
-      Configuration replConfig = replBuilder.build();
+            .indexing().index(Index.NONE).build();
 
-      ConfigurationBuilder distBuilder = new ConfigurationBuilder();
-      distBuilder.clustering().cacheMode(CacheMode.DIST_SYNC).partitionHandling()
+      Configuration distConfig = new ConfigurationBuilder()
+            .clustering().cacheMode(CacheMode.DIST_SYNC).partitionHandling()
             .whenSplit(PartitionHandling.DENY_READ_WRITES)
-            .indexing().index(Index.NONE);
-      Configuration distConfig = distBuilder.build();
+            .indexing().index(Index.NONE).build();
 
-      cacheManagers.forEach(cm -> {
-         cm.defineConfiguration(DEFAULT_LOCKING_CACHENAME, replConfig);
-         cm.defineConfiguration(DEFAULT_INDEXESDATA_CACHENAME, distConfig);
-         cm.defineConfiguration(DEFAULT_INDEXESMETADATA_CACHENAME, replConfig);
-      });
+      cm.defineConfiguration(DEFAULT_LOCKING_CACHENAME, replConfig);
+      cm.defineConfiguration(DEFAULT_INDEXESDATA_CACHENAME, distConfig);
+      cm.defineConfiguration(DEFAULT_INDEXESMETADATA_CACHENAME, replConfig);
    }
 
    @Test(expectedExceptions = AvailabilityException.class)
@@ -110,6 +101,6 @@ public class SharedIndexTest extends BasePartitionHandlingTest {
    }
 
    protected String getQuery() {
-      return "From " + Person.class.getName() + " p where p.name:'person*'";
+      return "from " + Person.class.getName() + " p where p.name:'person*'";
    }
 }

--- a/query/src/test/java/org/infinispan/query/programmaticmapping/SearchMappingTest.java
+++ b/query/src/test/java/org/infinispan/query/programmaticmapping/SearchMappingTest.java
@@ -24,8 +24,8 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 /**
- * Verify programmatic configuration of indexing properties via SearchMapping
- * is properly enabled in the Search engine. See also ISPN-1820.
+ * Verify programmatic configuration of indexing properties via SearchMapping is properly enabled in the Search engine.
+ * See also ISPN-1820.
  *
  * @author Michael Wittig
  * @author Sanne Grinovero
@@ -35,40 +35,41 @@ import org.testng.annotations.Test;
 public class SearchMappingTest extends AbstractInfinispanTest {
 
    /**
-    * Here we use SearchMapping to have the ability to add Objects to the cache
-    * where people can not (or don't want to) use Annotations.
+    * Here we use SearchMapping to have the ability to add Objects to the cache where people can not (or don't want to)
+    * use Annotations.
     */
    @Test
    public void testSearchMapping() {
-      final SearchMapping mapping = new SearchMapping();
+      SearchMapping mapping = new SearchMapping();
       mapping.entity(BondPVO.class).indexed()
-            .property("id", ElementType.METHOD).field()
-            .property("name", ElementType.METHOD).field()
-            .property("isin", ElementType.METHOD).field();
+             .property("id", ElementType.METHOD).field()
+             .property("name", ElementType.METHOD).field()
+             .property("isin", ElementType.METHOD).field();
 
-      final Properties properties = new Properties();
+      Properties properties = new Properties();
       properties.put("default.directory_provider", "local-heap");
       properties.put("lucene_version", "LUCENE_CURRENT");
       properties.put(Environment.MODEL_MAPPING, mapping);
 
       ConfigurationBuilder builder = new ConfigurationBuilder();
       builder.indexing()
-            .index(Index.PRIMARY_OWNER).withProperties(properties);
+             .index(Index.PRIMARY_OWNER)
+             .addIndexedEntity(BondPVO.class)
+             .withProperties(properties);
 
-      withCacheManager(new CacheManagerCallable(
-            TestCacheManagerFactory.createCacheManager(builder)) {
+      withCacheManager(new CacheManagerCallable(TestCacheManagerFactory.createCacheManager(builder)) {
          @Override
          public void call() {
-            final Cache<Long, BondPVO> cache = cm.getCache();
-            final SearchManager sm = Search.getSearchManager(cache);
+            Cache<Long, BondPVO> cache = cm.getCache();
+            SearchManager sm = Search.getSearchManager(cache);
 
-            final BondPVO bond = new BondPVO(1, "Test", "DE000123");
+            BondPVO bond = new BondPVO(1, "Test", "DE000123");
             cache.put(bond.getId(), bond);
 
-            final QueryBuilder qb = sm.buildQueryBuilderForClass(BondPVO.class).get();
-            final Query q = qb.keyword().onField("name").matching("Test")
-                  .createQuery();
-            final CacheQuery<?> cq = sm.getQuery(q, BondPVO.class);
+            QueryBuilder qb = sm.buildQueryBuilderForClass(BondPVO.class).get();
+            Query q = qb.keyword().onField("name").matching("Test")
+                        .createQuery();
+            CacheQuery<?> cq = sm.getQuery(q, BondPVO.class);
             Assert.assertEquals(cq.getResultSize(), 1);
          }
       });
@@ -116,27 +117,27 @@ public class SearchMappingTest extends AbstractInfinispanTest {
     */
    @Test
    public void testWithoutSearchMapping() {
-      final Properties properties = new Properties();
+      Properties properties = new Properties();
       properties.put("default.directory_provider", "local-heap");
       properties.put("lucene_version", "LUCENE_CURRENT");
 
       ConfigurationBuilder builder = new ConfigurationBuilder();
-      builder.indexing().index(Index.PRIMARY_OWNER).withProperties(properties);
+      builder.indexing()
+             .index(Index.PRIMARY_OWNER)
+             .addIndexedEntity(BondPVO2.class)
+             .withProperties(properties);
 
-      withCacheManager(new CacheManagerCallable(
-            TestCacheManagerFactory.createCacheManager(builder)) {
+      withCacheManager(new CacheManagerCallable(TestCacheManagerFactory.createCacheManager(builder)) {
          @Override
          public void call() {
-            final Cache<Long, BondPVO2> cache = cm.getCache();
-            final SearchManager sm = Search.getSearchManager(cache);
+            Cache<Long, BondPVO2> cache = cm.getCache();
+            SearchManager sm = Search.getSearchManager(cache);
 
-            final BondPVO2 bond = new BondPVO2(1, "Test", "DE000123");
+            BondPVO2 bond = new BondPVO2(1, "Test", "DE000123");
             cache.put(bond.getId(), bond);
-            final QueryBuilder qb = sm.buildQueryBuilderForClass(BondPVO2.class)
-                  .get();
-            final Query q = qb.keyword().onField("name").matching("Test")
-                  .createQuery();
-            final CacheQuery<?> cq = sm.getQuery(q, BondPVO2.class);
+            QueryBuilder qb = sm.buildQueryBuilderForClass(BondPVO2.class).get();
+            Query q = qb.keyword().onField("name").matching("Test").createQuery();
+            CacheQuery<?> cq = sm.getQuery(q, BondPVO2.class);
             Assert.assertEquals(cq.getResultSize(), 1);
          }
       });

--- a/query/src/test/resources/configuration-parsing-test-enbledInDefault.xml
+++ b/query/src/test/resources/configuration-parsing-test-enbledInDefault.xml
@@ -8,8 +8,11 @@
       <jmx duplicate-domains="true" />
       <local-cache-configuration name="base">
          <indexing index="ALL">
-            <property name="hibernate.search.default.directory_provider">someDefault</property>
-            <property name="lucene_version">LUCENE_48</property>
+            <indexed-entities>
+               <indexed-entity>org.infinispan.query.test.Person</indexed-entity>
+            </indexed-entities>
+            <property name="hibernate.search.default.directory_provider">local-heap</property>
+            <property name="lucene_version">LUCENE_CURRENT</property>
          </indexing>
       </local-cache-configuration>
       <local-cache name="default" configuration="base"/>
@@ -19,15 +22,21 @@
       </local-cache>
       <local-cache name="memory-searchable" configuration="base">
          <indexing index="ALL">
+            <indexed-entities>
+               <indexed-entity>org.infinispan.query.test.Person</indexed-entity>
+            </indexed-entities>
             <property name="hibernate.search.default.directory_provider">local-heap</property>
-            <property name="lucene_version">LUCENE_48</property>
+            <property name="lucene_version">LUCENE_CURRENT</property>
          </indexing>
       </local-cache>
       <local-cache name="disk-searchable" configuration="base">
-         <indexing index="LOCAL">
+         <indexing index="PRIMARY_OWNER">
+            <indexed-entities>
+               <indexed-entity>org.infinispan.query.test.Person</indexed-entity>
+            </indexed-entities>
             <property name="hibernate.search.default.directory_provider">filesystem</property>
             <property name="hibernate.search.cats.exclusive_index_use">true</property>
-            <property name="lucene_version">LUCENE_48</property>
+            <property name="lucene_version">LUCENE_CURRENT</property>
          </indexing>
       </local-cache>
    </cache-container>

--- a/query/src/test/resources/configuration-parsing-test.xml
+++ b/query/src/test/resources/configuration-parsing-test.xml
@@ -16,25 +16,34 @@
       <local-cache name="simple" />
       <local-cache name="memory-searchable">
          <indexing index="ALL">
+            <indexed-entities>
+               <indexed-entity>org.infinispan.query.test.Person</indexed-entity>
+            </indexed-entities>
             <property name="default.directory_provider">local-heap</property>
-            <property name="lucene_version">LUCENE_48</property>
+            <property name="lucene_version">LUCENE_CURRENT</property>
          </indexing>
       </local-cache>
       <local-cache name="disk-searchable">
-         <indexing index="LOCAL">
+         <indexing index="PRIMARY_OWNER">
+            <indexed-entities>
+               <indexed-entity>org.infinispan.query.test.Person</indexed-entity>
+            </indexed-entities>
             <property name="hibernate.search.default.directory_provider">filesystem</property>
             <property name="hibernate.search.cats.exclusive_index_use">true</property>
-            <property name="lucene_version">LUCENE_48</property>
+            <property name="lucene_version">LUCENE_CURRENT</property>
          </indexing>
       </local-cache>
       <replicated-cache name="repl-with-default">
-         <indexing index="LOCAL" auto-config="true"/>
+         <indexing index="PRIMARY_OWNER" auto-config="true"/>
       </replicated-cache>
       <distributed-cache name="dist-with-default">
           <indexing index="ALL" auto-config="true"/>
       </distributed-cache>
       <distributed-cache name="dist-with-affinity">
          <indexing index="PRIMARY_OWNER">
+            <indexed-entities>
+               <indexed-entity>org.infinispan.query.test.Person</indexed-entity>
+            </indexed-entities>
             <property name="default.indexmanager">org.infinispan.query.affinity.AffinityIndexManager</property>
          </indexing>
       </distributed-cache>

--- a/query/src/test/resources/dist-indexing-async.xml
+++ b/query/src/test/resources/dist-indexing-async.xml
@@ -9,7 +9,7 @@
         <jmx duplicate-domains="true"/>
 
         <distributed-cache name="default" mode="SYNC" remote-timeout="20000" statistics="true">
-            <indexing index="LOCAL">
+            <indexing index="PRIMARY_OWNER">
                 <indexed-entities>
                     <indexed-entity>org.infinispan.query.distributed.Transaction</indexed-entity>
                 </indexed-entities>

--- a/query/src/test/resources/dynamic-indexing-distribution.xml
+++ b/query/src/test/resources/dynamic-indexing-distribution.xml
@@ -14,7 +14,7 @@
          <locking acquire-timeout="20000" write-skew="false" concurrency-level="500" striping="false" />
          <eviction size="-1" strategy="NONE" />
          <expiration max-idle="-1" />
-            <indexing index="LOCAL">
+            <indexing index="PRIMARY_OWNER">
                <indexed-entities>
                   <indexed-entity>org.infinispan.query.test.Person</indexed-entity>
                   <indexed-entity>org.infinispan.query.queries.faceting.Car</indexed-entity>

--- a/query/src/test/resources/dynamic-indexing-replication.xml
+++ b/query/src/test/resources/dynamic-indexing-replication.xml
@@ -14,7 +14,10 @@
          <locking acquire-timeout="20000" write-skew="false" concurrency-level="500" striping="false" />
          <eviction size="-1" strategy="NONE" />
          <expiration max-idle="-1" />
-         <indexing index="LOCAL">
+         <indexing index="PRIMARY_OWNER">
+            <indexed-entities>
+               <indexed-entity>org.infinispan.query.test.Person</indexed-entity>
+            </indexed-entities>
             <!-- Use our custom IndexManager; TODO autoinject by default? -->
             <property name="hibernate.search.default.indexmanager">org.infinispan.query.indexmanager.InfinispanIndexManager</property>
             <!-- Enable error safety net -->

--- a/query/src/test/resources/dynamic-transactional-indexing-distribution.xml
+++ b/query/src/test/resources/dynamic-transactional-indexing-distribution.xml
@@ -15,7 +15,7 @@
          <transaction mode="NON_XA" />
          <eviction size="-1" strategy="NONE" />
          <expiration max-idle="-1" />
-            <indexing index="LOCAL">
+            <indexing index="PRIMARY_OWNER">
                <indexed-entities>
                   <indexed-entity>org.infinispan.query.test.Person</indexed-entity>
                </indexed-entities>

--- a/query/src/test/resources/dynamic-transactional-indexing-replication.xml
+++ b/query/src/test/resources/dynamic-transactional-indexing-replication.xml
@@ -15,7 +15,10 @@
          <transaction mode="NON_XA" />
          <eviction size="-1" strategy="NONE" />
          <expiration max-idle="-1" />
-         <indexing index="LOCAL">
+         <indexing index="PRIMARY_OWNER">
+            <indexed-entities>
+               <indexed-entity>org.infinispan.query.test.Person</indexed-entity>
+            </indexed-entities>
             <!-- Use our custom IndexManager; TODO autoinject by default? -->
             <property name="hibernate.search.default.indexmanager">org.infinispan.query.indexmanager.InfinispanIndexManager</property>
             <!-- Enable error safety net -->

--- a/query/src/test/resources/indexing-perf.xml
+++ b/query/src/test/resources/indexing-perf.xml
@@ -12,7 +12,7 @@
          <transaction mode="BATCH" locking="PESSIMISTIC"/>
          <eviction size="-1" strategy="NONE" />
          <expiration max-idle="-1" />
-         <indexing index="LOCAL">
+         <indexing index="PRIMARY_OWNER">
             <indexed-entities>
                <indexed-entity>org.infinispan.query.queries.faceting.Car</indexed-entity>
             </indexed-entities>

--- a/query/src/test/resources/mass-index-with-security.xml
+++ b/query/src/test/resources/mass-index-with-security.xml
@@ -17,7 +17,7 @@
          <locking acquire-timeout="20000" write-skew="false" concurrency-level="500" striping="false" />
          <eviction size="-1" strategy="NONE" />
          <expiration max-idle="-1" />
-         <indexing index="LOCAL">
+         <indexing index="PRIMARY_OWNER">
             <indexed-entities>
                <indexed-entity>org.infinispan.query.test.Person</indexed-entity>
                <indexed-entity>org.infinispan.query.queries.faceting.Car</indexed-entity>

--- a/server/integration/infinispan/src/main/resources/subsystem-templates/infinispan-core.xml
+++ b/server/integration/infinispan/src/main/resources/subsystem-templates/infinispan-core.xml
@@ -37,7 +37,7 @@
             </distributed-cache-configuration>
 
             <distributed-cache-configuration name="indexed">
-               <indexing index="LOCAL" auto-config="true"/>
+               <indexing index="PRIMARY_OWNER" auto-config="true"/>
             </distributed-cache-configuration>
 
             <distributed-cache-configuration name="memory-bounded">
@@ -425,13 +425,13 @@
             </local-cache>
             <!-- Indexes are shared between all nodes, stored on infinispan itself -->
             <distributed-cache name="InfinispanSharedIndex">
-               <indexing index="LOCAL">
+               <indexing index="PRIMARY_OWNER">
                   <property name="default.indexmanager">org.infinispan.query.indexmanager.InfinispanIndexManager</property>
                </indexing>
             </distributed-cache>
             <!-- Auto config based on cache type -->
             <distributed-cache name="sharedIndexInfinispanDirectory">
-               <indexing index="LOCAL" auto-config="true"/>
+               <indexing index="PRIMARY_OWNER" auto-config="true"/>
             </distributed-cache>
             <replicated-cache name="nearRealtimeFileSystemIndex">
                <indexing index="ALL" auto-config="true"/>

--- a/server/integration/testsuite/src/test/resources/config/infinispan/indexing-minimal.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/indexing-minimal.xml
@@ -4,7 +4,7 @@
         <distributed-cache name="default"/>
 
         <distributed-cache name="indexed">
-            <indexing index="LOCAL">
+            <indexing index="PRIMARY_OWNER">
                 <property name="default.directory_provider">local-heap</property>
             </indexing>
         </distributed-cache>


### PR DESCRIPTION
* improve tests to use pre-declared indexed entities
* avoid deadlock when the indexed cache and the infinispan directory caches are the same

https://issues.redhat.com/browse/ISPN-11170