### PR TITLE
ISPN-11998 Keep new and legacy memory attributes in sync

### DIFF
--- a/commons/all/src/main/java/org/infinispan/commons/configuration/attributes/Attribute.java
+++ b/commons/all/src/main/java/org/infinispan/commons/configuration/attributes/Attribute.java
@@ -90,7 +90,7 @@ public final class Attribute<T> implements Cloneable, Matchable<Attribute<?>> {
    }
 
    public void addListener(AttributeListener<T> listener) {
-      if (isImmutable()) {
+      if (isImmutable() && isProtect()) {
          throw new UnsupportedOperationException();
       }
       if (listeners == null) {

--- a/commons/all/src/main/java/org/infinispan/commons/logging/Log.java
+++ b/commons/all/src/main/java/org/infinispan/commons/logging/Log.java
@@ -242,7 +242,7 @@ public interface Log extends BasicLogger {
    @Message(value = "Cannot load %s", id = 29523)
    void cannotLoadMimeTypes(String mimeTypes);
 
-   @Message(value = "Cannot parse %s", id = 29524)
+   @Message(value = "Cannot parse bytes quantity %s", id = 29524)
    IllegalArgumentException cannotParseQuantity(String str);
 
    //----- counters exceptions // don't use the same id range  ------

--- a/core/src/main/java/org/infinispan/configuration/cache/MemoryStorageConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/MemoryStorageConfiguration.java
@@ -3,7 +3,6 @@ package org.infinispan.configuration.cache;
 import org.infinispan.commons.configuration.ConfigurationInfo;
 import org.infinispan.commons.configuration.attributes.AttributeDefinition;
 import org.infinispan.commons.configuration.attributes.AttributeSet;
-import org.infinispan.commons.configuration.elements.DefaultElementDefinition;
 import org.infinispan.commons.configuration.elements.ElementDefinition;
 import org.infinispan.eviction.EvictionStrategy;
 import org.infinispan.eviction.EvictionType;
@@ -16,31 +15,18 @@ import org.infinispan.eviction.EvictionType;
 public class MemoryStorageConfiguration implements ConfigurationInfo {
 
    public static final AttributeDefinition<Long> SIZE = AttributeDefinition.builder("size", -1L).build();
-   public static final AttributeDefinition<EvictionType> EVICTION_TYPE = AttributeDefinition.builder("type", EvictionType.COUNT).xmlName(org.infinispan.configuration.parsing.Attribute.EVICTION.getLocalName()).build();
-   public static final AttributeDefinition<EvictionStrategy> EVICTION_STRATEGY = AttributeDefinition.builder("strategy", EvictionStrategy.NONE).build();
-   public static final AttributeDefinition<StorageType> STORAGE_TYPE = AttributeDefinition.builder("storage-type", StorageType.OBJECT).build();
+   public static final AttributeDefinition<EvictionType> EVICTION_TYPE = AttributeDefinition.builder("type", EvictionType.COUNT).xmlName(org.infinispan.configuration.parsing.Attribute.EVICTION.getLocalName()).immutable().build();
+   public static final AttributeDefinition<EvictionStrategy> EVICTION_STRATEGY = AttributeDefinition.builder("strategy", EvictionStrategy.NONE).immutable().build();
+   public static final AttributeDefinition<StorageType> STORAGE_TYPE = AttributeDefinition.builder("storage-type", StorageType.HEAP).immutable().build();
 
    private final AttributeSet attributes;
-   private final boolean enabled;
-   private final ElementDefinition<MemoryStorageConfiguration> elementDefinition;
 
    static public AttributeSet attributeDefinitionSet() {
       return new AttributeSet(MemoryStorageConfiguration.class, SIZE, EVICTION_TYPE, EVICTION_STRATEGY, STORAGE_TYPE);
    }
 
-   public MemoryStorageConfiguration(AttributeSet attributes, boolean enabled) {
+   public MemoryStorageConfiguration(AttributeSet attributes) {
       this.attributes = attributes;
-      this.enabled = enabled;
-      StorageType storageType = attributes.attribute(STORAGE_TYPE).get();
-      String storage = storageType == null ? StorageType.OBJECT.getElement().getLocalName() : storageType.getElement().getLocalName();
-      this.elementDefinition = new DefaultElementDefinition<>(storage, true, false);
-   }
-
-   /**
-    * @return true if the {@link MemoryStorageConfigurationBuilder} was non-empty when building this configuration.
-    */
-   boolean isEnabled() {
-      return enabled;
    }
 
    @Override
@@ -50,7 +36,7 @@ public class MemoryStorageConfiguration implements ConfigurationInfo {
 
    @Override
    public ElementDefinition<MemoryStorageConfiguration> getElementDefinition() {
-      return elementDefinition;
+      throw new UnsupportedOperationException();
    }
 
    public StorageType storageType() {

--- a/core/src/main/java/org/infinispan/configuration/cache/MemoryStorageConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/MemoryStorageConfigurationBuilder.java
@@ -1,19 +1,10 @@
 package org.infinispan.configuration.cache;
 
-import static org.infinispan.configuration.cache.MemoryStorageConfiguration.EVICTION_STRATEGY;
-import static org.infinispan.configuration.cache.MemoryStorageConfiguration.EVICTION_TYPE;
-import static org.infinispan.configuration.cache.MemoryStorageConfiguration.SIZE;
-import static org.infinispan.configuration.cache.MemoryStorageConfiguration.STORAGE_TYPE;
-import static org.infinispan.util.logging.Log.CONFIG;
-
 import org.infinispan.commons.configuration.Builder;
 import org.infinispan.commons.configuration.ConfigurationBuilderInfo;
 import org.infinispan.commons.configuration.attributes.AttributeSet;
 import org.infinispan.commons.configuration.elements.ElementDefinition;
-import org.infinispan.commons.util.ByteQuantity;
 import org.infinispan.configuration.global.GlobalConfiguration;
-import org.infinispan.eviction.EvictionStrategy;
-import org.infinispan.eviction.EvictionType;
 
 /**
  * @since 10.0
@@ -22,35 +13,10 @@ import org.infinispan.eviction.EvictionType;
 @Deprecated
 public class MemoryStorageConfigurationBuilder extends AbstractConfigurationChildBuilder implements Builder<MemoryStorageConfiguration>, ConfigurationBuilderInfo {
    private AttributeSet attributes;
-   private final AttributeChangeTracker attributeChangeTracker;
-   private boolean enabled;
 
    MemoryStorageConfigurationBuilder(ConfigurationBuilder builder) {
       super(builder);
       attributes = MemoryStorageConfiguration.attributeDefinitionSet();
-      attributeChangeTracker = new AttributeChangeTracker(attributes);
-   }
-
-   AttributeChangeTracker getAttributeTracker() {
-      return attributeChangeTracker;
-   }
-
-   void enable() {
-      enabled = true;
-   }
-
-   public MemoryStorageConfigurationBuilder storageType(StorageType storageType) {
-      attributes.attribute(STORAGE_TYPE).set(storageType);
-      return this;
-   }
-
-   public StorageType storageType() {
-      return attributes.attribute(STORAGE_TYPE).get();
-   }
-
-   public MemoryStorageConfigurationBuilder size(long size) {
-      attributes.attribute(SIZE).set(size);
-      return this;
    }
 
    @Override
@@ -60,71 +26,11 @@ public class MemoryStorageConfigurationBuilder extends AbstractConfigurationChil
 
    @Override
    public ElementDefinition<?> getElementDefinition() {
-      return MemoryConfiguration.ELEMENT_DEFINITION;
-   }
-
-   public long size() {
-      return attributes.attribute(SIZE).get();
-   }
-
-   public MemoryStorageConfigurationBuilder evictionType(EvictionType type) {
-      attributes.attribute(EVICTION_TYPE).set(type);
-      return this;
-   }
-
-   public EvictionType evictionType() {
-      return attributes.attribute(EVICTION_TYPE).get();
-   }
-
-   public MemoryStorageConfigurationBuilder evictionStrategy(EvictionStrategy strategy) {
-      attributes.attribute(EVICTION_STRATEGY).set(strategy);
-      return this;
-   }
-
-   public EvictionStrategy evictionStrategy() {
-      return attributes.attribute(EVICTION_STRATEGY).get();
+      return null;
    }
 
    @Override
    public void validate() {
-      if (storageType() != StorageType.OBJECT) {
-         if (getBuilder().clustering().hash().groups().isEnabled()) {
-            throw CONFIG.groupingOnlyCompatibleWithObjectStorage(storageType());
-         }
-      }
-
-      long size = attributes.attribute(SIZE).get();
-      EvictionType evictionType = attributes.attribute(EVICTION_TYPE).get();
-      if (evictionType == EvictionType.MEMORY) {
-         if (storageType() == StorageType.OBJECT) {
-            throw CONFIG.offHeapMemoryEvictionNotSupportedWithObject();
-         }
-      }
-
-      EvictionStrategy strategy = attributes.attribute(EVICTION_STRATEGY).get();
-      if (!strategy.isEnabled()) {
-         if (size > 0) {
-            EvictionStrategy newStrategy = EvictionStrategy.REMOVE;
-            evictionStrategy(newStrategy);
-            CONFIG.debugf("Max entries configured (%d) without eviction strategy. Eviction strategy overridden to %s", size, newStrategy);
-         } else if (getBuilder().persistence().passivation() && strategy != EvictionStrategy.MANUAL &&
-               !getBuilder().template()) {
-            CONFIG.passivationWithoutEviction();
-         }
-      } else {
-         if (size <= 0) {
-            throw CONFIG.invalidEvictionSize();
-         }
-         if (strategy.isExceptionBased()) {
-            TransactionConfigurationBuilder transactionConfiguration = getBuilder().transaction();
-            org.infinispan.transaction.TransactionMode transactionMode = transactionConfiguration.transactionMode();
-            if (transactionMode == null || !transactionMode.isTransactional() ||
-                  transactionConfiguration.useSynchronization() ||
-                  transactionConfiguration.use1PcForAutoCommitTransactions()) {
-               throw CONFIG.exceptionBasedEvictionOnlySupportedInTransactionalCaches();
-            }
-         }
-      }
    }
 
    @Override
@@ -133,43 +39,16 @@ public class MemoryStorageConfigurationBuilder extends AbstractConfigurationChil
 
    @Override
    public MemoryStorageConfiguration create() {
-      MemoryStorageConfiguration memoryStorageConfiguration = new MemoryStorageConfiguration(attributes.protect(), enabled);
-      attributeChangeTracker.reset();
-      return memoryStorageConfiguration;
+      return new MemoryStorageConfiguration(attributes.protect());
    }
 
    @Override
    public MemoryStorageConfigurationBuilder read(MemoryStorageConfiguration template) {
-      attributes.read(template.attributes());
-      enabled = template.isEnabled();
       return this;
-   }
-
-   void read(MemoryConfigurationBuilder builder) {
-      if (builder.isCountBounded()) {
-         size(builder.maxCount());
-         evictionType(EvictionType.COUNT);
-      } else if (builder.isSizeBounded()) {
-         size(ByteQuantity.parse(builder.maxSize()));
-         evictionType(EvictionType.MEMORY);
-      }
-      StorageType newStorage = builder.storage();
-      if (newStorage == StorageType.OFF_HEAP) {
-         storageType(StorageType.OFF_HEAP);
-      } else if (encoding().isStorageBinary() || newStorage == StorageType.BINARY) {
-         storageType(StorageType.BINARY);
-      } else {
-         storageType(StorageType.OBJECT);
-      }
-      evictionStrategy(builder.whenFull());
    }
 
    @Override
    public String toString() {
       return "MemoryStorageConfigurationBuilder [attributes=" + attributes + "]";
-   }
-
-   public boolean isEnabled() {
-      return enabled;
    }
 }

--- a/core/src/main/java/org/infinispan/configuration/cache/StorageType.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/StorageType.java
@@ -58,6 +58,10 @@ public enum StorageType {
       return STORAGE_PER_ELEMENT.get(element);
    }
 
+   public boolean canStoreReferences() {
+      return this == HEAP || this == OBJECT;
+   }
+
    private static final Map<String, StorageType> STORAGE_PER_ELEMENT = new HashMap<>(3);
 
    static {

--- a/core/src/main/java/org/infinispan/configuration/parsing/Parser.java
+++ b/core/src/main/java/org/infinispan/configuration/parsing/Parser.java
@@ -1628,6 +1628,7 @@ public class Parser implements ConfigurationParser {
       }
       while (reader.hasNext() && (reader.nextTag() != XMLStreamConstants.END_ELEMENT)) {
          Element element = Element.forName(reader.getLocalName());
+         CONFIG.warnUsingDeprecatedMemoryConfigs(element.getLocalName());
          switch (element) {
             case OFF_HEAP:
                memoryBuilder.storageType(StorageType.OFF_HEAP);

--- a/core/src/main/java/org/infinispan/encoding/impl/StorageConfigurationManager.java
+++ b/core/src/main/java/org/infinispan/encoding/impl/StorageConfigurationManager.java
@@ -10,7 +10,6 @@ import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.Configurations;
 import org.infinispan.configuration.cache.ContentTypeConfiguration;
 import org.infinispan.configuration.cache.EncodingConfiguration;
-import org.infinispan.configuration.cache.StorageType;
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.factories.KnownComponentNames;
 import org.infinispan.factories.annotations.ComponentName;
@@ -108,9 +107,8 @@ public class StorageConfigurationManager {
       if (internalCache) return MediaType.APPLICATION_OBJECT;
 
       if (embeddedMode) {
-         boolean heap = configuration.memory().storage() == StorageType.OBJECT ||
-                        configuration.memory().storage() == StorageType.HEAP;
-         return heap ? MediaType.APPLICATION_OBJECT : mediaType;
+         boolean canStoreReferences = configuration.memory().storage().canStoreReferences();
+         return canStoreReferences ? MediaType.APPLICATION_OBJECT : mediaType;
       }
 
       return APPLICATION_UNKNOWN;

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -1980,7 +1980,7 @@ public interface Log extends BasicLogger {
    @Message(value = "Cannot configure both maxCount and maxSize in memory configuration", id = 583)
    CacheConfigurationException cannotProvideBothSizeAndCount();
 
-   @Message(value = "The memory configuration(s) %s have been deprecated and cannot be used in conjunction to the new configuration. Please update your code ", id = 584)
+   @Message(value = "The memory attribute(s) %s have been deprecated and cannot be used in conjunction with the new configuration", id = 584)
    CacheConfigurationException cannotUseDeprecatedAndReplacement(String legacyName);
 
    @LogMessage(level = WARN)
@@ -1988,14 +1988,14 @@ public interface Log extends BasicLogger {
    void ignoringSpecificMediaTypes();
 
    @LogMessage(level = WARN)
-   @Message(value = "The memory configuration attribute(s) '%s' have been deprecated. Please update your configuration", id = 586)
-   void warnUsingDeprecatedMemoryConfigs(String config);
+   @Message(value = "The memory configuration element '%s' has been deprecated. Please update your configuration", id = 586)
+   void warnUsingDeprecatedMemoryConfigs(String element);
 
    @Message(value = "Cannot change max-size since max-count is already defined", id = 587)
-   CacheException cannotIncreaseMaxSize();
+   CacheConfigurationException cannotChangeMaxSize();
 
    @Message(value = "Cannot change max-count since max-size is already defined", id = 588)
-   CacheException cannotIncreaseMaxCount();
+   CacheConfigurationException cannotChangeMaxCount();
 
    @Message(value = "A store cannot be configured with both preload and purgeOnStartup", id = 589)
    CacheConfigurationException preloadAndPurgeOnStartupConflict();

--- a/core/src/main/resources/schema/infinispan-config-11.0.xsd
+++ b/core/src/main/resources/schema/infinispan-config-11.0.xsd
@@ -1305,7 +1305,7 @@
           <xs:annotation>
             <xs:documentation>
               Deprecated since 11.0. Use instead the 'encoding' element to specify the media type of keys
-              and values, plus the storage attribute as 'heap'.
+              and values, plus the storage attribute as 'HEAP'.
               Store keys and values as instance variables in the Java heap.
               Instances of byte[] are wrapped to ensure equality. This is the
               default storage format.
@@ -1316,7 +1316,7 @@
           <xs:annotation>
             <xs:documentation>
               Deprecated since 11.0. Use instead the 'encoding' element to specify the media type of keys
-              and values, plus the storage attribute as 'heap'.
+              and values, plus the storage attribute as 'HEAP'.
               Store keys and values as bytes in the Java heap. Cache
               entries are serialized to binary representations. Note that
               binary storage violates object equality. This occurs because
@@ -1329,7 +1329,7 @@
           <xs:annotation>
             <xs:documentation>
               Deprecated since 11.0. Use instead the 'encoding' element to specify the media type of keys
-              and values, plus the storage attribute as 'off-heap'.
+              and values, plus the storage attribute as 'OFF_HEAP'.
               Store keys and values as bytes in native memory. Cache
               entries are serialized to binary representations. Temporary
               objects are stored in the Java heap space until processing
@@ -1394,6 +1394,22 @@
           <xs:documentation>
             Stores cache entries as bytes in native memory outside the Java
             heap.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="OBJECT">
+        <xs:annotation>
+          <xs:documentation>
+            Deprecated, only added in 11.0 to simplify the transition from the &lt;object/&gt; element.
+            Please use HEAP instead.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="BINARY">
+        <xs:annotation>
+          <xs:documentation>
+            Deprecated, only added in 11.0 to simplify the transition from the &lt;binary/&gt; element.
+            Please use HEAP and set the encoding media type instead.
           </xs:documentation>
         </xs:annotation>
       </xs:enumeration>

--- a/core/src/test/java/org/infinispan/configuration/XmlFileParsingTest.java
+++ b/core/src/test/java/org/infinispan/configuration/XmlFileParsingTest.java
@@ -148,7 +148,7 @@ public class XmlFileParsingTest extends AbstractInfinispanTest {
       );
       holder = parseStringConfiguration(config);
       cfg = holder.getDefaultConfigurationBuilder().build();
-      assertEquals(StorageType.OBJECT, cfg.memory().storageType());
+      assertEquals(StorageType.HEAP, cfg.memory().storageType());
 
       config = TestingUtil.wrapXMLWithoutSchema(
             "<cache-container default-cache=\"default\">" +
@@ -475,7 +475,7 @@ public class XmlFileParsingTest extends AbstractInfinispanTest {
       assertEquals(20000, c.locking().lockAcquisitionTimeout());
       assertEquals(1000, c.locking().concurrencyLevel());
       assertEquals(IsolationLevel.REPEATABLE_READ, c.locking().isolationLevel());
-      assertEquals(StorageType.OBJECT, c.memory().storageType());
+      assertEquals(StorageType.HEAP, c.memory().storageType());
 
       c = getCacheConfiguration(holder, "storeAsBinary");
       assertEquals(StorageType.BINARY, c.memory().storageType());

--- a/core/src/test/java/org/infinispan/configuration/parsing/UnifiedXmlFileParsingTest.java
+++ b/core/src/test/java/org/infinispan/configuration/parsing/UnifiedXmlFileParsingTest.java
@@ -104,7 +104,7 @@ public class UnifiedXmlFileParsingTest extends AbstractInfinispanTest {
       ConfigurationBuilderHolder holder = parserRegistry.parse(url);
       for (ParserVersionCheck check : ParserVersionCheck.values()) {
          if (check.isIncludedBy(major, minor)) {
-            check.check(holder);
+            check.check(holder, major, minor);
          }
       }
    }
@@ -112,7 +112,7 @@ public class UnifiedXmlFileParsingTest extends AbstractInfinispanTest {
    public enum ParserVersionCheck {
       INFINISPAN_110(11, 0) {
          @Override
-         public void check(ConfigurationBuilderHolder holder) {
+         public void check(ConfigurationBuilderHolder holder, int schemaMajor, int schemaMinor) {
             DefaultThreadFactory threadFactory;
             BlockingThreadPoolExecutorFactory threadPool;
 
@@ -149,7 +149,7 @@ public class UnifiedXmlFileParsingTest extends AbstractInfinispanTest {
 
             Configuration heapBinary = getConfiguration(holder, "heap_binary");
             assertEquals(MediaType.APPLICATION_PROTOSTREAM, heapBinary.encoding().keyDataType().mediaType());
-            assertEquals(StorageType.BINARY, heapBinary.memory().storageType());
+            assertEquals(StorageType.HEAP, heapBinary.memory().storageType());
             assertEquals(EvictionStrategy.REMOVE, heapBinary.memory().evictionStrategy());
             assertEquals(1_500_000_000, heapBinary.memory().maxSizeBytes());
             assertEquals(MediaType.APPLICATION_PROTOSTREAM, heapBinary.encoding().keyDataType().mediaType());
@@ -158,7 +158,7 @@ public class UnifiedXmlFileParsingTest extends AbstractInfinispanTest {
       },
       INFINISPAN_100(10, 0) {
          @Override
-         public void check(ConfigurationBuilderHolder holder) {
+         public void check(ConfigurationBuilderHolder holder, int schemaMajor, int schemaMinor) {
             // tcp-test and mytcp should be identical aside from MERGE3.max_interval
             ProtocolStackConfigurator tcp = holder.getJGroupsStack("tcp-test");
             ProtocolStackConfigurator mytcp = holder.getJGroupsStack("mytcp");
@@ -194,7 +194,7 @@ public class UnifiedXmlFileParsingTest extends AbstractInfinispanTest {
 
       INFINISPAN_93(9, 3) {
          @Override
-         public void check(ConfigurationBuilderHolder holder) {
+         public void check(ConfigurationBuilderHolder holder, int schemaMajor, int schemaMinor) {
             Configuration local = getConfiguration(holder, "local");
             PersistenceConfiguration persistenceConfiguration = local.persistence();
             assertEquals(5, persistenceConfiguration.connectionAttempts());
@@ -208,7 +208,7 @@ public class UnifiedXmlFileParsingTest extends AbstractInfinispanTest {
 
       INFINISPAN_92(9, 2) {
          @Override
-         public void check(ConfigurationBuilderHolder holder) {
+         public void check(ConfigurationBuilderHolder holder, int schemaMajor, int schemaMinor) {
             GlobalStateConfiguration gs = getGlobalConfiguration(holder).globalState();
             assertEquals(ConfigurationStorage.OVERLAY, gs.configurationStorage());
             assertEquals(Paths.get(TMPDIR, "sharedPath").toString(), gs.sharedPersistentLocation());
@@ -224,7 +224,7 @@ public class UnifiedXmlFileParsingTest extends AbstractInfinispanTest {
 
       INFINISPAN_91(9, 1) {
          @Override
-         public void check(ConfigurationBuilderHolder holder) {
+         public void check(ConfigurationBuilderHolder holder, int schemaMajor, int schemaMinor) {
             PartitionHandlingConfiguration ph = getConfiguration(holder, "dist").clustering().partitionHandling();
             assertEquals(PartitionHandling.ALLOW_READS, ph.whenSplit());
             assertEquals(MergePolicy.PREFERRED_NON_NULL, ph.mergePolicy());
@@ -237,7 +237,7 @@ public class UnifiedXmlFileParsingTest extends AbstractInfinispanTest {
 
       INFINISPAN_90(9, 0) {
          @Override
-         public void check(ConfigurationBuilderHolder holder) {
+         public void check(ConfigurationBuilderHolder holder, int schemaMajor, int schemaMinor) {
             GlobalConfiguration globalConfiguration = getGlobalConfiguration(holder);
             assertEquals(4, globalConfiguration.transport().initialClusterSize());
             assertEquals(30000, globalConfiguration.transport().initialClusterTimeout());
@@ -263,7 +263,7 @@ public class UnifiedXmlFileParsingTest extends AbstractInfinispanTest {
          }
 
          @Override
-         public void check(ConfigurationBuilderHolder holder) {
+         public void check(ConfigurationBuilderHolder holder, int schemaMajor, int schemaMinor) {
             GlobalStateConfiguration gs = getGlobalConfiguration(holder).globalState();
             assertEquals(ConfigurationStorage.OVERLAY, gs.configurationStorage());
             assertEquals(Paths.get(TMPDIR, "sharedPath").toString(), gs.sharedPersistentLocation());
@@ -296,21 +296,21 @@ public class UnifiedXmlFileParsingTest extends AbstractInfinispanTest {
 
       INFINISPAN_84(8, 4) {
          @Override
-         public void check(ConfigurationBuilderHolder holder) {
+         public void check(ConfigurationBuilderHolder holder, int schemaMajor, int schemaMinor) {
             // Nothing new
          }
       },
 
       INFINISPAN_83(8, 3) {
          @Override
-         public void check(ConfigurationBuilderHolder holder) {
+         public void check(ConfigurationBuilderHolder holder, int schemaMajor, int schemaMinor) {
             // Nothing new
          }
       },
 
       INFINISPAN_82(8, 2) {
          @Override
-         public void check(ConfigurationBuilderHolder holder) {
+         public void check(ConfigurationBuilderHolder holder, int schemaMajor, int schemaMinor) {
             GlobalConfiguration globalConfiguration = getGlobalConfiguration(holder);
             assertEquals(4, globalConfiguration.transport().initialClusterSize());
             assertEquals(30000, globalConfiguration.transport().initialClusterTimeout());
@@ -319,7 +319,7 @@ public class UnifiedXmlFileParsingTest extends AbstractInfinispanTest {
 
       INFINISPAN_81(8, 1) {
          @Override
-         public void check(ConfigurationBuilderHolder holder) {
+         public void check(ConfigurationBuilderHolder holder, int schemaMajor, int schemaMinor) {
             GlobalConfiguration globalConfiguration = getGlobalConfiguration(holder);
             assertTrue(globalConfiguration.globalState().enabled());
             assertEquals(Paths.get(TMPDIR, "persistentPath").toString(), globalConfiguration.globalState().persistentLocation());
@@ -329,7 +329,7 @@ public class UnifiedXmlFileParsingTest extends AbstractInfinispanTest {
 
       INFINISPAN_80(8, 0) {
          @Override
-         public void check(ConfigurationBuilderHolder holder) {
+         public void check(ConfigurationBuilderHolder holder, int schemaMajor, int schemaMinor) {
             Configuration c = holder.getDefaultConfigurationBuilder().build();
             assertFalse(c.memory().evictionType() == EvictionType.MEMORY);
             c = getConfiguration(holder, "invalid");
@@ -375,7 +375,7 @@ public class UnifiedXmlFileParsingTest extends AbstractInfinispanTest {
       },
 
       INFINISPAN_70(7, 0) {
-         public void check(ConfigurationBuilderHolder holder) {
+         public void check(ConfigurationBuilderHolder holder, int schemaMajor, int schemaMinor) {
             GlobalConfiguration g = getGlobalConfiguration(holder);
             assertEquals("maximal", g.cacheManagerName());
             assertTrue(g.statistics());
@@ -557,7 +557,10 @@ public class UnifiedXmlFileParsingTest extends AbstractInfinispanTest {
             assertEquals(TransactionMode.TRANSACTIONAL, c.transaction().transactionMode()); // Non XA
             assertTrue(c.transaction().useSynchronization()); // Non XA
             assertFalse(c.transaction().recovery().enabled()); // Non XA
-            assertEquals(StorageType.OBJECT, c.memory().storageType());
+            // Storage type was not configurable before 9.0/8.5
+            StorageType objectOrDefaultStorageType =
+                  (schemaMajor < 9 && schemaMinor < 5) ? StorageType.HEAP : StorageType.OBJECT;
+            assertEquals(objectOrDefaultStorageType, c.memory().storageType());
             assertEquals(-1, c.memory().size());
             fileStore = getStoreConfiguration(c, SingleFileStoreConfiguration.class);
             assertTrue(fileStore.preload());
@@ -568,7 +571,7 @@ public class UnifiedXmlFileParsingTest extends AbstractInfinispanTest {
             assertEquals(TransactionMode.TRANSACTIONAL, c.transaction().transactionMode()); // Non XA
             assertTrue(c.transaction().useSynchronization()); // Non XA
             assertFalse(c.transaction().recovery().enabled()); // Non XA
-            assertEquals(StorageType.OBJECT, c.memory().storageType());
+            assertEquals(objectOrDefaultStorageType, c.memory().storageType());
             assertEquals(-1, c.memory().size());
             DummyInMemoryStoreConfiguration dummyStore = getStoreConfiguration(c, DummyInMemoryStoreConfiguration.class);
             assertFalse(dummyStore.preload());
@@ -579,7 +582,7 @@ public class UnifiedXmlFileParsingTest extends AbstractInfinispanTest {
             assertEquals(TransactionMode.TRANSACTIONAL, c.transaction().transactionMode()); // Non XA
             assertTrue(c.transaction().useSynchronization()); // Non XA
             assertFalse(c.transaction().recovery().enabled()); // Non XA
-            assertEquals(StorageType.OBJECT, c.memory().storageType());
+            assertEquals(objectOrDefaultStorageType, c.memory().storageType());
             assertEquals(-1, c.memory().size());
             assertEquals(LockingMode.PESSIMISTIC, c.transaction().lockingMode());
 
@@ -588,7 +591,7 @@ public class UnifiedXmlFileParsingTest extends AbstractInfinispanTest {
             assertEquals(TransactionMode.TRANSACTIONAL, c.transaction().transactionMode()); // Non XA
             assertTrue(c.transaction().useSynchronization()); // Non XA
             assertFalse(c.transaction().recovery().enabled()); // Non XA
-            assertEquals(StorageType.OBJECT, c.memory().storageType());
+            assertEquals(objectOrDefaultStorageType, c.memory().storageType());
             assertEquals(-1, c.memory().size());
             fileStore = getStoreConfiguration(c, SingleFileStoreConfiguration.class);
             assertTrue(fileStore.preload());
@@ -600,7 +603,7 @@ public class UnifiedXmlFileParsingTest extends AbstractInfinispanTest {
             assertEquals(TransactionMode.TRANSACTIONAL, c.transaction().transactionMode()); // Non XA
             assertTrue(c.transaction().useSynchronization()); // Non XA
             assertFalse(c.transaction().recovery().enabled()); // Non XA
-            assertEquals(StorageType.OBJECT, c.memory().storageType());
+            assertEquals(objectOrDefaultStorageType, c.memory().storageType());
             assertEquals(-1, c.memory().size());
             assertEquals(LockingMode.PESSIMISTIC, c.transaction().lockingMode());
             fileStore = getStoreConfiguration(c, SingleFileStoreConfiguration.class);
@@ -686,7 +689,7 @@ public class UnifiedXmlFileParsingTest extends AbstractInfinispanTest {
          this.minor = minor;
       }
 
-      public abstract void check(ConfigurationBuilderHolder cm);
+      public abstract void check(ConfigurationBuilderHolder cm, int schemaMajor, int schemaMinor);
 
       public boolean isIncludedBy(int major, int minor) {
          return major > this.major || (major == this.major && minor >= this.minor);

--- a/core/src/test/java/org/infinispan/encoding/impl/StorageConfigurationManagerTest.java
+++ b/core/src/test/java/org/infinispan/encoding/impl/StorageConfigurationManagerTest.java
@@ -1,0 +1,126 @@
+package org.infinispan.encoding.impl;
+
+import static org.infinispan.test.TestingUtil.extractComponent;
+import static org.testng.AssertJUnit.assertEquals;
+
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+
+import org.infinispan.Cache;
+import org.infinispan.commons.dataconversion.MediaType;
+import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.cache.StorageType;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.test.SingleCacheManagerTest;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.Test;
+
+@Test(groups = "unit", testName = "encoding.impl.StorageConfigurationManagerTest")
+public class StorageConfigurationManagerTest extends SingleCacheManagerTest {
+
+   public static final String CACHE_NAME = "testCache";
+
+   @Override
+   protected EmbeddedCacheManager createCacheManager() throws Exception {
+      return TestCacheManagerFactory.createCacheManager();
+   }
+
+   public static long wallClockTime() {
+      return TIME_SERVICE.wallClockTime();
+   }
+
+   public static long time() {
+      return TIME_SERVICE.time();
+   }
+
+   public static Instant instant() {
+      return TIME_SERVICE.instant();
+   }
+
+   public static long timeDuration(long startTimeNanos, TimeUnit outputTimeUnit) {
+      return TIME_SERVICE.timeDuration(startTimeNanos, outputTimeUnit);
+   }
+
+   public static long timeDuration(long startTimeNanos, long endTimeNanos, TimeUnit outputTimeUnit) {
+      return TIME_SERVICE.timeDuration(startTimeNanos, endTimeNanos, outputTimeUnit);
+   }
+
+   public static boolean isTimeExpired(long endTimeNanos) {
+      return TIME_SERVICE.isTimeExpired(endTimeNanos);
+   }
+
+   public static long remainingTime(long endTimeNanos, TimeUnit outputTimeUnit) {
+      return TIME_SERVICE.remainingTime(endTimeNanos, outputTimeUnit);
+   }
+
+   public static long expectedEndTime(long duration, TimeUnit inputTimeUnit) {
+      return TIME_SERVICE.expectedEndTime(duration, inputTimeUnit);
+   }
+
+   public void testDefaultMediaType() {
+      ConfigurationBuilder configurationBuilder = new ConfigurationBuilder();
+      assertStorageMediaTypes(configurationBuilder, StorageType.HEAP, StorageType.HEAP,
+                              MediaType.APPLICATION_OBJECT);
+
+
+      configurationBuilder = new ConfigurationBuilder();
+      configurationBuilder.memory().storage(StorageType.HEAP);
+      assertStorageMediaTypes(configurationBuilder, StorageType.HEAP, StorageType.HEAP,
+                              MediaType.APPLICATION_OBJECT);
+
+      configurationBuilder = new ConfigurationBuilder();
+      configurationBuilder.memory().storageType(StorageType.HEAP);
+      assertStorageMediaTypes(configurationBuilder, StorageType.HEAP, StorageType.HEAP,
+                              MediaType.APPLICATION_OBJECT);
+
+
+      configurationBuilder = new ConfigurationBuilder();
+      configurationBuilder.memory().storage(StorageType.OBJECT);
+      assertStorageMediaTypes(configurationBuilder, StorageType.OBJECT, StorageType.OBJECT,
+                              MediaType.APPLICATION_OBJECT);
+
+
+      configurationBuilder = new ConfigurationBuilder();
+      configurationBuilder.memory().storageType(StorageType.OBJECT);
+      assertStorageMediaTypes(configurationBuilder, StorageType.OBJECT, StorageType.OBJECT,
+                              MediaType.APPLICATION_OBJECT);
+
+
+      configurationBuilder = new ConfigurationBuilder();
+      configurationBuilder.memory().storageType(StorageType.BINARY);
+      assertStorageMediaTypes(configurationBuilder, StorageType.BINARY, StorageType.BINARY,
+                              MediaType.APPLICATION_PROTOSTREAM);
+
+      configurationBuilder = new ConfigurationBuilder();
+      configurationBuilder.memory().storageType(StorageType.BINARY);
+      assertStorageMediaTypes(configurationBuilder, StorageType.BINARY, StorageType.BINARY,
+                              MediaType.APPLICATION_PROTOSTREAM);
+
+
+      configurationBuilder = new ConfigurationBuilder();
+      configurationBuilder.memory().storageType(StorageType.OFF_HEAP);
+      assertStorageMediaTypes(configurationBuilder, StorageType.OFF_HEAP, StorageType.OFF_HEAP,
+                              MediaType.APPLICATION_PROTOSTREAM);
+
+      configurationBuilder = new ConfigurationBuilder();
+      configurationBuilder.memory().storageType(StorageType.OFF_HEAP);
+      assertStorageMediaTypes(configurationBuilder, StorageType.OFF_HEAP, StorageType.OFF_HEAP,
+                              MediaType.APPLICATION_PROTOSTREAM);
+   }
+
+   private void assertStorageMediaTypes(ConfigurationBuilder configurationBuilder, StorageType storage,
+                                        StorageType storageType, MediaType mediaType) {
+      cacheManager.defineConfiguration(CACHE_NAME, configurationBuilder.build());
+      Cache<Object, Object> cache = cacheManager.getCache(CACHE_NAME);
+      Configuration cacheConfiguration = cache.getCacheConfiguration();
+      assertEquals("Wrong storage", storage, cacheConfiguration.memory().storage());
+      assertEquals("Wrong storageType", storageType, cacheConfiguration.memory().storageType());
+      assertEquals("Wrong heapConfiguration.storageType", storageType,
+                   cacheConfiguration.memory().heapConfiguration().storageType());
+      StorageConfigurationManager scm = extractComponent(cache, StorageConfigurationManager.class);
+      assertEquals("Wrong key media type", mediaType, scm.getKeyStorageMediaType());
+      assertEquals("Wrong value media type", mediaType, scm.getValueStorageMediaType());
+      cacheManager.administration().removeCache(CACHE_NAME);
+   }
+}

--- a/core/src/test/java/org/infinispan/expiration/impl/ClusterExpirationFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/expiration/impl/ClusterExpirationFunctionalTest.java
@@ -73,7 +73,9 @@ public class ClusterExpirationFunctionalTest extends MultipleCacheManagersTest {
       configurationBuilder.clustering().cacheMode(cacheMode);
       configurationBuilder.transaction().transactionMode(transactionMode()).lockingMode(lockingMode);
       configurationBuilder.expiration().disableReaper();
-      configurationBuilder.memory().storageType(storageType);
+      if (storageType != null) {
+         configurationBuilder.memory().storage(storageType);
+      }
       createCluster(TestDataSCI.INSTANCE, configurationBuilder, 3);
       waitForClusterToForm();
       injectTimeServices();

--- a/core/src/test/java/org/infinispan/jmx/JmxStatsFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/jmx/JmxStatsFunctionalTest.java
@@ -303,7 +303,7 @@ public class JmxStatsFunctionalTest extends AbstractInfinispanTest {
       Properties propsGlobal = (Properties) server.getAttribute(getCacheManagerObjectName(jmxDomain), "globalConfigurationAsProperties");
       // configurationAsProperties excludes deprecated methods from the reflection, so 'storageType' is not available anymore.
       assert "BINARY".equals(props1.getProperty("memory.storage"));
-      assert "HEAP".equals(props2.getProperty("memory.storage"));
+      assert "OBJECT".equals(props2.getProperty("memory.storage"));
       log.tracef("propsGlobal=%s", propsGlobal);
       assert "TESTVALUE1".equals(propsGlobal.getProperty("transport.siteId"));
       assert "TESTVALUE2".equals(propsGlobal.getProperty("transport.rackId"));

--- a/core/src/test/java/org/infinispan/manager/CacheManagerTest.java
+++ b/core/src/test/java/org/infinispan/manager/CacheManagerTest.java
@@ -145,11 +145,11 @@ public class CacheManagerTest extends AbstractInfinispanTest {
       holder.newConfigurationBuilder("*")
             .template(true)
             .clustering().cacheMode(CacheMode.LOCAL)
-            .memory().maxSize("1");
+            .memory().maxCount(1);
       EmbeddedCacheManager cm = createClusteredCacheManager(holder);
       try {
          Cache<Object, Object> aCache = cm.getCache("a");
-         assertEquals("1", aCache.getCacheConfiguration().memory().maxSize());
+         assertEquals(1L, aCache.getCacheConfiguration().memory().maxCount());
       } finally {
          killCacheManagers(cm);
       }

--- a/core/src/test/java/org/infinispan/statetransfer/StateTransferTimestampsTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateTransferTimestampsTest.java
@@ -48,7 +48,9 @@ public class StateTransferTimestampsTest extends MultipleCacheManagersTest {
       timeService = new ControlledTimeService();
       ConfigurationBuilder replConfig = new ConfigurationBuilder();
       replConfig.clustering().cacheMode(cacheMode).hash().numSegments(4);
-      replConfig.memory().storageType(storageType);
+      if (storageType != null) {
+         replConfig.memory().storage(storageType);
+      }
       for (EmbeddedCacheManager manager : managers()) {
          TestingUtil.replaceComponent(manager, TimeService.class, timeService, true);
          manager.defineConfiguration(CACHE_NAME, replConfig.build());

--- a/core/src/test/java/org/infinispan/tx/ContextAffectsTransactionReadCommittedTest.java
+++ b/core/src/test/java/org/infinispan/tx/ContextAffectsTransactionReadCommittedTest.java
@@ -8,6 +8,7 @@ import static org.testng.AssertJUnit.fail;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
+
 import javax.transaction.Transaction;
 
 import org.infinispan.configuration.cache.ConfigurationBuilder;
@@ -17,6 +18,7 @@ import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.util.concurrent.IsolationLevel;
+import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 
 /**
@@ -30,6 +32,7 @@ public class ContextAffectsTransactionReadCommittedTest extends SingleCacheManag
 
    protected StorageType storage;
 
+   @Factory
    public Object[] factory() {
       return new Object[] {
             new ContextAffectsTransactionReadCommittedTest().withStorage(StorageType.BINARY),

--- a/core/src/test/java/org/infinispan/tx/ContextAffectsTransactionRepeatableReadTest.java
+++ b/core/src/test/java/org/infinispan/tx/ContextAffectsTransactionRepeatableReadTest.java
@@ -2,10 +2,11 @@ package org.infinispan.tx;
 
 import javax.transaction.RollbackException;
 
+import org.infinispan.commons.test.Exceptions;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.StorageType;
-import org.infinispan.commons.test.Exceptions;
 import org.infinispan.util.concurrent.IsolationLevel;
+import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 
 /**
@@ -16,6 +17,7 @@ import org.testng.annotations.Test;
  */
 @Test (groups = "functional", testName = "tx.ContextAffectsTransactionRepeatableReadTest")
 public class ContextAffectsTransactionRepeatableReadTest extends ContextAffectsTransactionReadCommittedTest {
+   @Factory
    public Object[] factory() {
       return new Object[] {
             new ContextAffectsTransactionRepeatableReadTest().withStorage(StorageType.BINARY),

--- a/query/src/test/java/org/infinispan/query/blackbox/ClusteredQueryTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/ClusteredQueryTest.java
@@ -76,8 +76,10 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
             .addIndexedEntity(Person.class)
             .addProperty("default.directory_provider", "local-heap")
             .addProperty("error_handler", StaticTestingErrorHandler.class.getName());
-      cacheCfg.memory()
-            .storageType(storageType);
+      if (storageType != null) {
+         cacheCfg.memory()
+                 .storageType(storageType);
+      }
       createClusteredCaches(2, QueryTestSCI.INSTANCE, cacheCfg);
       cacheAMachine1 = cache(0);
       cacheAMachine2 = cache(1);


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-11998

* Change default storage to HEAP everywhere
* Document deprecated storage attribute values
  in the XSD
* Synchronize new and old eviction attributes
  both in the buider and in the runtime configuration
* Synchronize when copying configurations
* Synchronize when reading JSON
* Add new configuration and defaults tests
* Make attributes that cannot change at runtime immutable
* Eviction new and legacy attributes should stay in sync
* Fix tests that set the storage to null
* Update tests for new default storage type