### PR TITLE
[13.0.x] ISPN-13625 Scaling up 8.3 cluster with payload is slower compared to 8.2

### DIFF
--- a/core/src/main/resources/default-configs/default-jgroups-azure.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-azure.xml
@@ -43,7 +43,8 @@
                    xmit_table_max_compaction_time="30000"
                    resend_last_seqno="true"
    />
-   <UNICAST3 xmit_interval="200"
+   <UNICAST3 conn_close_timeout="5000"
+             xmit_interval="200"
              xmit_table_num_rows="50"
              xmit_table_msgs_per_row="1024"
              xmit_table_max_compaction_time="30000"

--- a/core/src/main/resources/default-configs/default-jgroups-azure.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-azure.xml
@@ -37,13 +37,13 @@
    />
    <VERIFY_SUSPECT timeout="1000"/>
    <pbcast.NAKACK2 use_mcast_xmit="false"
-                   xmit_interval="100"
+                   xmit_interval="200"
                    xmit_table_num_rows="50"
                    xmit_table_msgs_per_row="1024"
                    xmit_table_max_compaction_time="30000"
                    resend_last_seqno="true"
    />
-   <UNICAST3 xmit_interval="100"
+   <UNICAST3 xmit_interval="200"
              xmit_table_num_rows="50"
              xmit_table_msgs_per_row="1024"
              xmit_table_max_compaction_time="30000"

--- a/core/src/main/resources/default-configs/default-jgroups-ec2.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-ec2.xml
@@ -36,13 +36,13 @@
    />
    <VERIFY_SUSPECT timeout="1000"/>
    <pbcast.NAKACK2 use_mcast_xmit="false"
-                   xmit_interval="100"
+                   xmit_interval="200"
                    xmit_table_num_rows="50"
                    xmit_table_msgs_per_row="1024"
                    xmit_table_max_compaction_time="30000"
                    resend_last_seqno="true"
    />
-   <UNICAST3 xmit_interval="100"
+   <UNICAST3 xmit_interval="200"
              xmit_table_num_rows="50"
              xmit_table_msgs_per_row="1024"
              xmit_table_max_compaction_time="30000"

--- a/core/src/main/resources/default-configs/default-jgroups-ec2.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-ec2.xml
@@ -42,7 +42,8 @@
                    xmit_table_max_compaction_time="30000"
                    resend_last_seqno="true"
    />
-   <UNICAST3 xmit_interval="200"
+   <UNICAST3 conn_close_timeout="5000"
+             xmit_interval="200"
              xmit_table_num_rows="50"
              xmit_table_msgs_per_row="1024"
              xmit_table_max_compaction_time="30000"

--- a/core/src/main/resources/default-configs/default-jgroups-google.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-google.xml
@@ -36,13 +36,13 @@
    />
    <VERIFY_SUSPECT timeout="1000"/>
    <pbcast.NAKACK2 use_mcast_xmit="false"
-                   xmit_interval="100"
+                   xmit_interval="200"
                    xmit_table_num_rows="50"
                    xmit_table_msgs_per_row="1024"
                    xmit_table_max_compaction_time="30000"
                    resend_last_seqno="true"
    />
-   <UNICAST3 xmit_interval="100"
+   <UNICAST3 xmit_interval="200"
              xmit_table_num_rows="50"
              xmit_table_msgs_per_row="1024"
              xmit_table_max_compaction_time="30000"

--- a/core/src/main/resources/default-configs/default-jgroups-google.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-google.xml
@@ -42,7 +42,8 @@
                    xmit_table_max_compaction_time="30000"
                    resend_last_seqno="true"
    />
-   <UNICAST3 xmit_interval="200"
+   <UNICAST3 conn_close_timeout="5000"
+             xmit_interval="200"
              xmit_table_num_rows="50"
              xmit_table_msgs_per_row="1024"
              xmit_table_max_compaction_time="30000"

