### PR TITLE
[10.1.x] ISPN-11367 getCache(name) should never use the default cache's configuration

### DIFF
--- a/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/DefaultTestEmbeddedCacheManagerProducer.java
+++ b/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/DefaultTestEmbeddedCacheManagerProducer.java
@@ -1,5 +1,7 @@
 package org.infinispan.cdi.embedded.test;
 
+import static org.infinispan.test.fwk.TestCacheManagerFactory.createClusteredCacheManager;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Disposes;
 import javax.enterprise.inject.Produces;
@@ -9,7 +11,6 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.TestingUtil;
-import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.commons.test.TestResourceTracker;
 
 /**
@@ -35,7 +36,11 @@ public class DefaultTestEmbeddedCacheManagerProducer {
       ConfigurationBuilder builder = new ConfigurationBuilder();
       GlobalConfigurationBuilder globalConfigurationBuilder = new GlobalConfigurationBuilder();
       builder.read(defaultConfiguration);
-      return TestCacheManagerFactory.createClusteredCacheManager(globalConfigurationBuilder, builder);
+      EmbeddedCacheManager manager = createClusteredCacheManager(globalConfigurationBuilder, builder);
+      // Defie a wildcard configuration for the CDI integration tests
+      manager.defineConfiguration("org.infinispan.integrationtests.cdijcache.interceptor.service.Cache*Service*",
+                                  new ConfigurationBuilder().template(true).build());
+      return manager;
    }
 
    /**

--- a/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cache/DefaultCacheTest.java
+++ b/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cache/DefaultCacheTest.java
@@ -8,7 +8,7 @@ import javax.inject.Inject;
 import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
 import org.infinispan.cdi.embedded.test.DefaultTestEmbeddedCacheManagerProducer;
-import org.infinispan.commons.test.TestResourceTracker;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
@@ -42,7 +42,7 @@ public class DefaultCacheTest extends Arquillian {
       cache.put("manik", "Sri Lankan");
       assertEquals(cache.get("pete"), "British");
       assertEquals(cache.get("manik"), "Sri Lankan");
-      assertEquals(cache.getName(), TestResourceTracker.getCurrentTestShortName());
+      assertEquals(cache.getName(), TestCacheManagerFactory.DEFAULT_CACHE_NAME);
       /*
        * Check that the advanced cache contains the same data as the simple
        * cache. As we can inject either Cache or AdvancedCache, this is double
@@ -51,6 +51,6 @@ public class DefaultCacheTest extends Arquillian {
        */
       assertEquals(advancedCache.get("pete"), "British");
       assertEquals(advancedCache.get("manik"), "Sri Lankan");
-      assertEquals(advancedCache.getName(), TestResourceTracker.getCurrentTestShortName());
+      assertEquals(advancedCache.getName(), TestCacheManagerFactory.DEFAULT_CACHE_NAME);
    }
 }

--- a/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cachemanager/DefaultConfigurationTest.java
+++ b/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cachemanager/DefaultConfigurationTest.java
@@ -11,7 +11,7 @@ import org.infinispan.Cache;
 import org.infinispan.cdi.embedded.test.DefaultTestEmbeddedCacheManagerProducer;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
