### PR TITLE
ISPN-12584 Protobuf serialization in library mode with spring starter

### DIFF
--- a/spring/spring-boot/embedded/src/main/java/org/infinispan/spring/starter/embedded/InfinispanEmbeddedAutoConfiguration.java
+++ b/spring/spring-boot/embedded/src/main/java/org/infinispan/spring/starter/embedded/InfinispanEmbeddedAutoConfiguration.java
@@ -1,9 +1,15 @@
 package org.infinispan.spring.starter.embedded;
 
-import org.infinispan.commons.api.CacheContainerAdmin;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
 import org.infinispan.commons.marshall.JavaSerializationMarshaller;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.configuration.parsing.ConfigurationBuilderHolder;
+import org.infinispan.configuration.parsing.ParserRegistry;
 import org.infinispan.manager.DefaultCacheManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -17,11 +23,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-
-import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
 
 @Configuration
 @ComponentScan
@@ -61,37 +62,47 @@ public class InfinispanEmbeddedAutoConfiguration {
    public DefaultCacheManager defaultCacheManager() throws IOException {
       final String configXml = infinispanProperties.getConfigXml();
       final DefaultCacheManager manager;
-      GlobalConfigurationBuilder globalConfigurationBuilder = new GlobalConfigurationBuilder();
-      // spring session needs does not work with protostream right now, easy users to configure the marshaller
-      // and the classes we need for spring embedded
-      globalConfigurationBuilder.serialization().marshaller(new JavaSerializationMarshaller());
-      globalConfigurationBuilder.serialization().whiteList().addClass("org.springframework.session.MapSession");
-      globalConfigurationBuilder.serialization().whiteList().addRegexp("java.util.*");
 
-      ConfigurationBuilder configurationBuilder = new ConfigurationBuilder();
+      ConfigurationBuilderHolder holder;
       if (!configXml.isEmpty()) {
-         manager = new DefaultCacheManager(configXml, false);
+         holder = new ParserRegistry().parseFile(configXml);
+         GlobalConfigurationBuilder globalConfigurationBuilder = holder.getGlobalConfigurationBuilder();
+         if (globalConfigurationBuilder.serialization().getMarshaller() == null) {
+            // spring session needs does not work with protostream right now, easy users to configure the marshaller
+            // and the classes we need for spring embedded
+            globalConfigurationBuilder.serialization().marshaller(new JavaSerializationMarshaller());
+         }
+         allowInternalClasses(globalConfigurationBuilder);
+         manager = new DefaultCacheManager(holder, false);
       } else {
+         GlobalConfigurationBuilder globalConfigurationBuilder = new GlobalConfigurationBuilder();
+         globalConfigurationBuilder.serialization().marshaller(new JavaSerializationMarshaller());
+         allowInternalClasses(globalConfigurationBuilder);
+
          if (infinispanGlobalConfigurer != null) {
             globalConfigurationBuilder.read(infinispanGlobalConfigurer.getGlobalConfiguration());
          } else {
             globalConfigurationBuilder.transport().clusterName(infinispanProperties.getClusterName());
             globalConfigurationBuilder.jmx().enable();
          }
-         globalConfigurationCustomizers.forEach(customizer -> customizer.customize(globalConfigurationBuilder));
-         configurationCustomizers.forEach(customizer -> customizer.customize(configurationBuilder));
 
+         globalConfigurationCustomizers.forEach(customizer -> customizer.customize(globalConfigurationBuilder));
          manager = new DefaultCacheManager(globalConfigurationBuilder.build(), false);
+
+         ConfigurationBuilder configurationBuilder = new ConfigurationBuilder();
+         configurationCustomizers.forEach(customizer -> customizer.customize(configurationBuilder));
+         manager.defineConfiguration("default", configurationBuilder.build());
       }
 
       cacheConfigurations.forEach(manager::defineConfiguration);
       configurers.forEach(configurer -> configurer.configureCache(manager));
 
       manager.start();
-      if (configXml.isEmpty()) {
-         manager.administration().withFlags(CacheContainerAdmin.AdminFlag.VOLATILE)
-               .getOrCreateCache("default", configurationBuilder.build());
-      }
       return manager;
+   }
+
+   private void allowInternalClasses(GlobalConfigurationBuilder globalConfigurationBuilder) {
+      globalConfigurationBuilder.serialization().allowList().addClass("org.springframework.session.MapSession");
+      globalConfigurationBuilder.serialization().allowList().addRegexp("java.util.*");
    }
 }

--- a/spring/spring-boot/embedded/src/test/java/test/org/infinispan/spring/starter/embedded/InfinispanEmbeddedAutoConfigurationPropertiesTest.java
+++ b/spring/spring-boot/embedded/src/test/java/test/org/infinispan/spring/starter/embedded/InfinispanEmbeddedAutoConfigurationPropertiesTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
 
+import org.infinispan.commons.marshall.JavaSerializationMarshaller;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -36,6 +37,7 @@ public class InfinispanEmbeddedAutoConfigurationPropertiesTest {
       final GlobalConfiguration globalConfiguration = defaultCacheManager.getCacheManagerConfiguration();
       assertThat(globalConfiguration.globalJmxStatistics().enabled()).isTrue();
       assertThat(globalConfiguration.globalJmxStatistics().domain()).isEqualTo("properties.test.spring.infinispan");
+      assertThat(globalConfiguration.serialization().marshaller()).isInstanceOf(JavaSerializationMarshaller.class);
 
       final Configuration defaultCacheConfiguration = defaultCacheManager.getDefaultCacheConfiguration();
       assertThat(defaultCacheConfiguration.memory().size()).isEqualTo(2000L);


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12584

Make JavaSerializationMarshaller the default marshaller even when
the configXml property is present.
Users can still change it if they want protostream marshalling
and they aren't storing Spring sessions in the cache.