### PR TITLE
[9.4.x] ISPN-11231 Transcoder lookup is inefficient

### DIFF
--- a/commons/src/main/java/org/infinispan/commons/dataconversion/EncoderIds.java
+++ b/commons/src/main/java/org/infinispan/commons/dataconversion/EncoderIds.java
@@ -4,7 +4,7 @@ package org.infinispan.commons.dataconversion;
  * @since 9.2
  */
 public interface EncoderIds {
-
+   short NO_ENCODER = 0;
    short IDENTITY = 1;
    short BINARY = 2;
    short UTF8 = 3;

--- a/commons/src/main/java/org/infinispan/commons/dataconversion/Transcoder.java
+++ b/commons/src/main/java/org/infinispan/commons/dataconversion/Transcoder.java
@@ -3,6 +3,11 @@ package org.infinispan.commons.dataconversion;
 import java.util.Set;
 
 /**
+ * Converts content between two or more {@link MediaType}s.
+ *
+ * <p>Note: A transcoder must be symmetric: if it can convert from media type X to media type Y,
+ * it must also be able to convert from Y to X.</p>
+ *
  * @since 9.2
  */
 public interface Transcoder {
@@ -23,12 +28,15 @@ public interface Transcoder {
    Set<MediaType> getSupportedMediaTypes();
 
    /**
-    * @return true if the transcoder supports the conversion between supplied {@link MediaType}.
+    * @return {@code true} if the transcoder supports the conversion between the supplied {@link MediaType}s.
     */
    default boolean supportsConversion(MediaType mediaType, MediaType other) {
       return !mediaType.match(other) && supports(mediaType) && supports(other);
    }
 
+   /**
+    * @return {@code true} iff the transcoder supports the conversion to and from the given {@link MediaType}.
+    */
    default boolean supports(MediaType mediaType) {
       return getSupportedMediaTypes().stream().anyMatch(m -> m.match(mediaType));
    }

--- a/commons/src/main/java/org/infinispan/commons/dataconversion/WrapperIds.java
+++ b/commons/src/main/java/org/infinispan/commons/dataconversion/WrapperIds.java
@@ -4,6 +4,7 @@ package org.infinispan.commons.dataconversion;
  * @since 9.2
  */
 public interface WrapperIds {
+   byte NO_WRAPPER = 0;
 
    byte BYTE_ARRAY_WRAPPER = 1;
 

--- a/core/src/main/java/org/infinispan/encoding/DataConversion.java
+++ b/core/src/main/java/org/infinispan/encoding/DataConversion.java
@@ -9,6 +9,7 @@ import java.util.Set;
 import org.infinispan.commons.dataconversion.BinaryEncoder;
 import org.infinispan.commons.dataconversion.ByteArrayWrapper;
 import org.infinispan.commons.dataconversion.Encoder;
+import org.infinispan.commons.dataconversion.EncoderIds;
 import org.infinispan.commons.dataconversion.EncodingException;
 import org.infinispan.commons.dataconversion.GlobalMarshallerEncoder;
 import org.infinispan.commons.dataconversion.IdentityEncoder;
@@ -41,22 +42,18 @@ public final class DataConversion {
    public static final DataConversion IDENTITY_KEY = new DataConversion(IdentityEncoder.INSTANCE, IdentityWrapper.INSTANCE, true);
    public static final DataConversion IDENTITY_VALUE = new DataConversion(IdentityEncoder.INSTANCE, IdentityWrapper.INSTANCE, false);
 
+   // On the origin node the conversion is initialized with the encoder/wrapper classes, on remote nodes with the ids
    private Class<? extends Encoder> encoderClass;
    private Class<? extends Wrapper> wrapperClass;
+   private short encoderId;
+   private byte wrapperId;
    private MediaType requestMediaType;
    private MediaType storageMediaType;
-
-   public MediaType getRequestMediaType() {
-      return requestMediaType;
-   }
-
-   private Short encoderId;
-   private Byte wrapperId;
-   private Encoder encoder;
-   private Wrapper wrapper;
-
    private boolean isKey;
-   private Transcoder transcoder;
+
+   private transient Encoder encoder;
+   private transient Wrapper wrapper;
+   private transient Transcoder transcoder;
    private transient EncoderRegistry encoderRegistry;
 
    private DataConversion(Class<? extends Encoder> encoderClass, Class<? extends Wrapper> wrapperClass,
@@ -150,14 +147,25 @@ public final class DataConversion {
 
    @Inject
    public void injectDependencies(GlobalConfiguration gcr, EncoderRegistry encoderRegistry, Configuration configuration) {
+      if (this.encoder != null && this.wrapper != null) {
+         // This must be one of the static encoders, we can't inject any component in it
+         return;
+      }
+
       this.encoderRegistry = encoderRegistry;
       boolean embeddedMode = Configurations.isEmbeddedMode(gcr);
       this.storageMediaType = getStorageMediaType(configuration, embeddedMode);
 
+      lookupEncoder(encoderRegistry, configuration, embeddedMode);
+      this.lookupWrapper();
+      this.lookupTranscoder();
+   }
+
+   private void lookupEncoder(EncoderRegistry encoderRegistry, Configuration configuration, boolean embeddedMode) {
       StorageType storageType = configuration.memory().storageType();
       boolean offheap = storageType == StorageType.OFF_HEAP;
       boolean binary = storageType == StorageType.BINARY;
-      boolean isEncodingEmpty = encoderClass == null && encoderId == null && encoder == null;
+      boolean isEncodingEmpty = encoderClass == null && encoderId == EncoderIds.NO_ENCODER;
       if (isEncodingEmpty) {
          encoderClass = IdentityEncoder.class;
          if (offheap) {
@@ -169,13 +177,7 @@ public final class DataConversion {
             encoderClass = BinaryEncoder.class;
          }
       }
-      this.lookupWrapper();
       this.encoder = encoderRegistry.getEncoder(encoderClass, encoderId);
-      this.lookupTranscoder();
-   }
-
-   public MediaType getStorageMediaType() {
-      return storageMediaType;
    }
 
    private void lookupTranscoder() {
@@ -221,6 +223,14 @@ public final class DataConversion {
          return wrapper.isFilterable() ? stored : wrapper.unwrap(stored);
       }
       return encoder.fromStorage(wrapper.isFilterable() ? stored : wrapper.unwrap(stored));
+   }
+
+   public MediaType getRequestMediaType() {
+      return requestMediaType;
+   }
+
+   public MediaType getStorageMediaType() {
+      return storageMediaType;
    }
 
    public Encoder getEncoder() {

--- a/core/src/main/java/org/infinispan/factories/EncoderRegistryFactory.java
+++ b/core/src/main/java/org/infinispan/factories/EncoderRegistryFactory.java
@@ -9,6 +9,7 @@ import org.infinispan.commons.dataconversion.GlobalMarshallerEncoder;
 import org.infinispan.commons.dataconversion.IdentityEncoder;
 import org.infinispan.commons.dataconversion.IdentityWrapper;
 import org.infinispan.commons.dataconversion.JavaSerializationEncoder;
+import org.infinispan.commons.dataconversion.TranscoderMarshallerAdapter;
 import org.infinispan.commons.dataconversion.UTF8Encoder;
 import org.infinispan.commons.marshall.JavaSerializationMarshaller;
 import org.infinispan.commons.marshall.StreamingMarshaller;
@@ -49,6 +50,8 @@ public class EncoderRegistryFactory extends AbstractComponentFactory implements 
       encoderRegistry.registerEncoder(new GenericJbossMarshallerEncoder(jBossMarshaller));
       encoderRegistry.registerEncoder(new GlobalMarshallerEncoder(globalMarshaller.wired()));
       encoderRegistry.registerTranscoder(new DefaultTranscoder(jBossMarshaller, javaSerializationMarshaller));
+      // Wraps the GlobalMarshaller so that it can be used as a transcoder
+      encoderRegistry.registerTranscoder(new TranscoderMarshallerAdapter(globalMarshaller.wired()));
 
       encoderRegistry.registerWrapper(ByteArrayWrapper.INSTANCE);
       encoderRegistry.registerWrapper(IdentityWrapper.INSTANCE);

--- a/core/src/main/java/org/infinispan/factories/InternalCacheFactory.java
+++ b/core/src/main/java/org/infinispan/factories/InternalCacheFactory.java
@@ -200,6 +200,9 @@ public class InternalCacheFactory<K, V> extends AbstractNamedCacheComponentFacto
       EncoderRegistry encoderRegistry = globalComponentRegistry.getComponent(EncoderRegistry.class);
 
       // Wraps the compatibility marshaller so that it can be used as a transcoder
+      // Note: The encoder registry is global, so all caches with compatibility enabled
+      // will use the same compatibility marshaller for transcoding
+      // Note: The global marshaller is registered in EncoderRegistryFactory
       if (configuration.compatibility().enabled() && configuration.compatibility().marshaller() != null) {
          Marshaller marshaller = configuration.compatibility().marshaller();
          componentRegistry.wireDependencies(marshaller);
@@ -207,9 +210,6 @@ public class InternalCacheFactory<K, V> extends AbstractNamedCacheComponentFacto
             encoderRegistry.registerTranscoder(new TranscoderMarshallerAdapter(marshaller));
          }
       }
-
-      // Wraps the GlobalMarshaller so that it can be used as a transcoder
-      encoderRegistry.registerTranscoder(new TranscoderMarshallerAdapter(globalMarshaller));
 
       /*
          --------------------------------------------------------------------------------------------------------------

--- a/core/src/main/java/org/infinispan/marshall/core/EncoderRegistry.java
+++ b/core/src/main/java/org/infinispan/marshall/core/EncoderRegistry.java
@@ -12,11 +12,11 @@ import org.infinispan.commons.dataconversion.Wrapper;
  */
 public interface EncoderRegistry {
 
-   Encoder getEncoder(Class<? extends Encoder> encoderClass, Short encoderId);
+   Encoder getEncoder(Class<? extends Encoder> encoderClass, short encoderId);
 
    boolean isRegistered(Class<? extends Encoder> encoderClass);
 
-   Wrapper getWrapper(Class<? extends Wrapper> wrapperClass, Byte wrapperId);
+   Wrapper getWrapper(Class<? extends Wrapper> wrapperClass, byte wrapperId);
 
    /**
     * @param encoder {@link Encoder to be registered}.

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/test/HotRodClient.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/test/HotRodClient.java
@@ -988,7 +988,7 @@ class Decoder extends ReplayingDecoder<Void> {
       }
       // We cannot assert this since in concurrent case we could get two responses in single buffer
       if (log.isTraceEnabled() && buf.readerIndex() != buf.writerIndex()) {
-         log.tracef("Left bytes in the buffer: " +
+         log.tracef("Left bytes in the buffer: %s",
                new String(ByteBufUtil.getBytes(buf, buf.readerIndex(), buf.writerIndex() - buf.readerIndex())));
       }
       if (resp != null) {


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-11231

* Register transcoder adapter for global marshaller only once
* Cache transcoders in a map by source and target media type
* Look up encoders and wrappers directly by id
* Don't allow injection in the static encoders