### PR TITLE
ISPN-12607 Only compute the accurate size when enabled

### DIFF
--- a/client/infinispan-key-value-store-hotrod/src/main/java/org/infinispan/api/reactive/client/impl/KeyValueStoreImpl.java
+++ b/client/infinispan-key-value-store-hotrod/src/main/java/org/infinispan/api/reactive/client/impl/KeyValueStoreImpl.java
@@ -1,9 +1,7 @@
 package org.infinispan.api.reactive.client.impl;
 
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ForkJoinPool;
 
 import org.infinispan.api.client.listener.ClientKeyValueStoreListener;
 import org.infinispan.api.reactive.KeyValueEntry;
@@ -92,8 +90,7 @@ public class KeyValueStoreImpl<K, V> implements KeyValueStore<K, V> {
 
    @Override
    public CompletionStage<Long> estimateSize() {
-      // TODO: this should be replaced with cache.sizeAsync when https://issues.jboss.org/browse/ISPN-10802 is complete
-      return CompletableFuture.supplyAsync(() -> Long.valueOf(cache.size()), ForkJoinPool.commonPool());
+      return cache.sizeAsync();
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/stats/Stats.java
+++ b/core/src/main/java/org/infinispan/stats/Stats.java
@@ -38,7 +38,9 @@ public interface Stats extends JsonSerialization {
 
    /**
     * Number of entries stored in cache since the cache started running.
+    * @deprecated Since 13.0, please use {@link #getStores()} instead
     */
+   @Deprecated
    long getTotalNumberOfEntries();
 
    /**

--- a/core/src/main/java/org/infinispan/stats/impl/AbstractClusterStats.java
+++ b/core/src/main/java/org/infinispan/stats/impl/AbstractClusterStats.java
@@ -124,7 +124,7 @@ public abstract class AbstractClusterStats implements JmxStatisticsExposer {
       }
    }
 
-   private long addLongAttributes(Collection<Map<String, Number>> responseList, String attribute) {
+   long addLongAttributes(Collection<Map<String, Number>> responseList, String attribute) {
       long total = 0;
       for (Map<String, Number> m : responseList) {
          Number value = m.get(attribute);

--- a/core/src/main/java/org/infinispan/stats/impl/AbstractClusterStats.java
+++ b/core/src/main/java/org/infinispan/stats/impl/AbstractClusterStats.java
@@ -112,7 +112,7 @@ public abstract class AbstractClusterStats implements JmxStatisticsExposer {
 
    synchronized void fetchClusterWideStatsIfNeeded() {
       long duration = timeService.timeDuration(statsUpdateTimestamp, timeService.time(), TimeUnit.MILLISECONDS);
-      if (duration > DEFAULT_STALE_STATS_THRESHOLD) {
+      if (duration > staleStatsThreshold) {
          try {
             updateStats();
          } catch (Exception e) {

--- a/core/src/main/java/org/infinispan/stats/impl/CacheContainerStatsImpl.java
+++ b/core/src/main/java/org/infinispan/stats/impl/CacheContainerStatsImpl.java
@@ -563,6 +563,7 @@ public class CacheContainerStatsImpl implements CacheContainerStats, JmxStatisti
       return getNumberOfEntries();
    }
 
+   @Deprecated
    @Override
    public long getTotalNumberOfEntries() {
       return getStores();

--- a/core/src/main/java/org/infinispan/stats/impl/ClusterCacheStatsImpl.java
+++ b/core/src/main/java/org/infinispan/stats/impl/ClusterCacheStatsImpl.java
@@ -331,6 +331,7 @@ public class ClusterCacheStatsImpl extends AbstractClusterStats implements Clust
       return getNumberOfEntries();
    }
 
+   @Deprecated
    @Override
    public long getTotalNumberOfEntries() {
       return getStores();

--- a/core/src/main/java/org/infinispan/stats/impl/StatsCollector.java
+++ b/core/src/main/java/org/infinispan/stats/impl/StatsCollector.java
@@ -295,6 +295,7 @@ public final class StatsCollector implements Stats, JmxStatisticsExposer {
       return getNumberOfEntries();
    }
 
+   @Deprecated
    @Override
    public long getTotalNumberOfEntries() {
       return stores.longValue();

--- a/core/src/main/java/org/infinispan/stats/impl/StatsImpl.java
+++ b/core/src/main/java/org/infinispan/stats/impl/StatsImpl.java
@@ -169,6 +169,7 @@ public class StatsImpl implements Stats {
       return Math.toIntExact(statsMap.get(NUMBER_OF_ENTRIES_IN_MEMORY));
    }
 
+   @Deprecated
    @Override
    public long getTotalNumberOfEntries() {
       return statsMap.get(STORES);

--- a/core/src/test/java/org/infinispan/commands/module/TestGlobalConfigurationBuilder.java
+++ b/core/src/test/java/org/infinispan/commands/module/TestGlobalConfigurationBuilder.java
@@ -29,6 +29,10 @@ public class TestGlobalConfigurationBuilder implements Builder<TestGlobalConfigu
       return this;
    }
 
+   public TestGlobalConfigurationBuilder testGlobalComponent(Class<?> componentClass, Object instance) {
+      return testGlobalComponent(componentClass.getName(), instance);
+   }
+
    public TestGlobalConfigurationBuilder testCacheComponent(String cacheName, String componentName, Object instance) {
       this.attributes.attribute(TestGlobalConfiguration.CACHE_TEST_COMPONENTS).get()
                      .computeIfAbsent(cacheName, name -> new HashMap<>())

--- a/core/src/test/java/org/infinispan/jmx/AbstractClusterMBeanTest.java
+++ b/core/src/test/java/org/infinispan/jmx/AbstractClusterMBeanTest.java
@@ -47,6 +47,7 @@ abstract class AbstractClusterMBeanTest extends MultipleCacheManagersTest {
    private CacheContainer createManager(ConfigurationBuilder builder, String jmxDomain) {
       GlobalConfigurationBuilder gcb1 = GlobalConfigurationBuilder.defaultClusteredBuilder();
       gcb1.cacheContainer().statistics(true)
+          .metrics().accurateSize(true)
           .jmx().enabled(true).domain(jmxDomain)
           .mBeanServerLookup(mBeanServerLookup);
       gcb1.serialization().addContextInitializer(TestDataSCI.INSTANCE);

--- a/core/src/test/java/org/infinispan/jmx/AbstractClusterMBeanTest.java
+++ b/core/src/test/java/org/infinispan/jmx/AbstractClusterMBeanTest.java
@@ -1,18 +1,21 @@
 package org.infinispan.jmx;
 
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
+
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
+import org.infinispan.commands.module.TestGlobalConfigurationBuilder;
 import org.infinispan.commons.jmx.MBeanServerLookup;
 import org.infinispan.commons.jmx.TestMBeanServerLookup;
+import org.infinispan.commons.time.ControlledTimeService;
+import org.infinispan.commons.time.TimeService;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
-import org.infinispan.manager.CacheContainer;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestDataSCI;
-import org.infinispan.test.fwk.TestCacheManagerFactory;
-import org.infinispan.test.fwk.TransportFlags;
 
 /**
  * @author Ryan Emerson
@@ -23,6 +26,7 @@ abstract class AbstractClusterMBeanTest extends MultipleCacheManagersTest {
    final String jmxDomain1;
    final String jmxDomain2;
    final String jmxDomain3;
+   final ControlledTimeService timeService = new ControlledTimeService();
 
    protected final MBeanServerLookup mBeanServerLookup = TestMBeanServerLookup.create();
 
@@ -34,47 +38,44 @@ abstract class AbstractClusterMBeanTest extends MultipleCacheManagersTest {
 
    @Override
    protected void createCacheManagers() throws Throwable {
-      ConfigurationBuilder cb = new ConfigurationBuilder();
-      cb.clustering().cacheMode(CacheMode.REPL_SYNC).statistics().enable();
-      CacheContainer c1 = createManager(cb, jmxDomain1);
-      CacheContainer c2 = createManager(cb, jmxDomain2);
-      CacheContainer c3 = createManager(cb, jmxDomain3);
-      registerCacheManager(c1, c2, c3);
-      createCluster(TestDataSCI.INSTANCE, cb, 3);
+      createManager(jmxDomain1);
+      createManager(jmxDomain2);
+      createManager(jmxDomain3);
       waitForClusterToForm(getDefaultCacheName());
    }
 
-   private CacheContainer createManager(ConfigurationBuilder builder, String jmxDomain) {
-      GlobalConfigurationBuilder gcb1 = GlobalConfigurationBuilder.defaultClusteredBuilder();
-      gcb1.cacheContainer().statistics(true)
-          .metrics().accurateSize(true)
+   private void createManager(String jmxDomain) {
+      ConfigurationBuilder cb = new ConfigurationBuilder();
+      cb.clustering().cacheMode(CacheMode.REPL_SYNC).statistics().enable();
+
+      GlobalConfigurationBuilder gcb = GlobalConfigurationBuilder.defaultClusteredBuilder();
+      gcb.cacheContainer().statistics(true)
+         .metrics().accurateSize(true)
+         .metrics().accurateSize(true)
           .jmx().enabled(true).domain(jmxDomain)
-          .mBeanServerLookup(mBeanServerLookup);
-      gcb1.serialization().addContextInitializer(TestDataSCI.INSTANCE);
-      CacheContainer cacheManager = TestCacheManagerFactory.createClusteredCacheManager(gcb1, builder,
-            new TransportFlags());
-      cacheManager.start();
-      return cacheManager;
+         .mBeanServerLookup(mBeanServerLookup)
+         .serialization().addContextInitializer(TestDataSCI.INSTANCE);
+      gcb.addModule(TestGlobalConfigurationBuilder.class)
+         .testGlobalComponent(TimeService.class.getName(), timeService);
+
+      addClusterEnabledCacheManager(gcb, cb);
    }
 
    void assertAttributeValue(MBeanServer mBeanServer, ObjectName oName, String attrName, double expectedValue)
          throws Exception {
       String receivedVal = mBeanServer.getAttribute(oName, attrName).toString();
-      assert Double.parseDouble(receivedVal) == expectedValue : "expecting " + expectedValue + " for " + attrName
-            + ", but received " + receivedVal;
+      assertEquals(expectedValue, Double.parseDouble(receivedVal));
    }
 
    void assertAttributeValue(MBeanServer mBeanServer, ObjectName oName, String attrName, long expectedValue)
          throws Exception {
       String receivedVal = mBeanServer.getAttribute(oName, attrName).toString();
-      assert Long.parseLong(receivedVal) == expectedValue : "expecting " + expectedValue + " for " + attrName
-            + ", but received " + receivedVal;
+      assertEquals(expectedValue, Long.parseLong(receivedVal));
    }
 
    void assertAttributeValueGreaterThanOrEqualTo(MBeanServer mBeanServer, ObjectName oName, String attrName,
                                                          long valueToCompare) throws Exception {
       String receivedVal = mBeanServer.getAttribute(oName, attrName).toString();
-      assert Long.parseLong(receivedVal) >= valueToCompare : "expecting " + receivedVal + " for " + attrName
-            + ", to be greater than " + valueToCompare;
+      assertTrue(valueToCompare <= Long.parseLong(receivedVal));
    }
 }

--- a/core/src/test/java/org/infinispan/jmx/ClusterCacheStatsMBeanTest.java
+++ b/core/src/test/java/org/infinispan/jmx/ClusterCacheStatsMBeanTest.java
@@ -9,8 +9,6 @@ import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
 import org.infinispan.Cache;
-import org.infinispan.stats.impl.AbstractClusterStats;
-import org.infinispan.test.TestingUtil;
 import org.testng.annotations.Test;
 
 @Test(groups = "functional", testName = "jmx.ClusterCacheStatsMBeanTest")
@@ -30,7 +28,7 @@ public class ClusterCacheStatsMBeanTest extends AbstractClusterMBeanTest {
       mBeanServer.setAttribute(clusterStats, new Attribute("StatisticsEnabled", true));
       assert (boolean) mBeanServer.getAttribute(clusterStats, "StatisticsEnabled");
 
-      long newStaleThreshold = AbstractClusterStats.DEFAULT_STALE_STATS_THRESHOLD - 1;
+      long newStaleThreshold = 1000;
       mBeanServer.setAttribute(clusterStats, new Attribute("StaleStatsThreshold", newStaleThreshold));
       assertAttributeValue(mBeanServer, clusterStats, "StaleStatsThreshold", newStaleThreshold);
 
@@ -49,7 +47,7 @@ public class ClusterCacheStatsMBeanTest extends AbstractClusterMBeanTest {
       cache1.get("a2");
 
       //sleep so we pick up refreshed values after remove
-      TestingUtil.sleepThread(AbstractClusterStats.DEFAULT_STALE_STATS_THRESHOLD + 1000);
+      timeService.advance(newStaleThreshold + 1);
 
       assertAttributeValueGreaterThanOrEqualTo(mBeanServer, clusterStats, "AverageWriteTime", 0);
       assertAttributeValueGreaterThanOrEqualTo(mBeanServer, clusterStats, "AverageReadTime", 0);

--- a/server/rest/src/main/java/org/infinispan/rest/resources/CacheResourceV2.java
+++ b/server/rest/src/main/java/org/infinispan/rest/resources/CacheResourceV2.java
@@ -54,6 +54,7 @@ import org.infinispan.commons.util.ProcessorInfo;
 import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.configuration.parsing.ConfigurationBuilderHolder;
 import org.infinispan.configuration.parsing.ParserRegistry;
 import org.infinispan.distribution.DistributionManager;
@@ -551,6 +552,7 @@ public class CacheResourceV2 extends BaseCacheResource implements ResourceHandle
    private RestResponse getDetailResponse(Cache<?, ?> cache) {
       Configuration configuration = SecurityActions.getCacheConfiguration(cache.getAdvancedCache());
       EmbeddedCacheManager cacheManager = invocationHelper.getRestCacheManager().getInstance();
+      GlobalConfiguration globalConfiguration = SecurityActions.getCacheManagerConfiguration(cacheManager);
       PersistenceManager persistenceManager = SecurityActions.getPersistenceManager(cacheManager, cache.getName());
       Stats stats = null;
       Boolean rehashInProgress = null;
@@ -558,6 +560,7 @@ public class CacheResourceV2 extends BaseCacheResource implements ResourceHandle
       Boolean queryable = null;
 
       try {
+         // TODO Shouldn't we return the clustered stats, like Hot Rod does?
          stats = cache.getAdvancedCache().getStats();
          DistributionManager distributionManager = cache.getAdvancedCache().getDistributionManager();
          rehashInProgress = distributionManager != null && distributionManager.isRehashInProgress();
@@ -577,10 +580,12 @@ public class CacheResourceV2 extends BaseCacheResource implements ResourceHandle
       }
 
       Integer size = null;
-      try {
-         size = cache.size();
-      } catch (SecurityException ex) {
-         // Bulk Read is needed
+      if (globalConfiguration.metrics().accurateSize()) {
+         try {
+            size = cache.size();
+         } catch (SecurityException ex) {
+            // Bulk Read is needed
+         }
       }
 
       SearchStatistics searchStatistics = Search.getSearchStatistics(cache);


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12607

Please do not close the issue, I have not yet implemented the approximate size metrics that are supposed to always be available.

ISPN-12607 Only compute the accurate size when enabled
* In clustered cache stats
* In REST cache details

ISPN-12607 Only report client size in Micrometer integration
ISPN-12607 Use sizeAsync in KeyValueStoreImpl
ISPN-12607 Deprecate getTotalNumberOfEntries()
ISPN-12607 Use dynamic stats update threshold