### PR TITLE
ISPN-12435 SingleKeyBackupWriteCommands run out of memory

### DIFF
--- a/core/src/main/java/org/infinispan/commands/CommandsFactory.java
+++ b/core/src/main/java/org/infinispan/commands/CommandsFactory.java
@@ -59,6 +59,7 @@ import org.infinispan.commands.statetransfer.StateTransferCancelCommand;
 import org.infinispan.commands.statetransfer.StateTransferGetListenersCommand;
 import org.infinispan.commands.statetransfer.StateTransferGetTransactionsCommand;
 import org.infinispan.commands.statetransfer.StateTransferStartCommand;
+import org.infinispan.commands.triangle.BackupNoopCommand;
 import org.infinispan.commands.triangle.MultiEntriesFunctionalBackupWriteCommand;
 import org.infinispan.commands.triangle.MultiKeyFunctionalBackupWriteCommand;
 import org.infinispan.commands.triangle.PutMapBackupWriteCommand;
@@ -604,6 +605,8 @@ public interface CommandsFactory {
    MultiEntriesFunctionalBackupWriteCommand buildMultiEntriesFunctionalBackupWriteCommand();
 
    MultiKeyFunctionalBackupWriteCommand buildMultiKeyFunctionalBackupWriteCommand();
+
+   BackupNoopCommand buildBackupNoopCommand();
 
    <K, R> ReductionPublisherRequestCommand<K> buildKeyReductionPublisherCommand(boolean parallelStream, DeliveryGuarantee deliveryGuarantee,
          IntSet segments, Set<K> keys, Set<K> excludedKeys, boolean includeLoader,

--- a/core/src/main/java/org/infinispan/commands/CommandsFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/commands/CommandsFactoryImpl.java
@@ -60,6 +60,7 @@ import org.infinispan.commands.statetransfer.StateTransferCancelCommand;
 import org.infinispan.commands.statetransfer.StateTransferGetListenersCommand;
 import org.infinispan.commands.statetransfer.StateTransferGetTransactionsCommand;
 import org.infinispan.commands.statetransfer.StateTransferStartCommand;
+import org.infinispan.commands.triangle.BackupNoopCommand;
 import org.infinispan.commands.triangle.MultiEntriesFunctionalBackupWriteCommand;
 import org.infinispan.commands.triangle.MultiKeyFunctionalBackupWriteCommand;
 import org.infinispan.commands.triangle.PutMapBackupWriteCommand;
@@ -647,6 +648,11 @@ public class CommandsFactoryImpl implements CommandsFactory {
    @Override
    public MultiKeyFunctionalBackupWriteCommand buildMultiKeyFunctionalBackupWriteCommand() {
       return new MultiKeyFunctionalBackupWriteCommand(cacheName);
+   }
+
+   @Override
+   public BackupNoopCommand buildBackupNoopCommand() {
+         return new BackupNoopCommand(cacheName);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/commands/RemoteCommandsFactory.java
+++ b/core/src/main/java/org/infinispan/commands/RemoteCommandsFactory.java
@@ -59,6 +59,7 @@ import org.infinispan.commands.topology.RebalanceStartCommand;
 import org.infinispan.commands.topology.RebalanceStatusRequestCommand;
 import org.infinispan.commands.topology.TopologyUpdateCommand;
 import org.infinispan.commands.topology.TopologyUpdateStableCommand;
+import org.infinispan.commands.triangle.BackupNoopCommand;
 import org.infinispan.commands.triangle.MultiEntriesFunctionalBackupWriteCommand;
 import org.infinispan.commands.triangle.MultiKeyFunctionalBackupWriteCommand;
 import org.infinispan.commands.triangle.PutMapBackupWriteCommand;
@@ -416,6 +417,9 @@ public class RemoteCommandsFactory {
                break;
             case MultiKeyFunctionalBackupWriteCommand.COMMAND_ID:
                command = new MultiKeyFunctionalBackupWriteCommand(cacheName);
+               break;
+            case BackupNoopCommand.COMMAND_ID:
+               command = new BackupNoopCommand(cacheName);
                break;
             case InvalidateVersionsCommand.COMMAND_ID:
                command = new InvalidateVersionsCommand(cacheName);

--- a/core/src/main/java/org/infinispan/commands/triangle/BackupNoopCommand.java
+++ b/core/src/main/java/org/infinispan/commands/triangle/BackupNoopCommand.java
@@ -1,0 +1,63 @@
+package org.infinispan.commands.triangle;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+import org.infinispan.commands.write.WriteCommand;
+import org.infinispan.util.ByteString;
+
+/**
+ * A command that tell a backup owner to ignore a sequence id after the primary failed to send a regular write command.
+ *
+ * @author Dan Berindei
+ * @since 12.1
+ */
+public class BackupNoopCommand extends BackupWriteCommand {
+
+   public static final byte COMMAND_ID = 81;
+   //for testing
+   @SuppressWarnings("unused")
+   public BackupNoopCommand() {
+      super(null);
+   }
+
+   public BackupNoopCommand(ByteString cacheName) {
+      super(cacheName);
+   }
+
+   @Override
+   public byte getCommandId() {
+      return COMMAND_ID;
+   }
+
+   public void setWriteCommand(WriteCommand command) {
+      super.setCommonAttributesFromCommand(command);
+   }
+
+
+   @Override
+   public void writeTo(ObjectOutput output) throws IOException {
+      writeBase(output);
+   }
+
+   @Override
+   public void readFrom(ObjectInput input) throws IOException, ClassNotFoundException {
+      readBase(input);
+   }
+
+   @Override
+   public String toString() {
+      return "BackupNoopCommand{" + toStringFields() + '}';
+   }
+
+   @Override
+   WriteCommand createWriteCommand() {
+      return null;
+   }
+
+   @Override
+   String toStringFields() {
+      return super.toStringFields();
+   }
+}

--- a/core/src/main/java/org/infinispan/commands/triangle/BackupWriteCommand.java
+++ b/core/src/main/java/org/infinispan/commands/triangle/BackupWriteCommand.java
@@ -16,6 +16,7 @@ import org.infinispan.context.impl.FlagBitSets;
 import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.util.ByteString;
+import org.infinispan.util.concurrent.CompletableFutures;
 
 /**
  * A write operation sent from the primary owner to the backup owners.
@@ -45,6 +46,10 @@ public abstract class BackupWriteCommand extends BaseRpcCommand {
    @Override
    public final CompletionStage<?> invokeAsync(ComponentRegistry componentRegistry) {
       WriteCommand command = createWriteCommand();
+      if (command == null) {
+         // No-op command
+         return CompletableFutures.completedNull();
+      }
       command.init(componentRegistry);
       command.setFlagsBitSet(flags);
       // Mark the command as a backup write and skip locking

--- a/core/src/main/java/org/infinispan/marshall/exts/CacheRpcCommandExternalizer.java
+++ b/core/src/main/java/org/infinispan/marshall/exts/CacheRpcCommandExternalizer.java
@@ -34,6 +34,7 @@ import org.infinispan.commands.statetransfer.StateTransferCancelCommand;
 import org.infinispan.commands.statetransfer.StateTransferGetListenersCommand;
 import org.infinispan.commands.statetransfer.StateTransferGetTransactionsCommand;
 import org.infinispan.commands.statetransfer.StateTransferStartCommand;
+import org.infinispan.commands.triangle.BackupNoopCommand;
 import org.infinispan.commands.triangle.MultiEntriesFunctionalBackupWriteCommand;
 import org.infinispan.commands.triangle.MultiKeyFunctionalBackupWriteCommand;
 import org.infinispan.commands.triangle.PutMapBackupWriteCommand;
@@ -105,6 +106,7 @@ public final class CacheRpcCommandExternalizer extends AbstractExternalizer<Cach
             PutMapBackupWriteCommand.class,
             MultiEntriesFunctionalBackupWriteCommand.class,
             MultiKeyFunctionalBackupWriteCommand.class,
+            BackupNoopCommand.class,
             InvalidateVersionsCommand.class,
             RevokeBiasCommand.class, RenewBiasCommand.class, ReductionPublisherRequestCommand.class,
             MultiClusterEventCommand.class, InitialPublisherCommand.class, NextPublisherCommand.class,

--- a/core/src/main/java/org/infinispan/remoting/inboundhandler/TrianglePerCacheInboundInvocationHandler.java
+++ b/core/src/main/java/org/infinispan/remoting/inboundhandler/TrianglePerCacheInboundInvocationHandler.java
@@ -17,6 +17,7 @@ import org.infinispan.commands.statetransfer.StateTransferCancelCommand;
 import org.infinispan.commands.statetransfer.StateTransferGetListenersCommand;
 import org.infinispan.commands.statetransfer.StateTransferGetTransactionsCommand;
 import org.infinispan.commands.statetransfer.StateTransferStartCommand;
+import org.infinispan.commands.triangle.BackupNoopCommand;
 import org.infinispan.commands.triangle.BackupWriteCommand;
 import org.infinispan.commands.triangle.MultiEntriesFunctionalBackupWriteCommand;
 import org.infinispan.commands.triangle.MultiKeyFunctionalBackupWriteCommand;
@@ -83,6 +84,7 @@ public class TrianglePerCacheInboundInvocationHandler extends BasePerCacheInboun
                return;
             case SingleKeyBackupWriteCommand.COMMAND_ID:
             case SingleKeyFunctionalBackupWriteCommand.COMMAND_ID:
+            case BackupNoopCommand.COMMAND_ID:
                handleSingleKeyBackupCommand((BackupWriteCommand) command);
                break;
             case PutMapBackupWriteCommand.COMMAND_ID:

--- a/core/src/test/java/org/infinispan/distribution/TriangleExceptionDuringMarshallingTest.java
+++ b/core/src/test/java/org/infinispan/distribution/TriangleExceptionDuringMarshallingTest.java
@@ -1,0 +1,220 @@
+package org.infinispan.distribution;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singleton;
+import static org.infinispan.commons.test.Exceptions.expectException;
+import static org.infinispan.test.TestingUtil.extractCacheTopology;
+import static org.infinispan.test.TestingUtil.extractComponent;
+import static org.infinispan.test.TestingUtil.extractInterceptorChain;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.infinispan.Cache;
+import org.infinispan.commons.marshall.JavaSerializationMarshaller;
+import org.infinispan.commons.marshall.MarshallingException;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.interceptors.AsyncInterceptorChain;
+import org.infinispan.interceptors.distribution.TriangleDistributionInterceptor;
+import org.infinispan.remoting.RemoteException;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.TestException;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.MarshallingExceptionGenerator;
+import org.infinispan.util.ControlledConsistentHashFactory;
+import org.infinispan.util.concurrent.CommandAckCollector;
+import org.infinispan.util.concurrent.locks.LockManager;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Test that ack collectors are closed properly after a marshalling exception.
+ *
+ * <p>See ISPN-12435</p>
+ *
+ * @author Dan Berindei
+ * @since 12.1
+ */
+@Test(groups = "unit", testName = "distribution.TriangleExceptionDuringMarshallingTest")
+public class TriangleExceptionDuringMarshallingTest extends MultipleCacheManagersTest {
+   public static final int NUM_SEGMENTS = 3;
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      GlobalConfigurationBuilder globalBuilder = GlobalConfigurationBuilder.defaultClusteredBuilder();
+      globalBuilder.serialization().marshaller(new JavaSerializationMarshaller());
+      globalBuilder.serialization().allowList()
+                   .addClasses(MagicKey.class, MarshallingExceptionGenerator.class);
+
+      ConfigurationBuilder cacheBuilder = new ConfigurationBuilder();
+      ControlledConsistentHashFactory<?> chf =
+            new ControlledConsistentHashFactory.Default(new int[][]{{0, 1}, {1, 2}, {2, 0}});
+      cacheBuilder.clustering().cacheMode(CacheMode.DIST_SYNC)
+                  .hash().numSegments(NUM_SEGMENTS).consistentHashFactory(chf);
+
+      createCluster(globalBuilder, cacheBuilder, 3);
+
+      // Make sure we're using the triangle algorithm
+      AsyncInterceptorChain asyncInterceptorChain = extractInterceptorChain(cache(0));
+      assertTrue(asyncInterceptorChain.containsInterceptorType(TriangleDistributionInterceptor.class));
+   }
+
+   public void testExceptionDuringMarshallingOnOriginator() {
+      // fail during the first serialization (i.e. on the originator)
+      Object value = MarshallingExceptionGenerator.failOnSerialization(0);
+
+      Cache<Object, Object> originCache = cache(0);
+      MagicKey primaryKey = new MagicKey("primary", cache(0));
+      expectException(MarshallingException.class, () -> originCache.put(primaryKey, value));
+      assertCleanFailure(originCache, primaryKey);
+
+      MagicKey nonOwnerKey = new MagicKey("non-owner", cache(1));
+      expectException(MarshallingException.class, () -> originCache.put(nonOwnerKey, value));
+      assertCleanFailure(originCache, nonOwnerKey);
+
+      MagicKey backupKey = new MagicKey("backup", cache(2));
+      expectException(MarshallingException.class, () -> originCache.put(backupKey, value));
+      assertCleanFailure(originCache, backupKey);
+   }
+
+   public void testExceptionDuringMarshallingOnRemote() {
+      // fail during the second serialization, i.e. remotely
+      Object value = MarshallingExceptionGenerator.failOnSerialization(1);
+
+      Cache<Object, Object> originCache = cache(0);
+      // does not fail when the originator is the primary, as there is no remote serialization
+      MagicKey primaryKey = new MagicKey("primary", cache(0));
+      originCache.put(primaryKey, value);
+      originCache.remove(primaryKey);
+
+      // fails when the originator is not an owner
+      MagicKey nonOwnerKey = new MagicKey("non-owner", cache(1));
+      expectException(RemoteException.class, MarshallingException.class, () -> originCache.put(nonOwnerKey, value));
+      assertCleanFailure(originCache, nonOwnerKey);
+
+      // fails when the originator is a backup
+      MagicKey backupKey = new MagicKey("backup", cache(2));
+      expectException(RemoteException.class, MarshallingException.class, () -> originCache.put(backupKey, value));
+      assertCleanFailure(originCache, backupKey);
+   }
+
+   @Test(enabled = false, description = "See ISPN-12770")
+   public void testExceptionDuringUnmarshalling() {
+      // fail during the second serialization, i.e. remotely
+      Object value = MarshallingExceptionGenerator.failOnDeserialization(0);
+
+      Cache<Object, Object> originCache = cache(0);
+      MagicKey primaryKey = new MagicKey("primary", cache(0));
+      expectException(MarshallingException.class, () -> originCache.put(primaryKey, value));
+      assertCleanFailure(originCache, primaryKey);
+
+      MagicKey nonOwnerKey = new MagicKey("non-owner", cache(1));
+      expectException(MarshallingException.class, () -> originCache.put(nonOwnerKey, value));
+      assertCleanFailure(originCache, nonOwnerKey);
+
+      MagicKey backupKey = new MagicKey("backup", cache(2));
+      expectException(MarshallingException.class, () -> originCache.put(backupKey, value));
+      assertCleanFailure(originCache, backupKey);
+   }
+
+   private void assertCleanFailure(Cache<Object, Object> originCache, MagicKey key) {
+      // verify that ack collector it cleaned up and value is not inserted
+      assertInvocationIsDone(singleton(key));
+      assertCacheIsEmpty();
+
+      // verify that a put and remove with the same key and a marshallable value succeeds
+      originCache.put(key, "good_value");
+      originCache.remove(key);
+   }
+
+   public void testExceptionDuringMarshallingOnOriginatorMultiKey() {
+      MarshallingExceptionGenerator value = MarshallingExceptionGenerator.failOnSerialization(0);
+      Map<Object, Object> values = new HashMap<>();
+      values.put(new MagicKey(cache(0)), value);
+      values.put(new MagicKey(cache(1)), value);
+      values.put(new MagicKey(cache(2)), value);
+
+      for (Cache<Object, Object> cache : caches()) {
+         expectException(MarshallingException.class, () -> cache.putAll(values));
+         assertInvocationIsDone(values.keySet());
+         assertCacheIsEmpty();
+      }
+   }
+
+   public void testExceptionDuringMarshallingOnRemoteMultiKey() {
+      MarshallingExceptionGenerator value = MarshallingExceptionGenerator.failOnSerialization(1);
+      Map<Object, Object> values = new HashMap<>();
+      values.put(new MagicKey(cache(0)), value);
+      values.put(new MagicKey(cache(1)), value);
+      values.put(new MagicKey(cache(2)), value);
+
+      for (Cache<Object, Object> cache : caches()) {
+         expectException(RemoteException.class, MarshallingException.class, () -> cache.putAll(values));
+         assertInvocationIsDone(values.keySet());
+
+         for (Object key : values.keySet()) {
+            cache.remove(key);
+         }
+      }
+   }
+
+   private void assertCacheIsEmpty() {
+      for (Cache<Object, Object> cache : caches()) {
+         assertEquals(0, cache.getAdvancedCache().getDataContainer().sizeIncludingExpired());
+      }
+   }
+
+   private void assertInvocationIsDone(Collection<?> keys) {
+      for (Cache<Object, Object> cache : caches()) {
+         CommandAckCollector ackCollector = extractComponent(cache, CommandAckCollector.class);
+         assertEquals(emptyList(), ackCollector.getPendingCommands());
+
+         LockManager lm = TestingUtil.extractLockManager(cache);
+         for (Object key : keys) {
+            assert !lm.isLocked(key);
+         }
+      }
+   }
+
+   @AfterMethod(alwaysRun = true)
+   public void cleanup() {
+      LocalizedCacheTopology cacheTopology = extractCacheTopology(cache(0));
+      int topologyId = cacheTopology.getTopologyId();
+
+      for (Cache<Object, Object> cache : caches()) {
+         // Complete pending commands
+         CommandAckCollector ackCollector = extractComponent(cache, CommandAckCollector.class);
+         for (Long pendingCommand : ackCollector.getPendingCommands()) {
+            ackCollector.completeExceptionally(pendingCommand, new TestException(), topologyId);
+         }
+
+         // Release locks
+         LockManager lockManager = extractComponent(cache, LockManager.class);
+         assertEquals(0, lockManager.getNumberOfLocksHeld());
+      }
+
+      // Mark all sequence ids as delivered
+      for (int segment = 0; segment < NUM_SEGMENTS; segment++) {
+         DistributionInfo segmentDistribution = cacheTopology.getSegmentDistribution(segment);
+         Address primary = segmentDistribution.primary();
+         Cache<?, ?> primaryCache = manager(primary).getCache();
+         long latestSequenceId = extractComponent(primaryCache, TriangleOrderManager.class)
+               .latestSent(segment, topologyId);
+
+         for (int i = 0; i <= latestSequenceId; i++) {
+            for (Address backup : segmentDistribution.writeBackups()) {
+               Cache<Object, Object> backupCache = manager(backup).getCache();
+               extractComponent(backupCache, TriangleOrderManager.class)
+                     .markDelivered(segment, i, topologyId);
+            }
+         }
+      }
+   }
+
+}

--- a/core/src/test/java/org/infinispan/remoting/rpc/RpcManagerTest.java
+++ b/core/src/test/java/org/infinispan/remoting/rpc/RpcManagerTest.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.concurrent.CompletionStage;
 
 import org.infinispan.commands.remote.ClusteredGetCommand;
+import org.infinispan.commons.test.Exceptions;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.distribution.DistributionManager;
@@ -24,7 +25,6 @@ import org.infinispan.remoting.transport.impl.MapResponseCollector;
 import org.infinispan.remoting.transport.impl.SingleResponseCollector;
 import org.infinispan.remoting.transport.jgroups.JGroupsAddress;
 import org.infinispan.remoting.transport.jgroups.SuspectException;
-import org.infinispan.commons.test.Exceptions;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.topology.CacheTopology;

--- a/core/src/test/java/org/infinispan/test/fwk/MarshallingExceptionGenerator.java
+++ b/core/src/test/java/org/infinispan/test/fwk/MarshallingExceptionGenerator.java
@@ -1,0 +1,62 @@
+package org.infinispan.test.fwk;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+import org.infinispan.test.TestException;
+
+/**
+ * Class that throws an exception on serialization or deserialization.
+ *
+ * @author Dan Berindei
+ * @since 12.1
+ */
+public class MarshallingExceptionGenerator implements Externalizable {
+   private int countDownToMarshallingException;
+   private int countDownToUnmarshallingException;
+
+   public static MarshallingExceptionGenerator failOnSerialization(int count) {
+      return new MarshallingExceptionGenerator(count, -1);
+   }
+
+   public static MarshallingExceptionGenerator failOnDeserialization(int count) {
+      return new MarshallingExceptionGenerator(-1, count);
+   }
+
+   public MarshallingExceptionGenerator(int countDownToMarshallingException, int countDownToUnmarshallingException) {
+      this.countDownToMarshallingException = countDownToMarshallingException;
+      this.countDownToUnmarshallingException = countDownToUnmarshallingException;
+   }
+
+   public MarshallingExceptionGenerator() {
+      this(0, 0);
+   }
+
+   @Override
+   public String toString() {
+      return "MarshallingExceptionGenerator{" +
+             "countDownToMarshallingException=" + countDownToMarshallingException +
+             ", countDownToUnmarshallingException=" + countDownToUnmarshallingException +
+             '}';
+   }
+
+   @Override
+   public void writeExternal(ObjectOutput out) throws IOException {
+      if (countDownToMarshallingException == 0) {
+         throw new TestException();
+      }
+      out.writeInt(countDownToMarshallingException - 1);
+      out.writeInt(countDownToUnmarshallingException - 1);
+   }
+
+   @Override
+   public void readExternal(ObjectInput in) throws IOException {
+      this.countDownToMarshallingException = in.readInt();
+      this.countDownToUnmarshallingException = in.readInt();
+      if (countDownToUnmarshallingException == -1) {
+         throw new TestException();
+      }
+   }
+}

--- a/core/src/test/java/org/infinispan/util/mocks/ControlledCommandFactory.java
+++ b/core/src/test/java/org/infinispan/util/mocks/ControlledCommandFactory.java
@@ -66,6 +66,7 @@ import org.infinispan.commands.statetransfer.StateTransferCancelCommand;
 import org.infinispan.commands.statetransfer.StateTransferGetListenersCommand;
 import org.infinispan.commands.statetransfer.StateTransferGetTransactionsCommand;
 import org.infinispan.commands.statetransfer.StateTransferStartCommand;
+import org.infinispan.commands.triangle.BackupNoopCommand;
 import org.infinispan.commands.triangle.MultiEntriesFunctionalBackupWriteCommand;
 import org.infinispan.commands.triangle.MultiKeyFunctionalBackupWriteCommand;
 import org.infinispan.commands.triangle.PutMapBackupWriteCommand;
@@ -621,6 +622,11 @@ public class ControlledCommandFactory implements CommandsFactory {
    @Override
    public MultiKeyFunctionalBackupWriteCommand buildMultiKeyFunctionalBackupWriteCommand() {
       return actual.buildMultiKeyFunctionalBackupWriteCommand();
+   }
+
+   @Override
+   public BackupNoopCommand buildBackupNoopCommand() {
+      return actual.buildBackupNoopCommand();
    }
 
    @Override


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12435

* JGroupsTransport: complete request exceptionally instead of
  throwing an exception when marshalling fails.
* TriangleDistributionInterceptor: catch exception from JGroupsTransport
  when there is no request (sendToX methods).