### PR TITLE
ISPN-12962 PreferConsistencyStrategy should ignore zero-capacity nodes 

### DIFF
--- a/core/src/main/java/org/infinispan/partitionhandling/impl/PreferConsistencyStrategy.java
+++ b/core/src/main/java/org/infinispan/partitionhandling/impl/PreferConsistencyStrategy.java
@@ -89,6 +89,8 @@ public class PreferConsistencyStrategy implements AvailabilityStrategy {
       // the results of the strategy harder to reason about.
       CacheTopology stableTopology = context.getStableTopology();
       List<Address> stableMembers = stableTopology.getMembers();
+      // Ignore members without any segments (e.g. zero-capacity nodes)
+      stableMembers.removeIf(a -> stableTopology.getCurrentCH().getSegmentsForOwner(a).isEmpty());
       List<Address> lostMembers = new ArrayList<>(stableMembers);
       lostMembers.removeAll(newMembers);
       if (lostDataCheck.test(stableTopology.getCurrentCH(), newMembers)) {

--- a/core/src/main/java/org/infinispan/topology/ClusterCacheStatus.java
+++ b/core/src/main/java/org/infinispan/topology/ClusterCacheStatus.java
@@ -41,6 +41,7 @@ import org.infinispan.remoting.transport.jgroups.SuspectException;
 import org.infinispan.statetransfer.RebalanceType;
 import org.infinispan.util.concurrent.CompletableFutures;
 import org.infinispan.util.concurrent.ConditionFuture;
+import org.infinispan.util.concurrent.TimeoutException;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 import org.infinispan.util.logging.events.EventLogCategory;
@@ -753,6 +754,7 @@ public class ClusterCacheStatus implements AvailabilityStrategyContext {
 
       // Creating the initial topology requires at least one node with a non-zero capacity factor
       return hasInitialTopologyFuture.newConditionStage(ccs -> ccs.getCurrentTopology() != null,
+                                                        () -> new TimeoutException("Timed out waiting for initial cache topology"),
                                                         joinInfo.getTimeout(), TimeUnit.MILLISECONDS);
    }
 

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -2163,6 +2163,13 @@ public interface Log extends BasicLogger {
    @Message(value = "[%s] Failed to receive a response from any nodes. Automatic cross-site state transfer to site '%s' is not started.", id = 635)
    void unableToStartXSiteAutStateTransfer(String cacheName, String targetSite, @Cause Throwable t);
 
-   @Message(value = "State transfer timeout (%d) must be greater than or equal to the remote timeout (%d)")
+   @Message(value = "State transfer timeout (%d) must be greater than or equal to the remote timeout (%d)", id = 636)
    CacheConfigurationException invalidStateTransferTimeout(Long stateTransferTimeout, Long remoteTimeout);
+
+   @Message(value = "Timeout waiting for topology %d, current topology is %d", id = 637)
+   TimeoutException topologyTimeout(int expectedTopologyId, int currentTopologyId);
+
+   @Message(value = "Timeout waiting for topology %d transaction data", id = 638)
+   TimeoutException transactionDataTimeout(int expectedTopologyId);
+
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12962
https://issues.redhat.com/browse/ISPN-4996

The fix itself was pretty simple: Remove nodes with no segments from stable members list before computing the majority.

Writing the test revealed a problem with `TestingUtil.installNewView()` and that ISPN-4996 had not been fixed completely (a non-zero-capacity node cannot join because the old non-zero-capacity node is still in the current CH).