### PR TITLE
[11.0.x] ISPN-12109 TcpConnection.Receiver.run() blocking call

### DIFF
--- a/core/src/test/java/org/infinispan/util/CoreTestBlockHoundIntegration.java
+++ b/core/src/test/java/org/infinispan/util/CoreTestBlockHoundIntegration.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
+import org.apache.logging.log4j.spi.AbstractLogger;
 import org.infinispan.commons.internal.CommonsBlockHoundIntegration;
 import org.infinispan.commons.test.PolarionJUnitXMLWriter;
 import org.infinispan.commons.test.TestResourceTracker;
@@ -39,6 +40,9 @@ public class CoreTestBlockHoundIntegration implements BlockHoundIntegration {
       }
 
       builder.allowBlockingCallsInside(CoreTestBlockHoundIntegration.class.getName(), "writeJUnitReport");
+
+      // Ignore log4j2 blocking
+      builder.allowBlockingCallsInside(AbstractLogger.class.getName(), "logMessage");
 
       builder.blockingMethodCallback(bm -> {
          String testName = TestResourceTracker.getCurrentTestName();

--- a/pom.xml
+++ b/pom.xml
@@ -2757,28 +2757,10 @@
          </properties>
       </profile>
       <profile>
-         <id>test-CI</id>
-         <activation>
-            <activeByDefault>true</activeByDefault>
-         </activation>
-         <properties>
-            <defaultTestNGGroups>functional,unit,xsite,arquillian</defaultTestNGGroups>
-            <infinispan.cluster.stack>tcp</infinispan.cluster.stack>
-         </properties>
-      </profile>
-      <profile>
-         <id>test-functional</id>
-         <properties>
-            <defaultTestNGGroups>functional</defaultTestNGGroups>
-            <infinispan.cluster.stack>tcp</infinispan.cluster.stack>
-         </properties>
-      </profile>
-      <profile>
          <id>smoke</id>
          <properties>
             <defaultTestNGGroups>smoke</defaultTestNGGroups>
             <defaultJUnitGroups>org.infinispan.commons.test.categories.Smoke</defaultJUnitGroups>
-            <infinispan.cluster.stack>tcp</infinispan.cluster.stack>
          </properties>
       </profile>
       <profile>
@@ -2789,7 +2771,6 @@
             <!-- empty since we are not going to exclude any group -->
             <defaultExcludedTestNGGroups/>
             <defaultExcludedJUnitGroups/>
-            <infinispan.cluster.stack>tcp</infinispan.cluster.stack>
          </properties>
          <build>
             <plugins>
@@ -2798,7 +2779,7 @@
                   <artifactId>maven-surefire-plugin</artifactId>
                   <configuration>
                      <systemPropertyVariables>
-                        <log4j.configurationFile>log4j2-trace.xml</log4j.configurationFile>
+                        <log4j.configurationFile>${infinispan.root}/etc/log4j2-trace.xml</log4j.configurationFile>
                      </systemPropertyVariables>
                   </configuration>
                </plugin>
@@ -2813,25 +2794,6 @@
             <defaultExcludedTestNGGroups/>
             <defaultExcludedJUnitGroups/>
             <infinispan.test.parallel.threads>1</infinispan.test.parallel.threads>
-            <infinispan.cluster.stack>tcp</infinispan.cluster.stack>
-         </properties>
-      </profile>
-      <profile>
-         <id>test-unit</id>
-         <properties>
-            <defaultTestNGGroups>unit</defaultTestNGGroups>
-         </properties>
-      </profile>
-      <profile>
-         <id>test-jgroups</id>
-         <properties>
-            <defaultTestNGGroups>jgroups</defaultTestNGGroups>
-         </properties>
-      </profile>
-      <profile>
-         <id>test-transaction</id>
-         <properties>
-            <defaultTestNGGroups>transaction</defaultTestNGGroups>
          </properties>
       </profile>
       <profile>
@@ -2899,7 +2861,6 @@
          </activation>
          <properties>
             <infinispan.test.parallel.threads>1</infinispan.test.parallel.threads>
-            <infinispan.cluster.stack>tcp</infinispan.cluster.stack>
          </properties>
       </profile>
       <profile>

--- a/server/testdriver/pom.xml
+++ b/server/testdriver/pom.xml
@@ -14,7 +14,6 @@
 
    <properties>
       <server.output.dir.prefix>${infinispan.brand.prefix}-testdriver</server.output.dir.prefix>
-      <infinispan.cluster.stack>tcp</infinispan.cluster.stack>
    </properties>
    <modules>
       <module>core</module>


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12109

Backport of https://github.com/infinispan/infinispan/pull/8551

* Add BlockHound exceptions for JGroups w/ TCP transport
* Add BlockHound exception for Log4j2
* Remove property infinispan.cluster.stack from all profiles