### PR TITLE
ISPN-11005 HotRod decoder small performance improvements

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/AbstractAuthenticationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/AbstractAuthenticationTest.java
@@ -35,7 +35,6 @@ public abstract class AbstractAuthenticationTest extends SingleCacheManagerTest 
    }
 
    ConfigurationBuilder initServerAndClient(Map<String, String> mechProperties) {
-      hotrodServer = new HotRodServer();
       HotRodServerConfigurationBuilder serverBuilder = HotRodTestingUtil.getDefaultHotRodConfiguration();
       serverBuilder.authentication()
          .enable()
@@ -43,7 +42,7 @@ public abstract class AbstractAuthenticationTest extends SingleCacheManagerTest 
          .addAllowedMech("CRAM-MD5")
          .serverAuthenticationProvider(createAuthenticationProvider());
       serverBuilder.authentication().mechProperties(mechProperties);
-      hotrodServer.start(serverBuilder.build(), cacheManager);
+      hotrodServer = HotRodTestingUtil.startHotRodServer(cacheManager, serverBuilder);
       log.info("Started server on port: " + hotrodServer.getPort());
 
       ConfigurationBuilder clientBuilder = HotRodClientTestingUtil.newRemoteConfigurationBuilder();

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/SslAuthenticationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/SslAuthenticationTest.java
@@ -79,7 +79,6 @@ public class SslAuthenticationTest extends SingleCacheManagerTest {
          if (cache == null) cache = cacheManager.getCache();
          return null;
       });
-      hotrodServer = new HotRodServer();
       HotRodServerConfigurationBuilder serverBuilder = HotRodTestingUtil.getDefaultHotRodConfiguration();
 
       ClassLoader cl = SslAuthenticationTest.class.getClassLoader();
