### PR TITLE
ISPN-12808 Per-cache Hot Rod client marshaller

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/DataFormat.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/DataFormat.java
@@ -3,6 +3,7 @@ package org.infinispan.client.hotrod;
 import static org.infinispan.client.hotrod.marshall.MarshallerUtil.bytes2obj;
 import static org.infinispan.client.hotrod.marshall.MarshallerUtil.obj2bytes;
 
+import org.infinispan.client.hotrod.configuration.RemoteCacheConfiguration;
 import org.infinispan.client.hotrod.impl.MarshallerRegistry;
 import org.infinispan.client.hotrod.logging.Log;
 import org.infinispan.client.hotrod.logging.LogFactory;
@@ -62,10 +63,27 @@ public final class DataFormat {
       return marshaller == null ? null : marshaller.mediaType();
    }
 
+   /**
+    * @deprecated Replaced by {@link #initialize(RemoteCacheManager, String, boolean)}.
+    */
+   @Deprecated
    public void initialize(RemoteCacheManager remoteCacheManager, boolean serverObjectStorage) {
       this.marshallerRegistry = remoteCacheManager.getMarshallerRegistry();
       this.defaultMarshaller = remoteCacheManager.getMarshaller();
       this.isObjectStorage = serverObjectStorage;
+   }
+
+   public void initialize(RemoteCacheManager remoteCacheManager, String cacheName, boolean serverObjectStorage) {
+      this.marshallerRegistry = remoteCacheManager.getMarshallerRegistry();
+      this.isObjectStorage = serverObjectStorage;
+      this.defaultMarshaller = remoteCacheManager.getMarshaller();
+      RemoteCacheConfiguration remoteCacheConfiguration = remoteCacheManager.getConfiguration().remoteCaches().get(cacheName);
+      if (remoteCacheConfiguration != null) {
+         Marshaller cacheMarshaller = remoteCacheConfiguration.marshaller();
+         if (cacheMarshaller != null) {
+            defaultMarshaller = cacheMarshaller;
+         }
+      }
    }
 
    private Marshaller resolveValueMarshaller() {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
@@ -572,9 +572,9 @@ public class RemoteCacheManager implements RemoteCacheContainer, Closeable, Remo
    // Method that handles cache initialization - needed as a placeholder
    private void initRemoteCache(InternalRemoteCache<?, ?> remoteCache, OperationsFactory operationsFactory) {
       if (configuration.statistics().jmxEnabled()) {
-         remoteCache.init(marshaller, operationsFactory, configuration, mbeanObjectName);
+         remoteCache.init(operationsFactory, configuration, mbeanObjectName);
       } else {
-         remoteCache.init(marshaller, operationsFactory, configuration);
+         remoteCache.init(operationsFactory, configuration);
       }
    }
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/Configuration.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/Configuration.java
@@ -6,6 +6,7 @@ import static org.infinispan.client.hotrod.impl.ConfigurationProperties.AUTH_CLI
 import static org.infinispan.client.hotrod.impl.ConfigurationProperties.AUTH_SERVER_NAME;
 import static org.infinispan.client.hotrod.impl.ConfigurationProperties.BATCH_SIZE;
 import static org.infinispan.client.hotrod.impl.ConfigurationProperties.CACHE_CONFIGURATION_SUFFIX;
+import static org.infinispan.client.hotrod.impl.ConfigurationProperties.CACHE_MARSHALLER;
 import static org.infinispan.client.hotrod.impl.ConfigurationProperties.CACHE_NEAR_CACHE_MODE_SUFFIX;
 import static org.infinispan.client.hotrod.impl.ConfigurationProperties.CACHE_PREFIX;
 import static org.infinispan.client.hotrod.impl.ConfigurationProperties.CACHE_TEMPLATE_NAME_SUFFIX;
@@ -477,6 +478,9 @@ public class Configuration {
          }
          properties.setProperty(prefix + CACHE_NEAR_CACHE_MODE_SUFFIX, remoteCache.nearCacheMode().name());
          properties.setProperty(prefix + CACHE_NEAR_CACHE_MODE_SUFFIX, remoteCache.nearCacheMaxEntries());
+         if (remoteCache.marshaller() != null) {
+            properties.setProperty(prefix + CACHE_MARSHALLER, remoteCache.marshaller().getClass().getName());
+         }
       }
 
       return properties;

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/RemoteCacheConfiguration.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/RemoteCacheConfiguration.java
@@ -5,6 +5,7 @@ import org.infinispan.commons.configuration.BuiltBy;
 import org.infinispan.commons.configuration.attributes.Attribute;
 import org.infinispan.commons.configuration.attributes.AttributeDefinition;
 import org.infinispan.commons.configuration.attributes.AttributeSet;
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.commons.tx.lookup.TransactionManagerLookup;
 
 /**
@@ -22,13 +23,15 @@ public class RemoteCacheConfiguration {
    public static final AttributeDefinition<String> TEMPLATE_NAME = AttributeDefinition.builder("template-name", null, String.class).build();
    public static final AttributeDefinition<TransactionMode> TRANSACTION_MODE = AttributeDefinition.builder("transaction-mode", TransactionMode.NONE).build();
    public static final AttributeDefinition<TransactionManagerLookup> TRANSACTION_MANAGER = AttributeDefinition.builder("transaction-manager", GenericTransactionManagerLookup.getInstance(), TransactionManagerLookup.class).build();
+   public static final AttributeDefinition<Marshaller> MARSHALLER = AttributeDefinition.builder("marshaller", null, Marshaller.class).build();
 
    static AttributeSet attributeDefinitionSet() {
-      return new AttributeSet(RemoteCacheConfiguration.class, CONFIGURATION, FORCE_RETURN_VALUES, NAME, NEAR_CACHE_MODE, NEAR_CACHE_MAX_ENTRIES, NEAR_CACHE_BLOOM_FILTER, TEMPLATE_NAME, TRANSACTION_MODE, TRANSACTION_MANAGER);
+      return new AttributeSet(RemoteCacheConfiguration.class, CONFIGURATION, FORCE_RETURN_VALUES, NAME, MARSHALLER, NEAR_CACHE_MODE, NEAR_CACHE_MAX_ENTRIES, NEAR_CACHE_BLOOM_FILTER, TEMPLATE_NAME, TRANSACTION_MODE, TRANSACTION_MANAGER);
    }
 
    private final Attribute<String> configuration;
    private final Attribute<Boolean> forceReturnValues;
+   private final Attribute<Marshaller> marshaller;
    private final Attribute<String> name;
    private final Attribute<NearCacheMode> nearCacheMode;
    private final Attribute<Integer> nearCacheMaxEntries;
@@ -43,6 +46,7 @@ public class RemoteCacheConfiguration {
       configuration = attributes.attribute(CONFIGURATION);
       forceReturnValues = attributes.attribute(FORCE_RETURN_VALUES);
       name = attributes.attribute(NAME);
+      marshaller = attributes.attribute(MARSHALLER);
       nearCacheMode = attributes.attribute(NEAR_CACHE_MODE);
       nearCacheMaxEntries = attributes.attribute(NEAR_CACHE_MAX_ENTRIES);
       nearCacheBloomFilter = attributes.attribute(NEAR_CACHE_BLOOM_FILTER);
@@ -61,6 +65,10 @@ public class RemoteCacheConfiguration {
 
    public String name() {
       return name.get();
+   }
+
+   public Marshaller marshaller() {
+      return marshaller.get();
    }
 
    public NearCacheMode nearCacheMode() {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/RemoteCacheConfigurationBuilder.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/RemoteCacheConfigurationBuilder.java
@@ -2,6 +2,7 @@ package org.infinispan.client.hotrod.configuration;
 
 import static org.infinispan.client.hotrod.configuration.RemoteCacheConfiguration.CONFIGURATION;
 import static org.infinispan.client.hotrod.configuration.RemoteCacheConfiguration.FORCE_RETURN_VALUES;
+import static org.infinispan.client.hotrod.configuration.RemoteCacheConfiguration.MARSHALLER;
 import static org.infinispan.client.hotrod.configuration.RemoteCacheConfiguration.NAME;
 import static org.infinispan.client.hotrod.configuration.RemoteCacheConfiguration.NEAR_CACHE_BLOOM_FILTER;
 import static org.infinispan.client.hotrod.configuration.RemoteCacheConfiguration.NEAR_CACHE_MAX_ENTRIES;
@@ -30,6 +31,7 @@ import org.infinispan.client.hotrod.transaction.lookup.GenericTransactionManager
 import org.infinispan.commons.CacheConfigurationException;
 import org.infinispan.commons.configuration.Builder;
 import org.infinispan.commons.configuration.attributes.AttributeSet;
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.commons.tx.lookup.TransactionManagerLookup;
 import org.infinispan.commons.util.FileLookupFactory;
 import org.infinispan.commons.util.TypedProperties;
@@ -161,6 +163,36 @@ public class RemoteCacheConfigurationBuilder implements Builder<RemoteCacheConfi
    }
 
    /**
+    * Specifies a custom {@link Marshaller} implementation. See {@link #marshaller(Marshaller)}.
+    *
+    * @param className Fully qualifies class name of the marshaller implementation.
+    */
+   public RemoteCacheConfigurationBuilder marshaller(String className) {
+      return marshaller(loadClass(className, Thread.currentThread().getContextClassLoader()));
+   }
+
+   /**
+    * Specifies a custom {@link Marshaller} implementation. See {@link #marshaller(Marshaller)}.
+    *
+    * @param marshallerClass the marshaller class.
+    */
+   public RemoteCacheConfigurationBuilder marshaller(Class<? extends Marshaller> marshallerClass) {
+      return marshaller(getInstance(marshallerClass));
+   }
+
+   /**
+    * Specifies a custom {@link Marshaller} implementation to serialize and deserialize user objects. If not configured,
+    * the marshaller from the {@link org.infinispan.client.hotrod.RemoteCacheManager} will be used for the cache
+    * operations.
+    *
+    * @param marshaller the marshaller instance
+    */
+   public RemoteCacheConfigurationBuilder marshaller(Marshaller marshaller) {
+      attributes.attribute(MARSHALLER).set(marshaller);
+      return this;
+   }
+
+   /**
     * The {@link javax.transaction.TransactionManager} to use for the cache
     *
     * @param manager an instance of a TransactionManager
@@ -219,6 +251,7 @@ public class RemoteCacheConfigurationBuilder implements Builder<RemoteCacheConfi
       findCacheProperty(typed, ConfigurationProperties.CACHE_NEAR_CACHE_MAX_ENTRIES_SUFFIX, v -> this.nearCacheMaxEntries(Integer.parseInt(v)));
       findCacheProperty(typed, ConfigurationProperties.CACHE_TRANSACTION_MODE_SUFFIX, v -> this.transactionMode(TransactionMode.valueOf(v)));
       findCacheProperty(typed, ConfigurationProperties.CACHE_TRANSACTION_MANAGER_LOOKUP_SUFFIX, this::transactionManagerLookupClass);
+      findCacheProperty(typed, ConfigurationProperties.CACHE_MARSHALLER, this::marshaller);
       return builder;
    }
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/ConfigurationProperties.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/ConfigurationProperties.java
@@ -113,6 +113,7 @@ public class ConfigurationProperties {
    public static final String CACHE_CONFIGURATION_SUFFIX = ".configuration";
    public static final String CACHE_CONFIGURATION_URI_SUFFIX = ".configuration_uri";
    public static final String CACHE_FORCE_RETURN_VALUES_SUFFIX = ".force_return_values";
+   public static final String CACHE_MARSHALLER = ".marshaller";
    public static final String CACHE_NEAR_CACHE_MODE_SUFFIX = ".near_cache.mode";
    public static final String CACHE_NEAR_CACHE_MAX_ENTRIES_SUFFIX = ".near_cache.max_entries";
    public static final String CACHE_TEMPLATE_NAME_SUFFIX = ".template_name";

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/DelegatingRemoteCache.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/DelegatingRemoteCache.java
@@ -22,7 +22,6 @@ import org.infinispan.client.hotrod.configuration.Configuration;
 import org.infinispan.client.hotrod.impl.operations.OperationsFactory;
 import org.infinispan.client.hotrod.impl.operations.PingResponse;
 import org.infinispan.client.hotrod.impl.operations.RetryAwareCompletionStage;
-import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.commons.util.CloseableIterator;
 import org.infinispan.commons.util.CloseableIteratorCollection;
 import org.infinispan.commons.util.CloseableIteratorSet;
@@ -346,13 +345,13 @@ public abstract class DelegatingRemoteCache<K, V> extends RemoteCacheSupport<K, 
    }
 
    @Override
-   public void init(Marshaller marshaller, OperationsFactory operationsFactory, Configuration configuration, ObjectName jmxParent) {
-      delegate.init(marshaller, operationsFactory, configuration, jmxParent);
+   public void init(OperationsFactory operationsFactory, Configuration configuration, ObjectName jmxParent) {
+      delegate.init(operationsFactory, configuration, jmxParent);
    }
 
    @Override
-   public void init(Marshaller marshaller, OperationsFactory operationsFactory, Configuration configuration) {
-      delegate.init(marshaller, operationsFactory, configuration);
+   public void init(OperationsFactory operationsFactory, Configuration configuration) {
+      delegate.init(operationsFactory, configuration);
    }
 
    @Override

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/InternalRemoteCache.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/InternalRemoteCache.java
@@ -15,7 +15,6 @@ import org.infinispan.client.hotrod.configuration.Configuration;
 import org.infinispan.client.hotrod.impl.operations.OperationsFactory;
 import org.infinispan.client.hotrod.impl.operations.PingResponse;
 import org.infinispan.client.hotrod.impl.operations.RetryAwareCompletionStage;
-import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.commons.util.CloseableIterator;
 import org.infinispan.commons.util.IntSet;
 
@@ -50,10 +49,10 @@ public interface InternalRemoteCache<K, V> extends RemoteCache<K, V> {
    @Override
    ClientStatistics clientStatistics();
 
-   void init(Marshaller marshaller, OperationsFactory operationsFactory, Configuration configuration,
-         ObjectName jmxParent);
+   void init(OperationsFactory operationsFactory, Configuration configuration,
+             ObjectName jmxParent);
 
-   void init(Marshaller marshaller, OperationsFactory operationsFactory, Configuration configuration);
+   void init(OperationsFactory operationsFactory, Configuration configuration);
 
    OperationsFactory getOperationsFactory();
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/iteration/RemotePublisher.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/iteration/RemotePublisher.java
@@ -23,7 +23,6 @@ import org.infinispan.client.hotrod.impl.operations.OperationsFactory;
 import org.infinispan.client.hotrod.impl.protocol.HotRodConstants;
 import org.infinispan.client.hotrod.logging.Log;
 import org.infinispan.client.hotrod.logging.LogFactory;
-import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.commons.reactive.RxJavaInterop;
 import org.infinispan.commons.util.IntSet;
 import org.infinispan.commons.util.IntSets;
@@ -37,7 +36,6 @@ public class RemotePublisher<K, E> implements Publisher<Map.Entry<K, E>> {
    private static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
 
    private final OperationsFactory operationsFactory;
-   protected final Marshaller marshaller;
    private final String filterConverterFactory;
    private final byte[][] filterParams;
    private final IntSet segments;
@@ -48,10 +46,9 @@ public class RemotePublisher<K, E> implements Publisher<Map.Entry<K, E>> {
 
    private final Set<SocketAddress> failedServers = ConcurrentHashMap.newKeySet();
 
-   public RemotePublisher(OperationsFactory operationsFactory, Marshaller marshaller, String filterConverterFactory,
+   public RemotePublisher(OperationsFactory operationsFactory, String filterConverterFactory,
          byte[][] filterParams, Set<Integer> segments, int batchSize, boolean metadata, DataFormat dataFormat) {
       this.operationsFactory = operationsFactory;
-      this.marshaller = marshaller;
       this.filterConverterFactory = filterConverterFactory;
       this.filterParams = filterParams;
       SegmentConsistentHash segmentConsistentHash = (SegmentConsistentHash) operationsFactory.getConsistentHash();

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/configuration/ConfigurationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/configuration/ConfigurationTest.java
@@ -80,7 +80,9 @@ import org.infinispan.client.hotrod.security.BasicCallbackHandler;
 import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
 import org.infinispan.client.hotrod.transaction.lookup.RemoteTransactionManagerLookup;
 import org.infinispan.commons.CacheConfigurationException;
+import org.infinispan.commons.marshall.JavaSerializationMarshaller;
 import org.infinispan.commons.marshall.ProtoStreamMarshaller;
+import org.infinispan.commons.marshall.UTF8StringMarshaller;
 import org.infinispan.commons.util.FileLookupFactory;
 import org.infinispan.test.AbstractInfinispanTest;
 import org.testng.annotations.Test;
@@ -707,4 +709,19 @@ public class ConfigurationTest extends AbstractInfinispanTest {
       assertEquals(TransactionMode.NON_XA, cache.transactionMode());
    }
 
+   @Test
+   public void testPerCacheMarshallerConfig() throws IOException {
+      Properties properties = new Properties();
+      try (InputStream is = this.getClass().getResourceAsStream("/hotrod-client-percache.properties")) {
+         properties.load(is);
+      }
+      Configuration configuration = new ConfigurationBuilder().withProperties(properties).build();
+
+      assertTrue(configuration.remoteCaches().get("mycache").marshaller() instanceof JavaSerializationMarshaller);
+      assertTrue(configuration.remoteCaches().get("org.infinispan.yourcache").marshaller() instanceof UTF8StringMarshaller);
+
+      Properties props = configuration.properties();
+      assertEquals(JavaSerializationMarshaller.class.getName(), props.getProperty("infinispan.client.hotrod.cache.mycache.marshaller"));
+      assertEquals(UTF8StringMarshaller.class.getName(), props.getProperty("infinispan.client.hotrod.cache.org.infinispan.yourcache.marshaller"));
+   }
 }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/MarshallerPerCacheTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/MarshallerPerCacheTest.java
@@ -1,0 +1,102 @@
+package org.infinispan.client.hotrod.marshall;
+
+import static org.infinispan.commons.dataconversion.MediaType.APPLICATION_PROTOSTREAM_TYPE;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.internal.junit.ArrayAsserts.assertArrayEquals;
+
+import java.io.IOException;
+
+import org.infinispan.AdvancedCache;
+import org.infinispan.Cache;
+import org.infinispan.client.hotrod.DataFormat;
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
+import org.infinispan.client.hotrod.test.SingleHotRodServerTest;
+import org.infinispan.commons.marshall.IdentityMarshaller;
+import org.infinispan.commons.marshall.JavaSerializationMarshaller;
+import org.infinispan.commons.marshall.Marshaller;
+import org.infinispan.commons.marshall.ProtoStreamMarshaller;
+import org.infinispan.commons.marshall.UTF8StringMarshaller;
+import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.configuration.internal.PrivateGlobalConfigurationBuilder;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.Test;
+
+/**
+ * @since 12.1
+ */
+@Test(groups = "functional", testName = "client.hotrod.MarshallerPerCacheTest")
+public class MarshallerPerCacheTest extends SingleHotRodServerTest {
+
+   private static final String CACHE_TEXT = "text";
+   private static final String CACHE_JAVA_SERIALIZED = "serialized";
+   private static final String CACHE_DEFAULT = "default";
+
+   private static final Object KEY = 1;
+   private static final Object VALUE = "this is the value";
+
+   @Override
+   protected EmbeddedCacheManager createCacheManager() throws Exception {
+      GlobalConfigurationBuilder gcb = new GlobalConfigurationBuilder().nonClusteredDefault();
+      gcb.addModule(PrivateGlobalConfigurationBuilder.class).serverMode(true);
+      EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(gcb, hotRodCacheConfiguration());
+      Configuration protobufConfig = new org.infinispan.configuration.cache.ConfigurationBuilder()
+            .encoding().mediaType(APPLICATION_PROTOSTREAM_TYPE)
+            .build();
+      Configuration defaultConfig = new org.infinispan.configuration.cache.ConfigurationBuilder().build();
+      cm.createCache(CACHE_TEXT, defaultConfig);
+      cm.createCache(CACHE_JAVA_SERIALIZED, defaultConfig);
+      cm.createCache(CACHE_DEFAULT, protobufConfig);
+      return cm;
+   }
+
+   @Override
+   protected ConfigurationBuilder createHotRodClientConfigurationBuilder(String host, int serverPort) {
+      ConfigurationBuilder builder = super.createHotRodClientConfigurationBuilder(host, serverPort);
+
+      // Configure RemoteCaches with different marshallers
+      builder.remoteCache(CACHE_TEXT).marshaller(UTF8StringMarshaller.class);
+      builder.remoteCache(CACHE_JAVA_SERIALIZED).marshaller(JavaSerializationMarshaller.class);
+      return builder;
+   }
+
+   @Test
+   public void testMarshallerPerCache() throws IOException, InterruptedException {
+      assertMarshallerUsed(CACHE_DEFAULT, new ProtoStreamMarshaller());
+      assertMarshallerUsed(CACHE_TEXT, new UTF8StringMarshaller());
+      assertMarshallerUsed(CACHE_JAVA_SERIALIZED, new JavaSerializationMarshaller());
+   }
+
+   @Test
+   public void testOverrideMarshallerAtRuntime() throws Exception {
+      // RemoteCache 'CACHE_JAVA_SERIALIZED' is configured to use the java marshaller
+      RemoteCache<String, String> cache = remoteCacheManager.getCache(CACHE_JAVA_SERIALIZED);
+      cache.put("KEY", "VALUE");
+
+      // Override the value marshaller at runtime
+      RemoteCache<String, byte[]> rawValueCache = cache.withDataFormat(DataFormat.builder().valueMarshaller(IdentityMarshaller.INSTANCE).build());
+
+      // Make sure the key marshaller stays the same as configured in the cache, but the value marshaller is replaced
+      byte[] rawValue = rawValueCache.get("KEY");
+      assertArrayEquals(new JavaSerializationMarshaller().objectToByteBuffer("VALUE"), rawValue);
+   }
+
+   private void assertMarshallerUsed(String cacheName, Marshaller expectedMarshaller) throws InterruptedException, IOException {
+      // Read and write to the remote cache
+      RemoteCache<Object, Object> remoteCache = remoteCacheManager.getCache(cacheName);
+      remoteCache.put(KEY, VALUE);
+      assertEquals(VALUE, remoteCache.get(KEY));
+
+      // Read data from the embedded cache as it is stored
+      Cache<byte[], byte[]> cache = cacheManager.getCache(remoteCache.getName());
+      AdvancedCache<byte[], byte[]> asStored = cache.getAdvancedCache().withStorageMediaType();
+
+      // Assert that data was written using the 'expectedMarshaller'
+      byte[] keyMarshalled = expectedMarshaller.objectToByteBuffer(KEY);
+      byte[] valueMarshalled = expectedMarshaller.objectToByteBuffer(VALUE);
+      assertArrayEquals(valueMarshalled, asStored.get(keyMarshalled));
+   }
+}

