### PR TITLE
[12.1] ISPN-11013 ISPN-11014 ISPN-12959 Fixes for query result count

### DIFF
--- a/client/infinispan-key-value-store-hotrod/src/main/java/org/infinispan/api/reactive/client/impl/QueryPublisherImpl.java
+++ b/client/infinispan-key-value-store-hotrod/src/main/java/org/infinispan/api/reactive/client/impl/QueryPublisherImpl.java
@@ -28,7 +28,7 @@ public class QueryPublisherImpl<T> implements Publisher<T> {
    @Override
    public void subscribe(Subscriber<? super T> subscriber) {
       CompletableFuture.supplyAsync(() ->
-            (List<T>) query.list(), executorService)
+            (List<T>) query.execute().list(), executorService)
             .whenComplete((r, ex) -> {
                Flowable<T> flowable;
                if (ex != null) {

--- a/query-core/src/main/java/org/infinispan/query/core/impl/AggregatingQuery.java
+++ b/query-core/src/main/java/org/infinispan/query/core/impl/AggregatingQuery.java
@@ -52,8 +52,8 @@ public final class AggregatingQuery<T> extends HybridQuery<T, Object[]> {
    @Override
    protected CloseableIterator<?> getBaseIterator() {
       RowGrouper grouper = new RowGrouper(noOfGroupingColumns, accumulators, twoPhaseAcc);
-      for (Object[] row : baseQuery) {
-         grouper.addRow(row);
+      try (CloseableIterator<Object[]> iterator = baseQuery.iterator()) {
+         iterator.forEachRemaining(item -> grouper.addRow(item));
       }
       return Closeables.iterator(grouper.finish());
    }

--- a/query-core/src/main/java/org/infinispan/query/core/impl/HybridQuery.java
+++ b/query-core/src/main/java/org/infinispan/query/core/impl/HybridQuery.java
@@ -46,11 +46,11 @@ public class HybridQuery<T, S> extends BaseEmbeddedQuery<T> {
 
    @Override
    protected CloseableIterator<ObjectFilter.FilterResult> getInternalIterator() {
-      return new FilteringIterator<>(getBaseIterator(), objectFilter::filter);
+      return new MappingIterator<>(getBaseIterator(), objectFilter::filter);
    }
 
    protected CloseableIterator<?> getBaseIterator() {
-      return baseQuery.iterator();
+      return baseQuery.startOffset(0).maxResults(-1).iterator();
    }
 
    @Override

--- a/query-core/src/main/java/org/infinispan/query/core/impl/QueryEngine.java
+++ b/query-core/src/main/java/org/infinispan/query/core/impl/QueryEngine.java
@@ -398,7 +398,7 @@ public class QueryEngine<TypeMetadata> {
       HybridQuery<?, ?> projectingAggregatingQuery = new HybridQuery<>(queryFactory, cache,
             secondPhaseQueryStr, namedParameters,
             getObjectFilter(matcher, secondPhaseQueryStr, namedParameters, secondPhaseAccumulators),
-            -1, -1, baseQuery, queryStatistics);
+            startOffset, maxResults, baseQuery, queryStatistics);
 
       StringBuilder thirdPhaseQuery = new StringBuilder();
       thirdPhaseQuery.append("SELECT ");

--- a/query-core/src/main/java/org/infinispan/query/core/impl/QueryResultImpl.java
+++ b/query-core/src/main/java/org/infinispan/query/core/impl/QueryResultImpl.java
@@ -1,5 +1,6 @@
 package org.infinispan.query.core.impl;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.OptionalLong;
 
@@ -11,6 +12,8 @@ import org.infinispan.query.dsl.QueryResult;
 public final class QueryResultImpl<E> implements QueryResult<E> {
 
    private final OptionalLong hitCount;
+
+   public static final QueryResult<?> EMPTY = new QueryResultImpl<>(0, Collections.emptyList());
 
    private final List<E> list;
 

--- a/query-core/src/main/java/org/infinispan/query/core/impl/SlicingCollector.java
+++ b/query-core/src/main/java/org/infinispan/query/core/impl/SlicingCollector.java
@@ -1,0 +1,61 @@
+package org.infinispan.query.core.impl;
+
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+
+/**
+ * Delegates to the underlying collector only if item is inside the supplied window, while still keeping the count
+ * of all items of the stream.
+ *
+ * @since 12.1
+ */
+class SlicingCollector<U, A, R> implements Collector<U, A, R> {
+   private final Collector<U, A, R> collector;
+   private final long skip;
+   private final long limit;
+   private long count = 0;
+
+   public SlicingCollector(Collector<U, A, R> collector, long skip, long limit) {
+      this.collector = collector;
+      this.skip = skip;
+      this.limit = limit < 0 ? -1 : limit;
+   }
+
+   long getCount() {
+      return count;
+   }
+
+   @Override
+   public Supplier<A> supplier() {
+      return collector.supplier();
+   }
+
+   @Override
+   public BiConsumer<A, U> accumulator() {
+      BiConsumer<A, U> accumulator = collector.accumulator();
+      return (a, u) -> {
+         count++;
+         if (count > skip && (limit == -1 || count <= skip + limit))
+            accumulator.accept(a, u);
+      };
+   }
+
+   @Override
+   public BinaryOperator<A> combiner() {
+      return collector.combiner();
+   }
+
+   @Override
+   public Function<A, R> finisher() {
+      return collector.finisher();
+   }
+
+   @Override
+   public Set<Characteristics> characteristics() {
+      return collector.characteristics();
+   }
+}

--- a/query-core/src/test/java/org/infinispan/query/core/impl/MappingIteratorTest.java
+++ b/query-core/src/test/java/org/infinispan/query/core/impl/MappingIteratorTest.java
@@ -2,6 +2,7 @@ package org.infinispan.query.core.impl;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Function;
 import java.util.stream.StreamSupport;
 
 import org.infinispan.commons.util.Closeables;
@@ -10,11 +11,10 @@ import org.testng.annotations.Test;
 
 @Test(groups = "unit", testName = "query.core.impl.MappingIteratorTest")
 public class MappingIteratorTest {
+   private final List<Integer> integers = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 
    @Test
    public void testIteration() {
-      List<Integer> integers = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-
       MappingIterator<Integer, String> mapIterator = createMappingIterator(integers);
       assertIterator(mapIterator, "1", "2", "3", "4", "5", "6", "7", "8", "9", "10");
 
@@ -44,10 +44,52 @@ public class MappingIteratorTest {
 
       mapIterator = createMappingIterator(integers).skip(50).limit(2);
       assertIterator(mapIterator);
+
+      mapIterator = createMappingIterator(Arrays.asList(1, null, 3, null, 4));
+      assertIterator(mapIterator, "1", "3", "4");
+
+      mapIterator = createMappingIterator(Arrays.asList(1, null, 3, null, 4, 5, 6)).skip(1).limit(3);
+      assertIterator(mapIterator, "3", "4", "5");
+   }
+
+   @Test
+   public void testFiltering() {
+      Function<Integer, String> EVEN = integer -> integer % 2 != 0 ? null : String.valueOf(integer);
+      Function<Integer, String> LT5 = integer -> integer < 5 ? String.valueOf(integer) : null;
+      Function<Integer, String> ALL = String::valueOf;
+      Function<Integer, String> NONE = integer -> null;
+
+      MappingIterator<Integer, String> mappingIterator = createMappingIterator(integers, EVEN).skip(1);
+      assertIterator(mappingIterator, "4", "6", "8", "10");
+
+      mappingIterator = createMappingIterator(integers, EVEN);
+      assertIterator(mappingIterator, "2", "4", "6", "8", "10");
+
+      mappingIterator = createMappingIterator(integers, EVEN).skip(1);
+      assertIterator(mappingIterator, "4", "6", "8", "10");
+
+      mappingIterator = createMappingIterator(integers, LT5);
+      assertIterator(mappingIterator, "1", "2", "3", "4");
+
+      mappingIterator = createMappingIterator(integers, ALL);
+      assertIterator(mappingIterator, "1", "2", "3", "4", "5", "6", "7", "8", "9", "10");
+
+      mappingIterator = createMappingIterator(integers, LT5).skip(1).limit(1);
+      assertIterator(mappingIterator, "2");
+
+      mappingIterator = createMappingIterator(integers, LT5).skip(5).limit(10);
+      assertIterator(mappingIterator);
+
+      mappingIterator = createMappingIterator(integers, NONE);
+      assertIterator(mappingIterator);
    }
 
    private MappingIterator<Integer, String> createMappingIterator(List<Integer> data) {
       return new MappingIterator<>(Closeables.iterator(data.iterator()), String::valueOf);
+   }
+
+   private MappingIterator<Integer, String> createMappingIterator(List<Integer> data, Function<Integer, String> fn) {
+      return new MappingIterator<>(Closeables.iterator(data.iterator()), fn);
    }
 
    private void assertIterator(MappingIterator<Integer, String> iterator, String... expected) {

--- a/query/src/main/java/org/infinispan/query/clustered/NodeTopDocs.java
+++ b/query/src/main/java/org/infinispan/query/clustered/NodeTopDocs.java
@@ -22,12 +22,14 @@ public final class NodeTopDocs {
 
    public final Address address;
    public final TopDocs topDocs;
+   public long totalHitCount;
    public final Object[] keys;
    public final Object[] projections;
 
-   public NodeTopDocs(Address address, TopDocs topDocs, Object[] keys, Object[] projections) {
+   public NodeTopDocs(Address address, TopDocs topDocs, long totalHitCount, Object[] keys, Object[] projections) {
       this.address = address;
       this.topDocs = topDocs;
+      this.totalHitCount = totalHitCount;
       this.keys = keys;
       this.projections = projections;
    }
@@ -58,7 +60,8 @@ public final class NodeTopDocs {
             projections[i] = input.readObject();
          }
          TopDocs innerTopDocs = (TopDocs) input.readObject();
-         return new NodeTopDocs(address, innerTopDocs, keys, projections);
+         long totalHitCount = input.readLong();
+         return new NodeTopDocs(address, innerTopDocs, totalHitCount, keys, projections);
       }
 
       @Override
@@ -77,6 +80,7 @@ public final class NodeTopDocs {
             output.writeObject(projections[i]);
          }
          output.writeObject(topDocs.topDocs);
+         output.writeLong(topDocs.totalHitCount);
       }
    }
 }

--- a/query/src/main/java/org/infinispan/query/clustered/QueryResponse.java
+++ b/query/src/main/java/org/infinispan/query/clustered/QueryResponse.java
@@ -18,49 +18,24 @@ import org.infinispan.query.impl.externalizers.ExternalizerIds;
 public final class QueryResponse {
 
    private final NodeTopDocs nodeTopDocs;
+   private final long resultSize;
 
-   private final Integer resultSize;
-
-   private final Object fetchedValue;
-
-   public QueryResponse() {
-      nodeTopDocs = null;
-      resultSize = null;
-      fetchedValue = null;
-   }
-
-   public QueryResponse(Object fetchedValue) {
-      this.fetchedValue = fetchedValue;
-      nodeTopDocs = null;
-      resultSize = null;
-   }
-
-   public QueryResponse(int resultSize) {
+   public QueryResponse(long resultSize) {
       this.resultSize = resultSize;
       nodeTopDocs = null;
-      fetchedValue = null;
    }
 
    public QueryResponse(NodeTopDocs nodeTopDocs) {
-      if (nodeTopDocs == null) {
-         this.resultSize = 0;
-      } else {
-         this.resultSize = Math.toIntExact(nodeTopDocs.topDocs == null ? 0 : nodeTopDocs.topDocs.totalHits.value);
-      }
+      this.resultSize = nodeTopDocs.totalHitCount;
       this.nodeTopDocs = nodeTopDocs;
-      this.fetchedValue = null;
    }
 
    public NodeTopDocs getNodeTopDocs() {
       return nodeTopDocs;
    }
 
-   public Integer getResultSize() {
+   public Long getResultSize() {
       return resultSize;
-   }
-
-   public Object getFetchedValue() {
-      return fetchedValue;
    }
 
    public static final class Externalizer implements AdvancedExternalizer<QueryResponse> {
@@ -79,10 +54,7 @@ public final class QueryResponse {
       public void writeObject(ObjectOutput output, QueryResponse queryResponse) throws IOException {
          output.writeObject(queryResponse.nodeTopDocs);
          if (queryResponse.nodeTopDocs == null) {
-            output.writeObject(queryResponse.resultSize);
-            if (queryResponse.resultSize == null) {
-               output.writeObject(queryResponse.fetchedValue);
-            }
+            output.writeLong(queryResponse.resultSize);
          }
       }
 
@@ -92,11 +64,7 @@ public final class QueryResponse {
          if (nodeTopDocs != null) {
             return new QueryResponse(nodeTopDocs);
          }
-         Integer resultSize = (Integer) input.readObject();
-         if (resultSize != null) {
-            return new QueryResponse(resultSize.intValue());
-         }
-         return new QueryResponse(input.readObject());
+         return new QueryResponse(input.readLong());
       }
    }
 }

--- a/query/src/main/java/org/infinispan/query/clustered/commandworkers/CQCreateEagerQuery.java
+++ b/query/src/main/java/org/infinispan/query/clustered/commandworkers/CQCreateEagerQuery.java
@@ -55,23 +55,23 @@ final class CQCreateEagerQuery extends CQWorker {
    private CompletionStage<NodeTopDocs> collectKeys(SearchQueryBuilder query) {
       return blockingManager.supplyBlocking(() -> fetchReferences(query), "CQCreateEagerQuery#collectKeys")
             .thenApply(queryResult -> {
-               if (queryResult.total().hitCount() == 0L) return null;
+               long hitCount = queryResult.total().hitCount();
 
                Object[] keys = queryResult.hits().stream()
                      .map(EntityReference::key)
                      .toArray(Object[]::new);
-               return new NodeTopDocs(cache.getRpcManager().getAddress(), queryResult.topDocs(), keys, null);
+               return new NodeTopDocs(cache.getRpcManager().getAddress(), queryResult.topDocs(), hitCount, keys, null);
             });
    }
 
    private CompletionStage<NodeTopDocs> collectProjections(SearchQueryBuilder query) {
       return blockingManager.supplyBlocking(() -> fetchHits(query), "CQCreateEagerQuery#collectProjections")
             .thenApply(queryResult -> {
-               if (queryResult.total().hitCount() == 0L) return null;
+               long hitCount = queryResult.total().hitCount();
 
                List<?> hits = queryResult.hits();
                Object[] projections = hits.toArray(new Object[0]);
-               return new NodeTopDocs(cache.getRpcManager().getAddress(), queryResult.topDocs(), null, projections);
+               return new NodeTopDocs(cache.getRpcManager().getAddress(), queryResult.topDocs(), hitCount, null, projections);
             });
    }
 }

--- a/query/src/main/java/org/infinispan/query/dsl/embedded/impl/QueryEngine.java
+++ b/query/src/main/java/org/infinispan/query/dsl/embedded/impl/QueryEngine.java
@@ -411,7 +411,7 @@ public class QueryEngine<TypeMetadata> extends org.infinispan.query.core.impl.Qu
       HybridQuery<?, ?> projectingAggregatingQuery = new HybridQuery<>(queryFactory, cache,
             secondPhaseQueryStr, namedParameters,
             getObjectFilter(matcher, secondPhaseQueryStr, namedParameters, secondPhaseAccumulators),
-            -1, -1, baseQuery, queryStatistics);
+            startOffset, maxResults, baseQuery, queryStatistics);
 
       StringBuilder thirdPhaseQuery = new StringBuilder();
       thirdPhaseQuery.append("SELECT ");
@@ -585,7 +585,7 @@ public class QueryEngine<TypeMetadata> extends org.infinispan.query.core.impl.Qu
                IckleParsingResult<TypeMetadata> fpr = makeFilterParsingResult(parsingResult, normalizedWhereClause, null, null, null, sortFields);
                Query<?> indexQuery = new EmbeddedLuceneQuery<>(this, queryFactory, namedParameters, fpr, null, null, startOffset, maxResults);
                String projectionQueryStr = SyntaxTreePrinter.printTree(parsingResult.getTargetEntityName(), parsingResult.getProjectedPaths(), null, null);
-               return new HybridQuery<>(queryFactory, cache, projectionQueryStr, null, getObjectFilter(matcher, projectionQueryStr, null, null), -1, -1, indexQuery, queryStatistics);
+               return new HybridQuery<>(queryFactory, cache, projectionQueryStr, null, getObjectFilter(matcher, projectionQueryStr, null, null), startOffset, maxResults, indexQuery, queryStatistics);
             }
          } else {
             // projections may be stored but some sort fields are not so we need to query the index and then execute in-memory sorting and projecting in a second phase
@@ -662,7 +662,7 @@ public class QueryEngine<TypeMetadata> extends org.infinispan.query.core.impl.Qu
       if (startOffset >= 0) {
          cacheQuery = cacheQuery.firstResult((int) startOffset);
       }
-      if (maxResults > 0) {
+      if (maxResults >= 0) {
          cacheQuery = cacheQuery.maxResults(maxResults);
       }
       return (IndexedQuery<E>) cacheQuery;

--- a/query/src/main/java/org/infinispan/query/impl/IndexedQuery.java
+++ b/query/src/main/java/org/infinispan/query/impl/IndexedQuery.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.infinispan.commons.util.CloseableIterator;
+import org.infinispan.query.dsl.QueryResult;
 
 /**
  * A distributed Lucene query.
@@ -33,6 +34,8 @@ public interface IndexedQuery<E> {
    IndexedQuery<E> maxResults(int numResults);
 
    CloseableIterator<E> iterator();
+
+   QueryResult<E> execute();
 
    int getResultSize();
 

--- a/query/src/main/java/org/infinispan/query/impl/QueryDefinition.java
+++ b/query/src/main/java/org/infinispan/query/impl/QueryDefinition.java
@@ -10,7 +10,6 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.hibernate.search.engine.search.query.SearchQuery;
-
 import org.infinispan.AdvancedCache;
 import org.infinispan.commons.marshall.AdvancedExternalizer;
 import org.infinispan.query.dsl.embedded.impl.QueryEngine;
@@ -29,8 +28,8 @@ public final class QueryDefinition {
    private final SerializableFunction<AdvancedCache<?, ?>, QueryEngine<?>> queryEngineProvider;
    private final String queryString;
    private SearchQueryBuilder searchQuery;
-   private int maxResults = 100;
-   private int firstResult;
+   private int maxResults = -1;
+   private int firstResult = 0;
    private long timeout = -1;
    private Set<String> sortableFields;
    private Class<?> indexedType;
@@ -90,7 +89,7 @@ public final class QueryDefinition {
    }
 
    public int getMaxResults() {
-      return maxResults;
+      return maxResults == -1 ? Integer.MAX_VALUE : maxResults;
    }
 
    public void setMaxResults(int maxResults) {

--- a/query/src/main/java/org/infinispan/query/impl/ScrollerIteratorAdaptor.java
+++ b/query/src/main/java/org/infinispan/query/impl/ScrollerIteratorAdaptor.java
@@ -1,0 +1,53 @@
+package org.infinispan.query.impl;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import org.hibernate.search.engine.search.query.SearchScroll;
+import org.hibernate.search.engine.search.query.SearchScrollResult;
+import org.infinispan.commons.util.CloseableIterator;
+
+/**
+ * Adaptor to use a link {@link SearchScroll} as an iterator.
+ *
+ * @since 12.0
+ */
+public class ScrollerIteratorAdaptor<E> implements CloseableIterator<E> {
+   private final SearchScroll<E> scroll;
+   private SearchScrollResult<E> scrollResult;
+   private List<E> chunk;
+   private int cursor = 0;
+
+   public ScrollerIteratorAdaptor(SearchScroll<E> scroll) {
+      this.scroll = scroll;
+      this.scrollResult = scroll.next();
+      this.chunk = scrollResult.hits();
+   }
+
+   @Override
+   public boolean hasNext() {
+      tryFetchMore();
+      return scrollResult.hasHits();
+   }
+
+   @Override
+   public E next() {
+      if (hasNext()) {
+         return chunk.get(cursor++);
+      }
+      throw new NoSuchElementException();
+   }
+
+   private void tryFetchMore() {
+      if (cursor == chunk.size()) {
+         scrollResult = scroll.next();
+         chunk = scrollResult.hits();
+         cursor = 0;
+      }
+   }
+
+   @Override
+   public void close() {
+      scroll.close();
+   }
+}

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/BaseRemoteQueryManager.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/BaseRemoteQueryManager.java
@@ -1,6 +1,5 @@
 package org.infinispan.query.remote.impl;
 
-import java.util.List;
 import java.util.Map;
 
 import org.infinispan.AdvancedCache;
@@ -14,6 +13,7 @@ import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
 import org.infinispan.marshall.core.EncoderRegistry;
 import org.infinispan.query.core.stats.impl.LocalQueryStatistics;
+import org.infinispan.query.dsl.QueryResult;
 import org.infinispan.query.dsl.impl.BaseQuery;
 import org.infinispan.query.remote.client.impl.QueryRequest;
 import org.infinispan.query.remote.impl.logging.Log;
@@ -59,10 +59,9 @@ abstract class BaseRemoteQueryManager implements RemoteQueryManager {
 
       QuerySerializer<?> querySerializer = querySerializers.getSerializer(outputFormat);
       BaseQuery<Object> query = getQueryEngine(cache).makeQuery(queryString, namedParametersMap, offset, maxResults);
-      List<Object> results = query.list();
-      int totalResults = query.getResultSize();
+      QueryResult<Object> queryResult = query.execute();
       String[] projection = query.getProjection();
-      RemoteQueryResult remoteQueryResult = new RemoteQueryResult(projection, totalResults, results);
+      RemoteQueryResult remoteQueryResult = new RemoteQueryResult(projection, queryResult.hitCount().orElse(-1), queryResult.list());
       Object response = querySerializer.createQueryResponse(remoteQueryResult);
       return querySerializer.encodeQueryResponse(response, outputFormat);
    }

--- a/server/rest/src/test/java/org/infinispan/rest/search/MultiNodeRestTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/search/MultiNodeRestTest.java
@@ -1,0 +1,75 @@
+package org.infinispan.rest.search;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.infinispan.client.rest.RestCacheClient;
+import org.infinispan.client.rest.RestClient;
+import org.infinispan.client.rest.RestResponse;
+import org.infinispan.client.rest.configuration.RestClientConfigurationBuilder;
+import org.infinispan.commons.test.TestResourceTracker;
+import org.infinispan.commons.util.Util;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.rest.assertion.ResponseAssertion;
+import org.infinispan.rest.helper.RestServerHelper;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+
+/**
+ * @since 12.1
+ */
+public abstract class MultiNodeRestTest extends MultipleCacheManagersTest {
+   private RestClient client;
+   protected Map<String, RestCacheClient> cacheClients;
+   private final List<RestServerHelper> restServers = new ArrayList<>();
+
+   abstract int getMembers();
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      createClusteredCaches(getMembers(), GlobalConfigurationBuilder.defaultClusteredBuilder(), new ConfigurationBuilder(), true);
+
+      cacheManagers.forEach(cm -> {
+         getCacheConfigs().forEach((name, configBuilder) -> cm.defineConfiguration(name, configBuilder.build()));
+         RestServerHelper restServer = new RestServerHelper(cm);
+         restServer.start(TestResourceTracker.getCurrentTestShortName());
+         restServers.add(restServer);
+      });
+
+      RestClientConfigurationBuilder clientConfigurationBuilder = new RestClientConfigurationBuilder();
+      restServers.forEach(s -> clientConfigurationBuilder.addServer().host(s.getHost()).port(s.getPort()));
+
+      this.client = RestClient.forConfiguration(clientConfigurationBuilder.build());
+
+      cacheClients = getCacheConfigs().keySet().stream().collect(Collectors.toMap(Function.identity(), client::cache));
+
+      String protoFileContents = Util.getResourceAsString(getProtoFile(), getClass().getClassLoader());
+      registerProtobuf(protoFileContents);
+   }
+
+   @AfterClass(alwaysRun = true)
+   public void tearDown() throws Exception {
+      client.close();
+      restServers.forEach(RestServerHelper::stop);
+   }
+
+   @AfterMethod
+   @Override
+   protected void clearContent() {
+   }
+
+   protected void registerProtobuf(String protoFileContents) {
+      CompletionStage<RestResponse> response = client.schemas().post("file.proto", protoFileContents);
+      ResponseAssertion.assertThat(response).hasNoErrors();
+   }
+
+   protected abstract Map<String, ConfigurationBuilder> getCacheConfigs();
+
+   protected abstract String getProtoFile();
+}

--- a/server/rest/src/test/java/org/infinispan/rest/search/SearchCountClusteredTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/search/SearchCountClusteredTest.java
@@ -1,0 +1,361 @@
+package org.infinispan.rest.search;
+
+import static org.infinispan.client.rest.RestQueryMode.BROADCAST;
+import static org.infinispan.commons.dataconversion.MediaType.APPLICATION_JSON;
+import static org.infinispan.commons.dataconversion.MediaType.APPLICATION_PROTOSTREAM_TYPE;
+import static org.infinispan.functional.FunctionalTestUtils.await;
+import static org.testng.AssertJUnit.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.LongStream;
+
+import org.infinispan.client.rest.RestCacheClient;
+import org.infinispan.client.rest.RestEntity;
+import org.infinispan.client.rest.RestResponse;
+import org.infinispan.commons.dataconversion.MediaType;
+import org.infinispan.commons.dataconversion.internal.Json;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.cache.IndexStorage;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * Tests for the query "total_results" for all types of query.
+ *
+ * @since 12.1
+ */
+@Test(groups = "functional", testName = "rest.search.SearchCountClusteredTest")
+public class SearchCountClusteredTest extends MultiNodeRestTest {
+
+   static final int INDEXED_ENTRIES = 300;
+   private static final int NOT_INDEXED_ENTRIES = 200;
+   static final String INDEXED_CACHE = "indexed";
+   static final String NOT_INDEXED_CACHE = "not-indexed";
+   public static final int DEFAULT_PAGE_SIZE = 10;
+
+   @Override
+   int getMembers() {
+      return 3;
+   }
+
+   protected CacheMode getCacheMode() {
+      return CacheMode.DIST_SYNC;
+   }
+
+   @Override
+   protected Map<String, ConfigurationBuilder> getCacheConfigs() {
+      Map<String, ConfigurationBuilder> caches = new HashMap<>();
+
+      final ConfigurationBuilder indexedCache = new ConfigurationBuilder();
+      final CacheMode cacheMode = getCacheMode();
+      if (cacheMode.isClustered()) {
+         indexedCache.clustering().cacheMode(cacheMode);
+      }
+      indexedCache.statistics().enable().indexing().enable().addIndexedEntity("IndexedEntity").storage(IndexStorage.LOCAL_HEAP);
+      indexedCache.encoding().mediaType(MediaType.APPLICATION_PROTOSTREAM_TYPE);
+      caches.put(INDEXED_CACHE, indexedCache);
+
+      final ConfigurationBuilder notIndexedCache = new ConfigurationBuilder();
+      if (cacheMode.isClustered()) {
+         notIndexedCache.clustering().cacheMode(cacheMode);
+      }
+      notIndexedCache.encoding().mediaType(APPLICATION_PROTOSTREAM_TYPE);
+      caches.put(NOT_INDEXED_CACHE, notIndexedCache);
+
+      return caches;
+   }
+
+   @Override
+   protected String getProtoFile() {
+      return "count.proto";
+   }
+
+   @BeforeClass
+   public void setUp() {
+      LongStream.range(0, INDEXED_ENTRIES).forEach(i -> {
+         String str = "index " + i;
+         String value = Json.object()
+               .set("_type", "IndexedEntity")
+               .set("indexedStoredField", str)
+               .set("indexedNotStoredField", str)
+               .set("sortableStoredField", i % 20)
+               .set("sortableNotStoredField", "index_" + i % 20)
+               .set("notIndexedField", str).toString();
+         await(indexedCache().put(String.valueOf(i), RestEntity.create(APPLICATION_JSON, value)));
+      });
+
+      LongStream.range(0, NOT_INDEXED_ENTRIES).forEach(i -> {
+         String value = "text " + i;
+         Json json = Json.object().set("_type", "NotIndexedEntity").set("field1", value).set("field2", value);
+         await(nonIndexedCache().put(String.valueOf(i), RestEntity.create(APPLICATION_JSON, json.toString())));
+      });
+   }
+
+   /**
+    * Pure indexed queries
+    */
+   @Test
+   public void testMatchAll() {
+      CompletionStage<RestResponse> result = queryWithoutPagination(indexedCache(), "FROM IndexedEntity");
+      assertTotalAndPageSize(result, INDEXED_ENTRIES, INDEXED_ENTRIES);
+   }
+
+   @Test
+   public void testMatchAllPagination() {
+      CompletionStage<RestResponse> result = queryWithPagination(indexedCache(), "FROM IndexedEntity", 17, 0);
+      assertTotalAndPageSize(result, INDEXED_ENTRIES, 17);
+   }
+
+   @Test
+   public void testLimit() {
+      CompletionStage<RestResponse> result = queryWithoutPagination(indexedCache(), "FROM IndexedEntity");
+      assertTotalAndPageSize(result, INDEXED_ENTRIES, INDEXED_ENTRIES);
+   }
+
+   @Test
+   public void testLimitPagination() {
+      CompletionStage<RestResponse> result = queryWithDefaultPagination(indexedCache(), "FROM IndexedEntity");
+      assertTotalAndPageSize(result, INDEXED_ENTRIES, DEFAULT_PAGE_SIZE);
+   }
+
+   @Test
+   public void testSortedStored() {
+      CompletionStage<RestResponse> result = queryWithoutPagination(indexedCache(), "FROM IndexedEntity ORDER BY sortableStoredField DESC");
+      assertTotalAndPageSize(result, INDEXED_ENTRIES, INDEXED_ENTRIES);
+   }
+
+   @Test
+   public void testSortedStoredPagination() {
+      CompletionStage<RestResponse> result = queryWithPagination(indexedCache(), "SELECT sortableStoredField FROM IndexedEntity ORDER BY sortableStoredField DESC", 35, 0);
+      assertTotalAndPageSize(result, INDEXED_ENTRIES, 35);
+   }
+
+   @Test
+   public void testSelectIndexed() {
+      CompletionStage<RestResponse> result = queryWithoutPagination(indexedCache(), "SELECT indexedStoredField FROM IndexedEntity");
+      assertTotalAndPageSize(result, INDEXED_ENTRIES, INDEXED_ENTRIES);
+   }
+
+   @Test
+   public void testSelectIndexedPagination() {
+      CompletionStage<RestResponse> result = queryWithDefaultPagination(indexedCache(), "SELECT indexedStoredField FROM IndexedEntity");
+      assertTotalAndPageSize(result, INDEXED_ENTRIES, DEFAULT_PAGE_SIZE);
+   }
+
+   @Test
+   public void testPagination() {
+      CompletionStage<RestResponse> result = queryWithPagination(indexedCache(), "SELECT indexedStoredField FROM IndexedEntity", 8, 2);
+      assertTotalAndPageSize(result, INDEXED_ENTRIES, 8);
+   }
+
+   @Test
+   public void testAggregation() {
+      CompletionStage<RestResponse> result = queryWithoutPagination(indexedCache(), "SELECT count(indexedStoredField) FROM IndexedEntity");
+      int indexedStoredField = getFieldAggregationValue(result, "indexedStoredField");
+      assertEquals(INDEXED_ENTRIES, indexedStoredField);
+   }
+
+   @Test
+   public void testGrouping() {
+      CompletionStage<RestResponse> result = queryWithoutPagination(indexedCache(), "SELECT count(sortableStoredField) FROM IndexedEntity GROUP BY sortableStoredField");
+      assertTotalAndPageSize(result, 20, 20);
+   }
+
+   @Test
+   public void testGroupingPagination() {
+      CompletionStage<RestResponse> result = queryWithDefaultPagination(indexedCache(), "SELECT count(sortableStoredField) FROM IndexedEntity GROUP BY sortableStoredField");
+      assertTotalAndPageSize(result, 20, 10);
+   }
+
+   @Test
+   public void testCountOnly() {
+      CompletionStage<RestResponse> result = queryWithPagination(indexedCache(), "FROM IndexedEntity", 0, 0);
+      assertTotalAndPageSize(result, INDEXED_ENTRIES, 0);
+   }
+
+   /**
+    * Hybrid queries
+    */
+   @Test
+   public void testSortedNotStored() {
+      CompletionStage<RestResponse> result = queryWithoutPagination(indexedCache(), "FROM IndexedEntity ORDER BY sortableNotStoredField DESC");
+      assertTotalAndPageSize(result, INDEXED_ENTRIES, INDEXED_ENTRIES);
+   }
+
+   @Test
+   public void testSortedNotStoredPagination() {
+      CompletionStage<RestResponse> result = queryWithDefaultPagination(indexedCache(), "FROM IndexedEntity ORDER BY sortableNotStoredField DESC");
+      assertTotalAndPageSize(result, INDEXED_ENTRIES, DEFAULT_PAGE_SIZE);
+   }
+
+   @Test
+   public void testSelectNonStoredField() {
+      CompletionStage<RestResponse> result = queryWithoutPagination(indexedCache(), "SELECT indexedNotStoredField FROM IndexedEntity");
+      assertTotalAndPageSize(result, INDEXED_ENTRIES, INDEXED_ENTRIES);
+   }
+
+   @Test
+   public void testSelectNonStoredFieldPagination() {
+      CompletionStage<RestResponse> result = queryWithDefaultPagination(indexedCache(), "SELECT indexedNotStoredField FROM IndexedEntity");
+      assertTotalAndPageSize(result, INDEXED_ENTRIES, DEFAULT_PAGE_SIZE);
+   }
+
+   @Test
+   public void testSelectNotIndexedField() {
+      CompletionStage<RestResponse> result = queryWithoutPagination(indexedCache(), "SELECT notIndexedField FROM IndexedEntity");
+      assertTotalAndPageSize(result, INDEXED_ENTRIES, INDEXED_ENTRIES);
+   }
+
+   @Test
+   public void testSelectNotIndexedFieldPagination() {
+      CompletionStage<RestResponse> result = queryWithDefaultPagination(indexedCache(), "SELECT notIndexedField FROM IndexedEntity");
+      assertTotalAndPageSize(result, INDEXED_ENTRIES, DEFAULT_PAGE_SIZE);
+   }
+
+   @Test
+   public void testHybridPaginated() {
+      CompletionStage<RestResponse> result = queryWithDefaultPagination(indexedCache(), "SELECT notIndexedField FROM IndexedEntity WHERE indexedStoredField : 'index'");
+      assertTotalAndPageSize(result, INDEXED_ENTRIES, DEFAULT_PAGE_SIZE);
+   }
+
+   @Test
+   public void testHybridNonPaginated() {
+      CompletionStage<RestResponse> result = queryWithoutPagination(indexedCache(), "SELECT notIndexedField FROM IndexedEntity WHERE indexedStoredField : 'index'");
+      assertTotalAndPageSize(result, INDEXED_ENTRIES, INDEXED_ENTRIES);
+   }
+
+   @Test
+   public void testAggregationHybrid() {
+      CompletionStage<RestResponse> result = queryWithoutPagination(indexedCache(), "SELECT count(indexedStoredField), max(notIndexedField) FROM IndexedEntity");
+      int indexedStoredField = getFieldAggregationValue(result, "indexedStoredField");
+      assertEquals(INDEXED_ENTRIES, indexedStoredField);
+   }
+
+   @Test
+   public void testAggregationHybridPagination() {
+      CompletionStage<RestResponse> result = queryWithDefaultPagination(indexedCache(), "SELECT count(indexedStoredField), max(notIndexedField) FROM IndexedEntity");
+      int indexedStoredField = getFieldAggregationValue(result, "indexedStoredField");
+      assertEquals(INDEXED_ENTRIES, indexedStoredField);
+   }
+
+   @Test
+   public void testCountOnlyHybrid() {
+      CompletionStage<RestResponse> result = queryWithPagination(indexedCache(), "SELECT notIndexedField FROM IndexedEntity", 0, 0);
+      assertTotalAndPageSize(result, INDEXED_ENTRIES, 0);
+   }
+
+   /**
+    * Non-indexed queries
+    */
+   @Test
+   public void testMatchAllNotIndexed() {
+      CompletionStage<RestResponse> result = queryWithoutPagination(nonIndexedCache(), "FROM NotIndexedEntity");
+      assertTotalAndPageSize(result, NOT_INDEXED_ENTRIES, NOT_INDEXED_ENTRIES);
+   }
+
+   public void testMatchAllNotIndexedPaginated() {
+      CompletionStage<RestResponse> result = queryWithDefaultPagination(nonIndexedCache(), "FROM NotIndexedEntity");
+      assertTotalAndPageSize(result, NOT_INDEXED_ENTRIES, DEFAULT_PAGE_SIZE);
+   }
+
+   @Test
+   public void testMaxResultsNotIndexedPaginated() {
+      CompletionStage<RestResponse> result = queryWithPagination(nonIndexedCache(), "FROM NotIndexedEntity", 5, 1);
+      assertTotalAndPageSize(result, NOT_INDEXED_ENTRIES, 5);
+   }
+
+   @Test
+   public void testMaxResultsNotIndexed() {
+      CompletionStage<RestResponse> result = queryWithoutPagination(nonIndexedCache(), "FROM NotIndexedEntity");
+      assertTotalAndPageSize(result, NOT_INDEXED_ENTRIES, NOT_INDEXED_ENTRIES);
+   }
+
+   @Test
+   public void testSortedNotIndexed() {
+      CompletionStage<RestResponse> result = queryWithoutPagination(nonIndexedCache(), "FROM NotIndexedEntity ORDER BY field2");
+      assertTotalAndPageSize(result, NOT_INDEXED_ENTRIES, NOT_INDEXED_ENTRIES);
+   }
+
+   @Test
+   public void testSortedNotIndexedPaginated() {
+      CompletionStage<RestResponse> result = queryWithDefaultPagination(nonIndexedCache(), "FROM NotIndexedEntity ORDER BY field2");
+      assertTotalAndPageSize(result, NOT_INDEXED_ENTRIES, DEFAULT_PAGE_SIZE);
+   }
+
+   @Test
+   public void testPaginatedNotIndexed() {
+      CompletionStage<RestResponse> result = queryWithPagination(nonIndexedCache(), "SELECT field1 FROM NotIndexedEntity", 5, 2);
+      assertTotalAndPageSize(result, NOT_INDEXED_ENTRIES, 5);
+   }
+
+   @Test
+   public void testSelectNotIndexed() {
+      CompletionStage<RestResponse> result = queryWithDefaultPagination(nonIndexedCache(), "SELECT field1 FROM NotIndexedEntity");
+      assertTotalAndPageSize(result, NOT_INDEXED_ENTRIES, DEFAULT_PAGE_SIZE);
+   }
+
+   @Test
+   public void testSelectNotIndexedPaginated() {
+      CompletionStage<RestResponse> result = queryWithDefaultPagination(nonIndexedCache(), "SELECT field1 FROM NotIndexedEntity");
+      assertTotalAndPageSize(result, NOT_INDEXED_ENTRIES, DEFAULT_PAGE_SIZE);
+   }
+
+   @Test
+   public void testAggregationNotIndexed() {
+      CompletionStage<RestResponse> result = queryWithoutPagination(nonIndexedCache(), "SELECT count(field1), max(field2) FROM NotIndexedEntity");
+      int field1Count = getFieldAggregationValue(result, "field1");
+      assertEquals(NOT_INDEXED_ENTRIES, field1Count);
+   }
+
+   @Test
+   public void testAggregationNotIndexedPagination() {
+      CompletionStage<RestResponse> result = queryWithDefaultPagination(nonIndexedCache(), "SELECT count(field1), max(field2) FROM NotIndexedEntity");
+      int field1Count = getFieldAggregationValue(result, "field1");
+      assertEquals(NOT_INDEXED_ENTRIES, field1Count);
+   }
+
+   @Test
+   public void testCountOnlyNotIndexed() {
+      CompletionStage<RestResponse> result = queryWithPagination(nonIndexedCache(), "SELECT field1 FROM NotIndexedEntity", 0, 0);
+      assertTotalAndPageSize(result, NOT_INDEXED_ENTRIES, 0);
+   }
+
+   private void assertTotalAndPageSize(CompletionStage<RestResponse> response, int totalResults, int pageSize) {
+      RestResponse restResponse = await(response);
+      String body = restResponse.getBody();
+      Json responseDoc = Json.read(body);
+      Json total = responseDoc.at("total_results");
+      assertEquals(totalResults, total.asLong());
+      long hitsSize = responseDoc.at("hits").asJsonList().size();
+      assertEquals(pageSize, hitsSize);
+   }
+
+   private CompletionStage<RestResponse> queryWithoutPagination(RestCacheClient client, String query) {
+      return client.query(query, -1, 0, BROADCAST);
+   }
+
+   private CompletionStage<RestResponse> queryWithDefaultPagination(RestCacheClient client, String query) {
+      return client.query(query);
+   }
+
+   private CompletionStage<RestResponse> queryWithPagination(RestCacheClient client, String query, int maxResults, int offset) {
+      return client.query(query, maxResults, offset, BROADCAST);
+   }
+
+   private int getFieldAggregationValue(CompletionStage<RestResponse> response, String field) {
+      RestResponse restResponse = await(response);
+      String body = restResponse.getBody();
+      return Json.read(body).at("hits").asJsonList().get(0).at("hit").at(field).asInteger();
+   }
+
+   private RestCacheClient indexedCache() {
+      return cacheClients.get(INDEXED_CACHE);
+   }
+
+   private RestCacheClient nonIndexedCache() {
+      return cacheClients.get(NOT_INDEXED_CACHE);
+   }
+}

--- a/server/rest/src/test/java/org/infinispan/rest/search/SearchCountLocalTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/search/SearchCountLocalTest.java
@@ -1,0 +1,21 @@
+package org.infinispan.rest.search;
+
+import org.infinispan.configuration.cache.CacheMode;
+import org.testng.annotations.Test;
+
+/**
+ * @since 12.1
+ */
+@Test(groups = "functional", testName = "rest.search.SearchCountLocalTest")
+public class SearchCountLocalTest extends SearchCountClusteredTest {
+
+   @Override
+   int getMembers() {
+      return 1;
+   }
+
+   @Override
+   protected CacheMode getCacheMode() {
+      return CacheMode.LOCAL;
+   }
+}

--- a/server/rest/src/test/resources/count.proto
+++ b/server/rest/src/test/resources/count.proto
@@ -1,0 +1,33 @@
+/**
+ * @Indexed
+ */
+message IndexedEntity {
+
+  /**
+   * @Field(analyze = Analyze.YES, store = Store.YES)
+   */
+  required string indexedStoredField = 1;
+
+  /**
+   * @Field(analyze = Analyze.YES, store = Store.NO)
+   */
+  required string indexedNotStoredField = 2;
+
+  /**
+  * @Field(analyze = Analyze.NO, store = Store.NO)
+  */
+  required string sortableNotStoredField = 3;
+
+  /**
+  * @Field(analyze = Analyze.NO, store = Store.YES)
+  */
+  required int64 sortableStoredField = 4;
+
+  required string notIndexedField = 5;
+}
+
+message NotIndexedEntity {
+
+  required string field1 = 1;
+  required string field2 = 2;
+}

--- a/server/runtime/src/main/java/org/infinispan/server/logging/events/ServerEventLogger.java
+++ b/server/runtime/src/main/java/org/infinispan/server/logging/events/ServerEventLogger.java
@@ -112,7 +112,7 @@ public class ServerEventLogger implements EventLogger {
             query.setParameter("when", start);
             category.ifPresent(c -> query.setParameter("category", c));
             level.ifPresent(l -> query.setParameter("level", l));
-            return query.list();
+            return query.execute().list();
          }, (address, nodeEvents, t) -> {
             if (t == null) {
                events.addAll(nodeEvents);


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-11013
https://issues.redhat.com/browse/ISPN-11014
https://issues.redhat.com/browse/ISPN-12959

* Fix result size for all types of queries
* Avoid executing additional query to obtain the result size
* Avoid storing results in memory in the iterator()
* Remove internal usages of deprecate list() and resultSize()