### PR TITLE
ISPN-11463 Cache manager stats are mistakenly exported as MP metrics …

### DIFF
--- a/core/src/main/java/org/infinispan/metrics/impl/CacheManagerMetricsRegistration.java
+++ b/core/src/main/java/org/infinispan/metrics/impl/CacheManagerMetricsRegistration.java
@@ -1,6 +1,10 @@
 package org.infinispan.metrics.impl;
 
+import java.util.Set;
+
+import org.eclipse.microprofile.metrics.MetricID;
 import org.infinispan.factories.annotations.SurvivesRestarts;
+import org.infinispan.factories.impl.MBeanMetadata;
 import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
 
@@ -15,10 +19,12 @@ import org.infinispan.factories.scopes.Scopes;
 public final class CacheManagerMetricsRegistration extends AbstractMetricsRegistration {
 
    @Override
-   protected String initNamePrefix() {
-      String prefix = globalConfig.metrics().namesAsTags() ?
-            "" : "cache_manager_" + NameUtils.filterIllegalChars(globalConfig.cacheManagerName()) + '_';
-      String globalPrefix = globalConfig.metrics().prefix();
-      return globalPrefix != null && !globalPrefix.isEmpty() ? globalPrefix + '_' + prefix : prefix;
+   public boolean metricsEnabled() {
+      return metricsCollector != null && globalConfig.statistics();
+   }
+
+   @Override
+   protected Set<MetricID> internalRegisterMetrics(Object instance, MBeanMetadata beanMetadata, String metricPrefix) {
+      return metricsCollector.registerMetrics(instance, beanMetadata, metricPrefix, null);
    }
 }

--- a/core/src/main/java/org/infinispan/metrics/impl/CacheMetricsRegistration.java
+++ b/core/src/main/java/org/infinispan/metrics/impl/CacheMetricsRegistration.java
@@ -29,17 +29,14 @@ public final class CacheMetricsRegistration extends AbstractMetricsRegistration 
    @Inject
    String cacheName;
 
-   @Inject
-   CacheManagerMetricsRegistration globalMetricsRegistration;
-
    @Override
    public boolean metricsEnabled() {
-      return globalMetricsRegistration.metricsEnabled() && cacheConfiguration.statistics().enabled();
+      return metricsCollector != null && cacheConfiguration.statistics().enabled();
    }
 
    @Override
    protected String initNamePrefix() {
-      String prefix = globalMetricsRegistration.namePrefix;
+      String prefix = super.initNamePrefix();
       if (!globalConfig.metrics().namesAsTags()) {
          prefix += "cache_" + NameUtils.filterIllegalChars(cacheName) + '_';
       }

--- a/core/src/test/java/org/infinispan/metrics/ClusteredCacheManagerMetricsTest.java
+++ b/core/src/test/java/org/infinispan/metrics/ClusteredCacheManagerMetricsTest.java
@@ -31,7 +31,8 @@ public class ClusteredCacheManagerMetricsTest extends MultipleCacheManagersTest 
    @Override
    protected void createCacheManagers() throws Throwable {
       GlobalConfigurationBuilder globalConfig1 = GlobalConfigurationBuilder.defaultClusteredBuilder();
-      globalConfig1.metrics().prefix("ispn").gauges(true).histograms(true).namesAsTags(true);
+      globalConfig1.cacheContainer().statistics(true)
+                   .metrics().prefix("ispn").gauges(true).histograms(true).namesAsTags(true);
 
       ConfigurationBuilder config = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC);
       config.statistics().enable();

--- a/server/rest/src/main/java/org/infinispan/rest/resources/CacheResourceV2.java
+++ b/server/rest/src/main/java/org/infinispan/rest/resources/CacheResourceV2.java
@@ -331,7 +331,7 @@ public class CacheResourceV2 extends BaseCacheResource implements ResourceHandle
       return completedFuture(responseBuilder.build());
    }
 
-   class CacheFullDetail {
+   static class CacheFullDetail {
       public Stats stats;
       public int size;
       @JsonRawValue
@@ -346,5 +346,4 @@ public class CacheResourceV2 extends BaseCacheResource implements ResourceHandle
       public boolean indexingInProgress;
       public boolean statistics;
    }
-
 }

--- a/server/rest/src/main/java/org/infinispan/rest/resources/MetricsResource.java
+++ b/server/rest/src/main/java/org/infinispan/rest/resources/MetricsResource.java
@@ -42,6 +42,11 @@ public final class MetricsResource implements ResourceHandler {
    private final MetricsRequestHandler requestHandler = new MetricsRequestHandler();
 
    public MetricsResource() {
+      registerBaseMetrics();
+   }
+
+   // this is kept separate just in case Quarkus needs to replace it with nil
+   private void registerBaseMetrics() {
       try {
          new JmxRegistrar().init();
       } catch (IOException | IllegalArgumentException e) {


### PR DESCRIPTION
…even when stats disabled

The actual values are just constant and meaningless 0s, so better just skip registering those metrics.

https://issues.redhat.com/browse/ISPN-11463