### PR TITLE
ISPN-12321 Leaked thread: mysql-cj-abandoned-connection-cleanup

### DIFF
--- a/commons-test/src/main/java/org/infinispan/commons/test/ThreadLeakChecker.java
+++ b/commons-test/src/main/java/org/infinispan/commons/test/ThreadLeakChecker.java
@@ -89,6 +89,8 @@ public class ThreadLeakChecker {
                       "|OkHttp ConnectionPool" +
                        // OkHttp uses daemon threads for HTTP/2
                       "|OkHttp Http2Connection" +
+                      // The mysql driver uses a daemon thread to check for connection leaks
+                      "|mysql-cj-abandoned-connection-cleanup" +
                       ").*");
    private static final String ARQUILLIAN_CONSOLE_CONSUMER =
       "org.jboss.as.arquillian.container.managed.ManagedDeployableContainer$ConsoleConsumer";


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12321

Ignore the thread.
We could stop it explicitly at the end of the test suite,
but it would add an explicit mysql dependency.