### PR TITLE
ISPN-13208 Create profile to disable marshallers

### DIFF
--- a/build-configuration/bom/pom.xml
+++ b/build-configuration/bom/pom.xml
@@ -235,27 +235,6 @@
             </dependency>
             <dependency>
                 <groupId>org.infinispan</groupId>
-                <artifactId>infinispan-marshaller-kryo</artifactId>
-                <version>${version.infinispan}</version>
-            </dependency>
-            <!-- TODO should be here? -->
-            <dependency>
-                <groupId>org.infinispan</groupId>
-                <artifactId>infinispan-marshaller-kryo-bundle</artifactId>
-                <version>${version.infinispan}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.infinispan</groupId>
-                <artifactId>infinispan-marshaller-protostuff</artifactId>
-                <version>${version.infinispan}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.infinispan</groupId>
-                <artifactId>infinispan-marshaller-protostuff-bundle</artifactId>
-                <version>${version.infinispan}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.infinispan</groupId>
                 <artifactId>infinispan-multimap</artifactId>
                 <version>${version.infinispan}</version>
             </dependency>
@@ -417,4 +396,37 @@
            </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <profiles>
+        <profile>
+            <id>deprecated-marshallers</id>
+            <activation>
+               <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencyManagement>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.infinispan</groupId>
+                        <artifactId>infinispan-marshaller-kryo</artifactId>
+                        <version>${version.infinispan}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.infinispan</groupId>
+                        <artifactId>infinispan-marshaller-kryo-bundle</artifactId>
+                        <version>${version.infinispan}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.infinispan</groupId>
+                        <artifactId>infinispan-marshaller-protostuff</artifactId>
+                        <version>${version.infinispan}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.infinispan</groupId>
+                        <artifactId>infinispan-marshaller-protostuff-bundle</artifactId>
+                        <version>${version.infinispan}</version>
+                    </dependency>
+                </dependencies>
+            </dependencyManagement>
+        </profile>
+    </profiles>
 </project>

--- a/client/marshaller/pom.xml
+++ b/client/marshaller/pom.xml
@@ -15,10 +15,6 @@
 
     <modules>
         <module>marshaller-tests</module>
-        <module>kryo/kryo-marshaller</module>
-        <module>kryo/kryo-marshaller-compatibility-bundle</module>
-        <module>protostuff/protostuff-marshaller</module>
-        <module>protostuff/protostuff-marshaller-compatibility-bundle</module>
     </modules>
 
     <dependencies>
@@ -107,4 +103,19 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>deprecated-marshallers</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>kryo/kryo-marshaller</module>
+                <module>kryo/kryo-marshaller-compatibility-bundle</module>
+                <module>protostuff/protostuff-marshaller</module>
+                <module>protostuff/protostuff-marshaller-compatibility-bundle</module>
+            </modules>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Kryo and Protostuff marshallers are deprecated and not supported
downstream. A profile will allow disabling the build of these modules
downstream with minimal changes required to the pom.xml files

https://issues.redhat.com/browse/ISPN-13208