### PR TITLE
ISPN-13520 Replace usages of getParameters().length with getParameterCount()

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/format/PropertyFormatter.java
+++ b/core/src/main/java/org/infinispan/configuration/format/PropertyFormatter.java
@@ -60,7 +60,7 @@ public final class PropertyFormatter {
          for (Method m : c.getDeclaredMethods()) {
             if (Modifier.isPublic(m.getModifiers())
                   && !Modifier.isStatic(m.getModifiers())
-                  && m.getParameters().length == 0
+                  && m.getParameterCount() == 0
                   && !m.isAnnotationPresent(Deprecated.class)
                   && !"hashCode".equals(m.getName())
                   && !"toString".equals(m.getName())


### PR DESCRIPTION
This issue is similar to https://issues.redhat.com/browse/ISPN-13520, so I have reused the Jira ID.
`getParameters().length` creates an array clone, while `getParameterCount()` directly returns the length.