### PR TITLE
ISPN-11627 InfinispanServerRule returning FileAlreadyExistsException if you use mavenArtifacts and restart the server

### DIFF
--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/core/ContainerInfinispanServerDriver.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/core/ContainerInfinispanServerDriver.java
@@ -12,6 +12,7 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -263,7 +264,7 @@ public class ContainerInfinispanServerDriver extends AbstractInfinispanServerDri
          for (MavenResolvedArtifact archive : archives) {
             Exceptions.unchecked(() -> {
                Path source = archive.asFile().toPath();
-               Files.copy(source, libDir.toPath().resolve(source.getFileName()));
+               Files.copy(source, libDir.toPath().resolve(source.getFileName()), StandardCopyOption.REPLACE_EXISTING);
             });
          }
       }


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-11627