### PR TITLE
ISPN-13130 SoftIndexFileStore index update concurrency issue

### DIFF
--- a/core/src/main/java/org/infinispan/persistence/sifs/Index.java
+++ b/core/src/main/java/org/infinispan/persistence/sifs/Index.java
@@ -366,7 +366,10 @@ class Index {
             request.completeExceptionally(e);
          }
          temporaryTable.removeConditionally(request.getSegment(), request.getKey(), request.getFile(), request.getOffset());
-         nonBlockingManager.complete(request, null);
+         if (request.getType() != IndexRequest.Type.UPDATE) {
+            // The update type will complete it in the switch statement above
+            nonBlockingManager.complete(request, null);
+         }
       }
 
       // This is ran when the flowable ends either via normal termination or error

--- a/core/src/main/java/org/infinispan/persistence/sifs/IndexRequest.java
+++ b/core/src/main/java/org/infinispan/persistence/sifs/IndexRequest.java
@@ -2,7 +2,6 @@ package org.infinispan.persistence.sifs;
 
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.infinispan.commons.util.Util;
 
@@ -32,8 +31,6 @@ class IndexRequest extends CompletableFuture<Object> {
    private final int prevOffset;
    private final byte[] serializedKey;
    private final int size;
-   private volatile Object result;
-   private AtomicInteger countDown;
 
    private IndexRequest(Type type, int segment, Object key, byte[] serializedKey, int file, int offset, int size, int prevFile, int prevOffset) {
       this.type = type;


### PR DESCRIPTION
* Also removed some extra unused fields from IndexRequest

https://issues.redhat.com/browse/ISPN-13130

Note that no tests has been added as this could intermittently occur before due to completing the Future from two different spots which has now been reduced to one.