### PR TITLE
[PREVIEW] ISPN-3226 Enable Error Prone 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
                 // Workaround for JENKINS-47230
                 script {
                     env.MAVEN_HOME = tool('Maven')
-                    env.MAVEN_OPTS = "-Xmx800m -XX:+HeapDumpOnOutOfMemoryError"
+                    env.MAVEN_OPTS = "-Xmx800m -XX:+HeapDumpOnOutOfMemoryError --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED"
                     env.JAVA_HOME = tool('JDK 11')
                 }
 

--- a/commons/all/pom.xml
+++ b/commons/all/pom.xml
@@ -115,9 +115,10 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
             <configuration>
-               <compilerArgument combine.children="append">-XDignore.symbol.file</compilerArgument>
-               <!-- Forking is necessary to allow for the compiler args to be picked up. -->
-               <fork combine.children="append">true</fork>
+               <compilerArgs combine.children="append">
+                  <!-- Do not warn about Unsafe -->
+                  <arg>-XDignore.symbol.file</arg>
+               </compilerArgs>
                <release>8</release>
             </configuration>
          </plugin>

--- a/commons/all/src/main/java/org/infinispan/commons/util/Closeables.java
+++ b/commons/all/src/main/java/org/infinispan/commons/util/Closeables.java
@@ -99,8 +99,7 @@ public class Closeables {
     */
    public static <E> Stream<E> stream(CloseableSpliterator<E> spliterator, boolean parallel) {
       Stream<E> stream = StreamSupport.stream(spliterator, parallel);
-      stream.onClose(spliterator::close);
-      return stream;
+      return stream.onClose(spliterator::close);
    }
 
    /**
@@ -114,8 +113,7 @@ public class Closeables {
     */
    public static <E> Stream<E> stream(CloseableIterator<E> iterator, boolean parallel, long size, int characteristics) {
       Stream<E> stream = StreamSupport.stream(Spliterators.spliterator(iterator, size, characteristics), parallel);
-      stream.onClose(iterator::close);
-      return stream;
+      return stream.onClose(iterator::close);
    }
 
    private static class IteratorAsCloseableIterator<E> implements CloseableIterator<E> {

--- a/commons/all/src/main/java/org/infinispan/commons/util/EmptyIntSet.java
+++ b/commons/all/src/main/java/org/infinispan/commons/util/EmptyIntSet.java
@@ -92,6 +92,11 @@ class EmptyIntSet extends AbstractImmutableIntSet {
    }
 
    @Override
+   public int hashCode() {
+      return -1;
+   }
+
+   @Override
    public String toString() {
       return "{}";
    }

--- a/commons/all/src/test/java/org/infinispan/commons/hash/MurmurHash3StringCompatTest.java
+++ b/commons/all/src/test/java/org/infinispan/commons/hash/MurmurHash3StringCompatTest.java
@@ -17,6 +17,7 @@ public class MurmurHash3StringCompatTest {
    public void compareHashes() {
       Random random = new Random(9005);
       for (int i = 0; i < NUM_KEYS; i++) {
+         @SuppressWarnings("IdentityBinaryExpression")
          int cpLen = Math.abs(random.nextInt(MAX_KEY_SIZE) - random.nextInt(MAX_KEY_SIZE)) + 1;
          int[] codePoints = random.ints(cpLen, 0, 0x110000).filter(Character::isDefined).toArray();
          String s = new String(codePoints, 0, codePoints.length);

--- a/component-processor/pom.xml
+++ b/component-processor/pom.xml
@@ -52,6 +52,11 @@
                      <artifactId>metainf-services</artifactId>
                      <version>${versionx.org.kohsuke.metainf-services.metainf-services}</version>
                   </path>
+                  <path>
+                     <groupId>com.google.errorprone</groupId>
+                     <artifactId>error_prone_core</artifactId>
+                     <version>2.4.0</version>
+                  </path>
                </annotationProcessorPaths>
             </configuration>
          </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1737,6 +1737,14 @@
          <classifier>runtime</classifier>
          <scope>test</scope>
       </dependency>
+
+      <!-- To help debug errorprone issues -->
+      <dependency>
+         <groupId>javax.annotation</groupId>
+         <artifactId>javax.annotation-api</artifactId>
+         <version>${versionx.javax.annotation.javax.annotation-api}</version>
+         <optional>true</optional>
+      </dependency>
    </dependencies>
 
    <build>
@@ -2022,6 +2030,34 @@
                   </excludes>
                   <!-- Include method parameter debug info -->
                   <parameters>true</parameters>
+                  <compilerArgs>
+                     <!-- In case the compiler is forked -->
+                     <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+                     <arg>-XDcompilePolicy=simple</arg>
+                     <arg>-Xplugin:ErrorProne</arg>
+                  </compilerArgs>
+                  <annotationProcessorPaths>
+                     <path>
+                        <groupId>org.kohsuke.metainf-services</groupId>
+                        <artifactId>metainf-services</artifactId>
+                        <version>${versionx.org.kohsuke.metainf-services.metainf-services}</version>
+                     </path>
+                     <path>
+                        <groupId>com.google.errorprone</groupId>
+                        <artifactId>error_prone_core</artifactId>
+                        <version>2.4.0</version>
+                     </path>
+                     <path>
+                        <groupId>org.infinispan.protostream</groupId>
+                        <artifactId>protostream-processor</artifactId>
+                        <version>${version.protostream}</version>
+                     </path>
+                     <path>
+                        <groupId>javax.annotation</groupId>
+                        <artifactId>javax.annotation-api</artifactId>
+                        <version>${versionx.javax.annotation.javax.annotation-api}</version>
+                     </path>
+                  </annotationProcessorPaths>
                </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
It's only a draft for now, because I'm not sure we should enable it just yet.

* It flags the issues it finds as errors, so we need to fix all of them before integrating.
* It requires us to mention all the annotation processors explicitly in the POM, so e.g. every module gets the component annotation processor by default (OR we add it explicitly in every module that does need it).
* A bug in maven-compiler-plugin (MCOMPILER-434) makes it hard to debug problems with the explicit annotation processor path.
