### PR TITLE
[12.1.x] ISPN-12946 CloudEventsIntegrationIT fails because of rate limit

### DIFF
--- a/server/tests/src/test/java/org/infinispan/server/functional/CloudEventsIntegrationIT.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/CloudEventsIntegrationIT.java
@@ -34,7 +34,9 @@ public class CloudEventsIntegrationIT {
    public static final String CACHE_ENTRIES_TOPIC = "cache-entries";
 
    @ClassRule
-   public static KafkaContainer KAFKA = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:5.4.3"));
+   public static KafkaContainer KAFKA =
+         new KafkaContainer(DockerImageName.parse("quay.io/cloudservices/cp-kafka:5.4.3")
+                                           .asCompatibleSubstituteFor("confluentinc/cp-kafka"));
 
    @ClassRule
    public static final InfinispanServerRule SERVERS =
@@ -47,6 +49,11 @@ public class CloudEventsIntegrationIT {
                      KAFKA.start();
                      driver.getConfiguration().properties()
                            .setProperty("kafka.bootstrap.servers", KAFKA.getBootstrapServers());
+                  }
+
+                  @Override
+                  public void after(InfinispanServerDriver driver) {
+                     KAFKA.stop();
                   }
                })
                .build();


### PR DESCRIPTION
https://issues.redhat.com/browse/JDG-4542

Use Kafka image mirror from quay.io/cloudservices