### PR TITLE
ISPN-13495 IRAC send tombstones in state transfer

### DIFF
--- a/bin/list_command_ids.py
+++ b/bin/list_command_ids.py
@@ -40,30 +40,31 @@ for test_file in GlobDirectoryWalker(get_search_path(sys.argv[0]) + 'core/src/ma
   finally:
     tf.close()
 
-print 'Scanned %s Command source files.  IDs are (in order):' % len(command_ids)
+print('Scanned %s Command source files.  IDs are (in order):' % len(command_ids))
 
-sorted_keys = command_ids.keys()
-sorted_keys.sort()
+sorted_keys = sorted(command_ids.keys())
 
 i=1
 prev_id = 0
 for k in sorted_keys:
   prev_id += 1
   while k > prev_id:
-    print '  ---'
+    print('  ---')
     prev_id += 1
 
   zeropad = ""
   if (i < 10 and len(sorted_keys) > 9):
     zeropad = " "
-  print '   %s%s) Class [%s%s%s] has COMMAND_ID [%s%s%s]' % (zeropad, i, Colors.green(), command_ids[k], Colors.end_color(), Colors.yellow(), k, Colors.end_color())
+  if i < 100 and len(sorted_keys) > 90:
+    zeropad += " "
+  print('  %s%s) Class [%s%s%s] has COMMAND_ID [%s%s%s]' % (zeropad, i, Colors.green(), command_ids[k], Colors.end_color(), Colors.yellow(), k, Colors.end_color()))
   i += 1
 
-print "\n"
+print("\n")
 if len(warnings) > 0:
-  print "WARNINGS:"
+  print("WARNINGS:")
   for w in warnings:
-    print "  *** %s" % w
-  print "\n"
+    print("  *** %s" % w)
+  print("\n")
 
-print "Next available ID is %s%s%s" % (Colors.cyan(), get_next(sorted_keys), Colors.end_color())
+print("Next available ID is %s%s%s" % (Colors.cyan(), get_next(sorted_keys), Colors.end_color()))

--- a/bin/utils.py
+++ b/bin/utils.py
@@ -91,7 +91,7 @@ def prettyprint(message, level):
   start_color = Levels.get_color(level)
   end_color = Levels.end_color()
     
-  print "[%s%s%s] %s" % (start_color, level, end_color, message)
+  print("[%s%s%s] %s" % (start_color, level, end_color, message))
 
 def apply_defaults(s):
   for e in default_settings.items():

--- a/core/src/main/java/org/infinispan/commands/CommandsFactory.java
+++ b/core/src/main/java/org/infinispan/commands/CommandsFactory.java
@@ -26,13 +26,16 @@ import org.infinispan.commands.functional.WriteOnlyKeyValueCommand;
 import org.infinispan.commands.functional.WriteOnlyManyCommand;
 import org.infinispan.commands.functional.WriteOnlyManyEntriesCommand;
 import org.infinispan.commands.irac.IracCleanupKeyCommand;
-import org.infinispan.commands.irac.IracCleanupTombstoneCommand;
+import org.infinispan.commands.irac.IracTombstoneCleanupCommand;
 import org.infinispan.commands.irac.IracClearKeysCommand;
 import org.infinispan.commands.irac.IracMetadataRequestCommand;
 import org.infinispan.commands.irac.IracPutKeyCommand;
 import org.infinispan.commands.irac.IracRemoveKeyCommand;
 import org.infinispan.commands.irac.IracRequestStateCommand;
 import org.infinispan.commands.irac.IracStateResponseCommand;
+import org.infinispan.commands.irac.IracTombstonePrimaryCheckCommand;
+import org.infinispan.commands.irac.IracTombstoneRemoteSiteCheckCommand;
+import org.infinispan.commands.irac.IracTombstoneStateResponseCommand;
 import org.infinispan.commands.irac.IracTouchKeyCommand;
 import org.infinispan.commands.irac.IracUpdateVersionCommand;
 import org.infinispan.commands.read.EntrySetCommand;
@@ -93,6 +96,7 @@ import org.infinispan.configuration.cache.XSiteStateTransferMode;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.container.versioning.irac.IracEntryVersion;
+import org.infinispan.container.versioning.irac.IracTombstoneInfo;
 import org.infinispan.encoding.DataConversion;
 import org.infinispan.expiration.impl.TouchCommand;
 import org.infinispan.factories.ComponentRegistry;
@@ -644,7 +648,7 @@ public interface CommandsFactory {
 
    IracCleanupKeyCommand buildIracCleanupKeyCommand(int segment, Object key, Object lockOwner);
 
-   IracCleanupTombstoneCommand buildIracCleanupTombstoneCommand(Object key, IracMetadata tombstone);
+   IracTombstoneCleanupCommand buildIracTombstoneCleanupCommand(IracTombstoneInfo tombstone);
 
    IracMetadataRequestCommand buildIracMetadataRequestCommand(int segment, IracEntryVersion versionSeen);
 
@@ -662,4 +666,10 @@ public interface CommandsFactory {
    XSiteAutoTransferStatusCommand buildXSiteAutoTransferStatusCommand(String site);
 
    XSiteSetStateTransferModeCommand buildXSiteSetStateTransferModeCommand(String site, XSiteStateTransferMode mode);
+
+   IracTombstoneRemoteSiteCheckCommand buildIracTombstoneRemoteSiteCheckCommand(Object key);
+
+   IracTombstoneStateResponseCommand buildIracTombstoneStateResponseCommand(Collection<IracTombstoneInfo> state);
+
+   IracTombstonePrimaryCheckCommand buildIracTombstonePrimaryCheckCommand(int capacity);
 }

--- a/core/src/main/java/org/infinispan/commands/CommandsFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/commands/CommandsFactoryImpl.java
@@ -27,13 +27,16 @@ import org.infinispan.commands.functional.WriteOnlyKeyValueCommand;
 import org.infinispan.commands.functional.WriteOnlyManyCommand;
 import org.infinispan.commands.functional.WriteOnlyManyEntriesCommand;
 import org.infinispan.commands.irac.IracCleanupKeyCommand;
-import org.infinispan.commands.irac.IracCleanupTombstoneCommand;
+import org.infinispan.commands.irac.IracTombstoneCleanupCommand;
 import org.infinispan.commands.irac.IracClearKeysCommand;
 import org.infinispan.commands.irac.IracMetadataRequestCommand;
 import org.infinispan.commands.irac.IracPutKeyCommand;
 import org.infinispan.commands.irac.IracRemoveKeyCommand;
 import org.infinispan.commands.irac.IracRequestStateCommand;
 import org.infinispan.commands.irac.IracStateResponseCommand;
+import org.infinispan.commands.irac.IracTombstonePrimaryCheckCommand;
+import org.infinispan.commands.irac.IracTombstoneRemoteSiteCheckCommand;
+import org.infinispan.commands.irac.IracTombstoneStateResponseCommand;
 import org.infinispan.commands.irac.IracTouchKeyCommand;
 import org.infinispan.commands.irac.IracUpdateVersionCommand;
 import org.infinispan.commands.read.EntrySetCommand;
@@ -102,6 +105,7 @@ import org.infinispan.configuration.cache.XSiteStateTransferMode;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.container.versioning.irac.IracEntryVersion;
+import org.infinispan.container.versioning.irac.IracTombstoneInfo;
 import org.infinispan.context.impl.FlagBitSets;
 import org.infinispan.encoding.DataConversion;
 import org.infinispan.expiration.impl.TouchCommand;
@@ -734,8 +738,8 @@ public class CommandsFactoryImpl implements CommandsFactory {
    }
 
    @Override
-   public IracCleanupTombstoneCommand buildIracCleanupTombstoneCommand(Object key, IracMetadata tombstone) {
-      return new IracCleanupTombstoneCommand(cacheName, key, tombstone);
+   public IracTombstoneCleanupCommand buildIracTombstoneCleanupCommand(IracTombstoneInfo tombstone) {
+      return new IracTombstoneCleanupCommand(cacheName, tombstone);
    }
 
    @Override
@@ -777,5 +781,20 @@ public class CommandsFactoryImpl implements CommandsFactory {
    @Override
    public XSiteSetStateTransferModeCommand buildXSiteSetStateTransferModeCommand(String site, XSiteStateTransferMode mode) {
       return new XSiteSetStateTransferModeCommand(cacheName, site, mode);
+   }
+
+   @Override
+   public IracTombstoneRemoteSiteCheckCommand buildIracTombstoneRemoteSiteCheckCommand(Object key) {
+      return new IracTombstoneRemoteSiteCheckCommand(cacheName, key);
+   }
+
+   @Override
+   public IracTombstoneStateResponseCommand buildIracTombstoneStateResponseCommand(Collection<IracTombstoneInfo> state) {
+      return new IracTombstoneStateResponseCommand(cacheName, state);
+   }
+
+   @Override
+   public IracTombstonePrimaryCheckCommand buildIracTombstonePrimaryCheckCommand(int capacity) {
+      return new IracTombstonePrimaryCheckCommand(cacheName, capacity);
    }
 }

--- a/core/src/main/java/org/infinispan/commands/RemoteCommandsFactory.java
+++ b/core/src/main/java/org/infinispan/commands/RemoteCommandsFactory.java
@@ -16,13 +16,16 @@ import org.infinispan.commands.functional.WriteOnlyKeyValueCommand;
 import org.infinispan.commands.functional.WriteOnlyManyCommand;
 import org.infinispan.commands.functional.WriteOnlyManyEntriesCommand;
 import org.infinispan.commands.irac.IracCleanupKeyCommand;
-import org.infinispan.commands.irac.IracCleanupTombstoneCommand;
+import org.infinispan.commands.irac.IracTombstoneCleanupCommand;
 import org.infinispan.commands.irac.IracClearKeysCommand;
 import org.infinispan.commands.irac.IracMetadataRequestCommand;
 import org.infinispan.commands.irac.IracPutKeyCommand;
 import org.infinispan.commands.irac.IracRemoveKeyCommand;
 import org.infinispan.commands.irac.IracRequestStateCommand;
 import org.infinispan.commands.irac.IracStateResponseCommand;
+import org.infinispan.commands.irac.IracTombstonePrimaryCheckCommand;
+import org.infinispan.commands.irac.IracTombstoneRemoteSiteCheckCommand;
+import org.infinispan.commands.irac.IracTombstoneStateResponseCommand;
 import org.infinispan.commands.irac.IracTouchKeyCommand;
 import org.infinispan.commands.irac.IracUpdateVersionCommand;
 import org.infinispan.commands.module.ModuleCommandFactory;
@@ -488,8 +491,17 @@ public class RemoteCommandsFactory {
             case XSiteSetStateTransferModeCommand.COMMAND_ID:
                command = new XSiteSetStateTransferModeCommand(cacheName);
                break;
-            case IracCleanupTombstoneCommand.COMMAND_ID:
-               command = new IracCleanupTombstoneCommand(cacheName);
+            case IracTombstoneCleanupCommand.COMMAND_ID:
+               command = new IracTombstoneCleanupCommand(cacheName);
+               break;
+            case IracTombstoneRemoteSiteCheckCommand.COMMAND_ID:
+               command = new IracTombstoneRemoteSiteCheckCommand(cacheName);
+               break;
+            case IracTombstoneStateResponseCommand.COMMAND_ID:
+               command = new IracTombstoneStateResponseCommand(cacheName);
+               break;
+            case IracTombstonePrimaryCheckCommand.COMMAND_ID:
+               command = new IracTombstonePrimaryCheckCommand(cacheName);
                break;
             default:
                throw new CacheException("Unknown command id " + id + "!");

--- a/core/src/main/java/org/infinispan/commands/irac/IracTombstoneCleanupCommand.java
+++ b/core/src/main/java/org/infinispan/commands/irac/IracTombstoneCleanupCommand.java
@@ -1,0 +1,98 @@
+package org.infinispan.commands.irac;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.concurrent.CompletionStage;
+
+import org.infinispan.commands.remote.CacheRpcCommand;
+import org.infinispan.container.versioning.irac.IracTombstoneInfo;
+import org.infinispan.factories.ComponentRegistry;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.util.ByteString;
+import org.infinispan.util.concurrent.CompletableFutures;
+
+/**
+ * A {@link CacheRpcCommand} to clean up tombstones for IRAC algorithm.
+ * <p>
+ * This command is sent from the primary owners to the backup owner with the tombstone to be removed. No response is
+ * expected from the backup owners.
+ *
+ * @since 14.0
+ */
+public class IracTombstoneCleanupCommand implements CacheRpcCommand {
+
+   public static final byte COMMAND_ID = 37;
+
+   private final ByteString cacheName;
+   // TODO add batching https://issues.redhat.com/browse/ISPN-13496
+   private IracTombstoneInfo tombstone;
+
+   @SuppressWarnings("unused")
+   public IracTombstoneCleanupCommand() {
+      this(null);
+   }
+
+   public IracTombstoneCleanupCommand(ByteString cacheName) {
+      this.cacheName = cacheName;
+   }
+
+   public IracTombstoneCleanupCommand(ByteString cacheName, IracTombstoneInfo tombstone) {
+      this(cacheName);
+      this.tombstone = tombstone;
+   }
+
+   @Override
+   public ByteString getCacheName() {
+      return cacheName;
+   }
+
+   @Override
+   public CompletionStage<Boolean> invokeAsync(ComponentRegistry registry) {
+      registry.getIracTombstoneManager().running().removeTombstone(tombstone);
+      return CompletableFutures.completedNull();
+   }
+
+   @Override
+   public byte getCommandId() {
+      return COMMAND_ID;
+   }
+
+   @Override
+   public boolean isReturnValueExpected() {
+      return false;
+   }
+
+   @Override
+   public void writeTo(ObjectOutput output) throws IOException {
+      IracTombstoneInfo.writeTo(output, tombstone);
+   }
+
+   @Override
+   public void readFrom(ObjectInput input) throws IOException, ClassNotFoundException {
+      this.tombstone = IracTombstoneInfo.readFrom(input);
+   }
+
+   @Override
+   public Address getOrigin() {
+      //not needed
+      return null;
+   }
+
+   @Override
+   public void setOrigin(Address origin) {
+      //no-op
+   }
+
+   @Override
+   public String toString() {
+      return "IracTombstoneCleanupCommand{" +
+            "cacheName=" + cacheName +
+            ", tombstone=" + tombstone +
+            '}';
+   }
+
+   public IracTombstoneInfo getTombstone() {
+      return tombstone;
+   }
+}

--- a/core/src/main/java/org/infinispan/commands/irac/IracTombstonePrimaryCheckCommand.java
+++ b/core/src/main/java/org/infinispan/commands/irac/IracTombstonePrimaryCheckCommand.java
@@ -1,0 +1,109 @@
+package org.infinispan.commands.irac;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.CompletionStage;
+
+import org.infinispan.commands.remote.CacheRpcCommand;
+import org.infinispan.commons.marshall.MarshallUtil;
+import org.infinispan.container.versioning.irac.IracTombstoneInfo;
+import org.infinispan.factories.ComponentRegistry;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.util.ByteString;
+import org.infinispan.util.concurrent.CompletableFutures;
+import org.infinispan.xsite.irac.IracManager;
+
+/**
+ * A {@link CacheRpcCommand} to check if one or more tombstones are still valid.
+ * <p>
+ * Periodically, the backup owner send this command for the tombstones they have stored if the key is not present in
+ * {@link IracManager}.
+ *
+ * @since 14.0
+ */
+public class IracTombstonePrimaryCheckCommand implements CacheRpcCommand {
+
+   public static final byte COMMAND_ID = 47;
+
+   private ByteString cacheName;
+   private Collection<IracTombstoneInfo> tombstoneToCheck;
+
+   @SuppressWarnings("unused")
+   public IracTombstonePrimaryCheckCommand() {
+   }
+
+   public IracTombstonePrimaryCheckCommand(ByteString cacheName) {
+      this.cacheName = cacheName;
+   }
+
+   public IracTombstonePrimaryCheckCommand(ByteString cacheName, int capacity) {
+      this.cacheName = cacheName;
+      this.tombstoneToCheck = new ArrayList<>(capacity);
+   }
+
+   @Override
+   public CompletionStage<Void> invokeAsync(ComponentRegistry registry) {
+      registry.getIracTombstoneManager().running().checkStaleTombstone(tombstoneToCheck);
+      return CompletableFutures.completedNull();
+   }
+
+   @Override
+   public byte getCommandId() {
+      return COMMAND_ID;
+   }
+
+   @Override
+   public boolean isReturnValueExpected() {
+      return false;
+   }
+
+   @Override
+   public void writeTo(ObjectOutput output) throws IOException {
+      MarshallUtil.marshallCollection(tombstoneToCheck, output, IracTombstoneInfo::writeTo);
+   }
+
+   @Override
+   public void readFrom(ObjectInput input) throws IOException, ClassNotFoundException {
+      tombstoneToCheck = MarshallUtil.unmarshallCollection(input, ArrayList::new, IracTombstoneInfo::readFrom);
+   }
+
+   @Override
+   public ByteString getCacheName() {
+      return cacheName;
+   }
+
+   @Override
+   public Address getOrigin() {
+      //no-op
+      return null;
+   }
+
+   @Override
+   public void setOrigin(Address origin) {
+      //no-op
+   }
+
+   @Override
+   public String toString() {
+      return "IracTombstonePrimaryCheckCommand{" +
+            "cacheName=" + cacheName +
+            ", tombstoneToCheck=" + tombstoneToCheck +
+            '}';
+   }
+
+   public int addTombstone(IracTombstoneInfo tombstone) {
+      tombstoneToCheck.add(tombstone);
+      return tombstoneToCheck.size();
+   }
+
+   public boolean isEmpty() {
+      return tombstoneToCheck.isEmpty();
+   }
+
+   public Collection<IracTombstoneInfo> getTombstoneToCheck() {
+      return tombstoneToCheck;
+   }
+}

--- a/core/src/main/java/org/infinispan/commands/irac/IracTombstoneStateResponseCommand.java
+++ b/core/src/main/java/org/infinispan/commands/irac/IracTombstoneStateResponseCommand.java
@@ -1,0 +1,98 @@
+package org.infinispan.commands.irac;
+
+import static org.infinispan.commons.marshall.MarshallUtil.marshallCollection;
+import static org.infinispan.commons.marshall.MarshallUtil.unmarshallCollection;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.CompletionStage;
+
+import org.infinispan.commands.remote.CacheRpcCommand;
+import org.infinispan.container.versioning.irac.IracTombstoneInfo;
+import org.infinispan.container.versioning.irac.IracTombstoneManager;
+import org.infinispan.factories.ComponentRegistry;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.util.ByteString;
+import org.infinispan.util.concurrent.CompletableFutures;
+
+/**
+ * Response for a state request with the tombstones stored in the local node.
+ *
+ * @since 14.0
+ */
+public class IracTombstoneStateResponseCommand implements CacheRpcCommand {
+
+   public static final byte COMMAND_ID = 39;
+
+   private ByteString cacheName;
+   private Collection<IracTombstoneInfo> state;
+
+   @SuppressWarnings("unused")
+   public IracTombstoneStateResponseCommand() {
+   }
+
+   public IracTombstoneStateResponseCommand(ByteString cacheName) {
+      this.cacheName = cacheName;
+   }
+
+   public IracTombstoneStateResponseCommand(ByteString cacheName, Collection<IracTombstoneInfo> state) {
+      this.cacheName = cacheName;
+      this.state = state;
+   }
+
+   @Override
+   public CompletionStage<Void> invokeAsync(ComponentRegistry registry) {
+      IracTombstoneManager tombstoneManager = registry.getIracTombstoneManager().running();
+      for (IracTombstoneInfo data : state) {
+         tombstoneManager.storeTombstoneIfAbsent(data);
+      }
+      return CompletableFutures.completedNull();
+   }
+
+   @Override
+   public byte getCommandId() {
+      return COMMAND_ID;
+   }
+
+   @Override
+   public boolean isReturnValueExpected() {
+      return false;
+   }
+
+   @Override
+   public void writeTo(ObjectOutput output) throws IOException {
+      marshallCollection(state, output, IracTombstoneInfo::writeTo);
+   }
+
+   @Override
+   public void readFrom(ObjectInput input) throws IOException, ClassNotFoundException {
+      state = unmarshallCollection(input, ArrayList::new, IracTombstoneInfo::readFrom);
+   }
+
+   @Override
+   public ByteString getCacheName() {
+      return cacheName;
+   }
+
+   @Override
+   public Address getOrigin() {
+      //no-op
+      return null;
+   }
+
+   @Override
+   public void setOrigin(Address origin) {
+      //no-op
+   }
+
+   @Override
+   public String toString() {
+      return "IracTombstoneStateResponseCommand{" +
+            "cacheName=" + cacheName +
+            ", state=" + state +
+            '}';
+   }
+}

--- a/core/src/main/java/org/infinispan/container/versioning/irac/IracTombstoneInfo.java
+++ b/core/src/main/java/org/infinispan/container/versioning/irac/IracTombstoneInfo.java
@@ -1,0 +1,83 @@
+package org.infinispan.container.versioning.irac;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.Objects;
+
+import org.infinispan.commons.util.Util;
+import org.infinispan.metadata.impl.IracMetadata;
+
+/**
+ * A data class to store the tombstone information for a key.
+ *
+ * @since 14.0
+ */
+public class IracTombstoneInfo {
+
+   private final Object key;
+   private final int segment;
+   private final IracMetadata metadata;
+
+   public IracTombstoneInfo(Object key, int segment, IracMetadata metadata) {
+      this.key = Objects.requireNonNull(key);
+      this.segment = segment;
+      this.metadata = Objects.requireNonNull(metadata);
+   }
+
+   public Object getKey() {
+      return key;
+   }
+
+   public int getSegment() {
+      return segment;
+   }
+
+   public IracMetadata getMetadata() {
+      return metadata;
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      IracTombstoneInfo that = (IracTombstoneInfo) o;
+
+      if (segment != that.segment) return false;
+      if (!key.equals(that.key)) return false;
+      return metadata.equals(that.metadata);
+   }
+
+   @Override
+   public int hashCode() {
+      int result = key.hashCode();
+      result = 31 * result + segment;
+      result = 31 * result + metadata.hashCode();
+      return result;
+   }
+
+   @Override
+   public String toString() {
+      return "IracTombstoneInfo{" +
+            "key=" + Util.toStr(key) +
+            ", segment=" + segment +
+            ", metadata=" + metadata +
+            '}';
+   }
+
+   public static void writeTo(ObjectOutput output, IracTombstoneInfo tombstone) throws IOException {
+      if (tombstone == null) {
+         output.writeObject(null);
+         return;
+      }
+      output.writeObject(tombstone.key);
+      output.writeInt(tombstone.segment);
+      IracMetadata.writeTo(output, tombstone.metadata);
+   }
+
+   public static IracTombstoneInfo readFrom(ObjectInput input) throws IOException, ClassNotFoundException {
+      Object key = input.readObject();
+      return key == null ? null : new IracTombstoneInfo(key, input.readInt(), IracMetadata.readFrom(input));
+   }
+}

--- a/core/src/main/java/org/infinispan/container/versioning/irac/NoOpIracTombstoneManager.java
+++ b/core/src/main/java/org/infinispan/container/versioning/irac/NoOpIracTombstoneManager.java
@@ -1,6 +1,10 @@
 package org.infinispan.container.versioning.irac;
 
+import java.util.Collection;
+
+import org.infinispan.commons.util.IntSet;
 import org.infinispan.metadata.impl.IracMetadata;
+import org.infinispan.remoting.transport.Address;
 
 /**
  * No-op implementation for {@link IracTombstoneManager}.
@@ -26,12 +30,12 @@ public final class NoOpIracTombstoneManager implements IracTombstoneManager {
    }
 
    @Override
-   public void storeTombstoneIfAbsent(int segment, Object key, IracMetadata metadata) {
+   public void storeTombstoneIfAbsent(IracTombstoneInfo tombstone) {
       //no-op
    }
 
    @Override
-   public void removeTombstone(Object key, IracMetadata iracMetadata) {
+   public void removeTombstone(IracTombstoneInfo tombstone) {
       //no-op
    }
 
@@ -63,5 +67,15 @@ public final class NoOpIracTombstoneManager implements IracTombstoneManager {
    @Override
    public long getCurrentDelayMillis() {
       return 0;
+   }
+
+   @Override
+   public void sendStateTo(Address requestor, IntSet segments) {
+      //no-op
+   }
+
+   @Override
+   public void checkStaleTombstone(Collection<? extends IracTombstoneInfo> tombstones) {
+      //no-op
    }
 }

--- a/core/src/main/java/org/infinispan/factories/ComponentRegistry.java
+++ b/core/src/main/java/org/infinispan/factories/ComponentRegistry.java
@@ -460,7 +460,7 @@ public class ComponentRegistry extends AbstractComponentRegistry {
       return iracVersionGenerator;
    }
 
-   public ComponentRef<IracTombstoneManager> getIracTombstoneCleaner() {
+   public ComponentRef<IracTombstoneManager> getIracTombstoneManager() {
       return iracTombstoneCleaner;
    }
 

--- a/core/src/main/java/org/infinispan/marshall/exts/CacheRpcCommandExternalizer.java
+++ b/core/src/main/java/org/infinispan/marshall/exts/CacheRpcCommandExternalizer.java
@@ -7,13 +7,16 @@ import java.util.Set;
 
 import org.infinispan.commands.control.LockControlCommand;
 import org.infinispan.commands.irac.IracCleanupKeyCommand;
-import org.infinispan.commands.irac.IracCleanupTombstoneCommand;
+import org.infinispan.commands.irac.IracTombstoneCleanupCommand;
 import org.infinispan.commands.irac.IracClearKeysCommand;
 import org.infinispan.commands.irac.IracMetadataRequestCommand;
 import org.infinispan.commands.irac.IracPutKeyCommand;
 import org.infinispan.commands.irac.IracRemoveKeyCommand;
 import org.infinispan.commands.irac.IracRequestStateCommand;
 import org.infinispan.commands.irac.IracStateResponseCommand;
+import org.infinispan.commands.irac.IracTombstonePrimaryCheckCommand;
+import org.infinispan.commands.irac.IracTombstoneRemoteSiteCheckCommand;
+import org.infinispan.commands.irac.IracTombstoneStateResponseCommand;
 import org.infinispan.commands.irac.IracTouchKeyCommand;
 import org.infinispan.commands.irac.IracUpdateVersionCommand;
 import org.infinispan.commands.remote.CacheRpcCommand;
@@ -129,7 +132,10 @@ public final class CacheRpcCommandExternalizer extends AbstractExternalizer<Cach
             IracUpdateVersionCommand.class,
             XSiteAutoTransferStatusCommand.class,
             XSiteSetStateTransferModeCommand.class,
-            IracCleanupTombstoneCommand.class);
+            IracTombstoneCleanupCommand.class,
+            IracTombstoneStateResponseCommand.class,
+            IracTombstonePrimaryCheckCommand.class,
+            IracTombstoneRemoteSiteCheckCommand.class);
       // Only interested in cache specific replicable commands
       coreCommands.addAll(gcr.getModuleProperties().moduleCacheRpcCommands());
       return coreCommands;

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -33,6 +33,7 @@ import org.infinispan.commons.dataconversion.EncodingException;
 import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.commons.marshall.AdvancedExternalizer;
 import org.infinispan.commons.marshall.MarshallingException;
+import org.infinispan.commons.util.IntSet;
 import org.infinispan.commons.util.TypedProperties;
 import org.infinispan.configuration.cache.BackupFailurePolicy;
 import org.infinispan.configuration.cache.CacheMode;
@@ -2249,4 +2250,8 @@ public interface Log extends BasicLogger {
    @LogMessage(level = WARN)
    @Message(value = "'%s' has been deprecated with no replacement.", id = 661)
    void configDeprecated(Enum<?> element);
+
+   @LogMessage(level = WARN)
+   @Message(value = "Failed to transfer cross-site tombstones to %s for segments %s.", id = 662)
+   void failedToTransferTombstones(Address requestor, IntSet segments,  @Cause Throwable t);
 }

--- a/core/src/main/java/org/infinispan/xsite/irac/DefaultIracManager.java
+++ b/core/src/main/java/org/infinispan/xsite/irac/DefaultIracManager.java
@@ -240,6 +240,7 @@ public class DefaultIracManager implements IracManager, JmxStatisticsExposer, Ir
    @Override
    public void requestState(Address requestor, IntSet segments) {
       transferStateTo(requestor, segments, updatedKeys.values());
+      iracTombstoneManager.sendStateTo(requestor, segments);
    }
 
    @Override

--- a/core/src/test/java/org/infinispan/util/mocks/ControlledCommandFactory.java
+++ b/core/src/test/java/org/infinispan/util/mocks/ControlledCommandFactory.java
@@ -33,13 +33,16 @@ import org.infinispan.commands.functional.WriteOnlyKeyValueCommand;
 import org.infinispan.commands.functional.WriteOnlyManyCommand;
 import org.infinispan.commands.functional.WriteOnlyManyEntriesCommand;
 import org.infinispan.commands.irac.IracCleanupKeyCommand;
-import org.infinispan.commands.irac.IracCleanupTombstoneCommand;
+import org.infinispan.commands.irac.IracTombstoneCleanupCommand;
 import org.infinispan.commands.irac.IracClearKeysCommand;
 import org.infinispan.commands.irac.IracMetadataRequestCommand;
 import org.infinispan.commands.irac.IracPutKeyCommand;
 import org.infinispan.commands.irac.IracRemoveKeyCommand;
 import org.infinispan.commands.irac.IracRequestStateCommand;
 import org.infinispan.commands.irac.IracStateResponseCommand;
+import org.infinispan.commands.irac.IracTombstonePrimaryCheckCommand;
+import org.infinispan.commands.irac.IracTombstoneRemoteSiteCheckCommand;
+import org.infinispan.commands.irac.IracTombstoneStateResponseCommand;
 import org.infinispan.commands.irac.IracTouchKeyCommand;
 import org.infinispan.commands.irac.IracUpdateVersionCommand;
 import org.infinispan.commands.read.EntrySetCommand;
@@ -100,6 +103,7 @@ import org.infinispan.configuration.cache.XSiteStateTransferMode;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.container.versioning.irac.IracEntryVersion;
+import org.infinispan.container.versioning.irac.IracTombstoneInfo;
 import org.infinispan.encoding.DataConversion;
 import org.infinispan.expiration.impl.TouchCommand;
 import org.infinispan.factories.ComponentRegistry;
@@ -699,8 +703,8 @@ public class ControlledCommandFactory implements CommandsFactory {
    }
 
    @Override
-   public IracCleanupTombstoneCommand buildIracCleanupTombstoneCommand(Object key, IracMetadata tombstone) {
-      return actual.buildIracCleanupTombstoneCommand(key, tombstone);
+   public IracTombstoneCleanupCommand buildIracTombstoneCleanupCommand(IracTombstoneInfo tombstone) {
+      return actual.buildIracTombstoneCleanupCommand(tombstone);
    }
 
    @Override
@@ -742,5 +746,20 @@ public class ControlledCommandFactory implements CommandsFactory {
    @Override
    public XSiteSetStateTransferModeCommand buildXSiteSetStateTransferModeCommand(String site, XSiteStateTransferMode mode) {
       return actual.buildXSiteSetStateTransferModeCommand(site, mode);
+   }
+
+   @Override
+   public IracTombstoneRemoteSiteCheckCommand buildIracTombstoneRemoteSiteCheckCommand(Object key) {
+      return actual.buildIracTombstoneRemoteSiteCheckCommand(key);
+   }
+
+   @Override
+   public IracTombstoneStateResponseCommand buildIracTombstoneStateResponseCommand(Collection<IracTombstoneInfo> state) {
+      return actual.buildIracTombstoneStateResponseCommand(state);
+   }
+
+   @Override
+   public IracTombstonePrimaryCheckCommand buildIracTombstonePrimaryCheckCommand(int capacity) {
+      return actual.buildIracTombstonePrimaryCheckCommand(capacity);
    }
 }

--- a/core/src/test/java/org/infinispan/xsite/irac/IracTombstoneCleanupTest.java
+++ b/core/src/test/java/org/infinispan/xsite/irac/IracTombstoneCleanupTest.java
@@ -1,0 +1,377 @@
+package org.infinispan.xsite.irac;
+
+import static org.infinispan.test.TestingUtil.extractCacheTopology;
+import static org.infinispan.test.TestingUtil.extractComponent;
+import static org.infinispan.test.TestingUtil.k;
+import static org.infinispan.test.TestingUtil.wrapComponent;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertTrue;
+import static org.testng.AssertJUnit.fail;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.infinispan.Cache;
+import org.infinispan.commands.ReplicableCommand;
+import org.infinispan.commands.irac.IracTombstoneCleanupCommand;
+import org.infinispan.commands.irac.IracTombstonePrimaryCheckCommand;
+import org.infinispan.commands.remote.CacheRpcCommand;
+import org.infinispan.commons.util.IntSets;
+import org.infinispan.configuration.cache.BackupConfiguration;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.container.versioning.irac.DefaultIracTombstoneManager;
+import org.infinispan.container.versioning.irac.IracEntryVersion;
+import org.infinispan.container.versioning.irac.IracTombstoneInfo;
+import org.infinispan.container.versioning.irac.IracTombstoneManager;
+import org.infinispan.container.versioning.irac.TopologyIracVersion;
+import org.infinispan.metadata.impl.IracMetadata;
+import org.infinispan.remoting.rpc.RpcManager;
+import org.infinispan.remoting.rpc.RpcOptions;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.remoting.transport.ResponseCollector;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.fwk.TransportFlags;
+import org.infinispan.util.AbstractDelegatingRpcManager;
+import org.infinispan.xsite.status.TakeOfflineManager;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import net.jcip.annotations.GuardedBy;
+
+/**
+ * Basic tests for IRAC tombstone cleanup
+ *
+ * @since 14.0
+ */
+@Test(groups = "xsite", testName = "xsite.irac.IracTombstoneCleanupTest")
+public class IracTombstoneCleanupTest extends MultipleCacheManagersTest {
+
+   private static final String CACHE_NAME = "xsite-tombstone";
+   private static final String SITE_NAME = "LON-1";
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      TransportFlags flags = new TransportFlags().withSiteIndex(0).withSiteName(SITE_NAME).withFD(true);
+      createClusteredCaches(3, CACHE_NAME, cacheConfiguration(), flags);
+      for (Cache<?, ?> cache : caches(CACHE_NAME)) {
+         // stop automatic cleanup to avoid adding random events to the tests
+         tombstoneManager(cache).stopCleanupTask();
+         extractComponent(cache, TakeOfflineManager.class).takeSiteOffline("NYC");
+      }
+   }
+
+   @AfterMethod(alwaysRun = true)
+   @Override
+   protected void clearContent() throws Throwable {
+      for (Cache<String, String> cache : this.<String, String>caches(CACHE_NAME)) {
+         recordingRpcManager(cache).stopRecording();
+      }
+      super.clearContent();
+   }
+
+   private static ConfigurationBuilder cacheConfiguration() {
+      ConfigurationBuilder builder = new ConfigurationBuilder();
+      builder.clustering().cacheMode(CacheMode.DIST_SYNC);
+      builder.clustering().hash().numOwners(2).numSegments(16);
+      builder.sites().addBackup().site("NYC").strategy(BackupConfiguration.BackupStrategy.ASYNC).stateTransfer().chunkSize(1);
+      return builder;
+   }
+
+   public void testPrimaryOwnerRoundCleanupsBackup(Method method) {
+      String key = k(method);
+      int segment = getSegment(key);
+      Cache<String, String> pCache = findPrimaryOwner(segment);
+      Cache<String, String> bCache = findBackupOwner(segment);
+
+      IracMetadata metadata = dummyMetadata(1);
+
+      tombstoneManager(pCache).storeTombstone(segment, key, metadata);
+      tombstoneManager(bCache).storeTombstone(segment, key, metadata);
+
+      assertEquals(1, tombstoneManager(pCache).size());
+      assertEquals(1, tombstoneManager(bCache).size());
+
+      RecordingRpcManager pRpcManager = recordingRpcManager(pCache);
+
+      pRpcManager.startRecording();
+
+      tombstoneManager(pCache).runCleanupAndWait();
+
+      eventuallyEquals(0, () -> tombstoneManager(pCache).size());
+      eventuallyEquals(0, () -> tombstoneManager(bCache).size());
+
+      IracTombstoneCleanupCommand cmd = pRpcManager.findSingleCommand(IracTombstoneCleanupCommand.class);
+
+      assertNotNull(cmd);
+      assertEquals(segment, cmd.getTombstone().getSegment());
+      assertEquals(key, cmd.getTombstone().getKey());
+      assertEquals(metadata, cmd.getTombstone().getMetadata());
+   }
+
+   public void testBackupOwnerRoundCleanupDoNotCleanupPrimary(Method method) {
+      String key = k(method);
+      int segment = getSegment(key);
+      Cache<String, String> pCache = findPrimaryOwner(segment);
+      Cache<String, String> bCache = findBackupOwner(segment);
+
+      IracMetadata metadata = dummyMetadata(2);
+
+      tombstoneManager(pCache).storeTombstone(segment, key, metadata);
+      tombstoneManager(bCache).storeTombstone(segment, key, metadata);
+
+      assertEquals(1, tombstoneManager(pCache).size());
+      assertEquals(1, tombstoneManager(bCache).size());
+
+      RecordingRpcManager pRpcManager = recordingRpcManager(pCache);
+      RecordingRpcManager bRpcManager = recordingRpcManager(bCache);
+
+      pRpcManager.startRecording();
+      bRpcManager.startRecording();
+
+      tombstoneManager(bCache).runCleanupAndWait();
+
+      IracTombstonePrimaryCheckCommand cmd = bRpcManager.findSingleCommand(IracTombstonePrimaryCheckCommand.class);
+
+      assertNotNull(cmd);
+      assertEquals(1, cmd.getTombstoneToCheck().size());
+      IracTombstoneInfo tombstoneInfo = cmd.getTombstoneToCheck().iterator().next();
+      assertEquals(segment, tombstoneInfo.getSegment());
+      assertEquals(key, tombstoneInfo.getKey());
+      assertEquals(metadata, tombstoneInfo.getMetadata());
+
+      assertFalse(pRpcManager.isCommandSent(IracTombstoneCleanupCommand.class));
+
+      // check if nothing is removed... should we sleep here?
+      assertEquals(1, tombstoneManager(pCache).size());
+      assertEquals(1, tombstoneManager(bCache).size());
+
+      // remove tombstone to avoid messing up with other tests
+      tombstoneManager(pCache).removeTombstone(key);
+      tombstoneManager(bCache).removeTombstone(key);
+   }
+
+   public void testNonOwnerRoundCleanupLocally(Method method) {
+      String key = k(method);
+      int segment = getSegment(key);
+      Cache<String, String> pCache = findPrimaryOwner(segment);
+      Cache<String, String> bCache = findBackupOwner(segment);
+      Cache<String, String> nCache = findNonOwner(segment);
+
+      IracMetadata metadata = dummyMetadata(3);
+
+      tombstoneManager(pCache).storeTombstone(segment, key, metadata);
+      tombstoneManager(bCache).storeTombstone(segment, key, metadata);
+      tombstoneManager(nCache).storeTombstone(segment, key, metadata);
+
+      assertEquals(1, tombstoneManager(pCache).size());
+      assertEquals(1, tombstoneManager(bCache).size());
+      assertEquals(1, tombstoneManager(nCache).size());
+
+      RecordingRpcManager pRpcManager = recordingRpcManager(pCache);
+      RecordingRpcManager bRpcManager = recordingRpcManager(bCache);
+      RecordingRpcManager nRpcManager = recordingRpcManager(nCache);
+
+      pRpcManager.startRecording();
+      bRpcManager.startRecording();
+      nRpcManager.startRecording();
+
+      tombstoneManager(nCache).runCleanupAndWait();
+
+      // check if nothing is removed... should we sleep here?
+      assertEquals(1, tombstoneManager(pCache).size());
+      assertEquals(1, tombstoneManager(bCache).size());
+      assertEquals(0, tombstoneManager(nCache).size());
+
+      assertFalse(nRpcManager.isCommandSent(IracTombstonePrimaryCheckCommand.class));
+      assertFalse(nRpcManager.isCommandSent(IracTombstoneCleanupCommand.class));
+      assertFalse(bRpcManager.isCommandSent(IracTombstonePrimaryCheckCommand.class));
+      assertFalse(bRpcManager.isCommandSent(IracTombstoneCleanupCommand.class));
+      assertFalse(pRpcManager.isCommandSent(IracTombstonePrimaryCheckCommand.class));
+      assertFalse(pRpcManager.isCommandSent(IracTombstoneCleanupCommand.class));
+
+      // remove tombstone to avoid messing up with other tests
+      tombstoneManager(pCache).removeTombstone(key);
+      tombstoneManager(bCache).removeTombstone(key);
+   }
+
+   public void testStateTransfer(Method method) {
+      int numberOfKeys = 100;
+      List<IracTombstoneInfo> keys = new ArrayList<>(numberOfKeys);
+      for (int i = 0; i < numberOfKeys; ++i) {
+         String key = k(method, i);
+         int segment = getSegment(key);
+         IracMetadata metadata = dummyMetadata(i * 2);
+         keys.add(new IracTombstoneInfo(key, segment, metadata));
+      }
+
+      Cache<String, String> cache0 = cache(0, CACHE_NAME);
+      Cache<String, String> cache1 = cache(1, CACHE_NAME);
+
+      for (IracTombstoneInfo tombstoneInfo : keys) {
+         tombstoneManager(cache1).storeTombstone(tombstoneInfo.getSegment(), tombstoneInfo.getKey(), tombstoneInfo.getMetadata());
+      }
+
+      assertEquals(0, tombstoneManager(cache0).size());
+      assertEquals(numberOfKeys, tombstoneManager(cache1).size());
+
+      // request singe segment
+      int segment = keys.get(0).getSegment();
+      tombstoneManager(cache1).sendStateTo(address(cache0), IntSets.immutableSet(segment));
+
+      List<IracTombstoneInfo> segmentKeys = keys.stream()
+            .filter(tombstoneInfo -> segment == tombstoneInfo.getSegment())
+            .collect(Collectors.toList());
+
+      // wait until it is transferred
+      eventuallyEquals(segmentKeys.size(), () -> tombstoneManager(cache0).size());
+
+      for (IracTombstoneInfo tombstone : segmentKeys) {
+         assertTrue(tombstoneManager(cache0).contains(tombstone));
+      }
+
+      // send all segments
+      tombstoneManager(cache1).sendStateTo(address(cache0), IntSets.immutableRangeSet(16));
+      eventuallyEquals(numberOfKeys, () -> tombstoneManager(cache0).size());
+
+      for (IracTombstoneInfo tombstone : keys) {
+         assertTrue(tombstoneManager(cache0).contains(tombstone));
+      }
+   }
+
+   private Cache<String, String> findPrimaryOwner(int segment) {
+      for (Cache<String, String> cache : this.<String, String>caches(CACHE_NAME)) {
+         if (extractCacheTopology(cache).getSegmentDistribution(segment).isPrimary()) {
+            return cache;
+         }
+      }
+      throw new IllegalStateException("Find primary owner failed!");
+   }
+
+   private Cache<String, String> findBackupOwner(int segment) {
+      for (Cache<String, String> cache : this.<String, String>caches(CACHE_NAME)) {
+         if (extractCacheTopology(cache).getSegmentDistribution(segment).isWriteBackup()) {
+            return cache;
+         }
+      }
+      throw new IllegalStateException("Find backup owner failed!");
+   }
+
+   private Cache<String, String> findNonOwner(int segment) {
+      for (Cache<String, String> cache : this.<String, String>caches(CACHE_NAME)) {
+         if (!extractCacheTopology(cache).getSegmentDistribution(segment).isWriteOwner()) {
+            return cache;
+         }
+      }
+      throw new IllegalStateException("Find non owner failed!");
+   }
+
+   private IracMetadata dummyMetadata(long version) {
+      TopologyIracVersion iracVersion = TopologyIracVersion.create(1, version);
+      return new IracMetadata(SITE_NAME, new IracEntryVersion(Collections.singletonMap(SITE_NAME, iracVersion)));
+   }
+
+   private int getSegment(String key) {
+      return extractCacheTopology(cache(0, CACHE_NAME)).getSegment(key);
+   }
+
+   private DefaultIracTombstoneManager tombstoneManager(Cache<?, ?> cache) {
+      IracTombstoneManager tombstoneManager = extractComponent(cache, IracTombstoneManager.class);
+      assert tombstoneManager instanceof DefaultIracTombstoneManager;
+      return (DefaultIracTombstoneManager) tombstoneManager;
+   }
+
+   private RecordingRpcManager recordingRpcManager(Cache<?, ?> cache) {
+      RpcManager rpcManager = extractComponent(cache, RpcManager.class);
+      if (rpcManager instanceof RecordingRpcManager) {
+         return (RecordingRpcManager) rpcManager;
+      }
+      return wrapComponent(cache, RpcManager.class, RecordingRpcManager::new);
+   }
+
+   private static class RecordingRpcManager extends AbstractDelegatingRpcManager {
+
+      @GuardedBy("this")
+      private final List<CacheRpcCommand> commandList;
+      private volatile boolean recording;
+
+      public RecordingRpcManager(RpcManager realOne) {
+         super(realOne);
+         commandList = new LinkedList<>();
+      }
+
+      <T extends CacheRpcCommand> T findSingleCommand(Class<T> commandClass) {
+         T found = null;
+         synchronized (this) {
+            for (CacheRpcCommand rpcCommand : commandList) {
+               if (rpcCommand.getClass() == commandClass) {
+                  if (found != null) {
+                     fail("More than one " + commandClass + " found in list: " + commandList);
+                  }
+                  found = commandClass.cast(rpcCommand);
+               }
+            }
+         }
+         return found;
+      }
+
+      <T extends CacheRpcCommand> boolean isCommandSent(Class<T> commandClass) {
+         boolean found = false;
+         synchronized (this) {
+            for (CacheRpcCommand rpcCommand : commandList) {
+               if (rpcCommand.getClass() == commandClass) {
+                  if (found) {
+                     fail("More than one " + commandClass + " found in list: " + commandList);
+                  }
+                  found = true;
+               }
+            }
+         }
+         return found;
+      }
+
+      void startRecording() {
+         synchronized (this) {
+            commandList.clear();
+         }
+         recording = true;
+      }
+
+      void stopRecording() {
+         recording = false;
+         synchronized (this) {
+            commandList.clear();
+         }
+
+      }
+
+      @Override
+      protected <T> CompletionStage<T> performRequest(Collection<Address> targets, ReplicableCommand command, ResponseCollector<T> collector, Function<ResponseCollector<T>, CompletionStage<T>> invoker, RpcOptions rpcOptions) {
+         if (recording && command instanceof CacheRpcCommand) {
+            synchronized (this) {
+               commandList.add((CacheRpcCommand) command);
+            }
+         }
+         return super.performRequest(targets, command, collector, invoker, rpcOptions);
+      }
+
+      @Override
+      protected <T> void performSend(Collection<Address> targets, ReplicableCommand command, Function<ResponseCollector<T>, CompletionStage<T>> invoker) {
+         if (recording && command instanceof CacheRpcCommand) {
+            synchronized (this) {
+               commandList.add((CacheRpcCommand) command);
+            }
+         }
+         super.performSend(targets, command, invoker);
+      }
+   }
+}

--- a/core/src/test/java/org/infinispan/xsite/irac/IracTombstoneUnitTest.java
+++ b/core/src/test/java/org/infinispan/xsite/irac/IracTombstoneUnitTest.java
@@ -12,7 +12,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.infinispan.commands.CommandsFactory;
-import org.infinispan.commands.irac.IracCleanupTombstoneCommand;
+import org.infinispan.commands.irac.IracTombstoneRemoteSiteCheckCommand;
 import org.infinispan.configuration.cache.BackupConfiguration;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.Configuration;
@@ -80,8 +80,8 @@ public class IracTombstoneUnitTest extends AbstractInfinispanTest {
 
    private static CommandsFactory createCommandFactory() {
       CommandsFactory factory = Mockito.mock(CommandsFactory.class);
-      IracCleanupTombstoneCommand cmd = Mockito.mock(IracCleanupTombstoneCommand.class);
-      Mockito.when(factory.buildIracCleanupTombstoneCommand(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(cmd);
+      IracTombstoneRemoteSiteCheckCommand cmd = Mockito.mock(IracTombstoneRemoteSiteCheckCommand.class);
+      Mockito.when(factory.buildIracTombstoneRemoteSiteCheckCommand(ArgumentMatchers.any())).thenReturn(cmd);
       return factory;
    }
 

--- a/core/src/test/java/org/infinispan/xsite/statetransfer/XSiteAutoStateTransferTest.java
+++ b/core/src/test/java/org/infinispan/xsite/statetransfer/XSiteAutoStateTransferTest.java
@@ -17,6 +17,7 @@ import java.util.concurrent.TimeoutException;
 import org.infinispan.commands.irac.IracCleanupKeyCommand;
 import org.infinispan.commands.irac.IracRequestStateCommand;
 import org.infinispan.commands.irac.IracStateResponseCommand;
+import org.infinispan.commands.irac.IracTombstoneStateResponseCommand;
 import org.infinispan.commands.irac.IracUpdateVersionCommand;
 import org.infinispan.commands.statetransfer.StateResponseCommand;
 import org.infinispan.commands.statetransfer.StateTransferCancelCommand;
@@ -196,7 +197,8 @@ public class XSiteAutoStateTransferTest extends AbstractMultipleSitesTest {
       SiteMasterController controller = findSiteMaster();
 
       //let the state command go through
-      controller.getRpcManager().excludeCommands(XSiteStatePushCommand.class, IracCleanupKeyCommand.class);
+      controller.getRpcManager().excludeCommands(XSiteStatePushCommand.class, IracCleanupKeyCommand.class,
+            IracTombstoneStateResponseCommand.class, StateTransferCancelCommand.class);
       CompletableFuture<ControlledRpcManager.BlockedRequest<XSiteAutoTransferStatusCommand>> req1 =
             controller.getRpcManager().expectCommandAsync(XSiteAutoTransferStatusCommand.class);
       CompletableFuture<ControlledRpcManager.BlockedRequest<XSiteBringOnlineCommand>> req2 =
@@ -277,7 +279,8 @@ public class XSiteAutoStateTransferTest extends AbstractMultipleSitesTest {
                                                     StateTransferStartCommand.class, StateResponseCommand.class,
                                                     StateTransferCancelCommand.class,
                                                     IracRequestStateCommand.class, IracStateResponseCommand.class,
-                                                    IracUpdateVersionCommand.class, IracCleanupKeyCommand.class);
+                                                    IracUpdateVersionCommand.class, IracCleanupKeyCommand.class,
+                                                    IracTombstoneStateResponseCommand.class);
       //the JGroups events triggers this command where NodeB checks if it needs to starts the transfer
       CompletableFuture<ControlledRpcManager.BlockedRequest<XSiteAutoTransferStatusCommand>> req1 = newSiteMaster
             .getRpcManager().expectCommandAsync(XSiteAutoTransferStatusCommand.class);


### PR DESCRIPTION
Two changes are made in the commit:

* all tombstones are sent to the new owner.
* backup owner ping primary owner if there is tombstone stored without any update in IracManager.

https://issues.redhat.com/browse/ISPN-13495

offtopic, updated python script to python3