### PR TITLE
ISPN-13549 EntryWrappingInterceptor data race handling expired entries

### DIFF
--- a/core/src/main/java/org/infinispan/container/impl/EntryFactory.java
+++ b/core/src/main/java/org/infinispan/container/impl/EntryFactory.java
@@ -89,10 +89,10 @@ import org.infinispan.util.concurrent.CompletableFutures;
  */
 public interface EntryFactory {
    /**
-    * Use to synchronize multiple {@link #wrapEntryForReading(InvocationContext, Object, int, boolean, CompletionStage)}
-    * or {@link #wrapEntryForReading(InvocationContext, Object, int, boolean, CompletionStage)} calls.
+    * Use to synchronize multiple {@link #wrapEntryForReading(InvocationContext, Object, int, boolean, boolean, CompletionStage)}
+    * or {@link #wrapEntryForWriting(InvocationContext, Object, int, boolean, boolean, CompletionStage)} calls.
     *
-    * The basic pattern is:
+    * <p>The basic pattern is:</p>
     *
     * <pre>{@code
     * CompletableFuture<Void> initialStage = new CompletableFuture<>();
@@ -102,6 +102,10 @@ public interface EntryFactory {
     * }
     * return asyncInvokeNext(ctx, command, expirationCheckDelay(currentStage, initialStage));
     * }</pre>
+    *
+    * <p>The effect {@code expirationCheckDelay(currentStage, initialStage)} call is equivalent to completing the
+    * {@code initialStage} and returning {@code currentStage}, but it optimizes the common case where
+    * {@code currentStage} and {@code initialStage} are the same.</p>
     */
    static CompletionStage<Void> expirationCheckDelay(CompletionStage<Void> currentStage, CompletableFuture<Void> initialStage) {
       if (currentStage == initialStage) {
@@ -124,7 +128,8 @@ public interface EntryFactory {
     * @param segment segment for the key
     * @param isOwner true if this node is current owner in readCH (or we ignore CH)
     * @param hasLock true if the invoker already has the lock for this key
-    * @param previousStage don't access the invocation context from another thread before this stage is complete
+    * @param previousStage if wrapping can't be performed synchronously, only access the invocation context
+    *                      from another thread after this stage is complete
     * @return stage that when complete the value should be in the context
     */
    CompletionStage<Void> wrapEntryForReading(InvocationContext ctx, Object key, int segment, boolean isOwner,
@@ -143,7 +148,8 @@ public interface EntryFactory {
     * @param segment segment for the key
     * @param isOwner true if this node is current owner in readCH (or we ignore CH)
     * @param isRead true if this operation is expected to read the value of the entry
-    * @param previousStage don't access the invocation context from another thread before this stage is complete
+    * @param previousStage if wrapping can't be performed synchronously, only access the invocation context
+    *                      from another thread after this stage is complete
     * @since 8.1
     */
    CompletionStage<Void> wrapEntryForWriting(InvocationContext ctx, Object key, int segment, boolean isOwner, boolean isRead, CompletionStage<Void> previousStage);

--- a/core/src/main/java/org/infinispan/container/impl/EntryFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/container/impl/EntryFactoryImpl.java
@@ -70,11 +70,10 @@ public class EntryFactoryImpl implements EntryFactory {
 
    @Override
    public final CompletionStage<Void> wrapEntryForReading(InvocationContext ctx, Object key, int segment, boolean isOwner,
-                                                          boolean hasLock) {
+                                                          boolean hasLock, CompletionStage<Void> previousStage) {
       if (!isOwner && !isL1Enabled) {
          return CompletableFutures.completedNull();
       }
-      CompletionStage<Void> returnedStage = CompletableFutures.completedNull();
       CacheEntry cacheEntry = getFromContext(ctx, key);
       if (cacheEntry == null) {
          InternalCacheEntry readEntry = getFromContainer(key, segment);
@@ -89,9 +88,8 @@ public class EntryFactoryImpl implements EntryFactory {
                   Boolean expired = CompletionStages.join(expiredStage);
                   handleExpiredEntryContextAddition(expired, ctx, readEntry, key, isOwner);
                } else {
-                  returnedStage = expiredStage.thenApply(expired -> {
+                  return expiredStage.thenAcceptBoth(previousStage, (expired, __) -> {
                      handleExpiredEntryContextAddition(expired, ctx, readEntry, key, isOwner);
-                     return null;
                   });
                }
             } else {
@@ -100,18 +98,16 @@ public class EntryFactoryImpl implements EntryFactory {
          }
       }
 
-      return returnedStage;
+      return previousStage;
    }
 
    private void handleExpiredEntryContextAddition(Boolean expired, InvocationContext ctx, InternalCacheEntry readEntry,
          Object key, boolean isOwner) {
       // Multi-key commands perform the expiration check in parallel, so they need synchronization
-      synchronized (ctx) {
-         if (expired == Boolean.FALSE) {
-            addReadEntryToContext(ctx, readEntry, key);
-         } else if (isOwner) {
-            addReadEntryToContext(ctx, NullCacheEntry.getInstance(), key);
-         }
+      if (expired == Boolean.FALSE) {
+         addReadEntryToContext(ctx, readEntry, key);
+      } else if (isOwner) {
+         addReadEntryToContext(ctx, NullCacheEntry.getInstance(), key);
       }
    }
 
@@ -143,9 +139,9 @@ public class EntryFactoryImpl implements EntryFactory {
    }
 
    @Override
-   public CompletionStage<Void> wrapEntryForWriting(InvocationContext ctx, Object key, int segment, boolean isOwner, boolean isRead) {
+   public CompletionStage<Void> wrapEntryForWriting(InvocationContext ctx, Object key, int segment, boolean isOwner,
+                                                    boolean isRead, CompletionStage<Void> previousStage) {
       CacheEntry contextEntry = getFromContext(ctx, key);
-      CompletionStage<Void> returnedStage = CompletableFutures.completedNull();
       if (contextEntry instanceof MVCCEntry) {
          // Nothing to do, already wrapped.
       } else if (contextEntry != null) {
@@ -168,9 +164,9 @@ public class EntryFactoryImpl implements EntryFactory {
                      Boolean expired = CompletionStages.join(expiredStage);
                      handleWriteExpiredEntryContextAddition(expired, ctx, ice, key, isRead);
                   } else {
-                     returnedStage = expiredStage.thenApply(expired -> {
+                     // Serialize invocation context access
+                     return expiredStage.thenAcceptBoth(previousStage, (expired, __) -> {
                         handleWriteExpiredEntryContextAddition(expired, ctx, ice, key, isRead);
-                        return null;
                      });
                   }
                } else {
@@ -182,18 +178,16 @@ public class EntryFactoryImpl implements EntryFactory {
          }
       }
 
-      return returnedStage;
+      return previousStage;
    }
 
    private void handleWriteExpiredEntryContextAddition(Boolean expired, InvocationContext ctx, InternalCacheEntry ice,
          Object key, boolean isRead) {
       // Multi-key commands perform the expiration check in parallel, so they need synchronization
-      synchronized (ctx) {
-         if (expired == Boolean.FALSE) {
-            addWriteEntryToContext(ctx, ice, key, isRead);
-         } else {
-            addWriteEntryToContext(ctx, NullCacheEntry.getInstance(), key, isRead);
-         }
+      if (expired == Boolean.FALSE) {
+         addWriteEntryToContext(ctx, ice, key, isRead);
+      } else {
+         addWriteEntryToContext(ctx, NullCacheEntry.getInstance(), key, isRead);
       }
    }
 

--- a/core/src/main/java/org/infinispan/container/impl/EntryFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/container/impl/EntryFactoryImpl.java
@@ -24,7 +24,6 @@ import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
 import org.infinispan.metadata.Metadata;
 import org.infinispan.metadata.impl.PrivateMetadata;
-import org.infinispan.util.concurrent.CompletableFutures;
 import org.infinispan.util.concurrent.CompletionStages;
 import org.infinispan.util.concurrent.IsolationLevel;
 import org.infinispan.util.logging.Log;
@@ -72,7 +71,7 @@ public class EntryFactoryImpl implements EntryFactory {
    public final CompletionStage<Void> wrapEntryForReading(InvocationContext ctx, Object key, int segment, boolean isOwner,
                                                           boolean hasLock, CompletionStage<Void> previousStage) {
       if (!isOwner && !isL1Enabled) {
-         return CompletableFutures.completedNull();
+         return previousStage;
       }
       CacheEntry cacheEntry = getFromContext(ctx, key);
       if (cacheEntry == null) {

--- a/core/src/main/java/org/infinispan/interceptors/distribution/BaseDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/BaseDistributionInterceptor.java
@@ -560,7 +560,7 @@ public abstract class BaseDistributionInterceptor extends ClusteringInterceptor 
             Collection<Address> ignoreForKey = null;
             for (Address address : distributionInfo.readOwners()) {
                if (address.equals(rpcManager.getAddress())) {
-                  throw new IllegalStateException("Entry should be always wrapped!");
+                  throw new IllegalStateException("Entry should already be wrapped on read owners!");
                } else if (ignoredOwners != null) {
                   if (ignoreForKey == null) {
                      ignoreForKey = ignoredOwners.get(key);

--- a/core/src/main/java/org/infinispan/interceptors/distribution/L1NonTxInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/L1NonTxInterceptor.java
@@ -326,8 +326,7 @@ public class L1NonTxInterceptor extends BaseRpcInterceptor {
                                                             true, false, currentStage);
          }
       }
-      if (currentStage == initialStage) return invokeNext(ctx, invalidateL1Command);
-      return asyncInvokeNext(ctx, invalidateL1Command, currentStage);
+      return asyncInvokeNext(ctx, invalidateL1Command, EntryFactory.expirationCheckDelay(currentStage, initialStage));
    }
 
    private void abortL1UpdateOrWait(Object key) {

--- a/core/src/main/java/org/infinispan/interceptors/distribution/TxDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/TxDistributionInterceptor.java
@@ -570,7 +570,7 @@ public class TxDistributionInterceptor extends BaseDistributionInterceptor {
       return cf.thenCompose(ignore -> {
          // TODO Dan: apply the modifications before wrapping the entry in the context
          CompletionStage<Void> stage = entryFactory.wrapEntryForWriting(ctx, key, SegmentSpecificCommand.extractSegment(command, key, keyPartitioner),
-               false, true);
+                                                                        false, true, CompletableFutures.completedNull());
          return stage.thenRun(() -> {
             MVCCEntry cacheEntry = (MVCCEntry) ctx.lookupEntry(key);
             for (Mutation mutation : mutationsOnKey) {
@@ -596,8 +596,8 @@ public class TxDistributionInterceptor extends BaseDistributionInterceptor {
       Iterator<List<Mutation<Object, Object, ?>>> mutationsIterator = mutations.iterator();
       for (; keysIterator.hasNext() && mutationsIterator.hasNext(); ) {
          Object key = keysIterator.next();
-         CompletionStage<Void> stage = entryFactory.wrapEntryForWriting(ctx, key, keyPartitioner.getSegment(key), false, true);
-         // We rely on the fact that when isOwner is false that this never blocks
+         CompletionStage<Void> stage = entryFactory.wrapEntryForWriting(ctx, key, keyPartitioner.getSegment(key), false, true, CompletableFutures.completedNull());
+         // We rely on the fact that when isOwner is false this never blocks
          assert CompletionStages.isCompletedSuccessfully(stage);
          MVCCEntry cacheEntry = (MVCCEntry) ctx.lookupEntry(key);
          EntryView.ReadWriteEntryView readWriteEntryView = EntryViews.readWrite(cacheEntry, DataConversion.IDENTITY_KEY, DataConversion.IDENTITY_VALUE);

--- a/core/src/main/java/org/infinispan/interceptors/impl/EntryWrappingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/EntryWrappingInterceptor.java
@@ -237,7 +237,7 @@ public class EntryWrappingInterceptor extends DDAsyncInterceptor {
       for (Object key : command.getKeys()) {
          currentStage = entryFactory.wrapEntryForReading(ctx, key, keyPartitioner.getSegment(key),
                                                          ignoreOwnership || canReadKey(key), false,
-                                                         CompletableFutures.completedNull());
+                                                         currentStage);
       }
 
       return makeStage(asyncInvokeNext(ctx, command, expirationCheckDelay(currentStage, initialStage)))

--- a/core/src/main/java/org/infinispan/interceptors/impl/EntryWrappingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/EntryWrappingInterceptor.java
@@ -1,11 +1,13 @@
 package org.infinispan.interceptors.impl;
 
 import static org.infinispan.commons.util.Util.toStr;
+import static org.infinispan.container.impl.EntryFactory.expirationCheckDelay;
 import static org.infinispan.transaction.impl.WriteSkewHelper.versionFromEntry;
 
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import org.infinispan.commands.AbstractVisitor;
@@ -223,21 +225,22 @@ public class EntryWrappingInterceptor extends DDAsyncInterceptor {
       final Object key = command.getKey();
       CompletionStage<Void> stage = entryFactory.wrapEntryForReading(ctx, key, command.getSegment(),
             ignoreOwnership(command) || canRead(command), command.hasAnyFlag(FlagBitSets.ALREADY_HAS_LOCK)
-                  || (isPessimistic && command.hasAnyFlag(FlagBitSets.FORCE_WRITE_LOCK)));
+                  || (isPessimistic && command.hasAnyFlag(FlagBitSets.FORCE_WRITE_LOCK)), CompletableFutures.completedNull());
       return makeStage(asyncInvokeNext(ctx, command, stage)).thenApply(ctx, command, dataReadReturnHandler);
    }
 
    @Override
    public Object visitGetAllCommand(InvocationContext ctx, GetAllCommand command) throws Throwable {
       boolean ignoreOwnership = ignoreOwnership(command);
-      AggregateCompletionStage<Void> aggregateCompletionStage = null;
+      CompletableFuture<Void> initialStage = new CompletableFuture<>();
+      CompletionStage<Void> currentStage = initialStage;
       for (Object key : command.getKeys()) {
-         CompletionStage<Void> stage = entryFactory.wrapEntryForReading(ctx, key, keyPartitioner.getSegment(key),
-               ignoreOwnership || canReadKey(key), false);
-         aggregateCompletionStage = accumulateStage(stage, aggregateCompletionStage);
+         currentStage = entryFactory.wrapEntryForReading(ctx, key, keyPartitioner.getSegment(key),
+                                                         ignoreOwnership || canReadKey(key), false,
+                                                         CompletableFutures.completedNull());
       }
 
-      return makeStage(asyncInvokeNext(ctx, command, aggregatedStageOrCompleted(aggregateCompletionStage)))
+      return makeStage(asyncInvokeNext(ctx, command, expirationCheckDelay(currentStage, initialStage)))
             .andHandle(ctx, command, getAllHandleFunction);
    }
 
@@ -277,33 +280,18 @@ public class EntryWrappingInterceptor extends DDAsyncInterceptor {
 
    @Override
    public final Object visitInvalidateCommand(InvocationContext ctx, InvalidateCommand command) {
-      AggregateCompletionStage<Void> aggregateCompletionStage = null;
+      CompletableFuture<Void> initialStage = new CompletableFuture<>();
+      CompletionStage<Void> currentStage = initialStage;
       if (command.getKeys() != null) {
          for (Object key : command.getKeys()) {
             // TODO: move this to distribution interceptors?
             // we need to try to wrap the entry to get it removed
             // for the removal itself, wrapping null would suffice, but listeners need previous value
-            CompletionStage<Void> stage = entryFactory.wrapEntryForWriting(ctx, key, keyPartitioner.getSegment(key),
-                  true, false);
-            aggregateCompletionStage = accumulateStage(stage, aggregateCompletionStage);
+            currentStage = entryFactory.wrapEntryForWriting(ctx, key, keyPartitioner.getSegment(key),
+                                                                           true, false, currentStage);
          }
       }
-      return setSkipRemoteGetsAndInvokeNextForManyEntriesCommand(ctx, command,
-            aggregatedStageOrCompleted(aggregateCompletionStage));
-   }
-
-   private CompletionStage<Void> aggregatedStageOrCompleted(AggregateCompletionStage<Void> aggregateCompletionStage) {
-      return aggregateCompletionStage != null ? aggregateCompletionStage.freeze() : CompletableFutures.completedNull();
-   }
-
-   private AggregateCompletionStage<Void> accumulateStage(CompletionStage<Void> stage, AggregateCompletionStage<Void> current) {
-      if (!CompletionStages.isCompletedSuccessfully(stage)) {
-         if (current == null) {
-            current = CompletionStages.aggregateCompletionStage();
-         }
-         current.dependsOn(stage);
-      }
-      return current;
+      return setSkipRemoteGetsAndInvokeNextForManyEntriesCommand(ctx, command, expirationCheckDelay(currentStage, initialStage));
    }
 
    @Override
@@ -331,19 +319,18 @@ public class EntryWrappingInterceptor extends DDAsyncInterceptor {
 
    @Override
    public Object visitInvalidateL1Command(InvocationContext ctx, InvalidateL1Command command) {
-      AggregateCompletionStage<Void> aggregateCompletionStage = null;
+      CompletableFuture<Void> initialStage = new CompletableFuture<>();
+      CompletionStage<Void> currentStage = initialStage;
       for (Object key : command.getKeys()) {
          // TODO: move to distribution interceptors?
          // we need to try to wrap the entry to get it removed
          // for the removal itself, wrapping null would suffice, but listeners need previous value
-         CompletionStage<Void> stage = entryFactory.wrapEntryForWriting(ctx, key, keyPartitioner.getSegment(key),
-               false, false);
-         aggregateCompletionStage = accumulateStage(stage, aggregateCompletionStage);
+         currentStage = entryFactory.wrapEntryForWriting(ctx, key, keyPartitioner.getSegment(key),
+                                                                        false, false, currentStage);
          if (log.isTraceEnabled())
            log.tracef("Entry to be removed: %s", toStr(key));
       }
-      return setSkipRemoteGetsAndInvokeNextForManyEntriesCommand(ctx, command,
-            aggregatedStageOrCompleted(aggregateCompletionStage));
+      return setSkipRemoteGetsAndInvokeNextForManyEntriesCommand(ctx, command, expirationCheckDelay(currentStage, initialStage));
    }
 
    @Override
@@ -372,7 +359,8 @@ public class EntryWrappingInterceptor extends DDAsyncInterceptor {
          return CompletableFutures.completedNull();
       }
       return entryFactory.wrapEntryForWriting(ctx, command.getKey(), command.getSegment(), isOwner,
-                                              command.loadType() != VisitableCommand.LoadType.DONT_LOAD);
+                                              command.loadType() != VisitableCommand.LoadType.DONT_LOAD,
+                                              CompletableFutures.completedNull());
    }
 
    private void removeFromContextOnRetry(InvocationContext ctx, Object key) {
@@ -450,15 +438,14 @@ public class EntryWrappingInterceptor extends DDAsyncInterceptor {
       if (command.hasAnyFlag(FlagBitSets.COMMAND_RETRY)) {
          removeFromContextOnRetry(ctx, command.getAffectedKeys());
       }
-      AggregateCompletionStage<Void> aggregateCompletionStage = null;
+      CompletableFuture<Void> initialStage = new CompletableFuture<>();
+      CompletionStage<Void> currentStage = initialStage;
       for (Object key : command.getMap().keySet()) {
          // as listeners may need the value, we'll load the previous value
-         CompletionStage<Void> stage = entryFactory.wrapEntryForWriting(ctx, key, keyPartitioner.getSegment(key),
-               ignoreOwnership || canReadKey(key), command.loadType() != VisitableCommand.LoadType.DONT_LOAD);
-         aggregateCompletionStage = accumulateStage(stage, aggregateCompletionStage);
+         currentStage = entryFactory.wrapEntryForWriting(ctx, key, keyPartitioner.getSegment(key),
+               ignoreOwnership || canReadKey(key), command.loadType() != VisitableCommand.LoadType.DONT_LOAD, currentStage);
       }
-      return setSkipRemoteGetsAndInvokeNextForManyEntriesCommand(ctx, command,
-            aggregatedStageOrCompleted(aggregateCompletionStage));
+      return setSkipRemoteGetsAndInvokeNextForManyEntriesCommand(ctx, command, expirationCheckDelay(currentStage, initialStage));
    }
 
    @Override
@@ -508,9 +495,13 @@ public class EntryWrappingInterceptor extends DDAsyncInterceptor {
       CompletionStage<Void> stage;
       if (command instanceof TxReadOnlyKeyCommand) {
          // TxReadOnlyKeyCommand may apply some mutations on the entry in context so we need to always wrap it
-         stage = entryFactory.wrapEntryForWriting(ctx, command.getKey(), command.getSegment(), ignoreOwnership(command) || canRead(command), true);
+         stage = entryFactory.wrapEntryForWriting(ctx, command.getKey(), command.getSegment(),
+                                                  ignoreOwnership(command) || canRead(command), true,
+                                                  CompletableFutures.completedNull());
       } else {
-         stage = entryFactory.wrapEntryForReading(ctx, command.getKey(), command.getSegment(), ignoreOwnership(command) || canRead(command), false);
+         stage = entryFactory.wrapEntryForReading(ctx, command.getKey(), command.getSegment(),
+                                                  ignoreOwnership(command) || canRead(command), false,
+                                                  CompletableFutures.completedNull());
       }
 
       // Repeatable reads are not achievable with functional commands, as we don't store the value locally
@@ -523,24 +514,23 @@ public class EntryWrappingInterceptor extends DDAsyncInterceptor {
    @Override
    public Object visitReadOnlyManyCommand(InvocationContext ctx, ReadOnlyManyCommand command) throws Throwable {
       boolean ignoreOwnership = ignoreOwnership(command);
-      AggregateCompletionStage<Void> aggregateCompletionStage = null;
+      CompletableFuture<Void> initialStage = new CompletableFuture<>();
+      CompletionStage<Void> currentStage = initialStage;
       if (command instanceof TxReadOnlyManyCommand) {
          // TxReadOnlyManyCommand may apply some mutations on the entry in context so we need to always wrap it
          for (Object key : command.getKeys()) {
             // TODO: need to handle this
-            CompletionStage<Void> stage = entryFactory.wrapEntryForWriting(ctx, key, keyPartitioner.getSegment(key),
-                  ignoreOwnership(command) || canReadKey(key), true);
-            aggregateCompletionStage = accumulateStage(stage, aggregateCompletionStage);
+            currentStage = entryFactory.wrapEntryForWriting(ctx, key, keyPartitioner.getSegment(key),
+                  ignoreOwnership(command) || canReadKey(key), true, currentStage);
          }
       } else {
          for (Object key : command.getKeys()) {
-            CompletionStage<Void> stage = entryFactory.wrapEntryForReading(ctx, key, keyPartitioner.getSegment(key),
-                  ignoreOwnership || canReadKey(key), false);
-            aggregateCompletionStage = accumulateStage(stage, aggregateCompletionStage);
+            currentStage = entryFactory.wrapEntryForReading(ctx, key, keyPartitioner.getSegment(key),
+                  ignoreOwnership || canReadKey(key), false, currentStage);
          }
       }
       // Repeatable reads are not achievable with functional commands, see visitReadOnlyKeyCommand
-      return asyncInvokeNext(ctx, command, aggregatedStageOrCompleted(aggregateCompletionStage));
+      return asyncInvokeNext(ctx, command, expirationCheckDelay(currentStage, initialStage));
    }
 
    @Override
@@ -568,15 +558,14 @@ public class EntryWrappingInterceptor extends DDAsyncInterceptor {
          removeFromContextOnRetry(ctx, command.getAffectedKeys());
       }
       boolean ignoreOwnership = ignoreOwnership(command);
-      AggregateCompletionStage<Void> aggregateCompletionStage = null;
+      CompletableFuture<Void> initialStage = new CompletableFuture<>();
+      CompletionStage<Void> currentStage = initialStage;
       for (Object key : command.getArguments().keySet()) {
          //the put map never reads the keys
-         CompletionStage<Void> stage = entryFactory.wrapEntryForWriting(ctx, key, keyPartitioner.getSegment(key),
-               ignoreOwnership || canReadKey(key), false);
-         aggregateCompletionStage = accumulateStage(stage, aggregateCompletionStage);
+         currentStage = entryFactory.wrapEntryForWriting(ctx, key, keyPartitioner.getSegment(key),
+               ignoreOwnership || canReadKey(key), false, currentStage);
       }
-      return setSkipRemoteGetsAndInvokeNextForManyEntriesCommand(ctx, command,
-            aggregatedStageOrCompleted(aggregateCompletionStage));
+      return setSkipRemoteGetsAndInvokeNextForManyEntriesCommand(ctx, command, expirationCheckDelay(currentStage, initialStage));
    }
 
    @Override
@@ -586,14 +575,13 @@ public class EntryWrappingInterceptor extends DDAsyncInterceptor {
          removeFromContextOnRetry(ctx, command.getAffectedKeys());
       }
       boolean ignoreOwnership = ignoreOwnership(command);
-      AggregateCompletionStage<Void> aggregateCompletionStage = null;
+      CompletableFuture<Void> initialStage = new CompletableFuture<>();
+      CompletionStage<Void> currentStage = initialStage;
       for (Object key : command.getAffectedKeys()) {
-         CompletionStage<Void> stage = entryFactory.wrapEntryForWriting(ctx, key, keyPartitioner.getSegment(key),
-               ignoreOwnership || canReadKey(key), false);
-         aggregateCompletionStage = accumulateStage(stage, aggregateCompletionStage);
+         currentStage = entryFactory.wrapEntryForWriting(ctx, key, keyPartitioner.getSegment(key),
+               ignoreOwnership || canReadKey(key), false, currentStage);
       }
-      return setSkipRemoteGetsAndInvokeNextForManyEntriesCommand(ctx, command,
-            aggregatedStageOrCompleted(aggregateCompletionStage));
+      return setSkipRemoteGetsAndInvokeNextForManyEntriesCommand(ctx, command, expirationCheckDelay(currentStage, initialStage));
    }
 
    @Override
@@ -609,14 +597,13 @@ public class EntryWrappingInterceptor extends DDAsyncInterceptor {
          removeFromContextOnRetry(ctx, command.getAffectedKeys());
       }
       boolean ignoreOwnership = ignoreOwnership(command);
-      AggregateCompletionStage<Void> aggregateCompletionStage = null;
+      CompletableFuture<Void> initialStage = new CompletableFuture<>();
+      CompletionStage<Void> currentStage = initialStage;
       for (Object key : command.getAffectedKeys()) {
-         CompletionStage<Void> stage = entryFactory.wrapEntryForWriting(ctx, key, keyPartitioner.getSegment(key),
-               ignoreOwnership || canReadKey(key), true);
-         aggregateCompletionStage = accumulateStage(stage, aggregateCompletionStage);
+         currentStage = entryFactory.wrapEntryForWriting(ctx, key, keyPartitioner.getSegment(key),
+               ignoreOwnership || canReadKey(key), true, currentStage);
       }
-      return setSkipRemoteGetsAndInvokeNextForManyEntriesCommand(ctx, command,
-            aggregatedStageOrCompleted(aggregateCompletionStage));
+      return setSkipRemoteGetsAndInvokeNextForManyEntriesCommand(ctx, command, expirationCheckDelay(currentStage, initialStage));
    }
 
    @Override
@@ -626,14 +613,13 @@ public class EntryWrappingInterceptor extends DDAsyncInterceptor {
          removeFromContextOnRetry(ctx, command.getAffectedKeys());
       }
       boolean ignoreOwnership = ignoreOwnership(command);
-      AggregateCompletionStage<Void> aggregateCompletionStage = null;
+      CompletableFuture<Void> initialStage = new CompletableFuture<>();
+      CompletionStage<Void> currentStage = initialStage;
       for (Object key : command.getAffectedKeys()) {
-         CompletionStage<Void> stage = entryFactory.wrapEntryForWriting(ctx, key, keyPartitioner.getSegment(key),
-               ignoreOwnership || canReadKey(key), true);
-         aggregateCompletionStage = accumulateStage(stage, aggregateCompletionStage);
+         currentStage = entryFactory.wrapEntryForWriting(ctx, key, keyPartitioner.getSegment(key),
+               ignoreOwnership || canReadKey(key), true, currentStage);
       }
-      return setSkipRemoteGetsAndInvokeNextForManyEntriesCommand(ctx, command,
-            aggregatedStageOrCompleted(aggregateCompletionStage));
+      return setSkipRemoteGetsAndInvokeNextForManyEntriesCommand(ctx, command, expirationCheckDelay(currentStage, initialStage));
    }
 
    protected final CompletionStage<Void> commitContextEntries(InvocationContext ctx, FlagAffectedCommand command) {
@@ -918,19 +904,20 @@ public class EntryWrappingInterceptor extends DDAsyncInterceptor {
 
       private Object handleWriteCommand(InvocationContext ctx, DataWriteCommand command) throws Throwable {
          CompletionStage<Void> stage = entryFactory.wrapEntryForWriting(ctx, command.getKey(), command.getSegment(),
-               ignoreOwnership(command) || canRead(command), command.loadType() != VisitableCommand.LoadType.DONT_LOAD);
+               ignoreOwnership(command) || canRead(command), command.loadType() != VisitableCommand.LoadType.DONT_LOAD,
+                                                                        CompletableFutures.completedNull());
          return asyncInvokeNext(ctx, command, stage);
       }
 
       private Object handleWriteManyCommand(InvocationContext ctx, WriteCommand command) {
          boolean ignoreOwnership = ignoreOwnership(command);
-         AggregateCompletionStage<Void> aggregateCompletionStage = null;
+         CompletableFuture<Void> initialStage = new CompletableFuture<>();
+         CompletionStage<Void> currentStage = initialStage;
          for (Object key : command.getAffectedKeys()) {
-            CompletionStage<Void> stage = entryFactory.wrapEntryForWriting(ctx, key, keyPartitioner.getSegment(key),
-                  ignoreOwnership || canReadKey(key), command.loadType() != VisitableCommand.LoadType.DONT_LOAD);
-            aggregateCompletionStage = accumulateStage(stage, aggregateCompletionStage);
+            currentStage = entryFactory.wrapEntryForWriting(ctx, key, keyPartitioner.getSegment(key),
+                  ignoreOwnership || canReadKey(key), command.loadType() != VisitableCommand.LoadType.DONT_LOAD, currentStage);
          }
-         return asyncInvokeNext(ctx, command, aggregatedStageOrCompleted(aggregateCompletionStage));
+         return asyncInvokeNext(ctx, command, expirationCheckDelay(currentStage, initialStage));
       }
    }
 

--- a/core/src/test/java/org/infinispan/api/ConditionalOperationPrimaryOwnerFailTest.java
+++ b/core/src/test/java/org/infinispan/api/ConditionalOperationPrimaryOwnerFailTest.java
@@ -3,8 +3,8 @@ package org.infinispan.api;
 import static org.infinispan.test.TestingUtil.extractComponent;
 import static org.infinispan.test.TestingUtil.wrapInboundInvocationHandler;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.spy;
 import static org.testng.Assert.assertNull;
@@ -76,7 +76,7 @@ public class ConditionalOperationPrimaryOwnerFailTest extends MultipleCacheManag
          assertNull(context.lookupEntry(key), "Entry should not be wrapped!");
          return stage;
       }).when(spyEntryFactory).wrapEntryForWriting(any(InvocationContext.class), any(), anyInt(),
-                                                      anyBoolean(), anyBoolean());
+                                                   anyBoolean(), anyBoolean(), any());
 
       Future<?> killMemberResult = fork(() -> killMember(1));
 

--- a/core/src/test/java/org/infinispan/expiration/impl/ClusterExpirationMaxIdleTest.java
+++ b/core/src/test/java/org/infinispan/expiration/impl/ClusterExpirationMaxIdleTest.java
@@ -321,20 +321,18 @@ public class ClusterExpirationMaxIdleTest extends MultipleCacheManagersTest {
                         "Disabled in transactional caches because of ISPN-13618");
       SkipTestNG.skipIf(cacheMode.isScattered(), "Disabled in scattered caches because of ISPN-13619");
 
-      Map<String, String> v1s = new HashMap<>();
       // Can reproduce ISPN-13549 with nKey=20_000 and no trace logs (and without the fix)
       int nKeys = 4;
-      for (int i = 0; i < nKeys; i++) {
-         v1s.put("k" + i, "v1");
+      for (int i = 0; i < nKeys * 3 / 4; i++) {
+         cache0.put("k" + i, "v1", -1, SECONDS, 10, SECONDS);
       }
+
+      incrementAllTimeServices(11, SECONDS);
+
       Map<String, String> v2s = new HashMap<>();
       for (int i = 0; i < nKeys; i++) {
          v2s.put("k" + i, "v2");
       }
-      cache0.putAll(v1s, -1, SECONDS, 10, SECONDS);
-
-      incrementAllTimeServices(11, SECONDS);
-
       cache0.putAll(v2s, -1, SECONDS, 10, SECONDS);
    }
 

--- a/core/src/test/java/org/infinispan/expiration/impl/ClusterExpirationMaxIdleTest.java
+++ b/core/src/test/java/org/infinispan/expiration/impl/ClusterExpirationMaxIdleTest.java
@@ -10,6 +10,7 @@ import static org.testng.AssertJUnit.assertTrue;
 
 import java.lang.invoke.MethodHandles;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
@@ -334,6 +335,22 @@ public class ClusterExpirationMaxIdleTest extends MultipleCacheManagersTest {
          v2s.put("k" + i, "v2");
       }
       cache0.putAll(v2s, -1, SECONDS, 10, SECONDS);
+   }
+
+   public void testGetAllExpiredEntries() {
+      // Can reproduce ISPN-13549 with nKey=20_000 and no trace logs (and without the fix)
+      int nKeys = 4;
+      for (int i = 0; i < nKeys * 3 / 4; i++) {
+         cache0.put("k" + i, "v1", -1, SECONDS, 10, SECONDS);
+      }
+
+      incrementAllTimeServices(11, SECONDS);
+
+      Map<String, String> v1s = new HashMap<>();
+      for (int i = 0; i < nKeys; i++) {
+         v1s.put("k" + i, "v1");
+      }
+      assertEquals(Collections.emptyMap(), cache0.getAdvancedCache().getAll(v1s.keySet()));
    }
 
    private void assertLastUsedUpdate(Object key, long expectedLastUsed, Cache<Object, String> readCache,


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-13549

Synchronize the invocation context access when an async expiration
check is needed.

The test reproduces the problem but only with a huge number of keys.

Improves on #9788 by making sure that the sync part of entry wrapping is done before any entry wrapping that was delayed by an async expiration check. The code is much clunkier, though.
