### PR TITLE
ISPN-12220: expression defaults not working correctly

### DIFF
--- a/cli/cli-client/src/test/resources/patch/v1/server/conf/infinispan.xml
+++ b/cli/cli-client/src/test/resources/patch/v1/server/conf/infinispan.xml
@@ -6,7 +6,7 @@
         xmlns:server="urn:infinispan:server:12.0">
 
    <cache-container name="default" statistics="true">
-      <transport cluster="${infinispan.cluster.name}" stack="${infinispan.cluster.stack:tcp}" node-name="${infinispan.node.name:}"/>
+      <transport cluster="${infinispan.cluster.name:cluster}" stack="${infinispan.cluster.stack:tcp}" node-name="${infinispan.node.name:}"/>
    </cache-container>
 
    <server xmlns="urn:infinispan:server:12.0">

--- a/cli/cli-client/src/test/resources/patch/v2/server/conf/infinispan.xml
+++ b/cli/cli-client/src/test/resources/patch/v2/server/conf/infinispan.xml
@@ -6,7 +6,7 @@
         xmlns:server="urn:infinispan:server:12.0">
 
    <cache-container name="default" statistics="true">
-      <transport cluster="${infinispan.cluster.name}" stack="${infinispan.cluster.stack:tcp}" node-name="${infinispan.node.name:}"/>
+      <transport cluster="${infinispan.cluster.name:cluster}" stack="${infinispan.cluster.stack:tcp}" node-name="${infinispan.node.name:}"/>
    </cache-container>
 
    <server xmlns="urn:infinispan:server:12.0">

--- a/cli/cli-client/src/test/resources/patch/v3/server/conf/infinispan.xml
+++ b/cli/cli-client/src/test/resources/patch/v3/server/conf/infinispan.xml
@@ -6,7 +6,7 @@
         xmlns:server="urn:infinispan:server:12.0">
 
    <cache-container name="default" statistics="true">
-      <transport cluster="${infinispan.cluster.name}" stack="${infinispan.cluster.stack:tcp}" node-name="${infinispan.node.name:}"/>
+      <transport cluster="${infinispan.cluster.name:cluster}" stack="${infinispan.cluster.stack:tcp}" node-name="${infinispan.node.name:}"/>
    </cache-container>
 
    <!-- This comment alters the file compared to v1 and v2 -->

--- a/documentation/src/main/asciidoc/topics/ref_default_cm_remote.adoc
+++ b/documentation/src/main/asciidoc/topics/ref_default_cm_remote.adoc
@@ -10,9 +10,9 @@ create caches at run-time.
 ----
 <cache-container name="default" <1>
                  statistics="true"> <2>
-  <transport cluster="${infinispan.cluster.name}" <3>
+  <transport cluster="${infinispan.cluster.name:cluster}" <3>
              stack="${infinispan.cluster.stack:tcp}" <4>
-             node-name="${infinispan.node.name:}"/>
+             node-name="${infinispan.node.name:}"/> <5>
 </cache-container>
 ----
 
@@ -21,6 +21,7 @@ create caches at run-time.
 <3> Adds a JGroups cluster transport that allows {ProductName} servers to
 automatically discover each other and form clusters.
 <4> Uses the default TCP stack for cluster traffic.
+<5> Individual name for the node, must be unique across the cluster. Uses a unified hostname by default.
 
 .Examining the Cache Manager
 

--- a/integrationtests/server-integration/server-integration-commons/src/test/resources/infinispan-custom.xml
+++ b/integrationtests/server-integration/server-integration-commons/src/test/resources/infinispan-custom.xml
@@ -14,7 +14,7 @@
     </jgroups>
 
     <cache-container default-cache="default" statistics="true">
-        <transport cluster="${infinispan.cluster.name}" stack="wildfly-modules-it"/>
+        <transport cluster="${infinispan.cluster.name:cluster}" stack="wildfly-modules-it"/>
         <global-state />
         <local-cache name="default" />
     </cache-container>

