### PR TITLE
[11.0.x] ISPN-12518 Possible deadlock if an entry is replaced at the same time expiration take effect

### DIFF
--- a/core/src/main/java/org/infinispan/commands/triangle/BackupWriteCommand.java
+++ b/core/src/main/java/org/infinispan/commands/triangle/BackupWriteCommand.java
@@ -47,7 +47,8 @@ public abstract class BackupWriteCommand extends BaseRpcCommand {
       WriteCommand command = createWriteCommand();
       command.init(componentRegistry);
       command.setFlagsBitSet(flags);
-      command.addFlags(FlagBitSets.SKIP_LOCKING);
+      // Mark the command as a backup write and skip locking
+      command.addFlags(FlagBitSets.SKIP_LOCKING | FlagBitSets.BACKUP_WRITE);
       command.setValueMatcher(MATCH_ALWAYS);
       command.setTopologyId(topologyId);
       InvocationContextFactory invocationContextFactory = componentRegistry.getInvocationContextFactory().running();

--- a/core/src/main/java/org/infinispan/container/impl/EntryFactory.java
+++ b/core/src/main/java/org/infinispan/container/impl/EntryFactory.java
@@ -95,9 +95,11 @@ public interface EntryFactory {
     * @param key key to look up and wrap
     * @param segment segment for the key
     * @param isOwner true if this node is current owner in readCH (or we ignore CH)
+    * @param hasLock true if the invoker already has the lock for this key
     * @return stage that when complete the value should be in the context
     */
-   CompletionStage<Void> wrapEntryForReading(InvocationContext ctx, Object key, int segment, boolean isOwner);
+   CompletionStage<Void> wrapEntryForReading(InvocationContext ctx, Object key, int segment, boolean isOwner,
+                                             boolean hasLock);
 
    /**
     * Insert an entry that exists in the data container into the context.

--- a/core/src/main/java/org/infinispan/container/impl/EntryFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/container/impl/EntryFactoryImpl.java
@@ -70,7 +70,8 @@ public class EntryFactoryImpl implements EntryFactory {
    }
 
    @Override
-   public final CompletionStage<Void> wrapEntryForReading(InvocationContext ctx, Object key, int segment, boolean isOwner) {
+   public final CompletionStage<Void> wrapEntryForReading(InvocationContext ctx, Object key, int segment, boolean isOwner,
+                                                          boolean hasLock) {
       if (!isOwner && !isL1Enabled) {
          return CompletableFutures.completedNull();
       }
@@ -84,7 +85,7 @@ public class EntryFactoryImpl implements EntryFactory {
             }
          } else if (isOwner || readEntry.isL1Entry()) {
             if (readEntry.canExpire()) {
-               CompletionStage<Boolean> expiredStage = expirationManager.handlePossibleExpiration(readEntry, segment, false);
+               CompletionStage<Boolean> expiredStage = expirationManager.handlePossibleExpiration(readEntry, segment, hasLock);
                if (CompletionStages.isCompletedSuccessfully(expiredStage)) {
                   Boolean expired = CompletionStages.join(expiredStage);
                   handleExpiredEntryContextAddition(expired, ctx, readEntry, key, isOwner);

--- a/core/src/main/java/org/infinispan/context/Flag.java
+++ b/core/src/main/java/org/infinispan/context/Flag.java
@@ -252,6 +252,12 @@ public enum Flag {
     * key.
     */
    ALREADY_HAS_LOCK,
+
+   /**
+    * Signals that a {@link org.infinispan.commands.write.WriteCommand} was sent from the primary as a backup operation.
+    * Some things do not need to be checked in this case.
+    */
+   BACKUP_WRITE,
    ;
 
    private static final Flag[] CACHED_VALUES = values();

--- a/core/src/main/java/org/infinispan/context/Flag.java
+++ b/core/src/main/java/org/infinispan/context/Flag.java
@@ -246,6 +246,12 @@ public enum Flag {
     * Internal use
     */
    IRAC_STATE,
+
+   /**
+    * Flag to designate that this operation was performed on behalf of another that already has the lock for the given
+    * key.
+    */
+   ALREADY_HAS_LOCK,
    ;
 
    private static final Flag[] CACHED_VALUES = values();

--- a/core/src/main/java/org/infinispan/context/impl/FlagBitSets.java
+++ b/core/src/main/java/org/infinispan/context/impl/FlagBitSets.java
@@ -44,6 +44,7 @@ public class FlagBitSets {
    public static final long IGNORE_TRANSACTION = EnumUtil.bitSetOf(Flag.IGNORE_TRANSACTION);
    public static final long IRAC_UPDATE = EnumUtil.bitSetOf(Flag.IRAC_UPDATE);
    public static final long IRAC_STATE = EnumUtil.bitSetOf(Flag.IRAC_STATE);
+   public static final long ALREADY_HAS_LOCK = EnumUtil.bitSetOf(Flag.ALREADY_HAS_LOCK);
 
    /**
     * Creates a copy of a Flag BitSet removing instances of FAIL_SILENTLY.

--- a/core/src/main/java/org/infinispan/context/impl/FlagBitSets.java
+++ b/core/src/main/java/org/infinispan/context/impl/FlagBitSets.java
@@ -45,6 +45,7 @@ public class FlagBitSets {
    public static final long IRAC_UPDATE = EnumUtil.bitSetOf(Flag.IRAC_UPDATE);
    public static final long IRAC_STATE = EnumUtil.bitSetOf(Flag.IRAC_STATE);
    public static final long ALREADY_HAS_LOCK = EnumUtil.bitSetOf(Flag.ALREADY_HAS_LOCK);
+   public static final long BACKUP_WRITE = EnumUtil.bitSetOf(Flag.BACKUP_WRITE);
 
    /**
     * Creates a copy of a Flag BitSet removing instances of FAIL_SILENTLY.

--- a/core/src/main/java/org/infinispan/interceptors/distribution/BaseDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/BaseDistributionInterceptor.java
@@ -305,10 +305,14 @@ public abstract class BaseDistributionInterceptor extends ClusteringInterceptor 
       }
       MapResponseCollector collector = MapResponseCollector.ignoreLeavers(isReplicated, owners.size());
       RpcOptions rpcOptions = rpcManager.getSyncRpcOptions();
+      // Mark the command as a backup write so it can skip some checks
+      command.addFlags(FlagBitSets.BACKUP_WRITE);
       CompletionStage<Map<Address, Response>> remoteInvocation = isReplicated ?
             rpcManager.invokeCommandOnAll(command, collector, rpcOptions) :
             rpcManager.invokeCommand(owners, command, collector, rpcOptions);
       return asyncValue(remoteInvocation.handle((responses, t) -> {
+         // Unset the backup write bit as the command will be retried
+         command.setFlagsBitSet(command.getFlagsBitSet() & ~FlagBitSets.BACKUP_WRITE);
          // Switch to the retry policy, in case the primary owner changed and the write already succeeded on the new primary
          command.setValueMatcher(originalMatcher.matcherForRetry());
          CompletableFutures.rethrowExceptionIfPresent(t);

--- a/core/src/main/java/org/infinispan/interceptors/impl/EntryWrappingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/EntryWrappingInterceptor.java
@@ -213,7 +213,7 @@ public class EntryWrappingInterceptor extends DDAsyncInterceptor {
    private Object visitDataReadCommand(InvocationContext ctx, AbstractDataCommand command) {
       final Object key = command.getKey();
       CompletionStage<Void> stage = entryFactory.wrapEntryForReading(ctx, key, command.getSegment(),
-            ignoreOwnership(command) || canRead(command));
+            ignoreOwnership(command) || canRead(command), command.hasAnyFlag(FlagBitSets.ALREADY_HAS_LOCK));
       return makeStage(asyncInvokeNext(ctx, command, stage)).thenApply(ctx, command, dataReadReturnHandler);
    }
 
@@ -223,7 +223,7 @@ public class EntryWrappingInterceptor extends DDAsyncInterceptor {
       AggregateCompletionStage<Void> aggregateCompletionStage = null;
       for (Object key : command.getKeys()) {
          CompletionStage<Void> stage = entryFactory.wrapEntryForReading(ctx, key, keyPartitioner.getSegment(key),
-               ignoreOwnership || canReadKey(key));
+               ignoreOwnership || canReadKey(key), false);
          aggregateCompletionStage = accumulateStage(stage, aggregateCompletionStage);
       }
 
@@ -483,7 +483,7 @@ public class EntryWrappingInterceptor extends DDAsyncInterceptor {
          // TxReadOnlyKeyCommand may apply some mutations on the entry in context so we need to always wrap it
          stage = entryFactory.wrapEntryForWriting(ctx, command.getKey(), command.getSegment(), ignoreOwnership(command) || canRead(command), true);
       } else {
-         stage = entryFactory.wrapEntryForReading(ctx, command.getKey(), command.getSegment(), ignoreOwnership(command) || canRead(command));
+         stage = entryFactory.wrapEntryForReading(ctx, command.getKey(), command.getSegment(), ignoreOwnership(command) || canRead(command), false);
       }
 
       // Repeatable reads are not achievable with functional commands, as we don't store the value locally
@@ -508,7 +508,7 @@ public class EntryWrappingInterceptor extends DDAsyncInterceptor {
       } else {
          for (Object key : command.getKeys()) {
             CompletionStage<Void> stage = entryFactory.wrapEntryForReading(ctx, key, keyPartitioner.getSegment(key),
-                  ignoreOwnership || canReadKey(key));
+                  ignoreOwnership || canReadKey(key), false);
             aggregateCompletionStage = accumulateStage(stage, aggregateCompletionStage);
          }
       }

--- a/core/src/main/java/org/infinispan/interceptors/impl/EntryWrappingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/EntryWrappingInterceptor.java
@@ -346,6 +346,11 @@ public class EntryWrappingInterceptor extends DDAsyncInterceptor {
       if (command.hasAnyFlag(FlagBitSets.COMMAND_RETRY)) {
          removeFromContextOnRetry(ctx, command.getKey());
       }
+      // The command is from a backup, we don't care if the entry is expired or not
+      if (command.hasAnyFlag(FlagBitSets.BACKUP_WRITE)) {
+         entryFactory.wrapEntryForExpired(ctx, command.getKey(), command.getSegment());
+         return CompletableFutures.completedNull();
+      }
       return entryFactory.wrapEntryForWriting(ctx, command.getKey(), command.getSegment(), ignoreOwnership(command) || canRead(command), command.loadType() != VisitableCommand.LoadType.DONT_LOAD);
    }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12518
https://issues.redhat.com/browse/ISPN-12337

Also includes ISPN-12337 which prevents a deadlock with pessimistic tx with clustered expiration.