### PR TITLE
ISPN-12666 ReplicationIndexTest random failures

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/ReplicationIndexTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/ReplicationIndexTest.java
@@ -67,6 +67,12 @@ public class ReplicationIndexTest extends MultiHotRodServersTest {
       cacheManager.defineConfiguration(CACHE_NAME, builder.build());
    }
 
+   private void killLastNode() {
+      int index = serverCount.decrementAndGet();
+      clients.remove(index).close();
+      killServer(index);
+   }
+
    protected boolean isTransactional() {
       return false;
    }
@@ -127,10 +133,14 @@ public class ReplicationIndexTest extends MultiHotRodServersTest {
 
       addNode();
 
-      waitForClusterToForm(CACHE_NAME);
+      try {
+         waitForClusterToForm(CACHE_NAME);
 
-      RemoteCache<Object, Object> secondRemoteCache = clients.get(1).getCache(CACHE_NAME);
-      assertIndexed(secondRemoteCache);
+         RemoteCache<Object, Object> secondRemoteCache = clients.get(1).getCache(CACHE_NAME);
+         assertIndexed(secondRemoteCache);
+      } finally {
+         killLastNode();
+      }
    }
 
    private void assertIndexed(RemoteCache<?, ?> remoteCache) {

--- a/core/src/main/java/org/infinispan/container/impl/AbstractDelegatingInternalDataContainer.java
+++ b/core/src/main/java/org/infinispan/container/impl/AbstractDelegatingInternalDataContainer.java
@@ -1,5 +1,11 @@
 package org.infinispan.container.impl;
 
+import java.util.Iterator;
+import java.util.Spliterator;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Consumer;
+import java.util.function.ObjIntConsumer;
+
 import org.infinispan.commons.util.IntSet;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.factories.ComponentRegistry;
@@ -10,12 +16,6 @@ import org.infinispan.factories.scopes.Scopes;
 import org.infinispan.metadata.Metadata;
 import org.infinispan.metadata.impl.PrivateMetadata;
 
-import java.util.Iterator;
-import java.util.Spliterator;
-import java.util.concurrent.CompletionStage;
-import java.util.function.Consumer;
-import java.util.function.ObjIntConsumer;
-
 /**
  * Delegating data container that delegates all calls to the container returned from {@link #delegate()}
  * @author wburns
@@ -25,7 +25,7 @@ import java.util.function.ObjIntConsumer;
 public abstract class AbstractDelegatingInternalDataContainer<K, V> implements InternalDataContainer<K, V> {
    @Inject
    void inject(ComponentRegistry componentRegistry) {
-      componentRegistry.wireDependencies(delegate());
+      componentRegistry.wireDependencies(delegate(), false);
    }
 
    protected abstract InternalDataContainer<K, V> delegate();

--- a/core/src/main/java/org/infinispan/factories/AbstractComponentRegistry.java
+++ b/core/src/main/java/org/infinispan/factories/AbstractComponentRegistry.java
@@ -84,7 +84,20 @@ public abstract class AbstractComponentRegistry implements Lifecycle {
     * @throws CacheConfigurationException if there is a problem wiring the instance
     */
    public void wireDependencies(Object target) throws CacheConfigurationException {
-      boolean startDependencies = state == ComponentStatus.RUNNING || state == ComponentStatus.INITIALIZING;
+      basicComponentRegistry.wireDependencies(target, true);
+   }
+
+   /**
+    * Wires an object instance with dependencies annotated with the {@link Inject} annotation, creating more components
+    * as needed based on the Configuration passed in if these additional components don't exist in the {@link
+    * ComponentRegistry}.  Strictly for components that don't otherwise live in the registry and have a lifecycle, such
+    * as Commands.
+    *
+    * @param target object to wire
+    * @param startDependencies whether to start injected components (if not already started)
+    * @throws CacheConfigurationException if there is a problem wiring the instance
+    */
+   public void wireDependencies(Object target, boolean startDependencies) throws CacheConfigurationException {
       basicComponentRegistry.wireDependencies(target, startDependencies);
    }
 

--- a/core/src/main/java/org/infinispan/factories/InternalCacheFactory.java
+++ b/core/src/main/java/org/infinispan/factories/InternalCacheFactory.java
@@ -115,7 +115,7 @@ public class InternalCacheFactory<K, V> {
       // TODO Register the cache without encoding in the component registry
       bootstrap(cacheName, encodedCache, configuration, globalComponentRegistry, marshaller);
       if (marshaller != null) {
-         componentRegistry.wireDependencies(marshaller);
+         componentRegistry.wireDependencies(marshaller, false);
       }
       return encodedCache;
    }
@@ -213,7 +213,7 @@ public class InternalCacheFactory<K, V> {
       @Inject
       public void wireRealCache() {
          // Wire the cache to ensure all components are ready
-         componentRegistry.wireDependencies(cache);
+         componentRegistry.wireDependencies(cache, false);
       }
 
       /**

--- a/core/src/main/java/org/infinispan/factories/TransactionManagerFactory.java
+++ b/core/src/main/java/org/infinispan/factories/TransactionManagerFactory.java
@@ -3,8 +3,8 @@ package org.infinispan.factories;
 import javax.transaction.TransactionManager;
 
 import org.infinispan.commons.CacheException;
-import org.infinispan.factories.annotations.DefaultFactoryFor;
 import org.infinispan.commons.tx.lookup.TransactionManagerLookup;
+import org.infinispan.factories.annotations.DefaultFactoryFor;
 import org.infinispan.transaction.tm.BatchModeTransactionManager;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -33,7 +33,7 @@ public class TransactionManagerFactory extends AbstractNamedCacheComponentFactor
       TransactionManagerLookup lookup = configuration.transaction().transactionManagerLookup();
       try {
          if (lookup != null) {
-            componentRegistry.wireDependencies(lookup);
+            componentRegistry.wireDependencies(lookup, false);
             transactionManager = lookup.getTransactionManager();
          }
       } catch (Exception e) {

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/LifecycleManager.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/LifecycleManager.java
@@ -149,8 +149,6 @@ public final class LifecycleManager implements ModuleLifecycle {
          // a remote query manager must be added for each non-internal cache
          SerializationContext serCtx = protobufMetadataManager.getSerializationContext();
 
-         // RemoteQueryManager can manipulate the registry, so create it before rewiring the cache below
-         // to avoid triggering a state transfer
          RemoteQueryManager remoteQueryManager = buildQueryManager(cfg, serCtx, cr);
          cr.registerComponent(remoteQueryManager, RemoteQueryManager.class);
 

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/ObjectRemoteQueryManager.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/ObjectRemoteQueryManager.java
@@ -44,6 +44,7 @@ final class ObjectRemoteQueryManager extends BaseRemoteQueryManager {
       ObjectReflectionMatcher objectReflectionMatcher = ObjectReflectionMatcher.create(
             createEntityNamesResolver(APPLICATION_OBJECT), searchMapping);
       bcr.replaceComponent(ObjectReflectionMatcher.class.getName(), objectReflectionMatcher, true);
+      bcr.rewire();
 
       ProtobufObjectReflectionMatcher protobufObjectReflectionMatcher = ProtobufObjectReflectionMatcher.create(createEntityNamesResolver(APPLICATION_PROTOSTREAM), serCtx);
       bcr.registerComponent(ProtobufObjectReflectionMatcher.class, protobufObjectReflectionMatcher, true);


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12666

Follows up on #9021 

Add a new AbstractComponentRegistry.wireDependencies() overload
to not start injected component.
Use the new overload in components, and keep using the old overload in
external classes like commands, converters, filters, etc.