### PR TITLE
[10.1.x] ISPN-11435 test fixes + ISPN-11467 IteratorHandler cannot start in a secure cache

### DIFF
--- a/core/src/main/java/org/infinispan/stream/impl/IteratorHandler.java
+++ b/core/src/main/java/org/infinispan/stream/impl/IteratorHandler.java
@@ -19,8 +19,8 @@ import org.infinispan.factories.annotations.Start;
 import org.infinispan.factories.annotations.Stop;
 import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
-import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.notifications.Listener;
+import org.infinispan.notifications.cachemanagerlistener.CacheManagerNotifier;
 import org.infinispan.notifications.cachemanagerlistener.annotation.ViewChanged;
 import org.infinispan.notifications.cachemanagerlistener.event.ViewChangedEvent;
 import org.infinispan.remoting.transport.Address;
@@ -42,7 +42,7 @@ public class IteratorHandler {
    private final Map<Object, CloseableIterator<?>> currentRequests = new ConcurrentHashMap<>();
    private final Map<Address, Set<Object>> ownerRequests = new ConcurrentHashMap<>();
 
-   @Inject EmbeddedCacheManager manager;
+   @Inject CacheManagerNotifier cacheManagerNotifier;
 
    /**
     * A {@link CloseableIterator} that also allows callers to attach {@link Runnable} instances to it, so that when
@@ -79,13 +79,13 @@ public class IteratorHandler {
 
    @Start
    public void start() {
-      manager.addListener(this);
+      cacheManagerNotifier.addListener(this);
    }
 
    @Stop
    public void stop() {
       // If our cache is stopped we should remove our listener, since this doesn't mean the cache manager is stopped
-      manager.removeListener(this);
+      cacheManagerNotifier.removeListener(this);
    }
 
    /**

--- a/core/src/test/java/org/infinispan/jmx/JmxStatsFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/jmx/JmxStatsFunctionalTest.java
@@ -174,7 +174,7 @@ public class JmxStatsFunctionalTest extends AbstractInfinispanTest {
       GlobalConfigurationBuilder globalConfiguration3 = GlobalConfigurationBuilder.defaultClusteredBuilder();
       configureJmx(globalConfiguration3, jmxDomain, mBeanServerLookup);
       globalConfiguration3.jmx().allowDuplicateDomains(true);
-      CacheContainer duplicateAllowedContainer = TestCacheManagerFactory.createClusteredCacheManager(globalConfiguration3, new ConfigurationBuilder());
+      CacheContainer duplicateAllowedContainer = TestCacheManagerFactory.createClusteredCacheManager(globalConfiguration3, null);
       try {
          final String duplicateName = jmxDomain + "2";
          ObjectName duplicateObjectName = getCacheManagerObjectName(duplicateName);

--- a/core/src/test/java/org/infinispan/test/fwk/TestCacheManagerFactory.java
+++ b/core/src/test/java/org/infinispan/test/fwk/TestCacheManagerFactory.java
@@ -243,7 +243,9 @@ public class TestCacheManagerFactory {
                                                                   ConfigurationBuilder defaultCacheConfig,
                                                                   TransportFlags flags) {
       amendGlobalConfiguration(gcb, flags);
-      amendJTA(defaultCacheConfig);
+      if (defaultCacheConfig != null) {
+         amendJTA(defaultCacheConfig);
+      }
       return newDefaultCacheManager(true, gcb, defaultCacheConfig);
    }
 

--- a/counter/src/test/java/org/infinispan/counter/WeakCounterWithZeroCapacityNodesTest.java
+++ b/counter/src/test/java/org/infinispan/counter/WeakCounterWithZeroCapacityNodesTest.java
@@ -15,6 +15,6 @@ public class WeakCounterWithZeroCapacityNodesTest extends WeakCounterTest {
 
    @Override
    protected GlobalConfigurationBuilder configure(int nodeId) {
-      return GlobalConfigurationBuilder.defaultClusteredBuilder().zeroCapacityNode(nodeId % 2 == 0);
+      return GlobalConfigurationBuilder.defaultClusteredBuilder().zeroCapacityNode(nodeId % 2 == 1);
    }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-11467
https://issues.redhat.com/browse/ISPN-11435
