### PR TITLE
A bunch of component and maven plugin upgrades

### DIFF
--- a/build-configuration/pom.xml
+++ b/build-configuration/pom.xml
@@ -185,7 +185,7 @@
       <version.mockito_dep.objenesis>2.6</version.mockito_dep.objenesis>
       <version.net.bytebuddy>1.9.12</version.net.bytebuddy>
       <version.netty>4.1.49.Final</version.netty>
-      <version.okhttp>3.14.6</version.okhttp>
+      <version.okhttp>3.14.8</version.okhttp>
       <version.openjdk.jmh>1.12</version.openjdk.jmh>
       <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
       <version.org.wildfly.core>10.0.0.Final</version.org.wildfly.core>

--- a/build-configuration/pom.xml
+++ b/build-configuration/pom.xml
@@ -149,7 +149,7 @@
       <version.infinispan.arquillian>1.2.0.Beta3</version.infinispan.arquillian>
       <version.infinispan.doclets>1.3.0</version.infinispan.doclets>
       <version.infinispan.maven-plugins>1.0.2.Final</version.infinispan.maven-plugins>
-      <version.io.agroal>1.7</version.io.agroal>
+      <version.io.agroal>1.8</version.io.agroal>
       <version.jackson>2.11.0</version.jackson>
       <version.jackson.dataformat>${version.jackson}</version.jackson.dataformat>
       <version.jackson.databind>2.11.0</version.jackson.databind>

--- a/build-configuration/pom.xml
+++ b/build-configuration/pom.xml
@@ -150,9 +150,9 @@
       <version.infinispan.doclets>1.3.0</version.infinispan.doclets>
       <version.infinispan.maven-plugins>1.0.2.Final</version.infinispan.maven-plugins>
       <version.io.agroal>1.7</version.io.agroal>
-      <version.jackson>2.10.2</version.jackson>
+      <version.jackson>2.11.0</version.jackson>
       <version.jackson.dataformat>${version.jackson}</version.jackson.dataformat>
-      <version.jackson.databind>2.10.2</version.jackson.databind>
+      <version.jackson.databind>2.11.0</version.jackson.databind>
       <version.jacoco>0.7.5.201505241946</version.jacoco>
       <version.javax.cache>1.1.0</version.javax.cache>
       <version.javax.persistence>2.2</version.javax.persistence>

--- a/build-configuration/pom.xml
+++ b/build-configuration/pom.xml
@@ -174,7 +174,7 @@
       <version.jsr107>1.1.0</version.jsr107>
       <version.junit>4.13</version.junit>
       <version.karaf>4.2.3</version.karaf>
-      <version.log4j>2.13.1</version.log4j>
+      <version.log4j>2.13.2</version.log4j>
       <version.logback>1.1.7</version.logback>
       <version.lucene>5.5.5</version.lucene>
       <version.lucene.module.slot>5.5.5</version.lucene.module.slot>

--- a/build-configuration/pom.xml
+++ b/build-configuration/pom.xml
@@ -184,7 +184,7 @@
       <version.mockito_dep.hamcrest>1.3</version.mockito_dep.hamcrest>
       <version.mockito_dep.objenesis>2.6</version.mockito_dep.objenesis>
       <version.net.bytebuddy>1.9.12</version.net.bytebuddy>
-      <version.netty>4.1.45.Final</version.netty>
+      <version.netty>4.1.49.Final</version.netty>
       <version.okhttp>3.14.6</version.okhttp>
       <version.openjdk.jmh>1.12</version.openjdk.jmh>
       <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>

--- a/build-configuration/pom.xml
+++ b/build-configuration/pom.xml
@@ -222,30 +222,30 @@
       <version.lucene.featurepack>5.5.5.hibernate05</version.lucene.featurepack>
 
       <!-- Plugin dependencies -->
-      <version.checkstyle.maven-plugin>2.17</version.checkstyle.maven-plugin>
-      <version.karaf-maven-plugin>4.2.3</version.karaf-maven-plugin>
+      <version.checkstyle.maven-plugin>3.1.1</version.checkstyle.maven-plugin>
+      <version.karaf-maven-plugin>4.2.8</version.karaf-maven-plugin>
       <version.maven.antlr3>${version.antlr3}</version.maven.antlr3>
-      <version.maven.antrun>1.8</version.maven.antrun>
-      <version.maven.buildhelper>1.8</version.maven.buildhelper>
-      <version.maven.bundle>4.1.0</version.maven.bundle>
+      <version.maven.antrun>3.0.0</version.maven.antrun>
+      <version.maven.buildhelper>3.1.0</version.maven.buildhelper>
+      <version.maven.bundle>4.2.1</version.maven.bundle>
       <version.maven-compiler-plugin>3.8.1</version.maven-compiler-plugin>
