### PR TITLE
ISPN-12682 dependency-check-maven plugin fails CI builds

### DIFF
--- a/build-configuration/pom.xml
+++ b/build-configuration/pom.xml
@@ -221,7 +221,7 @@
       <version.maven.source>3.2.0</version.maven.source>
       <version.maven.surefire>3.0.0-M5</version.maven.surefire>
       <version.org.wildfly.build-tools>1.2.13.Final</version.org.wildfly.build-tools>
-      <version.owasp-dependency-check-plugin>6.0.2</version.owasp-dependency-check-plugin>
+      <version.owasp-dependency-check-plugin>6.1.0</version.owasp-dependency-check-plugin>
 
       <!-- versionx -->
       <versionx.com.puppycrawl.tools.checkstyle>8.32</versionx.com.puppycrawl.tools.checkstyle>


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12682

Upgrade org.owasp:dependency-check-maven to version 6.1.0.
It should at least improve the error reporting.