### PR TITLE
ISPN-13264 Hot Rod client cluster switch never happens if max-retries < cluster size

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
@@ -482,12 +482,12 @@ public class RemoteCacheManager implements RemoteCacheContainer, Closeable, Remo
 
    @Override
    public boolean switchToCluster(String clusterName) {
-      return channelFactory.switchToCluster(clusterName);
+      return channelFactory.manualSwitchToCluster(clusterName);
    }
 
    @Override
    public boolean switchToDefaultCluster() {
-      return channelFactory.switchToCluster(ChannelFactory.DEFAULT_CLUSTER_NAME);
+      return channelFactory.manualSwitchToCluster(ChannelFactory.DEFAULT_CLUSTER_NAME);
    }
 
    private Properties loadFromStream(InputStream stream) {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
@@ -23,7 +23,6 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -108,7 +107,6 @@ public class RemoteCacheManager implements RemoteCacheContainer, Closeable, Remo
    private volatile boolean started = false;
    private final Map<RemoteCacheKey, RemoteCacheHolder> cacheName2RemoteCache = new HashMap<>();
    private final MarshallerRegistry marshallerRegistry = new MarshallerRegistry();
-   private final AtomicInteger defaultCacheTopologyId = new AtomicInteger(HotRodConstants.DEFAULT_CACHE_TOPOLOGY);
    private final Configuration configuration;
    private Codec codec;
 
@@ -379,8 +377,8 @@ public class RemoteCacheManager implements RemoteCacheContainer, Closeable, Remo
          executorFactory = Util.getInstance(configuration.asyncExecutorFactory().factoryClass());
       }
       asyncExecutorService = executorFactory.getExecutor(configuration.asyncExecutorFactory().properties());
-      channelFactory.start(codec, configuration, defaultCacheTopologyId, marshaller, asyncExecutorService,
-            listenerNotifier, Collections.singletonList(listenerNotifier::failoverListeners), marshallerRegistry);
+      channelFactory.start(codec, configuration, marshaller, asyncExecutorService,
+                           listenerNotifier, marshallerRegistry);
       counterManager.start(channelFactory, codec, configuration, listenerNotifier);
 
       TransactionOperationFactory txOperationFactory = new TransactionOperationFactory(configuration, channelFactory, codec);

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/TopologyInfo.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/TopologyInfo.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -28,11 +29,15 @@ import org.infinispan.client.hotrod.logging.LogFactory;
 import org.infinispan.commons.marshall.WrappedByteArray;
 import org.infinispan.commons.marshall.WrappedBytes;
 
+import net.jcip.annotations.NotThreadSafe;
+
 /**
  * Maintains topology information about caches.
  *
  * @author gustavonalle
+ * @author Dan Berindei
  */
