### PR TITLE
ISPN-12739 Spring Session Repository should copy the MapSession for each request

### DIFF
--- a/spring/spring5/spring5-common/src/main/java/org/infinispan/spring/common/session/AbstractInfinispanSessionRepository.java
+++ b/spring/spring5/spring5-common/src/main/java/org/infinispan/spring/common/session/AbstractInfinispanSessionRepository.java
@@ -1,12 +1,8 @@
 package org.infinispan.spring.common.session;
 
 import java.time.Instant;
-import java.util.Collections;
-import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import org.infinispan.spring.common.provider.SpringCache;
 import org.springframework.beans.factory.DisposableBean;
@@ -32,7 +28,6 @@ public abstract class AbstractInfinispanSessionRepository implements FindByIndex
 
    protected final AbstractApplicationPublisherBridge applicationEventPublisher;
    protected final SpringCache cache;
-   protected final PrincipalNameResolver principalNameResolver = new PrincipalNameResolver();
 
    protected AbstractInfinispanSessionRepository(SpringCache cache, AbstractApplicationPublisherBridge eventsBridge) {
       Objects.requireNonNull(cache, "SpringCache can not be null");
@@ -116,17 +111,5 @@ public abstract class AbstractInfinispanSessionRepository implements FindByIndex
          cache.put(session.getId(), session, session.getMaxInactiveInterval().getSeconds(), TimeUnit.SECONDS);
       }
       return session;
-   }
-
-   @Override
-   public Map<String, MapSession> findByIndexNameAndIndexValue(String indexName, String indexValue) {
-      if (!PRINCIPAL_NAME_INDEX_NAME.equals(indexName)) {
-         return Collections.emptyMap();
-      }
-
-      return cache.getNativeCache().values().stream()
-            .map(cacheValue -> (MapSession) cacheValue)
-            .filter(session -> indexValue.equals(principalNameResolver.resolvePrincipal(session)))
-            .collect(Collectors.toMap(MapSession::getId, Function.identity()));
    }
 }

--- a/spring/spring5/spring5-common/src/main/java/org/infinispan/spring/common/session/PrincipalNameResolver.java
+++ b/spring/spring5/spring5-common/src/main/java/org/infinispan/spring/common/session/PrincipalNameResolver.java
@@ -15,10 +15,15 @@ import org.springframework.session.Session;
  * @since 9.0
  */
 public class PrincipalNameResolver {
+   private static final PrincipalNameResolver INSTANCE = new PrincipalNameResolver();
 
    private static final String SPRING_SECURITY_CONTEXT = "SPRING_SECURITY_CONTEXT";
 
-   private SpelExpressionParser parser = new SpelExpressionParser();
+   private final SpelExpressionParser parser = new SpelExpressionParser();
+
+   public static PrincipalNameResolver getInstance() {
+      return INSTANCE;
+   }
 
    /**
     * Resolves Principal Name (e.g. user name) based on session.

--- a/spring/spring5/spring5-embedded/src/main/java/org/infinispan/spring/embedded/session/InfinispanEmbeddedSessionRepository.java
+++ b/spring/spring5/spring5-embedded/src/main/java/org/infinispan/spring/embedded/session/InfinispanEmbeddedSessionRepository.java
@@ -1,9 +1,16 @@
 package org.infinispan.spring.embedded.session;
 
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
 import org.infinispan.Cache;
 import org.infinispan.context.Flag;
 import org.infinispan.spring.common.provider.SpringCache;
 import org.infinispan.spring.common.session.AbstractInfinispanSessionRepository;
+import org.infinispan.spring.common.session.PrincipalNameResolver;
+import org.springframework.session.MapSession;
 
 /**
  * Session Repository for Infinispan in Embedded mode.
@@ -26,5 +33,17 @@ public class InfinispanEmbeddedSessionRepository extends AbstractInfinispanSessi
    protected void removeFromCacheWithoutNotifications(String originalId) {
       Cache nativeCache = (Cache) cache.getNativeCache();
       nativeCache.getAdvancedCache().withFlags(Flag.SKIP_LISTENER_NOTIFICATION).remove(originalId);
+   }
+
+   @Override
+   public Map<String, MapSession> findByIndexNameAndIndexValue(String indexName, String indexValue) {
+      if (!PRINCIPAL_NAME_INDEX_NAME.equals(indexName)) {
+         return Collections.emptyMap();
+      }
+
+      Cache<String, MapSession> embeddedCache = (Cache<String, MapSession>) cache.getNativeCache();
+      return embeddedCache.values().stream()
+                          .filter(session -> indexValue.equals(PrincipalNameResolver.getInstance().resolvePrincipal(session)))
+                          .collect(() -> Collectors.toMap(MapSession::getId, Function.identity()));
    }
 }

--- a/spring/spring5/spring5-embedded/src/test/java/org/infinispan/spring/embedded/session/InfinispanEmbeddedSessionRepositoryTest.java
+++ b/spring/spring5/spring5-embedded/src/test/java/org/infinispan/spring/embedded/session/InfinispanEmbeddedSessionRepositoryTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.spring.embedded.session;
 
+import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.spring.common.provider.SpringCache;
@@ -16,10 +17,17 @@ import org.testng.annotations.Test;
 public class InfinispanEmbeddedSessionRepositoryTest extends InfinispanSessionRepositoryTCK {
 
    private EmbeddedCacheManager embeddedCacheManager;
+   private EmbeddedCacheManager cacheManager2;
+   private EmbeddedCacheManager cacheManager3;
+
 
    @BeforeClass
    public void beforeClass() {
-      embeddedCacheManager = TestCacheManagerFactory.createCacheManager(new ConfigurationBuilder());
+      ConfigurationBuilder defaultCacheBuilder = new ConfigurationBuilder();
+      defaultCacheBuilder.clustering().cacheMode(CacheMode.DIST_SYNC);
+      embeddedCacheManager = TestCacheManagerFactory.createClusteredCacheManager(defaultCacheBuilder);
+      cacheManager2 = TestCacheManagerFactory.createClusteredCacheManager(defaultCacheBuilder);
+      cacheManager3 = TestCacheManagerFactory.createClusteredCacheManager(defaultCacheBuilder);
    }
 
    @AfterMethod
@@ -30,6 +38,8 @@ public class InfinispanEmbeddedSessionRepositoryTest extends InfinispanSessionRe
    @AfterClass
    public void afterClass() {
       embeddedCacheManager.stop();
+      cacheManager2.stop();
+      cacheManager3.stop();
    }
 
    @BeforeMethod


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12739
https://issues.redhat.com/browse/ISPN-12751

Fixes `ConcurrentModificationException` during session serialization.
Includes fix for ISPN-12751 InfinispanEmbeddedSessionRepository.findByIndexNameAndIndexValue() fails in distributed cache

