### PR TITLE
ISPN-13590 include source.version field in migrator example

### DIFF
--- a/documentation/src/main/asciidoc/stories/assembly_migrating_data.adoc
+++ b/documentation/src/main/asciidoc/stories/assembly_migrating_data.adoc
@@ -1,6 +1,6 @@
-[id='offline_data_migration']
-:context: upgrade
-= Migrating Data Between Cache Stores
+[id='migrating-data-between-stores']
+:context: store-migrator
+= Migrating data between cache stores
 {brandname} provides a Java utility for migrating persisted data between cache
 stores.
 

--- a/documentation/src/main/asciidoc/topics/attributes/store_migrator_source_versions.adoc
+++ b/documentation/src/main/asciidoc/topics/attributes/store_migrator_source_versions.adoc
@@ -1,0 +1,13 @@
+//Downstream content only
+//Used in ref_store_migrator_properties.adoc
+Set one of the following values:
+
+* `8` for {brandname} 7.2.x
+
+* `9` for {brandname} 7.3.x
+
+* `10` for {brandname} 8.0.x
+
+* `11` for {brandname} 8.1.x
+
+* `12` for {brandname} 8.2.x

--- a/documentation/src/main/asciidoc/topics/proc_configuring_store_migrator.adoc
+++ b/documentation/src/main/asciidoc/topics/proc_configuring_store_migrator.adoc
@@ -9,15 +9,18 @@ file.
 . Configure the source cache store in `migrator.properties`.
 .. Prepend all configuration properties with `source.` as in the following example:
 +
+[source,bash,options="nowrap",subs=attributes+]
 ----
 source.type=SOFT_INDEX_FILE_STORE
 source.cache_name=myCache
 source.location=/path/to/source/sifs
+source.version=12
 ----
 +
 . Configure the target cache store in `migrator.properties`.
 .. Prepend all configuration properties with `target.` as in the following example:
 +
+[source,bash,options="nowrap",subs=attributes+]
 ----
 target.type=SINGLE_FILE_STORE
 target.cache_name=myCache

--- a/documentation/src/main/asciidoc/topics/ref_store_migrator_properties.adoc
+++ b/documentation/src/main/asciidoc/topics/ref_store_migrator_properties.adoc
@@ -62,35 +62,17 @@ same, {brandname} cannot read data from the cache store.
 |Required
 
 |`version`
-|Specifies the marshaller version for source cache stores. Set one of the following values:
-
+|Specifies the marshaller version for source cache stores. +
 ifdef::community[]
-* `8` for {brandname} 8.x
+Set the value that matches the {brandname} major version of the source cluster. For example; set a value of `12` for {brandname} 12.x.
 endif::community[]
-
 ifdef::downstream[]
-* `8` for {brandname} 7.2.x
-endif::downstream[]
-
-ifdef::community[]
-* `9` for {brandname} 9.x
-endif::community[]
-
-ifdef::downstream[]
-* `9` for {brandname} 7.3.x
-endif::downstream[]
-
-ifdef::community[]
-* `10` {brandname} 10.x
-endif::community[]
-
-ifdef::downstream[]
-* `10` {brandname} 8.x
+include::attributes/store_migrator_source_versions.adoc[]
 endif::downstream[]
 
 |Required for source stores only.
 
-For example: `source.version=9`
+For example: `source.version=12`
 
 |`marshaller.class`
 |Specifies a custom marshaller class.


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-13590

Needs backport to 13.0.x