### PR TITLE
ISPN-12315 REST server can't handle entry changes with value encoded as java primitives

### DIFF
--- a/server/rest/src/test/java/org/infinispan/rest/resources/CacheV2ResourceTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/resources/CacheV2ResourceTest.java
@@ -540,12 +540,15 @@ public class CacheV2ResourceTest extends AbstractRestResourceTest {
       ResponseAssertion.assertThat(response).isOk();
 
       // Read the changed value as an integer
-      response = client.get("1", integerType.toString());
+      Map<String, String> headers = new HashMap<>();
+      headers.put(KEY_CONTENT_TYPE_HEADER.getValue(), integerType.toString());
+      headers.put(ACCEPT_HEADER.getValue(), integerType.toString());
+      response = client.get("1", headers);
       ResponseAssertion.assertThat(response).isOk();
       ResponseAssertion.assertThat(response).hasReturnedText("2");
 
       // Read the changed value as protobuf
-      Map<String, String> headers = new HashMap<>();
+      headers = new HashMap<>();
       headers.put(KEY_CONTENT_TYPE_HEADER.getValue(), integerType.toString());
       headers.put(ACCEPT_HEADER.getValue(), MediaType.APPLICATION_PROTOSTREAM_TYPE);
       response = client.get("1", headers);


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12315

The test ```org.infinispan.rest.resources.CacheV2ResourceTest.testCRUDWithProtobufPrimitives``` started failing after https://github.com/infinispan/infinispan/pull/8747 was merged, it turned out the test was buggy and was not passing the correct headers