### PR TITLE
ISPN-12924 State transfer timeout should be validated

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientEventsOOMTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientEventsOOMTest.java
@@ -1,17 +1,5 @@
 package org.infinispan.client.hotrod.event;
 
-import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
-import static org.testng.AssertJUnit.assertEquals;
-
-import java.io.Serializable;
-import java.lang.management.BufferPoolMXBean;
-import java.lang.management.ManagementFactory;
-import java.lang.reflect.Method;
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.annotation.ClientCacheEntryCreated;
 import org.infinispan.client.hotrod.annotation.ClientListener;
@@ -27,6 +15,18 @@ import org.infinispan.notifications.cachelistener.filter.EventType;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 import org.testng.annotations.Test;
+
+import java.io.Serializable;
+import java.lang.management.BufferPoolMXBean;
+import java.lang.management.ManagementFactory;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * A remote listener over a slow channel that requires the initial state can lead to OOME in the server.
@@ -67,7 +67,7 @@ public class ClientEventsOOMTest extends MultiHotRodServersTest {
    private ConfigurationBuilder getConfigurationBuilder() {
       ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, false);
       //playing with OOM - weird things might happen when JVM will struggle for life
-      builder.clustering().remoteTimeout(5, TimeUnit.MINUTES);
+      builder.clustering().remoteTimeout(4, TimeUnit.MINUTES);
       return hotRodCacheConfiguration(builder);
    }
 

--- a/core/src/main/java/org/infinispan/configuration/cache/StateTransferConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/StateTransferConfiguration.java
@@ -67,7 +67,10 @@ public class StateTransferConfiguration implements Matchable<StateTransferConfig
    /**
     * This is the maximum amount of time - in milliseconds - to wait for state from neighboring
     * caches, before throwing an exception and aborting startup.
+    *
+    * @deprecated Since 12.1, the attribute was never writable
     */
