### PR TITLE
ISPN-12558 StackOverflowError during REST connection shutdown

### DIFF
--- a/server/rest/src/main/java/org/infinispan/rest/RestRequestHandler.java
+++ b/server/rest/src/main/java/org/infinispan/rest/RestRequestHandler.java
@@ -161,6 +161,9 @@ public class RestRequestHandler extends BaseHttpRequestHandler {
          // a Netty IO Exception. The only solution is to ignore it, just like Tomcat does.
          logger.debug("Native IO Exception", e);
          ctx.close();
+      } else if (e instanceof IllegalStateException && e.getMessage().equals("ssl is null")){
+         // Workaround for ISPN-12558 -- OpenSSLEngine shut itself down too soon
+         // Ignore the exception, trying to close the context will cause a StackOverflowError
       } else {
          logger.uncaughtExceptionInThePipeline(e);
          ctx.close();

--- a/server/rest/src/test/java/org/infinispan/rest/resources/AbstractRestResourceTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/resources/AbstractRestResourceTest.java
@@ -158,7 +158,7 @@ public class AbstractRestResourceTest extends MultipleCacheManagersTest {
    }
 
    @AfterClass
-   public void afterSuite() {
+   public void afterClass() {
       Subject.doAs(ADMIN_USER, (PrivilegedAction<Void>) () -> {
          restServers.forEach(RestServerHelper::stop);
          return null;

--- a/server/rest/src/test/java/org/infinispan/rest/resources/CacheV2ResourceTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/resources/CacheV2ResourceTest.java
@@ -645,6 +645,7 @@ public class CacheV2ResourceTest extends AbstractRestResourceTest {
 
       // Clear all stats
       RestResponse response = join(cacheClient.clearSearchStats());
+      ResponseAssertion.assertThat(response).isOk();
       if (security) {
          RestClient adminClient = RestClient.forConfiguration(getClientConfig().security().authentication().username("admin").password("admin").build());
          response = join(adminClient.cache("indexedCache").clearSearchStats());

--- a/server/rest/src/test/java/org/infinispan/rest/resources/StaticResourceTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/resources/StaticResourceTest.java
@@ -52,8 +52,8 @@ public class StaticResourceTest extends AbstractRestResourceTest {
    }
 
    @AfterClass
-   public void afterSuite() {
-      super.afterSuite();
+   public void afterClass() {
+      super.afterClass();
       Util.close(noRedirectsClient);
    }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12558

Ignore the IllegalStateException from OpenSSLEngine
in RestRequestHandler and avoid the StackOverflowError.