### PR TITLE
ISPN-6494 Change the default bundler to transfer-queue

### DIFF
--- a/core/src/main/resources/default-configs/default-jgroups-azure.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-azure.xml
@@ -12,7 +12,7 @@
         thread_naming_pattern="pl"
         send_buf_size="640k"
         sock_conn_timeout="300"
-        bundler_type="no-bundler"
+        bundler_type="transfer-queue"
 
         thread_pool.min_threads="${jgroups.thread_pool.min_threads:0}"
         thread_pool.max_threads="${jgroups.thread_pool.max_threads:200}"

--- a/core/src/main/resources/default-configs/default-jgroups-ec2.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-ec2.xml
@@ -12,7 +12,7 @@
         thread_naming_pattern="pl"
         send_buf_size="640k"
         sock_conn_timeout="300"
-        bundler_type="no-bundler"
+        bundler_type="transfer-queue"
 
         thread_pool.min_threads="${jgroups.thread_pool.min_threads:0}"
         thread_pool.max_threads="${jgroups.thread_pool.max_threads:200}"

--- a/core/src/main/resources/default-configs/default-jgroups-google.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-google.xml
@@ -13,7 +13,7 @@
         thread_naming_pattern="pl"
         send_buf_size="640k"
         sock_conn_timeout="300"
-        bundler_type="no-bundler"
+        bundler_type="transfer-queue"
 
         thread_pool.min_threads="${jgroups.thread_pool.min_threads:0}"
         thread_pool.max_threads="${jgroups.thread_pool.max_threads:200}"

--- a/core/src/main/resources/default-configs/default-jgroups-kubernetes.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-kubernetes.xml
@@ -13,7 +13,7 @@
         thread_naming_pattern="pl"
         send_buf_size="640k"
         sock_conn_timeout="300"
-        bundler_type="no-bundler"
+        bundler_type="transfer-queue"
         logical_addr_cache_expiration="360000"
         port_range="0"
 

--- a/core/src/main/resources/default-configs/default-jgroups-tcp.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-tcp.xml
@@ -8,7 +8,7 @@
         thread_naming_pattern="pl"
         send_buf_size="640k"
         sock_conn_timeout="300"
-        bundler_type="no-bundler"
+        bundler_type="transfer-queue"
 
         thread_pool.min_threads="${jgroups.thread_pool.min_threads:0}"
         thread_pool.max_threads="${jgroups.thread_pool.max_threads:200}"

--- a/core/src/main/resources/default-configs/default-jgroups-udp.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-udp.xml
@@ -14,7 +14,7 @@
         ip_ttl="${jgroups.ip_ttl:2}"
         thread_naming_pattern="pl"
         enable_diagnostics="false"
-        bundler_type="no-bundler"
+        bundler_type="transfer-queue"
         max_bundle_size="8500"
 
         thread_pool.min_threads="${jgroups.thread_pool.min_threads:0}"

