### PR TITLE
[12.1] ISPN-13024 Implicit Cache Lock Release Failure

### DIFF
--- a/commons/all/src/main/java/org/infinispan/commons/tx/TransactionManagerImpl.java
+++ b/commons/all/src/main/java/org/infinispan/commons/tx/TransactionManagerImpl.java
@@ -69,15 +69,21 @@ public abstract class TransactionManagerImpl implements TransactionManager {
    public void commit() throws RollbackException, HeuristicMixedException,
          HeuristicRollbackException, SecurityException,
          IllegalStateException, SystemException {
-      getTransactionAndFailIfNone().commit();
-      dissociateTransaction();
+      try {
+         getTransactionAndFailIfNone().commit();
+      } finally {
+         dissociateTransaction();
+      }
    }
 
    @Override
    public void rollback() throws IllegalStateException, SecurityException,
          SystemException {
-      getTransactionAndFailIfNone().rollback();
-      dissociateTransaction();
+      try {
+         getTransactionAndFailIfNone().rollback();
+      } finally {
+         dissociateTransaction();
+      }
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/transaction/impl/AbstractCacheTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/impl/AbstractCacheTransaction.java
@@ -380,6 +380,12 @@ public abstract class AbstractCacheTransaction implements CacheTransaction {
       }
    }
 
+   protected final void checkIfRolledBack() {
+      if (isMarkedForRollback()) {
+         throw log.transactionAlreadyRolledBack(getGlobalTransaction());
+      }
+   }
+
    final void internalSetStateTransferFlag(Flag stateTransferFlag) {
       this.stateTransferFlag = stateTransferFlag;
    }

--- a/core/src/main/java/org/infinispan/transaction/impl/RemoteTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/impl/RemoteTransaction.java
@@ -15,7 +15,6 @@ import org.infinispan.commands.write.WriteCommand;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.context.Flag;
 import org.infinispan.transaction.xa.GlobalTransaction;
-import org.infinispan.transaction.xa.InvalidTransactionException;
 import org.infinispan.util.concurrent.CompletableFutures;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -127,12 +126,6 @@ public class RemoteTransaction extends AbstractCacheTransaction implements Clone
 
    public int lookedUpEntriesTopology() {
       return lookedUpEntriesTopology;
-   }
-
-   private void checkIfRolledBack() {
-      if (isMarkedForRollback()) {
-         throw new InvalidTransactionException("This remote transaction " + getGlobalTransaction() + " is already rolled back");
-      }
    }
 
    public final CompletableFuture<Void> enterSynchronizationAsync(CompletableFuture<Void> releaseFuture) {

--- a/core/src/main/java/org/infinispan/transaction/impl/TransactionTable.java
+++ b/core/src/main/java/org/infinispan/transaction/impl/TransactionTable.java
@@ -909,6 +909,7 @@ public class TransactionTable implements org.infinispan.transaction.TransactionT
             return null;
          });
       } else if (status == Status.STATUS_ROLLEDBACK) {
+         localTransaction.markForRollback(true); //make sure writes no longer succeed
          return txCoordinator.rollback(localTransaction).exceptionally(t -> {
             throw new CacheException("Could not commit.", t);
          });

--- a/core/src/main/java/org/infinispan/util/concurrent/locks/LockReleasedException.java
+++ b/core/src/main/java/org/infinispan/util/concurrent/locks/LockReleasedException.java
@@ -1,0 +1,32 @@
+package org.infinispan.util.concurrent.locks;
+
+import org.infinispan.commons.CacheException;
+
+/**
+ * The exception is thrown if a locks is released while waiting for it to be acquired.
+ *
+ * @author Pedro Ruivo
+ * @since 13.0
+ */
+public class LockReleasedException extends CacheException {
+
+   public LockReleasedException() {
+   }
+
+   public LockReleasedException(Throwable cause) {
+      super(cause);
+   }
+
+   public LockReleasedException(String msg) {
+      super(msg);
+   }
+
+   public LockReleasedException(String msg, Throwable cause) {
+      super(msg, cause);
+   }
+
+   public LockReleasedException(String message, Throwable cause, boolean enableSuppression,
+         boolean writableStackTrace) {
+      super(message, cause, enableSuppression, writableStackTrace);
+   }
+}

--- a/core/src/main/java/org/infinispan/util/concurrent/locks/impl/InfinispanLock.java
+++ b/core/src/main/java/org/infinispan/util/concurrent/locks/impl/InfinispanLock.java
@@ -24,6 +24,7 @@ import org.infinispan.util.concurrent.locks.DeadlockChecker;
 import org.infinispan.util.concurrent.locks.DeadlockDetectedException;
 import org.infinispan.util.concurrent.locks.ExtendedLockPromise;
 import org.infinispan.util.concurrent.locks.LockListener;
+import org.infinispan.util.concurrent.locks.LockReleasedException;
 import org.infinispan.util.concurrent.locks.LockState;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -342,7 +343,7 @@ public class InfinispanLock {
                case ACQUIRED:
                   return; //acquired!
                case RELEASED:
-                  throw new IllegalStateException("Lock already released!");
+                  throw new LockReleasedException("Requestor '" + owner + "' failed to acquire lock. Lock already released!");
                case TIMED_OUT:
                   cleanup();
                   throw new TimeoutException("Timeout waiting for lock.");
@@ -433,7 +434,7 @@ public class InfinispanLock {
             case ACQUIRED:
                return acquired.get();
             case RELEASED:
-               return exception.apply(new IllegalStateException("Lock already released!"));
+               return exception.apply(new LockReleasedException("Requestor '" + owner + "' failed to acquire lock. Lock already released!"));
             case TIMED_OUT:
                cleanup();
                return exception.apply(timeoutSupplier.get());

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -54,6 +54,7 @@ import org.infinispan.topology.CacheTopology;
 import org.infinispan.transaction.WriteSkewException;
 import org.infinispan.transaction.impl.LocalTransaction;
 import org.infinispan.transaction.xa.GlobalTransaction;
+import org.infinispan.transaction.xa.InvalidTransactionException;
 import org.infinispan.transaction.xa.recovery.RecoveryAwareRemoteTransaction;
 import org.infinispan.transaction.xa.recovery.RecoveryAwareTransaction;
 import org.infinispan.util.ByteString;
@@ -2175,4 +2176,10 @@ public interface Log extends BasicLogger {
    @LogMessage(level = ERROR)
    @Message(value = "Failed to send remove request to remote site(s). Reason: tombstone was lost. Key='%s'", id = 639)
    void sendFailMissingTombstone(Object key);
+
+   // id = 640 is a new log from main
+
+   @Message(value = "The transaction %s is already rolled back", id = 641)
+   InvalidTransactionException transactionAlreadyRolledBack(GlobalTransaction gtx);
+
 }

--- a/core/src/test/java/org/infinispan/tx/locking/LocalPessimisticTxTest.java
+++ b/core/src/test/java/org/infinispan/tx/locking/LocalPessimisticTxTest.java
@@ -15,7 +15,7 @@ import org.testng.annotations.Test;
  * @author Mircea Markus
  * @since 5.1
  */
-@Test (groups = "functional", testName = "tx.locking.LocalPessimisticTxTest")
+@Test(groups = "functional", testName = "tx.locking.LocalPessimisticTxTest")
 public class LocalPessimisticTxTest extends AbstractLocalTest {
 
    public void testLockingWithRollback() throws Exception {

--- a/core/src/test/java/org/infinispan/tx/locking/RollbackDuringLockAcquisitionTest.java
+++ b/core/src/test/java/org/infinispan/tx/locking/RollbackDuringLockAcquisitionTest.java
@@ -1,0 +1,190 @@
+package org.infinispan.tx.locking;
+
+import static org.infinispan.test.TestingUtil.extractComponent;
+import static org.infinispan.test.TestingUtil.extractLockManager;
+
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import javax.transaction.Transaction;
+import javax.transaction.TransactionManager;
+
+import org.infinispan.Cache;
+import org.infinispan.commands.tx.RollbackCommand;
+import org.infinispan.commons.test.Exceptions;
+import org.infinispan.commons.tx.lookup.TransactionManagerLookup;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.statetransfer.TransactionSynchronizerInterceptor;
+import org.infinispan.test.SingleCacheManagerTest;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.transaction.LockingMode;
+import org.infinispan.transaction.TransactionMode;
+import org.infinispan.transaction.impl.TransactionTable;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
+import org.infinispan.transaction.lookup.JBossStandaloneJTAManagerLookup;
+import org.infinispan.transaction.xa.GlobalTransaction;
+import org.infinispan.transaction.xa.InvalidTransactionException;
+import org.infinispan.util.concurrent.locks.LockManager;
+import org.testng.AssertJUnit;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Reproducer for ISPN-13024
+ * <p>
+ * Note: remote transactions are synchronized in {@link TransactionSynchronizerInterceptor}, so you cannot have a
+ * {@link RollbackCommand} executing while waiting for any lock.
+ *
+ * @author Pedro Ruivo
+ * @since 13.0
+ */
+@Test(groups = "functional", testName = "tx.locking.RollbackDuringLockAcquisitionTest")
+public class RollbackDuringLockAcquisitionTest extends SingleCacheManagerTest {
+
+   private static String concat(Object... components) {
+      return Arrays.stream(components)
+                   .map(String::valueOf)
+                   .map(String::toLowerCase)
+                   .collect(Collectors.joining("-"));
+   }
+
+   @DataProvider(name = "sync-tm")
+   public Object[][] transactionManagerLookup() {
+      //use sync & tm lookup instance
+      return new Object[][]{
+            {true, new EmbeddedTransactionManagerLookup()},
+            {true, new JBossStandaloneJTAManagerLookup()},
+            {false, new EmbeddedTransactionManagerLookup()},
+            {false, new JBossStandaloneJTAManagerLookup()}
+      };
+   }
+
+   /*
+    * The "real world" conditions are:
+    *  - Narayana timeout <= lock timeout
+    *
+    * Cause/Steps:
+    *  - Narayana aborts a transaction which is waiting for a lock "L"
+    *  - The RollbackCommand is sent.
+    *    - Lock "L" is not locked by the transaction, so unlockAll(context.getLockedKeys(), context.getLockOwner());
+    *      never changes the state from WAITING => RELEASED
+    *  - When the lock "L" is released, the state changes from WAITING => ACQUIRED
+    *  - No RollbackCommand/CommitCommand is followed leaving the lock "L" in ACQUIRED state forever
+    */
+   @Test(dataProvider = "sync-tm")
+   public void testRollbackWhileWaitingForLockDuringPut(boolean useSynchronization, TransactionManagerLookup lookup)
+         throws Exception {
+      final String cacheName = concat("local-put", lookup.getClass().getSimpleName(), useSynchronization);
+      final String key = concat("reaper-put", lookup.getClass().getSimpleName(), useSynchronization);
+
+      ConfigurationBuilder builder = new ConfigurationBuilder();
+      builder.transaction()
+             .transactionManagerLookup(lookup)
+             .transactionMode(TransactionMode.TRANSACTIONAL)
+             .lockingMode(LockingMode.PESSIMISTIC)
+             .useSynchronization(useSynchronization)
+             .recovery().disable();
+      builder.locking()
+             .lockAcquisitionTimeout(TimeUnit.MINUTES.toMillis(1));
+
+      cacheManager.defineConfiguration(cacheName, builder.build());
+      Cache<String, String> cache = cacheManager.getCache(cacheName);
+      LockManager lockManager = extractLockManager(cache);
+      TransactionManager tm = cache.getAdvancedCache().getTransactionManager();
+
+      // simulates lock acquired by other transaction
+      lockManager.lock(key, "_tx_", 1, TimeUnit.SECONDS).lock();
+      assertLocked(cache, key);
+
+      tm.begin();
+      CompletableFuture<?> put = cache.putAsync(key, "value1");
+
+      GlobalTransaction gtx = extractComponent(cache, TransactionTable.class).getGlobalTransaction(tm.getTransaction());
+
+      // wait until the tx is queued in the InfinispanLock
+      eventually(() -> lockManager.getLock(key).containsLockOwner(gtx));
+
+      //abort the transaction, simulates the TM's reaper aborting a long running transaction
+      tm.rollback();
+
+      // release the lock. the "put" must not acquire the lock
+      lockManager.unlock(key, "_tx_");
+
+      Exceptions.expectCompletionException(InvalidTransactionException.class, put);
+
+      assertNotLocked(cache, key);
+      assertNoTransactions(cache);
+   }
+
+   @Test(dataProvider = "sync-tm")
+   public void testRollbackWhileWaitingForLockDuringLock(boolean useSynchronization, TransactionManagerLookup lookup)
+         throws Exception {
+      final String cacheName = concat("local-lock", lookup.getClass().getSimpleName(), useSynchronization);
+      final String key = concat("reaper-lock", lookup.getClass().getSimpleName(), useSynchronization);
+
+      ConfigurationBuilder builder = new ConfigurationBuilder();
+      builder.transaction()
+             .transactionManagerLookup(lookup)
+             .transactionMode(TransactionMode.TRANSACTIONAL)
+             .lockingMode(LockingMode.PESSIMISTIC)
+             .useSynchronization(useSynchronization)
+             .recovery().disable();
+      builder.locking()
+             .lockAcquisitionTimeout(TimeUnit.MINUTES.toMillis(1));
+
+      cacheManager.defineConfiguration(cacheName, builder.build());
+      Cache<String, String> cache = cacheManager.getCache(cacheName);
+      LockManager lockManager = extractLockManager(cache);
+      TransactionManager tm = cache.getAdvancedCache().getTransactionManager();
+
+      // simulates lock acquired by other transaction
+      lockManager.lock(key, "_tx_", 1, TimeUnit.SECONDS).lock();
+      assertLocked(cache, key);
+
+      AtomicReference<Transaction> tx = new AtomicReference<>();
+
+      Future<Boolean> lock = fork(() -> {
+         tm.begin();
+         tx.set(tm.getTransaction());
+         try {
+            return cache.getAdvancedCache().lock(key);
+         } finally {
+            // ignore transaction from rollback.
+            // if the tests works as expected, the transaction is rolled back when it reaches this point and the rollback()
+            //    method will throw an IllegalStateException (which we don't want for the test)
+            safeRollback(tm);
+         }
+      });
+
+      TransactionTable txTable = extractComponent(cache, TransactionTable.class);
+      eventually(() -> !txTable.getLocalGlobalTransaction().isEmpty());
+
+      AssertJUnit.assertEquals(1, txTable.getLocalGlobalTransaction().size());
+      GlobalTransaction gtx = txTable.getLocalGlobalTransaction().iterator().next();
+
+      AssertJUnit.assertTrue(lockManager.getLock(key).containsLockOwner(gtx));
+
+      //abort the transaction, simulates the TM's reaper aborting a long running transaction
+      tx.get().rollback();
+
+      // release the lock. the "lock" must not acquire the lock
+      lockManager.unlock(key, "_tx_");
+
+      Exceptions.expectException(ExecutionException.class, InvalidTransactionException.class, lock::get);
+      assertNotLocked(cache, key);
+      assertNoTransactions(cache);
+   }
+
+
+   @Override
+   protected EmbeddedCacheManager createCacheManager() throws Exception {
+      return TestCacheManagerFactory.createCacheManager();
+   }
+
+}


### PR DESCRIPTION
Fix concurrency issue between the TM's reaper and lock acquisition which
can lead to unreleased lock

backport of https://github.com/infinispan/infinispan/pull/9309

https://issues.redhat.com/browse/ISPN-13024