### PR TITLE
ISPN-11231 Transcoder lookup is inefficient

### DIFF
--- a/commons/src/main/java/org/infinispan/commons/dataconversion/EncoderIds.java
+++ b/commons/src/main/java/org/infinispan/commons/dataconversion/EncoderIds.java
@@ -4,7 +4,7 @@ package org.infinispan.commons.dataconversion;
  * @since 9.2
  */
 public interface EncoderIds {
-
+   short NO_ENCODER = 0;
    short IDENTITY = 1;
    short BINARY = 2;
    short UTF8 = 3;

--- a/commons/src/main/java/org/infinispan/commons/dataconversion/Transcoder.java
+++ b/commons/src/main/java/org/infinispan/commons/dataconversion/Transcoder.java
@@ -3,6 +3,11 @@ package org.infinispan.commons.dataconversion;
 import java.util.Set;
 
 /**
+ * Converts content between two or more {@link MediaType}s.
+ *
+ * <p>Note: A transcoder must be symmetric: if it can convert from media type X to media type Y,
+ * it must also be able to convert from Y to X.</p>
+ *
  * @since 9.2
  */
 public interface Transcoder {
@@ -23,12 +28,15 @@ public interface Transcoder {
    Set<MediaType> getSupportedMediaTypes();
 
    /**
-    * @return true if the transcoder supports the conversion between supplied {@link MediaType}.
+    * @return {@code true} if the transcoder supports the conversion between the supplied {@link MediaType}s.
     */
    default boolean supportsConversion(MediaType mediaType, MediaType other) {
       return !mediaType.match(other) && supports(mediaType) && supports(other);
    }
 
+   /**
+    * @return {@code true} iff the transcoder supports the conversion to and from the given {@link MediaType}.
+    */
    default boolean supports(MediaType mediaType) {
       return getSupportedMediaTypes().stream().anyMatch(m -> m.match(mediaType));
    }

--- a/commons/src/main/java/org/infinispan/commons/dataconversion/WrapperIds.java
+++ b/commons/src/main/java/org/infinispan/commons/dataconversion/WrapperIds.java
@@ -4,6 +4,7 @@ package org.infinispan.commons.dataconversion;
  * @since 9.2
  */
 public interface WrapperIds {
+   byte NO_WRAPPER = 0;
 
    byte BYTE_ARRAY_WRAPPER = 1;
 

--- a/core/src/main/java/org/infinispan/factories/EncoderRegistryFactory.java
+++ b/core/src/main/java/org/infinispan/factories/EncoderRegistryFactory.java
@@ -9,6 +9,7 @@ import org.infinispan.commons.dataconversion.GlobalMarshallerEncoder;
 import org.infinispan.commons.dataconversion.IdentityEncoder;
 import org.infinispan.commons.dataconversion.IdentityWrapper;
 import org.infinispan.commons.dataconversion.JavaSerializationEncoder;
+import org.infinispan.commons.dataconversion.TranscoderMarshallerAdapter;
 import org.infinispan.commons.dataconversion.UTF8Encoder;
 import org.infinispan.commons.marshall.StreamingMarshaller;
 import org.infinispan.factories.annotations.ComponentName;
@@ -46,6 +47,8 @@ public class EncoderRegistryFactory extends AbstractComponentFactory implements 
       encoderRegistry.registerEncoder(new GlobalMarshallerEncoder(globalMarshaller.wired()));
       encoderRegistry.registerTranscoder(new DefaultTranscoder(persistenceMarshaller.getUserMarshaller()));
       encoderRegistry.registerTranscoder(new BinaryTranscoder(persistenceMarshaller.getUserMarshaller()));
+      // Wraps the GlobalMarshaller so that it can be used as a transcoder
+      encoderRegistry.registerTranscoder(new TranscoderMarshallerAdapter(globalMarshaller.wired()));
 
       encoderRegistry.registerWrapper(ByteArrayWrapper.INSTANCE);
       encoderRegistry.registerWrapper(IdentityWrapper.INSTANCE);

--- a/core/src/main/java/org/infinispan/factories/InternalCacheFactory.java
+++ b/core/src/main/java/org/infinispan/factories/InternalCacheFactory.java
@@ -19,7 +19,6 @@ import org.infinispan.cache.impl.StatsCollectingCache;
 import org.infinispan.commons.CacheConfigurationException;
 import org.infinispan.commons.dataconversion.ByteArrayWrapper;
 import org.infinispan.commons.dataconversion.MediaType;
-import org.infinispan.commons.dataconversion.TranscoderMarshallerAdapter;
 import org.infinispan.commons.marshall.StreamingMarshaller;
 import org.infinispan.commons.time.TimeService;
 import org.infinispan.commons.util.EnumUtil;
@@ -45,7 +44,6 @@ import org.infinispan.factories.scopes.Scopes;
 import org.infinispan.interceptors.impl.CacheMgmtInterceptor;
 import org.infinispan.jmx.CacheJmxRegistration;
 import org.infinispan.lifecycle.ComponentStatus;
-import org.infinispan.marshall.core.EncoderRegistry;
 import org.infinispan.notifications.cachelistener.CacheNotifier;
 import org.infinispan.notifications.cachelistener.cluster.ClusterEventManager;
 import org.infinispan.notifications.cachelistener.cluster.impl.ClusterEventManagerStub;
@@ -174,11 +172,6 @@ public class InternalCacheFactory<K, V> extends AbstractNamedCacheComponentFacto
 
       // injection bootstrap stuff
       componentRegistry = new ComponentRegistry(cacheName, configuration, cache, globalComponentRegistry, globalComponentRegistry.getClassLoader());
-
-      EncoderRegistry encoderRegistry = globalComponentRegistry.getComponent(EncoderRegistry.class);
-
-      // Wraps the GlobalMarshaller so that it can be used as a transcoder
-      encoderRegistry.registerTranscoder(new TranscoderMarshallerAdapter(globalMarshaller));
 
       /*
          --------------------------------------------------------------------------------------------------------------

--- a/core/src/main/java/org/infinispan/marshall/core/EncoderRegistry.java
+++ b/core/src/main/java/org/infinispan/marshall/core/EncoderRegistry.java
@@ -12,11 +12,11 @@ import org.infinispan.commons.dataconversion.Wrapper;
  */
 public interface EncoderRegistry {
 
-   Encoder getEncoder(Class<? extends Encoder> encoderClass, Short encoderId);
+   Encoder getEncoder(Class<? extends Encoder> encoderClass, short encoderId);
 
    boolean isRegistered(Class<? extends Encoder> encoderClass);
 
-   Wrapper getWrapper(Class<? extends Wrapper> wrapperClass, Byte wrapperId);
+   Wrapper getWrapper(Class<? extends Wrapper> wrapperClass, byte wrapperId);
 
    /**
     * @param encoder {@link Encoder to be registered}.


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-11231

* Register transcoder adapter for global marshaller only once
* Cache transcoders in a map by source and target media type
* Look up encoders and wrappers directly by id
* Don't allow injection in the static encoders