### PR TITLE
ISPN-12895 Upgrade to protostream 4.4.0.Beta3

### DIFF
--- a/build-configuration/bom/pom.xml
+++ b/build-configuration/bom/pom.xml
@@ -405,6 +405,11 @@
             </dependency>
             <dependency>
                 <groupId>org.infinispan.protostream</groupId>
+                <artifactId>protostream-types</artifactId>
+                <version>${version.protostream}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.infinispan.protostream</groupId>
                 <artifactId>protostream-processor</artifactId>
                 <version>${version.protostream}</version>
                 <!-- compile-only dependency -->

--- a/build-configuration/pom.xml
+++ b/build-configuration/pom.xml
@@ -187,7 +187,7 @@
       <version.org.wildfly.openssl>1.0.12.Final</version.org.wildfly.openssl>
       <version.picketbox>5.0.3.Final</version.picketbox>
       <version.picketlink>2.5.5.SP12</version.picketlink>
-      <version.protostream>4.4.0.Beta1</version.protostream>
+      <version.protostream>4.4.0.Beta3</version.protostream>
       <version.protostuff>1.6.2</version.protostuff>
       <version.reactivestreams>1.0.3</version.reactivestreams>
       <version.rocksdb>6.15.5</version.rocksdb>

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/logging/Log.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/logging/Log.java
@@ -367,4 +367,8 @@ public interface Log extends BasicLogger {
 
    @Message(value = "Near cache with bloom filter requires pool max active to be 1, was %s, and exhausted action to be WAIT, was %s", id = 4103)
    CacheConfigurationException bloomFilterRequiresMaxActiveOneAndWait(int maxActive, ExhaustedAction action);
+
+   @LogMessage(level = WARN)
+   @Message(value = "Failed to load and create an optional ProtoStream serialization context initializer: %s", id = 4104)
+   void failedToCreatePredefinedSerializationContextInitializer(String className, @Cause Throwable throwable);
 }

--- a/commons/all/pom.xml
+++ b/commons/all/pom.xml
@@ -21,6 +21,11 @@
 
       <dependency>
          <groupId>org.infinispan.protostream</groupId>
+         <artifactId>protostream-types</artifactId>
+      </dependency>
+
+      <dependency>
+         <groupId>org.infinispan.protostream</groupId>
          <artifactId>protostream-processor</artifactId>
       </dependency>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -30,6 +30,11 @@
 
       <dependency>
          <groupId>org.infinispan.protostream</groupId>
+         <artifactId>protostream-types</artifactId>
+      </dependency>
+
+      <dependency>
+         <groupId>org.infinispan.protostream</groupId>
          <artifactId>protostream-processor</artifactId>
       </dependency>
 

--- a/query-core/pom.xml
+++ b/query-core/pom.xml
@@ -43,6 +43,12 @@
 
         <dependency>
             <groupId>org.infinispan.protostream</groupId>
+            <artifactId>protostream-types</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.infinispan.protostream</groupId>
             <artifactId>protostream-processor</artifactId>
         </dependency>
 

--- a/remote-query/remote-query-client/pom.xml
+++ b/remote-query/remote-query-client/pom.xml
@@ -24,6 +24,11 @@
       </dependency>
 
       <dependency>
+         <groupId>org.infinispan.protostream</groupId>
+         <artifactId>protostream-types</artifactId>
+      </dependency>
+
+      <dependency>
          <groupId>org.infinispan</groupId>
          <artifactId>infinispan-commons-test</artifactId>
          <scope>test</scope>

--- a/remote-query/remote-query-server/pom.xml
+++ b/remote-query/remote-query-server/pom.xml
@@ -43,6 +43,16 @@
       </dependency>
 
       <dependency>
+         <groupId>org.infinispan.protostream</groupId>
+         <artifactId>protostream</artifactId>
+      </dependency>
+
+      <dependency>
+         <groupId>org.infinispan.protostream</groupId>
+         <artifactId>protostream-types</artifactId>
+      </dependency>
+
+      <dependency>
          <groupId>org.infinispan</groupId>
          <artifactId>infinispan-server-core</artifactId>
       </dependency>

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/ProtobufMetadataManagerImpl.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/ProtobufMetadataManagerImpl.java
@@ -39,6 +39,8 @@ import org.infinispan.protostream.ProtobufUtil;
 import org.infinispan.protostream.SerializationContext;
 import org.infinispan.protostream.SerializationContextInitializer;
 import org.infinispan.protostream.config.Configuration;
