### PR TITLE
ISPN-6901 ConsistentHashV2IntegrationTest.testCorrectBalancingOfKeysAfterNodeKill fails

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ConsistentHashV2IntegrationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ConsistentHashV2IntegrationTest.java
@@ -131,7 +131,6 @@ public class ConsistentHashV2IntegrationTest extends MultipleCacheManagersTest {
       hitCountInterceptor(cacheIndex).reset();
    }
 
-   @Test(groups = "unstable", description = "ISPN-6901")
    public void testCorrectBalancingOfKeysAfterNodeKill() {
       //final AtomicInteger clientTopologyId = TestingUtil.extractField(remoteCacheManager, "defaultCacheTopologyId");
       ChannelFactory channelFactory = TestingUtil.extractField(remoteCacheManager, "channelFactory");
@@ -146,8 +145,8 @@ public class ConsistentHashV2IntegrationTest extends MultipleCacheManagersTest {
          int topologyId = channelFactory.getTopologyId(new byte[]{});
          log.tracef("Client topology id is %d, waiting for it to become %d", topologyId,
                topologyIdBeforeJoin + 2);
-         // The put operation will update the client topology (if necessary)
-         remoteCache.put("k", "v");
+         // The get operation will update the client topology (if necessary)
+         remoteCache.get("k");
          return topologyId >= topologyIdBeforeJoin + 2;
       });
 

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/HotRodServer.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/HotRodServer.java
@@ -28,7 +28,7 @@ import javax.security.auth.Subject;
 
 import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
-import org.infinispan.IllegalLifecycleStateException;
+import org.infinispan.commons.IllegalLifecycleStateException;
 import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.commons.logging.LogFactory;
 import org.infinispan.commons.marshall.Externalizer;
@@ -673,7 +673,7 @@ public class HotRodServer extends AbstractProtocolServer<HotRodServerConfigurati
                   log.debug("Error re-adding address to topology cache, retrying", t);
                   recursionTopologyChanged();
                }
-               if (!v) {
+               if (t == null && !v) {
                   log.debugf("Re-adding %s to the topology cache", clusterAddress);
                   addressCache.putAsync(clusterAddress, address);
                }


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-6901
https://issues.redhat.com/browse/ISPN-12254

I was not able to reproduce the failure, so I'm re-enabling the test.
I did find a NPE in CheckAddressTask, but it's just a cosmetic issue.