### PR TITLE
ISPN-12256 InfinispanServerExtensionContainerTest fails to start

### DIFF
--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/core/AbstractInfinispanServerDriver.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/core/AbstractInfinispanServerDriver.java
@@ -65,7 +65,7 @@ public abstract class AbstractInfinispanServerDriver implements InfinispanServer
    private File rootDir;
    private File confDir;
    private ComponentStatus status;
-   private AtomicLong certSerial = new AtomicLong(1);
+   private final AtomicLong certSerial = new AtomicLong(1);
 
    protected AbstractInfinispanServerDriver(InfinispanServerTestConfiguration configuration, InetAddress testHostAddress) {
       this.configuration = configuration;

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/core/AbstractServerConfigBuilder.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/core/AbstractServerConfigBuilder.java
@@ -13,9 +13,9 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
  * @author Katia Aresti
  * @since 11
  */
-public abstract class AbstractServerConfigBuilder<T> {
+public abstract class AbstractServerConfigBuilder<T extends AbstractServerConfigBuilder<T>> {
    private final String configurationFile;
-   private boolean defaultFile;
+   private final boolean defaultFile;
    private final Properties properties;
    private String[] mavenArtifacts;
    private int numServers = 2;

--- a/server/testdriver/junit4/src/main/java/org/infinispan/server/test/junit4/InfinispanServerRuleBuilder.java
+++ b/server/testdriver/junit4/src/main/java/org/infinispan/server/test/junit4/InfinispanServerRuleBuilder.java
@@ -1,9 +1,9 @@
 package org.infinispan.server.test.junit4;
 
+import static org.infinispan.server.test.core.AbstractInfinispanServerDriver.DEFAULT_CLUSTERED_INFINISPAN_CONFIG_FILE_NAME;
+
 import org.infinispan.server.test.core.AbstractServerConfigBuilder;
 import org.infinispan.server.test.core.ServerRunMode;
-
-import static org.infinispan.server.test.core.AbstractInfinispanServerDriver.DEFAULT_CLUSTERED_INFINISPAN_CONFIG_FILE_NAME;
 
 /**
  * Builder for {@link InfinispanServerRule}.
@@ -26,6 +26,14 @@ public class InfinispanServerRuleBuilder extends AbstractServerConfigBuilder<Inf
       return new InfinispanServerRuleBuilder(DEFAULT_CLUSTERED_INFINISPAN_CONFIG_FILE_NAME, true)
             .numServers(1)
             .runMode(container? ServerRunMode.CONTAINER : ServerRunMode.EMBEDDED)
+            .parallelStartup(false)
+            .build();
+   }
+
+   public static InfinispanServerRule server(String configurationFile) {
+      return new InfinispanServerRuleBuilder(configurationFile, false)
+            .numServers(1)
+            .runMode(ServerRunMode.CONTAINER)
             .parallelStartup(false)
             .build();
    }

--- a/server/testdriver/junit5/pom.xml
+++ b/server/testdriver/junit5/pom.xml
@@ -51,7 +51,6 @@
                   <usedefaultlisteners>false</usedefaultlisteners>
                   <listener>${junitListener}</listener>
                </properties>
-               <argLine>-Xmx512m</argLine>
             </configuration>
             <dependencies>
                <dependency>

--- a/server/testdriver/junit5/src/main/java/org/infinispan/server/test/junit5/InfinispanServerExtensionBuilder.java
+++ b/server/testdriver/junit5/src/main/java/org/infinispan/server/test/junit5/InfinispanServerExtensionBuilder.java
@@ -1,9 +1,9 @@
 package org.infinispan.server.test.junit5;
 
+import static org.infinispan.server.test.core.AbstractInfinispanServerDriver.DEFAULT_CLUSTERED_INFINISPAN_CONFIG_FILE_NAME;
+
 import org.infinispan.server.test.core.AbstractServerConfigBuilder;
 import org.infinispan.server.test.core.ServerRunMode;
-
-import static org.infinispan.server.test.core.AbstractInfinispanServerDriver.DEFAULT_CLUSTERED_INFINISPAN_CONFIG_FILE_NAME;
 
 /**
  * Infinispan Server Extension Builder
@@ -13,12 +13,21 @@ import static org.infinispan.server.test.core.AbstractInfinispanServerDriver.DEF
  */
 public class InfinispanServerExtensionBuilder extends AbstractServerConfigBuilder<InfinispanServerExtensionBuilder> {
    /**
-    * Use this method to instantiate a single clustered embedded server
-    *
-    * @return InfinispanServerExtension
+    * Use this method to instantiate a single clustered server in a container, using the default configuration.
     */
    public static InfinispanServerExtension server() {
       return new InfinispanServerExtensionBuilder(DEFAULT_CLUSTERED_INFINISPAN_CONFIG_FILE_NAME, true)
+            .numServers(1)
+            .runMode(ServerRunMode.CONTAINER)
+            .parallelStartup(false)
+            .build();
+   }
+
+   /**
+    * Use this method to instantiate a single clustered server in a container, using a custom configuration.
+    */
+   public static InfinispanServerExtension server(String configurationFile) {
+      return new InfinispanServerExtensionBuilder(configurationFile, false)
             .numServers(1)
             .runMode(ServerRunMode.CONTAINER)
             .parallelStartup(false)

--- a/server/testdriver/junit5/src/test/java/org/infinispan/server/test/junit5/InfinispanServerExtensionContainerTest.java
+++ b/server/testdriver/junit5/src/test/java/org/infinispan/server/test/junit5/InfinispanServerExtensionContainerTest.java
@@ -1,16 +1,16 @@
 package org.infinispan.server.test.junit5;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.configuration.cache.CacheMode;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 public class InfinispanServerExtensionContainerTest {
 
    @RegisterExtension
-   static InfinispanServerExtension SERVER = InfinispanServerExtensionBuilder.server();
+   static InfinispanServerExtension SERVER = InfinispanServerExtensionBuilder.server("infinispan.xml");
 
    @Test
    public void testSingleServer() {

--- a/server/testdriver/junit5/src/test/resources/infinispan.xml
+++ b/server/testdriver/junit5/src/test/resources/infinispan.xml
@@ -1,4 +1,20 @@
 <infinispan>
+    <jgroups>
+        <stack name="test-tcp" extends="tcp">
+            <MERGE3 min_interval="1000" max_interval="5000" stack.combine="REPLACE"/>
+            <FD_SOCK sock_conn_timeout="3000"/>
+            <FD_ALL3 timeout="3000"
+                     interval="1000"
+                     stack.combine="REPLACE" stack.position="FD_ALL"/>
+        </stack>
+        <stack name="test-udp" extends="udp">
+            <MERGE3 min_interval="1000" max_interval="5000" stack.combine="REPLACE"/>
+            <FD_SOCK sock_conn_timeout="3000"/>
+            <FD_ALL3 timeout="3000"
+                     interval="1000"
+                     stack.combine="REPLACE" stack.position="FD_ALL"/>
+        </stack>
+    </jgroups>
     <cache-container name="default" statistics="true">
         <transport cluster="${infinispan.cluster.name}" stack="${infinispan.cluster.stack:tcp}" node-name="${infinispan.node.name:}"/>
     </cache-container>

--- a/server/testdriver/pom.xml
+++ b/server/testdriver/pom.xml
@@ -14,6 +14,7 @@
 
    <properties>
       <server.output.dir.prefix>${infinispan.brand.prefix}-testdriver</server.output.dir.prefix>
+      <infinispan.cluster.stack>test-tcp</infinispan.cluster.stack>
    </properties>
    <modules>
       <module>core</module>


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12256

* Make InfinispanServerExtensionContainerTest use custom configuration
* Add test-tcp and test-udp stacks to custom configuration
* Remove surefire <argLine> element and use args from parent POM
* Define infinispan.cluster.stack=test-tcp in all testdriver modules