### PR TITLE
ISPN-12550 java.lang.IllegalArgumentException: ISPN027002: Unknown ta…

### DIFF
--- a/server/runtime/src/main/java/org/infinispan/server/tasks/admin/ServerAdminOperationsHandler.java
+++ b/server/runtime/src/main/java/org/infinispan/server/tasks/admin/ServerAdminOperationsHandler.java
@@ -5,6 +5,8 @@ import org.infinispan.server.core.admin.AdminOperationsHandler;
 import org.infinispan.server.core.admin.embeddedserver.CacheNamesTask;
 import org.infinispan.server.core.admin.embeddedserver.CacheReindexTask;
 import org.infinispan.server.core.admin.embeddedserver.CacheRemoveTask;
+import org.infinispan.server.core.admin.embeddedserver.TemplateCreateTask;
+import org.infinispan.server.core.admin.embeddedserver.TemplateRemoveTask;
 
 /**
  * @author Tristan Tarrant &lt;tristan@infinispan.org&gt;
@@ -20,7 +22,9 @@ public class ServerAdminOperationsHandler extends AdminOperationsHandler {
             new CacheRemoveTask(),
             new CacheReindexTask(),
             new LoggingSetTask(),
-            new LoggingRemoveTask()
+            new LoggingRemoveTask(),
+            new TemplateCreateTask(),
+            new TemplateRemoveTask()
       );
    }
 }

--- a/server/tests/src/test/java/org/infinispan/server/functional/ClusteredIT.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/ClusteredIT.java
@@ -36,6 +36,7 @@ import org.junit.runners.Suite;
       RestRouter.class,
       RestServerResource.class,
       MemcachedOperations.class,
+      HotRodAdmin.class,
       HotRodCounterOperations.class,
       HotRodMultiMapOperations.class,
       HotRodTransactionalCacheOperations.class,

--- a/server/tests/src/test/java/org/infinispan/server/functional/HotRodAdmin.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/HotRodAdmin.java
@@ -1,0 +1,55 @@
+package org.infinispan.server.functional;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.client.hotrod.exceptions.HotRodClientException;
+import org.infinispan.commons.configuration.XMLStringConfiguration;
+import org.infinispan.commons.test.Exceptions;
+import org.infinispan.server.test.junit4.InfinispanServerRule;
+import org.infinispan.server.test.junit4.InfinispanServerTestMethodRule;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Ryan Emerson
+ * @since 12.0
+ */
+public class HotRodAdmin {
+
+   @ClassRule
+   public static InfinispanServerRule SERVERS = ClusteredIT.SERVERS;
+
+   @Rule
+   public InfinispanServerTestMethodRule SERVER_TEST = new InfinispanServerTestMethodRule(SERVERS);
+
+   @Test
+   public void testCreateDeleteCache() {
+      RemoteCacheManager rcm = SERVER_TEST.hotrod().createRemoteCacheManager();
+      String cacheName = "testCreateDeleteCache";
+      String config = String.format("<infinispan><cache-container><distributed-cache name=\"%s\"/></cache-container></infinispan>", cacheName);
+      RemoteCache<String, String> cache = rcm.administration().createCache(cacheName, new XMLStringConfiguration(config));
+      cache.put("k", "v");
+      assertNotNull(cache.get("k"));
+
+      rcm.administration().removeCache(cacheName);
+      assertNull(rcm.getCache(cacheName));
+   }
+
+   @Test
+   public void testCreateDeleteTemplate() {
+      RemoteCacheManager rcm = SERVER_TEST.hotrod().createRemoteCacheManager();
+      String templateName = "template";
+      String template = String.format("<infinispan><cache-container><distributed-cache name=\"%s\"/></cache-container></infinispan>", templateName);
+      rcm.administration().createTemplate(templateName, new XMLStringConfiguration(template));
+      RemoteCache<String, String> cache = rcm.administration().createCache("testCreateDeleteTemplate", templateName);
+      cache.put("k", "v");
+      assertNotNull(cache.get("k"));
+
+      rcm.administration().removeTemplate(templateName);
+      Exceptions.expectException(HotRodClientException.class, () -> rcm.administration().createCache("anotherCache", templateName));
+   }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12550

@tristantarrant This is a good example of where the `client/hotrod-client` testsuite not being representative of a real client/server can hide issues. In this case I had added the tasks to the `EmbeddedServerAdminOperationHandler` in the original PR, but was unware of `ServerAdminOperationHandler`. The problem was only uncovered by @wfink manually testing.