### PR TITLE
ISPN-13343 The test Hot Rod client in the server module is slow

### DIFF
--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodConcurrentStartTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodConcurrentStartTest.java
@@ -77,7 +77,7 @@ public class HotRodConcurrentStartTest extends MultipleCacheManagersTest {
          }
 
          try (HotRodClient client = new HotRodClient(servers.get(0).getHost(), servers.get(0).getPort(),
-                                                     CACHE_NAME, 10, HotRodConstants.VERSION_30)) {
+                                                     CACHE_NAME, HotRodConstants.VERSION_30)) {
             client.assertPut(m);
          }
       } finally {

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodConcurrentTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodConcurrentTest.java
@@ -7,8 +7,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.Future;
 
-import org.infinispan.server.hotrod.test.HotRodClient;
 import org.infinispan.commons.test.TestResourceTracker;
+import org.infinispan.server.hotrod.test.HotRodClient;
 import org.testng.annotations.Test;
 
 /**
@@ -61,7 +61,7 @@ public class HotRodConcurrentTest extends HotRodSingleNodeTest {
          this.numOpsPerClient = numOpsPerClient;
       }
 
-      private HotRodClient client = new HotRodClient("127.0.0.1", server().getPort(), cacheName, 60, (byte) 20);
+      private HotRodClient client = new HotRodClient("127.0.0.1", server().getPort(), cacheName, (byte) 20);
 
       @Override
       public Void call() throws Exception {

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodDistributionTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodDistributionTest.java
@@ -90,7 +90,7 @@ public class HotRodDistributionTest extends HotRodMultiNodeTest {
       assertSuccess(client2.get(k(m), 0), v(m, "v5-"));
 
       HotRodServer newServer = startClusteredServer(servers().get(1).getPort() + 25);
-      HotRodClient newClient = new HotRodClient("127.0.0.1", newServer.getPort(), cacheName(), 60, protocolVersion());
+      HotRodClient newClient = new HotRodClient("127.0.0.1", newServer.getPort(), cacheName(), protocolVersion());
       List<HotRodServer> allServers =
             Stream.concat(Stream.of(newServer), servers().stream()).collect(Collectors.toList());
       try {

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodIdleTimeoutTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodIdleTimeoutTest.java
@@ -1,17 +1,18 @@
 package org.infinispan.server.hotrod;
 
+import static org.infinispan.commons.test.Exceptions.expectException;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.k;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.killClient;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.serverPort;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.startHotRodServer;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.v;
-import static org.testng.AssertJUnit.assertNull;
 
 import java.lang.reflect.Method;
+import java.nio.channels.ClosedChannelException;
+import java.util.concurrent.CompletionException;
 
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.server.hotrod.test.HotRodClient;
-import org.infinispan.server.hotrod.test.TestErrorResponse;
 import org.testng.annotations.Test;
 
 /**
@@ -22,24 +23,28 @@ import org.testng.annotations.Test;
  */
 @Test(groups = "functional", testName = "server.hotrod.HotRodIdleTimeoutTest")
 public class HotRodIdleTimeoutTest extends HotRodSingleNodeTest {
+   public static final int IDLE_TIMEOUT = 1;
 
    @Override
    protected HotRodServer createStartHotRodServer(EmbeddedCacheManager cacheManager) {
-      return startHotRodServer(cacheManager, serverPort(), 5);
+      return startHotRodServer(cacheManager, serverPort(), IDLE_TIMEOUT);
    }
 
    @Override
    protected HotRodClient connectClient() {
-      return new HotRodClient("127.0.0.1", server().getPort(), cacheName, 10, (byte) 20);
+      return new HotRodClient("127.0.0.1", server().getPort(), cacheName, (byte) 20);
    }
 
    public void testSendPartialRequest(Method m) {
       client().assertPut(m);
-      TestErrorResponse resp = client().executePartial(0xA0, (byte) 0x03, cacheName, k(m), 0, 0, v(m), 0);
-      assertNull(resp); // No response received within expected timeout.
+      expectException(CompletionException.class, ClosedChannelException.class,
+                      () -> client().executePartial(0xA0, (byte) 0x03, cacheName, k(m), 0, 0, v(m), 0));
+
+      // The connection cannot be used to send another request
       client().assertPutFail(m);
       shutdownClient();
 
+      // But another connection will work
       HotRodClient newClient = connectClient();
       try {
          newClient.assertPut(m);

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodMergeTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodMergeTest.java
@@ -63,7 +63,7 @@ public class HotRodMergeTest extends BasePartitionHandlingTest {
          nextServerPort += 1;
       }
 
-      client = new HotRodClient("127.0.0.1", servers.get(0).getPort(), getDefaultCacheName(), 60, (byte) 21);
+      client = new HotRodClient("127.0.0.1", servers.get(0).getPort(), getDefaultCacheName(), (byte) 21);
    }
 
    @AfterClass(alwaysRun = true)

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodMultiNodeTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodMultiNodeTest.java
@@ -80,7 +80,7 @@ public abstract class HotRodMultiNodeTest extends MultipleCacheManagersTest {
    }
 
    protected HotRodClient createClient(HotRodServer server, String cacheName, String address) {
-      return new HotRodClient(address, server.getPort(), cacheName, 60, protocolVersion());
+      return new HotRodClient(address, server.getPort(), cacheName, protocolVersion());
    }
 
    protected HotRodServer startTestHotRodServer(EmbeddedCacheManager cacheManager, int port) {

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodNoDefaultCacheTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodNoDefaultCacheTest.java
@@ -38,7 +38,7 @@ public class HotRodNoDefaultCacheTest extends SingleCacheManagerTest {
       // super() creates the default cache and we do not want that
       cacheManager = createCacheManager();
       server = startHotRodServer(cacheManager, (String)null);
-      client = new HotRodClient("127.0.0.1", server.getPort(), "", 60, HotRodVersion.HOTROD_21.getVersion());
+      client = new HotRodClient("127.0.0.1", server.getPort(), "", HotRodVersion.HOTROD_21.getVersion());
    }
 
    @Override

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodSharedContainerTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodSharedContainerTest.java
@@ -57,9 +57,9 @@ public class HotRodSharedContainerTest extends MultipleCacheManagersTest {
       hotRodServer2 =
             startHotRodServer(cacheManagers.get(0), basePort + 50, new HotRodServerConfigurationBuilder().name("2"));
 
-      hotRodClient1 = new HotRodClient("127.0.0.1", hotRodServer1.getPort(), cacheName, 60, (byte) 20);
+      hotRodClient1 = new HotRodClient("127.0.0.1", hotRodServer1.getPort(), cacheName, (byte) 20);
 
-      hotRodClient2 = new HotRodClient("127.0.0.1", hotRodServer2.getPort(), cacheName, 60, (byte) 20);
+      hotRodClient2 = new HotRodClient("127.0.0.1", hotRodServer2.getPort(), cacheName, (byte) 20);
       hotRodClient1.put(k(m), 0, 0, v(m));
       assertSuccess(hotRodClient2.get(k(m), 0), v(m));
    }

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodSingleClusteredNonLoopbackTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodSingleClusteredNonLoopbackTest.java
@@ -56,7 +56,7 @@ public class HotRodSingleClusteredNonLoopbackTest extends MultipleCacheManagersT
       NetworkInterface iface = nonLoopInterfaces.iterator().next();
       String address = iface.getInetAddresses().nextElement().getHostAddress();
       hotRodServer = startHotRodServer(cacheManagers.get(0), address, serverPort(), getDefaultHotRodConfiguration());
-      hotRodClient = new HotRodClient(address, hotRodServer.getPort(), cacheName, 60, (byte) 20);
+      hotRodClient = new HotRodClient(address, hotRodServer.getPort(), cacheName, (byte) 20);
    }
 
    @AfterClass(alwaysRun = true)

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodSingleClusteredTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodSingleClusteredTest.java
@@ -51,7 +51,7 @@ public class HotRodSingleClusteredTest extends MultipleCacheManagersTest {
    public void createBeforeClass() throws Throwable {
       super.createBeforeClass();
       hotRodServer = startHotRodServer(cacheManagers.get(0));
-      hotRodClient = new HotRodClient("127.0.0.1", hotRodServer.getPort(), cacheName, 60, (byte) 20);
+      hotRodClient = new HotRodClient("127.0.0.1", hotRodServer.getPort(), cacheName, (byte) 20);
    }
 
    @AfterClass(alwaysRun = true)

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodSingleNodeTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodSingleNodeTest.java
@@ -87,6 +87,6 @@ public abstract class HotRodSingleNodeTest extends SingleCacheManagerTest {
    }
 
    protected HotRodClient connectClient(byte protocolVersion) {
-      return new HotRodClient("127.0.0.1", hotRodServer.getPort(), cacheName, 60, protocolVersion);
+      return new HotRodClient("127.0.0.1", hotRodServer.getPort(), cacheName, protocolVersion);
    }
 }

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodSniFunctionalTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodSniFunctionalTest.java
@@ -167,7 +167,8 @@ public class HotRodSniFunctionalTest extends HotRodSingleNodeTest {
       }
 
       public HotRodClient build() {
-         return new HotRodClient("127.0.0.1", hotRodServer.getPort(), cacheName, 60, (byte) 20, sslEngine);
+         return new HotRodClient(hotRodServer.getHost(), hotRodServer.getPort(), cacheName,
+                                 HotRodClient.DEFAULT_TIMEOUT_SECONDS, (byte) 20, sslEngine);
       }
    }
 

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodSslFunctionalTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodSslFunctionalTest.java
@@ -52,6 +52,7 @@ public class HotRodSslFunctionalTest extends HotRodFunctionalTest {
             .trustStoreType("pkcs12")
             .getContext();
       SSLEngine sslEngine = SslContextFactory.getEngine(sslContext, true, false);
-      return new HotRodClient(host(), hotRodServer.getPort(), cacheName, 60, protocolVersion, sslEngine);
+      return new HotRodClient(hotRodServer.getHost(), hotRodServer.getPort(), cacheName,
+                              HotRodClient.DEFAULT_TIMEOUT_SECONDS, protocolVersion, sslEngine);
    }
 }

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/counter/impl/TestCounterManager.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/counter/impl/TestCounterManager.java
@@ -73,8 +73,7 @@ public class TestCounterManager implements CounterManager {
    @Override
    public boolean defineCounter(String name, CounterConfiguration configuration) {
       CreateCounterOp op = new CreateCounterOp(client.protocolVersion(), name, configuration);
-      client.writeOp(op);
-      TestResponse response = client.getResponse(op);
+      TestResponse response = client.execute(op);
       return response.getStatus() == Success;
    }
 
@@ -85,16 +84,14 @@ public class TestCounterManager implements CounterManager {
    @Override
    public boolean isDefined(String name) {
       CounterOp op = new CounterOp(client.protocolVersion(), COUNTER_IS_DEFINED, name);
-      client.writeOp(op);
-      TestResponse response = client.getResponse(op);
+      TestResponse response = client.execute(op);
       return response.getStatus() == Success;
    }
 
    @Override
    public CounterConfiguration getConfiguration(String counterName) {
       CounterOp op = new CounterOp(client.protocolVersion(), COUNTER_GET_CONFIGURATION, counterName);
-      client.writeOp(op);
-      TestResponse response = client.getResponse(op);
+      TestResponse response = client.execute(op);
       return response.getStatus() == Success ?
              ((CounterConfigurationTestResponse) response).getConfiguration() :
              null;
@@ -103,15 +100,13 @@ public class TestCounterManager implements CounterManager {
    @Override
    public void remove(String counterName) {
       CounterOp op = new CounterOp(client.protocolVersion(), COUNTER_REMOVE, counterName);
-      client.writeOp(op);
-      client.getResponse(op);
+      client.execute(op);
    }
 
    public Collection<String> getCounterNames() {
       Op op = new Op(0xA0, client.protocolVersion(), (byte) COUNTER_GET_NAMES.getRequestOpCode(), "", null, 0, 0, null,
             0, 0, (byte) 0, 0);
-      client.writeOp(op);
-      CounterNamesTestResponse response = (CounterNamesTestResponse) client.getResponse(op);
+      CounterNamesTestResponse response = client.execute(op);
       return response.getCounterNames();
    }
 }

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/counter/impl/TestCounterNotificationManager.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/counter/impl/TestCounterNotificationManager.java
@@ -61,8 +61,7 @@ public class TestCounterNotificationManager {
    private List<UserListener<?>> add(String counterName, List<UserListener<?>> list, UserListener<?> listener) {
       if (list == null) {
          CounterListenerOp op = createListener(client.protocolVersion(), counterName, listenerId.getBytes());
-         client.writeOp(op);
-         TestResponse response = client.getResponse(op);
+         TestResponse response = client.execute(op);
          switch (response.getStatus()) {
             case Success:
                break;
@@ -84,8 +83,7 @@ public class TestCounterNotificationManager {
          list.remove(listener);
          if (list.isEmpty()) {
             CounterListenerOp op = removeListener(client.protocolVersion(), counterName, listenerId.getBytes());
-            client.writeOp(op);
-            TestResponse response = client.getResponse(op);
+            TestResponse response = client.execute(op);
             switch (response.getStatus()) {
                case Success:
                   break;

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/counter/impl/TestStrongCounter.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/counter/impl/TestStrongCounter.java
@@ -91,8 +91,7 @@ class TestStrongCounter implements StrongCounter {
    @Override
    public CompletableFuture<Void> remove() {
       CounterOp op = new CounterOp(client.protocolVersion(), COUNTER_REMOVE, name);
-      client.writeOp(op);
-      client.getResponse(op);
+      client.execute(op);
       return CompletableFutures.completedNull();
    }
 
@@ -111,8 +110,7 @@ class TestStrongCounter implements StrongCounter {
 
    private <T> CompletableFuture<T> executeOp(CounterOp op,
          BiConsumer<CompletableFuture<T>, TestResponse> responseHandler, BooleanSupplier canReachUpperBound) {
-      client.writeOp(op);
-      TestResponse response = client.getResponse(op);
+      TestResponse response = client.execute(op);
       CompletableFuture<T> future = new CompletableFuture<>();
       switch (response.getStatus()) {
          case Success:

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/counter/impl/TestWeakCounter.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/counter/impl/TestWeakCounter.java
@@ -49,8 +49,7 @@ class TestWeakCounter implements WeakCounter {
    @Override
    public long getValue() {
       CounterOp op = new CounterOp(client.protocolVersion(), COUNTER_GET, name);
-      client.writeOp(op);
-      TestResponse response = client.getResponse(op);
+      TestResponse response = client.execute(op);
       switch (response.getStatus()) {
          case Success:
             return ((CounterValueTestResponse) response).getValue();
@@ -86,8 +85,7 @@ class TestWeakCounter implements WeakCounter {
    @Override
    public CompletableFuture<Void> remove() {
       CounterOp op = new CounterOp(client.protocolVersion(), COUNTER_REMOVE, name);
-      client.writeOp(op);
-      client.getResponse(op);
+      client.execute(op);
       return CompletableFutures.completedNull();
    }
 
@@ -97,8 +95,7 @@ class TestWeakCounter implements WeakCounter {
    }
 
    private CompletableFuture<Void> executeOp(CounterOp op) {
-      client.writeOp(op);
-      TestResponse response = client.getResponse(op);
+      TestResponse response = client.execute(op);
       CompletableFuture<Void> future = new CompletableFuture<>();
       switch (response.getStatus()) {
          case Success:

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/event/AbstractHotRodClusterEventsTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/event/AbstractHotRodClusterEventsTest.java
@@ -142,7 +142,7 @@ public abstract class AbstractHotRodClusterEventsTest extends HotRodMultiNodeTes
    public void testClientDisconnectListenerCleanup(Method m) throws InterruptedException {
       HotRodClient client1 = clients().get(0);
       HotRodClient
-            newClient = new HotRodClient("127.0.0.1", servers().get(1).getPort(), cacheName(), 60, protocolVersion());
+            newClient = new HotRodClient("127.0.0.1", servers().get(1).getPort(), cacheName(), protocolVersion());
       EventLogListener listener = new EventLogListener();
       assertStatus(newClient.addClientListener(listener, false, Optional.empty(), Optional.empty(), true), Success);
       byte[] key = k(m);
@@ -168,7 +168,7 @@ public abstract class AbstractHotRodClusterEventsTest extends HotRodMultiNodeTes
          client2.remove(key);
          listener1.expectOnlyRemovedEvent(anyCache(), key);
          HotRodServer newServer = startClusteredServer(servers().get(2).getPort() + 50);
-         HotRodClient client4 = new HotRodClient("127.0.0.1", newServer.getPort(), cacheName(), 60, protocolVersion());
+         HotRodClient client4 = new HotRodClient("127.0.0.1", newServer.getPort(), cacheName(), protocolVersion());
          try {
             withClientListener(client4, listener2, Optional.empty(), Optional.empty(), false, true, () -> {
                byte[] newKey = k(m, "k2-");

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/test/HotRodTestingUtil.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/test/HotRodTestingUtil.java
@@ -199,9 +199,7 @@ public class HotRodTestingUtil {
    }
 
    public static byte[] k(Method m, String prefix) {
-      byte[] bytes = (prefix + m.getName()).getBytes();
-      log.tracef("String %s is converted to %s bytes", prefix + m.getName(), Util.printArray(bytes, true));
-      return bytes;
+      return (prefix + m.getName()).getBytes();
    }
 
    public static byte[] v(Method m, String prefix) {

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/tx/ServerConfigurationTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/tx/ServerConfigurationTest.java
@@ -148,7 +148,7 @@ public class ServerConfigurationTest extends HotRodMultiNodeTest {
    }
 
    private HotRodClient createClient(String cacheName) {
-      return new HotRodClient("127.0.0.1", servers().get(0).getPort(), cacheName, 60, protocolVersion());
+      return new HotRodClient("127.0.0.1", servers().get(0).getPort(), cacheName, protocolVersion());
    }
 
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-13343

* Use CompletableFuture to receive responses without sleep(100)
* Verify the expiration metadata directly instead of
  waiting for expiration
* Remove trace logging of generated test keys
* Wait for server to close connection in HotRodIdleTimeoutTest,
  instead of waiting for a response that will never arrive