### PR TITLE
Use finally block to close resource for better fault tolerance.

### DIFF
--- a/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/stringbased/JdbcStringBasedStore.java
+++ b/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/stringbased/JdbcStringBasedStore.java
@@ -525,7 +525,7 @@ public class JdbcStringBasedStore<K,V> implements SegmentedAdvancedLoadWriteStor
          }
          ps.setFetchSize(tableManager.getFetchSize());
          ResultSet rs = ps.executeQuery();
-         return function.apply(rs).doOnComplete(() -> JdbcUtil.safeClose(rs));
+         return function.apply(rs).doFinally(() -> JdbcUtil.safeClose(rs));
       }, FlowableConnection::close);
    }
 


### PR DESCRIPTION
This change swaps out a method call to use another to cover normal operation and exceptions. 