### PR TITLE
[13.0.x] ISPN-13611 REST server invokes potentially blocking operations

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/admin/RemoteCacheAdminTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/admin/RemoteCacheAdminTest.java
@@ -72,13 +72,6 @@ public class RemoteCacheAdminTest extends MultiHotRodServersTest {
    }
 
    @Override
-   protected org.infinispan.client.hotrod.configuration.ConfigurationBuilder createHotRodClientConfigurationBuilder(
-         String host, int serverPort) {
-      return super.createHotRodClientConfigurationBuilder(host, serverPort)
-                  .socketTimeout(1_000);
-   }
-
-   @Override
    protected SerializationContextInitializer contextInitializer() {
       return TestDomainSCI.INSTANCE;
    }

--- a/commons/all/src/main/java/org/infinispan/commons/internal/BlockHoundUtil.java
+++ b/commons/all/src/main/java/org/infinispan/commons/internal/BlockHoundUtil.java
@@ -1,0 +1,13 @@
+package org.infinispan.commons.internal;
+
+public class BlockHoundUtil {
+   /**
+    * Signal to BlockHound that a method must not be called from a non-blocking thread.
+    *
+    * <p>Helpful when the method only blocks some of the time, and it is hard to force it to block
+    * in all the scenarios that use it.</p>
+    */
+   public static void pretendBlock() {
+      // Do nothing
+   }
+}

