### PR TITLE
[9.4.x] ISPN-11923 Another node leaving may break SingleFileStore

### DIFF
--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
@@ -1345,7 +1345,7 @@ public class JGroupsTransport implements Transport {
             invocationHandler.handleFromCluster(fromJGroupsAddress(src), command, reply, deliverOrder);
          }
       } catch (Throwable t) {
-         log.errorProcessingRequest(requestId, src);
+         log.errorProcessingRequest(requestId, src, t);
          Exception e = t instanceof Exception ? ((Exception) t) : new CacheException(t);
          sendResponse(src, new ExceptionResponse(e), requestId, null);
       }
@@ -1368,7 +1368,7 @@ public class JGroupsTransport implements Transport {
          Address address = fromJGroupsAddress(src);
          requests.addResponse(requestId, address, response);
       } catch (Throwable t) {
-         log.errorProcessingResponse(requestId, src);
+         log.errorProcessingResponse(requestId, src, t);
       }
    }
 

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -1631,11 +1631,11 @@ public interface Log extends BasicLogger {
 
    @LogMessage(level = ERROR)
    @Message(value = "Error processing request %d@%s", id = 474)
-   void errorProcessingRequest(long requestId, org.jgroups.Address origin);
+   void errorProcessingRequest(long requestId, org.jgroups.Address origin, @Cause Throwable t);
 
    @LogMessage(level = ERROR)
    @Message(value = "Error processing response for request %d from %s", id = 475)
-   void errorProcessingResponse(long requestId, org.jgroups.Address sender);
+   void errorProcessingResponse(long requestId, org.jgroups.Address sender, @Cause Throwable t);
 
    @Message(value = "Timed out waiting for responses for request %d from %s", id = 476)
    TimeoutException requestTimedOut(long requestId, String targetsWithoutResponses);


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-11923

Use `Future.cancel(false)` to avoid an `InterruptedIOException` closing `SingleFileStore`'s `FileChannel`.