### PR TITLE
ISPN-10373 Rework put map and simplify batch

### DIFF
--- a/commons/all/src/main/java/org/infinispan/commons/util/ByRef.java
+++ b/commons/all/src/main/java/org/infinispan/commons/util/ByRef.java
@@ -63,6 +63,33 @@ public class ByRef<T> {
       public void inc() {
          ref++;
       }
+
+      public void dec() {
+         ref--;
+      }
    }
 
+   public static class Long {
+      long ref;
+
+      public Long(int i) {
+         ref = i;
+      }
+
+      public long get() {
+         return ref;
+      }
+
+      public void set(long i) {
+         ref = i;
+      }
+
+      public void inc() {
+         ref++;
+      }
+
+      public void dec() {
+         ref--;
+      }
+   }
 }

--- a/core/src/main/java/org/infinispan/eviction/impl/PassivationManagerImpl.java
+++ b/core/src/main/java/org/infinispan/eviction/impl/PassivationManagerImpl.java
@@ -1,7 +1,7 @@
 package org.infinispan.eviction.impl;
 
 import static org.infinispan.commons.util.Util.toStr;
-import static org.infinispan.persistence.manager.PersistenceManager.AccessMode.BOTH;
+import static org.infinispan.persistence.manager.PersistenceManager.AccessMode.PRIVATE;
 import static org.infinispan.util.logging.Log.CONTAINER;
 
 import java.util.concurrent.CompletionStage;
