### PR TITLE
ISPN-12060 WildFly modules integration tests do not on WildFly 19

### DIFF
--- a/integrationtests/wildfly-modules/src/test/resources/as-config/standalone/configuration/standalone-test.xml
+++ b/integrationtests/wildfly-modules/src/test/resources/as-config/standalone/configuration/standalone-test.xml
@@ -31,6 +31,7 @@
         <extension module="org.wildfly.extension.request-controller"/>
         <extension module="org.wildfly.extension.security.manager"/>
         <extension module="org.wildfly.extension.undertow"/>
+        <extension module="org.wildfly.extension.microprofile.config-smallrye"/>
     </extensions>
     <management>
         <security-realms>


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12060

Add missing org.wildfly.extension.microprofile.config-smallrye
extension to the test WildFly configuration.