### PR TITLE
ISPN-12322 GetAllCommandNodeCrashTest.test random failures

### DIFF
--- a/core/src/test/java/org/infinispan/commands/GetAllCommandNodeCrashTest.java
+++ b/core/src/test/java/org/infinispan/commands/GetAllCommandNodeCrashTest.java
@@ -2,32 +2,29 @@ package org.infinispan.commands;
 
 import static org.infinispan.test.TestingUtil.extractComponent;
 import static org.infinispan.test.TestingUtil.replaceComponent;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Matchers.anyInt;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.spy;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertNotNull;
-import static org.testng.AssertJUnit.assertTrue;
 
 import java.util.Collections;
 import java.util.Map;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import org.infinispan.commands.remote.ClusteredGetAllCommand;
 import org.infinispan.commands.statetransfer.StateResponseCommand;
+import org.infinispan.commands.statetransfer.StateTransferCancelCommand;
 import org.infinispan.commands.statetransfer.StateTransferStartCommand;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.distribution.MagicKey;
 import org.infinispan.statetransfer.StateConsumer;
-import org.infinispan.statetransfer.StateTransferLock;
 import org.infinispan.test.MultipleCacheManagersTest;
-import org.infinispan.test.TestBlocking;
 import org.infinispan.test.TestDataSCI;
+import org.infinispan.test.fwk.CheckPoint;
 import org.infinispan.util.ControlledRpcManager;
 import org.testng.annotations.Test;
 
@@ -42,33 +39,39 @@ public class GetAllCommandNodeCrashTest extends MultipleCacheManagersTest {
       MagicKey key = new MagicKey(cache(0), cache(1));
       cache(2).put(key, "value");
 
+      CheckPoint checkPoint = new CheckPoint();
       ControlledRpcManager rpcManager = ControlledRpcManager.replaceRpcManager(cache(2));
-      rpcManager.excludeCommands(StateResponseCommand.class, StateTransferStartCommand.class);
+      rpcManager.excludeCommands(StateResponseCommand.class, StateTransferStartCommand.class,
+                                 StateTransferCancelCommand.class);
 
-      CountDownLatch blockTopologyUpdate = new CountDownLatch(1);
-      StateConsumer stateConsumerMock = spy(extractComponent(cache(2), StateConsumer.class));
+      StateConsumer stateConsumerSpy = spy(extractComponent(cache(2), StateConsumer.class));
       doAnswer(invocation -> {
-         assertTrue(TestBlocking.await(blockTopologyUpdate,10, TimeUnit.SECONDS));
+         checkPoint.trigger("topology_update_blocked");
+         checkPoint.awaitStrict("topology_update_resumed", 10, TimeUnit.SECONDS);
          return invocation.callRealMethod();
-      }).when(stateConsumerMock).onTopologyUpdate(any(), anyBoolean());
-      replaceComponent(cache(2), StateConsumer.class, stateConsumerMock, true);
-
-      StateTransferLock stateTransferLockMock = spy(extractComponent(cache(2), StateTransferLock.class));
-      doAnswer(invocation -> {
-         blockTopologyUpdate.countDown();
-         return invocation.callRealMethod();
-      }).when(stateTransferLockMock).topologyFuture(anyInt());
-      replaceComponent(cache(2), StateTransferLock.class, stateTransferLockMock, true);
+      }).when(stateConsumerSpy).onTopologyUpdate(any(), anyBoolean());
+      replaceComponent(cache(2), StateConsumer.class, stateConsumerSpy, true);
 
       Future<Map<Object, Object>> f = fork(() -> cache(2).getAdvancedCache().getAll(Collections.singleton(key)));
 
-      ControlledRpcManager.BlockedRequest blockedGetAll = rpcManager.expectCommand(ClusteredGetAllCommand.class);
+      // Block the request before being sent
+      ControlledRpcManager.BlockedRequest<?> blockedGetAll = rpcManager.expectCommand(ClusteredGetAllCommand.class);
+
       // it's necessary to stop whole cache manager, not just cache, because otherwise the exception would have
       // suspect node defined
       cacheManagers.get(0).stop();
+      checkPoint.awaitStrict("topology_update_blocked", 10, TimeUnit.SECONDS);
 
-      // Send the blocked GetAllCommand and the retried one
+      // Send the blocked request and wait for the CacheNotFoundResponse
       blockedGetAll.send().receiveAll();
+
+      // The retry can't be sent at this point
+      rpcManager.expectNoCommand();
+
+      // Resume the topology update
+      checkPoint.trigger("topology_update_resumed");
+
+      // Now the command can be retried, and the operation can finish
       rpcManager.expectCommand(ClusteredGetAllCommand.class).send().receiveAll();
 
       try {
@@ -77,7 +80,7 @@ public class GetAllCommandNodeCrashTest extends MultipleCacheManagersTest {
          assertFalse(map.isEmpty());
          assertEquals("value", map.get(key));
       } finally {
-         blockTopologyUpdate.countDown();
+         checkPoint.triggerForever("topology_update_resumed");
          rpcManager.stopBlocking();
       }
    }


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12322

* Ignore StateTransferCancelCommand
* Remove the StateTransferLock mock, since it wasn't clear
  what command was supposed to trigger it
* Explicitly assert that the command is retried only once