--- a/commons/all/src/main/java/org/infinispan/commons/internal/CommonsBlockHoundIntegration.java
+++ b/commons/all/src/main/java/org/infinispan/commons/internal/CommonsBlockHoundIntegration.java
@@ -19,6 +19,9 @@ public class CommonsBlockHoundIntegration implements BlockHoundIntegration {
    public void applyTo(BlockHound.Builder builder) {
       builder.nonBlockingThreadPredicate(current -> current.or(thread -> thread.getThreadGroup() instanceof NonBlockingResource));
 
+      // Pretend to block without the overhead of calling Thread.yield()
+      builder.markAsBlocking(BlockHoundUtil.class, "pretendBlock", "()V");
+
       // This should never block as non blocking thread will run the task if pool was full
       builder.disallowBlockingCallsInside(NonBlockingRejectedExecutionHandler.class.getName(), "rejectedExecution");
 

--- a/core/src/main/java/org/infinispan/health/impl/HealthImpl.java
+++ b/core/src/main/java/org/infinispan/health/impl/HealthImpl.java
@@ -4,8 +4,9 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.infinispan.Cache;
 import org.infinispan.commons.CacheException;
+import org.infinispan.factories.ComponentRegistry;
+import org.infinispan.factories.GlobalComponentRegistry;
 import org.infinispan.health.CacheHealth;
 import org.infinispan.health.ClusterHealth;
 import org.infinispan.health.Health;
@@ -36,8 +37,12 @@ public class HealthImpl implements Health {
 
    private CacheHealth getHealth(String cacheName) {
       try {
-         Cache<?, ?> cache = SecurityActions.getCache(embeddedCacheManager, cacheName);
-         return new CacheHealthImpl(cache);
+         GlobalComponentRegistry gcr = SecurityActions.getGlobalComponentRegistry(embeddedCacheManager);
+         ComponentRegistry cr = gcr.getNamedComponentRegistry(cacheName);
+         if (cr == null)
+            return new InvalidCacheHealth(cacheName);
+
+         return new CacheHealthImpl(cr);
       } catch (CacheException cacheException) {
          return new InvalidCacheHealth(cacheName);
       }

--- a/core/src/main/java/org/infinispan/health/impl/SecurityActions.java
+++ b/core/src/main/java/org/infinispan/health/impl/SecurityActions.java
@@ -5,10 +5,12 @@ import java.security.PrivilegedAction;
 
 import org.infinispan.Cache;
 import org.infinispan.distribution.DistributionManager;
+import org.infinispan.factories.GlobalComponentRegistry;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.security.Security;
 import org.infinispan.security.actions.GetCacheAction;
 import org.infinispan.security.actions.GetCacheDistributionManagerAction;
+import org.infinispan.security.actions.GetGlobalComponentRegistryAction;
 
 final class SecurityActions {
 
@@ -29,4 +31,7 @@ final class SecurityActions {
       return doPrivileged(new GetCacheAction(cacheManager, cacheName));
    }
 
+   static GlobalComponentRegistry getGlobalComponentRegistry(EmbeddedCacheManager cacheManager) {
+      return doPrivileged(new GetGlobalComponentRegistryAction(cacheManager));
+   }
 }

--- a/core/src/main/java/org/infinispan/security/actions/GetPersistenceManagerAction.java
+++ b/core/src/main/java/org/infinispan/security/actions/GetPersistenceManagerAction.java
@@ -1,6 +1,7 @@
 package org.infinispan.security.actions;
 
-import org.infinispan.Cache;
+import org.infinispan.commons.IllegalLifecycleStateException;
+import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.persistence.manager.PersistenceManager;
 
@@ -15,7 +16,10 @@ public class GetPersistenceManagerAction extends AbstractEmbeddedCacheManagerAct
 
    @Override
    public PersistenceManager run() {
-      Cache<?, ?> cache = cacheManager.getCache(cacheName);
-      return cache.getAdvancedCache().getComponentRegistry().getComponent(PersistenceManager.class);
+      ComponentRegistry cr = cacheManager.getGlobalComponentRegistry().getNamedComponentRegistry(cacheName);
+      if (cr == null)
+         throw new IllegalLifecycleStateException();
+
+      return cr.getComponent(PersistenceManager.class);
    }
 }

--- a/core/src/main/java/org/infinispan/stats/impl/CacheContainerStatsImpl.java
+++ b/core/src/main/java/org/infinispan/stats/impl/CacheContainerStatsImpl.java
@@ -633,7 +633,7 @@ public class CacheContainerStatsImpl implements CacheContainerStats, JmxStatisti
 
       List<Stats> stats = new ArrayList<>();
       for (String cn : cm.getCacheNames()) {
-         if (cm.cacheExists(cn)) {
+         if (cm.isRunning(cn)) {
             AdvancedCache<?, ?> cache = getCache(cn);
             if (cache != null) {
                Configuration cfg = cache.getCacheConfiguration();

--- a/core/src/main/java/org/infinispan/topology/ClusterTopologyManagerImpl.java
+++ b/core/src/main/java/org/infinispan/topology/ClusterTopologyManagerImpl.java
@@ -520,7 +520,7 @@ public class ClusterTopologyManagerImpl implements ClusterTopologyManager {
          Optional<GlobalStateManager> globalStateManager = gcr.getOptionalComponent(GlobalStateManager.class);
          Optional<ScopedPersistentState> persistedState =
                globalStateManager.flatMap(gsm -> gsm.readScopedState(cacheName));
-         return new ClusterCacheStatus(cacheManager, cacheName, availabilityStrategy, RebalanceType.from(cacheMode),
+         return new ClusterCacheStatus(cacheManager, gcr, cacheName, availabilityStrategy, RebalanceType.from(cacheMode),
                                        this, transport,
                                        persistentUUIDManager, eventLogManager, persistedState, resolveConflictsOnMerge);
       });

--- a/core/src/test/java/org/infinispan/health/impl/ClusterHealthImplTest.java
+++ b/core/src/test/java/org/infinispan/health/impl/ClusterHealthImplTest.java
@@ -1,26 +1,23 @@
 package org.infinispan.health.impl;
 
-import static org.infinispan.lifecycle.ComponentStatus.INSTANTIATED;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertTrue;
 
-import java.util.Collections;
 import java.util.EnumSet;
 
-import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.health.ClusterHealth;
 import org.infinispan.health.HealthStatus;
-import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.registry.InternalCacheRegistry;
 import org.infinispan.test.AbstractInfinispanTest;
+import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
@@ -33,25 +30,21 @@ public class ClusterHealthImplTest extends AbstractInfinispanTest {
 
    private static final String INTERNAL_CACHE_NAME = "internal_cache";
    private static final String CACHE_NAME = "test_cache";
+   private EmbeddedCacheManager localCacheManager;
    private EmbeddedCacheManager cacheManager;
-   private DefaultCacheManager mockedCacheManager;
    private ClusterHealth clusterHealth;
    private InternalCacheRegistry internalCacheRegistry;
 
    @BeforeClass
    private void init() {
+      localCacheManager = TestCacheManagerFactory.createCacheManager();
       cacheManager = TestCacheManagerFactory.createClusteredCacheManager();
-      internalCacheRegistry = cacheManager.getGlobalComponentRegistry().getComponent(InternalCacheRegistry.class);
+      internalCacheRegistry = TestingUtil.extractGlobalComponent(cacheManager, InternalCacheRegistry.class);
       clusterHealth = new ClusterHealthImpl(cacheManager, internalCacheRegistry);
    }
 
    @BeforeMethod
    private void configureBeforeMethod() {
-      mockedCacheManager = mock(DefaultCacheManager.class);
-
-      // We return the real global component registry to avoid to mock all the dependencies in the world
-      when(mockedCacheManager.getGlobalComponentRegistry()).thenReturn(cacheManager.getGlobalComponentRegistry());
-
       internalCacheRegistry.registerInternalCache(INTERNAL_CACHE_NAME, new ConfigurationBuilder().clustering().cacheMode(CacheMode.DIST_ASYNC).build(),
             EnumSet.of(InternalCacheRegistry.Flag.EXCLUSIVE));
 
@@ -107,18 +100,19 @@ public class ClusterHealthImplTest extends AbstractInfinispanTest {
 
       HealthStatus healthStatus = clusterHealth.getHealthStatus();
 
-      assertEquals(HealthStatus.DEGRADED, healthStatus);
+      assertEquals(HealthStatus.FAILED, healthStatus);
+
+      cacheManager.administration().removeCache(CACHE_NAME);
+
+      healthStatus = clusterHealth.getHealthStatus();
+
+      assertEquals(HealthStatus.HEALTHY, healthStatus);
    }
 
    public void testRebalancingStatusWhenUserCacheIsRebalancing() {
-      Cache mockedCache = mock(Cache.class);
-      AdvancedCache mockedAdvancedCache = mock(AdvancedCache.class);
-      DistributionManager mockedDistributionManager = mock(DistributionManager.class);
-      when(mockedCacheManager.getCacheNames()).thenReturn(Collections.singleton(CACHE_NAME));
+      mockRehashInProgress(CACHE_NAME);
 
-      mockRehashInProgress(CACHE_NAME, mockedCache, mockedAdvancedCache, mockedDistributionManager);
-
-      ClusterHealth clusterHealth = new ClusterHealthImpl(mockedCacheManager, mockedCacheManager.getGlobalComponentRegistry().getComponent(InternalCacheRegistry.class));
+      ClusterHealth clusterHealth = new ClusterHealthImpl(cacheManager, internalCacheRegistry);
 
       assertEquals(HealthStatus.HEALTHY_REBALANCING, clusterHealth.getHealthStatus());
    }
@@ -133,18 +127,13 @@ public class ClusterHealthImplTest extends AbstractInfinispanTest {
       Cache<Object, Object> internalCache = cacheManager.getCache(INTERNAL_CACHE_NAME, true);
       internalCache.stop();
 
-      assertEquals(HealthStatus.DEGRADED, clusterHealth.getHealthStatus());
+      assertEquals(HealthStatus.FAILED, clusterHealth.getHealthStatus());
    }
 
    public void testRebalancingStatusWhenInternalCacheIsRebalancing() {
-      Cache mockedCache = mock(Cache.class);
-      AdvancedCache mockedAdvancedCache = mock(AdvancedCache.class);
-      DistributionManager mockedDistributionManager = mock(DistributionManager.class);
+      mockRehashInProgress(INTERNAL_CACHE_NAME);
 
-      when(mockedCacheManager.getCacheNames()).thenReturn(Collections.emptySet());
-      mockRehashInProgress(INTERNAL_CACHE_NAME, mockedCache, mockedAdvancedCache, mockedDistributionManager);
-
-      ClusterHealth clusterHealth = new ClusterHealthImpl(mockedCacheManager, mockedCacheManager.getGlobalComponentRegistry().getComponent(InternalCacheRegistry.class));
+      ClusterHealth clusterHealth = new ClusterHealthImpl(cacheManager, internalCacheRegistry);
 
       assertEquals(HealthStatus.HEALTHY_REBALANCING, clusterHealth.getHealthStatus());
    }
@@ -158,22 +147,20 @@ public class ClusterHealthImplTest extends AbstractInfinispanTest {
    }
 
    public void testGetNumberOfNodesWithNullTransport() {
-      ClusterHealth clusterHealth = new ClusterHealthImpl(mockedCacheManager, mockedCacheManager.getGlobalComponentRegistry().getComponent(InternalCacheRegistry.class));
+      ClusterHealth clusterHealth = new ClusterHealthImpl(localCacheManager, internalCacheRegistry);
 
       assertEquals(0, clusterHealth.getNumberOfNodes());
    }
 
    public void testGetNodeNamesWithNullTransport() {
-      ClusterHealth clusterHealth = new ClusterHealthImpl(mockedCacheManager, mockedCacheManager.getGlobalComponentRegistry().getComponent(InternalCacheRegistry.class));
+      ClusterHealth clusterHealth = new ClusterHealthImpl(localCacheManager, internalCacheRegistry);
 
       assertTrue(clusterHealth.getNodeNames().isEmpty());
    }
 
-   private void mockRehashInProgress(String cacheName, Cache mockedCache, AdvancedCache mockedAdvancedCache, DistributionManager mockedDistributionManager) {
-      when(mockedCacheManager.getCache(cacheName, false)).thenReturn(mockedCache);
-      when(mockedCache.getAdvancedCache()).thenReturn(mockedAdvancedCache);
-      when(mockedCache.getStatus()).thenReturn(INSTANTIATED);
-      when(mockedAdvancedCache.getDistributionManager()).thenReturn(mockedDistributionManager);
-      when(mockedDistributionManager.isRehashInProgress()).thenReturn(true);
+   private void mockRehashInProgress(String cacheName) {
+      DistributionManager mockDistributionManager = mock(DistributionManager.class);
+      when(mockDistributionManager.isRehashInProgress()).thenReturn(true);
+      TestingUtil.replaceComponent(cacheManager.getCache(cacheName), DistributionManager.class, mockDistributionManager, false);
    }
 }

--- a/core/src/test/java/org/infinispan/manager/DefaultCacheManagerHelper.java
+++ b/core/src/test/java/org/infinispan/manager/DefaultCacheManagerHelper.java
@@ -1,0 +1,11 @@
+package org.infinispan.manager;
+
+/**
+ * Let tests access package-protected methods in DefaultCacheManager
+ */
+public class DefaultCacheManagerHelper {
+   public static void enableManagerGetCacheBlockingCheck() {
+      // Require isRunning(cache) before getCache(name) on non-blocking threads
+      DefaultCacheManager.enableGetCacheBlockingCheck();
+   }
+}

--- a/core/src/test/java/org/infinispan/partitionhandling/PreferConsistencyStrategyTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/PreferConsistencyStrategyTest.java
@@ -33,7 +33,7 @@ public class PreferConsistencyStrategyTest {
       EmbeddedCacheManager cacheManager = mock(EmbeddedCacheManager.class);
 
       preferConsistencyStrategy = new PreferConsistencyStrategy(eventLogManager, persistentUUIDManager, null);
-      status = new ClusterCacheStatus(cacheManager, "does-not-matter", preferConsistencyStrategy, RebalanceType.FOUR_PHASE, topologyManager,
+      status = new ClusterCacheStatus(cacheManager, null, "does-not-matter", preferConsistencyStrategy, RebalanceType.FOUR_PHASE, topologyManager,
                                       null, persistentUUIDManager, eventLogManager, Optional.empty(), false);
    }
 

--- a/core/src/test/java/org/infinispan/scattered/statetransfer/PrefetchTest.java
+++ b/core/src/test/java/org/infinispan/scattered/statetransfer/PrefetchTest.java
@@ -142,8 +142,12 @@ public class PrefetchTest extends MultipleCacheManagersTest {
 
       controlledRpcManager.stopBlocking();
       // release any threads waiting
-      beforeBarrier.reset();
-      afterBarrier.reset();
+      if (beforeBarrier.getNumberWaiting() == 1) {
+         beforeBarrier.await(0, TimeUnit.SECONDS);
+      }
+      if (afterBarrier.getNumberWaiting() == 1) {
+         afterBarrier.await(0, TimeUnit.SECONDS);
+      }
    }
 
    private static boolean isStateTransferPut(VisitableCommand command) {

--- a/core/src/test/java/org/infinispan/statetransfer/WriteSkewDuringStateTransferTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/WriteSkewDuringStateTransferTest.java
@@ -228,7 +228,7 @@ public class WriteSkewDuringStateTransferTest extends MultipleCacheManagersTest 
          @Override
          public void after(InvocationContext context, VisitableCommand command, Cache<?, ?> cache) {
             log.tracef("After: command=%s. origin=%s", command, context.getOrigin());
-            if (context.getOrigin().equals(address(cache(0)))) {
+            if (context.getOrigin().equals(address(0))) {
                newNode.commandLatch.countDown();
             }
          }

--- a/core/src/test/java/org/infinispan/topology/ClusterCacheStatusTest.java
+++ b/core/src/test/java/org/infinispan/topology/ClusterCacheStatusTest.java
@@ -56,7 +56,7 @@ public class ClusterCacheStatusTest extends AbstractInfinispanTest {
       PreferAvailabilityStrategy availabilityStrategy =
          new PreferAvailabilityStrategy(eventLogManager, persistentUUIDManager,
                                         ClusterTopologyManagerImpl::distLostDataCheck);
-      status = new ClusterCacheStatus(cacheManager, CACHE_NAME, availabilityStrategy, RebalanceType.FOUR_PHASE,
+      status = new ClusterCacheStatus(cacheManager, null, CACHE_NAME, availabilityStrategy, RebalanceType.FOUR_PHASE,
                                       topologyManager, transport, persistentUUIDManager, eventLogManager,
                                       Optional.empty(), false);
    }

--- a/core/src/test/java/org/infinispan/util/BlockingLocalTopologyManager.java
+++ b/core/src/test/java/org/infinispan/util/BlockingLocalTopologyManager.java
@@ -170,6 +170,8 @@ public class BlockingLocalTopologyManager extends AbstractControlledLocalTopolog
    }
 
    public void stopBlocking() {
+      enabled = false;
+
       if (exception != null) {
          throw exception;
       }
@@ -177,7 +179,6 @@ public class BlockingLocalTopologyManager extends AbstractControlledLocalTopolog
          log.error("Stopped blocking topology updates, but there are " + queuedTopologies.size() +
                       " blocked updates in the queue: " + queuedTopologies);
       }
-      enabled = false;
       log.debugf("Stopped blocking topology updates");
    }
 
@@ -211,7 +212,7 @@ public class BlockingLocalTopologyManager extends AbstractControlledLocalTopolog
 
    @Override
    protected final void beforeConfirmRebalancePhase(String cacheName, int topologyId, Throwable throwable) {
-      if (!expectedCacheName.equals(cacheName))
+      if (!enabled || !expectedCacheName.equals(cacheName))
          return;
 
       Event event = new Event(null, topologyId, -1, Type.CONFIRMATION);

--- a/core/src/test/java/org/infinispan/util/CoreTestBlockHoundIntegration.java
+++ b/core/src/test/java/org/infinispan/util/CoreTestBlockHoundIntegration.java
@@ -14,6 +14,7 @@ import org.infinispan.commons.test.TestSuiteProgress;
 import org.infinispan.distribution.BlockingInterceptor;
 import org.infinispan.eviction.impl.EvictionWithConcurrentOperationsTest;
 import org.infinispan.functional.FunctionalTestUtils;
+import org.infinispan.manager.DefaultCacheManagerHelper;
 import org.infinispan.notifications.cachelistener.CacheListenerVisibilityTest;
 import org.infinispan.persistence.support.WaitNonBlockingStore;
 import org.infinispan.test.ReplListener;
@@ -41,6 +42,8 @@ public class CoreTestBlockHoundIntegration implements BlockHoundIntegration {
       } catch (ClassNotFoundException e) {
          throw new AssertionError(e);
       }
+
+      DefaultCacheManagerHelper.enableManagerGetCacheBlockingCheck();
 
       builder.allowBlockingCallsInside(CoreTestBlockHoundIntegration.class.getName(), "writeJUnitReport");
 

--- a/lock/src/main/java/org/infinispan/lock/impl/manager/EmbeddedClusteredLockManager.java
+++ b/lock/src/main/java/org/infinispan/lock/impl/manager/EmbeddedClusteredLockManager.java
@@ -68,6 +68,9 @@ public class EmbeddedClusteredLockManager implements ClusteredLockManager {
       if (log.isTraceEnabled())
          log.trace("Starting EmbeddedClusteredLockManager");
 
+      cache = cacheManager.<ClusteredLockKey, ClusteredLockValue>getCache(ClusteredLockModuleLifecycle.CLUSTERED_LOCK_CACHE_NAME)
+            .getAdvancedCache()
+            .withFlags(Flag.SKIP_CACHE_LOAD, Flag.SKIP_CACHE_STORE);
       started = true;
    }
 
@@ -81,13 +84,9 @@ public class EmbeddedClusteredLockManager implements ClusteredLockManager {
    }
 
    private AdvancedCache<ClusteredLockKey, ClusteredLockValue> cache() {
-      if (!started) {
+      if (!started)
         throw new IllegalStateException("Component not running, cannot request the lock cache");
-      } else if (cache == null) {
-         cache = cacheManager.<ClusteredLockKey, ClusteredLockValue>getCache(ClusteredLockModuleLifecycle.CLUSTERED_LOCK_CACHE_NAME)
-               .getAdvancedCache()
-               .withFlags(Flag.SKIP_CACHE_LOAD, Flag.SKIP_CACHE_STORE);
-      }
+
       return cache;
    }
 

--- a/persistence/remote/src/test/java/org/infinispan/persistence/remote/RemoteStoreSSLTest.java
+++ b/persistence/remote/src/test/java/org/infinispan/persistence/remote/RemoteStoreSSLTest.java
@@ -102,7 +102,7 @@ public class RemoteStoreSSLTest extends BaseNonBlockingStoreTest {
 
    @Override
    protected PersistenceMarshaller getMarshaller() {
-      return localCacheManager.getCache(REMOTE_CACHE).getAdvancedCache().getComponentRegistry().getPersistenceMarshaller();
+      return TestingUtil.extractPersistenceMarshaller(localCacheManager);
    }
 
    @Override

--- a/persistence/remote/src/test/java/org/infinispan/persistence/remote/RemoteStoreTest.java
+++ b/persistence/remote/src/test/java/org/infinispan/persistence/remote/RemoteStoreTest.java
@@ -143,7 +143,7 @@ public class RemoteStoreTest extends BaseNonBlockingStoreTest {
 
    @Override
    protected PersistenceMarshaller getMarshaller() {
-      return localCacheManager.getCache(REMOTE_CACHE).getAdvancedCache().getComponentRegistry().getPersistenceMarshaller();
+      return TestingUtil.extractPersistenceMarshaller(localCacheManager);
    }
 
    @Override

--- a/query/src/test/java/org/infinispan/query/blackbox/IndexedCacheRestartTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/IndexedCacheRestartTest.java
@@ -2,7 +2,6 @@ package org.infinispan.query.blackbox;
 
 import static org.infinispan.configuration.cache.IndexStorage.LOCAL_HEAP;
 import static org.infinispan.test.TestingUtil.extractInterceptorChain;
-import static org.infinispan.test.TestingUtil.withCacheManager;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertTrue;
@@ -16,13 +15,14 @@ import org.infinispan.configuration.cache.InterceptorConfiguration;
 import org.infinispan.configuration.cache.InterceptorConfiguration.Position;
 import org.infinispan.interceptors.AsyncInterceptor;
 import org.infinispan.interceptors.DDAsyncInterceptor;
+import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.query.Search;
 import org.infinispan.query.backend.QueryInterceptor;
 import org.infinispan.query.dsl.Query;
 import org.infinispan.query.indexedembedded.Book;
 import org.infinispan.test.AbstractInfinispanTest;
-import org.infinispan.test.CacheManagerCallable;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
 /**
@@ -35,16 +35,17 @@ import org.testng.annotations.Test;
  */
 @Test(testName = "query.blackbox.IndexedCacheRestartTest", groups = "functional")
 public class IndexedCacheRestartTest extends AbstractInfinispanTest {
+   private EmbeddedCacheManager cm;
 
-   public void testIndexedCacheRestart() {
+   public void testLocalIndexedCacheRestart() throws Exception {
       indexedCacheRestart(false);
    }
 
-   public void testLocalIndexedCacheRestart() {
+   public void testLocalIndexedCacheRestartManager() throws Exception {
       indexedCacheRestart(true);
    }
 
-   private void indexedCacheRestart(boolean localOnly) {
+   private void indexedCacheRestart(boolean stopManager) {
       ConfigurationBuilder builder = new ConfigurationBuilder();
       builder.indexing().enable()
             .storage(LOCAL_HEAP)
@@ -54,36 +55,41 @@ public class IndexedCacheRestartTest extends AbstractInfinispanTest {
       final NoOpInterceptor noOpInterceptor = new NoOpInterceptor();
       builder.customInterceptors().addInterceptor().interceptor(noOpInterceptor).position(Position.FIRST);
 
-      withCacheManager(new CacheManagerCallable(TestCacheManagerFactory.createCacheManager(builder)) {
-         @Override
-         public void call() {
-            Cache<String, Book> cache = cm.getCache();
-            assertNotNull(extractInterceptorChain(cache).findInterceptorExtending(QueryInterceptor.class));
-            assertTrue(cache.isEmpty());
-            addABook(cache);
-            assertFindBook(cache);
-            cache.stop();
+      cm = TestCacheManagerFactory.createCacheManager(builder);
+      Cache<String, Book> cache = cm.getCache();
+      assertNotNull(extractInterceptorChain(cache).findInterceptorExtending(QueryInterceptor.class));
+      assertTrue(cache.isEmpty());
+      addABook(cache);
+      assertFindBook(cache);
 
-            assertCacheHasCustomInterceptor(cache, noOpInterceptor);
+      if (stopManager) {
+         cm.stop();
 
-            cache.start();
-            assertNotNull(extractInterceptorChain(cache).findInterceptorExtending(QueryInterceptor.class));
-            assertTrue(cache.isEmpty());
-            //stopped cache lost all data, and in memory index is lost: re-store both
-            //(not needed with permanent indexes and caches using a cachestore)
-            addABook(cache);
-            assertFindBook(cache);
+         cm = TestCacheManagerFactory.createCacheManager(builder);
+         cache = cm.getCache();
+      } else {
+         cache.stop();
 
-            assertCacheHasCustomInterceptor(cache, noOpInterceptor);
-         }
+         assertCacheHasCustomInterceptor(cache, noOpInterceptor);
 
-         private void addABook(Cache<String, Book> cache) {
-            cache.put("1",
-                  new Book("Infinispan Data Grid Platform",
-                        "Francesco Marchioni and Manik Surtani",
-                        "Packt Publishing"));
-         }
-      });
+         cache.start();
+      }
+
+      assertNotNull(extractInterceptorChain(cache).findInterceptorExtending(QueryInterceptor.class));
+      assertTrue(cache.isEmpty());
+      //stopped cache lost all data, and in memory index is lost: re-store both
+      //(not needed with permanent indexes and caches using a cachestore)
+      addABook(cache);
+      assertFindBook(cache);
+
+      assertCacheHasCustomInterceptor(cache, noOpInterceptor);
+   }
+
+   private void addABook(Cache<String, Book> cache) {
+      cache.put("1",
+            new Book("Infinispan Data Grid Platform",
+                  "Francesco Marchioni and Manik Surtani",
+                  "Packt Publishing"));
    }
 
    private void assertCacheHasCustomInterceptor(Cache<?, ?> cache, AsyncInterceptor interceptor) {
@@ -101,6 +107,11 @@ public class IndexedCacheRestartTest extends AbstractInfinispanTest {
       Query cacheQuery = Search.getQueryFactory(cache).create(q);
       List<Book> list = cacheQuery.list();
       assertEquals(1, list.size());
+   }
+
+   @AfterMethod(alwaysRun = true)
+   public void stopManager() {
+      cm.stop();
    }
 
    static class NoOpInterceptor extends DDAsyncInterceptor {

--- a/server/core/src/main/java/org/infinispan/server/core/AbstractProtocolServer.java
+++ b/server/core/src/main/java/org/infinispan/server/core/AbstractProtocolServer.java
@@ -21,6 +21,7 @@ import org.infinispan.server.core.logging.Log;
 import org.infinispan.server.core.transport.NettyTransport;
 import org.infinispan.server.core.utils.ManageableThreadPoolExecutorService;
 import org.infinispan.tasks.TaskManager;
+import org.infinispan.util.concurrent.BlockingManager;
 
 /**
  * A common protocol server dealing with common property parameter validation and assignment and transport lifecycle.
@@ -42,6 +43,7 @@ public abstract class AbstractProtocolServer<C extends ProtocolServerConfigurati
    private ServerStateManager serverStateManager;
    private ObjectName transportObjName;
    private CacheManagerJmxRegistration jmxRegistration;
+   private BlockingManager blockingManager;
    private ExecutorService executor;
    private ManageableThreadPoolExecutorService manageableThreadPoolExecutorService;
    private ObjectName executorObjName;
@@ -109,6 +111,7 @@ public abstract class AbstractProtocolServer<C extends ProtocolServerConfigurati
       }
       bcr.replaceComponent(getQualifiedName(), this, false);
 
+      blockingManager = bcr.getComponent(BlockingManager.class).running();
       executor = bcr.getComponent(KnownComponentNames.BLOCKING_EXECUTOR, ExecutorService.class).running();
       manageableThreadPoolExecutorService = new ManageableThreadPoolExecutorService(executor);
 
@@ -141,6 +144,10 @@ public abstract class AbstractProtocolServer<C extends ProtocolServerConfigurati
       }
 
       registerMetrics();
+   }
+
+   public BlockingManager getBlockingManager() {
+      return blockingManager;
    }
 
    public ExecutorService getExecutor() {

--- a/server/rest/src/main/java/org/infinispan/rest/BaseHttpRequestHandler.java
+++ b/server/rest/src/main/java/org/infinispan/rest/BaseHttpRequestHandler.java
@@ -30,15 +30,17 @@ public abstract class BaseHttpRequestHandler extends SimpleChannelInboundHandler
       NettyRestResponse errorResponse;
       if (cause instanceof RestResponseException) {
          RestResponseException responseException = (RestResponseException) throwable;
-         getLogger().errorWhileResponding(responseException);
+         if (getLogger().isTraceEnabled()) getLogger().tracef("Request failed: %s", responseException);
          errorResponse = new NettyRestResponse.Builder().status(responseException.getStatus()).entity(responseException.getText()).build();
       } else if (cause instanceof SecurityException) {
+         if (getLogger().isTraceEnabled()) getLogger().tracef("Request failed: %s", cause);
          errorResponse = new NettyRestResponse.Builder().status(FORBIDDEN).entity(cause.getMessage()).build();
       } else if (cause instanceof CacheConfigurationException || cause instanceof IllegalArgumentException) {
+         if (getLogger().isTraceEnabled()) getLogger().tracef("Request failed: %s", cause);
          errorResponse = new NettyRestResponse.Builder().status(BAD_REQUEST).entity(cause.getMessage()).build();
       } else {
-         Throwable rootCause = Util.getRootCause(throwable);
-         errorResponse = new NettyRestResponse.Builder().status(INTERNAL_SERVER_ERROR).entity(rootCause.getMessage()).build();
+         getLogger().errorWhileResponding(throwable);
+         errorResponse = new NettyRestResponse.Builder().status(INTERNAL_SERVER_ERROR).entity(cause.getMessage()).build();
       }
       sendResponse(ctx, request, errorResponse);
    }

--- a/server/rest/src/main/java/org/infinispan/rest/logging/Log.java
+++ b/server/rest/src/main/java/org/infinispan/rest/logging/Log.java
@@ -2,7 +2,6 @@ package org.infinispan.rest.logging;
 
 import static org.jboss.logging.Logger.Level.ERROR;
 import static org.jboss.logging.Logger.Level.INFO;
-import static org.jboss.logging.Logger.Level.TRACE;
 import static org.jboss.logging.Logger.Level.WARN;
 
 import org.infinispan.commons.CacheConfigurationException;
@@ -37,9 +36,9 @@ public interface Log extends BasicLogger {
    @Message(value = "Unsupported configuration option", id = 12004)
    UnsupportedOperationException unsupportedConfigurationOption();
 
-   @LogMessage(level = TRACE)
+   @LogMessage(level = ERROR)
    @Message(value = "An error occurred while responding to the client", id = 12005)
-   void errorWhileResponding(@Cause Exception e);
+   void errorWhileResponding(@Cause Throwable t);
 
    @LogMessage(level = ERROR)
    @Message(value = "Uncaught exception in the pipeline", id = 12006)

--- a/server/rest/src/main/java/org/infinispan/rest/resources/CacheResourceV2.java
+++ b/server/rest/src/main/java/org/infinispan/rest/resources/CacheResourceV2.java
@@ -107,6 +107,8 @@ public class CacheResourceV2 extends BaseCacheResource implements ResourceHandle
    private static final int STREAM_BATCH_SIZE = 1000;
    private static final String MIGRATOR_NAME = "hotrod";
 
+   private ParserRegistry parserRegistry = new ParserRegistry();
+
    public CacheResourceV2(InvocationHelper invocationHelper) {
       super(invocationHelper);
    }
@@ -627,11 +629,10 @@ public class CacheResourceV2 extends BaseCacheResource implements ResourceHandle
          return notFoundResponseFuture();
 
       Configuration cacheConfiguration = SecurityActions.getCacheConfiguration(cache.getAdvancedCache());
-      ParserRegistry registry = new ParserRegistry();
 
       ByteArrayOutputStream entity = new ByteArrayOutputStream();
       try (ConfigurationWriter writer = ConfigurationWriter.to(entity).withType(accept).prettyPrint(false).build()) {
-         registry.serialize(writer, cacheName, cacheConfiguration);
+         parserRegistry.serialize(writer, cacheName, cacheConfiguration);
       } catch (Exception e) {
          return CompletableFuture.completedFuture(responseBuilder.status(INTERNAL_SERVER_ERROR).entity(Util.getRootCause(e)).build());
       }
@@ -642,6 +643,8 @@ public class CacheResourceV2 extends BaseCacheResource implements ResourceHandle
    private CompletionStage<RestResponse> getCacheAvailability(RestRequest request) {
       String cacheName = request.variables().get("cacheName");
       // Use EmbeddedCacheManager directly to allow internal caches to be updated
+      if (!invocationHelper.getRestCacheManager().getInstance().isRunning(cacheName))
+         return notFoundResponseFuture();
       AdvancedCache<?, ?> cache = invocationHelper.getRestCacheManager().getInstance().getCache(cacheName).getAdvancedCache();
       if (cache == null) {
          return notFoundResponseFuture();
@@ -660,6 +663,8 @@ public class CacheResourceV2 extends BaseCacheResource implements ResourceHandle
       String cacheName = request.variables().get("cacheName");
       String availability = request.getParameter("availability");
       // Use EmbeddedCacheManager directly to allow internal caches to be updated
+      if (!invocationHelper.getRestCacheManager().getInstance().isRunning(cacheName))
+         return notFoundResponseFuture();
       AdvancedCache<?, ?> cache = invocationHelper.getRestCacheManager().getInstance().getCache(cacheName).getAdvancedCache();
       if (cache == null) {
          return notFoundResponseFuture();

--- a/server/rest/src/main/java/org/infinispan/rest/resources/ServerResource.java
+++ b/server/rest/src/main/java/org/infinispan/rest/resources/ServerResource.java
@@ -144,10 +144,9 @@ public class ServerResource implements ResourceHandler {
       }
       ServerManagement server = invocationHelper.getServer();
       ServerStateManager ignoreManager = server.getServerStateManager();
-      return Security.doAs(restRequest.getSubject(), (PrivilegedAction<CompletionStage<RestResponse>>) () ->
-            add ? ignoreManager.ignoreCache(cacheName).thenApply(r -> builder.build()) :
-                  ignoreManager.unignoreCache(cacheName).thenApply(r -> builder.build())
-      );
+      return Security.doAs(restRequest.getSubject(), (PrivilegedAction<CompletionStage<Void>>) () ->
+                           add ? ignoreManager.ignoreCache(cacheName) : ignoreManager.unignoreCache(cacheName))
+                     .thenApply(r -> builder.build());
    }
 
    private CompletionStage<RestResponse> listIgnored(RestRequest restRequest) {

--- a/server/rest/src/test/java/org/infinispan/rest/cachemanager/RestCacheManagerTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/cachemanager/RestCacheManagerTest.java
@@ -27,8 +27,8 @@ public class RestCacheManagerTest extends SingleCacheManagerTest {
    @BeforeClass
    public void prepare() {
       Configuration config = new ConfigurationBuilder().build();
-      cacheManager.defineConfiguration("cache1", config);
-      cacheManager.defineConfiguration("cache2", config);
+      cacheManager.createCache("cache1", config);
+      cacheManager.createCache("cache2", config);
    }
 
    @Test

--- a/server/rest/src/test/java/org/infinispan/rest/resources/CacheResourceV2Test.java
+++ b/server/rest/src/test/java/org/infinispan/rest/resources/CacheResourceV2Test.java
@@ -1154,10 +1154,9 @@ public class CacheResourceV2Test extends AbstractRestResourceTest {
       Closeable listen = client.raw().listen("/rest/v2/caches/default?action=listen", Collections.singletonMap("Accept", "text/plain"), sseListener);
       assertTrue(sseListener.openLatch.await(10, TimeUnit.SECONDS));
       putTextEntryInCache("default", "AKey", "AValue");
-      assertEquals("cache-entry-created", sseListener.events.poll(10, TimeUnit.SECONDS));
-      assertEquals("AKey", sseListener.data.removeFirst());
+      sseListener.expectEvent("cache-entry-created", "AKey");
       removeTextEntryFromCache("default", "AKey");
-      assertEquals("cache-entry-removed", sseListener.events.poll(10, TimeUnit.SECONDS));
+      sseListener.expectEvent("cache-entry-removed", "AKey");
       listen.close();
    }
 

--- a/server/rest/src/test/java/org/infinispan/rest/resources/ContainerResourceTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/resources/ContainerResourceTest.java
@@ -329,33 +329,23 @@ public class ContainerResourceTest extends AbstractRestResourceTest {
          AssertJUnit.assertTrue(sseListener.openLatch.await(10, TimeUnit.SECONDS));
 
          // Assert that all of the existing caches and templates have a corresponding event
-         assertEquals("create-template", sseListener.events.poll(10, TimeUnit.SECONDS));
-         AssertJUnit.assertTrue(sseListener.data.removeFirst().contains("template"));
-         assertEquals("create-cache", sseListener.events.poll(10, TimeUnit.SECONDS));
-         AssertJUnit.assertTrue(sseListener.data.removeFirst().contains("___protobuf_metadata"));
-         assertEquals("create-cache", sseListener.events.poll(10, TimeUnit.SECONDS));
-         AssertJUnit.assertTrue(sseListener.data.removeFirst().contains("cache2"));
-         assertEquals("create-cache", sseListener.events.poll(10, TimeUnit.SECONDS));
-         AssertJUnit.assertTrue(sseListener.data.removeFirst().contains("invalid"));
-         assertEquals("create-cache", sseListener.events.poll(10, TimeUnit.SECONDS));
-         AssertJUnit.assertTrue(sseListener.data.removeFirst().contains("cache1"));
-         assertEquals("create-cache", sseListener.events.poll(10, TimeUnit.SECONDS));
-         AssertJUnit.assertTrue(sseListener.data.removeFirst().contains("defaultcache"));
-         assertEquals("create-cache", sseListener.events.poll(10, TimeUnit.SECONDS));
-         AssertJUnit.assertTrue(sseListener.data.removeFirst().contains("___script_cache"));
+         sseListener.expectEvent("create-template", "template");
+         sseListener.expectEvent("create-cache", "___protobuf_metadata");
+         sseListener.expectEvent("create-cache", "cache2");
+         sseListener.expectEvent("create-cache", "invalid");
+         sseListener.expectEvent("create-cache", "cache1");
+         sseListener.expectEvent("create-cache", "defaultcache");
+         sseListener.expectEvent("create-cache", "___script_cache");
 
          // Assert that new cache creations create an event
          createCache("{\"local-cache\":{\"encoding\":{\"media-type\":\"text/plain\"}}}", "listen1");
-         assertEquals("create-cache", sseListener.events.poll(10, TimeUnit.SECONDS));
-         AssertJUnit.assertTrue(sseListener.data.removeFirst().contains("text/plain"));
+         sseListener.expectEvent("create-cache", "text/plain");
          createCache("{\"local-cache\":{\"encoding\":{\"media-type\":\"application/octet-stream\"}}}", "listen2");
-         assertEquals("create-cache", sseListener.events.poll(10, TimeUnit.SECONDS));
-         AssertJUnit.assertTrue(sseListener.data.removeFirst().contains("application/octet-stream"));
+         sseListener.expectEvent("create-cache", "application/octet-stream");
 
          // Assert that deletions create an event
          assertThat(client.cache("listen1").delete()).isOk();
-         assertEquals("remove-cache", sseListener.events.poll(10, TimeUnit.SECONDS));
-         assertEquals("listen1", sseListener.data.removeFirst());
+         sseListener.expectEvent("remove-cache", "listen1");
       }
    }
 

--- a/server/rest/src/test/java/org/infinispan/rest/resources/SSEListener.java
+++ b/server/rest/src/test/java/org/infinispan/rest/resources/SSEListener.java
@@ -1,29 +1,46 @@
 package org.infinispan.rest.resources;
 
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertEquals;
+
 import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
 
 import org.infinispan.client.rest.RestEventListener;
 import org.infinispan.client.rest.RestResponse;
+import org.infinispan.util.KeyValuePair;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
 
 /**
  * @author Tristan Tarrant &lt;tristan@infinispan.org&gt;
  * @since 13.0
  **/
 public class SSEListener implements RestEventListener {
-   BlockingDeque<String> events = new LinkedBlockingDeque<>();
-   BlockingDeque<String> data = new LinkedBlockingDeque<>();
+   private static final Log log = LogFactory.getLog(SSEListener.class);
+
+   BlockingDeque<KeyValuePair<String, String>> events = new LinkedBlockingDeque<>();
    CountDownLatch openLatch = new CountDownLatch(1);
 
    @Override
    public void onOpen(RestResponse response) {
+      log.tracef("open");
       openLatch.countDown();
    }
 
    @Override
    public void onMessage(String id, String type, String data) {
-      this.events.add(type);
-      this.data.add(data);
+      log.tracef("Received %s %s %s", id, type, data);
+      this.events.add(new KeyValuePair<>(type, data));
+   }
+
+   public void expectEvent(String type, String subString) throws InterruptedException {
+      KeyValuePair<String, String> event = events.poll(10, TimeUnit.SECONDS);
+      assertNotNull(event);
+      assertEquals(type, event.getKey());
+      assertTrue(event.getValue().contains(subString));
    }
 }

--- a/server/rest/src/test/java/org/infinispan/rest/search/SearchCountClusteredTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/search/SearchCountClusteredTest.java
@@ -4,6 +4,7 @@ import static org.infinispan.commons.dataconversion.MediaType.APPLICATION_JSON;
 import static org.infinispan.commons.dataconversion.MediaType.APPLICATION_PROTOSTREAM_TYPE;
 import static org.infinispan.functional.FunctionalTestUtils.await;
 import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -83,13 +84,18 @@ public class SearchCountClusteredTest extends MultiNodeRestTest {
                .set("sortableStoredField", i % 20)
                .set("sortableNotStoredField", "index_" + i % 20)
                .set("notIndexedField", str).toString();
-         await(indexedCache().put(String.valueOf(i), RestEntity.create(APPLICATION_JSON, value)));
+         RestResponse response = await(indexedCache().put(String.valueOf(i), RestEntity.create(APPLICATION_JSON, value)));
+         assertEquals(204, response.getStatus());
+         assertTrue(response.getBody().isEmpty());
       });
 
       LongStream.range(0, NOT_INDEXED_ENTRIES).forEach(i -> {
          String value = "text " + i;
          Json json = Json.object().set("_type", "NotIndexedEntity").set("field1", value).set("field2", value);
-         await(nonIndexedCache().put(String.valueOf(i), RestEntity.create(APPLICATION_JSON, json.toString())));
+         RestResponse response =
+               await(nonIndexedCache().put(String.valueOf(i), RestEntity.create(APPLICATION_JSON, json.toString())));
+         assertEquals(204, response.getStatus());
+         assertTrue(response.getBody().isEmpty());
       });
    }
 

--- a/server/router/src/test/java/org/infinispan/server/router/utils/RestTestingUtil.java
+++ b/server/router/src/test/java/org/infinispan/server/router/utils/RestTestingUtil.java
@@ -23,13 +23,14 @@ public class RestTestingUtil {
     }
 
     public static RestServer createRest(String ctx, RestServerConfigurationBuilder configuration, GlobalConfigurationBuilder globalConfigurationBuilder, ConfigurationBuilder cacheConfigurationBuilder, String... definedCaches) {
-      configuration.contextPath(ctx);
+        configuration.contextPath(ctx);
         RestServer nettyRestServer = new RestServer();
         Configuration cacheConfiguration = cacheConfigurationBuilder.build();
-        DefaultCacheManager cacheManager = new DefaultCacheManager(globalConfigurationBuilder.build());
+        DefaultCacheManager cacheManager = new DefaultCacheManager(globalConfigurationBuilder.build(), false);
         for (String cache : definedCaches) {
             cacheManager.defineConfiguration(cache, cacheConfiguration);
         }
+        cacheManager.start();
         nettyRestServer.setServerManagement(new DummyServerManagement(), true);
         nettyRestServer.start(configuration.build(), cacheManager);
         return nettyRestServer;

--- a/server/runtime/src/test/java/org/infinispan/server/configuration/ServerConfigurationSerializerTest.java
+++ b/server/runtime/src/test/java/org/infinispan/server/configuration/ServerConfigurationSerializerTest.java
@@ -28,6 +28,7 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.configuration.parsing.ConfigurationBuilderHolder;
 import org.infinispan.configuration.parsing.ParserRegistry;
+import org.infinispan.server.Server;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 import org.junit.Test;
@@ -60,6 +61,7 @@ public class ServerConfigurationSerializerTest {
    public void testConfigurationSerialization() throws IOException {
       Properties properties = new Properties();
       properties.put("infinispan.server.config.path", config.getParent().getParent().toString());
+      properties.setProperty(Server.INFINISPAN_SERVER_HOME_PATH, Paths.get(System.getProperty("build.directory")).toString());
       ParserRegistry registry = new ParserRegistry(Thread.currentThread().getContextClassLoader(), false, properties);
       ConfigurationBuilderHolder holderBefore = registry.parse(config);
       ByteArrayOutputStream baos = new ByteArrayOutputStream();


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-13611

* Always call isRunning(cacheName) before getCache(cacheName)
  on non-blocking threads
* Enforce the rule with BlockHound
* Use getNamedComponentRegistry() instead of getCache() when possible
* Start caches eagerly in REST tests
* Log unexpected exceptions in BaseHttpRequestHandler
* Make cache health status FAILED if the cache failed to start
  or was stopped.

Backport of #9807 