+   @Deprecated
    public StateTransferConfiguration timeout(long l) {
       timeout.set(l);
       return this;

--- a/core/src/main/java/org/infinispan/configuration/cache/StateTransferConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/StateTransferConfigurationBuilder.java
@@ -78,6 +78,8 @@ public class StateTransferConfigurationBuilder extends
    /**
     * This is the maximum amount of time - in milliseconds - to wait for state from neighboring
     * caches, before throwing an exception and aborting startup.
+    *
+    * Must be greater than or equal to 'remote-timeout' in the clustering configuration.
     */
    public StateTransferConfigurationBuilder timeout(long l) {
       attributes.attribute(TIMEOUT).set(l);
@@ -87,6 +89,8 @@ public class StateTransferConfigurationBuilder extends
    /**
     * This is the maximum amount of time - in milliseconds - to wait for state from neighboring
     * caches, before throwing an exception and aborting startup.
+    *
+    * Must be greater than or equal to 'remote-timeout' in the clustering configuration.
     */
    public StateTransferConfigurationBuilder timeout(long l, TimeUnit unit) {
       return timeout(unit.toMillis(l));
@@ -110,6 +114,12 @@ public class StateTransferConfigurationBuilder extends
       if (awaitInitialTransfer.isModified() && awaitInitialTransfer.get()
             && !getClusteringBuilder().cacheMode().needsStateTransfer())
          throw CONFIG.awaitInitialTransferOnlyForDistOrRepl();
+
+      Attribute<Long> timeoutAttribute = attributes.attribute(TIMEOUT);
+      Attribute<Long> remoteTimeoutAttribute = clustering().attributes().attribute(ClusteringConfiguration.REMOTE_TIMEOUT);
+      if (timeoutAttribute.get() < remoteTimeoutAttribute.get()) {
+         throw CONFIG.invalidStateTransferTimeout(timeoutAttribute.get(), remoteTimeoutAttribute.get());
+      }
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeUnit;
 import javax.transaction.Synchronization;
 import javax.transaction.TransactionManager;
 import javax.transaction.xa.XAResource;
+
 import org.infinispan.commands.ReplicableCommand;
 import org.infinispan.commons.CacheConfigurationException;
 import org.infinispan.commons.CacheException;
@@ -2161,4 +2162,7 @@ public interface Log extends BasicLogger {
    @LogMessage(level = WARN)
    @Message(value = "[%s] Failed to receive a response from any nodes. Automatic cross-site state transfer to site '%s' is not started.", id = 635)
    void unableToStartXSiteAutStateTransfer(String cacheName, String targetSite, @Cause Throwable t);
+
+   @Message(value = "State transfer timeout (%d) must be greater than or equal to the remote timeout (%d)")
+   CacheConfigurationException invalidStateTransferTimeout(Long stateTransferTimeout, Long remoteTimeout);
 }

--- a/core/src/main/resources/schema/infinispan-config-12.1.xsd
+++ b/core/src/main/resources/schema/infinispan-config-12.1.xsd
@@ -2062,7 +2062,8 @@
     </xs:attribute>
     <xs:attribute name="timeout" type="xs:long" default="${StateTransfer.timeout}">
       <xs:annotation>
-        <xs:documentation>The maximum amount of time (ms) to wait for state from neighboring caches, before throwing an exception and aborting startup.</xs:documentation>
+        <xs:documentation>The maximum amount of time (ms) to wait for state from neighboring caches, before throwing an exception and aborting startup.
+        Must be greater than or equal to 'remote-timeout' in the clustering configuration.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="chunk-size" type="xs:integer" default="${StateTransfer.chunkSize}">

--- a/core/src/test/java/org/infinispan/configuration/JsonSerializationTest.java
+++ b/core/src/test/java/org/infinispan/configuration/JsonSerializationTest.java
@@ -96,7 +96,7 @@ public class JsonSerializationTest extends AbstractInfinispanTest {
             .locking().isolationLevel(IsolationLevel.REPEATABLE_READ).lockAcquisitionTimeout(30, TimeUnit.MILLISECONDS).useLockStriping(true).concurrencyLevel(12)
             .clustering()
             .cacheMode(CacheMode.DIST_SYNC)
-            .remoteTimeout(12, TimeUnit.DAYS)
+            .remoteTimeout(12, TimeUnit.SECONDS)
 
             .hash()
             .capacityFactor(23.4f)
@@ -111,7 +111,7 @@ public class JsonSerializationTest extends AbstractInfinispanTest {
 
             .l1().enable().lifespan(49).cleanupTaskFrequency(1201).invalidationThreshold(2)
 
-            .stateTransfer().fetchInMemoryState(true).awaitInitialTransfer(false).timeout(13).chunkSize(12)
+            .stateTransfer().fetchInMemoryState(true).awaitInitialTransfer(false).timeout(13, TimeUnit.SECONDS).chunkSize(12)
 
             .partitionHandling().mergePolicy(MergePolicy.PREFERRED_ALWAYS).whenSplit(PartitionHandling.DENY_READ_WRITES)
             .statistics().enable()

--- a/core/src/test/java/org/infinispan/container/offheap/OffHeapMultiNodeTest.java
+++ b/core/src/test/java/org/infinispan/container/offheap/OffHeapMultiNodeTest.java
@@ -37,7 +37,7 @@ public class OffHeapMultiNodeTest extends MultipleCacheManagersTest {
    protected void createCacheManagers() throws Throwable {
       ConfigurationBuilder dcc = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false);
       dcc.memory().storageType(StorageType.OFF_HEAP);
-      dcc.clustering().stateTransfer().timeout(10, TimeUnit.SECONDS);
+      dcc.clustering().stateTransfer().timeout(30, TimeUnit.SECONDS);
       createCluster(dcc, 4);
       waitForClusterToForm();
    }

--- a/core/src/test/java/org/infinispan/container/versioning/DistL1WriteSkewTest.java
+++ b/core/src/test/java/org/infinispan/container/versioning/DistL1WriteSkewTest.java
@@ -17,7 +17,7 @@ public class DistL1WriteSkewTest extends DistWriteSkewTest {
    protected void decorate(ConfigurationBuilder builder) {
       // Enable L1
       builder.clustering().l1().enable();
-      builder.clustering().remoteTimeout(100, TimeUnit.MINUTES);
+      builder.clustering().remoteTimeout(4, TimeUnit.MINUTES);
    }
 
    @Test

--- a/core/src/test/java/org/infinispan/globalstate/GlobalStateBackwardsCompatibilityTest.java
+++ b/core/src/test/java/org/infinispan/globalstate/GlobalStateBackwardsCompatibilityTest.java
@@ -59,7 +59,7 @@ public class GlobalStateBackwardsCompatibilityTest extends MultipleCacheManagers
       global.globalState().enable().persistentLocation(stateDirectory);
 
       ConfigurationBuilder config = new ConfigurationBuilder();
-      config.clustering().cacheMode(CacheMode.REPL_SYNC).stateTransfer().timeout(1, TimeUnit.SECONDS)
+      config.clustering().cacheMode(CacheMode.REPL_SYNC).stateTransfer().timeout(30, TimeUnit.SECONDS)
             .persistence().addSingleFileStore().location(stateDirectory);
       EmbeddedCacheManager manager = addClusterEnabledCacheManager(global, null);
       manager.defineConfiguration(CACHE_NAME, config.build());

--- a/core/src/test/java/org/infinispan/invalidation/BaseInvalidationTest.java
+++ b/core/src/test/java/org/infinispan/invalidation/BaseInvalidationTest.java
@@ -57,13 +57,13 @@ public abstract class BaseInvalidationTest extends MultipleCacheManagersTest {
    @Override
    protected void createCacheManagers() throws Throwable {
       ConfigurationBuilder c = getDefaultClusteredCacheConfig(isSync ? CacheMode.INVALIDATION_SYNC : CacheMode.INVALIDATION_ASYNC, false);
-      c.clustering().stateTransfer().timeout(10000)
+      c.clustering().stateTransfer().timeout(30000)
        .locking().lockAcquisitionTimeout(TestingUtil.shortTimeoutMillis());
       createClusteredCaches(2, "invalidation", c);
 
       if (isSync) {
          c = getDefaultClusteredCacheConfig(CacheMode.INVALIDATION_SYNC, true);
-         c.clustering().stateTransfer().timeout(10000)
+         c.clustering().stateTransfer().timeout(30000)
           .transaction().transactionManagerLookup(new EmbeddedTransactionManagerLookup())
           .transaction().lockingMode(LockingMode.OPTIMISTIC)
           .locking().lockAcquisitionTimeout(TestingUtil.shortTimeoutMillis());

--- a/core/src/test/java/org/infinispan/partitionhandling/PessimisticTxPartitionHandlingReleaseLockTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/PessimisticTxPartitionHandlingReleaseLockTest.java
@@ -65,7 +65,7 @@ public class PessimisticTxPartitionHandlingReleaseLockTest extends MultipleCache
       ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, true);
       builder.transaction().lockingMode(LockingMode.PESSIMISTIC).useSynchronization(true);
       builder.clustering().partitionHandling().mergePolicy(MergePolicy.NONE).whenSplit(PartitionHandling.DENY_READ_WRITES);
-      builder.clustering().remoteTimeout(Integer.MAX_VALUE); // we don't want timeouts
+      builder.clustering().remoteTimeout(4, TimeUnit.MINUTES); // we don't want timeouts
       createClusteredCaches(5, TestDataSCI.INSTANCE, builder, new TransportFlags().withFD(true).withMerge(true));
    }
 

--- a/core/src/test/java/org/infinispan/replication/ReplicatedAPITest.java
+++ b/core/src/test/java/org/infinispan/replication/ReplicatedAPITest.java
@@ -17,7 +17,7 @@ public class ReplicatedAPITest extends MultipleCacheManagersTest {
 
    protected void createCacheManagers() throws Throwable {
       ConfigurationBuilder build = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, true);
-      build.clustering().stateTransfer().timeout(10000);
+      build.clustering().stateTransfer().timeout(30000);
       createClusteredCaches(2, "replication", build);
    }
 

--- a/core/src/test/java/org/infinispan/scattered/BaseScatteredTest.java
+++ b/core/src/test/java/org/infinispan/scattered/BaseScatteredTest.java
@@ -25,7 +25,7 @@ public abstract class BaseScatteredTest extends MultipleCacheManagersTest {
          cfg.clustering().biasAcquisition(biasAcquisition);
       }
       cfg.clustering().hash().numSegments(16);
-      cfg.clustering().remoteTimeout(1, TimeUnit.DAYS); // for debugging
+      cfg.clustering().remoteTimeout(4, TimeUnit.MINUTES); // for debugging
       createCluster(TestDataSCI.INSTANCE, cfg, 3);
       cm1 = manager(0);
       cm2 = manager(1);

--- a/core/src/test/java/org/infinispan/statetransfer/ConcurrentStartChanelLookupTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/ConcurrentStartChanelLookupTest.java
@@ -10,6 +10,7 @@ import java.io.ByteArrayInputStream;
 import java.util.concurrent.Future;
 
 import org.infinispan.Cache;
+import org.infinispan.commons.test.TestResourceTracker;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
@@ -19,7 +20,6 @@ import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.infinispan.test.fwk.JGroupsConfigBuilder;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
-import org.infinispan.commons.test.TestResourceTracker;
 import org.infinispan.test.fwk.TransportFlags;
 import org.jgroups.JChannel;
 import org.testng.annotations.DataProvider;
@@ -106,7 +106,7 @@ public class ConcurrentStartChanelLookupTest extends MultipleCacheManagersTest {
 
       ConfigurationBuilder replCfg = new ConfigurationBuilder();
       replCfg.clustering().cacheMode(CacheMode.REPL_SYNC);
-      replCfg.clustering().stateTransfer().timeout(10, SECONDS);
+      replCfg.clustering().stateTransfer().timeout(30, SECONDS);
 
       EmbeddedCacheManager cm1 = TestCacheManagerFactory.newDefaultCacheManager(false, gcb1, replCfg);
       registerCacheManager(cm1);

--- a/core/src/test/java/org/infinispan/statetransfer/StateConsumerTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateConsumerTest.java
@@ -106,7 +106,7 @@ public class StateConsumerTest extends AbstractInfinispanTest {
       ConfigurationBuilder cb = new ConfigurationBuilder();
       cb.clustering().invocationBatching().enable()
             .clustering().cacheMode(CacheMode.DIST_SYNC)
-            .clustering().stateTransfer().timeout(10000)
+            .clustering().stateTransfer().timeout(30000)
             .locking().lockAcquisitionTimeout(TestingUtil.shortTimeoutMillis())
             .locking().isolationLevel(IsolationLevel.REPEATABLE_READ);
 

--- a/core/src/test/java/org/infinispan/statetransfer/StateProviderTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateProviderTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.CompletionStage;
 import org.infinispan.Cache;
 import org.infinispan.commands.CommandsFactory;
 import org.infinispan.commands.statetransfer.StateResponseCommand;
+import org.infinispan.commons.test.Exceptions;
 import org.infinispan.commons.util.IntSet;
 import org.infinispan.commons.util.IntSets;
 import org.infinispan.commons.util.SmallIntSet;
@@ -42,7 +43,6 @@ import org.infinispan.notifications.cachelistener.cluster.ClusterCacheNotifier;
 import org.infinispan.persistence.manager.PersistenceManager;
 import org.infinispan.remoting.rpc.RpcManager;
 import org.infinispan.remoting.transport.Address;
-import org.infinispan.commons.test.Exceptions;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.topology.CacheTopology;
 import org.infinispan.topology.PersistentUUID;
@@ -106,7 +106,7 @@ public class StateProviderTest {
       ConfigurationBuilder cb = new ConfigurationBuilder();
       cb.clustering().invocationBatching().enable()
             .clustering().cacheMode(CacheMode.DIST_SYNC)
-            .clustering().stateTransfer().timeout(10000)
+            .clustering().stateTransfer().timeout(30000)
             .locking().lockAcquisitionTimeout(TestingUtil.shortTimeoutMillis())
             .locking().isolationLevel(IsolationLevel.REPEATABLE_READ);
       configuration = cb.build();


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12924

Require state transfer timeout >= remote timeout
and update tests that were using an invalid timeout.