+@NotThreadSafe
 public final class TopologyInfo {
 
    private static final Log log = LogFactory.getLog(TopologyInfo.class, Log.class);
@@ -41,7 +46,7 @@ public final class TopologyInfo {
    private final ConsistentHashFactory hashFactory = new ConsistentHashFactory();
 
    private final ConcurrentMap<WrappedBytes, CacheInfo> caches = new ConcurrentHashMap<>();
-   private volatile ClusterInfo currentCluster;
+   private volatile ClusterInfo cluster;
    // Topology age provides a way to avoid concurrent cluster view changes,
    // affecting a cluster switch. After a cluster switch, the topology age is
    // increased and so any old requests that might have received topology
@@ -53,7 +58,7 @@ public final class TopologyInfo {
       this.hashFactory.init(configuration);
 
       this.topologyAge = 0;
-      this.currentCluster = clusterInfo;
+      this.cluster = clusterInfo;
    }
 
    public Map<SocketAddress, Set<Integer>> getPrimarySegmentsByServer(byte[] cacheName) {
@@ -70,7 +75,7 @@ public final class TopologyInfo {
       return getCacheInfo(cacheName).getServers();
    }
 
-   public Collection<InetSocketAddress> getCurrentServers() {
+   public Collection<InetSocketAddress> getAllServers() {
       return caches.values().stream().flatMap(ct -> ct.getServers().stream()).collect(Collectors.toSet());
    }
 
@@ -88,21 +93,6 @@ public final class TopologyInfo {
       return hash;
    }
 
-   public SocketAddress getHashAwareServer(Object key, byte[] cacheName) {
-      CacheInfo cacheInfo = caches.get(wrapBytes(cacheName));
-      if (cacheInfo != null && cacheInfo.isValidTopology() && cacheInfo.getConsistentHash() != null) {
-         return cacheInfo.getConsistentHash().getServer(key);
-      }
-
-      return null;
-   }
-
-   public boolean isTopologyValid(byte[] cacheName) {
-      CacheInfo cacheInfo = caches.get(wrapBytes(cacheName));
-
-      return cacheInfo != null && cacheInfo.isValidTopology();
-   }
-
    public ConsistentHashFactory getConsistentHashFactory() {
       return hashFactory;
    }
@@ -116,23 +106,12 @@ public final class TopologyInfo {
       return caches.get(cacheName);
    }
 
-   public CacheInfo createCacheInfo(WrappedBytes cacheName) {
-      CacheInfo cacheInfo = new CacheInfo(cacheName, balancerFactory.get(), currentCluster);
-      cacheInfo.updateBalancerServers();
-      caches.put(cacheName, cacheInfo);
-      return cacheInfo;
-   }
-
    public CacheInfo getOrCreateCacheInfo(WrappedBytes cacheName) {
       return caches.computeIfAbsent(cacheName, cn -> {
-         CacheInfo cacheInfo = new CacheInfo(cn, balancerFactory.get(), currentCluster);
-         // Copy the servers and consistent hash from the default cache, if it exists
-         CacheInfo defaultCacheInfo = caches.get(WrappedByteArray.EMPTY_BYTES);
-         if (defaultCacheInfo != null) {
-            cacheInfo = cacheInfo.withNewHash(-1, defaultCacheInfo.getServers(),
-                                              defaultCacheInfo.getConsistentHash(), defaultCacheInfo.getNumSegments());
-         }
+         CacheInfo cacheInfo = new CacheInfo(cn, balancerFactory.get(), topologyAge, cluster.getInitialServers());
          cacheInfo.updateBalancerServers();
+         if (log.isTraceEnabled()) log.tracef("Creating cache info %s with topology age %d",
+                                              cacheInfo.getCacheName(), topologyAge);
          return cacheInfo;
       });
    }
@@ -140,24 +119,43 @@ public final class TopologyInfo {
    /**
     * Switch the cluster or reset to the initial server list of the current cluster.
     *
-    * <p>Reset the topology id and server list of all caches.</p>
+    * <p>Does not itself reset the topology id and server list of individual caches.
+    * New operations will send the incremented topology age to the server,
+    * and </p>
     */
-   public void switchCluster(ClusterInfo newCluster, WrappedBytes cacheName) {
-      if (log.isTraceEnabled()) log.tracef("Updating cluster for %s: %s -> %s",
-                                           cacheName, currentCluster.getName(), newCluster.getName());
-      // FIXME We need this hack because the switch to the initial server list can be triggered before the cluster switch
-      int tempTopologyId = (newCluster != currentCluster) ? HotRodConstants.SWITCH_CLUSTER_TOPOLOGY : -1;
-      // TODO Remove the cacheName parameter?
-      topologyAge++;
-      currentCluster = newCluster;
+   public void switchCluster(ClusterInfo newCluster) {
+      if (log.isTraceEnabled())
+         log.tracef("Switching cluster: %s -> %s", cluster.getName(), newCluster.getName());
 
-      // TODO Maybe it 's enough to update the topology age here and to update the cache infos lazily
-      //  as we get new operations and they notice the topology age is outdated?
-      //  We'd have to keep track of topologyAge in CacheInfo for that to work
-      //  The old code (pre-ISPN-13264) only updated the topology id and server list for the cache
-      //  given as a parameter, but that seems wrong
+      // Stop accepting topology updates from old requests
       caches.replaceAll((name, oldInfo) -> {
-         CacheInfo newInfo = oldInfo.withNewCluster(currentCluster, currentCluster.getInitialServers(), tempTopologyId);
+         CacheInfo newInfo = oldInfo.withNewServers(topologyAge + 1, HotRodConstants.SWITCH_CLUSTER_TOPOLOGY,
+                                                    newCluster.getInitialServers());
+         // Updates the balancer in both infos
+         newInfo.updateBalancerServers();
+         // Update the topology ref for both infos and ongoing operations
+         newInfo.getTopologyIdRef().set(HotRodConstants.SWITCH_CLUSTER_TOPOLOGY);
+         return newInfo;
+      });
+
+      // Actual cluster switch
+      cluster = newCluster;
+      // Increment the topology age for new requests so that the topology updates from their responses are accepted
+      topologyAge++;
+   }
+
+   /**
+    * Reset a single ache to the initial server list.
+    *
+    * <p>Useful if there are still live servers in the cluster, but all the server in this cache's
+    * current topology are unreachable.</p>
+    */
+   public void reset(WrappedBytes cacheName) {
+      if (log.isTraceEnabled()) log.tracef("Switching to initial server list for cache %s, cluster %s",
+                                           cacheName, cluster.getName());
+      caches.computeIfPresent(cacheName, (name, oldInfo) -> {
+         CacheInfo newInfo = oldInfo.withNewServers(topologyAge, HotRodConstants.DEFAULT_CACHE_TOPOLOGY,
+                                                    cluster.getInitialServers());
          // Updates the balancer in both infos
          newInfo.updateBalancerServers();
          // Update the topology ref for both infos and ongoing operations
@@ -166,8 +164,8 @@ public final class TopologyInfo {
       });
    }
 
-   public ClusterInfo getCurrentCluster() {
-      return currentCluster;
+   public ClusterInfo getCluster() {
+      return cluster;
    }
 
    public int getTopologyAge() {
@@ -175,12 +173,16 @@ public final class TopologyInfo {
    }
 
    public void updateCacheInfo(WrappedBytes cacheName, CacheInfo oldCacheInfo, CacheInfo newCacheInfo) {
-      if (log.isTraceEnabled()) log.tracef("Updating topology for %s: %s -> %s",
-                                           cacheName, oldCacheInfo.getTopologyId(), newCacheInfo.getTopologyId());
+      if (log.isTraceEnabled()) log.tracef("Updating topology for %s: %s -> %s", newCacheInfo.getCacheName(),
+                                           oldCacheInfo.getTopologyId(), newCacheInfo.getTopologyId());
       CacheInfo existing = caches.put(cacheName, newCacheInfo);
       assert existing == oldCacheInfo : "Locking should have prevented concurrent updates";
 
       // The new CacheInfo doesn't have a new balancer instance, so the server update affects both
       newCacheInfo.updateBalancerServers();
+   }
+
+   public void forEachCache(BiConsumer<WrappedBytes, CacheInfo> action) {
+      caches.forEach(action);
    }
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/TopologyInfo.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/TopologyInfo.java
@@ -113,18 +113,15 @@ public final class TopologyInfo {
    }
 
    /**
-    * Switch the cluster or reset to the initial server list of the current cluster.
-    *
-    * <p>Does not itself reset the topology id and server list of individual caches.
-    * New operations will send the incremented topology age to the server,
-    * and </p>
+    * Switch to another cluster and update the topologies of all caches with its initial server list.
     */
    public void switchCluster(ClusterInfo newCluster) {
       ClusterInfo oldCluster = this.cluster;
-
       int newTopologyAge = oldCluster.getTopologyAge() + 1;
+
       if (log.isTraceEnabled()) {
-         log.tracef("Switching cluster: %s -> %s", oldCluster.getName(), newCluster.getName());
+         log.tracef("Switching cluster: %s -> %s with servers %s", oldCluster.getName(),
+                    newCluster.getName(), newCluster.getInitialServers());
       }
 
       // Stop accepting topology updates from old requests
@@ -140,8 +137,6 @@ public final class TopologyInfo {
 
       // Update the topology age for new requests so that the topology updates from their responses are accepted
       this.cluster = newCluster.withTopologyAge(newTopologyAge);
-
-      // TODO Check for new caches?
    }
 
    /**

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/TopologyInfo.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/TopologyInfo.java
@@ -144,12 +144,11 @@ public final class TopologyInfo {
    public void reset(WrappedBytes cacheName) {
       if (log.isTraceEnabled()) log.tracef("Switching to initial server list for cache %s, cluster %s",
                                            cacheName, cluster.getName());
-      caches.forEach((name, oldCacheInfo) -> {
-         CacheInfo newCacheInfo = oldCacheInfo.withNewServers(cluster.getTopologyAge(),
-                                                              HotRodConstants.DEFAULT_CACHE_TOPOLOGY,
-                                                              cluster.getInitialServers());
-         updateCacheInfo(cacheName, oldCacheInfo, newCacheInfo);
-      });
+      CacheInfo oldCacheInfo = caches.get(cacheName);
+      CacheInfo newCacheInfo = oldCacheInfo.withNewServers(cluster.getTopologyAge(),
+                                                           HotRodConstants.DEFAULT_CACHE_TOPOLOGY,
+                                                           cluster.getInitialServers());
+      updateCacheInfo(cacheName, oldCacheInfo, newCacheInfo);
    }
 
    public ClusterInfo getCluster() {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/Util.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/Util.java
@@ -18,6 +18,7 @@ import org.infinispan.client.hotrod.impl.operations.OperationsFactory;
 import org.infinispan.client.hotrod.impl.transaction.operations.PrepareTransactionOperation;
 import org.infinispan.client.hotrod.logging.Log;
 import org.infinispan.commons.CacheException;
+import org.infinispan.commons.marshall.WrappedByteArray;
 
 public class Util {
    private final static long BIG_DELAY_NANOS = TimeUnit.DAYS.toNanos(1);
@@ -112,5 +113,15 @@ public class Util {
          log.debugf("Exception while checking transaction support in server", e);
       }
       return false;
+   }
+
+   public static WrappedByteArray wrapBytes(byte[] cacheName) {
+      WrappedByteArray wrappedCacheName;
+      if (cacheName == null || cacheName.length == 0) {
+         wrappedCacheName = WrappedByteArray.EMPTY_BYTES;
+      } else {
+         wrappedCacheName = new WrappedByteArray(cacheName);
+      }
+      return wrappedCacheName;
    }
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/consistenthash/SegmentConsistentHash.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/consistenthash/SegmentConsistentHash.java
@@ -39,10 +39,11 @@ public final class SegmentConsistentHash implements ConsistentHash {
    @Override
    public SocketAddress getServer(Object key) {
       int segmentId = getSegment(key);
-      if (log.isTraceEnabled())
-         log.tracef("Find server in segment id %s for key %s", segmentId, Util.toStr(key));
+      SocketAddress server = segmentOwners[segmentId][0];
 
-      return segmentOwners[segmentId][0];
+      if (log.isTraceEnabled())
+         log.tracef("Found server %s for segment %s of key %s", server, segmentId, Util.toStr(key));
+      return server;
    }
 
    public int getSegment(Object key) {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/consistenthash/SegmentConsistentHash.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/consistenthash/SegmentConsistentHash.java
@@ -1,13 +1,10 @@
 package org.infinispan.client.hotrod.impl.consistenthash;
 
-import static java.util.Arrays.stream;
-
 import java.net.SocketAddress;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.IntStream;
 
 import org.infinispan.client.hotrod.logging.Log;
 import org.infinispan.client.hotrod.logging.LogFactory;
@@ -61,20 +58,22 @@ public final class SegmentConsistentHash implements ConsistentHash {
    @Override
    public Map<SocketAddress, Set<Integer>> getSegmentsByServer() {
       Map<SocketAddress, Set<Integer>> map = new HashMap<>();
-      IntStream.range(0, segmentOwners.length).forEach(seg -> {
-         SocketAddress[] owners = segmentOwners[seg];
-         stream(owners).forEach(s -> map.computeIfAbsent(s, k -> new HashSet<>()).add(seg));
-      });
+      for (int segment = 0; segment < segmentOwners.length; segment++) {
+         SocketAddress[] owners = segmentOwners[segment];
+         for (SocketAddress s : owners) {
+            map.computeIfAbsent(s, k -> new HashSet<>()).add(segment);
+         }
+      }
       return Immutables.immutableMapWrap(map);
    }
 
    @Override
    public Map<SocketAddress, Set<Integer>> getPrimarySegmentsByServer() {
       Map<SocketAddress, Set<Integer>> map = new HashMap<>();
-      IntStream.range(0, segmentOwners.length).forEach(seg -> {
-         SocketAddress[] owners = segmentOwners[seg];
-         map.computeIfAbsent(owners[0], k -> new HashSet<>()).add(seg);
-      });
+      for (int segment = 0; segment < segmentOwners.length; segment++) {
+         SocketAddress[] owners = segmentOwners[segment];
+         map.computeIfAbsent(owners[0], k -> new HashSet<>()).add(segment);
+      }
       return Immutables.immutableMapWrap(map);
    }
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/GetAllParallelOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/GetAllParallelOperation.java
@@ -33,7 +33,7 @@ public class GetAllParallelOperation<K, V> extends ParallelHotRodOperation<Map<K
       Map<SocketAddress, Set<byte[]>> splittedKeys = new HashMap<>();
 
       for (byte[] key : keys) {
-         SocketAddress socketAddress = channelFactory.getSocketAddress(key, cacheName);
+         SocketAddress socketAddress = channelFactory.getHashAwareServer(key, cacheName);
          Set<byte[]> keys = splittedKeys.computeIfAbsent(socketAddress, k -> new HashSet<>());
          keys.add(key);
       }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/HotRodOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/HotRodOperation.java
@@ -13,7 +13,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.infinispan.client.hotrod.DataFormat;
 import org.infinispan.client.hotrod.configuration.Configuration;
 import org.infinispan.client.hotrod.exceptions.HotRodClientException;
-import org.infinispan.client.hotrod.impl.MarshallerRegistry;
 import org.infinispan.client.hotrod.impl.protocol.Codec;
 import org.infinispan.client.hotrod.impl.protocol.HeaderParams;
 import org.infinispan.client.hotrod.impl.protocol.HotRodConstants;
@@ -49,7 +48,6 @@ public abstract class HotRodOperation<T> extends CompletableFuture<T> implements
    protected final ChannelFactory channelFactory;
    protected final DataFormat dataFormat;
    protected final HeaderParams header;
-   private final MarshallerRegistry marshallerRegistry;
    protected volatile ScheduledFuture<?> timeoutFuture;
    private Channel channel;
 
@@ -64,7 +62,6 @@ public abstract class HotRodOperation<T> extends CompletableFuture<T> implements
       this.cacheName = cacheName;
       this.codec = codec;
       this.channelFactory = channelFactory;
-      this.marshallerRegistry = channelFactory.getMarshallerRegistry();
       this.dataFormat = dataFormat;
       // TODO: we could inline all the header here
       this.header = new HeaderParams(requestCode, responseCode, MSG_ID.getAndIncrement())

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/OperationsFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/OperationsFactory.java
@@ -314,7 +314,7 @@ public class OperationsFactory implements HotRodConstants {
    }
 
    public int getTopologyId() {
-      return channelFactory.getTopologyId(cacheNameBytes);
+      return topologyId.get();
    }
 
    public IterationStartOperation newIterationStartOperation(String filterConverterFactory, byte[][] filterParameters, IntSet segments, int batchSize, boolean metadata, DataFormat dataFormat, SocketAddress targetAddress) {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/PutAllParallelOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/PutAllParallelOperation.java
@@ -42,7 +42,7 @@ public class PutAllParallelOperation extends ParallelHotRodOperation<Void, PutAl
       Map<SocketAddress, Map<byte[], byte[]>> splittedMaps = new HashMap<>();
 
       for (Map.Entry<byte[], byte[]> entry : map.entrySet()) {
-         SocketAddress socketAddress = channelFactory.getSocketAddress(entry.getKey(), cacheName);
+         SocketAddress socketAddress = channelFactory.getHashAwareServer(entry.getKey(), cacheName);
          Map<byte[], byte[]> keyValueMap = splittedMaps.get(socketAddress);
          if (keyValueMap == null) {
             keyValueMap = new HashMap<>();

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/RetryOnFailureOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/RetryOnFailureOperation.java
@@ -41,7 +41,6 @@ public abstract class RetryOnFailureOperation<T> extends HotRodOperation<T> impl
 
    private int retryCount = 0;
    private Set<SocketAddress> failedServers = null;
-   private boolean triedCompleteRestart = false;
    private String currentClusterName;
 
    protected RetryOnFailureOperation(short requestCode, short responseCode, Codec codec, ChannelFactory channelFactory,
@@ -206,7 +205,6 @@ public abstract class RetryOnFailureOperation<T> extends HotRodOperation<T> impl
             }
             switch (status) {
                case SWITCHED:
-                  triedCompleteRestart = true;
                   retryCount = 0;
                   failedServers.clear();
                   break;

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec.java
@@ -15,7 +15,6 @@ import org.infinispan.client.hotrod.event.impl.AbstractClientEvent;
 import org.infinispan.client.hotrod.impl.operations.OperationsFactory;
 import org.infinispan.client.hotrod.impl.operations.PingResponse;
 import org.infinispan.client.hotrod.impl.transport.netty.ChannelFactory;
-import org.infinispan.client.hotrod.logging.Log;
 import org.infinispan.commons.configuration.ClassAllowList;
 import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.commons.marshall.Marshaller;
@@ -68,11 +67,6 @@ public interface Codec {
    AbstractClientEvent readCacheEvent(ByteBuf buf, Function<byte[], DataFormat> listenerDataFormat, short eventTypeId, ClassAllowList allowList, SocketAddress serverAddress);
 
    Object returnPossiblePrevValue(ByteBuf buf, short status, DataFormat dataFormat, int flags, ClassAllowList allowList, Marshaller marshaller);
-
-   /**
-    * Logger for Hot Rod client codec
-    */
-   Log getLog();
 
    void writeClientListenerInterests(ByteBuf buf, Set<Class<? extends Annotation>> classes);
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec21.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec21.java
@@ -11,17 +11,11 @@ import org.infinispan.client.hotrod.event.ClientEvent;
 import org.infinispan.client.hotrod.event.impl.AbstractClientEvent;
 import org.infinispan.client.hotrod.event.impl.ExpiredEventImpl;
 import org.infinispan.client.hotrod.impl.transport.netty.ByteBufUtil;
-import org.infinispan.client.hotrod.logging.Log;
 import org.infinispan.commons.configuration.ClassAllowList;
 
 import io.netty.buffer.ByteBuf;
 
 public class Codec21 extends Codec20 {
-
-   @Override
-   public Log getLog() {
-      return log;
-   }
 
    @Override
    public HeaderParams writeHeader(ByteBuf buf, HeaderParams params) {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/topology/CacheInfo.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/topology/CacheInfo.java
@@ -1,0 +1,158 @@
+package org.infinispan.client.hotrod.impl.topology;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.infinispan.client.hotrod.CacheTopologyInfo;
+import org.infinispan.client.hotrod.FailoverRequestBalancingStrategy;
+import org.infinispan.client.hotrod.impl.CacheTopologyInfoImpl;
+import org.infinispan.client.hotrod.impl.consistenthash.ConsistentHash;
+import org.infinispan.client.hotrod.impl.protocol.HotRodConstants;
+import org.infinispan.commons.marshall.WrappedBytes;
+import org.infinispan.commons.util.Immutables;
+import org.infinispan.commons.util.IntSets;
+
+/**
+ * Holds all the cluster topology information the client has for a single cache.
+ *
+ * <p>Each segment is mapped to a single server, even though the Hot Rod protocol and {@link ConsistentHash}
+ * implementations allow more than one owner.</p>
+ *
+ * @author Dan Berindei
+ * @since 13.0
+ */
+public class CacheInfo {
+   private final WrappedBytes cacheName;
+   private final ClusterInfo cluster;
+   // The balancer is final, but using it still needs synchronization
+   private final FailoverRequestBalancingStrategy balancer;
+   private final int numSegments;
+   private final int topologyId;
+   private final List<InetSocketAddress> servers;
+   private final Map<SocketAddress, Set<Integer>> primarySegments;
+   private final ConsistentHash consistentHash;
+   private final AtomicInteger topologyIdRef;
+
+   public CacheInfo(WrappedBytes cacheName, FailoverRequestBalancingStrategy balancer, ClusterInfo cluster) {
+      this.balancer = balancer;
+      this.cluster = cluster;
+      this.cacheName = cacheName;
+      this.numSegments = -1;
+      this.topologyId = HotRodConstants.DEFAULT_CACHE_TOPOLOGY;
+      this.consistentHash = null;
+
+      this.servers = Immutables.immutableListCopy(cluster.getInitialServers());
+
+      // Before the first topology update or after a topology-aware (non-hash) topology update
+      this.primarySegments = null;
+
+      this.topologyIdRef = new AtomicInteger(topologyId);
+   }
+
+   public void updateBalancerServers() {
+      // The servers list is immutable, so it doesn't matter that the balancer see it as a Collection<SocketAddress>
+      balancer.setServers((List) servers);
+   }
+
+   public CacheInfo withNewServers(int topologyId, List<InetSocketAddress> servers) {
+      return new CacheInfo(cacheName, balancer, cluster, topologyId, servers, null, -1, topologyIdRef);
+   }
+
+   public CacheInfo withNewHash(int topologyId, List<InetSocketAddress> servers, ConsistentHash consistentHash,
+                                int numSegments) {
+      return new CacheInfo(cacheName, balancer, cluster, topologyId, servers, consistentHash, numSegments,
+                           topologyIdRef);
+   }
+
+   public CacheInfo withNewCluster(ClusterInfo newCluster, List<InetSocketAddress> servers, int tempTopologyId) {
+      return new CacheInfo(cacheName, balancer, newCluster, tempTopologyId, servers, null, -1, topologyIdRef);
+   }
+
+   private CacheInfo(WrappedBytes cacheName, FailoverRequestBalancingStrategy balancer, ClusterInfo cluster,
+                     int topologyId, List<InetSocketAddress> servers, ConsistentHash consistentHash,
+                     int numSegments, AtomicInteger topologyIdRef) {
+      this.balancer = balancer;
+      this.cluster = cluster;
+      this.cacheName = cacheName;
+      this.numSegments = numSegments;
+      this.topologyId = topologyId;
+      this.consistentHash = consistentHash;
+      this.topologyIdRef = topologyIdRef;
+
+      this.servers = Immutables.immutableListCopy(servers);
+
+      if (numSegments > 0) {
+         // After the servers sent a hash-aware topology update
+         this.primarySegments = consistentHash.getPrimarySegmentsByServer();
+      } else {
+         // Before the first topology update or after a topology-aware (non-hash) topology update
+         this.primarySegments = null;
+      }
+   }
+
+   public ClusterInfo getCluster() {
+      return cluster;
+   }
+
+   public WrappedBytes getCacheName() {
+      return cacheName;
+   }
+
+   public FailoverRequestBalancingStrategy getBalancer() {
+      return balancer;
+   }
+
+   public int getNumSegments() {
+      return numSegments;
+   }
+
+   public int getTopologyId() {
+      return topologyId;
+   }
+
+   public AtomicInteger getTopologyIdRef() {
+      return topologyIdRef;
+   }
+
+   public List<InetSocketAddress> getServers() {
+      return servers;
+   }
+
+   public Map<SocketAddress, Set<Integer>> getPrimarySegments() {
+      if (primarySegments == null) {
+         return Collections.emptyMap();
+      }
+
+      return primarySegments;
+   }
+
+   public ConsistentHash getConsistentHash() {
+      return consistentHash;
+   }
+
+   public CacheTopologyInfo getCacheTopologyInfo() {
+      Map<SocketAddress, Set<Integer>> segmentsByServer;
+      if (consistentHash != null) {
+         segmentsByServer = consistentHash.getSegmentsByServer();
+      } else {
+         segmentsByServer = new HashMap<>();
+         for (InetSocketAddress server : servers) {
+            segmentsByServer.put(server, IntSets.immutableEmptySet());
+         }
+      }
+      return new CacheTopologyInfoImpl(segmentsByServer,
+                                       numSegments > 0 ? numSegments : null,
+                                       topologyId > 0 ? topologyId : null);
+   }
+
+   public boolean isValidTopology() {
+      // TODO Is it ok to consider -1 a valid topology?
+      return topologyId != HotRodConstants.SWITCH_CLUSTER_TOPOLOGY;
+   }
+}

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/topology/CacheInfo.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/topology/CacheInfo.java
@@ -28,9 +28,10 @@ import org.infinispan.commons.util.IntSets;
  * @since 13.0
  */
 public class CacheInfo {
-   private final WrappedBytes cacheName;
-   private final ClusterInfo cluster;
-   // The balancer is final, but using it still needs synchronization
+   private final String cacheName;
+   // The topology age at the time this topology was received
+   private final int topologyAge;
+   // The balancer is final, but using it still needs synchronization because it is not thread-safe
    private final FailoverRequestBalancingStrategy balancer;
    private final int numSegments;
    private final int topologyId;
@@ -39,15 +40,16 @@ public class CacheInfo {
    private final ConsistentHash consistentHash;
    private final AtomicInteger topologyIdRef;
 
-   public CacheInfo(WrappedBytes cacheName, FailoverRequestBalancingStrategy balancer, ClusterInfo cluster) {
+   public CacheInfo(WrappedBytes cacheName, FailoverRequestBalancingStrategy balancer, int topologyAge, List<InetSocketAddress> servers) {
       this.balancer = balancer;
-      this.cluster = cluster;
-      this.cacheName = cacheName;
+      this.topologyAge = topologyAge;
+      this.cacheName = cacheName == null || cacheName.getLength() == 0 ? "<default>" :
+                       new String(cacheName.getBytes(), HotRodConstants.HOTROD_STRING_CHARSET);
       this.numSegments = -1;
       this.topologyId = HotRodConstants.DEFAULT_CACHE_TOPOLOGY;
       this.consistentHash = null;
 
-      this.servers = Immutables.immutableListCopy(cluster.getInitialServers());
+      this.servers = Immutables.immutableListCopy(servers);
 
       // Before the first topology update or after a topology-aware (non-hash) topology update
       this.primarySegments = null;
@@ -60,25 +62,20 @@ public class CacheInfo {
       balancer.setServers((List) servers);
    }
 
-   public CacheInfo withNewServers(int topologyId, List<InetSocketAddress> servers) {
-      return new CacheInfo(cacheName, balancer, cluster, topologyId, servers, null, -1, topologyIdRef);
+   public CacheInfo withNewServers(int topologyAge, int topologyId, List<InetSocketAddress> servers) {
+      return new CacheInfo(cacheName, balancer, topologyAge, topologyIdRef, topologyId, servers, null, -1);
    }
 
-   public CacheInfo withNewHash(int topologyId, List<InetSocketAddress> servers, ConsistentHash consistentHash,
-                                int numSegments) {
-      return new CacheInfo(cacheName, balancer, cluster, topologyId, servers, consistentHash, numSegments,
-                           topologyIdRef);
+   public CacheInfo withNewHash(int topologyAge, int topologyId, List<InetSocketAddress> servers,
+                                ConsistentHash consistentHash, int numSegments) {
+      return new CacheInfo(cacheName, balancer, topologyAge, topologyIdRef, topologyId, servers, consistentHash, numSegments);
    }
 
-   public CacheInfo withNewCluster(ClusterInfo newCluster, List<InetSocketAddress> servers, int tempTopologyId) {
-      return new CacheInfo(cacheName, balancer, newCluster, tempTopologyId, servers, null, -1, topologyIdRef);
-   }
-
-   private CacheInfo(WrappedBytes cacheName, FailoverRequestBalancingStrategy balancer, ClusterInfo cluster,
-                     int topologyId, List<InetSocketAddress> servers, ConsistentHash consistentHash,
-                     int numSegments, AtomicInteger topologyIdRef) {
+   private CacheInfo(String cacheName, FailoverRequestBalancingStrategy balancer, int topologyAge,
+                     AtomicInteger topologyIdRef, int topologyId, List<InetSocketAddress> servers,
+                     ConsistentHash consistentHash, int numSegments) {
       this.balancer = balancer;
-      this.cluster = cluster;
+      this.topologyAge = topologyAge;
       this.cacheName = cacheName;
       this.numSegments = numSegments;
       this.topologyId = topologyId;
@@ -96,12 +93,12 @@ public class CacheInfo {
       }
    }
 
-   public ClusterInfo getCluster() {
-      return cluster;
+   public String getCacheName() {
+      return cacheName;
    }
 
-   public WrappedBytes getCacheName() {
-      return cacheName;
+   public int getTopologyAge() {
+      return topologyAge;
    }
 
    public FailoverRequestBalancingStrategy getBalancer() {
@@ -149,10 +146,5 @@ public class CacheInfo {
       return new CacheTopologyInfoImpl(segmentsByServer,
                                        numSegments > 0 ? numSegments : null,
                                        topologyId > 0 ? topologyId : null);
-   }
-
-   public boolean isValidTopology() {
-      // TODO Is it ok to consider -1 a valid topology?
-      return topologyId != HotRodConstants.SWITCH_CLUSTER_TOPOLOGY;
    }
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/topology/ClusterInfo.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/topology/ClusterInfo.java
@@ -7,6 +7,8 @@ import org.infinispan.commons.util.Immutables;
 
 /**
  * Cluster definition
+ *
+ * @author Dan Berindei
  */
 public class ClusterInfo {
    private final String clusterName;

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/topology/ClusterInfo.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/topology/ClusterInfo.java
@@ -2,6 +2,7 @@ package org.infinispan.client.hotrod.impl.topology;
 
 import java.net.InetSocketAddress;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 import org.infinispan.commons.util.Immutables;
 
@@ -13,10 +14,26 @@ import org.infinispan.commons.util.Immutables;
 public class ClusterInfo {
    private final String clusterName;
    private final List<InetSocketAddress> servers;
+   // Topology age provides a way to avoid concurrent cluster view changes,
+   // affecting a cluster switch. After a cluster switch, the topology age is
+   // increased and so any old requests that might have received topology
+   // updates won't be allowed to apply since they refer to older views.
+   private final int topologyAge;
+   // This completable future is completed when we switch away from the cluster
+   private final CompletableFuture<ClusterInfo> clusterSwitchFuture = new CompletableFuture<>();
 
    public ClusterInfo(String clusterName, List<InetSocketAddress> servers) {
+      this(clusterName, servers, -1);
+   }
+
+   private ClusterInfo(String clusterName, List<InetSocketAddress> servers, int topologyAge) {
       this.clusterName = clusterName;
       this.servers = Immutables.immutableListCopy(servers);
+      this.topologyAge = topologyAge;
+   }
+
+   public ClusterInfo withTopologyAge(int topologyAge) {
+      return new ClusterInfo(clusterName, servers, topologyAge);
    }
 
    public String getName() {
@@ -27,11 +44,20 @@ public class ClusterInfo {
       return servers;
    }
 
+   public int getTopologyAge() {
+      return topologyAge;
+   }
+
+   public CompletableFuture<ClusterInfo> getClusterSwitchFuture() {
+      return clusterSwitchFuture;
+   }
+
    @Override
    public String toString() {
       return "ClusterInfo{" +
              "name='" + clusterName + '\'' +
              ", servers=" + servers +
+             ", age=" + topologyAge +
              '}';
    }
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/topology/ClusterInfo.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/topology/ClusterInfo.java
@@ -1,0 +1,35 @@
+package org.infinispan.client.hotrod.impl.topology;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+
+import org.infinispan.commons.util.Immutables;
+
+/**
+ * Cluster definition
+ */
+public class ClusterInfo {
+   private final String clusterName;
+   private final List<InetSocketAddress> servers;
+
+   public ClusterInfo(String clusterName, List<InetSocketAddress> servers) {
+      this.clusterName = clusterName;
+      this.servers = Immutables.immutableListCopy(servers);
+   }
+
+   public String getName() {
+      return clusterName;
+   }
+
+   public List<InetSocketAddress> getInitialServers() {
+      return servers;
+   }
+
+   @Override
+   public String toString() {
+      return "ClusterInfo{" +
+             "name='" + clusterName + '\'' +
+             ", servers=" + servers +
+             '}';
+   }
+}

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/ChannelFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/ChannelFactory.java
@@ -327,7 +327,6 @@ public class ChannelFactory {
                newCacheInfo = cacheInfo.withNewServers(responseTopologyAge, responseTopologyId, addressList);
             }
             updateCacheInfo(wrappedCacheName, newCacheInfo, false);
-            newCacheInfo.getTopologyIdRef().set(responseTopologyId);
          } else {
             if (log.isTraceEnabled())
                log.tracef("[%s] Ignoring outdated topology: topology id = %s, topology age = %s, servers = %s",

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/ChannelFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/ChannelFactory.java
@@ -1,6 +1,5 @@
 package org.infinispan.client.hotrod.impl.transport.netty;
 
-import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.infinispan.client.hotrod.impl.Util.await;
 import static org.infinispan.client.hotrod.impl.Util.wrapBytes;
 import static org.infinispan.client.hotrod.logging.Log.HOTROD;
@@ -8,6 +7,7 @@ import static org.infinispan.client.hotrod.logging.Log.HOTROD;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -44,6 +44,7 @@ import org.infinispan.client.hotrod.impl.operations.OperationsFactory;
 import org.infinispan.client.hotrod.impl.protocol.Codec;
 import org.infinispan.client.hotrod.impl.topology.CacheInfo;
 import org.infinispan.client.hotrod.impl.topology.ClusterInfo;
+import org.infinispan.client.hotrod.impl.transport.netty.ChannelPool.ChannelEventType;
 import org.infinispan.client.hotrod.logging.Log;
 import org.infinispan.client.hotrod.logging.LogFactory;
 import org.infinispan.commons.marshall.Marshaller;
@@ -69,9 +70,6 @@ public class ChannelFactory {
 
    public static final String DEFAULT_CLUSTER_NAME = "___DEFAULT-CLUSTER___";
    private static final Log log = LogFactory.getLog(ChannelFactory.class, Log.class);
-   private static final CompletableFuture<ClusterSwitchStatus> NOT_SWITCHED_FUTURE = completedFuture(ClusterSwitchStatus.NOT_SWITCHED);
-   private static final CompletableFuture<ClusterSwitchStatus> IN_PROGRESS_FUTURE = completedFuture(ClusterSwitchStatus.IN_PROGRESS);
-   private static final CompletableFuture<ClusterSwitchStatus> SWITCHED_FUTURE = completedFuture(ClusterSwitchStatus.SWITCHED);
 
    private final ReadWriteLock lock = new ReentrantReadWriteLock();
    private final ConcurrentMap<SocketAddress, ChannelPool> channelPoolMap = new ConcurrentHashMap<>();
@@ -90,6 +88,12 @@ public class ChannelFactory {
 
    private MarshallerRegistry marshallerRegistry;
    private final LongAdder totalRetries = new LongAdder();
+
+   @GuardedBy("lock")
+   private CompletableFuture<Void> clusterSwitchStage;
+   // Servers for which the last connection attempt failed and which have no established connections
+   @GuardedBy("lock")
+   private final Set<SocketAddress> failedServers = new HashSet<>();
 
    public void start(Codec codec, Configuration configuration, Marshaller marshaller, ExecutorService executorService,
                      ClientListenerNotifier listenerNotifier, MarshallerRegistry marshallerRegistry) {
@@ -139,7 +143,7 @@ public class ChannelFactory {
          maxRetries = configuration.maxRetries();
 
          WrappedByteArray defaultCacheName = wrapBytes(RemoteCacheManager.cacheNameBytes());
-         topologyInfo.createCacheInfo(defaultCacheName);
+         topologyInfo.getOrCreateCacheInfo(defaultCacheName);
       } finally {
          lock.writeLock().unlock();
       }
@@ -173,16 +177,19 @@ public class ChannelFactory {
       if (maxConnections < 0) {
          maxConnections = Integer.MAX_VALUE;
       }
-      ChannelInitializer channelInitializer = new ChannelInitializer(bootstrap, address, operationsFactory, configuration, this);
+      ChannelInitializer channelInitializer =
+            new ChannelInitializer(bootstrap, address, operationsFactory, configuration, this);
       bootstrap.handler(channelInitializer);
-      ChannelPool pool = new ChannelPool(bootstrap.config().group().next(), address, channelInitializer, configuration.connectionPool().exhaustedAction(),
-            configuration.connectionPool().maxWait(), maxConnections, configuration.connectionPool().maxPendingRequests());
+      ChannelPool pool = new ChannelPool(bootstrap.config().group().next(), address, channelInitializer,
+                                         configuration.connectionPool().exhaustedAction(), this::onConnectionEvent,
+                                         configuration.connectionPool().maxWait(), maxConnections,
+                                         configuration.connectionPool().maxPendingRequests());
       channelInitializer.setChannelPool(pool);
       return pool;
    }
 
    private void pingServersIgnoreException() {
-      Collection<InetSocketAddress> servers = topologyInfo.getCurrentServers();
+      Collection<InetSocketAddress> servers = topologyInfo.getAllServers();
       for (SocketAddress addr : servers) {
          // Go through all statically configured nodes and force a
          // connection to be established and a ping message to be sent.
@@ -227,57 +234,33 @@ public class ChannelFactory {
       }
    }
 
-   public void updateConsistentHash(SocketAddress[][] segmentOwners, int numSegments, short hashFunctionVersion,
-                                    byte[] cacheName, int topologyId, List<InetSocketAddress> servers) {
+   public <T extends ChannelOperation> T fetchChannelAndInvoke(Set<SocketAddress> failedServers, byte[] cacheName,
+                                                               T operation) {
+      SocketAddress server;
+      // Need the write lock because FailoverRequestBalancingStrategy is not thread-safe
       lock.writeLock().lock();
       try {
-         WrappedByteArray wrappedCacheName = wrapBytes(cacheName);
-         CacheInfo oldCacheInfo = topologyInfo.getCacheInfo(wrappedCacheName);
-         assert oldCacheInfo != null : "The cache info must exist before receiving a topology update";
-         SegmentConsistentHash consistentHash =
-               topologyInfo.createConsistentHash(numSegments, hashFunctionVersion, segmentOwners);
-         CacheInfo newCacheInfo = oldCacheInfo.withNewHash(topologyId, servers, consistentHash, numSegments);
-         updateCacheInfo(wrappedCacheName, newCacheInfo, false);
-         newCacheInfo.getTopologyIdRef().set(topologyId);
+         if (failedServers != null) {
+            CompletableFuture<Void> switchStage = this.clusterSwitchStage;
+            if (switchStage != null) {
+               switchStage.whenComplete((__, t) -> fetchChannelAndInvoke(failedServers, cacheName, operation));
+               return operation;
+            }
+         }
+
+         CacheInfo cacheInfo = topologyInfo.getCacheInfo(wrapBytes(cacheName));
+         FailoverRequestBalancingStrategy balancer = cacheInfo.getBalancer();
+         server = balancer.nextServer(failedServers);
       } finally {
          lock.writeLock().unlock();
       }
-   }
-
-   public <T extends ChannelOperation> T fetchChannelAndInvoke(Set<SocketAddress> failedServers, byte[] cacheName, T operation) {
-      return fetchChannelAndInvoke(getNextServer(failedServers, cacheName), operation);
+      return fetchChannelAndInvoke(server, operation);
    }
 
    public <T extends ChannelOperation> T fetchChannelAndInvoke(SocketAddress server, T operation) {
       ChannelPool pool = channelPoolMap.computeIfAbsent(server, newPool);
       pool.acquire(operation);
       return operation;
-   }
-
-   private SocketAddress getNextServer(Set<SocketAddress> failedServers, byte[] cacheName) {
-      // This needs to be synchronized from two reasons:
-      // 1) balancers are not synchronized (that's TODO)
-      // 2) FailoverRequestBalancingStrategy is not threadsafe - maybe we should make this thread-local
-      // or un-share it somehow
-      SocketAddress server;
-      lock.writeLock().lock();
-      try {
-         CacheInfo cacheInfo = topologyInfo.getCacheInfo(wrapBytes(cacheName));
-         if (failedServers != null && failedServers.containsAll(cacheInfo.getServers())) {
-            log.switchToInitialServerList();
-            reset(wrapBytes(cacheName));
-            closeChannelPools(failedServers);
-            failedServers.clear();
-         }
-         FailoverRequestBalancingStrategy balancer = cacheInfo.getBalancer();
-         server = balancer.nextServer(failedServers);
-      } finally {
-         lock.writeLock().unlock();
-      }
-      if (log.isTraceEnabled())
-         log.tracef("[%s] Using the balancer for determining the server: %s", new String(cacheName), server);
-
-      return server;
    }
 
    private void closeChannelPools(Set<? extends SocketAddress> failedServers) {
@@ -290,16 +273,25 @@ public class ChannelFactory {
       }
    }
 
-   public SocketAddress getSocketAddress(Object key, byte[] cacheName) {
-      return topologyInfo.getHashAwareServer(key, cacheName);
+   public SocketAddress getHashAwareServer(Object key, byte[] cacheName) {
+      CacheInfo cacheInfo = topologyInfo.getCacheInfo(wrapBytes(cacheName));
+      if (cacheInfo != null && cacheInfo.getConsistentHash() != null) {
+         return cacheInfo.getConsistentHash().getServer(key);
+      }
+
+      return null;
    }
 
-   public <T extends ChannelOperation> T fetchChannelAndInvoke(Object key, Set<SocketAddress> failedServers, byte[] cacheName, T operation) {
-      SocketAddress server = topologyInfo.getHashAwareServer(key, cacheName);
-      if (server == null || (failedServers != null && failedServers.contains(server))) {
-         server = getNextServer(failedServers, cacheName);
+   public <T extends ChannelOperation> T fetchChannelAndInvoke(Object key, Set<SocketAddress> failedServers,
+                                                               byte[] cacheName, T operation) {
+      CacheInfo cacheInfo = topologyInfo.getCacheInfo(wrapBytes(cacheName));
+      if (cacheInfo != null && cacheInfo.getConsistentHash() != null) {
+         SocketAddress server = cacheInfo.getConsistentHash().getServer(key);
+         if (server != null && (failedServers == null || !failedServers.contains(server))) {
+            return fetchChannelAndInvoke(server, operation);
+         }
       }
-      return fetchChannelAndInvoke(server, operation);
+      return fetchChannelAndInvoke(failedServers, cacheName, operation);
    }
 
    public void releaseChannel(Channel channel) {
@@ -311,34 +303,70 @@ public class ChannelFactory {
       record.release(channel);
    }
 
-   public void updateServers(List<InetSocketAddress> newServers, byte[] cacheName, int topologyId, boolean quiet) {
+   public void receiveTopology(byte[] cacheName, int responseTopologyAge, int responseTopologyId,
+                               InetSocketAddress[] addresses, SocketAddress[][] segmentOwners,
+                               short hashFunctionVersion) {
+      WrappedByteArray wrappedCacheName = wrapBytes(cacheName);
       lock.writeLock().lock();
       try {
-         WrappedByteArray wrappedCacheName = wrapBytes(cacheName);
-         CacheInfo oldCacheInfo = topologyInfo.getCacheInfo(wrappedCacheName);
-         CacheInfo newCacheInfo = oldCacheInfo.withNewServers(topologyId, newServers);
-         updateCacheInfo(wrappedCacheName, newCacheInfo, quiet);
-         newCacheInfo.getTopologyIdRef().set(topologyId);
+         CacheInfo cacheInfo = topologyInfo.getCacheInfo(wrappedCacheName);
+         assert cacheInfo != null : "The cache info must exist before receiving a topology update";
+
+         // Only accept the update if it's from the current age and the topology id is greater than the current one
+         // Relies on TopologyInfo.switchCluster() to update the topologyAge for caches first
+         if (responseTopologyAge == cacheInfo.getTopologyAge() && responseTopologyId > cacheInfo.getTopologyId()) {
+            List<InetSocketAddress> addressList = Arrays.asList(addresses);
+            HOTROD.newTopology(responseTopologyId, responseTopologyAge, addresses.length, addressList);
+            CacheInfo newCacheInfo;
+            if (hashFunctionVersion >= 0) {
+               SegmentConsistentHash consistentHash =
+                     createConsistentHash(segmentOwners, hashFunctionVersion, cacheInfo.getCacheName());
+               newCacheInfo = cacheInfo.withNewHash(responseTopologyAge, responseTopologyId, addressList,
+                                                       consistentHash, segmentOwners.length);
+            } else {
+               newCacheInfo = cacheInfo.withNewServers(responseTopologyAge, responseTopologyId, addressList);
+            }
+            updateCacheInfo(wrappedCacheName, newCacheInfo, false);
+            newCacheInfo.getTopologyIdRef().set(responseTopologyId);
+         } else {
+            if (log.isTraceEnabled())
+               log.tracef("[%s] Ignoring outdated topology: topology id = %s, topology age = %s, servers = %s",
+                          cacheInfo.getCacheName(), responseTopologyId, responseTopologyAge,
+                          Arrays.toString(addresses));
+         }
       } finally {
          lock.writeLock().unlock();
       }
    }
 
+   private SegmentConsistentHash createConsistentHash(SocketAddress[][] segmentOwners, short hashFunctionVersion,
+                                                      String cacheNameString) {
+      if (log.isTraceEnabled()) {
+         if (hashFunctionVersion == 0)
+            log.tracef("[%s] Not using a consistent hash function (hash function version == 0).",
+                       cacheNameString);
+         else
+            log.tracef("[%s] Updating client hash function with %s number of segments",
+                       cacheNameString, segmentOwners.length);
+      }
+      return topologyInfo.createConsistentHash(segmentOwners.length, hashFunctionVersion, segmentOwners);
+   }
+
    @GuardedBy("lock")
-   protected CacheInfo updateCacheInfo(WrappedBytes cacheName, CacheInfo newCacheInfo, boolean quiet) {
+   protected void updateCacheInfo(WrappedBytes cacheName, CacheInfo newCacheInfo, boolean quiet) {
       List<InetSocketAddress> newServers = newCacheInfo.getServers();
       CacheInfo oldCacheInfo = topologyInfo.getCacheInfo(cacheName);
       List<InetSocketAddress> oldServers = oldCacheInfo.getServers();
       Set<SocketAddress> addedServers = new HashSet<>(newServers);
       addedServers.removeAll(oldServers);
-      Set<SocketAddress> failedServers = new HashSet<>(oldServers);
-      failedServers.removeAll(newServers);
+      Set<SocketAddress> removedServers = new HashSet<>(oldServers);
+      removedServers.removeAll(newServers);
       if (log.isTraceEnabled()) {
-         String cacheNameString = cacheName == null ? "<default>" : new String(cacheName.getBytes());
+         String cacheNameString = newCacheInfo.getCacheName();
          log.tracef("[%s] Current list: %s", cacheNameString, oldServers);
          log.tracef("[%s] New list: %s", cacheNameString, newServers);
          log.tracef("[%s] Added servers: %s", cacheNameString, addedServers);
-         log.tracef("[%s] Removed servers: %s", cacheNameString, failedServers);
+         log.tracef("[%s] Removed servers: %s", cacheNameString, removedServers);
       }
 
       // First add new servers. For servers that went down, the returned transport will fail for now
@@ -350,20 +378,19 @@ public class ChannelFactory {
       // Then update the server list for new operations
       topologyInfo.updateCacheInfo(cacheName, oldCacheInfo, newCacheInfo);
 
+      // TODO Do not close a server pool until the server has been removed from all cache infos
       // And finally remove the failed servers
-      closeChannelPools(failedServers);
+      closeChannelPools(removedServers);
 
-      if (!failedServers.isEmpty()) {
-         listenerNotifier.failoverListeners(failedServers);
+      if (!removedServers.isEmpty()) {
+         listenerNotifier.failoverListeners(removedServers);
       }
-
-      return oldCacheInfo;
    }
 
    public Collection<InetSocketAddress> getServers() {
       lock.readLock().lock();
       try {
-         return topologyInfo.getCurrentServers();
+         return topologyInfo.getAllServers();
       } finally {
          lock.readLock().unlock();
       }
@@ -406,75 +433,164 @@ public class ChannelFactory {
       return maxRetries;
    }
 
-   private void reset(WrappedBytes cacheName) {
+   public AtomicInteger createTopologyId(byte[] cacheName) {
       lock.writeLock().lock();
       try {
-         // Switch to the initial server list of the current cluster
-         ClusterInfo cluster = topologyInfo.getCurrentCluster();
-         topologyInfo.switchCluster(cluster, cacheName);
+         return topologyInfo.getOrCreateCacheInfo(wrapBytes(cacheName)).getTopologyIdRef();
       } finally {
          lock.writeLock().unlock();
       }
-   }
-
-   public AtomicInteger createTopologyId(byte[] cacheName) {
-      return topologyInfo.getOrCreateCacheInfo(wrapBytes(cacheName)).getTopologyIdRef();
    }
 
    public int getTopologyId(byte[] cacheName) {
       return topologyInfo.getCacheInfo(wrapBytes(cacheName)).getTopologyId();
    }
 
-   public CompletableFuture<ClusterSwitchStatus> trySwitchCluster(String failedClusterName, byte[] cacheName) {
+   public void onConnectionEvent(ChannelPool pool, ChannelEventType type) {
+      boolean allInitialServersFailed;
       lock.writeLock().lock();
       try {
-         if (log.isTraceEnabled())
-            log.tracef("Trying to switch cluster away from '%s'", failedClusterName);
-
-         if (clusters.isEmpty()) {
-            log.debugf("No alternative clusters configured, so can't switch cluster");
-            return NOT_SWITCHED_FUTURE;
-         }
-
-         String currentClusterName = topologyInfo.getCurrentCluster().getName();
-         if (!isSwitchedClusterNotAvailable(failedClusterName, currentClusterName)) {
-            log.debugf("Cluster already switched from failed cluster `%s` to `%s`, try again",
-                  failedClusterName, currentClusterName);
-            return IN_PROGRESS_FUTURE;
-         }
-
-         // Switch cluster if there has not been a topology id cluster switch reset recently,
-         if (!topologyInfo.isTopologyValid(cacheName)) {
-            if (log.isTraceEnabled())
-               log.tracef("Cluster switch is already in progress for topology age %d", getTopologyAge());
-            return IN_PROGRESS_FUTURE;
+         // TODO Replace with a simpler "pool healthy/unhealthy" event?
+         if (type == ChannelEventType.CONNECTED) {
+            failedServers.remove(pool.getAddress());
+            return;
+         } else if (type == ChannelEventType.CONNECT_FAILED) {
+            if (pool.getConnected() == 0) {
+               failedServers.add(pool.getAddress());
+            }
+         } else {
+            // Nothing to do
+            return;
          }
 
          if (log.isTraceEnabled())
-            log.tracef("Switching clusters, failed cluster is '%s' and current cluster name is '%s'",
-                       failedClusterName, currentClusterName);
-
-         List<ClusterInfo> candidateClusters = new ArrayList<>();
-         for (ClusterInfo cluster : clusters) {
-            String clusterName = cluster.getName();
-            if (!clusterName.equals(failedClusterName))
-               candidateClusters.add(cluster);
+            log.tracef("Connection attempt failed, we now have %d servers with no established connections: %s",
+                       failedServers.size(), failedServers);
+         allInitialServersFailed = failedServers.containsAll(topologyInfo.getCluster().getInitialServers());
+         if (!allInitialServersFailed) {
+            resetCachesWithFailedServers();
          }
-
-         Iterator<ClusterInfo> clusterIterator = candidateClusters.iterator();
-         if (!clusterIterator.hasNext()) {
-            log.debug("No clusters to switch to.");
-            return NOT_SWITCHED_FUTURE;
-         }
-         ClusterInfo cluster = clusterIterator.next();
-         return checkServersAlive(cluster.getInitialServers())
-               .thenCompose(new ClusterSwitcher(clusterIterator, cacheName, cluster));
       } finally {
          lock.writeLock().unlock();
       }
+
+      if (allInitialServersFailed && !clusters.isEmpty()) {
+         trySwitchCluster(allInitialServersFailed);
+      }
    }
 
-   private CompletableFuture<Boolean> checkServersAlive(Collection<InetSocketAddress> servers) {
+   private void trySwitchCluster(boolean allInitialServersFailed) {
+      int ageBeforeSwitch;
+      ClusterInfo cluster;
+      lock.writeLock().lock();
+      try {
+         ageBeforeSwitch = topologyInfo.getTopologyAge();
+         cluster = topologyInfo.getCluster();
+         if (clusterSwitchStage != null) {
+            if (log.isTraceEnabled())
+               log.tracef("Cluster switch is already in progress for topology age %d", ageBeforeSwitch);
+            return;
+         }
+
+         clusterSwitchStage = new CompletableFuture<>();
+      } finally {
+         lock.writeLock().unlock();
+      }
+
+      checkServersAlive(cluster.getInitialServers())
+            .thenCompose(alive -> {
+               if (alive) {
+                  // The live check removed the server from failedServers when it established a connection
+                  if (log.isTraceEnabled()) log.tracef("Cluster %s is still alive, not switching", cluster);
+                  return CompletableFuture.completedFuture(null);
+               }
+
+               if (log.isTraceEnabled())
+                  log.tracef("Trying to switch cluster away from '%s'", cluster.getName());
+               return findLiveCluster(cluster, ageBeforeSwitch);
+            })
+            .thenAccept(newCluster -> {
+               if (newCluster != null) {
+                  automaticSwitchToCluster(newCluster, cluster, ageBeforeSwitch);
+               }
+            })
+            .whenComplete((__, t) -> completeClusterSwitch());
+   }
+
+   @GuardedBy("lock")
+   private void resetCachesWithFailedServers() {
+      List<WrappedBytes> failedCaches = new ArrayList<>();
+      List<String> nameStrings = new ArrayList<>();
+      topologyInfo.forEachCache((cacheNameBytes, cacheInfo) -> {
+         if (failedServers.containsAll(cacheInfo.getServers())) {
+            failedCaches.add(cacheNameBytes);
+            nameStrings.add(cacheInfo.getCacheName());
+         }
+      });
+      if (!failedCaches.isEmpty()) {
+         HOTROD.revertCacheToInitialServerList(nameStrings);
+         for (WrappedBytes cacheNameBytes : failedCaches) {
+            topologyInfo.reset(cacheNameBytes);
+         }
+      }
+   }
+
+   private void completeClusterSwitch() {
+      CompletableFuture<Void> localStage;
+      lock.writeLock().lock();
+      try {
+         localStage = this.clusterSwitchStage;
+         this.clusterSwitchStage = null;
+      } finally {
+         lock.writeLock().unlock();
+      }
+
+      // An automatic cluster switch could be cancelled by a manual switch,
+      // and a manual cluster switch would not have a stage to begin with
+      if (localStage != null) {
+         localStage.complete(null);
+      }
+   }
+
+   private CompletionStage<ClusterInfo> findLiveCluster(ClusterInfo failedCluster, int ageBeforeSwitch) {
+      List<ClusterInfo> candidateClusters = new ArrayList<>();
+      for (ClusterInfo cluster : clusters) {
+         String clusterName = cluster.getName();
+         if (!clusterName.equals(failedCluster.getName()))
+            candidateClusters.add(cluster);
+      }
+
+      Iterator<ClusterInfo> clusterIterator = candidateClusters.iterator();
+      return findLiveCluster0(false, null, clusterIterator, ageBeforeSwitch);
+   }
+
+   private CompletionStage<ClusterInfo> findLiveCluster0(boolean alive, ClusterInfo testedCluster,
+                                                         Iterator<ClusterInfo> clusterIterator, int ageBeforeSwitch) {
+      lock.writeLock().lock();
+      try {
+         if (clusterSwitchStage == null || topologyInfo.getTopologyAge() != ageBeforeSwitch) {
+            log.debugf("Cluster switch already completed by another thread, bailing out");
+            return CompletableFuture.completedFuture(null);
+         }
+      } finally {
+         lock.writeLock().unlock();
+      }
+
+      if (alive) return CompletableFuture.completedFuture(testedCluster);
+
+      if (!clusterIterator.hasNext()) {
+         log.debugf("All cluster addresses viewed and none worked: %s", clusters);
+         return CompletableFuture.completedFuture(null);
+      }
+      ClusterInfo nextCluster = clusterIterator.next();
+      return checkServersAlive(nextCluster.getInitialServers())
+            .thenCompose(aliveNext -> findLiveCluster0(aliveNext, nextCluster, clusterIterator, ageBeforeSwitch));
+   }
+
+   private CompletionStage<Boolean> checkServersAlive(Collection<InetSocketAddress> servers) {
+      if (servers.isEmpty())
+         return CompletableFuture.completedFuture(false);
+
       AtomicInteger remainingResponses = new AtomicInteger(servers.size());
       CompletableFuture<Boolean> allFuture = new CompletableFuture<>();
       for (SocketAddress server : servers) {
@@ -496,43 +612,73 @@ public class ChannelFactory {
       return allFuture;
    }
 
-   private boolean isSwitchedClusterNotAvailable(String failedClusterName, String currentClusterName) {
-      return currentClusterName.equals(failedClusterName);
+   private void automaticSwitchToCluster(ClusterInfo newCluster, ClusterInfo failedCluster, int ageBeforeSwitch) {
+      lock.writeLock().lock();
+      try {
+         if (clusterSwitchStage == null || topologyInfo.getTopologyAge() != ageBeforeSwitch) {
+            log.debugf("Cluster switch already completed by another thread, bailing out");
+            return;
+         }
+
+         topologyInfo.switchCluster(newCluster);
+      } finally {
+         lock.writeLock().unlock();
+      }
+
+      if (!newCluster.getName().equals(DEFAULT_CLUSTER_NAME))
+         HOTROD.switchedToCluster(newCluster.getName());
+      else
+         HOTROD.switchedBackToMainCluster();
    }
 
-   public Marshaller getMarshaller() {
-      return marshaller;
-   }
-
-   public boolean switchToCluster(String clusterName) {
+   /**
+    * Switch to an alternate cluster (or from an alternate cluster back to the main cluster).
+    *
+    * <p>Overrides any automatic cluster switch in progress, which may be useful
+    * when the automatic switch takes too long.</p>
+    */
+   public boolean manualSwitchToCluster(String clusterName) {
       if (clusters.isEmpty()) {
          log.debugf("No alternative clusters configured, so can't switch cluster");
          return false;
       }
 
       ClusterInfo cluster = findCluster(clusterName);
-      if (cluster != null) {
-         lock.writeLock().lock();
-         try {
-            log.debugf("Switching to %s, servers: %s, setting topology.", clusterName, cluster.getInitialServers());
-            topologyInfo.switchCluster(cluster, WrappedByteArray.EMPTY_BYTES);
-
-            if (!clusterName.equals(DEFAULT_CLUSTER_NAME))
-               HOTROD.manuallySwitchedToCluster(clusterName);
-            else
-               HOTROD.manuallySwitchedBackToMainCluster();
-
-            return true;
-         } finally {
-            lock.writeLock().unlock();
-         }
+      if (cluster == null) {
+         log.debugf("Cluster named %s does not exist in the configuration", clusterName);
+         return false;
       }
 
-      return false;
+      lock.writeLock().lock();
+      boolean shouldComplete = false;
+      try {
+         if (clusterSwitchStage != null) {
+            log.debugf("Another cluster switch is already in progress, overriding it");
+            shouldComplete = true;
+         }
+         log.debugf("Switching to cluster %s, servers: %s", clusterName, cluster.getInitialServers());
+         topologyInfo.switchCluster(cluster);
+      } finally {
+         lock.writeLock().unlock();
+      }
+
+      if (!clusterName.equals(DEFAULT_CLUSTER_NAME))
+         HOTROD.manuallySwitchedToCluster(clusterName);
+      else
+         HOTROD.manuallySwitchedBackToMainCluster();
+
+      if (shouldComplete) {
+         completeClusterSwitch();
+      }
+      return true;
+   }
+
+   public Marshaller getMarshaller() {
+      return marshaller;
    }
 
    public String getCurrentClusterName() {
-      return topologyInfo.getCurrentCluster().getName();
+      return topologyInfo.getCluster().getName();
    }
 
    public int getTopologyAge() {
@@ -591,42 +737,6 @@ public class ChannelFactory {
 
    public void incrementRetryCount() {
       totalRetries.increment();
-   }
-
-   public enum ClusterSwitchStatus {
-      NOT_SWITCHED, SWITCHED, IN_PROGRESS
-   }
-
-   private class ClusterSwitcher implements Function<Boolean, CompletionStage<ClusterSwitchStatus>> {
-      private final Iterator<ClusterInfo> clusterIterator;
-      private final byte[] cacheName;
-      private ClusterInfo cluster;
-
-      ClusterSwitcher(Iterator<ClusterInfo> clusterIterator, byte[] cacheName, ClusterInfo cluster) {
-         this.clusterIterator = clusterIterator;
-         this.cacheName = cacheName;
-         this.cluster = cluster;
-      }
-
-      @Override
-      public CompletionStage<ClusterSwitchStatus> apply(Boolean alive) {
-         if (!alive) {
-            if (!clusterIterator.hasNext()) {
-               log.debugf("All cluster addresses viewed and none worked: %s", clusters);
-               return NOT_SWITCHED_FUTURE;
-            }
-            cluster = clusterIterator.next();
-            return checkServersAlive(cluster.getInitialServers()).thenCompose(this);
-         }
-         topologyInfo.switchCluster(cluster, wrapBytes(cacheName));
-
-         if (!cluster.getName().equals(DEFAULT_CLUSTER_NAME))
-            HOTROD.switchedToCluster(cluster.getName());
-         else
-            HOTROD.switchedBackToMainCluster();
-
-         return SWITCHED_FUTURE;
-      }
    }
 
    private class ReleaseChannelOperation implements ChannelOperation {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/tcp/RoundRobinBalancingStrategy.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/tcp/RoundRobinBalancingStrategy.java
@@ -48,9 +48,9 @@ public class RoundRobinBalancingStrategy implements FailoverRequestBalancingStra
          if (failedServers == null || !failedServers.contains(server) || i >= failedServers.size()) {
             if (log.isTraceEnabled()) {
                if (failedServers == null)
-                  log.tracef("Selected %s from %s", server, Arrays.toString(servers));
+                  log.tracef("Found server %s", server);
                else
-                  log.tracef("Selected %s from %s, with failed servers %s", server, Arrays.toString(servers), failedServers.toString());
+                  log.tracef("Found server %s, with failed servers %s", server, failedServers.toString());
             }
 
             return server;

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/logging/Log.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/logging/Log.java
@@ -11,7 +11,6 @@ import java.net.SocketAddress;
 import java.util.Collection;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Set;
 
 import javax.transaction.xa.Xid;
 
@@ -66,7 +65,7 @@ public interface Log extends BasicLogger {
 
    @LogMessage(level = INFO)
    @Message(value = "Server sent new topology view (id=%d, age=%d) containing %d addresses: %s", id = 4006)
-   void newTopology(int viewId, int age, int topologySize, Set<SocketAddress> topology);
+   void newTopology(int viewId, int age, int topologySize, Collection<? extends SocketAddress> addresses);
 
    @LogMessage(level = ERROR)
    @Message(value = "Exception encountered. Retry %d out of %d", id = 4007)
@@ -373,6 +372,6 @@ public interface Log extends BasicLogger {
    void failedToCreatePredefinedSerializationContextInitializer(String className, @Cause Throwable throwable);
 
    @LogMessage(level = WARN)
-   @Message(value = "All the servers are marked as failed. Cluster might have completely shut down, reverting to the initial server list.", id = 4105)
-   void switchToInitialServerList();
+   @Message(value = "Reverting to the initial server list for caches %s", id = 4105)
+   void revertCacheToInitialServerList(Collection<String> cacheName);
 }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/AsymmetricRoutingTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/AsymmetricRoutingTest.java
@@ -128,6 +128,7 @@ public class AsymmetricRoutingTest extends HitsAwareCacheManagersTest {
       int attemptsLeft = 1000;
       do {
          r.nextBytes(dummy);
+         attemptsLeft--;
       } while (!isFirstOwner(cache, dummy) && attemptsLeft >= 0);
 
       if (attemptsLeft < 0)

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/PingOnStartupTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/PingOnStartupTest.java
@@ -74,7 +74,7 @@ public class PingOnStartupTest extends MultiHotRodServersTest {
    public void testTopologyAwareIntelligence() {
       org.infinispan.client.hotrod.configuration.ConfigurationBuilder clientBuilder =
             HotRodClientTestingUtil.newRemoteConfigurationBuilder();
-      clientBuilder.addServer().host("localhost").port(server(0).getPort());
+      clientBuilder.addServer().host("127.0.0.1").port(server(0).getPort());
       clientBuilder.clientIntelligence(ClientIntelligence.TOPOLOGY_AWARE);
       withRemoteCacheManager(new RemoteCacheManagerCallable(
             new InternalRemoteCacheManager(clientBuilder.build())) {
@@ -90,7 +90,7 @@ public class PingOnStartupTest extends MultiHotRodServersTest {
    public void testHashAwareIntelligence() {
       org.infinispan.client.hotrod.configuration.ConfigurationBuilder clientBuilder =
             HotRodClientTestingUtil.newRemoteConfigurationBuilder();
-      clientBuilder.addServer().host("localhost").port(server(0).getPort());
+      clientBuilder.addServer().host("127.0.0.1").port(server(0).getPort());
       clientBuilder.clientIntelligence(ClientIntelligence.HASH_DISTRIBUTION_AWARE);
       withRemoteCacheManager(new RemoteCacheManagerCallable(
             new InternalRemoteCacheManager(clientBuilder.build())) {

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ReplTopologyChangeTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ReplTopologyChangeTest.java
@@ -77,7 +77,7 @@ public class ReplTopologyChangeTest extends MultipleCacheManagersTest {
       //Important: this only connects to one of the two servers!
       org.infinispan.client.hotrod.configuration.ConfigurationBuilder clientBuilder =
             HotRodClientTestingUtil.newRemoteConfigurationBuilder();
-      clientBuilder.addServer().host("localhost").port(hotRodServer2.getPort());
+      clientBuilder.addServer().host("127.0.0.1").port(hotRodServer2.getPort());
       remoteCacheManager = new InternalRemoteCacheManager(clientBuilder.build());
       remoteCache = remoteCacheManager.getCache();
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ServerRestartTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ServerRestartTest.java
@@ -68,8 +68,6 @@ public class ServerRestartTest extends SingleCacheManagerTest {
       builder.host("127.0.0.1").port(port).workerThreads(2).idleTimeout(20000).tcpNoDelay(true).sendBufSize(15000).recvBufSize(25000);
       hotrodServer.start(builder.build(), cacheManager);
 
-      Thread.sleep(3000);
-
       assert defaultRemote.get("k").equals("v");
       defaultRemote.put("k","v");
    }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/xsite/SiteDownFailoverTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/xsite/SiteDownFailoverTest.java
@@ -20,8 +20,8 @@ public class SiteDownFailoverTest extends AbstractHotRodSiteFailoverTest {
    public void testFailoverAfterSiteShutdown() {
       clientA = client(SITE_A, Optional.of(SITE_B));
       clientB = client(SITE_B, Optional.empty());
-      RemoteCache<Integer, String> cacheA = clientA.getCache();
-      RemoteCache<Integer, String> cacheB = clientB.getCache();
+      RemoteCache<Integer, String> cacheA = clientA.getCache(CACHE_NAME);
+      RemoteCache<Integer, String> cacheB = clientB.getCache(CACHE_NAME);
 
       assertNull(cacheA.put(1, "v1"));
       assertEquals("v1", cacheA.get(1));

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/xsite/SiteManualSwitchTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/xsite/SiteManualSwitchTest.java
@@ -38,8 +38,8 @@ public class SiteManualSwitchTest extends AbstractHotRodSiteFailoverTest {
       clientA = client(SITE_A, Optional.of(SITE_B));
       clientB = client(SITE_B, Optional.empty());
 
-      RemoteCache<Integer, String> cacheA = clientA.getCache();
-      RemoteCache<Integer, String> cacheB = clientB.getCache();
+      RemoteCache<Integer, String> cacheA = clientA.getCache(CACHE_NAME);
+      RemoteCache<Integer, String> cacheB = clientB.getCache(CACHE_NAME);
 
       assertNoHits();
       assertSingleSiteHit(SITE_A, SITE_B, () -> assertNull(cacheA.put(1, "v1")));
@@ -56,7 +56,6 @@ public class SiteManualSwitchTest extends AbstractHotRodSiteFailoverTest {
       assertSingleSiteHit(SITE_A, SITE_B, () -> assertEquals("v4", cacheA.get(4)));
    }
 
-   @Test(enabled = false)
    public void testManualClusterSwitchViaJMX() throws Exception {
       clientA = client(SITE_A, Optional.of(SITE_B));
       clientB = client(SITE_B, Optional.empty());
@@ -64,8 +63,8 @@ public class SiteManualSwitchTest extends AbstractHotRodSiteFailoverTest {
       MBeanServer mbeanServer = mBeanServerLookup.getMBeanServer();
       ObjectName objectName = remoteCacheManagerObjectName(clientA);
 
-      RemoteCache<Integer, String> cacheA = clientA.getCache();
-      RemoteCache<Integer, String> cacheB = clientB.getCache();
+      RemoteCache<Integer, String> cacheA = clientA.getCache(CACHE_NAME);
+      RemoteCache<Integer, String> cacheB = clientB.getCache(CACHE_NAME);
 
       assertNoHits();
 

--- a/commons/all/src/main/java/org/infinispan/commons/marshall/WrappedByteArray.java
+++ b/commons/all/src/main/java/org/infinispan/commons/marshall/WrappedByteArray.java
@@ -92,7 +92,7 @@ public class WrappedByteArray implements WrappedBytes {
 
    @Override
    public String toString() {
-      return "WrappedByteArray(" + Util.hexDump(bytes) + ')';
+      return "WrappedByteArray[" + Util.hexDump(bytes) + ']';
    }
 
    public static final class Externalizer extends AbstractExternalizer<WrappedByteArray> {

--- a/commons/all/src/main/java/org/infinispan/commons/marshall/WrappedByteArray.java
+++ b/commons/all/src/main/java/org/infinispan/commons/marshall/WrappedByteArray.java
@@ -92,10 +92,7 @@ public class WrappedByteArray implements WrappedBytes {
 
    @Override
    public String toString() {
-      return "WrappedByteArray{" +
-            "bytes=" + Util.hexDump(bytes) +
-            ", hashCode=" + hashCode() +
-            '}';
+      return "WrappedByteArray(" + Util.hexDump(bytes) + ')';
    }
 
    public static final class Externalizer extends AbstractExternalizer<WrappedByteArray> {

--- a/commons/all/src/main/java/org/infinispan/commons/util/Immutables.java
+++ b/commons/all/src/main/java/org/infinispan/commons/util/Immutables.java
@@ -65,6 +65,7 @@ public class Immutables {
       if (list == null) return null;
       if (list.isEmpty()) return Collections.emptyList();
       if (list.size() == 1) return Collections.singletonList(list.get(0));
+      if (list instanceof ImmutableListCopy) return list;
       return new ImmutableListCopy<>(list);
    }
 

--- a/commons/all/src/main/java/org/infinispan/commons/util/Util.java
+++ b/commons/all/src/main/java/org/infinispan/commons/util/Util.java
@@ -643,7 +643,7 @@ public final class Util {
       for (byte b : buffer) {
          addHexByte(sb, b);
       }
-      if (buffer.length <= actualLength) {
+      if (buffer.length < actualLength) {
          sb.append("...");
       }
       sb.append(" (").append(actualLength).append(" bytes)");

--- a/core/src/main/java/org/infinispan/interceptors/distribution/TriangleDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/TriangleDistributionInterceptor.java
@@ -448,7 +448,7 @@ public class TriangleDistributionInterceptor extends BaseDistributionInterceptor
          Collection<Address> backupOwners = distributionInfo.writeBackups();
          if (!dwCommand.isSuccessful() || backupOwners.isEmpty()) {
             if (log.isTraceEnabled()) {
-               log.tracef("Command %s not successful in primary owner.", id);
+               log.tracef("Not sending command %s to backups", id);
             }
             return rv;
          }

--- a/core/src/test/java/org/infinispan/xsite/AbstractXSiteTest.java
+++ b/core/src/test/java/org/infinispan/xsite/AbstractXSiteTest.java
@@ -117,9 +117,15 @@ public abstract class AbstractXSiteTest extends AbstractCacheTest {
 
    protected abstract void createSites();
 
-   protected TestSite createSite(String siteName, int numNodes, GlobalConfigurationBuilder gcb, ConfigurationBuilder defaultCacheConfig) {
+   protected TestSite createSite(String siteName, int numNodes, GlobalConfigurationBuilder gcb,
+                                 ConfigurationBuilder cb) {
+      return createSite(siteName, numNodes, gcb, null, cb);
+   }
+
+   protected TestSite createSite(String siteName, int numNodes, GlobalConfigurationBuilder gcb,
+                                 String cacheName, ConfigurationBuilder cb) {
       TestSite testSite = addSite(siteName);
-      testSite.createClusteredCaches(numNodes, null, gcb, defaultCacheConfig);
+      testSite.createClusteredCaches(numNodes, cacheName, gcb, cb);
       return testSite;
    }
 
@@ -307,7 +313,13 @@ public abstract class AbstractXSiteTest extends AbstractCacheTest {
          builder.read(cacheTemplate.build());
          decorateCacheConfiguration(builder, siteIndex, i);
 
-         EmbeddedCacheManager cm = addClusterEnabledCacheManager(flags, gcb, builder);
+
+         ConfigurationBuilder defaultBuilder = cacheName == null ? builder : null;
+         EmbeddedCacheManager cm = addClusterEnabledCacheManager(flags, gcb, defaultBuilder);
+         if (cacheName != null) {
+            cm.defineConfiguration(cacheName, builder.build());
+            cm.getCache(cacheName);
+         }
          if (waitForCluster) {
             waitForClusterToForm(cacheName);
          }

--- a/core/src/test/java/org/infinispan/xsite/BackupWithSecurityTest.java
+++ b/core/src/test/java/org/infinispan/xsite/BackupWithSecurityTest.java
@@ -56,8 +56,11 @@ public class BackupWithSecurityTest extends AbstractMultipleSitesTest {
    }
 
    @Override
-   protected TestSite createSite(String siteName, int numNodes, GlobalConfigurationBuilder gcb, ConfigurationBuilder defaultCacheConfig) {
-      return Security.doAs(ADMIN, (PrivilegedAction<TestSite>) () -> BackupWithSecurityTest.super.createSite(siteName, numNodes, gcb, defaultCacheConfig));
+   protected TestSite createSite(String siteName, int numNodes, GlobalConfigurationBuilder gcb, String cacheName,
+                                 ConfigurationBuilder cb) {
+      return Security.doAs(ADMIN, (PrivilegedAction<TestSite>) () -> {
+         return BackupWithSecurityTest.super.createSite(siteName, numNodes, gcb, cacheName, cb);
+      });
    }
 
    @Override

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/internal/RemoteStoreBlockHoundIntegration.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/internal/RemoteStoreBlockHoundIntegration.java
@@ -1,5 +1,7 @@
 package org.infinispan.persistence.remote.internal;
 
+import org.infinispan.client.hotrod.impl.transport.netty.ChannelFactory;
+import org.infinispan.commons.internal.CommonsBlockHoundIntegration;
 import org.kohsuke.MetaInfServices;
 
 import reactor.blockhound.BlockHound;
@@ -12,5 +14,6 @@ public class RemoteStoreBlockHoundIntegration implements BlockHoundIntegration {
       // TODO: this needs to be moved to the client hotrod module when it adds BlockHound
       // https://issues.redhat.com/browse/ISPN-12180
       builder.allowBlockingCallsInside("org.infinispan.client.hotrod.impl.transport.netty.ChannelInitializer", "initSsl");
+      CommonsBlockHoundIntegration.allowPublicMethodsToBlock(builder, ChannelFactory.class);
    }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-13264
https://issues.redhat.com/browse/ISPN-13220

* Keep track of failed servers in ChannelFactory
  A server is failed if it has no connected channels
  and the last connection attempt failed
* When a new connection fails, check the status of the initial servers
* If all initial servers are down, try to switch to another cluster
* If not, but some caches have no live servers, reset those caches to
  the initial server list
* Retried operations wait for the cluster switch to finish
* Manual cluster switch overrides any running automatic switch
* Reject server topologies with an old topology age
* Update the request topology age only after updating the topology age
  to check for all the caches

