### PR TITLE
ISPN-11259 Remove Hash implementation from CacheJoinInfo

### DIFF
--- a/core/src/main/java/org/infinispan/statetransfer/StateTransferManagerImpl.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateTransferManagerImpl.java
@@ -16,7 +16,6 @@ import java.util.function.Function;
 
 import org.infinispan.commands.TopologyAffectedCommand;
 import org.infinispan.commons.CacheException;
-import org.infinispan.commons.hash.MurmurHash3;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.global.GlobalConfiguration;
@@ -109,7 +108,6 @@ public class StateTransferManagerImpl implements StateTransferManager {
       float capacityFactor = globalConfiguration.isZeroCapacityNode() ? 0.0f : configuration.clustering().hash().capacityFactor();
 
       CacheJoinInfo joinInfo = new CacheJoinInfo(pickConsistentHashFactory(globalConfiguration, configuration),
-            MurmurHash3.getInstance(),
             configuration.clustering().hash().numSegments(),
             configuration.clustering().hash().numOwners(),
             configuration.clustering().stateTransfer().timeout(),

--- a/core/src/main/java/org/infinispan/topology/CacheJoinInfo.java
+++ b/core/src/main/java/org/infinispan/topology/CacheJoinInfo.java
@@ -7,7 +7,6 @@ import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 
-import org.infinispan.commons.hash.Hash;
 import org.infinispan.commons.marshall.AbstractExternalizer;
 import org.infinispan.commons.marshall.MarshallUtil;
 import org.infinispan.configuration.cache.CacheMode;
@@ -23,7 +22,6 @@ import org.infinispan.marshall.core.Ids;
 public class CacheJoinInfo {
    // Global configuration
    private final ConsistentHashFactory consistentHashFactory;
-   private final Hash hashFunction;
    private final int numSegments;
    private final int numOwners;
    private final long timeout;
@@ -37,12 +35,9 @@ public class CacheJoinInfo {
    private final PersistentUUID persistentUUID;
    private final Optional<Integer> persistentStateChecksum;
 
-   public CacheJoinInfo(ConsistentHashFactory consistentHashFactory, Hash hashFunction, int numSegments,
-                        int numOwners, long timeout, boolean totalOrder, CacheMode cacheMode, float capacityFactor,
-                        PersistentUUID persistentUUID,
-                        Optional<Integer> persistentStateChecksum) {
+   public CacheJoinInfo(ConsistentHashFactory consistentHashFactory, int numSegments, int numOwners, long timeout, boolean totalOrder, CacheMode cacheMode, float capacityFactor,
+                        PersistentUUID persistentUUID, Optional<Integer> persistentStateChecksum) {
       this.consistentHashFactory = consistentHashFactory;
-      this.hashFunction = hashFunction;
       this.numSegments = numSegments;
       this.numOwners = numOwners;
       this.timeout = timeout;
@@ -55,10 +50,6 @@ public class CacheJoinInfo {
 
    public ConsistentHashFactory getConsistentHashFactory() {
       return consistentHashFactory;
-   }
-
-   public Hash getHashFunction() {
-      return hashFunction;
    }
 
    public int getNumSegments() {
@@ -100,7 +91,6 @@ public class CacheJoinInfo {
       result = prime * result + Float.floatToIntBits(capacityFactor);
       result = prime * result + ((consistentHashFactory == null) ? 0 : consistentHashFactory.hashCode());
       result = prime * result + cacheMode.hashCode();
-      result = prime * result + ((hashFunction == null) ? 0 : hashFunction.hashCode());
       result = prime * result + numOwners;
       result = prime * result + numSegments;
       result = prime * result + (int) (timeout ^ (timeout >>> 32));
@@ -128,11 +118,6 @@ public class CacheJoinInfo {
          return false;
       if (cacheMode != other.cacheMode)
          return false;
-      if (hashFunction == null) {
-         if (other.hashFunction != null)
-            return false;
-      } else if (!hashFunction.equals(other.hashFunction))
-         return false;
       if (numOwners != other.numOwners)
          return false;
       if (numSegments != other.numSegments)
@@ -158,7 +143,6 @@ public class CacheJoinInfo {
    public String toString() {
       return "CacheJoinInfo{" +
             "consistentHashFactory=" + consistentHashFactory +
-            ", hashFunction=" + hashFunction +
             ", numSegments=" + numSegments +
             ", numOwners=" + numOwners +
             ", timeout=" + timeout +
@@ -173,7 +157,6 @@ public class CacheJoinInfo {
       @Override
       public void writeObject(ObjectOutput output, CacheJoinInfo cacheJoinInfo) throws IOException {
          output.writeObject(cacheJoinInfo.consistentHashFactory);
-         output.writeObject(cacheJoinInfo.hashFunction);
          output.writeInt(cacheJoinInfo.numSegments);
          output.writeInt(cacheJoinInfo.numOwners);
          output.writeLong(cacheJoinInfo.timeout);
@@ -187,7 +170,6 @@ public class CacheJoinInfo {
       @Override
       public CacheJoinInfo readObject(ObjectInput unmarshaller) throws IOException, ClassNotFoundException {
          ConsistentHashFactory consistentHashFactory = (ConsistentHashFactory) unmarshaller.readObject();
-         Hash hashFunction = (Hash) unmarshaller.readObject();
          int numSegments = unmarshaller.readInt();
          int numOwners = unmarshaller.readInt();
          long timeout = unmarshaller.readLong();
@@ -196,8 +178,8 @@ public class CacheJoinInfo {
          float capacityFactor = unmarshaller.readFloat();
          PersistentUUID persistentUUID = (PersistentUUID) unmarshaller.readObject();
          Optional<Integer> persistentStateChecksum = (Optional<Integer>) unmarshaller.readObject();
-         return new CacheJoinInfo(consistentHashFactory, hashFunction, numSegments, numOwners, timeout,
-               totalOrder, cacheMode, capacityFactor, persistentUUID, persistentStateChecksum);
+         return new CacheJoinInfo(consistentHashFactory, numSegments, numOwners, timeout, totalOrder, cacheMode,
+               capacityFactor, persistentUUID, persistentStateChecksum);
       }
 
       @Override

--- a/core/src/test/java/org/infinispan/partitionhandling/impl/PreferAvailabilityStrategyTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/impl/PreferAvailabilityStrategyTest.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import org.infinispan.commons.hash.MurmurHash3;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.distribution.TestAddress;
 import org.infinispan.distribution.ch.impl.DefaultConsistentHashFactory;
@@ -62,7 +61,7 @@ public class PreferAvailabilityStrategyTest extends AbstractInfinispanTest {
    }
 
    private static final CacheJoinInfo JOIN_INFO =
-      new CacheJoinInfo(new DefaultConsistentHashFactory(), MurmurHash3.getInstance(), 8, 2, 1000, false,
+      new CacheJoinInfo(new DefaultConsistentHashFactory(), 8, 2, 1000, false,
                         CacheMode.DIST_SYNC, 1.0f, null, Optional.empty());
    private static final Address A = new TestAddress(1, "A");
    private static final Address B = new TestAddress(2, "B");

--- a/core/src/test/java/org/infinispan/topology/ClusterCacheStatusTest.java
+++ b/core/src/test/java/org/infinispan/topology/ClusterCacheStatusTest.java
@@ -10,7 +10,6 @@ import static org.testng.AssertJUnit.assertEquals;
 import java.util.List;
 import java.util.Optional;
 
-import org.infinispan.commons.hash.MurmurHash3;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.distribution.TestAddress;
 import org.infinispan.distribution.ch.impl.DefaultConsistentHashFactory;
@@ -34,7 +33,7 @@ import org.testng.annotations.Test;
 public class ClusterCacheStatusTest extends AbstractInfinispanTest {
    private static final String CACHE_NAME = "test";
    private static final CacheJoinInfo JOIN_INFO =
-      new CacheJoinInfo(new DefaultConsistentHashFactory(), MurmurHash3.getInstance(), 8, 2, 1000, false,
+      new CacheJoinInfo(new DefaultConsistentHashFactory(), 8, 2, 1000, false,
                         CacheMode.DIST_SYNC, 1.0f, null, Optional.empty());
    private static final Address A = new TestAddress(1, "A");
    private static final Address B = new TestAddress(2, "B");
@@ -139,9 +138,8 @@ public class ClusterCacheStatusTest extends AbstractInfinispanTest {
 
    private CacheJoinInfo makeJoinInfo(Address a) {
       PersistentUUID persistentUUID = new PersistentUUID(a.hashCode(), a.hashCode());
-      return new CacheJoinInfo(JOIN_INFO.getConsistentHashFactory(), JOIN_INFO.getHashFunction(),
-                               JOIN_INFO.getNumSegments(), JOIN_INFO.getNumOwners(), JOIN_INFO.getTimeout(),
-                               JOIN_INFO.isTotalOrder(), JOIN_INFO.getCacheMode(), JOIN_INFO.getCapacityFactor(),
-                               persistentUUID, Optional.empty());
+      return new CacheJoinInfo(JOIN_INFO.getConsistentHashFactory(), JOIN_INFO.getNumSegments(), JOIN_INFO.getNumOwners(),
+            JOIN_INFO.getTimeout(), JOIN_INFO.isTotalOrder(), JOIN_INFO.getCacheMode(), JOIN_INFO.getCapacityFactor(),
+            persistentUUID, Optional.empty());
    }
 }

--- a/core/src/test/java/org/infinispan/topology/ClusterTopologyManagerImplTest.java
+++ b/core/src/test/java/org/infinispan/topology/ClusterTopologyManagerImplTest.java
@@ -54,7 +54,7 @@ public class ClusterTopologyManagerImplTest extends AbstractInfinispanTest {
    private final CacheJoinInfo joinInfoB = makeJoinInfo();
 
    private CacheJoinInfo makeJoinInfo() {
-      return new CacheJoinInfo(replicatedChf, MurmurHash3.getInstance(), 16, 1, 1000, false,
+      return new CacheJoinInfo(replicatedChf, 16, 1, 1000, false,
                                CacheMode.REPL_SYNC, 1.0f, PersistentUUID.randomUUID(), Optional.empty());
    }
 

--- a/core/src/test/java/org/infinispan/topology/TestClusterCacheStatus.java
+++ b/core/src/test/java/org/infinispan/topology/TestClusterCacheStatus.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.infinispan.commons.hash.MurmurHash3;
 import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.distribution.ch.ConsistentHashFactory;
 import org.infinispan.partitionhandling.impl.AvailabilityStrategy;
@@ -47,7 +48,7 @@ public class TestClusterCacheStatus {
 
    public static TestClusterCacheStatus start(CacheJoinInfo joinInfo, List<Address> members) {
       ConsistentHash currentCH = joinInfo.getConsistentHashFactory()
-                                         .create(joinInfo.getHashFunction(), joinInfo.getNumOwners(),
+                                         .create(MurmurHash3.getInstance(), joinInfo.getNumOwners(),
                                                  joinInfo.getNumSegments(), members, null);
       CacheTopology topology = new CacheTopology(1, 1, currentCH, null, null, CacheTopology.Phase.NO_REBALANCE, members,
                                                  persistentUUIDs(members));
@@ -150,7 +151,7 @@ public class TestClusterCacheStatus {
 
    public ConsistentHash ch(Address... addresses) {
       return joinInfo.getConsistentHashFactory()
-                     .create(joinInfo.getHashFunction(), joinInfo.getNumOwners(), joinInfo.getNumSegments(),
+                     .create(MurmurHash3.getInstance(), joinInfo.getNumOwners(), joinInfo.getNumSegments(),
                              asList(addresses), null);
    }
 
@@ -166,10 +167,9 @@ public class TestClusterCacheStatus {
 
    public CacheJoinInfo joinInfo(Address a) {
       // Copy the generic CacheJoinInfo and replace the persistent UUID
-      return new CacheJoinInfo(joinInfo.getConsistentHashFactory(), joinInfo.getHashFunction(),
-                               joinInfo.getNumSegments(), joinInfo.getNumOwners(), joinInfo.getTimeout(),
-                               joinInfo.isTotalOrder(), joinInfo.getCacheMode(), joinInfo.getCapacityFactor(),
-                               persistentUUID(a), joinInfo.getPersistentStateChecksum());
+      return new CacheJoinInfo(joinInfo.getConsistentHashFactory(), joinInfo.getNumSegments(), joinInfo.getNumOwners(),
+            joinInfo.getTimeout(), joinInfo.isTotalOrder(), joinInfo.getCacheMode(), joinInfo.getCapacityFactor(),
+            persistentUUID(a), joinInfo.getPersistentStateChecksum());
    }
 
    public CacheTopology topology() {


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-11259

@danberindei As well as reducing the `CacheJoinInfo` payload size, this also benefits [ISPN-9622](https://issues.redhat.com/browse/ISPN-9622) as it's one less polymorphic variable to handle.