### PR TITLE
ISPN-12953 Zero Capacity Node TopologyJoinCommand frequently timing out

### DIFF
--- a/core/src/main/java/org/infinispan/globalstate/impl/CacheState.java
+++ b/core/src/main/java/org/infinispan/globalstate/impl/CacheState.java
@@ -26,7 +26,7 @@ public class CacheState {
    private final EnumSet<CacheContainerAdmin.AdminFlag> flags;
 
 
-   CacheState(String template, String configuration, EnumSet<CacheContainerAdmin.AdminFlag> flags) {
+   public CacheState(String template, String configuration, EnumSet<CacheContainerAdmin.AdminFlag> flags) {
       this.template = template;
       this.configuration = configuration;
       this.flags = flags.clone();

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/upgrade/SecurityActions.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/upgrade/SecurityActions.java
@@ -9,6 +9,7 @@ import org.infinispan.manager.ClusterExecutor;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.security.Security;
 import org.infinispan.security.actions.GetCacheComponentRegistryAction;
+import org.infinispan.security.actions.GetClusterExecutorAction;
 
 /**
  * @since 12.1
@@ -27,6 +28,6 @@ final class SecurityActions {
    }
 
    static ClusterExecutor getClusterExecutor(EmbeddedCacheManager cacheManager) {
-      return doPrivileged(cacheManager::executor);
+      return doPrivileged(new GetClusterExecutorAction(cacheManager));
    }
 }

--- a/server/core/src/main/java/org/infinispan/server/core/backup/resources/SecurityActions.java
+++ b/server/core/src/main/java/org/infinispan/server/core/backup/resources/SecurityActions.java
@@ -26,6 +26,7 @@ import org.infinispan.security.Security;
 import org.infinispan.security.actions.GetCacheComponentRegistryAction;
 import org.infinispan.security.actions.GetCacheConfigurationFromManagerAction;
 import org.infinispan.security.actions.GetCacheManagerConfigurationAction;
+import org.infinispan.security.actions.GetClusterExecutorAction;
 import org.infinispan.security.actions.GetGlobalComponentRegistryAction;
 import org.infinispan.security.actions.GetOrCreateCacheAction;
 import org.infinispan.security.actions.GetOrCreateTemplateAction;
@@ -82,6 +83,6 @@ final class SecurityActions {
    }
 
    static ClusterExecutor getClusterExecutor(EmbeddedCacheManager embeddedCacheManager) {
-      return doPrivileged(embeddedCacheManager::executor);
+      return doPrivileged(new GetClusterExecutorAction(embeddedCacheManager));
    }
 }

--- a/server/core/src/main/java/org/infinispan/server/core/backup/resources/SecurityActions.java
+++ b/server/core/src/main/java/org/infinispan/server/core/backup/resources/SecurityActions.java
@@ -19,6 +19,7 @@ import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.factories.GlobalComponentRegistry;
+import org.infinispan.manager.ClusterExecutor;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.security.AuthorizationPermission;
 import org.infinispan.security.Security;
@@ -78,5 +79,9 @@ final class SecurityActions {
    static ComponentRegistry getComponentRegistry(AdvancedCache<?,?> cache) {
       GetCacheComponentRegistryAction action = new GetCacheComponentRegistryAction(cache);
       return doPrivileged(action);
+   }
+
+   static ClusterExecutor getClusterExecutor(EmbeddedCacheManager embeddedCacheManager) {
+      return doPrivileged(embeddedCacheManager::executor);
    }
 }

--- a/server/core/src/main/java/org/infinispan/server/core/transport/SecurityActions.java
+++ b/server/core/src/main/java/org/infinispan/server/core/transport/SecurityActions.java
@@ -9,6 +9,7 @@ import org.infinispan.manager.ClusterExecutor;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.security.Security;
 import org.infinispan.security.actions.GetCacheManagerConfigurationAction;
+import org.infinispan.security.actions.GetClusterExecutorAction;
 import org.infinispan.security.actions.GetGlobalComponentRegistryAction;
 
 /**
@@ -39,6 +40,6 @@ final class SecurityActions {
    }
 
    static ClusterExecutor getClusterExecutor(EmbeddedCacheManager cacheManager) {
-      return doPrivileged(cacheManager::executor);
+      return doPrivileged(new GetClusterExecutorAction(cacheManager));
    }
 }

--- a/server/runtime/src/main/java/org/infinispan/server/tasks/SecurityActions.java
+++ b/server/runtime/src/main/java/org/infinispan/server/tasks/SecurityActions.java
@@ -10,6 +10,7 @@ import org.infinispan.manager.ClusterExecutor;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.security.Security;
 import org.infinispan.security.actions.GetCacheComponentRegistryAction;
+import org.infinispan.security.actions.GetClusterExecutorAction;
 import org.infinispan.security.actions.GetGlobalComponentRegistryAction;
 
 /**
@@ -31,7 +32,7 @@ final class SecurityActions {
    }
 
    static ClusterExecutor getClusterExecutor(EmbeddedCacheManager embeddedCacheManager) {
-      return doPrivileged(embeddedCacheManager::executor);
+      return doPrivileged(new GetClusterExecutorAction(embeddedCacheManager));
    }
 
    static ComponentRegistry getComponentRegistry(final AdvancedCache<?, ?> cache) {


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12953

The `DistributedServerTask` and `TaskParameter` had to be removed from `server/runtime/proto.lock` as these messages now exist in `server/core`. As these are internal types that are never persisted this should have no impact on the user.