### PR TITLE
ISPN-13682 CLI Schema manipulation commands

### DIFF
--- a/cli/src/main/java/org/infinispan/cli/commands/rest/Schema.java
+++ b/cli/src/main/java/org/infinispan/cli/commands/rest/Schema.java
@@ -1,18 +1,20 @@
 package org.infinispan.cli.commands.rest;
 
 import java.io.File;
-import java.util.List;
 import java.util.concurrent.CompletionStage;
 
 import org.aesh.command.Command;
 import org.aesh.command.CommandDefinition;
+import org.aesh.command.CommandResult;
+import org.aesh.command.GroupCommandDefinition;
 import org.aesh.command.impl.completer.FileOptionCompleter;
-import org.aesh.command.option.Arguments;
+import org.aesh.command.option.Argument;
 import org.aesh.command.option.Option;
 import org.aesh.io.Resource;
 import org.infinispan.cli.activators.ConnectionActivator;
+import org.infinispan.cli.commands.CliCommand;
+import org.infinispan.cli.completers.SchemaCompleter;
 import org.infinispan.cli.impl.ContextAwareCommandInvocation;
-import org.infinispan.cli.logging.Messages;
 import org.infinispan.client.rest.RestClient;
 import org.infinispan.client.rest.RestEntity;
 import org.infinispan.client.rest.RestResponse;
@@ -24,14 +26,8 @@ import org.kohsuke.MetaInfServices;
  * @since 10.0
  **/
 @MetaInfServices(Command.class)
