### PR TITLE
ISPN-12650 ThreadLocalLeakTest random failures (uncaught exception)

### DIFF
--- a/core/src/test/java/org/infinispan/marshall/core/ExternalizerConfigurationValidationTest.java
+++ b/core/src/test/java/org/infinispan/marshall/core/ExternalizerConfigurationValidationTest.java
@@ -28,13 +28,14 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /**
- * Test the behaviour of JBoss Marshalling based {@link org.infinispan.commons.marshall.StreamingMarshaller} implementation
- * which is {@link JBossMarshaller}}. This class should contain methods that exercise
- * logic in this particular implementation.
+ * Test the externalizer validation logic.
+ *
+ * Externalizers can only be used with jboss-marshalling, so we cannot test the actual functionality
+ * in the core module.
  */
-@Test(groups = "functional", testName = "marshall.jboss.JBossMarshallerTest")
-public class JBossMarshallerTest extends AbstractInfinispanTest {
-   private static final Log log = LogFactory.getLog(JBossMarshallerTest.class);
+@Test(groups = "functional", testName = "marshall.core.ExternalizerConfigurationValidationTest")
+public class ExternalizerConfigurationValidationTest extends AbstractInfinispanTest {
+   private static final Log log = LogFactory.getLog(ExternalizerConfigurationValidationTest.class);
 
    private EmbeddedCacheManager cm;
 

--- a/jboss-marshalling/src/test/java/org/infinispan/jboss/marshalling/JBossMarshallingThreadLocalLeakTest.java
+++ b/jboss-marshalling/src/test/java/org/infinispan/jboss/marshalling/JBossMarshallingThreadLocalLeakTest.java
@@ -1,0 +1,21 @@
+package org.infinispan.jboss.marshalling;
+
+import org.infinispan.commons.dataconversion.MediaType;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.util.ThreadLocalLeakTest;
+import org.testng.annotations.Test;
+
+/**
+ * AbstractJBossMarshaller uses a thread-local cache of RiverMarshaller instances,
+ * so it's worth checking for thread leaks.
+ *
+ * @author Dan Berindei
+ * @since 13.0
+ */
+@Test(groups = "functional", testName = "jboss.marshalling.JBossMarshallingThreadLocalLeakTest")
+public class JBossMarshallingThreadLocalLeakTest extends ThreadLocalLeakTest {
+   @Override
+   protected void amendConfiguration(ConfigurationBuilder builder) {
+      builder.encoding().mediaType(MediaType.APPLICATION_JBOSS_MARSHALLING_TYPE);
+   }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12650

* Make the main thread always stop the cache manager after
  the forked thread finishes the put operation
* Add invocation batching, because BatchContainer and
  BatchModeTransactionManager use thread-locals
* Duplicate the test in the jboss-marshalling module,
  because AbstractJBossMarshaller also uses a thread-local