### PR TITLE
JDG-2386 Verify getBulk methods in the Infinispan server

### DIFF
--- a/server/tests/pom.xml
+++ b/server/tests/pom.xml
@@ -20,6 +20,7 @@
       <defaultExcludedTestGroup/>
       <org.infinispan.test.server.dir>${project.basedir}/../runtime/target/${infinispan.brand.prefix}-server-${infinispan.brand.version}</org.infinispan.test.server.dir>
       <org.infinispan.test.server.lib.dir>${project.build.directory}/testlibs</org.infinispan.test.server.lib.dir>
+      <version.infinispan.backward.compatibility.test>9.4.19.Final</version.infinispan.backward.compatibility.test>
    </properties>
 
    <dependencies>
@@ -144,6 +145,37 @@
                   <artifactId>maven-surefire-plugin</artifactId>
                   <configuration>
                      <argLine>${container.argLine}</argLine>
+                  </configuration>
+               </plugin>
+            </plugins>
+         </build>
+      </profile>
+      <profile>
+         <id>backward-compatibility</id>
+         <activation>
+            <activeByDefault>false</activeByDefault>
+         </activation>
+         <dependencies>
+            <dependency>
+               <groupId>org.infinispan</groupId>
+               <artifactId>infinispan-client-hotrod</artifactId>
+               <version>${version.infinispan.backward.compatibility.test}</version>
+            </dependency>
+            <dependency>
+               <groupId>org.infinispan</groupId>
+               <artifactId>infinispan-commons</artifactId>
+               <version>${version.infinispan.backward.compatibility.test}</version>
+            </dependency>
+         </dependencies>
+         <build>
+            <plugins>
+               <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-compiler-plugin</artifactId>
+                  <configuration>
+                     <testIncludes>
+                        <testInclude>org/infinispan/server/backwardcompatibility/**</testInclude>
+                     </testIncludes>
                   </configuration>
                </plugin>
             </plugins>

--- a/server/tests/src/test/java/org/infinispan/server/backwardcompatibility/BackwardCompatibilityIT.java
+++ b/server/tests/src/test/java/org/infinispan/server/backwardcompatibility/BackwardCompatibilityIT.java
@@ -1,0 +1,27 @@
+package org.infinispan.server.backwardcompatibility;
+
+/**
+ * @author Gustavo Lira &lt;glira@redhat.com&gt;
+ * @since 11.0
+ **/
+
+import org.infinispan.server.test.core.ServerRunMode;
+import org.infinispan.server.test.junit4.InfinispanServerRule;
+import org.infinispan.server.test.junit4.InfinispanServerRuleBuilder;
+import org.junit.ClassRule;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+      HotrodClientBackwardCompatibility.class
+})
+public class BackwardCompatibilityIT {
+
+   @ClassRule
+   public static InfinispanServerRule SERVERS =
+         InfinispanServerRuleBuilder.config("configuration/ClusteredServerTest.xml")
+               .runMode(ServerRunMode.FORKED)
+               .numServers(1)
+               .build();
+}

--- a/server/tests/src/test/java/org/infinispan/server/backwardcompatibility/HotrodClientBackwardCompatibility.java
+++ b/server/tests/src/test/java/org/infinispan/server/backwardcompatibility/HotrodClientBackwardCompatibility.java
@@ -1,0 +1,69 @@
+package org.infinispan.server.backwardcompatibility;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.server.test.core.category.Compatibility;
+import org.infinispan.server.test.junit4.InfinispanServerRule;
+import org.infinispan.server.test.junit4.InfinispanServerTestMethodRule;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * @author Gustavo Lira &lt;glira@redhat.com&gt;
+ * @since 11.0
+ * https://issues.redhat.com/browse/JDG-2386
+ */
+
+@Category(Compatibility.class)
+public class HotrodClientBackwardCompatibility {
+
+   private static final int TOTAL_ENTRIES = 5;
+   private static final Integer ISPN_9 = 9;
+
+   @ClassRule
+   public static InfinispanServerRule SERVERS = BackwardCompatibilityIT.SERVERS;
+
+   @Rule
+   public InfinispanServerTestMethodRule SERVER_TEST = new InfinispanServerTestMethodRule(SERVERS);
+
+   @Test
+   public void getBulkTestCompatibility() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+      // This is a backward compatibility test which should only run with and older client
+      assumeTrue(getHotrodClientVersion() <= ISPN_9);
+      RemoteCache<String, String> remoteCache = SERVER_TEST.hotrod().create();
+
+      Map<String, String> map = new HashMap<>();
+      IntStream.rangeClosed(1, TOTAL_ENTRIES).forEach(i -> map.put("key" + i, "value" + i));
+      remoteCache.putAll(map);
+      //Using reflection to avoid IDE complain about missing method
+      Method getBulkMethod = remoteCache.getClass().getDeclaredMethod("getBulk");
+      Map<String, String> bulk = (Map<String, String>) getBulkMethod.invoke(remoteCache);
+
+      IntStream.rangeClosed(1, TOTAL_ENTRIES).forEach(i -> {
+         assertTrue(bulk.containsKey("key" + i));
+         assertTrue(bulk.containsValue("value" + i));
+      });
+
+      Assert.assertEquals(TOTAL_ENTRIES, bulk.size());
+
+      Method getBulkMethodWithSize = remoteCache.getClass().getDeclaredMethod("getBulk", int.class);
+      Map<String, String> bulk2 = (Map<String, String>) getBulkMethodWithSize.invoke(remoteCache, 2);
+      Assert.assertEquals(2, bulk2.size());
+   }
+
+   private int getHotrodClientVersion() {
+      String fullVersion = RemoteCache.class.getPackage().getImplementationVersion();
+      return Integer.parseInt(fullVersion.substring(0, fullVersion.indexOf(".")));
+   }
+}

--- a/server/tests/src/test/java/org/infinispan/server/test/core/category/Compatibility.java
+++ b/server/tests/src/test/java/org/infinispan/server/test/core/category/Compatibility.java
@@ -1,0 +1,8 @@
+package org.infinispan.server.test.core.category;
+
+/**
+ * @author Gustavo Lira &lt;glira@redhat.com&gt;
+ * @since 10.0
+ **/
+public class Compatibility {
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/JDG-2386
* Was needed to create a new maven profile to set an older version of hotrod client
* All other related tests was excluded from the compilation to avoid some errors
* Used reflection into the test to get "getBulk" method, it was needed to avoid IDE compilation error
* The test is run on a different category (Compatibility)
* Currently this test can only run using `ServerRunMode.FORKED`, `EMBEDDED` or `CONTAINER` are using some new methods from `infinispan-commons` which I will not have using older versions, that's why Forked mode was used in this scenario