### PR TITLE
ISPN-12524 Utilise ubi java image

### DIFF
--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/core/ContainerInfinispanServerDriver.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/core/ContainerInfinispanServerDriver.java
@@ -155,7 +155,7 @@ public class ContainerInfinispanServerDriver extends AbstractInfinispanServerDri
          String serverOutputDir = configuration.properties().getProperty(TestSystemPropertyNames.INFINISPAN_TEST_SERVER_DIR);
          if (serverOutputDir == null) {
             // We try to use the latest public image for this major.minor version
-            imageName = "infinispan/server:" + Version.getMajorMinor();
+            imageName = "quay.io/infinispan/server:" + Version.getMajorMinor();
             prebuiltImage = true;
             log.infof("Using prebuilt image '%s'", imageName);
          } else {

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/core/ContainerInfinispanServerDriver.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/core/ContainerInfinispanServerDriver.java
@@ -66,7 +66,7 @@ public class ContainerInfinispanServerDriver extends AbstractInfinispanServerDri
    private static final Long IMAGE_MEMORY_SWAP = Long.getLong(TestSystemPropertyNames.INFINISPAN_TEST_SERVER_CONTAINER_MEMORY_SWAP, null);
    public static final String INFINISPAN_SERVER_HOME = "/opt/infinispan";
    public static final int JMX_PORT = 9999;
-   public static final String JDK_BASE_IMAGE_NAME = "jboss/base-jdk:11";
+   public static final String JDK_BASE_IMAGE_NAME = "registry.access.redhat.com/ubi8/openjdk-11";
    public static final String IMAGE_USER = "200";
    private final InfinispanGenericContainer[] containers;
    private final String[] volumes;

--- a/server/testdriver/core/src/main/resources/testcontainers.properties
+++ b/server/testdriver/core/src/main/resources/testcontainers.properties
@@ -1,0 +1,1 @@
+tinyimage.container.image=registry.access.redhat.com/ubi8/ubi-minimal:8.3

--- a/server/testdriver/core/src/main/resources/testcontainers.properties
+++ b/server/testdriver/core/src/main/resources/testcontainers.properties
@@ -1,1 +1,2 @@
+ryuk.container.image=quay.io/infinispan-test/ryuk:0.3.0
 tinyimage.container.image=registry.access.redhat.com/ubi8/ubi-minimal:8.3


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12524

@tristantarrant Looks like I missed an image. `jboss/base-jdk` isn't available on quay.io, so this seems like a good opportunity to move to the ubi image.