### PR TITLE
ISPN-11554 Off-heap state transfer resets timestamps

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/StorageRoutingTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/StorageRoutingTest.java
@@ -27,7 +27,6 @@ public class StorageRoutingTest extends MultiHotRodServersTest {
 
    private static final int CLUSTER_SIZE = 3;
 
-   protected StorageType storageType;
    private Object key;
 
    public Object[] factory() {
@@ -45,11 +44,11 @@ public class StorageRoutingTest extends MultiHotRodServersTest {
    }
 
    protected String[] parameterNames() {
-      return new String[]{"storage", "key"};
+      return new String[]{null, "key"};
    }
 
    protected Object[] parameterValues() {
-      return new Object[]{storageType, key};
+      return new Object[]{storageType, key.getClass().getSimpleName()};
    }
 
    private StorageRoutingTest withStorageType(StorageType storageType) {

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/MultiServerStoreQueryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/MultiServerStoreQueryTest.java
@@ -40,7 +40,6 @@ public class MultiServerStoreQueryTest extends MultiHotRodServersTest {
 
    private RemoteCache<Object, Object> userCache;
 
-   private StorageType storageType;
    private long evictionSize = -1;
 
    @Override
@@ -71,7 +70,7 @@ public class MultiServerStoreQueryTest extends MultiHotRodServersTest {
       };
    }
 
-   MultiServerStoreQueryTest storageType(StorageType storageType) {
+   public MultiServerStoreQueryTest storageType(StorageType storageType) {
       this.storageType = storageType;
       return this;
    }

--- a/core/src/main/java/org/infinispan/container/offheap/OffHeapConcurrentMap.java
+++ b/core/src/main/java/org/infinispan/container/offheap/OffHeapConcurrentMap.java
@@ -581,7 +581,7 @@ public class OffHeapConcurrentMap implements ConcurrentMap<WrappedBytes, Interna
          if (prev == result) {
             // noop
          } else if (result != null) {
-            long newAddress = offHeapEntryFactory.create(key, result.getValue(), result.getMetadata(), result.getInternalMetadata());
+            long newAddress = offHeapEntryFactory.create(key, hashCode, result);
             // TODO: Technically actualAddress could be a 0 and bucketAddress != 0, which means we will loop through
             // entire bucket for no reason as it will never match (doing key equality checks)
             performPut(bucketAddress, actualAddress, newAddress, key, memoryOffset, false, false);
@@ -696,7 +696,7 @@ public class OffHeapConcurrentMap implements ConcurrentMap<WrappedBytes, Interna
 
          int memoryOffset = getMemoryOffset(hashCode);
          long address = memoryLookup.getMemoryAddressOffset(memoryOffset);
-         long newAddress = offHeapEntryFactory.create(key, hashCode, value.getValue(), value.getMetadata(), value.getInternalMetadata());
+         long newAddress = offHeapEntryFactory.create(key, hashCode, value);
          returnedValue = performPut(address, 0, newAddress, key, memoryOffset, true, false);
       } finally {
          stampedLock.unlockWrite(writeStamp);
@@ -1048,7 +1048,7 @@ public class OffHeapConcurrentMap implements ConcurrentMap<WrappedBytes, Interna
                ice = offHeapEntryFactory.fromMemory(address);
             }
 
-            long newAddress = offHeapEntryFactory.create(key, hashCode, newValue.getValue(), newValue.getMetadata(), newValue.getInternalMetadata());
+            long newAddress = offHeapEntryFactory.create(key, hashCode, newValue);
 
             entryReplaced(newAddress, address);
             if (prevAddress != 0) {

--- a/core/src/main/java/org/infinispan/container/offheap/OffHeapEntryFactory.java
+++ b/core/src/main/java/org/infinispan/container/offheap/OffHeapEntryFactory.java
@@ -16,54 +16,11 @@ public interface OffHeapEntryFactory extends KeyValueMetadataSizeCalculator<Wrap
    /**
     * Creates an off heap entry using the provided key value and metadata
     * @param key the key to use
-    * @param value the value to use
-    * @param metadata the metadata to use
-    * @return the address of where the entry was created
-    */
-   default long create(WrappedBytes key, WrappedBytes value, Metadata metadata) {
-      //TODO! can it ^ be removed?
-      return create(key, key.hashCode(), value, metadata, null);
-   }
-
-   /**
-    * Creates an off heap entry using the provided key value and metadata
-    *
-    * @param key              the key to use
-    * @param value            the value to use
-    * @param metadata         the metadata to use
-    * @param internalMetadata the internal metadata to use
-    * @return the address of where the entry was created
-    */
-   default long create(WrappedBytes key, WrappedBytes value, Metadata metadata,
-         MetaParamsInternalMetadata internalMetadata) {
-      return create(key, key.hashCode(), value, metadata, internalMetadata);
-   }
-
-   /**
-    * Creates an off heap entry using the provided key value and metadata
-    * @param key the key to use
     * @param hashCode the hashCode of the key
-    * @param value the value to use
-    * @param metadata the metadata to use
+    * @param ice the internal entry to use
     * @return the address of where the entry was created
     */
-   default long create(WrappedBytes key, int hashCode, WrappedBytes value, Metadata metadata) {
-      //TODO! can it ^ be removed?
-      return create(key, hashCode, value, metadata, null);
-   }
-
-   /**
-    * Creates an off heap entry using the provided key value and metadata(s)
-    *
-    * @param key              the key to use
-    * @param hashCode         the hashCode of the key
-    * @param value            the value to use
-    * @param metadata         the metadata to use
-    * @param internalMetadata the internal metadata to use
-    * @return the address of where the entry was created
-    */
-   long create(WrappedBytes key, int hashCode, WrappedBytes value, Metadata metadata,
-         MetaParamsInternalMetadata internalMetadata);
+   long create(WrappedBytes key, int hashCode, InternalCacheEntry<WrappedBytes, WrappedBytes> ice);
 
    /**
     * Returns how many bytes in memory this address location uses assuming it is an {@link InternalCacheEntry}.

--- a/core/src/test/java/org/infinispan/eviction/impl/ExceptionEvictionTest.java
+++ b/core/src/test/java/org/infinispan/eviction/impl/ExceptionEvictionTest.java
@@ -16,6 +16,7 @@ import javax.transaction.SystemException;
 import javax.transaction.TransactionManager;
 
 import org.infinispan.Cache;
+import org.infinispan.commons.test.Exceptions;
 import org.infinispan.commons.time.TimeService;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
@@ -33,7 +34,6 @@ import org.infinispan.interceptors.impl.ContainerFullException;
 import org.infinispan.interceptors.impl.TransactionalExceptionEvictionInterceptor;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.remoting.transport.Address;
-import org.infinispan.commons.test.Exceptions;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.transaction.LockingMode;
@@ -52,24 +52,12 @@ public class ExceptionEvictionTest extends MultipleCacheManagersTest {
    private static final int SIZE = 10;
 
    private int nodeCount;
-   private StorageType storageType;
-   private boolean optimisticTransaction;
    private ConfigurationBuilder configurationBuilder;
 
    protected ControlledTimeService timeService = new ControlledTimeService();
 
    public ExceptionEvictionTest nodeCount(int nodeCount) {
       this.nodeCount = nodeCount;
-      return this;
-   }
-
-   public ExceptionEvictionTest storageType(StorageType storageType) {
-      this.storageType = storageType;
-      return this;
-   }
-
-   public ExceptionEvictionTest optimisticTransaction(boolean optimisticTransaction) {
-      this.optimisticTransaction = optimisticTransaction;
       return this;
    }
 
@@ -83,52 +71,52 @@ public class ExceptionEvictionTest extends MultipleCacheManagersTest {
    @Override
    public Object[] factory() {
       return new Object[] {
-            new ExceptionEvictionTest().nodeCount(1).storageType(StorageType.OFF_HEAP).cacheMode(CacheMode.LOCAL).optimisticTransaction(true),
-            new ExceptionEvictionTest().nodeCount(1).storageType(StorageType.OFF_HEAP).cacheMode(CacheMode.DIST_SYNC).optimisticTransaction(true),
-            new ExceptionEvictionTest().nodeCount(1).storageType(StorageType.OFF_HEAP).cacheMode(CacheMode.REPL_SYNC).optimisticTransaction(true),
-            new ExceptionEvictionTest().nodeCount(3).storageType(StorageType.OFF_HEAP).cacheMode(CacheMode.DIST_SYNC).optimisticTransaction(true),
-            new ExceptionEvictionTest().nodeCount(3).storageType(StorageType.OFF_HEAP).cacheMode(CacheMode.REPL_SYNC).optimisticTransaction(true),
+            new ExceptionEvictionTest().nodeCount(1).storageType(StorageType.OFF_HEAP).cacheMode(CacheMode.LOCAL).lockingMode(LockingMode.OPTIMISTIC),
+            new ExceptionEvictionTest().nodeCount(1).storageType(StorageType.OFF_HEAP).cacheMode(CacheMode.DIST_SYNC).lockingMode(LockingMode.OPTIMISTIC),
+            new ExceptionEvictionTest().nodeCount(1).storageType(StorageType.OFF_HEAP).cacheMode(CacheMode.REPL_SYNC).lockingMode(LockingMode.OPTIMISTIC),
+            new ExceptionEvictionTest().nodeCount(3).storageType(StorageType.OFF_HEAP).cacheMode(CacheMode.DIST_SYNC).lockingMode(LockingMode.OPTIMISTIC),
+            new ExceptionEvictionTest().nodeCount(3).storageType(StorageType.OFF_HEAP).cacheMode(CacheMode.REPL_SYNC).lockingMode(LockingMode.OPTIMISTIC),
 
-            new ExceptionEvictionTest().nodeCount(1).storageType(StorageType.BINARY).cacheMode(CacheMode.LOCAL).optimisticTransaction(true),
-            new ExceptionEvictionTest().nodeCount(1).storageType(StorageType.BINARY).cacheMode(CacheMode.DIST_SYNC).optimisticTransaction(true),
-            new ExceptionEvictionTest().nodeCount(1).storageType(StorageType.BINARY).cacheMode(CacheMode.REPL_SYNC).optimisticTransaction(true),
-            new ExceptionEvictionTest().nodeCount(3).storageType(StorageType.BINARY).cacheMode(CacheMode.DIST_SYNC).optimisticTransaction(true),
-            new ExceptionEvictionTest().nodeCount(3).storageType(StorageType.BINARY).cacheMode(CacheMode.REPL_SYNC).optimisticTransaction(true),
+            new ExceptionEvictionTest().nodeCount(1).storageType(StorageType.BINARY).cacheMode(CacheMode.LOCAL).lockingMode(LockingMode.OPTIMISTIC),
+            new ExceptionEvictionTest().nodeCount(1).storageType(StorageType.BINARY).cacheMode(CacheMode.DIST_SYNC).lockingMode(LockingMode.OPTIMISTIC),
+            new ExceptionEvictionTest().nodeCount(1).storageType(StorageType.BINARY).cacheMode(CacheMode.REPL_SYNC).lockingMode(LockingMode.OPTIMISTIC),
+            new ExceptionEvictionTest().nodeCount(3).storageType(StorageType.BINARY).cacheMode(CacheMode.DIST_SYNC).lockingMode(LockingMode.OPTIMISTIC),
+            new ExceptionEvictionTest().nodeCount(3).storageType(StorageType.BINARY).cacheMode(CacheMode.REPL_SYNC).lockingMode(LockingMode.OPTIMISTIC),
 
-            new ExceptionEvictionTest().nodeCount(1).storageType(StorageType.OBJECT).cacheMode(CacheMode.LOCAL).optimisticTransaction(true),
-            new ExceptionEvictionTest().nodeCount(1).storageType(StorageType.OBJECT).cacheMode(CacheMode.DIST_SYNC).optimisticTransaction(true),
-            new ExceptionEvictionTest().nodeCount(1).storageType(StorageType.OBJECT).cacheMode(CacheMode.REPL_SYNC).optimisticTransaction(true),
-            new ExceptionEvictionTest().nodeCount(3).storageType(StorageType.OBJECT).cacheMode(CacheMode.DIST_SYNC).optimisticTransaction(true),
-            new ExceptionEvictionTest().nodeCount(3).storageType(StorageType.OBJECT).cacheMode(CacheMode.REPL_SYNC).optimisticTransaction(true),
+            new ExceptionEvictionTest().nodeCount(1).storageType(StorageType.OBJECT).cacheMode(CacheMode.LOCAL).lockingMode(LockingMode.OPTIMISTIC),
+            new ExceptionEvictionTest().nodeCount(1).storageType(StorageType.OBJECT).cacheMode(CacheMode.DIST_SYNC).lockingMode(LockingMode.OPTIMISTIC),
+            new ExceptionEvictionTest().nodeCount(1).storageType(StorageType.OBJECT).cacheMode(CacheMode.REPL_SYNC).lockingMode(LockingMode.OPTIMISTIC),
+            new ExceptionEvictionTest().nodeCount(3).storageType(StorageType.OBJECT).cacheMode(CacheMode.DIST_SYNC).lockingMode(LockingMode.OPTIMISTIC),
+            new ExceptionEvictionTest().nodeCount(3).storageType(StorageType.OBJECT).cacheMode(CacheMode.REPL_SYNC).lockingMode(LockingMode.OPTIMISTIC),
 
-            new ExceptionEvictionTest().nodeCount(1).storageType(StorageType.OFF_HEAP).cacheMode(CacheMode.LOCAL).optimisticTransaction(false),
-            new ExceptionEvictionTest().nodeCount(1).storageType(StorageType.OFF_HEAP).cacheMode(CacheMode.DIST_SYNC).optimisticTransaction(false),
-            new ExceptionEvictionTest().nodeCount(1).storageType(StorageType.OFF_HEAP).cacheMode(CacheMode.REPL_SYNC).optimisticTransaction(false),
-            new ExceptionEvictionTest().nodeCount(3).storageType(StorageType.OFF_HEAP).cacheMode(CacheMode.DIST_SYNC).optimisticTransaction(false),
-            new ExceptionEvictionTest().nodeCount(3).storageType(StorageType.OFF_HEAP).cacheMode(CacheMode.REPL_SYNC).optimisticTransaction(false),
+            new ExceptionEvictionTest().nodeCount(1).storageType(StorageType.OFF_HEAP).cacheMode(CacheMode.LOCAL).lockingMode(LockingMode.PESSIMISTIC),
+            new ExceptionEvictionTest().nodeCount(1).storageType(StorageType.OFF_HEAP).cacheMode(CacheMode.DIST_SYNC).lockingMode(LockingMode.PESSIMISTIC),
+            new ExceptionEvictionTest().nodeCount(1).storageType(StorageType.OFF_HEAP).cacheMode(CacheMode.REPL_SYNC).lockingMode(LockingMode.PESSIMISTIC),
+            new ExceptionEvictionTest().nodeCount(3).storageType(StorageType.OFF_HEAP).cacheMode(CacheMode.DIST_SYNC).lockingMode(LockingMode.PESSIMISTIC),
+            new ExceptionEvictionTest().nodeCount(3).storageType(StorageType.OFF_HEAP).cacheMode(CacheMode.REPL_SYNC).lockingMode(LockingMode.PESSIMISTIC),
 
-            new ExceptionEvictionTest().nodeCount(1).storageType(StorageType.BINARY).cacheMode(CacheMode.LOCAL).optimisticTransaction(false),
-            new ExceptionEvictionTest().nodeCount(1).storageType(StorageType.BINARY).cacheMode(CacheMode.DIST_SYNC).optimisticTransaction(false),
-            new ExceptionEvictionTest().nodeCount(1).storageType(StorageType.BINARY).cacheMode(CacheMode.REPL_SYNC).optimisticTransaction(false),
-            new ExceptionEvictionTest().nodeCount(3).storageType(StorageType.BINARY).cacheMode(CacheMode.DIST_SYNC).optimisticTransaction(false),
-            new ExceptionEvictionTest().nodeCount(3).storageType(StorageType.BINARY).cacheMode(CacheMode.REPL_SYNC).optimisticTransaction(false),
+            new ExceptionEvictionTest().nodeCount(1).storageType(StorageType.BINARY).cacheMode(CacheMode.LOCAL).lockingMode(LockingMode.PESSIMISTIC),
+            new ExceptionEvictionTest().nodeCount(1).storageType(StorageType.BINARY).cacheMode(CacheMode.DIST_SYNC).lockingMode(LockingMode.PESSIMISTIC),
+            new ExceptionEvictionTest().nodeCount(1).storageType(StorageType.BINARY).cacheMode(CacheMode.REPL_SYNC).lockingMode(LockingMode.PESSIMISTIC),
+            new ExceptionEvictionTest().nodeCount(3).storageType(StorageType.BINARY).cacheMode(CacheMode.DIST_SYNC).lockingMode(LockingMode.PESSIMISTIC),
+            new ExceptionEvictionTest().nodeCount(3).storageType(StorageType.BINARY).cacheMode(CacheMode.REPL_SYNC).lockingMode(LockingMode.PESSIMISTIC),
 
-            new ExceptionEvictionTest().nodeCount(1).storageType(StorageType.OBJECT).cacheMode(CacheMode.LOCAL).optimisticTransaction(false),
-            new ExceptionEvictionTest().nodeCount(1).storageType(StorageType.OBJECT).cacheMode(CacheMode.DIST_SYNC).optimisticTransaction(false),
-            new ExceptionEvictionTest().nodeCount(1).storageType(StorageType.OBJECT).cacheMode(CacheMode.REPL_SYNC).optimisticTransaction(false),
-            new ExceptionEvictionTest().nodeCount(3).storageType(StorageType.OBJECT).cacheMode(CacheMode.DIST_SYNC).optimisticTransaction(false),
-            new ExceptionEvictionTest().nodeCount(3).storageType(StorageType.OBJECT).cacheMode(CacheMode.REPL_SYNC).optimisticTransaction(false),
+            new ExceptionEvictionTest().nodeCount(1).storageType(StorageType.OBJECT).cacheMode(CacheMode.LOCAL).lockingMode(LockingMode.PESSIMISTIC),
+            new ExceptionEvictionTest().nodeCount(1).storageType(StorageType.OBJECT).cacheMode(CacheMode.DIST_SYNC).lockingMode(LockingMode.PESSIMISTIC),
+            new ExceptionEvictionTest().nodeCount(1).storageType(StorageType.OBJECT).cacheMode(CacheMode.REPL_SYNC).lockingMode(LockingMode.PESSIMISTIC),
+            new ExceptionEvictionTest().nodeCount(3).storageType(StorageType.OBJECT).cacheMode(CacheMode.DIST_SYNC).lockingMode(LockingMode.PESSIMISTIC),
+            new ExceptionEvictionTest().nodeCount(3).storageType(StorageType.OBJECT).cacheMode(CacheMode.REPL_SYNC).lockingMode(LockingMode.PESSIMISTIC),
       };
    }
 
    @Override
    protected String[] parameterNames() {
-      return concat(super.parameterNames(), "nodeCount", "storageType", "optimisticTransaction");
+      return concat(super.parameterNames(), "nodeCount");
    }
 
    @Override
    protected Object[] parameterValues() {
-      return concat(super.parameterValues(), nodeCount, storageType, optimisticTransaction);
+      return concat(super.parameterValues(), nodeCount);
    }
 
    @Override
@@ -156,7 +144,7 @@ public class ExceptionEvictionTest extends MultipleCacheManagersTest {
       configurationBuilder
             .transaction()
                .transactionMode(TransactionMode.TRANSACTIONAL)
-               .lockingMode(optimisticTransaction ? LockingMode.OPTIMISTIC : LockingMode.PESSIMISTIC);
+               .lockingMode(lockingMode);
       configurationBuilder
             .clustering()
                .cacheMode(cacheMode)
@@ -210,14 +198,15 @@ public class ExceptionEvictionTest extends MultipleCacheManagersTest {
    }
 
    long convertAmountForStorage(long expected) {
+      boolean optimistic = lockingMode == LockingMode.OPTIMISTIC;
       switch (storageType) {
          case OBJECT:
             return expected;
          case BINARY:
-            return expected * (optimisticTransaction ? 64 : 24);
+            return expected * (optimistic ? 64 : 24);
          case OFF_HEAP:
-            return expected * (optimisticTransaction ? UnpooledOffHeapMemoryAllocator.estimateSizeOverhead(51) :
-                  UnpooledOffHeapMemoryAllocator.estimateSizeOverhead(33));
+            return expected * (optimistic ? UnpooledOffHeapMemoryAllocator.estimateSizeOverhead(51) :
+                               UnpooledOffHeapMemoryAllocator.estimateSizeOverhead(33));
          default:
             throw new IllegalStateException("Unconfigured storage type: " + storageType);
       }

--- a/core/src/test/java/org/infinispan/expiration/impl/ClusterExpirationFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/expiration/impl/ClusterExpirationFunctionalTest.java
@@ -54,23 +54,6 @@ public class ClusterExpirationFunctionalTest extends MultipleCacheManagersTest {
 
    protected ConfigurationBuilder configurationBuilder;
 
-   protected StorageType storageType;
-
-   protected ClusterExpirationFunctionalTest storageType(StorageType storageType) {
-      this.storageType = storageType;
-      return this;
-   }
-
-   @Override
-   protected String[] parameterNames() {
-      return concat(super.parameterNames(), "storageType");
-   }
-
-   @Override
-   protected Object[] parameterValues() {
-      return concat(super.parameterValues(), storageType);
-   }
-
    @Override
    public Object[] factory() {
       return Arrays.stream(StorageType.values())

--- a/core/src/test/java/org/infinispan/functional/FunctionalStorageTypeTest.java
+++ b/core/src/test/java/org/infinispan/functional/FunctionalStorageTypeTest.java
@@ -6,8 +6,6 @@ import org.testng.annotations.Test;
 
 @Test(groups = "functional", testName = "functional.FunctionalStorageTypeTest")
 public class FunctionalStorageTypeTest extends FunctionalMapTest {
-   StorageType storageType;
-
    @Override
    protected void configureCache(ConfigurationBuilder builder) {
       builder.memory().storageType(storageType);
@@ -20,17 +18,5 @@ public class FunctionalStorageTypeTest extends FunctionalMapTest {
             new FunctionalStorageTypeTest().storageType(StorageType.BINARY),
             new FunctionalStorageTypeTest().storageType(StorageType.OBJECT),
       };
-   }
-
-   FunctionalStorageTypeTest storageType(StorageType storageType) {
-      this.storageType = storageType;
-      return this;
-   }
-   protected String[] parameterNames() {
-      return new String[]{"storage"};
-   }
-
-   protected Object[] parameterValues() {
-      return new Object[]{storageType};
    }
 }

--- a/core/src/test/java/org/infinispan/test/MultipleCacheManagersTest.java
+++ b/core/src/test/java/org/infinispan/test/MultipleCacheManagersTest.java
@@ -1,8 +1,8 @@
 package org.infinispan.test;
 
 import static java.util.Arrays.asList;
-import static org.infinispan.test.fwk.TestCacheManagerFactory.createClusteredCacheManager;
 import static org.infinispan.commons.test.TestResourceTracker.getCurrentTestShortName;
+import static org.infinispan.test.fwk.TestCacheManagerFactory.createClusteredCacheManager;
 import static org.testng.AssertJUnit.assertTrue;
 
 import java.lang.annotation.Annotation;
@@ -30,10 +30,12 @@ import javax.transaction.TransactionManager;
 
 import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
+import org.infinispan.commons.test.TestResourceTracker;
 import org.infinispan.configuration.cache.BiasAcquisition;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.cache.StorageType;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.configuration.internal.PrivateGlobalConfigurationBuilder;
 import org.infinispan.configuration.parsing.ConfigurationBuilderHolder;
@@ -47,7 +49,6 @@ import org.infinispan.remoting.transport.Address;
 import org.infinispan.test.fwk.InCacheMode;
 import org.infinispan.test.fwk.InTransactionMode;
 import org.infinispan.test.fwk.TestFrameworkFailure;
-import org.infinispan.commons.test.TestResourceTracker;
 import org.infinispan.test.fwk.TestSelector;
 import org.infinispan.test.fwk.TransportFlags;
 import org.infinispan.transaction.LockingMode;
@@ -107,6 +108,7 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
    protected IsolationLevel isolationLevel;
    // Disables the triangle algorithm if set to Boolean.FALSE
    protected Boolean useTriangle;
+   protected StorageType storageType;
 
    @BeforeClass(alwaysRun = true)
    public void createBeforeClass() throws Throwable {
@@ -700,6 +702,11 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
       return transactional ? TransactionMode.TRANSACTIONAL : TransactionMode.NON_TRANSACTIONAL;
    }
 
+   public MultipleCacheManagersTest storageType(StorageType storageType) {
+      this.storageType = storageType;
+      return this;
+   }
+
    @Override
    protected String parameters() {
       // cacheMode is self-explaining
@@ -730,11 +737,11 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
    }
 
    protected String[] parameterNames() {
-      return new String[]{null, "tx", "locking", "isolation", "bias", "triangle"};
+      return new String[]{null, "tx", "locking", "isolation", "bias", "triangle", null};
    }
 
    protected Object[] parameterValues() {
-      return new Object[]{cacheMode, transactional, lockingMode, isolationLevel, biasAcquisition, useTriangle};
+      return new Object[]{cacheMode, transactional, lockingMode, isolationLevel, biasAcquisition, useTriangle, storageType};
    }
 
    @SafeVarargs

--- a/multimap/src/test/java/org/infinispan/multimap/impl/StoreTypeMultimapCacheTest.java
+++ b/multimap/src/test/java/org/infinispan/multimap/impl/StoreTypeMultimapCacheTest.java
@@ -1,8 +1,6 @@
 package org.infinispan.multimap.impl;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import org.infinispan.configuration.cache.CacheMode;
@@ -20,8 +18,6 @@ public class StoreTypeMultimapCacheTest extends DistributedMultimapCacheTest {
 
    protected Map<Address, MultimapCache<String, String>> multimapCacheCluster = new HashMap<>();
 
-   protected StorageType storageType;
-
    public StoreTypeMultimapCacheTest() {
       super();
       l1CacheEnabled = false;
@@ -30,28 +26,13 @@ public class StoreTypeMultimapCacheTest extends DistributedMultimapCacheTest {
       fromOwner = true;
    }
 
-   public StoreTypeMultimapCacheTest storageType(StorageType storageType) {
-      this.storageType = storageType;
-      return this;
-   }
-
-   @Override
-   protected String[] parameterNames() {
-      return concat(super.parameterNames(), "storageType");
-   }
-
-   @Override
-   protected Object[] parameterValues() {
-      return concat(super.parameterValues(), storageType);
-   }
-
    @Override
    public Object[] factory() {
-      List testsToRun = new ArrayList<>();
-      testsToRun.add(new StoreTypeMultimapCacheTest().storageType(StorageType.OFF_HEAP));
-      testsToRun.add(new StoreTypeMultimapCacheTest().storageType(StorageType.OBJECT));
-      testsToRun.add(new StoreTypeMultimapCacheTest().storageType(StorageType.BINARY));
-      return testsToRun.toArray();
+      return new Object[]{
+            new StoreTypeMultimapCacheTest().storageType(StorageType.OFF_HEAP),
+            new StoreTypeMultimapCacheTest().storageType(StorageType.OBJECT),
+            new StoreTypeMultimapCacheTest().storageType(StorageType.BINARY),
+      };
    }
 
    @Override

--- a/query/src/test/java/org/infinispan/query/blackbox/ClusteredCacheTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/ClusteredCacheTest.java
@@ -52,7 +52,6 @@ public class ClusteredCacheTest extends MultipleCacheManagersTest {
 
    protected Cache<Object, Person> cache1;
    protected Cache<Object, Person> cache2;
-   protected StorageType storageType;
    private Person person1;
    private Person person2;
    private Person person3;
@@ -64,16 +63,6 @@ public class ClusteredCacheTest extends MultipleCacheManagersTest {
 
    public ClusteredCacheTest() {
       cleanup = CleanupPhase.AFTER_METHOD;
-   }
-
-   @Override
-   protected String[] parameterNames() {
-      return concat(super.parameterNames(), "StorageType");
-   }
-
-   @Override
-   protected Object[] parameterValues() {
-      return concat(super.parameterValues(), storageType);
    }
 
    public Object[] factory() {
@@ -90,11 +79,6 @@ public class ClusteredCacheTest extends MultipleCacheManagersTest {
       // Update the indexes as well -- see ISPN-9890
       cache(0).clear();
       super.clearContent();
-   }
-
-   ClusteredCacheTest storageType(StorageType storageType) {
-      this.storageType = storageType;
-      return this;
    }
 
    protected void enhanceConfig(ConfigurationBuilder cacheCfg) {

--- a/query/src/test/java/org/infinispan/query/blackbox/ClusteredQueryTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/ClusteredQueryTest.java
@@ -49,9 +49,8 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
 
    Cache<String, Person> cacheAMachine1, cacheAMachine2;
    private CacheQuery<Person> cacheQuery;
-   protected StorageType storageType;
    protected String queryString = String.format("FROM %s where blurb:'blurb1?'", Person.class.getName());
-   private String allPersonsQuery = "FROM " + Person.class.getName();
+   private final String allPersonsQuery = "FROM " + Person.class.getName();
 
    public Object[] factory() {
       return new Object[]{
@@ -59,21 +58,6 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
             new ClusteredQueryTest().storageType(StorageType.BINARY),
             new ClusteredQueryTest().storageType(StorageType.OBJECT),
       };
-   }
-
-   @Override
-   protected String[] parameterNames() {
-      return concat(super.parameterNames(), "StorageType");
-   }
-
-   @Override
-   protected Object[] parameterValues() {
-      return concat(super.parameterValues(), storageType);
-   }
-
-   ClusteredQueryTest storageType(StorageType storageType) {
-      this.storageType = storageType;
-      return this;
    }
 
    @AfterMethod


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-11554

* Preserve the timestamps in OffHeapEntryFactoryImpl
* Delete deprecated OffHeapEntryFactory.create overload
* Pull up the storageType parameter in MultipleCacheManagersTest
* Use the inherited lockingMode in ExceptionEvictionTest