### PR TITLE
ISPN-13431 IRAC: backup owners track keys twice

### DIFF
--- a/core/src/main/java/org/infinispan/interceptors/xsite/NonTransactionalBackupInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/xsite/NonTransactionalBackupInterceptor.java
@@ -144,7 +144,9 @@ public class NonTransactionalBackupInterceptor extends BaseBackupInterceptor {
       LocalizedCacheTopology localizedCacheTopology = clusteringDependentLogic.getCacheTopology();
       for (Object key : writeCommand.getAffectedKeys()) {
          DistributionInfo info = localizedCacheTopology.getDistribution(key);
-         if (info.isWriteOwner()) { //all owners need to keep track.
+         if (info.isPrimary() || (!ctx.isOriginLocal() && info.isWriteOwner())) {
+            // track the update for the ASYNC cross-site
+            // backup owner only track updates when the context is remote.
             iracManager.trackUpdatedKey(info.segmentId(), key, writeCommand.getCommandInvocationId());
          }
          if (!info.isPrimary()) {

--- a/core/src/main/java/org/infinispan/xsite/irac/IracManager.java
+++ b/core/src/main/java/org/infinispan/xsite/irac/IracManager.java
@@ -3,6 +3,7 @@ package org.infinispan.xsite.irac;
 import java.util.Collection;
 import java.util.concurrent.CompletionStage;
 
+import org.infinispan.commands.irac.IracClearKeysCommand;
 import org.infinispan.commons.util.IntSet;
 import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
@@ -58,8 +59,10 @@ public interface IracManager {
 
    /**
     * Sets all keys as removed.
+    *
+    * @param sendClear if {@code true}, an {@link IracClearKeysCommand} is sent to the backup sites.
     */
-   void trackClear();
+   void trackClear(boolean sendClear);
 
    /**
     * Sets the {@code key} as not changed and remove any tombstone related to it.

--- a/core/src/main/java/org/infinispan/xsite/irac/NoOpIracManager.java
+++ b/core/src/main/java/org/infinispan/xsite/irac/NoOpIracManager.java
@@ -46,7 +46,7 @@ public class NoOpIracManager implements IracManager {
    }
 
    @Override
-   public void trackClear() {
+   public void trackClear(boolean sendClear) {
       // no-op
    }
 

--- a/core/src/test/java/org/infinispan/xsite/irac/ControlledIracManager.java
+++ b/core/src/test/java/org/infinispan/xsite/irac/ControlledIracManager.java
@@ -43,8 +43,8 @@ public class ControlledIracManager implements IracManager {
    }
 
    @Override
-   public void trackClear() {
-      actual.trackClear();
+   public void trackClear(boolean sendClear) {
+      actual.trackClear(sendClear);
    }
 
    @Override


### PR DESCRIPTION
* Backup owners only track keys changed when the context is remote.
* Clear is now tracking the keys on backup owners.
* On topology change, trigger an IRAC round only when there are pending
  updates to be sent.

https://issues.redhat.com/browse/ISPN-13431