### PR TITLE
ISPN-13239 Fix jgroups-azure version

### DIFF
--- a/wildfly/feature-pack/pom.xml
+++ b/wildfly/feature-pack/pom.xml
@@ -479,7 +479,6 @@
         <dependency>
             <groupId>org.jgroups.azure</groupId>
             <artifactId>jgroups-azure</artifactId>
-            <version>1.2.1.Final</version>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>


### PR DESCRIPTION
Remove hardcoded version from feature-pack module added by mistake.

https://issues.redhat.com/browse/ISPN-13239