### PR TITLE
ISPN-12040 remoteCache.withFlags(Flag.SKIP_CACHE_LOAD).size() is retu…

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/SizeTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/SizeTest.java
@@ -64,6 +64,24 @@ public class SizeTest extends MultiHotRodServersTest {
       assertEquals(SIZE, clients.get(0).getCache(cacheName).size());
    }
 
+   public void testPersistentSizeWithFlag() {
+      String cacheName = "persistent-size-with-flag";
+      ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.LOCAL, false);
+      int evictionSize = 2;
+      builder.memory().maxCount(evictionSize);
+      builder.persistence()
+            .addStore(DummyInMemoryStoreConfigurationBuilder.class)
+            .storeName(getClass().getName())
+            .purgeOnStartup(true);
+      defineInAll(cacheName, builder);
+      RemoteCache<Integer, Integer> remoteCache = clients.get(0).getCache(cacheName);
+      assertEquals(0, remoteCache.size());
+      populateCache(remoteCache);
+      assertEquals(SIZE, remoteCache.size());
+
+      assertEquals(evictionSize, remoteCache.withFlags(Flag.SKIP_CACHE_LOAD).size());
+   }
+
    private void populateCache(String cacheName) {
       for (int i = 0; i < SIZE; i++) {
          clients.get(i % NUM_SERVERS).getCache(cacheName).put(i, i);

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/HotRodOperation.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/HotRodOperation.java
@@ -29,7 +29,7 @@ public enum HotRodOperation {
    PING(0x17, 0x18, EnumSet.noneOf(OpReqs.class), DecoderRequirements.HEADER),
    STATS(0x15, 0x16, EnumSet.of(OpReqs.REQUIRES_AUTH), DecoderRequirements.HEADER),
    CLEAR(0x13, 0x14, EnumSet.of(OpReqs.REQUIRES_AUTH), DecoderRequirements.HEADER),
-   SIZE(0x29, 0x2A, EnumSet.of(OpReqs.REQUIRES_AUTH), DecoderRequirements.HEADER),
+   SIZE(0x29, 0x2A, EnumSet.of(OpReqs.REQUIRES_AUTH, OpReqs.CAN_SKIP_CACHE_LOAD), DecoderRequirements.HEADER),
    AUTH_MECH_LIST(0x21, 0x22, EnumSet.noneOf(OpReqs.class), DecoderRequirements.HEADER),
 
    // Operation(s) that end after Custom Header is read


### PR DESCRIPTION
…rning all values in the cache

https://issues.redhat.com/browse/ISPN-12040