### PR TITLE
ISPN-10216 Implement bloom filter based near cache invalidations

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/ConnectionPoolConfigurationBuilder.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/ConnectionPoolConfigurationBuilder.java
@@ -34,6 +34,14 @@ public class ConnectionPoolConfigurationBuilder extends AbstractConfigurationChi
    }
 
    /**
+    * Returns the configured action when the pool has become exhausted.
+    * @return the action to perform
+    */
+   public ExhaustedAction exhaustedAction() {
+      return exhaustedAction;
+   }
+
+   /**
     * Controls the maximum number of connections per server that are allocated (checked out to
     * client threads, or idle in the pool) at one time. When non-positive, there is no limit to the
     * number of connections per server. When maxActive is reached, the connection pool for that
@@ -43,6 +51,15 @@ public class ConnectionPoolConfigurationBuilder extends AbstractConfigurationChi
    public ConnectionPoolConfigurationBuilder maxActive(int maxActive) {
       this.maxActive = maxActive;
       return this;
+   }
+
+   /**
+    * Returns the number of configured maximum connections per server that can be allocated. When this is non-positive
+    * there is no limit to the number of connections.
+    * @return maximum number of open connections to a server
+    */
+   public int maxActive() {
+      return maxActive;
    }
 
    /**

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/NearCacheConfigurationBuilder.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/NearCacheConfigurationBuilder.java
@@ -89,6 +89,14 @@ public class NearCacheConfigurationBuilder extends AbstractConfigurationChildBui
          } else if (maxEntries < 0 && bloomFilter) {
             throw HOTROD.nearCacheMaxEntriesPositiveWithBloom(maxEntries);
          }
+
+         if (bloomFilter) {
+            int maxActive = connectionPool().maxActive();
+            ExhaustedAction exhaustedAction = connectionPool().exhaustedAction();
+            if (maxActive != 1 || exhaustedAction != ExhaustedAction.WAIT) {
+               throw HOTROD.bloomFilterRequiresMaxActiveOneAndWait(maxEntries, exhaustedAction);
+            }
+         }
       }
    }
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/logging/Log.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/logging/Log.java
@@ -15,6 +15,7 @@ import java.util.Set;
 
 import javax.transaction.xa.Xid;
 
+import org.infinispan.client.hotrod.configuration.ExhaustedAction;
 import org.infinispan.client.hotrod.event.IncorrectClientListenerException;
 import org.infinispan.client.hotrod.exceptions.CacheNotTransactionalException;
 import org.infinispan.client.hotrod.exceptions.HotRodClientException;
@@ -363,4 +364,7 @@ public interface Log extends BasicLogger {
 
    @Message(value = "Near cache number of max entries must be a positive number when using bloom filter optimization, it was %d", id = 4102)
    CacheConfigurationException nearCacheMaxEntriesPositiveWithBloom(int maxEntries);
+
+   @Message(value = "Near cache with bloom filter requires pool max active to be 1, was %s, and exhausted action to be WAIT, was %s", id = 4103)
+   CacheConfigurationException bloomFilterRequiresMaxActiveOneAndWait(int maxActive, ExhaustedAction action);
 }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/AvoidStaleNearCacheReadsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/AvoidStaleNearCacheReadsTest.java
@@ -51,6 +51,9 @@ public class AvoidStaleNearCacheReadsTest extends SingleHotRodServerTest {
             .mode(NearCacheMode.INVALIDATED)
             .maxEntries(entryCount)
             .bloomFilter(bloomFilter);
+      if (bloomFilter) {
+         builder.connectionPool().maxActive(1);
+      }
       return new RemoteCacheManager(builder.build());
    }
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/ClusterInvalidatedNearCacheBloomTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/ClusterInvalidatedNearCacheBloomTest.java
@@ -86,6 +86,8 @@ public class ClusterInvalidatedNearCacheBloomTest extends MultiHotRodServersTest
       for (HotRodServer server : servers)
          clientBuilder.addServer().host("127.0.0.1").port(server.getPort());
 
+      clientBuilder.connectionPool().maxActive(1);
+
       clientBuilder.nearCache().mode(NearCacheMode.INVALIDATED)
             .maxEntries(NEAR_CACHE_SIZE)
             .bloomFilter(true);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/EvictInvalidatedNearCacheTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/EvictInvalidatedNearCacheTest.java
@@ -80,6 +80,7 @@ public class EvictInvalidatedNearCacheTest extends SingleHotRodServerTest {
       NearCacheConfigurationBuilder nearCacheConfigurationBuilder = builder.nearCache().mode(getNearCacheMode())
             .maxEntries(entryCount);
       if (bloomFilter) {
+         builder.connectionPool().maxActive(1);
          nearCacheConfigurationBuilder.bloomFilter(true);
       }
       return AssertsNearCache.create(cache(), builder);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/InvalidatedFailoverNearCacheBloomTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/InvalidatedFailoverNearCacheBloomTest.java
@@ -21,6 +21,8 @@ public class InvalidatedFailoverNearCacheBloomTest extends InvalidatedFailoverNe
       for (HotRodServer server : servers)
          clientBuilder.addServer().host("127.0.0.1").port(server.getPort());
 
+      clientBuilder.connectionPool().maxActive(1);
+
       clientBuilder.nearCache().mode(NearCacheMode.INVALIDATED)
             .maxEntries(4)
             .bloomFilter(true);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/InvalidatedNearCacheBloomTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/InvalidatedNearCacheBloomTest.java
@@ -85,6 +85,7 @@ public class InvalidatedNearCacheBloomTest extends SingleHotRodServerTest {
 
    private <K, V> AssertsNearCache<K, V> createAssertClient() {
       ConfigurationBuilder builder = clientConfiguration();
+      builder.connectionPool().maxActive(1);
       return AssertsNearCache.create(this.cache(), builder);
    }
 

--- a/documentation/src/main/asciidoc/topics/proc_configuring_hotrod_nearcaching.adoc
+++ b/documentation/src/main/asciidoc/topics/proc_configuring_hotrod_nearcaching.adoc
@@ -31,6 +31,12 @@ cache within the boundaries of the client JVM.
 can be configured with a bloom filter to significantly reduce this degredation. However bloom
 filter can only be enabled with a bounded near cache.
 
+[NOTE]
+====
+Bloom filter near cache requires the pool configuration to also have a maximum of 1 active
+connection per server and utilize the WAIT exhausted action. This is required so the server
+can keep the bloom filter updated on the server side to which listener was registered.
+
 .Procedure
 
 . Set the near cache mode to `INVALIDATED` in the client configuration for the caches you want
@@ -52,6 +58,12 @@ builder
   .remoteCache("unbounded").nearCache()
     .nearCacheMode(NearCacheMode.INVALIDATED)
     .nearCacheMaxEntries(-1);
+
+// Following required for bloom filter near cache
+// builder
+//    .connectionPool()
+//       .maxActive(1)
+//       .exhaustedAction(ExhaustedAction.WAIT);
 ----
 
 [NOTE]


### PR DESCRIPTION
* Limit pool configuration to 1 per server when bloom filter is enabled

https://issues.redhat.com/browse/ISPN-10216