### PR TITLE
Add UUID support in KeyMappers

### DIFF
--- a/core/src/main/java/org/infinispan/persistence/keymappers/DefaultTwoWayKey2StringMapper.java
+++ b/core/src/main/java/org/infinispan/persistence/keymappers/DefaultTwoWayKey2StringMapper.java
@@ -5,6 +5,7 @@ import java.util.Base64;
 import org.infinispan.commons.marshall.WrappedByteArray;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
+import java.util.UUID;
 
 /**
  * Default implementation for {@link TwoWayKey2StringMapper} that knows how to handle all primitive
@@ -28,6 +29,7 @@ public class DefaultTwoWayKey2StringMapper implements TwoWayKey2StringMapper {
    private static final char BOOLEAN_IDENTIFIER = '7';
    private static final char BYTEARRAYKEY_IDENTIFIER = '8';
    private static final char NATIVE_BYTEARRAYKEY_IDENTIFIER = '9';
+   private static final char UUID_IDENTIFIER = 'a';
 
    @Override
    public String getStringMapping(Object key) {
@@ -52,6 +54,8 @@ public class DefaultTwoWayKey2StringMapper implements TwoWayKey2StringMapper {
          return generateString(BYTEARRAYKEY_IDENTIFIER, Base64.getEncoder().encodeToString(((WrappedByteArray)key).getBytes()));
       } else if (key.getClass().equals(byte[].class)) {
          return generateString(NATIVE_BYTEARRAYKEY_IDENTIFIER, Base64.getEncoder().encodeToString((byte[]) key));
+      } else if (key.getClass().equals(UUID.class)) {
+         identifier = UUID_IDENTIFIER;
       } else {
          throw new IllegalArgumentException("Unsupported key type: " + key.getClass().getName());
       }
@@ -84,6 +88,8 @@ public class DefaultTwoWayKey2StringMapper implements TwoWayKey2StringMapper {
                return new WrappedByteArray(bytes);
             case NATIVE_BYTEARRAYKEY_IDENTIFIER:
                return Base64.getDecoder().decode(value);
+            case UUID_IDENTIFIER:
+               return UUID.fromString(value);
             default:
                throw new IllegalArgumentException("Unsupported type code: " + type);
          }
@@ -94,7 +100,7 @@ public class DefaultTwoWayKey2StringMapper implements TwoWayKey2StringMapper {
 
    @Override
    public boolean isSupportedType(Class<?> keyType) {
-      return isPrimitive(keyType) || keyType == WrappedByteArray.class;
+      return isPrimitive(keyType) || keyType == WrappedByteArray.class|| keyType == UUID.class;
    }
 
    private String generateString(char identifier, String s) {

--- a/core/src/test/java/org/infinispan/persistence/keymappers/DefaultTwoWayKey2StringMapperTest.java
+++ b/core/src/test/java/org/infinispan/persistence/keymappers/DefaultTwoWayKey2StringMapperTest.java
@@ -2,6 +2,8 @@ package org.infinispan.persistence.keymappers;
 
 import org.testng.annotations.Test;
 
+import java.util.UUID;
+
 @Test(groups = "unit", testName = "persistence.keymappers.DefaultTwoWayKey2StringMapperTest")
 public class DefaultTwoWayKey2StringMapperTest {
 
@@ -33,6 +35,14 @@ public class DefaultTwoWayKey2StringMapperTest {
       Double d = (Double) mapper.getKeyMapping(skey);
 
       assert d == 3.141592d;
+
+      UUID uuid = UUID.randomUUID();
+      skey = mapper.getStringMapping(uuid);
+      assert !uuid.equals(uuid.toString());
+
+      UUID u = (UUID) mapper.getKeyMapping(skey);
+      assert u.equals(uuid);
+
    }
 
    public void testPrimitivesAreSupported() {
@@ -102,6 +112,11 @@ public class DefaultTwoWayKey2StringMapperTest {
       assert mapper.isSupportedType(Boolean.class);
       assert assertWorks(true);
       assert assertWorks(false);
+   }
+
+   public void testUuid() {
+      assert mapper.isSupportedType(UUID.class);
+      assert assertWorks(UUID.randomUUID());
    }
 
    private boolean assertWorks(Object key) {


### PR DESCRIPTION
Add the java.util.UUID type to the supported types for keymappers.