--- a/jcache/tck-runner-remote/src/test/resources/infinispan.xml
+++ b/jcache/tck-runner-remote/src/test/resources/infinispan.xml
@@ -8,7 +8,7 @@
     <cache-container name="default" statistics="true">
         <!-- Note: Maven resources plugin replaces ${infinispan.cluster.stack} with the property value
              It would not replace ${infinispan.cluster.stack:tcp -->
-        <transport cluster="${infinispan.cluster.name}" stack="${infinispan.cluster.stack}"/>
+        <transport cluster="${infinispan.cluster.name:cluster}" stack="${infinispan.cluster.stack}"/>
         <serialization>
             <context-initializer class="org.infinispan.jcache.tck.JCacheTckContextInitializer"/>
         </serialization>

--- a/server/runtime/README.adoc
+++ b/server/runtime/README.adoc
@@ -76,7 +76,7 @@ The following is an example server configuration:
         xmlns="urn:infinispan:config:12.0"
         xmlns:server="urn:infinispan:server:12.0">
    <cache-container default-cache="default" statistics="false">
-      <transport cluster="${infinispan.cluster.name}" stack="udp"/>
+      <transport cluster="${infinispan.cluster.name:cluster}" stack="udp"/>
       <global-state/>
       <distributed-cache name="default"/>
    </cache-container>

--- a/server/runtime/src/main/java/org/infinispan/server/Bootstrap.java
+++ b/server/runtime/src/main/java/org/infinispan/server/Bootstrap.java
@@ -149,9 +149,9 @@ public class Bootstrap extends Main {
       out.printf("  -b, --bind-address=<address>  %s\n", MSG.serverHelpBindAddress());
       out.printf("  -c, --server-config=<config>  %s\n", MSG.serverHelpServerConfig(Server.DEFAULT_CONFIGURATION_FILE));
       out.printf("  -l, --logging-config=<config> %s\n", MSG.serverHelpLoggingConfig(Server.DEFAULT_LOGGING_FILE));
-      out.printf("  -g, --cluster-name=<name>     %s\n", MSG.serverHelpClusterName(Server.DEFAULT_CLUSTER_NAME));
+      out.printf("  -g, --cluster-name=<name>     %s\n", MSG.serverHelpClusterName());
       out.printf("  -h, --help                    %s\n", MSG.toolHelpHelp());
-      out.printf("  -j, --cluster-stack=<name>    %s\n", MSG.serverHelpClusterStack(Server.DEFAULT_CLUSTER_STACK));
+      out.printf("  -j, --cluster-stack=<name>    %s\n", MSG.serverHelpClusterStack());
       out.printf("  -k, --cluster-address=<name>  %s\n", MSG.serverHelpClusterAddress());
       out.printf("  -n, --node-name=<name>        %s\n", MSG.serverHelpNodeName());
       out.printf("  -o, --port-offset=<offset>    %s\n", MSG.serverHelpPortOffset());

--- a/server/runtime/src/main/java/org/infinispan/server/Server.java
+++ b/server/runtime/src/main/java/org/infinispan/server/Server.java
@@ -220,8 +220,6 @@ public class Server implements ServerManagement, AutoCloseable {
       properties.putIfAbsent(INFINISPAN_SERVER_DATA_PATH, new File(serverRoot, DEFAULT_SERVER_DATA).getAbsolutePath());
       properties.putIfAbsent(INFINISPAN_SERVER_LOG_PATH, new File(serverRoot, DEFAULT_SERVER_LOG).getAbsolutePath());
       properties.putIfAbsent(INFINISPAN_BIND_PORT, DEFAULT_BIND_PORT);
-      properties.putIfAbsent(INFINISPAN_CLUSTER_NAME, DEFAULT_CLUSTER_NAME);
-      properties.putIfAbsent(INFINISPAN_CLUSTER_STACK, DEFAULT_CLUSTER_STACK);
 
       this.serverConf = new File(properties.getProperty(INFINISPAN_SERVER_CONFIG_PATH));
 

--- a/server/runtime/src/main/java/org/infinispan/server/logging/Messages.java
+++ b/server/runtime/src/main/java/org/infinispan/server/logging/Messages.java
@@ -54,11 +54,11 @@ public interface Messages {
    @Message("Specifies a logging configuration file. Defaults to `%s`.")
    String serverHelpLoggingConfig(String defaultConfiguration);
 
-   @Message("Sets the name of the cluster. Defaults to `%s`.")
-   String serverHelpClusterName(String defaultClusterName);
+   @Message("Sets the name of the cluster. Default set by configuration expression")
+   String serverHelpClusterName();
 
-   @Message("Specifies the JGroups stack for clustering. Defaults to `%s`.")
-   String serverHelpClusterStack(String defaultStack);
+   @Message("Specifies the JGroups stack for clustering. Default set by configuration expression")
+   String serverHelpClusterStack();
 
    @Message("Specifies the JGroups bind address for clustering.")
    String serverHelpClusterAddress();

--- a/server/runtime/src/main/server/server/conf/infinispan-xsite.xml
+++ b/server/runtime/src/main/server/server/conf/infinispan-xsite.xml
@@ -17,7 +17,7 @@
    </jgroups>
 
    <cache-container name="default" statistics="true">
-      <transport cluster="${infinispan.cluster.name}" stack="xsite"/>
+      <transport cluster="${infinispan.cluster.name:cluster}" stack="xsite"/>
    </cache-container>
 
    <server xmlns="urn:infinispan:server:12.0">

--- a/server/runtime/src/main/server/server/conf/infinispan.xml
+++ b/server/runtime/src/main/server/server/conf/infinispan.xml
@@ -6,7 +6,7 @@
         xmlns:server="urn:infinispan:server:12.0">
 
    <cache-container name="default" statistics="true">
-      <transport cluster="${infinispan.cluster.name}" stack="${infinispan.cluster.stack:tcp}" node-name="${infinispan.node.name:}"/>
+      <transport cluster="${infinispan.cluster.name:cluster}" stack="${infinispan.cluster.stack:tcp}" node-name="${infinispan.node.name:}"/>
    </cache-container>
 
    <server xmlns="urn:infinispan:server:12.0">

--- a/server/testdriver/junit5/src/test/resources/infinispan.xml
+++ b/server/testdriver/junit5/src/test/resources/infinispan.xml
@@ -16,7 +16,7 @@
         </stack>
     </jgroups>
     <cache-container name="default" statistics="true">
-        <transport cluster="${infinispan.cluster.name}" stack="${infinispan.cluster.stack:tcp}" node-name="${infinispan.node.name:}"/>
+        <transport cluster="${infinispan.cluster.name:cluster}" stack="${infinispan.cluster.stack:tcp}" node-name="${infinispan.node.name:}"/>
     </cache-container>
 
     <server>

--- a/server/tests/src/test/resources/configuration/cache-container/clustered-anchored.xml
+++ b/server/tests/src/test/resources/configuration/cache-container/clustered-anchored.xml
@@ -4,7 +4,7 @@
                                      urn:infinispan:config:anchored:12.0 https://infinispan.org/schemas/infinispan-anchored-config-12.0.xsd"
                  xmlns="urn:infinispan:config:12.0"
                  name="default" statistics="true">
-    <transport cluster="${infinispan.cluster.name}" stack="${infinispan.cluster.stack}"/>
+    <transport cluster="${infinispan.cluster.name:cluster}" stack="${infinispan.cluster.stack}"/>
     <metrics gauges="true" histograms="true"/>
     <replicated-cache name="default">
         <locking concurrency-level="100" acquire-timeout="1000"/>

--- a/server/tests/src/test/resources/configuration/cache-container/clustered-authz.xml
+++ b/server/tests/src/test/resources/configuration/cache-container/clustered-authz.xml
@@ -2,7 +2,7 @@
                  xsi:schemaLocation="urn:infinispan:config:12.0 https://infinispan.org/schemas/infinispan-config-fragment-12.0.xsd"
                  xmlns="urn:infinispan:config:12.0"
                  name="default">
-   <transport cluster="${infinispan.cluster.name}" stack="${infinispan.cluster.stack}"/>
+   <transport cluster="${infinispan.cluster.name:cluster}" stack="${infinispan.cluster.stack}"/>
    <security>
       <authorization>
          <identity-role-mapper/>

--- a/server/tests/src/test/resources/configuration/cache-container/clustered.xml
+++ b/server/tests/src/test/resources/configuration/cache-container/clustered.xml
@@ -2,6 +2,6 @@
                  xsi:schemaLocation="urn:infinispan:config:12.0 https://infinispan.org/schemas/infinispan-config-fragment-12.0.xsd"
                  xmlns="urn:infinispan:config:12.0"
                  name="default" statistics="true">
-   <transport cluster="${infinispan.cluster.name}" stack="${infinispan.cluster.stack}"/>
+   <transport cluster="${infinispan.cluster.name:cluster}" stack="${infinispan.cluster.stack}"/>
    <metrics gauges="true" histograms="true"/>
 </cache-container>


### PR DESCRIPTION
Defaults for infinispan.cluster.name and infinispan.cluster.stack are set hardcoded, the defaults within the expression ${:XXX} are not working.

https://issues.redhat.com/browse/ISPN-12220