### PR TITLE
ISPN-13615 Create RAFT abstraction

### DIFF
--- a/commons/all/src/main/java/org/infinispan/commons/io/ByteBuffer.java
+++ b/commons/all/src/main/java/org/infinispan/commons/io/ByteBuffer.java
@@ -1,5 +1,10 @@
 package org.infinispan.commons.io;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import org.infinispan.commons.util.Util;
+
 /**
  * A byte buffer that exposes the internal byte array with minimal copying. To be instantiated with {@link
  * ByteBufferFactory}.
@@ -19,9 +24,8 @@ public interface ByteBuffer {
    int getOffset();
 
    /**
-    * Length bytes, starting from offset, within the underlying byte[] (as returned by {@link #getBuf()} are owned
-    * by this buffer instance.
-    *
+    * Length bytes, starting from offset, within the underlying byte[] (as returned by {@link #getBuf()} are owned by
+    * this buffer instance.
     */
    int getLength();
 
@@ -29,4 +33,34 @@ public interface ByteBuffer {
     * Returns a new byte[] instance of size {@link #getLength()} that contains all the bytes owned by this buffer.
     */
    ByteBuffer copy();
+
+   /**
+    * Returns a trimmed byte array.
+    * <p>
+    * The returned byte array should not be modified. A copy is not guaranteed.
+    * <p>
+    * It does not copy the byte array if {@link #getOffset()} is zero and {@link #getLength()} is equals to the
+    * underlying byte array length.
+    *
+    * @return A trimmed byte array.
+    */
+   default byte[] trim() {
+      if (getLength() == 0) {
+         return Util.EMPTY_BYTE_ARRAY;
+      }
+      if (getOffset() == 0 && getBuf().length == getLength()) {
+         // avoid copying it
+         return getBuf();
+      }
+      byte[] trimBuf = new byte[getLength()];
+      System.arraycopy(getBuf(), getOffset(), trimBuf, 0, getLength());
+      return trimBuf;
+   }
+
+   /**
+    * @return An {@link InputStream} for the content of this {@link ByteBuffer}.
+    */
+   default InputStream getStream() {
+      return new ByteArrayInputStream(getBuf(), getOffset(), getLength());
+   }
 }

--- a/commons/all/src/main/java/org/infinispan/commons/io/ByteBufferImpl.java
+++ b/commons/all/src/main/java/org/infinispan/commons/io/ByteBufferImpl.java
@@ -47,6 +47,10 @@ public class ByteBufferImpl implements ByteBuffer {
       return new ByteBufferImpl(javaBuffer.array(), javaBuffer.arrayOffset(), remaining);
    }
 
+   public static ByteBufferImpl create(byte b) {
+      return new ByteBufferImpl(new byte[] {b}, 0, 1);
+   }
+
    private ByteBufferImpl(byte[] buf, int offset, int length) {
       this.buf = buf;
       this.offset = offset;
@@ -132,7 +136,7 @@ public class ByteBufferImpl implements ByteBuffer {
       }
 
       @Override
-      public ByteBufferImpl readObject(ObjectInput input) throws IOException, ClassNotFoundException {
+      public ByteBufferImpl readObject(ObjectInput input) throws IOException {
          int length = UnsignedNumeric.readUnsignedInt(input);
          if (length == 0) { //no need to allocate new objects
             return EMPTY_INSTANCE;

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -61,6 +61,12 @@
       </dependency>
 
       <dependency>
+         <groupId>org.jgroups</groupId>
+         <artifactId>jgroups-raft</artifactId>
+         <optional>true</optional>
+      </dependency>
+
+      <dependency>
         <groupId>com.github.ben-manes.caffeine</groupId>
         <artifactId>caffeine</artifactId>
       </dependency>

--- a/core/src/main/java/org/infinispan/configuration/global/TransportConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/global/TransportConfiguration.java
@@ -1,5 +1,7 @@
 package org.infinispan.configuration.global;
 
+import java.util.Collections;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.infinispan.commons.configuration.attributes.Attribute;
@@ -28,10 +30,18 @@ public class TransportConfiguration {
    public static final AttributeDefinition<String> STACK = AttributeDefinition.builder("stack", null, String.class).build();
    public static final AttributeDefinition<String> TRANSPORT_EXECUTOR = AttributeDefinition.builder("executor", "transport-pool", String.class).build();
    public static final AttributeDefinition<String> REMOTE_EXECUTOR = AttributeDefinition.builder("remoteCommandExecutor", "remote-command-pool", String.class).build();
+   @SuppressWarnings("unchecked")
+   public static final AttributeDefinition<Set<String>> RAFT_MEMBERS = AttributeDefinition.builder(org.infinispan.configuration.parsing.Attribute.RAFT_MEMBERS, null, (Class<Set<String>>) (Class<?>) Set.class)
+         .initializer(Collections::emptySet)
+         // unable to use AttributeSerializer.STRING_COLLECTION because it breaks the parser for JSON and YAML
+         .serializer((writer, name, value) -> writer.writeAttribute(name, String.join(" ", value)))
+         .immutable()
+         .build();
 
    static AttributeSet attributeSet() {
       return new AttributeSet(TransportConfiguration.class, CLUSTER_NAME, MACHINE_ID, RACK_ID, SITE_ID, NODE_NAME,
-            DISTRIBUTED_SYNC_TIMEOUT, INITIAL_CLUSTER_SIZE, INITIAL_CLUSTER_TIMEOUT, STACK, TRANSPORT_EXECUTOR, REMOTE_EXECUTOR);
+            DISTRIBUTED_SYNC_TIMEOUT, INITIAL_CLUSTER_SIZE, INITIAL_CLUSTER_TIMEOUT, STACK, TRANSPORT_EXECUTOR, REMOTE_EXECUTOR,
+            RAFT_MEMBERS);
    }
 
    private final Attribute<String> clusterName;
@@ -138,6 +148,10 @@ public class TransportConfiguration {
 
    public JGroupsConfiguration jgroups() {
       return jgroupsConfiguration;
+   }
+
+   public Set<String> raftMembers() {
+      return attributes.attribute(RAFT_MEMBERS).get();
    }
 
    public AttributeSet attributes() {

--- a/core/src/main/java/org/infinispan/configuration/parsing/Attribute.java
+++ b/core/src/main/java/org/infinispan/configuration/parsing/Attribute.java
@@ -151,6 +151,7 @@ public enum Attribute {
     QUEUE_SIZE,
     RACK_ID("rack"),
     RAM_BUFFER_SIZE,
+    RAFT_MEMBERS,
     READ_ONLY,
     REAPER_WAKE_UP_INTERVAL("reaper-interval"),
     RECOVERY_INFO_CACHE_NAME("recovery-cache"),

--- a/core/src/main/java/org/infinispan/configuration/parsing/Parser.java
+++ b/core/src/main/java/org/infinispan/configuration/parsing/Parser.java
@@ -1203,6 +1203,9 @@ public class Parser extends CacheParser {
                   }
                   break;
                }
+               case RAFT_MEMBERS:
+                  transport.raftMembers(ParseUtils.getListAttributeValue(value));
+                  break;
                default: {
                   throw ParseUtils.unexpectedAttribute(reader, i);
                }

--- a/core/src/main/java/org/infinispan/configuration/serializing/CoreConfigurationSerializer.java
+++ b/core/src/main/java/org/infinispan/configuration/serializing/CoreConfigurationSerializer.java
@@ -8,6 +8,7 @@ import static org.infinispan.configuration.parsing.Attribute.EXTENDS;
 import static org.infinispan.configuration.parsing.Attribute.INVALIDATION_BATCH_SIZE;
 import static org.infinispan.configuration.parsing.Attribute.NAME;
 import static org.infinispan.configuration.parsing.Attribute.PATH;
+import static org.infinispan.configuration.parsing.Attribute.RAFT_MEMBERS;
 import static org.infinispan.configuration.parsing.Attribute.STACK;
 import static org.infinispan.configuration.serializing.SerializeUtils.writeOptional;
 import static org.infinispan.util.logging.Log.CONFIG;
@@ -522,6 +523,9 @@ public class CoreConfigurationSerializer extends AbstractStoreSerializer impleme
          attributes.write(writer, TransportConfiguration.DISTRIBUTED_SYNC_TIMEOUT, Attribute.LOCK_TIMEOUT);
          attributes.write(writer, TransportConfiguration.INITIAL_CLUSTER_SIZE, Attribute.INITIAL_CLUSTER_SIZE);
          attributes.write(writer, TransportConfiguration.INITIAL_CLUSTER_TIMEOUT, Attribute.INITIAL_CLUSTER_TIMEOUT);
+         if (!transport.raftMembers().isEmpty()) {
+            attributes.write(writer, TransportConfiguration.RAFT_MEMBERS, RAFT_MEMBERS);
+         }
          writer.writeEndElement();
       }
    }

--- a/core/src/main/java/org/infinispan/remoting/transport/AbstractDelegatingTransport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/AbstractDelegatingTransport.java
@@ -19,6 +19,7 @@ import org.infinispan.remoting.inboundhandler.DeliverOrder;
 import org.infinispan.remoting.responses.Response;
 import org.infinispan.remoting.rpc.ResponseFilter;
 import org.infinispan.remoting.rpc.ResponseMode;
+import org.infinispan.remoting.transport.raft.RaftManager;
 import org.infinispan.util.logging.Log;
 import org.infinispan.xsite.XSiteBackup;
 import org.infinispan.xsite.XSiteReplicateCommand;
@@ -222,5 +223,10 @@ public abstract class AbstractDelegatingTransport implements Transport {
                                                 long timeout,
                                                 TimeUnit timeUnit) {
       return actual.invokeCommands(targets, commandGenerator, collector, deliverOrder, timeout, timeUnit);
+   }
+
+   @Override
+   public RaftManager raftManager() {
+      return actual.raftManager();
    }
 }

--- a/core/src/main/java/org/infinispan/remoting/transport/Transport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/Transport.java
@@ -26,6 +26,7 @@ import org.infinispan.remoting.inboundhandler.DeliverOrder;
 import org.infinispan.remoting.responses.Response;
 import org.infinispan.remoting.rpc.ResponseFilter;
 import org.infinispan.remoting.rpc.ResponseMode;
+import org.infinispan.remoting.transport.raft.RaftManager;
 import org.infinispan.util.concurrent.AggregateCompletionStage;
 import org.infinispan.commons.util.concurrent.CompletableFutures;
 import org.infinispan.util.concurrent.CompletionStages;
@@ -471,7 +472,7 @@ public interface Transport extends Lifecycle {
                                                  ResponseCollector<T> collector, DeliverOrder deliverOrder,
                                                  long timeout, TimeUnit timeUnit) {
       AtomicReference<Object> result = new AtomicReference<>(null);
-      ResponseCollector<T> partCollector = new ResponseCollector<T>() {
+      ResponseCollector<T> partCollector = new ResponseCollector<>() {
          @Override
          public T addResponse(Address sender, Response response) {
             synchronized (this) {
@@ -505,4 +506,9 @@ public interface Transport extends Lifecycle {
          }
       });
    }
+
+   /**
+    * @return The {@link RaftManager} instance,
+    */
+   RaftManager raftManager();
 }

--- a/core/src/main/java/org/infinispan/remoting/transport/impl/EmptyRaftManager.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/impl/EmptyRaftManager.java
@@ -1,0 +1,50 @@
+package org.infinispan.remoting.transport.impl;
+
+import java.util.function.Supplier;
+
+import org.infinispan.remoting.transport.Transport;
+import org.infinispan.remoting.transport.raft.RaftChannelConfiguration;
+import org.infinispan.remoting.transport.raft.RaftManager;
+import org.infinispan.remoting.transport.raft.RaftStateMachine;
+
+/**
+ * A NO-OP implementation of {@link RaftManager}.
+ * <p>
+ * This implementation is used when RAFT is not supported by the {@link Transport}.
+ *
+ * @since 14.0
+ */
+public enum EmptyRaftManager implements RaftManager {
+   INSTANCE;
+
+
+   @Override
+   public <T extends RaftStateMachine> T getOrRegisterStateMachine(String channelName, Supplier<T> supplier, RaftChannelConfiguration configuration) {
+      return null;
+   }
+
+   @Override
+   public boolean isRaftAvailable() {
+      return false;
+   }
+
+   @Override
+   public boolean hasLeader(String channelName) {
+      return false;
+   }
+
+   @Override
+   public String raftId() {
+      return null;
+   }
+
+   @Override
+   public void start() {
+
+   }
+
+   @Override
+   public void stop() {
+
+   }
+}

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsRaftManager.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsRaftManager.java
@@ -1,0 +1,210 @@
+package org.infinispan.remoting.transport.jgroups;
+
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+import org.infinispan.commons.io.ByteBuffer;
+import org.infinispan.commons.io.ByteBufferImpl;
+import org.infinispan.commons.util.concurrent.CompletableFutures;
+import org.infinispan.configuration.global.GlobalConfiguration;
+import org.infinispan.remoting.transport.raft.RaftChannel;
+import org.infinispan.remoting.transport.raft.RaftChannelConfiguration;
+import org.infinispan.remoting.transport.raft.RaftManager;
+import org.infinispan.remoting.transport.raft.RaftStateMachine;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+import org.jgroups.JChannel;
+import org.jgroups.fork.ForkChannel;
+import org.jgroups.protocols.FORK;
+import org.jgroups.protocols.pbcast.GMS;
+import org.jgroups.protocols.raft.ELECTION;
+import org.jgroups.protocols.raft.FileBasedLog;
+import org.jgroups.protocols.raft.InMemoryLog;
+import org.jgroups.protocols.raft.NO_DUPES;
+import org.jgroups.protocols.raft.RAFT;
+import org.jgroups.protocols.raft.REDIRECT;
+import org.jgroups.protocols.raft.StateMachine;
+import org.jgroups.raft.RaftHandle;
+import org.jgroups.stack.ProtocolStack;
+
+/**
+ * A {@link RaftManager} implementation that use JGroups-RAFT protocol.
+ * <p>
+ * This implementation uses multiple {@link ForkChannel}, one of each {@link RaftStateMachine} registered, and it
+ * expects the {@link  FORK} protocol to be present in the main {@link  JChannel}.
+ *
+ * @since 14.0
+ */
+class JGroupsRaftManager implements RaftManager {
+
+   private static final Log log = LogFactory.getLog(JGroupsRaftManager.class);
+
+   private final JChannel mainChannel;
+   private final Collection<String> raftMembers;
+   private final String raftId;
+   private final String persistenceDirectory;
+   private final Map<String, JgroupsRaftChannel<? extends RaftStateMachine>> raftStateMachineMap = new ConcurrentHashMap<>(16);
+
+   JGroupsRaftManager(GlobalConfiguration globalConfiguration, JChannel mainChannel) {
+      if (JGroupsTransport.findFork(mainChannel) == null) {
+         throw log.forkProtocolRequired();
+      }
+      this.mainChannel = mainChannel;
+      raftMembers = globalConfiguration.transport().raftMembers();
+      raftId = globalConfiguration.transport().nodeName();
+      persistenceDirectory = globalConfiguration.globalState().enabled() ?
+            globalConfiguration.globalState().persistentLocation() :
+            null;
+   }
+
+   @Override
+   public <T extends RaftStateMachine> T getOrRegisterStateMachine(String channelName, Supplier<T> supplier, RaftChannelConfiguration configuration) {
+      Objects.requireNonNull(channelName);
+      Objects.requireNonNull(supplier);
+      Objects.requireNonNull(configuration);
+      //noinspection unchecked
+      JgroupsRaftChannel<T> raftChannel = (JgroupsRaftChannel<T>) raftStateMachineMap.computeIfAbsent(channelName, s -> createRaftChannel(s, configuration, supplier));
+      return raftChannel == null ? null : raftChannel.stateMachine();
+   }
+
+   @Override
+   public boolean isRaftAvailable() {
+      return true;
+   }
+
+   @Override
+   public boolean hasLeader(String channelName) {
+      JgroupsRaftChannel<?> raftChannel = raftStateMachineMap.get(channelName);
+      return raftChannel != null && raftChannel.raftHandle.leader() != null;
+   }
+
+   @Override
+   public String raftId() {
+      return raftId;
+   }
+
+   private <T extends RaftStateMachine> JgroupsRaftChannel<T> createRaftChannel(String name, RaftChannelConfiguration configuration, Supplier<? extends T> supplier) {
+      ForkChannel forkChannel = null;
+      try {
+         forkChannel = createForkChannel(name, configuration);
+         forkChannel.connect(name);
+      } catch (Exception e) {
+         log.errorCreatingForkChannel(name, e);
+         if (forkChannel != null) {
+            // disconnect removes channel from FORK protocol
+            forkChannel.disconnect();
+         } else {
+            JGroupsTransport.findFork(mainChannel).remove(name);
+         }
+         return null;
+      }
+      T stateMachine = supplier.get();
+      JgroupsRaftChannel<T> raftChannel = new JgroupsRaftChannel<>(name, forkChannel, stateMachine);
+      stateMachine.init(raftChannel);
+      return raftChannel;
+   }
+
+   private ForkChannel createForkChannel(String name, RaftChannelConfiguration configuration) throws Exception {
+      RAFT raftProtocol = new RAFT();
+      switch (configuration.logMode()) {
+         case VOLATILE:
+            raftProtocol
+                  .logClass(InMemoryLog.class.getCanonicalName())
+                  .logPrefix(name + "-" + raftId);
+            break;
+         case PERSISTENT:
+            if (persistenceDirectory == null) {
+               throw log.raftGlobalStateDisabled();
+            }
+            raftProtocol
+                  .logClass(FileBasedLog.class.getCanonicalName())
+                  .logPrefix(Path.of(persistenceDirectory, name, raftId).toAbsolutePath().toString());
+            break;
+         default:
+            throw new IllegalStateException();
+      }
+      raftProtocol
+            .members(raftMembers)
+            .raftId(raftId);
+
+      return new ForkChannel(mainChannel, name, name, new ELECTION(), raftProtocol, new REDIRECT());
+   }
+
+   /**
+    * Inserts the {@link NO_DUPES} protocol in the main {@link  JChannel}.
+    * <p>
+    * The {@link NO_DUPES} protocol must be set in the main {@link JChannel} below {@link GMS} to detect and reject any
+    * duplicated members with the same "raft-id".
+    */
+   @Override
+   public void start() {
+      // NO_DUPES need to be on the main channel
+      ProtocolStack protocolStack = mainChannel.getProtocolStack();
+      if (protocolStack.findProtocol(NO_DUPES.class) != null) {
+         // already in main channel
+         return;
+      }
+      GMS gms = protocolStack.findProtocol(GMS.class);
+      if (gms == null) {
+         // GMS not found, unable to use NO_DUPES
+         return;
+      }
+      protocolStack.insertProtocolInStack(new NO_DUPES(), gms, ProtocolStack.Position.BELOW);
+   }
+
+   @Override
+   public void stop() {
+      raftStateMachineMap.values().forEach(JgroupsRaftChannel::disconnect);
+      raftStateMachineMap.clear();
+   }
+
+   private static class JgroupsRaftChannel<T extends RaftStateMachine> implements RaftChannel {
+
+      private final RaftHandle raftHandle;
+      private final String channelName;
+      private final JChannel forkedChannel;
+
+      JgroupsRaftChannel(String channelName, JChannel forkedChannel, RaftStateMachine stateMachine) {
+         this.channelName = channelName;
+         this.forkedChannel = forkedChannel;
+         raftHandle = new RaftHandle(forkedChannel, new JGroupsStateMachineAdapter<>(stateMachine));
+      }
+
+      @Override
+      public CompletionStage<ByteBuffer> send(ByteBuffer buffer) {
+         try {
+            return raftHandle.setAsync(buffer.getBuf(), buffer.getOffset(), buffer.getLength()).thenApply(ByteBufferImpl::create);
+         } catch (Exception e) {
+            return CompletableFutures.completedExceptionFuture(e);
+         }
+      }
+
+      @Override
+      public String channelName() {
+         return channelName;
+      }
+
+      @Override
+      public String raftId() {
+         return raftHandle.raftId();
+      }
+
+      T stateMachine() {
+         StateMachine stateMachine = raftHandle.stateMachine();
+         assert stateMachine instanceof JGroupsStateMachineAdapter;
+         //noinspection unchecked
+         return ((JGroupsStateMachineAdapter<T>) stateMachine).getStateMachine();
+      }
+
+      void disconnect() {
+         // removes the forked channel from FORK
+         forkedChannel.disconnect();
+      }
+   }
+
+}

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsStateMachineAdapter.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsStateMachineAdapter.java
@@ -1,0 +1,45 @@
+package org.infinispan.remoting.transport.jgroups;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.util.Objects;
+
+import org.infinispan.commons.io.ByteBuffer;
+import org.infinispan.commons.io.ByteBufferImpl;
+import org.infinispan.commons.util.Util;
+import org.infinispan.remoting.transport.raft.RaftStateMachine;
+import org.jgroups.protocols.raft.StateMachine;
+
+/**
+ * An adapter that converts JGroups {@link StateMachine} calls to {@link  RaftStateMachine}.
+ *
+ * @since 14.0
+ */
+class JGroupsStateMachineAdapter<T extends RaftStateMachine> implements StateMachine {
+
+   private final T stateMachine;
+
+   JGroupsStateMachineAdapter(T stateMachine) {
+      this.stateMachine = Objects.requireNonNull(stateMachine);
+   }
+
+   @Override
+   public byte[] apply(byte[] data, int offset, int length) throws Exception {
+      ByteBuffer buffer = stateMachine.apply(ByteBufferImpl.create(data, offset, length));
+      return buffer == null ? Util.EMPTY_BYTE_ARRAY : buffer.trim();
+   }
+
+   @Override
+   public void readContentFrom(DataInput in) throws Exception {
+      stateMachine.readStateFrom(in);
+   }
+
+   @Override
+   public void writeContentTo(DataOutput out) throws Exception {
+      stateMachine.writeStateTo(out);
+   }
+
+   T getStateMachine() {
+      return stateMachine;
+   }
+}

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/RaftUtil.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/RaftUtil.java
@@ -1,0 +1,28 @@
+package org.infinispan.remoting.transport.jgroups;
+
+import org.infinispan.commons.util.Util;
+
+/**
+ * Utility methods for jgroups-raft
+ *
+ * @since 14.0
+ */
+public enum RaftUtil {
+   ;
+   private static final boolean RAFT_IN_CLASSPATH;
+   private static final String RAFT_CLASS = "org.jgroups.protocols.raft.RAFT";
+
+   static {
+      boolean raftFound = true;
+      try {
+         Util.loadClassStrict(RAFT_CLASS, JGroupsRaftManager.class.getClassLoader());
+      } catch (ClassNotFoundException e) {
+         raftFound = false;
+      }
+      RAFT_IN_CLASSPATH = raftFound;
+   }
+
+   public static boolean isRaftAvailable() {
+      return RAFT_IN_CLASSPATH;
+   }
+}

--- a/core/src/main/java/org/infinispan/remoting/transport/raft/RaftChannel.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/raft/RaftChannel.java
@@ -1,0 +1,36 @@
+package org.infinispan.remoting.transport.raft;
+
+import java.util.concurrent.CompletionStage;
+import java.util.function.Supplier;
+
+import org.infinispan.commons.io.ByteBuffer;
+
+/**
+ * A channel abstraction to invoke commands on the RAFT channel.
+ *
+ * @since 14.0
+ */
+public interface RaftChannel {
+
+   /**
+    * Sends a {@link ByteBuffer} to the RAFT channel to be ordered by the RAFT leader.
+    * <p>
+    * After the RAFT leader commits, {@link RaftStateMachine#apply(ByteBuffer)} is invoked with the {@link ByteBuffer}
+    * and its return value used to complete the {@link CompletionStage}.
+    *
+    * @param buffer The data to send.
+    * @return A {@link CompletionStage} which is completed with the {@link RaftStateMachine#apply(ByteBuffer)} response.
+    */
+   CompletionStage<ByteBuffer> send(ByteBuffer buffer);
+
+   /**
+    * @return The channel name used to register the {@link RaftStateMachine} via {@link
+    * RaftManager#getOrRegisterStateMachine(String, Supplier, RaftChannelConfiguration)}.
+    */
+   String channelName();
+
+   /**
+    * @return The node's raft-id.
+    */
+   String raftId();
+}

--- a/core/src/main/java/org/infinispan/remoting/transport/raft/RaftChannelConfiguration.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/raft/RaftChannelConfiguration.java
@@ -1,0 +1,74 @@
+package org.infinispan.remoting.transport.raft;
+
+import java.util.Objects;
+
+/**
+ * A configuration object to configure {@link RaftChannel}.
+ *
+ * @since 14.0
+ */
+public final class RaftChannelConfiguration {
+
+   private final RaftLogMode logMode;
+
+   private RaftChannelConfiguration(RaftLogMode logMode) {
+      this.logMode = logMode;
+   }
+
+   /**
+    * @return The {@link RaftLogMode}.
+    * @see RaftLogMode
+    */
+   public RaftLogMode logMode() {
+      return logMode;
+   }
+
+   @Override
+   public String toString() {
+      return "RaftChannelConfiguration{" +
+            "logMode=" + logMode +
+            '}';
+   }
+
+   public static class Builder {
+
+      private RaftLogMode logMode = RaftLogMode.PERSISTENT;
+
+      /**
+       * Sets the RAFT log mode.
+       * <p>
+       * The log mode can be {@link RaftLogMode#PERSISTENT} (default) or {@link RaftLogMode#VOLATILE}.
+       *
+       * @param logMode The log mode.
+       * @return This instance.
+       * @see RaftLogMode
+       */
+      public Builder logMode(RaftLogMode logMode) {
+         this.logMode = Objects.requireNonNull(logMode);
+         return this;
+      }
+
+      /**
+       * @return The {@link RaftChannelConfiguration} created.
+       */
+      public RaftChannelConfiguration build() {
+         return new RaftChannelConfiguration(logMode);
+      }
+
+   }
+
+   public enum RaftLogMode {
+      /**
+       * The RAFT log entries are stored in memory only.
+       * <p>
+       * It improves the performance, but it can cause data lost.
+       */
+      VOLATILE,
+      /**
+       * The RAFT log entries are persisted before applying to the {@link RaftStateMachine}.
+       * <p>
+       * This is the default option.
+       */
+      PERSISTENT
+   }
+}

--- a/core/src/main/java/org/infinispan/remoting/transport/raft/RaftManager.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/raft/RaftManager.java
@@ -1,0 +1,51 @@
+package org.infinispan.remoting.transport.raft;
+
+import java.util.function.Supplier;
+
+import org.infinispan.commons.api.Lifecycle;
+
+/**
+ * Use this class to create and register {@link RaftStateMachine}.
+ * <p>
+ * Each {@link RaftStateMachine} is identified by its name and they are independent of each other; each {@link
+ * RaftStateMachine} has it own {@link RaftChannel}.
+ *
+ * @since 14.0
+ */
+public interface RaftManager extends Lifecycle {
+
+   /**
+    * Register a {@link RaftStateMachine}.
+    * <p>
+    * If the RAFT protocol is not supported, this method return {@code null}. If a {@link RaftStateMachine} already
+    * exists with name {@code channelName}, the existing instance is returned.
+    * <p>
+    * If {@link #isRaftAvailable()} return {@code false}, this method always returns {@code null}.
+    *
+    * @param channelName   The name identifying the {@link  RaftStateMachine}.
+    * @param supplier      The factory to create a new instance of {@link RaftStateMachine}.
+    * @param configuration The {@link RaftChannelConfiguration} for the {@link RaftChannel}.
+    * @param <T>           The concrete {@link RaftStateMachine} implementation.
+    * @return The {@link RaftStateMachine} instance of {@code null} if unable to create or configure the {@link
+    * RaftChannel}.
+    */
+   <T extends RaftStateMachine> T getOrRegisterStateMachine(String channelName, Supplier<T> supplier, RaftChannelConfiguration configuration);
+
+   /**
+    * @return {@code true} if the RAFT protocol is available to be used, {@code false} otherwise.
+    */
+   boolean isRaftAvailable();
+
+   /**
+    * Check if a RAFT leader is elected for the {@link RaftStateMachine} with name {@code channelName}.
+    *
+    * @param channelName The name identifying the {@link  RaftStateMachine}.
+    * @return {@code true} if the leader exists, {@code false} otherwise.
+    */
+   boolean hasLeader(String channelName);
+
+   /**
+    * @return This node raft-id.
+    */
+   String raftId();
+}

--- a/core/src/main/java/org/infinispan/remoting/transport/raft/RaftStateMachine.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/raft/RaftStateMachine.java
@@ -1,0 +1,57 @@
+package org.infinispan.remoting.transport.raft;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+import org.infinispan.commons.io.ByteBuffer;
+
+/**
+ * A state machine interface.
+ *
+ * @since 14.0
+ */
+public interface RaftStateMachine {
+
+   /**
+    * Initializes this instance with the {@link RaftChannel} to be used to send the data.
+    *
+    * @param raftChannel The {@link RaftChannel} instance.
+    */
+   void init(RaftChannel raftChannel);
+
+   /**
+    * Applies the data from the RAFT protocol.
+    * <p>
+    * The RAFT protocol ensures that this method is invoked in the same order in all the members.
+    *
+    * @param buffer The data.
+    * @return A {@link ByteBuffer} with the response.
+    * @throws Exception If it fails to apply the data in {@link ByteBuffer}.
+    */
+   ByteBuffer apply(ByteBuffer buffer) throws Exception;
+
+   /**
+    * Discards current state and reads the state from {@link DataInput}.
+    * <p>
+    * There are 2 scenarios where this method may be invoked:
+    * <p>
+    * 1. when this node starts, it may receive the state from the RAFT leader. 2. when this node starts, it reads the
+    * persisted snapshot if available.
+    *
+    * @param dataInput The {@link DataInput} with the snapshot.
+    * @throws IOException If an I/O error happens.
+    */
+   void readStateFrom(DataInput dataInput) throws IOException;
+
+   /**
+    * Writes the current state into the {@link DataOutput}.
+    * <p>
+    * This method is invoked to truncate the RAFT logs.
+    *
+    * @param dataOutput The {@link DataOutput} to store the snapshot.
+    * @throws IOException If an I/O error happens.
+    */
+   void writeStateTo(DataOutput dataOutput) throws IOException;
+
+}

--- a/core/src/main/java/org/infinispan/remoting/transport/raft/package-info.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/raft/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * RAFT interfaces for internal usage.
+ *
+ * @api.private
+ */
+package org.infinispan.remoting.transport.raft;

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -2300,4 +2300,31 @@ public interface Log extends BasicLogger {
    @LogMessage(level = ERROR)
    @Message(value = "There was an error in submitted periodic task with %s, not rescheduling.", id = 665)
    void scheduledTaskEncounteredThrowable(Object identifier, @Cause Throwable t);
+
+   @Message(value = "Transport clusterName cannot be null.", id = 666)
+   CacheConfigurationException requireNonNullClusterName();
+
+   @Message(value = "Transport node-name is not set.", id = 667)
+   CacheConfigurationException requireNodeName();
+
+   @Message(value = "Transport node-name must be present in raft-members: %s", id = 668)
+   CacheConfigurationException nodeNameNotInRaftMembers(String members);
+
+   @Message(value = "FORK protocol required on JGroups channel.", id = 669)
+   IllegalArgumentException forkProtocolRequired();
+
+   @Message(value = "Error creating fork channel for %s", id = 670)
+   @LogMessage(level = ERROR)
+   void errorCreatingForkChannel(String name, @Cause Throwable throwable);
+
+   @Message(value = "RAFT protocol is not available. Reason: %s", id = 671)
+   @LogMessage(level = WARN)
+   void raftProtocolUnavailable(String reason);
+
+   @Message(value = "RAFT protocol is available.", id = 672)
+   @LogMessage(level = INFO)
+   void raftProtocolAvailable();
+
+   @Message(value = "Cannot persist RAFT data as global state is disabled", id = 673)
+   CacheConfigurationException raftGlobalStateDisabled();
 }

--- a/core/src/main/resources/schema/infinispan-config-14.0.xsd
+++ b/core/src/main/resources/schema/infinispan-config-14.0.xsd
@@ -491,6 +491,13 @@
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>
+    <xs:attribute name="raft-members" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          The list of raft members separated by space.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
     <xs:anyAttribute/>
   </xs:complexType>
 

--- a/core/src/test/java/org/infinispan/configuration/parsing/UnifiedXmlFileParsingTest.java
+++ b/core/src/test/java/org/infinispan/configuration/parsing/UnifiedXmlFileParsingTest.java
@@ -13,6 +13,7 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -122,6 +123,11 @@ public class UnifiedXmlFileParsingTest extends AbstractInfinispanTest {
       INFINISPAN_140(14, 0) {
          @Override
          public void check(ConfigurationBuilderHolder holder, int schemaMajor, int schemaMinor) {
+            GlobalConfiguration config = getGlobalConfiguration(holder);
+            Collection<String> raftMembers = config.transport().raftMembers();
+            assertEquals(2, raftMembers.size());
+            assertTrue(raftMembers.contains("a-node"));
+            assertTrue(raftMembers.contains("b-node"));
             IndexingConfiguration indexed = getConfiguration(holder, "indexed-reindex-at-startup").indexing();
             assertThat(indexed.enabled()).isTrue();
             assertThat(indexed.storage()).isEqualTo(IndexStorage.LOCAL_HEAP);

--- a/core/src/test/java/org/infinispan/remoting/RaftTest.java
+++ b/core/src/test/java/org/infinispan/remoting/RaftTest.java
@@ -1,0 +1,287 @@
+package org.infinispan.remoting;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.infinispan.commons.CacheException;
+import org.infinispan.commons.io.ByteBuffer;
+import org.infinispan.commons.io.ByteBufferImpl;
+import org.infinispan.commons.test.Exceptions;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.manager.EmbeddedCacheManagerStartupException;
+import org.infinispan.remoting.transport.Transport;
+import org.infinispan.remoting.transport.raft.RaftChannel;
+import org.infinispan.remoting.transport.raft.RaftChannelConfiguration;
+import org.infinispan.remoting.transport.raft.RaftManager;
+import org.infinispan.remoting.transport.raft.RaftStateMachine;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.TestingUtil;
+import org.testng.AssertJUnit;
+import org.testng.annotations.Test;
+
+/**
+ * Basic test for RAFT protocol.
+ *
+ * @since 14.0
+ */
+@Test(groups = "functional", testName = "remoting.RaftTest")
+public class RaftTest extends MultipleCacheManagersTest {
+
+   private static final RaftChannelConfiguration DEFAULT_CONFIGURATION = new RaftChannelConfiguration.Builder()
+         .logMode(RaftChannelConfiguration.RaftLogMode.VOLATILE)
+         .build();
+   private static final int CONCURRENT_THREADS = 16;
+   private static final int CLUSTER_SIZE = 3;
+   // note, node name must contain the test name!
+   private static final String[] RAFT_MEMBERS = new String[]{"RaftTest-A", "RaftTest-B", "RaftTest-C", "RaftTest-D"};
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      for (int i = 0; i < CLUSTER_SIZE; ++i) {
+         GlobalConfigurationBuilder builder = defaultGlobalConfigurationBuilder();
+         builder.transport().raftMembers(RAFT_MEMBERS);
+         builder.transport().nodeName(RAFT_MEMBERS[i]);
+         addClusterEnabledCacheManager(builder, null);
+      }
+   }
+
+   public void testRaft(Method method) throws ExecutionException, InterruptedException, TimeoutException {
+      List<RaftManager> raftManagerList = raftManagers();
+      for (RaftManager m : raftManagerList) {
+         AssertJUnit.assertTrue(m.isRaftAvailable());
+      }
+
+      List<RaftQueueStateMachine> stateMachines = registerStateMachine(raftManagerList, RaftQueueStateMachine::new, method.getName());
+      awaitForLeader(raftManagerList, method.getName());
+
+      List<Future<CompletionStage<ByteBuffer>>> futures = new ArrayList<>(CONCURRENT_THREADS);
+      CyclicBarrier barrier = new CyclicBarrier(CONCURRENT_THREADS);
+
+      for (int i = 0; i < CONCURRENT_THREADS; ++i) {
+         int idx = i % stateMachines.size();
+         byte b = (byte) i;
+         futures.add(fork(() -> {
+            barrier.await(10, TimeUnit.SECONDS);
+            return stateMachines.get(idx).raftChannel.send(ByteBufferImpl.create(b));
+         }));
+      }
+
+      for (Future<CompletionStage<ByteBuffer>> f : futures) {
+         CompletionStage<ByteBuffer> cf = f.get(10, TimeUnit.SECONDS);
+         ByteBuffer buffer = cf.toCompletableFuture().get(10, TimeUnit.SECONDS);
+         AssertJUnit.assertEquals(1, buffer.getLength());
+         AssertJUnit.assertEquals(0, buffer.getBuf()[0]);
+      }
+
+      List<Byte> expectedState = null;
+      // wait until all bytes are applied
+      for (int i = 0; i < stateMachines.size(); ++i) {
+         RaftQueueStateMachine m = stateMachines.get(i);
+         eventually(() -> m.state.size() == CONCURRENT_THREADS);
+         if (expectedState == null) {
+            expectedState = new ArrayList<>(m.state);
+         } else {
+            AssertJUnit.assertEquals("State is different for node " + i, expectedState, m.state);
+         }
+      }
+   }
+
+   public void testRaftStateTransfer(Method method) throws ExecutionException, InterruptedException, TimeoutException {
+      List<RaftManager> raftManagerList = raftManagers();
+      for (RaftManager m : raftManagerList) {
+         AssertJUnit.assertTrue(m.isRaftAvailable());
+      }
+
+      List<RaftQueueStateMachine> stateMachines = registerStateMachine(raftManagerList, RaftQueueStateMachine::new, method.getName());
+      awaitForLeader(raftManagerList, method.getName());
+
+      List<Future<CompletionStage<ByteBuffer>>> futures = new ArrayList<>(CONCURRENT_THREADS);
+      CyclicBarrier barrier = new CyclicBarrier(CONCURRENT_THREADS);
+
+      for (int i = 0; i < CONCURRENT_THREADS; ++i) {
+         int idx = i % stateMachines.size();
+         byte b = (byte) i;
+         futures.add(fork(() -> {
+            barrier.await(10, TimeUnit.SECONDS);
+            return stateMachines.get(idx).raftChannel.send(ByteBufferImpl.create(b));
+         }));
+      }
+
+      for (Future<CompletionStage<ByteBuffer>> f : futures) {
+         CompletionStage<ByteBuffer> cf = f.get(10, TimeUnit.SECONDS);
+         ByteBuffer buffer = cf.toCompletableFuture().get(10, TimeUnit.SECONDS);
+         AssertJUnit.assertEquals(1, buffer.getLength());
+         AssertJUnit.assertEquals(0, buffer.getBuf()[0]);
+      }
+
+      List<Byte> expectedState = null;
+      // wait until all bytes are applied
+      for (int i = 0; i < stateMachines.size(); ++i) {
+         RaftQueueStateMachine m = stateMachines.get(i);
+         eventually(() -> m.state.size() == CONCURRENT_THREADS);
+         if (expectedState == null) {
+            expectedState = new ArrayList<>(m.state);
+         } else {
+            AssertJUnit.assertEquals("State is different for node " + i, expectedState, m.state);
+         }
+      }
+
+      try {
+         GlobalConfigurationBuilder builder = defaultGlobalConfigurationBuilder();
+         builder.transport().raftMembers(RAFT_MEMBERS);
+         builder.transport().nodeName(RAFT_MEMBERS[3]);
+         EmbeddedCacheManager cm = addClusterEnabledCacheManager(builder, null);
+
+         RaftManager raftManager = raftManager(cm);
+         RaftQueueStateMachine sm = registerStateMachine(raftManager, RaftQueueStateMachine::new, method.getName());
+         awaitForLeader(raftManager, method.getName());
+
+         // eventually, receives all entries!
+         eventuallyEquals(CONCURRENT_THREADS, sm.state::size);
+         AssertJUnit.assertEquals("State is different for node 3", expectedState, sm.state);
+      } finally {
+         // kill the new member
+         if (cacheManagers.size() == 4) {
+            TestingUtil.killCacheManagers(cacheManagers.remove(3));
+         }
+      }
+   }
+
+   public void testNoDupes(Method method) throws ExecutionException, InterruptedException, TimeoutException {
+      List<RaftManager> raftManagerList = raftManagers();
+      for (RaftManager m : raftManagerList) {
+         AssertJUnit.assertTrue(m.isRaftAvailable());
+      }
+
+      List<RaftQueueStateMachine> stateMachines = registerStateMachine(raftManagerList, RaftQueueStateMachine::new, method.getName());
+      awaitForLeader(raftManagerList, method.getName());
+
+      List<Future<CompletionStage<ByteBuffer>>> futures = new ArrayList<>(CONCURRENT_THREADS);
+      CyclicBarrier barrier = new CyclicBarrier(CONCURRENT_THREADS);
+
+      for (int i = 0; i < CONCURRENT_THREADS; ++i) {
+         int idx = i % stateMachines.size();
+         byte b = (byte) i;
+         futures.add(fork(() -> {
+            barrier.await(10, TimeUnit.SECONDS);
+            return stateMachines.get(idx).raftChannel.send(ByteBufferImpl.create(b));
+         }));
+      }
+
+      for (Future<CompletionStage<ByteBuffer>> f : futures) {
+         CompletionStage<ByteBuffer> cf = f.get(10, TimeUnit.SECONDS);
+         ByteBuffer buffer = cf.toCompletableFuture().get(10, TimeUnit.SECONDS);
+         AssertJUnit.assertEquals(1, buffer.getLength());
+         AssertJUnit.assertEquals(0, buffer.getBuf()[0]);
+      }
+
+      List<Byte> expectedState = null;
+      // wait until all bytes are applied
+      for (int i = 0; i < stateMachines.size(); ++i) {
+         RaftQueueStateMachine m = stateMachines.get(i);
+         eventually(() -> m.state.size() == CONCURRENT_THREADS);
+         if (expectedState == null) {
+            expectedState = new ArrayList<>(m.state);
+         } else {
+            AssertJUnit.assertEquals("State is different for node " + i, expectedState, m.state);
+         }
+      }
+
+      try {
+         GlobalConfigurationBuilder builder = defaultGlobalConfigurationBuilder();
+         builder.transport().raftMembers(RAFT_MEMBERS);
+         // duplicated node name! the start should fail
+         builder.transport().nodeName(RAFT_MEMBERS[2]);
+         Exceptions.expectException(EmbeddedCacheManagerStartupException.class, CacheException.class, SecurityException.class, () -> addClusterEnabledCacheManager(builder, null));
+      } finally {
+         // kill the new member
+         if (cacheManagers.size() == 4) {
+            TestingUtil.killCacheManagers(cacheManagers.remove(3));
+         }
+      }
+   }
+
+   private List<RaftManager> raftManagers() {
+      return cacheManagers.stream()
+            .map(RaftTest::raftManager)
+            .collect(Collectors.toList());
+   }
+
+   private static RaftManager raftManager(EmbeddedCacheManager cacheManager) {
+      return TestingUtil.extractGlobalComponent(cacheManager, Transport.class).raftManager();
+   }
+
+   private static <T extends RaftStateMachine> List<T> registerStateMachine(List<? extends RaftManager> raftManagers, Supplier<? extends T> supplier, String name) {
+      return raftManagers.stream()
+            .map(m -> registerStateMachine(m, supplier, name))
+            .collect(Collectors.toList());
+   }
+
+   private static <T extends RaftStateMachine> T registerStateMachine(RaftManager manager, Supplier<T> supplier, String name) {
+      return manager.getOrRegisterStateMachine(name, supplier, DEFAULT_CONFIGURATION);
+   }
+
+   private static void awaitForLeader(List<? extends RaftManager> raftManagers, String name) {
+      for (RaftManager manager : raftManagers) {
+         awaitForLeader(manager, name);
+      }
+   }
+
+   private static void awaitForLeader(RaftManager manager, String name) {
+      eventually(() -> manager.hasLeader(name));
+   }
+
+   private static class RaftQueueStateMachine implements RaftStateMachine {
+
+      private volatile RaftChannel raftChannel;
+      final List<Byte> state = Collections.synchronizedList(new LinkedList<>());
+
+      @Override
+      public void init(RaftChannel raftChannel) {
+         this.raftChannel = raftChannel;
+      }
+
+      @Override
+      public ByteBuffer apply(ByteBuffer buffer) throws Exception {
+         AssertJUnit.assertEquals(1, buffer.getLength());
+         state.add(buffer.getBuf()[0]);
+         log.debugf("[%s | %s] apply: %d", raftChannel.channelName(), raftChannel.raftId(), state.size());
+         return ByteBufferImpl.create((byte) 0);
+      }
+
+      @Override
+      public void readStateFrom(DataInput dataInput) throws IOException {
+         int size = dataInput.readInt();
+         state.clear();
+         for (int i = 0; i < size; ++i) {
+            state.add(dataInput.readByte());
+         }
+         log.debugf("[%s | %s] received state: %d", raftChannel.channelName(), raftChannel.raftId(), state.size());
+      }
+
+      @Override
+      public void writeStateTo(DataOutput dataOutput) throws IOException {
+         List<Byte> copy = new ArrayList<>(state);
+         dataOutput.writeInt(copy.size());
+         for (byte b : copy) {
+            dataOutput.writeByte(b);
+         }
+         log.debugf("[%s | %s] sent state: %d", raftChannel.channelName(), raftChannel.raftId(), copy.size());
+      }
+   }
+}

--- a/core/src/test/java/org/infinispan/remoting/transport/MockTransport.java
+++ b/core/src/test/java/org/infinispan/remoting/transport/MockTransport.java
@@ -34,7 +34,9 @@ import org.infinispan.remoting.responses.ExceptionResponse;
 import org.infinispan.remoting.responses.Response;
 import org.infinispan.remoting.rpc.ResponseFilter;
 import org.infinispan.remoting.rpc.ResponseMode;
+import org.infinispan.remoting.transport.impl.EmptyRaftManager;
 import org.infinispan.remoting.transport.impl.MapResponseCollector;
+import org.infinispan.remoting.transport.raft.RaftManager;
 import org.infinispan.topology.HeartBeatCommand;
 import org.infinispan.commons.util.concurrent.CompletableFutures;
 import org.infinispan.util.logging.Log;
@@ -336,6 +338,11 @@ public class MockTransport implements Transport {
    public <T> CompletionStage<T> invokeCommands(Collection<Address> targets, Function<Address, ReplicableCommand>
       commandGenerator, ResponseCollector<T> responseCollector, DeliverOrder deliverOrder, long timeout, TimeUnit unit) {
       throw new UnsupportedOperationException();
+   }
+
+   @Override
+   public RaftManager raftManager() {
+      return EmptyRaftManager.INSTANCE;
    }
 
    private <T> CompletableFuture<T> blockRequest(Collection<Address> targets, ReplicableCommand command, ResponseCollector<T> collector) {

--- a/core/src/test/java/org/infinispan/test/AbstractInfinispanTest.java
+++ b/core/src/test/java/org/infinispan/test/AbstractInfinispanTest.java
@@ -241,11 +241,11 @@ public abstract class AbstractInfinispanTest {
       }
    }
 
-   protected void eventually(Condition ec, long timeoutMillis) {
+   protected static void eventually(Condition ec, long timeoutMillis) {
       eventually(ec, timeoutMillis, TimeUnit.MILLISECONDS);
    }
 
-   protected void eventually(Condition ec, long timeout, TimeUnit unit) {
+   protected static void eventually(Condition ec, long timeout, TimeUnit unit) {
       eventually(() -> "Condition is still false after " + timeout + " " + unit, ec, timeout, unit);
    }
 
@@ -382,7 +382,7 @@ public abstract class AbstractInfinispanTest {
          Arrays.stream(tasks).<ExceptionRunnable>map(task -> task::call).toArray(ExceptionRunnable[]::new));
    }
 
-   protected void eventually(Condition ec) {
+   protected static void eventually(Condition ec) {
       eventually(ec, 10000, TimeUnit.MILLISECONDS);
    }
 

--- a/core/src/test/resources/configs/all/14.0.xml
+++ b/core/src/test/resources/configs/all/14.0.xml
@@ -100,7 +100,7 @@
                     blocking-executor="infinispan-blocking"
                     statistics="true" shutdown-hook="DONT_REGISTER" zero-capacity-node="false">
       <transport cluster="maximal-cluster" lock-timeout="120000" stack="tcp" node-name="a-node" machine="a" rack="b" site="c"
-                 initial-cluster-size="4" initial-cluster-timeout="30000">
+                 initial-cluster-size="4" initial-cluster-timeout="30000" raft-members="a-node b-node">
          <property name="key">value</property>
       </transport>
       <security>

--- a/pom.xml
+++ b/pom.xml
@@ -376,6 +376,7 @@
       <versionx.org.jgroups.aws.s3.native-s3-ping>1.0.0.Final</versionx.org.jgroups.aws.s3.native-s3-ping>
       <versionx.org.jgroups.azure.jgroups-azure>1.3.0.Final</versionx.org.jgroups.azure.jgroups-azure>
       <versionx.org.jgroups.jgroups>${version.jgroups}</versionx.org.jgroups.jgroups>
+      <versionx.org.jgroups.jgroups-raft>1.0.8.Final</versionx.org.jgroups.jgroups-raft>
       <versionx.org.jgroups.kubernetes.jgroups-kubernetes>1.0.16.Final</versionx.org.jgroups.kubernetes.jgroups-kubernetes>
       <versionx.org.jsoup>1.14.2</versionx.org.jsoup>
       <versionx.org.kohsuke.metainf-services.metainf-services>${version.metainf-services}</versionx.org.kohsuke.metainf-services.metainf-services>
@@ -1521,6 +1522,17 @@
             <groupId>org.jgroups</groupId>
             <artifactId>jgroups</artifactId>
             <version>${versionx.org.jgroups.jgroups}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.jgroups</groupId>
+            <artifactId>jgroups-raft</artifactId>
+            <version>${versionx.org.jgroups.jgroups-raft}</version>
+            <exclusions>
+               <exclusion>
+                  <groupId>*</groupId>
+                  <artifactId>*</artifactId>
+               </exclusion>
+            </exclusions>
          </dependency>
          <dependency>
             <groupId>org.jgroups.aws.s3</groupId>


### PR DESCRIPTION
A very basic RAFT abstraction using jgroups-raft. Most of the features
are missing and they will be added later.

https://issues.redhat.com/browse/ISPN-13615

Review notes: the goal for this PR is the introduction of the APIs. I tried to keep them isolated from the "user space" but RAFT is highly coupled with the `Transport`. Open to suggestions here...

Missing features:

* Persistence

JGroups-raft uses LevelDB for persisted logs. Future work involves moving from LevelDB to RocksDB. Also, I'm thinking about adding a "file-based log" to be used when the RocksDB jar is not available (to avoid adding a new dependency).

* Dynamic membership

For the server, add to the REST endpoint a resource to add and remove RAFT members. Extend this work to CLI and Console.