--- a/core/src/main/resources/default-configs/default-jgroups-kubernetes.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-kubernetes.xml
@@ -43,7 +43,8 @@
                    xmit_table_max_compaction_time="30000"
                    resend_last_seqno="true"
    />
-   <UNICAST3 xmit_interval="200"
+   <UNICAST3 conn_close_timeout="5000"
+             xmit_interval="200"
              xmit_table_num_rows="50"
              xmit_table_msgs_per_row="1024"
              xmit_table_max_compaction_time="30000"

--- a/core/src/main/resources/default-configs/default-jgroups-kubernetes.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-kubernetes.xml
@@ -37,13 +37,13 @@
    />
    <VERIFY_SUSPECT timeout="1000"/>
    <pbcast.NAKACK2 use_mcast_xmit="false"
-                   xmit_interval="100"
+                   xmit_interval="200"
                    xmit_table_num_rows="50"
                    xmit_table_msgs_per_row="1024"
                    xmit_table_max_compaction_time="30000"
                    resend_last_seqno="true"
    />
-   <UNICAST3 xmit_interval="100"
+   <UNICAST3 xmit_interval="200"
              xmit_table_num_rows="50"
              xmit_table_msgs_per_row="1024"
              xmit_table_max_compaction_time="30000"

--- a/core/src/main/resources/default-configs/default-jgroups-tcp.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-tcp.xml
@@ -38,7 +38,8 @@
                    xmit_table_max_compaction_time="30000"
                    resend_last_seqno="true"
    />
-   <UNICAST3 xmit_interval="200"
+   <UNICAST3 conn_close_timeout="5000"
+             xmit_interval="200"
              xmit_table_num_rows="50"
              xmit_table_msgs_per_row="1024"
              xmit_table_max_compaction_time="30000"

--- a/core/src/main/resources/default-configs/default-jgroups-tcp.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-tcp.xml
@@ -32,13 +32,13 @@
    />
    <VERIFY_SUSPECT timeout="1000"/>
    <pbcast.NAKACK2 use_mcast_xmit="false"
-                   xmit_interval="100"
+                   xmit_interval="200"
                    xmit_table_num_rows="50"
                    xmit_table_msgs_per_row="1024"
                    xmit_table_max_compaction_time="30000"
                    resend_last_seqno="true"
    />
-   <UNICAST3 xmit_interval="100"
+   <UNICAST3 xmit_interval="200"
              xmit_table_num_rows="50"
              xmit_table_msgs_per_row="1024"
              xmit_table_max_compaction_time="30000"

--- a/core/src/test/resources/configs/all/10.0.xml
+++ b/core/src/test/resources/configs/all/10.0.xml
@@ -37,6 +37,7 @@
                  xmit_table_max_compaction_time="30000"
                  xmlns="urn:org:jgroups"/>
          <UNICAST3
+                 conn_close_timeout="5000"
                  xmit_interval="200"
                  xmit_table_num_rows="50"
                  xmit_table_msgs_per_row="1024"

--- a/core/src/test/resources/configs/all/10.0.xml
+++ b/core/src/test/resources/configs/all/10.0.xml
@@ -31,13 +31,13 @@
          <VERIFY_SUSPECT timeout="1000" xmlns="urn:org:jgroups"/>
          <pbcast.NAKACK2
                  use_mcast_xmit="false"
-                 xmit_interval="100"
+                 xmit_interval="200"
                  xmit_table_num_rows="50"
                  xmit_table_msgs_per_row="1024"
                  xmit_table_max_compaction_time="30000"
                  xmlns="urn:org:jgroups"/>
          <UNICAST3
-                 xmit_interval="100"
+                 xmit_interval="200"
                  xmit_table_num_rows="50"
                  xmit_table_msgs_per_row="1024"
                  xmit_table_max_compaction_time="30000"

--- a/core/src/test/resources/configs/all/10.1.xml
+++ b/core/src/test/resources/configs/all/10.1.xml
@@ -37,6 +37,7 @@
                  xmit_table_max_compaction_time="30000"
                  xmlns="urn:org:jgroups"/>
          <UNICAST3
