### PR TITLE
[10.1.x] ISPN-11390 Non-components cannot export metrics

### DIFF
--- a/build-configuration/pom.xml
+++ b/build-configuration/pom.xml
@@ -208,10 +208,10 @@
       <version.rocksdb>6.2.2</version.rocksdb>
       <version.rxjava>2.2.12</version.rxjava>
       <version.slf4j>1.7.25</version.slf4j>
-      <version.smallrye-config>1.3.9</version.smallrye-config>
-      <version.smallrye-metrics>2.3.0</version.smallrye-metrics>
+      <version.smallrye-config>1.3.6</version.smallrye-config>
+      <version.smallrye-metrics>2.1.5</version.smallrye-metrics>
       <version.microprofile-config-api>1.3</version.microprofile-config-api>
-      <version.microprofile-metrics-api>2.2</version.microprofile-metrics-api>
+      <version.microprofile-metrics-api>2.0.2</version.microprofile-metrics-api>
       <version.sonatype.plexus>1.4</version.sonatype.plexus>
       <version.spring.boot>2.2.4.RELEASE</version.spring.boot>
       <version.spring.security>5.2.2.RELEASE</version.spring.security>

--- a/client/rest-client/src/main/java/org/infinispan/client/rest/RestMetricsClient.java
+++ b/client/rest-client/src/main/java/org/infinispan/client/rest/RestMetricsClient.java
@@ -3,7 +3,7 @@ package org.infinispan.client.rest;
 import java.util.concurrent.CompletionStage;
 
 /**
- * An experimental rest client for microprofile metrics and OpenMetrics.
+ * An experimental rest client for microprofile metrics in native and Prometheus compatible OpenMetrics format.
  *
  * @author anistor@redhat.com
  * @since 10.0
@@ -14,9 +14,9 @@ public interface RestMetricsClient {
 
    CompletionStage<RestResponse> metrics(String path);
 
-   CompletionStage<RestResponse> metrics(boolean openMetrics);
+   CompletionStage<RestResponse> metrics(boolean openMetricsFormat);
 
-   CompletionStage<RestResponse> metrics(String path, boolean openMetrics);
+   CompletionStage<RestResponse> metrics(String path, boolean openMetricsFormat);
 
    CompletionStage<RestResponse> metricsMetadata();
 

--- a/core/src/main/java/org/infinispan/configuration/global/GlobalMetricsConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/global/GlobalMetricsConfiguration.java
@@ -13,9 +13,10 @@ public class GlobalMetricsConfiguration implements ConfigurationInfo {
    public static final AttributeDefinition<Boolean> GAUGES = AttributeDefinition.builder("gauges", true).immutable().build();
    public static final AttributeDefinition<Boolean> HISTOGRAMS = AttributeDefinition.builder("histograms", false).immutable().build();
    public static final AttributeDefinition<String> PREFIX = AttributeDefinition.builder("prefix", "").immutable().build();
+   public static final AttributeDefinition<Boolean> NAMES_AS_TAGS = AttributeDefinition.builder("namesAsTags", false).immutable().build();
 
    static AttributeSet attributeDefinitionSet() {
-      return new AttributeSet(GlobalMetricsConfiguration.class, GAUGES, HISTOGRAMS, PREFIX);
+      return new AttributeSet(GlobalMetricsConfiguration.class, GAUGES, HISTOGRAMS, PREFIX, NAMES_AS_TAGS);
    }
 
    private static final ElementDefinition<GlobalMetricsConfiguration> ELEMENT_DEFINITION = new DefaultElementDefinition<>(Element.METRICS.getLocalName());
@@ -28,11 +29,14 @@ public class GlobalMetricsConfiguration implements ConfigurationInfo {
 
    private final Attribute<String> prefix;
 
+   private final Attribute<Boolean> namesAsTags;
+
    GlobalMetricsConfiguration(AttributeSet attributes) {
       this.attributes = attributes.checkProtection();
       this.gauges = attributes.attribute(GAUGES);
       this.histograms = attributes.attribute(HISTOGRAMS);
       this.prefix = attributes.attribute(PREFIX);
+      this.namesAsTags = attributes.attribute(NAMES_AS_TAGS);
    }
 
    @Override
@@ -62,6 +66,10 @@ public class GlobalMetricsConfiguration implements ConfigurationInfo {
 
    public String prefix() {
       return prefix.get();
+   }
+
+   public boolean namesAsTags() {
+      return namesAsTags.get();
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/configuration/global/GlobalMetricsConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/global/GlobalMetricsConfigurationBuilder.java
@@ -2,6 +2,7 @@ package org.infinispan.configuration.global;
 
 import static org.infinispan.configuration.global.GlobalMetricsConfiguration.GAUGES;
 import static org.infinispan.configuration.global.GlobalMetricsConfiguration.HISTOGRAMS;
+import static org.infinispan.configuration.global.GlobalMetricsConfiguration.NAMES_AS_TAGS;
 import static org.infinispan.configuration.global.GlobalMetricsConfiguration.PREFIX;
 
 import org.infinispan.commons.configuration.Builder;
@@ -9,8 +10,8 @@ import org.infinispan.commons.configuration.attributes.AttributeSet;
 
 /**
  * Configures the types of metrics gathered and exported via microprofile metrics for all caches under this cache
- * manager. Gauges do not have any performance penalty so are enabled by default. Histograms are harder to compute so
- * should be enabled manually.
+ * manager. Gauges do not have any performance penalty so are enabled by default. Histograms are more expensive to
+ * compute so should be enabled manually when needed.
  */
 public class GlobalMetricsConfigurationBuilder extends AbstractGlobalConfigurationBuilder implements Builder<GlobalMetricsConfiguration> {
 
@@ -32,6 +33,9 @@ public class GlobalMetricsConfigurationBuilder extends AbstractGlobalConfigurati
       return attributes.attribute(GAUGES).get();
    }
 
+   /**
+    * Enables or disables gauges.
+    */
    public GlobalMetricsConfigurationBuilder gauges(boolean gauges) {
       attributes.attribute(GAUGES).set(gauges);
       return this;
@@ -41,6 +45,9 @@ public class GlobalMetricsConfigurationBuilder extends AbstractGlobalConfigurati
       return attributes.attribute(HISTOGRAMS).get();
    }
 
+   /**
+    * Enables or disables histograms.
+    */
    public GlobalMetricsConfigurationBuilder histograms(boolean histograms) {
       attributes.attribute(HISTOGRAMS).set(histograms);
       return this;
@@ -50,8 +57,23 @@ public class GlobalMetricsConfigurationBuilder extends AbstractGlobalConfigurati
       return attributes.attribute(PREFIX).get();
    }
 
+   /**
+    * The global prefix to add to all metric names.
+    */
    public GlobalMetricsConfigurationBuilder prefix(String prefix) {
       attributes.attribute(PREFIX).set(prefix);
+      return this;
+   }
+
+   public boolean namesAsTags() {
+      return attributes.attribute(NAMES_AS_TAGS).get();
+   }
+
+   /**
+    * Put the cache manager and cache name in tags rather then include them in the metric name.
+    */
+   public GlobalMetricsConfigurationBuilder namesAsTags(boolean namesAsTags) {
+      attributes.attribute(NAMES_AS_TAGS).set(namesAsTags);
       return this;
    }
 

