### PR TITLE
Fix StringLogAppender.getLog error message once again

### DIFF
--- a/commons-test/src/main/java/org/infinispan/commons/logging/log4j/ThreadNameFilter.java
+++ b/commons-test/src/main/java/org/infinispan/commons/logging/log4j/ThreadNameFilter.java
@@ -22,40 +22,36 @@ import org.apache.logging.log4j.message.Message;
  */
 @Plugin(name = "ThreadNameFilter", category = "Core", elementType = Filter.ELEMENT_TYPE, printObject = true)
 public final class ThreadNameFilter extends AbstractFilter {
-   /** The serialVersionUID */
-   private static final long serialVersionUID = 1L;
+
    private final Level level;
    private final Pattern includePattern;
 
-   public ThreadNameFilter(Level actualLevel, String includeRegex) {
-      this.level = actualLevel;
-      this.includePattern = Pattern.compile(includeRegex);
+   private ThreadNameFilter(Level level, String includeRegex) {
+      this.level = level == null ? Level.DEBUG : level;
+      this.includePattern = Pattern.compile(includeRegex == null ? ".*" : includeRegex);
    }
 
    @Override
-   public Result filter(final Logger logger, final Level level, final Marker marker, final String msg,
-                        final Object... params) {
-       return filter(level, Thread.currentThread().getName());
+   public Result filter(Logger logger, Level level, Marker marker, String msg, Object... params) {
+      return filter(level, Thread.currentThread().getName());
    }
 
    @Override
-   public Result filter(final Logger logger, final Level level, final Marker marker, final Object msg,
-                        final Throwable t) {
-       return filter(level, Thread.currentThread().getName());
+   public Result filter(Logger logger, Level level, Marker marker, Object msg, Throwable t) {
+      return filter(level, Thread.currentThread().getName());
    }
 
    @Override
-   public Result filter(final Logger logger, final Level level, final Marker marker, final Message msg,
-                        final Throwable t) {
-       return filter(level, Thread.currentThread().getName());
+   public Result filter(Logger logger, Level level, Marker marker, Message msg, Throwable t) {
+      return filter(level, Thread.currentThread().getName());
    }
 
    @Override
-   public Result filter(final LogEvent event) {
+   public Result filter(LogEvent event) {
       return filter(event.getLevel(), event.getThreadName());
    }
 
-   private Result filter(final Level level, String threadName) {
+   private Result filter(Level level, String threadName) {
       if (level.isMoreSpecificThan(this.level)) {
          return Result.NEUTRAL;
       } else if (includePattern == null || includePattern.matcher(threadName).find()) {
@@ -67,22 +63,19 @@ public final class ThreadNameFilter extends AbstractFilter {
 
    @Override
    public String toString() {
-       return level.toString();
+      return "ThreadNameFilter{level=" + level + ", include=" + includePattern.pattern() + '}';
    }
 
    /**
-    * Create a ThresholdFilter.
-    * @param level The log Level.
-    * @param match The action to take on a match.
-    * @param mismatch The action to take on a mismatch.
-    * @return The created ThresholdFilter.
+    * Create a ThreadNameFilter.
+    *
+    * @param level   The log Level.
+    * @param include The regex
+    * @return The created filter.
     */
    @PluginFactory
-   public static ThreadNameFilter createFilter(
-           @PluginAttribute("level") final Level level,
-           @PluginAttribute("include") final String include) {
-       final Level actualLevel = level == null ? Level.DEBUG : level;
-       final String includeRegex = include == null ? ".*" : include;
-       return new ThreadNameFilter(actualLevel, includeRegex);
+   public static ThreadNameFilter createFilter(@PluginAttribute("level") Level level,
+                                               @PluginAttribute("include") String include) {
+      return new ThreadNameFilter(level, include);
    }
 }

--- a/commons-test/src/main/java/org/infinispan/commons/test/skip/StringLogAppender.java
+++ b/commons-test/src/main/java/org/infinispan/commons/test/skip/StringLogAppender.java
@@ -14,6 +14,7 @@ import org.apache.logging.log4j.core.appender.AbstractAppender;
 import org.apache.logging.log4j.core.config.AppenderRef;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.config.Property;
 
 /**
  * A Log4J Appender which stores logs in a StringBuilder
@@ -28,8 +29,8 @@ public class StringLogAppender extends AbstractAppender {
    private final List<String> logs;
    private final Predicate<Thread> threadFilter;
 
-   public StringLogAppender(String category, Level level, Predicate<Thread> threadFilter, Layout layout) {
-      super(StringLogAppender.class.getName(), null, layout);
+   public StringLogAppender(String category, Level level, Predicate<Thread> threadFilter, Layout<?> layout) {
+      super(StringLogAppender.class.getName(), null, layout, true, Property.EMPTY_ARRAY);
       this.category = category;
       this.level = level;
       this.logs = Collections.synchronizedList(new ArrayList<>());
@@ -42,7 +43,7 @@ public class StringLogAppender extends AbstractAppender {
       this.start();
       config.addAppender(this);
       AppenderRef ref = AppenderRef.createAppenderRef(this.getName(), level, null);
-      AppenderRef[] refs = new AppenderRef[] {ref};
+      AppenderRef[] refs = new AppenderRef[]{ref};
       LoggerConfig loggerConfig = LoggerConfig.createLogger(true, level, category, null, refs, null, config, null);
       loggerConfig.addAppender(this, null, null);
       config.addLogger(category, loggerConfig);
@@ -63,12 +64,13 @@ public class StringLogAppender extends AbstractAppender {
    }
 
    public String getLog(int index) {
-      int size = logs.size();
-      if (size == 0) {
-         throw new IllegalStateException("No logs recorded yet");
+      if (index < 0) {
+         throw new IllegalArgumentException("Index must not be negative.");
       }
-      if (index < 0 || index >= size) {
-         throw new IllegalArgumentException("Index " + index + " is out of bounds: [0.." + size + "]");
+      int size = logs.size();
+      if (index >= size) {
+         throw new IllegalArgumentException("Index " + index + " is out of bounds. "
+                                                  + (size == 0 ? "No logs recorded yet." : "Accepted values are: [0 .. " + (size - 1) + "]"));
       }
       return logs.get(index);
    }


### PR DESCRIPTION
* fix the sometimes meaningless exception message when StringLogAppender.getLog fails
* ThreadNameFilter does not really need a serialVersionUID field; also remove needless finals for parameters

