### PR TITLE
ISPN-12598 Hot Rod java client retries too many times

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/RetryOnFailureOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/RetryOnFailureOperation.java
@@ -208,17 +208,11 @@ public abstract class RetryOnFailureOperation<T> extends HotRodOperation<T> impl
                case SWITCHED:
                   triedCompleteRestart = true;
                   retryCount = 0;
+                  failedServers.clear();
                   break;
                case NOT_SWITCHED:
-                  if (!triedCompleteRestart) {
-                     log.debug("Cluster might have completely shut down, try resetting transport layer and topology id", e);
-                     channelFactory.reset(cacheName);
-                     triedCompleteRestart = true;
-                     retryCount = 0;
-                  } else {
-                     HOTROD.exceptionAndNoRetriesLeft(retryCount, channelFactory.getMaxRetries(), e);
-                     completeExceptionally(e);
-                  }
+                  HOTROD.exceptionAndNoRetriesLeft(retryCount, channelFactory.getMaxRetries(), e);
+                  completeExceptionally(e);
                   break;
                case IN_PROGRESS:
                   log.trace("Cluster switch in progress, retry operation without increasing retry count");

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HitsAwareCacheManagersTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HitsAwareCacheManagersTest.java
@@ -78,6 +78,7 @@ public abstract class HitsAwareCacheManagersTest extends MultipleCacheManagersTe
       clientBuilder.addServer()
          .host("localhost")
          .port(serverPort);
+      clientBuilder.maxRetries(2);
       return clientBuilder;
    }
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/CompleteShutdownDistRetryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/CompleteShutdownDistRetryTest.java
@@ -16,6 +16,7 @@ import org.infinispan.client.hotrod.exceptions.TransportException;
 import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.server.hotrod.HotRodServer;
 import org.testng.annotations.Test;
 
@@ -29,6 +30,13 @@ public class CompleteShutdownDistRetryTest extends HitsAwareCacheManagersTest {
    protected void createCacheManagers() throws Throwable {
       ConfigurationBuilder builder = getConfiguration();
       createHotRodServers(3, builder);
+   }
+
+   @Override
+   protected GlobalConfigurationBuilder defaultGlobalConfigurationBuilder() {
+      GlobalConfigurationBuilder gcb = GlobalConfigurationBuilder.defaultClusteredBuilder();
+      gcb.serialization().addContextInitializer(new SCIImpl());
+      return gcb;
    }
 
    @Override
@@ -104,7 +112,8 @@ public class CompleteShutdownDistRetryTest extends HitsAwareCacheManagersTest {
 
    private ConfigurationBuilder getConfiguration() {
       ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false);
-      builder.clustering().hash().numOwners(1);
+      builder.clustering().hash().numSegments(3).numOwners(1);
+      builder.clustering().hash().consistentHashFactory(new StableControlledConsistentHashFactory());
       return hotRodCacheConfiguration(builder);
    }
 }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/StableControlledConsistentHashFactory.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/StableControlledConsistentHashFactory.java
@@ -1,0 +1,46 @@
+package org.infinispan.client.hotrod.retry;
+
+import java.util.List;
+
+import org.infinispan.distribution.ch.impl.DefaultConsistentHash;
+import org.infinispan.protostream.SerializationContextInitializer;
+import org.infinispan.protostream.annotations.AutoProtoSchemaBuilder;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.util.BaseControlledConsistentHashFactory;
+
+/**
+ * Consistent hash factory implementation keeping segments stable as nodes are stopped:
+ *
+ * <ol>
+ * <li>0 -> A, 1 -> B, 2 -> C
+ * <li>When A is stopped: 0, 1 -> B, 2 -> C
+ * <li>When B is also stopped: 0, 1, 2 -> C
+ * </ol>
+ */
+public class StableControlledConsistentHashFactory
+      extends BaseControlledConsistentHashFactory<DefaultConsistentHash> {
+   public StableControlledConsistentHashFactory() {
+      super(new DefaultTrait(), 3);
+   }
+
+   @Override
+   protected int[][] assignOwners(int numSegments, List<Address> members) {
+      switch (members.size()) {
+         case 1:
+            return new int[][]{{0}, {0}, {0}};
+         case 2:
+            return new int[][]{{0}, {0}, {1}};
+         default:
+            return new int[][]{{0}, {1}, {2}};
+      }
+   }
+
+   @AutoProtoSchemaBuilder(
+         includeClasses = {StableControlledConsistentHashFactory.class},
+         schemaFileName = "test.client.CompleteShutdownDistRetryTest.proto",
+         schemaFilePath = "proto/generated",
+         schemaPackageName = "org.infinispan.test.client.CompleteShutdownDistRetryTest"
+   )
+   public interface SCI extends SerializationContextInitializer {
+   }
+}

