### PR TITLE
[12.1.x] ISPN-12667 GlobalState incompatibility between 11.x and 12.x

### DIFF
--- a/core/src/main/java/org/infinispan/distribution/ch/impl/ReplicatedConsistentHash.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/impl/ReplicatedConsistentHash.java
@@ -140,7 +140,17 @@ public class ReplicatedConsistentHash implements ConsistentHash {
 
    private static Map<Address, Float> parseCapacityFactors(ScopedPersistentState state,
                                                            List<Address> members) {
-      int numCapacityFactors = Integer.parseInt(state.getProperty(STATE_CAPACITY_FACTORS));
+      String numCapacityFactorsString = state.getProperty(STATE_CAPACITY_FACTORS);
+      if (numCapacityFactorsString == null) {
+         // Cache state version 11 did not have capacity factors
+         Map<Address, Float> map = new HashMap<>();
+         for (Address a : members) {
+            map.put(a, 1f);
+         }
+         return map;
+      }
+
+      int numCapacityFactors = Integer.parseInt(numCapacityFactorsString);
       Map<Address, Float> capacityFactors = new HashMap<>(numCapacityFactors * 2);
       for (int i = 0; i < numCapacityFactors; i++) {
          float capacityFactor = Float.parseFloat(state.getProperty(String.format(STATE_CAPACITY_FACTOR, i)));

--- a/core/src/test/java/org/infinispan/globalstate/GlobalStateBackwardsCompatibilityTest.java
+++ b/core/src/test/java/org/infinispan/globalstate/GlobalStateBackwardsCompatibilityTest.java
@@ -32,9 +32,6 @@ public class GlobalStateBackwardsCompatibilityTest extends MultipleCacheManagers
 
    @Override
    protected void createCacheManagers() throws Throwable {
-      createCacheManagerWithGlobalState(MEMBER_0, tmpDirectory(this.getClass().getSimpleName(), "0"));
-      createCacheManagerWithGlobalState(MEMBER_1, tmpDirectory(this.getClass().getSimpleName(), "1"));
-      waitForClusterToForm(CACHE_NAME);
    }
 
    @AfterClass(alwaysRun = true)
@@ -42,6 +39,12 @@ public class GlobalStateBackwardsCompatibilityTest extends MultipleCacheManagers
    protected void destroy() {
       super.destroy();
       Util.recursiveFileRemove(tmpDirectory(this.getClass().getSimpleName()));
+   }
+
+   public void testCreateClusterWithGlobalState11() throws Exception {
+      createCacheManagerWithGlobalState(MEMBER_0, tmpDirectory(this.getClass().getSimpleName(), "0"));
+      createCacheManagerWithGlobalState(MEMBER_1, tmpDirectory(this.getClass().getSimpleName(), "1"));
+      waitForClusterToForm(CACHE_NAME);
    }
 
    private void createCacheManagerWithGlobalState(String uuid, String stateDirectory) throws Exception {
@@ -74,15 +77,8 @@ public class GlobalStateBackwardsCompatibilityTest extends MultipleCacheManagers
       cacheState.put("members", "2");
       cacheState.put("member.0", MEMBER_0);
       cacheState.put("member.1", MEMBER_1);
-      cacheState.put("capacityFactors", "2");
-      cacheState.put("capacityFactor.0", "1.0");
-      cacheState.put("capacityFactor.1", "1.0");
       cacheState.put("primaryOwners", "256");
       IntStream.range(0, 256).forEach(i -> cacheState.put("primaryOwners." + i, Integer.toString(i % 2)));
       cacheState.store(new FileOutputStream(new File(stateDirectory, CACHE_NAME + ".state")), null);
-   }
-
-   @Test
-   public void compatibilityTest() {
    }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/JDG-4713

Backport of #9435 

* Set all capacity factors to 1f if the persisted CH doesn't have
  the capacity factors properties
* Remove capacity factors in GlobalStateBackwardsCompatibilityTest
* Simplify handling of join errors in LocalTopologyManagerImpl
  to improve error messages.