### PR TITLE
ISPN-12638 Make NonBlockingStore.delete() return value optional

### DIFF
--- a/core/src/main/java/org/infinispan/persistence/async/AsyncNonBlockingStore.java
+++ b/core/src/main/java/org/infinispan/persistence/async/AsyncNonBlockingStore.java
@@ -510,9 +510,9 @@ public class AsyncNonBlockingStore<K, V> extends DelegatingNonBlockingStore<K, V
    @Override
    public CompletionStage<Boolean> delete(int segment, Object key) {
       assertNotStopped();
-      return submitModification(new RemoveModification(segment, key))
-            // We always assume it was removed with async
-            .thenCompose(ignore -> CompletableFutures.completedTrue());
+      // Return null to signal that we don't know if the key exists in the store
+      // Use erasure to avoid calling thenApply
+      return (CompletionStage)submitModification(new RemoveModification(segment, key));
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/persistence/manager/PersistenceManagerImpl.java
+++ b/core/src/main/java/org/infinispan/persistence/manager/PersistenceManagerImpl.java
@@ -704,7 +704,7 @@ public class PersistenceManagerImpl implements PersistenceManager {
                                  && predicate.test(storeStatus.config))
                      // Let the delete work in parallel across the stores
                      .flatMapSingle(storeStatus -> Single.fromCompletionStage(
-                           storeStatus.store.delete(segment, key)))
+                           storeStatus.store.delete(segment, key).thenApply(v -> v != null ? v : Boolean.TRUE)))
                      // Can't use any, as we have to reduce to ensure that all stores are updated
                      .reduce(Boolean.FALSE, (removed1, removed2) -> removed1 || removed2);
             },

