### PR TITLE
ISPN-11465 Upgrade to JGroups 4.2.1.Final

### DIFF
--- a/build-configuration/pom.xml
+++ b/build-configuration/pom.xml
@@ -171,7 +171,7 @@
       <version.jboss.xnio>3.7.7.Final</version.jboss.xnio>
       <version.jcip-annotations>1.0</version.jcip-annotations>
       <version.jetty>9.4.5.v20170502</version.jetty>
-      <version.jgroups>4.1.9.Final</version.jgroups>
+      <version.jgroups>4.2.1.Final</version.jgroups>
       <version.jsr107>1.1.0</version.jsr107>
       <version.junit>4.13</version.junit>
       <version.karaf>4.2.3</version.karaf>

--- a/core/src/main/resources/default-configs/default-jgroups-azure.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-azure.xml
@@ -4,7 +4,7 @@
 -->
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.1.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.2.xsd">
    <TCP bind_addr="${jgroups.bind.address,jgroups.tcp.address:SITE_LOCAL}"
         bind_port="${jgroups.bind.port,jgroups.tcp.port:7800}"
         enable_diagnostics="false"

--- a/core/src/main/resources/default-configs/default-jgroups-ec2.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-ec2.xml
@@ -4,7 +4,7 @@
 -->
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.1.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.2.xsd">
    <TCP bind_addr="${jgroups.bind.address,jgroups.tcp.address:SITE_LOCAL}"
         bind_port="${jgroups.bind.port,jgroups.tcp.port:7800}"
         enable_diagnostics="false"

--- a/core/src/main/resources/default-configs/default-jgroups-google.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-google.xml
@@ -4,7 +4,7 @@
 -->
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.1.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.2.xsd">
 
    <TCP bind_addr="${jgroups.bind.address,jgroups.tcp.address:SITE_LOCAL}"
         bind_port="${jgroups.bind.port,jgroups.tcp.port:7800}"

--- a/core/src/main/resources/default-configs/default-jgroups-kubernetes.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-kubernetes.xml
@@ -4,7 +4,7 @@
 -->
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.1.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.2.xsd">
 
    <TCP bind_addr="${jgroups.bind.address,jgroups.tcp.address:SITE_LOCAL}"
         bind_port="${jgroups.bind.port,jgroups.tcp.port:7800}"

--- a/core/src/main/resources/default-configs/default-jgroups-tcp.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-tcp.xml
@@ -1,6 +1,6 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.1.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.2.xsd">
    <TCP bind_addr="${jgroups.bind.address,jgroups.tcp.address:SITE_LOCAL}"
         bind_port="${jgroups.bind.port,jgroups.tcp.port:7800}"
         enable_diagnostics="false"
@@ -19,8 +19,8 @@
           num_discovery_runs="3"
           ip_ttl="${jgroups.udp.ip_ttl:2}"
    />
-   <MERGE3 min_interval="10000" 
-           max_interval="30000" 
+   <MERGE3 min_interval="10000"
+           max_interval="30000"
    />
    <FD_SOCK />
    <!-- Suspect node `timeout` to `timeout + timeout_check_interval` millis after the last heartbeat -->

--- a/core/src/main/resources/default-configs/default-jgroups-udp.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-udp.xml
@@ -1,6 +1,6 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.1.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.2.xsd">
    <UDP bind_addr="${jgroups.bind.address,jgroups.udp.address:SITE_LOCAL}"
         bind_port="${jgroups.bind.port,jgroups.udp.port:0}"
         mcast_addr="${jgroups.mcast_addr:228.6.7.8}"
@@ -21,8 +21,8 @@
         thread_pool.keep_alive_time="60000"
    />
    <PING num_discovery_runs="3"/>
-   <MERGE3 min_interval="10000" 
-           max_interval="30000" 
+   <MERGE3 min_interval="10000"
+           max_interval="30000"
    />
    <FD_SOCK />
    <!-- Suspect node `timeout` to `timeout + timeout_check_interval` millis after the last heartbeat -->

--- a/core/src/main/resources/schema/infinispan-config-11.0.xsd
+++ b/core/src/main/resources/schema/infinispan-config-11.0.xsd
@@ -5,7 +5,7 @@
            xmlns:jgroups="urn:org:jgroups"
            xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
-  <xs:import namespace="urn:org:jgroups" schemaLocation="http://www.jgroups.org/schema/jgroups-4.1.xsd"/>
+  <xs:import namespace="urn:org:jgroups" schemaLocation="http://www.jgroups.org/schema/jgroups-4.2.xsd"/>
 
   <xs:element name="infinispan" type="tns:infinispan">
     <xs:annotation>

