### PR TITLE
ISPN-12535 Fix WARN messages org.hibernate.search

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/cache/IndexMergeConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/IndexMergeConfigurationBuilder.java
@@ -1,15 +1,11 @@
 package org.infinispan.configuration.cache;
 
-
 import static org.infinispan.configuration.cache.IndexMergeConfiguration.CALIBRATE_BY_DELETES;
 import static org.infinispan.configuration.cache.IndexMergeConfiguration.FACTOR;
 import static org.infinispan.configuration.cache.IndexMergeConfiguration.MAX_ENTRIES;
 import static org.infinispan.configuration.cache.IndexMergeConfiguration.MAX_FORCED_SIZE;
 import static org.infinispan.configuration.cache.IndexMergeConfiguration.MAX_SIZE;
 import static org.infinispan.configuration.cache.IndexMergeConfiguration.MIN_SIZE;
-
-import java.util.HashMap;
-import java.util.Map;
 
 import org.infinispan.commons.configuration.Builder;
 import org.infinispan.commons.configuration.ConfigurationBuilderInfo;
@@ -23,14 +19,6 @@ import org.infinispan.configuration.global.GlobalConfiguration;
  */
 public class IndexMergeConfigurationBuilder extends AbstractIndexingConfigurationChildBuilder
       implements Builder<IndexMergeConfiguration>, ConfigurationBuilderInfo {
-
-   private static final String KEY_PREFIX = "hibernate.search.backend.io.merge";
-   private static final String MAX_ENTRIES_KEY = KEY_PREFIX + ".max_docs";
-   private static final String FACTOR_KEY = KEY_PREFIX + ".factor";
-   private static final String MIN_SIZE_KEY = KEY_PREFIX + ".min_size";
-   private static final String MAX_SIZE_KEY = KEY_PREFIX + ".max_size";
-   private static final String MAX_FORCED_SIZE_KEY = KEY_PREFIX + ".max_forced_size";
-   private static final String CALIBRATE_BY_DELETES_KEY = KEY_PREFIX + ".calibrate_by_deletes";
 
    private final AttributeSet attributes;
    private final Attribute<Integer> maxEntries;
@@ -51,29 +39,6 @@ public class IndexMergeConfigurationBuilder extends AbstractIndexingConfiguratio
       this.calibrateByDeletes = attributes.attribute(CALIBRATE_BY_DELETES);
    }
 
