### PR TITLE
ISPN-11205 DataSource support in the Server

### DIFF
--- a/server/runtime/src/main/resources/schema/infinispan-server-11.0.xsd
+++ b/server/runtime/src/main/resources/schema/infinispan-server-11.0.xsd
@@ -143,7 +143,7 @@
       </xs:attribute>
       <xs:attribute name="new-connection-sql" type="xs:token">
          <xs:annotation>
-            <xs:documentation>SQL statement to be executed on a connection after creation,]]></xs:documentation>
+            <xs:documentation>SQL statement to be executed on a connection after creation</xs:documentation>
          </xs:annotation>
       </xs:attribute>
       <xs:attribute name="username" type="xs:token">


### PR DESCRIPTION
* Fix server schema errors

caused by: https://issues.redhat.com/browse/ISPN-11205
error
```
[ERROR]      [java] org.xml.sax.SAXParseException; systemId: file:/mnt/data/pedro/work/infinispan/server/runtime/target/classes/schema/infinispan-server-11.0.xsd; lineNumber: 146; columnNumber: 94; The character sequence "]]>" must not appear in content unless used to mark the end of a CDATA section.
```