### PR TITLE
ISPN-13030 REST getEntries only supports JSON

### DIFF
--- a/client/rest-client/src/main/java/org/infinispan/client/rest/RestCacheClient.java
+++ b/client/rest-client/src/main/java/org/infinispan/client/rest/RestCacheClient.java
@@ -38,7 +38,17 @@ public interface RestCacheClient {
     *
     * @return Response with InputStream to get the entries
     */
-   CompletionStage<RestResponse> entries();
+   default CompletionStage<RestResponse> entries() {
+      return entries(false);
+   }
+
+   /**
+    * Retrieves entries without metadata
+    *
+    * @param contentNegotiation if true, the server will convert keys and values to a readable format and return headers with the negotiated media type.
+    * @return Response with InputStream to get the entries
+    */
+   CompletionStage<RestResponse> entries(boolean contentNegotiation);
 
    /**
     * Retrieves entries limited by count

--- a/client/rest-client/src/main/java/org/infinispan/client/rest/impl/okhttp/RestCacheClientOkHttp.java
+++ b/client/rest-client/src/main/java/org/infinispan/client/rest/impl/okhttp/RestCacheClientOkHttp.java
@@ -290,6 +290,13 @@ public class RestCacheClientOkHttp implements RestCacheClient {
    }
 
    @Override
+   public CompletionStage<RestResponse> entries(boolean contentNegotiation) {
+      Request.Builder builder = new Request.Builder();
+      builder.url(cacheUrl + "?action=entries&content-negotiation=" + contentNegotiation).get();
+      return client.execute(builder);
+   }
+
+   @Override
    public CompletionStage<RestResponse> entries(int limit) {
       Request.Builder builder = new Request.Builder();
       builder.url(cacheUrl + "?action=entries&limit=" + limit).get();

--- a/documentation/src/main/asciidoc/topics/ref_rest_caches.adoc
+++ b/documentation/src/main/asciidoc/topics/ref_rest_caches.adoc
@@ -346,6 +346,12 @@ GET /rest/v2/caches/{cacheName}?action=entries
 |`batch`
 |OPTIONAL
 |Specifies the internal batch size when retrieving the keys. The default value is `1000`.
+|`content-negotiation`
+|OPTIONAL
+| If `true`, will convert keys and values to a readable format.
+For caches with text encodings (e.g., text/plain, xml, json), the server returns keys and values as plain text.
+For caches with binary encodings, the server will return the entries as JSON if the conversion is supported, otherwise in a text hexadecimal format, e.g., `0xA123CF98`.
+When content-negotiation is used, the response will contain two headers: `key-content-type` and `value-content-type` to described the negotiated format.
 |===
 
 {brandname} provides a JSON response such as the following:

--- a/server/core/src/main/java/org/infinispan/server/core/dataconversion/XMLTranscoder.java
+++ b/server/core/src/main/java/org/infinispan/server/core/dataconversion/XMLTranscoder.java
@@ -55,6 +55,9 @@ public class XMLTranscoder extends OneToManyTranscoder {
    @Override
    public Object doTranscode(Object content, MediaType contentType, MediaType destinationType) {
       if (destinationType.match(APPLICATION_XML)) {
+         if (contentType.match(APPLICATION_XML)) {
+            return StandardConversions.convertCharset(content, contentType.getCharset(), destinationType.getCharset());
+         }
          if (contentType.match(APPLICATION_OBJECT)) {
             String xmlString = xstream.toXML(content);
             return xmlString.getBytes(destinationType.getCharset());

--- a/server/rest/src/main/java/org/infinispan/rest/ResponseHeader.java
+++ b/server/rest/src/main/java/org/infinispan/rest/ResponseHeader.java
@@ -17,12 +17,14 @@ public enum ResponseHeader {
    DATE_HEADER("Date"),
    ETAG_HEADER("Etag"),
    EXPIRES_HEADER("Expires"),
+   KEY_CONTENT_TYPE_HEADER("key-content-type"),
    LAST_MODIFIED_HEADER("Last-Modified"),
    LAST_USED_HEADER("lastUsed"),
    LOCATION("location"),
    MAX_IDLE_TIME_HEADER("maxIdleTimeSeconds"),
    TIME_TO_LIVE_HEADER("timeToLiveSeconds"),
    TRANSFER_ENCODING("Transfer-Encoding"),
+   VALUE_CONTENT_TYPE_HEADER("value-content-type"),
    WWW_AUTHENTICATE_HEADER("WWW-Authenticate");
 
    private static final CharSequence[] ALL_VALUES = Arrays.stream(values()).map(ResponseHeader::getValue).toArray(String[]::new);

--- a/server/rest/src/main/java/org/infinispan/rest/resources/MediaTypeUtils.java
+++ b/server/rest/src/main/java/org/infinispan/rest/resources/MediaTypeUtils.java
@@ -50,7 +50,7 @@ final class MediaTypeUtils {
    static MediaType negotiateMediaType(AdvancedCache<?, ?> cache, RestRequest restRequest) throws UnacceptableDataFormatException {
       try {
          String accept = restRequest.getAcceptHeader();
-         EncoderRegistry registry = SecurityActions.getEncoderRegistry(cache);
+         EncoderRegistry registry = SecurityActions.getEncoderRegistry(cache.getCacheManager());
          MediaType storageMedia = cache.getValueDataConversion().getStorageMediaType();
          Optional<MediaType> negotiated = MediaType.parseList(accept)
                .filter(media -> registry.isConversionSupported(storageMedia, media))

--- a/server/rest/src/main/java/org/infinispan/rest/resources/SecurityActions.java
+++ b/server/rest/src/main/java/org/infinispan/rest/resources/SecurityActions.java
@@ -63,8 +63,8 @@ final class SecurityActions {
       return doPrivileged(new GetCacheManagerConfigurationAction(cacheManager));
    }
 
-   public static EncoderRegistry getEncoderRegistry(AdvancedCache<?, ?> cache) {
-      return doPrivileged(() -> cache.getCacheManager().getGlobalComponentRegistry().getComponent(EncoderRegistry.class));
+   public static EncoderRegistry getEncoderRegistry(EmbeddedCacheManager cacheManager) {
+      return doPrivileged(() -> cacheManager.getGlobalComponentRegistry().getComponent(EncoderRegistry.class));
    }
 
    static <K, V> ComponentRegistry getComponentRegistry(AdvancedCache<K, V> cache) {

--- a/server/rest/src/test/java/org/infinispan/rest/resources/CacheResourceTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/resources/CacheResourceTest.java
@@ -147,7 +147,7 @@ public class CacheResourceTest extends BaseCacheResourceTest {
       join(objectCache.put("test", RestEntity.create(APPLICATION_XML, xml)));
 
       //when
-      CompletionStage<RestResponse> response = objectCache.get("test", APPLICATION_XML_TYPE);
+      RestResponse response = join(objectCache.get("test", APPLICATION_XML_TYPE));
 
       //then
       assertThat(response).isOk();


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-13030

Adds media type negotiation to the REST [entries](https://infinispan.org/docs/stable/titles/rest/rest.html#rest_v2_get_entries) operation to be able to display all kinds of key and value content, including binary. Returns extra pair of headers with the negotiated content.



~~Marking as preview as it depends on https://github.com/infinispan/infinispan/pull/9413~~