--- a/core/src/test/java/org/infinispan/configuration/JsonSerializationTest.java
+++ b/core/src/test/java/org/infinispan/configuration/JsonSerializationTest.java
@@ -349,7 +349,7 @@ public class JsonSerializationTest extends AbstractInfinispanTest {
       assertEquals("20000000", tcp.at("recv_buf_size").asString());
       assertEquals("640000", tcp.at("send_buf_size").asString());
       assertEquals("300", tcp.at("sock_conn_timeout").asString());
-      assertEquals("no-bundler", tcp.at("bundler_type").asString());
+      assertEquals("transfer-queue", tcp.at("bundler_type").asString());
       assertEquals("0", tcp.at("thread_pool.min_threads").asString());
       assertEquals("25", tcp.at("thread_pool.max_threads").asString());
       assertEquals("5000", tcp.at("thread_pool.keep_alive_time").asString());

--- a/core/src/test/resources/configs/config-with-jgroups-stack.xml
+++ b/core/src/test/resources/configs/config-with-jgroups-stack.xml
@@ -12,7 +12,7 @@
         <stack name="mping">
             <TCP bind_addr="127.0.0.1"
                  bind_port="7800" port_range="30" recv_buf_size="20000000" send_buf_size="640000"
-                 sock_conn_timeout="300" bundler_type="no-bundler"
+                 sock_conn_timeout="300" bundler_type="transfer-queue"
                  thread_pool.min_threads="0" thread_pool.max_threads="25" thread_pool.keep_alive_time="5000"
                  thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
                  xmlns="urn:org:jgroups"/>

--- a/core/src/test/resources/configs/unified/10.0.xml
+++ b/core/src/test/resources/configs/unified/10.0.xml
@@ -11,7 +11,7 @@
       <!-- Inline definition -->
       <stack name="mping">
          <TCP bind_port="7800" port_range="30" recv_buf_size="20000000" send_buf_size="640000"
-              sock_conn_timeout="300" bundler_type="no-bundler"
+              sock_conn_timeout="300" bundler_type="transfer-queue"
               thread_pool.min_threads="0" thread_pool.max_threads="25" thread_pool.keep_alive_time="5000"
               xmlns="urn:org:jgroups"/>
          <MPING break_on_coord_rsp="true"

--- a/core/src/test/resources/configs/unified/10.1.xml
+++ b/core/src/test/resources/configs/unified/10.1.xml
@@ -11,7 +11,7 @@
       <!-- Inline definition -->
       <stack name="mping">
          <TCP bind_port="7800" port_range="30" recv_buf_size="20000000" send_buf_size="640000"
-              sock_conn_timeout="300" bundler_type="no-bundler"
+              sock_conn_timeout="300" bundler_type="transfer-queue"
               thread_pool.min_threads="0" thread_pool.max_threads="25" thread_pool.keep_alive_time="5000"
               xmlns="urn:org:jgroups"/>
          <MPING break_on_coord_rsp="true"

--- a/core/src/test/resources/configs/unified/11.0.xml
+++ b/core/src/test/resources/configs/unified/11.0.xml
@@ -11,7 +11,7 @@
       <!-- Inline definition -->
       <stack name="mping">
          <TCP bind_port="7800" port_range="30" recv_buf_size="20000000" send_buf_size="640000"
-              sock_conn_timeout="300" bundler_type="no-bundler"
+              sock_conn_timeout="300" bundler_type="transfer-queue"
               thread_pool.min_threads="0" thread_pool.max_threads="25" thread_pool.keep_alive_time="5000"
               xmlns="urn:org:jgroups"/>
          <MPING break_on_coord_rsp="true"

--- a/core/src/test/resources/configs/unified/12.0.xml
+++ b/core/src/test/resources/configs/unified/12.0.xml
@@ -12,7 +12,7 @@
       <!-- Inline definition -->
       <stack name="mping">
          <TCP bind_port="7800" port_range="30" recv_buf_size="20000000" send_buf_size="640000"
-              sock_conn_timeout="300" bundler_type="no-bundler"
+              sock_conn_timeout="300" bundler_type="transfer-queue"
               thread_pool.min_threads="0" thread_pool.max_threads="25" thread_pool.keep_alive_time="5000"
               thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
               xmlns="urn:org:jgroups"/>

--- a/core/src/test/resources/configs/unified/12.1.xml
+++ b/core/src/test/resources/configs/unified/12.1.xml
@@ -12,7 +12,7 @@
       <!-- Inline definition -->
       <stack name="mping">
          <TCP bind_port="7800" port_range="30" recv_buf_size="20000000" send_buf_size="640000"
-              sock_conn_timeout="300" bundler_type="no-bundler"
+              sock_conn_timeout="300" bundler_type="transfer-queue"
               thread_pool.min_threads="0" thread_pool.max_threads="25" thread_pool.keep_alive_time="5000"
               thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
               xmlns="urn:org:jgroups"/>

--- a/core/src/test/resources/configs/xsite/bridge.xml
+++ b/core/src/test/resources/configs/xsite/bridge.xml
@@ -9,7 +9,7 @@
          send_buf_size="640000"
          sock_conn_timeout="300"
          enable_diagnostics="false"
-         bundler_type="no-bundler"
+         bundler_type="transfer-queue"
 
          thread_pool.min_threads="0"
          thread_pool.max_threads="8"

--- a/core/src/test/resources/configs/xsite/xsite-inline-test.xml
+++ b/core/src/test/resources/configs/xsite/xsite-inline-test.xml
@@ -13,7 +13,7 @@
               send_buf_size="640000"
               sock_conn_timeout="300"
               enable_diagnostics="false"
-              bundler_type="no-bundler"
+              bundler_type="transfer-queue"
 
               thread_pool.min_threads="0"
               thread_pool.max_threads="8"

--- a/core/src/test/resources/stacks/broken-tcp.xml
+++ b/core/src/test/resources/stacks/broken-tcp.xml
@@ -10,7 +10,7 @@
          max_bundle_size="8500"
          enable_diagnostics="false"
          tcp_nodelay="true"
-         bundler_type="no-bundler"
+         bundler_type="transfer-queue"
 
          thread_naming_pattern="pl"
 

--- a/core/src/test/resources/stacks/tcp.xml
+++ b/core/src/test/resources/stacks/tcp.xml
@@ -9,7 +9,7 @@
          recv_buf_size="20m"
          send_buf_size="640k"
          enable_diagnostics="false"
-         bundler_type="no-bundler"
+         bundler_type="transfer-queue"
 
          thread_naming_pattern="pl"
 

--- a/core/src/test/resources/stacks/tcp_mping/tcp1.xml
+++ b/core/src/test/resources/stacks/tcp_mping/tcp1.xml
@@ -7,7 +7,7 @@
         recv_buf_size="20000000"
         send_buf_size="640000"
         sock_conn_timeout="300"
-        bundler_type="no-bundler"
+        bundler_type="transfer-queue"
 
         thread_pool.min_threads="0"
         thread_pool.max_threads="25"

--- a/core/src/test/resources/stacks/tcp_mping/tcp2.xml
+++ b/core/src/test/resources/stacks/tcp_mping/tcp2.xml
@@ -7,7 +7,7 @@
         recv_buf_size="20000000"
         send_buf_size="640000"
         sock_conn_timeout="300"
-        bundler_type="no-bundler"
+        bundler_type="transfer-queue"
 
         thread_pool.min_threads="0"
         thread_pool.max_threads="25"

--- a/core/src/test/resources/stacks/udp.xml
+++ b/core/src/test/resources/stacks/udp.xml
@@ -14,7 +14,7 @@
          max_bundle_size="8500"
          ip_ttl="${jgroups.udp.ip_ttl:2}"
          enable_diagnostics="false"
-         bundler_type="no-bundler"
+         bundler_type="transfer-queue"
 
          thread_naming_pattern="pl"
 

--- a/documentation/src/main/asciidoc/topics/upgrading.adoc
+++ b/documentation/src/main/asciidoc/topics/upgrading.adoc
@@ -6,6 +6,11 @@
 The retransmission interval (`UNICAST3.xmit_interval` and `NAKACK2.xmit_interval`) is now 200ms, instead of 100ms.
 The maximum number of messages requested per retransmission (`UNICAST3.max_xmit_req_size` and `NAKACK2.max_xmit_req_size`) is now 500, instead of 8500 (with UDP) or 64000 (with TCP).
 
+=== Message bundler
+The default JGroups bundler has changed from
+"no-bundler" (a thread sending a message writes it to the TCP socket or sends the UDP datagram directly) to
+"transfer-queue" (a thread sending a message only adds the message to a queue, and a separate
+bundler thread groups the messages in "batches" then sends the batches).
 
 == Encoding
 

--- a/hibernate/cache-commons/src/test/resources/2lc-test-tcp.xml
+++ b/hibernate/cache-commons/src/test/resources/2lc-test-tcp.xml
@@ -13,7 +13,7 @@
         thread_naming_pattern="pl"
         send_buf_size="640k"
         sock_conn_timeout="300"
-        bundler_type="no-bundler"
+        bundler_type="transfer-queue"
 
         thread_pool.min_threads="${jgroups.thread_pool.min_threads:0}"
         thread_pool.max_threads="${jgroups.thread_pool.max_threads:200}"

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node0.xml
@@ -6,7 +6,7 @@
          bind_port="7800" port_range="10"
          recv_buf_size="20000000"
          send_buf_size="640000"
-         bundler_type="no-bundler"
+         bundler_type="transfer-queue"
          enable_diagnostics="true"
          thread_naming_pattern="cl"
 

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1-fail.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1-fail.xml
@@ -6,7 +6,7 @@
          bind_port="7800" port_range="10"
          recv_buf_size="20000000"
          send_buf_size="640000"
-         bundler_type="no-bundler"
+         bundler_type="transfer-queue"
          enable_diagnostics="true"
          thread_naming_pattern="cl"
 

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1.xml
@@ -6,7 +6,7 @@
          bind_port="7800" port_range="10"
          recv_buf_size="20000000"
          send_buf_size="640000"
-         bundler_type="no-bundler"
+         bundler_type="transfer-queue"
          enable_diagnostics="true"
          thread_naming_pattern="cl"
 

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node0.xml
@@ -6,7 +6,7 @@
          bind_port="7800" port_range="10"
          recv_buf_size="20000000"
          send_buf_size="640000"
-         bundler_type="no-bundler"
+         bundler_type="transfer-queue"
          enable_diagnostics="true"
          thread_naming_pattern="cl"
 

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node1.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node1.xml
@@ -6,7 +6,7 @@
          bind_port="7800" port_range="10"
          recv_buf_size="20000000"
          send_buf_size="640000"
-         bundler_type="no-bundler"
+         bundler_type="transfer-queue"
          enable_diagnostics="true"
          thread_naming_pattern="cl"
 

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-user-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-user-node0.xml
@@ -6,7 +6,7 @@
          bind_port="7800" port_range="10"
          recv_buf_size="20000000"
          send_buf_size="640000"
-         bundler_type="no-bundler"
+         bundler_type="transfer-queue"
          enable_diagnostics="true"
          thread_naming_pattern="cl"
 

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node0.xml
@@ -6,7 +6,7 @@
          bind_port="7800" port_range="10"
          recv_buf_size="20000000"
          send_buf_size="640000"
-         bundler_type="no-bundler"
+         bundler_type="transfer-queue"
          enable_diagnostics="true"
          thread_naming_pattern="cl"
 

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node1.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node1.xml
@@ -6,7 +6,7 @@
          bind_port="7800" port_range="10"
          recv_buf_size="20000000"
          send_buf_size="640000"
-         bundler_type="no-bundler"
+         bundler_type="transfer-queue"
          enable_diagnostics="true"
          thread_naming_pattern="cl"
 

--- a/persistence/jdbc/src/test/resources/configs/as7/jdbc-standalone.xml
+++ b/persistence/jdbc/src/test/resources/configs/as7/jdbc-standalone.xml
@@ -147,7 +147,7 @@
                     <property name="thread_pool.max_threads">200</property>
                     <property name="thread_pool.keep_alive_time">5000000000</property>
                     <property name="max_bundle_size">8500</property>
-                    <property name="bundler_type">no-bundler</property>
+                    <property name="bundler_type">transfer-queue</property>
                 </transport>
                 <protocol type="PING">
                     <property name="timeout">5000</property>

--- a/server/testdriver/junit5/src/test/resources/jgroups/xsite-stacks.xml
+++ b/server/testdriver/junit5/src/test/resources/jgroups/xsite-stacks.xml
@@ -34,7 +34,7 @@
            ip_ttl="${jgroups.ip_ttl:2}"
            thread_naming_pattern="pl"
            enable_diagnostics="false"
-           bundler_type="no-bundler"
+           bundler_type="transfer-queue"
            max_bundle_size="8500"
 
            thread_pool.min_threads="${jgroups.thread_pool.min_threads:0}"

--- a/server/tests/src/test/resources/configuration/jgroups/xsite-stacks.xml
+++ b/server/tests/src/test/resources/configuration/jgroups/xsite-stacks.xml
@@ -34,7 +34,7 @@
            ip_ttl="${jgroups.ip_ttl:2}"
            thread_naming_pattern="pl"
            enable_diagnostics="false"
-           bundler_type="no-bundler"
+           bundler_type="transfer-queue"
            max_bundle_size="8500"
 
            thread_pool.min_threads="${jgroups.thread_pool.min_threads:0}"

--- a/tools/src/test/resources/udp.xml
+++ b/tools/src/test/resources/udp.xml
@@ -14,7 +14,7 @@
          max_bundle_size="8500"
          ip_ttl="${jgroups.udp.ip_ttl:2}"
          enable_diagnostics="false"
-         bundler_type="no-bundler"
+         bundler_type="transfer-queue"
 
          thread_naming_pattern="pl"
 


### PR DESCRIPTION
Do not close ISPN-6494, bundlers still need evaluating.