### PR TITLE
ISPN-12559 SearchAdminResource.searchStats blocking call

### DIFF
--- a/query/src/main/java/org/infinispan/query/internal/QueryBlockHoundIntegration.java
+++ b/query/src/main/java/org/infinispan/query/internal/QueryBlockHoundIntegration.java
@@ -1,10 +1,16 @@
 package org.infinispan.query.internal;
 
+import org.apache.lucene.util.NamedSPILoader;
+import org.kohsuke.MetaInfServices;
+
 import reactor.blockhound.BlockHound;
 import reactor.blockhound.integration.BlockHoundIntegration;
 
+@MetaInfServices
 public class QueryBlockHoundIntegration implements BlockHoundIntegration {
    @Override
    public void applyTo(BlockHound.Builder builder) {
+      // Loading a service may require opening a file from classpath
+      builder.allowBlockingCallsInside(NamedSPILoader.class.getName(), "reload");
    }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12559

Ignore file reads in NamedSPILoader, which is a re-implementation
of java.util.ServiceLoader.