### PR TITLE
ISPN-12564 Remove support for property "infinispan.query.lucene.max-boolean-clauses" from the index config

### DIFF
--- a/documentation/src/main/asciidoc/topics/upgrading.adoc
+++ b/documentation/src/main/asciidoc/topics/upgrading.adoc
@@ -200,6 +200,12 @@ in an older Lucene version.
 
 Configuration of sharding through the property `default.sharding_strategy.nbr_of_shards` is deprecated and will be removed in a future version.
 
+==== Maximum boolean clauses
+
+The property `infinispan.query.lucene.max-boolean-clauses` is now only supported when used via JVM property. Support for using
+it inside the `<property>` element of the index configuration was removed.
+
+
 == Cache Health
 A new status `FAILED` has been added to the cache health, to indicate that a cache failed to start with the
 provided configuration. The possible statuses of the cache health are now HEALTHY, HEALTHY_REBALANCING, DEGRADED and FAILED.

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/core/EmbeddedInfinispanServerDriver.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/core/EmbeddedInfinispanServerDriver.java
@@ -59,7 +59,11 @@ public class EmbeddedInfinispanServerDriver extends AbstractInfinispanServerDriv
          properties.setProperty(Server.INFINISPAN_CLUSTER_STACK, System.getProperty(Server.INFINISPAN_CLUSTER_STACK));
          properties.setProperty(TEST_HOST_ADDRESS, testHostAddress.getHostName());
          configureSite(properties);
-         configuration.properties().forEach((k, v) -> properties.put(k, StringPropertyReplacer.replaceProperties((String) v, properties)));
+         configuration.properties().forEach((k, v) -> {
+            String value = StringPropertyReplacer.replaceProperties((String) v, properties);
+            properties.put(k, value);
+            System.setProperty(k.toString(), value);
+         });
          Server server = new Server(serverRoot, new File(configurationFile.getName()), properties);
          server.setExitHandler(new DefaultExitHandler());
          serverFutures.add(server.run());

--- a/server/tests/src/test/java/org/infinispan/server/functional/ClusteredIT.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/ClusteredIT.java
@@ -52,8 +52,9 @@ public class ClusteredIT {
    @ClassRule
    public static final InfinispanServerRule SERVERS =
          InfinispanServerRuleBuilder.config("configuration/ClusteredServerTest.xml")
-                                    .numServers(2)
-                                    .build();
+               .numServers(2)
+               .property("infinispan.query.lucene.max-boolean-clauses", "1025")
+               .build();
 
    static <K, V> RemoteCache<K, V> createQueryableCache(InfinispanServerTestMethodRule testMethodRule, boolean indexed) {
       ConfigurationBuilder config = new ConfigurationBuilder();
@@ -64,8 +65,7 @@ public class ClusteredIT {
       if (indexed) {
          builder.indexing().enable()
                .storage(LOCAL_HEAP)
-               .addIndexedEntity("sample_bank_account.User")
-               .addProperty("infinispan.query.lucene.max-boolean-clauses", "1025");
+               .addIndexedEntity("sample_bank_account.User");
       }
 
       HotRodTestClientDriver hotRodTestClientDriver = testMethodRule.hotrod().withClientConfiguration(config);


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12564

Should fix ```HotRodCacheQueries``` failures.
