### PR TITLE
[12.1] ISPN-13057 RemoveExpiredCommand ignored by IRAC

### DIFF
--- a/commons/all/src/test/java/org/infinispan/commons/time/ControlledTimeService.java
+++ b/commons/all/src/test/java/org/infinispan/commons/time/ControlledTimeService.java
@@ -7,7 +7,7 @@ import java.util.concurrent.TimeUnit;
  * TimeService that allows for wall clock time to be adjust manually.
  */
 public class ControlledTimeService extends DefaultTimeService {
-   protected long currentMillis;
+   protected volatile long currentMillis;
 
    public ControlledTimeService() {
       this(System.currentTimeMillis());
@@ -32,7 +32,7 @@ public class ControlledTimeService extends DefaultTimeService {
       return Instant.ofEpochMilli(currentMillis);
    }
 
-   public void advance(long time) {
+   public synchronized void advance(long time) {
       if (time <= 0) {
          throw new IllegalArgumentException("Argument must be greater than 0");
       }

--- a/core/src/main/java/org/infinispan/commands/CommandsFactory.java
+++ b/core/src/main/java/org/infinispan/commands/CommandsFactory.java
@@ -637,7 +637,7 @@ public interface CommandsFactory {
 
    <K,V> IracPutKeyCommand buildIracPutKeyCommand(InternalCacheEntry<K, V> entry);
 
-   IracRemoveKeyCommand buildIracRemoveKeyCommand(Object key, IracMetadata iracMetadata);
+   IracRemoveKeyCommand buildIracRemoveKeyCommand(Object key, IracMetadata iracMetadata, boolean expiration);
 
    IracClearKeysCommand buildIracClearKeysCommand();
 

--- a/core/src/main/java/org/infinispan/commands/CommandsFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/commands/CommandsFactoryImpl.java
@@ -718,8 +718,8 @@ public class CommandsFactoryImpl implements CommandsFactory {
    }
 
    @Override
-   public IracRemoveKeyCommand buildIracRemoveKeyCommand(Object key, IracMetadata iracMetadata) {
-      return new IracRemoveKeyCommand(cacheName, key, iracMetadata);
+   public IracRemoveKeyCommand buildIracRemoveKeyCommand(Object key, IracMetadata iracMetadata, boolean expiration) {
+      return new IracRemoveKeyCommand(cacheName, key, iracMetadata, expiration);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/commands/irac/IracRemoveKeyCommand.java
+++ b/core/src/main/java/org/infinispan/commands/irac/IracRemoveKeyCommand.java
@@ -22,6 +22,7 @@ public class IracRemoveKeyCommand extends IracUpdateKeyCommand {
 
    private Object key;
    private IracMetadata iracMetadata;
+   private boolean expiration;
 
    @SuppressWarnings("unused")
    public IracRemoveKeyCommand() {
@@ -32,14 +33,15 @@ public class IracRemoveKeyCommand extends IracUpdateKeyCommand {
       super(COMMAND_ID, cacheName);
    }
 
-   public IracRemoveKeyCommand(ByteString cacheName, Object key, IracMetadata iracMetadata) {
+   public IracRemoveKeyCommand(ByteString cacheName, Object key, IracMetadata iracMetadata, boolean expiration) {
       super(COMMAND_ID, cacheName);
       this.key = key;
       this.iracMetadata = iracMetadata;
+      this.expiration = expiration;
    }
 
    public CompletionStage<Void> executeOperation(BackupReceiver receiver) {
-      return receiver.removeKey(key, iracMetadata);
+      return receiver.removeKey(key, iracMetadata, expiration);
    }
 
    @Override
@@ -47,17 +49,18 @@ public class IracRemoveKeyCommand extends IracUpdateKeyCommand {
       return COMMAND_ID;
    }
 
-
    @Override
    public void writeTo(ObjectOutput output) throws IOException {
       output.writeObject(key);
       iracMetadata.writeTo(output);
+      output.writeBoolean(expiration);
    }
 
    @Override
    public void readFrom(ObjectInput input) throws IOException, ClassNotFoundException {
       this.key = input.readObject();
       this.iracMetadata = IracMetadata.readFrom(input);
+      this.expiration = input.readBoolean();
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/commands/write/IracPutKeyValueCommand.java
+++ b/core/src/main/java/org/infinispan/commands/write/IracPutKeyValueCommand.java
@@ -39,6 +39,7 @@ public class IracPutKeyValueCommand extends AbstractDataWriteCommand implements 
    private Metadata metadata;
    private PrivateMetadata privateMetadata;
    private boolean successful = true;
+   private boolean expiration;
 
    public IracPutKeyValueCommand() {}
 
@@ -164,6 +165,7 @@ public class IracPutKeyValueCommand extends AbstractDataWriteCommand implements 
       CommandInvocationId.writeTo(output, commandInvocationId);
       output.writeObject(privateMetadata);
       UnsignedNumeric.writeUnsignedInt(output, segment);
+      output.writeBoolean(expiration);
    }
 
    @Override
@@ -174,7 +176,16 @@ public class IracPutKeyValueCommand extends AbstractDataWriteCommand implements 
       commandInvocationId = CommandInvocationId.readFrom(input);
       privateMetadata = (PrivateMetadata) input.readObject();
       segment = UnsignedNumeric.readUnsignedInt(input);
+      expiration = input.readBoolean();
       setFlagsBitSet(FlagBitSets.IRAC_UPDATE);
+   }
+
+   public boolean isExpiration() {
+      return expiration;
+   }
+
+   public void setExpiration(boolean expiration) {
+      this.expiration = expiration;
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/interceptors/impl/AbstractIracLocalSiteInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/AbstractIracLocalSiteInterceptor.java
@@ -3,13 +3,17 @@ package org.infinispan.interceptors.impl;
 import static org.infinispan.metadata.impl.PrivateMetadata.getBuilder;
 import static org.infinispan.util.IracUtils.setIracMetadata;
 
+import java.lang.invoke.MethodHandles;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.infinispan.commands.FlagAffectedCommand;
 import org.infinispan.commands.SegmentSpecificCommand;
+import org.infinispan.commands.write.DataWriteCommand;
 import org.infinispan.commands.write.RemoveExpiredCommand;
 import org.infinispan.commands.write.WriteCommand;
 import org.infinispan.container.entries.CacheEntry;
+import org.infinispan.container.versioning.irac.IracEntryVersion;
 import org.infinispan.container.versioning.irac.IracVersionGenerator;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.FlagBitSets;
@@ -21,9 +25,13 @@ import org.infinispan.distribution.Ownership;
 import org.infinispan.distribution.ch.KeyPartitioner;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.interceptors.DDAsyncInterceptor;
+import org.infinispan.interceptors.InvocationFinallyAction;
 import org.infinispan.interceptors.locking.ClusteringDependentLogic;
 import org.infinispan.metadata.impl.IracMetadata;
 import org.infinispan.metadata.impl.PrivateMetadata;
+import org.infinispan.util.IracUtils;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
 import org.infinispan.util.logging.LogSupplier;
 
 /**
@@ -34,14 +42,27 @@ import org.infinispan.util.logging.LogSupplier;
  */
 public abstract class AbstractIracLocalSiteInterceptor extends DDAsyncInterceptor implements LogSupplier {
 
+   protected static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
+
    @Inject ClusteringDependentLogic clusteringDependentLogic;
    @Inject IracVersionGenerator iracVersionGenerator;
    @Inject KeyPartitioner keyPartitioner;
 
+   private final InvocationFinallyAction<DataWriteCommand> afterWriteCommand = this::handleNonTxDataWriteCommand;
+
    @Override
-   public Object visitRemoveExpiredCommand(InvocationContext ctx, RemoveExpiredCommand command) throws Throwable {
-      // Expiration isn't supported yet for xsite and lifespan doesn't need to be sent across sites
-      return invokeNext(ctx, command);
+   public final Object visitRemoveExpiredCommand(InvocationContext ctx, RemoveExpiredCommand command) {
+      return visitNonTxDataWriteCommand(ctx, command);
+   }
+
+   @Override
+   public final boolean isTraceEnabled() {
+      return log.isTraceEnabled();
+   }
+
+   @Override
+   public final Log getLog() {
+      return log;
    }
 
    protected static boolean isNormalWriteCommand(WriteCommand command) {
@@ -97,8 +118,8 @@ public abstract class AbstractIracLocalSiteInterceptor extends DDAsyncIntercepto
 
    protected void setMetadataToCacheEntry(CacheEntry<?, ?> entry, IracMetadata metadata) {
       if (entry.isEvicted()) {
-         if (isTraceEnabled()) {
-            getLog().tracef("[IRAC] Ignoring evict key: %s", entry.getKey());
+         if (log.isTraceEnabled()) {
+            log.tracef("[IRAC] Ignoring evict key: %s", entry.getKey());
          }
          return;
       }
@@ -116,6 +137,71 @@ public abstract class AbstractIracLocalSiteInterceptor extends DDAsyncIntercepto
 
    protected Stream<StreamData> streamKeysFromCommand(WriteCommand command) {
       return command.getAffectedKeys().stream().map(key -> new StreamData(key, command, getSegment(command, key)));
+   }
+
+   protected boolean skipEntryCommit(InvocationContext ctx, WriteCommand command, Object key) {
+      switch (getOwnership(getSegment(command, key))) {
+         case NON_OWNER:
+            //not a write owner, we do nothing
+            return true;
+         case BACKUP:
+            //if it is local, we do nothing.
+            //the update happens in the remote context after the primary validated the write
+            if (ctx.isOriginLocal()) {
+               return true;
+            }
+      }
+      return false;
+   }
+
+   protected Object visitNonTxDataWriteCommand(InvocationContext ctx, DataWriteCommand command) {
+      final Object key = command.getKey();
+      if (isIracState(command)) { //all the state transfer/preload is done via put commands.
+         setMetadataToCacheEntry(ctx.lookupEntry(key), command.getInternalMetadata(key).iracMetadata());
+         return invokeNext(ctx, command);
+      }
+      if (command.hasAnyFlag(FlagBitSets.IRAC_UPDATE)) {
+         return invokeNext(ctx, command);
+      }
+      visitNonTxKey(ctx, key, command);
+      return invokeNextAndFinally(ctx, command, afterWriteCommand);
+   }
+
+   /**
+    * Visits the {@link WriteCommand} before executing it.
+    * <p>
+    * The primary owner generates a new {@link IracMetadata} and stores it in the {@link WriteCommand}.
+    */
+   protected void visitNonTxKey(InvocationContext ctx, Object key, WriteCommand command) {
+      int segment = getSegment(command, key);
+      if (getOwnership(segment) != Ownership.PRIMARY) {
+         return;
+      }
+      Optional<IracMetadata> entryMetadata = IracUtils.findIracMetadataFromCacheEntry(ctx.lookupEntry(key));
+      IracMetadata metadata;
+      // RemoveExpired should lose to any other conflicting write
+      if (command instanceof RemoveExpiredCommand) {
+         metadata = entryMetadata.orElseGet(() -> iracVersionGenerator.generateMetadataWithCurrentVersion(segment));
+      } else {
+         IracEntryVersion versionSeen = entryMetadata.map(IracMetadata::getVersion).orElse(null);
+         metadata = iracVersionGenerator.generateNewMetadata(segment, versionSeen);
+      }
+      updateCommandMetadata(key, command, metadata);
+      if (log.isTraceEnabled()) {
+         log.tracef("[IRAC] New metadata for key '%s' is %s. Command=%s", key, metadata, command);
+      }
+   }
+
+   /**
+    * Visits th {@link WriteCommand} after executed and stores the {@link IracMetadata} if it was successful.
+    */
+   @SuppressWarnings("unused")
+   private void handleNonTxDataWriteCommand(InvocationContext ctx, DataWriteCommand command, Object rv, Throwable t) {
+      final Object key = command.getKey();
+      if (!command.isSuccessful() || skipEntryCommit(ctx, command, key)) {
+         return;
+      }
+      setMetadataToCacheEntry(ctx.lookupEntry(key), command.getInternalMetadata(key).iracMetadata());
    }
 
    static class StreamData {

--- a/core/src/main/java/org/infinispan/interceptors/impl/EntryWrappingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/EntryWrappingInterceptor.java
@@ -347,8 +347,10 @@ public class EntryWrappingInterceptor extends DDAsyncInterceptor {
    }
 
    @Override
-   public Object visitIracPutKeyValueCommand(InvocationContext ctx, IracPutKeyValueCommand command) {
-      return setSkipRemoteGetsAndInvokeNextForDataCommand(ctx, command, wrapEntryIfNeeded(ctx, command));
+   public final Object visitIracPutKeyValueCommand(InvocationContext ctx, IracPutKeyValueCommand command) {
+      boolean isOwner = ignoreOwnership(command) || canRead(command);
+      entryFactory.wrapEntryForWritingSkipExpiration(ctx, command.getKey(), command.getSegment(), isOwner);
+      return setSkipRemoteGetsAndInvokeNextForDataCommand(ctx, command, CompletableFutures.completedNull());
    }
 
    protected CompletionStage<Void> wrapEntryIfNeeded(InvocationContext ctx, AbstractDataWriteCommand command) {

--- a/core/src/main/java/org/infinispan/interceptors/impl/NonTxIracLocalSiteInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/NonTxIracLocalSiteInterceptor.java
@@ -1,8 +1,5 @@
 package org.infinispan.interceptors.impl;
 
-import java.util.Optional;
-
-import org.infinispan.commands.FlagAffectedCommand;
 import org.infinispan.commands.functional.ReadWriteKeyCommand;
 import org.infinispan.commands.functional.ReadWriteKeyValueCommand;
 import org.infinispan.commands.functional.ReadWriteManyCommand;
@@ -16,23 +13,16 @@ import org.infinispan.commands.tx.PrepareCommand;
 import org.infinispan.commands.tx.RollbackCommand;
 import org.infinispan.commands.write.ComputeCommand;
 import org.infinispan.commands.write.ComputeIfAbsentCommand;
-import org.infinispan.commands.write.DataWriteCommand;
 import org.infinispan.commands.write.PutKeyValueCommand;
 import org.infinispan.commands.write.PutMapCommand;
 import org.infinispan.commands.write.RemoveCommand;
-import org.infinispan.commands.write.RemoveExpiredCommand;
 import org.infinispan.commands.write.ReplaceCommand;
 import org.infinispan.commands.write.WriteCommand;
-import org.infinispan.container.versioning.irac.IracEntryVersion;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.FlagBitSets;
 import org.infinispan.context.impl.TxInvocationContext;
-import org.infinispan.distribution.Ownership;
 import org.infinispan.interceptors.InvocationFinallyAction;
 import org.infinispan.metadata.impl.IracMetadata;
-import org.infinispan.util.IracUtils;
-import org.infinispan.util.logging.Log;
-import org.infinispan.util.logging.LogFactory;
 
 /**
  * Interceptor used by IRAC for non transactional caches to handle the local site updates.
@@ -48,33 +38,31 @@ import org.infinispan.util.logging.LogFactory;
  */
 public class NonTxIracLocalSiteInterceptor extends AbstractIracLocalSiteInterceptor {
 
-   private static final Log log = LogFactory.getLog(NonTxIracLocalSiteInterceptor.class);
-
    private final InvocationFinallyAction<WriteCommand> afterWriteCommand = this::handleWriteCommand;
 
    @Override
    public Object visitPutKeyValueCommand(InvocationContext ctx, PutKeyValueCommand command) {
-      return visitDataWriteCommand(ctx, command);
+      return visitNonTxDataWriteCommand(ctx, command);
    }
 
    @Override
    public Object visitRemoveCommand(InvocationContext ctx, RemoveCommand command) {
-      return visitDataWriteCommand(ctx, command);
+      return visitNonTxDataWriteCommand(ctx, command);
    }
 
    @Override
    public Object visitReplaceCommand(InvocationContext ctx, ReplaceCommand command) {
-      return visitDataWriteCommand(ctx, command);
+      return visitNonTxDataWriteCommand(ctx, command);
    }
 
    @Override
    public Object visitComputeIfAbsentCommand(InvocationContext ctx, ComputeIfAbsentCommand command) {
-      return visitDataWriteCommand(ctx, command);
+      return visitNonTxDataWriteCommand(ctx, command);
    }
 
    @Override
    public Object visitComputeCommand(InvocationContext ctx, ComputeCommand command) {
-      return visitDataWriteCommand(ctx, command);
+      return visitNonTxDataWriteCommand(ctx, command);
    }
 
    @Override
@@ -103,19 +91,19 @@ public class NonTxIracLocalSiteInterceptor extends AbstractIracLocalSiteIntercep
    @SuppressWarnings("rawtypes")
    @Override
    public Object visitWriteOnlyKeyCommand(InvocationContext ctx, WriteOnlyKeyCommand command) {
-      return visitDataWriteCommand(ctx, command);
+      return visitNonTxDataWriteCommand(ctx, command);
    }
 
    @SuppressWarnings("rawtypes")
    @Override
    public Object visitReadWriteKeyValueCommand(InvocationContext ctx, ReadWriteKeyValueCommand command) {
-      return visitDataWriteCommand(ctx, command);
+      return visitNonTxDataWriteCommand(ctx, command);
    }
 
    @SuppressWarnings("rawtypes")
    @Override
    public Object visitReadWriteKeyCommand(InvocationContext ctx, ReadWriteKeyCommand command) {
-      return visitDataWriteCommand(ctx, command);
+      return visitNonTxDataWriteCommand(ctx, command);
    }
 
    @SuppressWarnings("rawtypes")
@@ -127,7 +115,7 @@ public class NonTxIracLocalSiteInterceptor extends AbstractIracLocalSiteIntercep
    @SuppressWarnings("rawtypes")
    @Override
    public Object visitWriteOnlyKeyValueCommand(InvocationContext ctx, WriteOnlyKeyValueCommand command) {
-      return visitDataWriteCommand(ctx, command);
+      return visitNonTxDataWriteCommand(ctx, command);
    }
 
    @SuppressWarnings("rawtypes")
@@ -148,77 +136,14 @@ public class NonTxIracLocalSiteInterceptor extends AbstractIracLocalSiteIntercep
       return visitWriteCommand(ctx, command);
    }
 
-   @Override
-   public boolean isTraceEnabled() {
-      return log.isTraceEnabled();
-   }
-
-   @Override
-   public Log getLog() {
-      return log;
-   }
-
-   private Object visitDataWriteCommand(InvocationContext ctx, DataWriteCommand command) {
-      final Object key = command.getKey();
-      if (isIracState(command)) { //all the state transfer/preload is done via put commands.
-         setMetadataToCacheEntry(ctx.lookupEntry(key), command.getInternalMetadata(key).iracMetadata());
-         return invokeNext(ctx, command);
-      }
-      if (skipCommand(ctx, command)) {
-         return invokeNext(ctx, command);
-      }
-      visitKey(ctx, key, command);
-      return invokeNextAndFinally(ctx, command, this::handleDataWriteCommand);
-   }
-
    private Object visitWriteCommand(InvocationContext ctx, WriteCommand command) {
-      if (skipCommand(ctx, command)) {
+      if (command.hasAnyFlag(FlagBitSets.IRAC_UPDATE)) {
          return invokeNext(ctx, command);
       }
       for (Object key : command.getAffectedKeys()) {
-         visitKey(ctx, key, command);
+         visitNonTxKey(ctx, key, command);
       }
       return invokeNextAndFinally(ctx, command, afterWriteCommand);
-   }
-
-   private boolean skipCommand(InvocationContext ctx, FlagAffectedCommand command) {
-      return ctx.isInTxScope() || command.hasAnyFlag(FlagBitSets.IRAC_UPDATE);
-   }
-
-   /**
-    * Visits the {@link WriteCommand} before executing it.
-    * <p>
-    * The primary owner generates a new {@link IracMetadata} and stores it in the {@link WriteCommand}.
-    */
-   private void visitKey(InvocationContext ctx, Object key, WriteCommand command) {
-      int segment = getSegment(command, key);
-      if (getOwnership(segment) != Ownership.PRIMARY) {
-         return;
-      }
-      Optional<IracMetadata> entryMetadata = IracUtils.findIracMetadataFromCacheEntry(ctx.lookupEntry(key));
-      IracMetadata metadata;
-      // RemoveExpired should lose to any other conflicting write
-      if (command instanceof RemoveExpiredCommand) {
-         metadata = entryMetadata.orElseGet(() -> iracVersionGenerator.generateMetadataWithCurrentVersion(segment));
-      } else {
-         IracEntryVersion versionSeen = entryMetadata.map(IracMetadata::getVersion).orElse(null);
-         metadata = iracVersionGenerator.generateNewMetadata(segment, versionSeen);
-      }
-      updateCommandMetadata(key, command, metadata);
-      if (log.isTraceEnabled()) {
-         log.tracef("[IRAC] New metadata for key '%s' is %s. Command=%s", key, metadata, command);
-      }
-   }
-
-   /**
-    * Visits th {@link WriteCommand} after executed and stores the {@link IracMetadata} if it was successful.
-    */
-   private void handleDataWriteCommand(InvocationContext ctx, DataWriteCommand command, Object rv, Throwable t) {
-      final Object key = command.getKey();
-      if (!command.isSuccessful() || skipEntryCommit(ctx, command, key)) {
-         return;
-      }
-      setMetadataToCacheEntry(ctx.lookupEntry(key), command.getInternalMetadata(key).iracMetadata());
    }
 
    /**
@@ -237,18 +162,5 @@ public class NonTxIracLocalSiteInterceptor extends AbstractIracLocalSiteIntercep
       }
    }
 
-   private boolean skipEntryCommit(InvocationContext ctx, WriteCommand command, Object key) {
-      switch (getOwnership(getSegment(command, key))) {
-         case NON_OWNER:
-            //not a write owner, we do nothing
-            return true;
-         case BACKUP:
-            //if it is local, we do nothing.
-            //the update happens in the remote context after the primary validated the write
-            if (ctx.isOriginLocal()) {
-               return true;
-            }
-      }
-      return false;
-   }
+
 }

--- a/core/src/main/java/org/infinispan/interceptors/impl/NonTxIracRemoteSiteInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/NonTxIracRemoteSiteInterceptor.java
@@ -145,6 +145,19 @@ public class NonTxIracRemoteSiteInterceptor extends DDAsyncInterceptor implement
       }
       IracEntryVersion localVersion = localMetadata.getVersion();
       IracEntryVersion remoteVersion = remoteMetadata.getVersion();
+      if (command.isExpiration()) {
+         // expiration rules
+         // if the version is newer of equals, then the remove can continue
+         // if not, or if there is a conflict, we abort
+         switch (remoteVersion.compareTo(localVersion)) {
+            case AFTER:
+            case EQUAL:
+               return CompletableFutures.completedTrue();
+            default:
+               discardUpdate(entry, command, remoteMetadata);
+               return CompletableFutures.completedFalse();
+         }
+      }
       switch (remoteVersion.compareTo(localVersion)) {
          case CONFLICTING:
             return resolveConflict(entry, command, localMetadata, remoteMetadata);

--- a/core/src/main/java/org/infinispan/interceptors/xsite/OptimisticBackupInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/xsite/OptimisticBackupInterceptor.java
@@ -3,6 +3,9 @@ package org.infinispan.interceptors.xsite;
 import org.infinispan.commands.tx.CommitCommand;
 import org.infinispan.commands.tx.PrepareCommand;
 import org.infinispan.commands.tx.RollbackCommand;
+import org.infinispan.commands.write.PutKeyValueCommand;
+import org.infinispan.context.InvocationContext;
+import org.infinispan.context.impl.FlagBitSets;
 import org.infinispan.context.impl.LocalTxInvocationContext;
 import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.interceptors.InvocationStage;
@@ -14,6 +17,14 @@ import org.infinispan.interceptors.InvocationStage;
  * @since 5.2
  */
 public class OptimisticBackupInterceptor extends BaseBackupInterceptor {
+
+   @Override
+   public Object visitPutKeyValueCommand(InvocationContext ctx, PutKeyValueCommand command) {
+      if (skipXSiteBackup(command) || !command.hasAnyFlag(FlagBitSets.PUT_FOR_EXTERNAL_READ)) {
+         return invokeNext(ctx, command);
+      }
+      return invokeNextThenApply(ctx, command, handleSingleKeyWriteReturn);
+   }
 
    @Override
    public Object visitPrepareCommand(TxInvocationContext ctx, PrepareCommand command) {

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -2172,4 +2172,7 @@ public interface Log extends BasicLogger {
    @Message(value = "Timeout waiting for topology %d transaction data", id = 638)
    TimeoutException transactionDataTimeout(int expectedTopologyId);
 
+   @LogMessage(level = ERROR)
+   @Message(value = "Failed to send remove request to remote site(s). Reason: tombstone was lost. Key='%s'", id = 639)
+   void sendFailMissingTombstone(Object key);
 }

--- a/core/src/main/java/org/infinispan/xsite/BackupReceiver.java
+++ b/core/src/main/java/org/infinispan/xsite/BackupReceiver.java
@@ -43,9 +43,10 @@ public interface BackupReceiver {
     *
     * @param key          The key to delete.
     * @param iracMetadata The {@link IracMetadata} for conflict resolution.
+    * @param expiration   {@code true} if it is to remove an expired key.
     * @return A {@link CompletionStage} that is completed when the key is deleted or it is discarded.
     */
-   CompletionStage<Void> removeKey(Object key, IracMetadata iracMetadata);
+   CompletionStage<Void> removeKey(Object key, IracMetadata iracMetadata, boolean expiration);
 
    /**
     * Clears the cache.

--- a/core/src/main/java/org/infinispan/xsite/ClusteredCacheBackupReceiver.java
+++ b/core/src/main/java/org/infinispan/xsite/ClusteredCacheBackupReceiver.java
@@ -221,9 +221,10 @@ public class ClusteredCacheBackupReceiver implements BackupReceiver {
    }
 
    @Override
-   public CompletionStage<Void> removeKey(Object key, IracMetadata iracMetadata) {
+   public CompletionStage<Void> removeKey(Object key, IracMetadata iracMetadata, boolean expiration) {
       IracPutKeyValueCommand cmd = commandsFactory.buildIracPutKeyValueCommand(key, segment(key), null, null,
             internalMetadata(iracMetadata));
+      cmd.setExpiration(expiration);
       InvocationContext ctx = invocationContextFactory.createSingleKeyNonTxInvocationContext();
       return invocationHelper.invokeAsync(ctx, cmd).handle(CHECK_EXCEPTION);
    }

--- a/core/src/main/java/org/infinispan/xsite/irac/IracExecutor.java
+++ b/core/src/main/java/org/infinispan/xsite/irac/IracExecutor.java
@@ -109,7 +109,7 @@ public class IracExecutor implements Function<Void, CompletionStage<Void>> {
          try {
             return runnable.get();
          } catch (Throwable e) {
-            log.trace("Unexpected exception", e);
+            log.unexpectedErrorFromIrac(e);
             return CompletableFutures.completedNull();
          }
       }

--- a/core/src/main/java/org/infinispan/xsite/irac/IracManager.java
+++ b/core/src/main/java/org/infinispan/xsite/irac/IracManager.java
@@ -33,6 +33,17 @@ public interface IracManager {
    void trackUpdatedKey(int segment, Object key, Object lockOwner);
 
    /**
+    * Similar to {@link #trackUpdatedKey(int, Object, Object)} but it tracks expired keys instead.
+    * <p>
+    * Expired key need a different conflict resolution algorithm since remove expired should never win any conflict.
+    *
+    * @param segment   The key's segment.
+    * @param key       The key expired.
+    * @param lockOwner The lock owner who updated the key.
+    */
+   void trackExpiredKey(int segment, Object key, Object lockOwner);
+
+   /**
     * Tracks a set of keys to be send to the remote site.
     * <p>
     * There is no much difference between this method and {@link #trackUpdatedKey(int, Object, Object)}. It just returns

--- a/core/src/main/java/org/infinispan/xsite/irac/NoOpIracManager.java
+++ b/core/src/main/java/org/infinispan/xsite/irac/NoOpIracManager.java
@@ -36,6 +36,11 @@ public class NoOpIracManager implements IracManager {
    }
 
    @Override
+   public void trackExpiredKey(int segment, Object key, Object lockOwner) {
+      // no-op
+   }
+
+   @Override
    public CompletionStage<Void> trackForStateTransfer(Collection<XSiteState> stateList) {
       return CompletableFutures.completedNull();
    }

--- a/core/src/test/java/org/infinispan/util/ControlledTimeService.java
+++ b/core/src/test/java/org/infinispan/util/ControlledTimeService.java
@@ -5,7 +5,9 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * TimeService that allows for wall clock time to be adjust manually.
+ * @deprecated Use {@link org.infinispan.commons.time.ControlledTimeService} instead.
  */
+@Deprecated
 public class ControlledTimeService extends EmbeddedTimeService {
    protected long currentMillis;
 

--- a/core/src/test/java/org/infinispan/util/mocks/ControlledCommandFactory.java
+++ b/core/src/test/java/org/infinispan/util/mocks/ControlledCommandFactory.java
@@ -683,8 +683,8 @@ public class ControlledCommandFactory implements CommandsFactory {
    }
 
    @Override
-   public IracRemoveKeyCommand buildIracRemoveKeyCommand(Object key, IracMetadata iracMetadata) {
-      return actual.buildIracRemoveKeyCommand(key, iracMetadata);
+   public IracRemoveKeyCommand buildIracRemoveKeyCommand(Object key, IracMetadata iracMetadata, boolean expiration) {
+      return actual.buildIracRemoveKeyCommand(key, iracMetadata, expiration);
    }
 
    @Override

--- a/core/src/test/java/org/infinispan/xsite/AbstractXSiteTest.java
+++ b/core/src/test/java/org/infinispan/xsite/AbstractXSiteTest.java
@@ -328,7 +328,6 @@ public abstract class AbstractXSiteTest extends AbstractCacheTest {
                                                                GlobalConfigurationBuilder globalTemplate,
                                                                ConfigurationBuilder cacheTemplate, boolean waitBetweenCacheManager) {
          List<Cache<K, V>> caches = new ArrayList<>(numMembersInCluster);
-         final TransportFlags flags = transportFlags();
          for (int i = 0; i < numMembersInCluster; i++) {
             EmbeddedCacheManager cm = addCacheManager(cacheName, globalTemplate, cacheTemplate, waitBetweenCacheManager);
             if (cacheName != null) {

--- a/core/src/test/java/org/infinispan/xsite/AsyncBackupTest.java
+++ b/core/src/test/java/org/infinispan/xsite/AsyncBackupTest.java
@@ -1,8 +1,11 @@
 package org.infinispan.xsite;
 
+import static org.infinispan.test.TestingUtil.extractComponent;
 import static org.infinispan.test.TestingUtil.extractInterceptorChain;
 import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertNull;
+import static org.testng.AssertJUnit.assertTrue;
 
 import java.util.Collections;
 import java.util.LinkedList;
@@ -10,6 +13,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import org.infinispan.Cache;
 import org.infinispan.commands.VisitableCommand;
 import org.infinispan.commands.functional.WriteOnlyManyEntriesCommand;
 import org.infinispan.commands.tx.CommitCommand;
@@ -23,9 +27,16 @@ import org.infinispan.commands.write.ReplaceCommand;
 import org.infinispan.configuration.cache.BackupConfiguration;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.container.entries.InternalCacheEntry;
+import org.infinispan.container.impl.InternalDataContainer;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.TxInvocationContext;
+import org.infinispan.distribution.DistributionInfo;
+import org.infinispan.distribution.DistributionTestHelper;
 import org.infinispan.interceptors.DDAsyncInterceptor;
+import org.infinispan.interceptors.locking.ClusteringDependentLogic;
+import org.infinispan.metadata.impl.IracMetadata;
+import org.infinispan.metadata.impl.PrivateMetadata;
 import org.infinispan.transaction.LockingMode;
 import org.infinispan.util.concurrent.IsolationLevel;
 import org.testng.annotations.BeforeMethod;
@@ -125,23 +136,24 @@ public class AsyncBackupTest extends AbstractTwoSitesTest {
 
    public void testPut() throws Exception {
       cache(LON, 0).put("k", "v");
-      blockingInterceptor.invocationReceivedLatch.await(20000, TimeUnit.MILLISECONDS);
+      assertReachedRemoteSite();
       assertEquals("v", cache(LON, 0).get("k"));
       assertEquals("v", cache(LON, 1).get("k"));
       assertNull(backup(LON).get("k"));
-      blockingInterceptor.waitingLatch.countDown();
+      resumeRemoteSite();
       eventuallyEquals("v", () -> backup(LON).get("k"));
+      assertDataContainerState("v");
    }
 
    public void testRemove() throws Exception {
       doPutWithDisabledBlockingInterceptor();
 
       cache(LON, 1).remove("k");
-      blockingInterceptor.invocationReceivedLatch.await(20000, TimeUnit.MILLISECONDS);
+      assertReachedRemoteSite();
       assertNull(cache(LON, 0).get("k"));
       assertNull(cache(LON, 1).get("k"));
       assertEquals("v", backup(LON).get("k"));
-      blockingInterceptor.waitingLatch.countDown();
+      resumeRemoteSite();
       eventuallyEquals(null, () -> backup(LON).get("k"));
    }
 
@@ -149,11 +161,11 @@ public class AsyncBackupTest extends AbstractTwoSitesTest {
       doPutWithDisabledBlockingInterceptor();
 
       cache(LON, 1).clear();
-      blockingInterceptor.invocationReceivedLatch.await(20000, TimeUnit.MILLISECONDS);
+      assertReachedRemoteSite();
       assertNull(cache(LON, 0).get("k"));
       assertNull(cache(LON, 1).get("k"));
       assertEquals("v", backup(LON).get("k"));
-      blockingInterceptor.waitingLatch.countDown();
+      resumeRemoteSite();
       eventuallyEquals(null, () -> backup(LON).get("k"));
    }
 
@@ -161,22 +173,36 @@ public class AsyncBackupTest extends AbstractTwoSitesTest {
       doPutWithDisabledBlockingInterceptor();
 
       cache(LON, 1).replace("k", "v2");
-      blockingInterceptor.invocationReceivedLatch.await(20000, TimeUnit.MILLISECONDS);
+      assertReachedRemoteSite();
       assertEquals("v2", cache(LON, 0).get("k"));
       assertEquals("v2", cache(LON, 1).get("k"));
       assertEquals("v", backup(LON).get("k"));
-      blockingInterceptor.waitingLatch.countDown();
+      resumeRemoteSite();
       eventuallyEquals("v2", () -> backup(LON).get("k"));
+      assertDataContainerState("v2");
    }
 
    public void testPutAll() throws Exception {
       cache(LON, 0).putAll(Collections.singletonMap("k", "v"));
-      blockingInterceptor.invocationReceivedLatch.await(20000, TimeUnit.MILLISECONDS);
+      assertReachedRemoteSite();
       assertEquals("v", cache(LON, 0).get("k"));
       assertEquals("v", cache(LON, 1).get("k"));
       assertNull(backup(LON).get("k"));
-      blockingInterceptor.waitingLatch.countDown();
+      resumeRemoteSite();
       eventuallyEquals("v", () -> backup(LON).get("k"));
+      assertDataContainerState("v");
+   }
+
+   public void testPutForExternalRead() throws InterruptedException {
+      cache(LON, 0).putForExternalRead("k", "v");
+      assertReachedRemoteSite();
+      // put for external read is async
+      eventuallyEquals("v", () -> cache(LON, 0).get("k"));
+      eventuallyEquals("v", () -> cache(LON, 1).get("k"));
+      assertNull(backup(LON).get("k"));
+      resumeRemoteSite();
+      eventuallyEquals("v", () -> backup(LON).get("k"));
+      assertDataContainerState("v");
    }
 
    private void doPutWithDisabledBlockingInterceptor() {
@@ -185,6 +211,76 @@ public class AsyncBackupTest extends AbstractTwoSitesTest {
 
       eventuallyEquals("v", () -> backup(LON).get("k"));
       blockingInterceptor.isActive = true;
+   }
+
+   private void assertReachedRemoteSite() throws InterruptedException {
+      try {
+         assertTrue(blockingInterceptor.invocationReceivedLatch.await(20000, TimeUnit.MILLISECONDS));
+      } catch (InterruptedException e) {
+         Thread.currentThread().interrupt();
+         throw e;
+      }
+   }
+
+   private void resumeRemoteSite() {
+      blockingInterceptor.waitingLatch.countDown();
+   }
+
+   private DistributionInfo getDistributionForKey(Cache<String, String> cache) {
+      return extractComponent(cache, ClusteringDependentLogic.class)
+            .getCacheTopology()
+            .getDistribution("k");
+   }
+
+   private boolean isNotWriteOwner(Cache<String, String> cache) {
+      return !getDistributionForKey(cache).isWriteOwner();
+   }
+
+   private Cache<String, String> findPrimaryOwner() {
+      for (Cache<String, String> c : this.<String, String>caches(LON)) {
+         if (getDistributionForKey(c).isPrimary()) {
+            return c;
+         }
+      }
+      throw new IllegalStateException(String.format("Unable to find primary owner for key %s", "k"));
+   }
+
+   private InternalDataContainer<String, String> getInternalDataContainer(Cache<String, String> cache) {
+      //noinspection unchecked
+      return extractComponent(cache, InternalDataContainer.class);
+   }
+
+   private IracMetadata extractMetadataFromPrimaryOwner() {
+      Cache<String, String> cache = findPrimaryOwner();
+      InternalDataContainer<String, String> dataContainer = getInternalDataContainer(cache);
+      InternalCacheEntry<String, String> entry = dataContainer.peek("k");
+      assertNotNull(entry);
+      PrivateMetadata internalMetadata = entry.getInternalMetadata();
+      assertNotNull(internalMetadata);
+      IracMetadata metadata = internalMetadata.iracMetadata();
+      assertNotNull(metadata);
+      return metadata;
+   }
+
+   private void assertInDataContainer(String site, String value, IracMetadata metadata) {
+      for (Cache<String, String> cache : this.<String, String>caches(site)) {
+         if (isNotWriteOwner(cache)) {
+            continue;
+         }
+         InternalDataContainer<String, String> dc = getInternalDataContainer(cache);
+         InternalCacheEntry<String, String> ice = dc.peek("k");
+         log.debugf("Checking DataContainer in %s. entry=%s", DistributionTestHelper.addressOf(cache), ice);
+         assertNotNull(String.format("Internal entry is null for key %s", "k"), ice);
+         assertEquals("Internal entry wrong key", "k", ice.getKey());
+         assertEquals("Internal entry wrong value", value, ice.getValue());
+         assertEquals("Internal entry wrong metadata", metadata, ice.getInternalMetadata().iracMetadata());
+      }
+   }
+
+   private void assertDataContainerState(String value) {
+      IracMetadata metadata = extractMetadataFromPrimaryOwner();
+      assertInDataContainer(LON, value, metadata);
+      assertInDataContainer(NYC, value, metadata);
    }
 
    public static class BlockingInterceptor extends DDAsyncInterceptor {
@@ -249,7 +345,7 @@ public class AsyncBackupTest extends AbstractTwoSitesTest {
       protected Object handle(InvocationContext ctx, VisitableCommand command) throws Throwable {
          if (isActive) {
             invocationReceivedLatch.countDown();
-            waitingLatch.await(30, TimeUnit.SECONDS);
+            assertTrue(waitingLatch.await(30, TimeUnit.SECONDS));
          }
          return super.handleDefault(ctx, command);
       }

--- a/core/src/test/java/org/infinispan/xsite/BackupReceiverDelegator.java
+++ b/core/src/test/java/org/infinispan/xsite/BackupReceiverDelegator.java
@@ -38,8 +38,8 @@ public abstract class BackupReceiverDelegator implements BackupReceiver {
    }
 
    @Override
-   public CompletionStage<Void> removeKey(Object key, IracMetadata iracMetadata) {
-      return delegate.removeKey(key, iracMetadata);
+   public CompletionStage<Void> removeKey(Object key, IracMetadata iracMetadata, boolean expiration) {
+      return delegate.removeKey(key, iracMetadata, expiration);
    }
 
    @Override

--- a/core/src/test/java/org/infinispan/xsite/irac/ControlledIracManager.java
+++ b/core/src/test/java/org/infinispan/xsite/irac/ControlledIracManager.java
@@ -33,6 +33,11 @@ public class ControlledIracManager implements IracManager {
    }
 
    @Override
+   public void trackExpiredKey(int segment, Object key, Object lockOwner) {
+      actual.trackExpiredKey(segment, key, lockOwner);
+   }
+
+   @Override
    public CompletionStage<Void> trackForStateTransfer(Collection<XSiteState> stateList) {
       return actual.trackForStateTransfer(stateList);
    }

--- a/core/src/test/java/org/infinispan/xsite/irac/IracMaxIdleTest.java
+++ b/core/src/test/java/org/infinispan/xsite/irac/IracMaxIdleTest.java
@@ -1,0 +1,169 @@
+package org.infinispan.xsite.irac;
+
+import static org.infinispan.test.TestingUtil.extractComponent;
+import static org.infinispan.test.TestingUtil.replaceComponent;
+import static org.testng.AssertJUnit.assertNull;
+import static org.testng.AssertJUnit.assertTrue;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.infinispan.Cache;
+import org.infinispan.commons.time.ControlledTimeService;
+import org.infinispan.commons.time.TimeService;
+import org.infinispan.configuration.cache.BackupConfiguration;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.container.impl.InternalDataContainer;
+import org.infinispan.transaction.LockingMode;
+import org.infinispan.transaction.TransactionMode;
+import org.infinispan.xsite.AbstractMultipleSitesTest;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Tests if max-idle expiration works properly with x-site (ISPN-13057)
+ *
+ * @author Pedro Ruivo
+ * @since 13.0
+ */
+@Test(groups = "functional", testName = "xsite.irac.IracMaxIdleTest")
+public class IracMaxIdleTest extends AbstractMultipleSitesTest {
+
+   private static final long MAX_IDLE = 1000; //milliseconds
+   private final ControlledTimeService timeService = new ControlledTimeService(0);
+
+   @Override
+   protected int defaultNumberOfSites() {
+      return 2;
+   }
+
+   @Override
+   protected int defaultNumberOfNodes() {
+      return 1;
+   }
+
+   @Override
+   protected ConfigurationBuilder defaultConfigurationForSite(int siteIndex) {
+      ConfigurationBuilder builder = super.defaultConfigurationForSite(siteIndex);
+      builder.expiration().reaperEnabled(false);
+      builder.sites().addBackup()
+            .site(siteIndex == 0 ? siteName(1) : siteName(0))
+            .strategy(BackupConfiguration.BackupStrategy.ASYNC);
+      return builder;
+   }
+
+   @DataProvider(name = "data")
+   public Object[][] data() {
+      return new Object[][]{
+            {TestData.NON_TX},
+            {TestData.PESSIMISTIC},
+            {TestData.OPTIMISTIC}
+      };
+   }
+
+   @Test(dataProvider = "data")
+   public void testMaxIdle(TestData testData) {
+      final String cacheName = createCaches(testData);
+      List<ManualIracManager> iracManagers = caches(0, cacheName).stream()
+            .map(ManualIracManager::wrapCache)
+            .peek(m -> m.disable(ManualIracManager.DisableMode.DROP)) // reset state
+            .collect(Collectors.toList());
+      final String key = createKeyOrValue(testData, "key");
+      final String value = createKeyOrValue(testData, "value");
+
+      cache(0, 0, cacheName).put(key, value, -1, TimeUnit.MILLISECONDS, MAX_IDLE, TimeUnit.MILLISECONDS);
+
+      eventuallyAssertInAllSitesAndCaches(cacheName, c -> Objects.equals(value, c.get(key)));
+
+      // block xsite replication (remove expired).
+      // the touch command is not blocked
+      iracManagers.forEach(ManualIracManager::enable);
+
+      timeService.advance(MAX_IDLE + 1);
+
+      // get should trigger the expiration
+      assertNull(cache(0, 0, cacheName).get(key));
+
+      // one of them should have the key there
+      assertTrue(iracManagers.stream().anyMatch(ManualIracManager::hasPendingKeys));
+
+      // let the key go
+      iracManagers.forEach(ManualIracManager::sendKeys);
+
+      // eventually it should go
+      eventually(() -> iracManagers.stream().noneMatch(ManualIracManager::hasPendingKeys));
+      eventually(() -> iracManagers.stream().allMatch(ManualIracManager::isEmpty));
+
+      assertNoKeyInDataContainer(1, cacheName, key);
+      assertNoKeyInDataContainer(0, cacheName, key);
+   }
+
+   private static String createKeyOrValue(TestData testData, String prefix) {
+      switch (testData) {
+         case NON_TX:
+            return prefix + "_ntx_";
+         case PESSIMISTIC:
+            return prefix + "_pes_";
+         case OPTIMISTIC:
+            return prefix + "_opt_";
+         default:
+            throw new IllegalStateException(String.valueOf(testData));
+      }
+   }
+
+   private String createCaches(TestData testData) {
+      String cacheName;
+      LockingMode lockingMode;
+      switch (testData) {
+         case NON_TX:
+            // default cache is fine
+            return null;
+         case PESSIMISTIC:
+            cacheName = "pes_cache";
+            lockingMode = LockingMode.PESSIMISTIC;
+            break;
+         case OPTIMISTIC:
+            cacheName = "opt_cache";
+            lockingMode = LockingMode.OPTIMISTIC;
+            break;
+         default:
+            throw new IllegalStateException(String.valueOf(testData));
+      }
+      for (int i = 0; i < defaultNumberOfSites(); ++i) {
+         defineInSite(site(i), cacheName, defaultConfigurationForSite(i)
+               .transaction()
+               .transactionMode(TransactionMode.TRANSACTIONAL)
+               .lockingMode(lockingMode)
+               .build());
+         site(i).waitForClusterToForm(cacheName);
+      }
+      return cacheName;
+   }
+
+   private void assertNoKeyInDataContainer(int siteIndex, String cacheName, String key) {
+      for (Cache<String, String> c : this.<String, String>caches(siteIndex, cacheName)) {
+         assertNull(internalDataContainer(c).peek(key));
+      }
+   }
+
+   private InternalDataContainer<String, String> internalDataContainer(Cache<String, String> c) {
+      //noinspection unchecked
+      return extractComponent(c, InternalDataContainer.class);
+   }
+
+   @Override
+   protected void afterSitesCreated() {
+      super.afterSitesCreated();
+      for (int i = 0; i < defaultNumberOfSites(); ++i) {
+         site(i).cacheManagers().forEach(cm -> replaceComponent(cm, TimeService.class, timeService, true));
+      }
+   }
+
+   private enum TestData {
+      NON_TX,
+      PESSIMISTIC,
+      OPTIMISTIC
+   }
+}


### PR DESCRIPTION
The IracLocalInterceptor was ignoring the RemoteExpiredCommand so the
tombstone was not properly recorded for the expired key.
This caused a NullPointerException when sending the remove request to
remote sites.

Other changes somehow related:
* Requests from remote site no longer check for expiration since the key
  is going to be updated.
* Tag Remove request from remote site for expired keys.
* New conflict resolution for expiration removals: they always lose in
  case of conflict.

Off-topic changes
* PutForExternal read was not backup for tx caches and they didn't
  generate the IracMetadata
* Fixed AsyncBackupExpirationTest random failure
* Deprecated org.infinispan.util.ControlledTimeService.

https://issues.redhat.com/browse/ISPN-13057