### PR TITLE
ISPN-13250 Server Patch: Do not remove OS from JAR name

### DIFF
--- a/cli/src/main/java/org/infinispan/cli/patching/ServerFile.java
+++ b/cli/src/main/java/org/infinispan/cli/patching/ServerFile.java
@@ -36,8 +36,6 @@ public class ServerFile {
    }
 
    private static String basename(String filename) {
-      // Hack: remove os + archs
-      filename = filename.replace("-linux-x86_64", "");
       // Get the artifact name up to the version
       int l = filename.length();
       for (int i = 0; i < l; i++) {


### PR DESCRIPTION
Do not remove the OS/arch from jar filename when computing the
differences when creating/applying the server patches.

https://issues.redhat.com/browse/ISPN-13250