### PR TITLE
ISPN-13121 Cache persistent state is not deleted after successful restart

### DIFF
--- a/core/src/main/java/org/infinispan/topology/CacheTopology.java
+++ b/core/src/main/java/org/infinispan/topology/CacheTopology.java
@@ -219,10 +219,10 @@ public class CacheTopology {
             '}';
    }
 
-   public final void logRoutingTableInformation() {
+   public final void logRoutingTableInformation(String cacheName) {
       if (log.isTraceEnabled()) {
-         log.tracef("Current consistent hash's routing table: %s", currentCH.getRoutingTableAsString());
-         if (pendingCH != null) log.tracef("Pending consistent hash's routing table: %s", pendingCH.getRoutingTableAsString());
+         log.tracef("[%s] Current consistent hash's routing table: %s", cacheName, currentCH.getRoutingTableAsString());
+         if (pendingCH != null) log.tracef("[%s] Pending consistent hash's routing table: %s", cacheName, pendingCH.getRoutingTableAsString());
       }
    }
 

--- a/core/src/main/java/org/infinispan/topology/ClusterCacheStatus.java
+++ b/core/src/main/java/org/infinispan/topology/ClusterCacheStatus.java
@@ -309,7 +309,7 @@ public class ClusterCacheStatus implements AvailabilityStrategyContext {
       if (log.isTraceEnabled()) log.tracef("Cache %s topology updated: %s, members = %s, joiners = %s",
             cacheName, currentTopology, expectedMembers, joiners);
       if (newTopology != null) {
-         newTopology.logRoutingTableInformation();
+         newTopology.logRoutingTableInformation(cacheName);
       }
    }
 

--- a/core/src/main/java/org/infinispan/topology/LocalTopologyManagerImpl.java
+++ b/core/src/main/java/org/infinispan/topology/LocalTopologyManagerImpl.java
@@ -371,7 +371,7 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager, GlobalSta
             resetLocalTopologyBeforeRebalance(cacheName, cacheTopology, existingTopology, handler);
 
       stage = stage.thenCompose(ignored -> {
-         unionTopology.logRoutingTableInformation();
+         unionTopology.logRoutingTableInformation(cacheName);
 
          if (updateAvailabilityModeFirst && availabilityMode != null) {
             return cacheStatus.getPartitionHandlingManager().setAvailabilityMode(availabilityMode);
@@ -567,7 +567,7 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager, GlobalSta
 
       return stage.thenCompose(ignored -> {
          log.debugf("Starting local rebalance for cache %s, topology = %s", cacheName, cacheTopology);
-         cacheTopology.logRoutingTableInformation();
+         cacheTopology.logRoutingTableInformation(cacheName);
 
          return handler.rebalance(newTopology);
       });

--- a/core/src/test/java/org/infinispan/globalstate/AbstractGlobalStateRestartTest.java
+++ b/core/src/test/java/org/infinispan/globalstate/AbstractGlobalStateRestartTest.java
@@ -74,7 +74,7 @@ public abstract class AbstractGlobalStateRestartTest extends MultipleCacheManage
 
       ConfigurationBuilder config = new ConfigurationBuilder();
       applyCacheManagerClusteringConfiguration(config);
-      config.persistence().addSingleFileStore().location(stateDirectory);
+      config.persistence().addSingleFileStore().location(stateDirectory).fetchPersistentState(true);
       EmbeddedCacheManager manager = addClusterEnabledCacheManager(global, null);
       manager.defineConfiguration(CACHE_NAME, config.build());
    }

--- a/core/src/test/java/org/infinispan/globalstate/ThreeNodeDistGlobalStateRestartTest.java
+++ b/core/src/test/java/org/infinispan/globalstate/ThreeNodeDistGlobalStateRestartTest.java
@@ -2,6 +2,7 @@ package org.infinispan.globalstate;
 
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.test.TestingUtil;
 import org.testng.annotations.Test;
 
 @Test(testName = "globalstate.ThreeNodeDistGlobalStateRestartTest", groups = "functional")
@@ -14,7 +15,7 @@ public class ThreeNodeDistGlobalStateRestartTest extends AbstractGlobalStateRest
 
    @Override
    protected void applyCacheManagerClusteringConfiguration(ConfigurationBuilder config) {
-      config.clustering().cacheMode(CacheMode.DIST_SYNC).hash().numOwners(1);
+      config.clustering().cacheMode(CacheMode.DIST_SYNC).hash().numOwners(2);
    }
 
    public void testGracefulShutdownAndRestart() throws Throwable {
@@ -37,5 +38,14 @@ public class ThreeNodeDistGlobalStateRestartTest extends AbstractGlobalStateRest
       shutdownAndRestart(-1, false);
 
       restartWithoutGracefulShutdown();
+   }
+
+   public void testClusterRecoveryAfterRestart() throws Throwable {
+      shutdownAndRestart(-1, false);
+
+      Thread.sleep(1000);
+
+      killMember(0, CACHE_NAME);
+      TestingUtil.waitForNoRebalance(caches(CACHE_NAME));
    }
 }

--- a/core/src/test/java/org/infinispan/globalstate/ThreeNodeDistGlobalStateRestartTest.java
+++ b/core/src/test/java/org/infinispan/globalstate/ThreeNodeDistGlobalStateRestartTest.java
@@ -1,5 +1,7 @@
 package org.infinispan.globalstate;
 
+import static org.testng.AssertJUnit.assertEquals;
+
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.test.TestingUtil;
@@ -43,9 +45,10 @@ public class ThreeNodeDistGlobalStateRestartTest extends AbstractGlobalStateRest
    public void testClusterRecoveryAfterRestart() throws Throwable {
       shutdownAndRestart(-1, false);
 
-      Thread.sleep(1000);
+      killMember(0, CACHE_NAME, false);
 
-      killMember(0, CACHE_NAME);
+      assertEquals(DATA_SIZE, (long) cache(0, CACHE_NAME).size());
+      assertEquals(DATA_SIZE, (long) cache(1, CACHE_NAME).size());
       TestingUtil.waitForNoRebalance(caches(CACHE_NAME));
    }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-13121

Validate the persistent state checksum only when a node tries to join.
Ignore the persistent state checksum when a node is replying to a
cluster recovery request (CacheStatusRequestCommand).