### PR TITLE
ISPN-13392 Fix Tomcat integration test setup

### DIFF
--- a/build-configuration/pom.xml
+++ b/build-configuration/pom.xml
@@ -222,6 +222,7 @@
       <version.org.jboss.galleon>4.2.8.Final</version.org.jboss.galleon>
       <version.org.wildfly.galleon-plugins>5.2.1.Final</version.org.wildfly.galleon-plugins>
       <version.owasp-dependency-check-plugin>6.1.0</version.owasp-dependency-check-plugin>
+      <version.weld-servlet>2.4.8.Final</version.weld-servlet>
 
       <!-- versionx -->
       <versionx.com.puppycrawl.tools.checkstyle>8.32</versionx.com.puppycrawl.tools.checkstyle>

--- a/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/store/AbstractInfinispanStoreRocksDBIT.java
+++ b/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/store/AbstractInfinispanStoreRocksDBIT.java
@@ -37,7 +37,7 @@ public abstract class AbstractInfinispanStoreRocksDBIT {
    @OperateOnDeployment("dep1")
    @InSequence(2)
    public void testRunningInDep1() {
-      DefaultCacheManager cm = getOrCreateCacheManager(1);
+      DefaultCacheManager cm = createCacheManager(1);
       Cache<String, String> cache = cm.getCache();
       cache.put("dep1", "dep1");
    }
@@ -52,7 +52,7 @@ public abstract class AbstractInfinispanStoreRocksDBIT {
    @OperateOnDeployment("dep2")
    @InSequence(4)
    public void testRunningInDep2() {
-      DefaultCacheManager cm = getOrCreateCacheManager(2);
+      DefaultCacheManager cm = createCacheManager(2);
       Cache<String, String> cache = cm.getCache();
       assertEquals("dep1", cache.get("dep1"));
    }
@@ -64,7 +64,7 @@ public abstract class AbstractInfinispanStoreRocksDBIT {
       deployer.undeploy("dep2");
    }
 
-   protected DefaultCacheManager getOrCreateCacheManager(int index) {
+   protected DefaultCacheManager createCacheManager(int index) {
       String baseDir = CommonsTestingUtil.tmpDirectory(this.getClass().getSimpleName(), "server-" + index);
       String dataDir = baseDir + separator + "data";
       String expiredDir = baseDir + separator + "expired";

--- a/integrationtests/server-integration/third-party-server/pom.xml
+++ b/integrationtests/server-integration/third-party-server/pom.xml
@@ -139,7 +139,7 @@
             </activation>
             <properties>
                 <infinispan.server.integration.launch>tomcat</infinispan.server.integration.launch>
-                <baseCatalinaHome>${project.build.directory}/tomcat</baseCatalinaHome>
+                <catalinaHome>${project.build.directory}/tomcat</catalinaHome>
                 <catalinaHome1>${project.build.directory}/tomcat1</catalinaHome1>
                 <catalinaHome2>${project.build.directory}/tomcat2</catalinaHome2>
                 <catalinaBindHttpPort1>8080</catalinaBindHttpPort1>
@@ -156,6 +156,11 @@
                     <artifactId>arquillian-tomcat-managed-8</artifactId>
                     <version>${version.arquillian-tomcat-managed}</version>
                     <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.weld.servlet</groupId>
+                    <artifactId>weld-servlet</artifactId>
+                    <version>${version.weld-servlet}</version>
                 </dependency>
             </dependencies>
             <build>
@@ -174,29 +179,23 @@
                                 </goals>
                                 <configuration>
                                     <target>
-                                        <echo message="unzipping tomcat server" />
-                                        <unzip src="${tomcat.zip}" dest="${baseCatalinaHome}" />
-                                        <pathconvert property="tomcat.unzip.dir">
-                                            <dirset dir="${baseCatalinaHome}" includes="${catalinaUnzipExpression}"/>
-                                        </pathconvert>
-                                        <move todir="${baseCatalinaHome}">
-                                            <fileset dir="${tomcat.unzip.dir}"/>
-                                        </move>
-
-                                        <echo message="copying tomcat server" />
+                                        <echo message="Copying tomcat server" />
                                         <delete dir="${catalinaHome1}" />
                                         <delete dir="${catalinaHome2}" />
-                                        <copydir src="${baseCatalinaHome}" dest="${catalinaHome1}" />
-                                        <copydir src="${baseCatalinaHome}" dest="${catalinaHome2}" />
-                                        <delete dir="${baseCatalinaHome}" />
+                                        <copy todir="${catalinaHome1}">
+                                            <fileset dir="${catalinaHome}"/>
+                                        </copy>
+                                        <copy todir="${catalinaHome2}">
+                                            <fileset dir="${catalinaHome}"/>
+                                        </copy>
 
-                                        <echo message="copying configurations" />
+                                        <echo message="Copying configurations" />
                                         <copy file="${basedir}/src/test/resources/tomcat/tomcat-users.xml" todir="${catalinaHome1}/conf" overwrite="true" />
                                         <copy file="${basedir}/src/test/resources/tomcat/context.xml" todir="${catalinaHome1}/conf" overwrite="true" />
                                         <copy file="${basedir}/src/test/resources/tomcat/tomcat-users.xml" todir="${catalinaHome2}/conf" overwrite="true" />
                                         <copy file="${basedir}/src/test/resources/tomcat/context.xml" todir="${catalinaHome2}/conf" overwrite="true" />
 
-                                        <echo message="replace configurations" />
+                                        <echo message="Replace configurations" />
                                         <replaceregexp file="${catalinaHome1}/conf/server.xml" match="port=&quot;8080&quot;" replace="port=&quot;${catalinaBindHttpPort1}&quot;" byline="true"/>
                                         <replaceregexp file="${catalinaHome1}/conf/server.xml" match="port=&quot;8005&quot;" replace="port=&quot;8005&quot;" byline="true"/>
                                         <replaceregexp file="${catalinaHome2}/conf/server.xml" match="port=&quot;8080&quot;" replace="port=&quot;${catalinaBindHttpPort2}&quot;" byline="true"/>

--- a/integrationtests/server-integration/third-party-server/src/test/java/org/infinispan/test/integration/thirdparty/DeploymentHelper.java
+++ b/integrationtests/server-integration/third-party-server/src/test/java/org/infinispan/test/integration/thirdparty/DeploymentHelper.java
@@ -1,5 +1,7 @@
 package org.infinispan.test.integration.thirdparty;
 
+import static org.infinispan.test.integration.GenericDeploymentHelper.addLibrary;
+
 import java.io.File;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -11,9 +13,7 @@ public class DeploymentHelper {
    private static final String ARQUILLIAN_LAUNCH = System.getProperty("arquillian.launch");
 
    public static WebArchive createDeployment() {
-
       WebArchive war = ShrinkWrap.create(WebArchive.class, "infinispan-server-integration.war");
-
       if (isTomcat()) {
          tomcat(war);
       } else if (isWildfly()) {
@@ -21,7 +21,6 @@ public class DeploymentHelper {
       } else {
          throw new IllegalStateException(String.format("'%s' not supported", ARQUILLIAN_LAUNCH));
       }
-
       return war;
    }
 
@@ -38,6 +37,7 @@ public class DeploymentHelper {
    }
 
    private static void tomcat(WebArchive war) {
-      // intentionally empty. if you need to implement a custom deploy the code is 'ready'
+      // required for cdi
+      addLibrary(war, "org.jboss.weld.servlet:weld-servlet");
    }
 }

--- a/integrationtests/server-integration/third-party-server/src/test/resources/arquillian.xml
+++ b/integrationtests/server-integration/third-party-server/src/test/resources/arquillian.xml
@@ -14,7 +14,7 @@
                 <property name="jmxPort">${catalinaJmxPort1}</property>
                 <!--
                 <property name="javaVmArguments">
-                    -agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=y
+                    -agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=y,timeout=600000
                 </property>
                 -->
                 <property name="javaVmArguments">
@@ -32,7 +32,7 @@
                 <property name="jmxPort">${catalinaJmxPort2}</property>
                 <!--
                 <property name="javaVmArguments">
-                    -agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=y
+                    -agentlib:jdwp=transport=dt_socket,address=9787,server=y,suspend=y,timeout=600000
                 </property>
                 -->
                 <property name="javaVmArguments">

--- a/persistence/rocksdb/src/main/java/org/infinispan/persistence/rocksdb/RocksDBStore.java
+++ b/persistence/rocksdb/src/main/java/org/infinispan/persistence/rocksdb/RocksDBStore.java
@@ -286,7 +286,10 @@ public class RocksDBStore<K, V> implements NonBlockingStore<K, V> {
    @Override
    public CompletionStage<Void> stop() {
       return blockingManager.runBlocking(() -> {
-         handler.close();
+         // it could be null if an issue occurs during the initialization
+         if (handler != null) {
+            handler.close();
+         }
       }, "rocksdb-stop");
    }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-13392

- During the rebase of 32615d12727c1865bcce39fa5169bf62d8169ec3, for some reason, the code that uses a zip file instead of a folder was added back
- 4b831656a766644455d39a5f2bc1c785c426031c fixes CDI tests but there is no integration tests running upstream for Tomcat. Weld dependency was added to fix it.
- Fix NPE in RocksDB. The hanlder could be null if an issue occurs during the initialization