### PR TITLE
ISPN-13576 SoftIndexFileStore segmentation can be made more performant

### DIFF
--- a/build/configuration/pom.xml
+++ b/build/configuration/pom.xml
@@ -188,7 +188,7 @@
       <version.protostuff>1.6.2</version.protostuff>
       <version.reactivestreams>1.0.3</version.reactivestreams>
       <version.rocksdb>6.22.1.1</version.rocksdb>
-      <version.rxjava>3.0.4</version.rxjava>
+      <version.rxjava>3.1.3</version.rxjava>
       <version.smallrye-config>2.0.2</version.smallrye-config>
       <version.smallrye-metrics>3.0.1</version.smallrye-metrics>
       <version.microprofile-config-api>2.0</version.microprofile-config-api>

--- a/commons/all/src/main/java/org/infinispan/commons/io/ByteBufferImpl.java
+++ b/commons/all/src/main/java/org/infinispan/commons/io/ByteBufferImpl.java
@@ -79,7 +79,7 @@ public class ByteBufferImpl implements ByteBuffer {
 
    @Override
    public String toString() {
-      return String.format("ByteBufferImpl{length=%d, offset=%d, bytes=%s}", length, offset, Util.hexDump(buf, offset + length));
+      return String.format("ByteBufferImpl{length=%d, offset=%d, bytes=%s}", length, offset, Util.hexDump(buf, offset, length));
    }
 
    @Override

--- a/commons/all/src/main/java/org/infinispan/commons/io/ByteBufferImpl.java
+++ b/commons/all/src/main/java/org/infinispan/commons/io/ByteBufferImpl.java
@@ -79,7 +79,7 @@ public class ByteBufferImpl implements ByteBuffer {
 
    @Override
    public String toString() {
-      return String.format("ByteBufferImpl{length=%d, offset=%d, bytes=%s}", length, offset, Util.hexDump(buf));
+      return String.format("ByteBufferImpl{length=%d, offset=%d, bytes=%s}", length, offset, Util.hexDump(buf, offset + length));
    }
 
    @Override

--- a/commons/all/src/main/java/org/infinispan/commons/io/UnsignedNumeric.java
+++ b/commons/all/src/main/java/org/infinispan/commons/io/UnsignedNumeric.java
@@ -1,9 +1,9 @@
 package org.infinispan.commons.io;
 
+import java.io.DataInput;
+import java.io.DataOutput;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.ObjectInput;
-import java.io.ObjectOutput;
 import java.io.OutputStream;
 
 /**
@@ -17,7 +17,7 @@ public class UnsignedNumeric {
     * Reads an int stored in variable-length format.  Reads between one and five bytes.  Smaller values take fewer
     * bytes.  Negative numbers are not supported.
     */
-   public static int readUnsignedInt(ObjectInput in) throws IOException {
+   public static int readUnsignedInt(DataInput in) throws IOException {
       byte b = in.readByte();
       int i = b & 0x7F;
       for (int shift = 7; (b & 0x80) != 0; shift += 7) {
@@ -53,7 +53,7 @@ public class UnsignedNumeric {
     *
     * @param i int to write
     */
-   public static void writeUnsignedInt(ObjectOutput out, int i) throws IOException {
+   public static void writeUnsignedInt(DataOutput out, int i) throws IOException {
       while ((i & ~0x7F) != 0) {
          out.writeByte((byte) ((i & 0x7f) | 0x80));
          i >>>= 7;
@@ -91,7 +91,7 @@ public class UnsignedNumeric {
     * Reads a long stored in variable-length format.  Reads between one and nine bytes.  Smaller values take fewer
     * bytes.  Negative numbers are not supported.
     */
-   public static long readUnsignedLong(ObjectInput in) throws IOException {
+   public static long readUnsignedLong(DataInput in) throws IOException {
       byte b = in.readByte();
       long i = b & 0x7F;
       for (int shift = 7; (b & 0x80) != 0; shift += 7) {
@@ -126,7 +126,7 @@ public class UnsignedNumeric {
     *
     * @param i int to write
     */
-   public static void writeUnsignedLong(ObjectOutput out, long i) throws IOException {
+   public static void writeUnsignedLong(DataOutput out, long i) throws IOException {
       while ((i & ~0x7F) != 0) {
          out.writeByte((byte) ((i & 0x7f) | 0x80));
          i >>>= 7;

--- a/commons/all/src/main/java/org/infinispan/commons/util/Util.java
+++ b/commons/all/src/main/java/org/infinispan/commons/util/Util.java
@@ -637,12 +637,12 @@ public final class Util {
    }
 
    public static String hexDump(byte[] buffer, int actualLength) {
-      int dumpLength = Math.min(buffer.length, HEX_DUMP_LIMIT);
+      int dumpLength = Math.min(Math.min(buffer.length, HEX_DUMP_LIMIT), actualLength);
       StringBuilder sb = new StringBuilder(dumpLength * 2 + 30);
       for (int i = 0; i < dumpLength; ++i) {
          addHexByte(sb, buffer[i]);
       }
-      if (dumpLength < actualLength) {
+      if (dumpLength < HEX_DUMP_LIMIT) {
          sb.append("...");
       }
       sb.append(" (").append(actualLength).append(" bytes)");
@@ -1087,5 +1087,29 @@ public final class Util {
     */
    public interface ByteGetter {
       byte get(int index);
+   }
+
+   /**
+    * This method is to be replaced by Java 9 Arrays#equals with the same arguments.
+    *
+    * @param a first array to test contents
+    * @param aFromIndex the offset into the first array to start comparison
+    * @param aToIndex the last element (exclusive) of the first array to compare
+    * @param b second array to test contents
+    * @param bFromIndex the offset into the second array to start comparison
+    * @param bToIndex the last element (exclusive) of the second array to compare
+    * @return if the bytes in the two array ranges are equal
+    */
+   public static boolean arraysEqual(byte[] a, int aFromIndex, int aToIndex, byte[] b, int bFromIndex, int bToIndex) {
+      int totalAmount = aToIndex - aFromIndex;
+      if (totalAmount != bToIndex - bFromIndex) {
+         return false;
+      }
+      for (int i = 0; i < totalAmount; ++i) {
+         if (a[aFromIndex + i] != b[bFromIndex + i]) {
+            return false;
+         }
+      }
+      return true;
    }
 }

--- a/commons/all/src/main/java/org/infinispan/commons/util/Util.java
+++ b/commons/all/src/main/java/org/infinispan/commons/util/Util.java
@@ -629,20 +629,21 @@ public final class Util {
    }
 
    public static String hexDump(byte[] data) {
-      return hexDump(data, data.length);
+      return hexDump(data, 0, data.length);
    }
 
    public static String hexDump(ByteBuffer buffer) {
       return hexDump(buffer::get, buffer.position(), buffer.remaining());
    }
 
-   public static String hexDump(byte[] buffer, int actualLength) {
-      int dumpLength = Math.min(Math.min(buffer.length, HEX_DUMP_LIMIT), actualLength);
+   public static String hexDump(byte[] buffer, int offset, int actualLength) {
+      assert actualLength + offset <= buffer.length;
+      int dumpLength = Math.min(actualLength, HEX_DUMP_LIMIT);
       StringBuilder sb = new StringBuilder(dumpLength * 2 + 30);
       for (int i = 0; i < dumpLength; ++i) {
-         addHexByte(sb, buffer[i]);
+         addHexByte(sb, buffer[offset + i]);
       }
-      if (dumpLength < HEX_DUMP_LIMIT) {
+      if (dumpLength < actualLength) {
          sb.append("...");
       }
       sb.append(" (").append(actualLength).append(" bytes)");

--- a/core/src/main/java/org/infinispan/persistence/sifs/EntryInfo.java
+++ b/core/src/main/java/org/infinispan/persistence/sifs/EntryInfo.java
@@ -5,11 +5,11 @@ package org.infinispan.persistence.sifs;
  */
 public class EntryInfo extends EntryPosition {
    public final short numRecords;
-   public final int segment;
+   public final int cacheSegment;
 
-   public EntryInfo(int file, int offset, short numRecords, int segment) {
+   public EntryInfo(int file, int offset, short numRecords, int cacheSegment) {
       super(file, offset);
       this.numRecords = numRecords;
-      this.segment = segment;
+      this.cacheSegment = cacheSegment;
    }
 }

--- a/core/src/main/java/org/infinispan/persistence/sifs/IndexRequest.java
+++ b/core/src/main/java/org/infinispan/persistence/sifs/IndexRequest.java
@@ -120,6 +120,7 @@ class IndexRequest extends CompletableFuture<Object> {
       return "IndexRequest{" +
             "key=" + key +
             ", serializedKey=" + serializedKey +
+            ", cacheSegment=" + segment +
             ", file=" + file +
             ", offset=" + offset +
             ", prevFile=" + prevFile +

--- a/core/src/main/java/org/infinispan/persistence/sifs/IndexRequest.java
+++ b/core/src/main/java/org/infinispan/persistence/sifs/IndexRequest.java
@@ -4,6 +4,7 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 import org.infinispan.commons.io.ByteBuffer;
+import org.infinispan.commons.util.Util;
 
 /**
  * Request for some change to be persisted in the Index or operation executed by index updater thread.
@@ -18,7 +19,6 @@ class IndexRequest extends CompletableFuture<Object> {
       FOUND_OLD,
       CLEAR,
       SYNC_REQUEST,
-      SIZE
    }
 
    private final Type type;
@@ -74,11 +74,6 @@ class IndexRequest extends CompletableFuture<Object> {
       return new IndexRequest(Type.SYNC_REQUEST, -1, runnable, null, -1, -1, -1, -1, -1);
    }
 
-   public static IndexRequest sizeRequest() {
-      return new IndexRequest(Type.SIZE, -1,null, null, -1, -1, -1, -1, -1);
-   }
-
-
    public Type getType() {
       return type;
    }
@@ -118,7 +113,7 @@ class IndexRequest extends CompletableFuture<Object> {
    @Override
    public String toString() {
       return "IndexRequest{" +
-            "key=" + key +
+            "key=" + Util.toStr(key) +
             ", serializedKey=" + serializedKey +
             ", cacheSegment=" + segment +
             ", file=" + file +

--- a/core/src/main/java/org/infinispan/persistence/sifs/IndexRequest.java
+++ b/core/src/main/java/org/infinispan/persistence/sifs/IndexRequest.java
@@ -3,7 +3,7 @@ package org.infinispan.persistence.sifs;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
-import org.infinispan.commons.util.Util;
+import org.infinispan.commons.io.ByteBuffer;
 
 /**
  * Request for some change to be persisted in the Index or operation executed by index updater thread.
@@ -29,10 +29,10 @@ class IndexRequest extends CompletableFuture<Object> {
    private final int offset;
    private final int prevFile;
    private final int prevOffset;
-   private final byte[] serializedKey;
+   private final ByteBuffer serializedKey;
    private final int size;
 
-   private IndexRequest(Type type, int segment, Object key, byte[] serializedKey, int file, int offset, int size, int prevFile, int prevOffset) {
+   private IndexRequest(Type type, int segment, Object key, ByteBuffer serializedKey, int file, int offset, int size, int prevFile, int prevOffset) {
       this.type = type;
       this.segment = segment;
       this.key = key;
@@ -44,19 +44,19 @@ class IndexRequest extends CompletableFuture<Object> {
       this.size = size;
    }
 
-   public static IndexRequest update(int segment, Object key, byte[] serializedKey, int file, int offset, int size) {
+   public static IndexRequest update(int segment, Object key, ByteBuffer serializedKey, int file, int offset, int size) {
       return new IndexRequest(Type.UPDATE, segment, Objects.requireNonNull(key), serializedKey, file, offset, size, -1, -1);
    }
 
-   public static IndexRequest moved(int segment, Object key, byte[] serializedKey, int file, int offset, int size, int prevFile, int prevOffset) {
+   public static IndexRequest moved(int segment, Object key, ByteBuffer serializedKey, int file, int offset, int size, int prevFile, int prevOffset) {
       return new IndexRequest(Type.MOVED, segment, Objects.requireNonNull(key), serializedKey, file, offset, size, prevFile, prevOffset);
    }
 
-   public static IndexRequest dropped(int segment, Object key, byte[] serializedKey, int prevFile, int prevOffset) {
+   public static IndexRequest dropped(int segment, Object key, ByteBuffer serializedKey, int prevFile, int prevOffset) {
       return new IndexRequest(Type.DROPPED, segment, Objects.requireNonNull(key), serializedKey, -1, -1, -1, prevFile, prevOffset);
    }
 
-   public static IndexRequest foundOld(int segment, Object key, byte[] serializedKey, int prevFile, int prevOffset) {
+   public static IndexRequest foundOld(int segment, Object key, ByteBuffer serializedKey, int prevFile, int prevOffset) {
       return new IndexRequest(Type.FOUND_OLD, segment, Objects.requireNonNull(key), serializedKey, -1, -1, -1, prevFile, prevOffset);
    }
 
@@ -99,7 +99,7 @@ class IndexRequest extends CompletableFuture<Object> {
       return prevOffset;
    }
 
-   public byte[] getSerializedKey() {
+   public ByteBuffer getSerializedKey() {
       return serializedKey;
    }
 
@@ -119,7 +119,7 @@ class IndexRequest extends CompletableFuture<Object> {
    public String toString() {
       return "IndexRequest{" +
             "key=" + key +
-            ", serializedKey=" + Util.printArray(serializedKey) +
+            ", serializedKey=" + serializedKey +
             ", file=" + file +
             ", offset=" + offset +
             ", prevFile=" + prevFile +

--- a/core/src/main/java/org/infinispan/persistence/sifs/LogAppender.java
+++ b/core/src/main/java/org/infinispan/persistence/sifs/LogAppender.java
@@ -159,7 +159,7 @@ public class LogAppender implements Consumer<LogAppender.WriteOperation> {
    private void handleRequestCompletion(LogRequest request) {
       int offset = request.getSerializedValue() == null ? ~request.getFileOffset() : request.getFileOffset();
       temporaryTable.set(request.getSement(), request.getKey(), request.getFile(), offset);
-      IndexRequest indexRequest = IndexRequest.update(request.getSement(), request.getKey(), raw(request.getSerializedKey()),
+      IndexRequest indexRequest = IndexRequest.update(request.getSement(), request.getKey(), request.getSerializedKey(),
             request.getFile(), offset, request.length());
       request.setIndexRequest(indexRequest);
       index.handleRequest(indexRequest);

--- a/core/src/main/java/org/infinispan/persistence/sifs/LogAppender.java
+++ b/core/src/main/java/org/infinispan/persistence/sifs/LogAppender.java
@@ -286,16 +286,6 @@ public class LogAppender implements Consumer<LogAppender.WriteOperation> {
       }
    }
 
-   private byte[] raw(ByteBuffer buffer) {
-      if (buffer.getBuf().length == buffer.getLength()) {
-         return buffer.getBuf();
-      } else {
-         byte[] bytes = new byte[buffer.getLength()];
-         System.arraycopy(buffer.getBuf(), buffer.getOffset(), bytes, 0, buffer.getLength());
-         return bytes;
-      }
-   }
-
    public void setSeqId(long seqId) {
       this.seqId = seqId;
    }

--- a/core/src/main/java/org/infinispan/persistence/sifs/TemporaryTable.java
+++ b/core/src/main/java/org/infinispan/persistence/sifs/TemporaryTable.java
@@ -8,7 +8,6 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
 import java.util.function.IntConsumer;
 
 import org.infinispan.commons.util.IntSet;
-import org.infinispan.commons.util.IntSets;
 import org.infinispan.util.logging.LogFactory;
 
 import io.reactivex.rxjava3.core.Flowable;
@@ -21,11 +20,9 @@ import io.reactivex.rxjava3.core.Flowable;
 public class TemporaryTable {
    private static final Log log = LogFactory.getLog(TemporaryTable.class, Log.class);
    private final AtomicReferenceArray<ConcurrentMap<Object, Entry>> table;
-   private final IntSet ownedSegments;
 
    public TemporaryTable(int numSegments) {
       table = new AtomicReferenceArray<>(numSegments);
-      ownedSegments = IntSets.concurrentSet(numSegments);
    }
 
    public int getSegmentMax() {
@@ -33,12 +30,10 @@ public class TemporaryTable {
    }
 
    public void addSegments(IntSet segments) {
-      ownedSegments.addAll(segments);
       segments.forEach((IntConsumer) segment -> table.compareAndSet(segment, null, new ConcurrentHashMap<>()));
    }
 
    public void removeSegments(IntSet segments) {
-      ownedSegments.removeAll(segments);
       segments.forEach((IntConsumer) segment -> table.set(segment, null));
    }
 
@@ -169,10 +164,6 @@ public class TemporaryTable {
             }
          }
       }
-   }
-
-   public IntSet getOwnedSegments() {
-      return ownedSegments;
    }
 
    private static class Entry extends LockedEntry {

--- a/core/src/main/java/org/infinispan/persistence/sifs/TemporaryTable.java
+++ b/core/src/main/java/org/infinispan/persistence/sifs/TemporaryTable.java
@@ -68,6 +68,8 @@ public class TemporaryTable {
                entry.update(file, offset);
                break;
             }
+         } else {
+            break;
          }
       }
       return true;

--- a/core/src/main/java/org/infinispan/persistence/sifs/configuration/IndexConfiguration.java
+++ b/core/src/main/java/org/infinispan/persistence/sifs/configuration/IndexConfiguration.java
@@ -8,7 +8,7 @@ public class IndexConfiguration {
 
    public static final AttributeDefinition<String> INDEX_LOCATION = AttributeDefinition.builder(Attribute.PATH, null, String.class).immutable().autoPersist(false).build();
    public static final AttributeDefinition<Integer> INDEX_QUEUE_LENGTH = AttributeDefinition.builder(Attribute.INDEX_QUEUE_LENGTH, 1000).immutable().autoPersist(false).build();
-   public static final AttributeDefinition<Integer> INDEX_SEGMENTS = AttributeDefinition.builder(Attribute.SEGMENTS, 16).immutable().autoPersist(false).build();
+   public static final AttributeDefinition<Integer> INDEX_SEGMENTS = AttributeDefinition.builder(Attribute.SEGMENTS, 3).immutable().autoPersist(false).build();
    public static final AttributeDefinition<Integer> MIN_NODE_SIZE = AttributeDefinition.builder(Attribute.MIN_NODE_SIZE, 0).immutable().autoPersist(false).build();
    public static final AttributeDefinition<Integer> MAX_NODE_SIZE = AttributeDefinition.builder(Attribute.MAX_NODE_SIZE, 4096).immutable().autoPersist(false).build();
 

--- a/core/src/main/java/org/infinispan/reactive/FlowableCreate.java
+++ b/core/src/main/java/org/infinispan/reactive/FlowableCreate.java
@@ -1,0 +1,768 @@
+/**
+ * Copyright (c) 2016-present, RxJava Contributors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package org.infinispan.reactive;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import io.reactivex.rxjava3.core.BackpressureStrategy;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.FlowableEmitter;
+import io.reactivex.rxjava3.core.FlowableOnSubscribe;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.exceptions.Exceptions;
+import io.reactivex.rxjava3.exceptions.MissingBackpressureException;
+import io.reactivex.rxjava3.functions.Cancellable;
+import io.reactivex.rxjava3.internal.disposables.CancellableDisposable;
+import io.reactivex.rxjava3.internal.disposables.SequentialDisposable;
+import io.reactivex.rxjava3.internal.subscriptions.SubscriptionHelper;
+import io.reactivex.rxjava3.internal.util.AtomicThrowable;
+import io.reactivex.rxjava3.internal.util.BackpressureHelper;
+import io.reactivex.rxjava3.internal.util.ExceptionHelper;
+import io.reactivex.rxjava3.operators.SimplePlainQueue;
+import io.reactivex.rxjava3.operators.SpscLinkedArrayQueue;
+import io.reactivex.rxjava3.plugins.RxJavaPlugins;
+
+/**
+ * Copied from rxjava3 80c83a4e000f0d054ea88a3bd500d36c2c041b05
+ * This has been modified to allow for Flowable create method to be invoked per subscription request instead of
+ * during the initial subscribe, which may not even include a request of any size. The callback <b>must</b> provide
+ * at least as many elements that were requested or be completed otherwise it can cause exhaustion as the upstream
+ * may not request any more elements and there is no one to call the callback again.
+ *
+ * @param <T>
+ */
+public final class FlowableCreate<T> extends Flowable<T> {
+
+    final FlowableOnSubscribe<T> source;
+
+    final BackpressureStrategy backpressure;
+
+    public FlowableCreate(FlowableOnSubscribe<T> source, BackpressureStrategy backpressure) {
+        this.source = source;
+        this.backpressure = backpressure;
+    }
+
+    @Override
+    public void subscribeActual(Subscriber<? super T> t) {
+        BaseEmitter<T> emitter;
+
+        switch (backpressure) {
+            case MISSING: {
+                emitter = new MissingEmitter<>(t, source);
+                break;
+            }
+            case ERROR: {
+                emitter = new ErrorAsyncEmitter<>(t, source);
+                break;
+            }
+            case DROP: {
+                emitter = new DropAsyncEmitter<>(t, source);
+                break;
+            }
+            case LATEST: {
+                emitter = new LatestAsyncEmitter<>(t, source);
+                break;
+            }
+            default: {
+                emitter = new BufferAsyncEmitter<>(t, source, bufferSize());
+                break;
+            }
+        }
+
+        t.onSubscribe(emitter);
+    }
+
+    /**
+     * Serializes calls to onNext, onError and onComplete.
+     *
+     * @param <T> the value type
+     */
+    static final class SerializedEmitter<T>
+          extends AtomicInteger
+          implements FlowableEmitter<T> {
+
+        private static final long serialVersionUID = 4883307006032401862L;
+
+        final BaseEmitter<T> emitter;
+
+        final AtomicThrowable errors;
+
+        final SimplePlainQueue<T> queue;
+
+        volatile boolean done;
+
+        SerializedEmitter(BaseEmitter<T> emitter) {
+            this.emitter = emitter;
+            this.errors = new AtomicThrowable();
+            this.queue = new SpscLinkedArrayQueue<>(16);
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (emitter.isCancelled() || done) {
+                return;
+            }
+            if (t == null) {
+                onError(ExceptionHelper.createNullPointerException("onNext called with a null value."));
+                return;
+            }
+            if (get() == 0 && compareAndSet(0, 1)) {
+                emitter.onNext(t);
+                if (decrementAndGet() == 0) {
+                    return;
+                }
+            } else {
+                SimplePlainQueue<T> q = queue;
+                synchronized (q) {
+                    q.offer(t);
+                }
+                if (getAndIncrement() != 0) {
+                    return;
+                }
+            }
+            drainLoop();
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            if (!tryOnError(t)) {
+                RxJavaPlugins.onError(t);
+            }
+        }
+
+        @Override
+        public boolean tryOnError(Throwable t) {
+            if (emitter.isCancelled() || done) {
+                return false;
+            }
+            if (t == null) {
+                t = ExceptionHelper.createNullPointerException("onError called with a null Throwable.");
+            }
+            if (errors.tryAddThrowable(t)) {
+                done = true;
+                drain();
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        public void onComplete() {
+            if (emitter.isCancelled() || done) {
+                return;
+            }
+            done = true;
+            drain();
+        }
+
+        void drain() {
+            if (getAndIncrement() == 0) {
+                drainLoop();
+            }
+        }
+
+        void drainLoop() {
+            BaseEmitter<T> e = emitter;
+            SimplePlainQueue<T> q = queue;
+            AtomicThrowable errors = this.errors;
+            int missed = 1;
+            for (; ; ) {
+
+                for (; ; ) {
+                    if (e.isCancelled()) {
+                        q.clear();
+                        return;
+                    }
+
+                    if (errors.get() != null) {
+                        q.clear();
+                        errors.tryTerminateConsumer(e);
+                        return;
+                    }
+
+                    boolean d = done;
+
+                    T v = q.poll();
+
+                    boolean empty = v == null;
+
+                    if (d && empty) {
+                        e.onComplete();
+                        return;
+                    }
+
+                    if (empty) {
+                        break;
+                    }
+
+                    e.onNext(v);
+                }
+
+                missed = addAndGet(-missed);
+                if (missed == 0) {
+                    break;
+                }
+            }
+        }
+
+        @Override
+        public void setDisposable(Disposable d) {
+            emitter.setDisposable(d);
+        }
+
+        @Override
+        public void setCancellable(Cancellable c) {
+            emitter.setCancellable(c);
+        }
+
+        @Override
+        public long requested() {
+            return emitter.requested();
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return emitter.isCancelled();
+        }
+
+        @Override
+        public FlowableEmitter<T> serialize() {
+            return this;
+        }
+
+        @Override
+        public String toString() {
+            return emitter.toString();
+        }
+    }
+
+    abstract static class BaseEmitter<T>
+          extends AtomicLong
+          implements FlowableEmitter<T>, Subscription {
+        private static final long serialVersionUID = 7326289992464377023L;
+
+        final Subscriber<? super T> downstream;
+        final FlowableOnSubscribe<T> source;
+
+        final SequentialDisposable serial;
+        final AtomicInteger sip;
+
+
+        BaseEmitter(Subscriber<? super T> downstream, FlowableOnSubscribe<T> source) {
+            this.downstream = downstream;
+            this.source = source;
+            this.serial = new SequentialDisposable();
+            this.sip = new AtomicInteger();
+        }
+
+        @Override
+        public void onComplete() {
+            completeDownstream();
+        }
+
+        protected void completeDownstream() {
+            if (isCancelled()) {
+                return;
+            }
+            try {
+                downstream.onComplete();
+            } finally {
+                serial.dispose();
+            }
+        }
+
+        @Override
+        public final void onError(Throwable e) {
+            if (e == null) {
+                e = ExceptionHelper.createNullPointerException("onError called with a null Throwable.");
+            }
+            if (!signalError(e)) {
+                RxJavaPlugins.onError(e);
+            }
+        }
+
+        @Override
+        public final boolean tryOnError(Throwable e) {
+            if (e == null) {
+                e = ExceptionHelper.createNullPointerException("tryOnError called with a null Throwable.");
+            }
+            return signalError(e);
+        }
+
+        public boolean signalError(Throwable e) {
+            return errorDownstream(e);
+        }
+
+        protected boolean errorDownstream(Throwable e) {
+            if (isCancelled()) {
+                return false;
+            }
+            try {
+                downstream.onError(e);
+            } finally {
+                serial.dispose();
+            }
+            return true;
+        }
+
+        @Override
+        public final void cancel() {
+            serial.dispose();
+            onUnsubscribed();
+        }
+
+        public final void attemptSubscribe() {
+            if (sip.getAndIncrement() == 0) {
+                int missed = 1;
+                for (; ; ) {
+                    // It is possible the last subscribe consumed all requests, but we haven't caught up to sip
+                    // so double check we still have outstanding requests
+                    if (get() > 0) {
+                        try {
+                            source.subscribe(this);
+                        } catch (Throwable ex) {
+                            Exceptions.throwIfFatal(ex);
+                            onError(ex);
+                        }
+                    }
+                    missed = sip.addAndGet(-missed);
+                    // missed will be 0 if there were no other "concurrent" subscribe calls
+                    // or if the flowable was completed it will be disposed then no more to do
+                    if (missed == 0 || serial.isDisposed()) {
+                        break;
+                    }
+                }
+            }
+        }
+
+        void onUnsubscribed() {
+            // default is no-op
+        }
+
+        @Override
+        public final boolean isCancelled() {
+            return serial.isDisposed();
+        }
+
+        @Override
+        public final void request(long n) {
+            if (SubscriptionHelper.validate(n) && !serial.isDisposed()) {
+                BackpressureHelper.add(this, n);
+                attemptSubscribe();
+                onRequested();
+            }
+        }
+
+        void onRequested() {
+            // default is no-op
+        }
+
+        @Override
+        public final void setDisposable(Disposable d) {
+            serial.update(d);
+        }
+
+        @Override
+        public final void setCancellable(Cancellable c) {
+            setDisposable(new CancellableDisposable(c));
+        }
+
+        @Override
+        public final long requested() {
+            return get();
+        }
+
+        @Override
+        public final FlowableEmitter<T> serialize() {
+            return new SerializedEmitter<>(this);
+        }
+
+        @Override
+        public String toString() {
+            return String.format("%s{%s}", getClass().getSimpleName(), super.toString());
+        }
+    }
+
+    static final class MissingEmitter<T> extends BaseEmitter<T> {
+
+        private static final long serialVersionUID = 3776720187248809713L;
+
+        MissingEmitter(Subscriber<? super T> downstream, FlowableOnSubscribe<T> source) {
+            super(downstream, source);
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (isCancelled()) {
+                return;
+            }
+
+            if (t != null) {
+                downstream.onNext(t);
+            } else {
+                onError(ExceptionHelper.createNullPointerException("onNext called with a null value."));
+                return;
+            }
+
+            for (; ; ) {
+                long r = get();
+                if (r == 0L || compareAndSet(r, r - 1)) {
+                    return;
+                }
+            }
+        }
+
+    }
+
+    static abstract class NoOverflowBaseAsyncEmitter<T> extends BaseEmitter<T> {
+
+        private static final long serialVersionUID = 4127754106204442833L;
+
+        NoOverflowBaseAsyncEmitter(Subscriber<? super T> downstream, FlowableOnSubscribe<T> source) {
+            super(downstream, source);
+        }
+
+        @Override
+        public final void onNext(T t) {
+            if (isCancelled()) {
+                return;
+            }
+
+            if (t == null) {
+                onError(ExceptionHelper.createNullPointerException("onNext called with a null value."));
+                return;
+            }
+
+            if (get() != 0) {
+                downstream.onNext(t);
+                BackpressureHelper.produced(this, 1);
+            } else {
+                onOverflow();
+            }
+        }
+
+        abstract void onOverflow();
+    }
+
+    static final class DropAsyncEmitter<T> extends NoOverflowBaseAsyncEmitter<T> {
+
+        private static final long serialVersionUID = 8360058422307496563L;
+
+        DropAsyncEmitter(Subscriber<? super T> downstream, FlowableOnSubscribe<T> source) {
+            super(downstream, source);
+        }
+
+        @Override
+        void onOverflow() {
+            // nothing to do
+        }
+
+    }
+
+    static final class ErrorAsyncEmitter<T> extends NoOverflowBaseAsyncEmitter<T> {
+
+        private static final long serialVersionUID = 338953216916120960L;
+
+        ErrorAsyncEmitter(Subscriber<? super T> downstream, FlowableOnSubscribe<T> source) {
+            super(downstream, source);
+        }
+
+        @Override
+        void onOverflow() {
+            onError(new MissingBackpressureException("create: could not emit value due to lack of requests"));
+        }
+
+    }
+
+    static final class BufferAsyncEmitter<T> extends BaseEmitter<T> {
+
+        private static final long serialVersionUID = 2427151001689639875L;
+
+        final SpscLinkedArrayQueue<T> queue;
+
+        Throwable error;
+        volatile boolean done;
+
+        final AtomicInteger wip;
+
+        BufferAsyncEmitter(Subscriber<? super T> actual, FlowableOnSubscribe<T> source, int capacityHint) {
+            super(actual, source);
+            this.queue = new SpscLinkedArrayQueue<>(capacityHint);
+            this.wip = new AtomicInteger();
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (done || isCancelled()) {
+                return;
+            }
+
+            if (t == null) {
+                onError(ExceptionHelper.createNullPointerException("onNext called with a null value."));
+                return;
+            }
+            queue.offer(t);
+            drain();
+        }
+
+        @Override
+        public boolean signalError(Throwable e) {
+            if (done || isCancelled()) {
+                return false;
+            }
+
+            error = e;
+            done = true;
+            drain();
+            return true;
+        }
+
+        @Override
+        public void onComplete() {
+            done = true;
+            drain();
+        }
+
+        @Override
+        void onRequested() {
+            drain();
+        }
+
+        @Override
+        void onUnsubscribed() {
+            if (wip.getAndIncrement() == 0) {
+                queue.clear();
+            }
+        }
+
+        void drain() {
+            if (wip.getAndIncrement() != 0) {
+                return;
+            }
+
+            int missed = 1;
+            final Subscriber<? super T> a = downstream;
+            final SpscLinkedArrayQueue<T> q = queue;
+
+            for (; ; ) {
+                long r = get();
+                long e = 0L;
+
+                while (e != r) {
+                    if (isCancelled()) {
+                        q.clear();
+                        return;
+                    }
+
+                    boolean d = done;
+
+                    T o = q.poll();
+
+                    boolean empty = o == null;
+
+                    if (d && empty) {
+                        Throwable ex = error;
+                        if (ex != null) {
+                            errorDownstream(ex);
+                        } else {
+                            completeDownstream();
+                        }
+                        return;
+                    }
+
+                    if (empty) {
+                        break;
+                    }
+
+                    a.onNext(o);
+
+                    e++;
+                }
+
+                if (e == r) {
+                    if (isCancelled()) {
+                        q.clear();
+                        return;
+                    }
+
+                    boolean d = done;
+
+                    boolean empty = q.isEmpty();
+
+                    if (d && empty) {
+                        Throwable ex = error;
+                        if (ex != null) {
+                            errorDownstream(ex);
+                        } else {
+                            completeDownstream();
+                        }
+                        return;
+                    }
+                }
+
+                if (e != 0) {
+                    BackpressureHelper.produced(this, e);
+                }
+
+                missed = wip.addAndGet(-missed);
+                if (missed == 0) {
+                    break;
+                }
+            }
+        }
+    }
+
+    static final class LatestAsyncEmitter<T> extends BaseEmitter<T> {
+
+        private static final long serialVersionUID = 4023437720691792495L;
+
+        final AtomicReference<T> queue;
+
+        Throwable error;
+        volatile boolean done;
+
+        final AtomicInteger wip;
+
+        LatestAsyncEmitter(Subscriber<? super T> downstream, FlowableOnSubscribe<T> source) {
+            super(downstream, source);
+            this.queue = new AtomicReference<>();
+            this.wip = new AtomicInteger();
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (done || isCancelled()) {
+                return;
+            }
+
+            if (t == null) {
+                onError(ExceptionHelper.createNullPointerException("onNext called with a null value."));
+                return;
+            }
+            queue.set(t);
+            drain();
+        }
+
+        @Override
+        public boolean signalError(Throwable e) {
+            if (done || isCancelled()) {
+                return false;
+            }
+            error = e;
+            done = true;
+            drain();
+            return true;
+        }
+
+        @Override
+        public void onComplete() {
+            done = true;
+            drain();
+        }
+
+        @Override
+        void onRequested() {
+            drain();
+        }
+
+        @Override
+        void onUnsubscribed() {
+            if (wip.getAndIncrement() == 0) {
+                queue.lazySet(null);
+            }
+        }
+
+        void drain() {
+            if (wip.getAndIncrement() != 0) {
+                return;
+            }
+
+            int missed = 1;
+            final Subscriber<? super T> a = downstream;
+            final AtomicReference<T> q = queue;
+
+            for (; ; ) {
+                long r = get();
+                long e = 0L;
+
+                while (e != r) {
+                    if (isCancelled()) {
+                        q.lazySet(null);
+                        return;
+                    }
+
+                    boolean d = done;
+
+                    T o = q.getAndSet(null);
+
+                    boolean empty = o == null;
+
+                    if (d && empty) {
+                        Throwable ex = error;
+                        if (ex != null) {
+                            errorDownstream(ex);
+                        } else {
+                            completeDownstream();
+                        }
+                        return;
+                    }
+
+                    if (empty) {
+                        break;
+                    }
+
+                    a.onNext(o);
+
+                    e++;
+                }
+
+                if (e == r) {
+                    if (isCancelled()) {
+                        q.lazySet(null);
+                        return;
+                    }
+
+                    boolean d = done;
+
+                    boolean empty = q.get() == null;
+
+                    if (d && empty) {
+                        Throwable ex = error;
+                        if (ex != null) {
+                            errorDownstream(ex);
+                        } else {
+                            completeDownstream();
+                        }
+                        return;
+                    }
+                }
+
+                if (e != 0) {
+                    BackpressureHelper.produced(this, e);
+                }
+
+                missed = wip.addAndGet(-missed);
+                if (missed == 0) {
+                    break;
+                }
+            }
+        }
+    }
+
+}

--- a/core/src/main/java/org/infinispan/util/CoreBlockHoundIntegration.java
+++ b/core/src/main/java/org/infinispan/util/CoreBlockHoundIntegration.java
@@ -75,6 +75,9 @@ public class CoreBlockHoundIntegration implements BlockHoundIntegration {
       // Loading up the EnhancedQueueExecutor class loads org.jboss.threads.Version that reads a file to determine version
       builder.allowBlockingCallsInside(EnhancedQueueExecutorFactory.class.getName(), "createExecutor");
 
+      // Reads from a file during initialization which is during store startup
+      builder.allowBlockingCallsInside("org.infinispan.persistence.sifs.Index$Segment", "readUnsignedLong");
+
       methodsToBeRemoved(builder);
 
       questionableMethodsAllowedToBlock(builder);

--- a/core/src/main/java/org/infinispan/util/CoreBlockHoundIntegration.java
+++ b/core/src/main/java/org/infinispan/util/CoreBlockHoundIntegration.java
@@ -76,7 +76,7 @@ public class CoreBlockHoundIntegration implements BlockHoundIntegration {
       builder.allowBlockingCallsInside(EnhancedQueueExecutorFactory.class.getName(), "createExecutor");
 
       // Reads from a file during initialization which is during store startup
-      builder.allowBlockingCallsInside("org.infinispan.persistence.sifs.Index$Segment", "readUnsignedLong");
+      builder.allowBlockingCallsInside("org.infinispan.persistence.sifs.Index", "checkForExistingIndexSizeFile");
 
       methodsToBeRemoved(builder);
 

--- a/core/src/test/java/org/infinispan/persistence/BaseNonBlockingStoreTest.java
+++ b/core/src/test/java/org/infinispan/persistence/BaseNonBlockingStoreTest.java
@@ -652,14 +652,6 @@ public abstract class BaseNonBlockingStoreTest extends AbstractInfinispanTest {
             MarshallableEntry::getKey, keyPartitioner)));
    }
 
-   public void testWriteAndDeleteBatchIterable() {
-      // Number of entries is randomized to even numbers between 80 and 120
-      int numberOfEntries = 2 * ThreadLocalRandom.current().nextInt(WRITE_DELETE_BATCH_MIN_ENTRIES / 2, WRITE_DELETE_BATCH_MAX_ENTRIES / 2 + 1);
-      testBatch(numberOfEntries, () -> store.batchUpdate(segmentCount, Flowable.empty(),
-            TestingUtil.multipleSegmentPublisher(Flowable.range(0, numberOfEntries).map(i -> marshalledEntry(i.toString(), "Val" + i)),
-            MarshallableEntry::getKey, keyPartitioner)));
-   }
-
    public void testEmptyWriteAndDeleteBatchIterable() {
       assertIsEmpty();
       assertNull("should not be present in the store", store.loadEntry(keyToStorage(0)));


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-13576
https://issues.redhat.com/browse/ISPN-13601

Biggest change is now the index is prefixed by the UnsignedNumeric bytes of the segment. This then stores all of the entries for the given segment in an easy way to iterate over and finding the head is O(logN) time. I have included an optimization for iterating over the data with multiple segments as well, which is used by reducer methods.

Iterating over 2 of 256 segments from 200_000_000 entries stored in 3 index segments took only 800 ms versus the current (main) implementation which took 11.5 seconds.

I also ran some tests to count all of the entries across all segments over the same 200 million entries and the old implementation could not do it and ran out of memory, where as the new one was able to do, just slowly as it had to read all files :)