### PR TITLE
[9.4.x] ISPN-13549 EntryWrappingInterceptor data race handling expired entries

### DIFF
--- a/core/src/main/java/org/infinispan/container/impl/EntryFactory.java
+++ b/core/src/main/java/org/infinispan/container/impl/EntryFactory.java
@@ -1,5 +1,6 @@
 package org.infinispan.container.impl;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import org.infinispan.commands.VisitableCommand;
@@ -10,6 +11,7 @@ import org.infinispan.context.InvocationContext;
 import org.infinispan.interceptors.impl.EntryWrappingInterceptor;
 import org.infinispan.interceptors.locking.ClusteringDependentLogic;
 import org.infinispan.topology.CacheTopology;
+import org.infinispan.util.concurrent.CompletableFutures;
 
 /**
  * A factory for constructing {@link org.infinispan.container.entries.MVCCEntry} instances for use in the {@link org.infinispan.context.InvocationContext}.
@@ -87,6 +89,32 @@ import org.infinispan.topology.CacheTopology;
  */
 public interface EntryFactory {
    /**
+    * Use to synchronize multiple {@link #wrapEntryForReading(InvocationContext, Object, int, boolean, CompletionStage)}
+    * or {@link #wrapEntryForReading(InvocationContext, Object, int, boolean, CompletionStage)} calls.
+    *
+    * The basic pattern is:
+    *
+    * <pre>{@code
+    * CompletableFuture<Void> initialStage = new CompletableFuture<>();
+    * CompletionStage<Void> currentStage = initialStage;
+    * for (Object key : ...) {
+    *    currentStage = entryFactory.wrapEntryForWriting(..., currentStage);
+    * }
+    * return asyncInvokeNext(ctx, command, expirationCheckDelay(currentStage, initialStage));
+    * }</pre>
+    */
+   static CompletionStage<Void> expirationCheckDelay(CompletionStage<Void> currentStage, CompletableFuture<Void> initialStage) {
+      if (currentStage == initialStage) {
+         // No expiration to process asynchronously, don't bother completing the initial stage
+         return CompletableFutures.completedNull();
+      }
+
+      // Allow the expiration check to modify the invocation context
+      initialStage.complete(null);
+      return currentStage;
+   }
+
+   /**
     * Wraps an entry for reading.  Usually this is just a raw {@link CacheEntry} but certain combinations of isolation
     * levels and the presence of an ongoing JTA transaction may force this to be a proper, wrapped MVCCEntry.  The entry
     * is also typically placed in the invocation context.
@@ -95,9 +123,10 @@ public interface EntryFactory {
     * @param key key to look up and wrap
     * @param segment segment for the key
     * @param isOwner true if this node is current owner in readCH (or we ignore CH)
+    * @param previousStage don't access the invocation context from another thread before this stage is complete
     * @return stage that when complete the value should be in the context
     */
-   CompletionStage<Void> wrapEntryForReading(InvocationContext ctx, Object key, int segment, boolean isOwner);
+   CompletionStage<Void> wrapEntryForReading(InvocationContext ctx, Object key, int segment, boolean isOwner, CompletionStage<Void> previousStage);
 
    /**
     * Insert an entry that exists in the data container into the context.
@@ -112,9 +141,10 @@ public interface EntryFactory {
     * @param segment segment for the key
     * @param isOwner true if this node is current owner in readCH (or we ignore CH)
     * @param isRead true if this operation is expected to read the value of the entry
+    * @param previousStage don't access the invocation context from another thread before this stage is complete
     * @since 8.1
     */
-   CompletionStage<Void> wrapEntryForWriting(InvocationContext ctx, Object key, int segment, boolean isOwner, boolean isRead);
+   CompletionStage<Void> wrapEntryForWriting(InvocationContext ctx, Object key, int segment, boolean isOwner, boolean isRead, CompletionStage<Void> previousStage);
 
    /**
     * Insert an entry that exists in the data container into the context, even if it is expired

--- a/core/src/main/java/org/infinispan/container/impl/EntryFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/container/impl/EntryFactoryImpl.java
@@ -98,10 +98,13 @@ public class EntryFactoryImpl implements EntryFactory {
 
    private void handleExpiredEntryContextAddition(Boolean expired, InvocationContext ctx, InternalCacheEntry readEntry,
          Object key, boolean isOwner) {
-      if (expired == Boolean.FALSE) {
-         addReadEntryToContext(ctx, readEntry, key);
-      } else if (isOwner) {
-         addReadEntryToContext(ctx, NullCacheEntry.getInstance(), key);
+      // Multi-key commands perform the expiration check in parallel, so they need synchronization
+      synchronized (ctx) {
+         if (expired == Boolean.FALSE) {
+            addReadEntryToContext(ctx, readEntry, key);
+         } else if (isOwner) {
+            addReadEntryToContext(ctx, NullCacheEntry.getInstance(), key);
+         }
       }
    }
 
@@ -177,13 +180,13 @@ public class EntryFactoryImpl implements EntryFactory {
 
    private void handleWriteExpiredEntryContextAddition(Boolean expired, InvocationContext ctx, InternalCacheEntry ice,
          Object key, boolean isRead) {
-      if (expired == Boolean.FALSE) {
-         addWriteEntryToContext(ctx, ice, key, isRead);
-      } else {
-         if (trace) {
-            log.tracef("Entry retrieved for key %s was expired, returning null entry", key);
+      // Multi-key commands perform the expiration check in parallel, so they need synchronization
+      synchronized (ctx) {
+         if (expired == Boolean.FALSE) {
+            addWriteEntryToContext(ctx, ice, key, isRead);
+         } else {
+            addWriteEntryToContext(ctx, NullCacheEntry.getInstance(), key, isRead);
          }
-         addWriteEntryToContext(ctx, NullCacheEntry.getInstance(), key, isRead);
       }
    }
 

--- a/core/src/main/java/org/infinispan/container/impl/EntryFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/container/impl/EntryFactoryImpl.java
@@ -22,7 +22,6 @@ import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
 import org.infinispan.metadata.EmbeddedMetadata;
 import org.infinispan.metadata.Metadata;
-import org.infinispan.util.concurrent.CompletableFutures;
 import org.infinispan.util.concurrent.CompletionStages;
 import org.infinispan.util.concurrent.IsolationLevel;
 import org.infinispan.util.logging.Log;
@@ -65,7 +64,7 @@ public class EntryFactoryImpl implements EntryFactory {
    @Override
    public final CompletionStage<Void> wrapEntryForReading(InvocationContext ctx, Object key, int segment, boolean isOwner, CompletionStage<Void> previousStage) {
       if (!isOwner && !isL1Enabled) {
-         return CompletableFutures.completedNull();
+         return previousStage;
       }
       CacheEntry cacheEntry = getFromContext(ctx, key);
       if (cacheEntry == null) {

--- a/core/src/main/java/org/infinispan/container/impl/EntryFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/container/impl/EntryFactoryImpl.java
@@ -63,11 +63,10 @@ public class EntryFactoryImpl implements EntryFactory {
    }
 
    @Override
-   public final CompletionStage<Void> wrapEntryForReading(InvocationContext ctx, Object key, int segment, boolean isOwner) {
+   public final CompletionStage<Void> wrapEntryForReading(InvocationContext ctx, Object key, int segment, boolean isOwner, CompletionStage<Void> previousStage) {
       if (!isOwner && !isL1Enabled) {
          return CompletableFutures.completedNull();
       }
-      CompletionStage<Void> returnedStage = CompletableFutures.completedNull();
       CacheEntry cacheEntry = getFromContext(ctx, key);
       if (cacheEntry == null) {
          InternalCacheEntry readEntry = getFromContainer(key, segment);
@@ -82,9 +81,8 @@ public class EntryFactoryImpl implements EntryFactory {
                   Boolean expired = CompletionStages.join(expiredStage);
                   handleExpiredEntryContextAddition(expired, ctx, readEntry, key, isOwner);
                } else {
-                  returnedStage = expiredStage.thenApply(expired -> {
+                  return expiredStage.thenAcceptBoth(previousStage, (expired, __) -> {
                      handleExpiredEntryContextAddition(expired, ctx, readEntry, key, isOwner);
-                     return null;
                   });
                }
             } else {
@@ -93,18 +91,16 @@ public class EntryFactoryImpl implements EntryFactory {
          }
       }
 
-      return returnedStage;
+      return previousStage;
    }
 
    private void handleExpiredEntryContextAddition(Boolean expired, InvocationContext ctx, InternalCacheEntry readEntry,
          Object key, boolean isOwner) {
       // Multi-key commands perform the expiration check in parallel, so they need synchronization
-      synchronized (ctx) {
-         if (expired == Boolean.FALSE) {
-            addReadEntryToContext(ctx, readEntry, key);
-         } else if (isOwner) {
-            addReadEntryToContext(ctx, NullCacheEntry.getInstance(), key);
-         }
+      if (expired == Boolean.FALSE) {
+         addReadEntryToContext(ctx, readEntry, key);
+      } else if (isOwner) {
+         addReadEntryToContext(ctx, NullCacheEntry.getInstance(), key);
       }
    }
 
@@ -136,9 +132,9 @@ public class EntryFactoryImpl implements EntryFactory {
    }
 
    @Override
-   public CompletionStage<Void> wrapEntryForWriting(InvocationContext ctx, Object key, int segment, boolean isOwner, boolean isRead) {
+   public CompletionStage<Void> wrapEntryForWriting(InvocationContext ctx, Object key, int segment, boolean isOwner,
+                                                    boolean isRead, CompletionStage<Void> previousStage) {
       CacheEntry contextEntry = getFromContext(ctx, key);
-      CompletionStage<Void> returnedStage = CompletableFutures.completedNull();
       if (contextEntry instanceof MVCCEntry) {
          // Nothing to do, already wrapped.
       } else if (contextEntry != null) {
@@ -161,9 +157,9 @@ public class EntryFactoryImpl implements EntryFactory {
                      Boolean expired = CompletionStages.join(expiredStage);
                      handleWriteExpiredEntryContextAddition(expired, ctx, ice, key, isRead);
                   } else {
-                     returnedStage = expiredStage.thenApply(expired -> {
+                     // Serialize invocation context access
+                     return expiredStage.thenAcceptBoth(previousStage, (expired, __) -> {
                         handleWriteExpiredEntryContextAddition(expired, ctx, ice, key, isRead);
-                        return null;
                      });
                   }
                } else {
@@ -175,18 +171,16 @@ public class EntryFactoryImpl implements EntryFactory {
          }
       }
 
-      return returnedStage;
+      return previousStage;
    }
 
    private void handleWriteExpiredEntryContextAddition(Boolean expired, InvocationContext ctx, InternalCacheEntry ice,
          Object key, boolean isRead) {
       // Multi-key commands perform the expiration check in parallel, so they need synchronization
-      synchronized (ctx) {
-         if (expired == Boolean.FALSE) {
-            addWriteEntryToContext(ctx, ice, key, isRead);
-         } else {
-            addWriteEntryToContext(ctx, NullCacheEntry.getInstance(), key, isRead);
-         }
+      if (expired == Boolean.FALSE) {
+         addWriteEntryToContext(ctx, ice, key, isRead);
+      } else {
+         addWriteEntryToContext(ctx, NullCacheEntry.getInstance(), key, isRead);
       }
    }
 

--- a/core/src/main/java/org/infinispan/interceptors/BaseAsyncInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/BaseAsyncInterceptor.java
@@ -11,6 +11,7 @@ import org.infinispan.context.InvocationContext;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.interceptors.impl.SimpleAsyncInvocationStage;
 import org.infinispan.util.concurrent.CompletableFutures;
+import org.infinispan.util.concurrent.CompletionStages;
 
 /**
  * Base class for an interceptor in the new asynchronous invocation chain.
@@ -222,6 +223,9 @@ public abstract class BaseAsyncInterceptor implements AsyncInterceptor {
     */
    public final Object asyncInvokeNext(InvocationContext ctx, VisitableCommand command,
                                        CompletionStage<?> delay) {
+      if (CompletionStages.isCompletedSuccessfully(delay))
+         return invokeNext(ctx, command);
+
       return asyncValue(delay).thenApply(ctx, command, invokeNextFunction);
    }
 

--- a/core/src/main/java/org/infinispan/interceptors/distribution/BaseDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/BaseDistributionInterceptor.java
@@ -595,7 +595,7 @@ public abstract class BaseDistributionInterceptor extends ClusteringInterceptor 
             Collection<Address> ignoreForKey = null;
             for (Address address : distributionInfo.readOwners()) {
                if (address.equals(rpcManager.getAddress())) {
-                  throw new IllegalStateException("Entry should be always wrapped!");
+                  throw new IllegalStateException("Entry should already be wrapped on read owners!");
                } else if (ignoredOwners != null) {
                   if (ignoreForKey == null) {
                      ignoreForKey = ignoredOwners.get(key);

--- a/core/src/main/java/org/infinispan/interceptors/distribution/L1NonTxInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/L1NonTxInterceptor.java
@@ -51,7 +51,7 @@ import org.infinispan.interceptors.impl.BaseRpcInterceptor;
 import org.infinispan.interceptors.impl.MultiSubCommandInvoker;
 import org.infinispan.interceptors.locking.ClusteringDependentLogic;
 import org.infinispan.statetransfer.StateTransferLock;
-import org.infinispan.util.concurrent.AggregateCompletionStage;
+import org.infinispan.util.concurrent.CompletableFutures;
 import org.infinispan.util.concurrent.CompletionStages;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -310,25 +310,20 @@ public class L1NonTxInterceptor extends BaseRpcInterceptor {
    @Override
    public Object visitInvalidateL1Command(InvocationContext ctx, InvalidateL1Command invalidateL1Command)
          throws Throwable {
-      AggregateCompletionStage<Void> aggregateCompletionStage = null;
+      CompletableFuture<Void> initialStage = new CompletableFuture<>();
+      CompletionStage<Void> currentStage = initialStage;
       for (Object key : invalidateL1Command.getKeys()) {
          abortL1UpdateOrWait(key);
          // If our invalidation was sent when the value wasn't yet cached but is still being requested the context
          // may not have the value - if so we need to add it then now that we know we waited for the get response
          // to complete
          if (ctx.lookupEntry(key) == null) {
-            CompletionStage<Void> stage = entryFactory.wrapEntryForWriting(ctx, key, keyPartitioner.getSegment(key),
-                  true, false);
-            if (!CompletionStages.isCompletedSuccessfully(stage)) {
-               if (aggregateCompletionStage == null) {
-                  aggregateCompletionStage = CompletionStages.aggregateCompletionStage();
-               }
-               aggregateCompletionStage.dependsOn(stage);
-            }
+            currentStage = entryFactory.wrapEntryForWriting(ctx, key, keyPartitioner.getSegment(key),
+                                                            true, false, currentStage);
          }
       }
-      return aggregateCompletionStage != null ? asyncInvokeNext(ctx, invalidateL1Command, aggregateCompletionStage.freeze()) :
-            invokeNext(ctx, invalidateL1Command);
+      if (currentStage == initialStage) return invokeNext(ctx, invalidateL1Command);
+      return asyncInvokeNext(ctx, invalidateL1Command, currentStage);
    }
 
    private void abortL1UpdateOrWait(Object key) {
@@ -422,7 +417,7 @@ public class L1NonTxInterceptor extends BaseRpcInterceptor {
       }
       abortL1UpdateOrWait(key);
       ctx.removeLookedUpEntry(key);
-      CompletionStage<Void> stage = entryFactory.wrapEntryForWriting(ctx, key, segment, true, false);
+      CompletionStage<Void> stage = entryFactory.wrapEntryForWriting(ctx, key, segment, true, false, CompletableFutures.completedNull());
 
       return stage.thenApply(ignore -> commandsFactory.buildInvalidateFromL1Command(EnumUtil.EMPTY_BIT_SET,
             Collections.singleton(key)));

--- a/core/src/main/java/org/infinispan/interceptors/distribution/L1NonTxInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/L1NonTxInterceptor.java
@@ -322,8 +322,7 @@ public class L1NonTxInterceptor extends BaseRpcInterceptor {
                                                             true, false, currentStage);
          }
       }
-      if (currentStage == initialStage) return invokeNext(ctx, invalidateL1Command);
-      return asyncInvokeNext(ctx, invalidateL1Command, currentStage);
+      return asyncInvokeNext(ctx, invalidateL1Command, EntryFactory.expirationCheckDelay(currentStage, initialStage));
    }
 
    private void abortL1UpdateOrWait(Object key) {

--- a/core/src/main/java/org/infinispan/interceptors/distribution/TxDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/TxDistributionInterceptor.java
@@ -555,7 +555,7 @@ public class TxDistributionInterceptor extends BaseDistributionInterceptor {
       return cf.thenCompose(ignore -> {
          // TODO Dan: apply the modifications before wrapping the entry in the context
          CompletionStage<Void> stage = entryFactory.wrapEntryForWriting(ctx, key, SegmentSpecificCommand.extractSegment(command, key, keyPartitioner),
-               false, true);
+                                                                        false, true, CompletableFutures.completedNull());
          return stage.thenRun(() -> {
             MVCCEntry cacheEntry = (MVCCEntry) ctx.lookupEntry(key);
             for (Mutation mutation : mutationsOnKey) {
@@ -581,8 +581,8 @@ public class TxDistributionInterceptor extends BaseDistributionInterceptor {
       Iterator<List<Mutation>> mutationsIterator = mutations.iterator();
       for (; keysIterator.hasNext() && mutationsIterator.hasNext(); ) {
          Object key = keysIterator.next();
-         CompletionStage<Void> stage = entryFactory.wrapEntryForWriting(ctx, key, keyPartitioner.getSegment(key), false, true);
-         // We rely on the fact that when isOwner is false that this never blocks
+         CompletionStage<Void> stage = entryFactory.wrapEntryForWriting(ctx, key, keyPartitioner.getSegment(key), false, true, CompletableFutures.completedNull());
+         // We rely on the fact that when isOwner is false this never blocks
          assert CompletionStages.isCompletedSuccessfully(stage);
          MVCCEntry cacheEntry = (MVCCEntry) ctx.lookupEntry(key);
          EntryView.ReadWriteEntryView readWriteEntryView = EntryViews.readWrite(cacheEntry, DataConversion.DEFAULT_KEY, DataConversion.DEFAULT_VALUE);

--- a/core/src/main/java/org/infinispan/interceptors/impl/EntryWrappingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/EntryWrappingInterceptor.java
@@ -1,9 +1,11 @@
 package org.infinispan.interceptors.impl;
 
 import static org.infinispan.commons.util.Util.toStr;
+import static org.infinispan.container.impl.EntryFactory.expirationCheckDelay;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import org.infinispan.commands.AbstractVisitor;
@@ -207,21 +209,21 @@ public class EntryWrappingInterceptor extends DDAsyncInterceptor {
    private Object visitDataReadCommand(InvocationContext ctx, AbstractDataCommand command) {
       final Object key = command.getKey();
       CompletionStage<Void> stage = entryFactory.wrapEntryForReading(ctx, key, command.getSegment(),
-            ignoreOwnership(command) || canRead(command));
+            ignoreOwnership(command) || canRead(command), CompletableFutures.completedNull());
       return makeStage(asyncInvokeNext(ctx, command, stage)).thenAccept(ctx, command, dataReadReturnHandler);
    }
 
    @Override
    public Object visitGetAllCommand(InvocationContext ctx, GetAllCommand command) throws Throwable {
       boolean ignoreOwnership = ignoreOwnership(command);
-      AggregateCompletionStage<Void> aggregateCompletionStage = null;
+      CompletableFuture<Void> initialStage = new CompletableFuture<>();
+      CompletionStage<Void> currentStage = initialStage;
       for (Object key : command.getKeys()) {
-         CompletionStage<Void> stage = entryFactory.wrapEntryForReading(ctx, key, keyPartitioner.getSegment(key),
-               ignoreOwnership || canReadKey(key));
-         aggregateCompletionStage = accumulateStage(stage, aggregateCompletionStage);
+         currentStage = entryFactory.wrapEntryForReading(ctx, key, keyPartitioner.getSegment(key),
+               ignoreOwnership || canReadKey(key), currentStage);
       }
 
-      return makeStage(asyncInvokeNext(ctx, command, aggregatedStageOrCompleted(aggregateCompletionStage)))
+      return makeStage(asyncInvokeNext(ctx, command, expirationCheckDelay(currentStage, initialStage)))
             .andHandle(ctx, command, getAllHandleFunction);
    }
 
@@ -262,33 +264,18 @@ public class EntryWrappingInterceptor extends DDAsyncInterceptor {
 
    @Override
    public final Object visitInvalidateCommand(InvocationContext ctx, InvalidateCommand command) {
-      AggregateCompletionStage<Void> aggregateCompletionStage = null;
+      CompletableFuture<Void> initialStage = new CompletableFuture<>();
+      CompletionStage<Void> currentStage = initialStage;
       if (command.getKeys() != null) {
          for (Object key : command.getKeys()) {
             // TODO: move this to distribution interceptors?
             // we need to try to wrap the entry to get it removed
             // for the removal itself, wrapping null would suffice, but listeners need previous value
-            CompletionStage<Void> stage = entryFactory.wrapEntryForWriting(ctx, key, keyPartitioner.getSegment(key),
-                  true, false);
-            aggregateCompletionStage = accumulateStage(stage, aggregateCompletionStage);
+            currentStage = entryFactory.wrapEntryForWriting(ctx, key, keyPartitioner.getSegment(key),
+                                                                           true, false, currentStage);
          }
       }
-      return setSkipRemoteGetsAndInvokeNextForManyEntriesCommand(ctx, command,
-            aggregatedStageOrCompleted(aggregateCompletionStage));
-   }
-
-   private CompletionStage<Void> aggregatedStageOrCompleted(AggregateCompletionStage<Void> aggregateCompletionStage) {
-      return aggregateCompletionStage != null ? aggregateCompletionStage.freeze() : CompletableFutures.completedNull();
-   }
-
-   private AggregateCompletionStage<Void> accumulateStage(CompletionStage<Void> stage, AggregateCompletionStage<Void> current) {
-      if (!CompletionStages.isCompletedSuccessfully(stage)) {
-         if (current == null) {
-            current = CompletionStages.aggregateCompletionStage();
-         }
-         current.dependsOn(stage);
-      }
-      return current;
+      return setSkipRemoteGetsAndInvokeNextForManyEntriesCommand(ctx, command, expirationCheckDelay(currentStage, initialStage));
    }
 
    @Override
@@ -316,19 +303,18 @@ public class EntryWrappingInterceptor extends DDAsyncInterceptor {
 
    @Override
    public Object visitInvalidateL1Command(InvocationContext ctx, InvalidateL1Command command) {
-      AggregateCompletionStage<Void> aggregateCompletionStage = null;
+      CompletableFuture<Void> initialStage = new CompletableFuture<>();
+      CompletionStage<Void> currentStage = initialStage;
       for (Object key : command.getKeys()) {
          // TODO: move to distribution interceptors?
          // we need to try to wrap the entry to get it removed
          // for the removal itself, wrapping null would suffice, but listeners need previous value
-         CompletionStage<Void> stage = entryFactory.wrapEntryForWriting(ctx, key, keyPartitioner.getSegment(key),
-               false, false);
-         aggregateCompletionStage = accumulateStage(stage, aggregateCompletionStage);
+         currentStage = entryFactory.wrapEntryForWriting(ctx, key, keyPartitioner.getSegment(key),
+                                                                        false, false, currentStage);
          if (trace)
            log.tracef("Entry to be removed: %s", toStr(key));
       }
-      return setSkipRemoteGetsAndInvokeNextForManyEntriesCommand(ctx, command,
-            aggregatedStageOrCompleted(aggregateCompletionStage));
+      return setSkipRemoteGetsAndInvokeNextForManyEntriesCommand(ctx, command, expirationCheckDelay(currentStage, initialStage));
    }
 
    @Override
@@ -341,7 +327,10 @@ public class EntryWrappingInterceptor extends DDAsyncInterceptor {
       if (command.hasAnyFlag(FlagBitSets.COMMAND_RETRY)) {
          removeFromContextOnRetry(ctx, command.getKey());
       }
-      return entryFactory.wrapEntryForWriting(ctx, command.getKey(), command.getSegment(), ignoreOwnership(command) || canRead(command), command.loadType() != VisitableCommand.LoadType.DONT_LOAD);
+      return entryFactory.wrapEntryForWriting(ctx, command.getKey(), command.getSegment(),
+                                              ignoreOwnership(command) || canRead(command),
+                                              command.loadType() != VisitableCommand.LoadType.DONT_LOAD,
+                                              CompletableFutures.completedNull());
    }
 
    private void removeFromContextOnRetry(InvocationContext ctx, Object key) {
@@ -418,15 +407,14 @@ public class EntryWrappingInterceptor extends DDAsyncInterceptor {
       if (command.hasAnyFlag(FlagBitSets.COMMAND_RETRY)) {
          removeFromContextOnRetry(ctx, command.getAffectedKeys());
       }
-      AggregateCompletionStage<Void> aggregateCompletionStage = null;
+      CompletableFuture<Void> initialStage = new CompletableFuture<>();
+      CompletionStage<Void> currentStage = initialStage;
       for (Object key : command.getMap().keySet()) {
          // as listeners may need the value, we'll load the previous value
-         CompletionStage<Void> stage = entryFactory.wrapEntryForWriting(ctx, key, keyPartitioner.getSegment(key),
-               ignoreOwnership || canReadKey(key), command.loadType() != VisitableCommand.LoadType.DONT_LOAD);
-         aggregateCompletionStage = accumulateStage(stage, aggregateCompletionStage);
+         currentStage = entryFactory.wrapEntryForWriting(ctx, key, keyPartitioner.getSegment(key),
+               ignoreOwnership || canReadKey(key), command.loadType() != VisitableCommand.LoadType.DONT_LOAD, currentStage);
       }
-      return setSkipRemoteGetsAndInvokeNextForManyEntriesCommand(ctx, command,
-            aggregatedStageOrCompleted(aggregateCompletionStage));
+      return setSkipRemoteGetsAndInvokeNextForManyEntriesCommand(ctx, command, expirationCheckDelay(currentStage, initialStage));
    }
 
    @Override
@@ -476,9 +464,13 @@ public class EntryWrappingInterceptor extends DDAsyncInterceptor {
       CompletionStage<Void> stage;
       if (command instanceof TxReadOnlyKeyCommand) {
          // TxReadOnlyKeyCommand may apply some mutations on the entry in context so we need to always wrap it
-         stage = entryFactory.wrapEntryForWriting(ctx, command.getKey(), command.getSegment(), ignoreOwnership(command) || canRead(command), true);
+         stage = entryFactory.wrapEntryForWriting(ctx, command.getKey(), command.getSegment(),
+                                                  ignoreOwnership(command) || canRead(command), true,
+                                                  CompletableFutures.completedNull());
       } else {
-         stage = entryFactory.wrapEntryForReading(ctx, command.getKey(), command.getSegment(), ignoreOwnership(command) || canRead(command));
+         stage = entryFactory.wrapEntryForReading(ctx, command.getKey(), command.getSegment(),
+                                                  ignoreOwnership(command) || canRead(command),
+                                                  CompletableFutures.completedNull());
       }
 
       // Repeatable reads are not achievable with functional commands, as we don't store the value locally
@@ -491,24 +483,23 @@ public class EntryWrappingInterceptor extends DDAsyncInterceptor {
    @Override
    public Object visitReadOnlyManyCommand(InvocationContext ctx, ReadOnlyManyCommand command) throws Throwable {
       boolean ignoreOwnership = ignoreOwnership(command);
-      AggregateCompletionStage<Void> aggregateCompletionStage = null;
+      CompletableFuture<Void> initialStage = new CompletableFuture<>();
+      CompletionStage<Void> currentStage = initialStage;
       if (command instanceof TxReadOnlyManyCommand) {
          // TxReadOnlyManyCommand may apply some mutations on the entry in context so we need to always wrap it
          for (Object key : command.getKeys()) {
             // TODO: need to handle this
-            CompletionStage<Void> stage = entryFactory.wrapEntryForWriting(ctx, key, keyPartitioner.getSegment(key),
-                  ignoreOwnership(command) || canReadKey(key), true);
-            aggregateCompletionStage = accumulateStage(stage, aggregateCompletionStage);
+            currentStage = entryFactory.wrapEntryForWriting(ctx, key, keyPartitioner.getSegment(key),
+                  ignoreOwnership(command) || canReadKey(key), true, currentStage);
          }
       } else {
          for (Object key : command.getKeys()) {
-            CompletionStage<Void> stage = entryFactory.wrapEntryForReading(ctx, key, keyPartitioner.getSegment(key),
-                  ignoreOwnership || canReadKey(key));
-            aggregateCompletionStage = accumulateStage(stage, aggregateCompletionStage);
+            currentStage = entryFactory.wrapEntryForReading(ctx, key, keyPartitioner.getSegment(key),
+                  ignoreOwnership || canReadKey(key), currentStage);
          }
       }
       // Repeatable reads are not achievable with functional commands, see visitReadOnlyKeyCommand
-      return asyncInvokeNext(ctx, command, aggregatedStageOrCompleted(aggregateCompletionStage));
+      return asyncInvokeNext(ctx, command, expirationCheckDelay(currentStage, initialStage));
    }
 
    @Override
@@ -536,15 +527,14 @@ public class EntryWrappingInterceptor extends DDAsyncInterceptor {
          removeFromContextOnRetry(ctx, command.getAffectedKeys());
       }
       boolean ignoreOwnership = ignoreOwnership(command);
-      AggregateCompletionStage<Void> aggregateCompletionStage = null;
+      CompletableFuture<Void> initialStage = new CompletableFuture<>();
+      CompletionStage<Void> currentStage = initialStage;
       for (Object key : command.getArguments().keySet()) {
          //the put map never reads the keys
-         CompletionStage<Void> stage = entryFactory.wrapEntryForWriting(ctx, key, keyPartitioner.getSegment(key),
-               ignoreOwnership || canReadKey(key), false);
-         aggregateCompletionStage = accumulateStage(stage, aggregateCompletionStage);
+         currentStage = entryFactory.wrapEntryForWriting(ctx, key, keyPartitioner.getSegment(key),
+               ignoreOwnership || canReadKey(key), false, currentStage);
       }
-      return setSkipRemoteGetsAndInvokeNextForManyEntriesCommand(ctx, command,
-            aggregatedStageOrCompleted(aggregateCompletionStage));
+      return setSkipRemoteGetsAndInvokeNextForManyEntriesCommand(ctx, command, expirationCheckDelay(currentStage, initialStage));
    }
 
    @Override
@@ -554,14 +544,13 @@ public class EntryWrappingInterceptor extends DDAsyncInterceptor {
          removeFromContextOnRetry(ctx, command.getAffectedKeys());
       }
       boolean ignoreOwnership = ignoreOwnership(command);
-      AggregateCompletionStage<Void> aggregateCompletionStage = null;
+      CompletableFuture<Void> initialStage = new CompletableFuture<>();
+      CompletionStage<Void> currentStage = initialStage;
       for (Object key : command.getAffectedKeys()) {
-         CompletionStage<Void> stage = entryFactory.wrapEntryForWriting(ctx, key, keyPartitioner.getSegment(key),
-               ignoreOwnership || canReadKey(key), false);
-         aggregateCompletionStage = accumulateStage(stage, aggregateCompletionStage);
+         currentStage = entryFactory.wrapEntryForWriting(ctx, key, keyPartitioner.getSegment(key),
+               ignoreOwnership || canReadKey(key), false, currentStage);
       }
-      return setSkipRemoteGetsAndInvokeNextForManyEntriesCommand(ctx, command,
-            aggregatedStageOrCompleted(aggregateCompletionStage));
+      return setSkipRemoteGetsAndInvokeNextForManyEntriesCommand(ctx, command, expirationCheckDelay(currentStage, initialStage));
    }
 
    @Override
@@ -577,14 +566,13 @@ public class EntryWrappingInterceptor extends DDAsyncInterceptor {
          removeFromContextOnRetry(ctx, command.getAffectedKeys());
       }
       boolean ignoreOwnership = ignoreOwnership(command);
-      AggregateCompletionStage<Void> aggregateCompletionStage = null;
+      CompletableFuture<Void> initialStage = new CompletableFuture<>();
+      CompletionStage<Void> currentStage = initialStage;
       for (Object key : command.getAffectedKeys()) {
-         CompletionStage<Void> stage = entryFactory.wrapEntryForWriting(ctx, key, keyPartitioner.getSegment(key),
-               ignoreOwnership || canReadKey(key), true);
-         aggregateCompletionStage = accumulateStage(stage, aggregateCompletionStage);
+         currentStage = entryFactory.wrapEntryForWriting(ctx, key, keyPartitioner.getSegment(key),
+               ignoreOwnership || canReadKey(key), true, currentStage);
       }
-      return setSkipRemoteGetsAndInvokeNextForManyEntriesCommand(ctx, command,
-            aggregatedStageOrCompleted(aggregateCompletionStage));
+      return setSkipRemoteGetsAndInvokeNextForManyEntriesCommand(ctx, command, expirationCheckDelay(currentStage, initialStage));
    }
 
    @Override
@@ -594,14 +582,13 @@ public class EntryWrappingInterceptor extends DDAsyncInterceptor {
          removeFromContextOnRetry(ctx, command.getAffectedKeys());
       }
       boolean ignoreOwnership = ignoreOwnership(command);
-      AggregateCompletionStage<Void> aggregateCompletionStage = null;
+      CompletableFuture<Void> initialStage = new CompletableFuture<>();
+      CompletionStage<Void> currentStage = initialStage;
       for (Object key : command.getAffectedKeys()) {
-         CompletionStage<Void> stage = entryFactory.wrapEntryForWriting(ctx, key, keyPartitioner.getSegment(key),
-               ignoreOwnership || canReadKey(key), true);
-         aggregateCompletionStage = accumulateStage(stage, aggregateCompletionStage);
+         currentStage = entryFactory.wrapEntryForWriting(ctx, key, keyPartitioner.getSegment(key),
+               ignoreOwnership || canReadKey(key), true, currentStage);
       }
-      return setSkipRemoteGetsAndInvokeNextForManyEntriesCommand(ctx, command,
-            aggregatedStageOrCompleted(aggregateCompletionStage));
+      return setSkipRemoteGetsAndInvokeNextForManyEntriesCommand(ctx, command, expirationCheckDelay(currentStage, initialStage));
    }
 
    protected final CompletionStage<Void> commitContextEntries(InvocationContext ctx, FlagAffectedCommand command) {
@@ -855,19 +842,20 @@ public class EntryWrappingInterceptor extends DDAsyncInterceptor {
 
       private Object handleWriteCommand(InvocationContext ctx, DataWriteCommand command) throws Throwable {
          CompletionStage<Void> stage = entryFactory.wrapEntryForWriting(ctx, command.getKey(), command.getSegment(),
-               ignoreOwnership(command) || canRead(command), command.loadType() != VisitableCommand.LoadType.DONT_LOAD);
+               ignoreOwnership(command) || canRead(command), command.loadType() != VisitableCommand.LoadType.DONT_LOAD,
+                                                                        CompletableFutures.completedNull());
          return asyncInvokeNext(ctx, command, stage);
       }
 
       private Object handleWriteManyCommand(InvocationContext ctx, WriteCommand command) {
          boolean ignoreOwnership = ignoreOwnership(command);
-         AggregateCompletionStage<Void> aggregateCompletionStage = null;
+         CompletableFuture<Void> initialStage = new CompletableFuture<>();
+         CompletionStage<Void> currentStage = initialStage;
          for (Object key : command.getAffectedKeys()) {
-            CompletionStage<Void> stage = entryFactory.wrapEntryForWriting(ctx, key, keyPartitioner.getSegment(key),
-                  ignoreOwnership || canReadKey(key), command.loadType() != VisitableCommand.LoadType.DONT_LOAD);
-            aggregateCompletionStage = accumulateStage(stage, aggregateCompletionStage);
+            currentStage = entryFactory.wrapEntryForWriting(ctx, key, keyPartitioner.getSegment(key),
+                  ignoreOwnership || canReadKey(key), command.loadType() != VisitableCommand.LoadType.DONT_LOAD, currentStage);
          }
-         return asyncInvokeNext(ctx, command, aggregatedStageOrCompleted(aggregateCompletionStage));
+         return asyncInvokeNext(ctx, command, expirationCheckDelay(currentStage, initialStage));
       }
    }
 

--- a/core/src/test/java/org/infinispan/api/ConditionalOperationPrimaryOwnerFailTest.java
+++ b/core/src/test/java/org/infinispan/api/ConditionalOperationPrimaryOwnerFailTest.java
@@ -3,8 +3,8 @@ package org.infinispan.api;
 import static org.infinispan.test.TestingUtil.extractComponent;
 import static org.infinispan.test.TestingUtil.wrapInboundInvocationHandler;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.spy;
 import static org.testng.Assert.assertNull;
@@ -72,7 +72,7 @@ public class ConditionalOperationPrimaryOwnerFailTest extends MultipleCacheManag
          assertNull(context.lookupEntry(key), "Entry should not be wrapped!");
          return mvccEntry;
       }).when(spyEntryFactory).wrapEntryForWriting(any(InvocationContext.class), any(), anyInt(),
-                                                      anyBoolean(), anyBoolean());
+                                                   anyBoolean(), anyBoolean(), any());
 
       Future<?> killMemberResult = fork(() -> killMember(1));
 

--- a/core/src/test/java/org/infinispan/expiration/impl/ClusterExpirationFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/expiration/impl/ClusterExpirationFunctionalTest.java
@@ -8,6 +8,7 @@ import static org.testng.AssertJUnit.assertTrue;
 
 import java.lang.invoke.MethodHandles;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -382,22 +383,36 @@ public class ClusterExpirationFunctionalTest extends MultipleCacheManagersTest {
    public void testPutAllExpiredEntries() {
       SkipTestNG.skipIf(cacheMode.isDistributed() && transactional,
                         "Disabled in transactional caches because of ISPN-13618");
-      SkipTestNG.skipIf(cacheMode.isScattered(), "Disabled in scattered caches because of ISPN-13619");
+      SkipTestNG.skipIf(cacheMode.isScattered(), "Disabled in transactional caches because of ISPN-13619");
 
-      Map<String, String> v1s = new HashMap<>();
       // Can reproduce ISPN-13549 with nKey=20_000 and no trace logs (and without the fix)
       int nKeys = 4;
-      Map<String, String> v2s = new HashMap<>();
-      for (int i = 0; i < nKeys; i++) {
-         v2s.put("k" + i, "v2");
-      }
-
       for (int i = 0; i < nKeys * 3 / 4; i++) {
          cache0.put("k" + i, "v1", -1, SECONDS, 10, SECONDS);
       }
 
       incrementAllTimeServices(11, SECONDS);
 
+      Map<String, String> v2s = new HashMap<>();
+      for (int i = 0; i < nKeys; i++) {
+         v2s.put("k" + i, "v2");
+      }
       cache0.putAll(v2s, -1, SECONDS, 10, SECONDS);
+   }
+
+   public void testGetAllExpiredEntries() {
+      // Can reproduce ISPN-13549 with nKey=20_000 and no trace logs (and without the fix)
+      int nKeys = 4;
+      for (int i = 0; i < nKeys * 3 / 4; i++) {
+         cache0.put("k" + i, "v1", -1, SECONDS, 10, SECONDS);
+      }
+
+      incrementAllTimeServices(11, SECONDS);
+
+      Map<String, String> v1s = new HashMap<>();
+      for (int i = 0; i < nKeys; i++) {
+         v1s.put("k" + i, "v1");
+      }
+      assertEquals(Collections.emptyMap(), cache0.getAdvancedCache().getAll(v1s.keySet()));
    }
 }

--- a/core/src/test/java/org/infinispan/expiration/impl/ClusterExpirationFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/expiration/impl/ClusterExpirationFunctionalTest.java
@@ -382,19 +382,19 @@ public class ClusterExpirationFunctionalTest extends MultipleCacheManagersTest {
    public void testPutAllExpiredEntries() {
       SkipTestNG.skipIf(cacheMode.isDistributed() && transactional,
                         "Disabled in transactional caches because of ISPN-13618");
-      SkipTestNG.skipIf(cacheMode.isScattered(), "Disabled in transactional caches because of ISPN-13619");
+      SkipTestNG.skipIf(cacheMode.isScattered(), "Disabled in scattered caches because of ISPN-13619");
 
       Map<String, String> v1s = new HashMap<>();
       // Can reproduce ISPN-13549 with nKey=20_000 and no trace logs (and without the fix)
       int nKeys = 4;
-      for (int i = 0; i < nKeys; i++) {
-         v1s.put("k" + i, "v1");
-      }
       Map<String, String> v2s = new HashMap<>();
       for (int i = 0; i < nKeys; i++) {
          v2s.put("k" + i, "v2");
       }
-      cache0.putAll(v1s, -1, SECONDS, 10, SECONDS);
+
+      for (int i = 0; i < nKeys * 3 / 4; i++) {
+         cache0.put("k" + i, "v1", -1, SECONDS, 10, SECONDS);
+      }
 
       incrementAllTimeServices(11, SECONDS);
 


### PR DESCRIPTION
https://issues.redhat.com/browse/JDG-5069
JDG-5069 Data race in EntryWrappingInterceptor handling expired entries

Backport of https://github.com/infinispan/infinispan/pull/9788 + #9805 for 9.4.x.

Synchronize the invocation context access after the expiration.
The test reproduces the problem but only with a huge number of keys.
I've disabled the test when the cache is transactional (ISPN-13618) or scattered (ISPN-13619).