### PR TITLE
ISPN-13182 BlockHound 1.0.6.FINAL

### DIFF
--- a/build-configuration/pom.xml
+++ b/build-configuration/pom.xml
@@ -125,7 +125,7 @@
       <version.ant-contrib>1.0b3</version.ant-contrib>
       <version.antlr3>3.5.2</version.antlr3>
       <version.arquillian>1.6.0.Final</version.arquillian>
-      <version.blockhound>1.0.3.RELEASE</version.blockhound>
+      <version.blockhound>1.0.6.RELEASE</version.blockhound>
       <version.bouncycastle>1.66</version.bouncycastle>
       <version.byteman>4.0.6</version.byteman>
       <version.caffeine>2.8.4</version.caffeine>


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-13182
This fixes builds on JDK 17 
(Splitting this to its own individual PR to ease integration)