+import org.infinispan.protostream.types.java.CommonContainerTypesSchema;
+import org.infinispan.protostream.types.java.CommonTypesSchema;
 import org.infinispan.query.remote.ProtobufMetadataManager;
 import org.infinispan.query.remote.client.ProtobufMetadataManagerConstants;
 import org.infinispan.query.remote.client.impl.MarshallerRegistration;
@@ -86,6 +88,13 @@ public final class ProtobufMetadataManagerImpl implements ProtobufMetadataManage
       } catch (DescriptorParserException e) {
          throw new CacheException("Failed to initialise the Protobuf serialization context", e);
       }
+      register(new CommonTypesSchema());
+      register(new CommonContainerTypesSchema());
+   }
+
+   void register(SerializationContextInitializer initializer) {
+      initializer.registerSchema(getSerializationContext());
+      initializer.registerMarshallers(getSerializationContext());
    }
 
    @Start

--- a/server/hotrod/pom.xml
+++ b/server/hotrod/pom.xml
@@ -54,6 +54,10 @@
          <artifactId>protostream</artifactId>
       </dependency>
       <dependency>
+         <groupId>org.infinispan.protostream</groupId>
+         <artifactId>protostream-types</artifactId>
+      </dependency>
+      <dependency>
          <groupId>io.projectreactor.tools</groupId>
          <artifactId>blockhound</artifactId>
          <optional>true</optional>

--- a/server/tests/src/test/java/org/infinispan/server/extensions/HelloServerTask.java
+++ b/server/tests/src/test/java/org/infinispan/server/extensions/HelloServerTask.java
@@ -1,5 +1,8 @@
 package org.infinispan.server.extensions;
 
+import java.util.ArrayList;
+import java.util.Collection;
+
 import org.infinispan.tasks.ServerTask;
 import org.infinispan.tasks.TaskContext;
 
@@ -8,6 +11,7 @@ import org.infinispan.tasks.TaskContext;
  * @since 10.0
  **/
 public class HelloServerTask implements ServerTask {
+
    private TaskContext taskContext;
 
    @Override
@@ -18,6 +22,20 @@ public class HelloServerTask implements ServerTask {
    @Override
    public Object call() {
       Object greetee = taskContext.getParameters().get().get("greetee");
+
+      // if we're dealing with a Collections of greetees we'll greet them individually
+      if (greetee instanceof Collection) {
+         ArrayList<String> messages = new ArrayList<>();
+         for (Object o : (Collection<?>) greetee) {
+            messages.add(greet(o));
+         }
+         return messages;
+      }
+
+      return greet(greetee);
+   }
+
+   private String greet(Object greetee) {
       return greetee == null ? "Hello world" : "Hello " + greetee;
    }
 
@@ -25,5 +43,4 @@ public class HelloServerTask implements ServerTask {
    public String getName() {
       return "hello";
    }
-
 }

--- a/server/tests/src/test/java/org/infinispan/server/extensions/ServerTasks.java
+++ b/server/tests/src/test/java/org/infinispan/server/extensions/ServerTasks.java
@@ -3,6 +3,8 @@ package org.infinispan.server.extensions;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -36,8 +38,10 @@ public class ServerTasks {
    @Test
    public void testServerTaskWithParameters() {
       RemoteCache<String, String> cache = SERVER_TEST.hotrod().create();
-      String hello = cache.execute("hello", Collections.singletonMap("greetee", "my friend"));
-      assertEquals("Hello my friend", hello);
+      ArrayList<String> messages = cache.execute("hello", Collections.singletonMap("greetee", new ArrayList<>(Arrays.asList("nurse", "kitty"))));
+      assertEquals(2, messages.size());
+      assertEquals("Hello nurse", messages.get(0));
+      assertEquals("Hello kitty", messages.get(1));
    }
 
    @Test


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12895

Adds protostream-types module as a maven dependency and registers by default (in HR client and server) some schemas defined by it:
* for java collections
* for some java util/math: UUID, BigDecimal...