+                 conn_close_timeout="5000"
                  xmit_interval="200"
                  xmit_table_num_rows="50"
                  xmit_table_msgs_per_row="1024"

--- a/core/src/test/resources/configs/all/10.1.xml
+++ b/core/src/test/resources/configs/all/10.1.xml
@@ -31,13 +31,13 @@
          <VERIFY_SUSPECT timeout="1000" xmlns="urn:org:jgroups"/>
          <pbcast.NAKACK2
                  use_mcast_xmit="false"
-                 xmit_interval="100"
+                 xmit_interval="200"
                  xmit_table_num_rows="50"
                  xmit_table_msgs_per_row="1024"
                  xmit_table_max_compaction_time="30000"
                  xmlns="urn:org:jgroups"/>
          <UNICAST3
-                 xmit_interval="100"
+                 xmit_interval="200"
                  xmit_table_num_rows="50"
                  xmit_table_msgs_per_row="1024"
                  xmit_table_max_compaction_time="30000"

--- a/core/src/test/resources/configs/all/11.0.xml
+++ b/core/src/test/resources/configs/all/11.0.xml
@@ -30,13 +30,13 @@
          <VERIFY_SUSPECT timeout="1000" xmlns="urn:org:jgroups"/>
          <pbcast.NAKACK2
                  use_mcast_xmit="false"
-                 xmit_interval="100"
+                 xmit_interval="200"
                  xmit_table_num_rows="50"
                  xmit_table_msgs_per_row="1024"
                  xmit_table_max_compaction_time="30000"
                  xmlns="urn:org:jgroups"/>
          <UNICAST3
-                 xmit_interval="100"
+                 xmit_interval="200"
                  xmit_table_num_rows="50"
                  xmit_table_msgs_per_row="1024"
                  xmit_table_max_compaction_time="30000"

--- a/core/src/test/resources/configs/all/11.0.xml
+++ b/core/src/test/resources/configs/all/11.0.xml
@@ -36,6 +36,7 @@
                  xmit_table_max_compaction_time="30000"
                  xmlns="urn:org:jgroups"/>
          <UNICAST3
+                 conn_close_timeout="5000"
                  xmit_interval="200"
                  xmit_table_num_rows="50"
                  xmit_table_msgs_per_row="1024"

--- a/core/src/test/resources/configs/all/12.0.xml
+++ b/core/src/test/resources/configs/all/12.0.xml
@@ -32,13 +32,13 @@
          <VERIFY_SUSPECT timeout="1000" xmlns="urn:org:jgroups"/>
          <pbcast.NAKACK2
                  use_mcast_xmit="false"
-                 xmit_interval="100"
+                 xmit_interval="200"
                  xmit_table_num_rows="50"
                  xmit_table_msgs_per_row="1024"
                  xmit_table_max_compaction_time="30000"
                  xmlns="urn:org:jgroups"/>
          <UNICAST3
-                 xmit_interval="100"
+                 xmit_interval="200"
                  xmit_table_num_rows="50"
                  xmit_table_msgs_per_row="1024"
                  xmit_table_max_compaction_time="30000"

--- a/core/src/test/resources/configs/all/12.0.xml
+++ b/core/src/test/resources/configs/all/12.0.xml
@@ -38,6 +38,7 @@
                  xmit_table_max_compaction_time="30000"
                  xmlns="urn:org:jgroups"/>
          <UNICAST3
+                 conn_close_timeout="5000"
                  xmit_interval="200"
                  xmit_table_num_rows="50"
                  xmit_table_msgs_per_row="1024"

--- a/core/src/test/resources/configs/all/12.1.xml
+++ b/core/src/test/resources/configs/all/12.1.xml
@@ -32,13 +32,13 @@
          <VERIFY_SUSPECT timeout="1000" xmlns="urn:org:jgroups"/>
          <pbcast.NAKACK2
                  use_mcast_xmit="false"
