### PR TITLE
ISPN-12343: Comment line where DEFAULT_CLUSTER_STACK is set as INFINISPAN_CLUSTER_STACK'

### DIFF
--- a/server/runtime/src/main/java/org/infinispan/server/Server.java
+++ b/server/runtime/src/main/java/org/infinispan/server/Server.java
@@ -221,7 +221,7 @@ public class Server implements ServerManagement, AutoCloseable {
       properties.putIfAbsent(INFINISPAN_SERVER_LOG_PATH, new File(serverRoot, DEFAULT_SERVER_LOG).getAbsolutePath());
       properties.putIfAbsent(INFINISPAN_BIND_PORT, DEFAULT_BIND_PORT);
       properties.putIfAbsent(INFINISPAN_CLUSTER_NAME, DEFAULT_CLUSTER_NAME);
-      properties.putIfAbsent(INFINISPAN_CLUSTER_STACK, DEFAULT_CLUSTER_STACK);
+   //   properties.putIfAbsent(INFINISPAN_CLUSTER_STACK, DEFAULT_CLUSTER_STACK); //Commented code for Jira ISPN-12343
 
       this.serverConf = new File(properties.getProperty(INFINISPAN_SERVER_CONFIG_PATH));
 


### PR DESCRIPTION
a) I see the code is setting the TCP as default stack in code in constructor of class Server (org.infinispan.server.Server.java line 224) as " properties.putIfAbsent(INFINISPAN_CLUSTER_STACK, DEFAULT_CLUSTER_STACK);".

b) When we try to parse the configuration in org.infinispan.configuration.parsing.Parser.parseTransport() at line 984(String value = reader.getAttributeValue(i);) as we set the default stack, the configured stack other than TCP, is replaced by TCP every time. As the method org.infinispan.commons.util.StringPropertyReplacer.replaceProperties() replaces the value from the properties set during startup.

c) I believe this case in org.infinispan.commons.util.StringPropertyReplacer.replaceProperties() is written to provide priority to the passed argument, however as we are setting the default in the code, its causing the issue. This method is generic so can't change just for a simple change.

d) I think the same issue will come for the following default properties setting in class org.infinispan.server.Server.java.

~~~
   // Populate system properties unless they have already been set externally
      properties.putIfAbsent(INFINISPAN_SERVER_HOME_PATH, serverHome);
      properties.putIfAbsent(INFINISPAN_SERVER_ROOT_PATH, serverRoot);
      properties.putIfAbsent(INFINISPAN_SERVER_CONFIG_PATH, new File(serverRoot, DEFAULT_SERVER_CONFIG).getAbsolutePath());
      properties.putIfAbsent(INFINISPAN_SERVER_DATA_PATH, new File(serverRoot, DEFAULT_SERVER_DATA).getAbsolutePath());
      properties.putIfAbsent(INFINISPAN_SERVER_LOG_PATH, new File(serverRoot, DEFAULT_SERVER_LOG).getAbsolutePath());
      properties.putIfAbsent(INFINISPAN_BIND_PORT, DEFAULT_BIND_PORT);
      properties.putIfAbsent(INFINISPAN_CLUSTER_NAME, DEFAULT_CLUSTER_NAME);
      properties.putIfAbsent(INFINISPAN_CLUSTER_STACK, DEFAULT_CLUSTER_STACK); -> Comment this line


~~~

e) The fix in my opinion either to comment "properties.putIfAbsent(INFINISPAN_CLUSTER_STACK, DEFAULT_CLUSTER_STACK);"

I don't see any branch for 12.0.0 thus sending for master