### PR TITLE
ISPN-12148 Hibernate-cache NullPointerException in CacheMgmtInterceptor

### DIFF
--- a/core/src/main/java/org/infinispan/functional/impl/Params.java
+++ b/core/src/main/java/org/infinispan/functional/impl/Params.java
@@ -129,7 +129,7 @@ public final class Params {
             flagsBitSet |= FlagBitSets.SKIP_LOCKING;
             break;
          case TRY_LOCK:
-            flagsBitSet |= FlagBitSets.ZERO_LOCK_ACQUISITION_TIMEOUT;
+            flagsBitSet |= FlagBitSets.ZERO_LOCK_ACQUISITION_TIMEOUT | FlagBitSets.FAIL_SILENTLY;
             break;
       }
       switch (executionMode) {

--- a/core/src/main/java/org/infinispan/interceptors/impl/CacheMgmtInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/CacheMgmtInterceptor.java
@@ -366,6 +366,10 @@ public final class CacheMgmtInterceptor extends JmxStatsCommandInterceptor {
 
       long start = timeService.time();
       return invokeNextThenApply(ctx, command, (rCtx, rCommand, rv) -> {
+         // FAIL_SILENTLY makes the return value null
+         if (rv == null && !rCommand.isSuccessful() && rCommand.hasAnyFlag(FlagBitSets.FAIL_SILENTLY))
+            return null;
+
          long intervalNanos = timeService.timeDuration(start, TimeUnit.NANOSECONDS);
          StripeB stripe = counters.stripeForCurrentThread();
          StatsEnvelope<?> envelope = (StatsEnvelope<?>) rv;

--- a/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/LockingInterceptor.java
+++ b/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/LockingInterceptor.java
@@ -66,7 +66,7 @@ public class LockingInterceptor extends NonTransactionalLockingInterceptor {
    protected final InvocationFinallyFunction<DataWriteCommand> invokeNextAndUnlock = (rCtx, dataWriteCommand, rv, throwable) -> {
       if (throwable != null) {
          lockManager.unlockAll(rCtx);
-         if (throwable instanceof TimeoutException && dataWriteCommand.hasAnyFlag(FlagBitSets.ZERO_LOCK_ACQUISITION_TIMEOUT)) {
+         if (throwable instanceof TimeoutException && dataWriteCommand.hasAnyFlag(FlagBitSets.FAIL_SILENTLY)) {
             dataWriteCommand.fail();
             return null;
          }

--- a/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/NonStrictAccessDelegate.java
+++ b/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/NonStrictAccessDelegate.java
@@ -116,7 +116,10 @@ public class NonStrictAccessDelegate implements AccessDelegate {
 		// Even if value is instanceof CacheEntry, we have to wrap it in VersionedEntry and add transaction timestamp.
 		// Otherwise, old eviction record wouldn't be overwritten.
 		CompletableFuture<Void> future = putFromLoadMap.eval(key, new VersionedEntry(value, version, txTimestamp));
-		assert future.isDone(); // async try-locking should be done immediately
+		// async try-locking should be done immediately
+		assert future.isDone();
+		// Rethrow exceptions
+		future.join();
 		return true;
 	}
 

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/AbstractNonInvalidationTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/AbstractNonInvalidationTest.java
@@ -47,7 +47,7 @@ import static org.junit.Assert.assertTrue;
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
 public abstract class AbstractNonInvalidationTest extends SingleNodeTest {
-   protected static final int WAIT_TIMEOUT = 2000;
+   protected static final int WAIT_TIMEOUT = 20; // seconds
    protected static final ControlledTimeService TIME_SERVICE = new ControlledTimeService();
 
    protected long TIMEOUT;

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/VersionedTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/VersionedTest.java
@@ -281,7 +281,7 @@ public class VersionedTest extends AbstractNonInvalidationTest {
 
       TIME_SERVICE.advance(1);
       Future<Boolean> addFuture = executor.submit(() -> withTxSessionApply(s -> {
-         collectionUpdateTestInterceptor.updateLatch.await();
+         awaitOrThrow(collectionUpdateTestInterceptor.updateLatch);
          Item item = s.load(Item.class, itemId);
          OtherItem otherItem = new OtherItem();
          otherItem.setName("Other 2");
@@ -319,7 +319,7 @@ public class VersionedTest extends AbstractNonInvalidationTest {
          if (command.hasAnyFlag(FlagBitSets.ZERO_LOCK_ACQUISITION_TIMEOUT)) {
             if (firstPutFromLoad.compareAndSet(true, false)) {
                updateLatch.countDown();
-               putFromLoadLatch.await();
+               awaitOrThrow(putFromLoadLatch);
             }
          }
          return super.visitReadWriteKeyCommand(ctx, command);

--- a/hibernate/cache-v51/src/main/java/org/infinispan/hibernate/cache/v51/impl/BaseRegion.java
+++ b/hibernate/cache-v51/src/main/java/org/infinispan/hibernate/cache/v51/impl/BaseRegion.java
@@ -64,7 +64,9 @@ public abstract class BaseRegion implements Region, InfinispanBaseRegion {
 		this.tm = transactionManager;
 		this.factory = factory;
 		this.localAndSkipLoadCache = cache.withFlags(
-				Flag.CACHE_MODE_LOCAL, Flag.ZERO_LOCK_ACQUISITION_TIMEOUT,
+				Flag.CACHE_MODE_LOCAL,
+				Flag.FAIL_SILENTLY,
+				Flag.ZERO_LOCK_ACQUISITION_TIMEOUT,
 				Flag.SKIP_CACHE_LOAD
 		);
 	}

--- a/hibernate/cache-v53/src/main/java/org/infinispan/hibernate/cache/v53/impl/BaseRegionImpl.java
+++ b/hibernate/cache-v53/src/main/java/org/infinispan/hibernate/cache/v53/impl/BaseRegionImpl.java
@@ -54,7 +54,9 @@ abstract class BaseRegionImpl implements Region, InfinispanBaseRegion, ExtendedS
       this.name = name;
       this.factory = factory;
       this.localAndSkipLoadCache = cache.withFlags(
-            Flag.CACHE_MODE_LOCAL, Flag.ZERO_LOCK_ACQUISITION_TIMEOUT,
+            Flag.CACHE_MODE_LOCAL,
+            Flag.FAIL_SILENTLY,
+            Flag.ZERO_LOCK_ACQUISITION_TIMEOUT,
             Flag.SKIP_CACHE_LOAD
       );
    }


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12148
https://issues.redhat.com/browse/ISPN-12147

ISPN-12148 Hibernate-cache NullPointerException in CacheMgmtInterceptor
* Skip statistics update if the command failed
  and it had flag FAIL_SILENTLY
* Throw exception on lock timeout for operations with flag
  ZERO_LOCK_ACQUISITION_TIMEOUT, do not throw exception
  with flag FAIL_SILENTLY
* Translate meta-param LockingMode.TRY_LOCK to flags
  ZERO_LOCK_ACQUISITION_TIMEOUT + FAIL_SILENTLY
* Explicitly use flag FAIL_SILENTLY for
  BaseRegion[Impl].beginInvalidation

ISPN-12147 NonStrictAccessDelegate ignores cache exceptions 
