### PR TITLE
ISPN-11902 WriteBehindFaultToleranceTest.testBlockingOnStoreAvailabilityChange random failures

### DIFF
--- a/core/src/main/java/org/infinispan/persistence/async/PutModification.java
+++ b/core/src/main/java/org/infinispan/persistence/async/PutModification.java
@@ -39,7 +39,7 @@ class PutModification implements Modification {
    public String toString() {
       return "PutModification{" +
             "segment=" + segment +
-            ", entry=" + entry +
+            ", key=" + entry.getKey() +
             '}';
    }
 }

--- a/core/src/test/java/org/infinispan/persistence/BaseNonBlockingStoreTest.java
+++ b/core/src/test/java/org/infinispan/persistence/BaseNonBlockingStoreTest.java
@@ -692,7 +692,7 @@ public abstract class BaseNonBlockingStoreTest extends AbstractInfinispanTest {
             .setTimeService(timeService)
             .setKeyPartitioner(keyPartitioner);
       modifyInitializationContext(builder);
-      initializationContext =  builder.build();
+      initializationContext = builder.build();
       return initializationContext;
    }
 

--- a/core/src/test/java/org/infinispan/persistence/dummy/DummyInMemoryStore.java
+++ b/core/src/test/java/org/infinispan/persistence/dummy/DummyInMemoryStore.java
@@ -22,6 +22,7 @@ import org.infinispan.commons.CacheException;
 import org.infinispan.commons.IllegalLifecycleStateException;
 import org.infinispan.commons.configuration.ConfiguredBy;
 import org.infinispan.commons.persistence.Store;
+import org.infinispan.commons.reactive.RxJavaInterop;
 import org.infinispan.commons.test.TestResourceTracker;
 import org.infinispan.commons.time.TimeService;
 import org.infinispan.commons.util.InfinispanCollections;
@@ -37,7 +38,6 @@ import org.infinispan.persistence.spi.MarshalledValue;
 import org.infinispan.persistence.spi.NonBlockingStore;
 import org.infinispan.persistence.spi.PersistenceException;
 import org.infinispan.persistence.support.WaitNonBlockingStore;
-import org.infinispan.commons.reactive.RxJavaInterop;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.util.concurrent.CompletableFutures;
 import org.infinispan.util.concurrent.CompletionStages;
@@ -341,6 +341,7 @@ public class DummyInMemoryStore implements WaitNonBlockingStore {
    }
 
    public void setAvailable(boolean available) {
+      log.debugf("Store availability change: %s -> %s", this.available, available);
       this.available = available;
    }
 

--- a/core/src/test/java/org/infinispan/persistence/dummy/DummyInMemoryStoreConfigurationBuilder.java
+++ b/core/src/test/java/org/infinispan/persistence/dummy/DummyInMemoryStoreConfigurationBuilder.java
@@ -21,7 +21,9 @@ public class DummyInMemoryStoreConfigurationBuilder extends
 
    /**
     * If true, then writes to this store are artificially slowed by {@value DummyInMemoryStore#SLOW_STORE_WAIT} milliseconds.
+    * @deprecated Use {@link org.infinispan.persistence.support.DelayStore} instead.
     */