--- a/core/src/test/java/org/infinispan/configuration/parsing/UnifiedXmlFileParsingTest.java
+++ b/core/src/test/java/org/infinispan/configuration/parsing/UnifiedXmlFileParsingTest.java
@@ -154,7 +154,7 @@ public class UnifiedXmlFileParsingTest extends AbstractInfinispanTest {
                ProtocolConfiguration proto1 = tcp.getProtocolStack().get(i);
                ProtocolConfiguration proto2 = mytcp.getProtocolStack().get(i);
                assertEquals(proto1.getProtocolName(), proto2.getProtocolName());
-               if (proto1.getProtocolName().equals("FD_ALL")) {
+               if (proto1.getProtocolName().equals("FD_ALL") || proto1.getProtocolName().equals("FD_ALL3")) {
                   assertEquals("tcp>FD_ALL>timeout", "3000", proto1.getProperties().get("timeout"));
                   assertEquals("tcp>FD_ALL>interval", "1000", proto1.getProperties().get("interval"));
                   assertEquals("mytcp>FD_ALL>timeout", "3500", proto2.getProperties().get("timeout"));

--- a/core/src/test/java/org/infinispan/test/fwk/JGroupsConfigBuilder.java
+++ b/core/src/test/java/org/infinispan/test/fwk/JGroupsConfigBuilder.java
@@ -4,6 +4,7 @@ import static org.infinispan.commons.util.Immutables.immutableMapCopy;
 import static org.infinispan.test.fwk.JGroupsConfigBuilder.ProtocolType.FD;
 import static org.infinispan.test.fwk.JGroupsConfigBuilder.ProtocolType.FD_ALL;
 import static org.infinispan.test.fwk.JGroupsConfigBuilder.ProtocolType.FD_ALL2;
+import static org.infinispan.test.fwk.JGroupsConfigBuilder.ProtocolType.FD_ALL3;
 import static org.infinispan.test.fwk.JGroupsConfigBuilder.ProtocolType.FD_SOCK;
 import static org.infinispan.test.fwk.JGroupsConfigBuilder.ProtocolType.MERGE3;
 import static org.infinispan.test.fwk.JGroupsConfigBuilder.ProtocolType.TCP;
@@ -113,8 +114,9 @@ public class JGroupsConfigBuilder {
     * protocols from the given JGroups stack.
     */
    private static void removeFailureDetection(JGroupsProtocolCfg jgroupsCfg) {
-      jgroupsCfg.removeProtocol(FD).removeProtocol(FD_SOCK).removeProtocol(FD_ALL).removeProtocol(FD_ALL2)
-            .removeProtocol(VERIFY_SUSPECT);
+      jgroupsCfg.removeProtocol(FD).removeProtocol(FD_SOCK)
+                .removeProtocol(FD_ALL).removeProtocol(FD_ALL2).removeProtocol(FD_ALL3)
+                .removeProtocol(VERIFY_SUSPECT);
    }
 
    private static void removeRelay2(JGroupsProtocolCfg jgroupsCfg) {
@@ -262,7 +264,7 @@ public class JGroupsConfigBuilder {
       TCP, TCP_NIO2, UDP, SHARED_LOOPBACK,
       MPING, PING, TCPPING, LOCAL_PING, SHARED_LOOPBACK_PING,
       MERGE2, MERGE3,
-      FD_SOCK, FD, VERIFY_SUSPECT, FD_ALL, FD_ALL2,
+      FD_SOCK, FD, VERIFY_SUSPECT, FD_ALL, FD_ALL2, FD_ALL3,
       BARRIER,
       UNICAST, UNICAST2, UNICAST3,
       NAKACK, NAKACK2,

--- a/core/src/test/resources/configs/config-with-jgroups-stack.xml
+++ b/core/src/test/resources/configs/config-with-jgroups-stack.xml
@@ -1,9 +1,9 @@
 <infinispan
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:infinispan:config:10.1 https://infinispan.org/schemas/infinispan-config-10.1.xsd
-                          urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.1.xsd"
-        xmlns="urn:infinispan:config:10.1"
-        xmlns:ispn="urn:infinispan:config:10.1">
+        xsi:schemaLocation="urn:infinispan:config:11.0 https://infinispan.org/schemas/infinispan-config-11.0.xsd
+                          urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.2.xsd"
+        xmlns="urn:infinispan:config:11.0"
+        xmlns:ispn="urn:infinispan:config:11.0">
     <jgroups transport="org.infinispan.remoting.transport.jgroups.JGroupsTransport">
         <!-- Load external JGroups stacks -->
         <stack-file name="udp-test" path="stacks/udp.xml"/>
@@ -22,7 +22,7 @@
                    xmlns="urn:org:jgroups"/>
             <MERGE3 xmlns="urn:org:jgroups"/>
             <FD_SOCK xmlns="urn:org:jgroups"/>
-            <FD_ALL timeout="3000"
+            <FD_ALL3 timeout="3000"
                     interval="1000"
                     timeout_check_interval="1000"
                     xmlns="urn:org:jgroups"
@@ -56,7 +56,7 @@
         </stack>
         <!-- Use the "tcp" stack but override some protocol attributes -->
         <stack name="mytcp" extends="tcp-test">
-            <FD_ALL timeout="3500" ispn:stack.combine="COMBINE" xmlns="urn:org:jgroups"/>
+            <FD_ALL3 timeout="3500" ispn:stack.combine="COMBINE" xmlns="urn:org:jgroups"/>
         </stack>
         <!-- Use the "tcp" stack but replace the discovery -->
         <stack name="tcpgossip" extends="tcp-test">

--- a/core/src/test/resources/configs/unified/10.0.xml
+++ b/core/src/test/resources/configs/unified/10.0.xml
@@ -23,7 +23,7 @@
 
          <MERGE3 xmlns="urn:org:jgroups"/>
          <FD_SOCK xmlns="urn:org:jgroups"/>
-         <FD_ALL timeout="3000"
+         <FD_ALL3 timeout="3000"
                  interval="1000"
                  timeout_check_interval="1000"
                  xmlns="urn:org:jgroups"
@@ -57,7 +57,7 @@
       </stack>
       <!-- Use the "tcp" stack but override some protocol attributes -->
       <stack name="mytcp" extends="tcp-test">
-         <FD_ALL timeout="3500" ispn:stack.combine="COMBINE" xmlns="urn:org:jgroups"/>
+         <FD_ALL3 timeout="3500" ispn:stack.combine="COMBINE" xmlns="urn:org:jgroups"/>
       </stack>
       <!-- Use the "tcp" stack but replace the discovery -->
       <stack name="tcpgossip" extends="tcp-test">

--- a/core/src/test/resources/configs/unified/10.1.xml
+++ b/core/src/test/resources/configs/unified/10.1.xml
@@ -23,7 +23,7 @@
 
          <MERGE3 xmlns="urn:org:jgroups"/>
          <FD_SOCK xmlns="urn:org:jgroups"/>
-         <FD_ALL timeout="3000"
+         <FD_ALL3 timeout="3000"
                  interval="1000"
                  timeout_check_interval="1000"
                  xmlns="urn:org:jgroups"
@@ -57,7 +57,7 @@
       </stack>
       <!-- Use the "tcp" stack but override some protocol attributes -->
       <stack name="mytcp" extends="tcp-test">
-         <FD_ALL timeout="3500" ispn:stack.combine="COMBINE" xmlns="urn:org:jgroups"/>
+         <FD_ALL3 timeout="3500" ispn:stack.combine="COMBINE" xmlns="urn:org:jgroups"/>
       </stack>
       <!-- Use the "tcp" stack but replace the discovery -->
       <stack name="tcpgossip" extends="tcp-test">

--- a/core/src/test/resources/configs/unified/11.0.xml
+++ b/core/src/test/resources/configs/unified/11.0.xml
@@ -1,13 +1,14 @@
 <infinispan
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:infinispan:config:11.0 https://infinispan.org/schemas/infinispan-config-11.0.xsd
-                          urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.1.xsd"
+                          urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.2.xsd"
       xmlns="urn:infinispan:config:11.0"
       xmlns:ispn="urn:infinispan:config:11.0">
    <jgroups transport="org.infinispan.remoting.transport.jgroups.JGroupsTransport">
       <!-- Load external JGroups stacks -->
       <stack-file name="udp-test" path="stacks/udp.xml"/>
       <stack-file name="tcp-test" path="stacks/tcp_mping/tcp1.xml"/>
+      <!-- Inline definition -->
       <!-- Inline definition -->
       <stack name="mping">
          <TCP bind_port="7800" port_range="30" recv_buf_size="20000000" send_buf_size="640000"
@@ -23,10 +24,9 @@
 
          <MERGE3 xmlns="urn:org:jgroups"/>
          <FD_SOCK xmlns="urn:org:jgroups"/>
-         <FD_ALL timeout="3000"
-                 interval="1000"
-                 timeout_check_interval="1000"
-                 xmlns="urn:org:jgroups"
+         <FD_ALL3 timeout="3000"
+                  interval="1000"
+                  xmlns="urn:org:jgroups"
          />
          <VERIFY_SUSPECT timeout="1000" xmlns="urn:org:jgroups"/>
          <pbcast.NAKACK2
@@ -57,7 +57,7 @@
       </stack>
       <!-- Use the "tcp" stack but override some protocol attributes -->
       <stack name="mytcp" extends="tcp-test">
-         <FD_ALL timeout="3500" ispn:stack.combine="COMBINE" xmlns="urn:org:jgroups"/>
+         <FD_ALL3 timeout="3500" ispn:stack.combine="COMBINE" xmlns="urn:org:jgroups"/>
       </stack>
       <!-- Use the "tcp" stack but replace the discovery -->
       <stack name="tcpgossip" extends="tcp-test">

--- a/core/src/test/resources/configs/xsite/bridge.xml
+++ b/core/src/test/resources/configs/xsite/bridge.xml
@@ -1,6 +1,6 @@
 <config xmlns="urn:org:jgroups"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.1.xsd">
+      xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.2.xsd">
 
     <TCP bind_addr="127.0.0.1"
          bind_port="7200"
@@ -29,7 +29,7 @@
            <!--break_on_coord_rsp="true"/>-->
     <MERGE3 max_interval="5000"
             min_interval="3000"/>
-    <FD_SOCK bind_addr="127.0.0.1"/>
+    <FD_SOCK/>
 
     <pbcast.NAKACK2 xmit_interval="100"
                     xmit_table_num_rows="50"

--- a/core/src/test/resources/configs/xsite/xsite-inline-test.xml
+++ b/core/src/test/resources/configs/xsite/xsite-inline-test.xml
@@ -2,7 +2,7 @@
 <infinispan
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="urn:infinispan:config:${infinispan.core.schema.version} https://infinispan.org/schemas/infinispan-config:${infinispan.core.schema.version}
-                            urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.1.xsd"
+                            urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.2.xsd"
         xmlns="urn:infinispan:config:${infinispan.core.schema.version}">
    <jgroups>
       <stack name="bridge">
@@ -23,6 +23,10 @@
          <MERGE3 max_interval="5000"
                  min_interval="3000"/>
          <FD_SOCK bind_addr="127.0.0.1"/>
+         <FD_ALL3 timeout="3000"
+                  interval="1000"
+         />
+         <VERIFY_SUSPECT timeout="1000"/>
          <pbcast.NAKACK2 xmit_interval="100"
                          xmit_table_num_rows="50"
                          xmit_table_msgs_per_row="1024"

--- a/core/src/test/resources/stacks/broken-tcp.xml
+++ b/core/src/test/resources/stacks/broken-tcp.xml
@@ -1,6 +1,6 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.1.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.2.xsd">
    <TCP
          bind_addr="${jgroups.tcp.address:127.0.0.1}"
          bind_port="${jgroups.tcp.port:7800}"

--- a/core/src/test/resources/stacks/tcp.xml
+++ b/core/src/test/resources/stacks/tcp.xml
@@ -1,6 +1,6 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.1.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.2.xsd">
    <!-- Disable the regular thread pool queue for tests so we can set a lower min_threads -->
    <TCP_NIO2
          bind_addr="${jgroups.tcp.address:127.0.0.1}"
@@ -36,9 +36,9 @@
 
    <FD_SOCK sock_conn_timeout="3000"/>
    <!-- Suspect node `timeout` to `timeout + timeout_check_interval` millis after the last heartbeat -->
-   <FD_ALL timeout="3000"
-           interval="1000"
-           timeout_check_interval="1000"
+   <FD_ALL3 timeout="3000"
+            interval="1000"
+            timeout_check_interval="1000"
    />
    <VERIFY_SUSPECT timeout="1000"/>
 

--- a/core/src/test/resources/stacks/tcp_mping/tcp1.xml
+++ b/core/src/test/resources/stacks/tcp_mping/tcp1.xml
@@ -1,6 +1,6 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.1.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.2.xsd">
    <TCP bind_port="7800"
         port_range="30"
         recv_buf_size="20000000"
@@ -27,9 +27,8 @@
    <MERGE3/>
    <FD_SOCK/>
    <!-- Suspect node `timeout` to `timeout + timeout_check_interval` millis after the last heartbeat -->
-   <FD_ALL timeout="3000"
+   <FD_ALL3 timeout="3000"
            interval="1000"
-           timeout_check_interval="1000"
    />
    <VERIFY_SUSPECT timeout="1000"/>
    <pbcast.NAKACK2

--- a/core/src/test/resources/stacks/tcp_mping/tcp2.xml
+++ b/core/src/test/resources/stacks/tcp_mping/tcp2.xml
@@ -1,6 +1,6 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.1.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.2.xsd">
    <TCP bind_port="7800"
         port_range="30"
         recv_buf_size="20000000"
@@ -27,9 +27,8 @@
    <MERGE3/>
    <FD_SOCK/>
    <!-- Suspect node `timeout` to `timeout + timeout_check_interval` millis after the last heartbeat -->
-   <FD_ALL timeout="3000"
+   <FD_ALL3 timeout="3000"
            interval="1000"
-           timeout_check_interval="1000"
    />
    <VERIFY_SUSPECT timeout="1000"/>
    <pbcast.NAKACK2

--- a/core/src/test/resources/stacks/udp.xml
+++ b/core/src/test/resources/stacks/udp.xml
@@ -1,6 +1,6 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.1.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.2.xsd">
    <UDP
          bind_addr="${jgroups.udp.address:SITE_LOCAL}"
          bind_port="${jgroups.udp.port:0}"
@@ -29,9 +29,8 @@
    <MERGE3 min_interval="1000" max_interval="5000"/>
    <FD_SOCK sock_conn_timeout="3000"/>
    <!-- Suspect node `timeout` to `timeout + timeout_check_interval` millis after the last heartbeat -->
-   <FD_ALL timeout="3000"
+   <FD_ALL3 timeout="3000"
            interval="1000"
-           timeout_check_interval="1000"
    />
    <VERIFY_SUSPECT timeout="1000"/>
 

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/util/TestDisconnectHandler.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/util/TestDisconnectHandler.java
@@ -11,6 +11,7 @@ import org.jgroups.Address;
 import org.jgroups.Event;
 import org.jgroups.protocols.FD_ALL;
 import org.jgroups.protocols.FD_ALL2;
+import org.jgroups.protocols.FD_ALL3;
 import org.jgroups.protocols.FD_HOST;
 import org.jgroups.protocols.FD_SOCK;
 import org.jgroups.protocols.pbcast.GMS;
@@ -22,9 +23,9 @@ import org.jgroups.stack.Protocol;
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
 public class TestDisconnectHandler extends Protocol {
-	private static Set<Protocol> connected = ConcurrentHashMap.newKeySet();
-	private static Executor executor = Executors.newCachedThreadPool(new ThreadFactory() {
-		AtomicInteger counter = new AtomicInteger();
+	private static final Set<Protocol> connected = ConcurrentHashMap.newKeySet();
+	private static final Executor executor = Executors.newCachedThreadPool(new ThreadFactory() {
+		final AtomicInteger counter = new AtomicInteger();
 		@Override
 		public Thread newThread(Runnable r) {
 			Thread t = new Thread(r);
@@ -39,7 +40,7 @@ public class TestDisconnectHandler extends Protocol {
 	public Object down(Event evt) {
 		switch (evt.getType()) {
 			case Event.SET_LOCAL_ADDRESS:
-				localAddress = (Address) evt.getArg();
+				localAddress = evt.getArg();
 				log.trace("Set address " + localAddress);
 				break;
 			case Event.CONNECT:
@@ -54,7 +55,7 @@ public class TestDisconnectHandler extends Protocol {
 				log.trace("Disconnecting on " + localAddress);
 				connected.remove(getFD());
 				// reduce view ack collection timeout to minimum, since we don't want to wait anymore
-				GMS gms = (GMS) getProtocolStack().findProtocol(GMS.class);
+				GMS gms = getProtocolStack().findProtocol(GMS.class);
 				gms.setViewAckCollectionTimeout(1);
 				for (Protocol other : connected) {
 					executor.execute(() -> {
@@ -70,7 +71,7 @@ public class TestDisconnectHandler extends Protocol {
 	}
 
 	private Protocol getFD() {
-		Protocol protocol = getProtocolStack().findProtocol(FD_ALL.class, FD_ALL2.class, FD_SOCK.class, FD_HOST.class);
+		Protocol protocol = getProtocolStack().findProtocol(FD_ALL.class, FD_ALL2.class, FD_ALL3.class, FD_SOCK.class, FD_HOST.class);
 		log.trace("Found protocol " + protocol);
 		return protocol;
 	}

--- a/hibernate/cache-commons/src/test/resources/2lc-test-tcp.xml
+++ b/hibernate/cache-commons/src/test/resources/2lc-test-tcp.xml
@@ -6,7 +6,7 @@
   -->
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.1.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.2.xsd">
    <TCP bind_port="7800"
         enable_diagnostics="false"
         thread_naming_pattern="pl"

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node0.xml
@@ -1,7 +1,7 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.1.xsd">
- 
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.2.xsd">
+
    <TCP  bind_port="7800" port_range="10"
          recv_buf_size="20000000"
          send_buf_size="640000"
@@ -21,12 +21,11 @@
           ip_ttl="${jgroups.udp.ip_ttl:2}"/>
 
    <MERGE3/>
- 
+
    <FD_SOCK/>
    <!-- Suspect node `timeout` to `timeout + timeout_check_interval` millis after the last heartbeat -->
-   <FD_ALL timeout="10000"
+   <FD_ALL3 timeout="10000"
            interval="2000"
-           timeout_check_interval="1000"
    />
    <VERIFY_SUSPECT timeout="1000"/>
 

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1-fail.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1-fail.xml
@@ -1,6 +1,6 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.1.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.2.xsd">
 
    <TCP  bind_port="7800" port_range="10"
          recv_buf_size="20000000"
@@ -24,9 +24,8 @@
 
    <FD_SOCK/>
    <!-- Suspect node `timeout` to `timeout + timeout_check_interval` millis after the last heartbeat -->
-   <FD_ALL timeout="10000"
+   <FD_ALL3 timeout="10000"
            interval="2000"
-           timeout_check_interval="1000"
    />
    <VERIFY_SUSPECT timeout="1000"/>
 

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1.xml
@@ -1,6 +1,6 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.1.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.2.xsd">
 
    <TCP  bind_port="7800" port_range="10"
          recv_buf_size="20000000"
@@ -24,9 +24,8 @@
 
    <FD_SOCK/>
    <!-- Suspect node `timeout` to `timeout + timeout_check_interval` millis after the last heartbeat -->
-   <FD_ALL timeout="10000"
+   <FD_ALL3 timeout="10000"
            interval="2000"
-           timeout_check_interval="1000"
    />
    <VERIFY_SUSPECT timeout="1000"/>
 

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node0.xml
@@ -1,6 +1,6 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.1.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.2.xsd">
 
    <TCP  bind_port="7800" port_range="10"
          recv_buf_size="20000000"
@@ -24,9 +24,8 @@
 
    <FD_SOCK/>
    <!-- Suspect node `timeout` to `timeout + timeout_check_interval` millis after the last heartbeat -->
-   <FD_ALL timeout="10000"
+   <FD_ALL3 timeout="10000"
            interval="2000"
-           timeout_check_interval="1000"
    />
    <VERIFY_SUSPECT timeout="1000"/>
 
@@ -45,7 +44,7 @@
          client_name="coordinator_user"
          client_password="coordinator_password"
          server_callback_handler_class="org.infinispan.test.integration.security.utils.SaslPropCallbackHandler"
-         client_callback_handler_class="org.infinispan.test.integration.security.utils.SaslPropCallbackHandler" 
+         client_callback_handler_class="org.infinispan.test.integration.security.utils.SaslPropCallbackHandler"
          sasl_props="com.sun.security.sasl.digest.realm=test_realm" />
 
    <pbcast.STABLE stability_delay="500"

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node1.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node1.xml
@@ -1,7 +1,7 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.1.xsd">
-   
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.2.xsd">
+
    <TCP bind_port="7800" port_range="10"
          recv_buf_size="20000000"
          send_buf_size="640000"
@@ -24,9 +24,8 @@
 
    <FD_SOCK/>
    <!-- Suspect node `timeout` to `timeout + timeout_check_interval` millis after the last heartbeat -->
-   <FD_ALL timeout="10000"
+   <FD_ALL3 timeout="10000"
            interval="2000"
-           timeout_check_interval="1000"
    />
    <VERIFY_SUSPECT timeout="1000"/>
 
@@ -41,7 +40,7 @@
               xmit_table_msgs_per_row="1024"
               xmit_table_max_compaction_time="30000"
    />
-   <SASL mech="DIGEST-MD5" 
+   <SASL mech="DIGEST-MD5"
          client_callback_handler_class="org.infinispan.test.integration.security.utils.SaslPropCallbackHandler" />
 
    <pbcast.STABLE stability_delay="500"

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-user-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-user-node0.xml
@@ -1,7 +1,7 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.1.xsd">
-   
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.2.xsd">
+
    <TCP  bind_port="7800" port_range="10"
          recv_buf_size="20000000"
          send_buf_size="640000"
@@ -24,9 +24,8 @@
 
    <FD_SOCK/>
    <!-- Suspect node `timeout` to `timeout + timeout_check_interval` millis after the last heartbeat -->
-   <FD_ALL timeout="10000"
+   <FD_ALL3 timeout="10000"
            interval="2000"
-           timeout_check_interval="1000"
    />
    <VERIFY_SUSPECT timeout="1000"/>
 
@@ -45,7 +44,7 @@
          client_name="coordinator_user"
          client_password="coordinator_password"
          server_callback_handler_class="org.infinispan.test.integration.security.utils.SaslPropAuthUserCallbackHandler"
-         client_callback_handler_class="org.infinispan.test.integration.security.utils.SaslPropCallbackHandler" 
+         client_callback_handler_class="org.infinispan.test.integration.security.utils.SaslPropCallbackHandler"
          sasl_props="com.sun.security.sasl.digest.realm=test_realm" />
 
    <pbcast.STABLE stability_delay="500"

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node0.xml
@@ -1,6 +1,6 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.1.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.2.xsd">
 
    <TCP  bind_port="7800" port_range="10"
          recv_buf_size="20000000"
@@ -24,9 +24,8 @@
 
    <FD_SOCK/>
    <!-- Suspect node `timeout` to `timeout + timeout_check_interval` millis after the last heartbeat -->
-   <FD_ALL timeout="10000"
+   <FD_ALL3 timeout="10000"
            interval="2000"
-           timeout_check_interval="1000"
    />
    <VERIFY_SUSPECT timeout="1000"/>
 
@@ -43,7 +42,7 @@
    />
    <SASL mech="DIGEST-MD5"
          server_callback_handler_class="org.jgroups.auth.sasl.SimpleAuthorizingCallbackHandler"
-         client_callback_handler_class="org.jgroups.auth.sasl.SimpleAuthorizingCallbackHandler" 
+         client_callback_handler_class="org.jgroups.auth.sasl.SimpleAuthorizingCallbackHandler"
          sasl_props="com.sun.security.sasl.digest.realm=test_realm" />
 
    <pbcast.STABLE stability_delay="500"

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node1.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node1.xml
@@ -1,7 +1,7 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.1.xsd">
-   
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.2.xsd">
+
    <TCP bind_port="7800" port_range="10"
          recv_buf_size="20000000"
          send_buf_size="640000"
@@ -24,9 +24,8 @@
 
    <FD_SOCK/>
    <!-- Suspect node `timeout` to `timeout + timeout_check_interval` millis after the last heartbeat -->
-   <FD_ALL timeout="10000"
+   <FD_ALL3 timeout="10000"
            interval="2000"
-           timeout_check_interval="1000"
    />
    <VERIFY_SUSPECT timeout="1000"/>
 
@@ -41,7 +40,7 @@
               xmit_table_msgs_per_row="1024"
               xmit_table_max_compaction_time="30000"
    />
-   <SASL mech="DIGEST-MD5" 
+   <SASL mech="DIGEST-MD5"
          client_callback_handler_class="org.jgroups.auth.sasl.SimpleAuthorizingCallbackHandler" />
 
    <pbcast.STABLE stability_delay="500"

--- a/integrationtests/wildfly-modules/src/test/resources/as-config/standalone/configuration/standalone-test.xml
+++ b/integrationtests/wildfly-modules/src/test/resources/as-config/standalone/configuration/standalone-test.xml
@@ -339,7 +339,7 @@
                     <protocol type="PING" module="org.jgroups:${infinispan.module.slot}"/>
                     <protocol type="MERGE3" module="org.jgroups:${infinispan.module.slot}"/>
                     <protocol type="FD_SOCK" socket-binding="jgroups-udp-fd" module="org.jgroups:${infinispan.module.slot}"/>
-                    <protocol type="FD_ALL" module="org.jgroups:${infinispan.module.slot}"/>
+                    <protocol type="FD_ALL3" module="org.jgroups:${infinispan.module.slot}"/>
                     <protocol type="VERIFY_SUSPECT" module="org.jgroups:${infinispan.module.slot}"/>
                     <protocol type="pbcast.NAKACK2" module="org.jgroups:${infinispan.module.slot}"/>
                     <protocol type="UNICAST3" module="org.jgroups:${infinispan.module.slot}"/>

--- a/integrationtests/wildfly-modules/src/test/resources/infinispan-custom.xml
+++ b/integrationtests/wildfly-modules/src/test/resources/infinispan-custom.xml
@@ -2,7 +2,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="urn:infinispan:config:${infinispan.core.schema.version} https://infinispan.org/schemas/infinispan-config-${infinispan.core.schema.version}.xsd
                             urn:infinispan:server:${infinispan.core.schema.version} https://infinispan.org/schemas/infinispan-server-${infinispan.core.schema.version}.xsd
-                            urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.1.xsd"
+                            urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.2.xsd"
         xmlns="urn:infinispan:config:${infinispan.core.schema.version}"
         xmlns:ispn="urn:infinispan:config:${infinispan.core.schema.version}"
         xmlns:server="urn:infinispan:server:${infinispan.core.schema.version}">

--- a/jcache/tck-runner-remote/src/test/resources/infinispan.xml
+++ b/jcache/tck-runner-remote/src/test/resources/infinispan.xml
@@ -1,9 +1,9 @@
 <infinispan
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:infinispan:config:10.1 https://infinispan.org/schemas/infinispan-config-10.1.xsd
-                            urn:infinispan:server:10.1 https://infinispan.org/schemas/infinispan-server-10.1.xsd"
-        xmlns="urn:infinispan:config:10.1"
-        xmlns:server="urn:infinispan:server:10.1">
+        xsi:schemaLocation="urn:infinispan:config:11.0 https://infinispan.org/schemas/infinispan-config-11.0.xsd
+                            urn:infinispan:server:11.0 https://infinispan.org/schemas/infinispan-server-11.0.xsd"
+        xmlns="urn:infinispan:config:11.0"
+        xmlns:server="urn:infinispan:server:11.0">
 
     <cache-container name="default" statistics="true">
         <transport cluster="${infinispan.cluster.name}" stack="${infinispan.cluster.stack:tcp}"/>
@@ -12,7 +12,7 @@
         </serialization>
     </cache-container>
 
-    <server xmlns="urn:infinispan:server:10.1">
+    <server xmlns="urn:infinispan:server:11.0">
         <interfaces>
             <interface name="public">
                 <inet-address value="${infinispan.bind.address:127.0.0.1}"/>

--- a/lucene/directory-provider/src/test/resources/testing-flush-loopback.xml
+++ b/lucene/directory-provider/src/test/resources/testing-flush-loopback.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config xmlns="urn:org:jgroups"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.1.xsd">
+		xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.2.xsd">
 
 	<SHARED_LOOPBACK
 		bind_addr="127.0.0.1"
@@ -12,9 +12,8 @@
 	<MERGE3 max_interval="30000" min_interval="1000"/>
 	<FD_SOCK bind_addr="127.0.0.1" />
    <!-- Suspect node `timeout` to `timeout + timeout_check_interval` millis after the last heartbeat -->
-   <FD_ALL timeout="10000"
+   <FD_ALL3 timeout="10000"
            interval="2000"
-           timeout_check_interval="1000"
    />
 	<VERIFY_SUSPECT timeout="500" bind_addr="127.0.0.1" />
 	<pbcast.NAKACK2

--- a/persistence/jdbc/src/test/resources/configs/as7/jdbc-standalone.xml
+++ b/persistence/jdbc/src/test/resources/configs/as7/jdbc-standalone.xml
@@ -155,7 +155,7 @@
                 </protocol>
                 <protocol type="MERGE3"/>
                 <protocol type="FD_SOCK" socket-binding="jgroups-udp-fd"/>
-                <protocol type="FD_ALL"/>
+                <protocol type="FD_ALL3"/>
                 <protocol type="VERIFY_SUSPECT"/>
                 <protocol type="pbcast.NAKACK2"/>
                 <protocol type="UNICAST3">

--- a/server/runtime/README.adoc
+++ b/server/runtime/README.adoc
@@ -69,18 +69,17 @@ The following is an example server configuration:
 ----
 <infinispan
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:infinispan:config:10.1 https://infinispan.org/schemas/infinispan-config-10.1.xsd
-                            urn:infinispan:server:10.1 https://infinispan.org/schemas/infinispan-server-10.1.xsd"
-        xmlns="urn:infinispan:config:10.1"
-        xmlns:server="urn:infinispan:server:10.1">
-
-   <cache-container default-cache="default" statistics="false">
+        xsi:schemaLocation="urn:infinispan:config:11.0 https://infinispan.org/schemas/infinispan-config-11.0.xsd
+                            urn:infinispan:server:11.0 https://infinispan.org/schemas/infinispan-server-11.0.xsd"
+        xmlns="urn:infinispan:config:11.0"
+        xmlns:server="urn:infinispan:server:11.0">
+<cache-container default-cache="default" statistics="false">
       <transport cluster="${infinispan.cluster.name}" stack="udp"/>
       <global-state/>
       <distributed-cache name="default"/>
    </cache-container>
 
-   <server xmlns="urn:infinispan:server:10.1">
+   <server xmlns="urn:infinispan:server:11.0">
       <interfaces>
          <interface name="public">
             <loopback/>

--- a/server/runtime/src/test/resources/configuration/ServerConfigurationParserTest.xml
+++ b/server/runtime/src/test/resources/configuration/ServerConfigurationParserTest.xml
@@ -1,13 +1,12 @@
 <infinispan
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:infinispan:config:10.1 https://infinispan.org/schemas/infinispan-config-10.1.xsd
-                            urn:infinispan:server:10.1 https://infinispan.org/schemas/infinispan-server-10.1.xsd"
-        xmlns="urn:infinispan:config:10.1"
-        xmlns:server="urn:infinispan:server:10.1">
+        xsi:schemaLocation="urn:infinispan:config:11.0 https://infinispan.org/schemas/infinispan-config-11.0.xsd
+                            urn:infinispan:server:11.0 https://infinispan.org/schemas/infinispan-server-11.0.xsd"
+        xmlns="urn:infinispan:config:11.0"
+        xmlns:server="urn:infinispan:server:11.0">
+<cache-container/>
 
-   <cache-container/>
-
-   <server xmlns="urn:infinispan:server:10.1">
+   <server xmlns="urn:infinispan:server:11.0">
       <interfaces>
          <interface name="default">
             <loopback/>

--- a/server/tests/src/test/resources/configuration/AuthenticationKerberosTest.xml
+++ b/server/tests/src/test/resources/configuration/AuthenticationKerberosTest.xml
@@ -5,8 +5,7 @@
                             urn:infinispan:server:11.0 https://infinispan.org/schemas/infinispan-server-11.0.xsd"
         xmlns="urn:infinispan:config:11.0"
         xmlns:server="urn:infinispan:server:11.0">
-
-   <xi:include href="jgroups/tcp.xml"/>
+<xi:include href="jgroups/tcp.xml"/>
 
    <xi:include href="cache-container/clustered.xml"/>
 

--- a/server/tests/src/test/resources/configuration/AuthenticationKeyCloakTest.xml
+++ b/server/tests/src/test/resources/configuration/AuthenticationKeyCloakTest.xml
@@ -5,8 +5,7 @@
                             urn:infinispan:server:11.0 https://infinispan.org/schemas/infinispan-server-11.0.xsd"
         xmlns="urn:infinispan:config:11.0"
         xmlns:server="urn:infinispan:server:11.0">
-
-   <xi:include href="jgroups/tcp.xml"/>
+<xi:include href="jgroups/tcp.xml"/>
 
    <xi:include href="cache-container/clustered.xml"/>
 

--- a/server/tests/src/test/resources/configuration/AuthenticationLDAPTest.xml
+++ b/server/tests/src/test/resources/configuration/AuthenticationLDAPTest.xml
@@ -5,8 +5,7 @@
                             urn:infinispan:server:11.0 https://infinispan.org/schemas/infinispan-server-11.0.xsd"
         xmlns="urn:infinispan:config:11.0"
         xmlns:server="urn:infinispan:server:11.0">
-
-   <xi:include href="jgroups/tcp.xml"/>
+<xi:include href="jgroups/tcp.xml"/>
 
    <xi:include href="cache-container/clustered.xml"/>
 

--- a/server/tests/src/test/resources/configuration/AuthenticationServerTLSTest.xml
+++ b/server/tests/src/test/resources/configuration/AuthenticationServerTLSTest.xml
@@ -5,8 +5,7 @@
                             urn:infinispan:server:11.0 https://infinispan.org/schemas/infinispan-server-11.0.xsd"
         xmlns="urn:infinispan:config:11.0"
         xmlns:server="urn:infinispan:server:11.0">
-
-   <xi:include href="jgroups/tcp.xml"/>
+<xi:include href="jgroups/tcp.xml"/>
 
    <xi:include href="cache-container/clustered.xml"/>
 

--- a/server/tests/src/test/resources/configuration/AuthenticationServerTest.xml
+++ b/server/tests/src/test/resources/configuration/AuthenticationServerTest.xml
@@ -5,8 +5,7 @@
                             urn:infinispan:server:11.0 https://infinispan.org/schemas/infinispan-server-11.0.xsd"
         xmlns="urn:infinispan:config:11.0"
         xmlns:server="urn:infinispan:server:11.0">
-
-   <xi:include href="jgroups/tcp.xml"/>
+<xi:include href="jgroups/tcp.xml"/>
 
    <xi:include href="cache-container/clustered.xml"/>
 

--- a/server/tests/src/test/resources/configuration/AuthenticationServerTrustTest.xml
+++ b/server/tests/src/test/resources/configuration/AuthenticationServerTrustTest.xml
@@ -5,8 +5,7 @@
                             urn:infinispan:server:11.0 https://infinispan.org/schemas/infinispan-server-11.0.xsd"
         xmlns="urn:infinispan:config:11.0"
         xmlns:server="urn:infinispan:server:11.0">
-
-   <xi:include href="jgroups/tcp.xml"/>
+<xi:include href="jgroups/tcp.xml"/>
 
    <xi:include href="cache-container/clustered.xml"/>
 

--- a/server/tests/src/test/resources/configuration/AuthorizationKerberosTest.xml
+++ b/server/tests/src/test/resources/configuration/AuthorizationKerberosTest.xml
@@ -5,8 +5,7 @@
                             urn:infinispan:server:11.0 https://infinispan.org/schemas/infinispan-server-11.0.xsd"
         xmlns="urn:infinispan:config:11.0"
         xmlns:server="urn:infinispan:server:11.0">
-
-   <xi:include href="jgroups/tcp.xml"/>
+<xi:include href="jgroups/tcp.xml"/>
 
    <xi:include href="cache-container/clustered-authz.xml"/>
 

--- a/server/tests/src/test/resources/configuration/AuthorizationLDAPTest.xml
+++ b/server/tests/src/test/resources/configuration/AuthorizationLDAPTest.xml
@@ -5,8 +5,7 @@
                             urn:infinispan:server:11.0 https://infinispan.org/schemas/infinispan-server-11.0.xsd"
         xmlns="urn:infinispan:config:11.0"
         xmlns:server="urn:infinispan:server:11.0">
-
-   <xi:include href="jgroups/tcp.xml"/>
+<xi:include href="jgroups/tcp.xml"/>
 
    <xi:include href="cache-container/clustered-authz.xml"/>
 

--- a/server/tests/src/test/resources/configuration/all.xml
+++ b/server/tests/src/test/resources/configuration/all.xml
@@ -5,8 +5,7 @@
                             urn:infinispan:server:11.0 https://infinispan.org/schemas/infinispan-server-11.0.xsd"
         xmlns="urn:infinispan:config:11.0"
         xmlns:server="urn:infinispan:server:11.0">
-
-   <jgroups>
+<jgroups>
       <stack-file name="test" path="test-jgroups-tcp.xml"/>
    </jgroups>
 

--- a/server/tests/src/test/resources/configuration/test-jgroups-tcp.xml
+++ b/server/tests/src/test/resources/configuration/test-jgroups-tcp.xml
@@ -1,6 +1,6 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.1.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.2.xsd">
    <!-- Disable the regular thread pool queue for tests so we can set a lower min_threads -->
    <TCP_NIO2
            bind_addr="${jgroups.tcp.address:127.0.0.1}"
@@ -29,9 +29,8 @@
 
    <FD_SOCK sock_conn_timeout="3000"/>
    <!-- Suspect node `timeout` to `timeout + timeout_check_interval` millis after the last heartbeat -->
-   <FD_ALL timeout="3000"
+   <FD_ALL3 timeout="3000"
            interval="1000"
-           timeout_check_interval="1000"
    />
    <VERIFY_SUSPECT timeout="1000"/>
 

--- a/tools/src/test/resources/udp.xml
+++ b/tools/src/test/resources/udp.xml
@@ -1,6 +1,6 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.1.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.2.xsd">
    <UDP
          bind_addr="${jgroups.udp.address:SITE_LOCAL}"
          bind_port="${jgroups.udp.port:0}"
@@ -29,9 +29,8 @@
    <MERGE3 min_interval="1000" max_interval="5000"/>
    <FD_SOCK sock_conn_timeout="3000"/>
    <!-- Suspect node `timeout` to `timeout + timeout_check_interval` millis after the last heartbeat -->
-   <FD_ALL timeout="3000"
+   <FD_ALL3 timeout="3000"
            interval="1000"
-           timeout_check_interval="1000"
    />
    <VERIFY_SUSPECT timeout="1000"/>
 

--- a/wildfly/jgroups/src/main/resources/jgroups-defaults.xml
+++ b/wildfly/jgroups/src/main/resources/jgroups-defaults.xml
@@ -22,78 +22,80 @@
   -->
 <!-- N.B. This is *not* a usable protocol stack -->
 <!-- This file supplies the internal defaults per protocol -->
-<config xmlns="urn:org:jgroups">
+<config xmlns="urn:org:jgroups" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.2.xsd">
    <UDP
-      tos="0"
-      ucast_send_buf_size="1m"
-      mcast_send_buf_size="1m"
-      ucast_recv_buf_size="20m"
-      mcast_recv_buf_size="25m"
-      ip_ttl="${jgroups.ip_ttl:2}"
-      thread_naming_pattern="pl"
-      enable_diagnostics="false"
-      bundler_type="no-bundler"
-      max_bundle_size="8500"/>
+         tos="0"
+         ucast_send_buf_size="1m"
+         mcast_send_buf_size="1m"
+         ucast_recv_buf_size="20m"
+         mcast_recv_buf_size="25m"
+         ip_ttl="${jgroups.ip_ttl:2}"
+         thread_naming_pattern="pl"
+         enable_diagnostics="false"
+         bundler_type="no-bundler"
+         max_bundle_size="8500"/>
    <TCP
-      enable_diagnostics="false"
-      thread_naming_pattern="pl"
-      send_buf_size="640k"
-      sock_conn_timeout="300"
-      bundler_type="no-bundler"/>
+         enable_diagnostics="false"
+         thread_naming_pattern="pl"
+         send_buf_size="640k"
+         sock_conn_timeout="300"
+         bundler_type="no-bundler"/>
    <PING
-      num_discovery_runs="3"/>
+         num_discovery_runs="3"/>
    <MPING
-      num_discovery_runs="3"
-      ip_ttl="${jgroups.udp.ip_ttl:2}"/>
+         num_discovery_runs="3"
+         ip_ttl="${jgroups.udp.ip_ttl:2}"/>
    <TCPPING
-      num_discovery_runs="3"/>
+         num_discovery_runs="3"/>
    <MERGE3
-      min_interval="10000"
-      max_interval="30000"/>
+         min_interval="10000"
+         max_interval="30000"/>
    <FD_SOCK/>
    <FD timeout="6000" max_tries="5" msg_counts_as_heartbeat="false"/>
+   <FD_ALL3 timeout="10000" interval="2000"/>
    <FD_ALL2 timeout="10000" interval="2000"/>
    <!-- Suspect node `timeout` to `timeout + timeout_check_interval` millis after the last heartbeat -->
    <FD_ALL
-      timeout="10000"
-      interval="2000"
-      timeout_check_interval="1000"/>
+         timeout="10000"
+         interval="2000"
+         timeout_check_interval="1000"/>
    <VERIFY_SUSPECT
-      timeout="1000"/>
+         timeout="1000"/>
    <BARRIER/>
    <pbcast.NAKACK2
-      xmit_interval="100"
-      xmit_table_num_rows="50"
-      xmit_table_msgs_per_row="1024"
-      xmit_table_max_compaction_time="30000"
-      resend_last_seqno="true"/>
+         xmit_interval="100"
+         xmit_table_num_rows="50"
+         xmit_table_msgs_per_row="1024"
+         xmit_table_max_compaction_time="30000"
+         resend_last_seqno="true"/>
    <UNICAST3
-      xmit_interval="100"
-      xmit_table_num_rows="50"
-      xmit_table_msgs_per_row="1024"
-      xmit_table_max_compaction_time="30000"
+         xmit_interval="100"
+         xmit_table_num_rows="50"
+         xmit_table_msgs_per_row="1024"
+         xmit_table_max_compaction_time="30000"
    />
    <pbcast.STABLE
-      stability_delay="500"
-      desired_avg_gossip="5000"
-      max_bytes="1M"/>
+         stability_delay="500"
+         desired_avg_gossip="5000"
+         max_bytes="1M"/>
    <pbcast.GMS
-      print_local_addr="false"
-      join_timeout="${jgroups.join_timeout:2000}"/>
+         print_local_addr="false"
+         join_timeout="${jgroups.join_timeout:2000}"/>
    <UFC
-      max_credits="4m"
-      min_threshold="0.40"/>
+         max_credits="4m"
+         min_threshold="0.40"/>
    <MFC
-      max_credits="4m"
-      min_threshold="0.40"/>
+         max_credits="4m"
+         min_threshold="0.40"/>
    <UFC_NB
-      max_credits="3m"
-      max_queue_size="2m"
-      min_threshold="0.40"/>
+         max_credits="3m"
+         max_queue_size="2m"
+         min_threshold="0.40"/>
    <MFC_NB
-      max_credits="3m"
-      max_queue_size="2m"
-      min_threshold="0.40"/>
+         max_credits="3m"
+         max_queue_size="2m"
+         min_threshold="0.40"/>
    <FRAG2 frag_size="8000"/>
    <FRAG3 frag_size="8000"/>
    <RSVP timeout="60000" resend_interval="500" ack_on_delivery="false"/>


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-11465

* Update the Infinispan and JGroups schema versions
  in the XML configurations
* Switch to FD_ALL3 in the test JGroups stacks
* Keep using FD_ALL in the default stacks