### PR TITLE
ISPN-11547 Query test suite hangs intermitently

### DIFF
--- a/query/src/test/resources/async-file-store-config.xml
+++ b/query/src/test/resources/async-file-store-config.xml
@@ -30,7 +30,6 @@
       <!--  Cache to store Lucene's file metadata  -->
       <!-- *************************************** -->
       <local-cache name="LuceneIndexesMetadata_custom">
-         <transaction mode="NON_XA" />
          <persistence passivation="false">
             <file-store preload="true" fetch-state="true" read-only="false" purge="false" path="${java.io.tmpdir}/asyncStore">
                <write-behind thread-pool-size="5" />
@@ -42,7 +41,6 @@
       <!--  Cache to store Lucene data  -->
       <!-- **************************** -->
       <local-cache name="LuceneIndexesData_custom">
-         <transaction mode="NON_XA" />
          <persistence passivation="false">
             <file-store preload="true" fetch-state="true" read-only="false" purge="false" path="${java.io.tmpdir}/asyncStore">
                <write-behind thread-pool-size="5" />
@@ -54,7 +52,6 @@
       <!--  Cache to store Lucene locks  -->
       <!-- ***************************** -->
       <local-cache name="LuceneIndexesLocking_custom">
-         <transaction mode="NON_XA" />
          <persistence passivation="false">
             <file-store preload="true" fetch-state="true" read-only="false" purge="false" path="${java.io.tmpdir}/asyncStore">
                <write-behind thread-pool-size="5" />

--- a/query/src/test/resources/async-jdbc-store-config.xml
+++ b/query/src/test/resources/async-jdbc-store-config.xml
@@ -27,7 +27,6 @@
          </indexing>
       </replicated-cache>
       <replicated-cache name="LuceneIndexesMetadata_custom1">
-         <transaction mode="NON_XA" />
          <persistence>
             <string-keyed-jdbc-store xmlns="urn:infinispan:config:store:jdbc:${infinispan.core.schema.version}"
                                   key-to-string-mapper="org.infinispan.lucene.LuceneKey2StringMapper"
@@ -50,7 +49,6 @@
       <!--  Cache to store Lucene data  -->
       <!-- **************************** -->
       <replicated-cache name="LuceneIndexesData_custom1">
-         <transaction mode="NON_XA" />
          <persistence>
             <string-keyed-jdbc-store xmlns="urn:infinispan:config:store:jdbc:${infinispan.core.schema.version}"
                                      key-to-string-mapper="org.infinispan.lucene.LuceneKey2StringMapper"
@@ -72,7 +70,6 @@
       <!--  Cache to store Lucene locks  -->
       <!-- ***************************** -->
       <replicated-cache name="LuceneIndexesLocking_custom1">
-         <transaction mode="NON_XA" />
          <persistence>
             <string-keyed-jdbc-store xmlns="urn:infinispan:config:store:jdbc:${infinispan.core.schema.version}"
                                      key-to-string-mapper="org.infinispan.lucene.LuceneKey2StringMapper"


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-11547

This is mere a workaround that prevents tests from hanging. 

The root cause is the Hibernate Search engine has an executor that deletes files from index asynchronously, and after the teardown the tx cannot complete for some reason, possibly a race with the cache shutdown