### PR TITLE
Rest resource changes

### DIFF
--- a/server/rest/src/main/java/org/infinispan/rest/resources/JsonErrorResponseEntity.java
+++ b/server/rest/src/main/java/org/infinispan/rest/resources/JsonErrorResponseEntity.java
@@ -1,0 +1,38 @@
+package org.infinispan.rest.resources;
+
+import static org.infinispan.query.remote.json.JSONConstants.CAUSE;
+import static org.infinispan.query.remote.json.JSONConstants.ERROR;
+import static org.infinispan.query.remote.json.JSONConstants.MESSAGE;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+@JsonPropertyOrder({MESSAGE, CAUSE})
+@JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)
+@JsonTypeName(ERROR)
+class JsonErrorResponseEntity {
+
+   @JsonProperty(MESSAGE)
+   private String message;
+
+   @JsonProperty(CAUSE)
+   private String cause;
+
+   public JsonErrorResponseEntity(String message, String cause) {
+      this.message = message;
+      this.cause = cause;
+   }
+
+   public JsonErrorResponseEntity() {
+   }
+
+   public String getMessage() {
+      return message;
+   }
+
+   public String getCause() {
+      return cause;
+   }
+}

--- a/server/rest/src/main/java/org/infinispan/rest/resources/LoginResource.java
+++ b/server/rest/src/main/java/org/infinispan/rest/resources/LoginResource.java
@@ -1,8 +1,7 @@
 package org.infinispan.rest.resources;
 
-import static io.netty.handler.codec.http.HttpResponseStatus.OK;
-import static org.infinispan.commons.dataconversion.MediaType.APPLICATION_JSON;
 import static org.infinispan.rest.framework.Method.GET;
+import static org.infinispan.rest.resources.ResourceUtil.asJsonResponseFuture;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -14,8 +13,6 @@ import org.infinispan.rest.framework.ResourceHandler;
 import org.infinispan.rest.framework.RestRequest;
 import org.infinispan.rest.framework.RestResponse;
 import org.infinispan.rest.framework.impl.Invocations;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
 