-                 xmit_interval="100"
+                 xmit_interval="200"
                  xmit_table_num_rows="50"
                  xmit_table_msgs_per_row="1024"
                  xmit_table_max_compaction_time="30000"
                  xmlns="urn:org:jgroups"/>
          <UNICAST3
-                 xmit_interval="100"
+                 xmit_interval="200"
                  xmit_table_num_rows="50"
                  xmit_table_msgs_per_row="1024"
                  xmit_table_max_compaction_time="30000"

--- a/core/src/test/resources/configs/all/12.1.xml
+++ b/core/src/test/resources/configs/all/12.1.xml
@@ -38,6 +38,7 @@
                  xmit_table_max_compaction_time="30000"
                  xmlns="urn:org:jgroups"/>
          <UNICAST3
+                 conn_close_timeout="5000"
                  xmit_interval="200"
                  xmit_table_num_rows="50"
                  xmit_table_msgs_per_row="1024"

--- a/core/src/test/resources/configs/all/13.0.xml
+++ b/core/src/test/resources/configs/all/13.0.xml
@@ -39,6 +39,7 @@
                  xmit_table_max_compaction_time="30000"
                  xmlns="urn:org:jgroups"/>
          <UNICAST3
+                 conn_close_timeout="5000"
                  xmit_interval="200"
                  max_xmit_req_size="500"
                  xmit_table_num_rows="50"

--- a/core/src/test/resources/configs/config-with-jgroups-stack.xml
+++ b/core/src/test/resources/configs/config-with-jgroups-stack.xml
@@ -38,6 +38,7 @@
                     xmit_table_max_compaction_time="30000"
                     xmlns="urn:org:jgroups"/>
             <UNICAST3
+                    conn_close_timeout="5000"
                     xmit_interval="200"
                     xmit_table_num_rows="50"
                     xmit_table_msgs_per_row="1024"

--- a/core/src/test/resources/configs/config-with-jgroups-stack.xml
+++ b/core/src/test/resources/configs/config-with-jgroups-stack.xml
@@ -32,13 +32,13 @@
             <VERIFY_SUSPECT timeout="1000" xmlns="urn:org:jgroups"/>
             <pbcast.NAKACK2
                     use_mcast_xmit="false"
-                    xmit_interval="100"
+                    xmit_interval="200"
                     xmit_table_num_rows="50"
                     xmit_table_msgs_per_row="1024"
                     xmit_table_max_compaction_time="30000"
                     xmlns="urn:org:jgroups"/>
             <UNICAST3
-                    xmit_interval="100"
+                    xmit_interval="200"
                     xmit_table_num_rows="50"
                     xmit_table_msgs_per_row="1024"
                     xmit_table_max_compaction_time="30000"

--- a/core/src/test/resources/configs/xsite/bridge.xml
+++ b/core/src/test/resources/configs/xsite/bridge.xml
@@ -33,14 +33,14 @@
             min_interval="3000"/>
     <FD_SOCK/>
 
-    <pbcast.NAKACK2 xmit_interval="100"
+    <pbcast.NAKACK2 xmit_interval="200"
                     xmit_table_num_rows="50"
                     xmit_table_msgs_per_row="1024"
                     xmit_table_max_compaction_time="30000"
                     use_mcast_xmit="false"
                     discard_delivered_msgs="true"/>
     <UNICAST3
-            xmit_interval="100"
+            xmit_interval="200"
             xmit_table_num_rows="50"
             xmit_table_msgs_per_row="1024"
             xmit_table_max_compaction_time="30000"
@@ -61,5 +61,3 @@
 
     <FRAG3/>
 </config>
-
-

--- a/core/src/test/resources/configs/xsite/bridge.xml
+++ b/core/src/test/resources/configs/xsite/bridge.xml
@@ -40,6 +40,7 @@
                     use_mcast_xmit="false"
                     discard_delivered_msgs="true"/>
     <UNICAST3
