### PR TITLE
ISPN-12923 ProtobufMetadataManagerInterceptor IllegalStateException

### DIFF
--- a/core/src/main/java/org/infinispan/commands/tx/PrepareCommand.java
+++ b/core/src/main/java/org/infinispan/commands/tx/PrepareCommand.java
@@ -114,7 +114,7 @@ public class PrepareCommand extends AbstractTransactionBoundaryCommand implement
       if (CompletionStages.isCompletedSuccessfully(stage)) {
          return invoker.invokeAsync(ctx, this);
       } else {
-         return stage.thenCompose(v -> invoker.invokeAsync(ctx, this)).toCompletableFuture();
+         return stage.thenCompose(v -> invoker.invokeAsync(ctx, this));
       }
    }
 

--- a/core/src/main/java/org/infinispan/factories/InterceptorChainFactory.java
+++ b/core/src/main/java/org/infinispan/factories/InterceptorChainFactory.java
@@ -117,7 +117,7 @@ public class InterceptorChainFactory extends AbstractNamedCacheComponentFactory 
       TransactionMode transactionMode = configuration.transaction().transactionMode();
       boolean needsVersionAwareComponents = Configurations.isTxVersioned(configuration);
 
-      AsyncInterceptorChain interceptorChain = new AsyncInterceptorChainImpl(componentRegistry);
+      AsyncInterceptorChain interceptorChain = new AsyncInterceptorChainImpl();
 
       boolean invocationBatching = configuration.invocationBatching().enabled();
       CacheMode cacheMode = configuration.clustering().cacheMode();

