### PR TITLE
ISPN-12616 Rolling Upgrade fails for caches storing POJOs

### DIFF
--- a/persistence/remote/pom.xml
+++ b/persistence/remote/pom.xml
@@ -45,6 +45,11 @@
          <artifactId>infinispan-component-processor</artifactId>
       </dependency>
       <dependency>
+         <groupId>org.infinispan.protostream</groupId>
+         <artifactId>protostream-processor</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
          <groupId>org.infinispan</groupId>
          <artifactId>infinispan-jboss-marshalling</artifactId>
          <!-- Prevent transitive dependency -->

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/RemoteStore.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/RemoteStore.java
@@ -234,7 +234,15 @@ public class RemoteStore<K, V> implements NonBlockingStore<K, V> {
       } else {
          Object unwrappedKey = unwrap(key);
          return remoteCache.getAsync(unwrappedKey)
-               .thenApply(value -> value == null ? null : entryFactory.create(key, (MarshalledValue) value));
+               .thenApply(value -> {
+                  if(value == null) {
+                     return null;
+                  }
+                  if(value instanceof MarshalledValue) {
+                     return entryFactory.create(key, (MarshalledValue) value);
+                  }
+                  return entryFactory.create(key, value);
+               });
       }
    }
 

--- a/persistence/remote/src/test/java/org/infinispan/persistence/remote/upgrade/CustomObject.java
+++ b/persistence/remote/src/test/java/org/infinispan/persistence/remote/upgrade/CustomObject.java
@@ -1,0 +1,48 @@
+package org.infinispan.persistence.remote.upgrade;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import org.infinispan.protostream.annotations.ProtoFactory;
+import org.infinispan.protostream.annotations.ProtoField;
+
+public class CustomObject implements Serializable {
+
+   @ProtoFactory
+   public CustomObject(String text, Integer number) {
+      this.text = text;
+      this.number = number;
+   }
+
+   @ProtoField(number = 1)
+   String text;
+
+   @ProtoField(number = 2)
+   Integer number;
+
+   @Override
+   public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      CustomObject that = (CustomObject) o;
+
+      if (!Objects.equals(text, that.text)) return false;
+      return Objects.equals(number, that.number);
+   }
+
+   @Override
+   public int hashCode() {
+      int result = text != null ? text.hashCode() : 0;
+      result = 31 * result + (number != null ? number.hashCode() : 0);
+      return result;
+   }
+
+   @Override
+   public String toString() {
+      return "CustomObject{" +
+            "text='" + text + '\'' +
+            ", number=" + number +
+            '}';
+   }
+}

