### PR TITLE
ISPN-12971 RemoveExpiredCommand should never have a dummy invocation id

### DIFF
--- a/core/src/main/java/org/infinispan/commands/CommandsFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/commands/CommandsFactoryImpl.java
@@ -217,13 +217,13 @@ public class CommandsFactoryImpl implements CommandsFactory {
    public RemoveExpiredCommand buildRemoveExpiredCommand(Object key, Object value, int segment, Long lifespan,
          long flagsBitSet) {
       return new RemoveExpiredCommand(key, value, lifespan, false, segment, flagsBitSet,
-            generateUUID(transactional));
+            generateUUID(false));
    }
 
    @Override
    public RemoveExpiredCommand buildRemoveExpiredCommand(Object key, Object value, int segment, long flagsBitSet) {
       return new RemoveExpiredCommand(key, value, null, true, segment, flagsBitSet,
-            generateUUID(transactional));
+            generateUUID(false));
    }
 
    @Override

--- a/core/src/test/java/org/infinispan/eviction/impl/ExceptionEvictionTest.java
+++ b/core/src/test/java/org/infinispan/eviction/impl/ExceptionEvictionTest.java
@@ -481,13 +481,10 @@ public class ExceptionEvictionTest extends MultipleCacheManagersTest {
          assertNull(cache(0).get(expiringKey));
       }
 
-      // Off heap doesn't expire entries on access yet ISPN-8380
-      // Also max idle in a transaction don't remove entries until reaper runs
-      if (storageType == StorageType.OFF_HEAP || maxIdle) {
-         for (Cache cache : caches()) {
-            ExpirationManager em = cache.getAdvancedCache().getExpirationManager();
-            em.processExpiration();
-         }
+      // Manually triggering batch expiration is no longer required, but it helps reproduce ISPN-12971
+      for (Cache cache : caches()) {
+         ExpirationManager<?, ?> em = cache.getAdvancedCache().getExpirationManager();
+         em.processExpiration();
       }
 
       Object storageKey = cache(0).getAdvancedCache().getKeyDataConversion().toStorage(expiringKey);


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12971

* Always request a non-transactional CommandInvocationId
* Replace "increase" with "adjust" in
  TransactionalExceptionEvictionInterceptor
* Manually trigger batch expiration in all configurations
  in ExceptionEvictionTest