### PR TITLE
ISPN-11282 CLI: site command isn't working properly

### DIFF
--- a/cli/cli-client/src/main/java/org/infinispan/cli/commands/Site.java
+++ b/cli/cli-client/src/main/java/org/infinispan/cli/commands/Site.java
@@ -27,6 +27,7 @@ import org.kohsuke.MetaInfServices;
             Site.CancelPushState.class,
             Site.CancelReceiveState.class,
             Site.PushSiteStatus.class,
+            Site.ClearPushStateStatus.class,
       }
 )
 public class Site extends CliCommand {
@@ -40,7 +41,7 @@ public class Site extends CliCommand {
    public static final String BRING_ONLINE = "bring-online";
    public static final String STATUS = "status";
    public static final String CMD = "site";
-   public static final String NAME = "site";
+   public static final String SITE_NAME = "site";
    public static final String OP = "op";
    public static final String CACHE = "cache";
 
@@ -59,7 +60,7 @@ public class Site extends CliCommand {
 
       @Override
       public CommandResult exec(ContextAwareCommandInvocation invocation) {
-         CommandInputLine cmd = new CommandInputLine(CMD).arg(OP, STATUS).arg(CACHE, cache).optionalArg(NAME, site);
+         CommandInputLine cmd = new CommandInputLine(CMD).arg(OP, STATUS).arg(CACHE, cache).optionalArg(SITE_NAME, site);
          return invocation.execute(Collections.singletonList(cmd));
       }
    }
@@ -74,7 +75,7 @@ public class Site extends CliCommand {
 
       @Override
       public CommandResult exec(ContextAwareCommandInvocation invocation) {
-         CommandInputLine cmd = new CommandInputLine(CMD).arg(OP, BRING_ONLINE).arg(CACHE, cache).arg(NAME, site);
+         CommandInputLine cmd = new CommandInputLine(CMD).arg(OP, BRING_ONLINE).arg(CACHE, cache).arg(SITE_NAME, site);
          return invocation.execute(cmd);
       }
    }
@@ -89,7 +90,7 @@ public class Site extends CliCommand {
 
       @Override
       public CommandResult exec(ContextAwareCommandInvocation invocation) {
-         CommandInputLine cmd = new CommandInputLine(CMD).arg(OP, TAKE_OFFLINE).arg(CACHE, cache).arg(NAME, site);
+         CommandInputLine cmd = new CommandInputLine(CMD).arg(OP, TAKE_OFFLINE).arg(CACHE, cache).arg(SITE_NAME, site);
          return invocation.execute(Collections.singletonList(cmd));
       }
    }
@@ -104,7 +105,7 @@ public class Site extends CliCommand {
 
       @Override
       public CommandResult exec(ContextAwareCommandInvocation invocation) {
-         CommandInputLine cmd = new CommandInputLine(CMD).arg(OP, PUSH_SITE_STATE).arg(CACHE, cache).arg(NAME, site);
+         CommandInputLine cmd = new CommandInputLine(CMD).arg(OP, PUSH_SITE_STATE).arg(CACHE, cache).arg(SITE_NAME, site);
          return invocation.execute(Collections.singletonList(cmd));
       }
    }
@@ -119,7 +120,7 @@ public class Site extends CliCommand {
 
       @Override
       public CommandResult exec(ContextAwareCommandInvocation invocation) {
-         CommandInputLine cmd = new CommandInputLine(CMD).arg(OP, CANCEL_PUSH_STATE).arg(CACHE, cache).arg(NAME, site);
+         CommandInputLine cmd = new CommandInputLine(CMD).arg(OP, CANCEL_PUSH_STATE).arg(CACHE, cache).arg(SITE_NAME, site);
          return invocation.execute(Collections.singletonList(cmd));
       }
    }
@@ -134,7 +135,7 @@ public class Site extends CliCommand {
 
       @Override
       public CommandResult exec(ContextAwareCommandInvocation invocation) {
-         CommandInputLine cmd = new CommandInputLine(CMD).arg(OP, CANCEL_RECEIVE_STATE).arg(CACHE, cache).arg(NAME, site);
+         CommandInputLine cmd = new CommandInputLine(CMD).arg(OP, CANCEL_RECEIVE_STATE).arg(CACHE, cache).arg(SITE_NAME, site);
          return invocation.execute(Collections.singletonList(cmd));
       }
    }

--- a/cli/cli-client/src/main/java/org/infinispan/cli/connection/rest/RestConnection.java
+++ b/cli/cli-client/src/main/java/org/infinispan/cli/connection/rest/RestConnection.java
@@ -455,31 +455,31 @@ public class RestConnection implements Connection, Closeable {
                RestCacheClient cache = client.cache(command.arg(Site.CACHE));
                switch (command.arg(Site.OP)) {
                   case Site.STATUS: {
-                     if (command.hasArg(Site.NAME)) {
-                        response = cache.backupStatus(command.arg(Site.NAME));
+                     if (command.hasArg(Site.SITE_NAME)) {
+                        response = cache.backupStatus(command.arg(Site.SITE_NAME));
                      } else {
                         response = cache.xsiteBackups();
                      }
                      break;
                   }
                   case Site.BRING_ONLINE: {
-                     response = cache.bringSiteOnline(command.arg(Site.NAME));
+                     response = cache.bringSiteOnline(command.arg(Site.SITE_NAME));
                      break;
                   }
                   case Site.TAKE_OFFLINE: {
-                     response = cache.takeSiteOffline(command.arg(Site.NAME));
+                     response = cache.takeSiteOffline(command.arg(Site.SITE_NAME));
                      break;
                   }
                   case Site.PUSH_SITE_STATE: {
-                     response = cache.pushSiteState(command.arg(Site.NAME));
+                     response = cache.pushSiteState(command.arg(Site.SITE_NAME));
                      break;
                   }
                   case Site.CANCEL_PUSH_STATE: {
-                     response = cache.cancelPushState(command.arg(Site.NAME));
+                     response = cache.cancelPushState(command.arg(Site.SITE_NAME));
                      break;
                   }
                   case Site.CANCEL_RECEIVE_STATE: {
-                     response = cache.cancelReceiveState(command.arg(Site.NAME));
+                     response = cache.cancelReceiveState(command.arg(Site.SITE_NAME));
                      break;
                   }
                   case Site.PUSH_SITE_STATUS: {

--- a/cli/cli-client/src/main/resources/help/site.adoc
+++ b/cli/cli-client/src/main/resources/help/site.adoc
@@ -27,32 +27,38 @@ SYNOPSIS
 
 OPTIONS
 -------
-*-c, --cache*='CACHE_NAME'::
-Specifies a cache. Defaults to the currently selected cache.
+*--cache*='CACHE_NAME'::
+Specifies a cache.
 
-*-s, --site*='SITE_NAME'::
+*--site*='SITE_NAME'::
 Specifies a site.
 
 
 EXAMPLES
 --------
-`site status -s SITE_A` +
-Returns the status for `SITE_A`.
+`site status --cache=mycache` +
+Returns the status of all backup locations for `mycache`.
 
-`site bring-online --cache=mycache --site=SITE_A` +
-Brings the `mycache` cache online at `SITE_A`.
+`site status --cache=mycache --site=NYC` +
+Returns the status of `NYC` for `mycache`.
 
-`site take-offline --cache=mycache --site=SITE_B` +
-Takes the `mycache` cache offline at `SITE_B`.
+`site bring-online --cache=mycache --site=NYC` +
+Brings site `NYC` online for `mycache`.
 
-`site push-site-state --site=SITE_B` +
-Push the state of all caches to the backup site `SITE_B`.
+`site take-offline --cache=mycache --site=NYC` +
+Takes the site `NYC` offline for `mycache`.
 
-`site push-site-status --site=SITE_B` +
-Displays the current status of the push to the backup site `SITE_B`.
+`site push-site-state --cache=mycache --site=NYC` +
+Backs up the `mycache` cache to `NYC`.
 
-`site cancel-push-state --site=SITE_B` +
-Cancels the operation to push state to the backup site `SITE_B`.
+`site push-site-status --cache=mycache` +
+Displays the status of the backup operation for the `mycache` cache to all backup locations.
 
-`site cancel-receive-state --site=SITE_A` +
-Cancels the operation to receive state from a remote site.
+`site cancel-push-state --cache=mycache --site=NYC` +
+Cancels the backup operation for the `mycache` cache to `NYC`.
+
+`site cancel-receive-state --cache=mycache --site=NYC` +
+Cancels the operation to receive state from a remote location.
+
+`site clear-push-state-status --cache=myCache` +
+Clears the push state status for `mycache`.


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-11282

It was using `CliCommand.NAME` instead of `Site.NAME`. I changed `Site.NAME` => `Site.SITE_NAME` to avoid confusion.
Updated the help message.