### PR TITLE
ISPN-13081 XSiteMBeanTest fails randomly

### DIFF
--- a/core/src/test/java/org/infinispan/distribution/BlockingInterceptor.java
+++ b/core/src/test/java/org/infinispan/distribution/BlockingInterceptor.java
@@ -50,6 +50,10 @@ public class BlockingInterceptor<T extends VisitableCommand> extends DDAsyncInte
       this.suspended.set(s);
    }
 
+   public void proceed() throws Exception {
+      barrier.await(30, TimeUnit.SECONDS);
+   }
+
    private void blockIfNeeded(InvocationContext ctx, VisitableCommand command) throws Exception {
       if (suspended.get()) {
          log.tracef("Suspended, not blocking command %s", command);

--- a/core/src/test/java/org/infinispan/test/AbstractInfinispanTest.java
+++ b/core/src/test/java/org/infinispan/test/AbstractInfinispanTest.java
@@ -207,16 +207,16 @@ public abstract class AbstractInfinispanTest {
             () -> Objects.equals(expected, supplier.get()));
    }
 
-   protected <T> void eventuallyEquals(String message, T expected, Supplier<T> supplier) {
+   protected static <T> void eventuallyEquals(String message, T expected, Supplier<T> supplier) {
       eventually(() -> message + " expected:<" + expected + ">, got:<" + supplier.get() + ">",
                  () -> Objects.equals(expected, supplier.get()));
    }
 
-   protected void eventually(Supplier<String> messageSupplier, Condition condition) {
+   protected static void eventually(Supplier<String> messageSupplier, Condition condition) {
       eventually(messageSupplier, condition, 30, TimeUnit.SECONDS);
    }
 
-   protected void eventually(Supplier<String> messageSupplier, Condition condition, long timeout,
+   protected static void eventually(Supplier<String> messageSupplier, Condition condition, long timeout,
          TimeUnit timeUnit) {
       try {
          long timeoutNanos = timeUnit.toNanos(timeout);


### PR DESCRIPTION
Sometimes the conflict was not generated because of the async xsite
If the IRAC manager is delayed and sends the update later, it will send
the new value which generates "discard" events instead of "conflict".

Now we wait for the updates to arrive at the interceptor chain

https://issues.redhat.com/browse/ISPN-13081