### PR TITLE
ISPN-12596 Incorrect Hotrod Multimap get KeyDoesNotExist response

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/RetryOnFailureOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/RetryOnFailureOperation.java
@@ -191,14 +191,14 @@ public abstract class RetryOnFailureOperation<T> extends HotRodOperation<T> impl
    }
 
    protected void logAndRetryOrFail(Throwable e, boolean canSwitchCluster) {
-      if (retryCount < channelFactory.getMaxRetries() && channelFactory.getMaxRetries() >= 0) {
+      if (retryCount < channelFactory.getMaxRetries()) {
          if (log.isTraceEnabled()) {
             log.tracef(e, "Exception encountered in %s. Retry %d out of %d", this, retryCount, channelFactory.getMaxRetries());
          }
          retryCount++;
          channelFactory.incrementRetryCount();
          retryIfNotDone();
-      } else if (canSwitchCluster) {
+      } else if (canSwitchCluster && !cfg.clusters().isEmpty()) {
          channelFactory.trySwitchCluster(currentClusterName, cacheName).whenComplete((status, throwable) -> {
             if (throwable != null) {
                completeExceptionally(throwable);

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/tcp/RoundRobinBalancingStrategy.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/tcp/RoundRobinBalancingStrategy.java
@@ -59,11 +59,7 @@ public class RoundRobinBalancingStrategy implements FailoverRequestBalancingStra
    }
 
    private SocketAddress getServerByIndex(int pos) {
-      SocketAddress server = servers[pos];
-      if (log.isTraceEnabled()) {
-         log.tracef("Returning server: %s", server);
-      }
-      return server;
+      return servers[pos];
    }
 
    public SocketAddress[] getServers() {

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/RemoteMultimapCacheAPITest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/RemoteMultimapCacheAPITest.java
@@ -31,7 +31,8 @@ public class RemoteMultimapCacheAPITest extends SingleHotRodServerTest {
    @Override
    protected RemoteCacheManager getRemoteCacheManager() {
       ConfigurationBuilder builder = HotRodClientTestingUtil.newRemoteConfigurationBuilder();
-      builder.forceReturnValues(isForceReturnValuesViaConfiguration());
+      // Do not retry when the server response cannot be parsed, see ISPN-12596
+      builder.forceReturnValues(isForceReturnValuesViaConfiguration()).maxRetries(0);
       builder.addServer().host("127.0.0.1").port(hotrodServer.getPort());
       return new InternalRemoteCacheManager(builder.build());
    }

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/MultimapRequestProcessor.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/MultimapRequestProcessor.java
@@ -38,7 +38,8 @@ class MultimapRequestProcessor extends BaseRequestProcessor {
       } else try {
          OperationStatus status = OperationStatus.Success;
          if (result.isEmpty()) {
-            status = OperationStatus.KeyDoesNotExist;
+            writeNotExist(header);
+            return;
          }
          writeResponse(header, header.encoder().multimapCollectionResponse(header, server, channel, status,
                mapToCollectionOfByteArrays(result)));


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12596

When the server sends a KeyDoesNotExist response, it also includes
an empty collection of values.

Also includes a partial fix for https://issues.redhat.com/browse/ISPN-12598