--- a/core/src/main/java/org/infinispan/configuration/parsing/Attribute.java
+++ b/core/src/main/java/org/infinispan/configuration/parsing/Attribute.java
@@ -98,6 +98,7 @@ public enum Attribute {
     MODULE,
     NAME,
     NAMES,
+    NAMES_AS_TAGS("namesAsTags"),
     NOTIFICATIONS,
     ON_REHASH("onRehash"),
     OWNERS,

--- a/core/src/main/java/org/infinispan/configuration/parsing/Parser.java
+++ b/core/src/main/java/org/infinispan/configuration/parsing/Parser.java
@@ -884,6 +884,10 @@ public class Parser implements ConfigurationParser {
                builder.metrics().prefix(value);
                break;
             }
+            case NAMES_AS_TAGS: {
+               builder.metrics().namesAsTags(Boolean.parseBoolean(value));
+               break;
+            }
             default: {
                throw ParseUtils.unexpectedAttribute(reader, i);
             }

--- a/core/src/main/java/org/infinispan/configuration/serializing/Serializer.java
+++ b/core/src/main/java/org/infinispan/configuration/serializing/Serializer.java
@@ -485,6 +485,7 @@ public class Serializer extends AbstractStoreSerializer implements Configuration
          attributes.write(writer, GlobalMetricsConfiguration.GAUGES, Attribute.GAUGES);
          attributes.write(writer, GlobalMetricsConfiguration.HISTOGRAMS, Attribute.HISTOGRAMS);
          attributes.write(writer, GlobalMetricsConfiguration.PREFIX, Attribute.PREFIX);
+         attributes.write(writer, GlobalMetricsConfiguration.NAMES_AS_TAGS, Attribute.NAMES_AS_TAGS);
          writer.writeEndElement();
       }
    }

--- a/core/src/main/java/org/infinispan/executors/LazyInitializingScheduledExecutorService.java
+++ b/core/src/main/java/org/infinispan/executors/LazyInitializingScheduledExecutorService.java
@@ -89,7 +89,6 @@ public class LazyInitializingScheduledExecutorService extends ManageableExecutor
          return true;
       else
          return executor.awaitTermination(timeout, unit);
-
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/factories/AbstractComponentRegistry.java
+++ b/core/src/main/java/org/infinispan/factories/AbstractComponentRegistry.java
@@ -149,7 +149,6 @@ public abstract class AbstractComponentRegistry implements Lifecycle {
       return getComponent(componentClass, name);
    }
 
-   @SuppressWarnings("unchecked")
    protected <T> T getOrCreateComponent(Class<T> componentClass, String name, boolean nameIsFQCN) {
       return getComponent(componentClass, name);
    }
