### PR TITLE
[11.0.x] ISPN-12375 Add missing license information to wildfly modules

### DIFF
--- a/distribution/package.xml
+++ b/distribution/package.xml
@@ -62,7 +62,7 @@
          </java>
          <java classname="org.infinispan.tools.licenses.LicenseReplacer">
             <arg value="-i"/>
-            <arg value="src/main/resources/template/licenses-overwrite.xml"/>
+            <arg value="${basedir}/src/main/resources/template/licenses-overwrite.xml"/>
             <arg value="-l"/>
             <arg value="@{dir}/docs/licenses/licenses.xml"/>
             <arg value="-o"/>

--- a/pom.xml
+++ b/pom.xml
@@ -327,7 +327,6 @@
       <versionx.org.hibernate.gson-jbossmodules.gson-jbossmodules>${version.gson.featurepack}</versionx.org.hibernate.gson-jbossmodules.gson-jbossmodules>
       <versionx.org.hibernate.hibernate-core>${version.hibernate.core}</versionx.org.hibernate.hibernate-core>
       <versionx.org.hibernate.hibernate-osgi>${version.hibernate.core}</versionx.org.hibernate.hibernate-osgi>
-      <versionx.org.hibernate.hibernate-search-backend-jms>${version.hibernate.search}</versionx.org.hibernate.hibernate-search-backend-jms>
       <versionx.org.hibernate.hibernate-search-engine>${version.hibernate.search}</versionx.org.hibernate.hibernate-search-engine>
       <versionx.org.hibernate.hibernate-search-jbossmodules-engine>${version.hibernate.search}</versionx.org.hibernate.hibernate-search-jbossmodules-engine>
       <versionx.org.hibernate.hibernate-search-orm>${version.hibernate.search}</versionx.org.hibernate.hibernate-search-orm>
@@ -1000,12 +999,6 @@
             <artifactId>hibernate-osgi</artifactId>
             <version>${versionx.org.hibernate.hibernate-osgi}</version>
             <scope>runtime</scope>
-         </dependency>
-         <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-search-backend-jms</artifactId>
-            <version>${versionx.org.hibernate.hibernate-search-backend-jms}</version>
-            <scope>test</scope>
          </dependency>
          <dependency>
             <groupId>org.hibernate</groupId>

--- a/wildfly/feature-pack/pom.xml
+++ b/wildfly/feature-pack/pom.xml
@@ -201,18 +201,6 @@
             <type>zip</type>
         </dependency>
 
-        <!-- just to be caught by the licenses plugin -->
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-search-backend-jms</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
         <dependency>
             <groupId>org.hibernate.lucene-jbossmodules</groupId>
             <artifactId>lucene-jbossmodules</artifactId>


### PR DESCRIPTION
* Fix path: missing ${basedir}
* Remove hibernate-search-backend-jms
  The licenses-plugin is configured to ignore test dependencies and it
was ignoring the dep. Remove it from our pom.xml fix the issues. It
isn't used explicitly anywhere.

https://issues.redhat.com/browse/ISPN-12375