--- a/client/hotrod-client/src/test/resources/hotrod-client-percache.properties
+++ b/client/hotrod-client/src/test/resources/hotrod-client-percache.properties
@@ -1,6 +1,8 @@
 infinispan.client.hotrod.cache.mycache.template_name=org.infinispan.DIST_SYNC
 infinispan.client.hotrod.cache.mycache.force_return_values=true
+infinispan.client.hotrod.cache.mycache.marshaller=org.infinispan.commons.marshall.JavaSerializationMarshaller
 infinispan.client.hotrod.cache.[org.infinispan.yourcache].template_name=org.infinispan.DIST_ASYNC
+infinispan.client.hotrod.cache.[org.infinispan.yourcache].marshaller=org.infinispan.commons.marshall.UTF8StringMarshaller
 infinispan.client.hotrod.cache.[org.infinispan.yourcache].near_cache.mode=INVALIDATED
 infinispan.client.hotrod.cache.[org.infinispan.*].template_name=org.infinispan.REPL_SYNC
 infinispan.client.hotrod.cache.[org.infinispan.*].transaction.transaction_mode=NON_XA


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12808

The implementation is simpler that what was proposed in the JIRA: it only allows a marshaller to be configured per cache, instead of the full ```DataFormat```. This is enough for the Spring use cases.