### PR TITLE
ISPN-12725 Conflict resolution fails in transactional cache with auto-commit disabled

### DIFF
--- a/core/src/main/java/org/infinispan/conflict/impl/DefaultConflictManager.java
+++ b/core/src/main/java/org/infinispan/conflict/impl/DefaultConflictManager.java
@@ -109,7 +109,7 @@ public class DefaultConflictManager<K, V> implements InternalConflictManager<K, 
 
    @Start
    public void start() {
-      this.cacheName = cache.getName();
+      this.cacheName = cache.wired().getName();
       this.localAddress = rpcManager.getAddress();
 
       PartitionHandlingConfiguration config = cacheConfiguration.clustering().partitionHandling();
@@ -250,7 +250,6 @@ public class DefaultConflictManager<K, V> implements InternalConflictManager<K, 
             .toCompletableFuture();
       return conflictFuture.whenComplete((Void, t) -> {
          if (t != null) {
-            log.errorf("Cache %s encountered exception whilst trying to resolve conflicts on merge: %s", cacheName, t);
             if (conflictSpliterator != null) {
                conflictSpliterator.stop();
                conflictSpliterator = null;

--- a/core/src/main/java/org/infinispan/conflict/impl/DefaultConflictManager.java
+++ b/core/src/main/java/org/infinispan/conflict/impl/DefaultConflictManager.java
@@ -40,9 +40,9 @@ import org.infinispan.configuration.cache.PartitionHandlingConfiguration;
 import org.infinispan.conflict.EntryMergePolicy;
 import org.infinispan.conflict.EntryMergePolicyFactoryRegistry;
 import org.infinispan.container.entries.CacheEntry;
-import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.container.entries.InternalCacheValue;
 import org.infinispan.container.entries.NullCacheEntry;
+import org.infinispan.container.impl.InternalEntryFactory;
 import org.infinispan.context.Flag;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.InvocationContextFactory;
@@ -94,6 +94,7 @@ public class DefaultConflictManager<K, V> implements InternalConflictManager<K, 
    @Inject EntryMergePolicyFactoryRegistry mergePolicyRegistry;
    @Inject TimeService timeService;
    @Inject BlockingManager blockingManager;
+   @Inject InternalEntryFactory internalEntryFactory;
 
    private String cacheName;
    private Address localAddress;
@@ -389,8 +390,8 @@ public class DefaultConflictManager<K, V> implements InternalConflictManager<K, 
          if (keyOwners.contains(localAddress)) {
             GetCacheEntryCommand cmd = commandsFactory.buildGetCacheEntryCommand(key, info.segmentId(), localFlags);
             InvocationContext ctx = invocationContextFactory.createNonTxInvocationContext();
-            InternalCacheEntry<K, V> internalCacheEntry = (InternalCacheEntry<K, V>) interceptorChain.running().invoke(ctx, cmd);
-            InternalCacheValue<V> icv = internalCacheEntry == null ? null : internalCacheEntry.toInternalCacheValue();
+            CacheEntry<K, V> entry = (CacheEntry<K, V>) interceptorChain.running().invoke(ctx, cmd);
+            InternalCacheValue<V> icv = entry != null ? internalEntryFactory.createValue(entry) : null;
             synchronized (versionsMap) {
                versionsMap.put(localAddress, icv);
             }

--- a/core/src/main/java/org/infinispan/topology/ClusterCacheStatus.java
+++ b/core/src/main/java/org/infinispan/topology/ClusterCacheStatus.java
@@ -1098,7 +1098,7 @@ public class ClusterCacheStatus implements AvailabilityStrategyContext {
 
                   // TODO When CR fails because a node left the cluster, the new CR can start before we cancel the old one
                   Log.CLUSTER.failedConflictResolution(cacheName, topology, rootCause);
-                  eventLogger.info(EventLogCategory.CLUSTER, MESSAGES.conflictResolutionFailed(
+                  eventLogger.error(EventLogCategory.CLUSTER, MESSAGES.conflictResolutionFailed(
                      topology.getMembers(), topology.getTopologyId(), rootCause.getMessage()));
                   // If a node is suspected then we can't restart the CR until a new view is received, so we leave conflictResolution != null
                   // so that on a new view restartConflictResolution can return true

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -1791,7 +1791,7 @@ public interface Log extends BasicLogger {
    @Message(value = "Conflict resolution finished for cache %s with topology %s", id = 523)
    void finishedConflictResolution(String cacheName, CacheTopology currentTopology);
 
-   @LogMessage(level = DEBUG)
+   @LogMessage(level = ERROR)
    @Message(value = "Conflict resolution failed for cache %s with topology %s", id = 524)
    void failedConflictResolution(String cacheName, CacheTopology currentTopology, @Cause Throwable t);
 

--- a/core/src/test/java/org/infinispan/conflict/impl/BaseMergePolicyTest.java
+++ b/core/src/test/java/org/infinispan/conflict/impl/BaseMergePolicyTest.java
@@ -87,7 +87,8 @@ public abstract class BaseMergePolicyTest extends BasePartitionHandlingTest {
       cache(p0.node(0)).put(conflictKey, "BEFORE SPLIT");
    }
 
-   protected void duringSplit(AdvancedCache preferredPartitionCache, AdvancedCache otherCache) {
+   protected void duringSplit(AdvancedCache preferredPartitionCache, AdvancedCache otherCache)
+         throws Exception {
       preferredPartitionCache.put(conflictKey, "DURING SPLIT");
    }
 

--- a/core/src/test/java/org/infinispan/conflict/impl/TxConflictResolutionTest.java
+++ b/core/src/test/java/org/infinispan/conflict/impl/TxConflictResolutionTest.java
@@ -1,0 +1,100 @@
+package org.infinispan.conflict.impl;
+
+import static org.infinispan.configuration.cache.CacheMode.DIST_SYNC;
+
+import org.infinispan.AdvancedCache;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.conflict.MergePolicy;
+import org.infinispan.distribution.MagicKey;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.transaction.LockingMode;
+import org.infinispan.transaction.TransactionMode;
+import org.testng.annotations.Test;
+
+/**
+ * Check that conflict resolution completes successfully in transactional caches with autocommit disabled.
+ *
+ * <ol>
+ * <li>do a split, and let k -> A, k -> null in the two partitions</li>
+ * <li>merge partitions</li>
+ * <li>check that all members read A</li>
+ * </ol>
+ *
+ * <p>See ISPN-12725.</p>
+ *
+ * @author Dan Berindei
+ * @since 12.1
+ */
+@Test(groups = "functional", testName = "conflict.impl.TxConflictResolutionTest")
+public class TxConflictResolutionTest extends BaseMergePolicyTest {
+
+   private static final String VAL = "A";
+   private boolean autoCommit;
+
+   @Override
+   public Object[] factory() {
+      return new Object[] {
+            new TxConflictResolutionTest().autoCommit(true).lockingMode(LockingMode.PESSIMISTIC),
+            new TxConflictResolutionTest().autoCommit(false).lockingMode(LockingMode.PESSIMISTIC),
+            new TxConflictResolutionTest().autoCommit(true).lockingMode(LockingMode.OPTIMISTIC),
+            new TxConflictResolutionTest().autoCommit(false).lockingMode(LockingMode.OPTIMISTIC),
+      };
+   }
+
+   public TxConflictResolutionTest() {
+      super(DIST_SYNC, null, new int[]{0,1}, new int[]{2,3});
+      this.mergePolicy = MergePolicy.PREFERRED_NON_NULL;
+      this.valueAfterMerge = VAL;
+   }
+
+   TxConflictResolutionTest autoCommit(boolean autoCommit) {
+      this.autoCommit = autoCommit;
+      return this;
+   }
+
+   @Override
+   protected String[] parameterNames() {
+      return concat(super.parameterNames(), new String[]{"autoCommit"});
+   }
+
+   @Override
+   protected Object[] parameterValues() {
+      return concat(super.parameterValues(), autoCommit);
+   }
+
+   @Override
+   protected void customizeCacheConfiguration(ConfigurationBuilder dcc) {
+      dcc.transaction()
+         .transactionMode(TransactionMode.TRANSACTIONAL)
+         .lockingMode(lockingMode)
+         .autoCommit(autoCommit);
+   }
+
+   @Override
+   protected void beforeSplit() {
+      conflictKey = new MagicKey(cache(p0.node(0)), cache(p1.node(0)));
+   }
+
+   @Override
+   protected void duringSplit(AdvancedCache preferredPartitionCache, AdvancedCache otherCache) throws Exception {
+      try {
+         tm(p0.node(0)).begin();
+         cache(p0.node(0)).put(conflictKey, VAL);
+      } finally {
+         tm(p0.node(0)).commit();
+      }
+
+      assertCacheGet(conflictKey, VAL, p0.getNodes());
+      assertCacheGet(conflictKey, null, p1.getNodes());
+   }
+
+   @Override
+   protected void performMerge() {
+      assertCacheGet(conflictKey, VAL, p0.getNodes());
+      assertCacheGet(conflictKey, null, p1.getNodes());
+
+      partition(0).merge(partition(1), false);
+      TestingUtil.waitForNoRebalance(caches());
+      assertCacheGet(conflictKey, VAL, cacheIndexes());
+   }
+}

--- a/core/src/test/java/org/infinispan/partitionhandling/BasePartitionHandlingTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/BasePartitionHandlingTest.java
@@ -22,6 +22,8 @@ import java.util.stream.Stream;
 
 import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
+import org.infinispan.commons.test.Exceptions;
+import org.infinispan.commons.test.TestResourceTracker;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.conflict.EntryMergePolicy;
@@ -33,10 +35,8 @@ import org.infinispan.notifications.cachemanagerlistener.event.ViewChangedEvent;
 import org.infinispan.partitionhandling.impl.PartitionHandlingManager;
 import org.infinispan.protostream.SerializationContextInitializer;
 import org.infinispan.remoting.transport.jgroups.JGroupsAddress;
-import org.infinispan.commons.test.Exceptions;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestDataSCI;
-import org.infinispan.commons.test.TestResourceTracker;
 import org.infinispan.test.fwk.TransportFlags;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -81,9 +81,17 @@ public class BasePartitionHandlingTest extends MultipleCacheManagersTest {
       if (biasAcquisition != null) {
          dcc.clustering().biasAcquisition(biasAcquisition);
       }
+      if (lockingMode != null) {
+         dcc.transaction().lockingMode(lockingMode);
+      }
+      customizeCacheConfiguration(dcc);
       createClusteredCaches(numMembersInCluster, serializationContextInitializer(), dcc,
                             new TransportFlags().withFD(true).withMerge(true));
       waitForClusterToForm();
+   }
+
+   protected void customizeCacheConfiguration(ConfigurationBuilder dcc) {
+
    }
 
    @AfterMethod(alwaysRun = true)

--- a/query-core/src/main/java/org/infinispan/query/core/impl/eventfilter/IckleFilterAndConverter.java
+++ b/query-core/src/main/java/org/infinispan/query/core/impl/eventfilter/IckleFilterAndConverter.java
@@ -78,7 +78,7 @@ public class IckleFilterAndConverter<K, V> extends AbstractKeyValueFilterConvert
    @Inject
    protected void injectDependencies(ComponentRegistry componentRegistry, QueryCache queryCache) {
       this.queryCache = queryCache;
-      cacheName = componentRegistry.getCache().getName();
+      cacheName = componentRegistry.getCache().wired().getName();
       matcher = componentRegistry.getComponent(matcherImplClass);
       if (matcher == null) {
          throw new CacheException("Expected component not found in registry: " + matcherImplClass.getName());


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12725
https://issues.redhat.com/browse/ISPN-12715
https://issues.redhat.com/browse/ISPN-12717

ISPN-12725 Conflict resolution fails in transactional cache with auto-commit disabled
ISPN-12715 Conflict resolution failure logged at debug level
ISPN-12717 DefaultConflictManager.getAllVersions fails in tx caches