-@CommandDefinition(name = "schema", description = "Manipulates protobuf schemas", activator = ConnectionActivator.class)
-public class Schema extends RestCliCommand {
-   @Arguments(required = true, description = "The name of the schema")
-   List<String> args;
-
-   @Option(completer = FileOptionCompleter.class, shortName = 'u', description = "The protobuf file to upload")
-   Resource upload;
-
+@GroupCommandDefinition(name = "schema", description = "Manipulates Protobuf schemas", activator = ConnectionActivator.class, groupCommands = {Schema.Upload.class, Schema.Remove.class, Schema.Ls.class, Schema.Get.class})
+public class Schema extends CliCommand {
    @Option(shortName = 'h', hasValue = false, overrideRequired = true)
    protected boolean help;
 
@@ -41,16 +37,85 @@ public class Schema extends RestCliCommand {
    }
 
    @Override
-   protected CompletionStage<RestResponse> exec(ContextAwareCommandInvocation invocation, RestClient client, org.infinispan.cli.resources.Resource resource) {
-      if ((upload != null) && (args.size() != 1)) {
-         throw Messages.MSG.illegalCommandArguments();
-      } else if ((upload == null) && (args.size() != 2)) {
-         throw Messages.MSG.illegalCommandArguments();
+   public CommandResult exec(ContextAwareCommandInvocation invocation) {
+      // This command serves only to wrap the sub-commands
+      invocation.println(invocation.getHelpInfo());
+      return CommandResult.FAILURE;
+   }
+
+   @CommandDefinition(name = "upload", description = "Uploads Protobuf schemas to the server.")
+   public static class Upload extends RestCliCommand {
+      @Argument(required = true, description = "The name of the schema")
+      String name;
+
+      @Option(completer = FileOptionCompleter.class, shortName = 'f', description = "The Protobuf schema file to upload.", required = true)
+      Resource file;
+
+      @Option(shortName = 'h', hasValue = false, overrideRequired = true)
+      protected boolean help;
+
+      @Override
+      public boolean isHelp() {
+         return help;
       }
-      if (upload == null) {
-         return client.schemas().put(args.get(0), args.get(1));
-      } else {
-         return client.schemas().put(args.get(0), RestEntity.create(MediaType.TEXT_PLAIN, new File(upload.getAbsolutePath())));
+
+      @Override
+      protected CompletionStage<RestResponse> exec(ContextAwareCommandInvocation invocation, RestClient client, org.infinispan.cli.resources.Resource resource) {
+         return client.schemas().put(name, RestEntity.create(MediaType.TEXT_PLAIN, new File(file.getAbsolutePath())));
+      }
+   }
+
+   @CommandDefinition(name = "ls", description = "Lists available Protobuf schemas.")
+   public static class Ls extends RestCliCommand {
+      @Option(shortName = 'h', hasValue = false, overrideRequired = true)
+      protected boolean help;
+
+      @Override
+      public boolean isHelp() {
+         return help;
+      }
+
+      @Override
+      protected CompletionStage<RestResponse> exec(ContextAwareCommandInvocation invocation, RestClient client, org.infinispan.cli.resources.Resource resource) {
+         return client.schemas().names();
+      }
+   }
+
+   @CommandDefinition(name = "remove", aliases = "rm", description = "Deletes Protobuf schema.")
+   public static class Remove extends RestCliCommand {
+      @Argument(required = true, description = "The name of the schema", completer = SchemaCompleter.class)
+      String name;
+
+      @Option(shortName = 'h', hasValue = false, overrideRequired = true)
+      protected boolean help;
+
+      @Override
+      public boolean isHelp() {
+         return help;
+      }
+
+      @Override
+      protected CompletionStage<RestResponse> exec(ContextAwareCommandInvocation invocation, RestClient client, org.infinispan.cli.resources.Resource resource) {
+         return client.schemas().delete(name);
+      }
+   }
+
+   @CommandDefinition(name = "get", description = "Displays the Protobuf definition of a schema.")
+   public static class Get extends RestCliCommand {
+      @Argument(required = true, description = "The name of the schema", completer = SchemaCompleter.class)
+      String name;
+
+      @Option(shortName = 'h', hasValue = false, overrideRequired = true)
+      protected boolean help;
+
+      @Override
+      public boolean isHelp() {
+         return help;
+      }
+
+      @Override
+      protected CompletionStage<RestResponse> exec(ContextAwareCommandInvocation invocation, RestClient client, org.infinispan.cli.resources.Resource resource) {
+         return client.schemas().get(name);
       }
    }
 }

--- a/cli/src/main/resources/help/schema.adoc
+++ b/cli/src/main/resources/help/schema.adoc
@@ -5,23 +5,52 @@ SCHEMA(1)
 
 NAME
 ----
-schema - uploads and registers protobuf schemas.
+schema - manipulates Protobuf schemas.
 
 
 SYNOPSIS
 --------
-*schema* ['OPTIONS'] `SCHEMA_NAME`
+
+*schema ls*
+
+*schema upload --file=/path/to/schema.proto schema.proto*
+
+*schema remove schema.proto*
+
+*schema get schema.proto*
 
 
-OPTIONS
--------
-*-u, --upload*='FILE'::
+DESCRIPTION
+-----------
+
+Manage schemas with the `ls`, `upload`, `get`, `remove` subcommands.
+
+
+COMMAND SYNOPSIS
+----------------
+
+*schema ls*::
+Lists the schemas installed in the server.
+
+*schema upload* --file='/path/to/schema.proto' 'schema.proto'::
+Uploads a ProtoBuf schema file to the server.
+
+*schema get* 'schema.proto'::
+Shows the content of the specified schema.
+
+*schema remove* 'schema.proto'::
+Removes the specified schema from the server.
+
+
+UPLOAD OPTIONS
+--------------
+*-f, --file*='FILE'::
 Uploads a file as a protobuf schema with the given name.
 
 
 EXAMPLE
 --------
-`schema --upload=person.proto person.proto` +
+`schema upload --file=person.proto person.proto` +
 Registers a `person.proto` Protobuf schema.
 
 

--- a/server/tests/src/test/java/org/infinispan/server/cli/CliIT.java
+++ b/server/tests/src/test/java/org/infinispan/server/cli/CliIT.java
@@ -89,7 +89,7 @@ public class CliIT {
          terminal.assertContains("\"timetoliveseconds\" : [ \"10\" ]");
 
          terminal.readln("create cache --file=" + getCliResource("qcache.xml").getPath() + " qcache");
-         terminal.readln("schema -u=" + getCliResource("person.proto").getPath() + " person.proto");
+         terminal.readln("schema upload -f=" + getCliResource("person.proto").getPath() + " person.proto");
          terminal.clear();
          terminal.readln("cd /containers/default/schemas");
          terminal.readln("ls");
@@ -226,11 +226,21 @@ public class CliIT {
          connect(terminal);
 
          // upload
-         terminal.readln("schema --upload=" + getCliResource("person.proto").getPath() + " person.proto");
+         terminal.readln("schema upload --file=" + getCliResource("person.proto").getPath() + " person.proto");
+         terminal.assertContains("\"error\" : null");
          terminal.clear();
          terminal.readln("cd /containers/default/schemas");
          terminal.readln("ls");
          terminal.assertContains("person.proto");
+         terminal.clear();
+         terminal.readln("schema ls");
+         terminal.assertContains("person.proto");
+         terminal.readln("schema get person.proto");
+         terminal.assertContains("PhoneNumber");
+         terminal.readln("schema remove person.proto");
+         terminal.clear();
+         terminal.readln("schema ls");
+         terminal.assertContains("[]");
       }
    }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-13682

Unfortunately this introduces an incompatible change:

`schema -u /path/to/file.proto file.proto` 

must be replaced by

`schema upload -f /path/to/file.proto file.proto`
