### PR TITLE
ISPN-13138 + ISPN-13147 State transfer can lose entries

### DIFF
--- a/core/src/main/java/org/infinispan/scattered/impl/ScatteredStateConsumerImpl.java
+++ b/core/src/main/java/org/infinispan/scattered/impl/ScatteredStateConsumerImpl.java
@@ -344,10 +344,14 @@ public class ScatteredStateConsumerImpl extends StateConsumerImpl {
       // we must not remove the transfer before the requests for values are sent
       // as we could notify the end of rebalance too soon
       removeTransfer(inboundTransfer);
-      if (log.isTraceEnabled())
-         log.tracef("Inbound transfer removed, chunk counter is %s", chunkCounter.get());
-      if (chunkCounter.get() == 0) {
-         notifyEndOfStateTransferIfNeeded();
+
+      if (lastTransfer) {
+         if (log.isTraceEnabled())
+            log.tracef("Inbound transfer removed, chunk counter is %s", chunkCounter.get());
+         if (chunkCounter.get() == 0) {
+            // No values to transfer after all the keys were received, we can end state transfer immediately
+            notifyEndOfStateTransferIfNeeded();
+         }
       }
    }
 

--- a/core/src/main/java/org/infinispan/scattered/impl/ScatteredStateConsumerImpl.java
+++ b/core/src/main/java/org/infinispan/scattered/impl/ScatteredStateConsumerImpl.java
@@ -100,7 +100,7 @@ public class ScatteredStateConsumerImpl extends StateConsumerImpl {
    }
 
    @Override
-   protected void beforeTopologyInstalled(int topologyId, boolean startRebalance, ConsistentHash previousWriteCh, ConsistentHash newWriteCh) {
+   protected void beforeTopologyInstalled(int topologyId, ConsistentHash previousWriteCh, ConsistentHash newWriteCh) {
       // We have to block access to segments before the topology is installed, as otherwise
       // during remote reads PrefetchInvalidationInterceptor would not retrieve remote value
       // and ScatteringInterceptor would check according to the new CH.
@@ -133,8 +133,8 @@ public class ScatteredStateConsumerImpl extends StateConsumerImpl {
    }
 
    @Override
-   protected CompletionStage<Void> handleSegments(boolean startRebalance, IntSet addedSegments, IntSet removedSegments) {
-      if (!startRebalance) {
+   protected CompletionStage<Void> handleSegments(boolean isRebalance, IntSet addedSegments, IntSet removedSegments) {
+      if (!isRebalance) {
          log.trace("This is not a rebalance, not doing anything...");
          return CompletableFutures.completedNull();
       }


### PR DESCRIPTION
ISPN-13138 ScatteredVersionManagerImpl can mark segments owned too soon
ISPN-13147 State transfer can lose entries when a node leaves

https://issues.redhat.com/browse/ISPN-13138
https://issues.redhat.com/browse/ISPN-13147

Both issues cause random failure in StateTransferRestart2Test
