### PR TITLE
Updating links to contributing and Jira

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Guidelines for contributing to Infinispan
 Contributions from the community are essential in keeping Infinispan strong and successful.
 
 This guide focuses on how to contribute back to Infinispan using GitHub pull requests.
-If you need help with cloning, compiling or setting the project up in an IDE please refer to our [Contributing Guide](https://infinispan.org/docs/stable/titles/contributing/contributing.html).
+If you need help with cloning, compiling or setting the project up in an IDE please refer to our [Contributing Guide](https://infinispan.org/docs/dev/titles/contributing/contributing.html).
 
 ## Legal
 
@@ -50,7 +50,7 @@ Code away...
 
 ## Formatting rules and style conventions
 
-The Infinispan family projects share the same style conventions. Please refer to our [Contributing Guide](https://infinispan.org/docs/stable/titles/contributing/contributing.html) for more details.
+The Infinispan family projects share the same style conventions. Please refer to our [Contributing Guide](https://infinispan.org/docs/dev/titles/contributing/contributing.html) for more details.
 
 
 ## Commit

--- a/README-Build.md
+++ b/README-Build.md
@@ -1,6 +1,6 @@
 You can read more about how to build Infinispan in the documentation:
 
-http://infinispan.org/docs/dev/contributing/contributing.html
+link:https://infinispan.org/docs/dev/titles/contributing/contributing.html[Infinispan Contributor's Guide]
 
 Provided you already have the correct versions of Java and Maven installed, you can get started right away.
 For convenience you can use the provided maven-settings.xml file which enables all additional repositories required for
@@ -15,9 +15,3 @@ Available profiles
 
 * *distribution* Builds the full distribution
 * *java8-test*   Runs the testsuite using a Java 8 installation (the JAVA8_HOME environment variable must point to it)
-
-System properties
-=================
-
-* *server.test.provisioning* Set this to _dist_ to copy artifacts to the server used in the testsuite (uses more disk space but avoids runtime resolution of artifacts)
-

--- a/documentation/src/main/asciidoc/titles/cli/cli.asciidoc
+++ b/documentation/src/main/asciidoc/titles/cli/cli.asciidoc
@@ -2,7 +2,6 @@
 :stories: ../../stories
 :topics: ../topics
 :imagesdir: ../{topics}/images
-:cli_help: ../../../../../cli/cli-client/src/main/resources/help/
 
 //Community doc attributes
 include::../{topics}/attributes/community-attributes.adoc[]

--- a/documentation/src/main/asciidoc/topics/attributes/community-attributes.adoc
+++ b/documentation/src/main/asciidoc/topics/attributes/community-attributes.adoc
@@ -50,6 +50,11 @@
 :wildflybrandname: WildFly
 
 //
+// Path to CLI Help
+//
+:cli_help: ../../../../../cli/src/main/resources/help/
+
+//
 // Titles
 //
 

--- a/documentation/src/main/asciidoc/topics/contributing/basics.adoc
+++ b/documentation/src/main/asciidoc/topics/contributing/basics.adoc
@@ -14,7 +14,7 @@ In this chapter we quickly walk through the basics on contributing; future chapt
 
 == Issue Management
 
-{brandname} uses JIRA for issue management, hosted on link:http://issues.jboss.org/browse/ISPN[issues.jboss.org].
+{brandname} uses JIRA for issue management, hosted on link:https://issues.redhat.com/projects/ISPN/issues[issues.redhat.com].
 You can log in using your jboss.org username and password.
 
 === Reporting Issues
@@ -51,13 +51,13 @@ Version numbers are defined as `${major}.${minor}.${micro}.${modifier}`.  For ex
 
 If the issue relates to a _Task_ or _Feature Request_, please ensure that the `.Final` version is included in the _Fixed In_ field.
 For example, a new feature should contain `4.1.0.Beta1`, `4.1.0.Final` if it is new for 4.1.0 and was first made public in beta1.
-For example, see link:https://issues.jboss.org/browse/ISPN-299[ISPN-299] .
+For example, see link:https://issues.redhat.com/browse/ISPN-299[ISPN-299] .
 
 If the issue relates to a bug which affected a previous Final version, then the _Fixed In_ field should also contain the Final version which contains the fix, in addition to any Alpha, Beta or CR release.
-For example, see link:https://issues.jboss.org/browse/ISPN-546[ISPN-546].
+For example, see link:https://issues.redhat.com/browse/ISPN-546[ISPN-546].
 If the issue pertains to a bug in the current release, then the Final version should not be in the _Fixed In_ field.
 For example, a bug found in 4.1.0.Alpha2 (but not in 4.1.0.Alpha1) should be marked as fixed in 4.1.0.Alpha3, but not in 4.1.0.Final.
-For example, see link:https://issues.jboss.org/browse/ISPN-416[ISPN-416].
+For example, see link:https://issues.redhat.com/browse/ISPN-416[ISPN-416].
 
 == Version control
 {brandname} uses link:http://git-scm.com[git], hosted on link:http://github.com[GitHub], for version control.
@@ -181,7 +181,7 @@ If your comment does not follow this format, your commit may not be merged into 
 {brandname} follows the JBoss logging standards, which can be found link:https://community.jboss.org/wiki/LoggingStandards[here] .
 
 From {brandname} 5.0 onwards, {brandname} uses JBoss Logging to abstract over the logging backend.
-{brandname} supports localization of log message for categories of INFO or above as explained in link:http://community.jboss.org/docs/16738[the JBoss Logging guidelines] .
+{brandname} supports localization of log message for categories of INFO or above as explained in link:https://docs.jboss.org/process-guide/en/html/logging.html[the JBoss Logging guidelines] .
 As a developer, this means that for each INFO, WARN, ERROR and FATAL message your code emits, you need to modify the Log class in your module and add an explicit method for it with the right annotations.
 
 For example:

--- a/documentation/src/main/asciidoc/topics/contributing/building.adoc
+++ b/documentation/src/main/asciidoc/topics/contributing/building.adoc
@@ -5,7 +5,7 @@
 * Java 11 or above
 * Maven 3.5 or above
 
-WARNING: Make sure you follow the steps outlined in link:http://community.jboss.org/docs/15169[Maven Getting Started - Users] to set up your JBoss repository correctly.
+WARNING: Make sure you follow the steps outlined in link:https://developer.jboss.org/docs/DOC-15169[Maven Getting Started - Users] to set up your JBoss repository correctly.
 This step is _crucial_ to ensure your Maven setup can locate JBoss artifacts!
 If you also want to test the EAP integration modules you should also add the appropriate link:http://maven.repository.redhat.com/[Enterprise Red Hat Maven Repository.]
 


### PR DESCRIPTION
Some stale links in the Contributor's Guide to old Jira instances. Correcting link and stale details in README-Build.md.