### PR TITLE
ISPN-9784 Replace DistributedExecutor with ClusterExecutor for distri…

### DIFF
--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/HotRodServer.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/HotRodServer.java
@@ -18,12 +18,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.ServiceLoader;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
+import java.util.function.Function;
+
 import javax.security.auth.Subject;
 import javax.security.sasl.SaslServerFactory;
 
@@ -51,8 +50,6 @@ import org.infinispan.configuration.cache.Configurations;
 import org.infinispan.container.versioning.EntryVersion;
 import org.infinispan.container.versioning.VersionGenerator;
 import org.infinispan.context.Flag;
-import org.infinispan.distexec.DefaultExecutorService;
-import org.infinispan.distexec.DistributedCallable;
 import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.filter.AbstractKeyValueFilterConverter;
 import org.infinispan.filter.KeyValueFilterConverter;
@@ -60,6 +57,7 @@ import org.infinispan.filter.KeyValueFilterConverterFactory;
 import org.infinispan.filter.NamedFactory;
 import org.infinispan.filter.ParamKeyValueFilterConverterFactory;
 import org.infinispan.lifecycle.ComponentStatus;
+import org.infinispan.manager.ClusterExecutor;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.marshall.core.EncoderRegistry;
 import org.infinispan.metadata.EmbeddedMetadata;
@@ -136,7 +134,7 @@ public class HotRodServer extends AbstractProtocolServer<HotRodServerConfigurati
    private Map<String, SaslServerFactory> saslMechFactories = CollectionFactory.makeConcurrentMap(4, 0.9f, 16);
    private ClientListenerRegistry clientListenerRegistry;
    private Marshaller marshaller;
-   private DefaultExecutorService distributedExecutorService;
+   private ClusterExecutor clusterExecutor;
    private CrashedMemberDetectorListener viewChangeListener;
    private ReAddMyAddressListener topologyChangeListener;
    private IterationManager iterationManager;
@@ -320,7 +318,7 @@ public class HotRodServer extends AbstractProtocolServer<HotRodServerConfigurati
       addressCache = cacheManager.getCache(configuration.topologyCacheName());
       clusterAddress = cacheManager.getAddress();
       address = new ServerAddress(configuration.publicHost(), configuration.publicPort());
-      distributedExecutorService = new DefaultExecutorService(addressCache);
+      clusterExecutor = cacheManager.executor();
 
       viewChangeListener = new CrashedMemberDetectorListener(addressCache, this);
       cacheManager.addListener(viewChangeListener);
@@ -583,9 +581,6 @@ public class HotRodServer extends AbstractProtocolServer<HotRodServerConfigurati
          if (internalCacheRegistry != null)
             internalCacheRegistry.unregisterInternalCache(configuration.topologyCacheName());
       }
-      if (distributedExecutorService != null) {
-         distributedExecutorService.shutdownNow();
-      }
 
       if (clientListenerRegistry != null) clientListenerRegistry.stop();
       if (clientCounterNotificationManager != null) clientCounterNotificationManager.stop();
