### PR TITLE
[13.0.x] ISPN-13703 test and fix for clustered DIST_SYNC transactional cache f…

### DIFF
--- a/core/src/main/java/org/infinispan/commands/functional/Mutations.java
+++ b/core/src/main/java/org/infinispan/commands/functional/Mutations.java
@@ -8,6 +8,7 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import org.infinispan.commands.functional.functions.InjectableComponent;
 import org.infinispan.encoding.DataConversion;
 import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.functional.EntryView;
@@ -94,6 +95,15 @@ final class Mutations {
       public ReadWrite(DataConversion keyDataConversion, DataConversion valueDataConversion, Function<EntryView.ReadWriteEntryView<K, V>, R> f) {
          super(keyDataConversion, valueDataConversion);
          this.f = f;
+      }
+
+      @Override
+      public void inject(ComponentRegistry registry) {
+         super.inject(registry);
+
+         if(f instanceof InjectableComponent)         {
+            ((InjectableComponent) f).inject(registry);
+         }
       }
 
       @Override

--- a/core/src/test/java/org/infinispan/distribution/DistSyncTxFuncTest.java
+++ b/core/src/test/java/org/infinispan/distribution/DistSyncTxFuncTest.java
@@ -9,6 +9,7 @@ import static org.testng.AssertJUnit.assertTrue;
 import javax.transaction.TransactionManager;
 
 import org.infinispan.Cache;
+import org.infinispan.commands.functional.ReadWriteKeyCommand;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.util.ControlledConsistentHashFactory;
 import org.infinispan.util.concurrent.locks.LockManager;
@@ -296,6 +297,18 @@ public class DistSyncTxFuncTest extends BaseDistFunctionalTest<Object, String> {
       assertIsNotInL1(c3, k1);
 
       checkOwnership(k1, k2, "value1", "value2");
+   }
+
+   public void testMergeFromNonOwner() {
+      initAndTest();
+
+
+      // merge function applied
+      Object retval = getFirstNonOwner("k1").merge("k1", "value2", (v1, v2) -> "merged_" + v1 + "_" + v2);
+      asyncWait("k1", ReadWriteKeyCommand.class);
+      if (testRetVals) assertEquals("merged_value_value2", retval);
+      assertOnAllCachesAndOwnership("k1", "merged_value_value2");
+
    }
 
    @Override


### PR DESCRIPTION
Test and possible fix for [ISPN-13703](https://issues.redhat.com/browse/ISPN-13703). This is branched from 13.0.x, since there are some test fails already on this branch (at least when I run it) I can't be sure it doesn't create other test breaks but it certainly fixes the test that is submitted with this fix.