### PR TITLE
ISPN-12728 Add Persistent Memory to Soft Index File Store

### DIFF
--- a/build-configuration/pom.xml
+++ b/build-configuration/pom.xml
@@ -151,6 +151,7 @@
       <version.infinispan.doclets>1.3.0</version.infinispan.doclets>
       <version.infinispan.maven-plugins>1.0.2.Final</version.infinispan.maven-plugins>
       <version.io.agroal>1.8</version.io.agroal>
+      <version.io.mashona>1.0.0.Beta1</version.io.mashona>
       <version.jackson>2.11.0</version.jackson>
       <version.jackson.databind>2.11.0</version.jackson.databind>
       <version.jacoco>0.7.5.201505241946</version.jacoco>

--- a/persistence/soft-index/pom.xml
+++ b/persistence/soft-index/pom.xml
@@ -18,6 +18,11 @@
          <artifactId>metainf-services</artifactId>
       </dependency>
       <dependency>
+         <groupId>io.mashona</groupId>
+         <artifactId>mashona-logwriting</artifactId>
+         <optional>true</optional>
+      </dependency>
+      <dependency>
          <groupId>org.testng</groupId>
          <artifactId>testng</artifactId>
          <scope>test</scope>
@@ -95,6 +100,9 @@
                   <!-- TestNGSuiteChecksTest -->
                   <dependency>org.infinispan:infinispan-commons-test</dependency>
                </dependenciesToScan>
+               <classpathDependencyExcludes>
+                  <classpathDependencyExclude>io.mashona:mashona-logwriting</classpathDependencyExclude>
+               </classpathDependencyExcludes>
             </configuration>
          </plugin>
       </plugins>

--- a/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/SoftIndexFileStore.java
+++ b/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/SoftIndexFileStore.java
@@ -156,7 +156,8 @@ public class SoftIndexFileStore implements AdvancedLoadWriteStore<Object, Object
       temporaryTable = new TemporaryTable(configuration.indexQueueLength() * configuration.indexSegments());
       storeQueue = new SyncProcessingQueue<>();
       indexQueue = new IndexQueue(configuration.indexSegments(), configuration.indexQueueLength());
-      fileProvider = new FileProvider(getDataLocation(), configuration.openFilesLimit(), PREFIX_LATEST);
+      fileProvider = new FileProvider(getDataLocation(), configuration.openFilesLimit(), PREFIX_LATEST,
+            configuration.maxFileSize());
       compactor = new Compactor(fileProvider, temporaryTable, indexQueue, marshaller, timeService, configuration.maxFileSize(), configuration.compactionThreshold());
       logAppender = new LogAppender(storeQueue, indexQueue, temporaryTable, compactor, fileProvider, configuration.syncWrites(), configuration.maxFileSize());
       try {
@@ -174,11 +175,13 @@ public class SoftIndexFileStore implements AdvancedLoadWriteStore<Object, Object
       if (!configuration.purgeOnStartup()) {
          // we don't destroy the data on startup
          // get the old files
-         FileProvider oldFileProvider = new FileProvider(getDataLocation(), configuration.openFilesLimit(), PREFIX_10_1);
+         FileProvider oldFileProvider = new FileProvider(getDataLocation(), configuration.openFilesLimit(), PREFIX_10_1,
+               configuration.maxFileSize());
          if (oldFileProvider.hasFiles()) {
             throw PERSISTENCE.persistedDataMigrationAcrossMajorVersions();
          }
-         oldFileProvider = new FileProvider(getDataLocation(), configuration.openFilesLimit(), PREFIX_11_0);
+         oldFileProvider = new FileProvider(getDataLocation(), configuration.openFilesLimit(), PREFIX_11_0,
+               configuration.maxFileSize());
          if (oldFileProvider.hasFiles()) {
             migrateFromOldFormat(oldFileProvider);
             migrateData = true;

--- a/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/pmem/PmemUtilWrapper.java
+++ b/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/pmem/PmemUtilWrapper.java
@@ -1,0 +1,22 @@
+package org.infinispan.persistence.sifs.pmem;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.nio.channels.FileChannel;
+
+import io.mashona.logwriting.PmemUtil;
+
+/**
+ * This class is here solely for the purpose of encapsulating the {@link PmemUtil} class so we do not load it unless
+ * necessary, allowing this to be an optional dependency. Any code that invokes a method in this class should first
+ * check if the {@link PmemUtil} can be loaded via {@link Class#forName(String)} otherwise a {@link ClassNotFoundException}
+ * may be thrown when loading this class.
+ */
+public class PmemUtilWrapper {
+   /**
+    * Same as {@link PmemUtil#pmemChannelFor(File, int, boolean, boolean)}.
+    */
+   static public FileChannel pmemChannelFor(File file, int length, boolean create, boolean readSharedMetadata) throws FileNotFoundException {
+      return PmemUtil.pmemChannelFor(file, length, create, readSharedMetadata);
+   }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -620,6 +620,11 @@
             <version>${versionx.io.fabric8.kubernetes-client}</version>
          </dependency>
          <dependency>
+            <groupId>io.mashona</groupId>
+            <artifactId>mashona-logwriting</artifactId>
+            <version>${version.io.mashona}</version>
+         </dependency>
+         <dependency>
             <groupId>io.smallrye.config</groupId>
             <artifactId>smallrye-config</artifactId>
             <version>${version.smallrye-config}</version>

--- a/tools/src/main/java/org/infinispan/tools/store/migrator/file/SoftIndexFileStoreIterator.java
+++ b/tools/src/main/java/org/infinispan/tools/store/migrator/file/SoftIndexFileStoreIterator.java
@@ -60,11 +60,11 @@ public class SoftIndexFileStoreIterator implements StoreIterator {
 
       SoftIndexIterator() {
          if (majorVersion < 11) {
-            this.fileProvider = new FileProvider(location, 1000, SoftIndexFileStore.PREFIX_10_1);
+            this.fileProvider = new FileProvider(location, 1000, SoftIndexFileStore.PREFIX_10_1, 1024 * 1024);
             this.reader = EntryRecord::read10_1EntryHeader;
          } else {
             String prefix = majorVersion == 11 ? SoftIndexFileStore.PREFIX_11_0 : SoftIndexFileStore.PREFIX_12_0;
-            this.fileProvider = new FileProvider(location, 1000, prefix);
+            this.fileProvider = new FileProvider(location, 1000, prefix, 1024 * 1024);
             this.reader = EntryRecord::readEntryHeader;
          }
          this.iterator = fileProvider.getFileIterator();


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12728

This adds in support for persistent memory usage. The mashona library will only return a non null FileChannel if it was able to allocate it with persistent memory. In the case it is null we just fall back to the prior code as normal.

Unfortunately, there is no way to test this currently. However, Jonathan Halliday tested this before. We may need to discuss further with him how we can properly test this long term though.