@@ -699,25 +694,20 @@ public class HotRodServer extends AbstractProtocolServer<HotRodServerConfigurati
       @TopologyChanged
       public void topologyChanged(TopologyChangedEvent<Address, ServerAddress> event) {
          boolean success = false;
-         while (!success && !distributedExecutorService.isShutdown() && addressCache.getStatus().allowInvocations()) {
+         while (!success && addressCache.getStatus().allowInvocations()) {
             try {
-               List<CompletableFuture<Boolean>> futures = distributedExecutorService.submitEverywhere(
-                     new CheckAddressTask(clusterAddress));
-               // No need for a timeout here, the distributed executor has a default task timeout
-               AtomicBoolean result = new AtomicBoolean(true);
-               futures.forEach(f -> {
-                  try {
-                     if (!f.get()) {
-                        result.set(false);
-                     }
-                  } catch (InterruptedException | ExecutionException e) {
-                     throw new CacheException(e);
+               // No need for a timeout here, the cluster executor has a default timeout
+               CompletableFuture<Void> future = clusterExecutor.submitConsumer(new CheckAddressTask(addressCache.getName(),
+                     clusterAddress), (a, v, t) -> {
+                  if (t != null) {
+                     throw new CacheException(t);
+                  }
+                  if (!v) {
+                     log.debugf("Re-adding %s to the topology cache", clusterAddress);
+                     addressCache.putAsync(clusterAddress, address);
                   }
                });
-               if (!result.get()) {
-                  log.debugf("Re-adding %s to the topology cache", clusterAddress);
-                  addressCache.putAsync(clusterAddress, address);
-               }
+               future.get();
                success = true;
             } catch (Throwable e) {
                log.debug("Error re-adding address to topology cache, retrying", e);
@@ -737,22 +727,23 @@ public class HotRodServer extends AbstractProtocolServer<HotRodServerConfigurati
    }
 }
 
-class CheckAddressTask implements DistributedCallable<Address, ServerAddress, Boolean>, Serializable {
+class CheckAddressTask implements Function<EmbeddedCacheManager, Boolean>, Serializable {
+   private final String cacheName;
    private final Address clusterAddress;
 
-   private volatile Cache<Address, ServerAddress> cache = null;
-
-   CheckAddressTask(Address clusterAddress) {
+   CheckAddressTask(String cacheName, Address clusterAddress) {
+      this.cacheName = cacheName;
       this.clusterAddress = clusterAddress;
    }
 
    @Override
-   public void setEnvironment(Cache<Address, ServerAddress> cache, Set<Address> inputKeys) {
-      this.cache = cache;
-   }
-
-   @Override
-   public Boolean call() throws Exception {
-      return cache.containsKey(clusterAddress);
+   public Boolean apply(EmbeddedCacheManager embeddedCacheManager) {
+      if (embeddedCacheManager.isRunning(cacheName)) {
+         Cache<Address, ServerAddress> cache = embeddedCacheManager.getCache(cacheName);
+         return cache.containsKey(clusterAddress);
+      }
+      // If the cache isn't started just play like this node has the address in the cache - it will be added as it
+      // joins, so no worries
+      return true;
    }
 }

--- a/server/integration/infinispan/src/main/java/org/infinispan/server/infinispan/task/DistributedServerTask.java
+++ b/server/integration/infinispan/src/main/java/org/infinispan/server/infinispan/task/DistributedServerTask.java
@@ -3,14 +3,15 @@ package org.infinispan.server.infinispan.task;
 import java.io.Serializable;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
+import java.util.function.Function;
 
 import org.infinispan.Cache;
+import org.infinispan.commons.CacheException;
 import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.commons.marshall.StreamingMarshaller;
-import org.infinispan.distexec.DistributedCallable;
 import org.infinispan.factories.GlobalComponentRegistry;
+import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.tasks.TaskContext;
 
 /**
@@ -18,36 +19,33 @@ import org.infinispan.tasks.TaskContext;
  * Date: 1/28/16
  * Time: 1:49 PM
  */
-public class DistributedServerTask<T> implements Serializable, DistributedCallable<Object, Object, T> {
+public class DistributedServerTask<T> implements Serializable, Function<EmbeddedCacheManager, T> {
+   private final String cacheName;
    private final Optional<Map<String, ?>> parameters;
    private final String taskName;
 
-   private transient ServerTaskRegistry taskRegistry;
-   private transient Marshaller marshaller;
-   private transient Cache<Object, Object> cache;
-
-   public DistributedServerTask(String taskName, Optional<Map<String, ?>> parameters) {
+   public DistributedServerTask(String cacheName, String taskName, Optional<Map<String, ?>> parameters) {
+      this.cacheName = cacheName;
       this.taskName = taskName;
       this.parameters = parameters;
    }
 
    @Override
-   public void setEnvironment(Cache<Object, Object> cache, Set<Object> inputKeys) {
-      this.cache = cache;
-      // todo inject global component registry to be independent of existence of cache.
-      GlobalComponentRegistry componentRegistry = SecurityActions.getGlobalComponentRegistry(cache);
-      taskRegistry = componentRegistry.getComponent(ServerTaskRegistry.class);
-      marshaller = componentRegistry.getComponent(StreamingMarshaller.class);
-   }
-
-   @Override
-   public T call() throws Exception {
+   public T apply(EmbeddedCacheManager embeddedCacheManager) {
+      Cache<Object, Object> cache = embeddedCacheManager.getCache(cacheName);
+      GlobalComponentRegistry componentRegistry = SecurityActions.getGlobalComponentRegistry(embeddedCacheManager);
+      ServerTaskRegistry taskRegistry = componentRegistry.getComponent(ServerTaskRegistry.class);
+      Marshaller marshaller = componentRegistry.getComponent(StreamingMarshaller.class);
       ServerTaskWrapper<T> task = taskRegistry.getTask(taskName);
-      task.inject(prepareContext());
-      return task.run();
+      task.inject(prepareContext(cache, marshaller));
+      try {
+         return task.run();
+      } catch (Exception e) {
+         throw new CacheException(e);
+      }
    }
 
-   private TaskContext prepareContext() {
+   private TaskContext prepareContext(Cache<Object, Object> cache, Marshaller marshaller) {
       TaskContext context = new TaskContext();
       if (parameters.isPresent()) context.parameters(parameters.get());
       String type = MediaType.APPLICATION_OBJECT_TYPE;

--- a/server/integration/infinispan/src/main/java/org/infinispan/server/infinispan/task/DistributedServerTaskRunner.java
+++ b/server/integration/infinispan/src/main/java/org/infinispan/server/infinispan/task/DistributedServerTaskRunner.java
@@ -1,12 +1,15 @@
 package org.infinispan.server.infinispan.task;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import org.infinispan.Cache;
-import org.infinispan.distexec.DefaultExecutorService;
+import org.infinispan.commons.CacheException;
+import org.infinispan.manager.ClusterExecutor;
+import org.infinispan.remoting.transport.Address;
 import org.infinispan.tasks.TaskContext;
-import org.infinispan.util.concurrent.CompletableFutures;
+import org.infinispan.util.function.TriConsumer;
 
 /**
  * Author: Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
@@ -18,15 +21,22 @@ public class DistributedServerTaskRunner implements ServerTaskRunner {
    public <T> CompletableFuture<T> execute(String taskName, TaskContext context) {
       Cache<?, ?> masterCacheNode = context.getCache().get();
 
-      DefaultExecutorService des = new DefaultExecutorService(masterCacheNode);
-      try {
-         List<CompletableFuture<T>> tasks = des.submitEverywhere(new DistributedServerTask<>(taskName, context.getParameters()));
+      ClusterExecutor clusterExecutor = SecurityActions.getClusterExecutor(context.getCacheManager());
+
+      List<T> results = new ArrayList<>();
+      TriConsumer<Address, T, Throwable> triConsumer = (a, v, t) -> {
+         if (t != null) {
+            throw new CacheException(t);
+         }
+         synchronized (this) {
+            results.add(v);
+         }
+      };
+      CompletableFuture<Void> future = clusterExecutor.submitConsumer(new DistributedServerTask<>(
+            masterCacheNode.getName(), taskName, context.getParameters()), triConsumer);
 
 //         noinspection unchecked
-         return (CompletableFuture<T>) CompletableFutures.sequence(tasks);
-      } finally {
-         des.shutdown();
-      }
+      return (CompletableFuture<T>) future.thenApply(ignore -> results);
    }
 
 }

--- a/server/integration/infinispan/src/main/java/org/infinispan/server/infinispan/task/LocalServerTaskRunner.java
+++ b/server/integration/infinispan/src/main/java/org/infinispan/server/infinispan/task/LocalServerTaskRunner.java
@@ -2,7 +2,6 @@ package org.infinispan.server.infinispan.task;
 
 import java.util.concurrent.CompletableFuture;
 
-import org.infinispan.Cache;
 import org.infinispan.tasks.TaskContext;
 
 /**
@@ -26,7 +25,6 @@ public class LocalServerTaskRunner implements ServerTaskRunner {
    }
 
    private ServerTaskRegistry getRegistry(TaskContext context) {
-      Cache<?, ?> cache = context.getCache().get();
-      return SecurityActions.getComponentRegistry(cache.getAdvancedCache()).getComponent(ServerTaskRegistry.class);
+      return SecurityActions.getGlobalComponentRegistry(context.getCacheManager()).getComponent(ServerTaskRegistry.class);
    }
 }

--- a/server/integration/infinispan/src/main/java/org/infinispan/server/infinispan/task/SecurityActions.java
+++ b/server/integration/infinispan/src/main/java/org/infinispan/server/infinispan/task/SecurityActions.java
@@ -3,42 +3,36 @@ package org.infinispan.server.infinispan.task;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
-import org.infinispan.AdvancedCache;
-import org.infinispan.Cache;
-import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.factories.GlobalComponentRegistry;
+import org.infinispan.manager.ClusterExecutor;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.security.Security;
-import org.infinispan.security.actions.GetCacheComponentRegistryAction;
-import org.infinispan.security.actions.GetCacheGlobalComponentRegistryAction;
 import org.infinispan.security.actions.GetGlobalComponentRegistryAction;
 
 /**
- * SecurityActions for the org.infinispan.server.infinispan package
+ * SecurityActions for the org.infinispan.server.infinispan.task package.
+ * <p>
+ * Do not move. Do not change class and method visibility to avoid being called from other {@link
+ * java.security.CodeSource}s, thus granting privilege escalation to external code.
  *
- * @author Tristan Tarrant
- * @since 7.0
+ * @since 10.0
  */
-public final class SecurityActions {
-    private static <T> T doPrivileged(PrivilegedAction<T> action) {
-        if (System.getSecurityManager() != null) {
-            return AccessController.doPrivileged(action);
-        } else {
-            return Security.doPrivileged(action);
-        }
-    }
+final class SecurityActions {
 
-   static ComponentRegistry getComponentRegistry(final AdvancedCache<?, ?> cache) {
-        GetCacheComponentRegistryAction action = new GetCacheComponentRegistryAction(cache);
-        return doPrivileged(action);
-    }
+   private SecurityActions() {
+   }
 
-    static GlobalComponentRegistry getGlobalComponentRegistry(final EmbeddedCacheManager cacheManager) {
-        GetGlobalComponentRegistryAction action = new GetGlobalComponentRegistryAction(cacheManager);
-        return doPrivileged(action);
-    }
+   private static <T> T doPrivileged(PrivilegedAction<T> action) {
+      return System.getSecurityManager() != null ?
+            AccessController.doPrivileged(action) : Security.doPrivileged(action);
+   }
 
-   public static GlobalComponentRegistry getGlobalComponentRegistry(Cache<Object, Object> cache) {
-      return doPrivileged(new GetCacheGlobalComponentRegistryAction(cache.getAdvancedCache()));
+   static GlobalComponentRegistry getGlobalComponentRegistry(final EmbeddedCacheManager cacheManager) {
+      GetGlobalComponentRegistryAction action = new GetGlobalComponentRegistryAction(cacheManager);
+      return doPrivileged(action);
+   }
+
+   static ClusterExecutor getClusterExecutor(EmbeddedCacheManager embeddedCacheManager) {
+      return doPrivileged(embeddedCacheManager::executor);
    }
 }

--- a/tasks/scripting/src/main/java/org/infinispan/scripting/impl/DistributedRunner.java
+++ b/tasks/scripting/src/main/java/org/infinispan/scripting/impl/DistributedRunner.java
@@ -1,15 +1,18 @@
 package org.infinispan.scripting.impl;
 
 import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import org.infinispan.Cache;
-import org.infinispan.distexec.DefaultExecutorService;
+import org.infinispan.commons.CacheException;
+import org.infinispan.manager.ClusterExecutor;
+import org.infinispan.remoting.transport.Address;
 import org.infinispan.scripting.logging.Log;
-import org.infinispan.util.concurrent.CompletableFutures;
+import org.infinispan.util.function.TriConsumer;
 import org.infinispan.util.logging.LogFactory;
 
 /**
@@ -31,15 +34,21 @@ public class DistributedRunner implements ScriptRunner {
       if (masterCacheNode == null) {
          throw log.distributedTaskNeedCacheInBinding(metadata.name());
       }
-      DefaultExecutorService des = new DefaultExecutorService(masterCacheNode);
-      try {
-         Map<String, Object> ctxParams = extractContextParams(metadata, binding);
-         List<CompletableFuture<T>> tasks = des.submitEverywhere(new DistributedScript<T>(metadata, ctxParams));
+      Map<String, Object> ctxParams = extractContextParams(metadata, binding);
+      ClusterExecutor clusterExecutor = masterCacheNode.getCacheManager().executor();
+      List<T> results = new ArrayList<>();
+      TriConsumer<Address, T, Throwable> triConsumer = (a, v, t) -> {
+         if (t != null) {
+            throw new CacheException(t);
+         }
+         synchronized (this) {
+            results.add(v);
+         }
+      };
+      CompletableFuture<Void> future = clusterExecutor.submitConsumer(new DistributedScript<T>(masterCacheNode.getName(),
+                  metadata, ctxParams), triConsumer);
 
-         return (CompletableFuture<T>) CompletableFutures.sequence(tasks);
-      } finally {
-         des.shutdown();
-      }
+      return (CompletableFuture<T>) future.thenApply(ignore -> results);
    }
 
    private Map<String, Object> extractContextParams(ScriptMetadata metadata, CacheScriptBindings binding) {

--- a/tasks/scripting/src/main/java/org/infinispan/scripting/impl/DistributedScript.java
+++ b/tasks/scripting/src/main/java/org/infinispan/scripting/impl/DistributedScript.java
@@ -2,13 +2,15 @@ package org.infinispan.scripting.impl;
 
 import java.io.Serializable;
 import java.util.Map;
-import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
 
 import javax.script.Bindings;
 import javax.script.SimpleBindings;
 
-import org.infinispan.Cache;
-import org.infinispan.distexec.DistributedCallable;
+import org.infinispan.AdvancedCache;
+import org.infinispan.commons.CacheException;
+import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.scripting.ScriptingManager;
 
 /**
@@ -17,31 +19,33 @@ import org.infinispan.scripting.ScriptingManager;
  * @author Tristan Tarrant
  * @since 7.2
  */
-class DistributedScript<T> implements DistributedCallable<Object, Object, T>, Serializable {
+class DistributedScript<T> implements Function<EmbeddedCacheManager, T>, Serializable {
+   private final String cacheName;
    private final ScriptMetadata metadata;
    private final Map<String, ?> ctxParams;
-   private transient ScriptingManagerImpl scriptManager;
-   private transient Bindings bindings;
 
-   DistributedScript(ScriptMetadata metadata, Map<String, ?> ctxParams) {
+   DistributedScript(String cacheName, ScriptMetadata metadata, Map<String, ?> ctxParams) {
+      this.cacheName = cacheName;
       this.metadata = metadata;
       this.ctxParams = ctxParams;
    }
 
    @Override
-   public T call() throws Exception {
-      return (T) (scriptManager.execute(metadata, bindings).get());
-   }
+   public T apply(EmbeddedCacheManager embeddedCacheManager) {
+      ScriptingManagerImpl scriptManager = (ScriptingManagerImpl) SecurityActions.getGlobalComponentRegistry(embeddedCacheManager).getComponent(ScriptingManager.class);
+      Bindings bindings = new SimpleBindings();
 
-   @Override
-   public void setEnvironment(Cache<Object, Object> cache, Set<Object> inputKeys) {
-      scriptManager = (ScriptingManagerImpl) SecurityActions.getGlobalComponentRegistry(cache.getCacheManager()).getComponent(ScriptingManager.class);
-      bindings = new SimpleBindings();
-      bindings.put("inputKeys", inputKeys);
       String scriptMediaType = metadata.dataType().toString();
-      DataTypedCacheManager dataTypedCacheManager = new DataTypedCacheManager(scriptMediaType, cache.getCacheManager(), null);
+      DataTypedCacheManager dataTypedCacheManager = new DataTypedCacheManager(scriptMediaType, embeddedCacheManager, null);
       bindings.put("cacheManager", dataTypedCacheManager);
-      bindings.put("cache", cache.getAdvancedCache().withMediaType(scriptMediaType, scriptMediaType));
+      AdvancedCache<?, ?> cache = embeddedCacheManager.getCache(cacheName).getAdvancedCache();
+      bindings.put("cache", cache.withMediaType(scriptMediaType, scriptMediaType));
       ctxParams.forEach((key, value) -> bindings.put(key, value));
+
+      try {
+         return (T) (scriptManager.execute(metadata, bindings).get());
+      } catch (InterruptedException | ExecutionException e) {
+         throw new CacheException(e);
+      }
    }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-9784

…buted tasks

Switching to `ClusterExecutor` avoids the need to create a new `DefaultExecutorService` instance and a new executor service for every distributed task.