### PR TITLE
[11.0.x] ISPN-12594 Exception in cache streams with DENY_READ_WRITES

### DIFF
--- a/core/src/main/java/org/infinispan/reactive/publisher/impl/ClusterPublisherManagerImpl.java
+++ b/core/src/main/java/org/infinispan/reactive/publisher/impl/ClusterPublisherManagerImpl.java
@@ -75,7 +75,7 @@ import org.reactivestreams.Subscriber;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.processors.FlowableProcessor;
-import io.reactivex.rxjava3.processors.PublishProcessor;
+import io.reactivex.rxjava3.processors.UnicastProcessor;
 
 /**
  * ClusterPublisherManager that determines targets for the given segments and/or keys and then sends to local and
@@ -149,8 +149,8 @@ public class ClusterPublisherManagerImpl<K, V> implements ClusterPublisherManage
          Function<? super Publisher<I>, ? extends CompletionStage<R>> transformer,
          Function<? super Publisher<R>, ? extends CompletionStage<R>> finalizer) {
       // Needs to be serialized processor as we can write to it from different threads
-      FlowableProcessor<R> flowableProcessor = PublishProcessor.<R>create().toSerialized();
-      // We apply the finalizer first to ensure they can subscribe to the PublishProcessor before we emit any items
+      FlowableProcessor<R> flowableProcessor = UnicastProcessor.<R>create().toSerialized();
+      // Apply the finalizer first (which subscribes) before emitting items, to avoid buffering in UnicastProcessor
       CompletionStage<R> stage = finalizer.apply(flowableProcessor);
 
       Function<? super Publisher<R>, ? extends CompletionStage<R>> finalizerToUse =

--- a/core/src/main/java/org/infinispan/reactive/publisher/impl/PartitionAwareClusterPublisherManager.java
+++ b/core/src/main/java/org/infinispan/reactive/publisher/impl/PartitionAwareClusterPublisherManager.java
@@ -24,7 +24,7 @@ import org.infinispan.partitionhandling.AvailabilityMode;
 import org.reactivestreams.Publisher;
 
 import io.reactivex.rxjava3.processors.FlowableProcessor;
-import io.reactivex.rxjava3.processors.PublishProcessor;
+import io.reactivex.rxjava3.processors.UnicastProcessor;
 
 /**
  * Cluster stream manager that also pays attention to partition status and properly closes iterators and throws
@@ -129,7 +129,7 @@ public class PartitionAwareClusterPublisherManager<K, V> extends ClusterPublishe
    private <R> SegmentCompletionPublisher<R> registerPublisher(SegmentCompletionPublisher<R> original) {
       return (subscriber, segmentsComplete) -> {
          // Processor has to be serialized due to possibly invoking onError from a different thread
-         FlowableProcessor<R> earlyTerminatingProcessor = PublishProcessor.<R>create().toSerialized();
+         FlowableProcessor<R> earlyTerminatingProcessor = UnicastProcessor.<R>create().toSerialized();
          pendingProcessors.add(earlyTerminatingProcessor);
          // Have to check after registering in case if we got a partition between when the publisher was created and
          // subscribed to

--- a/core/src/test/java/org/infinispan/stream/DenyReadWritesStreamTest.java
+++ b/core/src/test/java/org/infinispan/stream/DenyReadWritesStreamTest.java
@@ -1,0 +1,99 @@
+package org.infinispan.stream;
+
+import java.util.Map;
+
+import org.infinispan.CacheStream;
+import org.infinispan.commons.util.CloseableIterator;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.manager.DefaultCacheManager;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.partitionhandling.PartitionHandling;
+import org.infinispan.test.SingleCacheManagerTest;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+import org.testng.annotations.Test;
+
+/**
+ * Test the handling of backpressure when partition handling is enabled.
+ *
+ * See ISPN-12594.
+ *
+ * @author Wolf-Dieter Fink
+ * @author Dan Berindei
+ */
+@Test(groups = "functional", testName = "stream.DenyReadWritesStreamTest")
+public class DenyReadWritesStreamTest extends SingleCacheManagerTest {
+   private static final Log log = LogFactory.getLog(DenyReadWritesStreamTest.class);
+   public static final int CHUNK_SIZE = 2;
+   public static final int NUM_KEYS = 20;
+
+   public DenyReadWritesStreamTest() {
+
+   }
+
+   @Override
+   protected EmbeddedCacheManager createCacheManager() throws Exception {
+      // Setup up a clustered cache manager
+      GlobalConfigurationBuilder global = GlobalConfigurationBuilder.defaultClusteredBuilder();
+      cacheManager = new DefaultCacheManager(global.build());
+      ConfigurationBuilder builder = new ConfigurationBuilder();
+
+      // With a dist cache
+      builder.clustering().cacheMode(CacheMode.DIST_SYNC)
+             .stateTransfer().chunkSize(CHUNK_SIZE)
+             .hash().numOwners(4);
+
+      // DENY_READ_WRITES will cause iteration to fail
+      // ALLOW_READS or ALLOW_READ_WRITES work as expected
+      builder.clustering().partitionHandling().whenSplit(PartitionHandling.DENY_READ_WRITES);
+
+      cacheManager.defineConfiguration("testCache", builder.build());
+      cache = cacheManager.getCache("testCache");
+
+      for (int i = 0; i < NUM_KEYS; i++) {
+         cache.put(String.valueOf(i), String.valueOf(i));
+      }
+
+      return cacheManager;
+   }
+
+   @Override
+   protected void clearCacheManager() {
+      // Do nothing
+   }
+
+   public void testValuesForEachNoBatchSize() {
+      try (CacheStream<Object> cacheStream = cache.values().stream()) {
+         cacheStream.forEach(v -> {
+            log.tracef("foreach: %s", v);
+         });
+      }
+   }
+
+   public void testEntriesIteratorNoBatchSize() {
+      try (CloseableIterator<Map.Entry<Object, Object>> it = cache.entrySet().iterator()) {
+         while (it.hasNext()) {
+            Object key = it.next();
+            log.tracef("iterator: %s", key);
+         }
+      }
+   }
+
+   public void testKeysForEachBatchSizeEqualsCacheSize() {
+      try (CacheStream<Object> cacheStream = cache.keySet().stream().distributedBatchSize(NUM_KEYS)) {
+         cacheStream.forEach(k -> {
+            log.tracef("foreach: %s", k);
+         });
+      }
+   }
+
+   public void testKeysForEachBatchSizeIsLessThanCacheSize() {
+      try (CacheStream<Object> cacheStream = cache.keySet().stream().distributedBatchSize(NUM_KEYS - 2)) {
+         cacheStream.forEach(k -> {
+            log.tracef("foreach %s", k);
+         });
+      }
+   }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12594
https://issues.redhat.com/browse/JDG-4262

Use UnicastProcessor instead of PublishProcessor,
as PublishProcessor starts emitting items too early
(before its subscribers call request()).