### PR TITLE
ISPN-12221 Add zero-capacity-node support for Replicated caches 

### DIFF
--- a/core/src/main/java/org/infinispan/distribution/ch/impl/ConsistentHashPersistenceConstants.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/impl/ConsistentHashPersistenceConstants.java
@@ -11,4 +11,6 @@ public class ConsistentHashPersistenceConstants {
     public static final String STATE_HASH_FUNCTION = "hashFunction";
     public static final String STATE_MEMBER = "member.%d";
     public static final String STATE_MEMBERS = "members";
+    public static final String STATE_MEMBER_NO_ENTRIES = "memberNoEntries.%d";
+    public static final String STATE_MEMBERS_NO_ENTRIES = "membersNoEntries";
 }

--- a/core/src/main/java/org/infinispan/distribution/ch/impl/ScatteredConsistentHash.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/impl/ScatteredConsistentHash.java
@@ -40,8 +40,7 @@ import net.jcip.annotations.Immutable;
  */
 @Immutable
 public class ScatteredConsistentHash extends AbstractConsistentHash {
-   private PersistentUUID ZERO_UUID = new PersistentUUID(0, 0);
-
+   private static final PersistentUUID ZERO_UUID = new PersistentUUID(0, 0);
    private static final String STATE_SEGMENT_OWNER = "segmentOwner.%d";
    private static final String REBALANCED = "rebalanced";
 
@@ -53,7 +52,7 @@ public class ScatteredConsistentHash extends AbstractConsistentHash {
    /**
     * Scattered cache guarantees that there will be always one owner of any segment.
     * However rebalance is started in {@link ClusterCacheStatus#startQueuedRebalance()}  based on equality
-    * of CH got from {@link ScatteredConsistentHashFactory#updateMembers(ConsistentHash, List, Map)} vs.
+    * of CH got from {@link ScatteredConsistentHashFactory#updateMembers(ScatteredConsistentHash, List, Map)} vs.
     * the on got from {@link ScatteredConsistentHashFactory#rebalance(ScatteredConsistentHash)}.
     * So this works as a flag to trigger the rebalance.
     */

--- a/core/src/main/java/org/infinispan/distribution/ch/impl/SyncConsistentHashFactory.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/impl/SyncConsistentHashFactory.java
@@ -89,7 +89,7 @@ public class SyncConsistentHashFactory implements ConsistentHashFactory<DefaultC
          for (Address node : members) {
             Float capacityFactor = capacityFactors.get(node);
             if (capacityFactor == null || capacityFactor < 0)
-               throw new IllegalArgumentException("Invalid capacity factor for node " + node);
+               throw new IllegalArgumentException("Invalid capacity factor for node " + node + ": " + capacityFactor);
             totalCapacity += capacityFactor;
          }
          if (totalCapacity == 0)

--- a/core/src/main/java/org/infinispan/distribution/ch/impl/SyncReplicatedConsistentHashFactory.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/impl/SyncReplicatedConsistentHashFactory.java
@@ -4,6 +4,7 @@ import static org.infinispan.util.logging.Log.CONTAINER;
 
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -29,8 +30,9 @@ public class SyncReplicatedConsistentHashFactory implements ConsistentHashFactor
    @Override
    public ReplicatedConsistentHash create(int numOwners, int numSegments,
          List<Address> members, Map<Address, Float> capacityFactors) {
-      DefaultConsistentHash dch = syncCHF.create(1, numSegments, members, null);
-      return replicatedFromDefault(dch);
+      DefaultConsistentHash dch = syncCHF.create(1, numSegments, members, capacityFactors);
+      List<Address> membersWithoutState = computeMembersWithoutState(members, null, capacityFactors);
+      return replicatedFromDefault(dch, membersWithoutState);
    }
 
    @Override
@@ -41,22 +43,24 @@ public class SyncReplicatedConsistentHashFactory implements ConsistentHashFactor
       return new ReplicatedConsistentHash(state);
    }
 
-   private ReplicatedConsistentHash replicatedFromDefault(DefaultConsistentHash dch) {
+   private ReplicatedConsistentHash replicatedFromDefault(DefaultConsistentHash dch,
+                                                          List<Address> membersWithoutState) {
       int numSegments = dch.getNumSegments();
       List<Address> members = dch.getMembers();
       int[] primaryOwners = new int[numSegments];
       for (int segment = 0; segment < numSegments; segment++) {
          primaryOwners[segment] = members.indexOf(dch.locatePrimaryOwnerForSegment(segment));
       }
-      return new ReplicatedConsistentHash(members, primaryOwners);
+      return new ReplicatedConsistentHash(members, dch.getCapacityFactors(), membersWithoutState, primaryOwners);
    }
 
    @Override
    public ReplicatedConsistentHash updateMembers(ReplicatedConsistentHash baseCH, List<Address> newMembers,
          Map<Address, Float> actualCapacityFactors) {
       DefaultConsistentHash baseDCH = defaultFromReplicated(baseCH);
-      DefaultConsistentHash dch = syncCHF.updateMembers(baseDCH, newMembers, null);
-      return replicatedFromDefault(dch);
+      DefaultConsistentHash dch = syncCHF.updateMembers(baseDCH, newMembers, actualCapacityFactors);
+      List<Address> membersWithoutState = computeMembersWithoutState(newMembers, baseCH.getMembers(), actualCapacityFactors);
+      return replicatedFromDefault(dch, membersWithoutState);
    }
 
    private DefaultConsistentHash defaultFromReplicated(ReplicatedConsistentHash baseCH) {
@@ -66,19 +70,42 @@ public class SyncReplicatedConsistentHashFactory implements ConsistentHashFactor
          baseSegmentOwners[segment] = Collections.singletonList(baseCH.locatePrimaryOwnerForSegment(segment));
       }
       return new DefaultConsistentHash(1,
-            numSegments, baseCH.getMembers(), null, baseSegmentOwners);
+            numSegments, baseCH.getMembers(), baseCH.getCapacityFactors(), baseSegmentOwners);
    }
 
    @Override
    public ReplicatedConsistentHash rebalance(ReplicatedConsistentHash baseCH) {
-      DefaultConsistentHash baseDCH = defaultFromReplicated(baseCH);
-      DefaultConsistentHash dch = syncCHF.rebalance(baseDCH);
-      return replicatedFromDefault(dch);
+      return create(baseCH.getNumOwners(), baseCH.getNumSegments(), baseCH.getMembers(), baseCH.getCapacityFactors());
    }
 
    @Override
    public ReplicatedConsistentHash union(ReplicatedConsistentHash ch1, ReplicatedConsistentHash ch2) {
       return ch1.union(ch2);
+   }
+
+   static List<Address> computeMembersWithoutState(List<Address> newMembers, List<Address> oldMembers, Map<Address, Float> capacityFactors) {
+      List<Address> membersWithoutState = Collections.emptyList();
+      if (capacityFactors != null) {
+         boolean hasNodeWithCapacity = false;
+         for (Address a : newMembers) {
+            float capacityFactor = capacityFactors.get(a);
+            if (capacityFactor != 0f && capacityFactor != 1f) {
+               throw new IllegalArgumentException("Invalid replicated cache capacity factor for node " + a);
+            }
+            if (capacityFactor == 0f || (oldMembers != null && !oldMembers.contains(a))) {
+               if (membersWithoutState.isEmpty()) {
+                  membersWithoutState = new ArrayList<>();
+               }
+               membersWithoutState.add(a);
+            } else {
+               hasNodeWithCapacity = true;
+            }
+         }
+         if (!hasNodeWithCapacity) {
+            throw new IllegalArgumentException("There must be at least one node with a non-zero capacity factor");
+         }
+      }
+      return membersWithoutState;
    }
 
    public static class Externalizer extends AbstractExternalizer<SyncReplicatedConsistentHashFactory> {
@@ -88,7 +115,6 @@ public class SyncReplicatedConsistentHashFactory implements ConsistentHashFactor
       }
 
       @Override
