### PR TITLE
ISPN-11614 PersistenceMarshaller should utilise an independent Serial…

### DIFF
--- a/commons/all/src/main/java/org/infinispan/commons/marshall/ImmutableProtoStreamMarshaller.java
+++ b/commons/all/src/main/java/org/infinispan/commons/marshall/ImmutableProtoStreamMarshaller.java
@@ -1,0 +1,62 @@
+package org.infinispan.commons.marshall;
+
+import java.io.IOException;
+
+import org.infinispan.commons.dataconversion.MediaType;
+import org.infinispan.commons.io.ByteBuffer;
+import org.infinispan.commons.io.ByteBufferImpl;
+import org.infinispan.protostream.ImmutableSerializationContext;
+import org.infinispan.protostream.ProtobufUtil;
+
+/**
+ * A ProtoStream {@link org.infinispan.commons.marshall.Marshaller} implementation that uses Protobuf encoding.
+ *
+ * @author Ryan Emerson
+ * @since 12.0
+ */
+public class ImmutableProtoStreamMarshaller extends AbstractMarshaller {
+
+   protected final ImmutableSerializationContext serializationContext;
+
+   public ImmutableProtoStreamMarshaller(ImmutableSerializationContext serializationContext) {
+      this.serializationContext = serializationContext;
+   }
+
+   public ImmutableSerializationContext getSerializationContext() {
+      return serializationContext;
+   }
+
+   @Override
+   public Object objectFromByteBuffer(byte[] buf, int offset, int length) throws IOException, ClassNotFoundException {
+      return ProtobufUtil.fromWrappedByteArray(getSerializationContext(), buf, offset, length);
+   }
+
+   @Override
+   public boolean isMarshallable(Object o) {
+      // our marshaller can handle all of these primitive/scalar types as well even if we do not
+      // have a per-type marshaller defined in our SerializationContext
+      return o instanceof String ||
+            o instanceof Long ||
+            o instanceof Integer ||
+            o instanceof Double ||
+            o instanceof Float ||
+            o instanceof Boolean ||
+            o instanceof byte[] ||
+            o instanceof Byte ||
+            o instanceof Short ||
+            o instanceof Character ||
+            o instanceof java.util.Date ||
+            o instanceof java.time.Instant ||
+            getSerializationContext().canMarshall(o.getClass());
+   }
+
+   @Override
+   protected ByteBuffer objectToBuffer(Object o, int estimatedSize) throws IOException {
+      return ByteBufferImpl.create(ProtobufUtil.toWrappedByteArray(getSerializationContext(), o));
+   }
+
+   @Override
+   public MediaType mediaType() {
+      return MediaType.APPLICATION_PROTOSTREAM;
+   }
+}

--- a/commons/all/src/main/java/org/infinispan/commons/marshall/ProtoStreamMarshaller.java
+++ b/commons/all/src/main/java/org/infinispan/commons/marshall/ProtoStreamMarshaller.java
@@ -1,10 +1,5 @@
 package org.infinispan.commons.marshall;
 
-import java.io.IOException;
-
-import org.infinispan.commons.dataconversion.MediaType;
-import org.infinispan.commons.io.ByteBuffer;
-import org.infinispan.commons.io.ByteBufferImpl;
 import org.infinispan.protostream.ProtobufUtil;
 import org.infinispan.protostream.SerializationContext;
 import org.infinispan.protostream.SerializationContextInitializer;
@@ -16,61 +11,23 @@ import org.infinispan.protostream.SerializationContextInitializer;
  * @author anistor@redhat.com
  * @since 6.0
  */
