### PR TITLE
ISPN-12030 Fix java8-test

### DIFF
--- a/hibernate/pom.xml
+++ b/hibernate/pom.xml
@@ -117,7 +117,7 @@
                <dependenciesToScan>
                   <dependency>${project.groupId}:infinispan-hibernate-cache-commons</dependency>
                </dependenciesToScan>
-                <argLine>${forkJvmArgs} ${testjvm.jigsawArgs} -Djdk.attach.allowAttachSelf=true</argLine>
+                <argLine>${forkJvmArgs} ${testjvm.jdkSpecificArgs} -Djdk.attach.allowAttachSelf=true</argLine>
                <systemPropertyVariables>
                   <java.net.preferIPv4Stack>true</java.net.preferIPv4Stack>
                   <jgroups.ping.timeout>500</jgroups.ping.timeout>

--- a/integrationtests/pom.xml
+++ b/integrationtests/pom.xml
@@ -16,7 +16,6 @@
 
     <properties>
         <forkJvmArgs>-Xmx500m ${testjvm.commonArgs}</forkJvmArgs>
-        <testjvm.jigsawArgs></testjvm.jigsawArgs>
     </properties>
 
     <profiles>
@@ -38,48 +37,6 @@
                 <forkJvmArgs>${env.MAVEN_FORK_OPTS}</forkJvmArgs>
             </properties>
         </profile>
