### PR TITLE
[13.0.x] ISPN-13454 Ickle DELETE should not allow usage of Query.startOffset/maxResults

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryStringTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryStringTest.java
@@ -240,4 +240,10 @@ public class RemoteQueryStringTest extends QueryStringTest {
    public void testDeleteWithGroupBy() {
       super.testDeleteWithGroupBy();
    }
+
+   @Override
+   @Test(expectedExceptions = HotRodClientException.class, expectedExceptionsMessageRegExp = ".*ISPN014057: DELETE statements cannot use paging \\(firstResult/maxResults\\)")
+   public void testDeleteWithPaging() {
+      super.testDeleteWithPaging();
+   }
 }

--- a/query-core/src/main/java/org/infinispan/query/core/impl/EmbeddedQuery.java
+++ b/query-core/src/main/java/org/infinispan/query/core/impl/EmbeddedQuery.java
@@ -11,6 +11,8 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
+import static org.infinispan.query.core.impl.Log.CONTAINER;
+
 import org.infinispan.AdvancedCache;
 import org.infinispan.CacheStream;
 import org.infinispan.commons.marshall.AdvancedExternalizer;
@@ -105,7 +107,11 @@ public final class EmbeddedQuery<T> extends BaseEmbeddedQuery<T> {
    @Override
    public int executeStatement() {
       if (isSelectStatement()) {
-         throw new UnsupportedOperationException("Only DELETE statements are supported by executeStatement");
+         throw CONTAINER.unsupportedStatement();
+      }
+
+      if (getStartOffset() != 0 || getMaxResults() != -1 && getMaxResults() != Integer.MAX_VALUE) {
+         throw CONTAINER.deleteStatementsCannotUsePaging();
       }
 
       IckleFilterAndConverter<Object, Object> ickleFilter = (IckleFilterAndConverter<Object, Object>) createFilter();

--- a/query-core/src/main/java/org/infinispan/query/core/impl/EmptyResultQuery.java
+++ b/query-core/src/main/java/org/infinispan/query/core/impl/EmptyResultQuery.java
@@ -11,6 +11,7 @@ import org.infinispan.objectfilter.ObjectFilter;
 import org.infinispan.objectfilter.impl.syntax.parser.IckleParsingResult;
 import org.infinispan.query.core.stats.impl.LocalQueryStatistics;
 import org.infinispan.query.dsl.QueryFactory;
+import org.infinispan.util.logging.LogFactory;
 
 /**
  * A query that does not return any results because the query filter is a boolean contradiction.
@@ -19,6 +20,8 @@ import org.infinispan.query.dsl.QueryFactory;
  * @since 8.0
  */
 public final class EmptyResultQuery<T> extends BaseEmbeddedQuery<T> {
+
+   private static final Log LOG = LogFactory.getLog(EmptyResultQuery.class, Log.class);
 
    public EmptyResultQuery(QueryFactory queryFactory, AdvancedCache<?, ?> cache, String queryString,
                            IckleParsingResult.StatementType statementType,
@@ -60,7 +63,7 @@ public final class EmptyResultQuery<T> extends BaseEmbeddedQuery<T> {
    @Override
    public int executeStatement() {
       if (isSelectStatement()) {
-         throw new UnsupportedOperationException("Only DELETE statements are supported by executeStatement");
+         throw LOG.unsupportedStatement();
       }
       return 0;
    }

--- a/query-core/src/main/java/org/infinispan/query/core/impl/HybridQuery.java
+++ b/query-core/src/main/java/org/infinispan/query/core/impl/HybridQuery.java
@@ -14,6 +14,7 @@ import org.infinispan.query.core.stats.impl.LocalQueryStatistics;
 import org.infinispan.query.dsl.Query;
 import org.infinispan.query.dsl.QueryFactory;
 import org.infinispan.query.dsl.QueryResult;
+import org.infinispan.util.logging.LogFactory;
 
 /**
  * A non-indexed query performed on top of the results returned by another query (usually a Lucene based query). This
@@ -24,6 +25,8 @@ import org.infinispan.query.dsl.QueryResult;
  * @since 8.0
  */
 public class HybridQuery<T, S> extends BaseEmbeddedQuery<T> {
+
+   private static final Log LOG = LogFactory.getLog(HybridQuery.class, Log.class);
 
    // An object filter is used to further filter the baseQuery
    protected final ObjectFilter objectFilter;
@@ -69,7 +72,7 @@ public class HybridQuery<T, S> extends BaseEmbeddedQuery<T> {
    @Override
    public int executeStatement() {
       if (isSelectStatement()) {
-         throw new UnsupportedOperationException("Only DELETE statements are supported by executeStatement");
+         throw LOG.unsupportedStatement();
       }
 
       try (CloseableIterator<Map.Entry<Object, S>> entryIterator = baseQuery.startOffset(0).maxResults(-1).local(local).entryIterator()) {

--- a/query-core/src/main/java/org/infinispan/query/core/impl/Log.java
+++ b/query-core/src/main/java/org/infinispan/query/core/impl/Log.java
@@ -1,5 +1,6 @@
 package org.infinispan.query.core.impl;
 
+import org.infinispan.commons.CacheException;
 import org.infinispan.objectfilter.ParsingException;
 import org.infinispan.partitionhandling.AvailabilityException;
 import org.jboss.logging.BasicLogger;
@@ -8,7 +9,7 @@ import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 import org.jboss.logging.annotations.ValidIdRange;
 
-//TODO [anistor] query-core and query modules share the id range!
+//TODO [anistor] query-core and query modules share the id range now and in the future these loggers will probably merge
 /**
  * Log abstraction for the query-core module. For this module, message ids ranging from 14001 to 14500 inclusively have been
  * reserved.
@@ -46,4 +47,13 @@ public interface Log extends BasicLogger {
 
    @Message(value = "Cannot execute query: cluster is operating in degraded mode and partition handling configuration doesn't allow reads and writes.", id = 14042)
    AvailabilityException partitionDegraded();
+
+   @Message(value = "Only DELETE statements are supported by executeStatement", id = 14056)
+   CacheException unsupportedStatement();
+
+   @Message(value = "DELETE statements cannot use paging (firstResult/maxResults)", id = 14057)
+   CacheException deleteStatementsCannotUsePaging();
+
+   @Message(value = "Projections are not supported with entryIterator()", id = 14058)
+   CacheException entryIteratorDoesNotAllowProjections();
 }

--- a/query-core/src/main/java/org/infinispan/query/core/impl/QueryResultImpl.java
+++ b/query-core/src/main/java/org/infinispan/query/core/impl/QueryResultImpl.java
@@ -22,7 +22,7 @@ public final class QueryResultImpl<E> implements QueryResult<E> {
       this.list = list;
    }
 
-   public QueryResultImpl(List<E> list) {
+   public QueryResultImpl(List<E> list) { //todo [anistor] why not used?
       this.hitCount = OptionalLong.empty();
       this.list = list;
    }

--- a/query-dsl/src/main/java/org/infinispan/query/dsl/Query.java
+++ b/query-dsl/src/main/java/org/infinispan/query/dsl/Query.java
@@ -45,10 +45,11 @@ public interface Query<T> extends Iterable<T>, PaginationContext<Query<T>>, Para
     */
    QueryResult<T> execute();
 
-   // TODO [anistor] disallow pagination params if any for non-SELECT statements
    /**
     * Executes a data modifying statement (typically a DELETE) that does not return results; instead it returns an
     * affected entries count. This method cannot be used to execute a SELECT.
+    * <p>
+    * <b>NOTE:</b> Paging params (firstResult/maxResults) are NOT allowed.
     *
     * @return the number of affected (deleted) entries
     */

--- a/query-dsl/src/main/java/org/infinispan/query/dsl/QueryResult.java
+++ b/query-dsl/src/main/java/org/infinispan/query/dsl/QueryResult.java
@@ -5,6 +5,9 @@ import java.util.OptionalLong;
 
 /**
  * Represents the result of a {@link Query}.
+ * <p>
+ * If the query was executed using {@link Query#executeStatement()}, the list of results will be empty and
+ * {@link #hitCount()} will return the number of affected entries.
  *
  * @param <E> The type of the result. Queries having projections (a SELECT clause) will return an Object[] for each
  *            result, with the field values. When not using SELECT, the results will contain instances of objects
@@ -20,8 +23,8 @@ public interface QueryResult<E> {
    OptionalLong hitCount();   // todo [anistor] if cache size is an int, how can hit count be a wider type?
 
    /**
-    * @return The results of the query as a list, respecting the bounds specified in {@link Query#startOffset(long)} and
-    * {@link Query#maxResults(int)}.
+    * @return The results of the query as a List, respecting the bounds specified in {@link Query#startOffset(long)} and
+    * {@link Query#maxResults(int)}. This never returns {@code null} but will always be an empty List for {@link Query#executeStatement}.
     */
    List<E> list();
 }

--- a/query-dsl/src/main/java/org/infinispan/query/dsl/impl/BaseQuery.java
+++ b/query-dsl/src/main/java/org/infinispan/query/dsl/impl/BaseQuery.java
@@ -210,7 +210,7 @@ public abstract class BaseQuery<T> implements Query<T> {
 
    @Override
    public <K> CloseableIterator<Map.Entry<K, T>> entryIterator() {
-      throw new UnsupportedOperationException();
+      throw new UnsupportedOperationException("Not implemented!");
    }
 
    @Override

--- a/query/src/main/java/org/infinispan/query/clustered/commandworkers/CQCreateEagerQuery.java
+++ b/query/src/main/java/org/infinispan/query/clustered/commandworkers/CQCreateEagerQuery.java
@@ -23,14 +23,13 @@ final class CQCreateEagerQuery extends CQWorker {
       SearchQueryBuilder query = queryDefinition.getSearchQueryBuilder();
       setFilter(segments);
 
-      CompletionStage<NodeTopDocs> nodeTopDocs = query.hasEntityProjection() ? collectKeys(query) : collectProjections(query);
+      CompletionStage<NodeTopDocs> nodeTopDocs = query.isEntityProjection() ? collectKeys(query) : collectProjections(query);
 
       return nodeTopDocs.thenApply(QueryResponse::new);
    }
 
    private LuceneSearchResult<?> fetchHits(SearchQueryBuilder query) {
-      long start = 0;
-      if (queryStatistics.isEnabled()) start = System.nanoTime();
+      long start = queryStatistics.isEnabled() ? System.nanoTime() : 0;
 
       LuceneSearchResult<?> result = query.build().fetch(queryDefinition.getMaxResults());
 
@@ -41,8 +40,7 @@ final class CQCreateEagerQuery extends CQWorker {
    }
 
    private LuceneSearchResult<EntityReference> fetchReferences(SearchQueryBuilder query) {
-      long start = 0;
-      if (queryStatistics.isEnabled()) start = System.nanoTime();
+      long start = queryStatistics.isEnabled() ? System.nanoTime() : 0;
 
       LuceneSearchResult<EntityReference> result = query.entityReference().fetch(queryDefinition.getMaxResults());
 

--- a/query/src/main/java/org/infinispan/query/dsl/embedded/impl/SearchQueryBuilder.java
+++ b/query/src/main/java/org/infinispan/query/dsl/embedded/impl/SearchQueryBuilder.java
@@ -79,7 +79,10 @@ public final class SearchQueryBuilder {
       routingKeys = Collections.emptySet();
    }
 
-   public boolean hasEntityProjection() {
+   /**
+    * Indicates if this query 'projects' just the entity and nothing else.
+    */
+   public boolean isEntityProjection() {
       return projectionInfo.isEntityProjection();
    }
 

--- a/query/src/main/java/org/infinispan/query/impl/IndexedQuery.java
+++ b/query/src/main/java/org/infinispan/query/impl/IndexedQuery.java
@@ -32,17 +32,34 @@ public interface IndexedQuery<E> {
    /**
     * Sets the maximum number of results to return from the query. Used for pagination.
     *
-    * @param numResults the maximum number of results to return.
+    * @param maxResults the maximum number of results to return.
     */
-   IndexedQuery<E> maxResults(int numResults);
+   IndexedQuery<E> maxResults(int maxResults);
 
    CloseableIterator<E> iterator();
 
-   // TODO [anistor] works for queries without projections only, should throw exception for projections
+   /**
+    * Returns the matching entries (both key and value).
+    * <p>
+    * <b>NOTE:</b> The query must not contain any projections or an exception will be thrown.
+    */
    <K> CloseableIterator<Map.Entry<K, E>> entryIterator();
 
+   /**
+    * Executes an Ickle statement returning results (query aka. SELECT). If the statement happens to be a DELETE it
+    * redirects it to {@link #executeStatement()}.
+    * <p>
+    * <b>NOTE:</b> Paging params (firstResult/maxResults) are honoured for SELECT and dissalowed for DELETE.
+    */
    QueryResult<?> execute();
 
+   /**
+    * Executes an Ickle statement not returning any results (ie. DELETE).
+    * <p>
+    * <b>NOTE:</b> Paging params (firstResult/maxResults) are NOT allowed.
+    *
+    * @return the number of affected entries
+    */
    int executeStatement();
 
    int getResultSize();

--- a/query/src/main/java/org/infinispan/query/logging/Log.java
+++ b/query/src/main/java/org/infinispan/query/logging/Log.java
@@ -182,4 +182,6 @@ public interface Log extends org.infinispan.query.core.impl.Log {
 
    @Message(value = "Cannot index entry since the search mapping failed to initialize.", id = 14055)
    CacheException searchMappingUnavailable();
+
+   // !!!!!! When adding anything new here please check the last used id in org.infinispan.query.core.impl.Log !!!!!!
 }

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/QueryStringTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/QueryStringTest.java
@@ -463,7 +463,10 @@ public class QueryStringTest extends AbstractQueryDslTest {
 
    @Test(expectedExceptions = ParsingException.class, expectedExceptionsMessageRegExp = "ISPN028526: Invalid query.*")
    public void testDeleteWithProjections() {
+      // exception thrown on create when in embedded mode
       Query<Transaction> delete = createQueryFromString("DELETE t.description FROM " + getModelFactory().getTransactionTypeName() + " as t WHERE t.description = 'bogus' ORDER BY amount");
+
+      // exception thrown just on execute when in remote mode
       delete.executeStatement();
    }
 
@@ -476,6 +479,13 @@ public class QueryStringTest extends AbstractQueryDslTest {
    @Test(expectedExceptions = ParsingException.class, expectedExceptionsMessageRegExp = "ISPN028526: Invalid query.*")
    public void testDeleteWithGroupBy() {
       Query<Transaction> delete = createQueryFromString("DELETE FROM " + getModelFactory().getTransactionTypeName() + " WHERE description = 'bogus' GROUP BY accountId");
+      delete.executeStatement();
+   }
+
+   @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "ISPN014057: DELETE statements cannot use paging \\(firstResult/maxResults\\)")
+   public void testDeleteWithPaging() {
+      Query<Transaction> delete = createQueryFromString("DELETE FROM " + getModelFactory().getTransactionTypeName() + " WHERE description = 'bogus'");
+      delete.maxResults(5);
       delete.executeStatement();
    }
 


### PR DESCRIPTION

* also prevent use of projections with Query.entryIterator() because
projecting anything other than key and value would work against the
purpose of entryIterator
* use proper i18n for some newly added exceptions
* prefer throwing CacheException in case of api misusage instead of other less specific RuntimeExceptions

https://issues.redhat.com/browse/ISPN-13454