### PR TITLE
[13.0.x] ISPN-13430 IRAC tombstones are leaking

### DIFF
--- a/core/src/main/java/org/infinispan/commands/CommandsFactory.java
+++ b/core/src/main/java/org/infinispan/commands/CommandsFactory.java
@@ -26,6 +26,7 @@ import org.infinispan.commands.functional.WriteOnlyKeyValueCommand;
 import org.infinispan.commands.functional.WriteOnlyManyCommand;
 import org.infinispan.commands.functional.WriteOnlyManyEntriesCommand;
 import org.infinispan.commands.irac.IracCleanupKeyCommand;
+import org.infinispan.commands.irac.IracCleanupTombstoneCommand;
 import org.infinispan.commands.irac.IracClearKeysCommand;
 import org.infinispan.commands.irac.IracMetadataRequestCommand;
 import org.infinispan.commands.irac.IracPutKeyCommand;
@@ -438,7 +439,7 @@ public interface CommandsFactory {
    LockControlCommand buildLockControlCommand(Collection<?> keys, long flagsBitSet, GlobalTransaction gtx);
 
    /**
-    * Same as {@link #buildLockControlCommand(Object, long, GlobalTransaction)}
+    * Same as {@link #buildLockControlCommand(Collection, long, GlobalTransaction)}
     * but for locking a single key vs a collection of keys.
     */
    LockControlCommand buildLockControlCommand(Object key, long flagsBitSet, GlobalTransaction gtx);
@@ -641,7 +642,9 @@ public interface CommandsFactory {
 
    IracClearKeysCommand buildIracClearKeysCommand();
 
-   IracCleanupKeyCommand buildIracCleanupKeyCommand(int segment, Object key, Object lockOwner, IracMetadata tombstone);
+   IracCleanupKeyCommand buildIracCleanupKeyCommand(int segment, Object key, Object lockOwner);
+
+   IracCleanupTombstoneCommand buildIracCleanupTombstoneCommand(Object key, IracMetadata tombstone);
 
    IracMetadataRequestCommand buildIracMetadataRequestCommand(int segment, IracEntryVersion versionSeen);
 

--- a/core/src/main/java/org/infinispan/commands/CommandsFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/commands/CommandsFactoryImpl.java
@@ -27,6 +27,7 @@ import org.infinispan.commands.functional.WriteOnlyKeyValueCommand;
 import org.infinispan.commands.functional.WriteOnlyManyCommand;
 import org.infinispan.commands.functional.WriteOnlyManyEntriesCommand;
 import org.infinispan.commands.irac.IracCleanupKeyCommand;
+import org.infinispan.commands.irac.IracCleanupTombstoneCommand;
 import org.infinispan.commands.irac.IracClearKeysCommand;
 import org.infinispan.commands.irac.IracMetadataRequestCommand;
 import org.infinispan.commands.irac.IracPutKeyCommand;
@@ -728,8 +729,13 @@ public class CommandsFactoryImpl implements CommandsFactory {
    }
 
    @Override
-   public IracCleanupKeyCommand buildIracCleanupKeyCommand(int segment, Object key, Object lockOwner, IracMetadata tombstone) {
-      return new IracCleanupKeyCommand(cacheName, segment, key, lockOwner, tombstone);
+   public IracCleanupKeyCommand buildIracCleanupKeyCommand(int segment, Object key, Object lockOwner) {
+      return new IracCleanupKeyCommand(cacheName, segment, key, lockOwner);
+   }
+
+   @Override
+   public IracCleanupTombstoneCommand buildIracCleanupTombstoneCommand(Object key, IracMetadata tombstone) {
+      return new IracCleanupTombstoneCommand(cacheName, key, tombstone);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/commands/RemoteCommandsFactory.java
+++ b/core/src/main/java/org/infinispan/commands/RemoteCommandsFactory.java
@@ -16,6 +16,7 @@ import org.infinispan.commands.functional.WriteOnlyKeyValueCommand;
 import org.infinispan.commands.functional.WriteOnlyManyCommand;
 import org.infinispan.commands.functional.WriteOnlyManyEntriesCommand;
 import org.infinispan.commands.irac.IracCleanupKeyCommand;
+import org.infinispan.commands.irac.IracCleanupTombstoneCommand;
 import org.infinispan.commands.irac.IracClearKeysCommand;
 import org.infinispan.commands.irac.IracMetadataRequestCommand;
 import org.infinispan.commands.irac.IracPutKeyCommand;
@@ -486,6 +487,9 @@ public class RemoteCommandsFactory {
                break;
             case XSiteSetStateTransferModeCommand.COMMAND_ID:
                command = new XSiteSetStateTransferModeCommand(cacheName);
+               break;
+            case IracCleanupTombstoneCommand.COMMAND_ID:
+               command = new IracCleanupTombstoneCommand(cacheName);
                break;
             default:
                throw new CacheException("Unknown command id " + id + "!");

--- a/core/src/main/java/org/infinispan/commands/irac/IracCleanupKeyCommand.java
+++ b/core/src/main/java/org/infinispan/commands/irac/IracCleanupKeyCommand.java
@@ -7,8 +7,8 @@ import java.util.concurrent.CompletableFuture;
 
 import org.infinispan.commands.CommandInvocationId;
 import org.infinispan.commands.remote.CacheRpcCommand;
+import org.infinispan.commons.util.Util;
 import org.infinispan.factories.ComponentRegistry;
-import org.infinispan.metadata.impl.IracMetadata;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.util.ByteString;
 import org.infinispan.util.concurrent.CompletableFutures;
@@ -16,7 +16,7 @@ import org.infinispan.util.concurrent.CompletableFutures;
 /**
  * Sends a cleanup request from primary owner to backup owners.
  * <p>
- * Sent after a successfully update of all remote sites.
+ * Sent after a successful update of all remote sites.
  *
  * @author Pedro Ruivo
  * @since 11.0
@@ -29,7 +29,6 @@ public class IracCleanupKeyCommand implements CacheRpcCommand {
    private int segment;
    private Object key;
    private Object lockOwner;
-   private IracMetadata tombstone;
 
    @SuppressWarnings("unused")
    public IracCleanupKeyCommand() {
@@ -39,12 +38,11 @@ public class IracCleanupKeyCommand implements CacheRpcCommand {
       this.cacheName = cacheName;
    }
 
-   public IracCleanupKeyCommand(ByteString cacheName, int segment, Object key, Object lockOwner, IracMetadata tombstone) {
+   public IracCleanupKeyCommand(ByteString cacheName, int segment, Object key, Object lockOwner) {
       this.cacheName = cacheName;
       this.segment = segment;
       this.key = key;
       this.lockOwner = lockOwner;
-      this.tombstone = tombstone;
    }
 
    @Override
@@ -54,7 +52,7 @@ public class IracCleanupKeyCommand implements CacheRpcCommand {
 
    @Override
    public CompletableFuture<Object> invokeAsync(ComponentRegistry componentRegistry) {
-      componentRegistry.getIracManager().running().cleanupKey(segment, key, lockOwner, tombstone);
+      componentRegistry.getIracManager().running().cleanupKey(segment, key, lockOwner);
       return CompletableFutures.completedNull();
    }
 
@@ -107,7 +105,8 @@ public class IracCleanupKeyCommand implements CacheRpcCommand {
    @Override
    public String toString() {
       return "IracCleanupKeyCommand{" +
-            "key=" + key +
+            "cacheName=" + cacheName +
+            ", key=" + Util.toStr(key) +
             ", lockOwner=" + lockOwner +
             '}';
    }

--- a/core/src/main/java/org/infinispan/commands/irac/IracCleanupTombstoneCommand.java
+++ b/core/src/main/java/org/infinispan/commands/irac/IracCleanupTombstoneCommand.java
@@ -1,0 +1,144 @@
+package org.infinispan.commands.irac;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.concurrent.CompletionStage;
+
+import org.infinispan.commons.util.Util;
+import org.infinispan.distribution.DistributionInfo;
+import org.infinispan.factories.ComponentRegistry;
+import org.infinispan.metadata.impl.IracMetadata;
+import org.infinispan.remoting.responses.ValidResponse;
+import org.infinispan.remoting.rpc.RpcManager;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.remoting.transport.ValidSingleResponseCollector;
+import org.infinispan.util.ByteString;
+import org.infinispan.util.concurrent.CompletableFutures;
+import org.infinispan.xsite.BackupReceiver;
+import org.infinispan.xsite.XSiteReplicateCommand;
+import org.infinispan.xsite.irac.IracManager;
+
+/**
+ * A {@link XSiteReplicateCommand} to check and cleanup tombstones for IRAC algorithm.
+ * <p>
+ * This command has 2 modes: (1, when tombstone==null) when it is sent to a remote site, it checks if the key exists in
+ * the {@link IracManager}. This check is performed in the primary owner of the key; (2, when tombstone!=null) if it is
+ * sent from primary owner to backup owners, the backup owners remove the tombstone.
+ *
+ * @since 14.0
+ */
+public class IracCleanupTombstoneCommand extends XSiteReplicateCommand<Boolean> {
+
+   public static final byte COMMAND_ID = 37;
+
+   private Object key;
+   private IracMetadata tombstone;
+
+   @SuppressWarnings("unused")
+   public IracCleanupTombstoneCommand() {
+      super(COMMAND_ID, null);
+   }
+
+   public IracCleanupTombstoneCommand(ByteString cacheName) {
+      super(COMMAND_ID, cacheName);
+   }
+
+   public IracCleanupTombstoneCommand(ByteString cacheName, Object key, IracMetadata tombstone) {
+      super(COMMAND_ID, cacheName);
+      this.key = key;
+      this.tombstone = tombstone;
+   }
+
+   @Override
+   public ByteString getCacheName() {
+      return cacheName;
+   }
+
+   @Override
+   public CompletionStage<Boolean> invokeAsync(ComponentRegistry registry) {
+      if (tombstone == null) {
+         // command received from a remote site.
+         // check if the key exists in IracManager
+         return isKeyInIracManager(registry);
+      }
+      // removes the tombstone
+      registry.getIracTombstoneCleaner().running().removeTombstone(key, tombstone);
+      return CompletableFutures.completedNull();
+   }
+
+   @Override
+   public byte getCommandId() {
+      return COMMAND_ID;
+   }
+
+   @Override
+   public CompletionStage<Boolean> performInLocalSite(ComponentRegistry registry, boolean preserveOrder) {
+      DistributionInfo distribution = registry.getDistributionManager().getCacheTopology().getDistribution(key);
+      if (distribution.isPrimary()) {
+         return isKeyInIracManager(registry);
+      } else {
+         RpcManager manager = registry.getRpcManager().running();
+         return manager.invokeCommand(distribution.primary(), this, new BooleanResponseCollector(), manager.getSyncRpcOptions());
+      }
+   }
+
+   @Override
+   public CompletionStage<Boolean> performInLocalSite(BackupReceiver receiver, boolean preserveOrder) {
+      throw new IllegalStateException("Should never be invoked!");
+   }
+
+   @Override
+   public boolean isReturnValueExpected() {
+      return true;
+   }
+
+   @Override
+   public void writeTo(ObjectOutput output) throws IOException {
+      output.writeObject(key);
+      IracMetadata.writeTo(output, tombstone);
+   }
+
+   @Override
+   public void readFrom(ObjectInput input) throws IOException, ClassNotFoundException {
+      this.key = input.readObject();
+      this.tombstone = IracMetadata.readFrom(input);
+   }
+
+   @Override
+   public Address getOrigin() {
+      //not needed
+      return null;
+   }
+
+   @Override
+   public void setOrigin(Address origin) {
+      //no-op
+   }
+
+   @Override
+   public String toString() {
+      return "IracCleanupTombstoneCommand{" +
+            "cacheName=" + cacheName +
+            ", key=" + Util.toStr(key) +
+            ", tombstone=" + tombstone +
+            '}';
+   }
+
+   private CompletionStage<Boolean> isKeyInIracManager(ComponentRegistry registry) {
+      return CompletableFutures.booleanStage(registry.getIracManager().running().containsKey(key));
+   }
+
+   private static final class BooleanResponseCollector extends ValidSingleResponseCollector<Boolean> {
+
+      @Override
+      protected Boolean withValidResponse(Address sender, ValidResponse response) {
+         return (Boolean) response.getResponseValue();
+      }
+
+      @Override
+      protected Boolean targetNotFound(Address sender) {
+         return Boolean.TRUE;
+      }
+   }
+}

--- a/core/src/main/java/org/infinispan/commands/irac/IracPutKeyCommand.java
+++ b/core/src/main/java/org/infinispan/commands/irac/IracPutKeyCommand.java
@@ -58,7 +58,7 @@ public class IracPutKeyCommand extends IracUpdateKeyCommand {
       output.writeObject(key);
       output.writeObject(value);
       output.writeObject(metadata);
-      iracMetadata.writeTo(output);
+      IracMetadata.writeTo(output, iracMetadata);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/commands/irac/IracRemoveKeyCommand.java
+++ b/core/src/main/java/org/infinispan/commands/irac/IracRemoveKeyCommand.java
@@ -52,7 +52,7 @@ public class IracRemoveKeyCommand extends IracUpdateKeyCommand {
    @Override
    public void writeTo(ObjectOutput output) throws IOException {
       output.writeObject(key);
-      iracMetadata.writeTo(output);
+      IracMetadata.writeTo(output, iracMetadata);
       output.writeBoolean(expiration);
    }
 

--- a/core/src/main/java/org/infinispan/commands/irac/IracStateResponseCommand.java
+++ b/core/src/main/java/org/infinispan/commands/irac/IracStateResponseCommand.java
@@ -72,11 +72,7 @@ public class IracStateResponseCommand implements CacheRpcCommand {
       } else {
          output.writeObject(lockOwner);
       }
-      boolean nullTombstone = tombstone == null;
-      output.writeBoolean(nullTombstone);
-      if (!nullTombstone) {
-         tombstone.writeTo(output);
-      }
+      IracMetadata.writeTo(output, tombstone);
    }
 
    @Override
@@ -88,11 +84,7 @@ public class IracStateResponseCommand implements CacheRpcCommand {
       } else {
          this.lockOwner = input.readObject();
       }
-      if (input.readBoolean()) {
-         tombstone = null;
-      } else {
-         tombstone = IracMetadata.readFrom(input);
-      }
+      this.tombstone = IracMetadata.readFrom(input);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/container/versioning/irac/DefaultIracTombstoneManager.java
+++ b/core/src/main/java/org/infinispan/container/versioning/irac/DefaultIracTombstoneManager.java
@@ -1,0 +1,227 @@
+package org.infinispan.container.versioning.irac;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import org.infinispan.commands.CommandsFactory;
+import org.infinispan.commands.irac.IracCleanupTombstoneCommand;
+import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.distribution.DistributionInfo;
+import org.infinispan.distribution.DistributionManager;
+import org.infinispan.factories.KnownComponentNames;
+import org.infinispan.factories.annotations.ComponentName;
+import org.infinispan.factories.annotations.Inject;
+import org.infinispan.factories.impl.ComponentRef;
+import org.infinispan.factories.scopes.Scope;
+import org.infinispan.factories.scopes.Scopes;
+import org.infinispan.metadata.impl.IracMetadata;
+import org.infinispan.remoting.rpc.RpcManager;
+import org.infinispan.remoting.transport.impl.VoidResponseCollector;
+import org.infinispan.util.ExponentialBackOff;
+import org.infinispan.util.concurrent.AggregateCompletionStage;
+import org.infinispan.util.concurrent.CompletableFutures;
+import org.infinispan.util.concurrent.CompletionStages;
+import org.infinispan.xsite.XSiteBackup;
+import org.infinispan.xsite.irac.DefaultIracManager;
+import org.infinispan.xsite.irac.IracExecutor;
+import org.infinispan.xsite.irac.IracManager;
+import org.infinispan.xsite.status.SiteState;
+import org.infinispan.xsite.status.TakeOfflineManager;
+
+/**
+ * A default implementation for {@link IracTombstoneManager}.
+ * <p>
+ * This class is responsible to keep track of the tombstones for the IRAC algorithm. Tombstones are used when a key is
+ * removed but its metadata is necessary to detect possible conflicts in this and remote sites. When all sites have
+ * updated the key, the tombstone can be removed.
+ * <p>
+ * Tombstones are removed periodically in the background.
+ *
+ * @since 14.0
+ */
+@Scope(Scopes.NAMED_CACHE)
+public class DefaultIracTombstoneManager implements IracTombstoneManager {
+
+   @Inject
+   DistributionManager distributionManager;
+   @Inject
+   RpcManager rpcManager;
+   @Inject
+   CommandsFactory commandsFactory;
+   @Inject
+   TakeOfflineManager takeOfflineManager;
+   @Inject
+   ComponentRef<IracManager> iracManager;
+   private final Map<Object, TombstoneData> tombstoneMap;
+   private final IracExecutor iracExecutor;
+   final Collection<XSiteBackup> asyncBackups;
+
+   public DefaultIracTombstoneManager(Configuration configuration) {
+      this.iracExecutor = new IracExecutor(this::performCleanup);
+      this.asyncBackups = DefaultIracManager.asyncBackups(configuration);
+      this.tombstoneMap = new ConcurrentHashMap<>();
+   }
+
+   @Inject
+   public void inject(@ComponentName(KnownComponentNames.TIMEOUT_SCHEDULE_EXECUTOR) ScheduledExecutorService executorService,
+                      @ComponentName(KnownComponentNames.BLOCKING_EXECUTOR) Executor blockingExecutor) {
+      // using the inject method here in order to decrease the class size
+      iracExecutor.setBackOff(ExponentialBackOff.NO_OP);
+      iracExecutor.setExecutor(blockingExecutor);
+      // TODO configure? https://issues.redhat.com/browse/ISPN-13446
+      executorService.scheduleAtFixedRate(iracExecutor::run, 30, 30, TimeUnit.SECONDS);
+   }
+
+   public void storeTombstone(int segment, Object key, IracMetadata metadata) {
+      tombstoneMap.put(key, new TombstoneData(segment, metadata));
+   }
+
+   @Override
+   public void storeTombstoneIfAbsent(int segment, Object key, IracMetadata metadata) {
+      if (metadata == null) {
+         return;
+      }
+      tombstoneMap.putIfAbsent(key, new TombstoneData(segment, metadata));
+   }
+
+   @Override
+   public IracMetadata getTombstone(Object key) {
+      TombstoneData data = tombstoneMap.get(key);
+      return data == null ? null : data.getMetadata();
+   }
+
+   @Override
+   public void removeTombstone(Object key, IracMetadata iracMetadata) {
+      if (iracMetadata == null) {
+         return;
+      }
+      remove(key, new TombstoneData(-1, iracMetadata));
+   }
+
+   @Override
+   public void removeTombstone(Object key) {
+      tombstoneMap.remove(key);
+   }
+
+
+   @Override
+   public boolean isEmpty() {
+      return tombstoneMap.isEmpty();
+   }
+
+   @Override
+   public int size() {
+      return tombstoneMap.size();
+   }
+
+   public void startCleanupTombstone() {
+      iracExecutor.run();
+   }
+
+   private CompletionStage<Void> performCleanup() {
+      AggregateCompletionStage<Void> stage = CompletionStages.aggregateCompletionStage();
+      for (Map.Entry<Object, TombstoneData> entry : tombstoneMap.entrySet()) {
+         DistributionInfo info = distributionManager.getCacheTopology().getSegmentDistribution(entry.getValue().getSegment());
+         if (!info.isWriteOwner()) {
+            // topology changed, no longer an owner
+            remove(entry.getKey(), entry.getValue());
+            continue;
+         }
+         if (!info.isPrimary() || iracManager.running().containsKey(entry.getKey())) {
+            // backup owner or the irac manager haven't sent the update successfully
+            continue;
+         }
+         stage.dependsOn(new CleanupTask(entry.getKey(), entry.getValue()).checkRemoteSites());
+      }
+      return stage.freeze();
+   }
+
+   private void remove(Object key, TombstoneData data) {
+      tombstoneMap.remove(key, data);
+   }
+
+   DistributionInfo getSegmentDistribution(int segment) {
+      return distributionManager.getCacheTopology().getSegmentDistribution(segment);
+   }
+
+   private static class TombstoneData {
+      private final int segment;
+      private final IracMetadata metadata;
+
+      private TombstoneData(int segment, IracMetadata metadata) {
+         this.segment = segment;
+         this.metadata = Objects.requireNonNull(metadata);
+      }
+
+      public int getSegment() {
+         return segment;
+      }
+
+      public IracMetadata getMetadata() {
+         return metadata;
+      }
+
+      @Override
+      public boolean equals(Object o) {
+         if (this == o) return true;
+         if (o == null || getClass() != o.getClass()) return false;
+         TombstoneData that = (TombstoneData) o;
+         return metadata.equals(that.metadata);
+      }
+
+      @Override
+      public int hashCode() {
+         return metadata.hashCode();
+      }
+   }
+
+   private class CleanupTask implements Function<Boolean, CompletionStage<Void>>, Runnable {
+      private final Object key;
+      private final TombstoneData tombstone;
+
+      private CleanupTask(Object key, TombstoneData tombstone) {
+         this.key = key;
+         this.tombstone = tombstone;
+      }
+
+      CompletionStage<Void> checkRemoteSites() {
+         // if one of the site return true (i.e. the key is in updateKeys map, then do not remove it)
+         AggregateCompletionStage<Boolean> stage = CompletionStages.orBooleanAggregateCompletionStage();
+         for (XSiteBackup backup : asyncBackups) {
+            if (takeOfflineManager.getSiteState(backup.getSiteName()) == SiteState.OFFLINE) {
+               continue; // backup is offline
+            }
+            // we don't need the tombstone to query the remote site
+            IracCleanupTombstoneCommand cmd = commandsFactory.buildIracCleanupTombstoneCommand(key, null);
+            stage.dependsOn(rpcManager.invokeXSite(backup, cmd));
+         }
+         // in case of exception, keep the tombstone
+         return stage.freeze()
+               .exceptionally(CompletableFutures.toTrueFunction())
+               .thenCompose(this);
+      }
+
+      @Override
+      public CompletionStage<Void> apply(Boolean keepTombstone) {
+         if (keepTombstone) {
+            return CompletableFutures.completedNull();
+         }
+         // send commit to all write owner
+         IracCleanupTombstoneCommand cmd = commandsFactory.buildIracCleanupTombstoneCommand(key, tombstone.getMetadata());
+         return rpcManager.invokeCommand(getSegmentDistribution(tombstone.getSegment()).writeOwners(),
+               cmd, VoidResponseCollector.validOnly(), rpcManager.getSyncRpcOptions()).thenRun(this);
+      }
+
+      @Override
+      public void run() {
+         remove(key, tombstone);
+      }
+   }
+}

--- a/core/src/main/java/org/infinispan/container/versioning/irac/DefaultIracVersionGenerator.java
+++ b/core/src/main/java/org/infinispan/container/versioning/irac/DefaultIracVersionGenerator.java
@@ -39,7 +39,6 @@ public class DefaultIracVersionGenerator implements IracVersionGenerator {
          .newUpdater(DefaultIracVersionGenerator.class, "topologyId");
 
    private final Map<Integer, Map<String, TopologyIracVersion>> segmentVersion;
-   private final Map<Object, IracMetadata> tombstone;
    private final String cacheName;
    @Inject RpcManager rpcManager;
    @Inject GlobalStateManager globalStateManager;
@@ -50,7 +49,6 @@ public class DefaultIracVersionGenerator implements IracVersionGenerator {
    public DefaultIracVersionGenerator(String cacheName) {
       this.cacheName = cacheName;
       this.segmentVersion = new ConcurrentHashMap<>();
-      this.tombstone = new ConcurrentHashMap<>();
    }
 
    @Start
@@ -106,36 +104,6 @@ public class DefaultIracVersionGenerator implements IracVersionGenerator {
       }
    }
 
-   @Override
-   public void storeTombstone(Object key, IracMetadata metadata) {
-      tombstone.put(key, metadata);
-   }
-
-   @Override
-   public void storeTombstoneIfAbsent(Object key, IracMetadata metadata) {
-      if (metadata == null) {
-         return;
-      }
-      tombstone.putIfAbsent(key, metadata);
-   }
-
-   @Override
-   public IracMetadata getTombstone(Object key) {
-      return tombstone.get(key);
-   }
-
-   @Override
-   public void removeTombstone(Object key, IracMetadata iracMetadata) {
-      if (iracMetadata == null) {
-         return;
-      }
-      tombstone.remove(key, iracMetadata);
-   }
-
-   @Override
-   public void removeTombstone(Object key) {
-      tombstone.remove(key);
-   }
 
    public Map<Integer, IracEntryVersion> peek() {
       Map<Integer, IracEntryVersion> copy = new HashMap<>();
@@ -155,7 +123,7 @@ public class DefaultIracVersionGenerator implements IracVersionGenerator {
    }
 
    private Map<String, TopologyIracVersion> getVectorFunction(Integer s,
-                                                               Map<String, TopologyIracVersion> versions) {
+                                                              Map<String, TopologyIracVersion> versions) {
       if (versions == null) {
          return Collections.singletonMap(localSite, TopologyIracVersion.newVersion(topologyId));
       } else {
@@ -203,7 +171,7 @@ public class DefaultIracVersionGenerator implements IracVersionGenerator {
          if (v == null) {
             return;
          }
-         segmentVersion.compute(segment, (seg, vectorClock) ->  {
+         segmentVersion.compute(segment, (seg, vectorClock) -> {
             if (vectorClock == null) {
                return Collections.singletonMap(site, v);
             } else {

--- a/core/src/main/java/org/infinispan/container/versioning/irac/IracTombstoneManager.java
+++ b/core/src/main/java/org/infinispan/container/versioning/irac/IracTombstoneManager.java
@@ -1,0 +1,69 @@
+package org.infinispan.container.versioning.irac;
+
+import org.infinispan.metadata.impl.IracMetadata;
+
+/**
+ * Stores and manages tombstones for removed keys.
+ * <p>
+ * It manages the tombstones for IRAC protocol. Tombstones are used when a key is removed but the version/metadata is
+ * required to perform conflict or duplicates detection.
+ * <p>
+ * Tombstones are removed when they are not required by any site or its value is updated (with a non-null value).
+ *
+ * @since 14.0
+ */
+public interface IracTombstoneManager {
+
+   /**
+    * Stores a tombstone for a removed key.
+    * <p>
+    * It overwrites any previous tombstone associated to the {@code key}.
+    *
+    * @param key      The key.
+    * @param segment  The key's segment.
+    * @param metadata The {@link IracMetadata}.
+    */
+   void storeTombstone(int segment, Object key, IracMetadata metadata);
+
+   /**
+    * Same as {@link #storeTombstone(int, Object, IracMetadata)} but it doesn't overwrite an existing tombstone.
+    *
+    * @param key      The key.
+    * @param segment  The key's segment.
+    * @param metadata The {@link IracMetadata}.
+    */
+   void storeTombstoneIfAbsent(int segment, Object key, IracMetadata metadata);
+
+   /**
+    * Removes the tombstone for {@code key} if the metadata matches.
+    *
+    * @param key          The key.
+    * @param iracMetadata The expected {@link IracMetadata}.
+    */
+   void removeTombstone(Object key, IracMetadata iracMetadata);
+
+   /**
+    * Removes the tombstone for {@code key}.
+    *
+    * @param key The key.
+    */
+   void removeTombstone(Object key);
+
+   /**
+    * Returns the tombstone associated to the {@code key} or {@code null} if it doesn't exist.
+    *
+    * @param key The key.
+    * @return The tombstone.
+    */
+   IracMetadata getTombstone(Object key);
+
+   /**
+    * @return {@code true} if no tombstones are stored.
+    */
+   boolean isEmpty();
+
+   /**
+    * @return the number of tombstones stored.
+    */
+   int size();
+}

--- a/core/src/main/java/org/infinispan/container/versioning/irac/IracVersionGenerator.java
+++ b/core/src/main/java/org/infinispan/container/versioning/irac/IracVersionGenerator.java
@@ -7,8 +7,6 @@ import org.infinispan.topology.CacheTopology;
 /**
  * A version generator for the IRAC protocol.
  * <p>
- * It also stores the tombstone from the keys removed.
- * <p>
  * The version is segment based and the new version is also after than the previous one.
  *
  * @author Pedro Ruivo
@@ -56,47 +54,6 @@ public interface IracVersionGenerator extends Lifecycle {
     * @param remoteVersion The remote {@link IracEntryVersion} received.
     */
    void updateVersion(int segment, IracEntryVersion remoteVersion);
-
-   /**
-    * Stores a tombstone for a key removed.
-    * <p>
-    * It overwrites any existing tombstone.
-    *
-    * @param key      The key.
-    * @param metadata The {@link IracMetadata}.
-    */
-   void storeTombstone(Object key, IracMetadata metadata);
-
-   /**
-    * Same as {@link #storeTombstone(Object, IracMetadata)} but it doesn't overwrite an existing tombstone.
-    *
-    * @param key      The key.
-    * @param metadata The {@link IracMetadata}.
-    */
-   void storeTombstoneIfAbsent(Object key, IracMetadata metadata);
-
-   /**
-    * Returns the tombstone associated to the {@code key} or {@code null} if it doesn't exist.
-    *
-    * @param key The key.
-    * @return The tombstone.
-    */
-   IracMetadata getTombstone(Object key);
-
-   /**
-    * Removes the tombstone for {@code key} if the metadata matches.
-    *
-    * @param key          The key.
-    * @param iracMetadata The expected {@link IracMetadata}.
-    */
-   void removeTombstone(Object key, IracMetadata iracMetadata);
-
-   /**
-    * Removes the tombstone for {@code key}.
-    *
-    * @param key The key.
-    */
-   void removeTombstone(Object key);
 
    /**
     * Invoked when a topology change occurs in the cluster.

--- a/core/src/main/java/org/infinispan/container/versioning/irac/NoOpIracTombstoneManager.java
+++ b/core/src/main/java/org/infinispan/container/versioning/irac/NoOpIracTombstoneManager.java
@@ -1,0 +1,57 @@
+package org.infinispan.container.versioning.irac;
+
+import org.infinispan.metadata.impl.IracMetadata;
+
+/**
+ * No-op implementation for {@link IracTombstoneManager}.
+ * <p>
+ * It is used when IRAC is not enabled.
+ *
+ * @since 14.0
+ */
+public final class NoOpIracTombstoneManager implements IracTombstoneManager {
+
+   private static final NoOpIracTombstoneManager INSTANCE = new NoOpIracTombstoneManager();
+
+   private NoOpIracTombstoneManager() {
+   }
+
+   public static NoOpIracTombstoneManager getInstance() {
+      return INSTANCE;
+   }
+
+   @Override
+   public void storeTombstone(int segment, Object key, IracMetadata metadata) {
+      //no-op
+   }
+
+   @Override
+   public void storeTombstoneIfAbsent(int segment, Object key, IracMetadata metadata) {
+      //no-op
+   }
+
+   @Override
+   public void removeTombstone(Object key, IracMetadata iracMetadata) {
+      //no-op
+   }
+
+   @Override
+   public void removeTombstone(Object key) {
+      //no-op
+   }
+
+   @Override
+   public IracMetadata getTombstone(Object key) {
+      return null;
+   }
+
+   @Override
+   public boolean isEmpty() {
+      return true;
+   }
+
+   @Override
+   public int size() {
+      return 0;
+   }
+}

--- a/core/src/main/java/org/infinispan/container/versioning/irac/NoOpIracVersionGenerator.java
+++ b/core/src/main/java/org/infinispan/container/versioning/irac/NoOpIracVersionGenerator.java
@@ -44,31 +44,6 @@ public class NoOpIracVersionGenerator implements IracVersionGenerator {
    }
 
    @Override
-   public void storeTombstone(Object key, IracMetadata metadata) {
-      //no-op
-   }
-
-   @Override
-   public void storeTombstoneIfAbsent(Object key, IracMetadata metadata) {
-      //no-op
-   }
-
-   @Override
-   public IracMetadata getTombstone(Object key) {
-      return null; //no-op
-   }
-
-   @Override
-   public void removeTombstone(Object key, IracMetadata iracMetadata) {
-      //no-op
-   }
-
-   @Override
-   public void removeTombstone(Object key) {
-      //no-op
-   }
-
-   @Override
    public void onTopologyChange(CacheTopology newTopology) {
       //no-op
    }

--- a/core/src/main/java/org/infinispan/factories/ComponentRegistry.java
+++ b/core/src/main/java/org/infinispan/factories/ComponentRegistry.java
@@ -14,6 +14,7 @@ import org.infinispan.container.impl.InternalDataContainer;
 import org.infinispan.container.impl.InternalEntryFactory;
 import org.infinispan.container.versioning.NumericVersionGenerator;
 import org.infinispan.container.versioning.VersionGenerator;
+import org.infinispan.container.versioning.irac.IracTombstoneManager;
 import org.infinispan.container.versioning.irac.IracVersionGenerator;
 import org.infinispan.context.InvocationContextFactory;
 import org.infinispan.distribution.DistributionManager;
@@ -99,6 +100,7 @@ public class ComponentRegistry extends AbstractComponentRegistry {
    private ComponentRef<InvocationContextFactory> invocationContextFactory;
    private ComponentRef<IracManager> iracManager;
    private ComponentRef<IracVersionGenerator> iracVersionGenerator;
+   private ComponentRef<IracTombstoneManager> iracTombstoneCleaner;
    private ComponentRef<LocalPublisherManager> localPublisherManager;
    private ComponentRef<LockManager> lockManager;
    private ComponentRef<OrderedUpdatesManager> orderedUpdatesManager;
@@ -179,10 +181,9 @@ public class ComponentRegistry extends AbstractComponentRegistry {
       return componentRef.running();
    }
 
-   @SuppressWarnings("unchecked")
    public final <T> T getLocalComponent(Class<T> componentType) {
       String componentTypeName = componentType.getName();
-      return (T) getLocalComponent(componentTypeName, componentTypeName, true);
+      return getLocalComponent(componentTypeName, componentTypeName, true);
    }
 
    public final GlobalComponentRegistry getGlobalComponentRegistry() {
@@ -385,6 +386,7 @@ public class ComponentRegistry extends AbstractComponentRegistry {
       invocationContextFactory = basicComponentRegistry.getComponent(InvocationContextFactory.class);
       iracManager = basicComponentRegistry.getComponent(IracManager.class);
       iracVersionGenerator = basicComponentRegistry.getComponent(IracVersionGenerator.class);
+      iracTombstoneCleaner = basicComponentRegistry.getComponent(IracTombstoneManager.class);
       localPublisherManager = basicComponentRegistry.getComponent(LocalPublisherManager.class);
       lockManager = basicComponentRegistry.getComponent(LockManager.class);
       orderedUpdatesManager = basicComponentRegistry.getComponent(OrderedUpdatesManager.class);
@@ -451,6 +453,10 @@ public class ComponentRegistry extends AbstractComponentRegistry {
 
    public ComponentRef<IracVersionGenerator> getIracVersionGenerator() {
       return iracVersionGenerator;
+   }
+
+   public ComponentRef<IracTombstoneManager> getIracTombstoneCleaner() {
+      return iracTombstoneCleaner;
    }
 
    public ComponentRef<BiasManager> getBiasManager() {

--- a/core/src/main/java/org/infinispan/factories/EmptyConstructorNamedCacheFactory.java
+++ b/core/src/main/java/org/infinispan/factories/EmptyConstructorNamedCacheFactory.java
@@ -16,8 +16,11 @@ import org.infinispan.container.offheap.OffHeapEntryFactory;
 import org.infinispan.container.offheap.OffHeapEntryFactoryImpl;
 import org.infinispan.container.offheap.OffHeapMemoryAllocator;
 import org.infinispan.container.offheap.UnpooledOffHeapMemoryAllocator;
+import org.infinispan.container.versioning.irac.DefaultIracTombstoneManager;
 import org.infinispan.container.versioning.irac.DefaultIracVersionGenerator;
+import org.infinispan.container.versioning.irac.IracTombstoneManager;
 import org.infinispan.container.versioning.irac.IracVersionGenerator;
+import org.infinispan.container.versioning.irac.NoOpIracTombstoneManager;
 import org.infinispan.container.versioning.irac.NoOpIracVersionGenerator;
 import org.infinispan.context.InvocationContextFactory;
 import org.infinispan.context.impl.NonTransactionalInvocationContextFactory;
@@ -105,7 +108,8 @@ import org.infinispan.xsite.status.TakeOfflineManager;
                               OrderedUpdatesManager.class, ScatteredVersionManager.class, TransactionOriginatorChecker.class,
                               BiasManager.class, OffHeapEntryFactory.class, OffHeapMemoryAllocator.class, PublisherHandler.class,
                               InvocationHelper.class, TakeOfflineManager.class, IracManager.class, IracVersionGenerator.class,
-                              BackupReceiver.class, StorageConfigurationManager.class, XSiteMetricsCollector.class
+                              BackupReceiver.class, StorageConfigurationManager.class, XSiteMetricsCollector.class,
+                              IracTombstoneManager.class
 })
 public class EmptyConstructorNamedCacheFactory extends AbstractNamedCacheComponentFactory implements AutoInstantiableFactory {
 
@@ -241,6 +245,10 @@ public class EmptyConstructorNamedCacheFactory extends AbstractNamedCacheCompone
          return configuration.sites().hasEnabledBackups() ?
                 new DefaultXSiteMetricsCollector(configuration) :
                 NoOpXSiteMetricsCollector.getInstance();
+      } else if (componentName.equals(IracTombstoneManager.class.getName())) {
+         return configuration.sites().hasAsyncEnabledBackups() ?
+               new DefaultIracTombstoneManager(configuration) :
+               NoOpIracTombstoneManager.getInstance();
       }
 
       throw CONTAINER.factoryCannotConstructComponent(componentName);

--- a/core/src/main/java/org/infinispan/interceptors/impl/NonTxIracLocalSiteInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/NonTxIracLocalSiteInterceptor.java
@@ -1,5 +1,7 @@
 package org.infinispan.interceptors.impl;
 
+import static org.infinispan.commands.SegmentSpecificCommand.extractSegment;
+
 import org.infinispan.commands.functional.ReadWriteKeyCommand;
 import org.infinispan.commands.functional.ReadWriteKeyValueCommand;
 import org.infinispan.commands.functional.ReadWriteManyCommand;
@@ -158,7 +160,7 @@ public class NonTxIracLocalSiteInterceptor extends AbstractIracLocalSiteIntercep
          if (skipEntryCommit(ctx, command, key)) {
             continue;
          }
-         setMetadataToCacheEntry(ctx.lookupEntry(key), command.getInternalMetadata(key).iracMetadata());
+         setMetadataToCacheEntry(ctx.lookupEntry(key), extractSegment(command, key, keyPartitioner), command.getInternalMetadata(key).iracMetadata());
       }
    }
 

--- a/core/src/main/java/org/infinispan/interceptors/impl/OptimisticTxIracLocalSiteInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/OptimisticTxIracLocalSiteInterceptor.java
@@ -46,7 +46,7 @@ public class OptimisticTxIracLocalSiteInterceptor extends AbstractIracLocalSiteI
       final Object key = command.getKey();
       if (isIracState(command)) {
          // if this is a state transfer from a remote site, we set the versions here
-         setMetadataToCacheEntry(ctx.lookupEntry(key), command.getInternalMetadata(key).iracMetadata());
+         setMetadataToCacheEntry(ctx.lookupEntry(key), command.getSegment(), command.getInternalMetadata(key).iracMetadata());
       }
       return invokeNext(ctx, command);
    }
@@ -144,7 +144,7 @@ public class OptimisticTxIracLocalSiteInterceptor extends AbstractIracLocalSiteI
 
          command.addIracMetadata(data.segment, metadata);
          if (isWriteOwner(data)) {
-            setMetadataToCacheEntry(ctx.lookupEntry(data.key), metadata);
+            setMetadataToCacheEntry(ctx.lookupEntry(data.key), data.segment, metadata);
          }
       }
       return invokeNext(ctx, command);
@@ -161,7 +161,7 @@ public class OptimisticTxIracLocalSiteInterceptor extends AbstractIracLocalSiteI
       while (iterator.hasNext()) {
          StreamData data = iterator.next();
          IracMetadata metadata = command.getIracMetadata(data.segment);
-         setMetadataToCacheEntry(ctx.lookupEntry(data.key), metadata);
+         setMetadataToCacheEntry(ctx.lookupEntry(data.key), data.segment, metadata);
       }
       return invokeNext(ctx, command);
    }

--- a/core/src/main/java/org/infinispan/interceptors/impl/PessimisticTxIracLocalInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/PessimisticTxIracLocalInterceptor.java
@@ -176,7 +176,7 @@ public class PessimisticTxIracLocalInterceptor extends AbstractIracLocalSiteInte
    private Object visitDataWriteCommand(InvocationContext ctx, DataWriteCommand command) {
       final Object key = command.getKey();
       if (isIracState(command)) {
-         setMetadataToCacheEntry(ctx.lookupEntry(key), command.getInternalMetadata(key).iracMetadata());
+         setMetadataToCacheEntry(ctx.lookupEntry(key), command.getSegment(), command.getInternalMetadata(key).iracMetadata());
          return invokeNext(ctx, command);
       }
       return skipCommand(ctx, command) ?
@@ -239,7 +239,7 @@ public class PessimisticTxIracLocalInterceptor extends AbstractIracLocalSiteInte
             .iterator();
       while (iterator.hasNext()) {
          StreamData data = iterator.next();
-         setMetadataToCacheEntry(ctx.lookupEntry(data.key), data.command.getInternalMetadata(data.key).iracMetadata());
+         setMetadataToCacheEntry(ctx.lookupEntry(data.key), data.segment, data.command.getInternalMetadata(data.key).iracMetadata());
       }
       return invokeNext(ctx, command);
    }
@@ -249,7 +249,7 @@ public class PessimisticTxIracLocalInterceptor extends AbstractIracLocalSiteInte
       assert entry != null;
       updateCommandMetadata(data.key, data.command, metadata);
       if (isWriteOwner(data)) {
-         setMetadataToCacheEntry(entry, metadata);
+         setMetadataToCacheEntry(entry, data.segment, metadata);
       }
    }
 

--- a/core/src/main/java/org/infinispan/marshall/exts/CacheRpcCommandExternalizer.java
+++ b/core/src/main/java/org/infinispan/marshall/exts/CacheRpcCommandExternalizer.java
@@ -7,6 +7,7 @@ import java.util.Set;
 
 import org.infinispan.commands.control.LockControlCommand;
 import org.infinispan.commands.irac.IracCleanupKeyCommand;
+import org.infinispan.commands.irac.IracCleanupTombstoneCommand;
 import org.infinispan.commands.irac.IracClearKeysCommand;
 import org.infinispan.commands.irac.IracMetadataRequestCommand;
 import org.infinispan.commands.irac.IracPutKeyCommand;
@@ -127,7 +128,8 @@ public final class CacheRpcCommandExternalizer extends AbstractExternalizer<Cach
             IracRequestStateCommand.class, IracStateResponseCommand.class, IracTouchKeyCommand.class,
             IracUpdateVersionCommand.class,
             XSiteAutoTransferStatusCommand.class,
-            XSiteSetStateTransferModeCommand.class);
+            XSiteSetStateTransferModeCommand.class,
+            IracCleanupTombstoneCommand.class);
       // Only interested in cache specific replicable commands
       coreCommands.addAll(gcr.getModuleProperties().moduleCacheRpcCommands());
       return coreCommands;

--- a/core/src/main/java/org/infinispan/metadata/impl/IracMetadata.java
+++ b/core/src/main/java/org/infinispan/metadata/impl/IracMetadata.java
@@ -30,11 +30,17 @@ public class IracMetadata {
    }
 
    public static void writeTo(ObjectOutput output, IracMetadata metadata) throws IOException {
-      metadata.writeTo(output);
+      if (metadata == null) {
+         output.writeObject(null);
+         return;
+      }
+      output.writeObject(metadata.version);
+      output.writeUTF(metadata.site);
    }
 
    public static IracMetadata readFrom(ObjectInput in) throws IOException, ClassNotFoundException {
-      return new IracMetadata(in.readUTF(), (IracEntryVersion) in.readObject());
+      IracEntryVersion version = (IracEntryVersion) in.readObject();
+      return version == null ? null : new IracMetadata(in.readUTF(), version);
    }
 
    @ProtoField(1)
@@ -74,10 +80,5 @@ public class IracMetadata {
             "site='" + site + '\'' +
             ", version=" + version +
             '}';
-   }
-
-   public void writeTo(ObjectOutput out) throws IOException {
-      out.writeUTF(site);
-      out.writeObject(version);
    }
 }

--- a/core/src/main/java/org/infinispan/util/IracUtils.java
+++ b/core/src/main/java/org/infinispan/util/IracUtils.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.container.versioning.irac.IracEntryVersion;
-import org.infinispan.container.versioning.irac.IracVersionGenerator;
+import org.infinispan.container.versioning.irac.IracTombstoneManager;
 import org.infinispan.metadata.impl.IracMetadata;
 import org.infinispan.metadata.impl.PrivateMetadata;
 import org.infinispan.util.logging.LogSupplier;
@@ -38,20 +38,20 @@ public final class IracUtils {
     * Stores the {@link IracMetadata} into {@link CacheEntry}.
     * <p>
     * If the {@link CacheEntry} is a remove, then the tombstone is added via {@link
-    * IracVersionGenerator#storeTombstone(Object, IracMetadata)}.
+    * IracTombstoneManager#storeTombstone(int, Object, IracMetadata)}.
     *
     * @param entry            The {@link CacheEntry} to update.
     * @param metadata         The {@link IracMetadata} to store.
-    * @param versionGenerator The {@link IracVersionGenerator} to update.
+    * @param versionGenerator The {@link IracTombstoneManager} to update.
     * @param logSupplier      The {@link LogSupplier} to log the {@link IracMetadata} and the key.
     */
-   public static void setIracMetadata(CacheEntry<?, ?> entry, IracMetadata metadata,
-         IracVersionGenerator versionGenerator, LogSupplier logSupplier) {
+   public static void setIracMetadata(CacheEntry<?, ?> entry, int segment, IracMetadata metadata,
+                                      IracTombstoneManager versionGenerator, LogSupplier logSupplier) {
       final Object key = entry.getKey();
       assert metadata != null : "[IRAC] Metadata must not be null!";
       if (entry.isRemoved()) {
          logTombstoneAssociated(key, metadata, logSupplier);
-         versionGenerator.storeTombstone(key, metadata);
+         versionGenerator.storeTombstone(segment, key, metadata);
       } else {
          logIracMetadataAssociated(key, metadata, logSupplier);
          updateCacheEntryMetadata(entry, metadata);
@@ -60,21 +60,24 @@ public final class IracUtils {
    }
 
    /**
-    * Same as {@link #setIracMetadata(CacheEntry, IracMetadata, IracVersionGenerator, LogSupplier)} but it stores a
+    * Same as {@link #setIracMetadata(CacheEntry, int, IracMetadata, IracTombstoneManager, LogSupplier)} but it stores a
     * "full" {@link PrivateMetadata} instead of {@link IracMetadata}.
+    * <p>
+    * This method is invoked to set the version from remote site updates. Note that the tombstone is stored in case
+    * of a remove operation.
     *
     * @param entry            The {@link CacheEntry} to update.
     * @param metadata         The {@link PrivateMetadata} to store.
-    * @param versionGenerator The {@link IracVersionGenerator} to update.
+    * @param versionGenerator The {@link IracTombstoneManager} to update.
     * @param logSupplier      The {@link LogSupplier} to log the {@link PrivateMetadata} and the key.
     */
-   public static void setPrivateMetadata(CacheEntry<?, ?> entry, PrivateMetadata metadata,
-         IracVersionGenerator versionGenerator, LogSupplier logSupplier) {
+   public static void setPrivateMetadata(CacheEntry<?, ?> entry, int segment, PrivateMetadata metadata,
+                                         IracTombstoneManager versionGenerator, LogSupplier logSupplier) {
       final Object key = entry.getKey();
       assert metadata.iracMetadata() != null : "[IRAC] Metadata must not be null!";
       if (entry.isRemoved()) {
          logTombstoneAssociated(key, metadata.iracMetadata(), logSupplier);
-         versionGenerator.storeTombstone(key, metadata.iracMetadata());
+         versionGenerator.storeTombstone(segment, key, metadata.iracMetadata());
       } else {
          logIracMetadataAssociated(key, metadata.iracMetadata(), logSupplier);
          entry.setInternalMetadata(metadata);

--- a/core/src/main/java/org/infinispan/util/concurrent/CompletableFutures.java
+++ b/core/src/main/java/org/infinispan/util/concurrent/CompletableFutures.java
@@ -31,6 +31,7 @@ public class CompletableFutures {
    private static final CompletableFuture completedNullFuture = CompletableFuture.completedFuture(null);
    private static final long BIG_DELAY_NANOS = TimeUnit.DAYS.toNanos(1);
    private static final Function<?, ?> TO_NULL = o -> null;
+   private static final Function<?, Boolean> TO_TRUE_FUNCTION = o -> Boolean.TRUE;
 
    @SuppressWarnings("unchecked")
    public static <K, V> CompletableFuture<Map<K, V>> completedEmptyMap() {
@@ -173,5 +174,10 @@ public class CompletableFutures {
    public static <T, R> Function<T, R> toNullFunction() {
       //noinspection unchecked
       return (Function<T, R>) TO_NULL;
+   }
+
+   public static <T> Function<T, Boolean> toTrueFunction() {
+      //noinspection unchecked
+      return (Function<T, Boolean>) TO_TRUE_FUNCTION;
    }
 }

--- a/core/src/main/java/org/infinispan/util/concurrent/CompletionStages.java
+++ b/core/src/main/java/org/infinispan/util/concurrent/CompletionStages.java
@@ -54,6 +54,10 @@ public class CompletionStages {
       return new ValueAggregateCompletionStage<>(valueToReturn);
    }
 
+   public static AggregateCompletionStage<Boolean> orBooleanAggregateCompletionStage() {
+      return new OrBooleanAggregateCompletionStage();
+   }
+
    /**
     * Returns if the provided {@link CompletionStage} has already completed normally, that is not due to an exception.
     * @param stage stage to check
@@ -195,6 +199,28 @@ public class CompletionStages {
       @Override
       R getValue() {
          return value;
+      }
+   }
+
+   private static class OrBooleanAggregateCompletionStage extends AbstractAggregateCompletionStage<Boolean> {
+
+      private volatile boolean value = false;
+
+      @Override
+      Boolean getValue() {
+         return value;
+      }
+
+      @Override
+      public void accept(Object o, Throwable t) {
+         if (t != null) {
+            super.accept(null, t);
+            return;
+         }
+         if (o instanceof Boolean && (Boolean) o) {
+            this.value = true;
+         }
+         super.accept(o, null);
       }
    }
 

--- a/core/src/main/java/org/infinispan/xsite/irac/IracManager.java
+++ b/core/src/main/java/org/infinispan/xsite/irac/IracManager.java
@@ -69,9 +69,8 @@ public interface IracManager {
     * @param segment   The key's segment.
     * @param key       The key.
     * @param lockOwner The lock owner who updated the key.
-    * @param tombstone The tombstone (can be {@code null}).
     */
-   void cleanupKey(int segment, Object key, Object lockOwner, IracMetadata tombstone);
+   void cleanupKey(int segment, Object key, Object lockOwner);
 
    /**
     * Notifies a topology changed.
@@ -127,4 +126,14 @@ public interface IracManager {
     * Increase the count of conflicts if merge policy created a new value (merge remote value with local value)
     */
    void incrementNumberOfConflictMerged();
+
+   /**
+    * Checks if the key is present.
+    * <p>
+    * A key is present as long as its latest update was not confirmed by all remote sites.
+    *
+    * @param key The key to check.
+    * @return {@code true} if the key is present.
+    */
+   boolean containsKey(Object key);
 }

--- a/core/src/main/java/org/infinispan/xsite/irac/NoOpIracManager.java
+++ b/core/src/main/java/org/infinispan/xsite/irac/NoOpIracManager.java
@@ -51,7 +51,7 @@ public class NoOpIracManager implements IracManager {
    }
 
    @Override
-   public void cleanupKey(int segment, Object key, Object lockOwner, IracMetadata tombstone) {
+   public void cleanupKey(int segment, Object key, Object lockOwner) {
       // no-op
    }
 
@@ -93,5 +93,10 @@ public class NoOpIracManager implements IracManager {
    @Override
    public void incrementNumberOfConflictMerged() {
       // no-op
+   }
+
+   @Override
+   public boolean containsKey(Object key) {
+      return false;
    }
 }

--- a/core/src/test/java/org/infinispan/util/mocks/ControlledCommandFactory.java
+++ b/core/src/test/java/org/infinispan/util/mocks/ControlledCommandFactory.java
@@ -33,6 +33,7 @@ import org.infinispan.commands.functional.WriteOnlyKeyValueCommand;
 import org.infinispan.commands.functional.WriteOnlyManyCommand;
 import org.infinispan.commands.functional.WriteOnlyManyEntriesCommand;
 import org.infinispan.commands.irac.IracCleanupKeyCommand;
+import org.infinispan.commands.irac.IracCleanupTombstoneCommand;
 import org.infinispan.commands.irac.IracClearKeysCommand;
 import org.infinispan.commands.irac.IracMetadataRequestCommand;
 import org.infinispan.commands.irac.IracPutKeyCommand;
@@ -693,9 +694,13 @@ public class ControlledCommandFactory implements CommandsFactory {
    }
 
    @Override
-   public IracCleanupKeyCommand buildIracCleanupKeyCommand(int segment, Object key, Object lockOwner,
-                                                           IracMetadata tombstone) {
-      return actual.buildIracCleanupKeyCommand(segment, key, lockOwner, tombstone);
+   public IracCleanupKeyCommand buildIracCleanupKeyCommand(int segment, Object key, Object lockOwner) {
+      return actual.buildIracCleanupKeyCommand(segment, key, lockOwner);
+   }
+
+   @Override
+   public IracCleanupTombstoneCommand buildIracCleanupTombstoneCommand(Object key, IracMetadata tombstone) {
+      return actual.buildIracCleanupTombstoneCommand(key, tombstone);
    }
 
    @Override

--- a/core/src/test/java/org/infinispan/xsite/AbstractXSiteTest.java
+++ b/core/src/test/java/org/infinispan/xsite/AbstractXSiteTest.java
@@ -20,6 +20,8 @@ import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.container.versioning.irac.DefaultIracTombstoneManager;
+import org.infinispan.container.versioning.irac.IracTombstoneManager;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.remoting.transport.Transport;
 import org.infinispan.remoting.transport.jgroups.JGroupsTransport;
@@ -30,6 +32,7 @@ import org.infinispan.test.fwk.TransportFlags;
 import org.infinispan.transaction.impl.TransactionTable;
 import org.infinispan.xsite.irac.DefaultIracManager;
 import org.infinispan.xsite.irac.IracManager;
+import org.infinispan.xsite.irac.ManualIracManager;
 import org.infinispan.xsite.status.DefaultTakeOfflineManager;
 import org.infinispan.xsite.status.TakeOfflineManager;
 import org.jgroups.protocols.relay.RELAY2;
@@ -453,6 +456,21 @@ public abstract class AbstractXSiteTest extends AbstractCacheTest {
 
    protected DefaultIracManager iracManager(String site, String cacheName, int index) {
       return (DefaultIracManager) TestingUtil.extractComponent(cache(site, cacheName, index), IracManager.class);
+   }
+
+   protected boolean isIracManagerEmpty(Cache<?, ?> cache) {
+      IracManager manager = TestingUtil.extractComponent(cache, IracManager.class);
+      if (manager instanceof ManualIracManager) {
+         return ((ManualIracManager) manager).isEmpty();
+      } else if (manager instanceof DefaultIracManager) {
+         return ((DefaultIracManager) manager).isEmpty();
+      } else {
+         return true;
+      }
+   }
+
+   protected DefaultIracTombstoneManager iracTombstoneManager(Cache<?, ?> cache) {
+      return (DefaultIracTombstoneManager) TestingUtil.extractComponent(cache, IracTombstoneManager.class);
    }
 
    @Override

--- a/core/src/test/java/org/infinispan/xsite/irac/ControlledIracManager.java
+++ b/core/src/test/java/org/infinispan/xsite/irac/ControlledIracManager.java
@@ -48,8 +48,8 @@ public class ControlledIracManager implements IracManager {
    }
 
    @Override
-   public void cleanupKey(int segment, Object key, Object lockOwner, IracMetadata tombstone) {
-      actual.cleanupKey(segment, key, lockOwner, tombstone);
+   public void cleanupKey(int segment, Object key, Object lockOwner) {
+      actual.cleanupKey(segment, key, lockOwner);
    }
 
    @Override
@@ -90,6 +90,11 @@ public class ControlledIracManager implements IracManager {
    @Override
    public void incrementNumberOfConflictMerged() {
       actual.incrementNumberOfConflictMerged();
+   }
+
+   @Override
+   public boolean containsKey(Object key) {
+      return actual.containsKey(key);
    }
 
    protected Optional<DefaultIracManager> asDefaultIracManager() {

--- a/core/src/test/java/org/infinispan/xsite/irac/ControlledIracVersionGenerator.java
+++ b/core/src/test/java/org/infinispan/xsite/irac/ControlledIracVersionGenerator.java
@@ -40,31 +40,6 @@ public class ControlledIracVersionGenerator implements IracVersionGenerator {
    }
 
    @Override
-   public void storeTombstone(Object key, IracMetadata metadata) {
-      actual.storeTombstone(key, metadata);
-   }
-
-   @Override
-   public void storeTombstoneIfAbsent(Object key, IracMetadata metadata) {
-      actual.storeTombstoneIfAbsent(key, metadata);
-   }
-
-   @Override
-   public IracMetadata getTombstone(Object key) {
-      return actual.getTombstone(key);
-   }
-
-   @Override
-   public void removeTombstone(Object key, IracMetadata iracMetadata) {
-      actual.removeTombstone(key, iracMetadata);
-   }
-
-   @Override
-   public void removeTombstone(Object key) {
-      actual.removeTombstone(key);
-   }
-
-   @Override
    public void onTopologyChange(CacheTopology newTopology) {
       actual.onTopologyChange(newTopology);
    }

--- a/core/src/test/java/org/infinispan/xsite/irac/Irac3SitesConflictTest.java
+++ b/core/src/test/java/org/infinispan/xsite/irac/Irac3SitesConflictTest.java
@@ -289,5 +289,6 @@ public class Irac3SitesConflictTest extends AbstractMultipleSitesTest {
 
       String expectedFinalValue = testConfig.getValueFromArray(finalValues);
       eventuallyAssertInAllSitesAndCaches(cache -> Objects.equals(expectedFinalValue, cache.get(key)));
+      assertNoDataLeak(null);
    }
 }

--- a/core/src/test/java/org/infinispan/xsite/irac/IracAlwaysRemoveConflictTest.java
+++ b/core/src/test/java/org/infinispan/xsite/irac/IracAlwaysRemoveConflictTest.java
@@ -148,5 +148,6 @@ public class IracAlwaysRemoveConflictTest extends AbstractMultipleSitesTest {
       iracManagerList.forEach(manualIracManager -> manualIracManager.disable(ManualIracManager.DisableMode.SEND));
 
       eventuallyAssertInAllSitesAndCaches(cache -> Objects.equals(null, cache.get(key)));
+      assertNoDataLeak(null);
    }
 }

--- a/core/src/test/java/org/infinispan/xsite/irac/IracCustomConflictTest.java
+++ b/core/src/test/java/org/infinispan/xsite/irac/IracCustomConflictTest.java
@@ -201,6 +201,7 @@ public class IracCustomConflictTest extends AbstractMultipleSitesTest {
                                new MySortedSet(new String[]{"a", "site_1"}) :
                                new MySortedSet(new String[]{"a", "site_0", "site_1"}); //the values should be merged.
       eventuallyAssertInAllSitesAndCaches(cache -> Objects.equals(finalValue, cache.get(key)));
+      assertNoDataLeak(null);
    }
 
    private enum ConfigMode {

--- a/core/src/test/java/org/infinispan/xsite/irac/IracMaxIdleTest.java
+++ b/core/src/test/java/org/infinispan/xsite/irac/IracMaxIdleTest.java
@@ -98,6 +98,7 @@ public class IracMaxIdleTest extends AbstractMultipleSitesTest {
 
       assertNoKeyInDataContainer(1, cacheName, key);
       assertNoKeyInDataContainer(0, cacheName, key);
+      assertNoDataLeak(cacheName);
    }
 
    private static String createKeyOrValue(TestData testData, String prefix) {

--- a/core/src/test/java/org/infinispan/xsite/irac/IracWriteSkewTest.java
+++ b/core/src/test/java/org/infinispan/xsite/irac/IracWriteSkewTest.java
@@ -114,6 +114,7 @@ public class IracWriteSkewTest extends AbstractMultipleSitesTest {
             checkKey(key, "write-skew-value");
          }
       }
+      assertNoDataLeak(CACHE_NAME);
    }
 
    @Override


### PR DESCRIPTION
Tombstones are required to detect conflicts with removed keys and they
can be removed when there are no pending updates from any site.

In this PR, the primary owner queries all sites and, if all sites do not
have any update pending for that key, it removes the tombstone from the
primary owner and backup owners.

https://issues.redhat.com/browse/ISPN-13430