### PR TITLE
Update ChannelFactory.java

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/ChannelFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/ChannelFactory.java
@@ -216,7 +216,7 @@ public class ChannelFactory {
    public void destroy() {
       try {
          channelPoolMap.values().forEach(ChannelPool::close);
-         eventLoopGroup.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS).get();
+         eventLoopGroup.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS).get();  //todo set this parameters by properties??
          executorService.shutdownNow();
       } catch (Exception e) {
          log.warn("Exception while shutting down the connection pool.", e);


### PR DESCRIPTION
Set shutdownGracefully quietPeriod & timeout as configurable parameters by properties wold be nice.

As described in the shutdownGracefully javadoc:
> Signals this executor that the caller wants the executor to be shut down. Once this method is called, isShuttingDown() starts to return true, and the executor prepares to shut itself down. Unlike shutdown(), graceful shutdown ensures that no tasks are submitted for 'the quiet period' (usually a couple seconds) before it shuts itself down. If a task is submitted during the quiet period, it is guaranteed to be accepted and the quiet period will start over.

- tomcat 8.5
- java / spring-boot 2.2.6
- infinispan-spring-boot-starter-remote:2.3.3.Final
- hodrot client

The SpringRemoteCacheManager.stop() is calling nativeCacheManager.getChannelFactory.destory() but there are still some threads not closing on context undeployment:

```
06-Oct-2020 05:38:49.075 SEVERE [ContainerBackgroundProcessor[StandardEngine[Catalina]]] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [ebo##000000013] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@508e050f]) and a value of type [io.netty.util.internal.InternalThreadLocalMap] (value [io.netty.util.internal.InternalThreadLocalMap@753fd803]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
```
The tomcat context.xml undeployTimeout option seems to minimize the number of threads still hanged but they are still appearing.