### PR TITLE
ISPN-11893 Remove deprecated DistributionManager methods

### DIFF
--- a/core/src/main/java/org/infinispan/distribution/DataLocality.java
+++ b/core/src/main/java/org/infinispan/distribution/DataLocality.java
@@ -7,6 +7,7 @@ package org.infinispan.distribution;
  * @author Manik Surtani
  * @author Mircea Markus
  * @since 4.2.1
+ * @deprecated Since 11.0. Will be removed in 14.0, no longer used.
  */
 public enum DataLocality {
    LOCAL(true,false),
@@ -19,7 +20,7 @@ public enum DataLocality {
 
    private final boolean local, uncertain;
 
-   private DataLocality(boolean local, boolean uncertain) {
+   DataLocality(boolean local, boolean uncertain) {
       this.local = local;
       this.uncertain = uncertain;
    }

--- a/core/src/main/java/org/infinispan/distribution/DistributionManager.java
+++ b/core/src/main/java/org/infinispan/distribution/DistributionManager.java
@@ -1,13 +1,8 @@
 package org.infinispan.distribution;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Set;
-
 import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
-import org.infinispan.remoting.transport.Address;
 import org.infinispan.topology.CacheTopology;
 
 /**
@@ -23,68 +18,17 @@ import org.infinispan.topology.CacheTopology;
 public interface DistributionManager {
 
    /**
-    * Returns the data locality characteristics of a given key.
-    * @param key key to test
-    * @return a DataLocality that allows you to test whether a key is mapped to the local node or not, and the degree of
-    * certainty of such a result.
-    *
-    * @deprecated Since 9.0, please use {@code getCacheTopology().getDistributionInfo(key)} instead.
-    */
-   @Deprecated
-   DataLocality getLocality(Object key);
-
-   /**
-    * Locates a key in a cluster.  The returned addresses <i>may not</i> be owners of the keys if a rehash happens to be
-    * in progress or is pending, so when querying these servers, invalid responses should be checked for and the next
-    * address checked accordingly.
-    *
-    * @param key key to test
-    * @return a list of addresses where the key may reside
-    *
-    * @deprecated Since 9.0, please use {@code getCacheTopology().getDistributionInfo(key)} instead.
-    */
-   @Deprecated
-   List<Address> locate(Object key);
-
-   /**
-    * Returns the first Address containing the key.  Equivalent to returning the first element of {@link #locate(Object)}
-    * @param key key to test
-    * @return the first address on which the key may reside
-    * @deprecated Since 9.0, please use {@code getCacheTopology().getDistributionInfo(key)} instead.
-    */
-   @Deprecated
-   Address getPrimaryLocation(Object key);
-
-   /**
-    * Locates a list of keys in a cluster.  Like {@link #locate(Object)} the returned addresses <i>may not</i> be owners
-    * of the keys if a rehash happens to be in progress or is pending, so when querying these servers, invalid responses
-    * should be checked for and the next address checked accordingly.
-    *
-    * @param keys list of keys to locate
-    * @return all the nodes that would need to write a copy of one of the keys.
-    * @deprecated Since 9.0, no direct replacement.
-    */
-   @Deprecated
-   Set<Address> locateAll(Collection<Object> keys);
-
-   /**
-    * @return the consistent hash used for writing.
-    *
-    * @deprecated Since 9.0, please use {@link #getWriteConsistentHash()} instead.
-    */
-   @Deprecated
-   default ConsistentHash getConsistentHash() {
-      return getWriteConsistentHash();
-   }
-
-   /**
     * @return the consistent hash used for reading.
+    * @deprecated Since 11.0, to be removed in 14.0. Please use {@link #getCacheTopology()} instead.
     */
+   @Deprecated
    ConsistentHash getReadConsistentHash();
 
    /**
     * @return the consistent hash used for writing.
+    * @deprecated Since 11.0, to be removed in 14.0. Please use {@link #getCacheTopology()} instead.
     */
+   @Deprecated
    ConsistentHash getWriteConsistentHash();
 
    /**

--- a/core/src/main/java/org/infinispan/distribution/group/impl/GroupManager.java
+++ b/core/src/main/java/org/infinispan/distribution/group/impl/GroupManager.java
@@ -1,8 +1,5 @@
 package org.infinispan.distribution.group.impl;
 
-import org.infinispan.distribution.DistributionManager;
-import org.infinispan.remoting.transport.Address;
-
 /**
  * Control's key grouping.
  *
@@ -17,38 +14,4 @@ public interface GroupManager {
     * @return the group, or null if no group is defined for the key
     */
    Object getGroup(Object key);
-
-   /**
-    * Checks if this node is an owner of the group.
-    *
-    * @param group the group name.
-    * @return {@code true} if this node is an owner of the group, {@code false} otherwise.
-    *
-    * @deprecated Since 9.0, please use {@link DistributionManager#getCacheTopology()} instead.
-    */
-   @Deprecated
-   boolean isOwner(Object group);
-
-   /**
-    * It returns the primary owner of the group.
-    *
-    * @param group the group name.
-    * @return the primary owner of the group.
-    *
-    * @deprecated Since 9.0, please use {@link DistributionManager#getCacheTopology()} instead.
-    */
-   @Deprecated
-   Address getPrimaryOwner(Object group);
-
-   /**
-    * It checks if this node is the primary owner of the group.
-    *
-    * @param group the group name.
-    * @return {@code true} if this node is the primary owner of the group, {@code false} otherwise.
-    *
-    * @deprecated Since 9.0, please use {@link DistributionManager#getCacheTopology()} instead.
-    */
-   @Deprecated
-   boolean isPrimaryOwner(Object group);
-
 }

--- a/core/src/main/java/org/infinispan/distribution/impl/DistributionManagerImpl.java
+++ b/core/src/main/java/org/infinispan/distribution/impl/DistributionManagerImpl.java
@@ -1,16 +1,12 @@
 package org.infinispan.distribution.impl;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.Configuration;
-import org.infinispan.distribution.DataLocality;
 import org.infinispan.distribution.DistributionInfo;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.distribution.LocalizedCacheTopology;
@@ -71,38 +67,6 @@ public class DistributionManagerImpl implements DistributionManager {
 
    private Address getAddress() {
       return transport.getAddress();
-   }
-
-   @Override
-   public DataLocality getLocality(Object key) {
-      LocalizedCacheTopology info = this.extendedTopology;
-      if (info == null) {
-         return DataLocality.NOT_LOCAL;
-      }
-      DistributionInfo segmentInfo = info.getDistribution(key);
-      if (segmentInfo.isReadOwner()) {
-         return DataLocality.LOCAL;
-      } else if (segmentInfo.isWriteOwner()) {
-         return DataLocality.LOCAL_UNCERTAIN;
-      } else {
-         return DataLocality.NOT_LOCAL;
-      }
-   }
-
-   @Override
-   public List<Address> locate(Object key) {
-      return extendedTopology.getDistribution(key).writeOwners();
-   }
-
-   @Override
-   public Address getPrimaryLocation(Object key) {
-      return extendedTopology.getDistribution(key).primary();
-   }
-
-   @Override
-   public Set<Address> locateAll(Collection<Object> keys) {
-      Collection<Address> owners = extendedTopology.getWriteOwners(keys);
-      return new HashSet<>(owners);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/interceptors/locking/ClusteringDependentLogic.java
+++ b/core/src/main/java/org/infinispan/interceptors/locking/ClusteringDependentLogic.java
@@ -2,8 +2,6 @@ package org.infinispan.interceptors.locking;
 
 import static org.infinispan.transaction.impl.WriteSkewHelper.performWriteSkewCheckAndReturnNewVersions;
 
-import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -82,8 +80,8 @@ public interface ClusteringDependentLogic {
        */
       COMMIT_LOCAL(true, true);
 
-      private boolean commit;
-      private boolean local;
+      private final boolean commit;
+      private final boolean local;
 
       Commit(boolean commit, boolean local) {
          this.commit = commit;
@@ -110,30 +108,6 @@ public interface ClusteringDependentLogic {
    LocalizedCacheTopology getCacheTopology();
 
    /**
-    * @deprecated Since 9.0, please use {@code getCacheTopology().isWriteOwner(key)} instead.
-    */
-   @Deprecated
-   default boolean localNodeIsOwner(Object key) {
-      return getCacheTopology().isWriteOwner(key);
-   }
-
-   /**
-    * @deprecated Since 9.0, please use {@code getCacheTopology().getDistribution(key).isPrimary()} instead.
-    */
-   @Deprecated
-   default boolean localNodeIsPrimaryOwner(Object key) {
-      return getCacheTopology().getDistribution(key).isPrimary();
-   }
-
-   /**
-    * @deprecated Since 9.0, please use {@code getCacheTopology().getDistributionInfo(key).primary()} instead.
-    */
-   @Deprecated
-   default Address getPrimaryOwner(Object key) {
-      return getCacheTopology().getDistribution(key).primary();
-   }
-
-   /**
     * Commits the entry to the data container. The commit operation is always done synchronously in the current thread.
     * However notifications for said operations can be performed asynchronously and the returned CompletionStage will
     * complete when the notifications if any are completed.
@@ -156,22 +130,6 @@ public interface ClusteringDependentLogic {
     * @return
     */
    Commit commitType(FlagAffectedCommand command, InvocationContext ctx, int segment, boolean removed);
-
-   /**
-    * @deprecated Since 9.0, please use {@code getCacheTopology().getWriteOwners(keys)} instead.
-    */
-   @Deprecated
-   default Collection<Address> getOwners(Collection<Object> keys) {
-      return getCacheTopology().getWriteOwners(keys);
-   }
-
-   /**
-    * @deprecated Since 9.0, please use {@code getCacheTopology().getWriteOwners(key)} instead.
-    */
-   @Deprecated
-   default Collection<Address> getOwners(Object key) {
-      return getCacheTopology().getWriteOwners(key);
-   }
 
 
    CompletionStage<Map<Object, IncrementableEntryVersion>> createNewVersionsAndCheckForWriteSkews(VersionGenerator versionGenerator, TxInvocationContext context, VersionedPrepareCommand prepareCommand);
@@ -441,19 +399,6 @@ public interface ClusteringDependentLogic {
 
       private final WriteSkewHelper.KeySpecificLogic localNodeIsPrimaryOwner =
             segment -> getCacheTopology().getSegmentDistribution(segment).isPrimary();
-
-      @Override
-      public Collection<Address> getOwners(Object key) {
-         return null;
-      }
-
-      @Override
-      public Collection<Address> getOwners(Collection<Object> keys) {
-         if (keys.isEmpty())
-            return Collections.emptyList();
-
-         return null;
-      }
 
       @Override
       public Commit commitType(FlagAffectedCommand command, InvocationContext ctx, int segment, boolean removed) {

--- a/core/src/test/java/org/infinispan/affinity/impl/ConcurrentStartupTest.java
+++ b/core/src/test/java/org/infinispan/affinity/impl/ConcurrentStartupTest.java
@@ -2,7 +2,6 @@ package org.infinispan.affinity.impl;
 
 import static org.testng.AssertJUnit.assertTrue;
 
-import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -12,7 +11,6 @@ import org.infinispan.affinity.KeyAffinityServiceFactory;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
-import org.infinispan.remoting.transport.Address;
 import org.infinispan.test.AbstractCacheTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
@@ -74,13 +72,12 @@ public class ConcurrentStartupTest extends AbstractCacheTest {
       log.trace("Test keys for cache2.");
       for (int i = 0; i < KEY_QUEUE_SIZE; i++) {
          Object keyForAddress = keyAffinityService2.getKeyForAddress(manager2.getAddress());
-         assertTrue(cache1.getDistributionManager().locate(keyForAddress).contains(manager2.getAddress()));
+         assertTrue(cache2.getDistributionManager().getCacheTopology().isWriteOwner(keyForAddress));
       }
       log.trace("Test keys for cache1.");
       for (int i = 0; i < KEY_QUEUE_SIZE; i++) {
          Object keyForAddress = keyAffinityService1.getKeyForAddress(manager1.getAddress());
-         List<Address> locate = cache1.getDistributionManager().locate(keyForAddress);
-         assertTrue("For key " + keyForAddress + " Locate " + locate + " should contain " + manager1.getAddress(), locate.contains(manager1.getAddress()));
+         assertTrue(cache1.getDistributionManager().getCacheTopology().isWriteOwner(keyForAddress));
       }
    }
 }

--- a/core/src/test/java/org/infinispan/api/ConcurrentOperationsTest.java
+++ b/core/src/test/java/org/infinispan/api/ConcurrentOperationsTest.java
@@ -124,7 +124,7 @@ public class ConcurrentOperationsTest extends MultipleCacheManagersTest {
                   log.tracef("Checking correctness for iteration %s", i);
                   print("Checking correctness");
 
-                  List<Address> owners = advancedCache(0).getDistributionManager().locate("k");
+                  List<Address> owners = cacheTopology(0).getDistribution("k").writeOwners();
                   if (!checkOwners(owners)) {
                      correctness.set(false);
                   }

--- a/core/src/test/java/org/infinispan/distribution/DistributionTestHelper.java
+++ b/core/src/test/java/org/infinispan/distribution/DistributionTestHelper.java
@@ -26,22 +26,22 @@ public class DistributionTestHelper {
    }
 
    public static void assertIsInL1(Cache<?, ?> cache, Object key) {
-      DataContainer dc = cache.getAdvancedCache().getDataContainer();
-      InternalCacheEntry ice = dc.get(key);
+      DataContainer<?, ?> dc = cache.getAdvancedCache().getDataContainer();
+      InternalCacheEntry<?, ?> ice = dc.peek(key);
       assert ice != null : "Entry for key [" + key + "] should be in L1 on cache at [" + addressOf(cache) + "]!";
       assert !(ice instanceof ImmortalCacheEntry) : "Entry for key [" + key + "] should have a lifespan on cache at [" + addressOf(cache) + "]!";
    }
 
    public static void assertIsNotInL1(Cache<?, ?> cache, Object key) {
-      DataContainer dc = cache.getAdvancedCache().getDataContainer();
-      InternalCacheEntry ice = dc.get(key);
+      DataContainer<?, ?> dc = cache.getAdvancedCache().getDataContainer();
+      InternalCacheEntry<?, ?> ice = dc.peek(key);
       assert ice == null : "Entry for key [" + key + "] should not be in data container at all on cache at [" + addressOf(cache) + "]!";
    }
 
    public static void assertIsInContainerImmortal(Cache<?, ?> cache, Object key) {
       Log log = LogFactory.getLog(BaseDistFunctionalTest.class);
-      DataContainer dc = cache.getAdvancedCache().getDataContainer();
-      InternalCacheEntry ice = dc.get(key);
+      DataContainer<?, ?> dc = cache.getAdvancedCache().getDataContainer();
+      InternalCacheEntry<?, ?> ice = dc.peek(key);
       if (ice == null) {
          String msg = "Entry for key [" + key + "] should be in data container on cache at [" + addressOf(cache) + "]!";
          log.fatal(msg);
@@ -56,8 +56,8 @@ public class DistributionTestHelper {
 
    public static void assertIsInL1OrNull(Cache<?, ?> cache, Object key) {
       Log log = LogFactory.getLog(BaseDistFunctionalTest.class);
-      DataContainer dc = cache.getAdvancedCache().getDataContainer();
-      InternalCacheEntry ice = dc.get(key);
+      DataContainer<?, ?> dc = cache.getAdvancedCache().getDataContainer();
+      InternalCacheEntry<?, ?> ice = dc.peek(key);
       if (ice instanceof ImmortalCacheEntry) {
          String msg = "Entry for key [" + key + "] on cache at [" + addressOf(cache) + "] should be mortal or null but was [" + ice + "]!";
          log.fatal(msg);
@@ -68,30 +68,28 @@ public class DistributionTestHelper {
 
    public static boolean isOwner(Cache<?, ?> c, Object key) {
       DistributionManager dm = c.getAdvancedCache().getDistributionManager();
-      List<Address> ownerAddresses = dm.locate(key);
-      return ownerAddresses.contains(addressOf(c));
+      return dm.getCacheTopology().isWriteOwner(key);
    }
 
    public static boolean isFirstOwner(Cache<?, ?> c, Object key) {
       DistributionManager dm = c.getAdvancedCache().getDistributionManager();
-      Address primaryOwnerAddress = dm.getPrimaryLocation(key);
-      return addressOf(c).equals(primaryOwnerAddress);
+      return dm.getCacheTopology().getDistribution(key).isPrimary();
    }
 
    public static boolean hasOwners(Object key, Cache<?, ?> primaryOwner, Cache<?, ?>... backupOwners) {
       DistributionManager dm = primaryOwner.getAdvancedCache().getDistributionManager();
-      List<Address> ownerAddresses = dm.locate(key);
+      List<Address> ownerAddresses = dm.getCacheTopology().getDistribution(key).writeOwners();
       if (!addressOf(primaryOwner).equals(ownerAddresses.get(0)))
          return false;
-      for (int i = 0; i < backupOwners.length; i++) {
-         if (!ownerAddresses.contains(addressOf(backupOwners[i])))
+      for (Cache<?, ?> backupOwner : backupOwners) {
+         if (!ownerAddresses.contains(addressOf(backupOwner)))
             return false;
       }
       return true;
    }
 
    public static <K, V> Collection<Cache<K, V>> getOwners(Object key, List<Cache<K, V>> caches) {
-      List<Cache<K, V>> owners = new ArrayList<Cache<K, V>>();
+      List<Cache<K, V>> owners = new ArrayList<>();
       for (Cache<K, V> c : caches) {
          if (isFirstOwner(c, key)) {
             owners.add(c);
@@ -110,7 +108,7 @@ public class DistributionTestHelper {
    }
 
    public static <K, V> Collection<Cache<K, V>> getNonOwners(Object key, List<Cache<K, V>> caches) {
-      List<Cache<K, V>> nonOwners = new ArrayList<Cache<K, V>>();
+      List<Cache<K, V>> nonOwners = new ArrayList<>();
       for (Cache<K, V> c : caches)
          if (!isOwner(c, key)) nonOwners.add(c);
 

--- a/core/src/test/java/org/infinispan/distribution/InvalidationNoReplicationTest.java
+++ b/core/src/test/java/org/infinispan/distribution/InvalidationNoReplicationTest.java
@@ -36,8 +36,8 @@ public class InvalidationNoReplicationTest extends MultipleCacheManagersTest {
 
    public void testInvalidation() throws Exception {
 
-      assertEquals(Collections.singletonList(address(0)), advancedCache(0).getDistributionManager().locate(k0));
-      assertEquals(Collections.singletonList(address(0)), advancedCache(1).getDistributionManager().locate(k0));
+      assertEquals(Collections.singletonList(address(0)), cacheTopology(0).getDistribution(k0).writeOwners());
+      assertEquals(Collections.singletonList(address(0)), cacheTopology(1).getDistribution(k0).writeOwners());
 
       advancedCache(1).put(k0, "k1");
       assertTrue(advancedCache(1).getDataContainer().containsKey(k0));

--- a/core/src/test/java/org/infinispan/distribution/RemoteGetPerfTest.java
+++ b/core/src/test/java/org/infinispan/distribution/RemoteGetPerfTest.java
@@ -20,7 +20,7 @@ public class RemoteGetPerfTest extends MultipleCacheManagersTest {
 
    public void testRepeatedRemoteGet() {
       String key = "key";
-      List<Address> owners = cache(0).getAdvancedCache().getDistributionManager().locate(key);
+      List<Address> owners = cacheTopology(0).getDistribution(key).writeOwners();
       Cache<Object, Object> nonOwnerCache = caches().stream()
                                                     .filter(c -> !owners.contains(address(c)))
                                                     .findAny()

--- a/core/src/test/java/org/infinispan/distribution/RemoteGetTest.java
+++ b/core/src/test/java/org/infinispan/distribution/RemoteGetTest.java
@@ -1,5 +1,7 @@
 package org.infinispan.distribution;
 
+import static org.infinispan.test.TestingUtil.extractCacheTopology;
+
 import java.util.List;
 
 import org.infinispan.Cache;
@@ -41,7 +43,7 @@ public class RemoteGetTest extends MultipleCacheManagersTest {
       Cache<MagicKey, String> c3 = cache(2);
       MagicKey k = new MagicKey(c1, c2);
 
-      List<Address> owners = c1.getAdvancedCache().getDistributionManager().locate(k);
+      List<Address> owners = extractCacheTopology(c1).getDistribution(k).writeOwners();
 
       assert owners.size() == 2: "Key should have 2 owners";
 

--- a/core/src/test/java/org/infinispan/distribution/rehash/NonTxOriginatorBecomingPrimaryOwnerTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/NonTxOriginatorBecomingPrimaryOwnerTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.distribution.rehash;
 
+import static org.infinispan.test.TestingUtil.extractCacheTopology;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNull;
 
@@ -87,7 +88,7 @@ public class NonTxOriginatorBecomingPrimaryOwnerTest extends MultipleCacheManage
          distInterceptorBarrier.await(10, TimeUnit.SECONDS);
          distInterceptorBarrier.await(10, TimeUnit.SECONDS);
 
-         if (cache2.getAdvancedCache().getDistributionManager().getPrimaryLocation(key).equals(address(2))) {
+         if (extractCacheTopology(cache2).getDistribution(key).isPrimary()) {
             // cache2 forwards the command back to cache0, blocking again
             distInterceptorBarrier.await(10, TimeUnit.SECONDS);
             distInterceptorBarrier.await(10, TimeUnit.SECONDS);

--- a/core/src/test/java/org/infinispan/distribution/rehash/RehashAfterJoinWithPreloadTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/RehashAfterJoinWithPreloadTest.java
@@ -105,7 +105,7 @@ public class RehashAfterJoinWithPreloadTest extends MultipleCacheManagersTest {
          for (int j = 0; j < NUM_KEYS; j++) {
             String key = "key" + j;
             // each key must only occur once (numOwners is one)
-            if (dm.getLocality(key).isLocal()) {
+            if (dm.getCacheTopology().isReadOwner(key)) {
                assertTrue("Key '" + key + "' is owned by node " + address(i) + " but it doesn't appear there",
                      dataContainer.containsKey(key));
             } else {

--- a/core/src/test/java/org/infinispan/distribution/rehash/SharedStoreInvalidationDuringRehashTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/SharedStoreInvalidationDuringRehashTest.java
@@ -158,7 +158,7 @@ public class SharedStoreInvalidationDuringRehashTest extends MultipleCacheManage
 
          for (int j = 0; j < NUM_KEYS; j++) {
             String key = "key" + j;
-            if (!dm.getLocality(key).isLocal()) {
+            if (!dm.getCacheTopology().isReadOwner(key)) {
                if (!cacheMode.isScattered()) {
                   assertFalse("Key '" + key + "' is not owned by node " + address(i) + " but it still appears there",
                         dataContainer.containsKey(key));

--- a/core/src/test/java/org/infinispan/functional/AbstractFunctionalOpTest.java
+++ b/core/src/test/java/org/infinispan/functional/AbstractFunctionalOpTest.java
@@ -154,7 +154,7 @@ public abstract class AbstractFunctionalOpTest extends AbstractFunctionalTest {
          // this is more complicated: we need a key that is *not* local to the originating node
          key = IntStream.iterate(0, i -> i + 1)
                .mapToObj(i -> "key" + i)
-               .filter(k -> !cache(0, cacheName).getAdvancedCache().getDistributionManager().getLocality(k).isLocal())
+               .filter(k -> !advancedCache(0, cacheName).getDistributionManager().getCacheTopology().isReadOwner(k))
                .findAny()
                .get();
       }
@@ -315,7 +315,7 @@ public abstract class AbstractFunctionalOpTest extends AbstractFunctionalTest {
    }
 
    protected static class CommandCachingInterceptor extends BaseCustomAsyncInterceptor {
-      private static ThreadLocal<VisitableCommand> current = new ThreadLocal<>();
+      private static final ThreadLocal<VisitableCommand> current = new ThreadLocal<>();
 
       public static VisitableCommand getCurrent() {
          return current.get();

--- a/core/src/test/java/org/infinispan/functional/FunctionalInMemoryTest.java
+++ b/core/src/test/java/org/infinispan/functional/FunctionalInMemoryTest.java
@@ -56,7 +56,7 @@ public class FunctionalInMemoryTest extends AbstractFunctionalOpTest {
 
       caches(DIST).forEach(cache -> assertEquals(cache.get(key), "value", getAddress(cache).toString()));
       caches(DIST).forEach(cache -> {
-         if (cache.getAdvancedCache().getDistributionManager().getLocality(key).isLocal()) {
+         if (cache.getAdvancedCache().getDistributionManager().getCacheTopology().isReadOwner(key)) {
             assertTrue(cacheContainsKey(key, cache), getAddress(cache).toString());
          } else {
             assertFalse(cacheContainsKey(key, cache), getAddress(cache).toString());
@@ -165,7 +165,7 @@ public class FunctionalInMemoryTest extends AbstractFunctionalOpTest {
 
       caches(DIST).forEach(cache -> assertEquals(cache.get(key), "value", getAddress(cache).toString()));
       caches(DIST).forEach(cache -> {
-         if (cache.getAdvancedCache().getDistributionManager().getLocality(key).isLocal()) {
+         if (cache.getAdvancedCache().getDistributionManager().getCacheTopology().isReadOwner(key)) {
             assertTrue(cacheContainsKey(key, cache), getAddress(cache).toString());
          } else {
             assertFalse(cacheContainsKey(key, cache), getAddress(cache).toString());
@@ -184,7 +184,7 @@ public class FunctionalInMemoryTest extends AbstractFunctionalOpTest {
    public void testReadLoadLocal(ReadMethod method) {
       Integer key = 1;
 
-      assertTrue((Boolean) method.eval(key, lro,
+      assertTrue(method.eval(key, lro,
             view -> { assertFalse(view.find().isPresent()); return true; }));
 
       // we can't add from read-only cache, so we put manually:

--- a/core/src/test/java/org/infinispan/functional/FunctionalTxInMemoryTest.java
+++ b/core/src/test/java/org/infinispan/functional/FunctionalTxInMemoryTest.java
@@ -26,7 +26,7 @@ import org.testng.annotations.Test;
 @Test(groups = "functional", testName = "functional.FunctionalTxInMemoryTest")
 public class FunctionalTxInMemoryTest extends FunctionalInMemoryTest {
    private static final int NUM_KEYS = 2;
-   private static final Integer[] INT_KEYS = IntStream.range(0, NUM_KEYS).mapToObj(Integer::valueOf).toArray(Integer[]::new);
+   private static final Integer[] INT_KEYS = IntStream.range(0, NUM_KEYS).boxed().toArray(Integer[]::new);
    TransactionManager tm;
 
    @Override
@@ -211,7 +211,7 @@ public class FunctionalTxInMemoryTest extends FunctionalInMemoryTest {
    private Object[] getKeys(boolean isOwner, int num) {
       return IntStream.iterate(0, i -> i + 1)
             .mapToObj(i -> "key" + i)
-            .filter(k -> cache(0, DIST).getAdvancedCache().getDistributionManager().getLocality(k).isLocal() == isOwner)
+            .filter(k -> cache(0, DIST).getAdvancedCache().getDistributionManager().getCacheTopology().isReadOwner(k) == isOwner)
             .limit(num).toArray(Object[]::new);
    }
 }

--- a/core/src/test/java/org/infinispan/lock/singlelock/SinglePhaseCommitForPessimisticCachesTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/SinglePhaseCommitForPessimisticCachesTest.java
@@ -45,8 +45,8 @@ public class SinglePhaseCommitForPessimisticCachesTest extends MultipleCacheMana
       final Object k0_2 = getKeyForCache(0);
 
       final List<Address> members = advancedCache(0).getRpcManager().getTransport().getMembers();
-      assert advancedCache(0).getDistributionManager().locate(k0_1).containsAll(members);
-      assert advancedCache(0).getDistributionManager().locate(k0_2).containsAll(members);
+      assert cacheTopology(0).getDistribution(k0_1).writeOwners().containsAll(members);
+      assert cacheTopology(0).getDistribution(k0_2).writeOwners().containsAll(members);
       TxCountInterceptor interceptor0 = new TxCountInterceptor();
       TxCountInterceptor interceptor1 = new TxCountInterceptor();
       extractInterceptorChain(advancedCache(0)).addInterceptor(interceptor0, 1);

--- a/core/src/test/java/org/infinispan/lock/singlelock/optimistic/BasicSingleLockOptimisticTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/optimistic/BasicSingleLockOptimisticTest.java
@@ -47,7 +47,7 @@ public class BasicSingleLockOptimisticTest extends AbstractNoCrashTest {
       final Object k1 = getKeyForCache(1);
       final Object k2 = getKeyForCache(2);
 
-      assertEquals(advancedCache(0).getDistributionManager().locate(k1).get(0), address(1));
+      assertEquals(cacheTopology(0).getDistribution(k1).primary(), address(1));
       log.tracef("k1=%s, k2=%s", k1, k2);
 
       tm(0).begin();

--- a/core/src/test/java/org/infinispan/lock/singlelock/pessimistic/BasicSingleLockPessimisticTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/pessimistic/BasicSingleLockPessimisticTest.java
@@ -45,7 +45,7 @@ public class BasicSingleLockPessimisticTest extends AbstractNoCrashTest {
       final Object k1 = getKeyForCache(1);
       final Object k2 = getKeyForCache(2);
 
-      assertEquals(advancedCache(0).getDistributionManager().locate(k1).get(0), address(1));
+      assertEquals(cacheTopology(0).getDistribution(k1).primary(), address(1));
       log.tracef("k1=%s, k2=%s", k1, k2);
 
       tm(0).begin();

--- a/core/src/test/java/org/infinispan/notifications/DistListenerTest.java
+++ b/core/src/test/java/org/infinispan/notifications/DistListenerTest.java
@@ -39,7 +39,7 @@ public class DistListenerTest extends MultipleCacheManagersTest {
    public void testRemoteGet() {
       final String key1 = this.getClass().getName() + "K1";
 
-      List<Address> owners = cache(0).getAdvancedCache().getDistributionManager().locate(key1);
+      List<Address> owners = cacheTopology(0).getDistribution(key1).writeOwners();
 
       assert owners.size() == 2: "Key should have 2 owners";
 

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/AbstractClusterListenerNonTxTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/AbstractClusterListenerNonTxTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.notifications.cachelistener.cluster;
 
+import static org.infinispan.test.TestingUtil.extractCacheTopology;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertTrue;
 
@@ -72,8 +73,8 @@ public abstract class AbstractClusterListenerNonTxTest extends AbstractClusterLi
       // Since the first event was generated properly it is a create without retry
       checkEvent(clusterListener.events.get(0), key, true, false);
 
-      Address cache0primary = cache0.getAdvancedCache().getDistributionManager().getPrimaryLocation(key);
-      Address cache2primary = cache2.getAdvancedCache().getDistributionManager().getPrimaryLocation(key);
+      Address cache0primary = extractCacheTopology(cache0).getDistribution(key).primary();
+      Address cache2primary = extractCacheTopology(cache2).getDistribution(key).primary();
       // we expect that now both nodes have the same topology
       assertEquals(cache0primary, cache2primary);
 

--- a/core/src/test/java/org/infinispan/statetransfer/CommitTimeoutTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/CommitTimeoutTest.java
@@ -83,7 +83,7 @@ public class CommitTimeoutTest extends MultipleCacheManagersTest {
             matchCommand(RollbackCommand.class).build())
             .after("tx1:after_rollback_on_backup");
 
-      assertEquals(Arrays.asList(address(1), address(2)), advancedCache(0).getDistributionManager().locate(TEST_KEY));
+      assertEquals(Arrays.asList(address(1), address(2)), cacheTopology(0).getDistribution(TEST_KEY).writeOwners());
       sequencer.advance("tx1:begin");
 
       tm(0).begin();
@@ -142,7 +142,7 @@ public class CommitTimeoutTest extends MultipleCacheManagersTest {
             matchCommand(RollbackCommand.class).build())
             .before("tx1:block_rollback_on_backup").after("tx1:after_rollback_on_backup");
 
-      assertEquals(Arrays.asList(address(1), address(2)), advancedCache(0).getDistributionManager().locate(TEST_KEY));
+      assertEquals(Arrays.asList(address(1), address(2)), cacheTopology(0).getDistribution(TEST_KEY).writeOwners());
       Future<Object> lockCheckFuture = fork(() -> {
          sequencer.enter("tx1:resume_rollback_on_backup");
          try {

--- a/core/src/test/java/org/infinispan/statetransfer/PrepareTimeoutTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/PrepareTimeoutTest.java
@@ -86,7 +86,7 @@ public class PrepareTimeoutTest extends MultipleCacheManagersTest {
             .after("backup:after_rollback");
 
 
-      assertEquals(Arrays.asList(address(1), address(2)), advancedCache(0).getDistributionManager().locate(TEST_KEY));
+      assertEquals(Arrays.asList(address(1), address(2)), cacheTopology(0).getDistribution(TEST_KEY));
       sequencer.advance("main:start");
 
       tm(0).begin();

--- a/core/src/test/java/org/infinispan/statetransfer/TxReplay2Test.java
+++ b/core/src/test/java/org/infinispan/statetransfer/TxReplay2Test.java
@@ -65,7 +65,7 @@ public class TxReplay2Test extends MultipleCacheManagersTest {
       sequencer.order("sim:after_extra_commit", "tx:mark_tx_completed");
 
       final Object key = "key";
-      assertEquals(Arrays.asList(address(0), address(1), address(2)), advancedCache(0).getDistributionManager().locate(key));
+      assertEquals(Arrays.asList(address(0), address(1), address(2)), cacheTopology(0).getDistribution(key).writeOwners());
       Cache<Object, Object> primaryOwnerCache = cache(0);
       final Cache<Object, Object> newBackupOwnerCache = cache(3);
       final CountingInterceptor newBackupCounter = CountingInterceptor.inject(newBackupOwnerCache);
@@ -168,7 +168,7 @@ public class TxReplay2Test extends MultipleCacheManagersTest {
    }
 
    static class CountingInterceptor extends DDAsyncInterceptor {
-      private static Log log = LogFactory.getLog(CountingInterceptor.class);
+      private static final Log log = LogFactory.getLog(CountingInterceptor.class);
 
       //counters
       private final AtomicInteger numberPrepares = new AtomicInteger(0);

--- a/core/src/test/java/org/infinispan/test/MultipleCacheManagersTest.java
+++ b/core/src/test/java/org/infinispan/test/MultipleCacheManagersTest.java
@@ -40,6 +40,7 @@ import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.configuration.internal.PrivateGlobalConfigurationBuilder;
 import org.infinispan.configuration.parsing.ConfigurationBuilderHolder;
 import org.infinispan.container.DataContainer;
+import org.infinispan.distribution.LocalizedCacheTopology;
 import org.infinispan.distribution.MagicKey;
 import org.infinispan.distribution.rehash.XAResourceAdapter;
 import org.infinispan.manager.CacheContainer;
@@ -763,6 +764,14 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
 
    protected LockManager lockManager(int i, String cacheName) {
       return TestingUtil.extractLockManager(getCache(i, cacheName));
+   }
+
+   protected LocalizedCacheTopology cacheTopology(int i) {
+      return TestingUtil.extractCacheTopology(cache(i));
+   }
+
+   protected LocalizedCacheTopology cacheTopology(int i, String cacheName) {
+      return TestingUtil.extractCacheTopology(cache(i, cacheName));
    }
 
    public List<EmbeddedCacheManager> getCacheManagers() {

--- a/core/src/test/java/org/infinispan/test/TestingUtil.java
+++ b/core/src/test/java/org/infinispan/test/TestingUtil.java
@@ -81,6 +81,7 @@ import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.container.impl.InternalDataContainer;
 import org.infinispan.context.Flag;
 import org.infinispan.distribution.DistributionManager;
+import org.infinispan.distribution.LocalizedCacheTopology;
 import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.distribution.ch.ConsistentHashFactory;
 import org.infinispan.distribution.ch.KeyPartitioner;
@@ -154,7 +155,7 @@ public class TestingUtil {
    private static final Log log = LogFactory.getLog(TestingUtil.class);
    private static final Random random = new Random();
    private static final int SHORT_TIMEOUT_MILLIS = Integer.getInteger("infinispan.test.shortTimeoutMillis", 500);
-   private static ScheduledExecutorService timeoutExecutor;
+   private static final ScheduledExecutorService timeoutExecutor;
 
    static {
       ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1, r -> {
@@ -1063,6 +1064,10 @@ public class TestingUtil {
       return extractComponent(cache, AsyncInterceptorChain.class);
    }
 
+   public static <K> LocalizedCacheTopology extractCacheTopology(Cache<K, ?> cache) {
+      return cache.getAdvancedCache().getDistributionManager().getCacheTopology();
+   }
+
    /**
     * Add a hook to cache startup sequence that will allow to replace existing component with a mock.
     */
@@ -1777,11 +1782,8 @@ public class TestingUtil {
             return false;
          TestPrincipal other = (TestPrincipal) obj;
          if (name == null) {
-            if (other.name != null)
-               return false;
-         } else if (!name.equals(other.name))
-            return false;
-         return true;
+            return other.name == null;
+         } else return name.equals(other.name);
       }
    }
 

--- a/extended-statistics/src/test/java/org/infinispan/extendedstats/AbstractTopKeyTest.java
+++ b/extended-statistics/src/test/java/org/infinispan/extendedstats/AbstractTopKeyTest.java
@@ -21,7 +21,7 @@ public abstract class AbstractTopKeyTest extends MultipleCacheManagersTest {
 
    private static boolean isOwner(Cache<?, ?> cache, Object key) {
       DistributionManager dm = cache.getAdvancedCache().getDistributionManager();
-      return dm == null || dm.locate(key).contains(addressOf(cache));
+      return dm == null || dm.getCacheTopology().isWriteOwner(key);
    }
 
    protected CacheUsageInterceptor getTopKey(Cache<?, ?> cache) {

--- a/extended-statistics/src/test/java/org/infinispan/extendedstats/BaseClusterTopKeyTest.java
+++ b/extended-statistics/src/test/java/org/infinispan/extendedstats/BaseClusterTopKeyTest.java
@@ -1,6 +1,5 @@
 package org.infinispan.extendedstats;
 
-import static org.infinispan.distribution.DistributionTestHelper.addressOf;
 import static org.infinispan.test.TestingUtil.k;
 
 import java.lang.reflect.Method;
@@ -226,7 +225,7 @@ public abstract class BaseClusterTopKeyTest extends AbstractTopKeyTest {
 
    protected boolean isPrimaryOwner(Cache<?, ?> cache, Object key) {
       DistributionManager dm = cache.getAdvancedCache().getDistributionManager();
-      return dm.getPrimaryLocation(key).equals(addressOf(cache));
+      return dm.getCacheTopology().getDistribution(key).isPrimary();
    }
 
    private void assertNoLocks(String key) {


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-11893

* Deprecate getReadConsistentHash and getWriteConsistentHash
* Remove deprecated GroupManager methods
* Remove deprecated ClusteringDependentLogic methods
* Deprecate DataLocality (unused)