### PR TITLE
[11.0.x] ISPN-12807 Simple cache does not update eviction statistics

### DIFF
--- a/core/src/main/java/org/infinispan/eviction/impl/EvictionManagerImpl.java
+++ b/core/src/main/java/org/infinispan/eviction/impl/EvictionManagerImpl.java
@@ -8,12 +8,14 @@ import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.context.impl.ImmutableContext;
 import org.infinispan.eviction.EvictionManager;
 import org.infinispan.factories.annotations.Inject;
+import org.infinispan.factories.annotations.Start;
 import org.infinispan.factories.impl.ComponentRef;
 import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
 import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.interceptors.impl.CacheMgmtInterceptor;
 import org.infinispan.notifications.cachelistener.CacheNotifier;
+import org.infinispan.stats.impl.StatsCollector;
 
 import net.jcip.annotations.ThreadSafe;
 
@@ -23,6 +25,15 @@ public class EvictionManagerImpl<K, V> implements EvictionManager<K, V> {
    @Inject CacheNotifier<K, V> cacheNotifier;
    @Inject ComponentRef<AsyncInterceptorChain> interceptorChain;
    @Inject Configuration cfg;
+   @Inject StatsCollector simpleCacheStatsCollector;
+
+   private CacheMgmtInterceptor cacheMgmtInterceptor;
+
+   @Start
+   public void findCacheMgmtInterceptor() {
+      // Allow the interceptor chain to start later, otherwise we'd have a dependency cycle
+      cacheMgmtInterceptor = interceptorChain.wired().findInterceptorExtending(CacheMgmtInterceptor.class);
+   }
 
    @Override
    public CompletionStage<Void> onEntryEviction(Map<K, Map.Entry<K,V>> evicted, FlagAffectedCommand command) {
@@ -35,10 +46,10 @@ public class EvictionManagerImpl<K, V> implements EvictionManager<K, V> {
    }
 
    private void updateEvictionStatistics(Map<K, Map.Entry<K, V>> evicted) {
-      CacheMgmtInterceptor mgmtInterceptor =
-            interceptorChain.running().findInterceptorExtending(CacheMgmtInterceptor.class);
-      if (mgmtInterceptor != null) {
-         mgmtInterceptor.addEvictions(evicted.size());
+      if (cacheMgmtInterceptor != null) {
+         cacheMgmtInterceptor.addEvictions(evicted.size());
+      } else if (simpleCacheStatsCollector != null) {
+         simpleCacheStatsCollector.recordEvictions(evicted.size());
       }
    }
 }

--- a/core/src/test/java/org/infinispan/api/SimpleCacheTest.java
+++ b/core/src/test/java/org/infinispan/api/SimpleCacheTest.java
@@ -1,7 +1,9 @@
 package org.infinispan.api;
 
-import static org.testng.Assert.assertTrue;
 import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertNull;
+import static org.testng.AssertJUnit.assertTrue;
 
 import java.util.function.BiConsumer;
 
@@ -14,8 +16,11 @@ import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.StorageType;
 import org.infinispan.container.entries.CacheEntry;
+import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.interceptors.BaseCustomAsyncInterceptor;
+import org.infinispan.interceptors.impl.InvocationContextInterceptor;
 import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.stats.Stats;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.transaction.TransactionMode;
 import org.testng.annotations.Test;
@@ -43,6 +48,12 @@ public class SimpleCacheTest extends APINonTxTest {
              .addInterceptor(new CustomInterceptorConfigTest.DummyInterceptor(), 0);
    }
 
+   public void testFindInterceptor() {
+      AsyncInterceptorChain interceptorChain = cache().getAdvancedCache().getAsyncInterceptorChain();
+      assertNotNull(interceptorChain);
+      assertNull(interceptorChain.findInterceptorExtending(InvocationContextInterceptor.class));
+   }
+
    @Test(expectedExceptions = CacheConfigurationException.class)
    public void testTransactions() {
       new ConfigurationBuilder().simpleCache(true)
@@ -50,7 +61,7 @@ public class SimpleCacheTest extends APINonTxTest {
    }
 
    @Test(expectedExceptions = CacheConfigurationException.class)
-   public void testInterceptors() {
+   public void testCustomInterceptors() {
       new ConfigurationBuilder().simpleCache(true)
                                 .customInterceptors().addInterceptor().interceptor(new BaseCustomAsyncInterceptor())
                                 .build();
@@ -74,7 +85,7 @@ public class SimpleCacheTest extends APINonTxTest {
    @Test(dataProvider = "lockedStreamActuallyLocks", expectedExceptions = UnsupportedOperationException.class)
    @Override
    public void testLockedStreamActuallyLocks(BiConsumer<Cache<Object, Object>, CacheEntry<Object, Object>> consumer,
-         boolean forEachOrInvokeAll) throws Throwable {
+                                             boolean forEachOrInvokeAll) throws Throwable {
       super.testLockedStreamActuallyLocks(consumer, forEachOrInvokeAll);
    }
 
@@ -103,12 +114,32 @@ public class SimpleCacheTest extends APINonTxTest {
    }
 
    public void testStatistics() {
-      Configuration cfg = new ConfigurationBuilder().simpleCache(true).statistics().enabled(true).build();
+      Configuration cfg = new ConfigurationBuilder().simpleCache(true).jmxStatistics().enabled(true).build();
       String name = "statsCache";
       cacheManager.defineConfiguration(name, cfg);
       Cache<Object, Object> cache = cacheManager.getCache(name);
       assertEquals(0L, cache.getAdvancedCache().getStats().getStores());
       cache.put("key", "value");
       assertEquals(1L, cache.getAdvancedCache().getStats().getStores());
+   }
+
+   public void testEvictionWithStatistics() {
+      int KEY_COUNT = 5;
+      Configuration cfg = new ConfigurationBuilder()
+            .simpleCache(true)
+            .memory().size(1)
+            .jmxStatistics().enable()
+            .build();
+      String name = "evictionCache";
+      cacheManager.defineConfiguration(name, cfg);
+      Cache<Object, Object> cache = cacheManager.getCache(name);
+      for (int i = 0; i < KEY_COUNT; i++) {
+         cache.put("key" + i, "value");
+      }
+
+      Stats stats = cache.getAdvancedCache().getStats();
+      assertEquals(1, stats.getCurrentNumberOfEntriesInMemory());
+      assertEquals(KEY_COUNT, stats.getStores());
+      assertEquals(KEY_COUNT - 1, stats.getEvictions());
    }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12807

EvictionManagerImpl must work with both CacheMgmtInterceptor
(regular cache) and StatsCollector (simple cache).

Backport of #9103, as requested by @pferraro 