--- a/core/src/main/java/org/infinispan/interceptors/AsyncInterceptorChain.java
+++ b/core/src/main/java/org/infinispan/interceptors/AsyncInterceptorChain.java
@@ -89,8 +89,19 @@ public interface AsyncInterceptorChain {
 
    /**
     * Walks the command through the interceptor chain. The received ctx is being passed in.
+    *
+    * <p>Note: Reusing the context for multiple invocations is allowed, however most context implementations are not
+    * thread-safe.</p>
     */
    CompletableFuture<Object> invokeAsync(InvocationContext ctx, VisitableCommand command);
+
+   /**
+    * Walks the command through the interceptor chain. The received ctx is being passed in.
+    *
+    * <p>Note: Reusing the context for multiple invocations is allowed, however most context implementations are not
+    * thread-safe.</p>
+    */
+   InvocationStage invokeStage(InvocationContext ctx, VisitableCommand command);
 
    /**
     * Returns the first interceptor extending the given class, or {@code null} if there is none.

--- a/core/src/main/java/org/infinispan/interceptors/EmptyAsyncInterceptorChain.java
+++ b/core/src/main/java/org/infinispan/interceptors/EmptyAsyncInterceptorChain.java
@@ -75,6 +75,11 @@ public class EmptyAsyncInterceptorChain implements AsyncInterceptorChain {
    }
 
    @Override
+   public InvocationStage invokeStage(InvocationContext ctx, VisitableCommand command) {
+      throw CONTAINER.interceptorStackNotSupported();
+   }
+
+   @Override
    public <T extends AsyncInterceptor> T findInterceptorExtending(Class<T> interceptorClass) {
       return null;
    }

--- a/core/src/main/java/org/infinispan/util/KeyValuePair.java
+++ b/core/src/main/java/org/infinispan/util/KeyValuePair.java
@@ -20,6 +20,10 @@ public class KeyValuePair<K,V> {
    private final K key;
    private final V value;
 
+   public static <K, V> KeyValuePair<K, V> of(K key, V value) {
+      return new KeyValuePair<>(key, value);
+   }
+
    public KeyValuePair(K key, V value) {
       this.key = key;
       this.value = value;

--- a/core/src/test/java/org/infinispan/interceptors/impl/AsyncInterceptorChainInvocationTest.java
+++ b/core/src/test/java/org/infinispan/interceptors/impl/AsyncInterceptorChainInvocationTest.java
@@ -2,7 +2,6 @@ package org.infinispan.interceptors.impl;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.infinispan.commons.test.Exceptions.expectExecutionException;
-import static org.mockito.Mockito.mock;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
 
@@ -18,7 +17,6 @@ import org.infinispan.commands.control.LockControlCommand;
 import org.infinispan.commands.read.GetKeyValueCommand;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.SingleKeyNonTxInvocationContext;
-import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.interceptors.AsyncInterceptor;
 import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.interceptors.BaseAsyncInterceptor;
@@ -381,7 +379,7 @@ public class AsyncInterceptorChainInvocationTest extends AbstractInfinispanTest 
    }
 
    private AsyncInterceptorChain newInterceptorChain(AsyncInterceptor... interceptors) {
-      AsyncInterceptorChainImpl chain = new AsyncInterceptorChainImpl(mock(ComponentRegistry.class));
+      AsyncInterceptorChainImpl chain = new AsyncInterceptorChainImpl();
       for (AsyncInterceptor i : interceptors) {
          chain.appendInterceptor(i, false);
       }

--- a/core/src/test/java/org/infinispan/interceptors/impl/AsyncInterceptorChainTest.java
+++ b/core/src/test/java/org/infinispan/interceptors/impl/AsyncInterceptorChainTest.java
@@ -1,7 +1,5 @@
 package org.infinispan.interceptors.impl;
 
-import static org.mockito.Mockito.mock;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -12,7 +10,6 @@ import java.util.concurrent.Future;
 
 import org.infinispan.commands.VisitableCommand;
 import org.infinispan.context.InvocationContext;
-import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.interceptors.AsyncInterceptor;
 import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.interceptors.BaseAsyncInterceptor;
@@ -35,7 +32,7 @@ public class AsyncInterceptorChainTest extends AbstractInfinispanTest {
    private static final Log log = LogFactory.getLog(AsyncInterceptorChainTest.class);
 
    public void testConcurrentAddRemove() throws Exception {
-      AsyncInterceptorChainImpl ic = new AsyncInterceptorChainImpl(mock(ComponentRegistry.class));
+      AsyncInterceptorChainImpl ic = new AsyncInterceptorChainImpl();
       ic.addInterceptor(new DummyCallInterceptor(), 0);
       ic.addInterceptor(new DummyActivationInterceptor(), 1);
       CyclicBarrier barrier = new CyclicBarrier(4);

--- a/remote-query/remote-query-server/src/test/java/org/infinispan/query/remote/impl/ProtobufMetadataManagerInterceptorTest.java
+++ b/remote-query/remote-query-server/src/test/java/org/infinispan/query/remote/impl/ProtobufMetadataManagerInterceptorTest.java
@@ -312,6 +312,7 @@ public class ProtobufMetadataManagerInterceptorTest extends MultipleCacheManager
          Cache<Object, Object> cache = manager.getCache();
          assertEquals("import \"test.proto\";", cache.get("state.proto"));
          cache(0).remove("state.proto");
+         assertFalse(cache.containsKey("state.proto"));
       } finally {
          killMember(2);
       }

--- a/server/core/src/main/java/org/infinispan/server/core/transport/NonRecursiveEventLoopGroup.java
+++ b/server/core/src/main/java/org/infinispan/server/core/transport/NonRecursiveEventLoopGroup.java
@@ -2,11 +2,8 @@ package org.infinispan.server.core.transport;
 
 import java.lang.invoke.MethodHandles;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
-import org.infinispan.commons.CacheException;
 import org.infinispan.commons.logging.LogFactory;
 import org.infinispan.factories.annotations.Stop;
 import org.infinispan.factories.scopes.Scope;
@@ -81,14 +78,11 @@ public class NonRecursiveEventLoopGroup extends DelegatingEventLoopGroup {
    @Stop
    public void shutdownGracefullyAndWait() {
       try {
-         shutdownGracefully().get(10, TimeUnit.SECONDS);
+         // Use the same timeouts as in NettyTransport
+         shutdownGracefully(100, 1000, TimeUnit.MILLISECONDS).await();
       } catch (InterruptedException e) {
          log.debug("Interrupted while waiting for event loop group to shut down");
          Thread.currentThread().interrupt();
-      } catch (ExecutionException e) {
-         throw new CacheException(e.getCause());
-      } catch (TimeoutException e) {
-         throw new org.infinispan.util.concurrent.TimeoutException("Timed out waiting for event loop group to shutdown", e);
       }
    }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12923

Remove .errors keys sequentially, because invocation contexts
are not thread-safe.

Add AsyncInterceptorChain.invokeStage()
Simplify the code in ProtobufMetadataManagerInterceptor
that needs to invoke another command and return an
InvocationStage.

Reduce NonRecursiveEventLoopGroup graceful shutdown timeout
Match the timeout with the one in NettyTransport.
The lower timeout speeds up tests in the server-core module
and any modules that depend on it.

