### PR TITLE
ISPN-13488 Fail fast if site connection is down

### DIFF
--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
@@ -187,7 +187,7 @@ public class JGroupsTransport implements Transport {
          new ClusterView(ClusterView.INITIAL_VIEW_ID, Collections.emptyList(), null);
    private CompletableFuture<Void> nextViewFuture = new CompletableFuture<>();
    private RequestRepository requests;
-   private final Set<String> unreachableSites;
+   private final Map<String, SiteUnreachableReason> unreachableSites;
 
    // ------------------------------------------------------------------------------------------------------------------
    // Lifecycle and setup stuff
@@ -211,7 +211,7 @@ public class JGroupsTransport implements Transport {
 
    public JGroupsTransport() {
       this.probeHandler = new ThreadPoolProbeHandler();
-      this.unreachableSites = ConcurrentHashMap.newKeySet();
+      this.unreachableSites = new ConcurrentHashMap<>();
    }
 
    @Override
@@ -349,7 +349,7 @@ public class JGroupsTransport implements Transport {
 
    @Override
    public <O> XSiteResponse<O> backupRemotely(XSiteBackup backup, XSiteReplicateCommand<O> rpcCommand) {
-      if (unreachableSites.contains(backup.getSiteName())) {
+      if (unreachableSites.containsKey(backup.getSiteName())) {
          // fail fast if we have thread handling a SITE_UNREACHABLE event.
          return new SiteUnreachableXSiteResponse<>(backup, timeService);
       }
@@ -1275,13 +1275,10 @@ public class JGroupsTransport implements Transport {
    }
 
    private void updateSitesView(Collection<String> sitesUp, Collection<String> sitesDown) {
-      viewUpdateLock.lock();
-      try {
+      if (isSiteCoordinator()) {
          Set<String> reachableSites = getSitesView();
          log.tracef("Sites view changed: up %s, down %s, new view is %s", sitesUp, sitesDown, reachableSites);
          XSITE.receivedXSiteClusterView(reachableSites);
-      } finally {
-         viewUpdateLock.unlock();
       }
       if (sitesUp.isEmpty()) {
          return;
@@ -1296,20 +1293,24 @@ public class JGroupsTransport implements Transport {
    }
 
    private void siteUnreachable(String site) {
-      if (!unreachableSites.add(site)) {
+      if (unreachableSites.putIfAbsent(site, SiteUnreachableReason.SITE_UNREACHABLE_EVENT) != null) {
          // only one thread handling the events. The other threads can be "dropped".
          return;
       }
       try {
-         requests.forEach(request -> {
-            if (request instanceof SingleSiteRequest) {
-               ((SingleSiteRequest<?>) request).sitesUnreachable(site);
-            }
-         });
+         cancelRequestsFromSite(site);
       } finally {
-         unreachableSites.remove(site);
+         unreachableSites.remove(site, SiteUnreachableReason.SITE_UNREACHABLE_EVENT);
       }
 
+   }
+
+   private void cancelRequestsFromSite(String site) {
+      requests.forEach(request -> {
+         if (request instanceof SingleSiteRequest) {
+            ((SingleSiteRequest<?>) request).sitesUnreachable(site);
+         }
+      });
    }
 
    /**
@@ -1497,11 +1498,22 @@ public class JGroupsTransport implements Transport {
       @Override
       public void sitesUp(String... sites) {
          updateSitesView(Arrays.asList(sites), Collections.emptyList());
+         for (String upSite : sites) {
+            unreachableSites.remove(upSite, SiteUnreachableReason.SITE_DOWN_EVENT);
+         }
       }
 
       @Override
       public void sitesDown(String... sites) {
          updateSitesView(Collections.emptyList(), Arrays.asList(sites));
+         List<String> requestsToCancel = new ArrayList<>(sites.length);
+         for (String downSite : sites) {
+            // if there is something stored in the map, do not try to cancel the requests.
+            if (unreachableSites.put(downSite, SiteUnreachableReason.SITE_DOWN_EVENT) == null) {
+               requestsToCancel.add(downSite);
+            }
+         }
+         requestsToCancel.forEach(JGroupsTransport.this::cancelRequestsFromSite);
       }
 
       @Override
@@ -1545,5 +1557,10 @@ public class JGroupsTransport implements Transport {
             nonBlockingExecutor.execute(() -> processMessage(message));
          });
       }
+   }
+
+   private enum SiteUnreachableReason {
+      SITE_DOWN_EVENT,
+      SITE_UNREACHABLE_EVENT
    }
 }


### PR DESCRIPTION
If a "site down" event is received, fail fast all cross-site requests to
that site until a "site up" event.

Includes ISPN-13443 "Non relay-nodes are reporting cross-site view
changes"

https://issues.redhat.com/browse/ISPN-13488
https://issues.redhat.com/browse/ISPN-13443