@@ -160,10 +159,9 @@ public abstract class AbstractComponentRegistry implements Lifecycle {
     * @param type type to find
     * @return component, or null
     */
-   @SuppressWarnings("unchecked")
    public <T> T getComponent(Class<T> type) {
       String className = type.getName();
-      return (T) getComponent(type, className);
+      return getComponent(type, className);
    }
 
    @SuppressWarnings("unchecked")
@@ -176,7 +174,6 @@ public abstract class AbstractComponentRegistry implements Lifecycle {
       return (T) getComponent(componentClassName, name, false);
    }
 
-   @SuppressWarnings("unchecked")
    public <T> T getComponent(Class<T> componentClass, String name) {
       ComponentRef<T> component = basicComponentRegistry.getComponent(name, componentClass);
       return component != null ? component.wired() : null;

--- a/core/src/main/java/org/infinispan/jmx/AbstractJmxRegistration.java
+++ b/core/src/main/java/org/infinispan/jmx/AbstractJmxRegistration.java
@@ -161,6 +161,13 @@ abstract class AbstractJmxRegistration implements ObjectNameKeys {
    protected abstract String initGroup();
 
    /**
+    * Checks that JMX is effectively enabled.
+    */
+   public final boolean enabled() {
+      return mBeanServer != null;
+   }
+
+   /**
     * Gets the domain name. This should not be called unless JMX is enabled.
     */
    public final String getDomain() {

--- a/core/src/main/java/org/infinispan/jmx/CacheJmxRegistration.java
+++ b/core/src/main/java/org/infinispan/jmx/CacheJmxRegistration.java
@@ -14,7 +14,7 @@ import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
 
 /**
- * If {@link org.infinispan.configuration.cache.Configuration#jmxStatistics()} is enabled, then class will register all
+ * If {@link org.infinispan.configuration.cache.Configuration#statistics()} is enabled, then class will register all
  * the MBeans from cache local's ConfigurationRegistry to the MBean server.
  *
  * @author Mircea.Markus@jboss.com

--- a/core/src/main/java/org/infinispan/jmx/ObjectNameKeys.java
+++ b/core/src/main/java/org/infinispan/jmx/ObjectNameKeys.java
@@ -8,7 +8,7 @@ public interface ObjectNameKeys {
 
    String NAME = "name";
 
-   String TYPE = "type";   // Cache, CacheManager, Query, RemoteQuery, etc.
+   String TYPE = "type";   // Cache, CacheManager, Query, RemoteQuery, Server, etc.
 
    String COMPONENT = "component";
 

--- a/core/src/main/java/org/infinispan/manager/EmbeddedCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/EmbeddedCacheManager.java
@@ -309,9 +309,12 @@ public interface EmbeddedCacheManager extends CacheContainer, Listenable, Closea
    /**
     * Returns statistics for this cache manager
     *
-    * since 7.1
+    * @since 7.1
     * @return statistics for this cache manager
+    * @deprecated Since 10.1.3. This mixes statistics across unrelated caches so the reported numbers don't have too much
+    * relevance.
     */
+   @Deprecated
    CacheContainerStats getStats();
 
    /**

--- a/core/src/main/java/org/infinispan/metrics/Constants.java
+++ b/core/src/main/java/org/infinispan/metrics/Constants.java
@@ -1,0 +1,16 @@
+package org.infinispan.metrics;
+
+/**
+ * Various public constant names, used by Infinispan's microprofile metrics support.
+ *
+ * @author anistor@redhat.com
+ * @since 10.1
+ */
+public interface Constants {
+
+   String NODE_TAG_NAME = "node";
+
+   String CACHE_MANAGER_TAG_NAME = "cache_manager";
+
+   String CACHE_TAG_NAME = "cache";
+}

--- a/core/src/main/java/org/infinispan/metrics/impl/CacheManagerMetricsRegistration.java
+++ b/core/src/main/java/org/infinispan/metrics/impl/CacheManagerMetricsRegistration.java
@@ -5,6 +5,8 @@ import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
 
 /**
+ * Creates and registers metrics for all components from a cache manager's global component registry.
+ *
  * @author anistor@redhat.com
  * @since 10.1.3
  */
@@ -14,6 +16,8 @@ public final class CacheManagerMetricsRegistration extends AbstractMetricsRegist
 
    @Override
    protected String initNamePrefix() {
-      return "cache_manager_" + NameUtils.filterIllegalChars(globalConfig.cacheManagerName());
+      String prefix = "cache_manager_" + NameUtils.filterIllegalChars(globalConfig.cacheManagerName());
+      String globalPrefix = globalConfig.metrics().prefix();
+      return globalPrefix != null && !globalPrefix.isEmpty() ? globalPrefix + '_' + prefix : prefix;
    }
 }

--- a/core/src/main/java/org/infinispan/metrics/impl/CacheManagerMetricsRegistration.java
+++ b/core/src/main/java/org/infinispan/metrics/impl/CacheManagerMetricsRegistration.java
@@ -16,7 +16,8 @@ public final class CacheManagerMetricsRegistration extends AbstractMetricsRegist
 
    @Override
    protected String initNamePrefix() {
-      String prefix = "cache_manager_" + NameUtils.filterIllegalChars(globalConfig.cacheManagerName());
+      String prefix = globalConfig.metrics().namesAsTags() ?
+            "" : "cache_manager_" + NameUtils.filterIllegalChars(globalConfig.cacheManagerName()) + '_';
       String globalPrefix = globalConfig.metrics().prefix();
       return globalPrefix != null && !globalPrefix.isEmpty() ? globalPrefix + '_' + prefix : prefix;
    }

--- a/core/src/main/java/org/infinispan/metrics/impl/CacheMetricsRegistration.java
+++ b/core/src/main/java/org/infinispan/metrics/impl/CacheMetricsRegistration.java
@@ -1,10 +1,14 @@
 package org.infinispan.metrics.impl;
 
+import java.util.Set;
+
+import org.eclipse.microprofile.metrics.MetricID;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.factories.KnownComponentNames;
 import org.infinispan.factories.annotations.ComponentName;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.SurvivesRestarts;
+import org.infinispan.factories.impl.MBeanMetadata;
 import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
 
@@ -35,6 +39,15 @@ public final class CacheMetricsRegistration extends AbstractMetricsRegistration 
 
    @Override
    protected String initNamePrefix() {
-      return globalMetricsRegistration.namePrefix + "_cache_" + NameUtils.filterIllegalChars(cacheName);
+      String prefix = globalMetricsRegistration.namePrefix;
+      if (!globalConfig.metrics().namesAsTags()) {
+         prefix += "cache_" + NameUtils.filterIllegalChars(cacheName) + '_';
+      }
+      return prefix;
+   }
+
+   @Override
+   protected Set<MetricID> internalRegisterMetrics(Object instance, MBeanMetadata beanMetadata, String metricPrefix) {
+      return metricsCollector.registerMetrics(instance, beanMetadata, metricPrefix, cacheName);
    }
 }

--- a/core/src/main/java/org/infinispan/metrics/impl/CacheMetricsRegistration.java
+++ b/core/src/main/java/org/infinispan/metrics/impl/CacheMetricsRegistration.java
@@ -9,6 +9,8 @@ import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
 
 /**
+ * Creates and registers metrics for all components from a cache's component registry.
+ *
  * @author anistor@redhat.com
  * @since 10.1.3
  */
@@ -27,7 +29,7 @@ public final class CacheMetricsRegistration extends AbstractMetricsRegistration 
    CacheManagerMetricsRegistration globalMetricsRegistration;
 
    @Override
-   protected boolean metricsEnabled() {
+   public boolean metricsEnabled() {
       return globalMetricsRegistration.metricsEnabled() && cacheConfiguration.statistics().enabled();
    }
 

--- a/core/src/main/java/org/infinispan/metrics/impl/InfinispanMetricRegistryFactory.java
+++ b/core/src/main/java/org/infinispan/metrics/impl/InfinispanMetricRegistryFactory.java
@@ -33,15 +33,15 @@ public final class InfinispanMetricRegistryFactory implements ComponentFactory, 
    @Override
    public Object construct(String componentName) {
       if (globalConfig.metrics().enabled()) {
+         // try cautiously
          try {
             // ensure microprofile config dependencies exist
             ConfigProvider.getConfig();
 
             // ensure microprofile metrics dependencies exist
-            MetricRegistries.get(MetricRegistry.Type.VENDOR);
+            MetricRegistry registry = MetricRegistries.get(MetricRegistry.Type.VENDOR);
 
-            // try, cautiously
-            return new InfinispanMetricRegistry();
+            return new InfinispanMetricRegistry(registry);
          } catch (Throwable e) {
             // missing dependency
             log.debug("Microprofile metrics are not available due to missing classpath dependencies.", e);

--- a/core/src/main/java/org/infinispan/metrics/impl/MetricsCollector.java
+++ b/core/src/main/java/org/infinispan/metrics/impl/MetricsCollector.java
@@ -30,16 +30,16 @@ import org.infinispan.util.logging.LogFactory;
 
 /**
  * Keeps a reference to the microprofile MetricRegistry. Optional component in component registry. Availability based on
- * available jars in classpath! See {@link InfinispanMetricRegistryFactory}.
+ * available jars in classpath! See {@link MetricsCollectorFactory}.
  *
  * @author anistor@redhat.com
  * @since 10.1.3
  */
 @Scope(Scopes.GLOBAL)
 @SurvivesRestarts
-public class InfinispanMetricRegistry {
+public class MetricsCollector {
 
-   private static final Log log = LogFactory.getLog(InfinispanMetricRegistry.class);
+   private static final Log log = LogFactory.getLog(MetricsCollector.class);
 
    public static final String NODE_TAG_NAME = "node";
 
@@ -50,7 +50,7 @@ public class InfinispanMetricRegistry {
    @Inject
    GlobalConfiguration globalConfig;
 
-   protected InfinispanMetricRegistry(MetricRegistry registry) {
+   protected MetricsCollector(MetricRegistry registry) {
       this.registry = registry;
    }
 

--- a/core/src/main/java/org/infinispan/metrics/impl/MetricsCollectorFactory.java
+++ b/core/src/main/java/org/infinispan/metrics/impl/MetricsCollectorFactory.java
@@ -15,12 +15,11 @@ import org.infinispan.util.logging.LogFactory;
 import io.smallrye.metrics.MetricRegistries;
 
 /**
- * Produces instances of {@link MetricsCollector}. MetricsCollector is optional, based on the presence of the
- * optional microprofile metrics API and the Smallrye implementation in classpath and the enabling of metrics in
- * config.
+ * Produces instances of {@link MetricsCollector}. MetricsCollector is optional, based on the presence of the optional
+ * microprofile metrics API and the Smallrye implementation in classpath and the enabling of metrics in config.
  *
  * @author anistor@redhat.com
- * @since 10.1.3
+ * @since 10.1
  */
 @DefaultFactoryFor(classes = MetricsCollector.class)
 @Scope(Scopes.GLOBAL)

--- a/core/src/main/java/org/infinispan/metrics/impl/MetricsCollectorFactory.java
+++ b/core/src/main/java/org/infinispan/metrics/impl/MetricsCollectorFactory.java
@@ -15,17 +15,18 @@ import org.infinispan.util.logging.LogFactory;
 import io.smallrye.metrics.MetricRegistries;
 
 /**
- * Produces instances of InfinispanMetricsRegistry. InfinispanMetricsRegistry is optional, based on the presence of
- * microprofile metrics API and the Smallrye implementation in classpath.
+ * Produces instances of {@link MetricsCollector}. MetricsCollector is optional, based on the presence of the
+ * optional microprofile metrics API and the Smallrye implementation in classpath and the enabling of metrics in
+ * config.
  *
  * @author anistor@redhat.com
  * @since 10.1.3
  */
-@DefaultFactoryFor(classes = InfinispanMetricRegistry.class)
+@DefaultFactoryFor(classes = MetricsCollector.class)
 @Scope(Scopes.GLOBAL)
-public final class InfinispanMetricRegistryFactory implements ComponentFactory, AutoInstantiableFactory {
+public final class MetricsCollectorFactory implements ComponentFactory, AutoInstantiableFactory {
 
-   private static final Log log = LogFactory.getLog(InfinispanMetricRegistryFactory.class);
+   private static final Log log = LogFactory.getLog(MetricsCollectorFactory.class);
 
    @Inject
    GlobalConfiguration globalConfig;
@@ -35,13 +36,13 @@ public final class InfinispanMetricRegistryFactory implements ComponentFactory, 
       if (globalConfig.metrics().enabled()) {
          // try cautiously
          try {
-            // ensure microprofile config dependencies exist
+            // ensure microprofile config dependencies exist and static initialization either succeeds or fails early
             ConfigProvider.getConfig();
 
             // ensure microprofile metrics dependencies exist
             MetricRegistry registry = MetricRegistries.get(MetricRegistry.Type.VENDOR);
 
-            return new InfinispanMetricRegistry(registry);
+            return new MetricsCollector(registry);
          } catch (Throwable e) {
             // missing dependency
             log.debug("Microprofile metrics are not available due to missing classpath dependencies.", e);

--- a/core/src/main/java/org/infinispan/metrics/impl/NameUtils.java
+++ b/core/src/main/java/org/infinispan/metrics/impl/NameUtils.java
@@ -15,7 +15,7 @@ final class NameUtils {
 
    /**
     * Transform a camel-cased name to snake-case, because microprofile metrics loves underscores. Eventual sequences of
-    * multiple underscores are replaced with a single underscore.
+    * multiple underscores are replaced with a single underscore. Illegal characters are also replaced with underscore.
     */
    public static String decamelize(String name) {
       StringBuilder sb = new StringBuilder(name);

--- a/core/src/main/java/org/infinispan/metrics/impl/package-info.java
+++ b/core/src/main/java/org/infinispan/metrics/impl/package-info.java
@@ -1,0 +1,9 @@
+/**
+ * Eclipse microprofile based metrics implementation. All exported metrics are placed in VENDOR scope. Implementation is
+ * based on smallrye-metrics. All org.eclipse.microprofile.metrics/config and io.smallrye.metrics references must be
+ * contained in MetricsCollector/MetricsCollectorFactory classes in way that allows the application to also be able to
+ * run without these dependencies.
+ *
+ * @private
+ */
+package org.infinispan.metrics.impl;

--- a/core/src/main/java/org/infinispan/metrics/package-info.java
+++ b/core/src/main/java/org/infinispan/metrics/package-info.java
@@ -1,6 +1,6 @@
 /**
- * Eclipse microprofile based metrics.
+ * Eclipse microprofile based metrics. All exported metrics are placed in VENDOR scope.
  *
- * @private
+ * @public
  */
 package org.infinispan.metrics;

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
@@ -540,7 +540,7 @@ public class JGroupsTransport implements Transport {
          // Normally this would be done by CacheManagerJmxRegistration but
          // the channel is not started when the cache manager starts but
          // when first cache starts, so it's safer to do it here.
-         if (configuration.jmx().enabled()) {
+         if (jmxRegistration.enabled()) {
             ObjectName namePrefix = new ObjectName(jmxRegistration.getDomain() + ":" + ObjectNameKeys.MANAGER + "=" + ObjectName.quote(configuration.cacheManagerName()));
             JmxConfigurator.registerChannel(channel, jmxRegistration.getMBeanServer(), namePrefix, clusterName, true);
          }
@@ -812,7 +812,7 @@ public class JGroupsTransport implements Transport {
 
    // This needs to stay as a separate method to allow for substitution for Substrate
    private void unregisterMBeansIfNeeded(String clusterName) throws Exception {
-      if (configuration.jmx().enabled() && channel != null) {
+      if (jmxRegistration.enabled() && channel != null) {
          ObjectName namePrefix = new ObjectName(jmxRegistration.getDomain() + ":" + ObjectNameKeys.MANAGER + "=" + ObjectName.quote(configuration.cacheManagerName()));
          JmxConfigurator.unregisterChannel(channel, jmxRegistration.getMBeanServer(), namePrefix, clusterName);
       }

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -1704,7 +1704,6 @@ public interface Log extends BasicLogger {
    @Message(value = "%s encountered unsupported content '%s' during transcoding", id = 497)
    EncodingException unsupportedContent(String transcoderName, Object content);
 
-
    @LogMessage(level = WARN)
    @Message(value = "Indexing mode ALL without owning all data locally (replicated mode).", id = 498)
    void allIndexingInNonReplicatedCache();

--- a/core/src/main/resources/features.xml
+++ b/core/src/main/resources/features.xml
@@ -11,9 +11,5 @@
       <bundle>mvn:org.jgroups/jgroups/${version.jgroups}</bundle>
       <bundle>mvn:io.reactivex.rxjava2/rxjava/${version.rxjava}</bundle>
       <bundle>mvn:org.reactivestreams/reactive-streams/${version.reactivestreams}</bundle>
-      <bundle>wrap:mvn:org.eclipse.microprofile.config/microprofile-config-api/${version.microprofile-config-api}</bundle>
-      <bundle>wrap:mvn:org.eclipse.microprofile.metrics/microprofile-metrics-api/${version.microprofile-metrics-api}</bundle>
-      <bundle>wrap:mvn:io.smallrye/smallrye-config/${version.smallrye-config}</bundle>
-      <bundle>wrap:mvn:io.smallrye/smallrye-metrics/${version.smallrye-metrics}</bundle>
    </feature>
 </features>

--- a/core/src/main/resources/schema/infinispan-config-10.1.xsd
+++ b/core/src/main/resources/schema/infinispan-config-10.1.xsd
@@ -645,6 +645,13 @@
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>
+    <xs:attribute name="namesAsTags" type="xs:boolean" default="${GlobalMetrics.namesAsTags}">
+      <xs:annotation>
+        <xs:documentation>
+          Put the cache manager and cache name in tags rather then include them in the metric name.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
   </xs:complexType>
 
   <xs:complexType name="jmx">

--- a/core/src/test/java/org/infinispan/metrics/ClusteredCacheManagerMetricsTest.java
+++ b/core/src/test/java/org/infinispan/metrics/ClusteredCacheManagerMetricsTest.java
@@ -1,0 +1,73 @@
+package org.infinispan.metrics;
+
+import static org.infinispan.test.fwk.TestCacheManagerFactory.createClusteredCacheManager;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertNotNull;
+
+import java.util.SortedMap;
+
+import org.eclipse.microprofile.metrics.Gauge;
+import org.eclipse.microprofile.metrics.MetricID;
+import org.eclipse.microprofile.metrics.Tag;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfiguration;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.metrics.impl.MetricsCollector;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.fwk.TransportFlags;
+import org.testng.annotations.Test;
+
+/**
+ * @author anistor@redhat.com
+ * @since 10.1
+ */
+@Test(groups = "functional", testName = "metrics.ClusteredCacheManagerMetricsTest")
+public class ClusteredCacheManagerMetricsTest extends MultipleCacheManagersTest {
+
+   private static final String CACHE_NAME = "MyCache";
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      GlobalConfigurationBuilder globalConfig1 = GlobalConfigurationBuilder.defaultClusteredBuilder();
+      globalConfig1.metrics().prefix("ispn").gauges(true).histograms(true).namesAsTags(true);
+
+      ConfigurationBuilder config = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC);
+      config.statistics().enable();
+
+      EmbeddedCacheManager cacheManager1 = createClusteredCacheManager(globalConfig1, config, new TransportFlags());
+      cacheManager1.start();
+
+      GlobalConfigurationBuilder globalConfig2 = GlobalConfigurationBuilder.defaultClusteredBuilder();
+      globalConfig2.metrics().prefix("ispn").gauges(true).histograms(true).namesAsTags(true);
+
+      EmbeddedCacheManager cacheManager2 = createClusteredCacheManager(globalConfig2, config, new TransportFlags());
+      cacheManager2.start();
+
+      registerCacheManager(cacheManager1, cacheManager2);
+
+      defineConfigurationOnAllManagers(CACHE_NAME, config);
+
+      manager(0).getCache(CACHE_NAME);
+      manager(1).getCache(CACHE_NAME);
+   }
+
+   public void testMetricsAreRegistered() {
+      MetricsCollector mc0 = manager(0).getGlobalComponentRegistry().getComponent(MetricsCollector.class);
+      SortedMap<MetricID, Gauge> gauges0 = mc0.getRegistry().getGauges((metricID, metric) -> metricID.getName().contains("ispn"));
+      assertFalse(gauges0.isEmpty());
+
+      MetricsCollector mc1 = manager(1).getGlobalComponentRegistry().getComponent(MetricsCollector.class);
+      SortedMap<MetricID, Gauge> gauges1 = mc1.getRegistry().getGauges((metricID, metric) -> metricID.getName().startsWith("ispn"));
+      assertFalse(gauges1.isEmpty());
+
+      GlobalConfiguration gcfg0 = manager(0).getCacheManagerConfiguration();
+      Tag nodeNameTag = new Tag(Constants.NODE_TAG_NAME, gcfg0.transport().nodeName());
+      Tag cacheManagerTag = new Tag(Constants.CACHE_MANAGER_TAG_NAME, gcfg0.cacheManagerName());
+      MetricID evictionsMetricId = new MetricID("ispn_cache_container_stats_evictions", nodeNameTag, cacheManagerTag);
+
+      Gauge<?> evictions = mc0.getRegistry().getGauges().get(evictionsMetricId);
+      assertNotNull(evictions);
+   }
+}

--- a/core/src/test/java/org/infinispan/test/fwk/MetricsCollectorTestHelper.java
+++ b/core/src/test/java/org/infinispan/test/fwk/MetricsCollectorTestHelper.java
@@ -4,7 +4,7 @@ import org.infinispan.commands.module.TestGlobalConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
-import org.infinispan.metrics.impl.InfinispanMetricRegistry;
+import org.infinispan.metrics.impl.MetricsCollector;
 
 import io.smallrye.metrics.MetricsRegistryImpl;
 
@@ -15,26 +15,26 @@ import io.smallrye.metrics.MetricsRegistryImpl;
  * @author anistor@redhat.com
  * @since 10.1
  */
-final class InfinispanMetricRegistryTestHelper {
+final class MetricsCollectorTestHelper {
 
    @Scope(Scopes.GLOBAL)
-   static class TestInfinispanMetricRegistry extends InfinispanMetricRegistry {
+   static class TestMetricsCollector extends MetricsCollector {
 
-      TestInfinispanMetricRegistry() {
+      TestMetricsCollector() {
          // executed once for each cache manager
          super(new MetricsRegistryImpl());
       }
    }
 
    /**
-    * Replaces InfinispanMetricRegistry component with one that uses a private MetricRegistry to allow isolation between
+    * Replaces the MetricsCollector component with one that uses a private MetricRegistry to allow isolation between
     * cache managers and avoid unintended metric collisions.
     */
    static void replace(GlobalConfigurationBuilder gcb) {
       if (gcb.metrics().enabled()) {
          try {
             gcb.addModule(TestGlobalConfigurationBuilder.class)
-               .testGlobalComponent(InfinispanMetricRegistry.class.getName(), new TestInfinispanMetricRegistry());
+               .testGlobalComponent(MetricsCollector.class.getName(), new TestMetricsCollector());
          } catch (LinkageError ignored) {
             // missing metrics related dependency
          }

--- a/core/src/test/java/org/infinispan/test/fwk/TestCacheManagerFactory.java
+++ b/core/src/test/java/org/infinispan/test/fwk/TestCacheManagerFactory.java
@@ -71,7 +71,7 @@ public class TestCacheManagerFactory {
          amendDefaultCache(gcb);
       }
       setNodeName(gcb);
-      InfinispanMetricRegistryTestHelper.replace(gcb);
+      MetricsCollectorTestHelper.replace(gcb);
       GlobalConfiguration globalConfiguration = gcb.build();
       checkJmx(globalConfiguration);
       DefaultCacheManager defaultCacheManager = new DefaultCacheManager(globalConfiguration, c == null ? null : c.build(globalConfiguration), start);
@@ -83,7 +83,7 @@ public class TestCacheManagerFactory {
       GlobalConfigurationBuilder gcb = holder.getGlobalConfigurationBuilder();
       amendDefaultCache(gcb);
       setNodeName(gcb);
-      InfinispanMetricRegistryTestHelper.replace(gcb);
+      MetricsCollectorTestHelper.replace(gcb);
       checkJmx(gcb.build());
       DefaultCacheManager defaultCacheManager = new DefaultCacheManager(holder, start);
       TestResourceTracker.addResource(new CacheManagerCleaner(defaultCacheManager));

--- a/query/src/main/java/org/infinispan/query/impl/LifecycleManager.java
+++ b/query/src/main/java/org/infinispan/query/impl/LifecycleManager.java
@@ -49,6 +49,7 @@ import org.infinispan.jmx.CacheJmxRegistration;
 import org.infinispan.lifecycle.ModuleLifecycle;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.marshall.protostream.impl.SerializationContextRegistry;
+import org.infinispan.metrics.impl.CacheMetricsRegistration;
 import org.infinispan.objectfilter.impl.syntax.parser.ReflectionEntityNamesResolver;
 import org.infinispan.query.MassIndexer;
 import org.infinispan.query.Transformer;
@@ -217,7 +218,7 @@ public class LifecycleManager implements ModuleLifecycle {
          MutableSearchFactory mutableSearchFactory = searchFactory.unwrap(MutableSearchFactory.class);
          mutableSearchFactory.getFilterDefinitions().remove(SEGMENT_FILTER_NAME);
          Class<?>[] indexedEntities = indexingConfiguration.indexedEntities().toArray(new Class<?>[0]);
-         for(Class<?> clazz : indexedEntities) {
+         for (Class<?> clazz : indexedEntities) {
             mutableSearchFactory.getProgrammaticMapping().entity(clazz).classBridge(SegmentFieldBridge.class);
          }
          searchFactory.addClasses(indexedEntities);
@@ -225,7 +226,22 @@ public class LifecycleManager implements ModuleLifecycle {
 
       checkIndexableClasses(searchFactory, indexingConfiguration.indexedEntities());
 
-      registerQueryMBeans(cr, configuration, searchFactory);
+      AdvancedCache<?, ?> cache = cr.getComponent(Cache.class).getAdvancedCache();
+      MassIndexer massIndexer = ComponentRegistryUtils.getMassIndexer(cache);
+      InfinispanQueryStatisticsInfo stats = new InfinispanQueryStatisticsInfo(searchFactory, massIndexer);
+      stats.setStatisticsEnabled(configuration.statistics().enabled());
+      cr.registerComponent(stats, InfinispanQueryStatisticsInfo.class);
+
+      registerQueryMBeans(cr, massIndexer, stats);
+
+      registerMetrics(cr, stats);
+   }
+
+   private void registerMetrics(ComponentRegistry cr, InfinispanQueryStatisticsInfo stats) {
+      CacheMetricsRegistration cacheMetricsRegistration = cr.getComponent(CacheMetricsRegistration.class);
+      if (cacheMetricsRegistration.metricsEnabled()) {
+         cacheMetricsRegistration.registerMetrics(stats, "query", "statistics");
+      }
    }
 
    /**
@@ -243,15 +259,10 @@ public class LifecycleManager implements ModuleLifecycle {
    /**
     * Register query statistics and mass-indexer MBeans for a cache.
     */
-   private void registerQueryMBeans(ComponentRegistry cr, Configuration cfg, SearchIntegrator searchIntegrator) {
-      AdvancedCache<?, ?> cache = cr.getComponent(Cache.class).getAdvancedCache();
-      MassIndexer massIndexer = ComponentRegistryUtils.getMassIndexer(cache);
-      InfinispanQueryStatisticsInfo stats = new InfinispanQueryStatisticsInfo(searchIntegrator, massIndexer);
-      stats.setStatisticsEnabled(cfg.statistics().enabled());
-      cr.registerComponent(stats, InfinispanQueryStatisticsInfo.class);
-
+   private void registerQueryMBeans(ComponentRegistry cr, MassIndexer massIndexer, InfinispanQueryStatisticsInfo stats) {
       GlobalConfiguration globalConfig = cr.getGlobalComponentRegistry().getGlobalConfiguration();
       if (globalConfig.jmx().enabled()) {
+         Cache<?, ?> cache = cr.getComponent(Cache.class);
          String queryGroupName = getQueryGroupName(globalConfig.cacheManagerName(), cache.getName());
          CacheJmxRegistration jmxRegistration = cr.getComponent(CacheJmxRegistration.class);
          try {

--- a/server/core/pom.xml
+++ b/server/core/pom.xml
@@ -76,6 +76,22 @@
          <optional>true</optional>
       </dependency>
       <dependency>
+         <groupId>org.eclipse.microprofile.config</groupId>
+         <artifactId>microprofile-config-api</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>io.smallrye</groupId>
+         <artifactId>smallrye-config</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>org.eclipse.microprofile.metrics</groupId>
+         <artifactId>microprofile-metrics-api</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>io.smallrye</groupId>
+         <artifactId>smallrye-metrics</artifactId>
+      </dependency>
+      <dependency>
          <groupId>org.kohsuke.metainf-services</groupId>
          <artifactId>metainf-services</artifactId>
       </dependency>

--- a/server/core/src/main/java/org/infinispan/server/core/CacheIgnoreManagerFactory.java
+++ b/server/core/src/main/java/org/infinispan/server/core/CacheIgnoreManagerFactory.java
@@ -1,0 +1,21 @@
+package org.infinispan.server.core;
+
+import org.infinispan.factories.AutoInstantiableFactory;
+import org.infinispan.factories.ComponentFactory;
+import org.infinispan.factories.annotations.DefaultFactoryFor;
+import org.infinispan.factories.scopes.Scope;
+import org.infinispan.factories.scopes.Scopes;
+
+/**
+ * @author anistor@redhat.com
+ * @since 10.1.4
+ */
+@DefaultFactoryFor(classes = CacheIgnoreManager.class)
+@Scope(Scopes.GLOBAL)
+public class CacheIgnoreManagerFactory implements ComponentFactory, AutoInstantiableFactory {
+
+   @Override
+   public Object construct(String componentName) {
+      return new CacheIgnoreManager();
+   }
+}

--- a/server/core/src/main/java/org/infinispan/server/core/ProtocolServer.java
+++ b/server/core/src/main/java/org/infinispan/server/core/ProtocolServer.java
@@ -18,17 +18,13 @@ import io.netty.channel.ChannelOutboundHandler;
 public interface ProtocolServer<C extends ProtocolServerConfiguration> {
 
    /**
-    * Starts the server backed by the given cache manager and with the corresponding configuration.
+    * Starts the server backed by the given cache manager, with the corresponding configuration. The cache manager is
+    * expected to be completely initialized and started prior to this call.
     */
    void start(C configuration, EmbeddedCacheManager cacheManager);
 
    /**
-    * Starts the server backed by the given cache manager, with the corresponding configuration and the handler for the ignored caches state
-    */
-   void start(C configuration, EmbeddedCacheManager cacheManager, CacheIgnoreManager cacheIgnore);
-
-   /**
-    *  Stops the server
+    * Stops the server.
     */
    void stop();
 

--- a/server/core/src/main/java/org/infinispan/server/core/transport/NettyTransportConnectionStats.java
+++ b/server/core/src/main/java/org/infinispan/server/core/transport/NettyTransportConnectionStats.java
@@ -95,22 +95,26 @@ class NettyTransportConnectionStats {
       public Integer apply(EmbeddedCacheManager embeddedCacheManager) {
          CacheManagerJmxRegistration jmxRegistration = SecurityActions.getGlobalComponentRegistry(embeddedCacheManager)
                .getComponent(CacheManagerJmxRegistration.class);
-         try {
-            ObjectName transportNamePattern = new ObjectName(jmxRegistration.getDomain() + ":type=Server,component=Transport,name=*");
-            Set<ObjectName> objectNames = jmxRegistration.getMBeanServer().queryNames(transportNamePattern, null);
+         if (jmxRegistration.enabled()) {
+            try {
+               ObjectName transportNamePattern = new ObjectName(jmxRegistration.getDomain() + ":type=Server,component=Transport,name=*");
+               Set<ObjectName> objectNames = jmxRegistration.getMBeanServer().queryNames(transportNamePattern, null);
 
-            // sum the NumberOfLocalConnections from all transport MBeans that match the pattern
-            int total = 0;
-            for (ObjectName name : objectNames) {
-               if (name.getKeyProperty("name").startsWith(serverName)) {
-                  Integer connections = (Integer) jmxRegistration.getMBeanServer().getAttribute(name, "NumberOfLocalConnections");
-                  total += connections;
+               // sum the NumberOfLocalConnections from all transport MBeans that match the pattern
+               int total = 0;
+               for (ObjectName name : objectNames) {
+                  if (name.getKeyProperty("name").startsWith(serverName)) {
+                     Integer connections = (Integer) jmxRegistration.getMBeanServer().getAttribute(name, "NumberOfLocalConnections");
+                     total += connections;
+                  }
                }
+               return total;
+            } catch (JMException e) {
+               throw new RuntimeException(e);
             }
-            return total;
-         } catch (JMException e) {
-            throw new RuntimeException(e);
          }
+
+         return 0; // jmx not enabled. computer says no.
       }
 
       public static class Externalizer implements org.infinispan.commons.marshall.Externalizer<ConnectionAdderTask> {

--- a/server/core/src/test/java/org/infinispan/server/core/AbstractProtocolServerTest.java
+++ b/server/core/src/test/java/org/infinispan/server/core/AbstractProtocolServerTest.java
@@ -1,6 +1,7 @@
 package org.infinispan.server.core;
 
 import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.server.core.configuration.MockServerConfiguration;
 import org.infinispan.server.core.configuration.MockServerConfigurationBuilder;
 import org.infinispan.server.core.configuration.ProtocolServerConfiguration;
 import org.infinispan.test.AbstractInfinispanTest;
@@ -49,10 +50,10 @@ public class AbstractProtocolServerTest extends AbstractInfinispanTest {
    public void testStartingWithoutTransport() {
       MockServerConfigurationBuilder b = new MockServerConfigurationBuilder();
       b.startTransport(false);
-      AbstractProtocolServer server = new MockProtocolServer();
+      AbstractProtocolServer<MockServerConfiguration> server = new MockProtocolServer();
       EmbeddedCacheManager manager = TestCacheManagerFactory.createCacheManager();
       try {
-         server.start(b.build(), manager, null);
+         server.start(b.build(), manager);
          Assert.assertFalse(server.isTransportEnabled());
       } finally {
          server.stop();

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/HotRodServer.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/HotRodServer.java
@@ -214,10 +214,7 @@ public class HotRodServer extends AbstractProtocolServer<HotRodServerConfigurati
    }
 
    @Override
-   protected void startInternal(HotRodServerConfiguration configuration, EmbeddedCacheManager cacheManager) {
-      // These are also initialized by super.startInternal, but we need them before
-      this.configuration = configuration;
-      this.cacheManager = cacheManager;
+   protected void startInternal() {
       GlobalComponentRegistry gcr = SecurityActions.getGlobalComponentRegistry(cacheManager);
       this.iterationManager = new DefaultIterationManager(gcr.getTimeService());
       this.hasDefaultCache = configuration.defaultCacheName() != null || cacheManager.getCacheManagerConfiguration().defaultCacheName().isPresent();
@@ -248,7 +245,7 @@ public class HotRodServer extends AbstractProtocolServer<HotRodServerConfigurati
       // Start default cache and the endpoint before adding self to
       // topology in order to avoid topology updates being used before
       // endpoint is available.
-      super.startInternal(configuration, cacheManager);
+      super.startInternal();
 
       // Add self to topology cache last, after everything is initialized
       if (Configurations.isClustered(SecurityActions.getCacheManagerConfiguration(cacheManager))) {

--- a/server/memcached/src/main/java/org/infinispan/server/memcached/MemcachedServer.java
+++ b/server/memcached/src/main/java/org/infinispan/server/memcached/MemcachedServer.java
@@ -1,6 +1,5 @@
 package org.infinispan.server.memcached;
 
-import java.lang.invoke.MethodHandles;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -11,7 +10,6 @@ import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.ExpirationConfiguration;
-import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.server.core.AbstractProtocolServer;
 import org.infinispan.server.core.transport.NettyChannelInitializer;
 import org.infinispan.server.core.transport.NettyInitializers;
@@ -33,16 +31,19 @@ import io.netty.channel.ChannelOutboundHandler;
  */
 @Deprecated
 public class MemcachedServer extends AbstractProtocolServer<MemcachedServerConfiguration> {
+
+   private final static Log log = LogFactory.getLog(MemcachedServer.class, Log.class);
+
+   protected final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+
+   private AdvancedCache<byte[], byte[]> memcachedCache;
+
    public MemcachedServer() {
       super("Memcached");
    }
 
-   private final static Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass(), Log.class);
-   protected ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
-   private AdvancedCache<byte[], byte[]> memcachedCache;
-
    @Override
-   protected void startInternal(MemcachedServerConfiguration configuration, EmbeddedCacheManager cacheManager) {
+   protected void startInternal() {
       if (cacheManager.getCacheConfiguration(configuration.defaultCacheName()) == null) {
          ConfigurationBuilder builder = new ConfigurationBuilder();
          Configuration defaultCacheConfiguration = cacheManager.getDefaultCacheConfiguration();
@@ -59,7 +60,7 @@ public class MemcachedServer extends AbstractProtocolServer<MemcachedServerConfi
       Cache<byte[], byte[]> cache = cacheManager.getCache(configuration.defaultCacheName());
       memcachedCache = cache.getAdvancedCache();
 
-      super.startInternal(configuration, cacheManager);
+      super.startInternal();
    }
 
    @Override

--- a/server/memcached/src/test/java/org/infinispan/server/memcached/MemcachedSingleNodeTest.java
+++ b/server/memcached/src/test/java/org/infinispan/server/memcached/MemcachedSingleNodeTest.java
@@ -43,7 +43,7 @@ abstract class MemcachedSingleNodeTest extends SingleCacheManagerTest {
    }
 
    protected EmbeddedCacheManager createTestCacheManager() {
-      return TestCacheManagerFactory.createCacheManager(false);
+      return TestCacheManagerFactory.createCacheManager(true);
    }
 
    @AfterClass(alwaysRun = true)

--- a/server/memcached/src/test/java/org/infinispan/server/memcached/test/MemcachedTestingUtil.java
+++ b/server/memcached/src/test/java/org/infinispan/server/memcached/test/MemcachedTestingUtil.java
@@ -97,16 +97,15 @@ public class MemcachedTestingUtil {
       if (server != null) server.stop();
    }
 
-}
+   private static final class UniquePortThreadLocal extends ThreadLocal<Integer> {
 
-class UniquePortThreadLocal extends ThreadLocal<Integer> {
-   private UniquePortThreadLocal() { }
+      static UniquePortThreadLocal INSTANCE = new UniquePortThreadLocal();
 
-   static UniquePortThreadLocal INSTANCE = new UniquePortThreadLocal();
+      private static final AtomicInteger uniqueAddr = new AtomicInteger(16211);
 
-   private static final AtomicInteger uniqueAddr = new AtomicInteger(16211);
-   @Override
-   protected Integer initialValue() {
-      return uniqueAddr.getAndAdd(100);
+      @Override
+      protected Integer initialValue() {
+         return uniqueAddr.getAndAdd(100);
+      }
    }
 }

--- a/server/rest/src/main/java/org/infinispan/rest/RestServer.java
+++ b/server/rest/src/main/java/org/infinispan/rest/RestServer.java
@@ -5,7 +5,6 @@ import java.nio.file.Path;
 
 import org.infinispan.counter.EmbeddedCounterManagerFactory;
 import org.infinispan.counter.impl.manager.EmbeddedCounterManager;
-import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.rest.cachemanager.RestCacheManager;
 import org.infinispan.rest.configuration.AuthenticationConfiguration;
 import org.infinispan.rest.configuration.RestServerConfiguration;
@@ -98,13 +97,12 @@ public class RestServer extends AbstractProtocolServer<RestServerConfiguration> 
    }
 
    @Override
-   protected void startInternal(RestServerConfiguration configuration, EmbeddedCacheManager cacheManager) {
-      this.configuration = configuration;
+   protected void startInternal() {
       AuthenticationConfiguration auth = configuration.authentication();
       if (auth.enabled()) {
          auth.authenticator().init(this);
       }
-      super.startInternal(configuration, cacheManager);
+      super.startInternal();
       restCacheManager = new RestCacheManager<>(cacheManager, this::isCacheIgnored);
 
       invocationHelper = new InvocationHelper(restCacheManager,

--- a/server/router/src/test/java/org/infinispan/server/router/utils/RestTestingUtil.java
+++ b/server/router/src/test/java/org/infinispan/server/router/utils/RestTestingUtil.java
@@ -1,11 +1,11 @@
 package org.infinispan.server.router.utils;
 
-import org.infinispan.rest.client.NettyHttpClient;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.rest.RestServer;
+import org.infinispan.rest.client.NettyHttpClient;
 import org.infinispan.rest.configuration.RestServerConfigurationBuilder;
 import org.infinispan.server.router.Router;
 

--- a/server/runtime/src/main/java/org/infinispan/server/SecurityActions.java
+++ b/server/runtime/src/main/java/org/infinispan/server/SecurityActions.java
@@ -11,7 +11,6 @@ import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.security.Security;
 import org.infinispan.security.actions.GetCacheManagerConfigurationAction;
 import org.infinispan.security.actions.GetGlobalComponentRegistryAction;
-import org.infinispan.server.core.CacheIgnoreManager;
 import org.infinispan.server.core.ProtocolServer;
 import org.infinispan.server.core.configuration.ProtocolServerConfiguration;
 
@@ -34,7 +33,7 @@ final class SecurityActions {
    }
 
    static Properties getSystemProperties() {
-      return doPrivileged(() -> System.getProperties());
+      return doPrivileged(System::getProperties);
    }
 
    static void addSecurityProvider(Provider provider) {
@@ -67,12 +66,11 @@ final class SecurityActions {
       return doPrivileged(action);
    }
 
-   static void startProtocolServer(final ProtocolServer server, final ProtocolServerConfiguration configuration, final EmbeddedCacheManager cacheManager, final CacheIgnoreManager cacheIgnoreManager) {
-      PrivilegedAction<Void> action = () -> {
-         server.start(configuration, cacheManager, cacheIgnoreManager);
+   static void startProtocolServer(ProtocolServer<ProtocolServerConfiguration> server, ProtocolServerConfiguration configuration, EmbeddedCacheManager cacheManager) {
+      doPrivileged(() -> {
+         server.start(configuration, cacheManager);
          return null;
-      };
-      doPrivileged(action);
+      });
    }
 
    static GlobalConfiguration getCacheManagerConfiguration(EmbeddedCacheManager manager) {

--- a/server/runtime/src/main/java/org/infinispan/server/Server.java
+++ b/server/runtime/src/main/java/org/infinispan/server/Server.java
@@ -33,6 +33,7 @@ import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.parsing.ConfigurationBuilderHolder;
 import org.infinispan.configuration.parsing.ParserRegistry;
+import org.infinispan.factories.impl.BasicComponentRegistry;
 import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.manager.ClusterExecutor;
 import org.infinispan.manager.DefaultCacheManager;
@@ -281,10 +282,12 @@ public class Server implements ServerManagement, AutoCloseable {
          DefaultCacheManager cm = new DefaultCacheManager(configurationBuilderHolder, false);
          cacheManagers.put(cm.getName(), cm);
          SecurityActions.startCacheManager(cm);
-         cacheIgnoreManager = new CacheIgnoreManager(cm);
+
+         BasicComponentRegistry bcr = SecurityActions.getGlobalComponentRegistry(cm).getComponent(BasicComponentRegistry.class.getName());
+         cacheIgnoreManager = bcr.getComponent(CacheIgnoreManager.class).running();
 
          // Register the task manager
-         TaskManager taskManager = SecurityActions.getGlobalComponentRegistry(cm).getComponent(TaskManager.class);
+         TaskManager taskManager = bcr.getComponent(TaskManager.class).running();
          taskManager.registerTaskEngine(extensions.getServerTaskEngine(cm));
 
          // Start the protocol servers
@@ -300,7 +303,7 @@ public class Server implements ServerManagement, AutoCloseable {
                ProtocolServer protocolServer = Util.getInstance(protocolServerClass);
                if (protocolServer instanceof RestServer) ((RestServer) protocolServer).setServer(this);
                protocolServers.put(protocolServer.getName() + "-" + configuration.name(), protocolServer);
-               SecurityActions.startProtocolServer(protocolServer, configuration, cm, cacheIgnoreManager);
+               SecurityActions.startProtocolServer(protocolServer, configuration, cm);
                ProtocolServerConfiguration protocolConfig = protocolServer.getConfiguration();
                if (protocolConfig.startTransport()) {
                   log.protocolStarted(protocolServer.getName(), protocolConfig.host(), protocolConfig.port());
@@ -411,7 +414,6 @@ public class Server implements ServerManagement, AutoCloseable {
          scheduler.shutdown();
       }
    }
-
 
    private void serverStopHandler(ExitStatus exitStatus) {
       scheduler = Executors.newSingleThreadScheduledExecutor();

--- a/server/tests/src/test/java/org/infinispan/server/functional/IgnoreCaches.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/IgnoreCaches.java
@@ -36,7 +36,7 @@ public class IgnoreCaches {
    private static final String CACHE_MANAGER = "default";
 
    @Test
-   public void testIgnoreCaches() throws Exception {
+   public void testIgnoreCaches() {
       RestClientConfigurationBuilder builder = new RestClientConfigurationBuilder();
       RestClient client = SERVER_TEST.rest().withClientConfiguration(builder).create();
       String testCache = SERVER_TEST.getMethodName();
@@ -82,7 +82,7 @@ public class IgnoreCaches {
       assertStatus(204, client.server().ignoreCache(CACHE_MANAGER, cacheName));
    }
 
-   private Set<String> getIgnoredCaches(RestClient client, String cacheManagerName) throws Exception {
+   private Set<String> getIgnoredCaches(RestClient client, String cacheManagerName) {
       JsonNode body = RestResponses.jsonResponseBody(client.server().listIgnoredCaches(cacheManagerName));
       Set<String> res = new HashSet<>();
       body.elements().forEachRemaining(n -> res.add(n.asText()));


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-11390
https://issues.redhat.com/browse/ISPN-11388
https://issues.redhat.com/browse/ISPN-11389
https://issues.redhat.com/browse/ISPN-11403
https://issues.redhat.com/browse/ISPN-11429
https://issues.redhat.com/browse/ISPN-11438

Some places need manual attention because automatic registration of metrics does not work there. See the 2 mbeans in AbstractProtocolServer