### PR TITLE
ISPN-13387 SoftIndexFileStoreParallelIterationTest.testParallelIterat…

### DIFF
--- a/core/src/test/java/org/infinispan/persistence/AsyncStoreParallelIterationTest.java
+++ b/core/src/test/java/org/infinispan/persistence/AsyncStoreParallelIterationTest.java
@@ -27,7 +27,7 @@ public class AsyncStoreParallelIterationTest extends ParallelIterationTest {
    }
 
    @Override
-   protected void assertMetadataEmpty(Metadata metadata) {
+   protected void assertMetadataEmpty(Metadata metadata, Object key) {
       // Async store always returns the metadata
    }
 }

--- a/core/src/test/java/org/infinispan/persistence/DummyStoreParallelIterationTest.java
+++ b/core/src/test/java/org/infinispan/persistence/DummyStoreParallelIterationTest.java
@@ -18,7 +18,7 @@ public class DummyStoreParallelIterationTest extends ParallelIterationTest {
    }
 
    @Override
-   protected void assertMetadataEmpty(Metadata metadata) {
+   protected void assertMetadataEmpty(Metadata metadata, Object key) {
       // Do nothing for now as keys require metadata - this can be fixed later
    }
 }

--- a/core/src/test/java/org/infinispan/persistence/ParallelIterationTest.java
+++ b/core/src/test/java/org/infinispan/persistence/ParallelIterationTest.java
@@ -151,7 +151,7 @@ public abstract class ParallelIterationTest extends SingleCacheManagerTest {
             assertEquals(metadata.get(i).lifespan(), lifespan(i), "For key " + i);
             assertEquals(metadata.get(i).maxIdle(), maxIdle(i), "For key " + i);
          } else {
-            assertMetadataEmpty(metadata.get(i));
+            assertMetadataEmpty(metadata.get(i), i);
          }
       }
    }
@@ -165,8 +165,8 @@ public abstract class ParallelIterationTest extends SingleCacheManagerTest {
       }
    }
 
-   protected void assertMetadataEmpty(Metadata metadata) {
-      assertNull(metadata);
+   protected void assertMetadataEmpty(Metadata metadata, Object key) {
+      assertNull(metadata, "For key " + key);
    }
 
    protected boolean insertMetadata(int i) {

--- a/core/src/test/java/org/infinispan/persistence/SoftIndexFileStoreParallelIterationTest.java
+++ b/core/src/test/java/org/infinispan/persistence/SoftIndexFileStoreParallelIterationTest.java
@@ -3,6 +3,7 @@ package org.infinispan.persistence;
 import org.infinispan.commons.test.CommonsTestingUtil;
 import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.metadata.Metadata;
 import org.testng.annotations.Test;
 
 /**
@@ -34,5 +35,11 @@ public class SoftIndexFileStoreParallelIterationTest extends ParallelIterationTe
    @Override
    protected boolean hasMetadata(boolean fetchValues, int i) {
       return fetchValues && super.hasMetadata(fetchValues, i);
+   }
+
+   @Override
+   protected void assertMetadataEmpty(Metadata metadata, Object key) {
+      // SoftIndexFileStore may return metadata even when not requested as it may already be in memory and there is
+      // no real reason to skip it
    }
 }


### PR DESCRIPTION
…ionWithoutValue random failures

* SIFS may return value or metadata even when not requested if
  initialized

https://issues.redhat.com/browse/ISPN-13387