### PR TITLE
ISPN-6044 NumericVersionGenerator stops removed caches from being GCed

### DIFF
--- a/core/src/main/java/org/infinispan/container/versioning/RankCalculator.java
+++ b/core/src/main/java/org/infinispan/container/versioning/RankCalculator.java
@@ -1,0 +1,71 @@
+package org.infinispan.container.versioning;
+
+import java.lang.invoke.MethodHandles;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.infinispan.factories.annotations.Inject;
+import org.infinispan.factories.annotations.Start;
+import org.infinispan.factories.annotations.Stop;
+import org.infinispan.factories.scopes.Scope;
+import org.infinispan.factories.scopes.Scopes;
+import org.infinispan.notifications.Listener;
+import org.infinispan.notifications.cachemanagerlistener.CacheManagerNotifier;
+import org.infinispan.notifications.cachemanagerlistener.annotation.ViewChanged;
+import org.infinispan.notifications.cachemanagerlistener.event.ViewChangedEvent;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.remoting.transport.Transport;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
+/**
+ * Compute the version prefix to be used by {@link NumericVersionGenerator} in clustered caches.
+ *
+ * @since 14.0
+ */
+@Scope(Scopes.GLOBAL)
+@Listener
+public class RankCalculator {
+   private static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
+
+   final AtomicLong versionPrefix = new AtomicLong();
+
+   @Inject CacheManagerNotifier cacheManagerNotifier;
+   @Inject Transport transport;
+
+   @Start
+   void start() {
+      if (transport != null) {
+         cacheManagerNotifier.addListener(this);
+
+         updateRank(transport.getAddress(), transport.getMembers(), transport.getViewId());
+      }
+   }
+
+   @Stop
+   void stop() {
+      if (transport != null) {
+         cacheManagerNotifier.removeListener(this);
+      }
+   }
+
+   @ViewChanged
+   public void updateRank(ViewChangedEvent e) {
+      long rank = updateRank(e.getLocalAddress(), e.getNewMembers(), e.getViewId());
+      if (log.isTraceEnabled())
+         log.tracef("Calculated rank based on view %s and result was %d", e, rank);
+   }
+
+   public long getVersionPrefix() {
+      return versionPrefix.get();
+   }
+
+   private long updateRank(Address address, List<Address> members, long viewId) {
+      long rank = members.indexOf(address) + 1;
+      // Version is composed of: <view id (2 bytes)><rank (2 bytes)><version counter (4 bytes)>
+      // View id and rank form the prefix which is updated on a view change.
+      long newVersionPrefix = (viewId << 48) | (rank << 32);
+      versionPrefix.set(newVersionPrefix);
+      return versionPrefix.get();
+   }
+}

--- a/core/src/main/java/org/infinispan/factories/EmptyConstructorFactory.java
+++ b/core/src/main/java/org/infinispan/factories/EmptyConstructorFactory.java
@@ -4,6 +4,7 @@ import static org.infinispan.util.logging.Log.CONTAINER;
 
 import org.infinispan.commands.RemoteCommandsFactory;
 import org.infinispan.commons.time.TimeService;
+import org.infinispan.container.versioning.RankCalculator;
 import org.infinispan.factories.annotations.DefaultFactoryFor;
 import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
@@ -38,7 +39,8 @@ import org.infinispan.util.logging.events.impl.EventLogManagerImpl;
       InboundInvocationHandler.class, PersistentUUIDManager.class,
       RemoteCommandsFactory.class, TimeService.class, DataOperationOrderer.class,
       GlobalStateManager.class, GlobalConfigurationManager.class,
-      SerializationContextRegistry.class, BlockingManager.class, NonBlockingManager.class
+      SerializationContextRegistry.class, BlockingManager.class, NonBlockingManager.class,
+      RankCalculator.class
 })
 @Scope(Scopes.GLOBAL)
 public class EmptyConstructorFactory extends AbstractComponentFactory implements AutoInstantiableFactory {
@@ -67,6 +69,8 @@ public class EmptyConstructorFactory extends AbstractComponentFactory implements
          return new BlockingManagerImpl();
       else if (componentName.equals(NonBlockingManager.class.getName()))
          return new NonBlockingManagerImpl();
+      else if (componentName.equals(RankCalculator.class.getName()))
+         return new RankCalculator();
 
       throw CONTAINER.factoryCannotConstructComponent(componentName);
    }

--- a/core/src/test/java/org/infinispan/container/versioning/NumericVersionGeneratorTest.java
+++ b/core/src/test/java/org/infinispan/container/versioning/NumericVersionGeneratorTest.java
@@ -5,7 +5,13 @@ import static org.testng.AssertJUnit.assertEquals;
 import java.util.Arrays;
 import java.util.List;
 
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.notifications.cachemanagerlistener.event.Event;
+import org.infinispan.notifications.cachemanagerlistener.event.impl.EventImpl;
 import org.infinispan.remoting.transport.Address;
+import org.infinispan.test.TestingUtil;
 import org.testng.annotations.Test;
 
 /**
@@ -15,18 +21,28 @@ import org.testng.annotations.Test;
 public class NumericVersionGeneratorTest {
 
    public void testGenerateVersion() {
-      NumericVersionGenerator vg = new NumericVersionGenerator().clustered(true);
+      RankCalculator rankCalculator = new RankCalculator();
+      Configuration config = new ConfigurationBuilder().clustering().cacheMode(CacheMode.DIST_SYNC).build();
+      NumericVersionGenerator vg = new NumericVersionGenerator();
+      TestingUtil.inject(vg, rankCalculator, config);
+      vg.start();
       vg.resetCounter();
+
       TestAddress addr1 = new TestAddress(1);
       TestAddress addr2 = new TestAddress(2);
       TestAddress addr3 = new TestAddress(1);
-      List<Address> members = Arrays.asList((Address)addr1, addr2, addr3);
-      vg.calculateRank(addr2, members, 1);
+      List<Address> members = Arrays.asList(addr1, addr2, addr3);
+      rankCalculator.updateRank(new EventImpl(null, null, Event.Type.VIEW_CHANGED, members, members, addr2, 1));
 
-
+      assertEquals(0x1000200000000L, rankCalculator.getVersionPrefix());
       assertEquals(new NumericVersion(0x1000200000001L), vg.generateNew());
       assertEquals(new NumericVersion(0x1000200000002L), vg.generateNew());
-      assertEquals(new NumericVersion(0x1000200000003L), vg.generateNew());
+
+      members = Arrays.asList(addr2, addr3);
+      rankCalculator.updateRank(new EventImpl(null, null, Event.Type.VIEW_CHANGED, members, members, addr2, 2));
+
+      assertEquals(0x2000100000000L, rankCalculator.getVersionPrefix());
+      assertEquals(new NumericVersion(0x2000100000003L), vg.generateNew());
    }
 
    class TestAddress implements Address {


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-6044

Make RankCalculator a global component and add it as a listener
only once.