+            conn_close_timeout="5000"
             xmit_interval="200"
             xmit_table_num_rows="50"
             xmit_table_msgs_per_row="1024"

--- a/core/src/test/resources/configs/xsite/xsite-inline-test.xml
+++ b/core/src/test/resources/configs/xsite/xsite-inline-test.xml
@@ -36,6 +36,7 @@
                          use_mcast_xmit="false"
                          discard_delivered_msgs="true"/>
          <UNICAST3
+                 conn_close_timeout="5000"
                  xmit_interval="200"
                  xmit_table_num_rows="50"
                  xmit_table_msgs_per_row="1024"

--- a/core/src/test/resources/configs/xsite/xsite-inline-test.xml
+++ b/core/src/test/resources/configs/xsite/xsite-inline-test.xml
@@ -29,14 +29,14 @@
                   interval="1000"
          />
          <VERIFY_SUSPECT timeout="1000"/>
-         <pbcast.NAKACK2 xmit_interval="100"
+         <pbcast.NAKACK2 xmit_interval="200"
                          xmit_table_num_rows="50"
                          xmit_table_msgs_per_row="1024"
                          xmit_table_max_compaction_time="30000"
                          use_mcast_xmit="false"
                          discard_delivered_msgs="true"/>
          <UNICAST3
-                 xmit_interval="100"
+                 xmit_interval="200"
                  xmit_table_num_rows="50"
                  xmit_table_msgs_per_row="1024"
                  xmit_table_max_compaction_time="30000"

--- a/core/src/test/resources/stacks/tcp.xml
+++ b/core/src/test/resources/stacks/tcp.xml
@@ -46,13 +46,13 @@
    <!-- resend_last_seqno_max_times=10000 is a workaround for JGRP-2167  -->
    <pbcast.NAKACK2
    					use_mcast_xmit="false"
-                    xmit_interval="100"
+                    xmit_interval="200"
                     xmit_table_num_rows="50"
                     xmit_table_msgs_per_row="1024"
                     xmit_table_max_compaction_time="30000"
                     resend_last_seqno_max_times="10000"/>
    <UNICAST3
-              xmit_interval="100"
+              xmit_interval="200"
               xmit_table_num_rows="50"
               xmit_table_msgs_per_row="1024"
               xmit_table_max_compaction_time="30000"

--- a/core/src/test/resources/stacks/tcp.xml
+++ b/core/src/test/resources/stacks/tcp.xml
@@ -52,6 +52,7 @@
                     xmit_table_max_compaction_time="30000"
                     resend_last_seqno_max_times="10000"/>
    <UNICAST3
+              conn_close_timeout="5000"
               xmit_interval="200"
               xmit_table_num_rows="50"
               xmit_table_msgs_per_row="1024"

--- a/core/src/test/resources/stacks/tcp_mping/tcp1.xml
+++ b/core/src/test/resources/stacks/tcp_mping/tcp1.xml
@@ -41,6 +41,7 @@
                     xmit_table_msgs_per_row="1024"
                     xmit_table_max_compaction_time="30000"/>
    <UNICAST3
+              conn_close_timeout="5000"
               xmit_interval="200"
               xmit_table_num_rows="50"
               xmit_table_msgs_per_row="1024"

--- a/core/src/test/resources/stacks/tcp_mping/tcp1.xml
+++ b/core/src/test/resources/stacks/tcp_mping/tcp1.xml
@@ -36,12 +36,12 @@
    <VERIFY_SUSPECT timeout="1000"/>
    <pbcast.NAKACK2
    					use_mcast_xmit="false"
-                    xmit_interval="100"
+                    xmit_interval="200"
                     xmit_table_num_rows="50"
                     xmit_table_msgs_per_row="1024"
                     xmit_table_max_compaction_time="30000"/>
    <UNICAST3
