### PR TITLE
ISPN-11922 Upgrade org.reactivestreams:reactive-streams to 1.0.3

### DIFF
--- a/build-configuration/pom.xml
+++ b/build-configuration/pom.xml
@@ -183,9 +183,9 @@
       <version.picketlink>2.5.5.SP12</version.picketlink>
       <version.protostream>4.3.2.Final</version.protostream>
       <version.protostuff>1.6.2</version.protostuff>
-      <version.reactivestreams>1.0.2</version.reactivestreams>
+      <version.reactivestreams>1.0.3</version.reactivestreams>
       <version.rocksdb>6.5.3</version.rocksdb>
-      <version.rxjava>3.0.2</version.rxjava>
+      <version.rxjava>3.0.4</version.rxjava>
       <version.smallrye-config>1.6.2</version.smallrye-config>
       <version.smallrye-metrics>2.4.0</version.smallrye-metrics>
       <version.microprofile-config-api>1.4</version.microprofile-config-api>

--- a/client/infinispan-key-value-store-hotrod/pom.xml
+++ b/client/infinispan-key-value-store-hotrod/pom.xml
@@ -33,11 +33,6 @@
          <artifactId>infinispan-remote-query-client</artifactId>
       </dependency>
 
-      <dependency>
-         <groupId>org.reactivestreams</groupId>
-         <artifactId>reactive-streams-flow-adapters</artifactId>
-      </dependency>
-
       <!-- Test dependencies -->
       <dependency>
          <groupId>org.testng</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1538,11 +1538,6 @@
             <version>${versionx.org.reactivestreams.reactive-streams}</version>
          </dependency>
          <dependency>
-            <groupId>org.reactivestreams</groupId>
-            <artifactId>reactive-streams-flow-adapters</artifactId>
-            <version>${versionx.org.reactivestreams.reactive-streams}</version>
-         </dependency>
-         <dependency>
             <groupId>org.rocksdb</groupId>
             <artifactId>rocksdbjni</artifactId>
             <version>${versionx.org.rocksdb.rocksdbjni}</version>


### PR DESCRIPTION
Set the same version as used by rxjava3. 

https://issues.redhat.com/browse/ISPN-11922