### PR TITLE
[9.4.x] ISPN-11377 Change default flow control back to UFC/MFC

### DIFF
--- a/cloud/src/main/resources/default-configs/default-jgroups-ec2.xml
+++ b/cloud/src/main/resources/default-configs/default-jgroups-ec2.xml
@@ -49,10 +49,10 @@
    <pbcast.GMS print_local_addr="false"
                join_timeout="${jgroups.join_timeout:5000}"
    />
-   <UFC max_credits="3m"
+   <UFC max_credits="4m"
         min_threshold="0.40"
    />
-   <MFC max_credits="3m"
+   <MFC max_credits="4m"
         min_threshold="0.40"
    />
    <FRAG3/>

--- a/cloud/src/main/resources/default-configs/default-jgroups-google.xml
+++ b/cloud/src/main/resources/default-configs/default-jgroups-google.xml
@@ -47,10 +47,10 @@
    <pbcast.GMS print_local_addr="false"
                join_timeout="${jgroups.join_timeout:5000}"
    />
-   <UFC max_credits="3m"
+   <UFC max_credits="4m"
         min_threshold="0.40"
    />
-   <MFC max_credits="3m"
+   <MFC max_credits="4m"
         min_threshold="0.40"
    />
    <FRAG3/>

--- a/cloud/src/main/resources/default-configs/default-jgroups-kubernetes.xml
+++ b/cloud/src/main/resources/default-configs/default-jgroups-kubernetes.xml
@@ -46,10 +46,10 @@
    <pbcast.GMS print_local_addr="false"
                join_timeout="${jgroups.join_timeout:5000}"
    />
-   <UFC max_credits="3m"
+   <UFC max_credits="4m"
         min_threshold="0.40"
    />
-   <MFC max_credits="3m"
+   <MFC max_credits="4m"
         min_threshold="0.40"
    />
    <FRAG3/>

--- a/core/src/main/resources/default-configs/default-jgroups-tcp.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-tcp.xml
@@ -16,7 +16,7 @@
    <MPING bind_addr="${jgroups.tcp.address:127.0.0.1}"
           mcast_addr="${jgroups.mping.mcast_addr:228.2.4.6}"
           mcast_port="${jgroups.mping.mcast_port:43366}"
-          ip_ttl="${jgroups.udp.ip_ttl:2}" 
+          ip_ttl="${jgroups.udp.ip_ttl:2}"
    />
    <MERGE3 min_interval="10000" 
            max_interval="30000" 
@@ -47,10 +47,10 @@
    <pbcast.GMS print_local_addr="false"
                join_timeout="${jgroups.join_timeout:5000}"
    />
-   <UFC max_credits="3m"
+   <UFC max_credits="4m"
         min_threshold="0.40"
    />
-   <MFC max_credits="3m"
+   <MFC max_credits="4m"
         min_threshold="0.40"
    />
    <FRAG3/>

--- a/core/src/main/resources/default-configs/default-jgroups-udp.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-udp.xml
@@ -47,10 +47,10 @@
    <pbcast.GMS print_local_addr="false"
                join_timeout="${jgroups.join_timeout:5000}"
    />
-   <UFC max_credits="3m"
+   <UFC max_credits="4m"
         min_threshold="0.40"
    />
-   <MFC max_credits="3m"
+   <MFC max_credits="4m"
         min_threshold="0.40"
    />
    <FRAG3 frag_size="8000"/>

--- a/core/src/test/resources/configs/xsite/bridge.xml
+++ b/core/src/test/resources/configs/xsite/bridge.xml
@@ -50,9 +50,9 @@
     <pbcast.GMS print_local_addr="false"
                 join_timeout="${jgroups.join_timeout:2000}"/>
 
-    <UFC max_credits="3m"
+    <UFC max_credits="4m"
          min_threshold="0.40"/>
-    <MFC max_credits="3m"
+    <MFC max_credits="4m"
          min_threshold="0.40"/>
 
     <RSVP />

