### PR TITLE
ISPN-13191 Deadlock: expiration blocks state transfer

### DIFF
--- a/core/src/main/java/org/infinispan/container/impl/AbstractInternalDataContainer.java
+++ b/core/src/main/java/org/infinispan/container/impl/AbstractInternalDataContainer.java
@@ -306,7 +306,7 @@ public abstract class AbstractInternalDataContainer<K, V> implements InternalDat
                   now = timeService.wallClockTime();
                   initializedTime = true;
                }
-               if (!entry.isExpired(now) || !expirationManager.entryExpiredInMemoryFromIteration(entry, now)) {
+               if (!entry.isExpired(now)) {
                   if (log.isTraceEnabled()) {
                      log.tracef("Return next entry %s", entry);
                   }
@@ -492,7 +492,6 @@ public abstract class AbstractInternalDataContainer<K, V> implements InternalDat
     * @return predicate that returns true if an entry is not expired
     */
    protected Predicate<InternalCacheEntry<K, V>> expiredIterationPredicate(long accessTime) {
-      return e -> ! e.canExpire() ||
-            ! (e.isExpired(accessTime) && expirationManager.entryExpiredInMemoryFromIteration(e, accessTime));
+      return e -> !e.isExpired(accessTime);
    }
 }

--- a/core/src/main/java/org/infinispan/expiration/impl/ClusterExpirationManager.java
+++ b/core/src/main/java/org/infinispan/expiration/impl/ClusterExpirationManager.java
@@ -396,20 +396,6 @@ public class ClusterExpirationManager<K, V> extends ExpirationManagerImpl<K, V> 
    }
 
    @Override
-   public boolean entryExpiredInMemoryFromIteration(InternalCacheEntry<K, V> entry, long currentTime) {
-      // We need to synchronize on the entry since {@link InternalCacheEntry} locks the entry when doing an update
-      // so we can see both the new value and the metadata
-      boolean expiredMortal;
-      synchronized (entry) {
-         expiredMortal = ExpiryHelper.isExpiredMortal(entry.getLifespan(), entry.getCreated(), currentTime);
-      }
-      // Note we don't check for transient expiration (maxIdle). We always ignore those as it would require remote
-      // overhead to confirm. Instead we only return if the entry expired mortally (lifespan) as we always expire
-      // entries that are found to be in this state.
-      return expiredMortal;
-   }
-
-   @Override
    public CompletionStage<Void> handleInStoreExpirationInternal(K key) {
       return handleInStoreExpirationInternal(key, null);
    }

--- a/core/src/main/java/org/infinispan/expiration/impl/ExpirationManagerImpl.java
+++ b/core/src/main/java/org/infinispan/expiration/impl/ExpirationManagerImpl.java
@@ -150,12 +150,6 @@ public class ExpirationManagerImpl<K, V> implements InternalExpirationManager<K,
    }
 
    @Override