-   Map<String, Object> asInternalProperties() {
-      Map<String, Object> props = new HashMap<>();
-      if (!maxEntries.isNull()) {
-         props.put(MAX_ENTRIES_KEY, maxEntries());
-      }
-      if (!minSize.isNull()) {
-         props.put(MIN_SIZE_KEY, minSize());
-      }
-      if (!maxSize.isNull()) {
-         props.put(MAX_SIZE_KEY, maxSize());
-      }
-      if (!factor.isNull()) {
-         props.put(FACTOR_KEY, factor());
-      }
-      if (!maxForceSize.isNull()) {
-         props.put(MAX_FORCED_SIZE_KEY, maxForcedSize());
-      }
-      if (!calibrateByDeletes.isNull()) {
-         props.put(CALIBRATE_BY_DELETES_KEY, isCalibrateByDeletes());
-      }
-      return props;
-   }
-
    @Override
    public ElementDefinition<IndexMergeConfiguration> getElementDefinition() {
       return IndexMergeConfiguration.ELEMENT_DEFINITION;
@@ -82,10 +47,6 @@ public class IndexMergeConfigurationBuilder extends AbstractIndexingConfiguratio
    public IndexMergeConfigurationBuilder maxEntries(int value) {
       maxEntries.set(value);
       return this;
-   }
-
-   public Integer maxEntries() {
-      return maxEntries.get();
    }
 
    public IndexMergeConfigurationBuilder factor(int value) {
@@ -111,26 +72,14 @@ public class IndexMergeConfigurationBuilder extends AbstractIndexingConfiguratio
       return this;
    }
 
-   public Integer maxSize() {
-      return maxSize.get();
-   }
-
    public IndexMergeConfigurationBuilder maxForcedSize(int value) {
       maxForceSize.set(value);
       return this;
    }
 
-   public Integer maxForcedSize() {
-      return maxForceSize.get();
-   }
-
    public IndexMergeConfigurationBuilder calibrateByDeletes(boolean value) {
       calibrateByDeletes.set(value);
       return this;
-   }
-
-   public Boolean isCalibrateByDeletes() {
-      return calibrateByDeletes.get();
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/configuration/cache/IndexReaderConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/IndexReaderConfigurationBuilder.java
@@ -2,9 +2,6 @@ package org.infinispan.configuration.cache;
 
 import static org.infinispan.configuration.cache.IndexReaderConfiguration.REFRESH_INTERVAL;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.infinispan.commons.configuration.Builder;
 import org.infinispan.commons.configuration.ConfigurationBuilderInfo;
 import org.infinispan.commons.configuration.attributes.Attribute;
@@ -18,8 +15,6 @@ import org.infinispan.configuration.global.GlobalConfiguration;
 public class IndexReaderConfigurationBuilder extends AbstractIndexingConfigurationChildBuilder
       implements Builder<IndexReaderConfiguration>, ConfigurationBuilderInfo {
 
-   private static final String REFRESH_INTERVAL_KEY = "hibernate.search.backend.io.refresh_interval";
-
    private final AttributeSet attributes;
    private final Attribute<Long> refreshInterval;
 
@@ -29,21 +24,9 @@ public class IndexReaderConfigurationBuilder extends AbstractIndexingConfigurati
       this.refreshInterval = attributes.attribute(REFRESH_INTERVAL);
    }
 
-   Map<String, Object> asInternalProperties() {
-      Map<String, Object> props = new HashMap<>();
-      if (refreshInterval.isModified() && refreshInterval.get() != 0) {
-         props.put(REFRESH_INTERVAL_KEY, refreshInterval());
-      }
-      return props;
-   }
-
    public IndexReaderConfigurationBuilder refreshInterval(long valueMillis) {
       refreshInterval.set(valueMillis);
       return this;
-   }
-
-   long refreshInterval() {
-      return refreshInterval.get();
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/configuration/cache/IndexWriterConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/IndexWriterConfigurationBuilder.java
@@ -10,9 +10,7 @@ import static org.infinispan.configuration.cache.IndexWriterConfiguration.INDEX_
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.infinispan.commons.configuration.Builder;
 import org.infinispan.commons.configuration.ConfigurationBuilderInfo;
@@ -26,17 +24,6 @@ import org.infinispan.configuration.global.GlobalConfiguration;
  */
 public class IndexWriterConfigurationBuilder extends AbstractIndexingConfigurationChildBuilder
       implements Builder<IndexWriterConfiguration>, ConfigurationBuilderInfo {
-
-   private static final String BACKEND_PREFIX = "hibernate.search.backend.";
-   private static final String QUEUE_COUNT_KEY = BACKEND_PREFIX + "indexing.queue_count";
-   private static final String QUEUE_SIZE_KEY = BACKEND_PREFIX + "indexing.queue_size";
-   private static final String THREAD_POOL_KEY = BACKEND_PREFIX + "thread_pool.size";
-
-   private static final String IO_PREFIX = "hibernate.search.backend.io.";
-   private static final String COMMIT_INTERVAL_KEY = IO_PREFIX + "commit_interval";
-   private static final String RAM_BUFFER_KEY = IO_PREFIX + "writer.ram_buffer_size";
-   private static final String MAX_BUFFER_ENTRIES_KEY = IO_PREFIX + "writer.max_buffered_docs";
-   private static final String LOW_LEVEL_TRACE_KEY = IO_PREFIX + "writer.infostream";
 
    private final AttributeSet attributes;
    private final IndexMergeConfigurationBuilder indexMergeConfigurationBuilder;
@@ -68,41 +55,8 @@ public class IndexWriterConfigurationBuilder extends AbstractIndexingConfigurati
       return subElements;
    }
 
-   Map<String, Object> asInternalProperties() {
-      Map<String, Object> props = new HashMap<>();
-      if (!commitInterval.isNull()) {
-         props.put(COMMIT_INTERVAL_KEY, commitInterval());
-      }
-      if (!threadPoolSize.isNull()) {
-         props.put(THREAD_POOL_KEY, threadPoolSize());
-      }
-      if (!queueCount.isNull()) {
-         props.put(QUEUE_COUNT_KEY, queueCount());
-      }
-      if (!queueSize.isNull()) {
-         props.put(QUEUE_SIZE_KEY, queueSize());
-      }
-      if (!ramBufferSize.isNull()) {
-         props.put(RAM_BUFFER_KEY, ramBufferSize());
-      }
-      if (!maxBufferedEntries.isNull()) {
-         props.put(MAX_BUFFER_ENTRIES_KEY, maxBufferedEntries());
-      }
-      if (lowLevelTrace.isModified()) {
-         props.put(LOW_LEVEL_TRACE_KEY, isLowLevelTrace());
-      }
-      props.putAll(indexMergeConfigurationBuilder.asInternalProperties());
-      return props;
-   }
-
-
-
    public IndexMergeConfigurationBuilder merge() {
       return indexMergeConfigurationBuilder;
-   }
-
-   public int threadPoolSize() {
-      return threadPoolSize.get();
    }
 
    public IndexWriterConfigurationBuilder threadPoolSize(int value) {
@@ -110,17 +64,9 @@ public class IndexWriterConfigurationBuilder extends AbstractIndexingConfigurati
       return this;
    }
 
-   public int queueCount() {
-      return queueCount.get();
-   }
-
    public IndexWriterConfigurationBuilder queueCount(int value) {
       queueCount.set(value);
       return this;
-   }
-
-   public int queueSize() {
-      return queueSize.get();
    }
 
    public IndexWriterConfigurationBuilder queueSize(int value) {
@@ -128,17 +74,9 @@ public class IndexWriterConfigurationBuilder extends AbstractIndexingConfigurati
       return this;
    }
 
-   public int commitInterval() {
-      return commitInterval.get();
-   }
-
    public IndexWriterConfigurationBuilder commitInterval(int value) {
       commitInterval.set(value);
       return this;
-   }
-
-   public int ramBufferSize() {
-      return ramBufferSize.get();
    }
 
    public IndexWriterConfigurationBuilder ramBufferSize(int value) {
@@ -146,17 +84,9 @@ public class IndexWriterConfigurationBuilder extends AbstractIndexingConfigurati
       return this;
    }
 
-   public int maxBufferedEntries() {
-      return maxBufferedEntries.get();
-   }
-
    public IndexWriterConfigurationBuilder maxBufferedEntries(int value) {
       maxBufferedEntries.set(value);
       return this;
-   }
-
-   public boolean isLowLevelTrace() {
-      return lowLevelTrace.get();
    }
 
    public IndexWriterConfigurationBuilder setLowLevelTrace(boolean value) {

--- a/core/src/main/java/org/infinispan/configuration/cache/IndexingConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/IndexingConfigurationBuilder.java
@@ -25,7 +25,6 @@ import org.infinispan.commons.configuration.Builder;
 import org.infinispan.commons.configuration.ConfigurationBuilderInfo;
 import org.infinispan.commons.configuration.attributes.AttributeSet;
 import org.infinispan.commons.configuration.elements.ElementDefinition;
-import org.infinispan.commons.util.StringPropertyReplacer;
 import org.infinispan.commons.util.TypedProperties;
 import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.global.GlobalConfiguration;
@@ -38,8 +37,6 @@ public class IndexingConfigurationBuilder extends AbstractConfigurationChildBuil
    private static final String BACKEND_PREFIX = "hibernate.search.backend.";
 
    private static final String DIRECTORY_PROVIDER_KEY = BACKEND_PREFIX + "directory.type";
-
-   private static final String DIRECTORY_ROOT_KEY = BACKEND_PREFIX + "directory.root";
 
    private static final String EXCLUSIVE_INDEX_USE = "hibernate.search.default.exclusive_index_use";
 
@@ -59,8 +56,6 @@ public class IndexingConfigurationBuilder extends AbstractConfigurationChildBuil
    private static final String RAM_DIRECTORY_PROVIDER = "ram";
 
    private static final String LOCAL_HEAP_DIRECTORY_PROVIDER = "local-heap";
-
-   private static final String LOCAL_HEAP_DIRECTORY_PROVIDER_FQN = "org.hibernate.search.store.impl.RAMDirectoryProvider";
 
    private final AttributeSet attributes;
 
@@ -378,20 +373,6 @@ public class IndexingConfigurationBuilder extends AbstractConfigurationChildBuil
       }
 
       // todo [anistor] if storage media type is not configured then log a warning because this is not supported with indexing
-      if (enabled()) {
-         IndexStorage storage = attributes.attribute(STORAGE).get();
-         if (storage.equals(IndexStorage.LOCAL_HEAP)) {
-            typedProperties.put(DIRECTORY_PROVIDER_KEY, LOCAL_HEAP_DIRECTORY_PROVIDER);
-         } else {
-            typedProperties.put(DIRECTORY_PROVIDER_KEY, FS_PROVIDER);
-            String path = attributes.attribute(PATH).get();
-            if (path != null) {
-               typedProperties.put(DIRECTORY_ROOT_KEY, StringPropertyReplacer.replaceProperties(path));
-            }
-         }
-         typedProperties.putAll(readerConfigurationBuilder.asInternalProperties());
-         typedProperties.putAll(writerConfigurationBuilder.asInternalProperties());
-      }
 
       return new IndexingConfiguration(attributes.protect(), resolvedIndexedClasses, readerConfigurationBuilder.create(), writerConfigurationBuilder.create());
    }

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -2089,11 +2089,13 @@ public interface Log extends BasicLogger {
    @LogMessage(level = WARN)
    @Message(value = "Indexing configuration using properties has been deprecated and will be removed in a future " +
          "version, please consult the docs for the replacements. The following properties have been found: '%s'", id = 612)
+   @Once
    void indexingPropertiesDeprecated(Properties properties);
 
    @LogMessage(level = WARN)
    @Message(value = "Indexing configuration using properties has been deprecated and will be removed in a future " +
          "version, please use the <index-writer> and <index-reader> elements to configure indexing behavior.", id = 613)
+   @Once
    void deprecatedIndexProperties();
 
    @Message(value = "It is not allowed to have different indexing configuration for each indexed type in a cache.", id = 614)

--- a/query/src/main/java/org/infinispan/query/impl/config/SearchPropertyExtractor.java
+++ b/query/src/main/java/org/infinispan/query/impl/config/SearchPropertyExtractor.java
@@ -1,0 +1,153 @@
+package org.infinispan.query.impl.config;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.hibernate.search.backend.lucene.analysis.LuceneAnalysisConfigurer;
+import org.infinispan.commons.util.ServiceFinder;
+import org.infinispan.commons.util.StringPropertyReplacer;
+import org.infinispan.configuration.cache.IndexMergeConfiguration;
+import org.infinispan.configuration.cache.IndexReaderConfiguration;
+import org.infinispan.configuration.cache.IndexStorage;
+import org.infinispan.configuration.cache.IndexWriterConfiguration;
+import org.infinispan.configuration.cache.IndexingConfiguration;
+import org.infinispan.query.logging.Log;
+import org.infinispan.search.mapper.mapping.impl.CompositeAnalysisConfigurer;
+import org.infinispan.util.logging.LogFactory;
+
+/**
+ * Extracts Hibernate Search native configuration properties from a {@link IndexingConfiguration}.
+ *
+ * @since 12.0
+ */
+public class SearchPropertyExtractor {
+   private static final Log log = LogFactory.getLog(SearchPropertyExtractor.class, Log.class);
+
+   private static final String BACKEND_PREFIX = "hibernate.search.backend.";
+   private static final String DIRECTORY_ROOT_KEY = BACKEND_PREFIX + "directory.root";
+   private static final String DIRECTORY_PROVIDER_KEY = BACKEND_PREFIX + "directory.type";
+   private static final String LOCAL_HEAP_DIRECTORY_PROVIDER = "local-heap";
+   private static final String FS_PROVIDER = "local-filesystem";
+   private static final String LUCENE_VERSION_PROPERTY_NAME = "lucene_version";
+   private static final String LUCENE_VERSION_LATEST = "LATEST";
+
+   private static final String REFRESH_INTERVAL_KEY = "hibernate.search.backend.io.refresh_interval";
+
+   private static final String IO_PREFIX = "hibernate.search.backend.io.";
+   private static final String COMMIT_INTERVAL_KEY = IO_PREFIX + "commit_interval";
+   private static final String RAM_BUFFER_KEY = IO_PREFIX + "writer.ram_buffer_size";
+   private static final String MAX_BUFFER_DOCS_KEY = IO_PREFIX + "writer.max_buffered_docs";
+   private static final String LOW_LEVEL_TRACE_KEY = IO_PREFIX + "writer.infostream";
+   private static final String QUEUE_COUNT_KEY = BACKEND_PREFIX + "indexing.queue_count";
+   private static final String QUEUE_SIZE_KEY = BACKEND_PREFIX + "indexing.queue_size";
+   private static final String THREAD_POOL_KEY = BACKEND_PREFIX + "thread_pool.size";
+
+   private static final String KEY_PREFIX = "hibernate.search.backend.io.merge";
+   private static final String MAX_DOCS_KEY = KEY_PREFIX + ".max_docs";
+   private static final String FACTOR_KEY = KEY_PREFIX + ".factor";
+   private static final String MIN_SIZE_KEY = KEY_PREFIX + ".min_size";
+   private static final String MAX_SIZE_KEY = KEY_PREFIX + ".max_size";
+   private static final String MAX_FORCED_SIZE_KEY = KEY_PREFIX + ".max_forced_size";
+   private static final String CALIBRATE_BY_DELETES_KEY = KEY_PREFIX + ".calibrate_by_deletes";
+
+   private static final String ANALYSIS_CONFIGURER_PROPERTY_NAME = "analysis.configurer";
+
+   public static Map<String, Object> extractProperties(IndexingConfiguration configuration, ClassLoader aggregatedClassLoader) {
+      Map<String, Object> props = new LinkedHashMap<>();
+
+      // load LuceneAnalysisDefinitionProvider from classpath
+      Collection<LuceneAnalysisConfigurer> analyzerDefProviders = ServiceFinder.load(LuceneAnalysisConfigurer.class, aggregatedClassLoader);
+      if (analyzerDefProviders.size() == 1) {
+         props.put(ANALYSIS_CONFIGURER_PROPERTY_NAME, analyzerDefProviders.iterator().next());
+      } else if (!analyzerDefProviders.isEmpty()) {
+         props.put(ANALYSIS_CONFIGURER_PROPERTY_NAME, new CompositeAnalysisConfigurer(analyzerDefProviders));
+      }
+
+      for (Map.Entry<Object, Object> entry : configuration.properties().entrySet()) {
+         if (!(entry.getKey() instanceof String)) {
+            throw log.invalidPropertyKey(entry.getKey());
+         }
+         props.put((String) entry.getKey(), entry.getValue());
+      }
+
+      if (configuration.enabled()) {
+         IndexStorage storage = configuration.storage();
+         if (storage.equals(IndexStorage.LOCAL_HEAP)) {
+            props.put(DIRECTORY_PROVIDER_KEY, LOCAL_HEAP_DIRECTORY_PROVIDER);
+         } else {
+            props.put(DIRECTORY_PROVIDER_KEY, FS_PROVIDER);
+            String path = configuration.path();
+            if (path != null) {
+               props.put(DIRECTORY_ROOT_KEY, StringPropertyReplacer.replaceProperties(path));
+            }
+         }
+         IndexReaderConfiguration readerConfiguration = configuration.reader();
+         long refreshInterval = readerConfiguration.getRefreshInterval();
+         if (refreshInterval != 0) {
+            props.put(REFRESH_INTERVAL_KEY, refreshInterval);
+         }
+
+         IndexWriterConfiguration writerConfiguration = configuration.writer();
+
+         Integer commitInterval = writerConfiguration.getCommitInterval();
+         if (commitInterval != null) {
+            props.put(COMMIT_INTERVAL_KEY, commitInterval);
+         }
+         Integer threadPoolSize = writerConfiguration.getThreadPoolSize();
+         if (threadPoolSize != null) {
+            props.put(THREAD_POOL_KEY, threadPoolSize);
+         }
+         Integer queueCount = writerConfiguration.getQueueCount();
+         if (queueCount != null) {
+            props.put(QUEUE_COUNT_KEY, queueCount);
+         }
+         Integer queueSize = writerConfiguration.getQueueSize();
+         if (queueSize != null) {
+            props.put(QUEUE_SIZE_KEY, queueSize);
+         }
+         Integer ramBufferSize = writerConfiguration.getRamBufferSize();
+         if (ramBufferSize != null) {
+            props.put(RAM_BUFFER_KEY, ramBufferSize);
+         }
+         Integer maxBufferedDocs = writerConfiguration.getMaxBufferedEntries();
+         if (maxBufferedDocs != null) {
+            props.put(MAX_BUFFER_DOCS_KEY, maxBufferedDocs);
+         }
+         Boolean lowLevelTrace = writerConfiguration.isLowLevelTrace();
+         if (lowLevelTrace) {
+            props.put(LOW_LEVEL_TRACE_KEY, true);
+         }
+
+         IndexMergeConfiguration mergeConfiguration = writerConfiguration.merge();
+         Integer maxDocs = mergeConfiguration.maxEntries();
+         if (maxDocs != null) {
+            props.put(MAX_DOCS_KEY, maxDocs);
+         }
+         Integer minSize = mergeConfiguration.minSize();
+         if (minSize != null) {
+            props.put(MIN_SIZE_KEY, minSize);
+         }
+         Integer maxSize = mergeConfiguration.maxSize();
+         if (maxSize != null) {
+            props.put(MAX_SIZE_KEY, maxSize);
+         }
+         Integer factor = mergeConfiguration.factor();
+         if (factor != null) {
+            props.put(FACTOR_KEY, factor);
+         }
+         Integer maxForcedSize = mergeConfiguration.maxForcedSize();
+         if (maxForcedSize != null) {
+            props.put(MAX_FORCED_SIZE_KEY, maxForcedSize);
+         }
+         Boolean calibrateByDeletes = mergeConfiguration.calibrateByDeletes();
+         if (calibrateByDeletes != null) {
+            props.put(CALIBRATE_BY_DELETES_KEY, calibrateByDeletes);
+         }
+      }
+      props.putIfAbsent(LUCENE_VERSION_PROPERTY_NAME, LUCENE_VERSION_LATEST);
+
+      return Collections.unmodifiableMap(props);
+   }
+}

--- a/query/src/test/java/org/infinispan/query/config/EngineConfigTest.java
+++ b/query/src/test/java/org/infinispan/query/config/EngineConfigTest.java
@@ -1,8 +1,10 @@
 package org.infinispan.query.config;
 
+import static org.infinispan.query.impl.config.SearchPropertyExtractor.extractProperties;
 import static org.testng.AssertJUnit.assertEquals;
 
-import org.infinispan.commons.util.TypedProperties;
+import java.util.Map;
+
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.IndexStorage;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -34,8 +36,7 @@ public class EngineConfigTest extends SingleCacheManagerTest {
    @Test
    public void testPropertiesGeneration() {
       cache.put(1, new Person("name", "blurb", 12));
-
-      TypedProperties properties = cache.getCacheConfiguration().indexing().properties();
+      Map<String, Object> properties = extractProperties(cache.getCacheConfiguration().indexing(), this.getClass().getClassLoader());
 
       // Storage
       assertEquals("local-filesystem", properties.get("hibernate.search.backend.directory.type"));

--- a/query/src/test/java/org/infinispan/query/config/IndexingConfigurationIgnoredTest.java
+++ b/query/src/test/java/org/infinispan/query/config/IndexingConfigurationIgnoredTest.java
@@ -1,6 +1,6 @@
 package org.infinispan.query.config;
 
-import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 import org.infinispan.Cache;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -20,8 +20,8 @@ public class IndexingConfigurationIgnoredTest extends AbstractInfinispanTest {
    public void testIndexingParametersForNamedCache() {
       Cache<Object, Object> inMemory = manager.getCache("memory-searchable");
       inMemory.start();
-      assertFalse(inMemory.getCacheConfiguration().indexing().properties().isEmpty(),
-            "should contain definition from xml");
+      assertTrue(inMemory.getCacheConfiguration().indexing().properties().isEmpty(),
+            "no property is defined explicitly");
    }
 
    @BeforeMethod

--- a/query/src/test/java/org/infinispan/query/config/ProgrammaticAutoConfigTest.java
+++ b/query/src/test/java/org/infinispan/query/config/ProgrammaticAutoConfigTest.java
@@ -2,6 +2,7 @@ package org.infinispan.query.config;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.AssertJUnit.assertTrue;
 
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
@@ -17,16 +18,13 @@ public class ProgrammaticAutoConfigTest {
 
    @Test
    public void testWithoutAutoConfig() {
-      IndexingConfiguration cfg = new ConfigurationBuilder()
-              .indexing().enable().create();
-      assertEquals(cfg.properties().size(), 3);
+      IndexingConfiguration cfg = new ConfigurationBuilder().indexing().enable().create();
+      assertTrue("No property was explicitly defined", cfg.properties().isEmpty());
    }
 
    @Test
    public void testLocalWitAutoConfig() {
-      IndexingConfiguration cfg = new ConfigurationBuilder()
-              .indexing().enable().autoConfig(true)
-              .create();
+      IndexingConfiguration cfg = new ConfigurationBuilder().indexing().enable().autoConfig(true).create();
 
       assertFalse(cfg.properties().isEmpty());
       assertEquals(cfg.properties().get("hibernate.search.backend.directory.type"), "local-filesystem");
@@ -35,9 +33,9 @@ public class ProgrammaticAutoConfigTest {
    @Test
    public void testDistWitAutoConfig() {
       IndexingConfiguration cfg = new ConfigurationBuilder()
-              .clustering().cacheMode(CacheMode.DIST_SYNC)
-              .indexing().enable().autoConfig(true)
-              .create();
+            .clustering().cacheMode(CacheMode.DIST_SYNC)
+            .indexing().enable().autoConfig(true)
+            .create();
 
       assertFalse(cfg.properties().isEmpty());
       assertEquals(cfg.properties().get("hibernate.search.backend.directory.type"), "local-filesystem");
@@ -47,10 +45,10 @@ public class ProgrammaticAutoConfigTest {
    public void testOverride() {
       String override = "hibernate.search.default.exclusive_index_use";
       IndexingConfiguration cfg = new ConfigurationBuilder()
-              .indexing()
-              .enable()
-              .autoConfig(true)
-              .addProperty(override, "false").create();
+            .indexing()
+            .enable()
+            .autoConfig(true)
+            .addProperty(override, "false").create();
 
       assertEquals(cfg.properties().get(override), "false");
    }

--- a/query/src/test/java/org/infinispan/query/config/QueryParsingTest.java
+++ b/query/src/test/java/org/infinispan/query/config/QueryParsingTest.java
@@ -33,12 +33,12 @@ public class QueryParsingTest extends AbstractInfinispanTest {
 
       Configuration memoryCfg = namedConfigurations.get("memory-searchable").build();
       assertTrue(memoryCfg.indexing().enabled());
-      assertEquals(memoryCfg.indexing().properties().size(), 3);
+      assertTrue(memoryCfg.indexing().properties().isEmpty());
       assertEquals(IndexStorage.LOCAL_HEAP, memoryCfg.indexing().storage());
 
       Configuration diskCfg = namedConfigurations.get("disk-searchable").build();
       assertTrue(diskCfg.indexing().enabled());
-      assertEquals(diskCfg.indexing().properties().size(), 4);
+      assertTrue(diskCfg.indexing().properties().isEmpty());
       assertEquals(diskCfg.indexing().storage(), IndexStorage.FILESYSTEM);
       assertEquals(diskCfg.indexing().path(), "target/");
 
@@ -53,7 +53,7 @@ public class QueryParsingTest extends AbstractInfinispanTest {
       Map<String, ConfigurationBuilder> namedConfigurations = holder.getNamedConfigurationBuilders();
       Configuration defaultConfiguration = namedConfigurations.get("default").build();
 
-      assertEquals(defaultConfiguration.indexing().properties().size(), 3);
+      assertTrue(defaultConfiguration.indexing().properties().isEmpty());
       assertTrue(defaultConfiguration.indexing().enabled());
       assertEquals(IndexStorage.LOCAL_HEAP, defaultConfiguration.indexing().storage());
 
@@ -62,16 +62,16 @@ public class QueryParsingTest extends AbstractInfinispanTest {
 
       Configuration simpleCfg = namedConfigurations.get("simple").build();
       assertTrue(simpleCfg.indexing().enabled());
-      assertEquals(simpleCfg.indexing().properties().size(), 3);
+      assertTrue(simpleCfg.indexing().properties().isEmpty());
 
       Configuration memoryCfg = namedConfigurations.get("memory-searchable").build();
       assertTrue(memoryCfg.indexing().enabled());
-      assertEquals(memoryCfg.indexing().properties().size(), 3);
+      assertTrue(memoryCfg.indexing().properties().isEmpty());
       assertEquals(memoryCfg.indexing().storage(), IndexStorage.LOCAL_HEAP);
 
       Configuration diskCfg = namedConfigurations.get("disk-searchable").build();
       assertTrue(diskCfg.indexing().enabled());
-      assertEquals(diskCfg.indexing().properties().size(), 4);
+      assertTrue(diskCfg.indexing().properties().isEmpty());
       assertEquals(diskCfg.indexing().storage(), IndexStorage.FILESYSTEM);
       assertEquals(diskCfg.indexing().path(), "target/");
    }


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12535

Avoids adding properties to ```IndexingConfigurationBuilder``` since they are deprecated: all config should be done via schema based elements. This will silence multiple WARN when an indexed cache is created, even if the user hasn't explicitly used properties

