### PR TITLE
[9.3.x] ISPN-12807 Simple cache does not update eviction statistics

### DIFF
--- a/core/src/main/java/org/infinispan/factories/InterceptorChainFactory.java
+++ b/core/src/main/java/org/infinispan/factories/InterceptorChainFactory.java
@@ -14,6 +14,7 @@ import org.infinispan.configuration.cache.StoreConfiguration;
 import org.infinispan.factories.annotations.DefaultFactoryFor;
 import org.infinispan.interceptors.AsyncInterceptor;
 import org.infinispan.interceptors.AsyncInterceptorChain;
+import org.infinispan.interceptors.EmptyAsyncInterceptorChain;
 import org.infinispan.interceptors.InterceptorChain;
 import org.infinispan.interceptors.distribution.BiasedScatteredDistributionInterceptor;
 import org.infinispan.interceptors.distribution.DistributionBulkInterceptor;
@@ -380,6 +381,9 @@ public class InterceptorChainFactory extends AbstractNamedCacheComponentFactory 
    @Override
    public <T> T construct(Class<T> componentType) {
       try {
+         if (configuration.simpleCache())
+            return componentType.cast(EmptyAsyncInterceptorChain.INSTANCE);
+
          AsyncInterceptorChain asyncInterceptorChain = buildInterceptorChain();
          if (componentType == InterceptorChain.class) {
             return componentType.cast(componentRegistry.getComponent(InterceptorChain.class));

--- a/core/src/main/java/org/infinispan/factories/InternalCacheFactory.java
+++ b/core/src/main/java/org/infinispan/factories/InternalCacheFactory.java
@@ -47,7 +47,6 @@ import org.infinispan.partitionhandling.PartitionHandling;
 import org.infinispan.partitionhandling.impl.PartitionHandlingManager;
 import org.infinispan.persistence.manager.PersistenceManager;
 import org.infinispan.persistence.manager.PersistenceManagerStub;
-import org.infinispan.stats.impl.StatsCollector;
 import org.infinispan.transaction.xa.recovery.RecoveryAdminOperations;
 import org.infinispan.upgrade.RollingUpgradeManager;
 import org.infinispan.util.TimeService;
@@ -155,9 +154,6 @@ public class InternalCacheFactory<K, V> extends AbstractNamedCacheComponentFacto
       componentRegistry = new ComponentRegistry(cacheName, configuration, cache, globalComponentRegistry, globalComponentRegistry.getClassLoader()) {
          @Override
          protected void bootstrapComponents() {
-            if (statisticsAvailable) {
-               registerComponent(new StatsCollector.Factory(), StatsCollector.Factory.class);
-            }
             registerComponent(new ClusterEventManagerStub<K, V>(), ClusterEventManager.class);
             registerComponent(new PassivationManagerStub(), PassivationManager.class);
             registerComponent(new ActivationManagerStub(), ActivationManager.class);

--- a/core/src/test/java/org/infinispan/api/APINonTxTest.java
+++ b/core/src/test/java/org/infinispan/api/APINonTxTest.java
@@ -66,8 +66,10 @@ public class APINonTxTest extends SingleCacheManagerTest {
    @AfterMethod
    public void checkForLeakedTransactions() {
       TransactionTable txTable = TestingUtil.getTransactionTable(cache);
-      assertEquals(0, txTable.getLocalTxCount());
-      assertEquals(0, txTable.getLocalTransactions().size());
+      if (txTable != null) {
+         assertEquals(0, txTable.getLocalTxCount());
+         assertEquals(0, txTable.getLocalTransactions().size());
+      }
    }
 
    @Override


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12807

EvictionManagerImpl must work with both CacheMgmtInterceptor
(regular cache) and StatsCollector (simple cache).

Backport of #9104 