-import org.infinispan.commons.test.TestResourceTracker;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
@@ -37,7 +37,7 @@ public class DefaultConfigurationTest extends Arquillian {
 
    public void testDefaultConfiguration() {
       assertEquals(cache.getCacheConfiguration().memory().size(), 16);
-      assertEquals(cache.getName(), TestResourceTracker.getCurrentTestShortName());
+      assertEquals(cache.getName(), TestCacheManagerFactory.DEFAULT_CACHE_NAME);
    }
 
    /**

--- a/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cachemanager/registration/CacheRegistrationTest.java
+++ b/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cachemanager/registration/CacheRegistrationTest.java
@@ -11,9 +11,9 @@ import javax.inject.Inject;
 import org.infinispan.Cache;
 import org.infinispan.cdi.embedded.test.DefaultTestEmbeddedCacheManagerProducer;
 import org.infinispan.cdi.embedded.test.testutil.Deployments;
-import org.infinispan.manager.EmbeddedCacheManager;
-import org.infinispan.commons.test.TestResourceTracker;
 import org.infinispan.commons.test.TestResourceTrackingListener;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
@@ -50,10 +50,10 @@ public class CacheRegistrationTest extends Arquillian {
        // Make sure the cache is registered
       cache.put("foo", "bar");
 
-      final Set<String> cacheNames = defaultCacheManager.getCacheConfigurationNames();
+      final Set<String> cacheNames = defaultCacheManager.getCacheNames();
 
       assertEquals(cacheNames.size(), 3);
-      assertTrue(cacheNames.containsAll(Arrays.asList("small", "large", TestResourceTracker.getCurrentTestShortName())));
+      assertTrue(cacheNames.containsAll(Arrays.asList("small", "large", TestCacheManagerFactory.DEFAULT_CACHE_NAME)));
    }
 
    public void testCacheRegistrationInSpecificCacheManager() {
@@ -61,7 +61,7 @@ public class CacheRegistrationTest extends Arquillian {
       cache.put("foo", "bar");
       final Set<String> cacheNames = specificCacheManager.getCacheConfigurationNames();
 
-      assertEquals(cacheNames.size(), 2);
-      assertTrue(cacheNames.containsAll(Arrays.asList("very-large", TestResourceTracker.getCurrentTestShortName())));
+      assertEquals(cacheNames.size(), 1);
+      assertTrue(cacheNames.containsAll(Arrays.asList("very-large")));
    }
 }

--- a/core/src/main/java/org/infinispan/configuration/ConfigurationManager.java
+++ b/core/src/main/java/org/infinispan/configuration/ConfigurationManager.java
@@ -53,12 +53,10 @@ public class ConfigurationManager {
          return namedConfiguration.get(cacheName);
    }
 
-   public Configuration getConfiguration(String cacheName, String defaultCacheName) {
+   public Configuration getConfiguration(String cacheName) {
       Configuration configuration = findConfiguration(cacheName);
-      if (configuration != null)
+      if (configuration != null) {
          return configuration;
-      if (defaultCacheName != null) {
-         return namedConfiguration.get(defaultCacheName);
       } else {
          throw CONFIG.noSuchCacheConfiguration(cacheName);
       }

--- a/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
@@ -640,7 +640,7 @@ public class DefaultCacheManager implements EmbeddedCacheManager {
     */
    private <K, V> Cache<K, V> wireAndStartCache(String cacheName, String configurationName) {
       boolean sameCache = cacheName.equals(configurationName);
-      Configuration c = configurationManager.getConfiguration(configurationName, defaultCacheName);
+      Configuration c = configurationManager.getConfiguration(configurationName);
       if (c == null) {
          throw CONFIG.noSuchCacheConfiguration(configurationName);
       } else if (!sameCache) {

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
@@ -821,7 +821,7 @@ public class JGroupsTransport implements Transport {
    @Override
    public int getViewId() {
       if (channel == null)
-         throw new CacheException("The cache has been stopped and invocations are not allowed!");
+         throw new IllegalLifecycleStateException("The cache has been stopped and invocations are not allowed!");
       return clusterView.getViewId();
    }
 

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -1503,7 +1503,7 @@ public interface Log extends BasicLogger {
    @Message(value = "Cache manager initialized with a default cache configuration but without a name for it. Set it in the GlobalConfiguration.", id = 435)
    CacheConfigurationException defaultCacheConfigurationWithoutName();
 
-   @Message(value = "Cache '%s' has been requested, but no cache configuration exists with that name and no default cache has been set for this container", id = 436)
+   @Message(value = "Cache '%s' has been requested, but no matching cache configuration exists", id = 436)
    CacheConfigurationException noSuchCacheConfiguration(String name);
 
    @LogMessage(level = WARN)

--- a/core/src/test/java/org/infinispan/api/StartCacheFromListenerTest.java
+++ b/core/src/test/java/org/infinispan/api/StartCacheFromListenerTest.java
@@ -4,7 +4,6 @@ import static org.testng.AssertJUnit.assertEquals;
 
 import java.util.LinkedList;
 import java.util.List;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -34,6 +33,7 @@ public class StartCacheFromListenerTest extends MultipleCacheManagersTest {
       addClusterEnabledCacheManager();
       ConfigurationBuilder dcc = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, true);
       manager(0).defineConfiguration("some", dcc.build());
+      manager(0).defineConfiguration("single", dcc.build());
       manager(0).defineConfiguration("cacheStarting", dcc.build());
       manager(0).defineConfiguration("cacheStarted", dcc.build());
    }
@@ -42,8 +42,8 @@ public class StartCacheFromListenerTest extends MultipleCacheManagersTest {
 
    public void testSingleInvocation() {
       final EmbeddedCacheManager cacheManager = manager(0);
-      GlobalComponentRegistry registry = (GlobalComponentRegistry) TestingUtil.extractField(cacheManager, "globalComponentRegistry");
-      List<ModuleLifecycle> lifecycles = new LinkedList<ModuleLifecycle>();
+      GlobalComponentRegistry registry = TestingUtil.extractGlobalComponentRegistry(cacheManager);
+      List<ModuleLifecycle> lifecycles = new LinkedList<>();
       TestingUtil.replaceField(lifecycles, "moduleLifecycles", registry, GlobalComponentRegistry.class);
       lifecycles.add(new ModuleLifecycle() {
          @Override
@@ -51,15 +51,12 @@ public class StartCacheFromListenerTest extends MultipleCacheManagersTest {
             log.debug("StartCacheFromListenerTest.cacheStarting");
             if (!cacheStartingInvoked.get()) {
                cacheStartingInvoked.set(true);
-               Future<Cache> fork = fork(new Callable<Cache>() {
-                  @Override
-                  public Cache call() throws Exception {
-                     try {
-                        return cacheManager.getCache("cacheStarting");
-                     } catch (Exception e) {
-                        log.error("Got", e);
-                        throw e;
-                     }
+               Future<Cache> fork = fork(() -> {
+                  try {
+                     return cacheManager.getCache("cacheStarting");
+                  } catch (Exception e) {
+                     log.error("Got", e);
+                     throw e;
                   }
                });
                try {
@@ -86,7 +83,7 @@ public class StartCacheFromListenerTest extends MultipleCacheManagersTest {
 
    public void testStartSameCache() {
       final EmbeddedCacheManager cacheManager = manager(0);
-      GlobalComponentRegistry registry = (GlobalComponentRegistry) TestingUtil.extractField(cacheManager, "globalComponentRegistry");
+      GlobalComponentRegistry registry = TestingUtil.extractGlobalComponentRegistry(cacheManager);
       List<ModuleLifecycle> lifecycles = new LinkedList<>();
       TestingUtil.replaceField(lifecycles, "moduleLifecycles", registry, GlobalComponentRegistry.class);
       lifecycles.add(new ModuleLifecycle() {

--- a/core/src/test/java/org/infinispan/api/flags/NonTxFlagsEnabledTest.java
+++ b/core/src/test/java/org/infinispan/api/flags/NonTxFlagsEnabledTest.java
@@ -8,6 +8,7 @@ import org.infinispan.AdvancedCache;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.distribution.MagicKey;
+import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.persistence.UnnecessaryLoadingTest;
 import org.infinispan.persistence.dummy.DummyInMemoryStoreConfigurationBuilder;
 import org.infinispan.test.TestDataSCI;
@@ -39,7 +40,8 @@ public class NonTxFlagsEnabledTest extends FlagsEnabledTest {
    }
 
    public void testCacheLocalInNonOwner() {
-      addClusterEnabledCacheManager(TestDataSCI.INSTANCE, getConfigurationBuilder());
+      EmbeddedCacheManager cm = addClusterEnabledCacheManager(TestDataSCI.INSTANCE);
+      cm.createCache(cacheName, getConfigurationBuilder().build());
       waitForClusterToForm(cacheName);
       final AdvancedCache<Object, String> cache1 = advancedCache(0, cacheName);
       final AdvancedCache<Object, String> cache2 = advancedCache(1, cacheName);

--- a/core/src/test/java/org/infinispan/commands/StressTest.java
+++ b/core/src/test/java/org/infinispan/commands/StressTest.java
@@ -10,9 +10,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.infinispan.Cache;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.commons.test.TestResourceTracker;
+import org.infinispan.test.fwk.TransportFlags;
 
 /**
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
@@ -45,7 +47,8 @@ public abstract class StressTest extends MultipleCacheManagersTest {
 
                log.trace("Adding new cache again to force rehash");
                // We should only create one so just make it the next cache manager to kill
-               cacheToKill = createClusteredCaches(1, CACHE_NAME, builderUsed).get(0);
+               EmbeddedCacheManager cm = addClusterEnabledCacheManager(new TransportFlags());
+               cacheToKill = cm.createCache(CACHE_NAME, builderUsed.build());
                log.trace("Added new cache again to force rehash");
             }
             return null;

--- a/core/src/test/java/org/infinispan/configuration/ConfigurationUnitTest.java
+++ b/core/src/test/java/org/infinispan/configuration/ConfigurationUnitTest.java
@@ -85,7 +85,7 @@ public class ConfigurationUnitTest extends AbstractInfinispanTest {
       ConfigurationBuilder cb = new ConfigurationBuilder();
       cb.transaction().use1PcForAutoCommitTransactions(true)
             .transactionManagerLookup(new EmbeddedTransactionManagerLookup());
-      withCacheManager(new CacheManagerCallable(createCacheManager()) {
+      withCacheManager(new CacheManagerCallable(createCacheManager(new ConfigurationBuilder())) {
          @Override
          public void call() {
             cm.getCache();
@@ -95,7 +95,7 @@ public class ConfigurationUnitTest extends AbstractInfinispanTest {
 
    @Test
    public void testGetCache() {
-      withCacheManager(new CacheManagerCallable(createCacheManager()) {
+      withCacheManager(new CacheManagerCallable(createCacheManager(new ConfigurationBuilder())) {
          @Override
          public void call() {
             cm.getCache();
@@ -115,7 +115,7 @@ public class ConfigurationUnitTest extends AbstractInfinispanTest {
 
    @Test
    public void testGetAndPut() {
-      withCacheManager(new CacheManagerCallable(createCacheManager()) {
+      withCacheManager(new CacheManagerCallable(createCacheManager(new ConfigurationBuilder())) {
          @Override
          public void call() {
             Cache<String, String> cache = cm.getCache();

--- a/core/src/test/java/org/infinispan/configuration/TransactionalCacheConfigTest.java
+++ b/core/src/test/java/org/infinispan/configuration/TransactionalCacheConfigTest.java
@@ -109,7 +109,7 @@ public class TransactionalCacheConfigTest extends SingleCacheManagerTest {
       assert c.invocationBatching().enabled();
       assert c.transaction().transactionMode().isTransactional();
 
-      withCacheManager(new CacheManagerCallable(TestCacheManagerFactory.createCacheManager()) {
+      withCacheManager(new CacheManagerCallable(TestCacheManagerFactory.createCacheManager(new ConfigurationBuilder())) {
          @Override
          public void call() {
             assert !cm.getCache().getCacheConfiguration().transaction().transactionMode().isTransactional();

--- a/core/src/test/java/org/infinispan/conflict/impl/MultipleCachesDuringConflictResolutionTest.java
+++ b/core/src/test/java/org/infinispan/conflict/impl/MultipleCachesDuringConflictResolutionTest.java
@@ -1,6 +1,7 @@
 package org.infinispan.conflict.impl;
 
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.conflict.MergePolicy;
 import org.infinispan.partitionhandling.BasePartitionHandlingTest;
 import org.infinispan.partitionhandling.PartitionHandling;
@@ -35,9 +36,14 @@ public class MultipleCachesDuringConflictResolutionTest extends BasePartitionHan
    protected void createCacheManagers() throws Throwable {
       ConfigurationBuilder dcc = cacheConfiguration();
       dcc.clustering().cacheMode(cacheMode)
-            .partitionHandling().whenSplit(PartitionHandling.ALLOW_READ_WRITES).mergePolicy(MergePolicy.PREFERRED_ALWAYS);
+         .partitionHandling().whenSplit(PartitionHandling.ALLOW_READ_WRITES).mergePolicy(MergePolicy.PREFERRED_ALWAYS);
       String[] cacheNames = getCacheNames();
-      createClusteredCaches(numMembersInCluster, dcc, new TransportFlags().withFD(true).withMerge(true), cacheNames);
+      // Create a default cache because waitForPartitionToForm() needs it
+      GlobalConfigurationBuilder gc = GlobalConfigurationBuilder.defaultClusteredBuilder();
+      gc.defaultCacheName(cacheNames[0]);
+      createClusteredCaches(numMembersInCluster, gc, dcc, false, new TransportFlags().withFD(true).withMerge(true),
+                            cacheNames);
+
       waitForClusterToForm(cacheNames);
    }
 

--- a/core/src/test/java/org/infinispan/distribution/BaseDistFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/distribution/BaseDistFunctionalTest.java
@@ -81,9 +81,9 @@ public abstract class BaseDistFunctionalTest<K, V> extends MultipleCacheManagers
       cacheName = "dist";
       configuration = buildConfiguration();
       // Create clustered caches with failure detection protocols on
-      caches = createClusteredCaches(INIT_CLUSTER_SIZE, cacheName, getSerializationContext(), configuration,
+      createClusteredCaches(INIT_CLUSTER_SIZE, cacheName, getSerializationContext(), configuration,
                                      new TransportFlags().withFD(false));
-
+      caches = caches(cacheName);
       if (INIT_CLUSTER_SIZE > 0) c1 = caches.get(0);
       if (INIT_CLUSTER_SIZE > 1) c2 = caches.get(1);
       if (INIT_CLUSTER_SIZE > 2) c3 = caches.get(2);

--- a/core/src/test/java/org/infinispan/distribution/DistStorePreloadTest.java
+++ b/core/src/test/java/org/infinispan/distribution/DistStorePreloadTest.java
@@ -74,12 +74,12 @@ public class DistStorePreloadTest<D extends DistStorePreloadTest<?>> extends Bas
       AdvancedCacheLoader<String, String> cs = TestingUtil.getFirstLoader(c1);
       assertEquals(NUM_KEYS, PersistenceUtil.count(cs, null));
 
-      addClusterEnabledCacheManager(TestDataSCI.INSTANCE, configuration, new TransportFlags().withFD(false));
+      addClusterEnabledCacheManager(TestDataSCI.INSTANCE, null, new TransportFlags().withFD(false));
       EmbeddedCacheManager cm2 = cacheManagers.get(1);
       cm2.defineConfiguration(cacheName, buildConfiguration().build());
       c2 = cache(1, cacheName);
       caches.add(c2);
-      waitForClusterToForm();
+      waitForClusterToForm(cacheName);
 
       DataContainer<String, String> dc2 = c2.getAdvancedCache().getDataContainer();
       assertEquals("Expected all the cache store entries to be preloaded on the second cache", NUM_KEYS, dc2.size());

--- a/core/src/test/java/org/infinispan/distribution/SingleOwnerTest.java
+++ b/core/src/test/java/org/infinispan/distribution/SingleOwnerTest.java
@@ -39,8 +39,9 @@ public class SingleOwnerTest extends BaseDistFunctionalTest<Object, String> {
       configuration.clustering().remoteTimeout(3, TimeUnit.SECONDS);
       configuration.clustering().hash().numOwners(1);
       configuration.locking().lockAcquisitionTimeout(45, TimeUnit.SECONDS);
-      caches = createClusteredCaches(2, cacheName, configuration);
+      createClusteredCaches(2, cacheName, configuration);
 
+      caches = caches(cacheName);
       c1 = caches.get(0);
       c2 = caches.get(1);
 

--- a/core/src/test/java/org/infinispan/distribution/rehash/BaseTxStateTransferOverwriteTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/BaseTxStateTransferOverwriteTest.java
@@ -65,7 +65,7 @@ public abstract class BaseTxStateTransferOverwriteTest extends BaseDistFunctiona
    }
 
    protected boolean l1Enabled() {
-      return cache(0).getCacheConfiguration().clustering().l1().enabled();
+      return cache(0, cacheName).getCacheConfiguration().clustering().l1().enabled();
    }
 
    @Override

--- a/core/src/test/java/org/infinispan/distribution/rehash/L1StateTransferRemovesValueTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/L1StateTransferRemovesValueTest.java
@@ -1,8 +1,8 @@
 package org.infinispan.distribution.rehash;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Matchers.anyInt;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.withSettings;
@@ -75,7 +75,7 @@ public class L1StateTransferRemovesValueTest extends BaseDistFunctionalTest<Stri
    @Test
    public void testStateTransferWithRequestorsForNonExistentL1Value() throws Exception {
       // First 2 caches are primary and backup respectively at the beginning
-      L1Manager l1Manager = c1.getAdvancedCache().getComponentRegistry().getComponent(L1Manager.class);
+      L1Manager l1Manager = TestingUtil.extractComponent(c1, L1Manager.class);
       l1Manager.addRequestor(key, c3.getCacheManager().getAddress());
 
       assertNull(c3.get(key));
@@ -91,7 +91,8 @@ public class L1StateTransferRemovesValueTest extends BaseDistFunctionalTest<Stri
       // Now force 1 and 3 to be owners so then 3 will get invalidation and state transfer
       factory.setOwnerIndexes(0, 2);
 
-      EmbeddedCacheManager cm = addClusterEnabledCacheManager(configuration);
+      EmbeddedCacheManager cm = addClusterEnabledCacheManager();
+      cm.defineConfiguration(cacheName, configuration.build());
 
       Future<Void> join = fork(() -> {
          waitForClusterToForm(cacheName);
@@ -133,7 +134,7 @@ public class L1StateTransferRemovesValueTest extends BaseDistFunctionalTest<Stri
       assertIsInL1(c3, key);
 
       CyclicBarrier barrier = new CyclicBarrier(2);
-      c3.getAdvancedCache().getAsyncInterceptorChain()
+      TestingUtil.extractInterceptorChain(c3)
             .addInterceptorAfter(new BlockingInterceptor<>(barrier, InvalidateL1Command.class, true, false),
                   EntryWrappingInterceptor.class);
 
@@ -152,7 +153,8 @@ public class L1StateTransferRemovesValueTest extends BaseDistFunctionalTest<Stri
       // Now force 1 and 3 to be owners so then 3 will get invalidation and state transfer
       factory.setOwnerIndexes(0, 2);
 
-      EmbeddedCacheManager cm = addClusterEnabledCacheManager(configuration);
+      EmbeddedCacheManager cm = addClusterEnabledCacheManager();
+      cm.defineConfiguration(cacheName, configuration.build());
 
       Future<Void> join = fork(() -> {
          waitForClusterToForm(cacheName);

--- a/core/src/test/java/org/infinispan/distribution/rehash/RehashAfterPartitionMergeTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/RehashAfterPartitionMergeTest.java
@@ -21,10 +21,11 @@ public class RehashAfterPartitionMergeTest extends MultipleCacheManagersTest {
 
    @Override
    protected void createCacheManagers() throws Throwable {
-      caches = createClusteredCaches(2, "test",
+      createClusteredCaches(2, "test",
             getDefaultClusteredCacheConfig(cacheMode),
                   new TransportFlags().withFD(true).withMerge(true));
 
+      caches = caches("test");
       c1 = caches.get(0);
       c2 = caches.get(1);
       d1 = TestingUtil.getDiscardForCache(c1.getCacheManager());

--- a/core/src/test/java/org/infinispan/functional/FunctionalJCacheTest.java
+++ b/core/src/test/java/org/infinispan/functional/FunctionalJCacheTest.java
@@ -23,6 +23,7 @@ import javax.cache.processor.MutableEntry;
 import org.infinispan.AdvancedCache;
 import org.infinispan.commons.marshall.Externalizer;
 import org.infinispan.commons.marshall.SerializeWith;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.functional.decorators.FunctionalJCache;
 import org.infinispan.test.CacheManagerCallable;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
@@ -719,7 +720,7 @@ public class FunctionalJCacheTest extends AbstractFunctionalTest {
    }
 
    public void testClose() {
-      withCacheManager(new CacheManagerCallable(TestCacheManagerFactory.createCacheManager()) {
+      withCacheManager(new CacheManagerCallable(TestCacheManagerFactory.createCacheManager(new ConfigurationBuilder())) {
          @Override
          public void call() throws Exception {
             AdvancedCache<Integer, String> advCache = cm.<Integer, String>getCache().getAdvancedCache();

--- a/core/src/test/java/org/infinispan/functional/FunctionalMapTest.java
+++ b/core/src/test/java/org/infinispan/functional/FunctionalMapTest.java
@@ -48,6 +48,8 @@ import org.infinispan.commons.marshall.Externalizer;
 import org.infinispan.commons.marshall.SerializeFunctionWith;
 import org.infinispan.commons.marshall.SerializeWith;
 import org.infinispan.commons.test.skip.SkipTestNG;
+import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.container.versioning.NumericVersion;
 import org.infinispan.functional.EntryView.ReadEntryView;
 import org.infinispan.functional.EntryView.ReadWriteEntryView;
@@ -403,21 +405,22 @@ public class FunctionalMapTest extends AbstractFunctionalTest {
       withCacheManager(new CacheManagerCallable(TestCacheManagerFactory.createCacheManager()) {
          @Override
          public void call() throws Exception {
-            cm.defineConfiguration("read-only", cm.getDefaultCacheConfiguration());
+            Configuration configBuilder = new ConfigurationBuilder().build();
+            cm.defineConfiguration("read-only", configBuilder);
             AdvancedCache<?, ?> readOnlyCache = getAdvancedCache(cm, "read-only");
             try (ReadOnlyMap<?, ?> ro = ReadOnlyMapImpl.create(FunctionalMapImpl.create(readOnlyCache))) {
                assertNotNull(ro); // No-op, just verify that it implements AutoCloseable
             }
             assertTrue(readOnlyCache.getStatus().isTerminated());
 
-            cm.defineConfiguration("write-only", cm.getDefaultCacheConfiguration());
+            cm.defineConfiguration("write-only", configBuilder);
             AdvancedCache<?, ?> writeOnlyCache = getAdvancedCache(cm, "write-only");
             try (WriteOnlyMap<?, ?> wo = WriteOnlyMapImpl.create(FunctionalMapImpl.create(writeOnlyCache))) {
                assertNotNull(wo); // No-op, just verify that it implements AutoCloseable
             }
             assertTrue(writeOnlyCache.getStatus().isTerminated());
 
-            cm.defineConfiguration("read-write", cm.getDefaultCacheConfiguration());
+            cm.defineConfiguration("read-write", configBuilder);
             AdvancedCache<?, ?> readWriteCache = getAdvancedCache(cm, "read-write");
             try (ReadWriteMap<?, ?> rw = ReadWriteMapImpl.create(FunctionalMapImpl.create(readWriteCache))) {
                assertNotNull(rw); // No-op, just verify that it implements AutoCloseable

--- a/core/src/test/java/org/infinispan/functional/FunctionalScatteredInMemoryTest.java
+++ b/core/src/test/java/org/infinispan/functional/FunctionalScatteredInMemoryTest.java
@@ -10,8 +10,13 @@ import static org.testng.Assert.fail;
 import java.util.NoSuchElementException;
 import java.util.concurrent.CompletionException;
 
+import org.infinispan.AdvancedCache;
 import org.infinispan.commons.CacheException;
 import org.infinispan.configuration.cache.BiasAcquisition;
+import org.infinispan.functional.impl.FunctionalMapImpl;
+import org.infinispan.functional.impl.ReadOnlyMapImpl;
+import org.infinispan.functional.impl.ReadWriteMapImpl;
+import org.infinispan.functional.impl.WriteOnlyMapImpl;
 import org.infinispan.remoting.RemoteException;
 import org.infinispan.scattered.Utils;
 import org.infinispan.test.TestException;
@@ -19,12 +24,30 @@ import org.testng.annotations.Test;
 
 @Test(groups = "functional", testName = "functional.FunctionalScatteredInMemoryTest")
 public class FunctionalScatteredInMemoryTest extends AbstractFunctionalOpTest {
+   AdvancedCache<Object, String> scatteredCache;
+   FunctionalMapImpl<Object, String> fmapS1;
+   FunctionalMapImpl<Object, String> fmapS2;
+   FunctionalMap.ReadOnlyMap<Object, String> sro;
+   FunctionalMap.WriteOnlyMap<Object, String> swo;
+   FunctionalMap.ReadWriteMap<Object, String> srw;
+
    @Override
    public Object[] factory() {
       return new Object[] {
             new FunctionalScatteredInMemoryTest().biasAcquisition(BiasAcquisition.NEVER),
             new FunctionalScatteredInMemoryTest().biasAcquisition(BiasAcquisition.ON_WRITE)
       };
+   }
+
+   @Override
+   protected void initMaps() {
+      super.initMaps();
+      this.scatteredCache = cacheManagers.get(0).<Object, String>getCache(SCATTERED).getAdvancedCache();
+      fmapS1 = FunctionalMapImpl.create(getAdvancedCache(cacheManagers.get(0), SCATTERED));
+      fmapS2 = FunctionalMapImpl.create(getAdvancedCache(cacheManagers.get(1), SCATTERED));
+      this.sro = ReadOnlyMapImpl.create(fmapS1);
+      this.swo = WriteOnlyMapImpl.create(fmapS1);
+      this.srw = ReadWriteMapImpl.create(fmapS1);
    }
 
    @Test(dataProvider = "owningModeAndWriteMethod")

--- a/core/src/test/java/org/infinispan/functional/FunctionalSimpleTutorialTest.java
+++ b/core/src/test/java/org/infinispan/functional/FunctionalSimpleTutorialTest.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import org.infinispan.AdvancedCache;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.functional.EntryView.ReadEntryView;
 import org.infinispan.functional.FunctionalMap.ReadOnlyMap;
 import org.infinispan.functional.FunctionalMap.ReadWriteMap;
@@ -25,7 +26,7 @@ public class FunctionalSimpleTutorialTest extends SingleCacheManagerTest {
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
-      return TestCacheManagerFactory.createCacheManager();
+      return TestCacheManagerFactory.createCacheManager(new ConfigurationBuilder());
    }
 
    public void testSimpleTutorial() throws Exception {

--- a/core/src/test/java/org/infinispan/io/GridFileTest.java
+++ b/core/src/test/java/org/infinispan/io/GridFileTest.java
@@ -23,6 +23,8 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.infinispan.Cache;
+import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
@@ -39,8 +41,9 @@ public class GridFileTest extends SingleCacheManagerTest {
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       EmbeddedCacheManager cacheManager = TestCacheManagerFactory.createCacheManager();
-      cacheManager.defineConfiguration("data", cacheManager.getDefaultCacheConfiguration());
-      cacheManager.defineConfiguration("metadata", cacheManager.getDefaultCacheConfiguration());
+      Configuration configuration = new ConfigurationBuilder().build();
+      cacheManager.defineConfiguration("data", configuration);
+      cacheManager.defineConfiguration("metadata", configuration);
       return cacheManager;
    }
 

--- a/core/src/test/java/org/infinispan/manager/CacheDependencyTest.java
+++ b/core/src/test/java/org/infinispan/manager/CacheDependencyTest.java
@@ -57,7 +57,7 @@ public class CacheDependencyTest extends SingleCacheManagerTest {
       cacheManager.stop();
 
       assertAllTerminated(cacheA, cacheB);
-      assertEquals(Arrays.asList("B", getDefaultCacheName(), GlobalConfigurationManager.CONFIG_STATE_CACHE_NAME), listener.stopOrder);
+      assertEquals(Arrays.asList("B", GlobalConfigurationManager.CONFIG_STATE_CACHE_NAME, getDefaultCacheName()), listener.stopOrder);
    }
 
    @Test
@@ -101,7 +101,7 @@ public class CacheDependencyTest extends SingleCacheManagerTest {
       cacheManager.stop();
 
       assertAllTerminated(cacheA, cacheB, cacheC, cacheD);
-      assertEquals(Arrays.asList("A", "B", "D", "C", getDefaultCacheName(), GlobalConfigurationManager.CONFIG_STATE_CACHE_NAME), listener.stopOrder);
+      assertEquals(Arrays.asList("A", "B", "D", "C", GlobalConfigurationManager.CONFIG_STATE_CACHE_NAME, getDefaultCacheName()), listener.stopOrder);
    }
 
    @Test
@@ -126,13 +126,13 @@ public class CacheDependencyTest extends SingleCacheManagerTest {
       cacheManager.stop();
 
       assertAllTerminated(cacheA, cacheB, cacheC);
-      assertEquals(Arrays.asList("A", "C", getDefaultCacheName(), GlobalConfigurationManager.CONFIG_STATE_CACHE_NAME), listener.stopOrder);
+      assertEquals(Arrays.asList("A", "C", GlobalConfigurationManager.CONFIG_STATE_CACHE_NAME, getDefaultCacheName()), listener.stopOrder);
 
    }
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
-      return TestCacheManagerFactory.createCacheManager();
+      return TestCacheManagerFactory.createCacheManager(new ConfigurationBuilder());
    }
 
    @Listener

--- a/core/src/test/java/org/infinispan/marshall/core/StoreAsBinaryTest.java
+++ b/core/src/test/java/org/infinispan/marshall/core/StoreAsBinaryTest.java
@@ -470,7 +470,7 @@ public class StoreAsBinaryTest extends MultipleCacheManagersTest {
    }
 
    public void testEqualsAndHashCode() throws Exception {
-      StreamingMarshaller marshaller = extractGlobalMarshaller(cache(0).getCacheManager());
+      StreamingMarshaller marshaller = extractGlobalMarshaller(manager(0));
       CountMarshallingPojo pojo = new CountMarshallingPojo();
       WrappedBytes wb = new WrappedByteArray(marshaller.objectToByteBuffer(pojo));
       WrappedBytes wb2 = new WrappedByteArray(marshaller.objectToByteBuffer(pojo));

--- a/core/src/test/java/org/infinispan/notifications/DistListenerTest.java
+++ b/core/src/test/java/org/infinispan/notifications/DistListenerTest.java
@@ -1,11 +1,12 @@
 package org.infinispan.notifications;
 
+import static org.testng.AssertJUnit.assertEquals;
+
 import java.util.List;
 import java.util.stream.IntStream;
 
 import org.infinispan.Cache;
 import org.infinispan.configuration.cache.CacheMode;
-import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryCreated;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryModified;
 import org.infinispan.notifications.cachelistener.event.CacheEntryEvent;
@@ -13,10 +14,7 @@ import org.infinispan.notifications.cachemanagerlistener.annotation.ViewChanged;
 import org.infinispan.notifications.cachemanagerlistener.event.ViewChangedEvent;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.test.MultipleCacheManagersTest;
-import org.infinispan.test.TestingUtil;
 import org.testng.annotations.Test;
-
-import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * Used to verify which nodes are going to receive events in case it's configured
@@ -113,13 +111,8 @@ public class DistListenerTest extends MultipleCacheManagersTest {
       assertViewChanged(false);
 
       // Now add a new node and shutdown
-      Cache<?, ?> shutdownCache = createClusteredCaches(1, getDefaultClusteredCacheConfig(
-            CacheMode.DIST_SYNC, true)).get(0);
-      EmbeddedCacheManager manager = shutdownCache.getCacheManager();
-      cacheManagers.remove(manager);
-      manager.stop();
-      TestingUtil.blockUntilViewsReceived(5000, false, caches());
-      TestingUtil.waitForNoRebalance(caches());
+      createClusteredCaches(1, getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, true));
+      killMember(cacheManagers.size() - 1);
 
       // We shouldn't have any events still...
       assertCreated(false);

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/CacheNotifierFilterTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/CacheNotifierFilterTest.java
@@ -10,6 +10,7 @@ import org.infinispan.Cache;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.filter.CollectionKeyFilter;
+import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.metadata.Metadata;
 import org.infinispan.notifications.Listener;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryActivated;
@@ -128,7 +129,8 @@ public class CacheNotifierFilterTest extends MultipleCacheManagersTest {
       // This would block all cache events
       cache0.addListener(listener, new CollectionKeyFilter<>(Collections.emptyList(), true));
 
-      addClusterEnabledCacheManager(builderUsed);
+      EmbeddedCacheManager cm = addClusterEnabledCacheManager();
+      cm.createCache(CACHE_NAME, builderUsed.build());
 
       waitForClusterToForm(CACHE_NAME);
 

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/MultipleListenerConverterTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/MultipleListenerConverterTest.java
@@ -7,6 +7,7 @@ import static org.testng.AssertJUnit.assertTrue;
 import java.util.Arrays;
 import java.util.Collection;
 
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.metadata.Metadata;
 import org.infinispan.notifications.cachelistener.event.CacheEntryCreatedEvent;
@@ -28,7 +29,7 @@ import org.testng.annotations.Test;
 public class MultipleListenerConverterTest extends SingleCacheManagerTest {
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
-      return TestCacheManagerFactory.createCacheManager();
+      return TestCacheManagerFactory.createCacheManager(new ConfigurationBuilder());
    }
 
    private static class StringConverter implements CacheEventConverter<Object, Object, String> {

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/AbstractClusterListenerUtilTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/AbstractClusterListenerUtilTest.java
@@ -1,10 +1,10 @@
 package org.infinispan.notifications.cachelistener.cluster;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.ArgumentMatchers.nullable;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.eq;
@@ -26,6 +26,7 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.filter.KeyValueFilter;
 import org.infinispan.manager.CacheContainer;
+import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.metadata.Metadata;
 import org.infinispan.notifications.Listener;
 import org.infinispan.notifications.cachelistener.CacheNotifier;
@@ -90,7 +91,8 @@ public abstract class AbstractClusterListenerUtilTest extends MultipleCacheManag
    protected void addClusteredCacheManager() {
       // First we add the new node, but block the dist exec execution
       log.info("Adding a new node ..");
-      addClusterEnabledCacheManager(sci, builderUsed);
+      EmbeddedCacheManager manager = addClusterEnabledCacheManager(sci);
+      manager.defineConfiguration(CACHE_NAME, builderUsed.build());
       log.info("Added a new node");
    }
 

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/ClusterListenerLocalTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/ClusterListenerLocalTest.java
@@ -7,6 +7,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.infinispan.Cache;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.notifications.Listener;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryCreated;
@@ -26,7 +27,7 @@ public class ClusterListenerLocalTest extends SingleCacheManagerTest {
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
-      return TestCacheManagerFactory.createCacheManager();
+      return TestCacheManagerFactory.createCacheManager(new ConfigurationBuilder());
    }
 
    public void testInsertEvent() {

--- a/core/src/test/java/org/infinispan/persistence/ClusteredConditionalCommandTest.java
+++ b/core/src/test/java/org/infinispan/persistence/ClusteredConditionalCommandTest.java
@@ -114,8 +114,14 @@ public class ClusteredConditionalCommandTest extends MultipleCacheManagersTest {
       return cacheHelper;
    }
 
-   private void doTest(List<Cache<String, String>> cacheList, ConditionalOperation operation, Ownership ownership,
+   private void doTest(String cacheName, ConditionalOperation operation, Ownership ownership,
                        Flag flag, boolean shared) {
+      if (shared && passivation) {
+         // Skip the test, shared stores don't support passivation
+         return;
+      }
+
+      List<Cache<String, String>> cacheList = getCaches(cacheName);
       // These are not valid test combinations - so just ignore them
       if (shared && passivation) {
          throw new SkipException("Shared passivation is not supported");
@@ -195,7 +201,7 @@ public class ClusteredConditionalCommandTest extends MultipleCacheManagersTest {
 
    @Override
    protected void createCacheManagers() throws Throwable {
-      createCluster(getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC), 3);
+      createCluster( 3);
 
       int index = 0;
       for (EmbeddedCacheManager cacheManager : cacheManagers) {
@@ -212,315 +218,344 @@ public class ClusteredConditionalCommandTest extends MultipleCacheManagersTest {
    }
 
    public void testPutIfAbsentOnPrimaryOwnerWithSkipCacheLoaderShared() {
-      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.PRIMARY, Flag.SKIP_CACHE_LOAD, true);
+      doTest(SHARED_STORE_CACHE_NAME, ConditionalOperation.PUT_IF_ABSENT, Ownership.PRIMARY, Flag.SKIP_CACHE_LOAD,
+             true);
    }
 
    public void testPutIfAbsentOnPrimaryOwnerWithSkipCacheLoader() {
-      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.PRIMARY, Flag.SKIP_CACHE_LOAD, false);
+      doTest(PRIVATE_STORE_CACHE_NAME, ConditionalOperation.PUT_IF_ABSENT, Ownership.PRIMARY, Flag.SKIP_CACHE_LOAD,
+             false);
    }
 
    public void testPutIfAbsentOnPrimaryOwnerWithIgnoreReturnValuesShared() {
-      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.PRIMARY, Flag.IGNORE_RETURN_VALUES, true);
+      doTest(SHARED_STORE_CACHE_NAME, ConditionalOperation.PUT_IF_ABSENT, Ownership.PRIMARY, Flag.IGNORE_RETURN_VALUES,
+             true);
    }
 
    public void testPutIfAbsentOnPrimaryOwnerWithIgnoreReturnValues() {
-      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.PRIMARY, Flag.IGNORE_RETURN_VALUES, false);
+      doTest(PRIVATE_STORE_CACHE_NAME, ConditionalOperation.PUT_IF_ABSENT, Ownership.PRIMARY, Flag.IGNORE_RETURN_VALUES,
+             false);
    }
 
    public void testPutIfAbsentOnPrimaryOwnerShared() {
-      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.PRIMARY, null, true);
+      doTest(SHARED_STORE_CACHE_NAME, ConditionalOperation.PUT_IF_ABSENT, Ownership.PRIMARY, null, true);
    }
 
    public void testPutIfAbsentOnPrimaryOwner() {
-      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.PRIMARY, null, false);
+      doTest(PRIVATE_STORE_CACHE_NAME, ConditionalOperation.PUT_IF_ABSENT, Ownership.PRIMARY, null, false);
    }
 
    @InCacheMode(CacheMode.DIST_SYNC)
    public void testPutIfAbsentOnBackupOwnerWithSkipCacheLoaderShared() {
-      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.BACKUP, Flag.SKIP_CACHE_LOAD, true);
+      doTest(SHARED_STORE_CACHE_NAME, ConditionalOperation.PUT_IF_ABSENT, Ownership.BACKUP, Flag.SKIP_CACHE_LOAD, true);
    }
 
    @InCacheMode(CacheMode.DIST_SYNC)
    public void testPutIfAbsentOnBackupOwnerWithSkipCacheLoader() {
-      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.BACKUP, Flag.SKIP_CACHE_LOAD, false);
+      doTest(PRIVATE_STORE_CACHE_NAME, ConditionalOperation.PUT_IF_ABSENT, Ownership.BACKUP, Flag.SKIP_CACHE_LOAD,
+             false);
    }
 
    @InCacheMode(CacheMode.DIST_SYNC)
    public void testPutIfAbsentOnBackupOwnerWithIgnoreReturnValuesShared() {
-      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.BACKUP, Flag.IGNORE_RETURN_VALUES, true);
+      doTest(SHARED_STORE_CACHE_NAME, ConditionalOperation.PUT_IF_ABSENT, Ownership.BACKUP, Flag.IGNORE_RETURN_VALUES,
+             true);
    }
 
    @InCacheMode(CacheMode.DIST_SYNC)
    public void testPutIfAbsentOnBackupOwnerWithIgnoreReturnValues() {
-      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.BACKUP, Flag.IGNORE_RETURN_VALUES, false);
+      doTest(PRIVATE_STORE_CACHE_NAME, ConditionalOperation.PUT_IF_ABSENT, Ownership.BACKUP, Flag.IGNORE_RETURN_VALUES,
+             false);
    }
 
    @InCacheMode(CacheMode.DIST_SYNC)
    public void testPutIfAbsentOnBackupOwnerShared() {
-      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.BACKUP, null, true);
+      doTest(SHARED_STORE_CACHE_NAME, ConditionalOperation.PUT_IF_ABSENT, Ownership.BACKUP, null, true);
    }
 
    @InCacheMode(CacheMode.DIST_SYNC)
    public void testPutIfAbsentOnBackupOwner() {
-      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.BACKUP, null, false);
+      doTest(PRIVATE_STORE_CACHE_NAME, ConditionalOperation.PUT_IF_ABSENT, Ownership.BACKUP, null, false);
    }
 
    public void testPutIfAbsentOnNonOwnerWithSkipCacheLoaderShared() {
-      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.NON_OWNER, Flag.SKIP_CACHE_LOAD, true);
+      doTest(SHARED_STORE_CACHE_NAME, ConditionalOperation.PUT_IF_ABSENT, Ownership.NON_OWNER, Flag.SKIP_CACHE_LOAD,
+             true);
    }
 
    public void testPutIfAbsentOnNonOwnerWithSkipCacheLoader() {
-      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.NON_OWNER, Flag.SKIP_CACHE_LOAD, false);
+      doTest(PRIVATE_STORE_CACHE_NAME, ConditionalOperation.PUT_IF_ABSENT, Ownership.NON_OWNER, Flag.SKIP_CACHE_LOAD,
+             false);
    }
 
    public void testPutIfAbsentOnNonOwnerWithIgnoreReturnValuesShared() {
-      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.NON_OWNER, Flag.IGNORE_RETURN_VALUES, true);
+      doTest(SHARED_STORE_CACHE_NAME, ConditionalOperation.PUT_IF_ABSENT, Ownership.NON_OWNER,
+             Flag.IGNORE_RETURN_VALUES, true);
    }
 
    public void testPutIfAbsentOnNonOwnerWithIgnoreReturnValues() {
-      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.NON_OWNER, Flag.IGNORE_RETURN_VALUES, false);
+      doTest(PRIVATE_STORE_CACHE_NAME, ConditionalOperation.PUT_IF_ABSENT, Ownership.NON_OWNER,
+             Flag.IGNORE_RETURN_VALUES, false);
    }
 
    public void testPutIfAbsentOnNonOwnerShared() {
-      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.NON_OWNER, null, true);
+      doTest(SHARED_STORE_CACHE_NAME, ConditionalOperation.PUT_IF_ABSENT, Ownership.NON_OWNER, null, true);
    }
 
    public void testPutIfAbsentOnNonOwner() {
-      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.NON_OWNER, null, false);
+      doTest(PRIVATE_STORE_CACHE_NAME, ConditionalOperation.PUT_IF_ABSENT, Ownership.NON_OWNER, null, false);
    }
 
    public void testReplaceOnPrimaryOwnerWithSkipCacheLoaderShared() {
-      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.PRIMARY, Flag.SKIP_CACHE_LOAD, true);
+      doTest(SHARED_STORE_CACHE_NAME, ConditionalOperation.REPLACE, Ownership.PRIMARY, Flag.SKIP_CACHE_LOAD, true);
    }
 
    public void testReplaceOnPrimaryOwnerWithSkipCacheLoader() {
-      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.PRIMARY, Flag.SKIP_CACHE_LOAD, false);
+      doTest(PRIVATE_STORE_CACHE_NAME, ConditionalOperation.REPLACE, Ownership.PRIMARY, Flag.SKIP_CACHE_LOAD, false);
    }
 
    public void testReplaceOnPrimaryOwnerWithIgnoreReturnValuesShared() {
-      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.PRIMARY, Flag.IGNORE_RETURN_VALUES, true);
+      doTest(SHARED_STORE_CACHE_NAME, ConditionalOperation.REPLACE, Ownership.PRIMARY, Flag.IGNORE_RETURN_VALUES, true);
    }
 
    public void testReplaceOnPrimaryOwnerWithIgnoreReturnValues() {
-      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.PRIMARY, Flag.IGNORE_RETURN_VALUES, false);
+      doTest(PRIVATE_STORE_CACHE_NAME, ConditionalOperation.REPLACE, Ownership.PRIMARY, Flag.IGNORE_RETURN_VALUES,
+             false);
    }
 
    public void testReplaceOnPrimaryOwnerShared() {
-      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.PRIMARY, null, true);
+      doTest(SHARED_STORE_CACHE_NAME, ConditionalOperation.REPLACE, Ownership.PRIMARY, null, true);
    }
 
    public void testReplaceOnPrimaryOwner() {
-      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.PRIMARY, null, false);
+      doTest(PRIVATE_STORE_CACHE_NAME, ConditionalOperation.REPLACE, Ownership.PRIMARY, null, false);
    }
 
    @InCacheMode(CacheMode.DIST_SYNC)
    public void testReplaceOnBackupOwnerWithSkipCacheLoaderShared() {
-      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.BACKUP, Flag.SKIP_CACHE_LOAD, true);
+      doTest(SHARED_STORE_CACHE_NAME, ConditionalOperation.REPLACE, Ownership.BACKUP, Flag.SKIP_CACHE_LOAD, true);
    }
 
    @InCacheMode(CacheMode.DIST_SYNC)
    public void testReplaceOnBackupOwnerWithSkipCacheLoader() {
-      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.BACKUP, Flag.SKIP_CACHE_LOAD, false);
+      doTest(PRIVATE_STORE_CACHE_NAME, ConditionalOperation.REPLACE, Ownership.BACKUP, Flag.SKIP_CACHE_LOAD, false);
    }
 
    @InCacheMode(CacheMode.DIST_SYNC)
    public void testReplaceOnBackupOwnerWithIgnoreReturnValuesShared() {
-      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.BACKUP, Flag.IGNORE_RETURN_VALUES, true);
+      doTest(SHARED_STORE_CACHE_NAME, ConditionalOperation.REPLACE, Ownership.BACKUP, Flag.IGNORE_RETURN_VALUES, true);
    }
 
    @InCacheMode(CacheMode.DIST_SYNC)
    public void testReplaceOnBackupOwnerWithIgnoreReturnValues() {
-      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.BACKUP, Flag.IGNORE_RETURN_VALUES, false);
+      doTest(PRIVATE_STORE_CACHE_NAME, ConditionalOperation.REPLACE, Ownership.BACKUP, Flag.IGNORE_RETURN_VALUES,
+             false);
    }
 
    @InCacheMode(CacheMode.DIST_SYNC)
    public void testReplaceOnBackupOwnerShared() {
-      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.BACKUP, null, true);
+      doTest(SHARED_STORE_CACHE_NAME, ConditionalOperation.REPLACE, Ownership.BACKUP, null, true);
    }
 
    @InCacheMode(CacheMode.DIST_SYNC)
    public void testReplaceOnBackupOwner() {
-      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.BACKUP, null, false);
+      doTest(PRIVATE_STORE_CACHE_NAME, ConditionalOperation.REPLACE, Ownership.BACKUP, null, false);
    }
 
    public void testReplaceOnNonOwnerWithSkipCacheLoaderShared() {
-      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.NON_OWNER, Flag.SKIP_CACHE_LOAD, true);
+      doTest(SHARED_STORE_CACHE_NAME, ConditionalOperation.REPLACE, Ownership.NON_OWNER, Flag.SKIP_CACHE_LOAD, true);
    }
 
    public void testReplaceOnNonOwnerWithSkipCacheLoader() {
-      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.NON_OWNER, Flag.SKIP_CACHE_LOAD, false);
+      doTest(PRIVATE_STORE_CACHE_NAME, ConditionalOperation.REPLACE, Ownership.NON_OWNER, Flag.SKIP_CACHE_LOAD, false);
    }
 
    public void testReplaceOnNonOwnerWithIgnoreReturnValuesShared() {
-      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.NON_OWNER, Flag.IGNORE_RETURN_VALUES, true);
+      doTest(SHARED_STORE_CACHE_NAME, ConditionalOperation.REPLACE, Ownership.NON_OWNER, Flag.IGNORE_RETURN_VALUES,
+             true);
    }
 
    public void testReplaceOnNonOwnerWithIgnoreReturnValues() {
-      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.NON_OWNER, Flag.IGNORE_RETURN_VALUES, false);
+      doTest(PRIVATE_STORE_CACHE_NAME, ConditionalOperation.REPLACE, Ownership.NON_OWNER, Flag.IGNORE_RETURN_VALUES,
+             false);
    }
 
    public void testReplaceOnNonOwnerShared() {
-      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.NON_OWNER, null, true);
+      doTest(SHARED_STORE_CACHE_NAME, ConditionalOperation.REPLACE, Ownership.NON_OWNER, null, true);
    }
 
    public void testReplaceOnNonOwner() {
-      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.NON_OWNER, null, false);
+      doTest(PRIVATE_STORE_CACHE_NAME, ConditionalOperation.REPLACE, Ownership.NON_OWNER, null, false);
    }
 
    public void testReplaceIfOnPrimaryOwnerWithSkipCacheLoaderShared() {
-      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.PRIMARY, Flag.SKIP_CACHE_LOAD, true);
+      doTest(SHARED_STORE_CACHE_NAME, ConditionalOperation.REPLACE_IF, Ownership.PRIMARY, Flag.SKIP_CACHE_LOAD, true);
    }
 
    public void testReplaceIfOnPrimaryOwnerWithSkipCacheLoader() {
-      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.PRIMARY, Flag.SKIP_CACHE_LOAD, false);
+      doTest(PRIVATE_STORE_CACHE_NAME, ConditionalOperation.REPLACE_IF, Ownership.PRIMARY, Flag.SKIP_CACHE_LOAD, false);
    }
 
    public void testReplaceIfOnPrimaryOwnerWithIgnoreReturnValuesShared() {
-      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.PRIMARY, Flag.IGNORE_RETURN_VALUES, true);
+      doTest(SHARED_STORE_CACHE_NAME, ConditionalOperation.REPLACE_IF, Ownership.PRIMARY, Flag.IGNORE_RETURN_VALUES,
+             true);
    }
 
    public void testReplaceIfOnPrimaryOwnerWithIgnoreReturnValues() {
-      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.PRIMARY, Flag.IGNORE_RETURN_VALUES, false);
+      doTest(PRIVATE_STORE_CACHE_NAME, ConditionalOperation.REPLACE_IF, Ownership.PRIMARY, Flag.IGNORE_RETURN_VALUES,
+             false);
    }
 
    public void testReplaceIfOnPrimaryOwnerShared() {
-      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.PRIMARY, null, true);
+      doTest(SHARED_STORE_CACHE_NAME, ConditionalOperation.REPLACE_IF, Ownership.PRIMARY, null, true);
    }
 
    public void testReplaceIfOnPrimaryOwner() {
-      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.PRIMARY, null, false);
+      doTest(PRIVATE_STORE_CACHE_NAME, ConditionalOperation.REPLACE_IF, Ownership.PRIMARY, null, false);
    }
 
    @InCacheMode(CacheMode.DIST_SYNC)
    public void testReplaceIfOnBackupOwnerWithSkipCacheLoaderShared() {
-      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.BACKUP, Flag.SKIP_CACHE_LOAD, true);
+      doTest(SHARED_STORE_CACHE_NAME, ConditionalOperation.REPLACE_IF, Ownership.BACKUP, Flag.SKIP_CACHE_LOAD, true);
    }
 
    @InCacheMode(CacheMode.DIST_SYNC)
    public void testReplaceIfOnBackupOwnerWithSkipCacheLoader() {
-      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.BACKUP, Flag.SKIP_CACHE_LOAD, false);
+      doTest(PRIVATE_STORE_CACHE_NAME, ConditionalOperation.REPLACE_IF, Ownership.BACKUP, Flag.SKIP_CACHE_LOAD, false);
    }
 
    @InCacheMode(CacheMode.DIST_SYNC)
    public void testReplaceIfOnBackupOwnerWithIgnoreReturnValuesShared() {
-      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.BACKUP, Flag.IGNORE_RETURN_VALUES, true);
+      doTest(SHARED_STORE_CACHE_NAME, ConditionalOperation.REPLACE_IF, Ownership.BACKUP, Flag.IGNORE_RETURN_VALUES,
+             true);
    }
 
    @InCacheMode(CacheMode.DIST_SYNC)
    public void testReplaceIfOnBackupOwnerWithIgnoreReturnValues() {
-      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.BACKUP, Flag.IGNORE_RETURN_VALUES, false);
+      doTest(PRIVATE_STORE_CACHE_NAME, ConditionalOperation.REPLACE_IF, Ownership.BACKUP, Flag.IGNORE_RETURN_VALUES,
+             false);
    }
 
    @InCacheMode(CacheMode.DIST_SYNC)
    public void testReplaceIfOnBackupOwnerShared() {
-      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.BACKUP, null, true);
+      doTest(SHARED_STORE_CACHE_NAME, ConditionalOperation.REPLACE_IF, Ownership.BACKUP, null, true);
    }
 
    @InCacheMode(CacheMode.DIST_SYNC)
    public void testReplaceIfOnBackupOwner() {
-      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.BACKUP, null, false);
+      doTest(PRIVATE_STORE_CACHE_NAME, ConditionalOperation.REPLACE_IF, Ownership.BACKUP, null, false);
    }
 
    public void testReplaceIfOnNonOwnerWithSkipCacheLoaderShared() {
-      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.NON_OWNER, Flag.SKIP_CACHE_LOAD, true);
+      doTest(SHARED_STORE_CACHE_NAME, ConditionalOperation.REPLACE_IF, Ownership.NON_OWNER, Flag.SKIP_CACHE_LOAD, true);
    }
 
    public void testReplaceIfOnNonOwnerWithSkipCacheLoader() {
-      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.NON_OWNER, Flag.SKIP_CACHE_LOAD, false);
+      doTest(PRIVATE_STORE_CACHE_NAME, ConditionalOperation.REPLACE_IF, Ownership.NON_OWNER, Flag.SKIP_CACHE_LOAD,
+             false);
    }
 
    public void testReplaceIfOnNonOwnerWithIgnoreReturnValuesShared() {
-      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.NON_OWNER, Flag.IGNORE_RETURN_VALUES, true);
+      doTest(SHARED_STORE_CACHE_NAME, ConditionalOperation.REPLACE_IF, Ownership.NON_OWNER, Flag.IGNORE_RETURN_VALUES,
+             true);
    }
 
    public void testReplaceIfOnNonOwnerWithIgnoreReturnValues() {
-      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.NON_OWNER, Flag.IGNORE_RETURN_VALUES, false);
+      doTest(PRIVATE_STORE_CACHE_NAME, ConditionalOperation.REPLACE_IF, Ownership.NON_OWNER, Flag.IGNORE_RETURN_VALUES,
+             false);
    }
 
    public void testReplaceIfOnNonOwnerShared() {
-      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.NON_OWNER, null, true);
+      doTest(SHARED_STORE_CACHE_NAME, ConditionalOperation.REPLACE_IF, Ownership.NON_OWNER, null, true);
    }
 
    public void testReplaceIfOnNonOwner() {
-      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.NON_OWNER, null, false);
+      doTest(PRIVATE_STORE_CACHE_NAME, ConditionalOperation.REPLACE_IF, Ownership.NON_OWNER, null, false);
    }
 
    public void testRemoveIfOnPrimaryOwnerWithSkipCacheLoaderShared() {
-      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.PRIMARY, Flag.SKIP_CACHE_LOAD, true);
+      doTest(SHARED_STORE_CACHE_NAME, ConditionalOperation.REMOVE_IF, Ownership.PRIMARY, Flag.SKIP_CACHE_LOAD, true);
    }
 
    public void testRemoveIfOnPrimaryOwnerWithSkipCacheLoader() {
-      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.PRIMARY, Flag.SKIP_CACHE_LOAD, false);
+      doTest(PRIVATE_STORE_CACHE_NAME, ConditionalOperation.REMOVE_IF, Ownership.PRIMARY, Flag.SKIP_CACHE_LOAD, false);
    }
 
    public void testRemoveIfOnPrimaryOwnerWithIgnoreReturnValuesShared() {
-      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.PRIMARY, Flag.IGNORE_RETURN_VALUES, true);
+      doTest(SHARED_STORE_CACHE_NAME, ConditionalOperation.REMOVE_IF, Ownership.PRIMARY, Flag.IGNORE_RETURN_VALUES,
+             true);
    }
 
    public void testRemoveIfOnPrimaryOwnerWithIgnoreReturnValues() {
-      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.PRIMARY, Flag.IGNORE_RETURN_VALUES, false);
+      doTest(PRIVATE_STORE_CACHE_NAME, ConditionalOperation.REMOVE_IF, Ownership.PRIMARY, Flag.IGNORE_RETURN_VALUES,
+             false);
    }
 
    public void testRemoveIfOnPrimaryOwnerShared() {
-      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.PRIMARY, null, true);
+      doTest(SHARED_STORE_CACHE_NAME, ConditionalOperation.REMOVE_IF, Ownership.PRIMARY, null, true);
    }
 
    public void testRemoveIfOnPrimaryOwner() {
-      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.PRIMARY, null, false);
+      doTest(PRIVATE_STORE_CACHE_NAME, ConditionalOperation.REMOVE_IF, Ownership.PRIMARY, null, false);
    }
 
    @InCacheMode(CacheMode.DIST_SYNC)
    public void testRemoveIfOnBackupOwnerWithSkipCacheLoaderShared() {
-      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.BACKUP, Flag.SKIP_CACHE_LOAD, true);
+      doTest(SHARED_STORE_CACHE_NAME, ConditionalOperation.REMOVE_IF, Ownership.BACKUP, Flag.SKIP_CACHE_LOAD, true);
    }
 
    @InCacheMode(CacheMode.DIST_SYNC)
    public void testRemoveIfOnBackupOwnerWithSkipCacheLoader() {
-      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.BACKUP, Flag.SKIP_CACHE_LOAD, false);
+      doTest(PRIVATE_STORE_CACHE_NAME, ConditionalOperation.REMOVE_IF, Ownership.BACKUP, Flag.SKIP_CACHE_LOAD, false);
    }
 
    @InCacheMode(CacheMode.DIST_SYNC)
    public void testRemoveIfOnBackupOwnerWithIgnoreReturnValuesShared() {
-      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.BACKUP, Flag.IGNORE_RETURN_VALUES, true);
+      doTest(SHARED_STORE_CACHE_NAME, ConditionalOperation.REMOVE_IF, Ownership.BACKUP, Flag.IGNORE_RETURN_VALUES,
+             true);
    }
 
    @InCacheMode(CacheMode.DIST_SYNC)
    public void testRemoveIfOnBackupOwnerWithIgnoreReturnValues() {
-      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.BACKUP, Flag.IGNORE_RETURN_VALUES, false);
+      doTest(PRIVATE_STORE_CACHE_NAME, ConditionalOperation.REMOVE_IF, Ownership.BACKUP, Flag.IGNORE_RETURN_VALUES,
+             false);
    }
 
    @InCacheMode(CacheMode.DIST_SYNC)
    public void testRemoveIfOnBackupOwnerShared() {
-      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.BACKUP, null, true);
+      doTest(SHARED_STORE_CACHE_NAME, ConditionalOperation.REMOVE_IF, Ownership.BACKUP, null, true);
    }
 
    @InCacheMode(CacheMode.DIST_SYNC)
    public void testRemoveIfOnBackupOwner() {
-      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.BACKUP, null, false);
+      doTest(PRIVATE_STORE_CACHE_NAME, ConditionalOperation.REMOVE_IF, Ownership.BACKUP, null, false);
    }
 
    public void testRemoveIfOnNonOwnerWithSkipCacheLoaderShared() {
-      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.NON_OWNER, Flag.SKIP_CACHE_LOAD, true);
+      doTest(SHARED_STORE_CACHE_NAME, ConditionalOperation.REMOVE_IF, Ownership.NON_OWNER, Flag.SKIP_CACHE_LOAD, true);
    }
 
    public void testRemoveIfOnNonOwnerWithSkipCacheLoader() {
-      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.NON_OWNER, Flag.SKIP_CACHE_LOAD, false);
+      doTest(PRIVATE_STORE_CACHE_NAME, ConditionalOperation.REMOVE_IF, Ownership.NON_OWNER, Flag.SKIP_CACHE_LOAD,
+             false);
    }
 
    public void testRemoveIfOnNonOwnerWithIgnoreReturnValuesShared() {
-      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.NON_OWNER, Flag.IGNORE_RETURN_VALUES, true);
+      doTest(SHARED_STORE_CACHE_NAME, ConditionalOperation.REMOVE_IF, Ownership.NON_OWNER, Flag.IGNORE_RETURN_VALUES,
+             true);
    }
 
    public void testRemoveIfOnNonOwnerWithIgnoreReturnValues() {
-      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.NON_OWNER, Flag.IGNORE_RETURN_VALUES, false);
+      doTest(PRIVATE_STORE_CACHE_NAME, ConditionalOperation.REMOVE_IF, Ownership.NON_OWNER, Flag.IGNORE_RETURN_VALUES,
+             false);
    }
 
    public void testRemoveIfOnNonOwnerShared() {
-      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.NON_OWNER, null, true);
+      doTest(SHARED_STORE_CACHE_NAME, ConditionalOperation.REMOVE_IF, Ownership.NON_OWNER, null, true);
    }
 
    public void testRemoveIfOnNonOwner() {
-      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.NON_OWNER, null, false);
+      doTest(PRIVATE_STORE_CACHE_NAME, ConditionalOperation.REMOVE_IF, Ownership.NON_OWNER, null, false);
    }
 
    protected enum ConditionalOperation {

--- a/core/src/test/java/org/infinispan/replication/SyncCacheListenerTest.java
+++ b/core/src/test/java/org/infinispan/replication/SyncCacheListenerTest.java
@@ -4,10 +4,8 @@ import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertNull;
-import static org.testng.AssertJUnit.assertTrue;
 import static org.testng.AssertJUnit.fail;
 
-import java.util.List;
 import java.util.Map;
 
 import javax.transaction.Transaction;
@@ -47,11 +45,10 @@ public class SyncCacheListenerTest extends MultipleCacheManagersTest {
             // TODO: Another case of default values changed (see ISPN-2651)
             .transaction().useSynchronization(false);
 
-      List<Cache<Object, Object>> caches =
-            createClusteredCaches(2, "cache", builder);
+      createClusteredCaches(2, "cache", builder);
 
-      cache1 = caches.get(0);
-      cache2 = caches.get(1);
+      cache1 = cache(0, "cache");
+      cache2 = cache(1, "cache");
    }
 
    public void testSyncTxRepl() throws Exception {
@@ -76,7 +73,7 @@ public class SyncCacheListenerTest extends MultipleCacheManagersTest {
       // value on cache2 must be 38
       age = (Integer) cache2.get("age");
       assertNotNull("\"age\" obtained from cache2 must be non-null ", age);
-      assertTrue("\"age\" must be 38", age == 38);
+      assertEquals("\"age\" must be 38", (int) age, 38);
    }
 
    public void testRemoteCacheListener() throws Exception {
@@ -89,7 +86,7 @@ public class SyncCacheListenerTest extends MultipleCacheManagersTest {
          // value on cache2 must be 38
          age = (Integer) cache2.get("age");
          assertNotNull("\"age\" obtained from cache2 must be non-null ", age);
-         assertTrue("\"age\" must be 38", age == 38);
+         assertEquals("\"age\" must be 38", (int) age, 38);
          cache1.remove("age");
       } finally {
          cache2.removeListener(lis);
@@ -109,7 +106,7 @@ public class SyncCacheListenerTest extends MultipleCacheManagersTest {
       // value on cache2 must be 38
       age = (Integer) cache2.get("age");
       assertNotNull("\"age\" obtained from cache2 must be non-null ", age);
-      assertTrue("\"age\" must be 38", age == 38);
+      assertEquals("\"age\" must be 38", (int) age, 38);
    }
 
 
@@ -149,7 +146,7 @@ public class SyncCacheListenerTest extends MultipleCacheManagersTest {
       // value on cache2 must be 38
       age = (Integer) cache2.get("age");
       assertNotNull("\"age\" obtained from cache2 must be non-null ", age);
-      assertTrue("\"age\" must be 38", age == 38);
+      assertEquals("\"age\" must be 38", (int) age, 38);
    }
 
    public void testSyncReplMap() throws Exception {
@@ -171,7 +168,7 @@ public class SyncCacheListenerTest extends MultipleCacheManagersTest {
       // value on cache2 must be 38
       age = (Integer) cache2.get("age");
       assertNotNull("\"age\" obtained from cache2 must be non-null ", age);
-      assertTrue("\"age\" must be 38", age == 38);
+      assertEquals("\"age\" must be 38", (int) age, 38);
       assertNull("lock info is " + lm1.printLockInfo(), lm1.getOwner("age"));
    }
 
@@ -184,13 +181,13 @@ public class SyncCacheListenerTest extends MultipleCacheManagersTest {
          cache1.put(key, val);
       }
 
-      public void put(Map map) {
+      public void put(Map<?, ?> map) {
          if (map.isEmpty()) fail("put(): map size can't be 0");
          cache1.putAll(map);
       }
 
       @CacheEntryModified
-      public void modified(Event ne) {
+      public void modified(Event<Object, Object> ne) {
          if (!ne.isPre()) {
             log.debug("modified visited with key: " + key);
             try {

--- a/core/src/test/java/org/infinispan/scattered/statetransfer/CrashJoinTest.java
+++ b/core/src/test/java/org/infinispan/scattered/statetransfer/CrashJoinTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import org.infinispan.Cache;
 import org.infinispan.distribution.MagicKey;
+import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.TestDataSCI;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.CleanupAfterMethod;
@@ -55,7 +56,8 @@ public class CrashJoinTest extends AbstractStateTransferTest {
 
    public void testNodeJoin() throws Exception {
       List<MagicKey> keys = init();
-      Cache c4 = addClusterEnabledCacheManager(TestDataSCI.INSTANCE, defaultConfig, TRANSPORT_FLAGS).getCache(CACHE_NAME);
+      EmbeddedCacheManager cm4 = addClusterEnabledCacheManager(TestDataSCI.INSTANCE, null, TRANSPORT_FLAGS);
+      Cache c4 = cm4.createCache(CACHE_NAME, defaultConfig.build());
       TestingUtil.blockUntilViewsReceived(30000, false, c1, c2, c3, c4);
       TestingUtil.waitForNoRebalance(c1, c2, c3, c4);
 

--- a/core/src/test/java/org/infinispan/scattered/statetransfer/PushTransferTest.java
+++ b/core/src/test/java/org/infinispan/scattered/statetransfer/PushTransferTest.java
@@ -44,7 +44,8 @@ public class PushTransferTest extends AbstractStateTransferTest {
 
    public void testNodeJoin() throws Exception {
       List<MagicKey> keys = init();
-      EmbeddedCacheManager cm4 = addClusterEnabledCacheManager(TestDataSCI.INSTANCE, defaultConfig, TRANSPORT_FLAGS);
+      EmbeddedCacheManager cm4 = addClusterEnabledCacheManager(TestDataSCI.INSTANCE, null, TRANSPORT_FLAGS);
+      cm4.defineConfiguration(CACHE_NAME, defaultConfig.build());
       int startTopologyId = c1.getAdvancedCache().getDistributionManager().getCacheTopology().getTopologyId();
 
       BlockingLocalTopologyManager bltm = BlockingLocalTopologyManager.replaceTopologyManager(cm4, CACHE_NAME);

--- a/core/src/test/java/org/infinispan/statetransfer/ClusterTopologyManagerTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/ClusterTopologyManagerTest.java
@@ -59,8 +59,7 @@ public class ClusterTopologyManagerTest extends MultipleCacheManagersTest {
    @Override
    protected void createCacheManagers() throws Throwable {
       defaultConfig = getDefaultClusteredCacheConfig(cacheMode, transactional);
-      createClusteredCaches(3, defaultConfig, new TransportFlags().withFD(true).withMerge(true));
-      defineConfigurationOnAllManagers(CACHE_NAME, defaultConfig);
+      createClusteredCaches(3, defaultConfig, new TransportFlags().withFD(true).withMerge(true), CACHE_NAME);
 
       c1 = cache(0, CACHE_NAME);
       c2 = cache(1, CACHE_NAME);
@@ -77,7 +76,7 @@ public class ClusterTopologyManagerTest extends MultipleCacheManagersTest {
 
    public void testNodeAbruptLeave() {
       // Create some more caches to trigger ISPN-2572
-      ConfigurationBuilder cfg = new ConfigurationBuilder().read(manager(0).getDefaultCacheConfiguration());
+      ConfigurationBuilder cfg = defaultConfig;
       defineConfigurationOnAllManagers("cache2", cfg);
       defineConfigurationOnAllManagers("cache3", cfg);
       defineConfigurationOnAllManagers("cache4", cfg);
@@ -114,7 +113,7 @@ public class ClusterTopologyManagerTest extends MultipleCacheManagersTest {
       assert endTime - startTime < 30000 : "Recovery took too long: " + Util.prettyPrintTime(endTime - startTime);
 
       // Check that a new node can join
-      EmbeddedCacheManager newCm = addClusterEnabledCacheManager(defaultConfig, new TransportFlags().withFD(true).withMerge(true));
+      EmbeddedCacheManager newCm = addClusterEnabledCacheManager(new TransportFlags().withFD(true).withMerge(true));
       newCm.defineConfiguration(CACHE_NAME, defaultConfig.build());
       Cache<Object, Object> c4 = cache(3, CACHE_NAME);
       TestingUtil.blockUntilViewsReceived(30000, true, c1, c2, c4);
@@ -153,7 +152,8 @@ public class ClusterTopologyManagerTest extends MultipleCacheManagersTest {
       assert endTime - startTime < 30000 : "Recovery took too long: " + Util.prettyPrintTime(endTime - startTime);
 
       // Check that a new node can join
-      addClusterEnabledCacheManager(defaultConfig, new TransportFlags().withFD(true).withMerge(true));
+      addClusterEnabledCacheManager(new TransportFlags().withFD(true).withMerge(true));
+      manager(3).defineConfiguration(CACHE_NAME, defaultConfig.build());
       Cache<Object, Object> c4 = cache(3, CACHE_NAME);
       TestingUtil.blockUntilViewsReceived(30000, true, c2, c3, c4);
       TestingUtil.waitForNoRebalance(c2, c3, c4);
@@ -194,7 +194,8 @@ public class ClusterTopologyManagerTest extends MultipleCacheManagersTest {
       assert endTime - startTime < 30000 : "Merge took too long: " + Util.prettyPrintTime(endTime - startTime);
 
       // Check that a new node can join
-      addClusterEnabledCacheManager(defaultConfig, new TransportFlags().withFD(true).withMerge(true));
+      addClusterEnabledCacheManager(new TransportFlags().withFD(true).withMerge(true));
+      manager(3).defineConfiguration(CACHE_NAME, defaultConfig.build());
       Cache<Object, Object> c4 = cache(3, CACHE_NAME);
       TestingUtil.blockUntilViewsReceived(30000, true, c1, c2, c3, c4);
       TestingUtil.waitForNoRebalance(c1, c2, c3, c4);
@@ -237,7 +238,8 @@ public class ClusterTopologyManagerTest extends MultipleCacheManagersTest {
       assert endTime - startTime < 30000 : "Merge took too long: " + Util.prettyPrintTime(endTime - startTime);
 
       // Check that a new node can join
-      addClusterEnabledCacheManager(defaultConfig, new TransportFlags().withFD(true).withMerge(true));
+      addClusterEnabledCacheManager(new TransportFlags().withFD(true).withMerge(true));
+      manager(3).defineConfiguration(CACHE_NAME, defaultConfig.build());
       Cache<Object, Object> c4 = cache(3, CACHE_NAME);
       TestingUtil.blockUntilViewsReceived(30000, true, c2, c3, c4);
       TestingUtil.waitForNoRebalance(c2, c3, c4);
@@ -279,8 +281,7 @@ public class ClusterTopologyManagerTest extends MultipleCacheManagersTest {
       final CheckPoint checkpoint = new CheckPoint();
       blockRebalanceStart(mergeCoordManager, checkpoint, 2);
 
-      final EmbeddedCacheManager cm4 = addClusterEnabledCacheManager(defaultConfig,
-            new TransportFlags().withFD(true).withMerge(true));
+      EmbeddedCacheManager cm4 = addClusterEnabledCacheManager(new TransportFlags().withFD(true).withMerge(true));
       blockRebalanceStart(cm4, checkpoint, 2);
       // Force the initialization of the transport
       cm4.defineConfiguration(CACHE_NAME, defaultConfig.build());
@@ -316,8 +317,7 @@ public class ClusterTopologyManagerTest extends MultipleCacheManagersTest {
       assert endTime - startTime < 30000 : "Merge took too long: " + Util.prettyPrintTime(endTime - startTime);
 
       // Check that another node can join
-      EmbeddedCacheManager cm5 = addClusterEnabledCacheManager(defaultConfig,
-            new TransportFlags().withFD(true).withMerge(true));
+      EmbeddedCacheManager cm5 = addClusterEnabledCacheManager(new TransportFlags().withFD(true).withMerge(true));
       cm5.defineConfiguration(CACHE_NAME, defaultConfig.build());
       Cache<Object, Object> c5 = cm5.getCache(CACHE_NAME);
       TestingUtil.blockUntilViewsReceived(30000, true, c1, c2, c3, c4, c5);

--- a/core/src/test/java/org/infinispan/test/AbstractCacheTest.java
+++ b/core/src/test/java/org/infinispan/test/AbstractCacheTest.java
@@ -91,6 +91,6 @@ public abstract class AbstractCacheTest extends AbstractInfinispanTest {
    }
 
    public String getDefaultCacheName() {
-      throw new UnsupportedOperationException();
+      return TestCacheManagerFactory.DEFAULT_CACHE_NAME;
    }
 }

--- a/core/src/test/java/org/infinispan/test/MultipleCacheManagersTest.java
+++ b/core/src/test/java/org/infinispan/test/MultipleCacheManagersTest.java
@@ -1,6 +1,7 @@
 package org.infinispan.test;
 
 import static java.util.Arrays.asList;
+import static org.infinispan.test.fwk.TestCacheManagerFactory.createClusteredCacheManager;
 import static org.infinispan.commons.test.TestResourceTracker.getCurrentTestShortName;
 import static org.testng.AssertJUnit.assertTrue;
 
@@ -45,7 +46,6 @@ import org.infinispan.protostream.SerializationContextInitializer;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.test.fwk.InCacheMode;
 import org.infinispan.test.fwk.InTransactionMode;
-import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.test.fwk.TestFrameworkFailure;
 import org.infinispan.commons.test.TestResourceTracker;
 import org.infinispan.test.fwk.TestSelector;
@@ -168,6 +168,12 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
       }
    }
 
+   final protected void registerCacheManager(List<? extends EmbeddedCacheManager> cacheContainers) {
+      for (CacheContainer ecm : cacheContainers) {
+         this.cacheManagers.add((EmbeddedCacheManager) ecm);
+      }
+   }
+
    /**
     * Creates a new cache manager, starts it, and adds it to the list of known cache managers on the current thread.
     * Uses a default clustered cache manager global config.
@@ -187,8 +193,8 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
     * @return the new CacheManager
     */
    protected EmbeddedCacheManager addClusterEnabledCacheManager(TransportFlags flags) {
-      EmbeddedCacheManager cm = TestCacheManagerFactory.createClusteredCacheManager(false,
-            GlobalConfigurationBuilder.defaultClusteredBuilder(), new ConfigurationBuilder(), flags);
+      EmbeddedCacheManager cm = createClusteredCacheManager(false, GlobalConfigurationBuilder.defaultClusteredBuilder(),
+                                                            null, flags);
       amendCacheManagerBeforeStart(cm);
       cacheManagers.add(cm);
       cm.start();
@@ -214,7 +220,7 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
    }
 
    protected EmbeddedCacheManager addClusterEnabledCacheManager(SerializationContextInitializer sci) {
-      return addClusterEnabledCacheManager(sci, new ConfigurationBuilder(), new TransportFlags());
+      return addClusterEnabledCacheManager(sci, null, new TransportFlags());
    }
 
    protected EmbeddedCacheManager addClusterEnabledCacheManager(SerializationContextInitializer sci, ConfigurationBuilder defaultConfig) {
@@ -240,7 +246,8 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
     * @return the new CacheManager
     */
    protected EmbeddedCacheManager addClusterEnabledCacheManager(ConfigurationBuilder builder, TransportFlags flags) {
-      EmbeddedCacheManager cm = TestCacheManagerFactory.createClusteredCacheManager(false, GlobalConfigurationBuilder.defaultClusteredBuilder(), builder, flags);
+      EmbeddedCacheManager cm = createClusteredCacheManager(false, GlobalConfigurationBuilder.defaultClusteredBuilder(),
+                                                            builder, flags);
       amendCacheManagerBeforeStart(cm);
       cacheManagers.add(cm);
       cm.start();
@@ -248,19 +255,24 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
    }
 
    protected EmbeddedCacheManager addClusterEnabledCacheManager(ConfigurationBuilderHolder builderHolder) {
-      EmbeddedCacheManager cm = TestCacheManagerFactory.createClusteredCacheManager(false, builderHolder);
+      EmbeddedCacheManager cm = createClusteredCacheManager(false, builderHolder);
       amendCacheManagerBeforeStart(cm);
       cacheManagers.add(cm);
       cm.start();
       return cm;
    }
 
-   protected EmbeddedCacheManager addClusterEnabledCacheManager(GlobalConfigurationBuilder globalBuilder, ConfigurationBuilder builder, TransportFlags flags) {
-      EmbeddedCacheManager cm = TestCacheManagerFactory.createClusteredCacheManager(false, globalBuilder, builder, flags);
+   protected EmbeddedCacheManager addClusterEnabledCacheManager(GlobalConfigurationBuilder globalBuilder,
+                                                                ConfigurationBuilder builder, TransportFlags flags) {
+      EmbeddedCacheManager cm = createClusteredCacheManager(false, globalBuilder, builder, flags);
       amendCacheManagerBeforeStart(cm);
       cacheManagers.add(cm);
       cm.start();
       return cm;
+   }
+
+   protected void createCluster(int count) {
+      for (int i = 0; i < count; i++) addClusterEnabledCacheManager();
    }
 
    protected void createCluster(ConfigurationBuilder builder, int count) {
@@ -358,51 +370,52 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
       }
    }
 
-   protected <K, V> List<Cache<K, V>> createClusteredCaches(int numMembersInCluster, String cacheName, ConfigurationBuilder builder) {
-      return createClusteredCaches(numMembersInCluster, cacheName, null, builder);
+   protected void createClusteredCaches(int numMembersInCluster, String cacheName, ConfigurationBuilder builder) {
+      createClusteredCaches(numMembersInCluster, cacheName, null, builder);
    }
 
-   protected <K, V> List<Cache<K, V>> createClusteredCaches(int numMembersInCluster, String cacheName, SerializationContextInitializer sci,
+   protected void createClusteredCaches(int numMembersInCluster, String cacheName, SerializationContextInitializer sci,
                                                             ConfigurationBuilder builder) {
-      return createClusteredCaches(numMembersInCluster, cacheName, sci, builder, new TransportFlags());
+      createClusteredCaches(numMembersInCluster, cacheName, sci, builder, new TransportFlags());
    }
 
-   protected <K, V> List<Cache<K, V>> createClusteredCaches(int numMembersInCluster, String cacheName, ConfigurationBuilder builder, TransportFlags flags) {
-      return createClusteredCaches(numMembersInCluster, null, builder, flags, cacheName);
+   protected void createClusteredCaches(int numMembersInCluster, String cacheName, ConfigurationBuilder builder, TransportFlags flags) {
+      createClusteredCaches(numMembersInCluster, null, builder, flags, cacheName);
    }
 
-   protected <K, V> List<Cache<K, V>> createClusteredCaches(
+   protected void createClusteredCaches(
          int numMembersInCluster, String cacheName, SerializationContextInitializer sci, ConfigurationBuilder builder, TransportFlags flags) {
-      return createClusteredCaches(numMembersInCluster, sci, builder, flags, cacheName);
+      createClusteredCaches(numMembersInCluster, sci, builder, flags, cacheName);
    }
 
-   protected <K, V> List<Cache<K, V>> createClusteredCaches(int numMembersInCluster,
+   protected void createClusteredCaches(int numMembersInCluster,
                                                             SerializationContextInitializer sci,
                                                             ConfigurationBuilder defaultConfigBuilder) {
-      return createClusteredCaches(numMembersInCluster, sci, defaultConfigBuilder, new TransportFlags());
+      createClusteredCaches(numMembersInCluster, sci, defaultConfigBuilder, new TransportFlags());
    }
 
-   protected <K, V> List<Cache<K, V>> createClusteredCaches(int numMembersInCluster,
+   protected void createClusteredCaches(int numMembersInCluster,
                                                             SerializationContextInitializer sci,
-                                                            ConfigurationBuilder defaultConfigBuilder,
+                                                            ConfigurationBuilder configBuilder,
                                                             TransportFlags flags, String... cacheNames) {
       GlobalConfigurationBuilder globalBuilder = GlobalConfigurationBuilder.defaultClusteredBuilder();
       if (sci != null) globalBuilder.serialization().addContextInitializer(sci);
-      return createClusteredCaches(numMembersInCluster, globalBuilder, defaultConfigBuilder, false, flags, cacheNames);
+      createClusteredCaches(numMembersInCluster, globalBuilder, configBuilder, false, flags, cacheNames);
    }
 
-   protected <K, V> List<Cache<K, V>> createClusteredCaches(int numMembersInCluster,
+   protected void createClusteredCaches(int numMembersInCluster,
                                                             GlobalConfigurationBuilder globalConfigurationBuilder,
                                                             ConfigurationBuilder defaultConfigBuilder,
                                                             boolean serverMode, String... cacheNames) {
-      return createClusteredCaches(numMembersInCluster, globalConfigurationBuilder, defaultConfigBuilder, serverMode, new TransportFlags(), cacheNames);
+      createClusteredCaches(numMembersInCluster, globalConfigurationBuilder, defaultConfigBuilder, serverMode,
+                            new TransportFlags(), cacheNames);
    }
 
-   protected <K, V> List<Cache<K, V>> createClusteredCaches(int numMembersInCluster,
+   protected void createClusteredCaches(int numMembersInCluster,
                                                             GlobalConfigurationBuilder globalConfigurationBuilder,
-                                                            ConfigurationBuilder defaultConfigBuilder,
-                                                            boolean serverMode, TransportFlags flags, String... cacheNames) {
-      List<Cache<K, V>> caches = new ArrayList<>(numMembersInCluster);
+                                                            ConfigurationBuilder configBuilder,
+                                                            boolean serverMode, TransportFlags flags,
+                                                            String... cacheNames) {
       for (int i = 0; i < numMembersInCluster; i++) {
          EmbeddedCacheManager cm;
          GlobalConfigurationBuilder global = new GlobalConfigurationBuilder();
@@ -411,74 +424,68 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
             global.addModule(PrivateGlobalConfigurationBuilder.class).serverMode(true);
             global.transport().defaultTransport();
          }
-         cm = addClusterEnabledCacheManager(global, defaultConfigBuilder, flags);
+         ConfigurationBuilder defaultBuilder = null;
+         if (cacheNames.length == 0 || global.defaultCacheName().isPresent()) {
+            defaultBuilder = configBuilder;
+         }
+
+         cm = addClusterEnabledCacheManager(global, defaultBuilder, flags);
+
          if (cacheNames.length == 0) {
-            Cache<K, V> cache = cm.getCache();
-            caches.add(cache);
+            cm.getCache();
          } else {
             for (String cacheName : cacheNames) {
-               cm.defineConfiguration(cacheName, defaultConfigBuilder.build());
-               caches.add(cm.getCache(cacheName));
+               // The default cache was already defined
+               if (!global.defaultCacheName().orElse("").equals(cacheName)) {
+                  cm.defineConfiguration(cacheName, configBuilder.build());
+               }
             }
          }
       }
       waitForClusterToForm(cacheNames);
-      return caches;
    }
 
-   protected <K, V> List<Cache<K, V>> createClusteredCaches(int numMembersInCluster,
+   protected void createClusteredCaches(int numMembersInCluster,
                                                             ConfigurationBuilder defaultConfigBuilder,
                                                             boolean serverMode, String... cacheNames) {
-      return createClusteredCaches(numMembersInCluster, GlobalConfigurationBuilder.defaultClusteredBuilder(), defaultConfigBuilder, serverMode, cacheNames);
+      createClusteredCaches(numMembersInCluster, GlobalConfigurationBuilder.defaultClusteredBuilder(),
+                            defaultConfigBuilder, serverMode, cacheNames);
    }
 
-   protected <K, V> List<Cache<K, V>> createClusteredCaches(int numMembersInCluster,
+   protected void createClusteredCaches(int numMembersInCluster,
                                                             ConfigurationBuilder defaultConfigBuilder) {
-      return createClusteredCaches(numMembersInCluster, defaultConfigBuilder, false);
+      createClusteredCaches(numMembersInCluster, defaultConfigBuilder, false);
    }
 
-   protected <K, V> List<Cache<K, V>> createClusteredCaches(int numMembersInCluster,
+   protected void createClusteredCaches(int numMembersInCluster,
                                                             ConfigurationBuilder defaultConfig,
                                                             TransportFlags flags) {
-      List<Cache<K, V>> caches = new ArrayList<>(numMembersInCluster);
       for (int i = 0; i < numMembersInCluster; i++) {
          EmbeddedCacheManager cm = addClusterEnabledCacheManager(defaultConfig, flags);
-         Cache<K, V> cache = cm.getCache();
-         caches.add(cache);
+         cm.getCache();
       }
       waitForClusterToForm();
-      return caches;
    }
 
    /**
     * Create cacheNames.length in each CacheManager (numMembersInCluster cacheManagers).
-    *
-    * @param numMembersInCluster
-    * @param defaultConfigBuilder
-    * @param cacheNames
-    * @return A list with size numMembersInCluster containing a list of cacheNames.length caches
     */
-   protected <K, V> List<List<Cache<K, V>>> createClusteredCaches(int numMembersInCluster,
-                                                                  ConfigurationBuilder defaultConfigBuilder, String... cacheNames) {
-      return createClusteredCaches(numMembersInCluster, defaultConfigBuilder, new TransportFlags(), cacheNames);
+   protected void createClusteredCaches(int numMembersInCluster,
+                                               ConfigurationBuilder defaultConfigBuilder, String... cacheNames) {
+      createClusteredCaches(numMembersInCluster, defaultConfigBuilder, new TransportFlags(), cacheNames);
    }
 
-   protected <K, V> List<List<Cache<K, V>>> createClusteredCaches(int numMembersInCluster,
-                                                                  ConfigurationBuilder defaultConfigBuilder, TransportFlags transportFlags, String... cacheNames) {
-      List<List<Cache<K, V>>> allCaches = new ArrayList<>(numMembersInCluster);
+   protected void createClusteredCaches(int numMembersInCluster, ConfigurationBuilder configBuilder,
+                                               TransportFlags transportFlags, String... cacheNames) {
       for (int i = 0; i < numMembersInCluster; i++) {
-         EmbeddedCacheManager cm = addClusterEnabledCacheManager(defaultConfigBuilder, transportFlags);
-         List<Cache<K, V>> currentCacheManagerCaches = new ArrayList<>(cacheNames.length);
+         EmbeddedCacheManager cm = addClusterEnabledCacheManager(null, transportFlags);
 
          for (String cacheName : cacheNames) {
-            cm.defineConfiguration(cacheName, defaultConfigBuilder.build());
-            Cache<K, V> cache = cm.getCache(cacheName);
-            currentCacheManagerCaches.add(cache);
+            cm.defineConfiguration(cacheName, configBuilder.build());
+            cm.getCache(cacheName);
          }
-         allCaches.add(currentCacheManagerCaches);
       }
       waitForClusterToForm(cacheNames);
-      return allCaches;
    }
 
    protected ReplListener replListener(Cache<?, ?> cache) {
@@ -1061,10 +1068,5 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
       public IsolationLevelFilter() {
          super("test.infinispan.isolationLevel", test -> test.isolationLevel);
       }
-   }
-
-   @Override
-   public String getDefaultCacheName() {
-      return cacheManagers.get(0).getCacheManagerConfiguration().defaultCacheName().orElse(null);
    }
 }

--- a/core/src/test/java/org/infinispan/test/SingleCacheManagerTest.java
+++ b/core/src/test/java/org/infinispan/test/SingleCacheManagerTest.java
@@ -29,7 +29,9 @@ public abstract class SingleCacheManagerTest extends AbstractCacheTest {
 
    protected void setup() throws Exception {
       cacheManager = createCacheManager();
-      if (cache == null) cache = cacheManager.getCache();
+      if (cache == null && SecurityActions.getCacheManagerConfiguration(cacheManager).defaultCacheName().isPresent()) {
+         cache = cacheManager.getCache();
+      }
    }
 
    protected void teardown() {
@@ -135,10 +137,5 @@ public abstract class SingleCacheManagerTest extends AbstractCacheTest {
             return true;
          }
       });
-   }
-
-   @Override
-   public String getDefaultCacheName() {
-      return cacheManager.getCacheManagerConfiguration().defaultCacheName().get();
    }
 }

--- a/core/src/test/java/org/infinispan/test/arquillian/DatagridManager.java
+++ b/core/src/test/java/org/infinispan/test/arquillian/DatagridManager.java
@@ -2,6 +2,7 @@ package org.infinispan.test.arquillian;
 
 import java.util.List;
 import java.util.concurrent.Future;
+
 import javax.transaction.RollbackException;
 import javax.transaction.SystemException;
 import javax.transaction.Transaction;
@@ -162,15 +163,15 @@ public class DatagridManager extends MultipleCacheManagersTest
    }
 
    @Override
-   public <K, V> List<Cache<K, V>> createClusteredCaches(
+   public void createClusteredCaches(
          int numMembersInCluster, String cacheName, ConfigurationBuilder builder) {
-      return super.createClusteredCaches(numMembersInCluster, cacheName, builder);
+      super.createClusteredCaches(numMembersInCluster, cacheName, builder);
    }
 
    @Override
-   public <K, V> List<Cache<K, V>> createClusteredCaches(
+   public void createClusteredCaches(
          int numMembersInCluster, String cacheName, ConfigurationBuilder builder, TransportFlags flags) {
-      return super.createClusteredCaches(numMembersInCluster, cacheName, builder, flags);
+      super.createClusteredCaches(numMembersInCluster, cacheName, builder, flags);
    }
 
    @Override

--- a/core/src/test/java/org/infinispan/test/concurrent/InboundRpcSequencerAction.java
+++ b/core/src/test/java/org/infinispan/test/concurrent/InboundRpcSequencerAction.java
@@ -83,7 +83,7 @@ public class InboundRpcSequencerAction {
                   reply.reply(response);
                }
             }, order);
-         } finally {
+         } catch (Throwable t) {
             advance(accepted, statesAfter, Reply.NO_OP);
          }
       }

--- a/core/src/test/java/org/infinispan/test/fwk/TestCacheManagerFactory.java
+++ b/core/src/test/java/org/infinispan/test/fwk/TestCacheManagerFactory.java
@@ -45,7 +45,7 @@ import org.infinispan.util.logging.LogFactory;
  * @author Galder Zamarreño
  */
 public class TestCacheManagerFactory {
-   private static final Log log = LogFactory.getLog(TestCacheManagerFactory.class);
+   public static final String DEFAULT_CACHE_NAME = "defaultcache";
    public static final int NAMED_EXECUTORS_THREADS_NO_QUEUE = 6;
    // Check *TxPartitionAndMerge*Test with taskset -c 1 before reducing the following 2
    private static final int NAMED_EXECUTORS_THREADS_WITH_QUEUE = 6;
@@ -53,7 +53,9 @@ public class TestCacheManagerFactory {
    private static final int NAMED_EXECUTORS_KEEP_ALIVE = 30000;
 
    private static final String MARSHALLER = LegacyKeySupportSystemProperties.getProperty(
-      "infinispan.test.marshaller.class", "infinispan.marshaller.class");
+         "infinispan.test.marshaller.class", "infinispan.marshaller.class");
+
+   private static final Log log = LogFactory.getLog(TestCacheManagerFactory.class);
 
    /**
     * Note this method does not amend the global configuration to reduce overall resource footprint.  It is therefore
@@ -81,7 +83,9 @@ public class TestCacheManagerFactory {
 
    private static DefaultCacheManager newDefaultCacheManager(boolean start, ConfigurationBuilderHolder holder) {
       GlobalConfigurationBuilder gcb = holder.getGlobalConfigurationBuilder();
-      amendDefaultCache(gcb);
+      if (holder.getDefaultConfigurationBuilder() != null) {
+         amendDefaultCache(gcb);
+      }
       setNodeName(gcb);
       MetricsCollectorTestHelper.replace(gcb);
       checkJmx(gcb.build());
@@ -247,12 +251,13 @@ public class TestCacheManagerFactory {
                                                                   ConfigurationBuilder defaultCacheConfig,
                                                                   TransportFlags flags) {
       amendGlobalConfiguration(gcb, flags);
-      amendJTA(defaultCacheConfig);
+      if (defaultCacheConfig != null) {
+         amendJTA(defaultCacheConfig);
+      }
       return newDefaultCacheManager(start, gcb, defaultCacheConfig);
    }
 
    public static void amendGlobalConfiguration(GlobalConfigurationBuilder gcb, TransportFlags flags) {
-      amendDefaultCache(gcb);
       amendMarshaller(gcb);
       minimizeThreads(gcb);
       amendTransport(gcb, flags);
@@ -271,11 +276,11 @@ public class TestCacheManagerFactory {
    }
 
    public static EmbeddedCacheManager createCacheManager() {
-      return createCacheManager(new ConfigurationBuilder());
+      return createCacheManager((ConfigurationBuilder) null);
    }
 
    public static EmbeddedCacheManager createServerModeCacheManager() {
-      return createServerModeCacheManager(new ConfigurationBuilder());
+      return createServerModeCacheManager((ConfigurationBuilder) null);
    }
 
    public static EmbeddedCacheManager createServerModeCacheManager(ConfigurationBuilder builder) {
@@ -317,12 +322,19 @@ public class TestCacheManagerFactory {
       return newDefaultCacheManager(start, globalBuilder, new ConfigurationBuilder());
    }
 
-   public static EmbeddedCacheManager createCacheManager(GlobalConfigurationBuilder globalBuilder, ConfigurationBuilder builder) {
+   public static EmbeddedCacheManager createCacheManager(GlobalConfigurationBuilder globalBuilder,
+                                                         ConfigurationBuilder builder) {
+      return createCacheManager(globalBuilder, builder, true);
+   }
+
+   public static EmbeddedCacheManager createCacheManager(GlobalConfigurationBuilder globalBuilder,
+                                                         ConfigurationBuilder builder, boolean start) {
       if (globalBuilder.transport().build().transport().transport() != null) {
-         throw new IllegalArgumentException("Use TestCacheManagerFactory.createClusteredCacheManager(...) for clustered cache managers");
+         throw new IllegalArgumentException(
+               "Use TestCacheManagerFactory.createClusteredCacheManager(...) for clustered cache managers");
       }
       amendTransport(globalBuilder);
-      return newDefaultCacheManager(true, globalBuilder, builder);
+      return newDefaultCacheManager(start, globalBuilder, builder);
    }
 
    public static EmbeddedCacheManager createCacheManager(CacheMode mode, boolean indexing) {
@@ -428,7 +440,7 @@ public class TestCacheManagerFactory {
 
    public static void amendDefaultCache(GlobalConfigurationBuilder builder) {
       if (!builder.defaultCacheName().isPresent()) {
-         builder.defaultCacheName(TestResourceTracker.getCurrentTestShortName());
+         builder.defaultCacheName(DEFAULT_CACHE_NAME);
       }
    }
 

--- a/core/src/test/java/org/infinispan/topology/AsymmetricClusterTest.java
+++ b/core/src/test/java/org/infinispan/topology/AsymmetricClusterTest.java
@@ -55,7 +55,8 @@ public class AsymmetricClusterTest extends MultipleCacheManagersTest {
 
       TestingUtil.blockUntilViewsReceived(30000, false, manager(0));
 
-      addClusterEnabledCacheManager(clusteredConfig, new TransportFlags().withFD(true));
+      addClusterEnabledCacheManager(new TransportFlags().withFD(true));
+      manager(2).defineConfiguration(CACHE_NAME, clusteredConfig.build());
 
       manager(2).getCache(CACHE_NAME);
    }

--- a/core/src/test/java/org/infinispan/tx/StaleLockRecoveryTest.java
+++ b/core/src/test/java/org/infinispan/tx/StaleLockRecoveryTest.java
@@ -1,7 +1,5 @@
 package org.infinispan.tx;
 
-import java.util.List;
-
 import javax.transaction.NotSupportedException;
 import javax.transaction.SystemException;
 import javax.transaction.TransactionManager;
@@ -32,9 +30,9 @@ public class StaleLockRecoveryTest extends MultipleCacheManagersTest {
       ConfigurationBuilder c = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, true);
       c.transaction().lockingMode(LockingMode.PESSIMISTIC)
             .locking().lockAcquisitionTimeout(TestingUtil.shortTimeoutMillis());
-      List<Cache<String, String>> caches = createClusteredCaches(2, "tx", c);
-      c1 = caches.get(0);
-      c2 = caches.get(1);
+      createClusteredCaches(2, "tx", c);
+      c1 = cache(0, "tx");
+      c2 = cache(1, "tx");
    }
 
    public void testStaleLock() throws SystemException, NotSupportedException {

--- a/core/src/test/java/org/infinispan/xsite/AbstractXSiteTest.java
+++ b/core/src/test/java/org/infinispan/xsite/AbstractXSiteTest.java
@@ -341,9 +341,4 @@ public abstract class AbstractXSiteTest extends AbstractCacheTest {
    protected  TransactionTable txTable(Cache cache) {
       return cache.getAdvancedCache().getComponentRegistry().getComponent(TransactionTable.class);
    }
-
-   @Override
-   public String getDefaultCacheName() {
-      return site(0).cacheManagers.get(0).getCacheManagerConfiguration().defaultCacheName().get();
-   }
 }

--- a/integrationtests/cdi-jcache-it/src/test/java/org/infinispan/integrationtests/cdijcache/interceptor/CachePutInterceptorTest.java
+++ b/integrationtests/cdi-jcache-it/src/test/java/org/infinispan/integrationtests/cdijcache/interceptor/CachePutInterceptorTest.java
@@ -17,7 +17,7 @@ import org.infinispan.integrationtests.cdijcache.interceptor.config.Custom;
 import org.infinispan.integrationtests.cdijcache.interceptor.service.CachePutService;
 import org.infinispan.integrationtests.cdijcache.interceptor.service.CustomCacheKey;
 import org.infinispan.jcache.annotation.DefaultCacheKey;
-import org.infinispan.manager.CacheContainer;
+import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.commons.test.TestResourceTrackingListener;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
@@ -48,7 +48,7 @@ public class CachePutInterceptorTest extends Arquillian {
    private CachePutService service;
 
    @Inject
-   private CacheContainer cacheContainer;
+   private EmbeddedCacheManager cacheContainer;
 
    @Custom
    @Inject

--- a/integrationtests/elasticsearch-indexmanager-it/src/test/java/org/infinispan/query/it/ClusteredCacheWithElasticsearchIndexManagerIT.java
+++ b/integrationtests/elasticsearch-indexmanager-it/src/test/java/org/infinispan/query/it/ClusteredCacheWithElasticsearchIndexManagerIT.java
@@ -1,8 +1,5 @@
 package org.infinispan.query.it;
 
-import java.util.List;
-
-import org.infinispan.Cache;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.Index;
@@ -41,8 +38,8 @@ public class ClusteredCacheWithElasticsearchIndexManagerIT extends ClusteredCach
                 .index(Index.PRIMARY_OWNER)
                 .addIndexedEntity(Person.class);
         ElasticsearchTesting.applyTestProperties(cacheCfg.indexing());
-        List<Cache<Object, Person>> caches = createClusteredCaches(2, QueryTestSCI.INSTANCE, cacheCfg);
-        cache1 = caches.get(0);
-        cache2 = caches.get(1);
+        createClusteredCaches(2, QueryTestSCI.INSTANCE, cacheCfg);
+        cache1 = cache(0);
+        cache2 = cache(1);
     }
 }

--- a/integrationtests/elasticsearch-indexmanager-it/src/test/java/org/infinispan/query/it/ElasticSearchMassIndexingIT.java
+++ b/integrationtests/elasticsearch-indexmanager-it/src/test/java/org/infinispan/query/it/ElasticSearchMassIndexingIT.java
@@ -1,9 +1,5 @@
 package org.infinispan.query.it;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
-import org.infinispan.Cache;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.Index;
@@ -26,7 +22,7 @@ public class ElasticSearchMassIndexingIT extends DistributedMassIndexingTest {
             .index(Index.PRIMARY_OWNER)
             .addIndexedEntity(Car.class);
       ElasticsearchTesting.applyTestProperties(cacheCfg.indexing());
-      List<Cache<Object, Object>> cacheList = createClusteredCaches(NUM_NODES, QueryTestSCI.INSTANCE, cacheCfg);
+      createClusteredCaches(NUM_NODES, QueryTestSCI.INSTANCE, cacheCfg);
       ConfigurationBuilder indexCache = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, false);
       indexCache.clustering().stateTransfer().fetchInMemoryState(true);
       defineConfigurationOnAllManagers(InfinispanIntegration.DEFAULT_INDEXESDATA_CACHENAME, indexCache);
@@ -34,7 +30,5 @@ public class ElasticSearchMassIndexingIT extends DistributedMassIndexingTest {
       defineConfigurationOnAllManagers(InfinispanIntegration.DEFAULT_INDEXESMETADATA_CACHENAME, indexCache);
 
       waitForClusterToForm();
-
-      caches.addAll(cacheList.stream().collect(Collectors.toList()));
    }
 }

--- a/lucene/lucene-directory/src/test/java/org/infinispan/lucene/configuration/NoLifespanValidationTest.java
+++ b/lucene/lucene-directory/src/test/java/org/infinispan/lucene/configuration/NoLifespanValidationTest.java
@@ -20,12 +20,12 @@ public class NoLifespanValidationTest extends SingleCacheManagerTest {
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       ConfigurationBuilder cfg = CacheTestSupport.createLocalCacheConfiguration();
-      cfg.expiration().lifespan(10l);
+      cfg.expiration().lifespan(10L);
       return TestCacheManagerFactory.createCacheManager(cfg);
    }
 
    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp =
-         "ISPN(\\d)*: Lucene Directory for index 'testIndexAlpha' can not use Cache 'NoLifespanValidationTest': maximum lifespan enabled on the Cache configuration!")
+         "ISPN(\\d)*: Lucene Directory for index 'testIndexAlpha' can not use Cache 'defaultcache': maximum lifespan enabled on the Cache configuration!")
    public void failOnExpiry() {
       DirectoryBuilder.newDirectoryInstance(cache, cache, cache, "testIndexAlpha").create();
    }

--- a/lucene/lucene-directory/src/test/java/org/infinispan/lucene/configuration/NotIdleValidationTest.java
+++ b/lucene/lucene-directory/src/test/java/org/infinispan/lucene/configuration/NotIdleValidationTest.java
@@ -20,12 +20,12 @@ public class NotIdleValidationTest extends SingleCacheManagerTest {
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       ConfigurationBuilder cfg = CacheTestSupport.createLocalCacheConfiguration();
-      cfg.expiration().maxIdle(10l);
+      cfg.expiration().maxIdle(10L);
       return TestCacheManagerFactory.createCacheManager(cfg);
    }
 
    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp =
-         "ISPN(\\d)*: Lucene Directory for index 'testIndexBeta' can not use Cache 'NotIdleValidationTest': expiration idle time enabled on the Cache configuration!")
+         "ISPN(\\d)*: Lucene Directory for index 'testIndexBeta' can not use Cache 'defaultcache': expiration idle time enabled on the Cache configuration!")
    public void failOnExpiry() {
       DirectoryBuilder.newDirectoryInstance(cache, cache, cache, "testIndexBeta").create();
    }

--- a/multimap/src/test/java/org/infinispan/multimap/impl/EmbeddedMultimapCacheTest.java
+++ b/multimap/src/test/java/org/infinispan/multimap/impl/EmbeddedMultimapCacheTest.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.function.Predicate;
 
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.multimap.api.embedded.EmbeddedMultimapCacheManagerFactory;
@@ -45,6 +46,7 @@ public class EmbeddedMultimapCacheTest extends SingleCacheManagerTest {
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       // start a single cache instance
       EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(MultimapSCI.INSTANCE);
+      cm.defineConfiguration("test", new ConfigurationBuilder().build());
       MultimapCacheManager multimapCacheManager = EmbeddedMultimapCacheManagerFactory.from(cm);
       multimapCache = multimapCacheManager.get("test");
       cm.getClassWhiteList().addClasses(SuperPerson.class);

--- a/multimap/src/test/java/org/infinispan/multimap/impl/MultimapStoreBucketTest.java
+++ b/multimap/src/test/java/org/infinispan/multimap/impl/MultimapStoreBucketTest.java
@@ -10,6 +10,7 @@ import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.marshall.persistence.impl.PersistenceMarshallerImpl;
 import org.infinispan.multimap.api.embedded.EmbeddedMultimapCacheManagerFactory;
+import org.infinispan.multimap.api.embedded.MultimapCache;
 import org.infinispan.multimap.api.embedded.MultimapCacheManager;
 import org.infinispan.persistence.dummy.DummyInMemoryStoreConfigurationBuilder;
 import org.infinispan.test.AbstractInfinispanTest;
@@ -23,6 +24,7 @@ public class MultimapStoreBucketTest extends AbstractInfinispanTest {
 
    public void testMultimapWithJavaSerializationMarshaller() throws Exception {
       GlobalConfigurationBuilder globalBuilder = new GlobalConfigurationBuilder().nonClusteredDefault();
+      globalBuilder.defaultCacheName("test");
       globalBuilder.serialization().marshaller(new JavaSerializationMarshaller()).whiteList().addClass(SuperPerson.class.getName());
 
       ConfigurationBuilder config = new ConfigurationBuilder();
@@ -30,7 +32,7 @@ public class MultimapStoreBucketTest extends AbstractInfinispanTest {
       EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(globalBuilder, config);
 
       MultimapCacheManager<String, Person> multimapCacheManager = EmbeddedMultimapCacheManagerFactory.from(cm);
-      EmbeddedMultimapCache<String, Person> multimapCache = (EmbeddedMultimapCache<String, Person>) multimapCacheManager.get("test");
+      MultimapCache<String, Person> multimapCache = multimapCacheManager.get("test");
       multimapCache.put("k1", new SuperPerson());
       PersistenceMarshallerImpl pm = TestingUtil.extractPersistenceMarshaller(cm);
       assertTrue(pm.getUserMarshaller() instanceof JavaSerializationMarshaller);

--- a/persistence/jdbc/src/test/java/org/infinispan/persistence/jdbc/stores/TxStoreTest.java
+++ b/persistence/jdbc/src/test/java/org/infinispan/persistence/jdbc/stores/TxStoreTest.java
@@ -1,9 +1,9 @@
 package org.infinispan.persistence.jdbc.stores;
 
 import static javax.transaction.Status.STATUS_ROLLEDBACK;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -19,6 +19,7 @@ import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.context.Flag;
 import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.persistence.jdbc.UnitTestDatabaseManager;
 import org.infinispan.persistence.jdbc.configuration.JdbcStringBasedStoreConfigurationBuilder;
 import org.infinispan.persistence.jdbc.connectionfactory.ConnectionFactory;
 import org.infinispan.persistence.jdbc.impl.table.TableName;
@@ -29,7 +30,6 @@ import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.commons.test.Exceptions;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
-import org.infinispan.persistence.jdbc.UnitTestDatabaseManager;
 import org.infinispan.util.concurrent.CompletableFutures;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -68,7 +68,7 @@ public class TxStoreTest extends AbstractInfinispanTest {
       UnitTestDatabaseManager.buildTableManipulation(storeBuilder.table());
 
       cacheManager = TestCacheManagerFactory.createClusteredCacheManager(cc);
-      cache = cacheManager.getCache("Test");
+      cache = cacheManager.getCache();
       store = TestingUtil.getFirstTxWriter(cache);
    }
 

--- a/persistence/remote/src/test/java/org/infinispan/persistence/remote/RemoteStoreConfigTest.java
+++ b/persistence/remote/src/test/java/org/infinispan/persistence/remote/RemoteStoreConfigTest.java
@@ -28,13 +28,15 @@ import org.testng.annotations.Test;
 public class RemoteStoreConfigTest extends AbstractInfinispanTest {
 
    public static final String CACHE_LOADER_CONFIG = "remote-cl-config.xml";
+   public static final String STORE_CACHE_NAME = "RemoteStoreConfigTest";
    private EmbeddedCacheManager cacheManager;
    private HotRodServer hotRodServer;
 
    @BeforeClass
    public void startUp() {
-      cacheManager = TestCacheManagerFactory.createCacheManager(hotRodCacheConfiguration());
-      assertEquals(cacheManager.getCache().size(), 0);
+      cacheManager = TestCacheManagerFactory.createCacheManager();
+      Cache<?, ?> storeCache = cacheManager.createCache(STORE_CACHE_NAME, hotRodCacheConfiguration().build());
+      assertEquals(storeCache.size(), 0);
       hotRodServer = HotRodTestingUtil.startHotRodServer(cacheManager, 19711);
    }
 
@@ -50,16 +52,17 @@ public class RemoteStoreConfigTest extends AbstractInfinispanTest {
 
             cache.put("k", "v");
 
-            assertEquals(1, cacheManager.getCache().size());
+            Cache<Object, Object> storeCache = cacheManager.getCache(STORE_CACHE_NAME);
+            assertEquals(1, storeCache.size());
             cache.stop();
-            assertEquals(1, cacheManager.getCache().size());
+            assertEquals(1, storeCache.size());
          }
       });
 
       withCacheManager(new CacheManagerCallable(TestCacheManagerFactory.fromXml(CACHE_LOADER_CONFIG)) {
          @Override
          public void call() {
-            Cache cache = cm.getCache();
+            Cache cache = cm.getCache(STORE_CACHE_NAME);
             assertEquals("v", cache.get("k"));
          }
       });

--- a/persistence/rest/src/main/java/org/infinispan/persistence/rest/RestStore.java
+++ b/persistence/rest/src/main/java/org/infinispan/persistence/rest/RestStore.java
@@ -41,7 +41,6 @@ import org.infinispan.util.logging.LogFactory;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
-
 import io.reactivex.Flowable;
 import net.jcip.annotations.ThreadSafe;
 
@@ -190,6 +189,7 @@ public class RestStore<K, V> implements AdvancedLoadWriteStore<K, V> {
       try {
          CompletionStage<RestResponse> clear = cacheClient.clear();
          RestResponse response = CompletionStages.join(clear);
+         response.close();
          if (!isSuccessful(response.getStatus())) throw new PersistenceException("Failed to clear remote store");
       } catch (Exception e) {
          throw new PersistenceException(e);

--- a/persistence/rest/src/test/java/org/infinispan/persistence/rest/RestCacheStoreFunctionalTest.java
+++ b/persistence/rest/src/test/java/org/infinispan/persistence/rest/RestCacheStoreFunctionalTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.persistence.rest;
 
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.PersistenceConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.persistence.BaseStoreFunctionalTest;
@@ -38,7 +39,7 @@ public class RestCacheStoreFunctionalTest extends BaseStoreFunctionalTest {
 
    @Override
    protected EmbeddedCacheManager createCacheManager() {
-      return TestCacheManagerFactory.createServerModeCacheManager();
+      return TestCacheManagerFactory.createServerModeCacheManager(new ConfigurationBuilder());
    }
 
    @Override

--- a/persistence/rest/src/test/java/org/infinispan/persistence/rest/RestStoreParallelIterationTest.java
+++ b/persistence/rest/src/test/java/org/infinispan/persistence/rest/RestStoreParallelIterationTest.java
@@ -25,7 +25,7 @@ public class RestStoreParallelIterationTest extends ParallelIterationTest {
    private RestServer restServer;
 
    protected void configurePersistence(ConfigurationBuilder cb) {
-      localCacheManager = TestCacheManagerFactory.createServerModeCacheManager();
+      localCacheManager = TestCacheManagerFactory.createServerModeCacheManager(new ConfigurationBuilder());
       RestServerConfigurationBuilder restServerConfigurationBuilder = new RestServerConfigurationBuilder();
       restServer = new RestServer();
       restServer.start(restServerConfigurationBuilder.build(), localCacheManager);

--- a/query/src/test/java/org/infinispan/query/api/ManualIndexingTest.java
+++ b/query/src/test/java/org/infinispan/query/api/ManualIndexingTest.java
@@ -30,12 +30,10 @@ public class ManualIndexingTest extends MultipleCacheManagersTest {
          Cache<String, Car> cache = cacheManager.getCache();
          caches.add(cache);
       }
-      waitForClusterToForm(new String[] {
-            getDefaultCacheName(),
-            "LuceneIndexesMetadata",
-            "LuceneIndexesData",
-            "LuceneIndexesLocking",
-      });
+      waitForClusterToForm("default",
+                           "LuceneIndexesMetadata",
+                           "LuceneIndexesData",
+                           "LuceneIndexesLocking");
    }
 
    public void testManualIndexing() throws Exception {

--- a/query/src/test/java/org/infinispan/query/backend/MergeTest.java
+++ b/query/src/test/java/org/infinispan/query/backend/MergeTest.java
@@ -4,7 +4,6 @@ import static org.infinispan.query.helper.StaticTestingErrorHandler.assertAllGoo
 import static org.infinispan.test.TestingUtil.killCacheManagers;
 
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
@@ -64,9 +63,9 @@ public class MergeTest extends MultipleCacheManagersTest {
             .addProperty("default.indexwriter.ram_buffer_size", "256")
             .addProperty("lucene_version", "LUCENE_CURRENT");
 
-      List<Cache<Long, Person>> caches = createClusteredCaches(2, cacheCfg);
-      cache1 = caches.get(0);
-      cache2 = caches.get(1);
+      createClusteredCaches(2, cacheCfg);
+      cache1 = cache(0);
+      cache2 = cache(1);
    }
 
    public void testMergesWrites() throws Exception {

--- a/query/src/test/java/org/infinispan/query/blackbox/ClusteredCacheTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/ClusteredCacheTest.java
@@ -127,9 +127,9 @@ public class ClusteredCacheTest extends MultipleCacheManagersTest {
       cacheCfg.memory()
             .storageType(storageType);
       enhanceConfig(cacheCfg);
-      List<Cache<Object, Person>> caches = createClusteredCaches(2, QueryTestSCI.INSTANCE, cacheCfg);
-      cache1 = caches.get(0);
-      cache2 = caches.get(1);
+      createClusteredCaches(2, QueryTestSCI.INSTANCE, cacheCfg);
+      cache1 = cache(0);
+      cache2 = cache(1);
    }
 
    private void prepareTestedObjects() {

--- a/query/src/test/java/org/infinispan/query/blackbox/ClusteredCacheWithLongIndexNameTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/ClusteredCacheWithLongIndexNameTest.java
@@ -3,7 +3,6 @@ package org.infinispan.query.blackbox;
 import static org.testng.AssertJUnit.assertEquals;
 
 import java.io.Serializable;
-import java.util.List;
 
 import org.apache.lucene.search.Query;
 import org.hibernate.search.annotations.Field;
@@ -39,11 +38,10 @@ public class ClusteredCacheWithLongIndexNameTest extends MultipleCacheManagersTe
 
    @Override
    protected void createCacheManagers() throws Throwable {
-      List<Cache<String, ClassWithLongIndexName>> caches =
-            createClusteredCaches(3, SCI.INSTANCE, getDefaultConfiguration());
-      cache0 = caches.get(0);
-      cache1 = caches.get(1);
-      cache2 = caches.get(2);
+      createClusteredCaches(3, SCI.INSTANCE, getDefaultConfiguration());
+      cache0 = cache(0);
+      cache1 = cache(1);
+      cache2 = cache(2);
    }
 
    private ConfigurationBuilder getDefaultConfiguration() {

--- a/query/src/test/java/org/infinispan/query/blackbox/ClusteredDistCacheTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/ClusteredDistCacheTest.java
@@ -1,7 +1,5 @@
 package org.infinispan.query.blackbox;
 
-import java.util.List;
-
 import org.infinispan.Cache;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
@@ -28,10 +26,10 @@ public class ClusteredDistCacheTest extends ClusteredCacheTest {
 
       cacheCfg.memory().storageType(storageType);
       enhanceConfig(cacheCfg);
-      List<Cache<Object, Person>> caches = createClusteredCaches(3, QueryTestSCI.INSTANCE, cacheCfg);
-      cache1 = caches.get(0);
-      cache2 = caches.get(1);
-      cache3 = caches.get(2);
+      createClusteredCaches(3, QueryTestSCI.INSTANCE, cacheCfg);
+      cache1 = cache(0);
+      cache2 = cache(1);
+      cache3 = cache(2);
    }
 
 }

--- a/query/src/test/java/org/infinispan/query/blackbox/ClusteredPessimisticLockingCacheTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/ClusteredPessimisticLockingCacheTest.java
@@ -1,8 +1,5 @@
 package org.infinispan.query.blackbox;
 
-import java.util.List;
-
-import org.infinispan.Cache;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.Index;
@@ -31,9 +28,9 @@ public class ClusteredPessimisticLockingCacheTest extends ClusteredCacheTest {
             .addProperty("error_handler", StaticTestingErrorHandler.class.getName())
             .addProperty("lucene_version", "LUCENE_CURRENT");
       enhanceConfig(cacheCfg);
-      List<Cache<Object, Person>> caches = createClusteredCaches(2, QueryTestSCI.INSTANCE, cacheCfg);
-      cache1 = caches.get(0);
-      cache2 = caches.get(1);
+      createClusteredCaches(2, QueryTestSCI.INSTANCE, cacheCfg);
+      cache1 = cache(0);
+      cache2 = cache(1);
    }
 
    protected boolean transactionsEnabled() {

--- a/query/src/test/java/org/infinispan/query/blackbox/ClusteredQueryMultipleCachesTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/ClusteredQueryMultipleCachesTest.java
@@ -1,7 +1,5 @@
 package org.infinispan.query.blackbox;
 
-import java.util.List;
-
 import org.infinispan.Cache;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.Index;
@@ -30,7 +28,7 @@ public class ClusteredQueryMultipleCachesTest extends ClusteredQueryTest {
             .addProperty("default.directory_provider", "local-heap")
             .addProperty("error_handler", "org.infinispan.query.helper.StaticTestingErrorHandler")
             .addProperty("lucene_version", "LUCENE_CURRENT");
-      List<Cache<String, Person>> caches = createClusteredCaches(2, QueryTestSCI.INSTANCE, cacheCfg, new TransportFlags(), "cacheA", "cacheB");
+      createClusteredCaches(2, QueryTestSCI.INSTANCE, cacheCfg, new TransportFlags(), "cacheA", "cacheB");
       cacheAMachine1 = manager(0).getCache("cacheA");
       cacheAMachine2 = manager(1).getCache("cacheA");
       cacheBMachine1 = manager(0).getCache("cacheB");

--- a/query/src/test/java/org/infinispan/query/blackbox/ClusteredQueryTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/ClusteredQueryTest.java
@@ -103,9 +103,9 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
             .addProperty("lucene_version", "LUCENE_CURRENT");
       cacheCfg.memory()
             .storageType(storageType);
-      List<Cache<String, Person>> caches = createClusteredCaches(2, QueryTestSCI.INSTANCE, cacheCfg);
-      cacheAMachine1 = caches.get(0);
-      cacheAMachine2 = caches.get(1);
+      createClusteredCaches(2, QueryTestSCI.INSTANCE, cacheCfg);
+      cacheAMachine1 = cache(0);
+      cacheAMachine2 = cache(1);
       populateCache();
    }
 

--- a/query/src/test/java/org/infinispan/query/blackbox/ObjectStorageClusteredCacheTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/ObjectStorageClusteredCacheTest.java
@@ -2,9 +2,6 @@ package org.infinispan.query.blackbox;
 
 import static org.infinispan.commons.dataconversion.MediaType.APPLICATION_OBJECT_TYPE;
 
-import java.util.List;
-
-import org.infinispan.Cache;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.Index;
@@ -34,9 +31,9 @@ public class ObjectStorageClusteredCacheTest extends ClusteredCacheTest {
             .addProperty("error_handler", "org.infinispan.query.helper.StaticTestingErrorHandler")
             .addProperty("lucene_version", "LUCENE_CURRENT");
       enhanceConfig(cacheCfg);
-      List<Cache<Object, Person>> caches = createClusteredCaches(2, QueryTestSCI.INSTANCE, cacheCfg);
-      cache1 = caches.get(0);
-      cache2 = caches.get(1);
+      createClusteredCaches(2, QueryTestSCI.INSTANCE, cacheCfg);
+      cache1 = cache(0);
+      cache2 = cache(1);
    }
 
 }

--- a/query/src/test/java/org/infinispan/query/blackbox/TopologyAwareClusteredCacheTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/TopologyAwareClusteredCacheTest.java
@@ -2,8 +2,8 @@ package org.infinispan.query.blackbox;
 
 import java.util.List;
 
-import org.infinispan.Cache;
 import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.query.helper.TestQueryHelperFactory;
 import org.infinispan.query.test.Person;
 import org.testng.annotations.Test;
@@ -18,15 +18,13 @@ public class TopologyAwareClusteredCacheTest extends ClusteredCacheTest {
 
    @Override
    protected void createCacheManagers() throws Throwable {
-      List caches = TestQueryHelperFactory.createTopologyAwareCacheNodes(
+      List<EmbeddedCacheManager> managers = TestQueryHelperFactory.createTopologyAwareCacheNodes(
                2, getCacheMode(), transactionEnabled(), isIndexLocalOnly(), isRamDirectory(), "default", Person.class);
 
-      for (Object cache : caches) {
-         cacheManagers.add(((Cache) cache).getCacheManager());
-      }
+      registerCacheManager(managers);
 
-      cache1 = (Cache<Object, Person>) caches.get(0);
-      cache2 = (Cache<Object, Person>) caches.get(1);
+      cache1 = cache(0);
+      cache2 = cache(1);
 
       waitForClusterToForm();
    }

--- a/query/src/test/java/org/infinispan/query/blackbox/TopologyAwareClusteredQueryTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/TopologyAwareClusteredQueryTest.java
@@ -1,10 +1,11 @@
 package org.infinispan.query.blackbox;
 
+import static org.infinispan.query.helper.TestQueryHelperFactory.createTopologyAwareCacheNodes;
+
 import java.util.List;
 
-import org.infinispan.Cache;
 import org.infinispan.configuration.cache.CacheMode;
-import org.infinispan.query.helper.TestQueryHelperFactory;
+import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.query.test.Person;
 import org.testng.annotations.Test;
 
@@ -18,15 +19,14 @@ public class TopologyAwareClusteredQueryTest extends ClusteredQueryTest {
 
    @Override
    protected void createCacheManagers() throws Throwable {
-      List caches = TestQueryHelperFactory.createTopologyAwareCacheNodes(2, getCacheMode(), transactionEnabled(),
-            isIndexLocalOnly(), isRamDirectory(), "default", Person.class);
+      List<EmbeddedCacheManager> managers = createTopologyAwareCacheNodes(2, getCacheMode(), transactionEnabled(),
+                                                                          isIndexLocalOnly(), isRamDirectory(),
+                                                                          "default", Person.class);
 
-      for (Object cache : caches) {
-         cacheManagers.add(((Cache) cache).getCacheManager());
-      }
+      registerCacheManager(managers);
 
-      cacheAMachine1 = (Cache<String, Person>) caches.get(0);
-      cacheAMachine2 = (Cache<String, Person>) caches.get(1);
+      cacheAMachine1 = cache(0);
+      cacheAMachine2 = cache(1);
 
       waitForClusterToForm();
       populateCache();

--- a/query/src/test/java/org/infinispan/query/distributed/AsyncMassIndexPerfTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/AsyncMassIndexPerfTest.java
@@ -1,6 +1,5 @@
 package org.infinispan.query.distributed;
 
-import java.util.List;
 import java.util.Scanner;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -11,6 +10,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.hibernate.search.spi.impl.PojoIndexedTypeIdentifier;
 import org.infinispan.Cache;
+import org.infinispan.commons.test.TestResourceTracker;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.Index;
@@ -23,7 +23,6 @@ import org.infinispan.query.impl.ComponentRegistryUtils;
 import org.infinispan.query.impl.massindex.IndexUpdater;
 import org.infinispan.query.test.Transaction;
 import org.infinispan.test.MultipleCacheManagersTest;
-import org.infinispan.commons.test.TestResourceTracker;
 
 /**
  * Long running test for the async MassIndexer, specially regarding cancellation. Supposed to be run as a main class.
@@ -75,9 +74,9 @@ public class AsyncMassIndexPerfTest extends MultipleCacheManagersTest {
             .addProperty("error_handler", "org.infinispan.query.helper.StaticTestingErrorHandler")
             .addProperty("lucene_version", "LUCENE_CURRENT");
 
-      List<Cache<Integer, Transaction>> caches = createClusteredCaches(2, cacheCfg);
-      cache1 = caches.get(0);
-      cache2 = caches.get(1);
+      createClusteredCaches(2, cacheCfg);
+      cache1 = cache(0);
+      cache2 = cache(1);
       massIndexer = Search.getSearchManager(cache1).getMassIndexer();
    }
 

--- a/query/src/test/java/org/infinispan/query/distributed/DistProgrammaticMassIndexTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/DistProgrammaticMassIndexTest.java
@@ -48,8 +48,6 @@ public class DistProgrammaticMassIndexTest extends DistributedMassIndexingTest {
          holder.newConfigurationBuilder(InfinispanIntegration.DEFAULT_INDEXESDATA_CACHENAME).read(cacheCfg1);
          holder.newConfigurationBuilder(InfinispanIntegration.DEFAULT_LOCKING_CACHENAME).read(cacheCfg1);
       }, NUM_NODES);
-
-      caches.addAll(caches());
    }
 
    protected void verifyFindsCar(Cache cache, int count, String carMake) throws Exception {

--- a/query/src/test/java/org/infinispan/query/distributed/DistributedMassIndexingTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/DistributedMassIndexingTest.java
@@ -2,9 +2,6 @@ package org.infinispan.query.distributed;
 
 import static org.testng.AssertJUnit.assertEquals;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.apache.lucene.search.Query;
 import org.hibernate.search.query.dsl.QueryBuilder;
 import org.infinispan.Cache;
@@ -17,7 +14,7 @@ import org.infinispan.query.helper.StaticTestingErrorHandler;
 import org.infinispan.query.queries.faceting.Car;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
-import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
 /**
@@ -28,7 +25,9 @@ public class DistributedMassIndexingTest extends MultipleCacheManagersTest {
 
    protected static final int NUM_NODES = 3;
 
-   protected List<Cache> caches = new ArrayList<>(NUM_NODES);
+   {
+      cleanup = CleanupPhase.AFTER_METHOD;
+   }
 
    protected String getConfigurationFile() {
       return "dynamic-indexing-distribution.xml";
@@ -39,25 +38,30 @@ public class DistributedMassIndexingTest extends MultipleCacheManagersTest {
       for (int i = 0; i < NUM_NODES; i++) {
          EmbeddedCacheManager cacheManager = TestCacheManagerFactory.fromXml(getConfigurationFile());
          registerCacheManager(cacheManager);
-         Cache cache = cacheManager.getCache(getClass().getSimpleName());
-         caches.add(cache);
+         cacheManager.getCache();
       }
       waitForClusterToForm();
    }
 
+   @AfterMethod(alwaysRun = true)
+   @Override
+   protected void clearContent() throws Throwable {
+      super.clearContent();
+   }
+
    public void testReindexing() throws Exception {
-      caches.get(0).put(key("F1NUM"), new Car("megane", "white", 300));
+      cache(0).put(key("F1NUM"), new Car("megane", "white", 300));
       verifyFindsCar(1, "megane");
-      caches.get(1).put(key("F2NUM"), new Car("megane", "blue", 300));
+      cache(1).put(key("F2NUM"), new Car("megane", "blue", 300));
       verifyFindsCar(2, "megane");
       //add an entry without indexing it:
-      caches.get(1).getAdvancedCache().withFlags(Flag.SKIP_INDEXING).put(key("F3NUM"), new Car("megane", "blue", 300));
+      cache(1).getAdvancedCache().withFlags(Flag.SKIP_INDEXING).put(key("F3NUM"), new Car("megane", "blue", 300));
       verifyFindsCar(2, "megane");
       //re-sync datacontainer with indexes:
       rebuildIndexes();
       verifyFindsCar(3, "megane");
       //verify we cleanup old stale index values:
-      caches.get(2).getAdvancedCache().withFlags(Flag.SKIP_INDEXING).remove(key("F2NUM"));
+      cache(2).getAdvancedCache().withFlags(Flag.SKIP_INDEXING).remove(key("F2NUM"));
       verifyFindsCar(3, "megane");
       //re-sync
       rebuildIndexes();
@@ -65,10 +69,10 @@ public class DistributedMassIndexingTest extends MultipleCacheManagersTest {
    }
 
    public void testPartiallyReindex() throws Exception {
-      caches.get(0).getAdvancedCache().withFlags(Flag.SKIP_INDEXING).put(key("F1NUM"), new Car("megane", "white", 300));
-      Search.getSearchManager(caches.get(0)).getMassIndexer().reindex(key("F1NUM")).get();
+      cache(0).getAdvancedCache().withFlags(Flag.SKIP_INDEXING).put(key("F1NUM"), new Car("megane", "white", 300));
+      Search.getSearchManager(cache(0)).getMassIndexer().reindex(key("F1NUM")).get();
       verifyFindsCar(1, "megane");
-      caches.get(0).remove(key("F1NUM"));
+      cache(0).remove(key("F1NUM"));
       verifyFindsCar(0, "megane");
    }
 
@@ -78,13 +82,13 @@ public class DistributedMassIndexingTest extends MultipleCacheManagersTest {
    }
 
    protected void rebuildIndexes() throws Exception {
-      Cache cache = caches.get(0);
+      Cache cache = cache(0);
       SearchManager searchManager = Search.getSearchManager(cache);
       searchManager.getMassIndexer().start();
    }
 
    protected void verifyFindsCar(int expectedCount, String carMake) throws Exception {
-      for (Cache cache : caches) {
+      for (Cache cache : caches()) {
          StaticTestingErrorHandler.assertAllGood(cache);
          verifyFindsCar(cache, expectedCount, carMake);
       }
@@ -96,22 +100,5 @@ public class DistributedMassIndexingTest extends MultipleCacheManagersTest {
       Query fullTextQuery = carQueryBuilder.keyword().onField("make").matching(carMake).createQuery();
       CacheQuery<Car> cacheQuery = searchManager.getQuery(fullTextQuery, Car.class);
       assertEquals(expectedCount, cacheQuery.getResultSize());
-   }
-
-   @Override
-   protected boolean cleanupAfterTest() {
-      return false;
-   }
-
-   @Override
-   protected boolean cleanupAfterMethod() {
-      return true;
-   }
-
-   @BeforeMethod
-   @Override
-   public void createBeforeMethod() throws Throwable {
-      caches.clear();
-      super.createBeforeMethod();
    }
 }

--- a/query/src/test/java/org/infinispan/query/distributed/MassIndexingTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/MassIndexingTest.java
@@ -28,32 +28,32 @@ import org.testng.annotations.Test;
 public class MassIndexingTest extends DistributedMassIndexingTest {
 
    public void testReindexing() throws Exception {
-      for (int i = 0; i < 200; i++) {
-         caches.get(i % 2).getAdvancedCache().withFlags(Flag.SKIP_INDEXING).put(key("F" + i + "NUM"),
+      for (int i = 0; i < 10; i++) {
+         cache(i % 2).getAdvancedCache().withFlags(Flag.SKIP_INDEXING).put(key("F" + i + "NUM"),
                new Car((i % 2 == 0 ? "megane" : "bmw"), "blue", 300 + i));
       }
 
       //Adding also non-indexed values
-      caches.get(0).getAdvancedCache().put(key("FNonIndexed1NUM"), new NotIndexedType("test1"));
-      caches.get(0).getAdvancedCache().put(key("FNonIndexed2NUM"), new NotIndexedType("test2"));
+      cache(0).getAdvancedCache().put(key("FNonIndexed1NUM"), new NotIndexedType("test1"));
+      cache(0).getAdvancedCache().put(key("FNonIndexed2NUM"), new NotIndexedType("test2"));
 
       verifyFindsCar(0, "megane");
       verifyFindsCar(0, "test1");
       verifyFindsCar(0, "test2");
 
-      caches.get(0).getAdvancedCache().withFlags(Flag.SKIP_INDEXING).put(key("FNonIndexed3NUM"), new NotIndexedType("test3"));
+      cache(0).getAdvancedCache().withFlags(Flag.SKIP_INDEXING).put(key("FNonIndexed3NUM"), new NotIndexedType("test3"));
       verifyFindsCar(0, "test3");
 
       //re-sync datacontainer with indexes:
       rebuildIndexes();
 
-      verifyFindsCar(100, "megane");
+      verifyFindsCar(5, "megane");
       verifyFindsCar(0, "test1");
       verifyFindsCar(0, "test2");
    }
 
    public void testOverlappingMassIndexers() {
-      Cache<Integer, Car> cache = caches.get(0);
+      Cache<Integer, Car> cache = cache(0);
       SearchManager searchManager = Search.getSearchManager(cache);
       MassIndexer massIndexer = searchManager.getMassIndexer();
 
@@ -92,7 +92,7 @@ public class MassIndexingTest extends DistributedMassIndexingTest {
 
    @Override
    protected void rebuildIndexes() throws Exception {
-      Cache cache = caches.get(0);
+      Cache cache = cache(0);
       SearchManager searchManager = Search.getSearchManager(cache);
       CompletableFuture<Void> future = searchManager.getMassIndexer().startAsync();
       future.get();

--- a/query/src/test/java/org/infinispan/query/distributed/MassIndexingWithStoreTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/MassIndexingWithStoreTest.java
@@ -20,7 +20,7 @@ public class MassIndexingWithStoreTest extends DistributedMassIndexingTest {
 
    @Override
    public void testReindexing() throws Exception {
-      Cache<String, Car> cache0 = caches.get(0);
+      Cache<String, Car> cache0 = cache(0);
       for (int i = 0; i < 10; i++) {
          cache0.put("CAR#" + i, new Car("Volkswagen", "white", 200));
       }

--- a/query/src/test/java/org/infinispan/query/distributed/OverlappingDistMassIndexTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/OverlappingDistMassIndexTest.java
@@ -1,8 +1,5 @@
 package org.infinispan.query.distributed;
 
-import java.util.List;
-
-import org.infinispan.Cache;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.Index;
@@ -32,12 +29,10 @@ public class OverlappingDistMassIndexTest extends OverlappingIndexMassIndexTest 
             .addProperty("default.indexmanager", "org.infinispan.query.indexmanager.InfinispanIndexManager")
             .addProperty("lucene_version", "LUCENE_CURRENT");
 
-      List<Cache<String, Object>> cacheList = createClusteredCaches(NUM_NODES, QueryTestSCI.INSTANCE, cacheCfg);
+      createClusteredCaches(NUM_NODES, QueryTestSCI.INSTANCE, cacheCfg);
 
       waitForClusterToForm(getDefaultCacheName());
 
-      for (Cache cache : cacheList) {
-         caches.add(cache);
-      }
+      caches = caches();
    }
 }

--- a/query/src/test/java/org/infinispan/query/distributed/OverlappingIndexMassIndexTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/OverlappingIndexMassIndexTest.java
@@ -44,13 +44,11 @@ public class OverlappingIndexMassIndexTest extends MultipleCacheManagersTest {
             .addProperty("error_handler", "org.infinispan.query.helper.StaticTestingErrorHandler")
             .addProperty("lucene_version", "LUCENE_CURRENT");
 
-      List<Cache<String, Object>> cacheList = createClusteredCaches(NUM_NODES, QueryTestSCI.INSTANCE, cacheCfg);
+      createClusteredCaches(NUM_NODES, QueryTestSCI.INSTANCE, cacheCfg);
 
       waitForClusterToForm(getDefaultCacheName());
 
-      for (Cache cache : cacheList) {
-         caches.add(cache);
-      }
+      caches = caches();
    }
 
    public void testReindex() throws Exception {

--- a/query/src/test/java/org/infinispan/query/distributed/ReplRamMassIndexingTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/ReplRamMassIndexingTest.java
@@ -3,8 +3,6 @@ package org.infinispan.query.distributed;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
-import java.util.List;
-
 import org.infinispan.Cache;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
@@ -34,29 +32,25 @@ public class ReplRamMassIndexingTest extends DistributedMassIndexingTest {
             .clustering()
             .hash().numSegments(10 * NUM_NODES);
       cacheCfg.clustering().stateTransfer().fetchInMemoryState(true);
-      List<Cache<String, Car>> cacheList = createClusteredCaches(NUM_NODES, QueryTestSCI.INSTANCE, cacheCfg);
+      createClusteredCaches(NUM_NODES, QueryTestSCI.INSTANCE, cacheCfg);
 
       waitForClusterToForm(getDefaultCacheName());
-
-      for (Cache cache : cacheList) {
-         caches.add(cache);
-      }
    }
 
    @Override
    public void testReindexing() throws Exception {
       final int NUM_CARS = 100;
       for (int i = 0; i < NUM_CARS; ++i) {
-         caches.get(i % NUM_NODES).put("car" + i, new Car("skoda", "white", 42));
+         cache(i % NUM_NODES).put("car" + i, new Car("skoda", "white", 42));
       }
-      for (Cache cache : caches) {
+      for (Cache cache : caches()) {
          assertEquals(cache.size(), NUM_CARS);
          verifyFindsCar(cache, NUM_CARS, "skoda");
       }
       rebuildIndexes();
       for (int i = 0; i < NUM_CARS; ++i) {
          String key = "car" + i;
-         for (Cache cache : caches) {
+         for (Cache cache : caches()) {
             assertNotNull(cache.get(key));
          }
       }
@@ -65,7 +59,7 @@ public class ReplRamMassIndexingTest extends DistributedMassIndexingTest {
 
    @Override
    protected void rebuildIndexes() {
-      for (Cache cache : caches) {
+      for (Cache cache : caches()) {
          MassIndexer massIndexer = Search.getSearchManager(cache).getMassIndexer();
          eventually(() -> !massIndexer.isRunning());
          massIndexer.start();

--- a/query/src/test/java/org/infinispan/query/distributed/TopologyAwareDistMassIndexingTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/TopologyAwareDistMassIndexingTest.java
@@ -1,10 +1,14 @@
 package org.infinispan.query.distributed;
 
-import org.infinispan.Cache;
+import static org.infinispan.query.helper.TestQueryHelperFactory.createTopologyAwareCacheNodes;
+
+import java.util.List;
+
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.hibernate.search.spi.InfinispanIntegration;
-import org.infinispan.query.helper.TestQueryHelperFactory;
+import org.infinispan.manager.CacheContainer;
+import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.query.queries.faceting.Car;
 import org.testng.annotations.Test;
 
@@ -16,19 +20,18 @@ public class TopologyAwareDistMassIndexingTest extends DistributedMassIndexingTe
 
    @Override
    protected void createCacheManagers() throws Throwable {
-      caches = TestQueryHelperFactory.createTopologyAwareCacheNodes(NUM_NODES, CacheMode.DIST_SYNC, false, true, false,
-            getClass().getSimpleName(), holder -> {
-               Configuration cacheCfg1 = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, false)
-                     .clustering().stateTransfer().fetchInMemoryState(true).build();
-               holder.newConfigurationBuilder(InfinispanIntegration.DEFAULT_INDEXESDATA_CACHENAME).read(cacheCfg1);
-               holder.newConfigurationBuilder(InfinispanIntegration.DEFAULT_LOCKING_CACHENAME).read(cacheCfg1);
-            },
-            Car.class);
+      List<EmbeddedCacheManager> managers =
+            createTopologyAwareCacheNodes(NUM_NODES, CacheMode.DIST_SYNC, false, true,
+                                          false, getClass().getSimpleName(), holder -> {
+                     Configuration cacheCfg1 = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, false)
+                           .clustering().stateTransfer().fetchInMemoryState(true).build();
+                     holder.newConfigurationBuilder(InfinispanIntegration.DEFAULT_INDEXESDATA_CACHENAME).read(
+                           cacheCfg1);
+                     holder.newConfigurationBuilder(InfinispanIntegration.DEFAULT_LOCKING_CACHENAME).read(cacheCfg1);
+                  },
+                                          Car.class);
 
-      for(Object cache : caches) {
-         Cache cacheObj = (Cache) cache;
-         cacheManagers.add(cacheObj.getCacheManager());
-      }
+      registerCacheManager(managers.toArray(new CacheContainer[0]));
 
       waitForClusterToForm();
    }

--- a/query/src/test/java/org/infinispan/query/helper/TestQueryHelperFactory.java
+++ b/query/src/test/java/org/infinispan/query/helper/TestQueryHelperFactory.java
@@ -61,16 +61,16 @@ public class TestQueryHelperFactory {
       return component;
    }
 
-   public static List createTopologyAwareCacheNodes(int numberOfNodes, CacheMode cacheMode, boolean transactional,
-         boolean indexLocalOnly, boolean isRamDirectoryProvider, String defaultCacheName, Class... indexedTypes) {
+   public static List<EmbeddedCacheManager> createTopologyAwareCacheNodes(int numberOfNodes, CacheMode cacheMode, boolean transactional,
+         boolean indexLocalOnly, boolean isRamDirectoryProvider, String defaultCacheName, Class<?>... indexedTypes) {
       return createTopologyAwareCacheNodes(numberOfNodes, cacheMode, transactional, indexLocalOnly,
             isRamDirectoryProvider, defaultCacheName, f -> {}, indexedTypes);
    }
 
-   public static List createTopologyAwareCacheNodes(int numberOfNodes, CacheMode cacheMode, boolean transactional,
+   public static List<EmbeddedCacheManager> createTopologyAwareCacheNodes(int numberOfNodes, CacheMode cacheMode, boolean transactional,
          boolean indexLocalOnly, boolean isRamDirectoryProvider, String defaultCacheName,
-         Consumer<ConfigurationBuilderHolder> holderConsumer, Class... indexedTypes) {
-      List caches = new ArrayList();
+         Consumer<ConfigurationBuilderHolder> holderConsumer, Class<?>... indexedTypes) {
+      List<EmbeddedCacheManager> managers = new ArrayList<>();
 
       ConfigurationBuilder builder = AbstractCacheTest.getDefaultClusteredCacheConfig(cacheMode, transactional);
 
@@ -90,7 +90,7 @@ public class TestQueryHelperFactory {
             builder.clustering().stateTransfer().fetchInMemoryState(true);
          }
       }
-      for (Class indexedType : indexedTypes) {
+      for (Class<?> indexedType : indexedTypes) {
          builder.indexing().addIndexedEntity(indexedType);
       }
 
@@ -103,12 +103,12 @@ public class TestQueryHelperFactory {
          holderConsumer.accept(holder);
          holder.newConfigurationBuilder(defaultCacheName).read(builder.build());
 
-         EmbeddedCacheManager cm1 = TestCacheManagerFactory.createClusteredCacheManager(holder);
+         EmbeddedCacheManager cm = TestCacheManagerFactory.createClusteredCacheManager(holder);
 
-         caches.add(cm1.getCache());
+         managers.add(cm);
       }
 
-      return caches;
+      return managers;
    }
 
 }

--- a/query/src/test/java/org/infinispan/query/jmx/DistributedMassIndexingViaJmxTest.java
+++ b/query/src/test/java/org/infinispan/query/jmx/DistributedMassIndexingViaJmxTest.java
@@ -7,7 +7,6 @@ import java.net.URL;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 
-import org.infinispan.Cache;
 import org.infinispan.commons.CacheException;
 import org.infinispan.commons.jmx.MBeanServerLookup;
 import org.infinispan.commons.jmx.TestMBeanServerLookup;
@@ -44,8 +43,7 @@ public class DistributedMassIndexingViaJmxTest extends DistributedMassIndexingTe
 
          EmbeddedCacheManager cm = TestCacheManagerFactory.createClusteredCacheManager(holder);
          registerCacheManager(cm);
-         Cache cache = cm.getCache(getClass().getSimpleName());
-         caches.add(cache);
+         cm.getCache();
       }
       waitForClusterToForm();
    }
@@ -53,8 +51,9 @@ public class DistributedMassIndexingViaJmxTest extends DistributedMassIndexingTe
    @Override
    protected void rebuildIndexes() throws Exception {
       String cacheManagerName = manager(0).getCacheManagerConfiguration().cacheManagerName();
+      String defaultCacheName = manager(0).getCacheManagerConfiguration().defaultCacheName().orElse(null);
       ObjectName massIndexerObjName = getMassIndexerObjectName(
-            BASE_JMX_DOMAIN + 0, cacheManagerName, getClass().getSimpleName());
+            BASE_JMX_DOMAIN + 0, cacheManagerName, defaultCacheName);
       mBeanServerLookup.getMBeanServer().invoke(massIndexerObjName, "start", new Object[0], new String[0]);
    }
 

--- a/query/src/test/java/org/infinispan/query/searchmanager/ClusteredCacheQueryTimeoutTest.java
+++ b/query/src/test/java/org/infinispan/query/searchmanager/ClusteredCacheQueryTimeoutTest.java
@@ -2,7 +2,6 @@ package org.infinispan.query.searchmanager;
 
 import static org.infinispan.query.helper.TestQueryHelperFactory.createQueryParser;
 
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.lucene.queryparser.classic.QueryParser;
@@ -16,7 +15,6 @@ import org.infinispan.query.CacheQuery;
 import org.infinispan.query.Search;
 import org.infinispan.query.SearchManager;
 import org.infinispan.query.dsl.IndexedQueryMode;
-import org.infinispan.query.test.Person;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.testng.annotations.Test;
 
@@ -38,8 +36,8 @@ public class ClusteredCacheQueryTimeoutTest extends MultipleCacheManagersTest {
             .addIndexedEntity(Foo.class)
             .addProperty("default.directory_provider", "local-heap")
             .addProperty("lucene_version", "LUCENE_CURRENT");
-      List<Cache<String, Person>> caches = createClusteredCaches(2, cacheCfg);
-      cache1 = caches.get(0);
+      createClusteredCaches(2, cacheCfg);
+      cache1 = cache(0);
    }
 
    @Test(expectedExceptions = UnsupportedOperationException.class, expectedExceptionsMessageRegExp = "Clustered queries do not support timeouts yet.")

--- a/server/core/src/test/java/org/infinispan/server/core/AbstractMarshallingTest.java
+++ b/server/core/src/test/java/org/infinispan/server/core/AbstractMarshallingTest.java
@@ -7,6 +7,7 @@ import java.util.Random;
 
 import org.infinispan.commons.CacheException;
 import org.infinispan.commons.marshall.StreamingMarshaller;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.test.TestingUtil;
@@ -28,7 +29,7 @@ public abstract class AbstractMarshallingTest extends AbstractInfinispanTest {
    @BeforeClass(alwaysRun=true)
    public void setUp() {
       // Manual addition of externalizers to replication what happens in fully functional tests
-      cm = TestCacheManagerFactory.createCacheManager();
+      cm = TestCacheManagerFactory.createCacheManager(new ConfigurationBuilder());
       marshaller = TestingUtil.extractGlobalMarshaller(cm.getCache().getCacheManager());
    }
 

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/CrashedMemberDetectorTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/CrashedMemberDetectorTest.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.infinispan.Cache;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.distribution.TestAddress;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.notifications.cachemanagerlistener.event.Event.Type;
@@ -26,7 +27,7 @@ public class CrashedMemberDetectorTest extends SingleCacheManagerTest {
 
    @Override
    protected EmbeddedCacheManager createCacheManager() {
-      return TestCacheManagerFactory.createCacheManager();
+      return TestCacheManagerFactory.createCacheManager(new ConfigurationBuilder());
    }
 
    public void testDetectCrashedMembers() {

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodMergeTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodMergeTest.java
@@ -52,7 +52,7 @@ public class HotRodMergeTest extends BasePartitionHandlingTest {
       ConfigurationBuilder dcc = hotRodCacheConfiguration();
       dcc.clustering().cacheMode(cacheMode).hash().numOwners(1);
       dcc.clustering().partitionHandling().whenSplit(partitionHandling);
-      createClusteredCaches(numMembersInCluster, dcc, new TransportFlags().withFD(true).withMerge(true), "merge");
+      createClusteredCaches(numMembersInCluster, dcc, new TransportFlags().withFD(true).withMerge(true));
       waitForClusterToForm();
 
       // Allow servers for both instances to run in parallel
@@ -63,8 +63,7 @@ public class HotRodMergeTest extends BasePartitionHandlingTest {
          nextServerPort += 1;
       }
 
-      client = new HotRodClient("127.0.0.1", servers.get(0).getPort(), "merge", 60, (byte) 21);
-      TestingUtil.waitForNoRebalance(cache(0), cache(1));
+      client = new HotRodClient("127.0.0.1", servers.get(0).getPort(), getDefaultCacheName(), 60, (byte) 21);
    }
 
    @AfterClass(alwaysRun = true)
@@ -145,7 +144,7 @@ public class HotRodMergeTest extends BasePartitionHandlingTest {
          if (resp.topologyResponse == null || (resp.topologyResponse.topologyId < expectedTopologyId)) {
             return false;
          }
-         assertHashTopology20Received(resp.topologyResponse, servers, getDefaultCacheName(), expectedTopologyId);
+         assertHashTopology20Received(resp.topologyResponse, servers, client.defaultCacheName(), expectedTopologyId);
          return true;
       });
    }
@@ -153,7 +152,7 @@ public class HotRodMergeTest extends BasePartitionHandlingTest {
    private void expectCompleteTopology(HotRodClient c, int expectedTopologyId) {
       TestResponse resp = c.ping(INTELLIGENCE_HASH_DISTRIBUTION_AWARE, 0);
       assertStatus(resp, Success);
-      assertHashTopology20Received(resp.topologyResponse, servers, getDefaultCacheName(), expectedTopologyId);
+      assertHashTopology20Received(resp.topologyResponse, servers, client.defaultCacheName(), expectedTopologyId);
    }
 
    private void eventuallyExpectPartialTopology(HotRodClient c, int expectedTopologyId) {
@@ -163,7 +162,7 @@ public class HotRodMergeTest extends BasePartitionHandlingTest {
          if (resp.topologyResponse == null || (resp.topologyResponse.topologyId < expectedTopologyId)) {
             return false;
          }
-         assertHashTopology20Received(resp.topologyResponse, Arrays.asList(servers.get(0)), getDefaultCacheName(),
+         assertHashTopology20Received(resp.topologyResponse, Arrays.asList(servers.get(0)), client.defaultCacheName(),
                                       expectedTopologyId);
          return true;
       });
@@ -172,7 +171,7 @@ public class HotRodMergeTest extends BasePartitionHandlingTest {
    private void expectPartialTopology(HotRodClient c, int expectedTopologyId) {
       TestResponse resp = c.ping(INTELLIGENCE_HASH_DISTRIBUTION_AWARE, 0);
       assertStatus(resp, Success);
-      assertHashTopology20Received(resp.topologyResponse, Arrays.asList(servers.get(0)), getDefaultCacheName(),
+      assertHashTopology20Received(resp.topologyResponse, Arrays.asList(servers.get(0)), client.defaultCacheName(),
                                    expectedTopologyId);
    }
 

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodSingleNodeTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodSingleNodeTest.java
@@ -12,7 +12,6 @@ import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.server.hotrod.test.HotRodClient;
 import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
-import org.infinispan.commons.test.TestResourceTracker;
 
 
 /**
@@ -39,7 +38,7 @@ public abstract class HotRodSingleNodeTest extends SingleCacheManagerTest {
 
    @Override
    protected void setup() throws Exception {
-      cacheName = TestResourceTracker.getCurrentTestShortName();
+      cacheName = TestCacheManagerFactory.DEFAULT_CACHE_NAME;
       super.setup();
       hotRodServer = createStartHotRodServer(cacheManager);
       hotRodClient = connectClient();

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/logging/HotRodAccessLoggingTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/logging/HotRodAccessLoggingTest.java
@@ -43,6 +43,6 @@ public class HotRodAccessLoggingTest extends HotRodSingleNodeTest {
       String logline = logAppender.getLog(0);
       assertTrue(logline, logline.matches(
             "^127\\.0\\.0\\.1 - \\[\\d+/\\w+/\\d+:\\d+:\\d+:\\d+ [+-]?\\d*] \"PUT /" +
-            testShortName + "/\\[B0x6B6579 HOTROD/2\\.1\" OK \\d+ \\d+ \\d+$"));
+            getDefaultCacheName() + "/\\[B0x6B6579 HOTROD/2\\.1\" OK \\d+ \\d+ \\d+$"));
    }
 }

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/test/HotRodTestingUtil.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/test/HotRodTestingUtil.java
@@ -148,7 +148,7 @@ public class HotRodTestingUtil {
 
    public static HotRodServer startHotRodServer(EmbeddedCacheManager manager, int port, int idleTimeout,
                                                 String proxyHost, int proxyPort, long delay) {
-      return startHotRodServer(manager, port, idleTimeout, proxyHost, proxyPort, delay, TestResourceTracker.getCurrentTestShortName());
+      return startHotRodServer(manager, port, idleTimeout, proxyHost, proxyPort, delay, null);
    }
 
    public static HotRodServer startHotRodServer(EmbeddedCacheManager manager, int port, HotRodServerConfigurationBuilder builder) {

--- a/server/memcached/src/test/java/org/infinispan/server/memcached/MemcachedClusteredStatsTest.java
+++ b/server/memcached/src/test/java/org/infinispan/server/memcached/MemcachedClusteredStatsTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.server.memcached;
 
+import static org.infinispan.commons.test.TestResourceTracker.getCurrentTestShortName;
 import static org.infinispan.test.fwk.TestCacheManagerFactory.configureJmx;
 
 import javax.management.JMException;
@@ -30,6 +31,7 @@ public class MemcachedClusteredStatsTest extends MemcachedMultiNodeTest {
    @Override
    public EmbeddedCacheManager createCacheManager(int index) {
       GlobalConfigurationBuilder globalBuilder = GlobalConfigurationBuilder.defaultClusteredBuilder();
+      globalBuilder.defaultCacheName(cacheName);
       configureJmx(globalBuilder, JMX_DOMAIN + "-" + index, mBeanServerLookup);
       ConfigurationBuilder builder = new ConfigurationBuilder();
       builder.clustering().cacheMode(CacheMode.REPL_SYNC);
@@ -38,7 +40,7 @@ public class MemcachedClusteredStatsTest extends MemcachedMultiNodeTest {
 
    public void testSingleConnectionPerServer() throws Exception {
       ObjectName objectName = new ObjectName(String.format("%s-0:type=Server,component=Transport,name=Memcached-%s-%d",
-            JMX_DOMAIN, getClass().getSimpleName(), servers.get(0).getPort()));
+                                                           JMX_DOMAIN, getCurrentTestShortName(), servers.get(0).getPort()));
 
       // Now verify that via JMX as well, these stats are also as expected
       eventuallyEquals(2, () -> {

--- a/server/rest/src/test/java/org/infinispan/rest/resources/CacheManagerResourceTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/resources/CacheManagerResourceTest.java
@@ -11,8 +11,10 @@ import static org.testng.AssertJUnit.assertFalse;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.eclipse.jetty.client.api.ContentResponse;
@@ -20,6 +22,7 @@ import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
 import org.infinispan.commons.configuration.JsonWriter;
 import org.infinispan.commons.dataconversion.MediaType;
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfiguration;
@@ -131,11 +134,8 @@ public class CacheManagerResourceTest extends AbstractRestResourceTest {
       String json = response.getContentAsString();
       JsonNode jsonNode = mapper.readTree(json);
       List<String> names = asText(jsonNode.findValues("name"));
-      assertEquals("CacheManagerResourceTest", names.get(0));
-      assertEquals("___protobuf_metadata", names.get(1));
-      assertEquals("___script_cache", names.get(2));
-      assertEquals("cache1", names.get(3));
-      assertEquals("cache2", names.get(4));
+      Set<String> expectedNames = Util.asSet("defaultcache", "___protobuf_metadata", "___script_cache", "cache1", "cache2");
+      assertEquals(expectedNames, new HashSet<>(names));
 
       List<String> status = asText(jsonNode.findValues("status"));
       assertTrue(status.contains("RUNNING"));

--- a/spring/spring5/spring5-embedded/src/test/java/org/infinispan/spring/embedded/provider/SpringEmbeddedCacheManagerTest.java
+++ b/spring/spring5/spring5-embedded/src/test/java/org/infinispan/spring/embedded/provider/SpringEmbeddedCacheManagerTest.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.util.Collection;
 
 import org.infinispan.commons.IllegalLifecycleStateException;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.spring.common.provider.SpringCache;
@@ -138,7 +139,7 @@ public class SpringEmbeddedCacheManagerTest extends AbstractInfinispanTest {
     */
    @Test
    public final void stopShouldStopTheNativeEmbeddedCacheManager() {
-      withCacheManager(new CacheManagerCallable(TestCacheManagerFactory.createCacheManager()) {
+      withCacheManager(new CacheManagerCallable(TestCacheManagerFactory.createCacheManager(new ConfigurationBuilder())) {
          @Override
          public void call() {
             cm.getCache(); // Implicitly starts EmbeddedCacheManager
@@ -165,11 +166,9 @@ public class SpringEmbeddedCacheManagerTest extends AbstractInfinispanTest {
       withCacheManager(new CacheManagerCallable(TestCacheManagerFactory.createCacheManager()) {
          @Override
          public void call() {
-            final SpringEmbeddedCacheManager objectUnderTest = new SpringEmbeddedCacheManager(
-                  cm);
+            final SpringEmbeddedCacheManager objectUnderTest = new SpringEmbeddedCacheManager(cm);
 
-            final EmbeddedCacheManager nativeCacheManagerReturned = objectUnderTest
-                  .getNativeCacheManager();
+            final EmbeddedCacheManager nativeCacheManagerReturned = objectUnderTest.getNativeCacheManager();
 
             assertSame(
                   "getNativeCacheManager() should have returned the EmbeddedCacheManager supplied at construction time. However, it retuned a different one.",
@@ -184,6 +183,7 @@ public class SpringEmbeddedCacheManagerTest extends AbstractInfinispanTest {
          @Override
          public void call() {
             // Given
+            cm.defineConfiguration("same", new ConfigurationBuilder().build());
             final SpringEmbeddedCacheManager objectUnderTest = new SpringEmbeddedCacheManager(cm);
             final String sameCacheName = "same";
 
@@ -205,6 +205,8 @@ public class SpringEmbeddedCacheManagerTest extends AbstractInfinispanTest {
          @Override
          public void call() {
             // Given
+            cm.defineConfiguration("thisCache", new ConfigurationBuilder().build());
+            cm.defineConfiguration("thatCache", new ConfigurationBuilder().build());
             final SpringEmbeddedCacheManager objectUnderTest = new SpringEmbeddedCacheManager(cm);
             final String firstCacheName = "thisCache";
             final String secondCacheName = "thatCache";
@@ -227,6 +229,7 @@ public class SpringEmbeddedCacheManagerTest extends AbstractInfinispanTest {
          @Override
          public void call() {
             // Given
+            cm.defineConfiguration("same", new ConfigurationBuilder().build());
             final SpringEmbeddedCacheManager objectUnderTest = new SpringEmbeddedCacheManager(cm);
             final String sameCacheName = "same";
 

--- a/spring/spring5/spring5-embedded/src/test/java/org/infinispan/spring/embedded/session/EmbeddedApplicationPublishedBridgeTest.java
+++ b/spring/spring5/spring5-embedded/src/test/java/org/infinispan/spring/embedded/session/EmbeddedApplicationPublishedBridgeTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.spring.embedded.session;
 
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.spring.common.provider.SpringCache;
 import org.infinispan.spring.common.session.AbstractInfinispanSessionRepository;
@@ -18,7 +19,7 @@ public class EmbeddedApplicationPublishedBridgeTest extends InfinispanApplicatio
 
    @BeforeClass
    public void beforeClass() {
-      embeddedCacheManager = TestCacheManagerFactory.createCacheManager();
+      embeddedCacheManager = TestCacheManagerFactory.createCacheManager(new ConfigurationBuilder());
    }
 
    @AfterMethod

--- a/spring/spring5/spring5-embedded/src/test/java/org/infinispan/spring/embedded/session/InfinispanEmbeddedSessionRepositoryTest.java
+++ b/spring/spring5/spring5-embedded/src/test/java/org/infinispan/spring/embedded/session/InfinispanEmbeddedSessionRepositoryTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.spring.embedded.session;
 
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.spring.common.provider.SpringCache;
 import org.infinispan.spring.common.session.AbstractInfinispanSessionRepository;
@@ -18,7 +19,7 @@ public class InfinispanEmbeddedSessionRepositoryTest extends InfinispanSessionRe
 
    @BeforeClass
    public void beforeClass() {
-      embeddedCacheManager = TestCacheManagerFactory.createCacheManager();
+      embeddedCacheManager = TestCacheManagerFactory.createCacheManager(new ConfigurationBuilder());
    }
 
    @AfterMethod

--- a/spring/spring5/spring5-embedded/src/test/java/org/infinispan/spring/embedded/support/InfinispanDefaultCacheFactoryBeanContextTest.java
+++ b/spring/spring5/spring5-embedded/src/test/java/org/infinispan/spring/embedded/support/InfinispanDefaultCacheFactoryBeanContextTest.java
@@ -4,7 +4,10 @@ import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertSame;
 
 import org.infinispan.Cache;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.spring.common.InfinispanTestExecutionListener;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ContextConfiguration;
@@ -49,5 +52,12 @@ public class InfinispanDefaultCacheFactoryBeanContextTest extends AbstractTestNG
             "InfinispanDefaultCacheFactoryBean should always return the same cache instance when being "
                   + "called repeatedly. However, the cache instances are not the same.",
             testDefaultCache1, testDefaultCache2);
+   }
+
+   /**
+    * Referenced in the Spring configuration.
+    */
+   public static EmbeddedCacheManager createCacheManager() {
+      return TestCacheManagerFactory.createCacheManager(new ConfigurationBuilder());
    }
 }

--- a/spring/spring5/spring5-embedded/src/test/java/org/infinispan/spring/embedded/support/InfinispanDefaultCacheFactoryBeanTest.java
+++ b/spring/spring5/spring5-embedded/src/test/java/org/infinispan/spring/embedded/support/InfinispanDefaultCacheFactoryBeanTest.java
@@ -3,6 +3,7 @@ package org.infinispan.spring.embedded.support;
 import static org.testng.AssertJUnit.assertEquals;
 
 import org.infinispan.Cache;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.spring.embedded.InfinispanDefaultCacheFactoryBean;
 import org.infinispan.test.AbstractInfinispanTest;
@@ -43,7 +44,7 @@ public class InfinispanDefaultCacheFactoryBeanTest extends AbstractInfinispanTes
    @Test
    public final void infinispanDefaultCacheFactoryBeanShouldProduceANonNullInfinispanCache() {
       final InfinispanDefaultCacheFactoryBean<Object, Object> objectUnderTest = new InfinispanDefaultCacheFactoryBean<Object, Object>();
-      TestingUtil.withCacheManager(new CacheManagerCallable(TestCacheManagerFactory.createCacheManager()) {
+      TestingUtil.withCacheManager(new CacheManagerCallable(TestCacheManagerFactory.createCacheManager(new ConfigurationBuilder())) {
          @Override
          public void call() {
             try {
@@ -70,7 +71,7 @@ public class InfinispanDefaultCacheFactoryBeanTest extends AbstractInfinispanTes
    @Test
    public final void getObjectTypeShouldReturnTheMostDerivedTypeOfTheProducedInfinispanCache() {
       final InfinispanDefaultCacheFactoryBean<Object, Object> objectUnderTest = new InfinispanDefaultCacheFactoryBean<Object, Object>();
-      TestingUtil.withCacheManager(new CacheManagerCallable(TestCacheManagerFactory.createCacheManager()) {
+      TestingUtil.withCacheManager(new CacheManagerCallable(TestCacheManagerFactory.createCacheManager(new ConfigurationBuilder())) {
          @Override
          public void call() {
             try {
@@ -92,7 +93,7 @@ public class InfinispanDefaultCacheFactoryBeanTest extends AbstractInfinispanTes
 
    /**
     * Test method for
-    * {@link org.infinispan.spring.support.InfinispanDefaultCacheFactoryBean#isSingleton()}.
+    * {@link org.infinispan.spring.embedded.InfinispanDefaultCacheFactoryBean#isSingleton()}.
     */
    @Test
    public final void infinispanDefaultCacheFactoryBeanShouldDeclareItselfToBeSingleton() {
@@ -105,12 +106,12 @@ public class InfinispanDefaultCacheFactoryBeanTest extends AbstractInfinispanTes
 
    /**
     * Test method for
-    * {@link org.infinispan.spring.support.InfinispanDefaultCacheFactoryBean#destroy()}.
+    * {@link org.infinispan.spring.embedded.InfinispanDefaultCacheFactoryBean#destroy()}.
     */
    @Test
    public final void infinispanDefaultCacheFactoryBeanShouldStopTheCreatedInfinispanCacheWhenItIsDestroyed() {
       final InfinispanDefaultCacheFactoryBean<Object, Object> objectUnderTest = new InfinispanDefaultCacheFactoryBean<Object, Object>();
-      TestingUtil.withCacheManager(new CacheManagerCallable(TestCacheManagerFactory.createCacheManager()) {
+      TestingUtil.withCacheManager(new CacheManagerCallable(TestCacheManagerFactory.createCacheManager(new ConfigurationBuilder())) {
          @Override
          public void call() {
             try {

--- a/spring/spring5/spring5-embedded/src/test/java/org/infinispan/spring/embedded/support/InfinispanNamedEmbeddedCacheFactoryBeanTest.java
+++ b/spring/spring5/spring5-embedded/src/test/java/org/infinispan/spring/embedded/support/InfinispanNamedEmbeddedCacheFactoryBeanTest.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import org.infinispan.Cache;
+import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -41,22 +42,15 @@ public class InfinispanNamedEmbeddedCacheFactoryBeanTest extends AbstractInfinis
    @BeforeClass
    public void startCacheManagers() {
       DEFAULT_CACHE_MANAGER = TestCacheManagerFactory.createCacheManager();
+      Configuration configuration = new ConfigurationBuilder().build();
+      DEFAULT_CACHE_MANAGER.defineConfiguration("test.cache.Name", configuration);
+      DEFAULT_CACHE_MANAGER.defineConfiguration("test.bean.Name", configuration);
       DEFAULT_CACHE_MANAGER.start();
 
-      InputStream configStream = null;
-      try {
-         configStream = NAMED_ASYNC_CACHE_CONFIG_LOCATION.getInputStream();
+      try (InputStream configStream = NAMED_ASYNC_CACHE_CONFIG_LOCATION.getInputStream()) {
          PRECONFIGURED_DEFAULT_CACHE_MANAGER = TestCacheManagerFactory.fromStream(configStream);
       } catch (final IOException e) {
          throw new ExceptionInInitializerError(e);
-      } finally {
-         if (configStream != null) {
-            try {
-               configStream.close();
-            } catch (final IOException e) {
-               // Ignore
-            }
-         }
       }
    }
 

--- a/spring/spring5/spring5-embedded/src/test/resources/org/infinispan/spring/embedded/support/InfinispanDefaultCacheFactoryBeanContextTest.xml
+++ b/spring/spring5/spring5-embedded/src/test/resources/org/infinispan/spring/embedded/support/InfinispanDefaultCacheFactoryBeanContextTest.xml
@@ -7,7 +7,7 @@
 
     <bean
             id="infinispanCacheContainer"
-            class="org.infinispan.test.fwk.TestCacheManagerFactory"
+            class="org.infinispan.spring.embedded.support.InfinispanDefaultCacheFactoryBeanContextTest"
             factory-method="createCacheManager"
             destroy-method="stop"/>
 

--- a/spring/spring5/spring5-remote/src/test/java/org/infinispan/spring/remote/session/RemoteApplicationPublishedBridgeTest.java
+++ b/spring/spring5/spring5-remote/src/test/java/org/infinispan/spring/remote/session/RemoteApplicationPublishedBridgeTest.java
@@ -35,7 +35,7 @@ public class RemoteApplicationPublishedBridgeTest extends InfinispanApplicationP
 
    @BeforeClass
    public void beforeClass() {
-      embeddedCacheManager = TestCacheManagerFactory.createCacheManager();
+      embeddedCacheManager = TestCacheManagerFactory.createCacheManager(new org.infinispan.configuration.cache.ConfigurationBuilder());
       hotrodServer = HotRodTestingUtil.startHotRodServer(embeddedCacheManager, 19723);
       ConfigurationBuilder builder = new ConfigurationBuilder();
       builder.addServer().host("localhost").port(hotrodServer.getPort())

--- a/tasks/scripting/src/test/java/org/infinispan/scripting/ScriptingTaskManagerTest.java
+++ b/tasks/scripting/src/test/java/org/infinispan/scripting/ScriptingTaskManagerTest.java
@@ -1,10 +1,12 @@
 package org.infinispan.scripting;
 
+import static org.infinispan.test.TestingUtil.extractGlobalComponent;
 import static org.testng.AssertJUnit.assertEquals;
 
 import java.util.List;
 
 import org.infinispan.commons.CacheException;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.scripting.impl.ScriptTask;
 import org.infinispan.scripting.utils.ScriptingUtils;
@@ -34,12 +36,12 @@ public class ScriptingTaskManagerTest extends SingleCacheManagerTest {
    @Override
    protected void setup() throws Exception {
       super.setup();
-      taskManager = cacheManager.getGlobalComponentRegistry().getComponent(TaskManager.class);
-      cacheManager.defineConfiguration(ScriptingTest.CACHE_NAME, cacheManager.getDefaultCacheConfiguration());
+      taskManager = extractGlobalComponent(cacheManager, TaskManager.class);
+      cacheManager.defineConfiguration(ScriptingTest.CACHE_NAME, new ConfigurationBuilder().build());
    }
 
    public void testTask() throws Exception {
-      ScriptingManager scriptingManager = cacheManager.getGlobalComponentRegistry().getComponent(ScriptingManager.class);
+      ScriptingManager scriptingManager = extractGlobalComponent(cacheManager, ScriptingManager.class);
       ScriptingUtils.loadScript(scriptingManager, TEST_SCRIPT);
       String result = (String) taskManager.runTask(TEST_SCRIPT, new TaskContext().addParameter("a", "a")).get();
       assertEquals("a", result);
@@ -61,7 +63,7 @@ public class ScriptingTaskManagerTest extends SingleCacheManagerTest {
 
    @Test(expectedExceptions = CacheException.class, expectedExceptionsMessageRegExp = ".*Script execution error.*")
    public void testBrokenTask() throws Exception {
-      ScriptingManager scriptingManager = cacheManager.getGlobalComponentRegistry().getComponent(ScriptingManager.class);
+      ScriptingManager scriptingManager = extractGlobalComponent(cacheManager, ScriptingManager.class);
       ScriptingUtils.loadScript(scriptingManager, BROKEN_SCRIPT);
       taskManager.runTask(BROKEN_SCRIPT, new TaskContext()).get();
    }

--- a/tasks/scripting/src/test/java/org/infinispan/scripting/ScriptingTest.java
+++ b/tasks/scripting/src/test/java/org/infinispan/scripting/ScriptingTest.java
@@ -13,6 +13,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
+import org.infinispan.Cache;
 import org.infinispan.commons.CacheException;
 import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
@@ -124,7 +125,7 @@ public class ScriptingTest extends AbstractScriptingTest {
 
       cacheManager.getCache(CACHE_NAME).put(key, value);
 
-      CompletableFuture exec = scriptingManager.runScript("testExecWithoutProp.js");
+      CompletableFuture<?> exec = scriptingManager.runScript("testExecWithoutProp.js");
       exec.get(1000, TimeUnit.MILLISECONDS);
 
       assertEquals(value + ":additionFromJavascript", cacheManager.getCache(CACHE_NAME).get(key));
@@ -214,10 +215,11 @@ public class ScriptingTest extends AbstractScriptingTest {
    public void testMapReduceScript() throws IOException, ExecutionException, InterruptedException {
       InputStream is = this.getClass().getResourceAsStream("/wordCountStream.js");
       String script = loadFileAsString(is);
-      loadData(cache(), "/macbeth.txt");
+      Cache<String, String> cache = cache(CACHE_NAME);
+      loadData(cache, "/macbeth.txt");
 
       scriptingManager.addScript("wordCountStream.js", script);
-      Map<String, Long> result = (Map<String, Long>) scriptingManager.runScript("wordCountStream.js", new TaskContext().cache(cache())).get();
+      Map<String, Long> result = (Map<String, Long>) scriptingManager.runScript("wordCountStream.js", new TaskContext().cache(cache)).get();
       assertEquals(3202, result.size());
       assertEquals(Long.valueOf(287), result.get("macbeth"));
    }

--- a/tools/src/test/java/org/infinispan/tools/store/migrator/AbstractReaderTest.java
+++ b/tools/src/test/java/org/infinispan/tools/store/migrator/AbstractReaderTest.java
@@ -83,6 +83,7 @@ public abstract class AbstractReaderTest extends AbstractInfinispanTest {
 
       GlobalConfigurationBuilder globalConfig = new GlobalConfigurationBuilder();
       globalConfig.serialization().addContextInitializer(TestUtil.SCI.INSTANCE);
+      globalConfig.defaultCacheName(TEST_CACHE_NAME);
 
       // Create a new cache instance, with the required externalizers, to ensure that the new RocksDbStore can be
       // loaded and contains all of the expected values.


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-11367

* Change tests to define the default cache only when necessary.
* Change TestCacheManagerFactory to define the default cache only when
  requested.
* Change default cache name to "defaultcache".