-      @SuppressWarnings("unchecked")
       public SyncReplicatedConsistentHashFactory readObject(ObjectInput unmarshaller) {
          return new SyncReplicatedConsistentHashFactory();
       }
@@ -100,8 +126,7 @@ public class SyncReplicatedConsistentHashFactory implements ConsistentHashFactor
 
       @Override
       public Set<Class<? extends SyncReplicatedConsistentHashFactory>> getTypeClasses() {
-         return Collections.<Class<? extends SyncReplicatedConsistentHashFactory>>singleton(
-               SyncReplicatedConsistentHashFactory.class);
+         return Collections.singleton(SyncReplicatedConsistentHashFactory.class);
       }
    }
 }

--- a/core/src/main/java/org/infinispan/distribution/impl/DistributionManagerImpl.java
+++ b/core/src/main/java/org/infinispan/distribution/impl/DistributionManagerImpl.java
@@ -150,7 +150,7 @@ public class DistributionManagerImpl implements DistributionManager {
       List<Address> members = Collections.singletonList(localAddress);
       int[] owners = new int[numSegments];
       Arrays.fill(owners, 0);
-      ConsistentHash ch = new ReplicatedConsistentHash(members, owners);
+      ConsistentHash ch = new ReplicatedConsistentHash(members, null, Collections.emptyList(), owners);
       CacheTopology cacheTopology = new CacheTopology(-1, -1, ch, null, CacheTopology.Phase.NO_REBALANCE, members, null);
       return new LocalizedCacheTopology(cacheMode, cacheTopology, keyPartitioner, localAddress, false);
    }

