### PR TITLE
ISPN-13160 Write may block topology update forever

### DIFF
--- a/core/src/main/java/org/infinispan/statetransfer/StateTransferLockImpl.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateTransferLockImpl.java
@@ -72,11 +72,13 @@ public class StateTransferLockImpl implements StateTransferLock {
    @SuppressWarnings("LockAcquiredButNotSafelyReleased")
    @Override
    public void acquireExclusiveTopologyLock() {
+      if (log.isTraceEnabled()) log.tracef("Acquire exclusive state transfer lock, readers = %d", ownershipLock.getReadLockCount());
       writeLock.lock();
    }
 
    @Override
    public void releaseExclusiveTopologyLock() {
+      if (log.isTraceEnabled()) log.tracef("Release exclusive state transfer lock");
       writeLock.unlock();
    }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-13160

Remove duplicate state transfer lock in EntryWrappingInterceptor.
Acquiring a second state transfer read lock from the same
thread can now hang if another thread is waiting for
the state transfer write lock.