-              xmit_interval="100"
+              xmit_interval="200"
               xmit_table_num_rows="50"
               xmit_table_msgs_per_row="1024"
               xmit_table_max_compaction_time="30000"

--- a/core/src/test/resources/stacks/tcp_mping/tcp2.xml
+++ b/core/src/test/resources/stacks/tcp_mping/tcp2.xml
@@ -41,6 +41,7 @@
                     xmit_table_msgs_per_row="1024"
                     xmit_table_max_compaction_time="30000"/>
    <UNICAST3
+              conn_close_timeout="5000"
               xmit_interval="200"
               xmit_table_num_rows="50"
               xmit_table_msgs_per_row="1024"

--- a/core/src/test/resources/stacks/tcp_mping/tcp2.xml
+++ b/core/src/test/resources/stacks/tcp_mping/tcp2.xml
@@ -36,12 +36,12 @@
    <VERIFY_SUSPECT timeout="1000"/>
    <pbcast.NAKACK2
    					use_mcast_xmit="false"
-                    xmit_interval="100"
+                    xmit_interval="200"
                     xmit_table_num_rows="50"
                     xmit_table_msgs_per_row="1024"
                     xmit_table_max_compaction_time="30000"/>
    <UNICAST3
-              xmit_interval="100"
+              xmit_interval="200"
               xmit_table_num_rows="50"
               xmit_table_msgs_per_row="1024"
               xmit_table_max_compaction_time="30000"

--- a/documentation/src/main/asciidoc/topics/xml/jgroups_inline_stack.xml
+++ b/documentation/src/main/asciidoc/topics/xml/jgroups_inline_stack.xml
@@ -15,8 +15,8 @@
       <VERIFY_SUSPECT timeout="1000" />
       <pbcast.NAKACK2 use_mcast_xmit="false" xmit_interval="200" xmit_table_num_rows="50"
                       xmit_table_msgs_per_row="1024" xmit_table_max_compaction_time="30000" />
-      <UNICAST3 xmit_interval="200" xmit_table_num_rows="50" xmit_table_msgs_per_row="1024"
-                xmit_table_max_compaction_time="30000" />
+      <UNICAST3 conn_close_timeout="5000" xmit_interval="200" xmit_table_num_rows="50"
+                xmit_table_msgs_per_row="1024" xmit_table_max_compaction_time="30000" />
       <pbcast.STABLE desired_avg_gossip="2000" max_bytes="1M" />
       <pbcast.GMS print_local_addr="false" join_timeout="${jgroups.join_timeout:2000}" />
       <UFC max_credits="4m" min_threshold="0.40" />

--- a/documentation/src/main/asciidoc/topics/xml/jgroups_inline_stack.xml
+++ b/documentation/src/main/asciidoc/topics/xml/jgroups_inline_stack.xml
@@ -13,9 +13,9 @@
       <FD_SOCK />
       <FD_ALL timeout="3000" interval="1000" timeout_check_interval="1000" />
       <VERIFY_SUSPECT timeout="1000" />
-      <pbcast.NAKACK2 use_mcast_xmit="false" xmit_interval="100" xmit_table_num_rows="50"
+      <pbcast.NAKACK2 use_mcast_xmit="false" xmit_interval="200" xmit_table_num_rows="50"
                       xmit_table_msgs_per_row="1024" xmit_table_max_compaction_time="30000" />
-      <UNICAST3 xmit_interval="100" xmit_table_num_rows="50" xmit_table_msgs_per_row="1024"
+      <UNICAST3 xmit_interval="200" xmit_table_num_rows="50" xmit_table_msgs_per_row="1024"
                 xmit_table_max_compaction_time="30000" />
       <pbcast.STABLE desired_avg_gossip="2000" max_bytes="1M" />
       <pbcast.GMS print_local_addr="false" join_timeout="${jgroups.join_timeout:2000}" />

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node0.xml
@@ -33,12 +33,12 @@
    <VERIFY_SUSPECT timeout="1000"/>
 
    <pbcast.NAKACK2
