### PR TITLE
ISPN-13814 Add timeout configuration value when raising exception ISP…

### DIFF
--- a/core/src/main/java/org/infinispan/remoting/transport/impl/MultiTargetRequest.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/impl/MultiTargetRequest.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.infinispan.commons.util.Util;
 import org.infinispan.remoting.responses.CacheNotFoundResponse;
 import org.infinispan.remoting.responses.Response;
 import org.infinispan.remoting.transport.AbstractRequest;
@@ -167,6 +168,6 @@ public class MultiTargetRequest<T> extends AbstractRequest<T> {
                                              .filter(Objects::nonNull)
                                              .map(Object::toString)
                                              .collect(Collectors.joining(","));
-      completeExceptionally(CLUSTER.requestTimedOut(requestId, targetsWithoutResponses));
+      completeExceptionally(CLUSTER.requestTimedOut(requestId, targetsWithoutResponses, Util.prettyPrintTime(getTimeoutMs())));
    }
 }

--- a/core/src/main/java/org/infinispan/remoting/transport/impl/SingleTargetRequest.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/impl/SingleTargetRequest.java
@@ -5,6 +5,7 @@ import static org.infinispan.util.logging.Log.CLUSTER;
 import java.util.Objects;
 import java.util.Set;
 
+import org.infinispan.commons.util.Util;
 import org.infinispan.remoting.responses.CacheNotFoundResponse;
 import org.infinispan.remoting.responses.Response;
 import org.infinispan.remoting.transport.AbstractRequest;
@@ -82,6 +83,6 @@ public class SingleTargetRequest<T> extends AbstractRequest<T> {
    protected void onTimeout() {
       // The target might be null
       String targetString = Objects.toString(target);
-      completeExceptionally(CLUSTER.requestTimedOut(requestId, targetString));
+      completeExceptionally(CLUSTER.requestTimedOut(requestId, targetString, Util.prettyPrintTime(getTimeoutMs())));
    }
 }

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/SingleSiteRequest.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/SingleSiteRequest.java
@@ -4,6 +4,7 @@ import static org.infinispan.util.logging.Log.CLUSTER;
 
 import java.util.Set;
 
+import org.infinispan.commons.util.Util;
 import org.infinispan.remoting.responses.CacheNotFoundResponse;
 import org.infinispan.remoting.responses.Response;
 import org.infinispan.remoting.transport.AbstractRequest;
@@ -59,7 +60,7 @@ public class SingleSiteRequest<T> extends AbstractRequest<T> {
 
    @Override
    protected void onTimeout() {
-      completeExceptionally(CLUSTER.requestTimedOut(requestId, site));
+      completeExceptionally(CLUSTER.requestTimedOut(requestId, site, Util.prettyPrintTime(getTimeoutMs())));
    }
 
    public void sitesUnreachable(String unreachableSite) {

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -1638,8 +1638,8 @@ public interface Log extends BasicLogger {
    @Message(value = "Error processing response for request %d from %s", id = 475)
    void errorProcessingResponse(long requestId, org.jgroups.Address sender, @Cause Throwable t);
 
-   @Message(value = "Timed out waiting for responses for request %d from %s", id = 476)
-   TimeoutException requestTimedOut(long requestId, String targetsWithoutResponses);
+   @Message(value = "Timed out waiting for responses for request %d from %s after %s", id = 476)
+   TimeoutException requestTimedOut(long requestId, String targetsWithoutResponses, String elapsed);
 
    @LogMessage(level = ERROR)
    @Message(value = "Unable to perform operation %s for site %s", id = 477)

--- a/core/src/test/java/org/infinispan/util/ControlledRpcManager.java
+++ b/core/src/test/java/org/infinispan/util/ControlledRpcManager.java
@@ -539,7 +539,7 @@ public class ControlledRpcManager extends AbstractDelegatingRpcManager {
        */
       public void forceTimeout() {
          assertFalse(request.isDone());
-         request.fail(log.requestTimedOut(-1, "Induced timeout failure"));
+         request.fail(log.requestTimedOut(-1, "Induced timeout failure", "some time"));
       }
 
       /**
@@ -800,7 +800,7 @@ public class ControlledRpcManager extends AbstractDelegatingRpcManager {
        * Complete the request with a {@link TimeoutException}
        */
       public void forceTimeout() {
-         fail(log.requestTimedOut(-1, "Induced failure"));
+         fail(log.requestTimedOut(-1, "Induced failure", "some time"));
       }
 
       /**

--- a/core/src/test/java/org/infinispan/util/ControlledTransport.java
+++ b/core/src/test/java/org/infinispan/util/ControlledTransport.java
@@ -738,7 +738,7 @@ public class ControlledTransport extends AbstractDelegatingTransport {
        */
       public void forceTimeout() {
          assertFalse(request.isDone());
-         request.fail(log.requestTimedOut(-1, "Induced timeout failure"));
+         request.fail(log.requestTimedOut(-1, "Induced timeout failure", "some time"));
       }
 
       /**
@@ -1023,7 +1023,7 @@ public class ControlledTransport extends AbstractDelegatingTransport {
        * Complete the request with a {@link TimeoutException}
        */
       public void forceTimeout() {
-         fail(log.requestTimedOut(-1, "Induced failure"));
+         fail(log.requestTimedOut(-1, "Induced failure", "some time"));
       }
 
       /**

--- a/core/src/test/java/org/infinispan/xsite/irac/IracExponentialBackOffTest.java
+++ b/core/src/test/java/org/infinispan/xsite/irac/IracExponentialBackOffTest.java
@@ -84,7 +84,7 @@ public class IracExponentialBackOffTest extends SingleCacheManagerTest {
    }
 
    public void testSimulatedTimeout(Method method) throws InterruptedException {
-      doTest(method, () -> log.requestTimedOut(1, NYC));
+      doTest(method, () -> log.requestTimedOut(1, NYC, "some time"));
    }
 
    public void testSimulatedUnreachableException(Method method) throws InterruptedException {


### PR DESCRIPTION
…N000476: Timed out waiting for responses for request

https://issues.redhat.com/browse/ISPN-13814

We have a message like:

```
org.infinispan.util.concurrent.TimeoutException: ISPN000476: Timed out waiting for responses for request 5 from TimeoutExceptionTest-NodeB after 1.5 seconds
	at org.infinispan.remoting.transport.impl.SingleTargetRequest.onTimeout(SingleTargetRequest.java:85)
	at org.infinispan.remoting.transport.AbstractRequest.call(AbstractRequest.java:88)
	at org.infinispan.remoting.transport.AbstractRequest.call(AbstractRequest.java:22)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
```