--- a/core/src/main/java/org/infinispan/persistence/spi/NonBlockingStore.java
+++ b/core/src/main/java/org/infinispan/persistence/spi/NonBlockingStore.java
@@ -345,8 +345,8 @@ public interface NonBlockingStore<K, V> {
    CompletionStage<Void> write(int segment, MarshallableEntry<? extends K, ? extends V> entry);
 
    /**
-    * Removes the entry for given key and segment from the store returning a stage that when completes normally
-    * contains whether the entry was actually removed or not.
+    * Removes the entry for given key and segment from the store
+    * and optionally report if the entry was actually removed or not.
     * <p>
     * <h4>Summary of Characteristics Effects</h4>
     * <table border="1" cellpadding="1" cellspacing="1" summary="Summary of Characteristics Effects">
@@ -368,7 +368,9 @@ public interface NonBlockingStore<K, V> {
     * {@link PersistenceException} and the stage be completed exceptionally.
     * @param segment the segment for the given key if segmentation is enabled, otherwise 0.
     * @param key key of the entry to delete from the store.
-    * @return a stage that when complete contains a boolean stating if the value was removed from the store.
+    * @return a stage that completes with {@code TRUE} if the key existed in the store,
+    * {@code FALSE} if the key did not exist in the store,
+    * or {@code null} if the store does not report this information.
     */
    CompletionStage<Boolean> delete(int segment, Object key);
 

--- a/core/src/test/java/org/infinispan/persistence/BaseNonBlockingStoreTest.java
+++ b/core/src/test/java/org/infinispan/persistence/BaseNonBlockingStoreTest.java
@@ -4,6 +4,7 @@ import static org.infinispan.test.TestingUtil.allEntries;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertNotSame;
 import static org.testng.AssertJUnit.assertNull;
 import static org.testng.AssertJUnit.assertTrue;
 
@@ -202,7 +203,8 @@ public abstract class BaseNonBlockingStoreTest extends AbstractInfinispanTest {
       assertTrue("Expected an immortalEntry",
                  entry.getMetadata() == null || entry.expiryTime() == -1 || entry.getMetadata().maxIdle() == -1);
       assertContains("k", true);
-      assertFalse(store.delete(keyToStorage("k2")));
+      // The store may return null or FALSE but not TRUE
+      assertNotSame(Boolean.TRUE, store.delete(keyToStorage("k2")));
    }
 
    public void testLoadAndStoreWithLifespan() throws Exception {
@@ -628,8 +630,11 @@ public abstract class BaseNonBlockingStoreTest extends AbstractInfinispanTest {
                  entry.getMetadata() == null || entry.expiryTime() == -1 || entry.getMetadata().maxIdle() == -1);
       assertTrue(store.contains(key));
 
-      assertFalse(store.delete(key2));
-      assertTrue(store.delete(key));
+      // Delete return value is optional
+      // The store may return null or FALSE but not TRUE
+      assertNotSame(Boolean.TRUE, store.delete(key2));
+      // The store may return null or TRUE but not FALSE
+      assertNotSame(Boolean.FALSE, store.delete(key));
    }
 
    public void testWriteAndDeleteBatch() {

--- a/core/src/test/java/org/infinispan/persistence/support/WaitNonBlockingStore.java
+++ b/core/src/test/java/org/infinispan/persistence/support/WaitNonBlockingStore.java
@@ -18,7 +18,7 @@ import io.reactivex.rxjava3.core.Flowable;
 public interface WaitNonBlockingStore<K, V> extends NonBlockingStore<K, V> {
    KeyPartitioner getKeyPartitioner();
 
-   default boolean delete(Object key) {
+   default Boolean delete(Object key) {
       int segment = getKeyPartitioner().getSegment(key);
       return join(delete(segment, key));
    }

--- a/core/src/test/java/org/infinispan/stress/AsyncStoreStressTest.java
+++ b/core/src/test/java/org/infinispan/stress/AsyncStoreStressTest.java
@@ -1,6 +1,7 @@
 package org.infinispan.stress;
 
 import static java.lang.Math.sqrt;
+import static org.testng.AssertJUnit.assertNull;
 import static org.testng.AssertJUnit.assertTrue;
 
 import java.util.ArrayList;
@@ -359,12 +360,11 @@ public class AsyncStoreStressTest extends AbstractInfinispanTest {
          public boolean call(final String key, long run) {
             // Remove acquiring locks and catching exceptions
             return withKeyLock(key, () -> {
-               boolean removed = CompletionStages.join(store.delete(0, key));
-               if (removed) {
-                  expectedState.remove(key);
-                  if (log.isTraceEnabled())
-                     log.tracef("Expected state removed key=%s", key);
-               }
+               Boolean removed = CompletionStages.join(store.delete(0, key));
+               assertNull(removed);
+               expectedState.remove(key);
+               if (log.isTraceEnabled())
+                  log.tracef("Expected state removed key=%s", key);
                return true;
             });
          }

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/RemoteStore.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/RemoteStore.java
@@ -3,7 +3,6 @@ package org.infinispan.persistence.remote;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
@@ -12,7 +11,6 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.infinispan.client.hotrod.DataFormat;
-import org.infinispan.client.hotrod.Flag;
 import org.infinispan.client.hotrod.MetadataValue;
 import org.infinispan.client.hotrod.ProtocolVersion;
 import org.infinispan.client.hotrod.RemoteCache;
@@ -385,11 +383,8 @@ public class RemoteStore<K, V> implements NonBlockingStore<K, V> {
    @Override
    public CompletionStage<Boolean> delete(int segment, Object key) {
       key = unwrap(key);
-      // Less than ideal, but RemoteCache, since it extends Cache, can only
-      // know whether the operation succeeded based on whether the previous
-      // value is null or not.
-      return remoteCache.withFlags(Flag.FORCE_RETURN_VALUE).removeAsync(key)
-            .thenApply(Objects::nonNull);
+      return remoteCache.removeAsync(key)
+            .thenApply(v -> null);
    }
 
    private long toSeconds(long millis, Object key, String desc) {

--- a/persistence/rocksdb/src/main/java/org/infinispan/persistence/rocksdb/RocksDBStore.java
+++ b/persistence/rocksdb/src/main/java/org/infinispan/persistence/rocksdb/RocksDBStore.java
@@ -768,11 +768,8 @@ public class RocksDBStore<K, V> implements NonBlockingStore<K, V> {
             ColumnFamilyHandle handle = getHandle(segment);
             return blockingManager.supplyBlocking(() -> {
                try {
-                  if (db.get(handle, keyBytes) == null) {
-                     return Boolean.FALSE;
-                  }
                   db.delete(handle, keyBytes);
-                  return Boolean.TRUE;
+                  return null;
                } catch (RocksDBException e) {
                   throw new PersistenceException(e);
                }


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12638

Skip the previous lookup in RocksDBStore and RemoteStore