### PR TITLE
ISPN-13192 Fix TCP start port

### DIFF
--- a/core/src/test/java/org/infinispan/test/fwk/JGroupsConfigBuilder.java
+++ b/core/src/test/java/org/infinispan/test/fwk/JGroupsConfigBuilder.java
@@ -47,7 +47,7 @@ public class JGroupsConfigBuilder {
    private static final Map<String, ProtocolStackConfigurator> protocolStackConfigurator = new HashMap<>();
 
    private static final ThreadLocal<Integer> threadTcpIndex = new ThreadLocal<Integer>() {
-      private final AtomicInteger counter = new AtomicInteger(BASE_TCP_PORT);
+      private final AtomicInteger counter = new AtomicInteger(0);
 
       @Override
       protected Integer initialValue() {


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-13192

The initial fix replaced broke the calculation of the TCP bind port, because the thread counter index from 7900 instead of 0, and the base port was computed as 7900 + thread index * 200, getting over 65535 very quickly.

I missed it at the time because that code path is only used when running the tests with `-Dinfinispan.cluster.stack=test-tcp`