### PR TITLE
ISPN-11489 PersistenceManagerImpl thread checks need to be updated

### DIFF
--- a/core/src/main/java/org/infinispan/cache/impl/CacheImpl.java
+++ b/core/src/main/java/org/infinispan/cache/impl/CacheImpl.java
@@ -20,7 +20,6 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -172,8 +171,6 @@ public class CacheImpl<K, V> implements AdvancedCache<K, V> {
    @Inject LocalTopologyManager localTopologyManager;
    @Inject StateTransferManager stateTransferManager;
    @Inject InvocationHelper invocationHelper;
-   @Inject @ComponentName(KnownComponentNames.NON_BLOCKING_EXECUTOR)
-   Executor nonBlockingExecutor;
 
    protected Metadata defaultMetadata;
    private final String name;
@@ -1284,7 +1281,7 @@ public class CacheImpl<K, V> implements AdvancedCache<K, V> {
 
    @Override
    public XAResource getXAResource() {
-      return new TransactionXaAdapter((XaTransactionTable) txTable, nonBlockingExecutor);
+      return new TransactionXaAdapter((XaTransactionTable) txTable);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/expiration/impl/ExpirationManagerImpl.java
+++ b/core/src/main/java/org/infinispan/expiration/impl/ExpirationManagerImpl.java
@@ -191,7 +191,7 @@ public class ExpirationManagerImpl<K, V> implements InternalExpirationManager<K,
     * @param metadata
     */
    private void deleteFromStoresAndNotifySync(K key, V value, Metadata metadata) {
-      persistenceManager.deleteFromAllStoresSync(key, keyPartitioner.getSegment(key), PersistenceManager.AccessMode.BOTH);
+      CompletionStages.join(persistenceManager.deleteFromAllStores(key, keyPartitioner.getSegment(key), PersistenceManager.AccessMode.BOTH));
       CompletionStages.join(cacheNotifier.notifyCacheEntryExpired(key, value, metadata, null));
    }
 

--- a/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
@@ -1139,15 +1139,13 @@ public class DefaultCacheManager implements EmbeddedCacheManager {
          long time = configurationManager.getGlobalConfiguration().transport().distributedSyncTimeout();
          return ClusterExecutors.allSubmissionExecutor(null, this, transport, time, TimeUnit.MILLISECONDS,
                // This can run arbitrary code, including user - such commands can block
-               // This should be remedied in https://issues.redhat.com/browse/ISPN-11482
-               globalComponentRegistry.getComponent(ExecutorService.class, KnownComponentNames.NON_BLOCKING_EXECUTOR),
+               globalComponentRegistry.getComponent(ExecutorService.class, KnownComponentNames.BLOCKING_EXECUTOR),
                globalComponentRegistry.getComponent(ScheduledExecutorService.class, KnownComponentNames.TIMEOUT_SCHEDULE_EXECUTOR));
       } else {
          return ClusterExecutors.allSubmissionExecutor(null, this, null,
                TransportConfiguration.DISTRIBUTED_SYNC_TIMEOUT.getDefaultValue(), TimeUnit.MILLISECONDS,
                // This can run arbitrary code, including user - such commands can block
-               // This should be remedied in https://issues.redhat.com/browse/ISPN-11482
-               globalComponentRegistry.getComponent(ExecutorService.class, KnownComponentNames.NON_BLOCKING_EXECUTOR),
+               globalComponentRegistry.getComponent(ExecutorService.class, KnownComponentNames.BLOCKING_EXECUTOR),
                globalComponentRegistry.getComponent(ScheduledExecutorService.class, KnownComponentNames.TIMEOUT_SCHEDULE_EXECUTOR));
       }
    }

--- a/core/src/main/java/org/infinispan/manager/impl/ReplicableRunnableCommand.java
+++ b/core/src/main/java/org/infinispan/manager/impl/ReplicableRunnableCommand.java
@@ -57,6 +57,6 @@ public class ReplicableRunnableCommand implements GlobalRpcCommand {
    @Override
    public boolean canBlock() {
       // These commands can be arbitrary user commands - so be careful about them blocking
-      return false;
+      return true;
    }
 }

--- a/core/src/main/java/org/infinispan/persistence/internal/PersistenceUtil.java
+++ b/core/src/main/java/org/infinispan/persistence/internal/PersistenceUtil.java
@@ -16,6 +16,7 @@ import org.infinispan.distribution.ch.KeyPartitioner;
 import org.infinispan.metadata.Metadata;
 import org.infinispan.persistence.manager.PersistenceManager;
 import org.infinispan.persistence.spi.MarshallableEntry;
+import org.infinispan.util.concurrent.CompletionStages;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 import org.infinispan.util.rxjava.FlowableFromIntSetFunction;
@@ -134,9 +135,9 @@ public class PersistenceUtil {
                                                                         int segment, InvocationContext context, boolean includeStores) {
       final MarshallableEntry<K, V> loaded;
       if (segment != SEGMENT_NOT_PROVIDED) {
-         loaded = persistenceManager.loadFromAllStoresSync(key, segment, context.isOriginLocal(), includeStores);
+         loaded = CompletionStages.join(persistenceManager.loadFromAllStores(key, segment, context.isOriginLocal(), includeStores));
       } else {
-         loaded = persistenceManager.loadFromAllStoresSync(key, context.isOriginLocal(), includeStores);
+         loaded = CompletionStages.join(persistenceManager.loadFromAllStores(key, context.isOriginLocal(), includeStores));
       }
       if (trace) {
          log.tracef("Loaded %s for key %s from persistence.", loaded, key);

--- a/core/src/main/java/org/infinispan/persistence/manager/PersistenceManager.java
+++ b/core/src/main/java/org/infinispan/persistence/manager/PersistenceManager.java
@@ -15,7 +15,6 @@ import org.infinispan.persistence.spi.MarshallableEntry;
 import org.infinispan.persistence.spi.PersistenceException;
 import org.infinispan.persistence.support.BatchModification;
 import org.infinispan.util.concurrent.CompletableFutures;
-import org.infinispan.util.concurrent.CompletionStages;
 import org.reactivestreams.Publisher;
 
 /**
@@ -62,14 +61,6 @@ public interface PersistenceManager extends Lifecycle {
     * Invokes {@link org.infinispan.persistence.spi.AdvancedCacheWriter#clear()} on all the stores that aloes it.
     */
    CompletionStage<Void> clearAllStores(Predicate<? super StoreConfiguration> predicate);
-
-   /**
-    * Same as {@link #deleteFromAllStores(Object, int, Predicate)} except synchronous - Should only be invoked
-    * from persistence thread and from passivation or activation code
-    * @deprecated should be using async version when available - only here for passivation
-    */
-   @Deprecated
-   boolean deleteFromAllStoresSync(Object key, int segment, Predicate<? super StoreConfiguration> predicate);
 
    CompletionStage<Boolean> deleteFromAllStores(Object key, int segment, Predicate<? super StoreConfiguration> predicate);
 
@@ -158,16 +149,6 @@ public interface PersistenceManager extends Lifecycle {
    <K, V> CompletionStage<MarshallableEntry<K, V>> loadFromAllStores(Object key, boolean localInvocation, boolean includeStores);
 
    /**
-    * Same as {@link #loadFromAllStores(Object, boolean, boolean)} except synchronous - Should only be invoked
-    * from persistence thread and from passivation or activation code
-    * @deprecated should be using async version when available - only here for passivation
-    */
-   @Deprecated
-   default <K, V> MarshallableEntry<K, V> loadFromAllStoresSync(Object key, boolean localInvocation, boolean includeStores) {
-      return CompletionStages.join(loadFromAllStores(key, localInvocation, includeStores));
-   }
-
-   /**
     * Same as {@link #loadFromAllStores(Object, boolean, boolean)} except that the segment of the key is also
     * provided to avoid having to calculate the segment.
     * @param key key to read the entry from
@@ -179,16 +160,6 @@ public interface PersistenceManager extends Lifecycle {
     */
    default <K, V> CompletionStage<MarshallableEntry<K, V>> loadFromAllStores(Object key, int segment, boolean localInvocation, boolean includeStores) {
       return loadFromAllStores(key, localInvocation, includeStores);
-   }
-
-   /**
-    * Same as {@link #loadFromAllStores(Object, int, boolean, boolean)} except synchronous - Should only be invoked
-    * from persistence thread and from passivation or activation code
-    * @deprecated should be using async version when available - only here for passivation
-    */
-   @Deprecated
-   default <K, V> MarshallableEntry<K, V> loadFromAllStoresSync(Object key, int segment, boolean localInvocation, boolean includeStores) {
-      return CompletionStages.join(loadFromAllStores(key, segment, localInvocation, includeStores));
    }
 
    default CompletionStage<Integer> size() {
@@ -265,13 +236,6 @@ public interface PersistenceManager extends Lifecycle {
    }
 
    void setClearOnStop(boolean clearOnStop);
-
-   /**
-    * Same as {@link #writeToAllNonTxStores(MarshallableEntry, int, Predicate)} except synchronous - Should only be invoked
-    * from persistence thread and from passivation or activation code
-    * @deprecated should be using async version when available - only here for passivation
-    */
-   void writeToAllNonTxStoresSync(MarshallableEntry marshalledEntry, int segment, Predicate<? super StoreConfiguration> predicate);
 
    /**
     * Write to all stores that are not transactional. A store is considered transactional if all of the following are true:

--- a/core/src/main/java/org/infinispan/persistence/manager/PersistenceManagerImpl.java
+++ b/core/src/main/java/org/infinispan/persistence/manager/PersistenceManagerImpl.java
@@ -181,7 +181,13 @@ public class PersistenceManagerImpl implements PersistenceManager {
       advancedListener = new AdvancedPurgeListener<>(expirationManager.wired());
       preloaded = false;
       enabled = configuration.persistence().usingStores();
-      blockingScheduler = Schedulers.from(blockingExecutor);
+      blockingScheduler = Schedulers.from(task -> {
+         if (isCurrentThreadBlocking()) {
+            SecurityActions.startThread(task, "persistence-bulk-blocking-operation");
+         } else {
+            blockingExecutor.execute(task);
+         }
+      });
       nonBlockingScheduler = Schedulers.from(nonBlockingExecutor);
       if (!enabled)
          return;
@@ -552,19 +558,27 @@ public class PersistenceManagerImpl implements PersistenceManager {
     * @param traceId the traceId to allow for code to be followed
     * @param <V> the return type
     * @return the stage to return that will continue the execution on the CPU thread
+    * @deprecated to be removed and check if the invoking thread is blocking and not use a new thread
     */
-   private <V> CompletionStage<V> continueOnCPUExecutor(CompletionStage<V> delay,
-         int traceId) {
+   @Deprecated
+   private <V> CompletionStage<V> continueOnCPUExecutor(CompletionStage<V> delay, int traceId) {
       return CompletionStages.continueOnExecutor(delay, nonBlockingExecutor, traceId);
    }
 
    private <V> CompletionStage<V> supplyOnPersistenceExAndContinue(IntFunction<V> function, String traceMessage) {
       int traceId = getNextTraceNumber(traceMessage);
+      if (isCurrentThreadBlocking()) {
+         return CompletableFuture.completedFuture(function.apply(traceId));
+      }
       return continueOnCPUExecutor(CompletableFuture.supplyAsync(() -> function.apply(traceId), blockingExecutor), traceId);
    }
 
    private CompletionStage<Void> runOnPersistenceExAndContinue(IntConsumer consumer, String traceMessage) {
       int traceId = getNextTraceNumber(traceMessage);
+      if (isCurrentThreadBlocking()) {
+         consumer.accept(traceId);
+         return CompletableFutures.completedNull();
+      }
       return continueOnCPUExecutor(CompletableFuture.runAsync(() -> consumer.accept(traceId), blockingExecutor), traceId);
    }
 
@@ -579,7 +593,6 @@ public class PersistenceManagerImpl implements PersistenceManager {
 
    @Override
    public CompletionStage<Void> clearAllStores(Predicate<? super StoreConfiguration> predicate) {
-      assert !Thread.currentThread().getName().startsWith("blocking") : "Thread name is: " + Thread.currentThread().getName();
       return runOnPersistenceExAndContinue(traceId -> clearAllStoresSync(predicate, traceId), "Clearing all stores for id %d");
    }
 
@@ -603,13 +616,6 @@ public class PersistenceManagerImpl implements PersistenceManager {
       } finally {
          storesMutex.readLock().unlock();
       }
-   }
-
-   @Override
-   public boolean deleteFromAllStoresSync(Object key, int segment, Predicate<? super StoreConfiguration> predicate) {
-      assert Thread.currentThread().getName().startsWith("blocking") : "Thread name is: " + Thread.currentThread().getName();
-      // Note this one doesn't need an additional trace messages as it is invoked synchronously
-      return deleteFromAllStoresSync(key, segment, predicate, -1);
    }
 
    private boolean deleteFromAllStoresSync(Object key, int segment, Predicate<? super StoreConfiguration> predicate,
@@ -642,7 +648,6 @@ public class PersistenceManagerImpl implements PersistenceManager {
    @Override
    public CompletionStage<Boolean> deleteFromAllStores(Object key, int segment, Predicate<? super StoreConfiguration> predicate) {
       Objects.requireNonNull(key);
-      assert !Thread.currentThread().getName().startsWith("blocking") : "Thread name is: " + Thread.currentThread().getName();
       return supplyOnPersistenceExAndContinue(traceId -> deleteFromAllStoresSync(key, segment, predicate, traceId),
             "Deleting from all stores for id %d");
    }
@@ -681,7 +686,6 @@ public class PersistenceManagerImpl implements PersistenceManager {
    @Override
    public <K, V> Flowable<MarshallableEntry<K, V>> publishEntries(Predicate<? super K> filter, boolean fetchValue,
                                                                    boolean fetchMetadata, Predicate<? super StoreConfiguration> predicate) {
-      assert !Thread.currentThread().getName().startsWith("blocking") : "Thread name is: " + Thread.currentThread().getName();
       AdvancedCacheLoader<K, V> advancedCacheLoader = getFirstAdvancedCacheLoader(predicate);
 
       if (advancedCacheLoader != null) {
@@ -700,7 +704,6 @@ public class PersistenceManagerImpl implements PersistenceManager {
    @Override
    public <K, V> Flowable<MarshallableEntry<K, V>> publishEntries(IntSet segments, Predicate<? super K> filter,
                                                                    boolean fetchValue, boolean fetchMetadata, Predicate<? super StoreConfiguration> predicate) {
-      assert !Thread.currentThread().getName().startsWith("blocking") : "Thread name is: " + Thread.currentThread().getName();
       SegmentedAdvancedLoadWriteStore<K, V> segmentedStore = getFirstSegmentedStore(predicate);
       if (segmentedStore != null) {
          return Flowable
@@ -715,7 +718,6 @@ public class PersistenceManagerImpl implements PersistenceManager {
 
    @Override
    public <K> Flowable<K> publishKeys(Predicate<? super K> filter, Predicate<? super StoreConfiguration> predicate) {
-      assert !Thread.currentThread().getName().startsWith("blocking") : "Thread name is: " + Thread.currentThread().getName();
       AdvancedCacheLoader<K, ?> advancedCacheLoader = getFirstAdvancedCacheLoader(predicate);
 
       if (advancedCacheLoader != null) {
@@ -734,7 +736,6 @@ public class PersistenceManagerImpl implements PersistenceManager {
    @Override
    public <K> Flowable<K> publishKeys(IntSet segments, Predicate<? super K> filter,
          Predicate<? super StoreConfiguration> predicate) {
-      assert !Thread.currentThread().getName().startsWith("blocking") : "Thread name is: " + Thread.currentThread().getName();
       SegmentedAdvancedLoadWriteStore<K, ?> segmentedStore = getFirstSegmentedStore(predicate);
 
       if (segmentedStore != null) {
@@ -749,16 +750,6 @@ public class PersistenceManagerImpl implements PersistenceManager {
       }
 
       return publishKeys(PersistenceUtil.combinePredicate(segments, keyPartitioner, filter), predicate);
-   }
-
-   @Override
-   public <K, V> MarshallableEntry<K, V> loadFromAllStoresSync(Object key, boolean localInvocation, boolean includeStores) {
-      // Some code calls into PersistenceManager even if there are no stores configured
-      if (loaders.isEmpty()) {
-         return null;
-      }
-      assert Thread.currentThread().getName().startsWith("blocking") : "Thread name is: " + Thread.currentThread().getName();
-      return loadFromAllStoresSync(key, localInvocation, includeStores, -1);
    }
 
    private <K, V> MarshallableEntry<K, V> loadFromAllStoresSync(Object key, boolean localInvocation, boolean includeStores, int traceId) {
@@ -788,19 +779,8 @@ public class PersistenceManagerImpl implements PersistenceManager {
 
    @Override
    public <K, V> CompletionStage<MarshallableEntry<K, V>> loadFromAllStores(Object key, boolean localInvocation, boolean includeStores) {
-      assert !Thread.currentThread().getName().startsWith("blocking") : "Thread name is: " + Thread.currentThread().getName();
       return supplyOnPersistenceExAndContinue(traceId -> loadFromAllStoresSync(key, localInvocation, includeStores, traceId),
             "Loading from first store for id %d");
-   }
-
-   @Override
-   public <K, V> MarshallableEntry<K, V> loadFromAllStoresSync(Object key, int segment, boolean localInvocation, boolean includeStores) {
-      // Some code calls into PersistenceManager even if there are no stores configured
-      if (loaders.isEmpty()) {
-         return null;
-      }
-      assert Thread.currentThread().getName().startsWith("blocking") : "Thread name is: " + Thread.currentThread().getName();
-      return loadFromAllStoresSync(key, segment, localInvocation, includeStores, -1);
    }
 
    private <K, V> MarshallableEntry<K, V> loadFromAllStoresSync(Object key, int segment, boolean localInvocation, boolean includeStores, int traceId) {
@@ -844,7 +824,6 @@ public class PersistenceManagerImpl implements PersistenceManager {
 
    @Override
    public <K, V> CompletionStage<MarshallableEntry<K, V>> loadFromAllStores(Object key, int segment, boolean localInvocation, boolean includeStores) {
-      assert !Thread.currentThread().getName().startsWith("blocking") : "Thread name is: " + Thread.currentThread().getName();
       return supplyOnPersistenceExAndContinue(traceId -> loadFromAllStoresSync(key, segment, localInvocation, includeStores, traceId),
             "Loading from first store for id %d");
    }
@@ -860,15 +839,6 @@ public class PersistenceManagerImpl implements PersistenceManager {
          return unwrappedLoader instanceof LocalOnlyCacheLoader;
       }
       return false;
-   }
-
-   @Override
-   public void writeToAllNonTxStoresSync(MarshallableEntry marshalledEntry, int segment,
-         Predicate<? super StoreConfiguration> predicate) {
-      // This is commented out due to the fact that caffeine may schedule a buffer drain on the thread doing just
-      // a simple get (note this is only an issue with passivation)
-//      assert Thread.currentThread().getName().startsWith("blocking") : "Thread name is: " + Thread.currentThread().getName();
-      writeToAllNonTxStoresSync(marshalledEntry, segment, predicate, 0, -1);
    }
 
    private void writeToAllNonTxStoresSync(MarshallableEntry marshalledEntry, int segment,
@@ -898,7 +868,6 @@ public class PersistenceManagerImpl implements PersistenceManager {
    @Override
    public CompletionStage<Void> writeToAllNonTxStores(MarshallableEntry marshalledEntry, int segment,
          Predicate<? super StoreConfiguration> predicate, long flags) {
-      assert !Thread.currentThread().getName().startsWith("blocking") : "Thread name is: " + Thread.currentThread().getName();
       return runOnPersistenceExAndContinue(traceId -> writeToAllNonTxStoresSync(marshalledEntry, segment, predicate, flags, traceId),
             "Writing to all stores for id %d");
    }
@@ -908,8 +877,6 @@ public class PersistenceManagerImpl implements PersistenceManager {
          Predicate<? super StoreConfiguration> predicate, long flags) {
       if (!entries.iterator().hasNext())
          return CompletableFutures.completedNull();
-
-      assert !Thread.currentThread().getName().startsWith("blocking") : "Thread name is: " + Thread.currentThread().getName();
 
       int id = getNextTraceNumber("Submitting persistence async operation of id %d to write a batch");
 
@@ -963,8 +930,6 @@ public class PersistenceManagerImpl implements PersistenceManager {
       if (!keys.iterator().hasNext())
          return CompletableFutures.completedNull();
 
-      assert !Thread.currentThread().getName().startsWith("blocking") : "Thread name is: " + Thread.currentThread().getName();
-
       return runOnPersistenceExAndContinue(traceId -> {
          storesMutex.readLock().lock();
          try {
@@ -984,7 +949,6 @@ public class PersistenceManagerImpl implements PersistenceManager {
    @Override
    public CompletionStage<Void> prepareAllTxStores(Transaction transaction, BatchModification batchModification,
          Predicate<? super StoreConfiguration> predicate) throws PersistenceException {
-      assert !Thread.currentThread().getName().startsWith("blocking") : "Thread name is: " + Thread.currentThread().getName();
       return runOnPersistenceExAndContinue(traceId -> {
          storesMutex.readLock().lock();
          try {
@@ -1006,21 +970,18 @@ public class PersistenceManagerImpl implements PersistenceManager {
 
    @Override
    public CompletionStage<Void> commitAllTxStores(Transaction transaction, Predicate<? super StoreConfiguration> predicate) {
-      assert !Thread.currentThread().getName().startsWith("blocking") : "Thread name is: " + Thread.currentThread().getName();
       return runOnPersistenceExAndContinue(traceId -> performOnAllTxStores(predicate, writer -> writer.commit(transaction), traceId),
             "Committing tx for all stores for id %d");
    }
 
    @Override
    public CompletionStage<Void> rollbackAllTxStores(Transaction transaction, Predicate<? super StoreConfiguration> predicate) {
-      assert !Thread.currentThread().getName().startsWith("blocking") : "Thread name is: " + Thread.currentThread().getName();
       return runOnPersistenceExAndContinue(traceId -> performOnAllTxStores(predicate, writer -> writer.rollback(transaction), traceId),
             "Rolling back tx for all stores for id %d");
    }
 
    @Override
    public CompletionStage<Integer> size(Predicate<? super StoreConfiguration> predicate) {
-      assert !Thread.currentThread().getName().startsWith("blocking") : "Thread name is: " + Thread.currentThread().getName();
       storesMutex.readLock().lock();
       try {
          checkStoreAvailability();
@@ -1043,40 +1004,41 @@ public class PersistenceManagerImpl implements PersistenceManager {
 
    @Override
    public CompletionStage<Integer> size(IntSet segments) {
-         storesMutex.readLock().lock();
-         try {
-            checkStoreAvailability();
-            for (CacheLoader l : loaders) {
-               StoreConfiguration storeConfiguration;
-               if (l instanceof SegmentedAdvancedLoadWriteStore &&
-                     ((storeConfiguration = getStoreConfig(l)) != null && storeConfiguration.segmented())) {
-                  return supplyOnPersistenceExAndContinue(traceId -> {
-                     if (trace) {
-                        log.tracef("Continuing size operation for id %d", traceId);
-                     }
-                     return ((SegmentedAdvancedLoadWriteStore) l).size(segments);
-                  }, "Retrieving size with segments for id %d");
-               }
+      storesMutex.readLock().lock();
+      try {
+         checkStoreAvailability();
+         for (CacheLoader l : loaders) {
+            StoreConfiguration storeConfiguration;
+            if (l instanceof SegmentedAdvancedLoadWriteStore &&
+                  ((storeConfiguration = getStoreConfig(l)) != null && storeConfiguration.segmented())) {
+               return supplyOnPersistenceExAndContinue(traceId -> {
+                  if (trace) {
+                     log.tracef("Continuing size operation for id %d", traceId);
+                  }
+                  return ((SegmentedAdvancedLoadWriteStore) l).size(segments);
+               }, "Retrieving size with segments for id %d");
             }
-            if (trace) {
-               log.tracef("Calculating size of store via publisher for segments %s", segments);
-            }
-            return Flowable.fromPublisher(publishKeys(segments, null, AccessMode.BOTH))
-                  .count()
-                  .map(count -> {
-                     long longValue = count.longValue();
-                     if (longValue > Integer.MAX_VALUE) {
-                        return Integer.MAX_VALUE;
-                     }
-                     return (int) longValue;
-                  })
-                  .subscribeOn(blockingScheduler)
-                  .observeOn(nonBlockingScheduler)
-                  .to(RxJavaInterop.singleToCompletionStage());
-
-         } finally {
-            storesMutex.readLock().unlock();
          }
+         if (trace) {
+            log.tracef("Calculating size of store via publisher for segments %s", segments);
+         }
+
+         return Flowable.fromPublisher(publishKeys(segments, null, AccessMode.BOTH))
+               .count()
+               .map(count -> {
+                  long longValue = count.longValue();
+                  if (longValue > Integer.MAX_VALUE) {
+                     return Integer.MAX_VALUE;
+                  }
+                  return (int) longValue;
+               })
+               .subscribeOn(blockingScheduler)
+               .observeOn(nonBlockingScheduler)
+               .to(RxJavaInterop.singleToCompletionStage());
+
+      } finally {
+         storesMutex.readLock().unlock();
+      }
    }
 
    @Override
@@ -1521,7 +1483,7 @@ public class PersistenceManagerImpl implements PersistenceManager {
       }
    }
 
-   class StoreStatus {
+   static class StoreStatus {
       final Object store;
       final StoreConfiguration config;
       boolean availability = true;
@@ -1544,5 +1506,9 @@ public class PersistenceManagerImpl implements PersistenceManager {
          }
          return oldAvailability != availability;
       }
+   }
+
+   private boolean isCurrentThreadBlocking() {
+      return Thread.currentThread().getName().startsWith("blocking");
    }
 }

--- a/core/src/main/java/org/infinispan/persistence/manager/PersistenceManagerStub.java
+++ b/core/src/main/java/org/infinispan/persistence/manager/PersistenceManagerStub.java
@@ -84,11 +84,6 @@ public class PersistenceManagerStub implements PersistenceManager {
    }
 
    @Override
-   public boolean deleteFromAllStoresSync(Object key, int segment, Predicate<? super StoreConfiguration> predicate) {
-      return false;
-   }
-
-   @Override
    public CompletionStage<Boolean> deleteFromAllStores(Object key, int segment, Predicate<? super StoreConfiguration> predicate) {
       return CompletableFutures.completedFalse();
    }
@@ -156,10 +151,6 @@ public class PersistenceManagerStub implements PersistenceManager {
    @Override
    public CompletionStage<Void> rollbackAllTxStores(Transaction transaction, Predicate<? super StoreConfiguration> predicate) {
       return CompletableFutures.completedNull();
-   }
-
-   @Override
-   public void writeToAllNonTxStoresSync(MarshallableEntry marshalledEntry, int segment, Predicate<? super StoreConfiguration> predicate) {
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/persistence/manager/SecurityActions.java
+++ b/core/src/main/java/org/infinispan/persistence/manager/SecurityActions.java
@@ -1,0 +1,30 @@
+package org.infinispan.persistence.manager;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+import org.infinispan.security.Security;
+
+/**
+ * SecurityActions for the org.infinispan.manager package.
+ *
+ * Do not move. Do not change class and method visibility to avoid being called from other
+ * {@link java.security.CodeSource}s, thus granting privilege escalation to external code.
+ *
+ * @author William Burns
+ * @since 11.0
+ */
+final class SecurityActions {
+   private static <T> T doPrivileged(PrivilegedAction<T> action) {
+      if (System.getSecurityManager() != null) {
+         return AccessController.doPrivileged(action);
+      } else {
+         return Security.doPrivileged(action);
+      }
+   }
+
+   static void startThread(Runnable task, String threadName) {
+      StartThreadAction action = new StartThreadAction(task, threadName);
+      doPrivileged(action);
+   }
+}

--- a/core/src/main/java/org/infinispan/persistence/manager/StartThreadAction.java
+++ b/core/src/main/java/org/infinispan/persistence/manager/StartThreadAction.java
@@ -1,0 +1,28 @@
+package org.infinispan.persistence.manager;
+
+import java.security.PrivilegedAction;
+
+/**
+ * StartThreadAction.
+ *
+ * @author William Burns
+ * @since 11.0
+ */
+public class StartThreadAction implements PrivilegedAction<Void> {
+
+   private final Runnable task;
+   private final String threadName;
+
+   public StartThreadAction(Runnable task, String threadName) {
+      this.task = task;
+      this.threadName = threadName;
+   }
+
+   @Override
+   public Void run() {
+      Thread thread = new Thread(task, threadName);
+      thread.setDaemon(true);
+      thread.start();
+      return null;
+   }
+}

--- a/core/src/main/java/org/infinispan/persistence/support/DelegatingPersistenceManager.java
+++ b/core/src/main/java/org/infinispan/persistence/support/DelegatingPersistenceManager.java
@@ -96,11 +96,6 @@ public class DelegatingPersistenceManager implements PersistenceManager, Lifecyc
    }
 
    @Override
-   public boolean deleteFromAllStoresSync(Object key, int segment, Predicate<? super StoreConfiguration> predicate) {
-      return persistenceManager.deleteFromAllStoresSync(key, segment, predicate);
-   }
-
-   @Override
    public CompletionStage<Boolean> deleteFromAllStores(Object key, int segment, Predicate<? super StoreConfiguration> predicate) {
       return persistenceManager.deleteFromAllStores(key, segment, predicate);
    }
@@ -148,12 +143,6 @@ public class DelegatingPersistenceManager implements PersistenceManager, Lifecyc
    @Override
    public void setClearOnStop(boolean clearOnStop) {
       persistenceManager.setClearOnStop(clearOnStop);
-   }
-
-   @Override
-   public void writeToAllNonTxStoresSync(MarshallableEntry marshalledEntry, int segment,
-                                         Predicate<? super StoreConfiguration> predicate) {
-      persistenceManager.writeToAllNonTxStoresSync(marshalledEntry, segment, predicate);
    }
 
    @Override
@@ -206,21 +195,10 @@ public class DelegatingPersistenceManager implements PersistenceManager, Lifecyc
    }
 
    @Override
-   public <K, V> MarshallableEntry<K, V> loadFromAllStoresSync(Object key, boolean localInvocation, boolean includeStores) {
-      return persistenceManager.loadFromAllStoresSync(key, localInvocation, includeStores);
-   }
-
-   @Override
    public <K, V> CompletionStage<MarshallableEntry<K, V>> loadFromAllStores(Object key, int segment,
                                                                             boolean localInvocation,
                                                                             boolean includeStores) {
       return persistenceManager.loadFromAllStores(key, segment, localInvocation, includeStores);
-   }
-
-   @Override
-   public <K, V> MarshallableEntry<K, V> loadFromAllStoresSync(Object key, int segment, boolean localInvocation,
-                                                               boolean includeStores) {
-      return persistenceManager.loadFromAllStoresSync(key, segment, localInvocation, includeStores);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/transaction/impl/TransactionTable.java
+++ b/core/src/main/java/org/infinispan/transaction/impl/TransactionTable.java
@@ -1,6 +1,5 @@
 package org.infinispan.transaction.impl;
 
-import static org.infinispan.factories.KnownComponentNames.NON_BLOCKING_EXECUTOR;
 import static org.infinispan.factories.KnownComponentNames.TIMEOUT_SCHEDULE_EXECUTOR;
 import static org.infinispan.util.logging.Log.CLUSTER;
 import static org.infinispan.util.logging.Log.CONTAINER;
@@ -18,7 +17,6 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -117,8 +115,6 @@ public class TransactionTable implements org.infinispan.transaction.TransactionT
    @Inject TransactionOriginatorChecker transactionOriginatorChecker;
    @Inject TransactionManager transactionManager;
    @Inject ComponentRegistry componentRegistry;
-   @Inject @ComponentName(NON_BLOCKING_EXECUTOR)
-   Executor nonBlockingExecutor;
 
    /**
     * minTxTopologyId is the minimum topology ID across all ongoing local and remote transactions.
@@ -212,7 +208,7 @@ public class TransactionTable implements org.infinispan.transaction.TransactionT
    public void enlist(Transaction transaction, LocalTransaction localTransaction) {
       if (!localTransaction.isEnlisted()) {
          SynchronizationAdapter sync =
-               new SynchronizationAdapter(localTransaction, this, nonBlockingExecutor);
+               new SynchronizationAdapter(localTransaction, this);
          if (transactionSynchronizationRegistry != null) {
             boolean needsSuspend = false;
             try {
@@ -254,7 +250,7 @@ public class TransactionTable implements org.infinispan.transaction.TransactionT
 
    public void enlistClientTransaction(Transaction transaction, LocalTransaction localTransaction) {
       if (!localTransaction.isEnlisted()) {
-         SynchronizationAdapter sync = new SynchronizationAdapter(localTransaction, this, nonBlockingExecutor);
+         SynchronizationAdapter sync = new SynchronizationAdapter(localTransaction, this);
          try {
             transaction.registerSynchronization(sync);
          } catch (Exception e) {

--- a/core/src/main/java/org/infinispan/transaction/synchronization/SynchronizationAdapter.java
+++ b/core/src/main/java/org/infinispan/transaction/synchronization/SynchronizationAdapter.java
@@ -1,13 +1,10 @@
 package org.infinispan.transaction.synchronization;
 
-import java.util.concurrent.Executor;
-
 import javax.transaction.Synchronization;
 
 import org.infinispan.transaction.impl.AbstractEnlistmentAdapter;
 import org.infinispan.transaction.impl.LocalTransaction;
 import org.infinispan.transaction.impl.TransactionTable;
-import org.infinispan.util.concurrent.CompletableFutures;
 import org.infinispan.util.concurrent.CompletionStages;
 
 /**
@@ -20,25 +17,21 @@ import org.infinispan.util.concurrent.CompletionStages;
 public class SynchronizationAdapter extends AbstractEnlistmentAdapter implements Synchronization {
    private final LocalTransaction localTransaction;
    private final TransactionTable txTable;
-   private final Executor executor;
 
-   public SynchronizationAdapter(LocalTransaction localTransaction, TransactionTable txTable, Executor executor) {
+   public SynchronizationAdapter(LocalTransaction localTransaction, TransactionTable txTable) {
       super(localTransaction);
       this.localTransaction = localTransaction;
       this.txTable = txTable;
-      this.executor = executor;
    }
 
    @Override
    public void beforeCompletion() {
-      CompletionStages.join(CompletableFutures.completedNull()
-            .thenComposeAsync(ignore -> txTable.beforeCompletion(localTransaction), executor));
+      CompletionStages.join(txTable.beforeCompletion(localTransaction));
    }
 
    @Override
    public void afterCompletion(int status) {
-      CompletionStages.join(CompletableFutures.completedNull()
-            .thenComposeAsync(ignore -> txTable.afterCompletion(localTransaction, status), executor));
+      CompletionStages.join(txTable.afterCompletion(localTransaction, status));
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/transaction/xa/XaTransactionTable.java
+++ b/core/src/main/java/org/infinispan/transaction/xa/XaTransactionTable.java
@@ -84,7 +84,7 @@ public class XaTransactionTable extends TransactionTable {
       LocalXaTransaction localTransaction = (LocalXaTransaction) ltx;
       if (!localTransaction.isEnlisted()) { //make sure that you only enlist it once
          try {
-            transaction.enlistResource(new TransactionXaAdapter(localTransaction, this, nonBlockingExecutor));
+            transaction.enlistResource(new TransactionXaAdapter(localTransaction, this));
          } catch (Exception e) {
             Xid xid = localTransaction.getXid();
             if (xid != null && !localTransaction.getLookedUpEntries().isEmpty()) {

--- a/core/src/main/java/org/infinispan/util/concurrent/CompletionStages.java
+++ b/core/src/main/java/org/infinispan/util/concurrent/CompletionStages.java
@@ -143,7 +143,9 @@ public class CompletionStages {
     * @param continuationExecutor the executor to run any further completion chain methods on
     * @param traceId the id to print when tracing is enabled
     * @return a CompletionStage that when depended upon will run any callback in the supplied executor
+    * @deprecated This method is to be removed and replaced with a component to handle thread continuations in a better manner
     */
+   @Deprecated
    public static <V> CompletionStage<V> continueOnExecutor(CompletionStage<V> delay,
                                                            Executor continuationExecutor, Object traceId) {
       if (isCompletedSuccessfully(delay)) {

--- a/core/src/test/java/org/infinispan/tx/TransactionXaAdapterTmIntegrationTest.java
+++ b/core/src/test/java/org/infinispan/tx/TransactionXaAdapterTmIntegrationTest.java
@@ -30,7 +30,6 @@ import org.infinispan.transaction.xa.TransactionFactory;
 import org.infinispan.transaction.xa.TransactionXaAdapter;
 import org.infinispan.transaction.xa.XaTransactionTable;
 import org.infinispan.util.concurrent.CompletableFutures;
-import org.infinispan.util.concurrent.WithinThreadExecutor;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -71,7 +70,7 @@ public class TransactionXaAdapterTmIntegrationTest {
       when(invoker.invokeAsync(any(), any())).thenReturn(CompletableFutures.completedNull());
 
       TestingUtil.inject(txCoordinator, commandsFactory, icf, invoker, txTable, configuration);
-      xaAdapter = new TransactionXaAdapter(localTx, txTable, new WithinThreadExecutor());
+      xaAdapter = new TransactionXaAdapter(localTx, txTable);
 
       xaAdapter.start(xid, 0);
    }


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-11489
https://issues.redhat.com/browse/ISPN-11443

This makes it so that when PersistenceManagerImpl is invoked by an Infinispan blocking thread that it runs the operation in the same thread, instead of spawning a new task. This prevents a blocking thread from waiting on another blocking thread, which can cause deadlocks. Also for bulk operations that are subscribed on a blocking thread we create a temporary thread to handle the load.