--- a/core/src/test/resources/stacks/tcp.xml
+++ b/core/src/test/resources/stacks/tcp.xml
@@ -64,8 +64,8 @@
                join_timeout="${jgroups.join_timeout:2000}"/>
    <tom.TOA/> <!-- the Total Order Anycast is only needed for total order transactions (in distributed mode)-->
 
-   <UFC max_credits="3m" min_threshold="0.40"/>
-   <MFC max_credits="3m" min_threshold="0.40"/>
+   <UFC max_credits="4m" min_threshold="0.40"/>
+   <MFC max_credits="4m" min_threshold="0.40"/>
    <RSVP timeout="60000" resend_interval="500" ack_on_delivery="false" />
 
    <org.infinispan.test.fwk.TEST_RELAY2 site="__site_name__" config="configs/xsite/relay-config.xml" relay_multicasts="true" async_relay_creation="false"/>

--- a/core/src/test/resources/stacks/tcp_mping/tcp1.xml
+++ b/core/src/test/resources/stacks/tcp_mping/tcp1.xml
@@ -51,7 +51,7 @@
    <pbcast.GMS print_local_addr="false"
                join_timeout="${jgroups.join_timeout:2000}"/>
    <tom.TOA/> <!-- the Total Order Anycast is only needed for total order transactions (in distributed mode)-->
-   <UFC max_credits="3m" min_threshold="0.40"/>
-   <MFC max_credits="3m" min_threshold="0.40"/>
+   <UFC max_credits="4m" min_threshold="0.40"/>
+   <MFC max_credits="4m" min_threshold="0.40"/>
    <FRAG3/>
 </config>

--- a/core/src/test/resources/stacks/tcp_mping/tcp2.xml
+++ b/core/src/test/resources/stacks/tcp_mping/tcp2.xml
@@ -51,7 +51,7 @@
    <pbcast.GMS print_local_addr="false"
                join_timeout="${jgroups.join_timeout:2000}"/>
    <tom.TOA/> <!-- the Total Order Anycast is only needed for total order transactions (in distributed mode)-->
-   <UFC max_credits="3m" min_threshold="0.40"/>
-   <MFC max_credits="3m" min_threshold="0.40"/>
+   <UFC max_credits="4m" min_threshold="0.40"/>
+   <MFC max_credits="4m" min_threshold="0.40"/>
    <FRAG3/>
 </config>

--- a/core/src/test/resources/stacks/udp.xml
+++ b/core/src/test/resources/stacks/udp.xml
@@ -52,8 +52,8 @@
                join_timeout="${jgroups.join_timeout:2000}"/>
    <tom.TOA/> <!-- the Total Order Anycast is only needed for total order transactions (in distributed mode)-->
 
-   <UFC max_credits="3m" min_threshold="0.40"/>
-   <MFC max_credits="3m" min_threshold="0.40"/>
+   <UFC max_credits="4m" min_threshold="0.40"/>
+   <MFC max_credits="4m" min_threshold="0.40"/>
    <FRAG3 frag_size="8000"  />
    <RSVP timeout="60000" resend_interval="500" ack_on_delivery="false" />
 

--- a/demos/gui/src/main/release/etc/config/jgroups-relay1.xml
+++ b/demos/gui/src/main/release/etc/config/jgroups-relay1.xml
@@ -47,9 +47,9 @@
     />
     <pbcast.GMS print_local_addr="true" join_timeout="${jgroups.join_timeout:5000}"
                 max_bundling_time="200"/>
-    <UFC max_credits="3m"
+    <UFC max_credits="4m"
           min_threshold="0.40"/>
-    <MFC max_credits="3m"
+    <MFC max_credits="4m"
           min_threshold="0.40"/>
     <FRAG3 frag_size="8000"/>
     <RELAY site="nyc" bridge_props="config-samples/jgroups-tcp.xml" />

