### PR TITLE
ISPN-12307 Improve media type parsing

### DIFF
--- a/commons/all/src/main/java/org/infinispan/commons/logging/Log.java
+++ b/commons/all/src/main/java/org/infinispan/commons/logging/Log.java
@@ -157,21 +157,21 @@ public interface Log extends BasicLogger {
    @Message(value = "end() failed for %s", id = 928)
    void xaResourceEndFailed(String xaResource, @Cause Throwable t);
 
-   @Message(value = "MediaType cannot be empty or null!", id = 929)
+   @Message(value = "Media type cannot be empty or null!", id = 929)
    EncodingException missingMediaType();
 
-   @Message(value = "MediaType must contain a type and a subtype separated by '/'", id = 930)
-   EncodingException invalidMediaTypeSubtype();
+   @Message(value = "Invalid media type '%s': must contain a type and a subtype separated by '/'", id = 930)
+   EncodingException invalidMediaTypeSubtype(String mediaType);
 
-   @Message(value = "Failed to parse MediaType: Invalid param description '%s'", id = 931)
-   EncodingException invalidMediaTypeParam(String param);
+   @Message(value = "Invalid media type '%s': invalid param '%s'", id = 931)
+   EncodingException invalidMediaTypeParam(String mediaType, String param);
 
-   @Message(value = "Unclosed param value quote", id = 932)
-   EncodingException unquotedMediaTypeParam();
+   @Message(value = "Invalid media type list '%s': comma expected", id = 932)
+   EncodingException invalidMediaTypeListCommaMissing(String mediaType);
 
-   @Message(value = "Invalid character '%s' found in token '%s'", id = 933)
-   EncodingException invalidCharMediaType(char character, String token);
-
+   @Message(value = "Invalid media type list '%s': type expected after comma", id = 933)
+   EncodingException invalidMediaTypeListCommaAtEnd(String mediaType);
+//
    @Message(value = "Errors converting '%s' from '%s' to '%s'", id = 934)
    EncodingException errorTranscoding(String content, MediaType contentType, MediaType requestType, @Cause Throwable t);
 

--- a/commons/all/src/test/java/org/infinispan/commons/dataconversion/MediaTypeTest.java
+++ b/commons/all/src/test/java/org/infinispan/commons/dataconversion/MediaTypeTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.commons.dataconversion;
 
+import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -11,11 +12,14 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.infinispan.commons.test.Exceptions;
 import org.junit.Test;
 
 /**
@@ -35,9 +39,10 @@ public class MediaTypeTest {
       MediaType.fromString("application/json/on");
    }
 
-   @Test(expected = EncodingException.class)
-   public void testParsingEmpty() {
-      MediaType.fromString("");
+   public void testParsingNoType() {
+      Exceptions.expectException(EncodingException.class, () -> MediaType.fromString(""));
+
+      Exceptions.expectException(EncodingException.class, () -> MediaType.fromString(";param=value"));
    }
 
    @Test(expected = EncodingException.class)
@@ -55,70 +60,98 @@ public class MediaTypeTest {
       MediaType.fromString(null);
    }
 
-   @Test
-   public void testParsingEmptySpaces() {
-      MediaType appJson = MediaType.fromString("application /json");
-      assertMediaTypeNoParams(appJson, "application", "json");
+   @Test(expected = EncodingException.class)
+   public void testParsingWhitespaceInType() {
+      MediaType.fromString("application /json");
+   }
+
+   @Test(expected = EncodingException.class)
+   public void testParsingWhitespaceInSubtype() {
+      MediaType.fromString("application/ json");
+   }
+
+   @Test(expected = EncodingException.class)
+   public void testParsingWhitespaceInTypeSubtype() {
+      MediaType.fromString("application  / json");
+   }
+
+   @Test(expected = EncodingException.class)
+   public void testParsingWhitespaceInParamName() {
+      MediaType.fromString("application/json; charset =utf-8");
    }
 
    @Test
-   public void testParsingEmptySpaces2() {
-      MediaType appJson = MediaType.fromString("application/ json");
-      assertMediaTypeNoParams(appJson, "application", "json");
-   }
-
-   @Test
-   public void testParsingEmptySpaces3() {
-      MediaType appJson = MediaType.fromString("application  / json");
-      assertMediaTypeNoParams(appJson, "application", "json");
-   }
-
-   @Test
-   public void testQuotedParams() {
+   public void testQuotedParam() {
       MediaType mediaType = MediaType.fromString("application/json; charset=\"UTF-8\"");
 
-      assertMediaTypeWithParam(mediaType, "application", "json", "charset", "UTF-8");
+      assertMediaTypeWithParam(mediaType, "application", "json", "charset", "\"UTF-8\"");
    }
 
    @Test
-   public void testQuotedParams2() {
-      MediaType mediaType = MediaType.fromString("application/json; charset='UTF-8'");
+   public void testQuotedParamsWithWhitespace() {
+      MediaType mediaType = MediaType.fromString("application/json; charset=\" UTF-8 \"");
 
-      assertMediaTypeWithParam(mediaType, "application", "json", "charset", "UTF-8");
+      assertMediaTypeWithParam(mediaType, "application", "json", "charset", "\" UTF-8 \"");
+   }
+
+   @Test
+   public void testQuotedParamsEscaping() {
+      MediaType mediaType = MediaType.fromString("application/json; charset=\"\\\"UTF-8\\\"\"");
+      assertMediaTypeWithParam(mediaType, "application", "json", "charset", "\"\\\"UTF-8\\\"\"");
+
+      MediaType mediaType2 = MediaType.fromString("application/json; charset=\"\\a\\\"\\\\\"");
+      assertMediaTypeWithParam(mediaType2, "application", "json", "charset", "\"\\a\\\"\\\\\"");
+
+      Exceptions.expectException(EncodingException.class, () -> MediaType.fromString("application/json; charset=\"\\\""));
+   }
+
+   @Test
+   public void testUnquotedParamWithSingleQuote() {
+      MediaType mediaType = MediaType.fromString("application/json; charset='UTF-8'");
+      assertMediaTypeWithParam(mediaType, "application", "json", "charset", "'UTF-8'");
+
+      Exceptions.expectException(EncodingException.class, () -> MediaType.fromString("application/json; charset='UTF 8'"));
    }
 
    @Test
    public void testUnQuotedParam() {
       MediaType mediaType = MediaType.fromString("application/json; charset=UTF-8");
-
       assertMediaTypeWithParam(mediaType, "application", "json", "charset", "UTF-8");
+
+      Exceptions.expectException(EncodingException.class, () -> MediaType.fromString("application/json; charset=utf 8"));
    }
 
    @Test
    public void testToString() {
-      assertEquals("application/xml", new MediaType("application", "xml", createMap(new MapEntry("q", "0.9"))).toString());
+      assertEquals("application/xml",
+                   new MediaType("application", "xml", createMap(new MapEntry("q", "0.9"))).toString());
       assertEquals("text/csv", new MediaType("text", "csv").toString());
       assertEquals("foo/bar; a=2", new MediaType("foo", "bar", createMap(new MapEntry("a", "2"))).toString());
       assertEquals("foo/bar; a=2; b=1; c=2", new MediaType("foo", "bar",
-            createMap(new MapEntry("a", "2"), new MapEntry("b", "1"), new MapEntry("c", "2"))).toString());
-      assertEquals("a/b; p=1", MediaType.fromString("a/b; p=1; q=2;").toStringExcludingParam("q"));
+                                                           createMap(new MapEntry("a", "2"), new MapEntry("b", "1"),
+                                                                     new MapEntry("c", "2"))).toString());
+      assertEquals("a/b; p=1", MediaType.fromString("a/b; p=1; q=2").toStringExcludingParam("q"));
    }
 
    @Test
+   public void testToStringQuotedParams() {
+      MediaType mediaType = MediaType.fromString("a/b; p=\"\"; r=\"\\\"\"");
+      assertEquals(mediaType, MediaType.fromString(mediaType.toString()));
+   }
+
+   @Test(expected = EncodingException.class)
    public void testUnQuotedParamWithSpaces() {
       MediaType mediaType = MediaType.fromString("application/json ; charset= UTF-8");
-
-      assertMediaTypeWithParam(mediaType, "application", "json", "charset", "UTF-8");
    }
 
    @Test(expected = EncodingException.class)
    public void testWrongQuoting() {
-      MediaType.fromString("application/json ; charset= \"UTF-8");
+      MediaType.fromString("application/json;charset= \"UTF-8");
    }
 
    @Test
    public void testMultipleParameters() {
-      MediaType mediaType = MediaType.fromString("application/json ; charset=UTF-8; param1=value1; param2 = value2");
+      MediaType mediaType = MediaType.fromString("application/json; charset=UTF-8; param1=value1 ;param2=value2");
       assertMediaTypeWithParams(mediaType, "application", "json",
             new String[]{"charset", "param1", "param2"},
             new String[]{"UTF-8", "value1", "value2"});
@@ -126,12 +159,12 @@ public class MediaTypeTest {
 
    @Test(expected = EncodingException.class)
    public void testMultipleParametersWrongSeparator() {
-      MediaType.fromString("application/json ; charset=UTF-8; param1=value1, param2 = value2");
+      MediaType.fromString("application/json; charset=UTF-8; param1=value1, param2=value2");
    }
 
    @Test
    public void testParseWeight() {
-      MediaType mediaType = MediaType.fromString("application/json ; q=0.8");
+      MediaType mediaType = MediaType.fromString("application/json; q=0.8");
       assertEquals(0.8, mediaType.getWeight(), 0.0);
    }
 
@@ -166,13 +199,16 @@ public class MediaTypeTest {
 
    @Test
    public void testParseList() {
-      Stream<MediaType> mediaTypes = MediaType.parseList("text/html, image/png,*/*");
-      Iterator<MediaType> mediaTypeIterator = mediaTypes.iterator();
+      List<MediaType> mediaTypes = MediaType.parseList("text/html, image/png,*/*").collect(Collectors.toList());
+      assertEquals(asList(MediaType.TEXT_HTML, MediaType.IMAGE_PNG, MediaType.MATCH_ALL), mediaTypes);
 
-      assertEquals(MediaType.TEXT_HTML, mediaTypeIterator.next());
-      assertEquals(MediaType.IMAGE_PNG, mediaTypeIterator.next());
-      assertEquals(MediaType.MATCH_ALL, mediaTypeIterator.next());
-      assertFalse(mediaTypeIterator.hasNext());
+      Exceptions.expectException(EncodingException.class, () -> MediaType.parseList("text/html,"));
+      Exceptions.expectException(EncodingException.class, () -> MediaType.parseList("text/html;a=b,"));
+      Exceptions.expectException(EncodingException.class, () -> MediaType.parseList("text/html;a=b,;b=c"));
+      Exceptions.expectException(EncodingException.class, () -> MediaType.parseList("text/html;a=b,image/png/"));
+
+      List<MediaType> mediaTypes2 = MediaType.parseList("text/html;a=\"b,\" ,*/*").collect(Collectors.toList());
+      assertEquals(asList(MediaType.TEXT_HTML.withParameter("a", "\"b,\""), MediaType.MATCH_ALL), mediaTypes2);
    }
 
    @Test
