### PR TITLE
ISPN-13473 Improve SingleSiteRequest.sitesUnreachable()

### DIFF
--- a/core/src/main/java/org/infinispan/remoting/rpc/RpcManagerImpl.java
+++ b/core/src/main/java/org/infinispan/remoting/rpc/RpcManagerImpl.java
@@ -416,6 +416,10 @@ public class RpcManagerImpl implements RpcManager, JmxStatisticsExposer, CustomM
    }
 
    private void registerXSiteTime(XSiteBackup backup, long sentTimestamp, long durationNanos, Throwable ignored) {
+      if (durationNanos <= 0) {
+         // no network involved
+         return;
+      }
       xSiteMetricsCollector.recordRequestSent(backup.getSiteName(), durationNanos, TimeUnit.NANOSECONDS);
    }
 

--- a/core/src/main/java/org/infinispan/remoting/transport/impl/SiteUnreachableXSiteResponse.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/impl/SiteUnreachableXSiteResponse.java
@@ -1,0 +1,43 @@
+package org.infinispan.remoting.transport.impl;
+
+import static org.infinispan.util.logging.Log.CLUSTER;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.infinispan.commons.time.TimeService;
+import org.infinispan.remoting.transport.SiteAddress;
+import org.infinispan.remoting.transport.XSiteResponse;
+import org.infinispan.remoting.transport.jgroups.SuspectException;
+import org.infinispan.xsite.XSiteBackup;
+
+/**
+ * A {@link XSiteResponse} which is competed with a {@link SuspectException}.
+ *
+ * @since 14.0
+ */
+public class SiteUnreachableXSiteResponse<T> extends CompletableFuture<T> implements XSiteResponse<T> {
+
+   private final XSiteBackup backup;
+   private final long sendTimeNanos;
+   private final SuspectException exception;
+
+   public SiteUnreachableXSiteResponse(XSiteBackup backup, TimeService timeService) {
+      this.backup = backup;
+      this.sendTimeNanos = timeService.time();
+      this.exception = CLUSTER.remoteNodeSuspected(new SiteAddress(backup.getSiteName()));
+      completeExceptionally(exception);
+   }
+
+   @Override
+   public void whenCompleted(XSiteResponseCompleted xSiteResponseCompleted) {
+      xSiteResponseCompleted.onCompleted(backup, sendTimeNanos, -1, exception);
+   }
+
+   @Override
+   public String toString() {
+      return "SiteUnreachableXSiteResponse{" +
+            "backup=" + backup +
+            ", sendTimeNanos=" + sendTimeNanos +
+            '}';
+   }
+}

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/SingleSiteRequest.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/SingleSiteRequest.java
@@ -43,8 +43,8 @@ public class SingleSiteRequest<T> extends AbstractRequest<T> {
          T result;
          synchronized (responseCollector) {
             if (isDone()) {
-               throw new IllegalStateException(
-                     "Duplicate response received for x-site request " + requestId + " from " + sender);
+               // CompletableFuture already completed. We can return immediately.
+               return;
             }
             result = responseCollector.addResponse(sender, response);
             if (result == null) {


### PR DESCRIPTION
* Use only one thread to handle the event for each site.
* While a thread is handling the event, fail the new requests.

https://issues.redhat.com/browse/ISPN-13473