### PR TITLE
ISPN-13205 Warnings Next Generation plugin slows down build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -144,8 +144,8 @@ pipeline {
 
         cleanup {
             // Archive logs and dump files
-            sh 'find . \\( -name "*.log" -o -name "*.dump*" -o -name "hs_err_*" -o -name "*.hprof" \\) -exec xz {} \\;'
-            archiveArtifacts allowEmptyArchive: true, artifacts: '**/*.xz,documentation/target/generated-html/**,**/target/*-reports*/**/TEST-*.xml'
+            sh 'find . \\( -name "*.log" -o -name "*.dump*" -o -name "hs_err_*" -o -name "*.hprof" \\) -exec xz -3 {} \\;'
+            archiveArtifacts allowEmptyArchive: true, artifacts: '**/*.xz,**/*.log.gz,documentation/target/generated-html/**,**/target/*-reports*/**/TEST-*.xml'
 
             // Remove all untracked files, ignoring .gitignore
             sh 'git clean -qfdx || echo "git clean failed, exit code $?"'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,11 +84,17 @@ pipeline {
 
     post {
         always {
-            recordIssues enabledForFailure: true, tools: [mavenConsole(), java(), javaDoc()]
-            recordIssues enabledForFailure: true, tool: checkStyle()
-            recordIssues enabledForFailure: true, tool: spotBugs()
-            recordIssues enabledForFailure: true, tool: pmdParser(pattern: '**/target/pmd.xml')
-            recordIssues enabledForFailure: true, tool: cpd(pattern: '**/target/cpd.xml')
+            // Record any warnings before the tests log their own stuff
+            recordIssues enabledForFailure: true,
+                         forensicsDisabled: true,
+                         blameDisabled: true,
+                         tools: [
+                mavenConsole(), java(), javaDoc(),
+                checkStyle(),
+                spotBugs(),
+                pmdParser(pattern: '**/target/pmd.xml'),
+                cpd(pattern: '**/target/cpd.xml')
+            ]
         }
 
         // Deploy snapshots of successful master builds

--- a/all/cli/pom.xml
+++ b/all/cli/pom.xml
@@ -45,6 +45,11 @@
                      <artifactSet>
                         <excludes>
                            <exclude>org.infinispan:infinispan-cli</exclude>
+                           <!-- wildfly-elytron already shades these dependencies -->
+                           <exclude>org.wildfly.security:wildfly-elytron-*</exclude>
+                           <exclude>org.jboss.logging:jboss-logging</exclude>
+                           <exclude>org.apache.sshd:sshd-common</exclude>
+                           <exclude>org.slf4j:slf4j-api</exclude>
                         </excludes>
                      </artifactSet>
                      <filters>
@@ -62,6 +67,7 @@
                               <exclude>META-INF/DEPENDENCIES.txt</exclude>
                               <exclude>META-INF/LICENSE</exclude>
                               <exclude>META-INF/LICENSE.txt</exclude>
+                              <exclude>META-INF/MANIFEST.MF</exclude>
                               <exclude>META-INF/NOTICE</exclude>
                               <exclude>META-INF/NOTICE.txt</exclude>
                               <exclude>META-INF/licenses.xml</exclude>

--- a/client/hotrod-client/pom.xml
+++ b/client/hotrod-client/pom.xml
@@ -308,7 +308,7 @@
                         <delete quiet="true">
                            <fileset dir="${project.build.testOutputDirectory}" includes="*.jks,*.csr,*.cer,*.p12"/>
                         </delete>
-                        <echo message="Generate the CA certificate"/>
+                        <echo level="info" message="Generate the CA certificate"/>
                         <keytool command="-genkeypair">
                            <args>
                               <arg value="-alias"/>
@@ -335,7 +335,7 @@
                               <arg value="${default.password}"/>
                            </args>
                         </keytool>
-                        <echo message="Import the CA certificate to the server truststore"/>
+                        <echo level="info" message="Import the CA certificate to the server truststore"/>
                         <keytool command="-importcert">
                            <args>
                               <arg value="-alias"/>
@@ -348,7 +348,7 @@
                               <arg value="${default.password}"/>
                            </args>
                         </keytool>
-                        <echo message="Import the CA certificate to the client truststore"/>
+                        <echo level="info" message="Import the CA certificate to the client truststore"/>
                         <keytool command="-importcert">
                            <args>
                               <arg value="-alias"/>
@@ -361,7 +361,7 @@
                               <arg value="${default.password}"/>
                            </args>
                         </keytool>
-                        <echo message="Generate the client certificate"/>
+                        <echo level="info" message="Generate the client certificate"/>
                         <keytool command="-genkeypair">
                            <args>
                               <arg value="-alias"/>
@@ -374,7 +374,7 @@
                               <arg value="${default.password}"/>
                            </args>
                         </keytool>
-                        <echo message="Sign the client certificate with the CA"/>
+                        <echo level="info" message="Sign the client certificate with the CA"/>
                         <keytool command="-certreq">
                            <args>
                               <arg value="-alias"/>
@@ -403,7 +403,7 @@
                               <arg value="${default.password}"/>
                            </args>
                         </keytool>
-                        <echo message="Import the CA certificate to the client keystore"/>
+                        <echo level="info" message="Import the CA certificate to the client keystore"/>
                         <keytool command="-importcert">
                            <args>
                               <arg value="-alias"/>
@@ -416,7 +416,7 @@
                               <arg value="${default.password}"/>
                            </args>
                         </keytool>
-                        <echo message="Import the client certificate to the client keystore"/>
+                        <echo level="info" message="Import the client certificate to the client keystore"/>
                         <keytool command="-importcert">
                            <args>
                               <arg value="-alias"/>
@@ -430,7 +430,7 @@
                            </args>
                         </keytool>
                         <!-- Server -->
-                        <echo message="Generate the server certificate"/>
+                        <echo level="info" message="Generate the server certificate"/>
                         <keytool command="-genkeypair">
                            <args>
                               <arg value="-alias"/>
@@ -443,7 +443,7 @@
                               <arg value="${default.password}"/>
                            </args>
                         </keytool>
-                        <echo message="Sign the server certificate with the CA"/>
+                        <echo level="info" message="Sign the server certificate with the CA"/>
                         <keytool command="-certreq">
                            <args>
                               <arg value="-alias"/>
@@ -472,7 +472,7 @@
                                <arg value="${default.password}"/>
                            </args>
                         </keytool>
-                        <echo message="Import the CA certificate to the server keystore"/>
+                        <echo level="info" message="Import the CA certificate to the server keystore"/>
                         <keytool command="-importcert">
                            <args>
                               <arg value="-alias"/>
@@ -485,7 +485,7 @@
                                <arg value="${default.password}"/>
                            </args>
                         </keytool>
-                        <echo message="Import the server certificate to the server keystore"/>
+                        <echo level="info" message="Import the server certificate to the server keystore"/>
                         <keytool command="-importcert">
                            <args>
                               <arg value="-alias"/>
@@ -499,7 +499,7 @@
                            </args>
                         </keytool>
                         <!-- Alternate password client certificate -->
-                        <echo message="Clone the client keystore with an alternate key password"/>
+                        <echo level="info" message="Clone the client keystore with an alternate key password"/>
                         <keytool command="-importkeystore">
                            <args>
                               <arg value="-srcalias"/>
@@ -537,7 +537,7 @@
                            </args>
                         </keytool>
                         <!-- Alternate password server certificate -->
-                        <echo message="Clone the server keystore with an alternate key password"/>
+                        <echo level="info" message="Clone the server keystore with an alternate key password"/>
                         <keytool command="-importkeystore">
                            <args>
                               <arg value="-srcalias"/>

--- a/client/marshaller/kryo/kryo-marshaller-compatibility-bundle/pom.xml
+++ b/client/marshaller/kryo/kryo-marshaller-compatibility-bundle/pom.xml
@@ -54,6 +54,15 @@
                             </artifactSet>
                             <filters>
                                 <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/LICENSE</exclude>
+                                        <exclude>META-INF/LICENSE.txt</exclude>
+                                        <exclude>META-INF/MANIFEST.MF</exclude>
+                                        <exclude>META-INF/licenses.xml</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
                                     <artifact>org.infinispan:infinispan-marshaller-kryo-bundle</artifact>
                                     <excludes>
                                         <exclude>META-INF/maven/org.infinispan/infinispan-marshaller-kryo-bundle</exclude>

--- a/client/marshaller/protostuff/protostuff-marshaller-compatibility-bundle/pom.xml
+++ b/client/marshaller/protostuff/protostuff-marshaller-compatibility-bundle/pom.xml
@@ -55,6 +55,15 @@
                             </artifactSet>
                             <filters>
                                 <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/LICENSE</exclude>
+                                        <exclude>META-INF/LICENSE.txt</exclude>
+                                        <exclude>META-INF/MANIFEST.MF</exclude>
+                                        <exclude>META-INF/licenses.xml</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
                                     <artifact>org.infinispan:infinispan-marshaller-protostuff-bundle</artifact>
                                     <excludes>
                                         <exclude>META-INF/maven/org.infinispan/infinispan-marshaller-protostuff-bundle</exclude>

--- a/distribution/package.xml
+++ b/distribution/package.xml
@@ -99,7 +99,7 @@
          <local name="output.dir" />
          <property name="src.dir" value="${root.dir}/demos/@{demo}" />
          <property name="output.dir" value="@{target}/demos/@{demo}" />
-         <echo message="ROOT = ${root.dir}"/>
+         <echo level="info" message="ROOT = ${root.dir}"/>
          <mkdir dir="${output.dir}" />
          <copy todir="${output.dir}">
             <fileset dir="${src.dir}/target">

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -202,7 +202,7 @@
                   <configuration>
                      <target>
                         <property name="plugin_classpath" refid="maven.plugin.classpath" />
-                        <echo message="Base dir: ${basedir}" />
+                        <echo level="info" message="Base dir: ${basedir}" />
                         <path id="xsd.fileset.path">
                            <fileset casesensitive="yes" dir="${basedir}/..">
                               <!-- make sure core comes first -->
@@ -215,7 +215,7 @@
                            </fileset>
                         </path>
                         <pathconvert pathsep=" " property="xsd.fileset" refid="xsd.fileset.path" />
-                        <echo message="XSDs: ${xsd.fileset}" />
+                        <echo level="info" message="XSDs: ${xsd.fileset}" />
                         <java classname="org.infinispan.tools.xsd.XSDoc">
                            <arg value="-o" />
                            <arg value="${project.build.directory}/site/configdocs" />
@@ -254,13 +254,13 @@
                   <configuration>
                      <skip>${skipArtifactUpload}</skip>
                      <target>
-                        <echo message="Creating checksums of distribution files"/>
+                        <echo level="info" message="Creating checksums of distribution files"/>
                         <checksum algorithm="SHA-1" fileext=".sha1">
                            <fileset dir="${project.build.directory}/distribution">
                               <include name="*.zip"/>
                            </fileset>
                         </checksum>
-                        <echo message="Uploading Distributions to ${upload.downloadsDir}"/>
+                        <echo level="info" message="Uploading Distributions to ${upload.downloadsDir}"/>
                         <exec dir="${project.build.directory}/distribution" executable="rsync">
                            <arg value="-rvm"/>
                            <arg line="--protocol=29"/>
@@ -271,7 +271,7 @@
                            <arg value="."/>
                            <arg value="${upload.downloadsDir}"/>
                         </exec>
-                        <echo message="Uploading Schema docs to ${upload.docsDir}"/>
+                        <echo level="info" message="Uploading Schema docs to ${upload.docsDir}"/>
                         <exec dir="${project.build.directory}/site" executable="rsync">
                            <arg value="-rvm"/>
                            <arg line="--protocol=29"/>

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -284,7 +284,7 @@
                                 <configuration>
                                     <skip>${skipArtifactUpload}</skip>
                                     <target>
-                                        <echo message="Uploading PDF docs"/>
+                                        <echo level="info" message="Uploading PDF docs"/>
                                         <exec dir="${project.build.directory}/generated/${infinispan.base.version}" executable="rsync">
                                             <arg value="-rvm"/>
                                             <arg line="--protocol=29"/>

--- a/javadoc/pom.xml
+++ b/javadoc/pom.xml
@@ -215,7 +215,7 @@
          <artifactId>jdk-misc</artifactId>
          <version>2.Final</version>
       </dependency>
-      
+
       <dependency>
          <groupId>org.infinispan</groupId>
          <artifactId>infinispan-scripting</artifactId>
@@ -225,12 +225,12 @@
          <groupId>io.projectreactor.tools</groupId>
          <artifactId>blockhound</artifactId>
       </dependency>
-      
+
       <dependency>
          <groupId>org.apache.logging.log4j</groupId>
          <artifactId>log4j-core</artifactId>
       </dependency>
-      
+
       <dependency>
          <groupId>io.mashona</groupId>
          <artifactId>mashona-logwriting</artifactId>
@@ -408,7 +408,7 @@
                         <configuration>
                            <skip>${skipArtifactUpload}</skip>
                            <target>
-                              <echo message="Uploading JavaDocs"/>
+                              <echo level="info" message="Uploading JavaDocs"/>
                               <exec dir="${project.build.directory}" executable="rsync">
                                  <arg value="-rvm"/>
                                  <arg line="--protocol=29"/>

--- a/object-filter/pom.xml
+++ b/object-filter/pom.xml
@@ -122,6 +122,15 @@
                            <exclude>org.infinispan:infinispan-component-annotations:</exclude>
                         </excludes>
                      </artifactSet>
+                     <filters>
+                        <filter>
+                           <artifact>*:*</artifact>
+                           <excludes>
+                              <exclude>META-INF/MANIFEST.MF</exclude>
+                              <exclude>META-INF/licenses.xml</exclude>
+                           </excludes>
+                        </filter>
+                     </filters>
                      <relocations>
                         <relocation>
                            <pattern>org.antlr.runtime</pattern>

--- a/persistence/remote/pom.xml
+++ b/persistence/remote/pom.xml
@@ -166,7 +166,7 @@
                         <delete quiet="true">
                            <fileset dir="${project.build.testOutputDirectory}" includes="*.jks,*.csr,*.cer"/>
                         </delete>
-                        <echo message="Generate the CA certificate"/>
+                        <echo level="info" message="Generate the CA certificate"/>
                         <keytool command="-genkeypair">
                            <args>
                               <arg value="-alias"/>
@@ -193,7 +193,7 @@
                               <arg value="${default.password}"/>
                            </args>
                         </keytool>
-                        <echo message="Import the CA certificate to the server truststore"/>
+                        <echo level="info" message="Import the CA certificate to the server truststore"/>
                         <keytool command="-importcert">
                            <args>
                               <arg value="-alias"/>
@@ -206,7 +206,7 @@
                               <arg value="${default.password}"/>
                            </args>
                         </keytool>
-                        <echo message="Import the CA certificate to the client truststore"/>
+                        <echo level="info" message="Import the CA certificate to the client truststore"/>
                         <keytool command="-importcert">
                            <args>
                               <arg value="-alias"/>
@@ -219,7 +219,7 @@
                               <arg value="${default.password}"/>
                            </args>
                         </keytool>
-                        <echo message="Generate the client certificate"/>
+                        <echo level="info" message="Generate the client certificate"/>
                         <keytool command="-genkeypair">
                            <args>
                               <arg value="-alias"/>
@@ -232,7 +232,7 @@
                               <arg value="${default.password}"/>
                            </args>
                         </keytool>
-                        <echo message="Sign the client certificate with the CA"/>
+                        <echo level="info" message="Sign the client certificate with the CA"/>
                         <keytool command="-certreq">
                            <args>
                               <arg value="-alias"/>
@@ -261,7 +261,7 @@
                               <arg value="${default.password}"/>
                            </args>
                         </keytool>
-                        <echo message="Import the CA certificate to the client keystore"/>
+                        <echo level="info" message="Import the CA certificate to the client keystore"/>
                         <keytool command="-importcert">
                            <args>
                               <arg value="-alias"/>
@@ -274,7 +274,7 @@
                               <arg value="${default.password}"/>
                            </args>
                         </keytool>
-                        <echo message="Import the client certificate to the client keystore"/>
+                        <echo level="info" message="Import the client certificate to the client keystore"/>
                         <keytool command="-importcert">
                            <args>
                               <arg value="-alias"/>
@@ -288,7 +288,7 @@
                            </args>
                         </keytool>
                         <!-- Server -->
-                        <echo message="Generate the server certificate"/>
+                        <echo level="info" message="Generate the server certificate"/>
                         <keytool command="-genkeypair">
                            <args>
                               <arg value="-alias"/>
@@ -301,7 +301,7 @@
                               <arg value="${default.password}"/>
                            </args>
                         </keytool>
-                        <echo message="Sign the server certificate with the CA"/>
+                        <echo level="info" message="Sign the server certificate with the CA"/>
                         <keytool command="-certreq">
                            <args>
                               <arg value="-alias"/>
@@ -330,7 +330,7 @@
                               <arg value="${default.password}"/>
                            </args>
                         </keytool>
-                        <echo message="Import the CA certificate to the server keystore"/>
+                        <echo level="info" message="Import the CA certificate to the server keystore"/>
                         <keytool command="-importcert">
                            <args>
                               <arg value="-alias"/>
@@ -343,7 +343,7 @@
                               <arg value="${default.password}"/>
                            </args>
                         </keytool>
-                        <echo message="Import the server certificate to the server keystore"/>
+                        <echo level="info" message="Import the server certificate to the server keystore"/>
                         <keytool command="-importcert">
                            <args>
                               <arg value="-alias"/>

--- a/pom.xml
+++ b/pom.xml
@@ -2329,6 +2329,7 @@
                      <goal>test-jar</goal>
                   </goals>
                   <configuration>
+                     <skipIfEmpty>true</skipIfEmpty>
                      <archive>
                         <manifest>
                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>

--- a/pom.xml
+++ b/pom.xml
@@ -2680,7 +2680,7 @@
                            <target>
                               <available file="${project.build.outputDirectory}/schema" type="dir" property="hasSchema"/>
 
-                              <echo message="Uploading Schema files to ${upload.schemaDir}" if:set="hasSchema" xmlns:if="ant:if"/>
+                              <echo level="info" message="Uploading Schema files to ${upload.schemaDir}" if:set="hasSchema" xmlns:if="ant:if"/>
                               <scp todir="${upload.schemaDir}" keyfile="${upload.keyFile}" verbose="true" compressed="true" if:set="hasSchema" xmlns:if="ant:if">
                                  <fileset dir="${project.build.outputDirectory}/schema">
                                     <include name="*-${infinispan.core.schema.version}.xsd" />
@@ -3001,7 +3001,7 @@
                         <configuration>
                            <target>
                                  <available file="${project.build.directory}/classes" type="dir" property="hasClasses"/>
-                                 <echo message="Copying test classes to jacoco folder" if:set="hasClasses" xmlns:if="ant:if"/>
+                                 <echo level="info" message="Copying test classes to jacoco folder" if:set="hasClasses" xmlns:if="ant:if"/>
                                  <copydir dest="${jacoco.reportPath}/classes"
                                           src="${project.build.directory}/classes"
                                           if:set="hasClasses" xmlns:if="ant:if"/>

--- a/server/hotrod/pom.xml
+++ b/server/hotrod/pom.xml
@@ -131,7 +131,7 @@
                         <delete quiet="true">
                            <fileset dir="${project.build.testOutputDirectory}" includes="*.jks,*.csr,*.cer,*.p12"/>
                         </delete>
-                        <echo message="Generate the server certificate"/>
+                        <echo level="info" message="Generate the server certificate"/>
                         <keytool command="-genkeypair">
                            <args>
                               <arg value="-alias"/>

--- a/server/rest/pom.xml
+++ b/server/rest/pom.xml
@@ -217,7 +217,7 @@
                         <delete quiet="true">
                            <fileset dir="${project.build.testOutputDirectory}" includes="*.jks,*.csr,*.cer,*.p12"/>
                         </delete>
-                        <echo message="Generate the CA certificate"/>
+                        <echo level="info" message="Generate the CA certificate"/>
                         <keytool command="-genkeypair">
                            <args>
                               <arg value="-alias"/>

--- a/server/router/pom.xml
+++ b/server/router/pom.xml
@@ -144,7 +144,7 @@
                                 <delete quiet="true">
                                     <fileset dir="${project.build.testOutputDirectory}" includes="*.jks,*.csr,*.cer"/>
                                 </delete>
-                                <echo message="Generate the default certificate"/>
+                                <echo level="info" message="Generate the default certificate"/>
                                 <keytool command="-genkeypair">
                                     <args>
                                         <arg value="-alias"/>
@@ -155,7 +155,7 @@
                                         <arg value="${project.build.testOutputDirectory}/default_server_keystore.jks"/>
                                     </args>
                                 </keytool>
-                                <echo message="Generate the SNI certificate"/>
+                                <echo level="info" message="Generate the SNI certificate"/>
                                 <keytool command="-genkeypair">
                                     <args>
                                         <arg value="-alias"/>

--- a/server/runtime/build.xml
+++ b/server/runtime/build.xml
@@ -91,7 +91,7 @@
    </target>
 
    <target name="default">
-      <echo message="This script needs to be executed by the maven ant plugin"/>
+      <echo level="info" message="This script needs to be executed by the maven ant plugin"/>
    </target>
 
 </project>

--- a/server/runtime/src/main/ant/infinispan-server.xml
+++ b/server/runtime/src/main/ant/infinispan-server.xml
@@ -11,8 +11,8 @@
     </target>
 
     <target name="create-distro" depends="-check.skipped" unless="tests.skipped">
-        <echo message="Creating test server distro at ${server.dist}"/>
-        <echo message="Using distribution ${server.build.dist}"/>
+        <echo level="info" message="Creating test server distro at ${server.dist}"/>
+        <echo level="info" message="Using distribution ${server.build.dist}"/>
         <copy todir="${server.dist}">
             <fileset dir="${server.build.dist}"/>
         </copy>
@@ -20,7 +20,7 @@
         <!-- It happens when you do not specify namespaces in the XSLT templates for the newly added nodes
              then the IBM jdk transformation is adding empty namespace there - not possible to influence this
              behaviour by any environmental property - this is a bit workaround for it -->
-        <echo message="Removing empty xmlns attributes (xmlns='') which IBM JDK could produce"/>
+        <echo level="info" message="Removing empty xmlns attributes (xmlns='') which IBM JDK could produce"/>
         <replace dir="target" value="">
             <include name="server/standalone/configuration/**/*.xml"/>
             <replacetoken><![CDATA[xmlns=""]]></replacetoken>
@@ -65,7 +65,7 @@
         </concat>
         <antcall target="kill-server" if:set="server.timeout"/>
         <fail message="Server did not start" if="server.timeout"/>
-        <echo message="Infinispan server started"/>
+        <echo level="info" message="Infinispan server started"/>
     </target>
 
     <macrodef name="checkoutput">


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-13205

The main fix was in the Jenkins agent: https://issues.jenkins.io/browse/JENKINS-66268 was slowing down the warnings report by downloading the same 2 Xerces classes thousands of times. I worked around it by downloading xercesImpl-2.12.2.jar on the agents and adding it to the agent's classpath with `-Xbootclasspath/a:`. That removed almost 20 minutes from the build time.

I estimate the xz compression level change also reduced the build time by about 2 minutes.