### PR TITLE
ISPN-13693 Fix AsyncBackupTest.testClear test

### DIFF
--- a/core/src/main/java/org/infinispan/xsite/irac/DefaultIracManager.java
+++ b/core/src/main/java/org/infinispan/xsite/irac/DefaultIracManager.java
@@ -184,7 +184,10 @@ public class DefaultIracManager implements IracManager, JmxStatisticsExposer, Ir
          log.tracef("Tracking clear request. Replicate to backup sites? %s", sendClear);
       }
       hasClear = sendClear;
-      updatedKeys.values().forEach(IracManagerKeyState::discard);
+      updatedKeys.values().removeIf(state -> {
+         state.discard();
+         return true;
+      });
       if (sendClear) {
          iracExecutor.run();
       }


### PR DESCRIPTION
DefaultIracManager.trackClear() is not clearing the keys from the map.
After IracManagerKeyState.discard(), the key is never retried again and
then never removed.

https://issues.redhat.com/browse/ISPN-13693