### PR TITLE
ISPN-11898 Missing transcoder for user marshaller's media type

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/package-info.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/package-info.java
@@ -169,7 +169,7 @@
  *       <tr>
  *          <td><b>infinispan.client.hotrod.marshaller</b></td>
  *          <td>String (class name)</td>
- *          <td>{@link org.infinispan.jboss.marshalling.commons.jboss.GenericJBossMarshaller} if the infinispan-jboss-marshalling module is present on the classpath, otherwise {@link org.infinispan.commons.marshall.ProtoStreamMarshaller} is used</td>
+ *          <td>{@link org.infinispan.jboss.marshalling.commons.GenericJBossMarshaller} if the infinispan-jboss-marshalling module is present on the classpath, otherwise {@link org.infinispan.commons.marshall.ProtoStreamMarshaller} is used</td>
  *          <td>The {@link org.infinispan.client.hotrod.configuration.ConfigurationBuilder#marshaller(String) marshaller} that serializes keys and values</td>
  *       </tr>
  *       <tr>

--- a/commons/all/src/main/java/org/infinispan/commons/dataconversion/EncoderIds.java
+++ b/commons/all/src/main/java/org/infinispan/commons/dataconversion/EncoderIds.java
@@ -8,7 +8,19 @@ public interface EncoderIds {
    short IDENTITY = 1;
    short BINARY = 2;
    short UTF8 = 3;
+   /**
+    * @deprecated Since 11.0, will be removed with ISPN-9622
+    */
+   @Deprecated
    short GLOBAL_MARSHALLER = 4;
+   /**
+    * @deprecated Since 11.0, will be removed in 14.0. Set the storage media type and use transcoding instead.
+    */
+   @Deprecated
    short GENERIC_MARSHALLER = 5;
+   /**
+    * @deprecated Since 11.0, will be removed in 14.0. Set the storage media type and use transcoding instead.
+    */
+   @Deprecated
    short JAVA_SERIALIZATION = 6;
 }

--- a/commons/all/src/main/java/org/infinispan/commons/dataconversion/GlobalMarshallerEncoder.java
+++ b/commons/all/src/main/java/org/infinispan/commons/dataconversion/GlobalMarshallerEncoder.java
@@ -6,7 +6,9 @@ import org.infinispan.commons.marshall.Marshaller;
  * Encoder that uses the GlobalMarshaller to encode/decode data.
  *
  * @since 9.2
+ * @deprecated Since 11.0, will be removed with ISPN-9622
  */
+@Deprecated
 public class GlobalMarshallerEncoder extends MarshallerEncoder {
 
    public GlobalMarshallerEncoder(Marshaller globalMarshaller) {

--- a/commons/all/src/main/java/org/infinispan/commons/dataconversion/JavaSerializationEncoder.java
+++ b/commons/all/src/main/java/org/infinispan/commons/dataconversion/JavaSerializationEncoder.java
@@ -7,7 +7,9 @@ import org.infinispan.commons.marshall.JavaSerializationMarshaller;
  * Encoder based on the default java serialization.
  *
  * @since 9.1
+ * @deprecated Since 11.0, will be removed in 14.0. Set the storage media type and use transcoding instead.
  */
+@Deprecated
 public class JavaSerializationEncoder extends MarshallerEncoder {
 
    public JavaSerializationEncoder(ClassWhiteList classWhiteList) {

--- a/commons/all/src/main/java/org/infinispan/commons/dataconversion/MediaType.java
+++ b/commons/all/src/main/java/org/infinispan/commons/dataconversion/MediaType.java
@@ -56,7 +56,15 @@ public final class MediaType {
    public static final String TEXT_CSV_TYPE = "text/csv";
    public static final String TEXT_PLAIN_TYPE = "text/plain";
    public static final String TEXT_HTML_TYPE = "text/html";
+   /**
+    * @deprecated Since 11.0, will be removed with ISPN-9622
+    */
+   @Deprecated
    public static final String APPLICATION_INFINISPAN_MARSHALLING_TYPE = "application/x-infinispan-marshalling";
+   /**
+    * @deprecated Since 11.0, will be removed in 14.0. No longer used for BINARY storage.
+    */
+   @Deprecated
    public static final String APPLICATION_INFINISPAN_BINARY_TYPE = "application/x-infinispan-binary";
    public static final String APPLICATION_PROTOSTUFF_TYPE = "application/x-protostuff";
    public static final String APPLICATION_KRYO_TYPE = "application/x-kryo";
@@ -72,6 +80,10 @@ public final class MediaType {
    public static final MediaType APPLICATION_XML = fromString(APPLICATION_XML_TYPE);
    public static final MediaType APPLICATION_PROTOSTREAM = fromString(APPLICATION_PROTOSTREAM_TYPE);
    public static final MediaType APPLICATION_JBOSS_MARSHALLING = fromString(APPLICATION_JBOSS_MARSHALLING_TYPE);
+   /**
+    * @deprecated Since 11.0, will be removed with ISPN-9622
+    */
+   @Deprecated
    public static final MediaType APPLICATION_INFINISPAN_MARSHALLED = fromString(APPLICATION_INFINISPAN_MARSHALLING_TYPE);
    public static final MediaType APPLICATION_WWW_FORM_URLENCODED = fromString(WWW_FORM_URLENCODED_TYPE);
    public static final MediaType IMAGE_PNG = fromString(IMAGE_PNG_TYPE);
@@ -83,10 +95,18 @@ public final class MediaType {
    public static final MediaType IMAGE_JPEG = fromString(IMAGE_JPEG_TYPE);
    public static final MediaType APPLICATION_PROTOSTUFF = fromString(APPLICATION_PROTOSTUFF_TYPE);
    public static final MediaType APPLICATION_KRYO = fromString(APPLICATION_KRYO_TYPE);
+   /**
+    * @deprecated Since 11.0, will be removed in 14.0. No longer used for BINARY storage.
+    */
+   @Deprecated
    public static final MediaType APPLICATION_INFINISPAN_BINARY = fromString(APPLICATION_INFINISPAN_BINARY_TYPE);
    public static final MediaType APPLICATION_PDF = fromString(APPLICATION_PDF_TYPE);
    public static final MediaType APPLICATION_RTF = fromString(APPLICATION_RTF_TYPE);
    public static final MediaType APPLICATION_ZIP = fromString(APPLICATION_ZIP_TYPE);
+   /**
+    * @deprecated Since 11.0, will be removed with ISPN-9622
+    */
+   @Deprecated
    public static final MediaType APPLICATION_INFINISPAN_MARSHALLING = fromString(APPLICATION_INFINISPAN_MARSHALLING_TYPE);
    public static final MediaType APPLICATION_UNKNOWN = fromString(APPLICATION_UNKNOWN_TYPE);
    public static final MediaType MATCH_ALL = fromString(MATCH_ALL_TYPE);

--- a/commons/all/src/main/java/org/infinispan/commons/util/KeyValueWithPrevious.java
+++ b/commons/all/src/main/java/org/infinispan/commons/util/KeyValueWithPrevious.java
@@ -48,12 +48,12 @@ public class KeyValueWithPrevious<K, V> implements Serializable {
 
    @ProtoField(number = 2)
    WrappedMessage getWrappedValue() {
-      return new WrappedMessage(key);
+      return new WrappedMessage(value);
    }
 
    @ProtoField(number = 3)
    WrappedMessage getWrappedPrev() {
-      return new WrappedMessage(key);
+      return new WrappedMessage(prev);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/configuration/global/SerializationConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/global/SerializationConfiguration.java
@@ -64,6 +64,10 @@ public class SerializationConfiguration implements ConfigurationInfo {
       return marshaller.get();
    }
 
+   /**
+    * @deprecated since 10.0, {@link AdvancedExternalizer}'s will be removed in a future release.
+    */
+   @Deprecated
    public Map<Integer, AdvancedExternalizer<?>> advancedExternalizers() {
       return advancedExternalizers.get();
    }

--- a/core/src/main/java/org/infinispan/encoding/impl/JavaSerializationTranscoder.java
+++ b/core/src/main/java/org/infinispan/encoding/impl/JavaSerializationTranscoder.java
@@ -1,4 +1,4 @@
-package org.infinispan.server.core.dataconversion;
+package org.infinispan.encoding.impl;
 
 import org.infinispan.commons.configuration.ClassWhiteList;
 import org.infinispan.commons.dataconversion.TranscoderMarshallerAdapter;

--- a/core/src/main/java/org/infinispan/encoding/impl/TwoStepTranscoder.java
+++ b/core/src/main/java/org/infinispan/encoding/impl/TwoStepTranscoder.java
@@ -1,0 +1,67 @@
+package org.infinispan.encoding.impl;
+
+import static org.infinispan.commons.dataconversion.MediaType.APPLICATION_OBJECT;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.infinispan.commons.dataconversion.MediaType;
+import org.infinispan.commons.dataconversion.Transcoder;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
+/**
+ * <p>
+ * Performs conversions where there is no direct transcoder, but there are two transcoders availabl:
+ * <ul>
+ *    <li>one from source media type to <b>application/x-java-object</b>
+ *    <li>one from <b>application/x-java-object</b> to the destination media type
+ * </ul>
+ * </p>
+ *
+ * @since 11.0
+ */
+public class TwoStepTranscoder implements Transcoder {
+
+   private static final Log logger = LogFactory.getLog(TwoStepTranscoder.class, Log.class);
+   private final Transcoder transcoder1;
+   private final Transcoder transcoder2;
+   private final HashSet<MediaType> supportedMediaTypes;
+
+   public TwoStepTranscoder(Transcoder transcoder1, Transcoder transcoder2) {
+      this.transcoder1 = transcoder1;
+      this.transcoder2 = transcoder2;
+
+      supportedMediaTypes = new HashSet<>(this.transcoder1.getSupportedMediaTypes());
+      supportedMediaTypes.addAll(transcoder2.getSupportedMediaTypes());
+   }
+
+   @Override
+   public Object transcode(Object content, MediaType contentType, MediaType destinationType) {
+      if (transcoder1.supportsConversion(contentType, APPLICATION_OBJECT)
+          && transcoder2.supportsConversion(APPLICATION_OBJECT, destinationType)) {
+         Object object = transcoder1.transcode(content, contentType, APPLICATION_OBJECT);
+         return transcoder2.transcode(object, APPLICATION_OBJECT, destinationType);
+      }
+      if (transcoder2.supportsConversion(contentType, APPLICATION_OBJECT)
+          && transcoder1.supportsConversion(APPLICATION_OBJECT, destinationType)) {
+         Object object = transcoder2.transcode(content, contentType, APPLICATION_OBJECT);
+         return transcoder1.transcode(object, APPLICATION_OBJECT, destinationType);
+      }
+
+      throw logger.unsupportedContent(TwoStepTranscoder.class.getSimpleName(), content);
+   }
+
+   @Override
+   public Set<MediaType> getSupportedMediaTypes() {
+      return supportedMediaTypes;
+   }
+
+   @Override
+   public boolean supportsConversion(MediaType mediaType, MediaType other) {
+      return (transcoder1.supportsConversion(mediaType, APPLICATION_OBJECT) &&
+              transcoder2.supportsConversion(APPLICATION_OBJECT, other)) ||
+             (transcoder2.supportsConversion(mediaType, APPLICATION_OBJECT) &&
+              transcoder1.supportsConversion(APPLICATION_OBJECT, other));
+   }
+}

--- a/core/src/main/java/org/infinispan/factories/EncoderRegistryFactory.java
+++ b/core/src/main/java/org/infinispan/factories/EncoderRegistryFactory.java
@@ -54,6 +54,7 @@ public class EncoderRegistryFactory extends AbstractComponentFactory implements 
 
       encoderRegistry.registerEncoder(IdentityEncoder.INSTANCE);
       encoderRegistry.registerEncoder(UTF8Encoder.INSTANCE);
+
       encoderRegistry.registerEncoder(new JavaSerializationEncoder(classWhiteList));
       encoderRegistry.registerEncoder(new GlobalMarshallerEncoder(globalMarshaller.wired()));
 
@@ -64,6 +65,7 @@ public class EncoderRegistryFactory extends AbstractComponentFactory implements 
       encoderRegistry.registerTranscoder(new ProtostreamTranscoder(ctxRegistry, classLoader));
       encoderRegistry.registerTranscoder(new JavaSerializationTranscoder(classWhiteList));
       // Wraps the GlobalMarshaller so that it can be used as a transcoder
+      // Keeps application/x-infinispan-marshalling available for backwards compatibility
       encoderRegistry.registerTranscoder(new TranscoderMarshallerAdapter(globalMarshaller.wired()));
       // Make the user marshaller's media type available as well
       // As custom marshaller modules like Kryo and Protostuff do not define their own transcoder

--- a/core/src/main/java/org/infinispan/factories/EncoderRegistryFactory.java
+++ b/core/src/main/java/org/infinispan/factories/EncoderRegistryFactory.java
@@ -12,6 +12,7 @@ import org.infinispan.commons.dataconversion.TranscoderMarshallerAdapter;
 import org.infinispan.commons.dataconversion.UTF8Encoder;
 import org.infinispan.commons.marshall.StreamingMarshaller;
 import org.infinispan.encoding.ProtostreamTranscoder;
+import org.infinispan.encoding.impl.JavaSerializationTranscoder;
 import org.infinispan.factories.annotations.ComponentName;
 import org.infinispan.factories.annotations.DefaultFactoryFor;
 import org.infinispan.factories.annotations.Inject;
@@ -57,6 +58,7 @@ public class EncoderRegistryFactory extends AbstractComponentFactory implements 
       // Wraps the GlobalMarshaller so that it can be used as a transcoder
       encoderRegistry.registerTranscoder(new TranscoderMarshallerAdapter(globalMarshaller.wired()));
       encoderRegistry.registerTranscoder(new ProtostreamTranscoder(ctxRegistry, classLoader));
+      encoderRegistry.registerTranscoder(new JavaSerializationTranscoder(classWhiteList));
 
       encoderRegistry.registerWrapper(ByteArrayWrapper.INSTANCE);
       encoderRegistry.registerWrapper(IdentityWrapper.INSTANCE);

--- a/core/src/main/java/org/infinispan/factories/EncoderRegistryFactory.java
+++ b/core/src/main/java/org/infinispan/factories/EncoderRegistryFactory.java
@@ -10,6 +10,7 @@ import org.infinispan.commons.dataconversion.IdentityWrapper;
 import org.infinispan.commons.dataconversion.JavaSerializationEncoder;
 import org.infinispan.commons.dataconversion.TranscoderMarshallerAdapter;
 import org.infinispan.commons.dataconversion.UTF8Encoder;
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.commons.marshall.StreamingMarshaller;
 import org.infinispan.encoding.ProtostreamTranscoder;
 import org.infinispan.encoding.impl.JavaSerializationTranscoder;
@@ -47,18 +48,26 @@ public class EncoderRegistryFactory extends AbstractComponentFactory implements 
       ClassWhiteList classWhiteList = embeddedCacheManager.getClassWhiteList();
       // TODO Move registration to GlobalMarshaller ISPN-9622
       String messageName = PersistenceContextInitializer.getFqTypeName(MarshallableUserObject.class);
-      ctxRegistry.addMarshaller(SerializationContextRegistry.MarshallerType.GLOBAL, new MarshallableUserObject.Marshaller(messageName, persistenceMarshaller.getUserMarshaller()));
+      Marshaller userMarshaller = persistenceMarshaller.getUserMarshaller();
+      ctxRegistry.addMarshaller(SerializationContextRegistry.MarshallerType.GLOBAL,
+                                new MarshallableUserObject.Marshaller(messageName, userMarshaller));
 
       encoderRegistry.registerEncoder(IdentityEncoder.INSTANCE);
       encoderRegistry.registerEncoder(UTF8Encoder.INSTANCE);
       encoderRegistry.registerEncoder(new JavaSerializationEncoder(classWhiteList));
       encoderRegistry.registerEncoder(new GlobalMarshallerEncoder(globalMarshaller.wired()));
-      encoderRegistry.registerTranscoder(new DefaultTranscoder(persistenceMarshaller.getUserMarshaller()));
-      encoderRegistry.registerTranscoder(new BinaryTranscoder(persistenceMarshaller.getUserMarshaller()));
-      // Wraps the GlobalMarshaller so that it can be used as a transcoder
-      encoderRegistry.registerTranscoder(new TranscoderMarshallerAdapter(globalMarshaller.wired()));
+
+      // Default and binary transcoder use the user marshaller to convert data to/from a byte array
+      encoderRegistry.registerTranscoder(new DefaultTranscoder(userMarshaller));
+      encoderRegistry.registerTranscoder(new BinaryTranscoder(userMarshaller));
+      // Core transcoders are always available
       encoderRegistry.registerTranscoder(new ProtostreamTranscoder(ctxRegistry, classLoader));
       encoderRegistry.registerTranscoder(new JavaSerializationTranscoder(classWhiteList));
+      // Wraps the GlobalMarshaller so that it can be used as a transcoder
+      encoderRegistry.registerTranscoder(new TranscoderMarshallerAdapter(globalMarshaller.wired()));
+      // Make the user marshaller's media type available as well
+      // As custom marshaller modules like Kryo and Protostuff do not define their own transcoder
+      encoderRegistry.registerTranscoder(new TranscoderMarshallerAdapter(userMarshaller));
 
       encoderRegistry.registerWrapper(ByteArrayWrapper.INSTANCE);
       encoderRegistry.registerWrapper(IdentityWrapper.INSTANCE);

--- a/core/src/main/java/org/infinispan/factories/GlobalComponentRegistry.java
+++ b/core/src/main/java/org/infinispan/factories/GlobalComponentRegistry.java
@@ -33,7 +33,6 @@ import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.lifecycle.ModuleLifecycle;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.manager.ModuleRepository;
-import org.infinispan.marshall.core.EncoderRegistry;
 import org.infinispan.metrics.impl.CacheManagerMetricsRegistration;
 import org.infinispan.notifications.cachemanagerlistener.CacheManagerNotifier;
 import org.infinispan.notifications.cachemanagerlistener.CacheManagerNotifierImpl;
@@ -150,7 +149,6 @@ public class GlobalComponentRegistry extends AbstractComponentRegistry {
          basicComponentRegistry.getComponent(EventLogManager.class);
          basicComponentRegistry.getComponent(Transport.class);
          basicComponentRegistry.getComponent(ClusterContainerStats.class);
-         basicComponentRegistry.getComponent(EncoderRegistry.class);
          basicComponentRegistry.getComponent(GlobalConfigurationManager.class);
          basicComponentRegistry.getComponent(CacheManagerJmxRegistration.class);
          basicComponentRegistry.getComponent(CacheManagerMetricsRegistration.class);

--- a/core/src/main/java/org/infinispan/marshall/persistence/impl/PersistenceMarshallerImpl.java
+++ b/core/src/main/java/org/infinispan/marshall/persistence/impl/PersistenceMarshallerImpl.java
@@ -6,7 +6,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.lang.reflect.Method;
 
 import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.commons.io.ByteBuffer;
@@ -14,8 +13,6 @@ import org.infinispan.commons.io.ByteBufferImpl;
 import org.infinispan.commons.marshall.BufferSizePredictor;
 import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.commons.marshall.MarshallingException;
-import org.infinispan.commons.util.ReflectionUtil;
-import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.configuration.global.SerializationConfiguration;
 import org.infinispan.factories.GlobalComponentRegistry;
@@ -92,16 +89,7 @@ public class PersistenceMarshallerImpl implements PersistenceMarshaller {
       SerializationConfiguration serializationConfig = globalConfig.serialization();
       Marshaller marshaller = serializationConfig.marshaller();
       if (marshaller != null) {
-         Class<?> clazz = marshaller.getClass();
-         if (clazz.getName().equals(Util.JBOSS_USER_MARSHALLER_CLASS)) {
-            // If the user has specified to use jboss-marshalling, we must initialize the instance with the GlobalComponentRegistry
-            // So that any user Externalizer implementations can be loaded.
-            Method method = ReflectionUtil.findMethod(clazz, "initialize", GlobalComponentRegistry.class);
-            ReflectionUtil.invokeAccessibly(marshaller, method, gcr);
-            PERSISTENCE.jbossMarshallingDetected();
-         } else {
-            marshaller.initialize(gcr.getCacheManager().getClassWhiteList());
-         }
+         marshaller.initialize(gcr.getCacheManager().getClassWhiteList());
          return marshaller;
       }
       return null;

--- a/core/src/test/java/org/infinispan/dataconversion/impl/JavaSerializationTranscoderTest.java
+++ b/core/src/test/java/org/infinispan/dataconversion/impl/JavaSerializationTranscoderTest.java
@@ -1,4 +1,4 @@
-package org.infinispan.server.core.dataconversion;
+package org.infinispan.dataconversion.impl;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -7,6 +7,7 @@ import java.util.Collections;
 
 import org.infinispan.commons.configuration.ClassWhiteList;
 import org.infinispan.commons.dataconversion.MediaType;
+import org.infinispan.encoding.impl.JavaSerializationTranscoder;
 import org.infinispan.test.data.Address;
 import org.infinispan.test.data.Person;
 import org.infinispan.test.dataconversion.AbstractTranscoderTest;

--- a/integrationtests/jboss-marshalling-it/src/test/java/org/infinispan/it/marshalling/jboss/JBMARRemoteQueryDslConditionsTest.java
+++ b/integrationtests/jboss-marshalling-it/src/test/java/org/infinispan/it/marshalling/jboss/JBMARRemoteQueryDslConditionsTest.java
@@ -21,6 +21,8 @@ import org.infinispan.client.hotrod.impl.query.RemoteQueryFactory;
 import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
 import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.jboss.marshalling.commons.GenericJBossMarshaller;
 import org.infinispan.query.dsl.QueryFactory;
 import org.infinispan.query.dsl.embedded.QueryDslConditionsTest;
 import org.infinispan.server.hotrod.HotRodServer;
@@ -66,8 +68,10 @@ public class JBMARRemoteQueryDslConditionsTest extends QueryDslConditionsTest {
 
    @Override
    protected void createCacheManagers() {
+      GlobalConfigurationBuilder globalCfg = GlobalConfigurationBuilder.defaultClusteredBuilder();
+      globalCfg.serialization().marshaller(new GenericJBossMarshaller());
       ConfigurationBuilder cfg = getConfigurationBuilder();
-      createClusteredCaches(1, cfg, true);
+      createClusteredCaches(1, globalCfg, cfg, true);
 
       cache = manager(0).getCache();
 
@@ -76,6 +80,7 @@ public class JBMARRemoteQueryDslConditionsTest extends QueryDslConditionsTest {
       org.infinispan.client.hotrod.configuration.ConfigurationBuilder clientBuilder = HotRodClientTestingUtil.newRemoteConfigurationBuilder();
       clientBuilder.addServer().host("127.0.0.1").port(hotRodServer.getPort());
       clientBuilder.version(getProtocolVersion());
+      clientBuilder.marshaller(new GenericJBossMarshaller());
       remoteCacheManager = new RemoteCacheManager(clientBuilder.build());
       remoteCache = remoteCacheManager.getCache();
       cacheManagers.forEach(c -> c.getClassWhiteList().addRegexps(".*"));

--- a/jboss-marshalling/pom.xml
+++ b/jboss-marshalling/pom.xml
@@ -22,6 +22,11 @@
 
         <dependency>
             <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-component-processor</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.infinispan</groupId>
             <artifactId>infinispan-commons</artifactId>
         </dependency>
 
@@ -104,6 +109,7 @@
                         </Import-package>
                         <Include-Resource>
                             {maven-resources},
+                            /META-INF/services=${project.build.outputDirectory}/META-INF/services,
                             /OSGI-INF/blueprint/blueprint.xml=${project.basedir}/target/classes/OSGI-INF/blueprint/blueprint.xml
                         </Include-Resource>
                     </instructions>

--- a/jboss-marshalling/src/main/java/org/infinispan/jboss/marshalling/JbossMarshallingModule.java
+++ b/jboss-marshalling/src/main/java/org/infinispan/jboss/marshalling/JbossMarshallingModule.java
@@ -1,0 +1,46 @@
+package org.infinispan.jboss.marshalling;
+
+import static org.infinispan.util.logging.Log.PERSISTENCE;
+
+import org.infinispan.commons.configuration.ClassWhiteList;
+import org.infinispan.commons.marshall.Marshaller;
+import org.infinispan.configuration.global.GlobalConfiguration;
+import org.infinispan.factories.GlobalComponentRegistry;
+import org.infinispan.factories.annotations.InfinispanModule;
+import org.infinispan.jboss.marshalling.commons.GenericJBossMarshaller;
+import org.infinispan.jboss.marshalling.core.JBossUserMarshaller;
+import org.infinispan.jboss.marshalling.dataconversion.JBossMarshallingTranscoder;
+import org.infinispan.lifecycle.ModuleLifecycle;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.marshall.core.EncoderRegistry;
+
+/**
+ * JBoss Marshalling module lifecycle callbacks
+ *
+ * <p>Registers a JBoss Marshalling encoder and transcoder.</p>
+ *
+ * @author Dan Berindei
+ * @since 11.0
+ */
+@InfinispanModule(name = "jboss-marshalling", requiredModules = "core")
+public class JbossMarshallingModule implements ModuleLifecycle {
+
+   @Override
+   public void cacheManagerStarting(GlobalComponentRegistry gcr, GlobalConfiguration globalConfiguration) {
+      PERSISTENCE.jbossMarshallingDetected();
+
+      Marshaller userMarshaller = globalConfiguration.serialization().marshaller();
+      if (userMarshaller instanceof JBossUserMarshaller) {
+         // Core automatically registers a transcoder for the user marshaller
+         // Initialize the externalizers from the serialization configuration
+         ((JBossUserMarshaller) userMarshaller).initialize(gcr);
+      } else {
+         // Register a JBoss Marshalling transcoder, ignoring any configured externalizers
+         ClassWhiteList classWhiteList = gcr.getComponent(EmbeddedCacheManager.class).getClassWhiteList();
+         ClassLoader classLoader = globalConfiguration.classLoader();
+         GenericJBossMarshaller jbossMarshaller = new GenericJBossMarshaller(classLoader, classWhiteList);
+         EncoderRegistry encoderRegistry = gcr.getComponent(EncoderRegistry.class);
+         encoderRegistry.registerTranscoder(new JBossMarshallingTranscoder(jbossMarshaller));
+      }
+   }
+}

--- a/jboss-marshalling/src/main/java/org/infinispan/jboss/marshalling/dataconversion/GenericJbossMarshallerEncoder.java
+++ b/jboss-marshalling/src/main/java/org/infinispan/jboss/marshalling/dataconversion/GenericJbossMarshallerEncoder.java
@@ -7,7 +7,9 @@ import org.infinispan.jboss.marshalling.commons.GenericJBossMarshaller;
 
 /**
  * @since 9.1
+ * @deprecated Since 11.0, will be removed in 14.0. Set the storage media type and use transcoding instead.
  */
+@Deprecated
 public class GenericJbossMarshallerEncoder extends MarshallerEncoder {
 
    public GenericJbossMarshallerEncoder(GenericJBossMarshaller marshaller) {

--- a/jcache/commons/src/main/java/org/infinispan/jcache/RICacheEntryEvent.java
+++ b/jcache/commons/src/main/java/org/infinispan/jcache/RICacheEntryEvent.java
@@ -124,4 +124,14 @@ public class RICacheEntryEvent<K, V> extends CacheEntryEvent<K, V> {
     public boolean isOldValueAvailable() {
         return oldValueAvailable;
     }
+
+   @Override
+   public String toString() {
+      return "RICacheEntryEvent{" +
+             "key=" + key +
+             ", value=" + value +
+             ", oldValue=" + oldValue +
+             ", source=" + source +
+             '}';
+   }
 }

--- a/jcache/tck-runner-remote/src/test/resources/hotrod-client.properties
+++ b/jcache/tck-runner-remote/src/test/resources/hotrod-client.properties
@@ -1,2 +1,4 @@
 infinispan.client.hotrod.server_list=127.0.0.1:11222
+# Needed because jboss-marshalling is on the classpath
+infinispan.client.hotrod.marshaller = org.infinispan.commons.marshall.ProtoStreamMarshaller
 infinispan.client.hotrod.context-initializers=org.infinispan.jcache.tck.JCacheTckContextInitializer

--- a/server/core/src/main/java/org/infinispan/server/core/LifecycleCallbacks.java
+++ b/server/core/src/main/java/org/infinispan/server/core/LifecycleCallbacks.java
@@ -18,7 +18,6 @@ import org.infinispan.marshall.core.EncoderRegistry;
 import org.infinispan.marshall.protostream.impl.SerializationContextRegistry;
 import org.infinispan.registry.InternalCacheRegistry;
 import org.infinispan.server.core.dataconversion.JBossMarshallingTranscoder;
-import org.infinispan.server.core.dataconversion.JavaSerializationTranscoder;
 import org.infinispan.server.core.dataconversion.JsonTranscoder;
 import org.infinispan.server.core.dataconversion.XMLTranscoder;
 
@@ -53,7 +52,6 @@ public class LifecycleCallbacks implements ModuleLifecycle {
 
       encoderRegistry.registerTranscoder(jsonTranscoder);
       encoderRegistry.registerTranscoder(new XMLTranscoder(classLoader, classWhiteList));
-      encoderRegistry.registerTranscoder(new JavaSerializationTranscoder(classWhiteList));
 
       if (jbossMarshaller != null) {
          encoderRegistry.registerTranscoder(new JBossMarshallingTranscoder(jsonTranscoder, jbossMarshaller));

--- a/server/core/src/main/java/org/infinispan/server/core/LifecycleCallbacks.java
+++ b/server/core/src/main/java/org/infinispan/server/core/LifecycleCallbacks.java
@@ -3,12 +3,12 @@ package org.infinispan.server.core;
 import java.util.EnumSet;
 
 import org.infinispan.commons.configuration.ClassWhiteList;
-import org.infinispan.commons.dataconversion.BinaryTranscoder;
-import org.infinispan.commons.marshall.Marshaller;
-import org.infinispan.commons.util.Util;
+import org.infinispan.commons.dataconversion.MediaType;
+import org.infinispan.commons.dataconversion.Transcoder;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfiguration;
+import org.infinispan.encoding.impl.TwoStepTranscoder;
 import org.infinispan.factories.GlobalComponentRegistry;
 import org.infinispan.factories.annotations.InfinispanModule;
 import org.infinispan.factories.impl.BasicComponentRegistry;
@@ -17,18 +17,16 @@ import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.marshall.core.EncoderRegistry;
 import org.infinispan.marshall.protostream.impl.SerializationContextRegistry;
 import org.infinispan.registry.InternalCacheRegistry;
-import org.infinispan.server.core.dataconversion.JBossMarshallingTranscoder;
 import org.infinispan.server.core.dataconversion.JsonTranscoder;
 import org.infinispan.server.core.dataconversion.XMLTranscoder;
 
 /**
- * Module lifecycle callbacks implementation that enables module specific
- * {@link org.infinispan.commons.marshall.AdvancedExternalizer} implementations to be registered.
+ * Server module lifecycle callbacks
  *
  * @author Galder Zamarreño
  * @since 5.0
  */
-@InfinispanModule(name = "server-core", requiredModules = "core")
+@InfinispanModule(name = "server-core", requiredModules = "core", optionalModules = "jboss-marshalling")
 public class LifecycleCallbacks implements ModuleLifecycle {
 
    static final String SERVER_STATE_CACHE = "org.infinispan.SERVER_STATE";
@@ -45,7 +43,6 @@ public class LifecycleCallbacks implements ModuleLifecycle {
 
       ClassWhiteList classWhiteList = gcr.getComponent(EmbeddedCacheManager.class).getClassWhiteList();
       ClassLoader classLoader = globalConfiguration.classLoader();
-      Marshaller jbossMarshaller = Util.getJBossMarshaller(classLoader, classWhiteList);
 
       EncoderRegistry encoderRegistry = gcr.getComponent(EncoderRegistry.class);
       JsonTranscoder jsonTranscoder = new JsonTranscoder(classLoader, classWhiteList);
@@ -53,10 +50,11 @@ public class LifecycleCallbacks implements ModuleLifecycle {
       encoderRegistry.registerTranscoder(jsonTranscoder);
       encoderRegistry.registerTranscoder(new XMLTranscoder(classLoader, classWhiteList));
 
-      if (jbossMarshaller != null) {
-         encoderRegistry.registerTranscoder(new JBossMarshallingTranscoder(jsonTranscoder, jbossMarshaller));
-         BinaryTranscoder transcoder = encoderRegistry.getTranscoder(BinaryTranscoder.class);
-         transcoder.overrideMarshaller(jbossMarshaller);
+      // Allow transcoding between JBoss Marshalling and JSON
+      if (encoderRegistry.isConversionSupported(MediaType.APPLICATION_OBJECT, MediaType.APPLICATION_JBOSS_MARSHALLING)) {
+         Transcoder jbossMarshallingTranscoder =
+               encoderRegistry.getTranscoder(MediaType.APPLICATION_OBJECT, MediaType.APPLICATION_JBOSS_MARSHALLING);
+         encoderRegistry.registerTranscoder(new TwoStepTranscoder(jbossMarshallingTranscoder, jsonTranscoder));
       }
    }
 


### PR DESCRIPTION
ISPN-11898 Missing transcoder for user marshaller's media type
https://issues.redhat.com/browse/ISPN-11898

ISPN-11899 application/x-java-serialized-object without custom marshaller
https://issues.redhat.com/browse/ISPN-11899

ISPN-11900 jboss-marshalling module missing application/x-jboss-marshalling transcoder
https://issues.redhat.com/browse/ISPN-11900

ISPN-11901 Deprecate unused encoders and media types
https://issues.redhat.com/browse/ISPN-11901

ISPN-11926 Remote JCacheManager creates two RemoteCacheManager instances
https://issues.redhat.com/browse/ISPN-11926

ISPN-11932 JCache remote events do not work with ProtostreamMarshaller
https://issues.redhat.com/browse/ISPN-11932

ISPN-11910 Server should see application/octet-stream as protostream
https://issues.redhat.com/browse/ISPN-11900