@@ -42,15 +39,8 @@ public class LoginResource implements ResourceHandler {
    }
 
    private CompletionStage<RestResponse> loginConfiguration(RestRequest restRequest) {
-      NettyRestResponse.Builder responseBuilder = new NettyRestResponse.Builder();
       Map<String, String> loginConfiguration = invocationHelper.getServer().getLoginConfiguration();
-      try {
-         byte[] bytes = invocationHelper.getMapper().writeValueAsBytes(loginConfiguration);
-         responseBuilder.contentType(APPLICATION_JSON).entity(bytes).status(OK);
-      } catch (JsonProcessingException e) {
-         responseBuilder.status(HttpResponseStatus.INTERNAL_SERVER_ERROR);
-      }
-      return CompletableFuture.completedFuture(responseBuilder.build());
+      return asJsonResponseFuture(loginConfiguration, invocationHelper);
    }
 
    private CompletionStage<RestResponse> login(RestRequest restRequest) {

--- a/server/rest/src/main/java/org/infinispan/rest/resources/ResourceUtil.java
+++ b/server/rest/src/main/java/org/infinispan/rest/resources/ResourceUtil.java
@@ -1,0 +1,71 @@
+package org.infinispan.rest.resources;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.infinispan.commons.dataconversion.MediaType.APPLICATION_JSON;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.infinispan.rest.InvocationHelper;
+import org.infinispan.rest.NettyRestResponse;
+import org.infinispan.rest.framework.RestResponse;
+import org.infinispan.rest.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.netty.handler.codec.http.HttpResponseStatus;
+
+/**
+ * Util class for REST resources.
+ *
+ * @author Ryan Emerson
+ * @since 11.0
+ */
+class ResourceUtil {
+   private final static Log logger = LogFactory.getLog(ResourceUtil.class, Log.class);
+
+   static CompletableFuture<RestResponse> notFoundResponseFuture() {
+      return CompletableFuture.completedFuture(
+            new NettyRestResponse.Builder()
+                  .status(HttpResponseStatus.NOT_FOUND)
+                  .build()
+      );
+   }
+
+   static RestResponse asJsonResponse(Object o, InvocationHelper invocationHelper) {
+      return addEntityAsJson(o, new NettyRestResponse.Builder(), invocationHelper).build();
+   }
+
+   static CompletableFuture<RestResponse> asJsonResponseFuture(Object o, InvocationHelper invocationHelper) {
+      return completedFuture(asJsonResponse(o, invocationHelper));
+   }
+
+   static CompletableFuture<RestResponse> asJsonResponseFuture(Object o, NettyRestResponse.Builder responseBuilder, InvocationHelper invocationHelper) {
+      RestResponse response = addEntityAsJson(o, responseBuilder, invocationHelper).build();
+      return completedFuture(response);
+   }
+
+   static NettyRestResponse.Builder addEntityAsJson(Object o, NettyRestResponse.Builder responseBuilder, InvocationHelper invocationHelper) {
+      responseBuilder.contentType(APPLICATION_JSON);
+      ObjectMapper mapper = invocationHelper.getMapper();
+      try {
+         byte[] bytes = mapper.writeValueAsBytes(o);
+         return responseBuilder.entity(bytes).status(OK);
+      } catch (JsonProcessingException e) {
+         logger.error(e);
+         Object entity = createJsonErrorResponse(mapper, e);
+         return responseBuilder.status(HttpResponseStatus.INTERNAL_SERVER_ERROR).entity(entity);
+      }
+   }
+
+   private static Object createJsonErrorResponse(ObjectMapper mapper, JsonProcessingException e) {
+      try {
+         return mapper.writeValueAsBytes(new JsonErrorResponseEntity("Unable to convert response object to json", e.getMessage()));
+      } catch (JsonProcessingException jpe) {
+         logger.error(jpe);
+         return jpe.getMessage();
+      }
+   }
+}

--- a/server/rest/src/main/java/org/infinispan/rest/resources/SearchAdminResource.java
+++ b/server/rest/src/main/java/org/infinispan/rest/resources/SearchAdminResource.java
@@ -4,8 +4,8 @@ import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static java.util.concurrent.CompletableFuture.completedFuture;
-import static org.infinispan.commons.dataconversion.MediaType.APPLICATION_JSON;
 import static org.infinispan.rest.framework.Method.GET;
+import static org.infinispan.rest.resources.ResourceUtil.asJsonResponseFuture;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -26,8 +26,6 @@ import org.infinispan.rest.framework.RestResponse;
 import org.infinispan.rest.framework.impl.Invocations;
 import org.infinispan.rest.logging.Log;
 import org.infinispan.util.logging.LogFactory;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
 
@@ -130,13 +128,7 @@ public class SearchAdminResource implements ResourceHandler {
       InfinispanQueryStatisticsInfo searchStats = lookupQueryStatistics(request, responseBuilder);
       if (searchStats == null) return completedFuture(responseBuilder.build());
 
-      try {
-         byte[] bytes = invocationHelper.getMapper().writeValueAsBytes(statExtractor.apply(searchStats));
-         responseBuilder.contentType(APPLICATION_JSON).entity(bytes).status(OK);
-      } catch (JsonProcessingException e) {
-         responseBuilder.status(HttpResponseStatus.INTERNAL_SERVER_ERROR);
-      }
-      return completedFuture(responseBuilder.build());
+      return asJsonResponseFuture(statExtractor.apply(searchStats), responseBuilder, invocationHelper);
    }
 
    private AdvancedCache<?, ?> lookupIndexedCache(RestRequest request, NettyRestResponse.Builder builder) {

--- a/server/rest/src/main/java/org/infinispan/rest/resources/ServerResource.java
+++ b/server/rest/src/main/java/org/infinispan/rest/resources/ServerResource.java
@@ -11,7 +11,6 @@ import static org.infinispan.rest.framework.Method.DELETE;
 import static org.infinispan.rest.framework.Method.GET;
 import static org.infinispan.rest.framework.Method.POST;
 
-import java.lang.management.ManagementFactory;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Set;
@@ -112,7 +111,7 @@ public class ServerResource implements ResourceHandler {
    }
 
    private CompletionStage<RestResponse> env(RestRequest restRequest) {
-      return serializeObject(ManagementFactory.getRuntimeMXBean().getSystemProperties());
+      return serializeObject(System.getProperties());
    }
 
    private CompletionStage<RestResponse> info(RestRequest restRequest) {

--- a/server/rest/src/main/java/org/infinispan/rest/resources/TasksResource.java
+++ b/server/rest/src/main/java/org/infinispan/rest/resources/TasksResource.java
@@ -2,15 +2,18 @@ package org.infinispan.rest.resources;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.infinispan.commons.dataconversion.MediaType.APPLICATION_JAVASCRIPT;
-import static org.infinispan.commons.dataconversion.MediaType.APPLICATION_JSON_TYPE;
 import static org.infinispan.commons.dataconversion.MediaType.TEXT_PLAIN_TYPE;
 import static org.infinispan.rest.framework.Method.GET;
 import static org.infinispan.rest.framework.Method.POST;
 import static org.infinispan.rest.framework.Method.PUT;
+import static org.infinispan.rest.resources.ResourceUtil.addEntityAsJson;
+import static org.infinispan.rest.resources.ResourceUtil.asJsonResponseFuture;
 
 import java.security.PrivilegedAction;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
+
+import javax.security.auth.Subject;
 
 import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.commons.dataconversion.StandardConversions;
@@ -26,12 +29,6 @@ import org.infinispan.scripting.ScriptingManager;
 import org.infinispan.tasks.Task;
 import org.infinispan.tasks.TaskContext;
 import org.infinispan.tasks.TaskManager;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-
-import io.netty.handler.codec.http.HttpResponseStatus;
-
-import javax.security.auth.Subject;
 
 /**
  * @since 10.1
@@ -58,15 +55,8 @@ public class TasksResource implements ResourceHandler {
 
       EmbeddedCacheManager cacheManager = invocationHelper.getRestCacheManager().getInstance();
       TaskManager taskManager = SecurityActions.getGlobalComponentRegistry(cacheManager).getComponent(TaskManager.class);
-      NettyRestResponse.Builder builder = new NettyRestResponse.Builder();
-      try {
-         List<Task> tasks = userOnly ? taskManager.getUserTasks() : taskManager.getTasks();
-         byte[] resultBytes = invocationHelper.getMapper().writeValueAsBytes(tasks);
-         builder.contentType(APPLICATION_JSON_TYPE).entity(resultBytes);
-      } catch (JsonProcessingException e) {
-         builder.status(HttpResponseStatus.INTERNAL_SERVER_ERROR).entity(e.getMessage());
-      }
-      return completedFuture(builder.build());
+      List<Task> tasks = userOnly ? taskManager.getUserTasks() : taskManager.getTasks();
+      return asJsonResponseFuture(tasks, invocationHelper);
    }
 
    private CompletionStage<RestResponse> createScriptTask(RestRequest request) {
@@ -101,15 +91,10 @@ public class TasksResource implements ResourceHandler {
 
       return runResult.thenApply(result -> {
          NettyRestResponse.Builder builder = new NettyRestResponse.Builder();
-         try {
-            if (result instanceof byte[]) {
-               builder.contentType(TEXT_PLAIN_TYPE).entity(result);
-            } else {
-               byte[] resultBytes = invocationHelper.getMapper().writeValueAsBytes(result);
-               builder.contentType(APPLICATION_JSON_TYPE).entity(resultBytes);
-            }
-         } catch (JsonProcessingException e) {
-            builder.status(HttpResponseStatus.INTERNAL_SERVER_ERROR).entity(e.getMessage());
+         if (result instanceof byte[]) {
+            builder.contentType(TEXT_PLAIN_TYPE).entity(result);
+         } else {
+            addEntityAsJson(result, builder, invocationHelper);
          }
          return builder.build();
       });


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-11927
https://issues.redhat.com/browse/ISPN-11928
https://issues.redhat.com/browse/ISPN-11934
https://issues.redhat.com/browse/ISPN-11935

@gustavonalle Most of these changes are to benefit the quarkus native server. ISPN-11935 reduces repetition, but also it makes it so that JSON transformations are consistent. It's necessary to register all of the classes that Jackson needs to access for reflection with Quarkus, however in lots of the resources the returned 500 message did not contain the message of the exception thrown making it impossible to know why the server throw a 500. So I have centralised this logic and made it so that the exception message is returned in the response body as well output to the server log. 