### PR TITLE
[11.0.x] ISPN-11924 Advise on using protostream-processor as a 'provided' dependenc

### DIFF
--- a/build-configuration/bom/pom.xml
+++ b/build-configuration/bom/pom.xml
@@ -389,6 +389,8 @@
                 <groupId>org.infinispan.protostream</groupId>
                 <artifactId>protostream-processor</artifactId>
                 <version>${version.protostream}</version>
+                <!-- compile-only dependency -->
+                <scope>provided</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/documentation/src/main/asciidoc/topics/dependencies_maven/protostream-processor.xml
+++ b/documentation/src/main/asciidoc/topics/dependencies_maven/protostream-processor.xml
@@ -13,5 +13,11 @@
   <dependency>
     <groupId>org.infinispan.protostream</groupId>
     <artifactId>protostream-processor</artifactId>
+    <!--
+      This dependency should be declared in the "provided" scope or made "optional"
+      because it is a compile-only dependency and is not required at runtime.
+      Transitive propagation of this dependency should be also be avoided.
+    -->
+    <scope>provided</scope>
   </dependency>
 </dependencies>

--- a/documentation/src/main/asciidoc/topics/proc_generating_serial_cxt_initializer.adoc
+++ b/documentation/src/main/asciidoc/topics/proc_generating_serial_cxt_initializer.adoc
@@ -1,8 +1,7 @@
 [id='generating_proto_marshallers']
 = Generating Serialization Context Initializers
-{brandname} provides an `protostream-processor` artifact that can generate
-`.proto` schemas and `SerializationContextInitializer` implementations from
-annotated Java classes.
+{brandname} provides a `protostream-processor` artifact which is a Java annotation processor that can generate
+`.proto` schemas, marshallers and `SerializationContextInitializer` implementations from annotated Java classes.
 
 .Procedure
 


### PR DESCRIPTION
Continuing on ISPN-11924 Protostream Processor Dependency XML is incorrect
see comment: #8402 (comment)

https://issues.redhat.com/browse/ISPN-11924