@@ -102,7 +101,7 @@ public class SslAuthenticationTest extends SingleCacheManagerTest {
                .addAllowedMech("EXTERNAL")
                .serverAuthenticationProvider(sap);
       Security.doAs(ADMIN, (PrivilegedExceptionAction<Object>) () -> {
-         hotrodServer.start(serverBuilder.build(), cacheManager);
+         hotrodServer = HotRodTestingUtil.startHotRodServer(cacheManager, serverBuilder);
          return null;
       });
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/SslTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/SslTest.java
@@ -49,7 +49,6 @@ public class SslTest extends SingleCacheManagerTest {
    }
 
    protected void initServerAndClient(boolean sslServer, boolean sslClient, boolean requireClientAuth, boolean clientAuth, boolean altCertPassword) {
-      hotrodServer = new HotRodServer();
       HotRodServerConfigurationBuilder serverBuilder = HotRodTestingUtil.getDefaultHotRodConfiguration();
 
       ClassLoader tccl = Thread.currentThread().getContextClassLoader();
@@ -69,7 +68,7 @@ public class SslTest extends SingleCacheManagerTest {
                .trustStoreType("PKCS12")
                .trustStorePassword(STORE_PASSWORD);
       }
-      hotrodServer.start(serverBuilder.build(), cacheManager);
+      hotrodServer = HotRodTestingUtil.startHotRodServer(cacheManager, serverBuilder);
       log.info("Started server on port: " + hotrodServer.getPort());
 
       String clientKeyStore = tccl.getResource(altCertPassword ? "keystore_client.jks" : "keystore_client.p12").getPath();

--- a/commons/all/src/main/java/org/infinispan/commons/dataconversion/MediaType.java
+++ b/commons/all/src/main/java/org/infinispan/commons/dataconversion/MediaType.java
@@ -133,6 +133,7 @@ public final class MediaType {
    private final String type;
    private final String subType;
    private final String typeSubtype;
+   private final boolean matchesAll;
    private final transient double weight;
 
    public MediaType(String type, String subtype) {
@@ -143,6 +144,7 @@ public final class MediaType {
       this.type = validate(type);
       this.subType = validate(subtype);
       this.typeSubtype = type + "/" + subtype;
+      this.matchesAll = typeSubtype.equalsIgnoreCase(MATCH_ALL_TYPE);
       if (params != null) {
          this.params.putAll(params);
          String weight = params.get(WEIGHT_PARAM_NAME);
@@ -240,11 +242,14 @@ public final class MediaType {
    }
 
    public boolean match(MediaType other) {
+      if (other == this)
+         return true;
+
       return other != null && (other.matchesAll() || this.matchesAll() || other.typeSubtype.equals(this.typeSubtype));
    }
 
    public boolean matchesAll() {
-      return this.typeSubtype.equals(MATCH_ALL_TYPE);
+      return matchesAll;
    }
 
    public String getTypeSubtype() {

--- a/commons/all/src/main/java/org/infinispan/commons/util/Immutables.java
+++ b/commons/all/src/main/java/org/infinispan/commons/util/Immutables.java
@@ -82,7 +82,6 @@ public class Immutables {
    /**
     * Wraps an array with an immutable list. There is no copying involved.
     *
-    * @param <T>
     * @param array the array to wrap
     * @return a list containing the array
     */
@@ -166,14 +165,8 @@ public class Immutables {
       if (set == null) return null;
       if (set.isEmpty()) return Collections.emptySet();
       if (set.size() == 1) return Collections.singleton(set.iterator().next());
-      Set<? extends T> copy = ObjectDuplicator.duplicateSet(set);
-      if (copy == null)
-         // Set uses Collection copy-ctor
-         copy = attemptCopyConstructor(set, Collection.class);
-      if (copy == null)
-         copy = new HashSet<>(set);
 
-      return new ImmutableSetWrapper<>(copy);
+      return new ImmutableSetWrapper<>(new HashSet<>(set));
    }
 
 
@@ -201,14 +194,7 @@ public class Immutables {
          return Collections.singletonMap(me.getKey(), me.getValue());
       }
 
-      Map<? extends K, ? extends V> copy = ObjectDuplicator.duplicateMap(map);
-
-      if (copy == null)
-         copy = attemptCopyConstructor(map, Map.class);
-      if (copy == null)
-         copy = new HashMap<>(map);
-
-      return new ImmutableMapWrapper<>(copy);
+      return new ImmutableMapWrapper<>(new HashMap<>(map));
    }
 
    /**
@@ -222,13 +208,7 @@ public class Immutables {
       if (collection.isEmpty()) return Collections.emptySet();
       if (collection.size() == 1) return Collections.singleton(collection.iterator().next());
 
-      Collection<? extends T> copy = ObjectDuplicator.duplicateCollection(collection);
-      if (copy == null)
-         copy = attemptCopyConstructor(collection, Collection.class);
-      if (copy == null)
-         copy = new ArrayList<>(collection);
-
-      return new ImmutableCollectionWrapper<>(copy);
+      return new ImmutableCollectionWrapper<>(new ArrayList<>(collection));
    }
 
    /**
@@ -239,17 +219,6 @@ public class Immutables {
     */
    public static <T> Collection<T> immutableCollectionWrap(Collection<? extends T> collection) {
       return new ImmutableCollectionWrapper<>(collection);
-   }
-
-   @SuppressWarnings("unchecked")
-   private static <T> T attemptCopyConstructor(T source, Class<? super T> clazz) {
-      try {
-         return (T) source.getClass().getConstructor(clazz).newInstance(source);
-      }
-      catch (Exception e) {
-      }
-
-      return null;
    }
 
    /**
@@ -283,7 +252,7 @@ public class Immutables {
     * simple to detect them (the class names are JDK dependent).
     */
    public static class ImmutableIteratorWrapper<E> implements Iterator<E> {
-      private Iterator<? extends E> iterator;
+      private final Iterator<? extends E> iterator;
 
       public ImmutableIteratorWrapper(Iterator<? extends E> iterator) {
          this.iterator = iterator;
@@ -401,9 +370,9 @@ public class Immutables {
     * Immutable version of Map.Entry for traversing immutable collections.
     */
    private static class ImmutableEntry<K, V> implements Entry<K, V>, Immutable {
-      private K key;
-      private V value;
-      private int hash;
+      private final K key;
+      private final V value;
+      private final int hash;
 
       ImmutableEntry(Entry<? extends K, ? extends V> entry) {
          this.key = entry.getKey();
@@ -462,19 +431,6 @@ public class Immutables {
 
       public ImmutableSetWrapper(Set<? extends E> set) {
          super(set);
-      }
-   }
-
-   private static class ImmutableReversibleOrderedSetWrapper<E> extends ImmutableCollectionWrapper<E> implements ReversibleOrderedSet<E>, Serializable, Immutable {
-      private static final long serialVersionUID = 7991492805176142615L;
-
-      public ImmutableReversibleOrderedSetWrapper(Set<? extends E> set) {
-         super(set);
-      }
-
-      @Override
-      public Iterator<E> reverseIterator() {
-         return new ImmutableIteratorWrapper<E>(((ReversibleOrderedSet<? extends E>) collection).reverseIterator());
       }
    }
 
@@ -539,7 +495,6 @@ public class Immutables {
       }
 
       @Override
-      @SuppressWarnings("unchecked")
       public Set<Class<? extends Set>> getTypeClasses() {
          return Util.asSet(ImmutableSetWrapper.class);
       }
@@ -548,7 +503,7 @@ public class Immutables {
    private static class ImmutableMapWrapper<K, V> implements Map<K, V>, Serializable, Immutable {
       private static final long serialVersionUID = 708144227046742221L;
 
-      private Map<? extends K, ? extends V> map;
+      private final Map<? extends K, ? extends V> map;
 
       public ImmutableMapWrapper(Map<? extends K, ? extends V> map) {
          this.map = map;
@@ -647,7 +602,6 @@ public class Immutables {
       }
 
       @Override
-      @SuppressWarnings("unchecked")
       public Set<Class<? extends Map>> getTypeClasses() {
          return Util.asSet(ImmutableMapWrapper.class);
       }
@@ -678,17 +632,17 @@ public class Immutables {
       }
 
       @Override
-      public synchronized void load(InputStream inStream) throws IOException {
+      public synchronized void load(InputStream inStream) {
          throw new UnsupportedOperationException();
       }
 
       @Override
-      public synchronized void load(Reader reader) throws IOException {
+      public synchronized void load(Reader reader) {
          throw new UnsupportedOperationException();
       }
 
       @Override
-      public synchronized void loadFromXML(InputStream in) throws IOException {
+      public synchronized void loadFromXML(InputStream in) {
          throw new UnsupportedOperationException();
       }
 

--- a/commons/all/src/main/java/org/infinispan/commons/util/ObjectDuplicator.java
+++ b/commons/all/src/main/java/org/infinispan/commons/util/ObjectDuplicator.java
@@ -14,13 +14,14 @@ import java.util.TreeSet;
  * A helper that efficiently duplicates known object types.
  *
  * @author (various)
- * @since 4.0
+ * @deprecated Since 12, will be removed in version 15.0
  */
+@Deprecated
 public class ObjectDuplicator {
    @SuppressWarnings("unchecked")
    public static <K, V> Map<K, V> duplicateMap(Map<K, V> original) {
       if (original instanceof FastCopyHashMap)
-         return (Map<K, V>) ((FastCopyHashMap<K, V>) original).clone();
+         return ((FastCopyHashMap<K, V>) original).clone();
       if (original instanceof HashMap)
          return (Map<K, V>) ((HashMap<K, V>) original).clone();
       if (original instanceof TreeMap)
@@ -41,13 +42,13 @@ public class ObjectDuplicator {
       if (original instanceof TreeSet)
          return (Set<E>) ((TreeSet<E>) original).clone();
       if (original instanceof FastCopyHashMap.EntrySet || original instanceof FastCopyHashMap.KeySet)
-         return new HashSet<E>(original);
+         return new HashSet<>(original);
       if (original.getClass().equals(Collections.emptySet().getClass()))
          return Collections.emptySet();
       if (original.getClass().equals(Collections.singleton("").getClass()))
          return Collections.singleton(original.iterator().next());
       if (original.getClass().getSimpleName().contains("$"))
-         return new HashSet<E>(original);
+         return new HashSet<>(original);
 
       return attemptClone(original);
    }
@@ -69,6 +70,7 @@ public class ObjectDuplicator {
             return (T) source.getClass().getMethod("clone").invoke(source);
          }
          catch (Exception e) {
+            // Will return null
          }
       }
 

--- a/core/src/main/java/org/infinispan/cache/impl/AbstractDelegatingAdvancedCache.java
+++ b/core/src/main/java/org/infinispan/cache/impl/AbstractDelegatingAdvancedCache.java
@@ -157,7 +157,7 @@ public abstract class AbstractDelegatingAdvancedCache<K, V> extends AbstractDele
       return getAvailability().toString();
    }
 
-   public void setCacheAvailability(String availabilityString) throws Exception {
+   public void setCacheAvailability(String availabilityString) {
       setAvailability(AvailabilityMode.valueOf(availabilityString));
    }
 
@@ -188,6 +188,16 @@ public abstract class AbstractDelegatingAdvancedCache<K, V> extends AbstractDele
          } catch (Exception e) {
             throw new CacheException(e);
          }
+      }
+   }
+
+   @Override
+   public AdvancedCache<K, V> withFlags(Flag flag) {
+      AdvancedCache<K, V> flagCache = cache.withFlags(flag);
+      if (flagCache != cache) {
+         return rewrap(flagCache);
+      } else {
+         return this;
       }
    }
 

--- a/core/src/main/java/org/infinispan/cache/impl/CacheImpl.java
+++ b/core/src/main/java/org/infinispan/cache/impl/CacheImpl.java
@@ -1692,6 +1692,11 @@ public class CacheImpl<K, V> implements AdvancedCache<K, V> {
    }
 
    @Override
+   public AdvancedCache<K, V> withFlags(Flag flag) {
+      return new DecoratedCache<>(this, EnumUtil.bitSetOf(flag));
+   }
+
+   @Override
    public AdvancedCache<K, V> withFlags(final Flag... flags) {
       if (flags == null || flags.length == 0)
          return this;

--- a/core/src/main/java/org/infinispan/interceptors/locking/ClusteringDependentLogic.java
+++ b/core/src/main/java/org/infinispan/interceptors/locking/ClusteringDependentLogic.java
@@ -535,7 +535,7 @@ public interface ClusteringDependentLogic {
                expired = false;
             }
 
-            if (stage == null) {
+            if (stage == null || CompletionStages.isCompletedSuccessfully(stage)) {
                return NotifyHelper.entryCommitted(notifier, functionalNotifier, created, removed, expired,
                      entry, ctx, command, previousValue, previousMetadata, evictionManager);
             } else {

--- a/core/src/main/java/org/infinispan/marshall/core/Primitives.java
+++ b/core/src/main/java/org/infinispan/marshall/core/Primitives.java
@@ -2,8 +2,9 @@ package org.infinispan.marshall.core;
 
 import java.io.EOFException;
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
+
+import org.infinispan.commons.util.HopscotchHashMap;
 
 final class Primitives {
 
@@ -40,7 +41,7 @@ final class Primitives {
    static final int MEDIUM_ARRAY_MIN               = 0x101;
    static final int MEDIUM_ARRAY_MAX               = 0x10100;
 
-   static final Map<Class<?>, Integer> PRIMITIVES = new HashMap<>(18);
+   static final Map<Class<?>, Integer> PRIMITIVES = new HopscotchHashMap<>(18);
 
    static {
       PRIMITIVES.put(String.class, ID_STRING);

--- a/server/core/src/main/java/org/infinispan/server/core/AbstractProtocolServer.java
+++ b/server/core/src/main/java/org/infinispan/server/core/AbstractProtocolServer.java
@@ -115,7 +115,7 @@ public abstract class AbstractProtocolServer<C extends ProtocolServerConfigurati
    }
 
    protected void startTransport() {
-      log.debugf("Starting Netty transport on %s:%s", configuration.host(), configuration.port());
+      log.debugf("Starting Netty transport for %s on %s:%s", configuration.name(), configuration.host(), configuration.port());
       InetSocketAddress address = new InetSocketAddress(configuration.host(), configuration.port());
       transport = new NettyTransport(address, configuration, getQualifiedName(), cacheManager);
       transport.initializeHandler(getInitializer());

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/Intrinsics.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/Intrinsics.java
@@ -53,14 +53,7 @@ public class Intrinsics {
 
    public static String string(ByteBuf buf) {
       buf.markReaderIndex();
-      byte[] bytes = ExtendedByteBufJava.readMaybeRangedBytes(buf);
-      if (bytes == null) {
-         return null;
-      } else if (bytes.length == 0) {
-         return "";
-      } else {
-         return new String(bytes, CharsetUtil.UTF_8);
-      }
+      return ExtendedByteBufJava.readString(buf);
    }
 
    public static byte[] optionalArray(ByteBuf buf) {

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/test/HotRodSslWithCertPasswdTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/test/HotRodSslWithCertPasswdTest.java
@@ -7,7 +7,6 @@ import static org.infinispan.test.fwk.TestCacheManagerFactory.createCacheManager
 import static org.testng.AssertJUnit.assertNotNull;
 
 import org.infinispan.server.core.test.Stoppable;
-import org.infinispan.server.hotrod.HotRodServer;
 import org.infinispan.server.hotrod.configuration.HotRodServerConfigurationBuilder;
 import org.infinispan.test.AbstractInfinispanTest;
 import org.testng.annotations.Test;
@@ -29,12 +28,11 @@ public class HotRodSslWithCertPasswdTest extends AbstractInfinispanTest {
       HotRodServerConfigurationBuilder builder = new HotRodServerConfigurationBuilder();
       builder.host(host()).port(serverPort()).idleTimeout(0);
       builder.ssl().enable().keyStoreFileName(keyStoreFileName).keyStorePassword("secret".toCharArray())
-            .keyStoreType("pkcs12")
+             .keyStoreType("pkcs12")
              .keyStoreCertificatePassword("secret2".toCharArray()).trustStoreFileName(trustStoreFileName)
              .trustStorePassword("secret".toCharArray()).trustStoreType("pkcs12");
       Stoppable.useCacheManager(createCacheManager(hotRodCacheConfiguration()), cm ->
-            Stoppable.useServer(new HotRodServer(), server -> {
-                                   server.start(builder.build(), cm);
+            Stoppable.useServer(HotRodTestingUtil.startHotRodServer(cm, builder), server -> {
                                    assertNotNull(server.getConfiguration().ssl().keyStoreCertificatePassword());
                                 }
             ));

--- a/server/rest/src/main/java/org/infinispan/rest/cachemanager/RestCacheManager.java
+++ b/server/rest/src/main/java/org/infinispan/rest/cachemanager/RestCacheManager.java
@@ -71,7 +71,7 @@ public class RestCacheManager<V> {
          throw logger.missingRequiredMediaType(name);
       }
       checkCacheAvailable(name);
-      String cacheKey = name + "-" + keyContentType.toString() + valueContentType.getTypeSubtype();
+      String cacheKey = name + "-" + keyContentType.getTypeSubtype() + valueContentType.getTypeSubtype();
       AdvancedCache<Object, V> cache = knownCaches.get(cacheKey);
       if (cache == null) {
          cache = instance.<Object, V>getCache(name).getAdvancedCache();


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-11005

* Avoid new byte[] instance when reading cache name
* Improve parsing and matching of media types
* Simplify copying of collections
* Avoid new array instance in withFlags(Flag)
* Avoid new lambda instance when stage is completed successfully
* Use HopscotchHashMap for GlobalMarshaller primitive ids
* Simplify ExtendedByteBufJava.readMaybeVInt() logic
* Call withFlags() only once in HotRodHeader.getOptimizedCache()
* Don't include key media type parameters in knownCaches key in
  RestCacheManager.getCache()