@@ -188,13 +224,10 @@ public class MediaTypeTest {
 
    @Test
    public void testParseSingleAsterix() {
-      Stream<MediaType> list = MediaType.parseList("text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2");
-      Iterator<MediaType> iterator = list.iterator();
-
-      assertEquals("text/html", iterator.next().getTypeSubtype());
-      assertEquals("image/gif", iterator.next().getTypeSubtype());
-      assertEquals("image/jpeg", iterator.next().getTypeSubtype());
-      assertEquals("*/*", iterator.next().getTypeSubtype());
+      List<String> list = MediaType.parseList("text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2")
+                                      .map(MediaType::getTypeSubtype)
+                                      .collect(Collectors.toList());
+      assertEquals(asList("text/html", "image/gif", "image/jpeg", "*/*", "*/*"), list);
    }
 
    @Test
@@ -214,8 +247,8 @@ public class MediaTypeTest {
 
    @Test
    public void testMediaTypeMatch() {
-      MediaType one = MediaType.APPLICATION_INFINISPAN_BINARY;
-      MediaType two = MediaType.APPLICATION_INFINISPAN_BINARY;
+      MediaType one = MediaType.APPLICATION_JSON;
+      MediaType two = MediaType.APPLICATION_JSON;
 
       assertTrue(one.match(two));
       assertTrue(two.match(one));
@@ -223,8 +256,8 @@ public class MediaTypeTest {
 
    @Test
    public void testMediaTypeUnMatch() {
-      MediaType one = MediaType.APPLICATION_INFINISPAN_BINARY;
-      MediaType two = MediaType.APPLICATION_INFINISPAN_MARSHALLED;
+      MediaType one = MediaType.APPLICATION_JSON;
+      MediaType two = MediaType.APPLICATION_JAVASCRIPT;
 
       assertFalse(one.match(two));
       assertFalse(two.match(one));
@@ -232,7 +265,7 @@ public class MediaTypeTest {
 
    @Test
    public void testMediaTypeMatchItself() {
-      MediaType one = MediaType.APPLICATION_INFINISPAN_BINARY;
+      MediaType one = MediaType.APPLICATION_JSON;
       assertTrue(one.match(one));
    }
 
@@ -278,9 +311,9 @@ public class MediaTypeTest {
       }
    }
 
-   private class MapEntry {
-      private String key;
-      private String value;
+   private static class MapEntry {
+      private final String key;
+      private final String value;
 
       String getKey() {
          return key;
@@ -308,7 +341,7 @@ public class MediaTypeTest {
 
       @Override
       public Object readObject() throws ClassNotFoundException, IOException {
-         return buffer.poll();
+         return buffer.remove();
       }
 
       @Override
@@ -438,7 +471,7 @@ public class MediaTypeTest {
 
       @Override
       public boolean readBoolean() {
-         return (boolean) buffer.poll();
+         return (boolean) buffer.remove();
       }
 
       @Override
@@ -453,7 +486,7 @@ public class MediaTypeTest {
 
       @Override
       public short readShort() {
-         return (short) buffer.poll();
+         return (short) buffer.remove();
       }
 
       @Override
@@ -493,7 +526,7 @@ public class MediaTypeTest {
 
       @Override
       public String readUTF() {
-         return (String) buffer.poll();
+         return (String) buffer.remove();
       }
    }
 }

--- a/server/rest/src/test/java/org/infinispan/rest/profiling/MediaTypeParsingBenchmark.java
+++ b/server/rest/src/test/java/org/infinispan/rest/profiling/MediaTypeParsingBenchmark.java
@@ -1,0 +1,83 @@
+package org.infinispan.rest.profiling;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.infinispan.commons.dataconversion.MediaType;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/**
+ * This benchmark tests the performance of media type parsing
+ *
+ * @author Dan Berindei
+ */
+public class MediaTypeParsingBenchmark {
+
+   private static final int MEASUREMENT_ITERATIONS_COUNT = 10;
+   private static final int WARMUP_ITERATIONS_COUNT = 10;
+
+   public static void main(String[] args) throws Exception {
+      Options opt = new OptionsBuilder()
+            .include(MediaTypeParsingBenchmark.class.getName() + ".State.*")
+//            .include(MediaTypeParsingBenchmark.class.getName() + ".State.parseOneQuotedParameter")
+            .mode(Mode.AverageTime)
+            .timeUnit(TimeUnit.NANOSECONDS)
+            .warmupIterations(WARMUP_ITERATIONS_COUNT)
+            .measurementIterations(MEASUREMENT_ITERATIONS_COUNT)
+            .threads(1)
+            .forks(3)
+            .shouldFailOnError(true)
+//            .jvmArgsAppend("-agentpath:/home/dan/Tools/async-profiler/build/libasyncProfiler.so=start,file=profile-%t.svg")
+//            .addProfiler("perfasm")
+            .build();
+
+      new Runner(opt).run();
+   }
+
+   @org.openjdk.jmh.annotations.State(Scope.Benchmark)
+   public static class State {
+      private final String mediaTypeNoParameter = "application/json";
+      private final String mediaTypeOneQuotedParameter = "application/json; charset=\"UTF-8\"";
+      private String mediaTypeOneParameter = "application/x-java-object; type=ByteArray";
+      private String mediaTypeTwoParameters = "application/x-java-object; q=0.2; type=java.lang.Integer";
+      private String mediaTypeList =
+            String.join(", ", mediaTypeNoParameter, mediaTypeOneParameter, mediaTypeOneQuotedParameter, mediaTypeTwoParameters);
+
+      @Benchmark
+      @OperationsPerInvocation(100)
+      public MediaType parseNoParameter() throws Exception {
+         return MediaType.fromString(mediaTypeNoParameter);
+      }
+
+      @Benchmark
+      @OperationsPerInvocation(100)
+      public MediaType parseOneParameter() throws Exception {
+         return MediaType.fromString(mediaTypeOneParameter);
+      }
+
+      @Benchmark
+      @OperationsPerInvocation(100)
+      public MediaType parseOneQuotedParameter() throws Exception {
+         return MediaType.fromString(mediaTypeOneQuotedParameter);
+      }
+
+      @Benchmark
+      @OperationsPerInvocation(100)
+      public MediaType parseTwoParameters() throws Exception {
+         return MediaType.fromString(mediaTypeTwoParameters);
+      }
+
+      @Benchmark
+      @OperationsPerInvocation(100)
+      public List<MediaType> parseList() throws Exception {
+         return MediaType.parseList(mediaTypeList).collect(Collectors.toList());
+      }
+   }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12307

* Use regular expressions for parsing to reduce allocations
  and to be closer to the spec
* Do not remove quotes or backlashes from quoted parameter values
* Add parsing benchmark

master Benchmark                                                |Mode  |Cnt  | Score   |Error  |Units
---------------------------------------------------------|------|-----|---------|-------|-----
MediaTypeParsingBenchmark.State.parseList                |avgt  | 30  |37.809 ± |0.225  |ns/op
MediaTypeParsingBenchmark.State.parseNoParameter         |avgt  | 30  | 2.787 ± |0.019  |ns/op
MediaTypeParsingBenchmark.State.parseOneParameter        |avgt  | 30  | 7.632 ± |0.105  |ns/op
MediaTypeParsingBenchmark.State.parseOneQuotedParameter  |avgt  | 30  | 7.720 ± |0.154  |ns/op
MediaTypeParsingBenchmark.State.parseTwoParameters       |avgt  | 30  |12.389 ± |0.156  |ns/op

ISPN-12307 Benchmark                               |Mode  |Cnt  | Score   |Error  |Units
---------------------------------------------------------|------|-----|---------|-------|-----
MediaTypeParsingBenchmark.State.parseList                |avgt  | 30  |30.559 ± |0.220  |ns/op
MediaTypeParsingBenchmark.State.parseNoParameter         |avgt  | 30  | 1.979 ± |0.078  |ns/op
MediaTypeParsingBenchmark.State.parseOneParameter        |avgt  | 30  | 4.650 ± |0.027  |ns/op
MediaTypeParsingBenchmark.State.parseOneQuotedParameter  |avgt  | 30  | 7.303 ± |0.037  |ns/op
MediaTypeParsingBenchmark.State.parseTwoParameters       |avgt  | 30  | 8.852 ± |0.115  |ns/op

```