### PR TITLE
ISPN-12251 HotRodClientJmxTest.testRemoteCacheManagerMBean fails on Java 14

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
@@ -7,7 +7,7 @@ import static org.infinispan.client.hotrod.logging.Log.HOTROD;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.SocketAddress;
+import java.net.InetSocketAddress;
 import java.net.URI;
 import java.security.Provider;
 import java.util.Arrays;
@@ -682,8 +682,8 @@ public class RemoteCacheManager implements RemoteCacheContainer, Closeable, Remo
     */
    @Override
    public String[] getServers() {
-      Collection<SocketAddress> addresses = channelFactory.getServers();
-      return addresses.stream().map(SocketAddress::toString).toArray(String[]::new);
+      Collection<InetSocketAddress> addresses = channelFactory.getServers();
+      return addresses.stream().map(socketAddress -> socketAddress.getHostString() + ":" + socketAddress.getPort()).toArray(String[]::new);
    }
 
    @Override

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec20.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec20.java
@@ -8,8 +8,8 @@ import java.lang.annotation.Annotation;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -369,7 +369,7 @@ public class Codec20 implements Codec, HotRodConstants {
       final Log localLog = getLog();
       int newTopologyId = ByteBufUtil.readVInt(buf);
 
-      SocketAddress[] addresses = readTopology(buf);
+      InetSocketAddress[] addresses = readTopology(buf);
 
       final short hashFunctionVersion;
       final SocketAddress[][] segmentOwners;
@@ -399,7 +399,7 @@ public class Codec20 implements Codec, HotRodConstants {
       // but we should still accept the topology
       if (params.topologyAge < topologyAge || params.topologyAge == topologyAge && currentTopology != newTopologyId) {
          params.topologyId.set(newTopologyId);
-         List<SocketAddress> addressList = Arrays.asList(addresses);
+         Collection<InetSocketAddress> addressList = Arrays.asList(addresses);
          if (HOTROD.isInfoEnabled()) {
             HOTROD.newTopology(newTopologyId, topologyAge,
                   addresses.length, new HashSet<>(addressList));
@@ -423,9 +423,9 @@ public class Codec20 implements Codec, HotRodConstants {
       }
    }
 
-   private SocketAddress[] readTopology(ByteBuf buf) {
+   private InetSocketAddress[] readTopology(ByteBuf buf) {
       int clusterSize = ByteBufUtil.readVInt(buf);
-      SocketAddress[] addresses = new SocketAddress[clusterSize];
+      InetSocketAddress[] addresses = new InetSocketAddress[clusterSize];
       for (int i = 0; i < clusterSize; i++) {
          String host = ByteBufUtil.readString(buf);
          int port = buf.readUnsignedShort();

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HitsAwareCacheManagersTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HitsAwareCacheManagersTest.java
@@ -205,10 +205,10 @@ public abstract class HitsAwareCacheManagersTest extends MultipleCacheManagersTe
          if (ctx.isOriginLocal()) {
             if ((command instanceof AbstractDataCommand) && ((AbstractDataCommand)command).hasAnyFlag(FlagBitSets.SKIP_XSITE_BACKUP)) {
                int count = backupSiteInvocationCount.incrementAndGet();
-               log.infof("Backup Hit %d for %s", count, command);
+               log.debugf("Backup Hit %d for %s", count, command);
             } else {
                int count = localSiteInvocationCount.incrementAndGet();
-               log.infof("Local Hit %d for %s", count, command);
+               log.debugf("Local Hit %d for %s", count, command);
             }
          }
          return invokeNext(ctx, command);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ReplTopologyChangeTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ReplTopologyChangeTest.java
@@ -6,7 +6,6 @@ import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheCon
 import static org.testng.AssertJUnit.assertEquals;
 
 import java.net.InetSocketAddress;
-import java.net.SocketAddress;
 import java.util.Collection;
 
 import org.infinispan.client.hotrod.impl.transport.netty.ChannelFactory;
@@ -138,7 +137,7 @@ public class ReplTopologyChangeTest extends MultipleCacheManagersTest {
          remoteCache.put("k" + i, "v" + i);
          if (added == channelFactory.getServers().contains(server1Address)) break;
       }
-      Collection<SocketAddress> addresses = channelFactory.getServers();
+      Collection<InetSocketAddress> addresses = channelFactory.getServers();
       assertEquals(server1Address + " not found in " + addresses, added, addresses.contains(server1Address));
    }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12251

* Make RemoteCacheManager.getServers return the unresolved
  hostname
* Make TopologyInfo use InetSocketAddress so we can extract
  the host name and port number
* Keep SocketAddress in FailoverRequestBalancingStrategy
  for source compatibility