### PR TITLE
ISPN-12867 SoftIndexFileStore LogAppender optimizations

### DIFF
--- a/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/EntryHeader.java
+++ b/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/EntryHeader.java
@@ -7,7 +7,7 @@ import java.nio.ByteBuffer;
  */
 public class EntryHeader {
    private static final byte MAGIC = 0x01;
-   /*
+   /* 1 byte  - magic key
     * 2 bytes - key length
     * 2 bytes - metadata length
     * 4 bytes - value length
@@ -15,7 +15,7 @@ public class EntryHeader {
     * 8 bytes - expiration time
     */
    static final int HEADER_SIZE_10_1 = 24;
-   /*
+   /* 1 byte  - magic key
     * 2 bytes - key length
     * 2 bytes - metadata length
     * 4 bytes - value length

--- a/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/EntryMetadata.java
+++ b/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/EntryMetadata.java
@@ -41,4 +41,8 @@ public class EntryMetadata {
    static short size(ByteBuffer buffer) {
       return (short) (buffer == null ? 0 : buffer.getLength() + TIMESTAMP_BYTES);
    }
+
+   static short size(java.nio.ByteBuffer buffer) {
+      return (short) (buffer == null ? 0 : buffer.remaining() + TIMESTAMP_BYTES);
+   }
 }

--- a/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/Index.java
+++ b/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/Index.java
@@ -333,7 +333,7 @@ class Index {
             case UPDATE:
                recordChange = IndexNode.RecordChange.INCREASE;
                overwriteHook = (overwritten, prevFile, prevOffset) -> {
-                  request.setResult(overwritten);
+                  nonBlockingManager.complete(request, overwritten);
                   if (request.getOffset() >= 0 && prevOffset < 0) {
                      size.incrementAndGet();
                   } else if (request.getOffset() < 0 && prevOffset >= 0) {

--- a/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/IndexRequest.java
+++ b/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/IndexRequest.java
@@ -106,30 +106,6 @@ class IndexRequest extends CompletableFuture<Object> {
       return serializedKey;
    }
 
-   public synchronized void setResult(Object result) {
-      if (this.result == null) {
-         this.result = result;
-      }
-      notifyAll();
-   }
-
-
-   public synchronized Object getResult() throws InterruptedException {
-      while (result == null) {
-         wait();
-      }
-      return result;
-   }
-
-   // TODO: delete this when replaced
-   public void setCountDown(int countDown) {
-      this.countDown = new AtomicInteger(countDown);
-   }
-
-   public boolean countDown() {
-      return countDown.decrementAndGet() == 0;
-   }
-
    public int getFile() {
       return file;
    }

--- a/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/LogRequest.java
+++ b/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/LogRequest.java
@@ -31,6 +31,8 @@ class LogRequest extends CompletableFuture<Void> {
    private final ByteBuffer serializedInternalMetadata;
    private final long created;
    private final long lastUsed;
+   private volatile int file;
+   private volatile int fileOffset;
    private volatile IndexRequest indexRequest;
 
    private LogRequest(Type type, int segment, Object key, long expirationTime, ByteBuffer serializedKey, ByteBuffer serializedMetadata,
@@ -129,6 +131,22 @@ class LogRequest extends CompletableFuture<Void> {
 
    public void setIndexRequest(IndexRequest indexRequest) {
       this.indexRequest = indexRequest;
+   }
+
+   public int getFile() {
+      return file;
+   }
+
+   public void setFile(int file) {
+      this.file = file;
+   }
+
+   public int getFileOffset() {
+      return fileOffset;
+   }
+
+   public void setFileOffset(int fileOffset) {
+      this.fileOffset = fileOffset;
    }
 
    public IndexRequest getIndexRequest() {


### PR DESCRIPTION
* Reuse bytebuffer used by same thread
* Offload passing off index submission to non blocking CPU thread instead of log
thread
* Do not create a new file object when finishing a file
* Delay is held in a List instead of async stage

https://issues.redhat.com/browse/ISPN-12867