--- a/demos/gui/src/main/release/etc/config/jgroups-relay2.xml
+++ b/demos/gui/src/main/release/etc/config/jgroups-relay2.xml
@@ -48,9 +48,9 @@
     />
     <pbcast.GMS print_local_addr="true" join_timeout="${jgroups.join_timeout:5000}"
                 max_bundling_time="200"/>
-    <UFC max_credits="3m"
+    <UFC max_credits="4m"
           min_threshold="0.40"/>
-    <MFC max_credits="3m"
+    <MFC max_credits="4m"
           min_threshold="0.40"/>
     <FRAG3 frag_size="8000"/>
     <RELAY site="zrh" bridge_props="config-samples/jgroups-tcp.xml"  />

--- a/demos/gui/src/main/release/etc/config/jgroups-tcp.xml
+++ b/demos/gui/src/main/release/etc/config/jgroups-tcp.xml
@@ -47,10 +47,10 @@
     />
     <pbcast.GMS print_local_addr="true" join_timeout="${jgroups.join_timeout:5000}"
                 max_bundling_time="30"/>
-    <UFC max_credits="3m"
+    <UFC max_credits="4m"
          min_threshold="0.40"
     />
-    <MFC max_credits="3m"
+    <MFC max_credits="4m"
          min_threshold="0.4"/>
     <FRAG3/>
 </config>

--- a/documentation/src/main/asciidoc/topics/jgroups/jgroups_default_stack.adoc
+++ b/documentation/src/main/asciidoc/topics/jgroups/jgroups_default_stack.adoc
@@ -11,8 +11,8 @@
   <protocol type="UNICAST3"/>
   <protocol type="pbcast.STABLE"/>
   <protocol type="pbcast.GMS"/>
-  <protocol type="UFC_NB"/>
-  <protocol type="MFC_NB"/>
+  <protocol type="UFC"/>
+  <protocol type="MFC"/>
   <protocol type="FRAG3"/>
 </stack>
 <stack name="tcp">
@@ -28,7 +28,7 @@
   <protocol type="UNICAST3"/>
   <protocol type="pbcast.STABLE"/>
   <protocol type="pbcast.GMS"/>
-  <protocol type="MFC_NB"/>
+  <protocol type="MFC"/>
   <protocol type="FRAG3"/>
 </stack>
 ----

--- a/hibernate/cache-commons/src/test/resources/2lc-test-tcp.xml
+++ b/hibernate/cache-commons/src/test/resources/2lc-test-tcp.xml
@@ -54,10 +54,10 @@
     <!-- It deadlocks with JGroups 4.0.6, enable only after making sure it works -->
     <!--<org.infinispan.test.hibernate.cache.util.TestDisconnectHandler />-->
 
-   <UFC max_credits="3m"
+   <UFC max_credits="4m"
         min_threshold="0.40"
    />
-   <MFC max_credits="3m"
+   <MFC max_credits="4m"
         min_threshold="0.40"
     />
    <FRAG2 frag_size="60000" />

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node0.xml
@@ -52,7 +52,7 @@
    <pbcast.GMS print_local_addr="false"
                join_timeout="${jgroups.join_timeout:2000}"/>
 
-   <UFC max_credits="3m" min_threshold="0.40"/>
-   <MFC max_credits="3m" min_threshold="0.40"/>
+   <UFC max_credits="4m" min_threshold="0.40"/>
+   <MFC max_credits="4m" min_threshold="0.40"/>
    <FRAG3/>
 </config>

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1-fail.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1-fail.xml
@@ -52,9 +52,9 @@
                join_timeout="${jgroups.join_timeout:2000}"/>
 
 
-   <UFC max_credits="3m" min_threshold="0.40"/>
-   <MFC max_credits="3m" min_threshold="0.40"/>
+   <UFC max_credits="4m" min_threshold="0.40"/>
+   <MFC max_credits="4m" min_threshold="0.40"/>
    <FRAG3/>
    <RSVP timeout="60000" resend_interval="500" ack_on_delivery="false" />
