### PR TITLE
[10.1.x] SPN-11416 ContainerInfinispanServerDriver should not change permissi…

### DIFF
--- a/server/runtime/src/test/java/org/infinispan/server/test/ContainerInfinispanServerDriver.java
+++ b/server/runtime/src/test/java/org/infinispan/server/test/ContainerInfinispanServerDriver.java
@@ -129,7 +129,7 @@ public class ContainerInfinispanServerDriver extends InfinispanServerDriver {
                .label("architecture", "x86_64")
                .user("root");
 
-         if (OS.getCurrentOs() != OS.WINDOWS) {
+         if (OS.getCurrentOs() != OS.WINDOWS && !usePrebuiltServerFromImage) {
             // We need to remap the UID/GID of the jboss user inside the container to the ones of the user outside so that files created on volume mounts have the correct ownership/permissions
             String uid = runProcess("id", "-u");
             String gid = runProcess("id", "-g");


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-11416

```bash
mvn verify -Dit.test=GracefulShutdownRestartIT -Dorg.infinispan.test.server.container.baseImageName=infinispan/server:10.1.3.Final-1 -Dorg.infinispan.test.server.container.usePrebuiltServer=true 
```