### PR TITLE
[10.1.x] add versioned operator and spring boot docs

### DIFF
--- a/documentation/src/main/asciidoc/index.asciidoc
+++ b/documentation/src/main/asciidoc/index.asciidoc
@@ -11,7 +11,8 @@ Getting Started::
 
 Operator for Kubernetes and OpenShift::
 
-* link:https://infinispan.org/infinispan-operator/master/operator.html[Infinispan Operator Guide]
+* link:https://infinispan.org/infinispan-operator/master/operator.html[{brandname} Operator Guide: Development]
+* link:https://infinispan.org/infinispan-operator/1.1.x/operator.html[{brandname} Operator Guide: Stable]
 
 Configuring Infinispan::
 

--- a/documentation/src/main/asciidoc/index.asciidoc
+++ b/documentation/src/main/asciidoc/index.asciidoc
@@ -42,7 +42,7 @@ APIs, Marshalling, Locks, Counters, Indexing and Querying, and more::
 Hibernate and Spring Framework Integration::
 
 * link:titles/integrating/integrating.html[Integration Guide]
-* link:https://infinispan.org/infinispan-spring-boot/master/spring_boot_starter.html[Spring Boot Starter]
+* link:https://infinispan.org/infinispan-spring-boot/10.1.x/spring_boot_starter.html[Spring Boot Starter]
 
 Security and Performance Tuning::
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-11808

This adds links to versioned docs for the Operator and SB Starter on 10.1.x. Depends on this change to the site: https://github.com/infinispan/infinispan.github.io/pull/109 