-public class ProtoStreamMarshaller extends AbstractMarshaller {
-
-   private final SerializationContext serializationContext;
+public class ProtoStreamMarshaller extends ImmutableProtoStreamMarshaller {
 
    public ProtoStreamMarshaller() {
       this(ProtobufUtil.newSerializationContext());
    }
 
    public ProtoStreamMarshaller(SerializationContext serializationContext) {
-      this.serializationContext = serializationContext;
+      super(serializationContext);
    }
 
    public void register(SerializationContextInitializer initializer) {
-      initializer.registerSchema(serializationContext);
-      initializer.registerMarshallers(serializationContext);
+      initializer.registerSchema(getSerializationContext());
+      initializer.registerMarshallers(getSerializationContext());
    }
 
-   /**
-    * @return the SerializationContext instance to use
-    */
+   @Override
    public SerializationContext getSerializationContext() {
-      return serializationContext;
-   }
-
-   @Override
-   public Object objectFromByteBuffer(byte[] buf, int offset, int length) throws IOException, ClassNotFoundException {
-      return ProtobufUtil.fromWrappedByteArray(getSerializationContext(), buf, offset, length);
-   }
-
-   @Override
-   public boolean isMarshallable(Object o) {
-      // our marshaller can handle all of these primitive/scalar types as well even if we do not
-      // have a per-type marshaller defined in our SerializationContext
-      return o instanceof String ||
-            o instanceof Long ||
-            o instanceof Integer ||
-            o instanceof Double ||
-            o instanceof Float ||
-            o instanceof Boolean ||
-            o instanceof byte[] ||
-            o instanceof Byte ||
-            o instanceof Short ||
-            o instanceof Character ||
-            o instanceof java.util.Date ||
-            o instanceof java.time.Instant ||
-            getSerializationContext().canMarshall(o.getClass());
-   }
-
-   @Override
-   protected ByteBuffer objectToBuffer(Object o, int estimatedSize) throws IOException {
-      return ByteBufferImpl.create(ProtobufUtil.toWrappedByteArray(getSerializationContext(), o));
-   }
-
-   @Override
-   public MediaType mediaType() {
-      return MediaType.APPLICATION_PROTOSTREAM;
+      return (SerializationContext) serializationContext;
    }
 }

--- a/core/src/main/java/org/infinispan/encoding/impl/StorageConfigurationManager.java
+++ b/core/src/main/java/org/infinispan/encoding/impl/StorageConfigurationManager.java
@@ -16,8 +16,6 @@ import org.infinispan.factories.annotations.ComponentName;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
-import org.infinispan.marshall.core.EncoderRegistry;
-import org.infinispan.marshall.persistence.PersistenceMarshaller;
 import org.infinispan.registry.InternalCacheRegistry;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -74,15 +72,14 @@ public class StorageConfigurationManager {
    }
 
    @Inject
-   void injectDependencies(@ComponentName(KnownComponentNames.PERSISTENCE_MARSHALLER) PersistenceMarshaller persistenceMarshaller,
+   void injectDependencies(@ComponentName(KnownComponentNames.USER_MARSHALLER) Marshaller userMarshaller,
                            @ComponentName(KnownComponentNames.CACHE_NAME) String cacheName,
-                           InternalCacheRegistry icr, GlobalConfiguration gcr,
-                           EncoderRegistry encoderRegistry, Configuration configuration) {
+                           InternalCacheRegistry icr, GlobalConfiguration gcr, Configuration configuration) {
       boolean internalCache = icr.isInternalCache(cacheName);
       boolean embeddedMode = Configurations.isEmbeddedMode(gcr);
-      this.keyStorageMediaType = getStorageMediaType(configuration, embeddedMode, internalCache, persistenceMarshaller,
+      this.keyStorageMediaType = getStorageMediaType(configuration, embeddedMode, internalCache, userMarshaller,
                                                      true);
-      this.valueStorageMediaType = getStorageMediaType(configuration, embeddedMode, internalCache, persistenceMarshaller,
+      this.valueStorageMediaType = getStorageMediaType(configuration, embeddedMode, internalCache, userMarshaller,
                                                      false);
 
       if(keyStorageMediaType.equals(APPLICATION_UNKNOWN) || valueStorageMediaType.equals(APPLICATION_UNKNOWN)) {
@@ -91,10 +88,9 @@ public class StorageConfigurationManager {
    }
 
    private MediaType getStorageMediaType(Configuration configuration, boolean embeddedMode, boolean internalCache,
-                                         PersistenceMarshaller persistenceMarshaller, boolean isKey) {
+                                         Marshaller userMarshaller, boolean isKey) {
       EncodingConfiguration encodingConfiguration = configuration.encoding();
       ContentTypeConfiguration contentTypeConfiguration = isKey ? encodingConfiguration.keyDataType() : encodingConfiguration.valueDataType();
-      Marshaller userMarshaller = persistenceMarshaller.getUserMarshaller();
       MediaType mediaType = userMarshaller.mediaType();
       // If explicitly configured, use the value provided
       if (contentTypeConfiguration.isMediaTypeChanged()) {

--- a/core/src/main/java/org/infinispan/factories/EncoderRegistryFactory.java
+++ b/core/src/main/java/org/infinispan/factories/EncoderRegistryFactory.java
@@ -21,9 +21,6 @@ import org.infinispan.factories.impl.ComponentRef;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.marshall.core.EncoderRegistry;
 import org.infinispan.marshall.core.EncoderRegistryImpl;
-import org.infinispan.marshall.persistence.PersistenceMarshaller;
-import org.infinispan.marshall.persistence.impl.PersistenceContextInitializer;
-import org.infinispan.marshall.protostream.impl.MarshallableUserObject;
 import org.infinispan.marshall.protostream.impl.SerializationContextRegistry;
 
 /**
@@ -36,8 +33,9 @@ public class EncoderRegistryFactory extends AbstractComponentFactory implements 
    // Must not start the global marshaller or it will be too late for modules to register their externalizers
    @Inject @ComponentName(KnownComponentNames.INTERNAL_MARSHALLER)
    ComponentRef<StreamingMarshaller> globalMarshaller;
-   @Inject @ComponentName(KnownComponentNames.PERSISTENCE_MARSHALLER)
-   PersistenceMarshaller persistenceMarshaller;
+   @Inject @ComponentName(KnownComponentNames.USER_MARSHALLER)
+   Marshaller userMarshaller;
+
    @Inject EmbeddedCacheManager embeddedCacheManager;
    @Inject SerializationContextRegistry ctxRegistry;
 
@@ -46,11 +44,6 @@ public class EncoderRegistryFactory extends AbstractComponentFactory implements 
       ClassLoader classLoader = globalConfiguration.classLoader();
       EncoderRegistryImpl encoderRegistry = new EncoderRegistryImpl();
       ClassAllowList classAllowList = embeddedCacheManager.getClassAllowList();
-      // TODO Move registration to GlobalMarshaller ISPN-9622
-      String messageName = PersistenceContextInitializer.getFqTypeName(MarshallableUserObject.class);
-      Marshaller userMarshaller = persistenceMarshaller.getUserMarshaller();
-      ctxRegistry.addMarshaller(SerializationContextRegistry.MarshallerType.GLOBAL,
-                                new MarshallableUserObject.Marshaller(messageName, userMarshaller));
 
       encoderRegistry.registerEncoder(IdentityEncoder.INSTANCE);
       encoderRegistry.registerEncoder(UTF8Encoder.INSTANCE);

--- a/core/src/main/java/org/infinispan/factories/KnownComponentNames.java
+++ b/core/src/main/java/org/infinispan/factories/KnownComponentNames.java
@@ -30,6 +30,7 @@ public class KnownComponentNames {
    public static final String CACHE_DEPENDENCY_GRAPH = "org.infinispan.CacheDependencyGraph";
    public static final String INTERNAL_MARSHALLER = "org.infinispan.marshaller.internal";
    public static final String PERSISTENCE_MARSHALLER = "org.infinispan.marshaller.persistence";
+   public static final String USER_MARSHALLER = "org.infinispan.marshaller.user";
 
    private static final Map<String, Integer> DEFAULT_THREAD_COUNT = new HashMap<>(7);
    private static final Map<String, Integer> DEFAULT_QUEUE_SIZE = new HashMap<>(7);

--- a/core/src/main/java/org/infinispan/marshall/core/impl/DelegatingUserMarshaller.java
+++ b/core/src/main/java/org/infinispan/marshall/core/impl/DelegatingUserMarshaller.java
@@ -1,0 +1,94 @@
+package org.infinispan.marshall.core.impl;
+
+import static org.infinispan.util.logging.Log.CONTAINER;
+
+import java.io.IOException;
+
+import org.infinispan.commons.configuration.ClassAllowList;
+import org.infinispan.commons.dataconversion.MediaType;
+import org.infinispan.commons.io.ByteBuffer;
+import org.infinispan.commons.marshall.BufferSizePredictor;
+import org.infinispan.commons.marshall.Marshaller;
+import org.infinispan.factories.annotations.Start;
+import org.infinispan.factories.annotations.Stop;
+import org.infinispan.factories.scopes.Scope;
+import org.infinispan.factories.scopes.Scopes;
+
+/**
+ * A delegate {@link Marshaller} implementation for the user marshaller that ensures that the {@link Marshaller#start()} and
+ * {@link Marshaller#stop()} of the configured marshaller are called and logged as required.
+ *
+ * @author Ryan Emerson
+ * @since 12.0
+ */
+@Scope(Scopes.GLOBAL)
+public class DelegatingUserMarshaller implements Marshaller {
+
+   final Marshaller marshaller;
+
+   public DelegatingUserMarshaller(Marshaller marshaller) {
+      this.marshaller = marshaller;
+   }
+
+   @Start
+   @Override
+   public void start() {
+      CONTAINER.startingUserMarshaller(marshaller.getClass().getName());
+      marshaller.start();
+   }
+
+   @Stop
+   @Override
+   public void stop() {
+      marshaller.stop();
+   }
+
+   @Override
+   public void initialize(ClassAllowList classAllowList) {
+      marshaller.initialize(classAllowList);
+   }
+
+   @Override
+   public byte[] objectToByteBuffer(Object obj, int estimatedSize) throws IOException, InterruptedException {
+      return marshaller.objectToByteBuffer(obj, estimatedSize);
+   }
+
+   @Override
+   public byte[] objectToByteBuffer(Object obj) throws IOException, InterruptedException {
+      return marshaller.objectToByteBuffer(obj);
+   }
+
+   @Override
+   public Object objectFromByteBuffer(byte[] buf) throws IOException, ClassNotFoundException {
+      return marshaller.objectFromByteBuffer(buf);
+   }
+
+   @Override
+   public Object objectFromByteBuffer(byte[] buf, int offset, int length) throws IOException, ClassNotFoundException {
+      return marshaller.objectFromByteBuffer(buf, offset, length);
+   }
+
+   @Override
+   public ByteBuffer objectToBuffer(Object o) throws IOException, InterruptedException {
+      return marshaller.objectToBuffer(o);
+   }
+
+   @Override
+   public boolean isMarshallable(Object o) throws Exception {
+      return marshaller.isMarshallable(o);
+   }
+
+   @Override
+   public BufferSizePredictor getBufferSizePredictor(Object o) {
+      return marshaller.getBufferSizePredictor(o);
+   }
+
+   @Override
+   public MediaType mediaType() {
+      return marshaller.mediaType();
+   }
+
+   public Marshaller getDelegate() {
+      return marshaller;
+   }
+}

--- a/core/src/main/java/org/infinispan/marshall/protostream/impl/AbstractInternalProtoStreamMarshaller.java
+++ b/core/src/main/java/org/infinispan/marshall/protostream/impl/AbstractInternalProtoStreamMarshaller.java
@@ -1,0 +1,159 @@
+package org.infinispan.marshall.protostream.impl;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import org.infinispan.commons.dataconversion.MediaType;
+import org.infinispan.commons.io.ByteBuffer;
+import org.infinispan.commons.io.ByteBufferImpl;
+import org.infinispan.commons.marshall.BufferSizePredictor;
+import org.infinispan.commons.marshall.Marshaller;
+import org.infinispan.commons.marshall.MarshallingException;
+import org.infinispan.commons.marshall.StreamAwareMarshaller;
+import org.infinispan.factories.KnownComponentNames;
+import org.infinispan.factories.annotations.ComponentName;
+import org.infinispan.factories.annotations.Inject;
+import org.infinispan.factories.annotations.Start;
+import org.infinispan.factories.impl.ComponentRef;
+import org.infinispan.factories.scopes.Scope;
+import org.infinispan.factories.scopes.Scopes;
+import org.infinispan.protostream.ImmutableSerializationContext;
+import org.infinispan.protostream.ProtobufUtil;
+import org.infinispan.util.logging.Log;
+
+/**
+ * An abstract ProtoStream based {@link Marshaller} and {@link StreamAwareMarshaller} implementation that is the basis
+ * of the Persistence and Global marshallers.
+ *
+ * @author Ryan Emerson
+ * @since 12.0
+ */
+@Scope(Scopes.GLOBAL)
+public abstract class AbstractInternalProtoStreamMarshaller implements Marshaller, StreamAwareMarshaller {
+   private static final int PROTOSTREAM_DEFAULT_BUFFER_SIZE = 4096;
+
+   @Inject protected SerializationContextRegistry ctxRegistry;
+   @Inject @ComponentName(KnownComponentNames.USER_MARSHALLER)
+   ComponentRef<Marshaller> userMarshallerRef;
+   protected Marshaller userMarshaller;
+
+   protected Log log;
+
+   abstract public ImmutableSerializationContext getSerializationContext();
+
+   protected AbstractInternalProtoStreamMarshaller(Log log) {
+      this.log = log;
+   }
+
+   @Start
+   @Override
+   public void start() {
+      userMarshaller = userMarshallerRef.running();
+   }
+
+   public Marshaller getUserMarshaller() {
+      return userMarshaller;
+   }
+
+   @Override
+   public ByteBuffer objectToBuffer(Object o) {
+      return ByteBufferImpl.create(objectToByteBuffer(o, -1));
+   }
+
+   @Override
+   public byte[] objectToByteBuffer(Object obj, int estimatedSize) {
+      if (obj == null)
+         return null;
+
+      try {
+         if (requiresWrapping(obj))
+            obj = new MarshallableUserObject<>(obj);
+         int size = estimatedSize < 0 ? PROTOSTREAM_DEFAULT_BUFFER_SIZE : estimatedSize;
+         ByteArrayOutputStream baos = new ByteArrayOutputStream(size);
+         ProtobufUtil.toWrappedStream(getSerializationContext(), baos, obj, size);
+         return baos.toByteArray();
+      } catch (Throwable t) {
+         log.cannotMarshall(obj.getClass(), t);
+         if (t instanceof MarshallingException)
+            throw (MarshallingException) t;
+         throw new MarshallingException(t.getMessage(), t.getCause());
+      }
+   }
+
+   @Override
+   public byte[] objectToByteBuffer(Object obj) {
+      return objectToByteBuffer(obj, sizeEstimate(obj));
+   }
+
+   @Override
+   public Object objectFromByteBuffer(byte[] buf) throws IOException {
+      return objectFromByteBuffer(buf, 0, buf.length);
+   }
+
+   @Override
+   public Object objectFromByteBuffer(byte[] buf, int offset, int length) throws IOException {
+      return unwrapAndInit(ProtobufUtil.fromWrappedByteArray(getSerializationContext(), buf, offset, length));
+   }
+
+   @Override
+   public BufferSizePredictor getBufferSizePredictor(Object o) {
+      // TODO if protobuf based, return estimate based upon schema
+      return userMarshaller.getBufferSizePredictor(o);
+   }
+
+   @Override
+   public void writeObject(Object o, OutputStream out) throws IOException {
+      if (requiresWrapping(o))
+         o = new MarshallableUserObject<>(o);
+      ProtobufUtil.toWrappedStream(getSerializationContext(), out, o, PROTOSTREAM_DEFAULT_BUFFER_SIZE);
+   }
+
+   @Override
+   public Object readObject(InputStream in) throws ClassNotFoundException, IOException {
+      return unwrapAndInit(ProtobufUtil.fromWrappedStream(getSerializationContext(), in));
+   }
+
+   protected Object unwrapAndInit(Object o) {
+      if (o instanceof MarshallableUserObject)
+         return ((MarshallableUserObject<?>) o).get();
+
+      return o;
+   }
+
+   @Override
+   public boolean isMarshallable(Object o) {
+      return isMarshallableWithProtoStream(o) || isUserMarshallable(o);
+   }
+
+   @Override
+   public int sizeEstimate(Object o) {
+      if (isMarshallableWithProtoStream(o))
+         return PROTOSTREAM_DEFAULT_BUFFER_SIZE;
+
+      int userBytesEstimate = userMarshaller.getBufferSizePredictor(o.getClass()).nextSize(o);
+      return MarshallableUserObject.size(userBytesEstimate);
+   }
+
+   @Override
+   public MediaType mediaType() {
+      return MediaType.APPLICATION_PROTOSTREAM;
+   }
+
+   private boolean requiresWrapping(Object o) {
+      return !isMarshallableWithProtoStream(o);
+   }
+
+   private boolean isMarshallableWithProtoStream(Object o) {
+      return getSerializationContext().canMarshall(o.getClass());
+   }
+
+   private boolean isUserMarshallable(Object o) {
+      try {
+         return userMarshaller.isMarshallable(o);
+      } catch (Exception ignore) {
+         return false;
+      }
+   }
+}

--- a/core/src/main/java/org/infinispan/marshall/protostream/impl/PersistenceContextManualInitializer.java
+++ b/core/src/main/java/org/infinispan/marshall/protostream/impl/PersistenceContextManualInitializer.java
@@ -1,4 +1,4 @@
-package org.infinispan.server.logging.events;
+package org.infinispan.marshall.protostream.impl;
 
 import java.io.UncheckedIOException;
 import java.util.UUID;
@@ -10,13 +10,17 @@ import org.infinispan.protostream.SerializationContextInitializer;
 
 public class PersistenceContextManualInitializer implements SerializationContextInitializer {
 
+   public static final SerializationContextInitializer INSTANCE = new PersistenceContextManualInitializer();
+
    private static String type(String message) {
-      return String.format("org.infinispan.persistence.m.event_logger.%s", message);
+      return String.format("org.infinispan.persistence.m.core.%s", message);
    }
+
+   private PersistenceContextManualInitializer() {}
 
    @Override
    public String getProtoFileName() {
-      return "persistence.m.event_logger.proto";
+      return "persistence.m.core.proto";
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/marshall/protostream/impl/SerializationContextRegistry.java
+++ b/core/src/main/java/org/infinispan/marshall/protostream/impl/SerializationContextRegistry.java
@@ -7,7 +7,9 @@ import org.infinispan.protostream.SerializationContext;
 import org.infinispan.protostream.SerializationContextInitializer;
 
 /**
- * Manages {@link SerializationContext} across modules for use by various components.
+ * Manages {@link SerializationContext} across modules for use by various components. The user context should only
+ * ever be updated using the {@link org.infinispan.configuration.global.GlobalConfiguration}, therefore we do not expose
+ * it via {@link MarshallerType}.
  *
  * @author Ryan Emerson
  * @since 10.0
@@ -24,8 +26,10 @@ public interface SerializationContextRegistry {
 
    ImmutableSerializationContext getPersistenceCtx();
 
+   ImmutableSerializationContext getUserCtx();
+
    enum MarshallerType {
       GLOBAL,
-      PERSISTENCE,
+      PERSISTENCE
    }
 }

--- a/core/src/main/java/org/infinispan/marshall/protostream/impl/SerializationContextRegistryImpl.java
+++ b/core/src/main/java/org/infinispan/marshall/protostream/impl/SerializationContextRegistryImpl.java
@@ -7,11 +7,16 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.configuration.global.GlobalConfiguration;
+import org.infinispan.factories.KnownComponentNames;
+import org.infinispan.factories.annotations.ComponentName;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
+import org.infinispan.factories.impl.ComponentRef;
 import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
+import org.infinispan.marshall.persistence.impl.PersistenceContextInitializer;
 import org.infinispan.marshall.persistence.impl.PersistenceContextInitializerImpl;
 import org.infinispan.protostream.BaseMarshaller;
 import org.infinispan.protostream.FileDescriptorSource;
@@ -24,14 +29,23 @@ import org.infinispan.protostream.SerializationContextInitializer;
 public class SerializationContextRegistryImpl implements SerializationContextRegistry {
 
    @Inject GlobalConfiguration globalConfig;
+   @Inject @ComponentName(KnownComponentNames.USER_MARSHALLER)
+   ComponentRef<Marshaller> userMarshaller;
 
    private final MarshallerContext global = new MarshallerContext();
    private final MarshallerContext persistence = new MarshallerContext();
+   private final SerializationContext user = ProtobufUtil.newSerializationContext();
 
    @Start
    public void start() {
-      // Add user configured SCIs to both the global and persistence context
+      // Add user configured SCIs
       List<SerializationContextInitializer> scis = globalConfig.serialization().contextInitializers();
+      if (scis != null) {
+         scis.forEach(sci -> register(sci, user));
+      }
+
+      String messageName = PersistenceContextInitializer.getFqTypeName(MarshallableUserObject.class);
+      BaseMarshaller userObjectMarshaller = new MarshallableUserObject.Marshaller(messageName, userMarshaller.wired());
       update(GLOBAL, ctx -> {
          if (scis != null)
             ctx.addContextIntializers(scis);
@@ -39,6 +53,7 @@ public class SerializationContextRegistryImpl implements SerializationContextReg
          ctx.addContextIntializer(new PersistenceContextInitializerImpl())
                // Register Commons util so that KeyValueWithPrevious can be used with JCache remote
                .addContextIntializer(new org.infinispan.commons.GlobalContextInitializerImpl())
+               .addMarshaller(userObjectMarshaller)
                .update();
       });
 
@@ -47,22 +62,24 @@ public class SerializationContextRegistryImpl implements SerializationContextReg
             ctx.addContextIntializers(scis);
 
          ctx.addContextIntializer(new PersistenceContextInitializerImpl())
+               .addMarshaller(userObjectMarshaller)
                .update();
       });
    }
 
    @Override
    public ImmutableSerializationContext getGlobalCtx() {
-      synchronized (global) {
-         return global.ctx;
-      }
+      return global.ctx;
    }
 
    @Override
    public ImmutableSerializationContext getPersistenceCtx() {
-      synchronized (persistence) {
-         return persistence.ctx;
-      }
+      return persistence.ctx;
+   }
+
+   @Override
+   public ImmutableSerializationContext getUserCtx() {
+      return user;
    }
 
    @Override
@@ -92,11 +109,20 @@ public class SerializationContextRegistryImpl implements SerializationContextReg
       }
    }
 
+   private static void register(SerializationContextInitializer sci, SerializationContext... ctxs) {
+      for (SerializationContext ctx : ctxs) {
+         sci.registerSchema(ctx);
+         sci.registerMarshallers(ctx);
+      }
+   }
+
+   // Required until IPROTO-136 is resolved to ensure that custom marshaller implementations are not overridden by
+   // non-core modules registering their SerializationContextInitializer(s) which depend on a core initializer.
    static class MarshallerContext {
       private final List<SerializationContextInitializer> initializers = new ArrayList<>();
       private final List<FileDescriptorSource> schemas = new ArrayList<>();
       private final List<BaseMarshaller<?>> marshallers = new ArrayList<>();
-      private SerializationContext ctx = ProtobufUtil.newSerializationContext();
+      private final SerializationContext ctx = ProtobufUtil.newSerializationContext();
 
       MarshallerContext addContextIntializers(List<SerializationContextInitializer> scis) {
          initializers.addAll(scis);

--- a/core/src/main/java/org/infinispan/marshall/protostream/impl/SerializationContextRegistryImpl.java
+++ b/core/src/main/java/org/infinispan/marshall/protostream/impl/SerializationContextRegistryImpl.java
@@ -62,6 +62,7 @@ public class SerializationContextRegistryImpl implements SerializationContextReg
             ctx.addContextIntializers(scis);
 
          ctx.addContextIntializer(new PersistenceContextInitializerImpl())
+               .addContextIntializer(PersistenceContextManualInitializer.INSTANCE)
                .addMarshaller(userObjectMarshaller)
                .update();
       });

--- a/core/src/main/java/org/infinispan/marshall/protostream/impl/marshallers/UUIDMarshaller.java
+++ b/core/src/main/java/org/infinispan/marshall/protostream/impl/marshallers/UUIDMarshaller.java
@@ -18,15 +18,20 @@ public class UUIDMarshaller implements MessageMarshaller<UUID> {
 
    @Override
    public UUID readFrom(ProtoStreamReader reader) throws IOException {
-      long mostSigBits = reader.readLong("mostSigBits");
-      long leastSigBits = reader.readLong("leastSigBits");
+      Long mostSigBits = reader.readLong("mostSigBits");
+      Long leastSigBits = reader.readLong("leastSigBits");
+
+      if (mostSigBits == null) {
+         mostSigBits = reader.readLong("mostSigBitsFixed");
+         leastSigBits = reader.readLong("leastSigBitsFixed");
+      }
       return new UUID(mostSigBits, leastSigBits);
    }
 
    @Override
    public void writeTo(ProtoStreamWriter writer, UUID uuid) throws IOException {
-      writer.writeLong("mostSigBits", uuid.getMostSignificantBits());
-      writer.writeLong("leastSigBits", uuid.getLeastSignificantBits());
+      writer.writeLong("mostSigBitsFixed", uuid.getMostSignificantBits());
+      writer.writeLong("leastSigBitsFixed", uuid.getLeastSignificantBits());
    }
 
    @Override

--- a/core/src/main/resources/proto/persistence.m.core.proto
+++ b/core/src/main/resources/proto/persistence.m.core.proto
@@ -1,6 +1,6 @@
 syntax = "proto2";
 
-package org.infinispan.persistence.m.event_logger;
+package org.infinispan.persistence.m.core;
 
 /**
  * @TypeId(1005)
@@ -9,4 +9,6 @@ package org.infinispan.persistence.m.event_logger;
 message UUID {
     optional uint64 mostSigBits = 1;
     optional uint64 leastSigBits = 2;
+    optional fixed64 mostSigBitsFixed = 3;
+    optional fixed64 leastSigBitsFixed = 4;
 }

--- a/core/src/test/java/org/infinispan/marshall/ProtostreamUserMarshallerTest.java
+++ b/core/src/test/java/org/infinispan/marshall/ProtostreamUserMarshallerTest.java
@@ -8,9 +8,11 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import org.infinispan.commons.marshall.ImmutableProtoStreamMarshaller;
 import org.infinispan.commons.marshall.MarshallingException;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.marshall.core.impl.DelegatingUserMarshaller;
 import org.infinispan.marshall.persistence.PersistenceMarshaller;
 import org.infinispan.protostream.SerializationContextInitializer;
 import org.infinispan.protostream.annotations.AutoProtoSchemaBuilder;
@@ -66,10 +68,11 @@ public class ProtostreamUserMarshallerTest extends MultipleCacheManagersTest {
       }
    }
 
-   public void testProtostreamMarshallerLoaded() throws Exception {
+   public void testProtostreamMarshallerLoaded() {
       PersistenceMarshaller pm = TestingUtil.extractPersistenceMarshaller(manager(0));
       testIsMarshallableAndPut(pm, new ExampleUserPojo("A Pojo!"), new AnotherExampleUserPojo("And another one!"));
-      assertTrue(pm.getUserMarshaller() instanceof PersistenceMarshaller);
+      DelegatingUserMarshaller userMarshaller = (DelegatingUserMarshaller) pm.getUserMarshaller();
+      assertTrue(userMarshaller.getDelegate() instanceof ImmutableProtoStreamMarshaller);
    }
 
    private void testIsMarshallableAndPut(PersistenceMarshaller pm, Object... pojos) {

--- a/core/src/test/java/org/infinispan/marshall/protostream/impl/ProtoStreamBackwardsCompatibilityTest.java
+++ b/core/src/test/java/org/infinispan/marshall/protostream/impl/ProtoStreamBackwardsCompatibilityTest.java
@@ -1,0 +1,90 @@
+package org.infinispan.marshall.protostream.impl;
+
+import static org.testng.AssertJUnit.assertEquals;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.UUID;
+
+import org.infinispan.marshall.protostream.impl.marshallers.UUIDMarshaller;
+import org.infinispan.protostream.ProtobufUtil;
+import org.infinispan.protostream.SerializationContext;
+import org.infinispan.protostream.SerializationContextInitializer;
+import org.testng.annotations.Test;
+
+@Test(groups = "unit", testName = "marshall.ProtoStreamBackwardsCompatibilityTest")
+public class ProtoStreamBackwardsCompatibilityTest {
+
+   public void testOldEventLoggerUUIDBytesAreReadable() throws IOException {
+      // Initialize SerializationContext like it used to be in the server
+      SerializationContext oldServerCtx = ProtobufUtil.newSerializationContext();
+      PersistenceContextManualInitializer serverInitializer = new PersistenceContextManualInitializer();
+      serverInitializer.registerSchema(oldServerCtx);
+      serverInitializer.registerMarshallers(oldServerCtx);
+
+      // Initialise SerializationContext using the new core initializer
+      SerializationContext coreCtx = ProtobufUtil.newSerializationContext();
+      org.infinispan.marshall.protostream.impl.PersistenceContextManualInitializer.INSTANCE.registerSchema(coreCtx);
+      org.infinispan.marshall.protostream.impl.PersistenceContextManualInitializer.INSTANCE.registerMarshallers(coreCtx);
+
+      UUID uuid = UUID.randomUUID();
+      byte[] oldBytes = ProtobufUtil.toWrappedByteArray(oldServerCtx, uuid);
+      UUID unmarshalled = ProtobufUtil.fromWrappedByteArray(coreCtx, oldBytes);
+      assertEquals(uuid, unmarshalled);
+
+      byte[] newBytes = ProtobufUtil.toWrappedByteArray(coreCtx, uuid);
+      unmarshalled = ProtobufUtil.fromWrappedByteArray(coreCtx, newBytes);
+      assertEquals(uuid, unmarshalled);
+   }
+
+   private static class PersistenceContextManualInitializer implements SerializationContextInitializer {
+
+      String type(String message) {
+         return String.format("org.infinispan.persistence.m.event_logger.%s", message);
+      }
+
+      private PersistenceContextManualInitializer() {}
+
+      @Override
+      public String getProtoFileName() {
+         return "persistence.m.event_logger.proto";
+      }
+
+      @Override
+      public String getProtoFile() throws UncheckedIOException {
+         return "package org.infinispan.persistence.m.event_logger;\n" +
+               "\n" +
+               "/**\n" +
+               " * @TypeId(1005)\n" +
+               " * ProtoStreamTypeIds.SERVER_EVENT_UUID\n" +
+               " */\n" +
+               "message UUID {\n" +
+               "    optional uint64 mostSigBits = 1;\n" +
+               "    optional uint64 leastSigBits = 2;\n" +
+               "}\n";
+      }
+
+      @Override
+      public void registerSchema(SerializationContext serCtx) {
+         serCtx.registerProtoFiles(org.infinispan.protostream.FileDescriptorSource.fromString(getProtoFileName(), getProtoFile()));
+      }
+
+      @Override
+      public void registerMarshallers(SerializationContext serCtx) {
+         serCtx.registerMarshaller(new OldUUIDMarshaller(type(UUID.class.getSimpleName())));
+      }
+   }
+
+   private static class OldUUIDMarshaller extends UUIDMarshaller {
+
+      public OldUUIDMarshaller(String typeName) {
+         super(typeName);
+      }
+
+      @Override
+      public void writeTo(ProtoStreamWriter writer, UUID uuid) throws IOException {
+         writer.writeLong("mostSigBits", uuid.getMostSignificantBits());
+         writer.writeLong("leastSigBits", uuid.getLeastSignificantBits());
+      }
+   }
+}

--- a/multimap/src/test/java/org/infinispan/multimap/impl/MultimapStoreBucketTest.java
+++ b/multimap/src/test/java/org/infinispan/multimap/impl/MultimapStoreBucketTest.java
@@ -8,6 +8,7 @@ import org.infinispan.commons.marshall.JavaSerializationMarshaller;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.marshall.core.impl.DelegatingUserMarshaller;
 import org.infinispan.marshall.persistence.impl.PersistenceMarshallerImpl;
 import org.infinispan.multimap.api.embedded.EmbeddedMultimapCacheManagerFactory;
 import org.infinispan.multimap.api.embedded.MultimapCache;
@@ -35,7 +36,8 @@ public class MultimapStoreBucketTest extends AbstractInfinispanTest {
       MultimapCache<String, Person> multimapCache = multimapCacheManager.get("test");
       multimapCache.put("k1", new SuperPerson());
       PersistenceMarshallerImpl pm = TestingUtil.extractPersistenceMarshaller(cm);
-      assertTrue(pm.getUserMarshaller() instanceof JavaSerializationMarshaller);
+      DelegatingUserMarshaller userMarshaller = (DelegatingUserMarshaller) pm.getUserMarshaller();
+      assertTrue(userMarshaller.getDelegate() instanceof JavaSerializationMarshaller);
       assertTrue(pm.getSerializationContext().canMarshall(Bucket.class));
       assertTrue(multimapCache.containsKey("k1").get(1, TimeUnit.SECONDS));
    }

--- a/server/runtime/proto.lock
+++ b/server/runtime/proto.lock
@@ -111,31 +111,6 @@
           "name": "org.infinispan.persistence.servertasks"
         }
       }
-    },
-    {
-      "protopath": "persistence.m.event_logger.proto",
-      "def": {
-        "messages": [
-          {
-            "name": "UUID",
-            "fields": [
-              {
-                "id": 1,
-                "name": "mostSigBits",
-                "type": "uint64"
-              },
-              {
-                "id": 2,
-                "name": "leastSigBits",
-                "type": "uint64"
-              }
-            ]
-          }
-        ],
-        "package": {
-          "name": "org.infinispan.persistence.m.event_logger"
-        }
-      }
     }
   ]
 }

--- a/server/runtime/src/main/java/org/infinispan/server/logging/events/LifecycleCallbacks.java
+++ b/server/runtime/src/main/java/org/infinispan/server/logging/events/LifecycleCallbacks.java
@@ -33,7 +33,6 @@ public class LifecycleCallbacks implements ModuleLifecycle {
    public void cacheManagerStarting(GlobalComponentRegistry gcr, GlobalConfiguration gc) {
       SerializationContextRegistry ctxRegistry = gcr.getComponent(SerializationContextRegistry.class);
       ctxRegistry.addContextInitializer(MarshallerType.PERSISTENCE, new PersistenceContextInitializerImpl());
-      ctxRegistry.addContextInitializer(MarshallerType.PERSISTENCE, new PersistenceContextManualInitializer());
 
       EmbeddedCacheManager cacheManager = gcr.getComponent(EmbeddedCacheManager.class);
       InternalCacheRegistry internalCacheRegistry = gcr.getComponent(InternalCacheRegistry.class);

--- a/tools/src/test/java/org/infinispan/tools/store/migrator/MigratorConfigurationTest.java
+++ b/tools/src/test/java/org/infinispan/tools/store/migrator/MigratorConfigurationTest.java
@@ -47,21 +47,23 @@ import org.infinispan.commons.CacheConfigurationException;
 import org.infinispan.commons.marshall.AdvancedExternalizer;
 import org.infinispan.commons.marshall.MarshallUtil;
 import org.infinispan.commons.marshall.Marshaller;
+import org.infinispan.commons.test.Exceptions;
 import org.infinispan.commons.test.ThreadLeakChecker;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.jboss.marshalling.commons.GenericJBossMarshaller;
+import org.infinispan.marshall.core.impl.DelegatingUserMarshaller;
 import org.infinispan.marshall.persistence.PersistenceMarshaller;
 import org.infinispan.persistence.jdbc.DatabaseType;
 import org.infinispan.persistence.jdbc.configuration.JdbcStringBasedStoreConfiguration;
 import org.infinispan.persistence.jdbc.configuration.JdbcStringBasedStoreConfigurationBuilder;
 import org.infinispan.persistence.jdbc.impl.table.TableManagerFactory;
-import org.infinispan.commons.test.Exceptions;
 import org.infinispan.test.data.Person;
 import org.infinispan.tools.store.migrator.jdbc.JdbcConfigurationUtil;
 import org.infinispan.tools.store.migrator.marshaller.SerializationConfigUtil;
 import org.infinispan.tools.store.migrator.marshaller.infinispan8.Infinispan8Marshaller;
 import org.infinispan.tools.store.migrator.marshaller.infinispan9.Infinispan9Marshaller;
+import org.testng.AssertJUnit;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -104,7 +106,8 @@ public class MigratorConfigurationTest {
       assertNotNull(marshaller);
       assertTrue(marshaller instanceof PersistenceMarshaller);
       PersistenceMarshaller pm = (PersistenceMarshaller) marshaller;
-      assertTrue(pm.getUserMarshaller() instanceof GenericJBossMarshaller);
+      DelegatingUserMarshaller userMarshaller = (DelegatingUserMarshaller) pm.getUserMarshaller();
+      AssertJUnit.assertTrue(userMarshaller.getDelegate() instanceof GenericJBossMarshaller);
    }
 
    public void testInfinipsan8MarshallerAndExternalizersLoaded() throws Exception {


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-11426
https://issues.redhat.com/browse/ISPN-11614

The second commit introducing the `AbstractInternalProtoStreamMarshaller` is not strictly necessary in this PR, however it is used by the refactored GlobalMarshaller, so I wanted to get this in sooner rather than later to slightly reduce the number of changes on that branch.