### PR TITLE
[11.0.x] ISPN-12725 Conflict resolution fails in transactional cache with auto-commit disabled

### DIFF
--- a/core/src/main/java/org/infinispan/conflict/impl/DefaultConflictManager.java
+++ b/core/src/main/java/org/infinispan/conflict/impl/DefaultConflictManager.java
@@ -110,7 +110,7 @@ public class DefaultConflictManager<K, V> implements InternalConflictManager<K, 
 
    @Start
    public void start() {
-      this.cacheName = cache.getName();
+      this.cacheName = cache.wired().getName();
       this.localAddress = rpcManager.getAddress();
 
       PartitionHandlingConfiguration config = cacheConfiguration.clustering().partitionHandling();
@@ -251,7 +251,6 @@ public class DefaultConflictManager<K, V> implements InternalConflictManager<K, 
             .toCompletableFuture();
       return conflictFuture.whenComplete((Void, t) -> {
          if (t != null) {
-            log.errorf("Cache %s encountered exception whilst trying to resolve conflicts on merge: %s", cacheName, t);
             if (conflictSpliterator != null) {
                conflictSpliterator.stop();
                conflictSpliterator = null;

--- a/core/src/main/java/org/infinispan/conflict/impl/DefaultConflictManager.java
+++ b/core/src/main/java/org/infinispan/conflict/impl/DefaultConflictManager.java
@@ -28,13 +28,15 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import org.infinispan.AdvancedCache;
+import javax.transaction.TransactionManager;
+
+import org.infinispan.cache.impl.InvocationHelper;
 import org.infinispan.commands.CommandsFactory;
+import org.infinispan.commands.VisitableCommand;
 import org.infinispan.commands.read.GetCacheEntryCommand;
 import org.infinispan.commands.remote.ClusteredGetCommand;
 import org.infinispan.commons.CacheException;
 import org.infinispan.commons.time.TimeService;
-import org.infinispan.commons.util.EnumUtil;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.PartitionHandlingConfiguration;
 import org.infinispan.conflict.EntryMergePolicy;
@@ -43,13 +45,15 @@ import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.container.entries.InternalCacheValue;
 import org.infinispan.container.entries.NullCacheEntry;
 import org.infinispan.container.impl.InternalEntryFactory;
-import org.infinispan.context.Flag;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.InvocationContextFactory;
 import org.infinispan.context.impl.FlagBitSets;
 import org.infinispan.distribution.DistributionInfo;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.distribution.LocalizedCacheTopology;
+import org.infinispan.distribution.ch.KeyPartitioner;
+import org.infinispan.factories.KnownComponentNames;
+import org.infinispan.factories.annotations.ComponentName;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
 import org.infinispan.factories.annotations.Stop;
@@ -67,6 +71,7 @@ import org.infinispan.remoting.transport.impl.MapResponseCollector;
 import org.infinispan.statetransfer.StateConsumer;
 import org.infinispan.topology.CacheTopology;
 import org.infinispan.util.concurrent.BlockingManager;
+import org.infinispan.util.concurrent.CompletableFutures;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -79,12 +84,14 @@ public class DefaultConflictManager<K, V> implements InternalConflictManager<K, 
    private static Log log = LogFactory.getLog(DefaultConflictManager.class);
    private static boolean trace = log.isTraceEnabled();
 
-   private static final long localFlags = EnumUtil.bitSetOf(Flag.CACHE_MODE_LOCAL, Flag.SKIP_OWNERSHIP_CHECK, Flag.SKIP_LOCKING);
-   private static final Flag[] userMergeFlags = new Flag[] {Flag.IGNORE_RETURN_VALUES};
-   private static final Flag[] autoMergeFlags = new Flag[] {Flag.IGNORE_RETURN_VALUES, Flag.PUT_FOR_STATE_TRANSFER, Flag.SKIP_REMOTE_LOOKUP};
+   private static final long localFlags = FlagBitSets.CACHE_MODE_LOCAL| FlagBitSets.SKIP_OWNERSHIP_CHECK| FlagBitSets.SKIP_LOCKING;
+   private static final long userMergeFlags = FlagBitSets.IGNORE_RETURN_VALUES;
+   private static final long autoMergeFlags = FlagBitSets.IGNORE_RETURN_VALUES | FlagBitSets.PUT_FOR_STATE_TRANSFER | FlagBitSets.SKIP_REMOTE_LOOKUP;
 
+   @ComponentName(KnownComponentNames.CACHE_NAME)
+   @Inject String cacheName;
    @Inject ComponentRef<AsyncInterceptorChain> interceptorChain;
-   @Inject ComponentRef<AdvancedCache<K, V>> cache;
+   @Inject InvocationHelper invocationHelper;
    @Inject Configuration cacheConfiguration;
    @Inject CommandsFactory commandsFactory;
    @Inject DistributionManager distributionManager;
@@ -96,8 +103,9 @@ public class DefaultConflictManager<K, V> implements InternalConflictManager<K, 
    @Inject TimeService timeService;
    @Inject BlockingManager blockingManager;
    @Inject InternalEntryFactory internalEntryFactory;
+   @Inject TransactionManager transactionManager;
+   @Inject KeyPartitioner keyPartitioner;
 
-   private String cacheName;
    private Address localAddress;
    private long conflictTimeout;
    private EntryMergePolicy<K, V> entryMergePolicy;
@@ -111,7 +119,6 @@ public class DefaultConflictManager<K, V> implements InternalConflictManager<K, 
 
    @Start
    public void start() {
-      this.cacheName = cache.wired().getName();
       this.localAddress = rpcManager.getAddress();
 
       PartitionHandlingConfiguration config = cacheConfiguration.clustering().partitionHandling();
@@ -272,7 +279,6 @@ public class DefaultConflictManager<K, V> implements InternalConflictManager<K, 
                                    final Set<Address> preferredNodes) {
       boolean userCall = preferredNodes == null;
       final Set<Address> preferredPartition = userCall ? new HashSet<>(topology.getCurrentCH().getMembers()) : preferredNodes;
-      final AdvancedCache<K, V> cache = this.cache.wired().withFlags(userCall ? userMergeFlags : autoMergeFlags);
 
       if (trace)
          log.tracef("Cache %s attempting to resolve conflicts.  All Members %s, Installed topology %s, Preferred Partition %s",
@@ -316,16 +322,10 @@ public class DefaultConflictManager<K, V> implements InternalConflictManager<K, 
             CacheEntry<K, V> mergedEntry = mergePolicy.merge(entry, otherEntries);
 
             CompletableFuture<V> future;
-            if (mergedEntry == null) {
-               if (trace) log.tracef("Cache %s executing remove on conflict: key %s", cacheName, key);
-               future = cache.removeAsync(key);
-            } else {
-               if (trace) log.tracef("Cache %s executing update on conflict: key %s with value %s", cacheName, key, mergedEntry.getValue());
-               future = cache.putAsync(key, mergedEntry.getValue(), mergedEntry.getMetadata());
-            }
-            future.whenComplete((responseMap, exception) -> {
-               if (trace) log.tracef("Cache %s resolveConflicts future complete for key %s: ResponseMap=%s, Exception=%s",
-                     cacheName, key, responseMap, exception);
+         future = applyMergeResult(userCall, key, mergedEntry);
+         future.whenComplete((responseMap, exception) -> {
+               if (trace) log.tracef("Cache %s resolveConflicts future complete for key %s: ResponseMap=%s",
+                     cacheName, key, responseMap);
 
                phaser.arriveAndDeregister();
                if (exception != null)
@@ -335,6 +335,27 @@ public class DefaultConflictManager<K, V> implements InternalConflictManager<K, 
       phaser.arriveAndAwaitAdvance();
 
       if (trace) log.tracef("Cache %s finished resolving conflicts for topologyId=%s", cacheName,  topology.getTopologyId());
+   }
+
+   private CompletableFuture<V> applyMergeResult(boolean userCall, K key, CacheEntry<K, V> mergedEntry) {
+      long flags = userCall ? userMergeFlags : autoMergeFlags;
+      VisitableCommand command;
+      if (mergedEntry == null) {
+         if (log.isTraceEnabled()) log.tracef("Cache %s executing remove on conflict: key %s", cacheName, key);
+         command = commandsFactory.buildRemoveCommand(key, null, keyPartitioner.getSegment(key), flags);
+      } else {
+         if (log.isTraceEnabled()) log.tracef("Cache %s executing update on conflict: key %s with value %s", cacheName, key, mergedEntry
+               .getValue());
+         command = commandsFactory.buildPutKeyValueCommand(key, mergedEntry.getValue(), keyPartitioner.getSegment(key),
+                                                           mergedEntry.getMetadata(), flags);
+      }
+      try {
+         assert transactionManager == null || transactionManager.getTransaction() == null : "Transaction active on conflict resolution thread";
+         InvocationContext ctx = invocationHelper.createInvocationContextWithImplicitTransaction(1, true);
+         return invocationHelper.invokeAsync(ctx, command);
+      } catch (Exception e) {
+         return CompletableFutures.completedExceptionFuture(e);
+      }
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/topology/ClusterCacheStatus.java
+++ b/core/src/main/java/org/infinispan/topology/ClusterCacheStatus.java
@@ -1099,7 +1099,7 @@ public class ClusterCacheStatus implements AvailabilityStrategyContext {
 
                   // TODO When CR fails because a node left the cluster, the new CR can start before we cancel the old one
                   Log.CLUSTER.failedConflictResolution(cacheName, topology, rootCause);
-                  eventLogger.info(EventLogCategory.CLUSTER, MESSAGES.conflictResolutionFailed(
+                  eventLogger.error(EventLogCategory.CLUSTER, MESSAGES.conflictResolutionFailed(
                      topology.getMembers(), topology.getTopologyId(), rootCause.getMessage()));
                   // If a node is suspected then we can't restart the CR until a new view is received, so we leave conflictResolution != null
                   // so that on a new view restartConflictResolution can return true

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -1788,7 +1788,7 @@ public interface Log extends BasicLogger {
    @Message(value = "Conflict resolution finished for cache %s with topology %s", id = 523)
    void finishedConflictResolution(String cacheName, CacheTopology currentTopology);
 
-   @LogMessage(level = DEBUG)
+   @LogMessage(level = ERROR)
    @Message(value = "Conflict resolution failed for cache %s with topology %s", id = 524)
    void failedConflictResolution(String cacheName, CacheTopology currentTopology, @Cause Throwable t);
 

--- a/core/src/test/java/org/infinispan/conflict/impl/BaseMergePolicyTest.java
+++ b/core/src/test/java/org/infinispan/conflict/impl/BaseMergePolicyTest.java
@@ -88,7 +88,8 @@ public abstract class BaseMergePolicyTest extends BasePartitionHandlingTest {
       cache(p0.node(0)).put(conflictKey, "BEFORE SPLIT");
    }
 
-   protected void duringSplit(AdvancedCache preferredPartitionCache, AdvancedCache otherCache) {
+   protected void duringSplit(AdvancedCache preferredPartitionCache, AdvancedCache otherCache)
+         throws Exception {
       preferredPartitionCache.put(conflictKey, "DURING SPLIT");
    }
 

--- a/core/src/test/java/org/infinispan/conflict/impl/TxConflictResolutionTest.java
+++ b/core/src/test/java/org/infinispan/conflict/impl/TxConflictResolutionTest.java
@@ -1,0 +1,100 @@
+package org.infinispan.conflict.impl;
+
+import static org.infinispan.configuration.cache.CacheMode.DIST_SYNC;
+
+import org.infinispan.AdvancedCache;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.conflict.MergePolicy;
+import org.infinispan.distribution.MagicKey;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.transaction.LockingMode;
+import org.infinispan.transaction.TransactionMode;
+import org.testng.annotations.Test;
+
+/**
+ * Check that conflict resolution completes successfully in transactional caches with autocommit disabled.
+ *
+ * <ol>
+ * <li>do a split, and let k -> A, k -> null in the two partitions</li>
+ * <li>merge partitions</li>
+ * <li>check that all members read A</li>
+ * </ol>
+ *
+ * <p>See ISPN-12725.</p>
+ *
+ * @author Dan Berindei
+ * @since 12.1
+ */
+@Test(groups = "functional", testName = "conflict.impl.TxConflictResolutionTest")
+public class TxConflictResolutionTest extends BaseMergePolicyTest {
+
+   private static final String VAL = "A";
+   private boolean autoCommit;
+
+   @Override
+   public Object[] factory() {
+      return new Object[] {
+            new TxConflictResolutionTest().autoCommit(true).lockingMode(LockingMode.PESSIMISTIC),
+            new TxConflictResolutionTest().autoCommit(false).lockingMode(LockingMode.PESSIMISTIC),
+            new TxConflictResolutionTest().autoCommit(true).lockingMode(LockingMode.OPTIMISTIC),
+            new TxConflictResolutionTest().autoCommit(false).lockingMode(LockingMode.OPTIMISTIC),
+      };
+   }
+
+   public TxConflictResolutionTest() {
+      super(DIST_SYNC, null, new int[]{0,1}, new int[]{2,3});
+      this.mergePolicy = MergePolicy.PREFERRED_NON_NULL;
+      this.valueAfterMerge = VAL;
+   }
+
+   TxConflictResolutionTest autoCommit(boolean autoCommit) {
+      this.autoCommit = autoCommit;
+      return this;
+   }
+
+   @Override
+   protected String[] parameterNames() {
+      return concat(super.parameterNames(), new String[]{"autoCommit"});
+   }
+
+   @Override
+   protected Object[] parameterValues() {
+      return concat(super.parameterValues(), autoCommit);
+   }
+
+   @Override
+   protected void customizeCacheConfiguration(ConfigurationBuilder dcc) {
+      dcc.transaction()
+         .transactionMode(TransactionMode.TRANSACTIONAL)
+         .lockingMode(lockingMode)
+         .autoCommit(autoCommit);
+   }
+
+   @Override
+   protected void beforeSplit() {
+      conflictKey = new MagicKey(cache(p0.node(0)), cache(p1.node(0)));
+   }
+
+   @Override
+   protected void duringSplit(AdvancedCache preferredPartitionCache, AdvancedCache otherCache) throws Exception {
+      try {
+         tm(p0.node(0)).begin();
+         cache(p0.node(0)).put(conflictKey, VAL);
+      } finally {
+         tm(p0.node(0)).commit();
+      }
+
+      assertCacheGet(conflictKey, VAL, p0.getNodes());
+      assertCacheGet(conflictKey, null, p1.getNodes());
+   }
+
+   @Override
+   protected void performMerge() {
+      assertCacheGet(conflictKey, VAL, p0.getNodes());
+      assertCacheGet(conflictKey, null, p1.getNodes());
+
+      partition(0).merge(partition(1), false);
+      TestingUtil.waitForNoRebalance(caches());
+      assertCacheGet(conflictKey, VAL, cacheIndexes());
+   }
+}

--- a/core/src/test/java/org/infinispan/partitionhandling/BasePartitionHandlingTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/BasePartitionHandlingTest.java
@@ -22,6 +22,8 @@ import java.util.stream.Stream;
 
 import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
+import org.infinispan.commons.test.Exceptions;
+import org.infinispan.commons.test.TestResourceTracker;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.conflict.EntryMergePolicy;
@@ -33,10 +35,8 @@ import org.infinispan.notifications.cachemanagerlistener.event.ViewChangedEvent;
 import org.infinispan.partitionhandling.impl.PartitionHandlingManager;
 import org.infinispan.protostream.SerializationContextInitializer;
 import org.infinispan.remoting.transport.jgroups.JGroupsAddress;
-import org.infinispan.commons.test.Exceptions;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestDataSCI;
-import org.infinispan.commons.test.TestResourceTracker;
 import org.infinispan.test.fwk.TransportFlags;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -81,9 +81,17 @@ public class BasePartitionHandlingTest extends MultipleCacheManagersTest {
       if (biasAcquisition != null) {
          dcc.clustering().biasAcquisition(biasAcquisition);
       }
+      if (lockingMode != null) {
+         dcc.transaction().lockingMode(lockingMode);
+      }
+      customizeCacheConfiguration(dcc);
       createClusteredCaches(numMembersInCluster, serializationContextInitializer(), dcc,
                             new TransportFlags().withFD(true).withMerge(true));
       waitForClusterToForm();
+   }
+
+   protected void customizeCacheConfiguration(ConfigurationBuilder dcc) {
+
    }
 
    @AfterMethod(alwaysRun = true)

--- a/query-core/src/main/java/org/infinispan/query/core/impl/eventfilter/IckleFilterAndConverter.java
+++ b/query-core/src/main/java/org/infinispan/query/core/impl/eventfilter/IckleFilterAndConverter.java
@@ -78,7 +78,7 @@ public class IckleFilterAndConverter<K, V> extends AbstractKeyValueFilterConvert
    @Inject
    protected void injectDependencies(ComponentRegistry componentRegistry, QueryCache queryCache) {
       this.queryCache = queryCache;
-      cacheName = componentRegistry.getCache().getName();
+      cacheName = componentRegistry.getCache().wired().getName();
       matcher = componentRegistry.getComponent(matcherImplClass);
       if (matcher == null) {
          throw new CacheException("Expected component not found in registry: " + matcherImplClass.getName());


### PR DESCRIPTION
Backport of https://github.com/infinispan/infinispan/pull/9051

https://issues.redhat.com/browse/ISPN-12725
https://issues.redhat.com/browse/ISPN-12715
https://issues.redhat.com/browse/ISPN-12717

ISPN-12725 Conflict resolution fails in transactional cache with auto-commit disabled
ISPN-12715 Conflict resolution failure logged at debug level
ISPN-12717 DefaultConflictManager.getAllVersions fails in tx caches