### PR TITLE
ISPN-13312 NonRecursiveEventLoopGroup shutdown deadlock

### DIFF
--- a/component-processor/src/main/java/org/infinispan/component/processor/ComponentAnnotationProcessor.java
+++ b/component-processor/src/main/java/org/infinispan/component/processor/ComponentAnnotationProcessor.java
@@ -441,9 +441,9 @@ public class ComponentAnnotationProcessor extends AbstractProcessor {
          if (annotation == null)
             return;
 
-         validateLifecycleMethod(e, annotationType);
-
          if (isValidComponent(e, annotationType)) {
+            validateLifecycleMethod(e, annotationType);
+
             List<Model.LifecycleMethod> methodList = methodsExtractor.apply(currentType.component);
             Integer priority = priorityExtractor.apply(annotation);
             methodList.add(new Model.LifecycleMethod(e.getSimpleName().toString(), priority));

--- a/core/src/main/java/org/infinispan/util/concurrent/BlockingTaskAwareExecutorServiceImpl.java
+++ b/core/src/main/java/org/infinispan/util/concurrent/BlockingTaskAwareExecutorServiceImpl.java
@@ -12,6 +12,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.infinispan.commons.time.TimeService;
+import org.infinispan.factories.annotations.Stop;
+import org.infinispan.factories.scopes.Scope;
+import org.infinispan.factories.scopes.Scopes;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -23,6 +26,7 @@ import org.infinispan.util.logging.LogFactory;
  * @author Pedro Ruivo
  * @since 5.3
  */
+@Scope(Scopes.GLOBAL)
 public class BlockingTaskAwareExecutorServiceImpl extends AbstractExecutorService implements BlockingTaskAwareExecutorService {
 
    private static final Log log = LogFactory.getLog(BlockingTaskAwareExecutorServiceImpl.class);
@@ -38,6 +42,15 @@ public class BlockingTaskAwareExecutorServiceImpl extends AbstractExecutorServic
       this.executorService = executorService;
       this.timeService = timeService;
       this.shutdown = false;
+   }
+
+   @Stop
+   void stop() {
+      // This method only runs in the server, in embedded mode
+      // BlockingTaskAwareExecutorServiceImpl is wrapped in a LazyInitializingScheduledExecutorService
+      // In the server, we do not need to stop the executorService, which has its own lifecycle
+      // But we need to stop retrying tasks
+      shutdown = true;
    }
 
    @Override

--- a/core/src/test/java/org/infinispan/jmx/CacheManagerMBeanTest.java
+++ b/core/src/test/java/org/infinispan/jmx/CacheManagerMBeanTest.java
@@ -13,6 +13,7 @@ import static org.testng.AssertJUnit.assertTrue;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.concurrent.ScheduledExecutorService;
 
 import javax.management.InstanceNotFoundException;
 import javax.management.MBeanException;
@@ -25,7 +26,6 @@ import org.infinispan.commons.jmx.TestMBeanServerLookup;
 import org.infinispan.commons.test.Exceptions;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
-import org.infinispan.executors.LazyInitializingScheduledExecutorService;
 import org.infinispan.manager.CacheContainer;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.manager.EmbeddedCacheManagerStartupException;
@@ -157,11 +157,9 @@ public class CacheManagerMBeanTest extends SingleCacheManagerTest {
    }
 
    public void testExecutorMBeans() throws Exception {
-      LazyInitializingScheduledExecutorService timeoutExecutor =
-            extractGlobalComponent(cacheManager, LazyInitializingScheduledExecutorService.class,
-                  TIMEOUT_SCHEDULE_EXECUTOR);
-      timeoutExecutor.submit(() -> {
-      });
+      ScheduledExecutorService timeoutExecutor =
+            extractGlobalComponent(cacheManager, ScheduledExecutorService.class, TIMEOUT_SCHEDULE_EXECUTOR);
+      timeoutExecutor.submit(() -> {});
 
       ObjectName objectName = getCacheManagerObjectName(JMX_DOMAIN, "DefaultCacheManager", TIMEOUT_SCHEDULE_EXECUTOR);
       assertTrue(server.isRegistered(objectName));

--- a/core/src/test/java/org/infinispan/jmx/ClusteredCacheManagerMBeanTest.java
+++ b/core/src/test/java/org/infinispan/jmx/ClusteredCacheManagerMBeanTest.java
@@ -11,6 +11,8 @@ import static org.testng.Assert.assertNotEquals;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertTrue;
 
+import java.util.concurrent.ExecutorService;
+
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
@@ -19,7 +21,6 @@ import org.infinispan.commons.jmx.TestMBeanServerLookup;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
-import org.infinispan.executors.LazyInitializingBlockingTaskAwareExecutorService;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
@@ -100,10 +101,8 @@ public class ClusteredCacheManagerMBeanTest extends MultipleCacheManagersTest {
       String javaVersion = System.getProperty("java.version");
       assertEquals(javaVersion.startsWith("1.8.") ? 0L : 10L, server.getAttribute(objectName, "KeepAliveTime"));
 
-      LazyInitializingBlockingTaskAwareExecutorService remoteExecutor =
-         extractGlobalComponent(manager(0), LazyInitializingBlockingTaskAwareExecutorService.class,
-                                NON_BLOCKING_EXECUTOR);
-      remoteExecutor.submit(() -> {});
+      ExecutorService executor = extractGlobalComponent(manager(0), ExecutorService.class, NON_BLOCKING_EXECUTOR);
+      executor.submit(() -> {});
 
       objectName = getCacheManagerObjectName(JMX_DOMAIN, "DefaultCacheManager", NON_BLOCKING_EXECUTOR);
       assertTrue(server.isRegistered(objectName));

--- a/server/core/src/main/java/org/infinispan/server/core/transport/NonRecursiveEventLoopGroup.java
+++ b/server/core/src/main/java/org/infinispan/server/core/transport/NonRecursiveEventLoopGroup.java
@@ -78,8 +78,8 @@ public class NonRecursiveEventLoopGroup extends DelegatingEventLoopGroup {
    @Stop
    public void shutdownGracefullyAndWait() {
       try {
-         // Use the same timeouts as in NettyTransport
-         shutdownGracefully(100, 1000, TimeUnit.MILLISECONDS).await();
+         // Use the same timeouts as in NettyTransport, and limit the wait time in case there's a bug in the executor
+         shutdownGracefully(100, 1000, TimeUnit.MILLISECONDS).await(2000, TimeUnit.MILLISECONDS);
       } catch (InterruptedException e) {
          log.debug("Interrupted while waiting for event loop group to shut down");
          Thread.currentThread().interrupt();


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-13312

Add a @Stop method to BlockingTaskAwareExecutorServiceImpl
that only stops retrying tasks -- in the server, the underlying
executor is stopped later.