### PR TITLE
ISPN-12847 Performance regression in new SIFS write performance with

### DIFF
--- a/persistence/soft-index/src/test/java/org/infinispan/persistence/sifs/SoftIndexFileStoreParallelIterationTest.java
+++ b/persistence/soft-index/src/test/java/org/infinispan/persistence/sifs/SoftIndexFileStoreParallelIterationTest.java
@@ -3,6 +3,7 @@ package org.infinispan.persistence.sifs;
 import org.infinispan.commons.test.CommonsTestingUtil;
 import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.metadata.Metadata;
 import org.infinispan.persistence.ParallelIterationTest;
 import org.infinispan.persistence.sifs.configuration.SoftIndexFileStoreConfigurationBuilder;
 import org.testng.annotations.Test;
@@ -31,5 +32,11 @@ public class SoftIndexFileStoreParallelIterationTest extends ParallelIterationTe
    protected boolean hasMetadata(boolean fetchValues, int i) {
       // We only include metadata if the value is requested
       return fetchValues && super.insertMetadata(i);
+   }
+
+   @Override
+   protected void assertMetadataEmpty(Metadata metadata) {
+      // If an entry is read from the temporary table it will include the value and metadata if it was present in the
+      // temporary table
    }
 }


### PR DESCRIPTION
sync flush

https://issues.redhat.com/browse/ISPN-12847

The new changes are that when sync flush is enabled are as follows. When a write operation is performed it will write the value to "disk". After this completes the thread will then check if the log appender has written all requested values and if so will immediately flush the value to disk. If not then the log write will wait until it is eventually flushed. To prevent too many operations from waiting we will flush after 1000 unflushed entries. This provides some back pressure, to ensure previous tasks finish. This approach doesn't require a time out or anything and should provided the lowest latency while also not flushing per entry.