@@ -119,7 +119,7 @@ public class PassivationManagerImpl extends AbstractPassivationManager {
 
       int count = container.sizeIncludingExpired();
       Iterable<MarshallableEntry<Object, Object>> iterable = () -> new IteratorMapper<>(container.iterator(), e -> marshalledEntryFactory.create((InternalCacheEntry) e));
-      return persistenceManager.writeBatchToAllNonTxStores(iterable, BOTH, 0)
+      return persistenceManager.writeEntries(iterable, PRIVATE)
                                .thenRun(() -> {
                                   long durationMillis = timeService.timeDuration(start, TimeUnit.MILLISECONDS);
                                   if (CONTAINER.isDebugEnabled()) {

--- a/core/src/main/java/org/infinispan/interceptors/impl/DistCacheWriterInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/DistCacheWriterInterceptor.java
@@ -19,7 +19,6 @@ import org.infinispan.distribution.DistributionInfo;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.util.concurrent.CompletableFutures;
-import org.infinispan.util.concurrent.CompletionStages;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -80,14 +79,13 @@ public class DistCacheWriterInterceptor extends CacheWriterInterceptor {
       return invokeNextThenApply(ctx, command, handlePutMapCommandReturn);
    }
 
-   @Override
-   protected Object handlePutMapCommandReturn(InvocationContext rCtx, PutMapCommand cmd, Object rv) {
-      CompletionStage<Void> writeStage = CompletionStages.allOf(
-            processIterableBatch(rCtx, cmd, BOTH, key -> !skipNonPrimary(rCtx, key, cmd) && isProperWriter(rCtx, cmd, key) &&
-                  !skipSharedStores(rCtx, key, cmd)),
-            processIterableBatch(rCtx, cmd, PRIVATE, key -> !skipNonPrimary(rCtx, key, cmd) && isProperWriter(rCtx, cmd, key) &&
-                  skipSharedStores(rCtx, key, cmd)));
-      return delayedValue(writeStage, rv);
+   protected Object handlePutMapCommandReturn(InvocationContext rCtx, PutMapCommand putMapCommand, Object rv) {
+      CompletionStage<Long> putMapStage = persistenceManager.writeMapCommand(putMapCommand, rCtx,
+            ((writeCommand, key) -> !skipNonPrimary(rCtx, key, writeCommand) && isProperWriter(rCtx, writeCommand, key)));
+      if (getStatisticsEnabled()) {
+         putMapStage.thenAccept(cacheStores::getAndAdd);
+      }
+      return delayedValue(putMapStage, rv);
    }
 
    private boolean skipNonPrimary(InvocationContext rCtx, Object key, PutMapCommand command) {

--- a/core/src/main/java/org/infinispan/persistence/manager/PersistenceManagerStub.java
+++ b/core/src/main/java/org/infinispan/persistence/manager/PersistenceManagerStub.java
@@ -8,9 +8,11 @@ import java.util.concurrent.CompletionStage;
 import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 
+import org.infinispan.commands.write.PutMapCommand;
 import org.infinispan.commands.write.WriteCommand;
 import org.infinispan.commons.util.IntSet;
 import org.infinispan.configuration.cache.StoreConfiguration;
+import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.factories.annotations.Start;
 import org.infinispan.factories.annotations.Stop;
@@ -157,12 +159,17 @@ public class PersistenceManagerStub implements PersistenceManager {
    }
 
    @Override
-   public <K, V> CompletionStage<Void> writeBatchToAllNonTxStores(Iterable<MarshallableEntry<K, V>> entries, Predicate<? super StoreConfiguration> predicate, long flags) {
+   public CompletionStage<Long> performBatch(TxInvocationContext<AbstractCacheTransaction> invocationContext, BiPredicate<? super WriteCommand, Object> commandKeyPredicate) {
       return CompletableFutures.completedNull();
    }
 
    @Override
-   public CompletionStage<Long> performBatch(TxInvocationContext<AbstractCacheTransaction> invocationContext, BiPredicate<WriteCommand, Object> commandKeyPredicate) {
+   public <K, V> CompletionStage<Void> writeEntries(Iterable<MarshallableEntry<K, V>> iterable, Predicate<? super StoreConfiguration> predicate) {
+      return CompletableFutures.completedNull();
+   }
+
+   @Override
+   public CompletionStage<Long> writeMapCommand(PutMapCommand putMapCommand, InvocationContext ctx, BiPredicate<? super PutMapCommand, Object> commandKeyPredicate) {
       return CompletableFutures.completedNull();
    }
 

--- a/core/src/main/java/org/infinispan/persistence/support/DelegatingPersistenceManager.java
+++ b/core/src/main/java/org/infinispan/persistence/support/DelegatingPersistenceManager.java
@@ -6,10 +6,12 @@ import java.util.concurrent.CompletionStage;
 import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 
+import org.infinispan.commands.write.PutMapCommand;
 import org.infinispan.commands.write.WriteCommand;
 import org.infinispan.commons.api.Lifecycle;
 import org.infinispan.commons.util.IntSet;
 import org.infinispan.configuration.cache.StoreConfiguration;
+import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.factories.annotations.Inject;
@@ -172,14 +174,20 @@ public class DelegatingPersistenceManager implements PersistenceManager, Lifecyc
    }
 
    @Override
-   public <K, V> CompletionStage<Void> writeBatchToAllNonTxStores(Iterable<MarshallableEntry<K, V>> entries,
-                                                           Predicate<? super StoreConfiguration> predicate, long flags) {
-      return persistenceManager.writeBatchToAllNonTxStores(entries, predicate, flags);
+   public CompletionStage<Long> writeMapCommand(PutMapCommand putMapCommand, InvocationContext ctx,
+         BiPredicate<? super PutMapCommand, Object> commandKeyPredicate) {
+      return persistenceManager.writeMapCommand(putMapCommand, ctx, commandKeyPredicate);
+   }
+
+   @Override
+   public <K, V> CompletionStage<Void> writeEntries(Iterable<MarshallableEntry<K, V>> iterable,
+         Predicate<? super StoreConfiguration> predicate) {
+      return persistenceManager.writeEntries(iterable, predicate);
    }
 
    @Override
    public CompletionStage<Long> performBatch(TxInvocationContext<AbstractCacheTransaction> invocationContext,
-         BiPredicate<WriteCommand, Object> commandKeyPredicate) {
+         BiPredicate<? super WriteCommand, Object> commandKeyPredicate) {
       return persistenceManager.performBatch(invocationContext, commandKeyPredicate);
    }
 

--- a/core/src/test/java/org/infinispan/distribution/BaseDistStoreTest.java
+++ b/core/src/test/java/org/infinispan/distribution/BaseDistStoreTest.java
@@ -5,6 +5,9 @@ import static org.testng.AssertJUnit.assertEquals;
 import org.infinispan.Cache;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.StoreConfigurationBuilder;
+import org.infinispan.interceptors.impl.CacheWriterInterceptor;
+import org.infinispan.interceptors.impl.DistCacheWriterInterceptor;
+import org.infinispan.interceptors.impl.ScatteredCacheWriterInterceptor;
 import org.infinispan.persistence.dummy.DummyInMemoryStore;
 import org.infinispan.persistence.dummy.DummyInMemoryStoreConfigurationBuilder;
 import org.infinispan.test.TestingUtil;
@@ -74,5 +77,18 @@ public abstract class BaseDistStoreTest<K, V, C extends BaseDistStoreTest> exten
    protected void clearStats(Cache<?, ?> cache) {
       DummyInMemoryStore store = TestingUtil.getFirstStore(cache);
       store.clearStats();
+
+      CacheWriterInterceptor cacheWriterInterceptor = getCacheWriterInterceptor(cache);
+      if (cacheWriterInterceptor != null) {
+         cacheWriterInterceptor.resetStatistics();
+      }
+   }
+
+   protected CacheWriterInterceptor getCacheWriterInterceptor(Cache<?, ?> cache) {
+      CacheWriterInterceptor cacheWriterInterceptor = TestingUtil.extractComponent(cache, DistCacheWriterInterceptor.class);
+      if (cacheWriterInterceptor == null) {
+         cacheWriterInterceptor = TestingUtil.extractComponent(cache, ScatteredCacheWriterInterceptor.class);
+      }
+      return cacheWriterInterceptor;
    }
 }

--- a/core/src/test/java/org/infinispan/persistence/BaseStoreFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/persistence/BaseStoreFunctionalTest.java
@@ -42,7 +42,6 @@ import org.infinispan.test.TestingUtil;
 import org.infinispan.test.data.Person;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.transaction.TransactionMode;
-import org.infinispan.util.concurrent.CompletableFutures;
 import org.infinispan.util.concurrent.CompletionStages;
 import org.testng.annotations.Test;
 
@@ -337,10 +336,10 @@ public abstract class BaseStoreFunctionalTest extends SingleCacheManagerTest {
       }
 
       @Override
-      public <K, V> CompletionStage<Void> writeBatchToAllNonTxStores(Iterable<MarshallableEntry<K, V>> entries,
-                                                              Predicate<? super StoreConfiguration> predicate, long flags) {
+      public <K, V> CompletionStage<Void> writeEntries(Iterable<MarshallableEntry<K, V>> iterable,
+            Predicate<? super StoreConfiguration> predicate) {
          passivate.set(true);
-         return CompletableFutures.completedNull();
+         return super.writeEntries(iterable, predicate);
       }
    }
 }

--- a/core/src/test/java/org/infinispan/scattered/store/ScatteredSyncStoreSharedTest.java
+++ b/core/src/test/java/org/infinispan/scattered/store/ScatteredSyncStoreSharedTest.java
@@ -28,4 +28,11 @@ public class ScatteredSyncStoreSharedTest extends DistSyncStoreSharedTest<Scatte
    protected void assertOwnershipAndNonOwnership(Object key, boolean allowL1) {
       Utils.assertOwnershipAndNonOwnership(caches, key);
    }
+
+   @Override
+   protected int expectedWriteCount() {
+      // Scattered cache does not use bulk write and always assumes the write was successful even when store is shared
+      // https://issues.redhat.com/browse/ISPN-11963
+      return 8;
+   }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-10373
https://issues.redhat.com/browse/ISPN-11902

* The putMap command now only iterates over the entries and calls into persistence manager once.
 Fixes random test failure in ISPN-11902
* PassivationManagerImpl batch now does not utilize ConnectableFlowable as this can mess with if there is more than 1 store and they subscribe on different threads (ConnectableFlowable shares the same subscribing thread).
* The passivation insertion and putMap command now both call into the same shared batch code internally in PassivationManagerImpl.
* Fixed shared stores not updating the store count correctly (was counting non owned entries) - was broken before refactoring.
* Added additional tracing