### PR TITLE
ISPN-12561 CacheV2ResourceTest does not close RestClient responses

### DIFF
--- a/server/rest/src/test/java/org/infinispan/rest/assertion/JsonAssertion.java
+++ b/server/rest/src/test/java/org/infinispan/rest/assertion/JsonAssertion.java
@@ -1,0 +1,59 @@
+package org.infinispan.rest.assertion;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertTrue;
+
+import org.infinispan.commons.dataconversion.internal.Json;
+
+/**
+ * Assertions on JSON contents.
+ *
+ * @author Dan Berindei
+ * @since 12
+ */
+public class JsonAssertion {
+   String path;
+   private Json node;
+
+   public JsonAssertion(Json node) {
+      this(node, "");
+   }
+
+   public JsonAssertion(Json node, String path) {
+      this.node = node;
+      this.path = path;
+      assertNotNull(path, node);
+   }
+
+   public JsonAssertion hasProperty(String propertyName) {
+      return new JsonAssertion(node.at(propertyName), propertyPath(propertyName));
+   }
+
+   public JsonAssertion hasNullProperty(String propertyName) {
+      hasProperty(propertyName).isNull();
+      return this;
+   }
+
+   public JsonAssertion hasNoProperty(String propertyName) {
+      assertFalse(propertyPath(propertyName), node.has(propertyName));
+      return this;
+   }
+
+   public void is(int value) {
+      assertEquals(value, node.asInteger());
+   }
+
+   public void is(String value) {
+      assertEquals(value, node.asString());
+   }
+
+   public void isNull() {
+      assertTrue(path, node.isNull());
+   }
+
+   private String propertyPath(String propertyName) {
+      return this.path.isEmpty() ? propertyName : this.path + "." + propertyName;
+   }
+}

--- a/server/rest/src/test/java/org/infinispan/rest/assertion/ResponseAssertion.java
+++ b/server/rest/src/test/java/org/infinispan/rest/assertion/ResponseAssertion.java
@@ -25,7 +25,7 @@ import static org.infinispan.rest.ResponseHeader.ETAG_HEADER;
 import static org.infinispan.rest.ResponseHeader.EXPIRES_HEADER;
 import static org.infinispan.rest.ResponseHeader.LAST_MODIFIED_HEADER;
 import static org.infinispan.rest.ResponseHeader.WWW_AUTHENTICATE_HEADER;
-import static org.testng.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -295,8 +295,12 @@ public class ResponseAssertion {
    }
 
    public ResponseAssertion hasNoErrors() {
-      Json node = Json.read(response.getBody());
-      Assertions.assertThat(node.at("error").isNull()).isTrue();
+      hasJson().hasProperty("error").isNull();
       return this;
+   }
+
+   public JsonAssertion hasJson() {
+      Json node = Json.read(response.getBody());
+      return new JsonAssertion(node);
    }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12561

Check the response body contents.
Reading the body automatically closes the response.