### PR TITLE
ISPN-12371 Remove LGPL header from new code for Search 6 integration

### DIFF
--- a/query/src/main/java/org/infinispan/query/impl/massindex/MassIndexerProgressNotifier.java
+++ b/query/src/main/java/org/infinispan/query/impl/massindex/MassIndexerProgressNotifier.java
@@ -1,9 +1,3 @@
-/*
- * Hibernate Search, full-text search for your domain model
- *
- * License: GNU Lesser General Public License (LGPL), version 2.1 or later
- * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
- */
 package org.infinispan.query.impl.massindex;
 
 import java.util.concurrent.atomic.AtomicReference;

--- a/search-mapper/src/main/java/org/infinispan/search/mapper/mapping/ProgrammaticSearchMappingProvider.java
+++ b/search-mapper/src/main/java/org/infinispan/search/mapper/mapping/ProgrammaticSearchMappingProvider.java
@@ -1,9 +1,3 @@
-/*
- * Hibernate Search, full-text search for your domain model
- *
- * License: GNU Lesser General Public License (LGPL), version 2.1 or later
- * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
- */
 package org.infinispan.search.mapper.mapping;
 
 /**

--- a/search-mapper/src/main/java/org/infinispan/search/mapper/mapping/SearchIndexedEntity.java
+++ b/search-mapper/src/main/java/org/infinispan/search/mapper/mapping/SearchIndexedEntity.java
@@ -1,9 +1,3 @@
-/*
- * Hibernate Search, full-text search for your domain model
- *
- * License: GNU Lesser General Public License (LGPL), version 2.1 or later
- * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
- */
 package org.infinispan.search.mapper.mapping;
 
 import org.hibernate.search.engine.backend.index.IndexManager;

--- a/search-mapper/src/main/java/org/infinispan/search/mapper/scope/impl/SearchWorkspaceImpl.java
+++ b/search-mapper/src/main/java/org/infinispan/search/mapper/scope/impl/SearchWorkspaceImpl.java
@@ -1,9 +1,3 @@
-/*
- * Hibernate Search, full-text search for your domain model
- *
- * License: GNU Lesser General Public License (LGPL), version 2.1 or later
- * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
- */
 package org.infinispan.search.mapper.scope.impl;
 
 import java.util.Collections;


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12371

The headers of The Hibernate 5 annotations package are related to old code, so probably we cannot remove the header from there...