### PR TITLE
ISPN-10804 JCache tck-runner does not run interception tests

### DIFF
--- a/jcache/commons/src/test/java/org/infinispan/jcache/tck/JCacheTckContextInitializer.java
+++ b/jcache/commons/src/test/java/org/infinispan/jcache/tck/JCacheTckContextInitializer.java
@@ -7,6 +7,7 @@ import org.infinispan.protostream.MessageMarshaller;
 import org.infinispan.protostream.SerializationContextInitializer;
 
 import domain.Beagle;
+import domain.Blog;
 import domain.BorderCollie;
 import domain.Chihuahua;
 import domain.Dachshund;
@@ -54,6 +55,7 @@ public class JCacheTckContextInitializer implements SerializationContextInitiali
       serCtx.registerMarshaller(new DogBreedMarshaller(Dachshund.class));
       serCtx.registerMarshaller(new DogBreedMarshaller(Papillon.class));
       serCtx.registerMarshaller(new DogBreedMarshaller(RoughCoatedCollie.class));
+      serCtx.registerMarshaller(new BlogMarshaller());
    }
 
    static class IdentityMarshaller implements MessageMarshaller<Identifier> {
@@ -175,6 +177,36 @@ public class JCacheTckContextInitializer implements SerializationContextInitiali
       @Override
       public String getTypeName() {
          return type(clazz.getSimpleName());
+      }
+   }
+
+   static class BlogMarshaller implements MessageMarshaller<Blog> {
+
+      @Override
+      public Blog readFrom(ProtoStreamReader reader) throws IOException {
+         try {
+            String title = reader.readString("title");
+            String body = reader.readString("body");
+            return new Blog(title, body);
+         } catch (Exception e) {
+            throw new IllegalStateException(e);
+         }
+      }
+
+      @Override
+      public void writeTo(ProtoStreamWriter writer, Blog blog) throws IOException {
+         writer.writeString("title", blog.getTitle());
+         writer.writeString("body", blog.getBody());
+      }
+
+      @Override
+      public Class<? extends Blog> getJavaClass() {
+         return Blog.class;
+      }
+
+      @Override
+      public String getTypeName() {
+         return type(Blog.class.getSimpleName());
       }
    }
 }

--- a/jcache/commons/src/test/resources/jcache.proto
+++ b/jcache/commons/src/test/resources/jcache.proto
@@ -44,3 +44,8 @@ message Papillon {
 message RoughCoatedCollie {
     optional Dog dog = 1;
 }
+
+message Blog {
+    optional string title = 1;
+    optional string body = 2;
+}

--- a/jcache/tck-runner-embedded/pom.xml
+++ b/jcache/tck-runner-embedded/pom.xml
@@ -33,6 +33,11 @@
       </dependency>
       <dependency>
          <groupId>org.infinispan</groupId>
+         <artifactId>infinispan-cdi-embedded</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.infinispan</groupId>
          <artifactId>infinispan-jcache-commons</artifactId>
          <scope>test</scope>
       </dependency>
@@ -67,6 +72,20 @@
          <groupId>javax.cache</groupId>
          <artifactId>cdi-weld-annotations-test-harness</artifactId>
          <scope>test</scope>
+         <exclusions>
+            <!--
+             Exclude the reference implementation's CDI interceptors
+             in cache-annotations-ri-cdi.
+             Because of org.jboss.weld.se.archive.isolation=false,
+             Weld uses the beans.xml in this jar as well.
+             The RI interceptors are added to the test beans
+             and could make the tests pass even if our interceptors don't work.
+             -->
+            <exclusion>
+               <groupId>org.jsr107.ri</groupId>
+               <artifactId>cache-annotations-ri-cdi</artifactId>
+            </exclusion>
+         </exclusions>
       </dependency>
    </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -363,6 +363,7 @@
       <versionx.org.jboss.threads.jboss-threads>2.3.3.Final</versionx.org.jboss.threads.jboss-threads>
       <versionx.org.jboss.weld.se.weld-se-core>3.1.2.Final</versionx.org.jboss.weld.se.weld-se-core>
       <versionx.org.jboss.weld.weld-core-impl>3.1.2.Final</versionx.org.jboss.weld.weld-core-impl>
+      <versionx.org.jboss.weld.weld-api>3.1.SP1</versionx.org.jboss.weld.weld-api>
       <versionx.org.jboss.xnio.xnio-api>${version.jboss.xnio}</versionx.org.jboss.xnio.xnio-api>
       <versionx.org.jboss.xnio.xnio-nio>${version.jboss.xnio}</versionx.org.jboss.xnio.xnio-nio>
       <versionx.org.jgroups.aws.s3.native-s3-ping>0.9.5.Final</versionx.org.jgroups.aws.s3.native-s3-ping>
@@ -1428,6 +1429,19 @@
             <groupId>org.jboss.threads</groupId>
             <artifactId>jboss-threads</artifactId>
             <version>${versionx.org.jboss.threads.jboss-threads}</version>
+         </dependency>
+         <!-- cdi-weld-annotations-test-harness requests weld-api and weld-spi, override the versions to match the impl -->
+         <dependency>
+            <groupId>org.jboss.weld</groupId>
+            <artifactId>weld-api</artifactId>
+            <version>${versionx.org.jboss.weld.weld-api}</version>
+            <scope>test</scope>
+         </dependency>
+         <dependency>
+            <groupId>org.jboss.weld</groupId>
+            <artifactId>weld-spi</artifactId>
+            <version>${versionx.org.jboss.weld.weld-api}</version>
+            <scope>test</scope>
          </dependency>
          <dependency>
             <groupId>org.jboss.weld</groupId>


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-10804
https://issues.redhat.com/browse/ISPN-12466

* Fix the weld-api and weld-spi versions.
* Add infinispan-cdi-embedded as a dependency of tck-runner-embedded.
  Needed because it's an optional dependency of infinispan-jcache.

    Allow DefaultCacheResolver to update the default cache manager reference.
    Closing a CachingProvider is supposed to close all existing managers
    but still allow the creation of new managers.