### PR TITLE
ISPN-12996 StackOverflowError during Hot Rod connection shutdown

### DIFF
--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/BaseRequestProcessor.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/BaseRequestProcessor.java
@@ -81,6 +81,7 @@ public class BaseRequestProcessor {
             status = OperationStatus.ServerError;
          }
       } else if (header != null) {
+         log.exceptionReported(cause);
          status = header.encoder().errorStatus(cause);
          msg = createErrorMsg(cause);
       } else {

--- a/server/rest/src/main/java/org/infinispan/rest/RestRequestHandler.java
+++ b/server/rest/src/main/java/org/infinispan/rest/RestRequestHandler.java
@@ -168,7 +168,8 @@ public class RestRequestHandler extends BaseHttpRequestHandler {
          // a Netty IO Exception. The only solution is to ignore it, just like Tomcat does.
          logger.debug("Native IO Exception", e);
          ctx.close();
-      } else if (e instanceof IllegalStateException && e.getMessage().equals("ssl is null")){
+      } else if (!ctx.channel().isActive() && e instanceof IllegalStateException &&
+                 e.getMessage().equals("ssl is null")) {
          // Workaround for ISPN-12558 -- OpenSSLEngine shut itself down too soon
          // Ignore the exception, trying to close the context will cause a StackOverflowError
       } else {


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12996

Ignore IllegalStateException("ssl is null") from SslHandler
if the channel is no longer active.