--- a/persistence/remote/src/test/java/org/infinispan/persistence/remote/upgrade/HotRodUpgradePojoTest.java
+++ b/persistence/remote/src/test/java/org/infinispan/persistence/remote/upgrade/HotRodUpgradePojoTest.java
@@ -1,0 +1,128 @@
+package org.infinispan.persistence.remote.upgrade;
+
+import static org.infinispan.commons.dataconversion.MediaType.APPLICATION_OBJECT_TYPE;
+import static org.testng.AssertJUnit.assertEquals;
+
+import java.util.concurrent.TimeUnit;
+
+import org.infinispan.Cache;
+import org.infinispan.client.hotrod.MetadataValue;
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.commons.marshall.ProtoStreamMarshaller;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.container.entries.CacheEntry;
+import org.infinispan.jboss.marshalling.commons.GenericJBossMarshaller;
+import org.infinispan.test.AbstractInfinispanTest;
+import org.infinispan.upgrade.RollingUpgradeManager;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Test for Hot Rod Rolling Upgrades from caches storing application/x-java-object.
+ *
+ * @since 12.0
+ */
+@Test(testName = "upgrade.hotrod.HotRodUpgradePojoTest", groups = "functional")
+public class HotRodUpgradePojoTest extends AbstractInfinispanTest {
+   protected TestCluster sourceCluster, targetCluster;
+
+   protected static final String CACHE_NAME = "theCache";
+
+   public static final int ENTRIES = 50;
+
+   @BeforeMethod
+   public void setup() throws Exception {
+      ConfigurationBuilder config = new ConfigurationBuilder();
+      config.clustering().cacheMode(CacheMode.DIST_SYNC);
+      config.encoding().key().mediaType(APPLICATION_OBJECT_TYPE);
+      config.encoding().value().mediaType(APPLICATION_OBJECT_TYPE);
+
+      sourceCluster = new TestCluster.Builder().setName("sourceCluster").setNumMembers(2)
+            .marshaller(ProtoStreamMarshaller.class)
+            .ctx(SerializationCtx.INSTANCE)
+            .cache().name(CACHE_NAME).configuredWith(config)
+            .build();
+
+      targetCluster = new TestCluster.Builder().setName("targetCluster").setNumMembers(2)
+            .marshaller(GenericJBossMarshaller.class)
+            .cache().name(CACHE_NAME).configuredWith(config)
+            .remotePort(sourceCluster.getHotRodPort()).remoteStoreWrapping(false).remoteStoreRawValues(false)
+            .remoteStoreMarshaller(GenericJBossMarshaller.class)
+            .build();
+   }
+
+   public void testSynchronization() throws Exception {
+      RemoteCache<Object, Object> sourceRemoteCache = sourceCluster.getRemoteCache(CACHE_NAME);
+      RemoteCache<Object, Object> targetRemoteCache = targetCluster.getRemoteCache(CACHE_NAME);
+
+      // Populate source cluster
+      for (int i = 0; i < ENTRIES; i++) {
+         sourceRemoteCache.put(i, new CustomObject("text", i), 20, TimeUnit.MINUTES, 30, TimeUnit.MINUTES);
+      }
+
+      assertEquals(ENTRIES, sourceRemoteCache.size());
+
+      // Verify data access from the target cluster
+      assertEquals(ENTRIES, targetRemoteCache.size());
+      assertEquals(new CustomObject("text", 2), targetRemoteCache.get(2));
+
+      // Do a Rolling Upgrade
+      RollingUpgradeManager upgradeManager = targetCluster.getRollingUpgradeManager(CACHE_NAME);
+      long count = upgradeManager.synchronizeData("hotrod");
+      assertEquals(ENTRIES, count);
+
+      // Disconnect remote store
+      upgradeManager.disconnectSource("hotrod");
+
+      // Check migrated data
+      assertEquals(sourceCluster.getEmbeddedCache(CACHE_NAME).size(), targetCluster.getEmbeddedCache(CACHE_NAME).size());
+      assertEquals(new CustomObject("text", 10), targetRemoteCache.get(10));
+      MetadataValue<Object> metadataValue = targetRemoteCache.getWithMetadata(ENTRIES - 1);
+      assertEquals(20 * 60, metadataValue.getLifespan());
+      assertEquals(30 * 60, metadataValue.getMaxIdle());
+   }
+
+   public void testSynchronizationBetweenEmbedded() throws Exception {
+      sourceCluster.cleanAllCaches();
+      targetCluster.cleanAllCaches();
+
+      Cache<Object, Object> sourceCache = sourceCluster.getEmbeddedCache(CACHE_NAME);
+      Cache<Object, Object> targetCache = targetCluster.getEmbeddedCache(CACHE_NAME);
+
+      // Populate source cluster
+      for (int i = 0; i < ENTRIES; i++) {
+         sourceCache.put(i, new CustomObject("text", i), 20, TimeUnit.MINUTES, 30, TimeUnit.MINUTES);
+      }
+
+      assertEquals(ENTRIES, sourceCache.size());
+
+      // Verify data access from the target cluster
+      assertEquals(ENTRIES, targetCache.size());
+      assertEquals(new CustomObject("text", 2), targetCache.get(2));
+
+      // Do a Rolling Upgrade
+      RollingUpgradeManager upgradeManager = targetCluster.getRollingUpgradeManager(CACHE_NAME);
+      long count = upgradeManager.synchronizeData("hotrod");
+      assertEquals(ENTRIES, count);
+
+      // Disconnect remote store
+      upgradeManager.disconnectSource("hotrod");
+
+      // Check migrated data
+      assertEquals(sourceCluster.getEmbeddedCache(CACHE_NAME).size(), targetCluster.getEmbeddedCache(CACHE_NAME).size());
+      assertEquals(new CustomObject("text", 10), targetCache.get(10));
+      CacheEntry<Object, Object> entry = targetCache.getAdvancedCache().getCacheEntry(ENTRIES - 1);
+      assertEquals(20 * 60 * 1000, entry.getLifespan());
+      assertEquals(30 * 60 * 1000, entry.getMaxIdle());
+
+   }
+
+   @AfterMethod
+   public void tearDown() {
+      sourceCluster.destroy();
+      targetCluster.destroy();
+   }
+
+}

--- a/persistence/remote/src/test/java/org/infinispan/persistence/remote/upgrade/SerializationCtx.java
+++ b/persistence/remote/src/test/java/org/infinispan/persistence/remote/upgrade/SerializationCtx.java
@@ -1,0 +1,13 @@
+package org.infinispan.persistence.remote.upgrade;
+
+import org.infinispan.protostream.SerializationContextInitializer;
+import org.infinispan.protostream.annotations.AutoProtoSchemaBuilder;
+
+@AutoProtoSchemaBuilder(
+      includeClasses = {CustomObject.class},
+      schemaFileName = "rolling.proto",
+      schemaFilePath = "proto/generated",
+      schemaPackageName = "org.infinispan.persistence.remote.upgrade")
+public interface SerializationCtx extends SerializationContextInitializer {
+   SerializationCtx INSTANCE = new SerializationCtxImpl();
+}

--- a/server/tests/src/test/java/org/infinispan/server/functional/RollingUpgradeIT.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/RollingUpgradeIT.java
@@ -74,6 +74,7 @@ public class RollingUpgradeIT extends AbstractMultiClusterIT {
 
       // Assert data was migrated successfully
       assertEquals(ENTRIES, getCacheSize(CACHE_NAME, restClientTarget));
+      assertEquals("name-35", getPersonName("35", restClientTarget));
    }
 
    protected void disconnectSource(RestClient client) {


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12616

Forward port from 11.0.x