### PR TITLE
ISPN-12413 Clustered listeners for replicated caches with zero capacity

### DIFF
--- a/anchored-keys/src/main/java/org/infinispan/anchored/impl/AnchoredCacheNotifier.java
+++ b/anchored-keys/src/main/java/org/infinispan/anchored/impl/AnchoredCacheNotifier.java
@@ -2,7 +2,6 @@ package org.infinispan.anchored.impl;
 
 import java.util.concurrent.CompletionStage;
 
-import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.notifications.cachelistener.CacheNotifierImpl;
 
 /**
@@ -19,8 +18,7 @@ import org.infinispan.notifications.cachelistener.CacheNotifierImpl;
  */
 public class AnchoredCacheNotifier<K, V> extends CacheNotifierImpl<K, V> {
    @Override
-   protected boolean clusterListenerOnPrimaryOnly(CacheMode mode) {
-      assert mode.isReplicated();
+   protected boolean clusterListenerOnPrimaryOnly() {
       return true;
    }
 

--- a/core/src/main/java/org/infinispan/configuration/global/CacheContainerConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/global/CacheContainerConfiguration.java
@@ -110,7 +110,7 @@ class CacheContainerConfiguration implements ConfigurationInfo {
    }
 
    public boolean getZeroCapacityNode() {
-      return zeroCapacityAvailable & zeroCapacityNode.get();
+      return zeroCapacityAvailable && zeroCapacityNode.get();
    }
 
    public GlobalMetricsConfiguration metrics() {

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/BaseCacheNotifierImplInitialTransferTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/BaseCacheNotifierImplInitialTransferTest.java
@@ -32,6 +32,8 @@ import org.infinispan.commons.marshall.StreamingMarshaller;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfiguration;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.container.entries.ImmortalCacheEntry;
 import org.infinispan.container.entries.TransientMortalCacheEntry;
@@ -137,6 +139,7 @@ public abstract class BaseCacheNotifierImplInitialTransferTest extends AbstractI
       when(mockCache.getKeyDataConversion()).thenReturn(DataConversion.IDENTITY_KEY);
       when(mockCache.getValueDataConversion()).thenReturn(DataConversion.IDENTITY_VALUE);
       Configuration config = new ConfigurationBuilder().clustering().cacheMode(cacheMode).build();
+      GlobalConfiguration globalConfig = GlobalConfigurationBuilder.defaultClusteredBuilder().build();
       when(mockCache.getStatus()).thenReturn(ComponentStatus.INITIALIZING);
 
       mockPublisherManager = mock(ClusterPublisherManager.class);
@@ -153,7 +156,7 @@ public abstract class BaseCacheNotifierImplInitialTransferTest extends AbstractI
       when(cem.sendEvents(any())).thenReturn(CompletableFutures.completedNull());
       BlockingManager handler = mock(BlockingManager.class);
       when(handler.continueOnNonBlockingThread(any(), any())).thenReturn(CompletableFutures.completedNull());
-      TestingUtil.inject(n, mockCache, cdl, config, mockRegistry, mockPublisherManager,
+      TestingUtil.inject(n, mockCache, cdl, config, globalConfig, mockRegistry, mockPublisherManager,
                          new InternalEntryFactoryImpl(), cem, mock(KeyPartitioner.class), handler,
                          TestingUtil.named(KnownComponentNames.ASYNC_NOTIFICATION_EXECUTOR, new WithinThreadExecutor()));
       n.start();


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12413

A replicated cache on a zero capacity node does not store any entries
locally, but it should still notify clustered listeners of changes.