### PR TITLE
ISPN-12953 Zero Capacity Node TopologyJoinCommand frequently timing out

### DIFF
--- a/core/src/main/java/org/infinispan/globalstate/GlobalConfigurationManager.java
+++ b/core/src/main/java/org/infinispan/globalstate/GlobalConfigurationManager.java
@@ -49,8 +49,9 @@ public interface GlobalConfigurationManager {
     * @param cacheName the name of the configuration
     * @param configuration the configuration object
     * @param flags the flags to apply
+    * @return
     */
-   CompletableFuture<Configuration> createCache(String cacheName, Configuration configuration, EnumSet<AdminFlag> flags);
+   CompletableFuture<Void> createCache(String cacheName, Configuration configuration, EnumSet<AdminFlag> flags);
 
    /**
     * Defines a cluster-wide cache configuration or retrieves an existing one
@@ -58,7 +59,7 @@ public interface GlobalConfigurationManager {
     * @param configuration the configuration object
     * @param flags the flags to apply
     */
-   CompletableFuture<Configuration> getOrCreateCache(String cacheName, Configuration configuration, EnumSet<AdminFlag> flags);
+   CompletableFuture<Void> getOrCreateCache(String cacheName, Configuration configuration, EnumSet<AdminFlag> flags);
 
    /**
     * Defines a cluster-wide cache configuration using the supplied template
@@ -66,7 +67,7 @@ public interface GlobalConfigurationManager {
     * @param template the template name to use
     * @param flags the flags to apply
     */
-   CompletableFuture<Configuration> createCache(String cacheName, String template, EnumSet<AdminFlag> flags);
+   CompletableFuture<Void> createCache(String cacheName, String template, EnumSet<AdminFlag> flags);
 
    /**
     * Defines a cluster-wide cache configuration using the supplied template or retrieves an existing one
@@ -74,7 +75,7 @@ public interface GlobalConfigurationManager {
     * @param template the template name to use
     * @param flags the flags to apply
     */
-   CompletableFuture<Configuration> getOrCreateCache(String cacheName, String template, EnumSet<AdminFlag> flags);
+   CompletableFuture<Void> getOrCreateCache(String cacheName, String template, EnumSet<AdminFlag> flags);
 
    /**
     * Removes a cluster-wide cache and its configuration

--- a/core/src/main/java/org/infinispan/globalstate/impl/GlobalConfigurationStateListener.java
+++ b/core/src/main/java/org/infinispan/globalstate/impl/GlobalConfigurationStateListener.java
@@ -4,15 +4,12 @@ import static org.infinispan.globalstate.impl.GlobalConfigurationManagerImpl.CAC
 import static org.infinispan.globalstate.impl.GlobalConfigurationManagerImpl.isKnownScope;
 import static org.infinispan.util.logging.Log.CONTAINER;
 
-import java.util.concurrent.CompletionStage;
-
 import org.infinispan.globalstate.ScopedState;
 import org.infinispan.notifications.Listener;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryCreated;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryRemoved;
 import org.infinispan.notifications.cachelistener.event.CacheEntryCreatedEvent;
 import org.infinispan.notifications.cachelistener.event.CacheEntryRemovedEvent;
-import org.infinispan.util.concurrent.CompletableFutures;
 
 /**
  * Listens to events on the global state cache and manages cache configuration creation / removal accordingly
@@ -29,34 +26,38 @@ public class GlobalConfigurationStateListener {
    }
 
    @CacheEntryCreated
-   public CompletionStage<Void> handleCreate(CacheEntryCreatedEvent<ScopedState, CacheState> event) {
+   public void handleCreate(CacheEntryCreatedEvent<ScopedState, CacheState> event) {
       String scope = event.getKey().getScope();
       if (!isKnownScope(scope))
-         return CompletableFutures.completedNull();
+         return;
 
       String name = event.getKey().getName();
       CacheState state = event.getValue();
 
-      return CACHE_SCOPE.equals(scope) ?
-            gcm.createCacheLocally(name, state) :
-            gcm.createTemplateLocally(name, state);
+      // Create the cache without delaying the CONFIG cache operation
+      if (CACHE_SCOPE.equals(scope)) {
+         gcm.createCacheLocally(name, state);
+      } else {
+         gcm.createTemplateLocally(name, state);
+      }
    }
 
    @CacheEntryRemoved
-   public CompletionStage<Void> handleRemove(CacheEntryRemovedEvent<ScopedState, CacheState> event) {
+   public void handleRemove(CacheEntryRemovedEvent<ScopedState, CacheState> event) {
       String scope = event.getKey().getScope();
       if (!isKnownScope(scope))
-         return CompletableFutures.completedNull();
+         return;
 
       String name = event.getKey().getName();
       CacheState state = event.getOldValue();
 
+      // Create the cache without delaying the CONFIG cache operation
       if (CACHE_SCOPE.equals(scope)) {
          CONTAINER.debugf("Stopping cache %s because it was removed from global state", name);
-         return gcm.removeCacheLocally(name, state);
+         gcm.removeCacheLocally(name, state);
       } else {
          CONTAINER.debugf("Removing template %s because it was removed from global state", name);
-         return gcm.removeTemplateLocally(name, state);
+         gcm.removeTemplateLocally(name, state);
       }
    }
 }

--- a/core/src/test/java/org/infinispan/globalstate/NoOpGlobalConfigurationManager.java
+++ b/core/src/test/java/org/infinispan/globalstate/NoOpGlobalConfigurationManager.java
@@ -20,22 +20,22 @@ public class NoOpGlobalConfigurationManager implements GlobalConfigurationManage
    }
 
    @Override
-   public CompletableFuture<Configuration> createCache(String cacheName, Configuration configuration, EnumSet<CacheContainerAdmin.AdminFlag> flags) {
+   public CompletableFuture<Void> createCache(String cacheName, Configuration configuration, EnumSet<CacheContainerAdmin.AdminFlag> flags) {
       return CompletableFutures.completedNull();
    }
 
    @Override
-   public CompletableFuture<Configuration> getOrCreateCache(String cacheName, Configuration configuration, EnumSet<CacheContainerAdmin.AdminFlag> flags) {
+   public CompletableFuture<Void> getOrCreateCache(String cacheName, Configuration configuration, EnumSet<CacheContainerAdmin.AdminFlag> flags) {
       return CompletableFutures.completedNull();
    }
 
    @Override
-   public CompletableFuture<Configuration> createCache(String cacheName, String template, EnumSet<CacheContainerAdmin.AdminFlag> flags) {
+   public CompletableFuture<Void> createCache(String cacheName, String template, EnumSet<CacheContainerAdmin.AdminFlag> flags) {
       return CompletableFutures.completedNull();
    }
 
    @Override
-   public CompletableFuture<Configuration> getOrCreateCache(String cacheName, String template, EnumSet<CacheContainerAdmin.AdminFlag> flags) {
+   public CompletableFuture<Void> getOrCreateCache(String cacheName, String template, EnumSet<CacheContainerAdmin.AdminFlag> flags) {
       return CompletableFutures.completedNull();
    }
 

--- a/core/src/test/java/org/infinispan/manager/CacheManagerAdminTest.java
+++ b/core/src/test/java/org/infinispan/manager/CacheManagerAdminTest.java
@@ -1,19 +1,17 @@
 package org.infinispan.manager;
 
 import static org.testng.AssertJUnit.assertEquals;
-import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertNotNull;
-import static org.testng.AssertJUnit.assertTrue;
 
 import org.infinispan.Cache;
 import org.infinispan.commons.CacheConfigurationException;
 import org.infinispan.commons.api.CacheContainerAdmin;
+import org.infinispan.commons.test.Exceptions;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.globalstate.ConfigurationStorage;
-import org.infinispan.commons.test.Exceptions;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.testng.annotations.Test;
@@ -67,11 +65,7 @@ public class CacheManagerAdminTest extends MultipleCacheManagersTest {
 
    protected void checkCacheExistenceAcrossCluster(String cacheName, boolean exists) {
       for (EmbeddedCacheManager m : cacheManagers) {
-         if (exists) {
-            assertTrue("Cache '" + cacheName + "' should be present on " + m, m.cacheExists(cacheName));
-         } else {
-            assertFalse("Cache '" + cacheName + "' should NOT be present on " + m, m.cacheExists(cacheName));
-         }
+         eventuallyEquals("Cache '" + cacheName + "' should be present on " + m, exists, () -> m.cacheExists(cacheName));
       }
    }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12953

Make GlobalConfigurationStateListener allow the CONFIG cache operation
to continue without waiting for the cache to start.

Start the local cache separately to ensure it is started.

I opened a PR to see what the test suite says but I'm not sure it's a good idea @tristantarrant @ryanemerson. Because starting a cache is blocking, we are doing it on a blocking thread, and there is no intermediary point where we could synchronize to make sure that an admin cache remove op following an admin cache create op create and remove the cache in the correct order on all the nodes.