### PR TITLE
ISPN-11586 CNFE when using testdriver in ServerRunMode.EMBEDDED mode

### DIFF
--- a/server/testdriver/core/pom.xml
+++ b/server/testdriver/core/pom.xml
@@ -38,7 +38,6 @@
          <artifactId>infinispan-core</artifactId>
          <type>test-jar</type>
          <scope>compile</scope>
-         <optional>true</optional>
       </dependency>
       <dependency>
          <groupId>org.testcontainers</groupId>


### PR DESCRIPTION
The org.infinispan:infinispan-core test-jar is required since its org.infinispan.test.TestingUtil is
used by org.infinispan.server.test.core.EmbeddedInfinispanServerDriver#start when running in
embedded run mode and optional maven dependency doesn't make it on the CP thus CNFE.

https://issues.redhat.com/browse/ISPN-11586
10.1 - https://github.com/infinispan/infinispan/pull/8159