### PR TITLE
ISPN-11566 Add StatefulSetRollingUpgradeTest to 'unstable' group

### DIFF
--- a/core/src/test/java/org/infinispan/statetransfer/StatefulSetRollingUpgradeTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StatefulSetRollingUpgradeTest.java
@@ -89,7 +89,7 @@ public class StatefulSetRollingUpgradeTest extends MultipleCacheManagersTest {
       config.clustering()
             .partitionHandling().whenSplit(PartitionHandling.DENY_READ_WRITES)
             .stateTransfer().timeout(5 * numNodes, TimeUnit.SECONDS);
-      EmbeddedCacheManager manager = createClusteredCacheManager(true, global, null, new TransportFlags());
+      EmbeddedCacheManager manager = createClusteredCacheManager(true, global, null, new TransportFlags().withFD(true));
       manager.defineConfiguration(CACHE_NAME, config.build());
       cacheManagers.add(id, manager);
    }

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodMergeTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodMergeTest.java
@@ -28,7 +28,7 @@ import org.infinispan.topology.CacheTopology;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
-@Test(groups = "functional", testName = "server.hotrod.HotRodMergeTest")
+@Test(groups = {"functional", "unstable"}, description = "ISPN-11566", testName = "server.hotrod.HotRodMergeTest")
 public class HotRodMergeTest extends BasePartitionHandlingTest {
 
    private List<HotRodServer> servers = new ArrayList<>();


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-11566

In order to fix the test failure it's necessary for [ISPN-11634](https://issues.redhat.com/browse/ISPN-11634) to be implemented, in the interim the test is added to the "unstable" group.