### PR TITLE
[12.0.x] ISPN-12651 CacheEntryCloudEventsTest test failures

### DIFF
--- a/cloudevents-integration/pom.xml
+++ b/cloudevents-integration/pom.xml
@@ -53,6 +53,11 @@
          <groupId>org.infinispan</groupId>
          <artifactId>infinispan-core</artifactId>
       </dependency>
+      <!-- jackson-core is an optional dependency in protostream, but it is required for converting to JSON -->
+      <dependency>
+         <groupId>com.fasterxml.jackson.core</groupId>
+         <artifactId>jackson-core</artifactId>
+      </dependency>
       <dependency>
          <groupId>org.infinispan</groupId>
          <artifactId>infinispan-component-processor</artifactId>

--- a/cloudevents-integration/src/test/java/org/infinispan/cloudevents/MockKafkaEventSender.java
+++ b/cloudevents-integration/src/test/java/org/infinispan/cloudevents/MockKafkaEventSender.java
@@ -1,5 +1,6 @@
 package org.infinispan.cloudevents;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
@@ -45,7 +46,8 @@ public class MockKafkaEventSender implements KafkaEventSender {
          }
          TestingUtil.sleepThread(10);
       }
-      log.tracef("Completed send %s", getProducer().history().get(getProducer().history().size() - 1).key());
+      List<ProducerRecord<byte[], byte[]>> history = getProducer().history();
+      log.tracef("Completed send %s", history.get(history.size() - 1).key());
    }
 
    public void completeSend(int count) {


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12651

* Make jackson-core a required dependency of cloudevents-integration.
* Cache history list in test to avoid ConcurrentModificationException.