### PR TITLE
ISPN-11810 RemoteCacheManager ignores per-cache near cache configuration

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
@@ -507,7 +507,7 @@ public class RemoteCacheManager implements RemoteCacheContainer, Closeable, Remo
                log.tracef("Enabling near-caching for cache '%s'", cacheName);
             }
             return new InvalidatedNearRemoteCache<>(this, cacheName, timeService,
-                  createNearCacheService(cacheName, configuration.nearCache()));
+                  createNearCacheService(cacheName, nearCache));
          case DISABLED:
          default:
             return new RemoteCacheImpl<>(this, cacheName, timeService);


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-11810

Please cherry-pick into 10.1.x.