### PR TITLE
ISPN-13240 Infinispan WildFly Modules: trim licenses.html

### DIFF
--- a/distribution/package.xml
+++ b/distribution/package.xml
@@ -38,7 +38,7 @@
             <fileset dir="${project.build.directory}/docs/licenses" />
          </copy>
          <path id="jar.fileset.path">
-            <fileset casesensitive="yes" dir="@{dir}">
+            <fileset casesensitive="yes" dir="@{dir}/modules/system/add-ons">
                <include name="**/*.jar" />
             </fileset>
          </path>


### PR DESCRIPTION
Create the licenses.html based on the jars in add-ons folder to avoid
including the WildFly server jars.

https://issues.redhat.com/browse/ISPN-13240