### PR TITLE
ISPN-12263 RemoteCacheMetricBinderTest fails

### DIFF
--- a/server/testdriver/junit5/src/main/java/org/infinispan/server/test/junit5/InfinispanServerExtension.java
+++ b/server/testdriver/junit5/src/main/java/org/infinispan/server/test/junit5/InfinispanServerExtension.java
@@ -1,5 +1,10 @@
 package org.infinispan.server.test.junit5;
 
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
 import org.infinispan.counter.api.CounterManager;
 import org.infinispan.server.test.api.HotRodTestClientDriver;
 import org.infinispan.server.test.api.RestTestClientDriver;
@@ -8,15 +13,10 @@ import org.infinispan.server.test.core.InfinispanServerTestConfiguration;
 import org.infinispan.server.test.core.TestClient;
 import org.infinispan.server.test.core.TestServer;
 import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
-
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Consumer;
 
 /**
  * JUnit 5 {@link 'https://junit.org/junit5'} extension. <br/>
@@ -44,8 +44,8 @@ import java.util.function.Consumer;
 public class InfinispanServerExtension implements
       TestClientDriver,
       BeforeAllCallback,
-      BeforeTestExecutionCallback,
-      AfterTestExecutionCallback,
+      BeforeEachCallback,
+      AfterEachCallback,
       AfterAllCallback {
 
    private final TestServer testServer;
@@ -58,7 +58,7 @@ public class InfinispanServerExtension implements
    }
 
    @Override
-   public void beforeAll(ExtensionContext extensionContext) throws Exception {
+   public void beforeAll(ExtensionContext extensionContext) {
       String testName = extensionContext.getRequiredTestClass().getName();
       // Don't manage the server when a test is using the same InfinispanServerRule instance as the parent suite
       boolean manageServer = !testServer.isDriverInitialized();
@@ -74,7 +74,7 @@ public class InfinispanServerExtension implements
    }
 
    @Override
-   public void beforeTestExecution(ExtensionContext extensionContext) throws Exception {
+   public void beforeEach(ExtensionContext extensionContext) {
       this.testClient = new TestClient(testServer);
       testClient.initResources();
       methodName =
@@ -83,12 +83,12 @@ public class InfinispanServerExtension implements
    }
 
    @Override
-   public void afterTestExecution(ExtensionContext extensionContext) throws Exception {
+   public void afterEach(ExtensionContext extensionContext) {
       testClient.clearResources();
    }
 
    @Override
-   public void afterAll(ExtensionContext extensionContext) throws Exception {
+   public void afterAll(ExtensionContext extensionContext) {
       String testName = extensionContext.getRequiredTestClass().getName();
       if (testServer.isDriverInitialized()) {
          testServer.afterListeners();

--- a/spring/spring-boot/remote/src/test/resources/infinispan.xml
+++ b/spring/spring-boot/remote/src/test/resources/infinispan.xml
@@ -1,0 +1,23 @@
+<infinispan>
+    <cache-container name="default" statistics="true">
+        <transport cluster="${infinispan.cluster.name}" stack="${infinispan.cluster.stack:tcp}" node-name="${infinispan.node.name:}"/>
+    </cache-container>
+
+    <server>
+        <interfaces>
+            <interface name="public">
+                <inet-address value="${infinispan.bind.address:127.0.0.1}"/>
+            </interface>
+        </interfaces>
+
+        <socket-bindings default-interface="public" port-offset="${infinispan.socket.binding.port-offset:0}">
+            <socket-binding name="default" port="${infinispan.bind.port:11222}"/>
+            <socket-binding name="memcached" port="11221"/>
+        </socket-bindings>
+
+        <endpoints socket-binding="default">
+            <hotrod-connector name="hotrod"/>
+            <rest-connector name="rest"/>
+        </endpoints>
+    </server>
+</infinispan>


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12263

* Make InfinispanServerExtension implement BeforeEachCallback
  and AfterEachCallback
* Add custom server configuration to remove security
* Remove InfinispanCacheMetricBinderTest.cleanCache()
* Enable statistics in the RemoteCacheManager
* Create the mycache cache

Not ready for review, depends on #8651 and #8653 