-                    xmit_interval="100"
+                    xmit_interval="200"
                     xmit_table_num_rows="50"
                     xmit_table_msgs_per_row="1024"
                     xmit_table_max_compaction_time="30000"/>
    <UNICAST3
-              xmit_interval="100"
+              xmit_interval="200"
               xmit_table_num_rows="50"
               xmit_table_msgs_per_row="1024"
               xmit_table_max_compaction_time="30000"

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node0.xml
@@ -38,6 +38,7 @@
                     xmit_table_msgs_per_row="1024"
                     xmit_table_max_compaction_time="30000"/>
    <UNICAST3
+              conn_close_timeout="5000"
               xmit_interval="200"
               xmit_table_num_rows="50"
               xmit_table_msgs_per_row="1024"

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1-fail.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1-fail.xml
@@ -33,12 +33,12 @@
    <VERIFY_SUSPECT timeout="1000"/>
 
    <pbcast.NAKACK2
-                    xmit_interval="100"
+                    xmit_interval="200"
                     xmit_table_num_rows="50"
                     xmit_table_msgs_per_row="1024"
                     xmit_table_max_compaction_time="30000"/>
    <UNICAST3
-              xmit_interval="100"
+              xmit_interval="200"
               xmit_table_num_rows="50"
               xmit_table_msgs_per_row="1024"
               xmit_table_max_compaction_time="30000"

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1-fail.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1-fail.xml
@@ -38,6 +38,7 @@
                     xmit_table_msgs_per_row="1024"
                     xmit_table_max_compaction_time="30000"/>
    <UNICAST3
+              conn_close_timeout="5000"
               xmit_interval="200"
               xmit_table_num_rows="50"
               xmit_table_msgs_per_row="1024"

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1.xml
@@ -33,12 +33,12 @@
    <VERIFY_SUSPECT timeout="1000"/>
 
    <pbcast.NAKACK2
-                    xmit_interval="100"
+                    xmit_interval="200"
                     xmit_table_num_rows="50"
                     xmit_table_msgs_per_row="1024"
                     xmit_table_max_compaction_time="30000"/>
    <UNICAST3
-              xmit_interval="100"
+              xmit_interval="200"
               xmit_table_num_rows="50"
               xmit_table_msgs_per_row="1024"
               xmit_table_max_compaction_time="30000"

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1.xml
@@ -38,6 +38,7 @@
                     xmit_table_msgs_per_row="1024"
                     xmit_table_max_compaction_time="30000"/>
    <UNICAST3
+              conn_close_timeout="5000"
               xmit_interval="200"
               xmit_table_num_rows="50"
               xmit_table_msgs_per_row="1024"

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node0.xml
@@ -33,12 +33,12 @@
    <VERIFY_SUSPECT timeout="1000"/>
 
    <pbcast.NAKACK2
-                    xmit_interval="100"
+                    xmit_interval="200"
                     xmit_table_num_rows="50"
                     xmit_table_msgs_per_row="1024"
                     xmit_table_max_compaction_time="30000"/>
    <UNICAST3
-              xmit_interval="100"
+              xmit_interval="200"
               xmit_table_num_rows="50"
               xmit_table_msgs_per_row="1024"
               xmit_table_max_compaction_time="30000"

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node0.xml
@@ -38,6 +38,7 @@
                     xmit_table_msgs_per_row="1024"
                     xmit_table_max_compaction_time="30000"/>
    <UNICAST3
+              conn_close_timeout="5000"
               xmit_interval="200"
               xmit_table_num_rows="50"
               xmit_table_msgs_per_row="1024"

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node1.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node1.xml
@@ -33,12 +33,12 @@
    <VERIFY_SUSPECT timeout="1000"/>
 
    <pbcast.NAKACK2
-                    xmit_interval="100"
+                    xmit_interval="200"
                     xmit_table_num_rows="50"
                     xmit_table_msgs_per_row="1024"
                     xmit_table_max_compaction_time="30000"/>
    <UNICAST3
