### PR TITLE
ISPN-13505 Set context classloader for worker threads explicitly

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/parsing/ParserRegistry.java
+++ b/core/src/main/java/org/infinispan/configuration/parsing/ParserRegistry.java
@@ -10,7 +10,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.lang.ref.WeakReference;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -55,7 +54,7 @@ import org.infinispan.configuration.serializing.CoreConfigurationSerializer;
  * @since 5.2
  */
 public class ParserRegistry implements NamespaceMappingParser {
-   private final WeakReference<ClassLoader> cl;
+   private final ClassLoader cl;
    private final ConcurrentMap<QName, NamespaceParserPair> parserMappings;
    private final Properties properties;
 
@@ -69,9 +68,9 @@ public class ParserRegistry implements NamespaceMappingParser {
 
    public ParserRegistry(ClassLoader classLoader, boolean defaultOnly, Properties properties) {
       this.parserMappings = new ConcurrentHashMap<>();
-      this.cl = new WeakReference<>(classLoader);
+      this.cl = classLoader;
       this.properties = properties;
-      Collection<ConfigurationParser> parsers = ServiceFinder.load(ConfigurationParser.class, cl.get(), ParserRegistry.class.getClassLoader());
+      Collection<ConfigurationParser> parsers = ServiceFinder.load(ConfigurationParser.class, cl, ParserRegistry.class.getClassLoader());
       for (ConfigurationParser parser : parsers) {
 
          Namespace[] namespaces = parser.getNamespaces();
@@ -113,7 +112,7 @@ public class ParserRegistry implements NamespaceMappingParser {
 
    public ConfigurationBuilderHolder parseFile(String filename) throws IOException {
       FileLookup fileLookup = FileLookupFactory.newInstance();
-      URL url = fileLookup.lookupFileLocation(filename, cl.get());
+      URL url = fileLookup.lookupFileLocation(filename, cl);
       if (url == null) {
          throw new FileNotFoundException(filename);
       }
@@ -153,7 +152,7 @@ public class ParserRegistry implements NamespaceMappingParser {
     */
    public ConfigurationBuilderHolder parse(InputStream is, ConfigurationResourceResolver resourceResolver, MediaType mediaType) {
       try {
-         ConfigurationBuilderHolder holder = new ConfigurationBuilderHolder(cl.get());
+         ConfigurationBuilderHolder holder = new ConfigurationBuilderHolder(cl);
          parse(is, holder, resourceResolver, mediaType);
          holder.validate();
          return holder;

--- a/core/src/main/java/org/infinispan/factories/threads/DefaultThreadFactory.java
+++ b/core/src/main/java/org/infinispan/factories/threads/DefaultThreadFactory.java
@@ -28,7 +28,7 @@ public class DefaultThreadFactory implements ThreadFactory {
    private static final AtomicLong factoryIndexSequence = new AtomicLong(1L);
    private String node;
    private String component;
-
+   private ClassLoader classLoader;
 
    /**
     * Construct a new instance.  The access control context of the calling thread will be the one used to create
@@ -54,6 +54,7 @@ public class DefaultThreadFactory implements ThreadFactory {
     */
    public DefaultThreadFactory(String name, ThreadGroup threadGroup, int initialPriority, String threadNamePattern,
          String node, String component) {
+      this.classLoader = Thread.currentThread().getContextClassLoader();
       this.name = name;
       if (threadGroup == null) {
          final SecurityManager sm = System.getSecurityManager();
@@ -106,8 +107,7 @@ public class DefaultThreadFactory implements ThreadFactory {
       thread.setName(nameInfo.format(thread, threadNamePattern));
       thread.setPriority(initialPriority);
       thread.setDaemon(true);
-      // Do not use the context classloader of the thread that submitted the task to the executor
-      SecurityActions.setContextClassLoader(thread, DefaultThreadFactory.class.getClassLoader());
+      SecurityActions.setContextClassLoader(thread, classLoader);
       return thread;
    }
 

--- a/core/src/main/java/org/infinispan/factories/threads/DefaultThreadFactory.java
+++ b/core/src/main/java/org/infinispan/factories/threads/DefaultThreadFactory.java
@@ -106,6 +106,8 @@ public class DefaultThreadFactory implements ThreadFactory {
       thread.setName(nameInfo.format(thread, threadNamePattern));
       thread.setPriority(initialPriority);
       thread.setDaemon(true);
+      // Do not use the context classloader of the thread that submitted the task to the executor
+      SecurityActions.setContextClassLoader(thread, DefaultThreadFactory.class.getClassLoader());
       return thread;
    }
 

--- a/core/src/main/java/org/infinispan/factories/threads/SecurityActions.java
+++ b/core/src/main/java/org/infinispan/factories/threads/SecurityActions.java
@@ -1,0 +1,32 @@
+package org.infinispan.factories.threads;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+import org.infinispan.security.Security;
+
+/**
+ * SecurityActions for the org.infinispan.factories.threads package.
+ * <p>
+ * Do not move. Do not change class and method visibility to avoid being called from other
+ * {@link java.security.CodeSource}s, thus granting privilege escalation to external code.
+ *
+ * @author Dan Berindei
+ * @since 14.0
+ */
+final class SecurityActions {
+   private static <T> T doPrivileged(PrivilegedAction<T> action) {
+      if (System.getSecurityManager() != null) {
+         return AccessController.doPrivileged(action);
+      } else {
+         return Security.doPrivileged(action);
+      }
+   }
+
+   static void setContextClassLoader(Thread thread, ClassLoader contextClassLoader) {
+      doPrivileged(() -> {
+         thread.setContextClassLoader(contextClassLoader);
+         return null;
+      });
+   }
+}

--- a/server/runtime/src/main/java/org/infinispan/server/Server.java
+++ b/server/runtime/src/main/java/org/infinispan/server/Server.java
@@ -291,11 +291,9 @@ public class Server implements ServerManagement, AutoCloseable {
          defaultsHolder.getGlobalConfigurationBuilder().security().authorization().auditLogger(new LoggingAuditLogger());
 
          // base the global configuration to the default
-         configurationBuilderHolder = new ConfigurationBuilderHolder();
+         configurationBuilderHolder = new ConfigurationBuilderHolder(classLoader);
          GlobalConfigurationBuilder global = configurationBuilderHolder.getGlobalConfigurationBuilder();
-         global
-               .read(defaultsHolder.getGlobalConfigurationBuilder().build())
-               .classLoader(classLoader);
+         global.read(defaultsHolder.getGlobalConfigurationBuilder().build());
 
          // Copy all default templates
          for (Map.Entry<String, ConfigurationBuilder> entry : defaultsHolder.getNamedConfigurationBuilders().entrySet()) {

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/core/ForkedInfinispanServerDriver.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/core/ForkedInfinispanServerDriver.java
@@ -89,7 +89,7 @@ public class ForkedInfinispanServerDriver extends AbstractInfinispanServerDriver
             createServerStructure(serverHome, serverRootPath);
             destConfDir = getServerConfDir(serverRootPath.getAbsolutePath());
             server = new ForkedServer(serverHome);
-            server.addVmArgument(Server.INFINISPAN_SERVER_ROOT_PATH, serverRootPath);
+            server.addSystemProperty(Server.INFINISPAN_SERVER_ROOT_PATH, serverRootPath);
          } else {
             String serverHome = serverHomes.get(i).toString();
             destConfDir = getServerConfDir(serverHome);
@@ -98,7 +98,7 @@ public class ForkedInfinispanServerDriver extends AbstractInfinispanServerDriver
          server
                .setServerConfiguration(configurationFile.getPath())
                .setPortsOffset(i);
-         server.addVmArgument(Server.INFINISPAN_CLUSTER_STACK, System.getProperty(Server.INFINISPAN_CLUSTER_STACK));
+         server.addSystemProperty(Server.INFINISPAN_CLUSTER_STACK, System.getProperty(Server.INFINISPAN_CLUSTER_STACK));
          try {
             File sourceServerConfiguration = new File(server.getServerConfiguration());
             FileUtils.copyFile(sourceServerConfiguration, destConfDir.resolve(sourceServerConfiguration.getName()).toFile());
@@ -132,8 +132,8 @@ public class ForkedInfinispanServerDriver extends AbstractInfinispanServerDriver
    protected void stop() {
       try {
          // check if the server is running
-         try {
-            RestResponse response = sync(getRestClient(0).cluster().stop());
+         try (RestClient restClient = getRestClient(0)) {
+            RestResponse response = sync(restClient.cluster().stop());
             // Ensure non-error response code from the REST endpoint.
             if (response.getStatus() >= 400) {
                throw new IllegalStateException(String.format("Failed to shutdown the cluster gracefully, got status %d.", response.getStatus()));

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/core/ForkedServer.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/core/ForkedServer.java
@@ -71,7 +71,7 @@ public class ForkedServer {
       commands.add(serverHome + File.separator + "bin" + File.separator + "server" + extension);
 
       // Append random UUID for this server to be used in the case of forceful shutdown.
-      addVmArgument(this.getClass().getName() + "-pid", this.serverId);
+      addSystemProperty(this.getClass().getName() + "-pid", this.serverId);
    }
 
    public ForkedServer setServerConfiguration(String serverConfiguration) {
@@ -107,6 +107,7 @@ public class ForkedServer {
 
       pb.redirectErrorStream(true);
       try {
+         log.infof("Starting forked server %s", commands);
          process = pb.start();
 
          // Start a server monitoring thread which
@@ -207,7 +208,7 @@ public class ForkedServer {
       return serverConfiguration;
    }
 
-   public void addVmArgument(String key, Object value) {
+   public void addSystemProperty(String key, Object value) {
       commands.add(String.format("-D%s=%s", key, value));
    }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-13505

This avoids leaks when the application lifecycle is shorter
than the cache manager lifecycle.