+   @Deprecated
    public DummyInMemoryStoreConfigurationBuilder slow(boolean slow) {
       attributes.attribute(SLOW).set(slow);
       return this;

--- a/core/src/test/java/org/infinispan/persistence/manager/PersistenceManagerTest.java
+++ b/core/src/test/java/org/infinispan/persistence/manager/PersistenceManagerTest.java
@@ -1,10 +1,11 @@
 package org.infinispan.persistence.manager;
 
 import static org.infinispan.commons.test.Exceptions.expectCompletionException;
-import static org.infinispan.commons.test.Exceptions.expectException;
 import static org.infinispan.persistence.manager.PersistenceManager.AccessMode.BOTH;
 import static org.infinispan.test.TestingUtil.extractComponent;
+import static org.infinispan.test.TestingUtil.getFirstStore;
 import static org.infinispan.test.TestingUtil.getStore;
+import static org.infinispan.util.concurrent.CompletionStages.join;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertTrue;
@@ -20,14 +21,12 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.distribution.ch.KeyPartitioner;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.marshall.persistence.impl.MarshalledEntryUtil;
-import org.infinispan.persistence.dummy.DummyInMemoryStore;
-import org.infinispan.persistence.dummy.DummyInMemoryStoreConfigurationBuilder;
+import org.infinispan.persistence.support.DelayStore;
 import org.infinispan.persistence.support.FailStore;
 import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.TestException;
 import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
-import org.infinispan.util.concurrent.CompletionStages;
 import org.testng.annotations.Test;
 
 import io.reactivex.rxjava3.core.Flowable;
@@ -43,67 +42,96 @@ import io.reactivex.rxjava3.subscribers.TestSubscriber;
 @CleanupAfterMethod
 public class PersistenceManagerTest extends SingleCacheManagerTest {
 
-   public void testProcessAfterStop() {
+   /**
+    * Simulates cache receiving a topology update while stopping.
+    */
+   public void testPublishAfterStop() {
       PersistenceManager persistenceManager = extractComponent(cache, PersistenceManager.class);
       KeyPartitioner keyPartitioner = extractComponent(cache, KeyPartitioner.class);
       String key = "k";
-      persistenceManager.writeToAllNonTxStores(MarshalledEntryUtil.create(key, "v", cache), keyPartitioner.getSegment(key), BOTH);
-      //simulates the scenario where, concurrently, the cache is stopping and handling a topology update.
+      insertEntry(persistenceManager, keyPartitioner, key, "v");
+
       persistenceManager.stop();
-      //the org.infinispan.persistence.dummy.DummyInMemoryStore throws an exception if the process() method is invoked after stopped.
-      Flowable.fromPublisher(persistenceManager.publishEntries(true, true)).subscribe(ignore -> fail("shouldn't run"));
+
+      // The stopped PersistenceManager should never pass the request to the store
+      Flowable.fromPublisher(persistenceManager.publishEntries(true, true))
+              .blockingSubscribe(ignore -> fail("shouldn't run"));
    }
 
-   public void testStopDuringProcess() throws ExecutionException, InterruptedException, TimeoutException {
+   /**
+    * Simulates cache stopping while processing a state request.
+    */
+   public void testStopDuringPublish() throws ExecutionException, InterruptedException, TimeoutException {
       PersistenceManager persistenceManager = extractComponent(cache, PersistenceManager.class);
       KeyPartitioner keyPartitioner = extractComponent(cache, KeyPartitioner.class);
-      //simulates the scenario where, concurrently, the cache is stopped during a process loop
-      CompletionStages.join(persistenceManager.writeToAllNonTxStores(MarshalledEntryUtil.create("k1", "v1", cache), keyPartitioner.getSegment("k1"), BOTH));
-      CompletionStages.join(persistenceManager.writeToAllNonTxStores(MarshalledEntryUtil.create("k2", "v2", cache), keyPartitioner.getSegment("k2"), BOTH));
-      CompletionStages.join(persistenceManager.writeToAllNonTxStores(MarshalledEntryUtil.create("k3", "v3", cache), keyPartitioner.getSegment("k3"), BOTH));
-      final CountDownLatch before = new CountDownLatch(1);
-      final CountDownLatch after = new CountDownLatch(1);
-      Future<Integer> c = fork(() -> {
+      insertEntry(persistenceManager, keyPartitioner, "k1", "v1");
+      insertEntry(persistenceManager, keyPartitioner, "k2", "v2");
+      insertEntry(persistenceManager, keyPartitioner, "k3", "v3");
+
+      DelayStore store = getFirstStore(cache);
+      store.delayBeforeEmit(1);
+
+      CountDownLatch before = new CountDownLatch(1);
+      CountDownLatch after = new CountDownLatch(1);
+      Future<Integer> publisherFuture = fork(() -> {
          TestSubscriber<Object> subscriber = TestSubscriber.create(0);
          Flowable.fromPublisher(persistenceManager.publishEntries(true, true))
-               .subscribe(subscriber);
+                 .subscribe(subscriber);
          before.countDown();
          assertTrue(after.await(10, TimeUnit.SECONDS));
-         // request all the elements after we have initiated stop (3 elements with 100ms wait for each will be run)
+         // request all the elements after we have initiated stop
          subscriber.request(Long.MAX_VALUE);
          subscriber.await(10, TimeUnit.SECONDS);
          subscriber.assertNoErrors();
          subscriber.assertComplete();
          return subscriber.values().size();
       });
+
       assertTrue(before.await(30, TimeUnit.SECONDS));
       Future<Void> stopFuture = fork(persistenceManager::stop);
-      //stop is unable to proceed while the process isn't finish - note that with slow store the publisher should take 300+ ms
-      expectException(TimeoutException.class, () -> stopFuture.get(50, TimeUnit.MILLISECONDS));
+      // Stop is unable to proceed while the publisher hasn't completed
+      Thread.sleep(50);
+      assertFalse(stopFuture.isDone());
+      assertFalse(publisherFuture.isDone());
+
       after.countDown();
-      Integer count = c.get(30, TimeUnit.SECONDS);
+
+      // Publisher can't continue because the store emit is delayed
+      Thread.sleep(50);
+      assertFalse(stopFuture.isDone());
+      assertFalse(publisherFuture.isDone());
+
+      // Emit the entries and allow PMI to stop
+      store.endDelay();
+      Integer count = publisherFuture.get(30, TimeUnit.SECONDS);
       stopFuture.get(30, TimeUnit.SECONDS);
       assertEquals(3, count.intValue());
    }
 
-   public void testEarlyTerminatedOperation() {
+   public void testEarlyTerminatedPublish() {
       PersistenceManager persistenceManager = extractComponent(cache, PersistenceManager.class);
       KeyPartitioner keyPartitioner = extractComponent(cache, KeyPartitioner.class);
       // This has to be > 128 - as the flowable pulls a chunk of that size
       for (int i = 0; i < 140; ++i) {
          String key = "k" + i;
-         CompletionStages.join(persistenceManager.writeToAllNonTxStores(MarshalledEntryUtil.create(key, "v", cache), keyPartitioner.getSegment(key), BOTH));
+         insertEntry(persistenceManager, keyPartitioner, key, "v");
       }
+
+      DelayStore store = getFirstStore(cache);
+      store.delayBeforeEmit(1);
+
       PersistenceManagerImpl pmImpl = (PersistenceManagerImpl) persistenceManager;
       assertFalse(pmImpl.anyLocksHeld());
       assertFalse(cache.isEmpty());
       assertFalse(pmImpl.anyLocksHeld());
+
+      store.endDelay();
    }
 
    public void testStoreExceptionInWrite() {
       PersistenceManager pm = extractComponent(cache, PersistenceManager.class);
       KeyPartitioner keyPartitioner = extractComponent(cache, KeyPartitioner.class);
-      DummyInMemoryStore store1 = getStore(cache, 0, true);
+      DelayStore store1 = getStore(cache, 0, true);
       FailStore store2 = getStore(cache, 1, true);
       store2.failModification(2);
 
@@ -120,8 +148,14 @@ public class PersistenceManagerTest extends SingleCacheManagerTest {
    @Override
    protected EmbeddedCacheManager createCacheManager() {
       ConfigurationBuilder cfg = getDefaultStandaloneCacheConfig(true);
-      cfg.persistence().addStore(DummyInMemoryStoreConfigurationBuilder.class).slow(true);
+      cfg.persistence().addStore(DelayStore.ConfigurationBuilder.class);
+      cfg.persistence().addStore(FailStore.ConfigurationBuilder.class);
       cfg.persistence().addStore(FailStore.ConfigurationBuilder.class);
       return TestCacheManagerFactory.createCacheManager(cfg);
+   }
+
+   private void insertEntry(PersistenceManager persistenceManager, KeyPartitioner keyPartitioner, String k, String v) {
+      join(persistenceManager.writeToAllNonTxStores(MarshalledEntryUtil.create(k, v, cache),
+                                                    keyPartitioner.getSegment(k), BOTH));
    }
 }

--- a/core/src/test/java/org/infinispan/persistence/support/DelayStore.java
+++ b/core/src/test/java/org/infinispan/persistence/support/DelayStore.java
@@ -1,0 +1,140 @@
+package org.infinispan.persistence.support;
+
+import static org.testng.AssertJUnit.assertTrue;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
+
+import org.infinispan.commons.configuration.BuiltBy;
+import org.infinispan.commons.configuration.ConfigurationFor;
+import org.infinispan.commons.configuration.attributes.AttributeSet;
+import org.infinispan.commons.util.IntSet;
+import org.infinispan.configuration.cache.AsyncStoreConfiguration;
+import org.infinispan.configuration.cache.PersistenceConfigurationBuilder;
+import org.infinispan.persistence.dummy.DummyInMemoryStore;
+import org.infinispan.persistence.dummy.DummyInMemoryStoreConfiguration;
+import org.infinispan.persistence.dummy.DummyInMemoryStoreConfigurationBuilder;
+import org.infinispan.persistence.spi.MarshallableEntry;
+import org.infinispan.util.concurrent.CompletableFutures;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
+
+/**
+ * Test store that can delay store operations (or their completion).
+ *
+ * @author Dan Berindei
+ * @since 13.0
+ */
+public class DelayStore extends DummyInMemoryStore {
+   private static final Log log = LogFactory.getLog(DelayStore.class);
+
+   private final AtomicInteger delayBeforeModificationCount = new AtomicInteger();
+   private final AtomicInteger delayAfterModificationCount = new AtomicInteger();
+   private final AtomicInteger delayBeforeEmitCount = new AtomicInteger();
+   private volatile CompletableFuture<Void> delayFuture = CompletableFutures.completedNull();
+
+   public void delayBeforeModification(int count) {
+      assertTrue(delayFuture.isDone());
+      delayFuture = new CompletableFuture<>();
+      delayBeforeModificationCount.set(count);
+   }
+
+   public void delayAfterModification(int count) {
+      assertTrue(delayFuture.isDone());
+      delayFuture = new CompletableFuture<>();
+      delayAfterModificationCount.set(count);
+   }
+
+   public void delayBeforeEmit(int count) {
+      assertTrue(delayFuture.isDone());
+      delayFuture = new CompletableFuture<>();
+      delayBeforeEmitCount.set(count);
+   }
+
+   public void endDelay() {
+      CompletableFuture<Void> oldFuture = delayFuture;
+      if (oldFuture.isDone())
+         return;
+
+      log.tracef("Resuming delayed store operations");
+      delayFuture = CompletableFutures.completedNull();
+      oldFuture.complete(null);
+   }
+
+   @Override
+   public CompletionStage<Void> write(int segment, MarshallableEntry entry) {
+      CompletionStage<Void> stage = CompletableFutures.completedNull();
+      if (!delayFuture.isDone() && delayBeforeModificationCount.decrementAndGet() >= 0) {
+         log.tracef("Delaying before write to %s", entry.getKey());
+         stage = delayFuture;
+      }
+
+      stage = stage.thenCompose(__ -> super.write(segment, entry));
+
+      if (!delayFuture.isDone() && delayAfterModificationCount.decrementAndGet() >= 0) {
+         log.tracef("Delaying after write to %s", entry.getKey());
+         stage = stage.thenCompose(ignore -> delayFuture.thenRun(() -> {
+            log.tracef("Resuming write to %s", entry.getKey());
+         }));
+      }
+      return stage;
+   }
+
+   @Override
+   public CompletionStage<Boolean> delete(int segment, Object key) {
+      CompletionStage<Boolean> stage = CompletableFutures.completedNull();
+      if (!delayFuture.isDone() && delayBeforeModificationCount.decrementAndGet() >= 0) {
+         log.tracef("Delaying before write to %s", key);
+         stage = delayFuture.thenApply(__ -> true);
+      }
+
+      stage = stage.thenCompose(__ -> super.delete(segment, key));
+
+      if (!delayFuture.isDone() && delayAfterModificationCount.decrementAndGet() >= 0) {
+         log.tracef("Delaying after write to %s", key);
+         stage = stage.thenCompose(removed -> delayFuture.thenApply(__ -> {
+            log.tracef("Resuming write to %s", key);
+            return removed;
+         }));
+      }
+      return stage;
+   }
+
+   @Override
+   public Flowable<MarshallableEntry> publishEntries(IntSet segments, Predicate filter, boolean fetchValue) {
+      return super.publishEntries(segments, filter, fetchValue)
+            .delay(me -> {
+                     if (!delayFuture.isDone() && delayBeforeEmitCount.decrementAndGet() >= 0) {
+                        return Completable.fromCompletionStage(delayFuture).toFlowable();
+                     } else {
+                        return Flowable.empty();
+                     }
+                  });
+   }
+
+   @BuiltBy(ConfigurationBuilder.class)
+   @ConfigurationFor(DelayStore.class)
+   public static class Configuration extends DummyInMemoryStoreConfiguration {
+
+      public Configuration(AttributeSet attributes, AsyncStoreConfiguration async) {
+         super(attributes, async);
+      }
+   }
+
+   public static class ConfigurationBuilder extends DummyInMemoryStoreConfigurationBuilder {
+
+      public ConfigurationBuilder(PersistenceConfigurationBuilder builder) {
+         super(builder);
+      }
+
+      @Override
+      public Configuration create() {
+         return new Configuration(attributes.protect(), async.create());
+      }
+   }
+}

--- a/core/src/test/java/org/infinispan/persistence/support/ReplAsyncStoreTest.java
+++ b/core/src/test/java/org/infinispan/persistence/support/ReplAsyncStoreTest.java
@@ -12,11 +12,10 @@ import java.util.stream.Stream;
 
 import org.infinispan.Cache;
 import org.infinispan.configuration.cache.CacheMode;
-import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.distribution.MagicKey;
-import org.infinispan.persistence.dummy.DummyInMemoryStoreConfigurationBuilder;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestDataSCI;
+import org.infinispan.test.TestingUtil;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -45,7 +44,7 @@ public class ReplAsyncStoreTest extends MultipleCacheManagersTest {
       KEY_ITERATOR {
          @Override
          void perform(MagicKey key, Cache<MagicKey, String> cache) {
-            Iterator iterator = cache.keySet().iterator();
+            Iterator<?> iterator = cache.keySet().iterator();
             assertTrue(iterator.hasNext());
             assertEquals(key, iterator.next());
             assertFalse(iterator.hasNext());
@@ -54,7 +53,7 @@ public class ReplAsyncStoreTest extends MultipleCacheManagersTest {
       ENTRY_COLLECT {
          @Override
          void perform(MagicKey key, Cache<MagicKey, String> cache) {
-            List<Map.Entry<MagicKey, String>> list = cache.entrySet().stream().collect(() -> Collectors.toList());
+            List<Map.Entry<MagicKey, String>> list = cache.entrySet().stream().collect(Collectors::toList);
             assertEquals(1, list.size());
             assertEquals(key, list.get(0).getKey());
          }
@@ -84,11 +83,11 @@ public class ReplAsyncStoreTest extends MultipleCacheManagersTest {
 
    @Override
    protected void createCacheManagers() throws Throwable {
-      ConfigurationBuilder cfg = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, true);
+      org.infinispan.configuration.cache.ConfigurationBuilder
+            cfg = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, true);
 
       cfg.persistence()
-            .addStore(DummyInMemoryStoreConfigurationBuilder.class)
-               .slow(true)
+            .addStore(DelayStore.ConfigurationBuilder.class)
                .storeName(shared ? ReplAsyncStoreTest.class.getName() : null)
                .shared(shared)
                .async().enable();
@@ -108,8 +107,15 @@ public class ReplAsyncStoreTest extends MultipleCacheManagersTest {
    @Test(dataProvider = "async-ops")
    public void testOperationAfterInsertAndEvict(boolean primary, Op consumer) {
       Cache<MagicKey, String> primaryOwner = cache(0, CACHE_NAME);
+      Cache<MagicKey, String> backupOwner = cache(1, CACHE_NAME);
       MagicKey key = getKeyForCache(primaryOwner);
-      // The actual store write is delayed 100 ms
+
+      // Delay the underlying store write
+      DelayStore primaryStore = TestingUtil.getFirstStore(primaryOwner);
+      primaryStore.delayBeforeModification(1);
+      DelayStore backupStore = TestingUtil.getFirstStore(backupOwner);
+      backupStore.delayBeforeModification(1);
+
       primaryOwner.put(key, "some-value");
 
       Cache<MagicKey, String> cacheToUse;
@@ -117,12 +123,15 @@ public class ReplAsyncStoreTest extends MultipleCacheManagersTest {
       if (primary) {
          cacheToUse = primaryOwner;
       } else {
-         cacheToUse = cache(1, CACHE_NAME);
+         cacheToUse = backupOwner;
       }
 
-      // This messes up some things - so evict so it is only in store (which shouldn't be written yet)
+      // Evict the key so it only exists in the store
       cacheToUse.evict(key);
 
       consumer.perform(key, cacheToUse);
+
+      primaryStore.endDelay();
+      backupStore.endDelay();
    }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-11902

* Invoke the 3rd putAll (2nd putAll in fork thread) only after PersistenceManagerImpl
  is available
* Clean up duplicate logging and add more batch ids
* Make test failures clearer