### PR TITLE
ISPN-12905 Many components ignore changes to remote-timeout at runtime

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/cache/ClusteringConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/ClusteringConfiguration.java
@@ -101,7 +101,7 @@ public class ClusteringConfiguration implements Matchable<ClusteringConfiguratio
     * the call is aborted and an exception is thrown.
     */
    public long remoteTimeout() {
-      return attributes.attribute(REMOTE_TIMEOUT).get();
+      return remoteTimeout.get();
    }
 
    /**
@@ -109,7 +109,7 @@ public class ClusteringConfiguration implements Matchable<ClusteringConfiguratio
     * the call is aborted and an exception is thrown.
     */
    public void remoteTimeout(long timeoutMillis) {
-      attributes.attribute(REMOTE_TIMEOUT).set(timeoutMillis);
+      remoteTimeout.set(timeoutMillis);
    }
 
    /**

--- a/core/src/main/java/org/infinispan/expiration/impl/ClusterExpirationManager.java
+++ b/core/src/main/java/org/infinispan/expiration/impl/ClusterExpirationManager.java
@@ -17,6 +17,7 @@ import org.infinispan.AdvancedCache;
 import org.infinispan.commons.util.IntSet;
 import org.infinispan.commons.util.IntSets;
 import org.infinispan.commons.util.Util;
+import org.infinispan.configuration.cache.ClusteringConfiguration;
 import org.infinispan.container.entries.ExpiryHelper;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.context.Flag;
@@ -73,6 +74,11 @@ public class ClusterExpirationManager<K, V> extends ExpirationManagerImpl<K, V> 
       super.start();
       this.localAddress = cache.getCacheManager().getAddress();
       this.timeout = configuration.clustering().remoteTimeout();
+      configuration.clustering()
+                   .attributes().attribute(ClusteringConfiguration.REMOTE_TIMEOUT)
+                   .addListener((a, ignored) -> {
+                      timeout = a.get();
+                   });
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/interceptors/distribution/L1NonTxInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/L1NonTxInterceptor.java
@@ -38,6 +38,7 @@ import org.infinispan.commands.write.RemoveCommand;
 import org.infinispan.commands.write.ReplaceCommand;
 import org.infinispan.commands.write.WriteCommand;
 import org.infinispan.commons.util.EnumUtil;
+import org.infinispan.configuration.cache.ClusteringConfiguration;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.container.impl.EntryFactory;
 import org.infinispan.container.impl.InternalDataContainer;
@@ -106,6 +107,11 @@ public class L1NonTxInterceptor extends BaseRpcInterceptor {
    public void start() {
       l1Lifespan = cacheConfiguration.clustering().l1().lifespan();
       replicationTimeout = cacheConfiguration.clustering().remoteTimeout();
+      cacheConfiguration.clustering()
+                   .attributes().attribute(ClusteringConfiguration.REMOTE_TIMEOUT)
+                   .addListener((a, ignored) -> {
+                      replicationTimeout = a.get();
+                   });
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/interceptors/impl/BaseStateTransferInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/BaseStateTransferInterceptor.java
@@ -19,6 +19,7 @@ import org.infinispan.commands.read.GetAllCommand;
 import org.infinispan.commands.read.GetCacheEntryCommand;
 import org.infinispan.commands.read.GetKeyValueCommand;
 import org.infinispan.commands.remote.GetKeysInGroupCommand;
+import org.infinispan.configuration.cache.ClusteringConfiguration;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.FlagBitSets;
@@ -67,8 +68,12 @@ public abstract class BaseStateTransferInterceptor extends DDAsyncInterceptor {
 
    @Start
    public void start() {
-      transactionDataTimeout = configuration.clustering().remoteTimeout();
       isScattered = configuration.clustering().cacheMode().isScattered();
+      transactionDataTimeout = configuration.clustering().remoteTimeout();
+      configuration.clustering().attributes().attribute(ClusteringConfiguration.REMOTE_TIMEOUT)
+                   .addListener((a, ignored) -> {
+                      transactionDataTimeout = a.get();
+                   });
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/cluster/impl/BatchingClusterEventManagerImpl.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/cluster/impl/BatchingClusterEventManagerImpl.java
@@ -11,6 +11,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 import org.infinispan.commands.CommandsFactory;
+import org.infinispan.configuration.cache.ClusteringConfiguration;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
@@ -49,6 +50,10 @@ public class BatchingClusterEventManagerImpl<K, V> implements ClusterEventManage
    @Start
    public void start() {
       timeout = configuration.clustering().remoteTimeout();
+      configuration.clustering().attributes().attribute(ClusteringConfiguration.REMOTE_TIMEOUT)
+                   .addListener((a, ignored) -> {
+                      timeout = a.get();
+                   });
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/reactive/publisher/impl/ClusterPublisherManagerImpl.java
+++ b/core/src/main/java/org/infinispan/reactive/publisher/impl/ClusterPublisherManagerImpl.java
@@ -32,6 +32,7 @@ import org.infinispan.commons.util.ByRef;
 import org.infinispan.commons.util.IntSet;
 import org.infinispan.commons.util.IntSets;
 import org.infinispan.commons.util.Util;
+import org.infinispan.configuration.cache.ClusteringConfiguration;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.PersistenceConfiguration;
 import org.infinispan.configuration.cache.StoreConfiguration;
@@ -126,6 +127,11 @@ public class ClusterPublisherManagerImpl<K, V> implements ClusterPublisherManage
       // increased payloads)
       rpcOptions = new RpcOptions(DeliverOrder.NONE, cacheConfiguration.clustering().remoteTimeout() * 3,
             TimeUnit.MILLISECONDS);
+      cacheConfiguration.clustering()
+                   .attributes().attribute(ClusteringConfiguration.REMOTE_TIMEOUT)
+                   .addListener((a, ignored) -> {
+                      rpcOptions = new RpcOptions(DeliverOrder.NONE, a.get() * 3, TimeUnit.MILLISECONDS);
+                   });
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/statetransfer/StateTransferLockImpl.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateTransferLockImpl.java
@@ -9,6 +9,7 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.infinispan.commons.IllegalLifecycleStateException;
+import org.infinispan.configuration.cache.ClusteringConfiguration;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.factories.annotations.ComponentName;
 import org.infinispan.factories.annotations.Inject;
@@ -51,6 +52,11 @@ public class StateTransferLockImpl implements StateTransferLock {
 
       stateTransferTimeout = configuration.clustering().stateTransfer().timeout();
       remoteTimeout = configuration.clustering().remoteTimeout();
+      configuration.clustering()
+                   .attributes().attribute(ClusteringConfiguration.REMOTE_TIMEOUT)
+                   .addListener((a, ignored) -> {
+                      remoteTimeout = a.get();
+                   });
    }
 
    @Stop

--- a/core/src/main/java/org/infinispan/util/concurrent/CommandAckCollector.java
+++ b/core/src/main/java/org/infinispan/util/concurrent/CommandAckCollector.java
@@ -22,6 +22,7 @@ import java.util.function.Function;
 
 import org.infinispan.commands.CommandInvocationId;
 import org.infinispan.commons.util.Util;
+import org.infinispan.configuration.cache.ClusteringConfiguration;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.factories.KnownComponentNames;
 import org.infinispan.factories.annotations.ComponentName;
@@ -74,6 +75,11 @@ public class CommandAckCollector {
    @Start
    public void start() {
       this.timeoutNanoSeconds = TimeUnit.MILLISECONDS.toNanos(configuration.clustering().remoteTimeout());
+      configuration.clustering()
+                   .attributes().attribute(ClusteringConfiguration.REMOTE_TIMEOUT)
+                   .addListener((a, ignored) -> {
+                      timeoutNanoSeconds = TimeUnit.MILLISECONDS.toNanos(a.get());
+                   });
    }
 
    /**


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12905

Follow-up on #9161, as I realized there was yet another wait of 100ms in the final `cache.get()` and I couldn't lower it without without risking a GC to cause random failures earlier.

I added an attribute listener to `StateTransferLockImpl` and other components to pick up runtime updates to `remote-timeout`, and then I could change the test to lower the timeout to 10ms just for the `cache.get()` that needs to fail.