### PR TITLE
ISPN-11914 ServerRunMode.FORKED should use by default the server folder

### DIFF
--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/core/ForkedInfinispanServerDriver.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/core/ForkedInfinispanServerDriver.java
@@ -83,7 +83,7 @@ public class ForkedInfinispanServerDriver extends AbstractInfinispanServerDriver
             Path destination = getServerConfDir(dest).resolve(source.getFileName());
             Files.copy(source, destination, StandardCopyOption.REPLACE_EXISTING);
          } catch (IOException e) {
-            throw new UncheckedIOException("Cannot copy the server to temp folder", e);
+            throw new UncheckedIOException("Cannot copy the server to temp directory", e);
          }
          // Replace 99 with index of server to debug
          if (i == 99) {

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/core/ForkedServer.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/core/ForkedServer.java
@@ -48,6 +48,7 @@ public class ForkedServer {
    private final String serverLogDir;
    private final String serverLog;
    private String jvmOptions;
+   private String serverConfiguration;
 
    // Runtime
    private final UUID serverId;
@@ -69,7 +70,7 @@ public class ForkedServer {
       commands.add(serverHome + File.separator + "bin" + File.separator + "server" + extension);
 
       // Append random UUID for this server to be used in the case of forceful shutdown.
-      commands.add(String.format("-D%s-pid=%s", this.getClass().getName(), this.serverId));
+      addVmArgument(this.getClass().getName() + "-pid", this.serverId);
    }
 
    public ForkedServer setServerConfiguration(String serverConfiguration) {
@@ -77,6 +78,7 @@ public class ForkedServer {
       if (!new File(serverConfiguration).isAbsolute()) {
          serverConfiguration = getClass().getClassLoader().getResource(serverConfiguration).getPath();
       }
+      this.serverConfiguration = serverConfiguration;
       commands.add(serverConfiguration);
       return this;
    }
@@ -200,4 +202,11 @@ public class ForkedServer {
       throw new IllegalStateException("Unable to determine PID of the running Infinispan server.");
    }
 
+   public String getServerConfiguration() {
+      return serverConfiguration;
+   }
+
+   public void addVmArgument(String key, Object value) {
+      commands.add(String.format("-D%s=%s", key, value));
+   }
 }

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/core/TestSystemPropertyNames.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/core/TestSystemPropertyNames.java
@@ -46,10 +46,6 @@ public class TestSystemPropertyNames {
     */
    public static final String INFINISPAN_TEST_SERVER_LOG_FILE = PREFIX + "container.logFile";
    /**
-    * Specifies a comma-separated list to server home path. Only for FORKED
-    */
-   public static final String INFINISPAN_SERVER_HOME = PREFIX + "home";
-   /**
     * The maximum amount of memory the container can use.
     */
    public static final String INFINISPAN_TEST_SERVER_CONTAINER_MEMORY = PREFIX + "container.memory";


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-11914

The goal of this PR is not to fix all tests that are broken for `ServerRunMode.FORKED`
The goal is allow we run the FORKED mode using the server that was built

A simple test that is working is: `mvn clean install -DskipTests && mvn verify -pl server/tests -Dit.test=RestOperations -Dorg.infinispan.test.server.driver=FORKED`

I have a plan to introduce a new `Jenkinsfile` that will run the tests for all `ServerRunMode`. The job will be running daily.