-      <version.maven.invoker>1.8</version.maven.invoker>
-      <version.maven.jar>3.0.2</version.maven.jar>
+      <version.maven.invoker>3.2.1</version.maven.invoker>
+      <version.maven.jar>3.2.0</version.maven.jar>
       <version.maven.javadoc>3.2.0</version.maven.javadoc>
       <version.maven-plugin-annotations>3.5.1</version.maven-plugin-annotations>
       <version.maven-plugin-api>3.5.3</version.maven-plugin-api>
       <version.maven-plugin-plugin>3.6.0</version.maven-plugin-plugin>
-      <version.maven.release>2.5.3</version.maven.release>
+      <version.maven.release>3.0.0-M1</version.maven.release>
       <version.maven.remote.resource>1.5</version.maven.remote.resource>
       <version.maven.resources>3.1.0</version.maven.resources>
-      <version.maven.shade>3.2.1</version.maven.shade>
-      <version.maven.source>3.0.1</version.maven.source>
-      <version.maven.surefire>3.0.0-M3</version.maven.surefire>
+      <version.maven.shade>3.2.3</version.maven.shade>
+      <version.maven.source>3.2.0</version.maven.source>
+      <version.maven.surefire>3.0.0-M4</version.maven.surefire>
       <version.org.wildfly.build-tools>1.2.10.Final</version.org.wildfly.build-tools>
       <version.owasp-dependency-check-plugin>4.0.2</version.owasp-dependency-check-plugin>
 
       <!-- versionx -->
-      <versionx.com.puppycrawl.tools.checkstyle>8.18</versionx.com.puppycrawl.tools.checkstyle>
+      <versionx.com.puppycrawl.tools.checkstyle>8.32</versionx.com.puppycrawl.tools.checkstyle>
 
       <!-- configuration properties -->
       <org.infinispan.attachServerZip>false</org.infinispan.attachServerZip>

--- a/checkstyle/src/main/resources/checkstyle-hibernate-cache.xml
+++ b/checkstyle/src/main/resources/checkstyle-hibernate-cache.xml
@@ -12,8 +12,6 @@
     <!--<module name="FileTabCharacter" />-->
 
     <module name="TreeWalker">
-        <property name="cacheFile" value="${checkstyle.cache.file}" />
-
         <!-- Checks for imports -->
         <module name="AvoidStarImport" />
         <module name="RedundantImport" />

--- a/checkstyle/src/main/resources/checkstyle.xml
+++ b/checkstyle/src/main/resources/checkstyle.xml
@@ -14,8 +14,6 @@
     <module name="SuppressWarningsFilter" />
 
     <module name="TreeWalker">
-        <property name="cacheFile" value="${checkstyle.cache.file}" />
-
         <!-- Checks for imports -->
         <module name="AvoidStarImport" />
         <module name="RedundantImport" />

--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,6 @@
          --add-modules=java.se
       </testjvm.jigsawArgs>
       <testjvm.extraArgs/>
-      <testjvm.extraArgs/>
       <forkJvmArgs>-Xmx1G ${testjvm.commonArgs} ${testjvm.extraArgs}</forkJvmArgs>
       <server.jvm>${env.JAVA_HOME}</server.jvm>
       <server.jvm.args>${testjvm.commonArgs} ${testjvm.jigsawArgs} ${testjvm.extraArgs}</server.jvm.args>
@@ -3790,7 +3789,9 @@
                   <failsOnError>true</failsOnError>
                   <violationSeverity>error</violationSeverity>
                   <includeTestSourceDirectory>true</includeTestSourceDirectory>
-                  <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
+                  <sourceDirectories>
+                     <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
+                  </sourceDirectories>
                   <linkXRef>false</linkXRef>
                </configuration>
             </plugin>
@@ -4459,7 +4460,15 @@
             </plugins>
          </build>
       </profile>
-
+      <profile>
+         <id>java13-test</id>
+         <activation>
+            <jdk>[13,</jdk>
+         </activation>
+         <properties>
+            <testjvm.extraArgs>-XX:+AllowRedefinitionToAddDeleteMethods</testjvm.extraArgs>
+         </properties>
+      </profile>
       <profile>
          <id>extras</id>
          <activation>
@@ -4928,3 +4937,4 @@
       </profile>
    </profiles>
 </project>
+


### PR DESCRIPTION
ISPN-11745 Netty 4.1.49
ISPN-11748 OkHTTP 3.14.8
ISPN-11747 Log4j 2.13.2
ISPN-11746 Jackson 2.11.0
ISPN-11752 Agroal 1.8 
ISPN-11751 Various Maven plugin upgrades, Checkstyle
* Maven Antrun 3.0.0
* Maven Checkstyle 3.1.1 Checkstyle 8.32
* Maven Bundle 4.2.1
* Maven Invoker 3.2.1
* Maven Jar 3.2.0
* Maven Release 3.0.0-M1
* Maven Shade 3.2.3
* Maven Source 3.2.0
* Maven Surefire 3.0.0-M4
* Karaf plugin 4.2.8
* Make BlockHound work with JDK 13