### PR TITLE
ISPN-11756 Deprecate IndexingConfiguration.indexShareable() and remov…

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/cache/IndexingConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/IndexingConfiguration.java
@@ -39,16 +39,6 @@ public class IndexingConfiguration extends AbstractTypedPropertiesConfiguration 
 
    static final ElementDefinition<IndexingConfiguration> ELEMENT_DEFINITION = new DefaultElementDefinition<>(INDEXING.getLocalName());
 
-   private static final String DIRECTORY_PROVIDER_KEY = "directory_provider";
-
-   /**
-    * Legacy name "ram" was replaced by "local-heap"
-    */
-   @Deprecated
-   private static final String RAM_DIRECTORY_PROVIDER = "ram";
-   private static final String LOCAL_HEAP_DIRECTORY_PROVIDER = "local-heap";
-   private static final String LOCAL_HEAP_DIRECTORY_PROVIDER_FQN = "org.hibernate.search.store.impl.RAMDirectoryProvider";
-
    /**
     * @deprecated since 11.
     */
@@ -58,9 +48,11 @@ public class IndexingConfiguration extends AbstractTypedPropertiesConfiguration 
    private final Attribute<Map<Class<?>, Class<?>>> keyTransformers;
    private final Attribute<Set<Class<?>>> indexedEntities;
    private final Attribute<Boolean> enabled;
+   private final boolean isVolatile;
 
-   IndexingConfiguration(AttributeSet attributes) {
+   IndexingConfiguration(AttributeSet attributes, boolean isVolatile) {
       super(attributes);
+      this.isVolatile = isVolatile;
       index = attributes.attribute(INDEX);
       autoConfig = attributes.attribute(AUTO_CONFIG);
       keyTransformers = attributes.attribute(KEY_TRANSFORMERS);
@@ -141,6 +133,13 @@ public class IndexingConfiguration extends AbstractTypedPropertiesConfiguration 
    @Deprecated
    public final boolean indexShareable() {
       return false;
+   }
+
+   /**
+    * Does the index use a provider that does not persist upon restart?
+    */
+   public boolean isVolatile() {
+      return isVolatile;
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/configuration/cache/IndexingConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/IndexingConfiguration.java
@@ -133,28 +133,14 @@ public class IndexingConfiguration extends AbstractTypedPropertiesConfiguration 
    }
 
    /**
-    * Check if the indexes can be shared. Currently only "ram" based indexes don't allow any sort of
-    * sharing.
+    * Check if the indexes can be shared. Currently no index can be shared, so it always returns false. sharing.
     *
-    * @return false if the index is ram only and thus not shared
+    * @return always false, starting with version 11
+    * @deprecated Since 11 with no replacement; to be removed in next major version.
     */
-   public boolean indexShareable() {
-      TypedProperties properties = properties();
-      boolean hasRamDirectoryProvider = false;
-      for (Object objKey : properties.keySet()) {
-         String key = (String) objKey;
-         if (key.endsWith(DIRECTORY_PROVIDER_KEY)) {
-            String directoryImplementationName = String.valueOf(properties.get(key)).trim();
-            if (LOCAL_HEAP_DIRECTORY_PROVIDER.equalsIgnoreCase(directoryImplementationName)
-                  || RAM_DIRECTORY_PROVIDER.equalsIgnoreCase(directoryImplementationName)
-                  || LOCAL_HEAP_DIRECTORY_PROVIDER_FQN.equals(directoryImplementationName)) {
-               hasRamDirectoryProvider = true;
-            } else {
-               return true;
-            }
-         }
-      }
-      return !hasRamDirectoryProvider;
+   @Deprecated
+   public final boolean indexShareable() {
+      return false;
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/persistence/manager/PersistenceManagerImpl.java
+++ b/core/src/main/java/org/infinispan/persistence/manager/PersistenceManagerImpl.java
@@ -1274,18 +1274,11 @@ public class PersistenceManagerImpl implements PersistenceManager {
          releaseReadLock();
       }
 
-      if (hasShared) {
-         if (indexShareable())
-            flags = EnumUtil.mergeBitSets(flags, FlagBitSets.SKIP_INDEXING);
-      } else {
+      if (!hasShared) {
          flags = EnumUtil.mergeBitSets(flags, FlagBitSets.SKIP_INDEXING);
       }
 
       return flags;
-   }
-
-   private boolean indexShareable() {
-      return configuration.indexing().indexShareable();
    }
 
    private long getMaxEntries() {

--- a/core/src/main/java/org/infinispan/persistence/manager/PersistenceManagerImpl.java
+++ b/core/src/main/java/org/infinispan/persistence/manager/PersistenceManagerImpl.java
@@ -608,7 +608,7 @@ public class PersistenceManagerImpl implements PersistenceManager {
             "Deleting from all stores for id %d");
    }
 
-   <K, V> AdvancedCacheLoader<K, V> getFirstAdvancedCacheLoader(Predicate<? super StoreConfiguration> predicate) {
+   private <K, V> AdvancedCacheLoader<K, V> getFirstAdvancedCacheLoader(Predicate<? super StoreConfiguration> predicate) {
       acquireReadLock();
       try {
          for (CacheLoader loader : loaders) {
@@ -1261,12 +1261,12 @@ public class PersistenceManagerImpl implements PersistenceManager {
             FlagBitSets.SKIP_LOCKING |
             FlagBitSets.SKIP_XSITE_BACKUP;
 
-      boolean hasShared = false;
+      boolean hasSharedStore = false;
       acquireReadLock();
       try {
          for (CacheWriter w : nonTxWriters) {
             if (getStoreConfig(w).shared()) {
-               hasShared = true;
+               hasSharedStore = true;
                break;
             }
          }
@@ -1274,7 +1274,7 @@ public class PersistenceManagerImpl implements PersistenceManager {
          releaseReadLock();
       }
 
-      if (!hasShared) {
+      if (!hasSharedStore || !configuration.indexing().isVolatile()) {
          flags = EnumUtil.mergeBitSets(flags, FlagBitSets.SKIP_INDEXING);
       }
 


### PR DESCRIPTION
…e all its usages

* this should always return false starting with 11
  https://issues.redhat.com/browse/ISPN-11756

* rebuild volatile index on store preload
  https://issues.redhat.com/browse/ISPN-11760

To validate ISPN-11670, modify locally ```IndexingConfiguration.isVolatile``` to always return false and then execute SharedCacheLoaderQueryIndexTest to see it fail
