### PR TITLE
ISPN-12065 Add the anchored-keys module to the server

### DIFF
--- a/build-configuration/bom/pom.xml
+++ b/build-configuration/bom/pom.xml
@@ -376,6 +376,11 @@
                 <version>${version.infinispan}</version>
             </dependency>
             <dependency>
+                <groupId>org.infinispan</groupId>
+                <artifactId>infinispan-anchored-keys</artifactId>
+                <version>${version.infinispan}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.infinispan.protostream</groupId>
                 <artifactId>protostream</artifactId>
                 <version>${version.protostream}</version>

--- a/server/runtime/pom.xml
+++ b/server/runtime/pom.xml
@@ -101,6 +101,10 @@
          <artifactId>infinispan-jboss-marshalling</artifactId>
       </dependency>
       <dependency>
+         <groupId>org.infinispan</groupId>
+         <artifactId>infinispan-anchored-keys</artifactId>
+      </dependency>
+      <dependency>
          <groupId>org.wildfly.security</groupId>
          <artifactId>wildfly-elytron</artifactId>
          <exclusions>

--- a/server/tests/src/test/java/org/infinispan/server/functional/AnchoredKeysIT.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/AnchoredKeysIT.java
@@ -1,0 +1,58 @@
+package org.infinispan.server.functional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.commons.configuration.BasicConfiguration;
+import org.infinispan.commons.configuration.XMLStringConfiguration;
+import org.infinispan.commons.util.Version;
+import org.infinispan.server.test.core.ServerRunMode;
+import org.infinispan.server.test.junit4.InfinispanServerRule;
+import org.infinispan.server.test.junit4.InfinispanServerRuleBuilder;
+import org.infinispan.server.test.junit4.InfinispanServerTestMethodRule;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Ryan Emerson
+ * @since 11.0
+ */
+public class AnchoredKeysIT {
+
+   @ClassRule
+   public static final InfinispanServerRule SERVERS =
+         InfinispanServerRuleBuilder.config("configuration/AnchoredKeys.xml")
+               .numServers(2)
+               .runMode(ServerRunMode.CONTAINER)
+               .build();
+
+   @Rule
+   public InfinispanServerTestMethodRule SERVER_TEST = new InfinispanServerTestMethodRule(SERVERS);
+
+   @Test
+   public void testAnchoredKeysCache() {
+      RemoteCacheManager rcm = SERVER_TEST.hotrod().createRemoteCacheManager();
+      test(rcm.getCache("default"));
+   }
+
+   @Test
+   public void testCreateAnchoredKeysCache() {
+      BasicConfiguration config = new XMLStringConfiguration("<infinispan><cache-container><replicated-cache name=\"anchored2\">\n" +
+                        "<locking concurrency-level=\"100\" acquire-timeout=\"1000\"/>\n" +
+                           "<anchored-keys xmlns=\"urn:infinispan:config:anchored:" + Version.getMajorMinor() + "\" enabled=\"true\"/>\n" +
+                       "</replicated-cache></cache-container></infinispan>");
+      RemoteCacheManager rcm = SERVER_TEST.hotrod().createRemoteCacheManager();
+      rcm.administration().createCache("anchored2", config);
+      test(rcm.getCache("anchored2"));
+   }
+
+   private void test(RemoteCache<String, String> cache) {
+      assertNotNull(cache);
+      cache.put("k1", "v1");
+      assertEquals(1, cache.size());
+      assertEquals("v1", cache.get("k1"));
+   }
+}

--- a/server/tests/src/test/resources/configuration/AnchoredKeys.xml
+++ b/server/tests/src/test/resources/configuration/AnchoredKeys.xml
@@ -1,0 +1,23 @@
+<infinispan
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:xi="http://www.w3.org/2001/XInclude"
+        xsi:schemaLocation="urn:infinispan:config:11.0 https://infinispan.org/schemas/infinispan-config-11.0.xsd
+                            urn:infinispan:server:11.0 https://infinispan.org/schemas/infinispan-server-11.0.xsd"
+        xmlns="urn:infinispan:config:11.0"
+        xmlns:server="urn:infinispan:server:11.0">
+
+    <xi:include href="jgroups/stacks.xml"/>
+
+    <xi:include href="cache-container/clustered-anchored.xml"/>
+
+    <server xmlns="urn:infinispan:server:11.0">
+
+        <xi:include href="interfaces/default.xml"/>
+
+        <xi:include href="socket-bindings/default.xml"/>
+
+        <xi:include href="security/none.xml"/>
+
+        <xi:include href="endpoints/default.xml"/>
+    </server>
+</infinispan>

--- a/server/tests/src/test/resources/configuration/cache-container/clustered-anchored.xml
+++ b/server/tests/src/test/resources/configuration/cache-container/clustered-anchored.xml
@@ -1,0 +1,13 @@
+<cache-container xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:anchored="urn:infinispan:config:anchored:11.0"
+                 xsi:schemaLocation="urn:infinispan:config:11.0 https://infinispan.org/schemas/infinispan-config-fragment-11.0.xsd
+                                     urn:infinispan:config:anchored:11.0 https://infinispan.org/schemas/infinispan-anchored-config-11.0.xsd"
+                 xmlns="urn:infinispan:config:11.0"
+                 name="default" statistics="true">
+    <transport cluster="${infinispan.cluster.name}" stack="${infinispan.cluster.stack}"/>
+    <metrics gauges="true" histograms="true"/>
+    <replicated-cache name="default">
+        <locking concurrency-level="100" acquire-timeout="1000"/>
+        <anchored:anchored-keys enabled="true"/>
+    </replicated-cache>
+</cache-container>


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12065

@tristantarrant I had to set the run mode to CONTAINER ... for some reason with the default I get the following errors on the server:

```java
org.infinispan.client.hotrod.exceptions.HotRodClientException:Request for messageId=10 returned server error (status=0x85): java.lang.ClassCastException: class org.infinispan.remoting.transport.jgroups.JGroupsAddress cannot be cast to class [B (org.infinispan.remoting.transport.jgroups.JGroupsAddress is in unnamed module of loader 'app'; [B is in module java.base of loader 'bootstrap')
```