### PR TITLE
Update log4j to 2.17 to address CVE-2021-45105.

### DIFF
--- a/build-configuration/pom.xml
+++ b/build-configuration/pom.xml
@@ -169,7 +169,7 @@
       <version.jsr107>1.1.0</version.jsr107>
       <version.junit>4.13.1</version.junit>
       <version.junit5>5.6.2</version.junit5>
-      <version.log4j>2.16.0</version.log4j>
+      <version.log4j>2.17.0</version.log4j>
       <version.lucene>8.7.0</version.lucene>
       <version.metainf-services>1.7</version.metainf-services>
       <version.mockito>2.27.0</version.mockito>


### PR DESCRIPTION
Log4j version update because of CVE-2021-45105 vulnerability.

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105