### PR TITLE
ISPN-12911 Testcontainers-based tests do not run on Fedora 33

### DIFF
--- a/server/testdriver/core/src/main/resources/testcontainers.properties
+++ b/server/testdriver/core/src/main/resources/testcontainers.properties
@@ -1,2 +1,3 @@
 ryuk.container.image=quay.io/infinispan-test/ryuk:0.3.0
 tinyimage.container.image=registry.access.redhat.com/ubi8/ubi-minimal:8.3
+ryuk.container.privileged=true


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12911

Make the Ryuk container privileged