### PR TITLE
ISPN-12951 Test TLSv1.3

### DIFF
--- a/build-configuration/pom.xml
+++ b/build-configuration/pom.xml
@@ -184,7 +184,8 @@
       <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
       <version.org.wildfly.core>10.0.3.Final</version.org.wildfly.core>
       <version.org.wildfly.elytron>1.15.1.Final</version.org.wildfly.elytron>
-      <version.org.wildfly.openssl>1.0.12.Final</version.org.wildfly.openssl>
+      <version.org.wildfly.openssl>2.1.3.Final</version.org.wildfly.openssl>
+      <version.org.wildfly.openssl.natives>2.1.0.Final</version.org.wildfly.openssl.natives>
       <version.picketbox>5.0.3.Final</version.picketbox>
       <version.picketlink>2.5.5.SP12</version.picketlink>
       <version.protostream>4.4.0.Final</version.protostream>

--- a/pom.xml
+++ b/pom.xml
@@ -410,7 +410,7 @@
       <versionx.org.wildfly.common.wildfly-common>1.5.1.Final</versionx.org.wildfly.common.wildfly-common>
       <versionx.org.wildfly.core.wildfly-core-testsuite-shared>${version.org.wildfly.core}</versionx.org.wildfly.core.wildfly-core-testsuite-shared>
       <versionx.org.wildfly.maven.plugins.licenses-plugin>2.1.0.Final</versionx.org.wildfly.maven.plugins.licenses-plugin>
-      <versionx.org.wildfly.openssl.natives>${version.org.wildfly.openssl}</versionx.org.wildfly.openssl.natives>
+      <versionx.org.wildfly.openssl.natives>${version.org.wildfly.openssl.natives}</versionx.org.wildfly.openssl.natives>
       <versionx.org.wildfly.openssl.wildfly-openssl-linux-x86_64>${versionx.org.wildfly.openssl.natives}</versionx.org.wildfly.openssl.wildfly-openssl-linux-x86_64>
       <versionx.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>${versionx.org.wildfly.openssl.natives}</versionx.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
       <versionx.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${versionx.org.wildfly.openssl.natives}</versionx.org.wildfly.openssl.wildfly-openssl-windows-x86_64>

--- a/server/tests/src/test/java/org/infinispan/server/security/TLSWithoutAuthenticationIT.java
+++ b/server/tests/src/test/java/org/infinispan/server/security/TLSWithoutAuthenticationIT.java
@@ -60,4 +60,20 @@ public class TLSWithoutAuthenticationIT {
       builder.security().ssl().ciphers("TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384");
       Exceptions.expectException(TransportException.class, ClosedChannelException.class, () -> SERVER_TEST.hotrod().withClientConfiguration(builder).withCacheMode(CacheMode.DIST_SYNC).create());
    }
+
+   @Test
+   public void testForceTLSv12() {
+      ConfigurationBuilder builder = new ConfigurationBuilder();
+      SERVERS.getServerDriver().applyTrustStore(builder, "ca");
+      builder.security().ssl().protocol("TLSv1.2");
+      SERVER_TEST.hotrod().withClientConfiguration(builder).withCacheMode(CacheMode.DIST_SYNC).create();
+   }
+
+   @Test
+   public void testForceTLSv13() {
+      ConfigurationBuilder builder = new ConfigurationBuilder();
+      SERVERS.getServerDriver().applyTrustStore(builder, "ca");
+      builder.security().ssl().protocol("TLSv1.3");
+      SERVER_TEST.hotrod().withClientConfiguration(builder).withCacheMode(CacheMode.DIST_SYNC).create();
+   }
 }

--- a/server/tests/src/test/resources/configuration/security/tls.xml
+++ b/server/tests/src/test/resources/configuration/security/tls.xml
@@ -7,7 +7,7 @@
             <ssl>
                <keystore path="server.pfx" relative-to="infinispan.server.config.path" keystore-password="secret"
                          alias="server"/>
-               <engine enabled-protocols="TLSv1.2" enabled-ciphersuites="TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"/>
+               <engine enabled-protocols="TLSv1.3 TLSv1.2" enabled-ciphersuites="TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"/>
             </ssl>
          </server-identities>
       </security-realm>


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12951

This PR upgrades WildFly OpenSSL to 2.1.3.Final to be able to get native TLSv1.3 support