### PR TITLE
[10.1] ISPN-11455 TestingUtil.waitForNoRebalanceAcrossManagers: do not start…

### DIFF
--- a/core/src/test/java/org/infinispan/test/TestingUtil.java
+++ b/core/src/test/java/org/infinispan/test/TestingUtil.java
@@ -442,11 +442,15 @@ public class TestingUtil {
       log.debugf("waitForNoRebalance with managers %s, for caches %s", Arrays.toString(managers), testCaches);
 
       for (String cacheName : testCaches) {
-         Cache<?, ?>[] caches = new Cache[numberOfManagers];
-         for (int i = 0; i < numberOfManagers; i++)
-            caches[i] = managers[i].getCache(cacheName);
+         ArrayList<Cache<?, ?>> caches = new ArrayList<>(numberOfManagers);
+         for (EmbeddedCacheManager manager : managers) {
+            Cache<?, ?> cache = manager.getCache(cacheName, false);
+            if (cache != null) {
+               caches.add(cache);
+            }
+         }
 
-         TestingUtil.waitForNoRebalance(caches);
+         TestingUtil.waitForNoRebalance(caches.toArray(new Cache[0]));
       }
    }
 


### PR DESCRIPTION
… internal caches

https://issues.redhat.com/browse/ISPN-11455