### PR TITLE
[10.1.x] ISPN-11512 The mass indexer should iterate over the cache only once

### DIFF
--- a/query/src/main/java/org/infinispan/query/impl/massindex/DistributedExecutorMassIndexer.java
+++ b/query/src/main/java/org/infinispan/query/impl/massindex/DistributedExecutorMassIndexer.java
@@ -180,35 +180,33 @@ public class DistributedExecutorMassIndexer implements MassIndexer {
 
          BiConsumer<Void, Throwable> flushIfNeeded = (v, t) -> {
             try {
-               for (IndexedTypeIdentifier type : toFlush) {
-                  indexUpdater.flush(type);
-               }
+               indexUpdater.flush(toFlush);
             } finally {
                lock.unlock();
             }
          };
-         CompletableFuture<Void> compositeFuture;
+         Map<MassIndexStrategy, Set<IndexedTypeIdentifier>> strategyPerType = new HashMap<>();
+         for (IndexedTypeIdentifier indexedType : searchIntegrator.getIndexBindings().keySet()) {
+            EntityIndexBinding indexBinding = searchIntegrator.getIndexBindings().get(indexedType);
+            MassIndexStrategy strategy = calculateStrategy(indexBinding, cache.getCacheConfiguration());
+            strategyPerType.computeIfAbsent(strategy, s -> new HashSet<>()).add(indexedType);
+         }
          try {
-            for (IndexedTypeIdentifier indexedType : searchIntegrator.getIndexBindings().keySet()) {
-               EntityIndexBinding indexBinding = searchIntegrator.getIndexBindings().get(indexedType);
-               MassIndexStrategy strategy = calculateStrategy(indexBinding, cache.getCacheConfiguration());
+            strategyPerType.forEach((strategy, indexedTypes) -> {
                boolean workerClean = true, workerFlush = true;
                if (strategy.getCleanStrategy() == CleanExecutionMode.ONCE_BEFORE) {
-                  indexUpdater.purge(indexedType);
+                  indexUpdater.purge(indexedTypes);
                   workerClean = false;
                }
                if (strategy.getFlushStrategy() == FlushExecutionMode.ONCE_AFTER) {
-                  toFlush.add(indexedType);
+                  toFlush.addAll(indexedTypes);
                   workerFlush = false;
                }
-
-            IndexingExecutionMode indexingStrategy = strategy.getIndexingStrategy();
-            IndexWorker indexWork = new IndexWorker(cache.getName(), indexedType, workerFlush, workerClean,
-                  skipIndex, indexingStrategy == IndexingExecutionMode.PRIMARY_OWNER, null);
-
+               IndexWorker indexWork = new IndexWorker(cache.getName(), indexedTypes, workerFlush, workerClean,
+                     skipIndex, strategy.getIndexingStrategy() == IndexingExecutionMode.PRIMARY_OWNER, null);
                futures.add(executor.submitConsumer(indexWork, TRI_CONSUMER));
-            }
-            compositeFuture = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+            });
+            CompletableFuture<Void> compositeFuture = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
             return compositeFuture.whenCompleteAsync(flushIfNeeded, localExecutor);
          } catch (Throwable t) {
             lock.unlock();

--- a/query/src/main/java/org/infinispan/query/impl/massindex/IndexUpdater.java
+++ b/query/src/main/java/org/infinispan/query/impl/massindex/IndexUpdater.java
@@ -1,5 +1,7 @@
 package org.infinispan.query.impl.massindex;
 
+import java.util.Collection;
+
 import org.hibernate.search.backend.UpdateLuceneWork;
 import org.hibernate.search.bridge.spi.ConversionContext;
 import org.hibernate.search.bridge.util.impl.ContextualExceptionBridgeHelper;
@@ -8,6 +10,7 @@ import org.hibernate.search.engine.spi.EntityIndexBinding;
 import org.hibernate.search.spi.DefaultInstanceInitializer;
 import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.spi.SearchIntegrator;
+import org.hibernate.search.spi.impl.IndexedTypeSets;
 import org.hibernate.search.spi.impl.PojoIndexedTypeIdentifier;
 import org.infinispan.commons.time.TimeService;
 import org.infinispan.query.backend.KeyTransformationHandler;
@@ -34,14 +37,14 @@ public class IndexUpdater {
       this.defaultBatchBackend = new ExtendedBatchBackend(searchIntegrator, new DefaultMassIndexerProgressMonitor(timeService));
    }
 
-   public void flush(IndexedTypeIdentifier entity) {
-      LOG.flushingIndex(entity.getName());
-      defaultBatchBackend.flush(entity.asTypeSet());
+   public void flush(Collection<IndexedTypeIdentifier> entities) {
+      LOG.flushingIndex(entities.toString());
+      defaultBatchBackend.flush(IndexedTypeSets.fromIdentifiers(entities));
    }
 
-   public void purge(IndexedTypeIdentifier entity) {
-      LOG.purgingIndex(entity.getName());
-      defaultBatchBackend.purge(entity.asTypeSet());
+   public void purge(Collection<IndexedTypeIdentifier> entities) {
+      LOG.purgingIndex(entities.toString());
+      defaultBatchBackend.purge(IndexedTypeSets.fromIdentifiers(entities));
    }
 
    public void waitForAsyncCompletion() {

--- a/query/src/test/java/org/infinispan/query/distributed/AsyncMassIndexPerfTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/AsyncMassIndexPerfTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.query.distributed;
 
+import java.util.Collections;
 import java.util.Scanner;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -262,7 +263,7 @@ public class AsyncMassIndexPerfTest extends MultipleCacheManagersTest {
       IndexUpdater indexUpdater = new IndexUpdater(ComponentRegistryUtils.getSearchIntegrator(cache1),
             ComponentRegistryUtils.getKeyTransformationHandler(cache1),
             ComponentRegistryUtils.getTimeService(cache1));
-      indexUpdater.flush(new PojoIndexedTypeIdentifier(Transaction.class));
+      indexUpdater.flush(Collections.singleton(new PojoIndexedTypeIdentifier(Transaction.class)));
    }
 
    class StopTimer {


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-11512