-        <profile>
-            <id>jigsaw</id>
-            <activation>
-                <jdk>[9,)</jdk>
-            </activation>
-            <properties>
-                <!--
-                  java.lang, java.util, java.io, java.lang.invoke, java.lang, reflect, java.util.concurrent, java.time:
-                    core externalizers for JDK types
-                  java.nio, jdk.internal.ref, jdk.internal.misc, sun.nio.ch: Netty, server/hotrod
-                  com.sun.security.sasl: CRAM-MD5 mechanism, server/hotrod
-                  java.text, java.awt.font: XStream, server/rest
-                  java.security: Wildfly, server/integration/*
-                -->
-                <testjvm.jigsawArgs>
-                    -Dsun.reflect.debugModuleAccessChecks=true
-                    --add-opens=java.base/java.lang=ALL-UNNAMED
-                    --add-opens=java.base/java.util=ALL-UNNAMED
-                    --add-opens=java.base/java.io=ALL-UNNAMED
-                    --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
-                    --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
-                    --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
-                    --add-opens=java.base/java.time=ALL-UNNAMED
-                    --add-opens=java.base/java.nio=ALL-UNNAMED
-                    --add-opens=java.base/jdk.internal.ref=ALL-UNNAMED
-                    --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED
-                    --add-exports=java.security.sasl/com.sun.security.sasl=ALL-UNNAMED
-                    --add-opens=java.base/java.text=ALL-UNNAMED
-                    --add-opens=java.base/java.security=ALL-UNNAMED
-                    --add-exports=jdk.security.jgss/com.sun.security.sasl.gsskerb=ALL-UNNAMED
-                    --add-exports=java.base/sun.nio.ch=ALL-UNNAMED
-                    --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
-                    --add-exports=java.security.sasl/com.sun.security.sasl.digest=ALL-UNNAMED
-                    --add-exports=java.security.sasl/com.sun.security.sasl.ntlm=ALL-UNNAMED
-                    --add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED
-                    --add-opens=java.management/javax.management=ALL-UNNAMED
-                    --add-exports=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED
-                    --add-opens=java.base/com.sun.crypto.provider=ALL-UNNAMED
-                    --add-modules java.se
-                </testjvm.jigsawArgs>
-            </properties>
-        </profile>
     </profiles>
 
     <build>
@@ -90,7 +47,7 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <configuration>
                         <trimStackTrace>false</trimStackTrace>
-                        <argLine>${forkJvmArgs} ${testjvm.jigsawArgs}</argLine>
+                        <argLine>${forkJvmArgs} ${testjvm.jdkSpecificArgs}</argLine>
                     </configuration>
                 </plugin>
             </plugins>

--- a/integrationtests/security-manager-it/pom.xml
+++ b/integrationtests/security-manager-it/pom.xml
@@ -68,7 +68,7 @@
                   <usedefaultlisteners>false</usedefaultlisteners>
                   <listener>${testNGListeners}</listener>
                </properties>
-               <argLine>${forkJvmArgs} ${testjvm.jigsawArgs}</argLine>
+               <argLine>${forkJvmArgs} ${testjvm.jdkSpecificArgs}</argLine>
                <dependenciesToScan>
                   <!-- TestNGSuiteChecksTest -->
                   <dependency>org.infinispan:infinispan-commons-test</dependency>

--- a/integrationtests/wildfly-modules/pom.xml
+++ b/integrationtests/wildfly-modules/pom.xml
@@ -18,14 +18,14 @@
       <server.build.dist>${ispnserver.project.dir}/target/${infinispan.brand.prefix}-server-${infinispan.brand.version}</server.build.dist>
       <ispnserver.dist>${basedir}/target/infinispan-server</ispnserver.dist>
       <resources.dir>${basedir}/src/test/resources</resources.dir>
-      <serverMemoryJvmArgs>-Xmx300m ${testjvm.commonArgs}</serverMemoryJvmArgs>
+      <serverMemoryJvmArgs>-Xmx300m</serverMemoryJvmArgs>
       <jvm.x64.args />
       <transport.stack>-Dinfinispan.cluster.stack=${infinispan.cluster.stack}</transport.stack>
       <jvm.ip.stack>-Djava.net.preferIPv4Stack=true</jvm.ip.stack>
       <mcast.ip>234.99.54.14</mcast.ip>
       <jvm.ip.stack>-Djava.net.preferIPv4Stack=true -Djava.net.preferIPv6Addresses=false -Djboss.default.multicast.address=${mcast.ip}</jvm.ip.stack>
       <server.jvm>${env.JAVA_HOME}</server.jvm>
-      <server.jvm.args>${testjvm.extraArgs} ${jvm.ip.stack} ${serverMemoryJvmArgs} ${transport.stack} ${jvm.x64.args} ${testjvm.jigsawArgs}</server.jvm.args>
+      <server.jvm.args>${testjvm.commonArgs} ${testjvm.jdkSpecificArgs} ${testjvm.extraArgs} ${jvm.ip.stack} ${serverMemoryJvmArgs} ${transport.stack} ${jvm.x64.args}</server.jvm.args>
       <log4j.configurationFile>log4j2.xml</log4j.configurationFile>
    </properties>
 
@@ -398,7 +398,7 @@
          </activation>
          <properties>
             <server.jvm>${env.JAVA8_HOME}</server.jvm>
-            <server.jvm.args>${testjvm.extraArgs} ${jvm.ip.stack} ${serverMemoryJvmArgs} ${transport.stack} ${jvm.x64.args}</server.jvm.args>
+            <server.jvm.args>${testjvm.commonArgs} ${testjvm.jdkSpecificArgs} ${testjvm.extraArgs} ${jvm.ip.stack} ${serverMemoryJvmArgs} ${transport.stack} ${jvm.x64.args}</server.jvm.args>
          </properties>
       </profile>
    </profiles>

--- a/jcache/tck-runner-embedded/pom.xml
+++ b/jcache/tck-runner-embedded/pom.xml
@@ -22,7 +22,6 @@
       <embedded.CacheEntryImpl>org.infinispan.jcache.JCacheEntry</embedded.CacheEntryImpl>
       <embedded.CacheInvocationContextImpl>org.infinispan.jcache.annotation.CacheKeyInvocationContextImpl</embedded.CacheInvocationContextImpl>
 
-      <transport.stack>-Dinfinispan.cluster.stack=${infinispan.cluster.stack}</transport.stack>
       <jvm.x64.args />
    </properties>
 
@@ -123,7 +122,7 @@
                   <infinispan.module-suffix>${infinispan.module-suffix}</infinispan.module-suffix>
                   <ansi.strip>${ansi.strip}</ansi.strip>
                </systemPropertyVariables>
-               <argLine>${forkJvmArgs} ${testjvm.jigsawArgs}</argLine>
+               <argLine>${forkJvmArgs} ${testjvm.jdkSpecificArgs}</argLine>
                <properties>
                   <listener>${junitListener}</listener>
                </properties>

--- a/jcache/tck-runner-remote/pom.xml
+++ b/jcache/tck-runner-remote/pom.xml
@@ -31,9 +31,9 @@
       <server.dir>${server.dir.parent}/${server.dir.name}</server.dir>
       <mcast.ip>234.99.54.14</mcast.ip>
       <server.jvm>${env.JAVA_HOME}</server.jvm>
-      <server.jvm.args>${testjvm.extraArgs} ${jvm.ip.stack} ${serverMemoryJvmArgs} ${testjvm.jigsawArgs}</server.jvm.args>
+      <server.jvm.args>${testjvm.commonArgs} ${testjvm.jdkSpecificArgs} ${testjvm.extraArgs} ${jvm.ip.stack} ${serverMemoryJvmArgs}</server.jvm.args>
       <jvm.ip.stack>-Djava.net.preferIPv4Stack=true -Djava.net.preferIPv6Addresses=false -Djboss.default.multicast.address=${mcast.ip}</jvm.ip.stack>
-      <serverMemoryJvmArgs>-Xmx500m ${testjvm.commonArgs}</serverMemoryJvmArgs>
+      <serverMemoryJvmArgs>-Xmx500m</serverMemoryJvmArgs>
 
       <!--
       Note: Maven resource plugin replaces ${infinispan.cluster.stack} in infinispan.xml at build time,
@@ -41,6 +41,7 @@
       TODO Reuse test-tcp stack from server/tests (ISPN-11772)
       -->
       <infinispan.cluster.stack>tcp</infinispan.cluster.stack>
+      <transport.stack>-Dinfinispan.cluster.stack=${infinispan.cluster.stack}</transport.stack>
       <jvm.x64.args />
    </properties>
 
@@ -242,7 +243,7 @@
                   <infinispan.module-suffix>${infinispan.module-suffix}</infinispan.module-suffix>
                   <ansi.strip>${ansi.strip}</ansi.strip>
                </systemPropertyVariables>
-               <argLine>${forkJvmArgs} ${testjvm.jigsawArgs}</argLine>
+               <argLine>${forkJvmArgs} ${testjvm.jdkSpecificArgs}</argLine>
                <properties>
                   <listener>${junitListener}</listener>
                </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -201,11 +201,13 @@
          --add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED
          --add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED
          --add-exports=jdk.unsupported/sun.reflect=ALL-UNNAMED
+         --add-opens=java.base/com.sun.crypto.provider=ALL-UNNAMED
          --add-modules=java.se
       </testjvm.jigsawArgs>
-      <testjvm.jdkSpecificArgs>${testjvm.jigsawArgs}</testjvm.jdkSpecificArgs>
+      <testjvm.blockHoundRedefinitionArgs/>
+      <testjvm.jdkSpecificArgs>${testjvm.jigsawArgs} ${testjvm.blockHoundRedefinitionArgs}</testjvm.jdkSpecificArgs>
       <testjvm.extraArgs/>
-      <forkJvmArgs>-Xmx1G ${testjvm.commonArgs} ${testjvm.extraArgs}</forkJvmArgs>
+      <forkJvmArgs>-Xmx1G ${testjvm.commonArgs} ${testjvm.jdkSpecificArgs} ${testjvm.extraArgs}</forkJvmArgs>
       <server.jvm>${env.JAVA_HOME}</server.jvm>
       <server.jvm.args>${testjvm.commonArgs} ${testjvm.jdkSpecificArgs} ${testjvm.extraArgs}</server.jvm.args>
       <infinispan.module-suffix>-${project.artifactId}</infinispan.module-suffix>
@@ -2667,6 +2669,10 @@
          <properties>
             <server.jvm>${env.JAVA8_HOME}</server.jvm>
             <server.jvm.args>${testjvm.commonArgs} ${testjvm.extraArgs}</server.jvm.args>
+            <!-- Unset all JDK-specific properties -->
+            <testjvm.jigsawArgs/>
+            <testjvm.blockHoundRedefinitionArgs/>
+            <!-- Also unset the aggregate property, just in case -->
             <testjvm.jdkSpecificArgs/>
          </properties>
          <dependencies>
@@ -2720,7 +2726,7 @@
             <jdk>[13,)</jdk>
          </activation>
          <properties>
-            <testjvm.jdkSpecificArgs>${testjvm.jigsawArgs} -XX:+AllowRedefinitionToAddDeleteMethods</testjvm.jdkSpecificArgs>
+            <testjvm.blockHoundRedefinitionArgs>-XX:+AllowRedefinitionToAddDeleteMethods</testjvm.blockHoundRedefinitionArgs>
          </properties>
       </profile>
       <profile>
@@ -3191,4 +3197,3 @@
       </profile>
    </profiles>
 </project>
-

--- a/query/pom.xml
+++ b/query/pom.xml
@@ -180,7 +180,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-               <argLine>${forkJvmArgs} ${testjvm.jigsawArgs} -Djdk.attach.allowAttachSelf=true</argLine>
+               <argLine>${forkJvmArgs} ${testjvm.jdkSpecificArgs} -Djdk.attach.allowAttachSelf=true</argLine>
             </configuration>
          </plugin>
 

--- a/server/router/pom.xml
+++ b/server/router/pom.xml
@@ -216,7 +216,7 @@
                         <usedefaultlisteners>false</usedefaultlisteners>
                         <listener>${junitListener}</listener>
                     </properties>
-                    <argLine>${forkJvmArgs} ${testjvm.jigsawArgs}</argLine>
+                    <argLine>${forkJvmArgs} ${testjvm.jdkSpecificArgs}</argLine>
                 </configuration>
                 <dependencies>
                     <dependency>

--- a/server/tests/pom.xml
+++ b/server/tests/pom.xml
@@ -120,7 +120,7 @@
                   <usedefaultlisteners>false</usedefaultlisteners>
                   <listener>${junitListener}</listener>
                </properties>
-               <argLine>${forkJvmArgs} ${testjvm.jigsawArgs} -Dorg.infinispan.test.server.dir=${org.infinispan.test.server.dir} -Djdk.attach.allowAttachSelf=true</argLine>
+               <argLine>${forkJvmArgs} ${testjvm.jdkSpecificArgs} -Dorg.infinispan.test.server.dir=${org.infinispan.test.server.dir} -Djdk.attach.allowAttachSelf=true</argLine>
             </configuration>
             <executions>
                <execution>
@@ -141,7 +141,7 @@
             <activeByDefault>false</activeByDefault>
          </activation>
          <properties>
-            <container.argLine>${forkJvmArgs} ${testjvm.jigsawArgs} -Dorg.infinispan.test.server.dir=${org.infinispan.test.server.dir}
+            <container.argLine>${forkJvmArgs} ${testjvm.jdkSpecificArgs} -Dorg.infinispan.test.server.dir=${org.infinispan.test.server.dir}
                -Djdk.attach.allowAttachSelf=true -Dorg.infinispan.test.server.driver=CONTAINER
             </container.argLine>
          </properties>


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12030

* Extract a separate property for BlockHound on JDK13+
* Use the aggregate testjvm.jdkSpecificArgs property
  everywhere
* Unset all JDK-specific properties in the java8-test
  profile