-              xmit_interval="100"
+              xmit_interval="200"
               xmit_table_num_rows="50"
               xmit_table_msgs_per_row="1024"
               xmit_table_max_compaction_time="30000"

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node1.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node1.xml
@@ -38,6 +38,7 @@
                     xmit_table_msgs_per_row="1024"
                     xmit_table_max_compaction_time="30000"/>
    <UNICAST3
+              conn_close_timeout="5000"
               xmit_interval="200"
               xmit_table_num_rows="50"
               xmit_table_msgs_per_row="1024"

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-user-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-user-node0.xml
@@ -33,12 +33,12 @@
    <VERIFY_SUSPECT timeout="1000"/>
 
    <pbcast.NAKACK2
-                    xmit_interval="100"
+                    xmit_interval="200"
                     xmit_table_num_rows="50"
                     xmit_table_msgs_per_row="1024"
                     xmit_table_max_compaction_time="30000"/>
    <UNICAST3
-              xmit_interval="100"
+              xmit_interval="200"
               xmit_table_num_rows="50"
               xmit_table_msgs_per_row="1024"
               xmit_table_max_compaction_time="30000"

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-user-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-user-node0.xml
@@ -38,6 +38,7 @@
                     xmit_table_msgs_per_row="1024"
                     xmit_table_max_compaction_time="30000"/>
    <UNICAST3
+              conn_close_timeout="5000"
               xmit_interval="200"
               xmit_table_num_rows="50"
               xmit_table_msgs_per_row="1024"

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node0.xml
@@ -33,12 +33,12 @@
    <VERIFY_SUSPECT timeout="1000"/>
 
    <pbcast.NAKACK2
-                    xmit_interval="100"
+                    xmit_interval="200"
                     xmit_table_num_rows="50"
                     xmit_table_msgs_per_row="1024"
                     xmit_table_max_compaction_time="30000"/>
    <UNICAST3
-              xmit_interval="100"
+              xmit_interval="200"
               xmit_table_num_rows="50"
               xmit_table_msgs_per_row="1024"
               xmit_table_max_compaction_time="30000"

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node0.xml
@@ -38,6 +38,7 @@
                     xmit_table_msgs_per_row="1024"
                     xmit_table_max_compaction_time="30000"/>
    <UNICAST3
+              conn_close_timeout="5000"
               xmit_interval="200"
               xmit_table_num_rows="50"
               xmit_table_msgs_per_row="1024"

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node1.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node1.xml
@@ -33,12 +33,12 @@
    <VERIFY_SUSPECT timeout="1000"/>
 
    <pbcast.NAKACK2
-                    xmit_interval="100"
+                    xmit_interval="200"
                     xmit_table_num_rows="50"
                     xmit_table_msgs_per_row="1024"
                     xmit_table_max_compaction_time="30000"/>
    <UNICAST3
-              xmit_interval="100"
+              xmit_interval="200"
               xmit_table_num_rows="50"
               xmit_table_msgs_per_row="1024"
               xmit_table_max_compaction_time="30000"

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node1.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node1.xml
@@ -38,6 +38,7 @@
                     xmit_table_msgs_per_row="1024"
                     xmit_table_max_compaction_time="30000"/>
    <UNICAST3
+              conn_close_timeout="5000"
               xmit_interval="200"
               xmit_table_num_rows="50"
               xmit_table_msgs_per_row="1024"


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-13625

Increase xmit_timeout in TCP stacks to 200ms
Increasing xmit_timeout reduces the number of attempts to resend
LEAVE_RSP when the destination is no longer reachable.

TCP already retransmits messages, so the UNICAST3 retransmission
is only needed when the connection is unstable or the destination's
thread pool is full.

ISPN-13625 Reduce UNICAST3.conn_close_timeout to 5000ms
Reducing conn_close_timeout reduces the number of attempts to resend
LEAVE_RSP when the destination is no longer reachable.