### PR TITLE
[PREVIEW] ISPN-6494 NonBlockingTransferQueueBundler

### DIFF
--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
@@ -133,8 +133,9 @@ public class JGroupsTransport implements Transport {
    public static final String CONFIGURATION_FILE = "configurationFile";
    public static final String CHANNEL_LOOKUP = "channelLookup";
    public static final String CHANNEL_CONFIGURATOR = "channelConfigurator";
-   public static final short REPLY_FLAGS =
-         (short) (Message.Flag.NO_FC.value() | Message.Flag.OOB.value() | Message.Flag.NO_TOTAL_ORDER.value());
+   public static final short REPLY_FLAGS = encodeFlags(Message.Flag.NO_FC, Message.Flag.OOB,
+                                                       Message.Flag.NO_TOTAL_ORDER, Message.Flag.DONT_BUNDLE);
+
    protected static final String DEFAULT_JGROUPS_CONFIGURATION_FILE = "default-configs/default-jgroups-udp.xml";
    public static final Log log = LogFactory.getLog(JGroupsTransport.class);
    private static final boolean trace = log.isTraceEnabled();
@@ -1107,7 +1108,8 @@ public class JGroupsTransport implements Transport {
          case PER_SENDER:
             return Message.Flag.NO_TOTAL_ORDER.value();
          case NONE:
-            return (short) (Message.Flag.OOB.value() | Message.Flag.NO_TOTAL_ORDER.value());
+            return (short) (Message.Flag.OOB.value() | Message.Flag.NO_TOTAL_ORDER.value() |
+                            Message.Flag.DONT_BUNDLE.value());
          default:
             throw new IllegalArgumentException("Unsupported deliver mode " + deliverOrder);
       }
@@ -1405,6 +1407,14 @@ public class JGroupsTransport implements Transport {
       } catch (Throwable t) {
          CLUSTER.errorProcessingResponse(requestId, src, t);
       }
+   }
+
+   private static short encodeFlags(Message.Flag... flags) {
+      short value = 0;
+      for (Message.Flag f : flags) {
+         value |= f.value();
+      }
+      return value;
    }
 
    private DeliverOrder decodeDeliverMode(short flags) {

--- a/core/src/main/resources/default-configs/default-jgroups-azure.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-azure.xml
@@ -11,7 +11,7 @@
         thread_naming_pattern="pl"
         send_buf_size="640k"
         sock_conn_timeout="300"
-        bundler_type="no-bundler"
+        bundler_type="org.infinispan.remoting.jgroups.NonBlockingTransferQueueBundler"
 
         thread_pool.min_threads="${jgroups.thread_pool.min_threads:0}"
         thread_pool.max_threads="${jgroups.thread_pool.max_threads:200}"

--- a/core/src/main/resources/default-configs/default-jgroups-ec2.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-ec2.xml
@@ -11,7 +11,7 @@
         thread_naming_pattern="pl"
         send_buf_size="640k"
         sock_conn_timeout="300"
-        bundler_type="no-bundler"
+        bundler_type="org.infinispan.remoting.jgroups.NonBlockingTransferQueueBundler"
 
         thread_pool.min_threads="${jgroups.thread_pool.min_threads:0}"
         thread_pool.max_threads="${jgroups.thread_pool.max_threads:200}"

--- a/core/src/main/resources/default-configs/default-jgroups-google.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-google.xml
@@ -12,7 +12,7 @@
         thread_naming_pattern="pl"
         send_buf_size="640k"
         sock_conn_timeout="300"
-        bundler_type="no-bundler"
+        bundler_type="org.infinispan.remoting.jgroups.NonBlockingTransferQueueBundler"
 
         thread_pool.min_threads="${jgroups.thread_pool.min_threads:0}"
         thread_pool.max_threads="${jgroups.thread_pool.max_threads:200}"

--- a/core/src/main/resources/default-configs/default-jgroups-kubernetes.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-kubernetes.xml
@@ -12,7 +12,7 @@
         thread_naming_pattern="pl"
         send_buf_size="640k"
         sock_conn_timeout="300"
-        bundler_type="no-bundler"
+        bundler_type="org.infinispan.remoting.jgroups.NonBlockingTransferQueueBundler"
         logical_addr_cache_expiration="360000"
 
         thread_pool.min_threads="${jgroups.thread_pool.min_threads:0}"

--- a/core/src/main/resources/default-configs/default-jgroups-tcp.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-tcp.xml
@@ -7,7 +7,7 @@
         thread_naming_pattern="pl"
         send_buf_size="640k"
         sock_conn_timeout="300"
-        bundler_type="no-bundler"
+        bundler_type="org.infinispan.remoting.jgroups.NonBlockingTransferQueueBundler"
 
         thread_pool.min_threads="${jgroups.thread_pool.min_threads:0}"
         thread_pool.max_threads="${jgroups.thread_pool.max_threads:200}"

--- a/core/src/main/resources/default-configs/default-jgroups-udp.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-udp.xml
@@ -13,7 +13,7 @@
         ip_ttl="${jgroups.ip_ttl:2}"
         thread_naming_pattern="pl"
         enable_diagnostics="false"
-        bundler_type="no-bundler"
+        bundler_type="org.infinispan.remoting.jgroups.NonBlockingTransferQueueBundler"
         max_bundle_size="8500"
 
         thread_pool.min_threads="${jgroups.thread_pool.min_threads:0}"

--- a/core/src/test/java/org/infinispan/configuration/JsonSerializationTest.java
+++ b/core/src/test/java/org/infinispan/configuration/JsonSerializationTest.java
@@ -84,8 +84,8 @@ public class JsonSerializationTest extends AbstractInfinispanTest {
 
    private final MBeanServerLookup mBeanServerLookup = TestMBeanServerLookup.create();
 
-   private JsonReader jsonReader = new JsonReader();
-   private JsonWriter jsonWriter = new JsonWriter();
+   private final JsonReader jsonReader = new JsonReader();
+   private final JsonWriter jsonWriter = new JsonWriter();
 
    @Test
    public void testMinimalCacheConfiguration() {
@@ -349,7 +349,7 @@ public class JsonSerializationTest extends AbstractInfinispanTest {
       assertEquals("20000000", tcp.get("recv_buf_size").asText());
       assertEquals("640000", tcp.get("send_buf_size").asText());
       assertEquals("300", tcp.get("sock_conn_timeout").asText());
-      assertEquals("no-bundler", tcp.get("bundler_type").asText());
+      assertEquals("org.infinispan.remoting.jgroups.NonBlockingTransferQueueBundler", tcp.get("bundler_type").asText());
       assertEquals("0", tcp.get("thread_pool.min_threads").asText());
       assertEquals("25", tcp.get("thread_pool.max_threads").asText());
       assertEquals("5000", tcp.get("thread_pool.keep_alive_time").asText());

--- a/core/src/test/java/org/infinispan/remoting/jgroups/NonBlockingTransferQueueBundler.java
+++ b/core/src/test/java/org/infinispan/remoting/jgroups/NonBlockingTransferQueueBundler.java
@@ -1,0 +1,23 @@
+package org.infinispan.remoting.jgroups;
+
+
+import org.jgroups.Message;
+import org.jgroups.protocols.SimplifiedTransferQueueBundler;
+
+/**
+ * This bundler extends {@link SimplifiedTransferQueueBundler} to drop messages if the queue is full.
+ *
+ * This bundler adds all (unicast or multicast) messages to a queue until max size has been exceeded, but does send
+ * messages immediately when no other messages are available.
+ *
+ * When the queue is full, messages are discarded immediately.
+ *
+ * @see org.jgroups.protocols.TransferQueueBundler
+ */
+public class NonBlockingTransferQueueBundler extends SimplifiedTransferQueueBundler {
+    @Override
+    public void send(Message msg) {
+        if(this.running)
+            this.queue.offer(msg);
+    }
+}

--- a/core/src/test/resources/configs/config-with-jgroups-stack.xml
+++ b/core/src/test/resources/configs/config-with-jgroups-stack.xml
@@ -11,7 +11,7 @@
         <!-- Inline definition -->
         <stack name="mping">
             <TCP bind_port="7800" port_range="30" recv_buf_size="20000000" send_buf_size="640000"
-                 sock_conn_timeout="300" bundler_type="no-bundler"
+                 sock_conn_timeout="300" bundler_type="org.infinispan.remoting.jgroups.NonBlockingTransferQueueBundler"
                  thread_pool.min_threads="0" thread_pool.max_threads="25" thread_pool.keep_alive_time="5000"
                  xmlns="urn:org:jgroups"/>
             <MPING bind_addr="127.0.0.1" break_on_coord_rsp="true"

--- a/core/src/test/resources/configs/unified/10.0.xml
+++ b/core/src/test/resources/configs/unified/10.0.xml
@@ -11,7 +11,7 @@
       <!-- Inline definition -->
       <stack name="mping">
          <TCP bind_port="7800" port_range="30" recv_buf_size="20000000" send_buf_size="640000"
-              sock_conn_timeout="300" bundler_type="no-bundler"
+              sock_conn_timeout="300" bundler_type="org.infinispan.remoting.jgroups.NonBlockingTransferQueueBundler"
               thread_pool.min_threads="0" thread_pool.max_threads="25" thread_pool.keep_alive_time="5000"
               xmlns="urn:org:jgroups"/>
          <MPING bind_addr="127.0.0.1" break_on_coord_rsp="true"

--- a/core/src/test/resources/configs/unified/10.1.xml
+++ b/core/src/test/resources/configs/unified/10.1.xml
@@ -11,7 +11,7 @@
       <!-- Inline definition -->
       <stack name="mping">
          <TCP bind_port="7800" port_range="30" recv_buf_size="20000000" send_buf_size="640000"
-              sock_conn_timeout="300" bundler_type="no-bundler"
+              sock_conn_timeout="300" bundler_type="org.infinispan.remoting.jgroups.NonBlockingTransferQueueBundler"
               thread_pool.min_threads="0" thread_pool.max_threads="25" thread_pool.keep_alive_time="5000"
               xmlns="urn:org:jgroups"/>
          <MPING bind_addr="127.0.0.1" break_on_coord_rsp="true"

--- a/core/src/test/resources/configs/unified/11.0.xml
+++ b/core/src/test/resources/configs/unified/11.0.xml
@@ -12,7 +12,7 @@
       <!-- Inline definition -->
       <stack name="mping">
          <TCP bind_port="7800" port_range="30" recv_buf_size="20000000" send_buf_size="640000"
-              sock_conn_timeout="300" bundler_type="no-bundler"
+              sock_conn_timeout="300" bundler_type="org.infinispan.remoting.jgroups.NonBlockingTransferQueueBundler"
               thread_pool.min_threads="0" thread_pool.max_threads="25" thread_pool.keep_alive_time="5000"
               xmlns="urn:org:jgroups"/>
          <MPING bind_addr="127.0.0.1" break_on_coord_rsp="true"

--- a/core/src/test/resources/configs/xsite/bridge.xml
+++ b/core/src/test/resources/configs/xsite/bridge.xml
@@ -9,7 +9,7 @@
          send_buf_size="640000"
          sock_conn_timeout="300"
          enable_diagnostics="false"
-         bundler_type="no-bundler"
+         bundler_type="org.infinispan.remoting.jgroups.NonBlockingTransferQueueBundler"
 
          thread_pool.min_threads="0"
          thread_pool.max_threads="8"

--- a/core/src/test/resources/configs/xsite/xsite-inline-test.xml
+++ b/core/src/test/resources/configs/xsite/xsite-inline-test.xml
@@ -13,7 +13,7 @@
               send_buf_size="640000"
               sock_conn_timeout="300"
               enable_diagnostics="false"
-              bundler_type="no-bundler"
+              bundler_type="org.infinispan.remoting.jgroups.NonBlockingTransferQueueBundler"
 
               thread_pool.min_threads="0"
               thread_pool.max_threads="8"

--- a/core/src/test/resources/stacks/broken-tcp.xml
+++ b/core/src/test/resources/stacks/broken-tcp.xml
@@ -10,7 +10,7 @@
          max_bundle_size="8500"
          enable_diagnostics="false"
          tcp_nodelay="true"
-         bundler_type="no-bundler"
+         bundler_type="org.infinispan.remoting.jgroups.NonBlockingTransferQueueBundler"
 
          thread_naming_pattern="pl"
 

--- a/core/src/test/resources/stacks/tcp.xml
+++ b/core/src/test/resources/stacks/tcp.xml
@@ -9,7 +9,7 @@
          recv_buf_size="20m"
          send_buf_size="640k"
          enable_diagnostics="false"
-         bundler_type="no-bundler"
+         bundler_type="org.infinispan.remoting.jgroups.NonBlockingTransferQueueBundler"
 
          thread_naming_pattern="pl"
 

--- a/core/src/test/resources/stacks/tcp_mping/tcp1.xml
+++ b/core/src/test/resources/stacks/tcp_mping/tcp1.xml
@@ -6,7 +6,7 @@
         recv_buf_size="20000000"
         send_buf_size="640000"
         sock_conn_timeout="300"
-        bundler_type="no-bundler"
+        bundler_type="org.infinispan.remoting.jgroups.NonBlockingTransferQueueBundler"
 
         thread_pool.min_threads="0"
         thread_pool.max_threads="25"

--- a/core/src/test/resources/stacks/tcp_mping/tcp2.xml
+++ b/core/src/test/resources/stacks/tcp_mping/tcp2.xml
@@ -6,7 +6,7 @@
         recv_buf_size="20000000"
         send_buf_size="640000"
         sock_conn_timeout="300"
-        bundler_type="no-bundler"
+        bundler_type="org.infinispan.remoting.jgroups.NonBlockingTransferQueueBundler"
 
         thread_pool.min_threads="0"
         thread_pool.max_threads="25"

--- a/core/src/test/resources/stacks/udp.xml
+++ b/core/src/test/resources/stacks/udp.xml
@@ -14,7 +14,7 @@
          max_bundle_size="8500"
          ip_ttl="${jgroups.udp.ip_ttl:2}"
          enable_diagnostics="false"
-         bundler_type="no-bundler"
+         bundler_type="org.infinispan.remoting.jgroups.NonBlockingTransferQueueBundler"
 
          thread_naming_pattern="pl"
 

--- a/hibernate/cache-commons/src/test/resources/2lc-test-tcp.xml
+++ b/hibernate/cache-commons/src/test/resources/2lc-test-tcp.xml
@@ -12,7 +12,7 @@
         thread_naming_pattern="pl"
         send_buf_size="640k"
         sock_conn_timeout="300"
-        bundler_type="no-bundler"
+        bundler_type="org.infinispan.remoting.jgroups.NonBlockingTransferQueueBundler"
 
          thread_pool.min_threads="${jgroups.thread_pool.min_threads:0}"
          thread_pool.max_threads="${jgroups.thread_pool.max_threads:200}"

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node0.xml
@@ -1,11 +1,10 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.2.xsd">
-
    <TCP  bind_port="7800" port_range="10"
          recv_buf_size="20000000"
          send_buf_size="640000"
-         bundler_type="no-bundler"
+         bundler_type="org.infinispan.remoting.jgroups.NonBlockingTransferQueueBundler"
          enable_diagnostics="true"
          thread_naming_pattern="cl"
 

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1-fail.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1-fail.xml
@@ -5,7 +5,7 @@
    <TCP  bind_port="7800" port_range="10"
          recv_buf_size="20000000"
          send_buf_size="640000"
-         bundler_type="no-bundler"
+         bundler_type="org.infinispan.remoting.jgroups.NonBlockingTransferQueueBundler"
          enable_diagnostics="true"
          thread_naming_pattern="cl"
 

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1.xml
@@ -5,7 +5,7 @@
    <TCP  bind_port="7800" port_range="10"
          recv_buf_size="20000000"
          send_buf_size="640000"
-         bundler_type="no-bundler"
+         bundler_type="org.infinispan.remoting.jgroups.NonBlockingTransferQueueBundler"
          enable_diagnostics="true"
          thread_naming_pattern="cl"
 

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node0.xml
@@ -5,7 +5,7 @@
    <TCP  bind_port="7800" port_range="10"
          recv_buf_size="20000000"
          send_buf_size="640000"
-         bundler_type="no-bundler"
+         bundler_type="org.infinispan.remoting.jgroups.NonBlockingTransferQueueBundler"
          enable_diagnostics="true"
          thread_naming_pattern="cl"
 

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node1.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node1.xml
@@ -1,11 +1,10 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.2.xsd">
-
    <TCP bind_port="7800" port_range="10"
          recv_buf_size="20000000"
          send_buf_size="640000"
-         bundler_type="no-bundler"
+         bundler_type="org.infinispan.remoting.jgroups.NonBlockingTransferQueueBundler"
          enable_diagnostics="true"
          thread_naming_pattern="cl"
 

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-user-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-user-node0.xml
@@ -1,11 +1,10 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.2.xsd">
-
    <TCP  bind_port="7800" port_range="10"
          recv_buf_size="20000000"
          send_buf_size="640000"
-         bundler_type="no-bundler"
+         bundler_type="org.infinispan.remoting.jgroups.NonBlockingTransferQueueBundler"
          enable_diagnostics="true"
          thread_naming_pattern="cl"
 

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node0.xml
@@ -5,7 +5,7 @@
    <TCP  bind_port="7800" port_range="10"
          recv_buf_size="20000000"
          send_buf_size="640000"
-         bundler_type="no-bundler"
+         bundler_type="org.infinispan.remoting.jgroups.NonBlockingTransferQueueBundler"
          enable_diagnostics="true"
          thread_naming_pattern="cl"
 

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node1.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node1.xml
@@ -1,11 +1,10 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.2.xsd">
-
    <TCP bind_port="7800" port_range="10"
          recv_buf_size="20000000"
          send_buf_size="640000"
-         bundler_type="no-bundler"
+         bundler_type="org.infinispan.remoting.jgroups.NonBlockingTransferQueueBundler"
          enable_diagnostics="true"
          thread_naming_pattern="cl"
 

--- a/server/tests/src/test/resources/configuration/test-jgroups-tcp.xml
+++ b/server/tests/src/test/resources/configuration/test-jgroups-tcp.xml
@@ -9,7 +9,7 @@
            recv_buf_size="20m"
            send_buf_size="640k"
            enable_diagnostics="false"
-           bundler_type="no-bundler"
+           bundler_type="org.infinispan.remoting.jgroups.NonBlockingTransferQueueBundler"
 
            thread_naming_pattern="pl"
 

--- a/tools/src/test/resources/udp.xml
+++ b/tools/src/test/resources/udp.xml
@@ -14,7 +14,7 @@
          max_bundle_size="8500"
          ip_ttl="${jgroups.udp.ip_ttl:2}"
          enable_diagnostics="false"
-         bundler_type="no-bundler"
+         bundler_type="org.infinispan.remoting.jgroups.NonBlockingTransferQueueBundler"
 
          thread_naming_pattern="pl"
 

--- a/wildfly/jgroups/src/main/resources/jgroups-defaults.xml
+++ b/wildfly/jgroups/src/main/resources/jgroups-defaults.xml
@@ -33,14 +33,14 @@
          ip_ttl="${jgroups.ip_ttl:2}"
          thread_naming_pattern="pl"
          enable_diagnostics="false"
-         bundler_type="no-bundler"
+         bundler_type="org.infinispan.remoting.jgroups.NonBlockingTransferQueueBundler"
          max_bundle_size="8500"/>
    <TCP
          enable_diagnostics="false"
          thread_naming_pattern="pl"
          send_buf_size="640k"
          sock_conn_timeout="300"
-         bundler_type="no-bundler"/>
+         bundler_type="org.infinispan.remoting.jgroups.NonBlockingTransferQueueBundler"/>
    <PING
          num_discovery_runs="3"/>
    <MPING


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-6494

Don't block the sender thread when the bundler's queue is full,
drop the message and send it when there's a xmit request.