-   public boolean entryExpiredInMemoryFromIteration(InternalCacheEntry<K, V> entry, long currentTime) {
-      entryExpiredInMemory(entry, currentTime, false);
-      return true;
-   }
-
-   @Override
    public void handleInMemoryExpiration(InternalCacheEntry<K, V> entry, long currentTime) {
       // Just invoke the new method and join
       entryExpiredInMemory(entry, currentTime, false).join();

--- a/core/src/main/java/org/infinispan/expiration/impl/InternalExpirationManager.java
+++ b/core/src/main/java/org/infinispan/expiration/impl/InternalExpirationManager.java
@@ -37,17 +37,6 @@ public interface InternalExpirationManager<K, V> extends ExpirationManager<K, V>
    CompletableFuture<Boolean> entryExpiredInMemory(InternalCacheEntry<K, V> entry, long currentTime, boolean isWrite);
 
    /**
-    * This method is very similar to {@link #entryExpiredInMemory(InternalCacheEntry, long, boolean)} except that it does the
-    * bare minimum when an entry expired to guarantee if the entry is valid or not. This is important to reduce time
-    * spent per entry when iterating. This method may not actually remove the entry and may just return immediately
-    * if it is safe to do so.
-    * @param entry the entry that has expired
-    * @param currentTime the current time when it expired
-    * @return if this entry actually expired or not
-    */
-   boolean entryExpiredInMemoryFromIteration(InternalCacheEntry<K, V> entry, long currentTime);
-
-   /**
     * This is to be invoked when a store entry expires.  This method may attempt to lock this key to preserve atomicity.
     * <p>
     * Note this method doesn't currently take a {@link InternalCacheEntry} and this is due to a limitation in the

--- a/core/src/main/java/org/infinispan/interceptors/impl/PrefetchInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/PrefetchInterceptor.java
@@ -210,7 +210,7 @@ public class PrefetchInterceptor<K, V> extends DDAsyncInterceptor {
 
    private InvocationStage lookupLocalAndRetrieveRemote(InvocationContext ctx, Object key, DataCommand cmd, int segment) {
       // We need to lookup the dataContainer directly as GetCacheEntryCommand won't return entry with null value
-      InternalCacheEntry entry = dataContainer.get(segment, key);
+      InternalCacheEntry<K, V> entry = dataContainer.peek(segment, key);
       if (log.isTraceEnabled()) {
          log.tracef("Locally prefetched entry %s", entry);
       }

--- a/core/src/main/java/org/infinispan/remoting/inboundhandler/BasePerCacheInboundInvocationHandler.java
+++ b/core/src/main/java/org/infinispan/remoting/inboundhandler/BasePerCacheInboundInvocationHandler.java
@@ -26,6 +26,7 @@ import org.infinispan.remoting.responses.CacheNotFoundResponse;
 import org.infinispan.remoting.responses.ExceptionResponse;
 import org.infinispan.remoting.responses.Response;
 import org.infinispan.remoting.responses.ResponseGenerator;
+import org.infinispan.remoting.rpc.RpcManager;
 import org.infinispan.statetransfer.OutdatedTopologyException;
 import org.infinispan.statetransfer.StateTransferLock;
 import org.infinispan.util.concurrent.BlockingRunnable;
@@ -56,6 +57,8 @@ public abstract class BasePerCacheInboundInvocationHandler implements PerCacheIn
    @Inject ResponseGenerator responseGenerator;
    @Inject ComponentRegistry componentRegistry;
    @Inject protected Configuration configuration;
+   // Stop after RpcManager, so we stop accepting requests before we are unable to send requests ourselves
+   @Inject RpcManager rpcManager;
 
    private volatile boolean stopped = false;
    private volatile int firstTopologyAsMember = Integer.MAX_VALUE;

--- a/core/src/main/java/org/infinispan/scattered/impl/ScatteredStateConsumerImpl.java
+++ b/core/src/main/java/org/infinispan/scattered/impl/ScatteredStateConsumerImpl.java
@@ -279,7 +279,7 @@ public class ScatteredStateConsumerImpl extends StateConsumerImpl {
          // With passivation, some key could be activated here and we could miss it,
          // but then it should be broadcast-loaded in PrefetchInvalidationInterceptor
          Publisher<MarshallableEntry<Object, Object>> persistencePublisher =
-            persistenceManager.publishEntries(completedSegments, k -> !dataContainer.containsKey(k), true, true,
+            persistenceManager.publishEntries(completedSegments, k -> dataContainer.peek(k) == null, true, true,
                                               Configurations::isStateTransferStore);
          try {
             blockingSubscribe(Flowable.fromPublisher(persistencePublisher)

--- a/core/src/main/java/org/infinispan/scattered/impl/ScatteredStateProviderImpl.java
+++ b/core/src/main/java/org/infinispan/scattered/impl/ScatteredStateProviderImpl.java
@@ -202,7 +202,7 @@ public class ScatteredStateProviderImpl extends StateProviderImpl implements Sca
    private Flowable<InternalCacheEntry<Object, Object>> publishStoreKeys(IntSet segments) {
       Address localAddress = rpcManager.getAddress();
       Publisher<MarshallableEntry<Object, Object>> loaderPublisher =
-         persistenceManager.publishEntries(segments, k -> !dataContainer.containsKey(k), true, true,
+         persistenceManager.publishEntries(segments, k -> dataContainer.peek(k) == null, true, true,
                                            Configurations::isStateTransferStore);
       return Flowable.fromPublisher(loaderPublisher)
                      // We rely on MarshallableEntry implementations caching the unmarshalled metadata for performance

--- a/core/src/main/java/org/infinispan/statetransfer/StateProviderImpl.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateProviderImpl.java
@@ -303,7 +303,7 @@ public class StateProviderImpl implements StateProvider {
 
    protected Flowable<InternalCacheEntry<Object, Object>> publishStoreEntries(IntSet segments) {
       Publisher<MarshallableEntry<Object, Object>> loaderPublisher =
-         persistenceManager.publishEntries(segments, k -> !dataContainer.containsKey(k), true, true,
+         persistenceManager.publishEntries(segments, k -> dataContainer.peek(k) == null, true, true,
                                            Configurations::isStateTransferStore);
       return Flowable.fromPublisher(loaderPublisher).map(this::defaultMapEntryFromStore);
    }

--- a/core/src/main/java/org/infinispan/statetransfer/StateTransferManagerImpl.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateTransferManagerImpl.java
@@ -1,7 +1,6 @@
 package org.infinispan.statetransfer;
 
 import static org.infinispan.globalstate.GlobalConfigurationManager.CONFIG_STATE_CACHE_NAME;
-import static org.infinispan.util.concurrent.CompletionStages.ignoreValue;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -202,7 +201,7 @@ public class StateTransferManagerImpl implements StateTransferManager {
             });
    }
 
-   private CompletionStage<Void> updateProviderAndConsumer(boolean isRebalance, int newTopologyId, CacheTopology newCacheTopology,
+   private CompletionStage<?> updateProviderAndConsumer(boolean isRebalance, int newTopologyId, CacheTopology newCacheTopology,
                                                            int newRebalanceId, CacheTopology.Phase phase) {
       CompletionStage<CompletionStage<Void>> consumerUpdateFuture =
             stateConsumer.onTopologyUpdate(newCacheTopology, isRebalance);
@@ -218,7 +217,7 @@ public class StateTransferManagerImpl implements StateTransferManager {
          }
       });
       // Block topology updates until the consumer finishes applying the topology update
-      return ignoreValue(consumerUpdateFuture);
+      return consumerUpdateFuture;
    }
 
    private void completeInitialTransferIfNeeded(CacheTopology newCacheTopology, CacheTopology.Phase phase) {

--- a/core/src/main/java/org/infinispan/xsite/statetransfer/XSiteStateProviderImpl.java
+++ b/core/src/main/java/org/infinispan/xsite/statetransfer/XSiteStateProviderImpl.java
@@ -197,6 +197,6 @@ public class XSiteStateProviderImpl implements XSiteStateProvider {
    }
 
    private boolean missingInDataContainer(Object key) {
-      return !dataContainer.containsKey(key);
+      return dataContainer.peek(key) == null;
    }
 }

--- a/core/src/test/java/org/infinispan/container/SimpleDataContainerTest.java
+++ b/core/src/test/java/org/infinispan/container/SimpleDataContainerTest.java
@@ -58,7 +58,6 @@ public class SimpleDataContainerTest extends AbstractInfinispanTest {
       ActivationManager activationManager = mock(ActivationManager.class);
       InternalExpirationManager expirationManager = mock(InternalExpirationManager.class);
       Mockito.when(expirationManager.entryExpiredInMemory(Mockito.any(), Mockito.anyLong(), Mockito.anyBoolean())).thenReturn(CompletableFutures.completedTrue());
-      Mockito.when(expirationManager.entryExpiredInMemoryFromIteration(Mockito.any(), Mockito.anyLong())).thenReturn(true);
       TestingUtil.inject(dc, internalEntryFactory, timeService, expirationManager);
       return dc;
    }

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/ClusterListenerReplTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/ClusterListenerReplTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.notifications.cachelistener.cluster;
 
+import static org.infinispan.test.TestingUtil.extractInterceptorChain;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertTrue;
 
@@ -16,7 +17,7 @@ import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.distribution.BlockingInterceptor;
 import org.infinispan.distribution.MagicKey;
 import org.infinispan.interceptors.impl.EntryWrappingInterceptor;
-import org.infinispan.remoting.responses.SuccessfulResponse;
+import org.infinispan.notifications.cachelistener.event.CacheEntryEvent;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.util.ControlledRpcManager;
 import org.testng.annotations.Test;
@@ -48,22 +49,25 @@ public class ClusterListenerReplTest extends AbstractClusterListenerNonTxTest {
       final MagicKey key = new MagicKey(cache1, cache2);
       Future<String> future = fork(() -> cache0.put(key, FIRST_VALUE));
 
-      // Wait until the primary owner has sent the put command successfully to  backup
-      ControlledRpcManager.BlockedRequest blockedPut = controlledRpcManager.expectCommand(PutKeyValueCommand.class);
+      // Wait until the primary owner has sent the put command successfully to the backups
+      ControlledRpcManager.BlockedRequest<?> blockedPut = controlledRpcManager.expectCommand(PutKeyValueCommand.class);
+      // And discard the request
+      blockedPut.skipSend();
 
       // Kill the cache now
       TestingUtil.killCacheManagers(cache1.getCacheManager());
-      blockedPut.skipSend().receive(address(0), SuccessfulResponse.SUCCESSFUL_EMPTY_RESPONSE,
-                                    address(2), SuccessfulResponse.SUCCESSFUL_EMPTY_RESPONSE);
 
-      // This should return null normally, but since it was retried it returns it's own value :(
-      // Maybe some day this can work properly
-      assertEquals(null, future.get(10, TimeUnit.SECONDS));
+      // This should return null normally, but when it was retried it returns its own value
+      String returnValue = future.get(10, TimeUnit.SECONDS);
+      assertTrue(returnValue == null || returnValue.equals(FIRST_VALUE));
 
-      // We should have received an event that was marked as retried - maybe even two!
+      // We should have received an event that was marked as retried
       assertTrue(clusterListener.events.size() >= 1);
-      assertTrue(clusterListener.events.size() <= 2);
-      checkEvent(clusterListener.events.get(0), key, true, true);
+      // Because a rebalance has 4 phases, the command may be retried 4 times
+      assertTrue(clusterListener.events.size() <= 4);
+      for (CacheEntryEvent<Object, String> event : clusterListener.events) {
+         checkEvent(event, key, true, true);
+      }
    }
 
    public void testPrimaryOwnerGoesDownAfterBackupRaisesEvent() throws InterruptedException, TimeoutException,
@@ -76,12 +80,12 @@ public class ClusterListenerReplTest extends AbstractClusterListenerNonTxTest {
       cache0.addListener(clusterListener);
 
       CyclicBarrier barrier = new CyclicBarrier(3);
-      BlockingInterceptor blockingInterceptor0 = new BlockingInterceptor<>(barrier, PutKeyValueCommand.class,
+      BlockingInterceptor<?> blockingInterceptor0 = new BlockingInterceptor<>(barrier, PutKeyValueCommand.class,
             true, false);
-      cache0.getAdvancedCache().getAsyncInterceptorChain().addInterceptorBefore(blockingInterceptor0, EntryWrappingInterceptor.class);
-      BlockingInterceptor blockingInterceptor2 = new BlockingInterceptor<>(barrier, PutKeyValueCommand.class,
+      extractInterceptorChain(cache0).addInterceptorBefore(blockingInterceptor0, EntryWrappingInterceptor.class);
+      BlockingInterceptor<?> blockingInterceptor2 = new BlockingInterceptor<>(barrier, PutKeyValueCommand.class,
             true, false);
-      cache2.getAdvancedCache().getAsyncInterceptorChain().addInterceptorBefore(blockingInterceptor2, EntryWrappingInterceptor.class);
+      extractInterceptorChain(cache2).addInterceptorBefore(blockingInterceptor2, EntryWrappingInterceptor.class);
 
       // this is a replicated cache, all other nodes are backup owners
       final MagicKey key = new MagicKey(cache1);
@@ -91,8 +95,8 @@ public class ClusterListenerReplTest extends AbstractClusterListenerNonTxTest {
       barrier.await(10, TimeUnit.SECONDS);
 
       // Remove the interceptor so the next command can proceed properly
-      cache0.getAdvancedCache().getAsyncInterceptorChain().removeInterceptor(BlockingInterceptor.class);
-      cache2.getAdvancedCache().getAsyncInterceptorChain().removeInterceptor(BlockingInterceptor.class);
+      extractInterceptorChain(cache0).removeInterceptor(BlockingInterceptor.class);
+      extractInterceptorChain(cache2).removeInterceptor(BlockingInterceptor.class);
       blockingInterceptor0.suspend(true);
       blockingInterceptor2.suspend(true);
 
@@ -107,13 +111,20 @@ public class ClusterListenerReplTest extends AbstractClusterListenerNonTxTest {
       String returnValue = future.get(10, TimeUnit.SECONDS);
       assertEquals(FIRST_VALUE, returnValue);
 
+      // We should have received an event that was marked as retried
       assertTrue(clusterListener.events.size() >= 2);
-      assertTrue(clusterListener.events.size() <= 3);
+      // Because a rebalance has 4 phases, the command may be retried 4 times
+      assertTrue(clusterListener.events.size() <= 4);
+
       // First create should not be retried since it was sent before node failure.
       checkEvent(clusterListener.events.get(0), key, true, false);
 
-      // We should receive a retry event since it doesn't know the exact state, but it will be a MODIFY since
-      // CREATE was already done
+      // Events from retried commands are a MODIFY since CREATE was already done
+      for (int i = 1; i < clusterListener.events.size(); i++) {
+         CacheEntryEvent<Object, String> event = clusterListener.events.get(i);
+         checkEvent(event, key, false, true);
+      }
+
       checkEvent(clusterListener.events.get(1), key, false, true);
    }
 }

--- a/core/src/test/java/org/infinispan/statetransfer/StateTransferExpiredStoreTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateTransferExpiredStoreTest.java
@@ -1,0 +1,84 @@
+package org.infinispan.statetransfer;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.testng.AssertJUnit.assertEquals;
+
+import org.infinispan.AdvancedCache;
+import org.infinispan.commons.time.ControlledTimeService;
+import org.infinispan.commons.time.TimeService;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.persistence.dummy.DummyInMemoryStoreConfigurationBuilder;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.TestDataSCI;
+import org.infinispan.test.TestingUtil;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Reproducer for ISPN-13191 Deadlock: expiration blocks state transfer
+ */
+@Test(testName = "statetransfer.StateTransferExpiredStoreTest", groups = "functional")
+public class StateTransferExpiredStoreTest extends MultipleCacheManagersTest {
+   private ControlledTimeService timeService;
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      timeService = new ControlledTimeService();
+      createCluster(TestDataSCI.INSTANCE, null, 2);
+
+      TestingUtil.replaceComponent(manager(0), TimeService.class, timeService, true);
+      TestingUtil.replaceComponent(manager(1), TimeService.class, timeService, true);
+   }
+
+   private ConfigurationBuilder getConfigurationBuilder(CacheMode cacheMode) {
+      ConfigurationBuilder cfg = new ConfigurationBuilder();
+      cfg.persistence()
+         .addStore(DummyInMemoryStoreConfigurationBuilder.class)
+         .fetchPersistentState(true);
+
+      cfg.clustering().cacheMode(cacheMode);
+      cfg.clustering().stateTransfer().timeout(30_000);
+      return cfg;
+   }
+
+   @DataProvider
+   Object[][] cacheModes() {
+      return new Object[][] {
+            {CacheMode.DIST_SYNC},
+            {CacheMode.REPL_SYNC},
+            {CacheMode.SCATTERED_SYNC},
+      };
+   }
+
+   @Test(dataProvider = "cacheModes")
+   public void testStateTransfer(CacheMode cacheMode) {
+      String cacheName = "cache_" + cacheMode;
+      Configuration configuration = getConfigurationBuilder(cacheMode).build();
+      manager(0).defineConfiguration(cacheName, configuration);
+      manager(1).defineConfiguration(cacheName, configuration);
+
+      AdvancedCache<Object, Object> cache0 = advancedCache(0, cacheName);
+      String value = "value";
+      cache0.put("immortal", value);
+      for (int i = 1; i <= 3; i++) {
+         cache0.put("lifespan+maxidle" + i, value, i, SECONDS, i, SECONDS);
+         cache0.put("lifespan" + i, value, i, SECONDS);
+         cache0.put("maxidle" + i, value, -1, SECONDS, i, SECONDS);
+         cache0.put("lifespan+maxidle" + i, value, i, SECONDS, i, SECONDS);
+      }
+
+      log.info("timeService.advance");
+      timeService.advance(SECONDS.toMillis(2));
+
+      AdvancedCache<Object, Object> cache1 = advancedCache(1, cacheName);
+      assertEquals(value, cache1.get("immortal"));
+      for (int i = 2; i <= 3; i++) {
+         assertEquals(value, cache0.get("lifespan+maxidle" + i));
+         assertEquals(value, cache0.get("lifespan" + i));
+         assertEquals(value, cache0.get("maxidle" + i));
+         assertEquals(value, cache0.get("lifespan+maxidle" + i));
+      }
+   }
+}

--- a/core/src/test/java/org/infinispan/stress/DataContainerStressTest.java
+++ b/core/src/test/java/org/infinispan/stress/DataContainerStressTest.java
@@ -100,12 +100,7 @@ public class DataContainerStressTest {
                     return null;
                  }
 
-                 @Override
-                 public boolean entryExpiredInMemoryFromIteration(InternalCacheEntry entry, long currentTime) {
-                    return true;
-                 }
-
-                 @Override
+               @Override
                  public CompletionStage<Void> handleInStoreExpirationInternal(Object key) {
                     return null;
                  }


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-13191
https://issues.redhat.com/browse/ISPN-5938
https://issues.redhat.com/browse/ISPN-13241

* Use peek() instead of containsKey() to skip the expiration check.
* Fix ClusterListenerReplInitialStateTest
* Remove InternalExpirationManager.entryExpiredInMemoryFromIteration