### PR TITLE
ISPN-13695 Add migration helper module to fp

### DIFF
--- a/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/data/Person.java
+++ b/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/data/Person.java
@@ -1,10 +1,18 @@
 package org.infinispan.test.integration.data;
 
+import org.hibernate.search.annotations.Analyze;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.annotations.SortableField;
+import org.hibernate.search.annotations.Store;
 import org.infinispan.protostream.annotations.ProtoField;
 
+@Indexed
 public class Person {
 
    @ProtoField(1)
+   @Field(store = Store.YES, analyze = Analyze.NO)
+   @SortableField
    public String name;
 
    @ProtoField(2)

--- a/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/data/PersonHibernate.java
+++ b/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/data/PersonHibernate.java
@@ -1,0 +1,36 @@
+package org.infinispan.test.integration.data;
+
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.infinispan.protostream.annotations.ProtoField;
+
+@Indexed
+public class PersonHibernate {
+
+   @ProtoField(1)
+   @FullTextField
+   public String name;
+
+   @ProtoField(2)
+   public Integer id;
+
+   public PersonHibernate() {
+   }
+
+   public PersonHibernate(String name) {
+      this.name = name;
+   }
+
+   public PersonHibernate(String name, Integer id) {
+      this.name = name;
+      this.id = id;
+   }
+
+   public String getName() {
+      return name;
+   }
+
+   public Integer getId() {
+      return id;
+   }
+}

--- a/integrationtests/server-integration/wildfly-modules/src/test/java/org/infinispan/test/integration/as/hibernate/HibernateIT.java
+++ b/integrationtests/server-integration/wildfly-modules/src/test/java/org/infinispan/test/integration/as/hibernate/HibernateIT.java
@@ -1,0 +1,82 @@
+package org.infinispan.test.integration.as.hibernate;
+
+import static org.infinispan.commons.dataconversion.MediaType.APPLICATION_OBJECT_TYPE;
+import static org.infinispan.configuration.cache.IndexStorage.LOCAL_HEAP;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.List;
+
+import org.infinispan.Cache;
+import org.infinispan.commons.util.Version;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.manager.DefaultCacheManager;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.query.dsl.Query;
+import org.infinispan.query.dsl.QueryFactory;
+import org.infinispan.test.integration.data.Person;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+import org.jboss.shrinkwrap.descriptor.api.spec.se.manifest.ManifestDescriptor;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class HibernateIT {
+
+   private EmbeddedCacheManager cm;
+
+   @After
+   public void cleanUp() {
+      if (cm != null)
+         cm.stop();
+   }
+
+   @Before
+   public void start() {
+      cm = new DefaultCacheManager();
+      cm.createCache("myCache", new ConfigurationBuilder()
+            .encoding().mediaType(APPLICATION_OBJECT_TYPE)
+            .indexing().enable().storage(LOCAL_HEAP)
+            .addIndexedEntity(Person.class)
+            .build());
+   }
+
+   @Deployment
+   public static Archive<?> deployment() {
+      return ShrinkWrap
+            .create(WebArchive.class, "hibernate.war")
+            .addClass(HibernateIT.class)
+            .addClass(Person.class)
+            .add(manifest(), "META-INF/MANIFEST.MF");
+   }
+
+   private static Asset manifest() {
+      String manifest = Descriptors.create(ManifestDescriptor.class).attribute("Dependencies", "org.infinispan:" + Version.getModuleSlot() + " services").exportAsString();
+      return new StringAsset(manifest);
+   }
+
+   @Test
+   public void testLuceneQuery() {
+      Cache<Integer, Person> cache = cm.getCache("myCache");
+      cache.put(1, new Person("foo", 1));
+      cache.put(2, new Person("bar", 2));
+
+      // get account back from local cache via query and check its attributes
+      QueryFactory queryFactory = org.infinispan.query.Search.getQueryFactory(cache);
+      Query<Person> query = queryFactory.create(String.format("FROM %s WHERE name LIKE '%%fo%%'", Person.class.getName()));
+      List<Person> list = query.execute().list();
+
+      assertNotNull(list);
+      assertEquals(1, list.size());
+      assertEquals("foo", list.get(0).getName());
+   }
+}

--- a/wildfly/feature-pack/pom.xml
+++ b/wildfly/feature-pack/pom.xml
@@ -437,6 +437,17 @@
         </dependency>
 
         <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-v5migrationhelper-engine</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-core</artifactId>
             <exclusions>

--- a/wildfly/feature-pack/src/main/resources/modules/org/infinispan/slot/module.xml
+++ b/wildfly/feature-pack/src/main/resources/modules/org/infinispan/slot/module.xml
@@ -64,6 +64,7 @@
       <artifact name="${org.hibernate.search:hibernate-search-mapper-pojo-base}"/>
       <artifact name="${org.hibernate.search:hibernate-search-util-common}"/>
       <artifact name="${org.hibernate.search:hibernate-search-backend-lucene}"/>
+      <artifact name="${org.hibernate.search:hibernate-search-v5migrationhelper-engine}"/>
       <artifact name="${org.apache.lucene:lucene-core}"/>
       <artifact name="${org.apache.lucene:lucene-analyzers-common}"/>
       <artifact name="${org.apache.lucene:lucene-queryparser}"/>


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-13695

Reopen of #9888 to support legacy/deprecated old Hibernate Search 5 annotations.
@diegolovison created the test for it (fixed by this patch)