--- a/core/src/main/java/org/infinispan/interceptors/impl/AsyncInterceptorChainImpl.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/AsyncInterceptorChainImpl.java
@@ -37,7 +37,7 @@ import org.infinispan.util.logging.LogFactory;
 public class AsyncInterceptorChainImpl implements AsyncInterceptorChain {
    // Using the same list type everywhere may help with the optimization of the invocation context methods
    private static final ImmutableListCopy<AsyncInterceptor> EMPTY_INTERCEPTORS_LIST =
-         new ImmutableListCopy<>(new AsyncInterceptor[0]);
+         new ImmutableListCopy<>();
    private static final Log log = LogFactory.getLog(AsyncInterceptorChainImpl.class);
 
    private final ComponentRegistry componentRegistry;

--- a/core/src/test/java/org/infinispan/distribution/ZeroCapacityNodeTest.java
+++ b/core/src/test/java/org/infinispan/distribution/ZeroCapacityNodeTest.java
@@ -2,15 +2,21 @@ package org.infinispan.distribution;
 
 import static org.testng.AssertJUnit.assertEquals;
 
-import java.util.Map;
+import java.util.Collections;
 
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.distribution.ch.ConsistentHash;
+import org.infinispan.distribution.ch.ConsistentHashFactory;
+import org.infinispan.distribution.ch.impl.DefaultConsistentHashFactory;
+import org.infinispan.distribution.ch.impl.ReplicatedConsistentHashFactory;
+import org.infinispan.distribution.ch.impl.ScatteredConsistentHashFactory;
+import org.infinispan.distribution.ch.impl.SyncConsistentHashFactory;
+import org.infinispan.distribution.ch.impl.SyncReplicatedConsistentHashFactory;
 import org.infinispan.manager.EmbeddedCacheManager;
-import org.infinispan.remoting.transport.Address;
 import org.infinispan.test.MultipleCacheManagersTest;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 /**
@@ -23,32 +29,64 @@ import org.testng.annotations.Test;
 public class ZeroCapacityNodeTest extends MultipleCacheManagersTest {
 
    public static final int NUM_SEGMENTS = 60;
+   private EmbeddedCacheManager node1;
+   private EmbeddedCacheManager node2;
+   private EmbeddedCacheManager zeroCapacityNode;
 
    @Override
    protected void createCacheManagers() throws Throwable {
-      // Do nothing here, create the cache managers in the test
+      node1 = addClusterEnabledCacheManager();
+      node2 = addClusterEnabledCacheManager();
+
+      GlobalConfigurationBuilder zeroCapacityBuilder =
+            GlobalConfigurationBuilder.defaultClusteredBuilder().zeroCapacityNode(true);
+      zeroCapacityNode = addClusterEnabledCacheManager(zeroCapacityBuilder, null);
    }
 
-   public void testCapacityFactorContainingAZeroCapacityNode() {
+   @DataProvider(name = "cm_chf")
+   protected Object[][] consistentHashFactory() {
+      return new Object[][]{
+            {CacheMode.DIST_SYNC, new DefaultConsistentHashFactory()},
+            {CacheMode.DIST_SYNC, new SyncConsistentHashFactory()},
+            {CacheMode.REPL_SYNC, new ReplicatedConsistentHashFactory()},
+            {CacheMode.REPL_SYNC, new SyncReplicatedConsistentHashFactory()},
+            {CacheMode.SCATTERED_SYNC, new ScatteredConsistentHashFactory()},
+            };
+   }
 
+   @Test(dataProvider = "cm_chf")
+   public void testCapacityFactorContainingAZeroCapacityNode(CacheMode cacheMode,
+                                                             ConsistentHashFactory<?> consistentHashFactory) {
       ConfigurationBuilder cb = new ConfigurationBuilder();
-      cb.clustering().cacheMode(CacheMode.DIST_SYNC);
-      cb.clustering().hash().numSegments(NUM_SEGMENTS);
-      cb.clustering().hash().capacityFactor(0.5f);
+      cb.clustering().cacheMode(cacheMode);
+      cb.clustering().hash().numSegments(NUM_SEGMENTS).consistentHashFactory(consistentHashFactory);
+      cb.clustering().hash().capacityFactor(1f);
 
-      EmbeddedCacheManager node1 = addClusterEnabledCacheManager(GlobalConfigurationBuilder.defaultClusteredBuilder(), cb);
-      EmbeddedCacheManager node2 = addClusterEnabledCacheManager(GlobalConfigurationBuilder.defaultClusteredBuilder(), cb);
-      EmbeddedCacheManager zeroCapacityNode = addClusterEnabledCacheManager(GlobalConfigurationBuilder.defaultClusteredBuilder().zeroCapacityNode(true), cb);
+      String cacheName = "" + cacheMode + consistentHashFactory;
+      node1.createCache(cacheName, cb.build());
+      node2.createCache(cacheName, cb.build());
+      zeroCapacityNode.createCache(cacheName, cb.build());
 
-      waitForClusterToForm();
-      assertCapacityFactors(node1, 0.5f);
-      assertCapacityFactors(node2, 0.5f);
-      assertCapacityFactors(zeroCapacityNode, 0.0f);
+      waitForClusterToForm(cacheName);
+
+      ConsistentHash ch =
+            cache(0, cacheName).getAdvancedCache().getDistributionManager().getCacheTopology().getReadConsistentHash();
+      assertEquals(1f, capacityFactor(ch, node1), 0.0);
+      assertEquals(1f, capacityFactor(ch, node2), 0.0);
+      assertEquals(0f, capacityFactor(ch, zeroCapacityNode), 0.0);
+
+      assertEquals(Collections.emptySet(), ch.getPrimarySegmentsForOwner(zeroCapacityNode.getAddress()));
+      assertEquals(Collections.emptySet(), ch.getSegmentsForOwner(zeroCapacityNode.getAddress()));
+
+      node1.getCache(cacheName).stop();
+
+      ConsistentHash ch2 =
+            cache(0, cacheName).getAdvancedCache().getDistributionManager().getCacheTopology().getReadConsistentHash();
+      assertEquals(Collections.emptySet(), ch2.getPrimarySegmentsForOwner(zeroCapacityNode.getAddress()));
+      assertEquals(Collections.emptySet(), ch2.getSegmentsForOwner(zeroCapacityNode.getAddress()));
    }
 
-   private void assertCapacityFactors(EmbeddedCacheManager cm, float expectedCapacityFactors) {
-      ConsistentHash ch = cache(0).getAdvancedCache().getDistributionManager().getReadConsistentHash();
-      Map<Address, Float> capacityFactors = ch.getCapacityFactors();
-      assertEquals(expectedCapacityFactors, capacityFactors.get(cm.getAddress()), 0.0);
+   private Float capacityFactor(ConsistentHash ch, EmbeddedCacheManager node) {
+      return ch.getCapacityFactors().get(node.getAddress());
    }
 }

--- a/core/src/test/java/org/infinispan/distribution/ch/ReplicatedConsistentHashFactoryTest.java
+++ b/core/src/test/java/org/infinispan/distribution/ch/ReplicatedConsistentHashFactoryTest.java
@@ -41,18 +41,23 @@ public class ReplicatedConsistentHashFactoryTest {
          checkDistribution(ch);
 
          ch = factory.updateMembers(ch, ab, null);
+         ch = factory.rebalance(ch);
          checkDistribution(ch);
 
          ch = factory.updateMembers(ch, abc, null);
+         ch = factory.rebalance(ch);
          checkDistribution(ch);
 
          ch = factory.updateMembers(ch, abcd, null);
+         ch = factory.rebalance(ch);
          checkDistribution(ch);
 
          ch = factory.updateMembers(ch, bcd, null);
+         ch = factory.rebalance(ch);
          checkDistribution(ch);
 
          ch = factory.updateMembers(ch, c, null);
+         ch = factory.rebalance(ch);
          checkDistribution(ch);
       }
    }

--- a/core/src/test/java/org/infinispan/distribution/ch/ReplicatedConsistentHashPersistenceTest.java
+++ b/core/src/test/java/org/infinispan/distribution/ch/ReplicatedConsistentHashPersistenceTest.java
@@ -1,8 +1,9 @@
 package org.infinispan.distribution.ch;
 
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.infinispan.distribution.ch.impl.ReplicatedConsistentHashFactory;
 import org.infinispan.profiling.testinternals.Generator;
@@ -23,8 +24,12 @@ public class ReplicatedConsistentHashPersistenceTest extends BaseCHPersistenceTe
       members.add(Generator.generateAddress());
       members.add(Generator.generateAddress());
       members.add(Generator.generateAddress());
+      Map<Address, Float> capacityFactors = new HashMap<>();
+      for (Address member : members) {
+         capacityFactors.put(member, 1.0f);
+      }
       ReplicatedConsistentHashFactory hashFactory = new ReplicatedConsistentHashFactory();
-      return hashFactory.create(2, 100, members, Collections.emptyMap());
+      return hashFactory.create(2, 100, members, capacityFactors);
    }
 
 }

--- a/core/src/test/java/org/infinispan/remoting/transport/MockTransport.java
+++ b/core/src/test/java/org/infinispan/remoting/transport/MockTransport.java
@@ -183,13 +183,14 @@ public class MockTransport implements Transport {
       throw new UnsupportedOperationException();
    }
 
+   @Deprecated
    @Override
    public BackupResponse backupRemotely(Collection<XSiteBackup> backups, XSiteReplicateCommand rpcCommand) {
       throw new UnsupportedOperationException();
    }
 
    @Override
-   public XSiteResponse backupRemotely(XSiteBackup backup, XSiteReplicateCommand rpcCommand) {
+   public <O> XSiteResponse<O> backupRemotely(XSiteBackup backup, XSiteReplicateCommand<O> rpcCommand) {
       throw new UnsupportedOperationException();
    }
 
@@ -278,6 +279,7 @@ public class MockTransport implements Transport {
       throw new UnsupportedOperationException();
    }
 
+   @Deprecated
    @Override
    public void checkTotalOrderSupported() {
    }
@@ -374,7 +376,7 @@ public class MockTransport implements Transport {
 
       public void finish() {
          if (collector == null) {
-            log.debugf("sendToX methods do not need a finish() call, ignoring it");
+            // sendToX methods do not need a finish() call, ignoring it
             return;
          }
 

--- a/core/src/test/java/org/infinispan/util/BaseControlledConsistentHashFactory.java
+++ b/core/src/test/java/org/infinispan/util/BaseControlledConsistentHashFactory.java
@@ -4,6 +4,7 @@ import static org.testng.AssertJUnit.assertEquals;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.IntFunction;
@@ -61,8 +62,7 @@ public abstract class BaseControlledConsistentHashFactory<CH extends ConsistentH
    }
 
    @Override
-   public CH updateMembers(CH baseCH, List<Address> newMembers,
-                                              Map<Address, Float> capacityFactors) {
+   public CH updateMembers(CH baseCH, List<Address> newMembers, Map<Address, Float> capacityFactors) {
       assertNumberOfSegments(baseCH.getNumSegments());
       List<Address>[] segmentOwners = new List[numSegments];
       List<Address>[] balancedOwners = null;
@@ -173,9 +173,10 @@ public abstract class BaseControlledConsistentHashFactory<CH extends ConsistentH
                                             Map<Address, Float> capacityFactors, List<Address>[] segmentOwners,
                                             boolean rebalanced) {
          int[] segmentOwners1 = Stream.of(segmentOwners)
-                                          .mapToInt(list -> list.isEmpty() ? 0 : members.indexOf(list.get(0)))
-                                          .toArray();
-         return new ReplicatedConsistentHash(members, segmentOwners1);
+                                      .mapToInt(list -> members.indexOf(list.get(0)))
+                                      .toArray();
+         // No support for zero-capacity nodes for now
+         return new ReplicatedConsistentHash(members, capacityFactors, Collections.emptyList(), segmentOwners1);
       }
 
       @Override
@@ -185,7 +186,7 @@ public abstract class BaseControlledConsistentHashFactory<CH extends ConsistentH
 
       @Override
       public boolean requiresPrimaryOwner() {
-         return false;
+         return true;
       }
 
       @Override


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12221

* Extend ZeroCapacityNodeTest to cover replicated
  and scattered caches
* Add a list of members without state and a capacity
  factors map to ReplicatedConsistentHash
* Ignore nodes with zero capacity when computing backups
* Change [Sync]ReplicatedConsistentHashFactory.
  updateMembers() no not assign new members as backups
