### PR TITLE
ISPN-13161 ClusterExpirationMaxIdleTest.testMaxIdleAccessSuspectedExpiredEntryRefreshesProperly

### DIFF
--- a/core/src/test/java/org/infinispan/xsite/AsyncBackupExpirationTest.java
+++ b/core/src/test/java/org/infinispan/xsite/AsyncBackupExpirationTest.java
@@ -137,7 +137,7 @@ public class AsyncBackupExpirationTest extends AbstractTwoSitesTest {
    }
 
    private ControlledTimeService replaceTimeService() {
-      ControlledTimeService timeService = new ControlledTimeService(0);
+      ControlledTimeService timeService = new ControlledTimeService();
       // Max idle requires all caches to show it as expired to be removed.
       for (Cache<?, ?> c : caches(LON)) {
          replaceComponent(c.getCacheManager(), TimeService.class, timeService, true);

--- a/core/src/test/java/org/infinispan/xsite/irac/IracMaxIdleTest.java
+++ b/core/src/test/java/org/infinispan/xsite/irac/IracMaxIdleTest.java
@@ -32,7 +32,7 @@ import org.testng.annotations.Test;
 public class IracMaxIdleTest extends AbstractMultipleSitesTest {
 
    private static final long MAX_IDLE = 1000; //milliseconds
-   private final ControlledTimeService timeService = new ControlledTimeService(0);
+   private final ControlledTimeService timeService = new ControlledTimeService();
 
    @Override
    protected int defaultNumberOfSites() {


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-13161

In scattered caches, the touch command doesn't always
run synchronously on the get originator.

Updated to include fix for `testMaxIdleNodeDies` random failures.