### PR TITLE
ISPN-12058 wildfly/feature-pack module doesn't build

### DIFF
--- a/wildfly/feature-pack/pom.xml
+++ b/wildfly/feature-pack/pom.xml
@@ -243,7 +243,7 @@
                             <goals>
                                 <goal>run</goal>
                             </goals>
-                            <phase>generate-resources</phase>
+                            <phase>process-resources</phase>
                             <configuration>
                                 <target>
                                     <ant antfile="build.xml" inheritRefs="true">


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12058

Move branding Ant script to phase process-resources,
after maven-resources-plugin has copied the files.