### PR TITLE
ISPN-13436 Spurious failures when a test name is wrong

### DIFF
--- a/core/src/test/java/org/infinispan/persistence/support/BatchAsyncStoreTest.java
+++ b/core/src/test/java/org/infinispan/persistence/support/BatchAsyncStoreTest.java
@@ -90,12 +90,12 @@ public class BatchAsyncStoreTest extends SingleCacheManagerTest {
       Assert.assertEquals(cacheCopy.keySet().size(), cache.keySet().size(), "have a different number of keys");
    }
 
-   @BeforeClass
+   @BeforeClass(alwaysRun = true)
    protected void setUpTempDir() {
       tmpDirectory = CommonsTestingUtil.tmpDirectory(this.getClass());
    }
 
-   @AfterClass
+   @AfterClass(alwaysRun = true)
    protected void clearTempDir() {
       Util.recursiveFileRemove(tmpDirectory);
    }

--- a/core/src/test/java/org/infinispan/util/ThreadLocalLeakTest.java
+++ b/core/src/test/java/org/infinispan/util/ThreadLocalLeakTest.java
@@ -49,7 +49,7 @@ public class ThreadLocalLeakTest extends AbstractInfinispanTest {
 
    private String tmpDirectory;
 
-   @BeforeClass
+   @BeforeClass(alwaysRun = true)
    protected void setUpTempDir() {
       tmpDirectory = CommonsTestingUtil.tmpDirectory(this.getClass());
    }


### PR DESCRIPTION
Set alwaysRun=true for setup methods required by other setup/teardown
methods with alwaysRun=true.