--- a/core/src/test/java/org/infinispan/test/MultipleCacheManagersTest.java
+++ b/core/src/test/java/org/infinispan/test/MultipleCacheManagersTest.java
@@ -194,7 +194,7 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
     * @return the new CacheManager
     */
    protected EmbeddedCacheManager addClusterEnabledCacheManager(TransportFlags flags) {
-      EmbeddedCacheManager cm = createClusteredCacheManager(false, GlobalConfigurationBuilder.defaultClusteredBuilder(),
+      EmbeddedCacheManager cm = createClusteredCacheManager(false, defaultGlobalConfigurationBuilder(),
                                                             null, flags);
       amendCacheManagerBeforeStart(cm);
       cacheManagers.add(cm);
@@ -230,7 +230,7 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
 
    protected EmbeddedCacheManager addClusterEnabledCacheManager(SerializationContextInitializer sci,
                                                                 ConfigurationBuilder defaultConfig, TransportFlags flags) {
-      GlobalConfigurationBuilder globalBuilder = GlobalConfigurationBuilder.defaultClusteredBuilder();
+      GlobalConfigurationBuilder globalBuilder = defaultGlobalConfigurationBuilder();
       if (sci != null) globalBuilder.serialization().addContextInitializer(sci);
       return addClusterEnabledCacheManager(globalBuilder, defaultConfig, flags);
    }
@@ -247,7 +247,7 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
     * @return the new CacheManager
     */
    protected EmbeddedCacheManager addClusterEnabledCacheManager(ConfigurationBuilder builder, TransportFlags flags) {
-      EmbeddedCacheManager cm = createClusteredCacheManager(false, GlobalConfigurationBuilder.defaultClusteredBuilder(),
+      EmbeddedCacheManager cm = createClusteredCacheManager(false, defaultGlobalConfigurationBuilder(),
                                                             builder, flags);
       amendCacheManagerBeforeStart(cm);
       cacheManagers.add(cm);
@@ -270,6 +270,10 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
       cacheManagers.add(cm);
       cm.start();
       return cm;
+   }
+
+   protected GlobalConfigurationBuilder defaultGlobalConfigurationBuilder() {
+      return GlobalConfigurationBuilder.defaultClusteredBuilder();
    }
 
    protected void createCluster(int count) {
@@ -399,7 +403,7 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
                                                             SerializationContextInitializer sci,
                                                             ConfigurationBuilder configBuilder,
                                                             TransportFlags flags, String... cacheNames) {
-      GlobalConfigurationBuilder globalBuilder = GlobalConfigurationBuilder.defaultClusteredBuilder();
+      GlobalConfigurationBuilder globalBuilder = defaultGlobalConfigurationBuilder();
       if (sci != null) globalBuilder.serialization().addContextInitializer(sci);
       createClusteredCaches(numMembersInCluster, globalBuilder, configBuilder, false, flags, cacheNames);
    }
@@ -449,7 +453,7 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
    protected void createClusteredCaches(int numMembersInCluster,
                                                             ConfigurationBuilder defaultConfigBuilder,
                                                             boolean serverMode, String... cacheNames) {
-      createClusteredCaches(numMembersInCluster, GlobalConfigurationBuilder.defaultClusteredBuilder(),
+      createClusteredCaches(numMembersInCluster, defaultGlobalConfigurationBuilder(),
                             defaultConfigBuilder, serverMode, cacheNames);
    }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12598
https://issues.redhat.com/browse/ISPN-7159

Add back the reset to the initial server list (removed by the initial
ISPN-12598 fix).
Perform the reset when all the servers are marked as failed,
not after max_retries attempts.

Fixes `CompleteShutdownDistRetryTest.testRetryAfterCompleteShutdown` test failures.
An additional commit adds a controlled consistent hash factory to avoid the older random failures.
