### PR TITLE
[11.0.x] ISPN-10851 correct asym protocol example

### DIFF
--- a/documentation/src/main/asciidoc/topics/config_examples/jgroups_asym_encrypt.xml
+++ b/documentation/src/main/asciidoc/topics/config_examples/jgroups_asym_encrypt.xml
@@ -10,8 +10,8 @@
                     change_key_on_coord_leave = "false" <7>
                     change_key_on_leave = "false" <8>
                     use_external_key_exchange = "true" <9>
-                    stack.combine="INSERT_BEFORE"
-                    stack.position="pbcast.NAKACK2"/> <10>
+                    stack.combine="INSERT_AFTER"
+                    stack.position="SSL_KEY_EXCHANGE"/> <10>
          </stack>
     </jgroups>
     <cache-container name="default" statistics="true">

--- a/documentation/src/main/asciidoc/topics/proc_configuring_jgroups_asym_encrypt.adoc
+++ b/documentation/src/main/asciidoc/topics/proc_configuring_jgroups_asym_encrypt.adoc
@@ -25,7 +25,7 @@ include::config_examples/jgroups_asym_encrypt.xml[]
 <7> Configures {brandname} to generate and distribute a new secret key when the coordinator node changes.
 <8> Configures {brandname} to generate and distribute a new secret key when nodes leave.
 <9> Configures {brandname} nodes to use the `SSL_KEY_EXCHANGE` protocol for certificate authentication.
-<10> Uses the `stack.combine` and `stack.position` attributes to insert `ASYM_ENCRYPT` into the default TCP stack before the `pbcast.NAKACK2` protocol.
+<10> Uses the `stack.combine` and `stack.position` attributes to insert `ASYM_ENCRYPT` into the default TCP stack after the `SSL_KEY_EXCHANGE` protocol.
 <11> Configures the {brandname} cluster to use the secure JGroups stack.
 
 .Verification


### PR DESCRIPTION
For 11.0.x, the example asym_encrypt configuration cannot use INSERT_BEFORE. See https://github.com/infinispan/infinispan/blob/497c5279c49455717211fb6a9e3ab159111bce92/core/src/main/resources/schema/infinispan-config-11.0.xsd#L2598 