### PR TITLE
ISPN-12682 dependency-check-maven plugin fails CI builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2182,6 +2182,7 @@
                </executions>
                <configuration>
                   <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
+                  <failOnError>false</failOnError>
                   <suppressionFile>${infinispan.root}/etc/dependency-check-suppressions.xml</suppressionFile>
                </configuration>
             </plugin>


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12682

Disable failOnError