### PR TITLE
ISPN-12335 Expose rebalacing progress.

### DIFF
--- a/core/src/main/java/org/infinispan/scattered/impl/ScatteredStateConsumerImpl.java
+++ b/core/src/main/java/org/infinispan/scattered/impl/ScatteredStateConsumerImpl.java
@@ -356,6 +356,12 @@ public class ScatteredStateConsumerImpl extends StateConsumerImpl {
       }
    }
 
+   @Override
+   protected void onCompletedSegment(int segmentId) {
+      // On scattered mode is used only the `onTaskCompletion` method to remove a task when all segments are completed.
+      // We override this method with no operation for scattered mode.
+   }
+
    // This should be fixed in https://issues.redhat.com/browse/ISPN-10864
    @SuppressWarnings("checkstyle:ForbiddenMethod")
    private void blockingSubscribe(Flowable<?> flowable) {

--- a/core/src/main/java/org/infinispan/statetransfer/StateConsumer.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateConsumer.java
@@ -22,6 +22,16 @@ public interface StateConsumer {
    boolean isStateTransferInProgressForKey(Object key);
 
    /**
+    * Returns the number of in-flight requested segments.
+    */
+   long inflightRequestCount();
+
+   /**
+    * Returns the number of in-flight transactional requested segments.
+    */
+   long inflightTransactionSegmentCount();
+
+   /**
     * Receive notification of topology changes. {@link org.infinispan.commands.statetransfer.StateTransferStartCommand},
     * or {@link org.infinispan.commands.statetransfer.ScatteredStateGetKeysCommand} for
     * {@link org.infinispan.configuration.cache.CacheMode#SCATTERED_SYNC}, are issued for segments that are new to this

--- a/core/src/main/java/org/infinispan/statetransfer/StateTransferManager.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateTransferManager.java
@@ -30,6 +30,16 @@ public interface StateTransferManager {
    boolean isStateTransferInProgress();
 
    /**
+    * Returns the number of requested segments to be transferred.
+    */
+   long getInflightSegmentTransferCount();
+
+   /**
+    * Returns the number of transactional segments requested which are still in-flight.
+    */
+   long getInflightTransactionalSegmentCount();
+
+   /**
     * Checks if an inbound state transfer is in progress for a given key.
     *
     * @deprecated since 10.0; to be removed in next major version

--- a/core/src/main/java/org/infinispan/statetransfer/StateTransferManagerImpl.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateTransferManagerImpl.java
@@ -283,6 +283,18 @@ public class StateTransferManagerImpl implements StateTransferManager {
       return stateConsumer.isStateTransferInProgress();
    }
 
+   @ManagedAttribute(description = "The number of in-flight segments the local node requested from other nodes", displayName = "In-flight requested segments", dataType = DataType.MEASUREMENT)
+   @Override
+   public long getInflightSegmentTransferCount() {
+      return stateConsumer.inflightRequestCount();
+   }
+
+   @ManagedAttribute(description = "The number of in-flight transactional segments the local node requested from other nodes", displayName = "In-flight requested transactional segments", dataType = DataType.MEASUREMENT)
+   @Override
+   public long getInflightTransactionalSegmentCount() {
+      return stateConsumer.inflightTransactionSegmentCount();
+   }
+
    @Override
    public Map<Address, Response> forwardCommandIfNeeded(TopologyAffectedCommand command, Set<Object> affectedKeys,
                                                         Address origin) {

--- a/core/src/test/java/org/infinispan/statetransfer/DelegatingStateConsumer.java
+++ b/core/src/test/java/org/infinispan/statetransfer/DelegatingStateConsumer.java
@@ -25,6 +25,16 @@ public class DelegatingStateConsumer implements StateConsumer {
    }
 
    @Override
+   public long inflightRequestCount() {
+      return delegate.inflightRequestCount();
+   }
+
+   @Override
+   public long inflightTransactionSegmentCount() {
+      return delegate.inflightTransactionSegmentCount();
+   }
+
+   @Override
    public CompletionStage<CompletionStage<Void>> onTopologyUpdate(CacheTopology cacheTopology, boolean isRebalance) {
       return delegate.onTopologyUpdate(cacheTopology, isRebalance);
    }

--- a/core/src/test/java/org/infinispan/statetransfer/StateTransferSegmentMetricsTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateTransferSegmentMetricsTest.java
@@ -1,0 +1,182 @@
+package org.infinispan.statetransfer;
+
+import org.infinispan.Cache;
+import org.infinispan.commons.util.IntSet;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.distribution.BaseDistFunctionalTest;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.test.TestException;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.CheckPoint;
+import org.infinispan.test.fwk.CleanupAfterMethod;
+import org.infinispan.topology.CacheTopology;
+import org.infinispan.transaction.LockingMode;
+import org.infinispan.transaction.TransactionMode;
+import org.infinispan.util.ControlledConsistentHashFactory;
+import org.mockito.AdditionalAnswers;
+import org.mockito.stubbing.Answer;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+@Test(groups = "functional", testName = "statetransfer.StateTransferSegmentMetricsTest")
+@CleanupAfterMethod
+public class StateTransferSegmentMetricsTest extends BaseDistFunctionalTest<String, String> {
+
+   private final int MAX_NUM_SEGMENTS = 6;
+   private final int[][] owners1And2 = new int[][]{{0, 1}, {0, 1}, {0, 1}, {0, 1}, {0, 1}, {0, 1}};
+   private final int[][] owners1And3 = new int[][]{{0, 2}, {0, 2}, {0, 2}, {0, 2}, {0, 2}, {0, 2}};
+   private final ControlledConsistentHashFactory factory = new ControlledConsistentHashFactory.Default(owners1And2);
+
+   public StateTransferSegmentMetricsTest() {
+      INIT_CLUSTER_SIZE = 3;
+      numOwners = 2;
+      performRehashing = true;
+      cleanup = CleanupPhase.AFTER_METHOD;
+   }
+
+   {
+      transactional = true;
+   }
+
+   @AfterMethod
+   public void resetFactory() {
+      factory.setOwnerIndexes(owners1And2);
+   }
+
+   @Override
+   protected ConfigurationBuilder buildConfiguration() {
+      ConfigurationBuilder builder = super.buildConfiguration();
+      builder.clustering().hash().consistentHashFactory(factory).numSegments(MAX_NUM_SEGMENTS)
+            .transaction().transactionMode(TransactionMode.TRANSACTIONAL).lockingMode(LockingMode.OPTIMISTIC);
+      return builder;
+   }
+
+   @Test
+   public void testSegmentCounterDuringStateTransfer() throws Exception {
+      final StateTransferManager manager = TestingUtil.extractComponent(c3, StateTransferManager.class);
+      final CheckPoint checkPoint = new CheckPoint();
+
+      // Node 3 will request node 1 for transactions
+      waitTransactionRequest(c1, checkPoint);
+
+      // We have to wait until non owner has the new topology installed before transferring state
+      waitRequestingSegments(c3, checkPoint);
+
+      // Wait to receive segment batch.
+      waitApplyingSegmentBatch(c3, checkPoint);
+
+      // Change the ownership.
+      factory.setOwnerIndexes(owners1And3);
+
+      // New node joins the cluster to trigger the topology change.
+      EmbeddedCacheManager cm = addClusterEnabledCacheManager();
+      cm.defineConfiguration(cacheName, configuration.build());
+      Future<Void> join = fork(() -> {
+         waitForClusterToForm(cacheName);
+         log.debug("4th has joined");
+         return null;
+      });
+
+      // Node 3 is notified about topology change and request all the segments since the ownership changed.
+      // This also involves requesting the transactions, we wait to the provider receive the request
+      checkPoint.awaitStrict("topology_update_notify_invoked_" + c3, 10, TimeUnit.SECONDS);
+      checkPoint.awaitStrict("transactions_requested_invoked_" + c1, 10, TimeUnit.SECONDS);
+
+      assertEquals(manager.getInflightTransactionalSegmentCount(), MAX_NUM_SEGMENTS);
+      // Transferring states should be in progress.
+      assertTrue(manager.isStateTransferInProgress());
+
+      checkPoint.triggerForever("transactions_requested_released_" + c1);
+      checkPoint.awaitStrict("topology_update_notify_executed_" + c3, 10, TimeUnit.SECONDS);
+
+      // Node 3 already received the transactional segments
+      assertEquals(manager.getInflightTransactionalSegmentCount(), 0);
+
+      // Node 3 ask for data from all the segments he currently owns.
+      assertEquals(manager.getInflightSegmentTransferCount(), MAX_NUM_SEGMENTS);
+
+      checkPoint.triggerForever("topology_update_notify_released_" + c3);
+
+      checkPoint.awaitStrict("state_installed_invoked_" + c3, 10, TimeUnit.SECONDS);
+      assertEquals(manager.getInflightSegmentTransferCount(), MAX_NUM_SEGMENTS);
+      checkPoint.triggerForever("state_installed_invoked_release_" + c3);
+
+      // Wait until the batch is applied. If, for any reason, the batch does not have all the segments this will fail.
+      checkPoint.awaitStrict("state_applied_" + c3, 10, TimeUnit.SECONDS);
+      assertEquals(manager.getInflightSegmentTransferCount(), 0);
+
+      // We do not actually care about the new node.
+      join.cancel(true);
+   }
+
+   private void waitTransactionRequest(final Cache<?, ?> cache, final CheckPoint checkPoint) {
+      StateProvider sp = TestingUtil.extractComponent(cache, StateProvider.class);
+      final Answer<Object> forwardedAnswer = AdditionalAnswers.delegatesTo(sp);
+      StateProvider mockProvider = mock(StateProvider.class, withSettings().defaultAnswer(forwardedAnswer));
+      doAnswer(invocation -> {
+         checkPoint.trigger("transactions_requested_invoked_" + cache);
+         Object response = forwardedAnswer.answer(invocation);
+
+         try {
+            checkPoint.awaitStrict("transactions_requested_released_" + cache, 10, TimeUnit.SECONDS);
+            return response;
+         } catch (InterruptedException | TimeoutException e) {
+            throw new TestException(e);
+         }
+      }).when(mockProvider).getTransactionsForSegments(any(Address.class), anyInt(), any(IntSet.class));
+      TestingUtil.replaceComponent(cache, StateProvider.class, mockProvider, true);
+   }
+
+   private void waitRequestingSegments(final Cache<?, ?> cache, final CheckPoint checkPoint) {
+      StateConsumer sc = TestingUtil.extractComponent(cache, StateConsumer.class);
+      final Answer<Object> forwardedAnswer = AdditionalAnswers.delegatesTo(sc);
+      StateConsumer mockConsumer = mock(StateConsumer.class, withSettings().defaultAnswer(forwardedAnswer));
+      doAnswer(invocation -> {
+         // Wait for main thread to sync up
+         checkPoint.trigger("topology_update_notify_invoked_" + cache);
+         return ((CompletionStage<?>) forwardedAnswer.answer(invocation)).thenRun(() -> {
+            // Now wait until main thread lets us through
+            checkPoint.trigger("topology_update_notify_executed_" + cache);
+            try {
+               checkPoint.awaitStrict("topology_update_notify_released_" + cache, 10, TimeUnit.SECONDS);
+            } catch (InterruptedException | TimeoutException e) {
+               Thread.currentThread().interrupt();
+            }
+         });
+      }).when(mockConsumer).onTopologyUpdate(any(CacheTopology.class), anyBoolean());
+      TestingUtil.replaceComponent(cache, StateConsumer.class, mockConsumer, true);
+   }
+
+   private void waitApplyingSegmentBatch(final Cache<?, ?> cache, final CheckPoint checkPoint) {
+      StateConsumer sc = TestingUtil.extractComponent(cache, StateConsumer.class);
+      final Answer<Object> forwardedAnswer = AdditionalAnswers.delegatesTo(sc);
+      StateConsumer mockConsumer = mock(StateConsumer.class, withSettings().defaultAnswer(forwardedAnswer));
+      doAnswer(invocation -> {
+         // Sync with main thread
+         checkPoint.trigger("state_installed_invoked_" + cache);
+         // Proceed when main thread allows
+         checkPoint.awaitStrict("state_installed_invoked_release_" + cache, 10, TimeUnit.SECONDS);
+
+         // Apply the whole batch of segments and then issue a signal back to main thread.
+         return ((CompletionStage<?>) forwardedAnswer.answer(invocation))
+               .thenRun(() -> checkPoint.trigger("state_applied_" + cache));
+      }).when(mockConsumer).applyState(any(Address.class), anyInt(), anyBoolean(), anyCollection());
+      TestingUtil.replaceComponent(cache, StateConsumer.class, mockConsumer, true);
+   }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12335

An initial efftort to expose some metrics during cache rebalance.
Here we are exposing only the number of inflight requests for segments
during a rebalance. To count the number of current request we use the number
of current `InboundTransferTask`. This value is around a synchronized block,
so I am not quite sure if is the best approach.

The test for `StateConsumer` was changed to verify the counter and a new
test was added to verify the counter on the `StateTransferManagerImpl`.