### PR TITLE
ISPN-11556 Remove '<cache-name/data' qualifiers from SFS for backward…

### DIFF
--- a/core/src/main/java/org/infinispan/persistence/PersistenceUtil.java
+++ b/core/src/main/java/org/infinispan/persistence/PersistenceUtil.java
@@ -155,21 +155,24 @@ public class PersistenceUtil {
    }
 
    public static Path getQualifiedLocation(GlobalConfiguration globalConfiguration, String location, String cacheName, String qualifier) {
+      Path persistentLocation = getLocation(globalConfiguration, location);
+      return persistentLocation.resolve(Paths.get(sanitizedCacheName(cacheName), qualifier));
+   }
+
+   public static Path getLocation(GlobalConfiguration globalConfiguration, String location) {
       Path persistentLocation = Paths.get(globalConfiguration.globalState().persistentLocation());
-      if (location == null) {
-         return persistentLocation.resolve(Paths.get(sanitizedCacheName(cacheName), qualifier));
-      } else {
-         Path path = Paths.get(location);
-         if (path.isAbsolute()) {
-            // Ensure that the path lives under the global persistent location
-            if (path.startsWith(persistentLocation)) {
-               return Paths.get(location, sanitizedCacheName(cacheName), qualifier);
-            } else {
-               throw PERSISTENCE.forbiddenStoreLocation(path, persistentLocation);
-            }
+      if (location == null)
+         return persistentLocation;
+
+      Path path = Paths.get(location);
+      if (path.isAbsolute()) {
+         // Ensure that the path lives under the global persistent location
+         if (path.startsWith(persistentLocation)) {
+            return path;
          } else {
-            return persistentLocation.resolve(path.resolve(Paths.get(sanitizedCacheName(cacheName), qualifier)));
+            throw PERSISTENCE.forbiddenStoreLocation(path, persistentLocation);
          }
       }
+      return persistentLocation.resolve(path);
    }
 }

--- a/core/src/main/java/org/infinispan/persistence/file/SingleFileStore.java
+++ b/core/src/main/java/org/infinispan/persistence/file/SingleFileStore.java
@@ -108,7 +108,7 @@ public class SingleFileStore<K, V> implements AdvancedLoadWriteStore<K, V> {
 
    @Override
    public void start() {
-      Path location = PersistenceUtil.getQualifiedLocation(ctx.getGlobalConfiguration(), configuration.location(), ctx.getCache().getName(), "data");
+      Path location = PersistenceUtil.getLocation(ctx.getGlobalConfiguration(), configuration.location());
       try {
          file = new File(location.toFile(), ctx.getCache().getName() + ".dat");
          if (!file.exists()) {

--- a/core/src/test/java/org/infinispan/persistence/file/SingleFileStoreStressTest.java
+++ b/core/src/test/java/org/infinispan/persistence/file/SingleFileStoreStressTest.java
@@ -65,7 +65,7 @@ public class SingleFileStoreStressTest extends SingleCacheManagerTest {
    }
 
    private File getFileStore() {
-      return new File(location, String.format("%1$s/data/%1$s.dat", CACHE_NAME));
+      return new File(location, CACHE_NAME + ".dat");
    }
 
    public void testReadsAndWrites() throws ExecutionException, InterruptedException {
@@ -148,7 +148,7 @@ public class SingleFileStoreStressTest extends SingleCacheManagerTest {
 
       long [] fileSizesWithoutPurge = new long [times];
       long [] fileSizesWithPurge = new long [times];
-      File file = getFileStore();
+      File file = new File(location, CACHE_NAME + ".dat");
 
       // Write values for all keys iteratively such that the entry size increases during each iteration
       // Also record the file size after each such iteration.


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-11556

The original PR for ISPN-11556 changed the storage path of the SFS from `location/cache-name.dat` to `location/<cache-name>/data/<cache-name>.dat` to be more consistent with other stores,  however this breaks backwards compatibilty unnecessarilly. 