### PR TITLE
[10.1] ISPN-11290 Optionally use a prebuilt server from the supplied container

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -704,7 +704,7 @@
       <versionx.org.springframework.spring-web>${version.spring5}</versionx.org.springframework.spring-web>
       <versionx.org.springframework.spring-webmvc>${version.spring5}</versionx.org.springframework.spring-webmvc>
       <versionx.org.syslog4j.syslog4j>0.9.30</versionx.org.syslog4j.syslog4j>
-      <versionx.org.testcontainers.testcontainers>1.12.4</versionx.org.testcontainers.testcontainers>
+      <versionx.org.testcontainers.testcontainers>1.12.5</versionx.org.testcontainers.testcontainers>
       <versionx.org.testng.testng>6.14.3</versionx.org.testng.testng>
       <versionx.org.tukaani.xz>1.0</versionx.org.tukaani.xz>
       <versionx.org.twdata.maven.mojo-executor>2.2.0</versionx.org.twdata.maven.mojo-executor>

--- a/server/runtime/TESTING.md
+++ b/server/runtime/TESTING.md
@@ -122,7 +122,9 @@ The default is to run all categories, but this can be overridden by setting the 
 
 The following is a list of properties which affect the build:
 
-* `org.infinispan.test.server.baseImageName` the base image to use for the server. Defaults to `jboss/base-jdk:11`.
+* `org.infinispan.test.server.container.baseImageName` the base image to use for the server. Defaults to `jboss/base-jdk:11`.
+* `org.infinispan.test.server.container.usePrebuiltServer` whether to use a prebuilt server from the supplied image above.
+* `org.infinispan.test.server.container.preserveImage` whether to preserve the created image after the test has run.
 * `org.infinispan.test.server.driver`  the driver to use, `EMBEDDED` or `CONTAINER`. Defaults to the `EMBEDDED` driver.
 * `org.infinispan.test.server.extension.libs` locates artifact defined by G:A:V, you can pass a list of libraries (comma separeted) to be copied to the server. Only needed for container mode.
 * `org.infinispan.test.server.jdbc.databases` database name to be used during persistence tests.

--- a/server/runtime/src/test/java/org/infinispan/server/test/ContainerInfinispanServerDriver.java
+++ b/server/runtime/src/test/java/org/infinispan/server/test/ContainerInfinispanServerDriver.java
@@ -35,6 +35,7 @@ import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.images.builder.ImageFromDockerfile;
+import org.testcontainers.utility.Base58;
 import org.testcontainers.utility.MountableFile;
 
 import com.github.dockerjava.api.DockerClient;
@@ -59,7 +60,6 @@ public class ContainerInfinispanServerDriver extends InfinispanServerDriver {
    CountdownLatchLoggingConsumer latch;
    ImageFromDockerfile image;
    private File rootDir;
-
    private final boolean preferContainerExposedPorts = Boolean.getBoolean("org.infinispan.test.server.container.preferContainerExposedPorts");
 
    protected ContainerInfinispanServerDriver(InfinispanServerTestConfiguration configuration) {
@@ -106,7 +106,7 @@ public class ContainerInfinispanServerDriver extends InfinispanServerDriver {
       properties.setProperty(TEST_HOST_ADDRESS, testHostAddress.getHostName());
       configuration.properties().forEach((k, v) -> args.add("-D" + k + "=" + StringPropertyReplacer.replaceProperties((String) v, properties)));
 
-      image = new ImageFromDockerfile()
+      image = new ImageFromDockerfile("testcontainers/" + Base58.randomString(16).toLowerCase(), false)
             .withFileFromPath("build", serverOutputDir)
             .withFileFromPath("test", rootDir.toPath())
             .withFileFromPath("target", serverOutputDir.getParent())

--- a/server/runtime/src/test/java/org/infinispan/server/test/ServerRunMode.java
+++ b/server/runtime/src/test/java/org/infinispan/server/test/ServerRunMode.java
@@ -20,7 +20,7 @@ public enum ServerRunMode {
    DEFAULT {
       @Override
       InfinispanServerDriver newDriver(InfinispanServerTestConfiguration configuration) {
-         String driverName = System.getProperty("org.infinispan.test.server.driver", EMBEDDED.name());
+         String driverName = System.getProperty(TestSystemPropertyNames.INFINISPAN_TEST_SERVER_DRIVER, EMBEDDED.name());
          ServerRunMode driver = ServerRunMode.valueOf(driverName);
          return driver.newDriver(configuration);
       }

--- a/server/runtime/src/test/java/org/infinispan/server/test/TestSystemPropertyNames.java
+++ b/server/runtime/src/test/java/org/infinispan/server/test/TestSystemPropertyNames.java
@@ -1,0 +1,33 @@
+package org.infinispan.server.test;
+
+/**
+ * @author Tristan Tarrant &lt;tristan@infinispan.org&gt;
+ * @since 11.0
+ **/
+public class TestSystemPropertyNames {
+   /**
+    * Specifies the name of the base image to use for the server container
+    */
+   public static final String INFINISPAN_TEST_SERVER_BASE_IMAGE_NAME = "org.infinispan.test.server.container.baseImageName";
+   /**
+    * Specifies whether to use the ports exposed by the container
+    */
+   public static final String INFINISPAN_TEST_SERVER_CONTAINER_PREFER_CONTAINER_EXPOSED_PORTS = "org.infinispan.test.server.container.preferContainerExposedPorts";
+   /**
+    * Specifies whether the base image contains a prebuilt server to use instead of using the one built locally
+    */
+   public static final String INFINISPAN_TEST_SERVER_PREBUILT = "org.infinispan.test.server.container.usePrebuiltServer";
+   /**
+    * Specifies whether the base image contains a prebuilt server to use instead of using the one built locally
+    */
+   public static final String INFINISPAN_TEST_SERVER_PRESERVE_IMAGE = "org.infinispan.test.server.container.preserveImage";
+   /**
+    * Specifies a comma-separated list of extra libraries (jars) to deploy into the server/lib directory
+    */
+   public static final String EXTRA_LIBS = "org.infinispan.test.server.extension.libs";
+   /**
+    * The driver to use for running the server tests. Will override the default driver. Can be either EMBEDDED or CONTAINER
+    */
+   public static final String INFINISPAN_TEST_SERVER_DRIVER = "org.infinispan.test.server.driver";
+
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-11290

To test this run a container test with the following properties
-Dorg.infinispan.test.server.container.usePrebuiltServer=true -Dorg.infinispan.test.server.container.baseImageName=infinispan/server:10.1.1.Final-3

Backport of #7843 also includes a fixed backport of ISPN-11071