-    
+
 </config>

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1.xml
@@ -51,9 +51,9 @@
    <pbcast.GMS print_local_addr="false"
                join_timeout="${jgroups.join_timeout:2000}"/>
 
-   <UFC max_credits="3m" min_threshold="0.40"/>
-   <MFC max_credits="3m" min_threshold="0.40"/>
+   <UFC max_credits="4m" min_threshold="0.40"/>
+   <MFC max_credits="4m" min_threshold="0.40"/>
    <FRAG3/>
    <RSVP timeout="60000" resend_interval="500" ack_on_delivery="false" />
-    
+
 </config>

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node0.xml
@@ -54,9 +54,9 @@
    <pbcast.GMS print_local_addr="false"
                join_timeout="${jgroups.join_timeout:2000}"/>
 
-   <UFC max_credits="3m" min_threshold="0.40"/>
-   <MFC max_credits="3m" min_threshold="0.40"/>
+   <UFC max_credits="4m" min_threshold="0.40"/>
+   <MFC max_credits="4m" min_threshold="0.40"/>
    <FRAG3/>
    <RSVP timeout="60000" resend_interval="500" ack_on_delivery="false" />
-    
+
 </config>

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node1.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node1.xml
@@ -50,9 +50,9 @@
    <pbcast.GMS print_local_addr="false"
                join_timeout="${jgroups.join_timeout:2000}"/>
 
-   <UFC max_credits="3m" min_threshold="0.40"/>
-   <MFC max_credits="3m" min_threshold="0.40"/>
+   <UFC max_credits="4m" min_threshold="0.40"/>
+   <MFC max_credits="4m" min_threshold="0.40"/>
    <FRAG3/>
    <RSVP timeout="60000" resend_interval="500" ack_on_delivery="false" />
-    
+
 </config>

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-user-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-user-node0.xml
@@ -54,9 +54,9 @@
    <pbcast.GMS print_local_addr="false"
                join_timeout="${jgroups.join_timeout:2000}"/>
 
-   <UFC max_credits="3m" min_threshold="0.40"/>
-   <MFC max_credits="3m" min_threshold="0.40"/>
+   <UFC max_credits="4m" min_threshold="0.40"/>
+   <MFC max_credits="4m" min_threshold="0.40"/>
    <FRAG3/>
    <RSVP timeout="60000" resend_interval="500" ack_on_delivery="false" />
-    
+
 </config>

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node0.xml
@@ -52,9 +52,9 @@
    <pbcast.GMS print_local_addr="false"
                join_timeout="${jgroups.join_timeout:2000}"/>
 
-   <UFC max_credits="3m" min_threshold="0.40"/>
-   <MFC max_credits="3m" min_threshold="0.40"/>
+   <UFC max_credits="4m" min_threshold="0.40"/>
+   <MFC max_credits="4m" min_threshold="0.40"/>
    <FRAG3/>
    <RSVP timeout="60000" resend_interval="500" ack_on_delivery="false" />
-    
+
 </config>

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node1.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node1.xml
@@ -50,9 +50,9 @@
    <pbcast.GMS print_local_addr="false"
                join_timeout="${jgroups.join_timeout:2000}"/>
 
-   <UFC max_credits="3m" min_threshold="0.40"/>
-   <MFC max_credits="3m" min_threshold="0.40"/>
+   <UFC max_credits="4m" min_threshold="0.40"/>
+   <MFC max_credits="4m" min_threshold="0.40"/>
    <FRAG3/>
    <RSVP timeout="60000" resend_interval="500" ack_on_delivery="false" />
-    
+
 </config>

--- a/integrationtests/wildfly-modules/src/test/resources/as-config/standalone/configuration/standalone-test.xml
+++ b/integrationtests/wildfly-modules/src/test/resources/as-config/standalone/configuration/standalone-test.xml
@@ -348,7 +348,7 @@
                     <protocol type="pbcast.GMS" module="org.jgroups:${infinispan.module.slot}"/>
                     <protocol type="UFC" module="org.jgroups:${infinispan.module.slot}"/>
                     <protocol type="MFC" module="org.jgroups:${infinispan.module.slot}"/>
