### PR TITLE
ISPN-12689 + ISPN-12690 Support spring caches and session in remote mode with protostream

### DIFF
--- a/spring/spring5/spring5-common/src/test/java/org/infinispan/spring/common/session/InfinispanSessionRepositoryTCK.java
+++ b/spring/spring5/spring5-common/src/test/java/org/infinispan/spring/common/session/InfinispanSessionRepositoryTCK.java
@@ -14,6 +14,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.spring.common.provider.SpringCache;
 import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.test.TestingUtil;
@@ -27,7 +28,17 @@ public abstract class InfinispanSessionRepositoryTCK extends AbstractInfinispanT
    protected SpringCache springCache;
 
    protected AbstractInfinispanSessionRepository sessionRepository;
+   protected MediaType mediaType;
 
+   protected InfinispanSessionRepositoryTCK mediaType(MediaType mediaType) {
+      this.mediaType = mediaType;
+      return this;
+   }
+
+   @Override
+   protected String parameters() {
+      return mediaType.toString();
+   }
    protected abstract SpringCache createSpringCache();
 
    protected abstract AbstractInfinispanSessionRepository createRepository(SpringCache springCache) throws Exception;

--- a/spring/spring5/spring5-embedded/src/main/java/org/infinispan/spring/embedded/SpringEmbeddedModule.java
+++ b/spring/spring5/spring5-embedded/src/main/java/org/infinispan/spring/embedded/SpringEmbeddedModule.java
@@ -53,9 +53,9 @@ public class SpringEmbeddedModule implements ModuleLifecycle {
          return;
       }
 
-      org.infinispan.spring.common.session.PersistenceContextInitializerImpl providerSci = new org.infinispan.spring.common.session.PersistenceContextInitializerImpl();
-      ctxRegistry.addContextInitializer(SerializationContextRegistry.MarshallerType.PERSISTENCE, providerSci);
-      ctxRegistry.addContextInitializer(SerializationContextRegistry.MarshallerType.GLOBAL, providerSci);
+      org.infinispan.spring.common.session.PersistenceContextInitializerImpl sessionSci = new org.infinispan.spring.common.session.PersistenceContextInitializerImpl();
+      ctxRegistry.addContextInitializer(SerializationContextRegistry.MarshallerType.PERSISTENCE, sessionSci);
+      ctxRegistry.addContextInitializer(SerializationContextRegistry.MarshallerType.GLOBAL, sessionSci);
 
       BaseMarshaller sessionAttributeMarshaller = new MapSessionProtoAdapter.SessionAttributeRawMarshaller(serializationMarshaller);
       ctxRegistry.addMarshaller(PERSISTENCE, sessionAttributeMarshaller);

--- a/spring/spring5/spring5-embedded/src/test/java/org/infinispan/spring/embedded/session/InfinispanEmbeddedSessionRepositoryTest.java
+++ b/spring/spring5/spring5-embedded/src/test/java/org/infinispan/spring/embedded/session/InfinispanEmbeddedSessionRepositoryTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.spring.embedded.session;
 
+import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -11,6 +12,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 
 @Test(testName = "spring.embedded.session.InfinispanEmbeddedSessionRepositoryTest", groups = "unit")
@@ -20,11 +22,18 @@ public class InfinispanEmbeddedSessionRepositoryTest extends InfinispanSessionRe
    private EmbeddedCacheManager cacheManager2;
    private EmbeddedCacheManager cacheManager3;
 
+   @Factory
+   public Object[] factory() {
+      return new Object[]{
+            new InfinispanEmbeddedSessionRepositoryTest().mediaType(MediaType.APPLICATION_PROTOSTREAM),
+            new InfinispanEmbeddedSessionRepositoryTest().mediaType(MediaType.APPLICATION_SERIALIZED_OBJECT),
+            };
+   }
 
    @BeforeClass
    public void beforeClass() {
       ConfigurationBuilder defaultCacheBuilder = new ConfigurationBuilder();
-      defaultCacheBuilder.clustering().cacheMode(CacheMode.DIST_SYNC);
+      defaultCacheBuilder.clustering().cacheMode(CacheMode.DIST_SYNC).encoding().mediaType(mediaType.getTypeSubtype());
       embeddedCacheManager = TestCacheManagerFactory.createClusteredCacheManager(defaultCacheBuilder);
       cacheManager2 = TestCacheManagerFactory.createClusteredCacheManager(defaultCacheBuilder);
       cacheManager3 = TestCacheManagerFactory.createClusteredCacheManager(defaultCacheBuilder);

--- a/spring/spring5/spring5-remote/src/test/java/org/infinispan/spring/remote/provider/SpringRemoteCacheTest.java
+++ b/spring/spring5/spring5-remote/src/test/java/org/infinispan/spring/remote/provider/SpringRemoteCacheTest.java
@@ -12,6 +12,7 @@ import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.server.hotrod.HotRodServer;
 import org.infinispan.server.hotrod.test.HotRodTestingUtil;
+import org.infinispan.spring.common.provider.NullValue;
 import org.infinispan.spring.common.provider.SpringCache;
 import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
@@ -90,5 +91,17 @@ public class SpringRemoteCacheTest extends SingleCacheManagerTest {
       assertEquals("thread1", valueAfterGetterIsDone.get());
       assertEquals("thread1", valueObtainedByThread1);
       assertEquals("thread1", valueObtainedByThread2);
+   }
+
+   public void testNullValues() {
+      //given
+      final SpringRemoteCacheManager springRemoteCacheManager = new SpringRemoteCacheManager(remoteCacheManager);
+      final SpringCache cache = springRemoteCacheManager.getCache(TEST_CACHE_NAME);
+
+      // when
+      cache.put("key", null);
+
+      // then
+      assertEquals(NullValue.NULL, cache.get("key"));
    }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12690
https://issues.redhat.com/browse/ISPN-12689

* Register provider and session marshallers in ProtoStreamMarshaller's
  serialization context
* Register a JavaSerializationMarshaller if it doesn't exist yet,
  for session attributes that cannot be serialized with protostream
* Add NullValue, java.util, and org.springframework classes
  to the allow list when wrapping a remote cache manager.