### PR TITLE
[9.4.x] ISPN-12807 Simple cache does not update eviction statistics

### DIFF
--- a/core/src/main/java/org/infinispan/eviction/impl/EvictionManagerImpl.java
+++ b/core/src/main/java/org/infinispan/eviction/impl/EvictionManagerImpl.java
@@ -8,10 +8,12 @@ import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.ImmutableContext;
 import org.infinispan.eviction.EvictionManager;
 import org.infinispan.factories.annotations.Inject;
+import org.infinispan.factories.annotations.Start;
 import org.infinispan.factories.impl.ComponentRef;
 import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.interceptors.impl.CacheMgmtInterceptor;
 import org.infinispan.notifications.cachelistener.CacheNotifier;
+import org.infinispan.stats.impl.StatsCollector;
 
 import net.jcip.annotations.ThreadSafe;
 
@@ -20,6 +22,15 @@ public class EvictionManagerImpl<K, V> implements EvictionManager<K, V> {
    @Inject private CacheNotifier<K, V> cacheNotifier;
    @Inject private ComponentRef<AsyncInterceptorChain> interceptorChain;
    @Inject private Configuration cfg;
+   @Inject private StatsCollector simpleCacheStatsCollector;
+
+   private CacheMgmtInterceptor cacheMgmtInterceptor;
+
+   @Start
+   public void findCacheMgmtInterceptor() {
+      // Allow the interceptor chain to start later, otherwise we'd have a dependency cycle
+      cacheMgmtInterceptor = interceptorChain.wired().findInterceptorExtending(CacheMgmtInterceptor.class);
+   }
 
    @Override
    public void onEntryEviction(Map<? extends K, InternalCacheEntry<? extends K, ? extends V>> evicted) {
@@ -41,10 +52,10 @@ public class EvictionManagerImpl<K, V> implements EvictionManager<K, V> {
    }
 
    private void updateEvictionStatistics(Map<? extends K, InternalCacheEntry<? extends K, ? extends V>> evicted) {
-      CacheMgmtInterceptor mgmtInterceptor =
-            interceptorChain.running().findInterceptorExtending(CacheMgmtInterceptor.class);
-      if (mgmtInterceptor != null) {
-         mgmtInterceptor.addEvictions(evicted.size());
+      if (cacheMgmtInterceptor != null) {
+         cacheMgmtInterceptor.addEvictions(evicted.size());
+      } else if (simpleCacheStatsCollector != null) {
+         simpleCacheStatsCollector.recordEvictions(evicted.size());
       }
    }
 }

--- a/core/src/main/java/org/infinispan/factories/InterceptorChainFactory.java
+++ b/core/src/main/java/org/infinispan/factories/InterceptorChainFactory.java
@@ -14,6 +14,7 @@ import org.infinispan.configuration.cache.StoreConfiguration;
 import org.infinispan.factories.annotations.DefaultFactoryFor;
 import org.infinispan.interceptors.AsyncInterceptor;
 import org.infinispan.interceptors.AsyncInterceptorChain;
+import org.infinispan.interceptors.EmptyAsyncInterceptorChain;
 import org.infinispan.interceptors.InterceptorChain;
 import org.infinispan.interceptors.distribution.BiasedScatteredDistributionInterceptor;
 import org.infinispan.interceptors.distribution.DistributionBulkInterceptor;
@@ -379,7 +380,7 @@ public class InterceptorChainFactory extends AbstractNamedCacheComponentFactory 
    public Object construct(String componentName) {
       try {
          if (configuration.simpleCache())
-            return null;
+            return EmptyAsyncInterceptorChain.INSTANCE;
 
          if (componentName.equals(AsyncInterceptorChain.class.getName())) {
             AsyncInterceptorChain asyncInterceptorChain = buildInterceptorChain();


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12807
https://issues.redhat.com/browse/ISPN-9901

EvictionManagerImpl must work with both CacheMgmtInterceptor
(regular cache) and StatsCollector (simple cache).

Backport of #9103 