### PR TITLE
ISPN-12856 SoftIndexFileStore some index updates write too much to disk

### DIFF
--- a/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/Index.java
+++ b/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/Index.java
@@ -167,6 +167,7 @@ class Index {
             // This guarantees that the index can't see an outdated value
             if (count.decrementAndGet() == 0) {
                fileProvider.deleteFile(fileId);
+               log.tracef("Deleted file %s", fileId);
                compactor.releaseStats(fileId);
             }
          });

--- a/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/LogAppender.java
+++ b/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/LogAppender.java
@@ -186,6 +186,7 @@ public class LogAppender implements Consumer<LogRequest>, Function<LogRequest, P
             log.tracef("Appending records to %s", logFile.fileId);
          }
          long seqId = nextSeqId();
+         log.tracef("Apppending record to %s:%s", logFile.fileId, currentOffset);
          EntryRecord.writeEntry(logFile.fileChannel, request.getSerializedKey(), request.getSerializedMetadata(),
                request.getSerializedInternalMetadata(),
                request.getSerializedValue(), seqId, request.getExpiration(), request.getCreated(), request.getLastUsed());


### PR DESCRIPTION
This PR doesn't increase throughput as the latency of the log appender is more important. This reduces CPU and disk usage with heavy replacements of values and compaction so it does more targeted replacements. In benchmark tests this completely removes the https://github.com/infinispan/infinispan/pull/9150#issuecomment-800821579 from the hotspot in JMC.

Also this fixes an issue with the compactor that it can run tasks from the indexer thread, which is not desired.