-                    <protocol type="FRAG2" module="org.jgroups:${infinispan.module.slot}"/>
+                    <protocol type="FRAG3" module="org.jgroups:${infinispan.module.slot}"/>
                 </stack>
             </stacks>
         </subsystem>

--- a/persistence/jdbc/src/test/resources/configs/as7/jdbc-standalone.xml
+++ b/persistence/jdbc/src/test/resources/configs/as7/jdbc-standalone.xml
@@ -167,11 +167,11 @@
                 </protocol>
                 <protocol type="pbcast.GMS"/>
                 <protocol type="UFC">
-                    <property name="max_credits">3m</property>
+                    <property name="max_credits">4m</property>
                     <property name="min_threshold">0.40</property>
                 </protocol>
                 <protocol type="MFC">
-                    <property name="max_credits">3m</property>
+                    <property name="max_credits">4m</property>
                     <property name="min_threshold">0.40</property>
                 </protocol>
                 <protocol type="FRAG3">
@@ -206,11 +206,11 @@
                 </protocol>
                 <protocol type="pbcast.GMS"/>
                 <protocol type="UFC">
-                  <property name="max_credits">3m</property>
+                  <property name="max_credits">4m</property>
                   <property name="min_threshold">0.40</property>
                 </protocol>
                 <protocol type="MFC">
-                    <property name="max_credits">3m</property>
+                    <property name="max_credits">4m</property>
                     <property name="min_threshold">0.40</property>
                 </protocol>
                 <protocol type="FRAG3"/>

--- a/server/integration/jgroups/src/main/resources/jgroups-defaults.xml
+++ b/server/integration/jgroups/src/main/resources/jgroups-defaults.xml
@@ -77,10 +77,10 @@
       print_local_addr="false"
       join_timeout="${jgroups.join_timeout:5000}"/>
    <UFC
-      max_credits="3m"
+      max_credits="4m"
       min_threshold="0.40"/>
    <MFC
-      max_credits="3m"
+      max_credits="4m"
       min_threshold="0.40"/>
    <UFC_NB
       max_credits="3m"

--- a/server/integration/jgroups/src/main/resources/subsystem-templates/infinispan-jgroups.xml
+++ b/server/integration/jgroups/src/main/resources/subsystem-templates/infinispan-jgroups.xml
@@ -19,8 +19,8 @@
                 <protocol type="UNICAST3" />
                 <protocol type="pbcast.STABLE" />
                 <protocol type="pbcast.GMS" />
-                <protocol type="UFC_NB" />
-                <protocol type="MFC_NB" />
+                <protocol type="UFC" />
+                <protocol type="MFC" />
                 <protocol type="FRAG3" />
                 <?RELAY?>
                 <?AUTH?>
@@ -38,7 +38,8 @@
                 <protocol type="UNICAST3" />
                 <protocol type="pbcast.STABLE" />
                 <protocol type="pbcast.GMS" />
-                <protocol type="MFC_NB" />
+                <protocol type="UFC" />
+                <protocol type="MFC" />
                 <protocol type="FRAG3"/>
                 <?AUTH?>
             </stack>
@@ -57,7 +58,8 @@
                 <protocol type="UNICAST3" />
                 <protocol type="pbcast.STABLE" />
                 <protocol type="pbcast.GMS" />
-                <protocol type="MFC_NB" />
+                <protocol type="UFC" />
+                <protocol type="MFC" />
                 <protocol type="FRAG3"/>
                 <?AUTH?>
             </stack>


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-11377

* Increase max_credits to 4MB to compensate for the queue.
* Embedded already used UFC/MFC, only server needed to change
* Server was also missing UFC from the TCP stacks