### PR TITLE
ISPN-13608 fix for NPE after stream.filterKeys(null) was used

### DIFF
--- a/core/src/main/java/org/infinispan/util/MappedCacheStream.java
+++ b/core/src/main/java/org/infinispan/util/MappedCacheStream.java
@@ -20,6 +20,6 @@ class MappedCacheStream<R> extends AbstractDelegatingCacheStream<R> {
 
    @Override
    public AbstractDelegatingCacheStream<R> filterKeys(Set<?> keys) {
-      return super.filterKeys(new SetMapper<>(keys, keyMapper));
+      return super.filterKeys(keys != null ? new SetMapper<>(keys, keyMapper) : null);
    }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-13608
