### PR TITLE
ISPN-9366 Cache.size optimizations

### DIFF
--- a/core/src/main/java/org/infinispan/cache/impl/CacheImpl.java
+++ b/core/src/main/java/org/infinispan/cache/impl/CacheImpl.java
@@ -493,7 +493,7 @@ public class CacheImpl<K, V> implements AdvancedCache<K, V> {
    }
 
    final int size(long explicitFlags) {
-      SizeCommand command = commandsFactory.buildSizeCommand(explicitFlags);
+      SizeCommand command = commandsFactory.buildSizeCommand(null, explicitFlags);
       long size = invocationHelper.invoke(invocationContextFactory.createInvocationContext(false, UNBOUNDED), command);
       return size > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) size;
    }
@@ -504,7 +504,7 @@ public class CacheImpl<K, V> implements AdvancedCache<K, V> {
    }
 
    final CompletableFuture<Long> sizeAsync(long explicitFlags) {
-      SizeCommand command = commandsFactory.buildSizeCommand(explicitFlags);
+      SizeCommand command = commandsFactory.buildSizeCommand(null, explicitFlags);
       return invocationHelper.invokeAsync(invocationContextFactory.createInvocationContext(false, UNBOUNDED), command);
    }
 

--- a/core/src/main/java/org/infinispan/commands/CommandsFactory.java
+++ b/core/src/main/java/org/infinispan/commands/CommandsFactory.java
@@ -268,7 +268,7 @@ public interface CommandsFactory {
     * @param flagsBitSet Command flags provided by cache
     * @return a SizeCommand
     */
-   SizeCommand buildSizeCommand(long flagsBitSet);
+   SizeCommand buildSizeCommand(IntSet segments, long flagsBitSet);
 
    /**
     * Builds a GetKeyValueCommand

--- a/core/src/main/java/org/infinispan/commands/CommandsFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/commands/CommandsFactoryImpl.java
@@ -244,8 +244,8 @@ public class CommandsFactoryImpl implements CommandsFactory {
    }
 
    @Override
-   public SizeCommand buildSizeCommand(long flagsBitSet) {
-      return new SizeCommand(flagsBitSet);
+   public SizeCommand buildSizeCommand(IntSet segments, long flagsBitSet) {
+      return new SizeCommand(cacheName, segments, flagsBitSet);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/commands/RemoteCommandsFactory.java
+++ b/core/src/main/java/org/infinispan/commands/RemoteCommandsFactory.java
@@ -30,6 +30,7 @@ import org.infinispan.commands.irac.IracUpdateVersionCommand;
 import org.infinispan.commands.module.ModuleCommandFactory;
 import org.infinispan.commands.read.GetCacheEntryCommand;
 import org.infinispan.commands.read.GetKeyValueCommand;
+import org.infinispan.commands.read.SizeCommand;
 import org.infinispan.commands.remote.CacheRpcCommand;
 import org.infinispan.commands.remote.CheckTransactionRpcCommand;
 import org.infinispan.commands.remote.ClusteredGetAllCommand;
@@ -494,6 +495,9 @@ public class RemoteCommandsFactory {
                break;
             case IracPutManyCommand.COMMAND_ID:
                command = new IracPutManyCommand(cacheName);
+               break;
+            case SizeCommand.COMMAND_ID:
+               command = new SizeCommand(cacheName);
                break;
             default:
                throw new CacheException("Unknown command id " + id + "!");

--- a/core/src/main/java/org/infinispan/commands/read/SizeCommand.java
+++ b/core/src/main/java/org/infinispan/commands/read/SizeCommand.java
@@ -1,8 +1,21 @@
 package org.infinispan.commands.read;
 
-import org.infinispan.commands.VisitableCommand;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.concurrent.CompletionStage;
+
+import org.infinispan.commands.FlagAffectedCommand;
+import org.infinispan.commands.TopologyAffectedCommand;
 import org.infinispan.commands.Visitor;
+import org.infinispan.commands.remote.BaseRpcCommand;
+import org.infinispan.commons.util.EnumUtil;
+import org.infinispan.commons.util.IntSet;
 import org.infinispan.context.InvocationContext;
+import org.infinispan.context.InvocationContextFactory;
+import org.infinispan.factories.ComponentRegistry;
+import org.infinispan.interceptors.AsyncInterceptorChain;
+import org.infinispan.util.ByteString;
 
 /**
  * Command to calculate the size of the cache
@@ -12,10 +25,29 @@ import org.infinispan.context.InvocationContext;
  * @author <a href="http://gleamynode.net/">Trustin Lee</a>
  * @since 4.0
  */
-public class SizeCommand extends AbstractLocalCommand implements VisitableCommand {
-   public SizeCommand(long flags) {
+public class SizeCommand extends BaseRpcCommand implements FlagAffectedCommand, TopologyAffectedCommand {
+   public static final byte COMMAND_ID = 61;
+
+   private int topologyId = -1;
+   private long flags = EnumUtil.EMPTY_BIT_SET;
+   private IntSet segments;
+
+   public SizeCommand(
+         ByteString cacheName,
+         IntSet segments,
+         long flags
+   ) {
+      super(cacheName);
       setFlagsBitSet(flags);
+      this.segments = segments;
    }
+
+   public SizeCommand(ByteString name) {
+      super(name);
+   }
+
+   // Only here for CommandIdUniquenessTest
+   private SizeCommand() { super(null); }
 
    @Override
    public Object acceptVisitor(InvocationContext ctx, Visitor visitor) throws Throwable {
@@ -23,7 +55,70 @@ public class SizeCommand extends AbstractLocalCommand implements VisitableComman
    }
 
    @Override
+   public CompletionStage<?> invokeAsync(ComponentRegistry registry) throws Throwable {
+      InvocationContextFactory icf = registry.getInvocationContextFactory().running();
+      InvocationContext ctx = icf.createRemoteInvocationContextForCommand(this, getOrigin());
+      AsyncInterceptorChain invoker = registry.getInterceptorChain().running();
+      return invoker.invokeAsync(ctx, this);
+   }
+
+   @Override
+   public LoadType loadType() {
+      return LoadType.DONT_LOAD;
+   }
+
+   @Override
+   public byte getCommandId() {
+      return COMMAND_ID;
+   }
+
+   @Override
+   public boolean isReturnValueExpected() {
+      return true;
+   }
+
+   @Override
+   public int getTopologyId() {
+      return topologyId;
+   }
+
+   @Override
+   public void setTopologyId(int topologyId) {
+      this.topologyId = topologyId;
+   }
+
+   @Override
+   public long getFlagsBitSet() {
+      return flags;
+   }
+
+   @Override
+   public void setFlagsBitSet(long bitSet) {
+      this.flags = bitSet;
+   }
+
+   public IntSet getSegments() {
+      return segments;
+   }
+
+   @Override
+   public void writeTo(ObjectOutput output) throws IOException {
+      output.writeLong(flags);
+      output.writeObject(segments);
+   }
+
+   @Override
+   public void readFrom(ObjectInput input) throws IOException, ClassNotFoundException {
+      setFlagsBitSet(input.readLong());
+      segments = (IntSet) input.readObject();
+   }
+
+   @Override
    public String toString() {
-      return "SizeCommand{}";
+      return "SizeCommand{" +
+            "topologyId=" + topologyId +
+            ", flags=" + flags +
+            ", segments=" + segments +
+            '}';
    }
 }

--- a/core/src/main/java/org/infinispan/container/impl/AbstractDelegatingInternalDataContainer.java
+++ b/core/src/main/java/org/infinispan/container/impl/AbstractDelegatingInternalDataContainer.java
@@ -227,4 +227,9 @@ public abstract class AbstractDelegatingInternalDataContainer<K, V> implements I
    public void resize(long newSize) {
       delegate().resize(newSize);
    }
+
+   @Override
+   public boolean hasExpirable() {
+      return delegate().hasExpirable();
+   }
 }

--- a/core/src/main/java/org/infinispan/container/impl/DefaultSegmentedDataContainer.java
+++ b/core/src/main/java/org/infinispan/container/impl/DefaultSegmentedDataContainer.java
@@ -289,6 +289,7 @@ public class DefaultSegmentedDataContainer<K, V> extends AbstractInternalDataCon
          if (notifyListener && !map.isEmpty()) {
             listeners.forEach(c -> c.accept(map.values()));
          }
+         segmentRemoved(map);
          if (map instanceof AutoCloseable) {
             try {
                ((AutoCloseable) map).close();

--- a/core/src/main/java/org/infinispan/container/impl/InternalDataContainer.java
+++ b/core/src/main/java/org/infinispan/container/impl/InternalDataContainer.java
@@ -282,4 +282,12 @@ public interface InternalDataContainer<K, V> extends DataContainer<K, V> {
    default void cleanUp() {
       // Default is to do nothing
    }
+
+   /**
+    * Verify if the container has entries that can expire. This is __not__ the same thing as verifying
+    * for expired entries. This method can return true even if entries are not expired.
+    *
+    * @return true if any entry can expire, false otherwise.
+    */
+   boolean hasExpirable();
 }

--- a/core/src/main/java/org/infinispan/factories/ComponentRegistry.java
+++ b/core/src/main/java/org/infinispan/factories/ComponentRegistry.java
@@ -88,6 +88,7 @@ public class ComponentRegistry extends AbstractComponentRegistry {
    private ComponentRef<BackupSender> backupSender;
    private ComponentRef<BlockingManager> blockingManager;
    private ComponentRef<ClusterPublisherManager> clusterPublisherManager;
+   private ComponentRef<ClusterPublisherManager> localClusterPublisherManager;
    private ComponentRef<BiasManager> biasManager;
    private ComponentRef<CacheNotifier> cacheNotifier;
    private ComponentRef<ClusterCacheNotifier> clusterCacheNotifier;
@@ -376,6 +377,7 @@ public class ComponentRegistry extends AbstractComponentRegistry {
       backupSender = basicComponentRegistry.getComponent(BackupSender.class);
       blockingManager = basicComponentRegistry.getComponent(BlockingManager.class);
       clusterPublisherManager = basicComponentRegistry.getComponent(ClusterPublisherManager.class);
+      localClusterPublisherManager = basicComponentRegistry.getComponent(PublisherManagerFactory.LOCAL_CLUSTER_PUBLISHER, ClusterPublisherManager.class);
       takeOfflineManager = basicComponentRegistry.getComponent(TakeOfflineManager.class);
       cache = basicComponentRegistry.getComponent(AdvancedCache.class);
       cacheNotifier = basicComponentRegistry.getComponent(CacheNotifier.class);
@@ -446,6 +448,10 @@ public class ComponentRegistry extends AbstractComponentRegistry {
 
    public ComponentRef<ClusterPublisherManager> getClusterPublisherManager() {
       return clusterPublisherManager;
+   }
+
+   public ComponentRef<ClusterPublisherManager> getLocalClusterPublisherManager() {
+      return localClusterPublisherManager;
    }
 
    public ComponentRef<TakeOfflineManager> getTakeOfflineManager() {

--- a/core/src/main/java/org/infinispan/marshall/exts/CacheRpcCommandExternalizer.java
+++ b/core/src/main/java/org/infinispan/marshall/exts/CacheRpcCommandExternalizer.java
@@ -18,6 +18,7 @@ import org.infinispan.commands.irac.IracTombstoneRemoteSiteCheckCommand;
 import org.infinispan.commands.irac.IracTombstoneStateResponseCommand;
 import org.infinispan.commands.irac.IracTouchKeyCommand;
 import org.infinispan.commands.irac.IracUpdateVersionCommand;
+import org.infinispan.commands.read.SizeCommand;
 import org.infinispan.commands.remote.CacheRpcCommand;
 import org.infinispan.commands.remote.CheckTransactionRpcCommand;
 import org.infinispan.commands.remote.ClusteredGetAllCommand;
@@ -111,6 +112,7 @@ public final class CacheRpcCommandExternalizer extends AbstractExternalizer<Cach
             PutMapBackupWriteCommand.class,
             MultiEntriesFunctionalBackupWriteCommand.class,
             MultiKeyFunctionalBackupWriteCommand.class,
+            SizeCommand.class,
             BackupNoopCommand.class,
             InvalidateVersionsCommand.class,
             RevokeBiasCommand.class, RenewBiasCommand.class, ReductionPublisherRequestCommand.class,

--- a/core/src/main/java/org/infinispan/persistence/manager/PersistenceManager.java
+++ b/core/src/main/java/org/infinispan/persistence/manager/PersistenceManager.java
@@ -208,6 +208,20 @@ public interface PersistenceManager extends Lifecycle {
        return size(AccessMode.BOTH);
    }
 
+   default CompletionStage<Long> size(IntSet segments) {
+      return size(AccessMode.BOTH, segments);
+   }
+
+   /**
+    * Returns the count of how many entries are persisted in the given segments. If no store can handle the request
+    * for the given mode a value of <b>-1</b> is returned instead.
+    *
+    * @param predicate whether a loader can be used
+    * @param segments segments to check
+    * @return size or -1 if size couldn't be computed
+    */
+   CompletionStage<Long> size(Predicate<? super StoreConfiguration> predicate, IntSet segments);
+
    /**
     * Returns the count of how many entries are persisted. If no store can handle the request for the given mode a
     * value of <b>-1</b> is returned instead.

--- a/core/src/main/java/org/infinispan/persistence/support/DelegatingPersistenceManager.java
+++ b/core/src/main/java/org/infinispan/persistence/support/DelegatingPersistenceManager.java
@@ -237,6 +237,11 @@ public class DelegatingPersistenceManager implements PersistenceManager, Lifecyc
    }
 
    @Override
+   public CompletionStage<Long> size(Predicate<? super StoreConfiguration> predicate, IntSet segments) {
+      return persistenceManager.size(predicate, segments);
+   }
+
+   @Override
    public CompletionStage<Void> writeToAllNonTxStores(MarshallableEntry marshalledEntry, int segment,
                                                       Predicate<? super StoreConfiguration> predicate) {
       return persistenceManager.writeToAllNonTxStores(marshalledEntry, segment, predicate);

--- a/core/src/main/java/org/infinispan/reactive/publisher/impl/ClusterPublisherManager.java
+++ b/core/src/main/java/org/infinispan/reactive/publisher/impl/ClusterPublisherManager.java
@@ -94,4 +94,6 @@ public interface ClusterPublisherManager<K, V> {
    <R> SegmentPublisherSupplier<R> entryPublisher(IntSet segments, Set<K> keysToInclude, InvocationContext invocationContext,
          long explicitFlags, DeliveryGuarantee deliveryGuarantee, int batchSize,
          Function<? super Publisher<CacheEntry<K, V>>, ? extends Publisher<R>> transformer);
+
+   CompletionStage<Long> sizePublisher(IntSet segments, InvocationContext ctx, long flags);
 }

--- a/core/src/main/java/org/infinispan/reactive/publisher/impl/ClusterPublisherManagerImpl.java
+++ b/core/src/main/java/org/infinispan/reactive/publisher/impl/ClusterPublisherManagerImpl.java
@@ -27,8 +27,11 @@ import java.util.function.ObjIntConsumer;
 import java.util.function.Supplier;
 
 import org.infinispan.commands.CommandsFactory;
+import org.infinispan.commands.TopologyAffectedCommand;
+import org.infinispan.commands.read.SizeCommand;
 import org.infinispan.commons.CacheException;
 import org.infinispan.commons.IllegalLifecycleStateException;
+import org.infinispan.commons.util.EnumUtil;
 import org.infinispan.commons.util.IntSet;
 import org.infinispan.commons.util.IntSets;
 import org.infinispan.commons.util.Util;
@@ -38,6 +41,7 @@ import org.infinispan.configuration.cache.PersistenceConfiguration;
 import org.infinispan.configuration.cache.StoreConfiguration;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.context.InvocationContext;
+import org.infinispan.context.impl.FlagBitSets;
 import org.infinispan.distribution.DistributionInfo;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.distribution.LocalizedCacheTopology;
@@ -52,6 +56,7 @@ import org.infinispan.marshall.core.MarshallableFunctions;
 import org.infinispan.persistence.manager.PersistenceManager;
 import org.infinispan.persistence.manager.PersistenceManager.StoreChangeListener;
 import org.infinispan.reactive.RxJavaInterop;
+import org.infinispan.reactive.publisher.PublisherReducers;
 import org.infinispan.reactive.publisher.impl.commands.batch.CancelPublisherCommand;
 import org.infinispan.reactive.publisher.impl.commands.batch.InitialPublisherCommand;
 import org.infinispan.reactive.publisher.impl.commands.batch.NextPublisherCommand;
@@ -114,6 +119,11 @@ public class ClusterPublisherManagerImpl<K, V> implements ClusterPublisherManage
 
    private <R> EntryComposedType<R> entryComposedType() {
       return ENTRY_COMPOSED;
+   }
+
+   private final SizeComposedType SIZE_COMPOSED = new SizeComposedType();
+   private SizeComposedType sizeComposedType() {
+      return SIZE_COMPOSED;
    }
 
    private int maxSegment;
@@ -272,7 +282,7 @@ public class ClusterPublisherManagerImpl<K, V> implements ClusterPublisherManage
          for (Map.Entry<Address, Set<K>> remoteTarget : keyTargets.entrySet()) {
             Address remoteAddress = remoteTarget.getKey();
             Set<K> remoteKeys = remoteTarget.getValue();
-            ReductionPublisherRequestCommand<K> command = composedType.remoteInvocation(parallelPublisher, null, remoteKeys,
+            TopologyAffectedCommand command = composedType.remoteInvocation(parallelPublisher, null, remoteKeys,
                   null, explicitFlags, deliveryGuarantee, transformer, finalizer);
             command.setTopologyId(topology.getTopologyId());
             CompletionStage<PublisherResult<R>> stage = rpcManager.invokeCommand(remoteAddress, command,
@@ -348,7 +358,7 @@ public class ClusterPublisherManagerImpl<K, V> implements ClusterPublisherManage
          for (Map.Entry<Address, IntSet> remoteTarget : targets.entrySet()) {
             Address remoteAddress = remoteTarget.getKey();
             IntSet remoteSegments = remoteTarget.getValue();
-            ReductionPublisherRequestCommand<K> command = composedType.remoteInvocation(parallelPublisher, remoteSegments, null,
+            TopologyAffectedCommand command = composedType.remoteInvocation(parallelPublisher, remoteSegments, null,
                   keysToExcludeByAddress.get(remoteAddress), explicitFlags, deliveryGuarantee, transformer, finalizer);
             command.setTopologyId(topology.getTopologyId());
             CompletionStage<PublisherResult<R>> stage = rpcManager.invokeCommand(remoteAddress, command,
@@ -611,12 +621,21 @@ public class ClusterPublisherManagerImpl<K, V> implements ClusterPublisherManage
 
       @Override
       protected PublisherResult<R> addValidResponse(Address sender, ValidResponse response) {
-         PublisherResult<R> results = (PublisherResult<R>) response.getResponseValue();
-         if (log.isTraceEnabled()) {
-            log.tracef("Result was: %s for segments %s from %s with %s suspected segments", results.getResult(),
-                  targetSegments, sender, results.getSuspectedSegments());
+         Object value = response.getResponseValue();
+         if (value instanceof PublisherResult) {
+            PublisherResult<R> results = (PublisherResult<R>) value;
+            if (log.isTraceEnabled()) {
+               log.tracef("Result was: %s for segments %s from %s with %s suspected segments", results.getResult(),
+                     targetSegments, sender, results.getSuspectedSegments());
+            }
+            return results;
          }
-         return results;
+
+         if (log.isTraceEnabled()) {
+            log.tracef("Result was: %s for segments %s from %s.", value, targetSegments, sender);
+         }
+
+         return new SegmentPublisherResult<>(null, (R) value);
       }
 
       @Override
@@ -721,7 +740,7 @@ public class ClusterPublisherManagerImpl<K, V> implements ClusterPublisherManage
             Function<? super Publisher<I>, ? extends CompletionStage<R>> transformer,
             Function<? super Publisher<R>, ? extends CompletionStage<R>> finalizer);
 
-      ReductionPublisherRequestCommand<K> remoteInvocation(boolean parallelPublisher, IntSet segments, Set<K> keysToInclude,
+      TopologyAffectedCommand remoteInvocation(boolean parallelPublisher, IntSet segments, Set<K> keysToInclude,
             Set<K> keysToExclude, long explicitFlags, DeliveryGuarantee deliveryGuarantee,
             Function<? super Publisher<I>, ? extends CompletionStage<R>> transformer,
             Function<? super Publisher<R>, ? extends CompletionStage<R>> finalizer);
@@ -825,6 +844,50 @@ public class ClusterPublisherManagerImpl<K, V> implements ClusterPublisherManage
       }
    }
 
+   private class SizeComposedType implements ComposedType<K, Long, Long> {
+
+      @Override
+      public CompletionStage<PublisherResult<Long>> localInvocation(boolean parallelPublisher,
+         IntSet segments, Set<K> keysToInclude, Set<K> keysToExclude, long explicitFlags,
+         DeliveryGuarantee deliveryGuarantee,
+         Function<? super Publisher<Long>, ? extends CompletionStage<Long>> transformer,
+         Function<? super Publisher<Long>, ? extends CompletionStage<Long>> finalizer) {
+         return localPublisherManager.sizePublisher(segments, explicitFlags)
+               .thenApply(size -> new SegmentPublisherResult<>(null, size));
+      }
+
+      @Override
+      public SizeCommand remoteInvocation(boolean parallelPublisher, IntSet segments,
+                                          Set<K> keysToInclude, Set<K> keysToExclude,
+                                          long explicitFlags,
+                                          DeliveryGuarantee deliveryGuarantee,
+                                          Function<? super Publisher<Long>, ? extends CompletionStage<Long>> transformer,
+                                          Function<? super Publisher<Long>, ? extends CompletionStage<Long>> finalizer) {
+         return commandsFactory.buildSizeCommand(segments, EnumUtil.mergeBitSets(explicitFlags, FlagBitSets.CACHE_MODE_LOCAL));
+      }
+
+      @Override
+      public CompletionStage<PublisherResult<Long>> contextInvocation(IntSet segments, Set<K> keysToInclude,
+         InvocationContext ctx, Function<? super Publisher<Long>, ? extends CompletionStage<Long>> transformer) {
+         throw new IllegalStateException("Should never be invoked!");
+      }
+
+      @Override
+      public boolean isEntry() {
+         return false;
+      }
+
+      @Override
+      public K toKey(Long value) {
+         throw new IllegalStateException("Should never be invoked!");
+      }
+
+      @Override
+      public Long fromCacheEntry(CacheEntry entry) {
+         throw new IllegalStateException("Should never be invoked!");
+      }
+   }
+
    private boolean hasWriteBehindSharedStore(PersistenceConfiguration persistenceConfiguration) {
       for (StoreConfiguration storeConfiguration : persistenceConfiguration.stores()) {
          if (storeConfiguration.shared() && storeConfiguration.async().enabled()) {
@@ -859,6 +922,12 @@ public class ClusterPublisherManagerImpl<K, V> implements ClusterPublisherManage
       }
       return new SegmentAwarePublisherImpl<>(segments, entryComposedType(), invocationContext, explicitFlags,
                                              deliveryGuarantee, batchSize, transformer);
+   }
+
+   @Override
+   public CompletionStage<Long> sizePublisher(IntSet segments, InvocationContext ctx, long flags) {
+      return reduction(false, segments, null, ctx, flags, DeliveryGuarantee.EXACTLY_ONCE,
+            sizeComposedType(), null, PublisherReducers.add());
    }
 
    private final static AtomicInteger requestCounter = new AtomicInteger();

--- a/core/src/main/java/org/infinispan/reactive/publisher/impl/LocalClusterPublisherManagerImpl.java
+++ b/core/src/main/java/org/infinispan/reactive/publisher/impl/LocalClusterPublisherManagerImpl.java
@@ -205,4 +205,9 @@ public class LocalClusterPublisherManagerImpl<K, V> implements ClusterPublisherM
          }
       };
    }
+
+   @Override
+   public CompletionStage<Long> sizePublisher(IntSet segments, InvocationContext ctx, long flags) {
+      return localPublisherManager.sizePublisher(segments, flags);
+   }
 }

--- a/core/src/main/java/org/infinispan/reactive/publisher/impl/LocalPublisherManager.java
+++ b/core/src/main/java/org/infinispan/reactive/publisher/impl/LocalPublisherManager.java
@@ -129,4 +129,6 @@ public interface LocalPublisherManager<K, V> {
     * @param lostSegments the segments that are being removed from this node
     */
    void segmentsLost(IntSet lostSegments);
+
+   CompletionStage<Long> sizePublisher(IntSet segments, long flags);
 }

--- a/core/src/main/java/org/infinispan/reactive/publisher/impl/LocalPublisherManagerImpl.java
+++ b/core/src/main/java/org/infinispan/reactive/publisher/impl/LocalPublisherManagerImpl.java
@@ -21,6 +21,7 @@ import org.infinispan.cache.impl.InvocationHelper;
 import org.infinispan.commands.CommandsFactory;
 import org.infinispan.commands.read.EntrySetCommand;
 import org.infinispan.commands.read.KeySetCommand;
+import org.infinispan.commands.read.SizeCommand;
 import org.infinispan.commons.util.EnumUtil;
 import org.infinispan.commons.util.IntSet;
 import org.infinispan.commons.util.IntSets;
@@ -34,6 +35,7 @@ import org.infinispan.container.entries.NullCacheEntry;
 import org.infinispan.context.Flag;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.InvocationContextFactory;
+import org.infinispan.context.impl.FlagBitSets;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.distribution.LocalizedCacheTopology;
 import org.infinispan.distribution.ch.KeyPartitioner;
@@ -383,6 +385,14 @@ public class LocalPublisherManagerImpl<K, V> implements LocalPublisherManager<K,
          log.tracef("Notifying listeners of lost segments %s", lostSegments);
       }
       changeListener.forEach(lostSegments::forEach);
+   }
+
+   @Override
+   public CompletionStage<Long> sizePublisher(IntSet segments, long flags) {
+      SizeCommand command = commandsFactory.buildSizeCommand(
+            segments, EnumUtil.mergeBitSets(flags, FlagBitSets.CACHE_MODE_LOCAL));
+      InvocationContext ctx = invocationContextFactory.createInvocationContext(false, UNBOUNDED);
+      return CompletableFuture.completedFuture(invocationHelper.running().invoke(ctx, command));
    }
 
    private static Function<Object, PublisherResult<Object>> ignoreSegmentsFunction = value ->

--- a/core/src/test/java/org/infinispan/api/SizeOptimizationTests.java
+++ b/core/src/test/java/org/infinispan/api/SizeOptimizationTests.java
@@ -1,0 +1,335 @@
+package org.infinispan.api;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
+import static org.testng.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+import javax.transaction.TransactionManager;
+
+import org.infinispan.Cache;
+import org.infinispan.commons.util.IntSet;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.container.entries.InternalCacheEntry;
+import org.infinispan.container.impl.AbstractDelegatingInternalDataContainer;
+import org.infinispan.container.impl.InternalDataContainer;
+import org.infinispan.context.Flag;
+import org.infinispan.persistence.dummy.DummyInMemoryStoreConfigurationBuilder;
+import org.infinispan.reactive.publisher.impl.ClusterPublisherManager;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.TestException;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.CheckPoint;
+import org.infinispan.transaction.LockingMode;
+import org.infinispan.transaction.lookup.EmbeddedTransactionManagerLookup;
+import org.mockito.AdditionalAnswers;
+import org.mockito.stubbing.Answer;
+import org.reactivestreams.Publisher;
+import org.testng.annotations.Test;
+
+@Test(groups = "functional", testName = "api.SizeOptimizationTests")
+public class SizeOptimizationTests extends MultipleCacheManagersTest {
+
+   private static final String CACHE_NAME = "SizeOptimizationsTest";
+   private static final int ENTRIES_SIZE = 42;
+   private Optimization optimization;
+
+   public SizeOptimizationTests optimization(Optimization optimization) {
+      this.optimization = optimization;
+      return this;
+   }
+
+   enum Optimization {
+      /**
+       * If the store is not asynchronous and is shared we can optimize to directly read the store size.
+       * Using this optimization, the default implementation should never be used.
+       */
+      SHARED {
+         @Override
+         public ConfigurationBuilder configure(ConfigurationBuilder builder) {
+            builder.persistence()
+                  .passivation(false)
+                  .addStore(DummyInMemoryStoreConfigurationBuilder.class)
+                     .storeName(name())
+                     .shared(true)
+                  .async()
+                     .disable();
+            return builder;
+         }
+
+         @Override
+         public void verify(Cache<Object, Object> cache, SizeOptimizationTests test) throws Exception {
+            neverCallDefault(cache);
+            replaceDataContainerNotIterable(cache);
+
+            assertEquals(cache.size(), ENTRIES_SIZE);
+            int halfEntries = ENTRIES_SIZE / 2;
+
+            for (int i = 0; i < halfEntries; i++) {
+               cache.remove("key-" + i);
+            }
+
+            assertEquals(cache.size(), halfEntries);
+         }
+      },
+
+      /**
+       * If the store is private, segmented, and we have the CACHE_MODE_LOCAL flag set, then we can optimize
+       * to directly call the container size. Using this optimization the default implementation should never be used.
+       */
+      SEGMENTED {
+         @Override
+         public ConfigurationBuilder configure(ConfigurationBuilder builder) {
+            builder.persistence()
+                  .passivation(false)
+                  .addStore(DummyInMemoryStoreConfigurationBuilder.class)
+                     .storeName(name())
+                     .shared(false)
+                     .segmented(true)
+                     .async().disable()
+                  .clustering()
+                     .hash().numSegments(3);
+            return builder;
+         }
+
+         @Override
+         public void verify(Cache<Object, Object> cache, SizeOptimizationTests test) {
+            neverCallDefault(cache);
+            final Cache<Object, Object> localCache = cache.getAdvancedCache().withFlags(Flag.CACHE_MODE_LOCAL);
+
+            // We retrieve the entries using __only__ the local cache and use it to verify the size.
+            // Do not use the constructor passing the original set because that will call the .size() method.
+            Set<Object> beforeEntries = new HashSet<>(ENTRIES_SIZE);
+            beforeEntries.addAll(localCache.entrySet());
+
+            // Replace the container only when verifying the size.
+            // We can not replace all because we retrieve the key set.
+            brieflyReplaceDataContainerNotIterable(localCache, () -> {
+               assertEquals(localCache.size(), beforeEntries.size());
+               return null;
+            });
+
+            int halfEntries = ENTRIES_SIZE / 2;
+            for (int i = 0; i < halfEntries; i++) {
+               cache.remove("key-" + i);
+            }
+
+            Set<Object> afterEntries = new HashSet<>(halfEntries);
+            afterEntries.addAll(localCache.entrySet());
+            brieflyReplaceDataContainerNotIterable(localCache, () -> {
+               assertEquals(localCache.size(), afterEntries.size());
+               return null;
+            });
+         }
+      },
+
+      /**
+       * If we are not using any store, do not have any entries that expire, and have the CACHE_MODE_LOCAL flag set,
+       * we can directly call the container size method. Here the test is a little longer because we verify that the
+       * optimization is called only when the entries with lifetime are removed.
+       */
+      NO_STORE {
+         @Override
+         public ConfigurationBuilder configure(ConfigurationBuilder builder) {
+            builder.persistence()
+                  .passivation(false)
+                  .clearStores();
+            builder.transaction()
+                  .lockingMode(LockingMode.OPTIMISTIC)
+                  .transactionManagerLookup(new EmbeddedTransactionManagerLookup());
+            return builder;
+         }
+
+         @Override
+         public void verify(Cache<Object, Object> cache, SizeOptimizationTests test) throws Exception {
+            final CheckPoint checkPoint = new CheckPoint();
+            final Cache<Object, Object> localCache = cache.getAdvancedCache().withFlags(Flag.CACHE_MODE_LOCAL);
+            waitDefaultCalledMaxTo(localCache, checkPoint, 1);
+
+            // We do a cluster wide search here, since we have entries with expiration set, the optimization is
+            // not triggered.
+            Future<Void> verifySize = test.fork(() -> {
+               // Execution in a transaction skip the distributed optimization.
+               TransactionManager tm = cache.getAdvancedCache().getTransactionManager();
+               tm.begin();
+               try {
+                  cache.put("key-tx", "value-tx");
+                  assertEquals(cache.size(), ENTRIES_SIZE + 1);
+                  cache.remove("key-tx");
+               } finally {
+                  tm.rollback();
+               }
+            });
+
+            checkPoint.awaitStrict("default_invoked_done_" + localCache, 10, TimeUnit.SECONDS);
+            checkPoint.trigger("default_invoked_done_proceed_" + localCache, 1);
+            verifySize.get(10, TimeUnit.SECONDS);
+
+            for (int i = 0; i < ENTRIES_SIZE; i++) {
+               if ((i & 1) == 1) {
+                  localCache.remove("key-" + i);
+               }
+            }
+
+
+            // We retrieve the entries using __only__ the local cache and use it to verify the size.
+            // Do not use the constructor passing the original set because that will call the .size() method.
+            Set<Object> entries = new HashSet<>(ENTRIES_SIZE / 2);
+            entries.addAll(localCache.entrySet());
+            replaceDataContainerNotIterable(cache);
+            assertEquals(localCache.size(), entries.size());
+         }
+      },
+      ;
+
+      public abstract ConfigurationBuilder configure(ConfigurationBuilder builder);
+
+      public abstract void verify(Cache<Object, Object> cache, SizeOptimizationTests test) throws Exception;
+   }
+
+   @Override public Object[] factory() {
+      return Arrays.stream(Optimization.values())
+            .map(o -> new SizeOptimizationTests().optimization(o))
+            .toArray();
+   }
+
+   @Override
+   protected Object[] parameterValues() {
+      return new Object[] { optimization };
+   }
+
+   @Override
+   protected String[] parameterNames() {
+      return new String[] { "optimization" };
+   }
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC);
+      createClusteredCaches(3, CACHE_NAME, optimization.configure(builder));
+   }
+
+   public void testSizeReturnsCorrectly() throws Exception {
+      final Cache<Object, Object> cache = cache(0, CACHE_NAME);
+
+      for (int i = 0; i < ENTRIES_SIZE; i++) {
+         if ((i & 1) == 1) {
+            cache.put("key-" + i, "v" + i, 30, TimeUnit.SECONDS);
+         } else {
+            cache.put("key-" + i, "v" + i);
+         }
+      }
+
+      optimization.verify(cache, this);
+   }
+
+   private static void waitDefaultCalledMaxTo(final Cache<?, ?> cache, final CheckPoint checkPoint, int maxCalls) {
+      final AtomicInteger executionTimes = new AtomicInteger(maxCalls);
+      createMocking(cache, original -> invocation -> {
+         if (executionTimes.getAndDecrement() == 0) {
+            throw new TestException("Called more than " + maxCalls + " times to " + invocation.getMethod().getName());
+         }
+
+         CompletionStage<Object> result = ((CompletionStage<Object>) original.answer(invocation));
+         result.thenRun(() -> {
+            checkPoint.trigger("default_invoked_done_" + cache, 1);
+            try {
+               checkPoint.awaitStrict("default_invoked_done_proceed_" + cache, 10, TimeUnit.SECONDS);
+            } catch (InterruptedException | TimeoutException e) {
+               throw new TestException(e);
+            }
+         });
+         return result;
+      });
+   }
+
+   private static void neverCallDefault(final Cache<?, ?> cache) {
+      waitDefaultCalledMaxTo(cache, null, 0);
+   }
+
+   private static void createMocking(final Cache<?, ?> cache, Function<Answer<Object>, Answer<?>> forward) {
+      ClusterPublisherManager<?, ?> cpm = TestingUtil.extractComponent(cache, ClusterPublisherManager.class);
+      final Answer<Object> forwardedAnswer = AdditionalAnswers.delegatesTo(cpm);
+      ClusterPublisherManager<?, ?> mockCpm = mock(ClusterPublisherManager.class, withSettings().defaultAnswer(forwardedAnswer));
+      doAnswer(forward.apply(forwardedAnswer))
+            .when(mockCpm).keyReduction(anyBoolean(), any(), any(), any(), anyLong(), any(), any(), any());
+      TestingUtil.replaceComponent(cache, ClusterPublisherManager.class, mockCpm, true);
+   }
+
+   private static void brieflyReplaceDataContainerNotIterable(final Cache<?, ?> cache, Callable<Void> callable) {
+      IDCNotIterable controlled = new IDCNotIterable(cache);
+      TestingUtil.replaceComponent(cache, InternalDataContainer.class, controlled, true);
+
+      try {
+         callable.call();
+      } catch (Exception e) {
+         throw new TestException("Failed on callable", e);
+      } finally {
+         TestingUtil.replaceComponent(cache, InternalDataContainer.class, controlled.current, true);
+      }
+   }
+
+   private static void replaceDataContainerNotIterable(final Cache<?, ?> cache) {
+      InternalDataContainer<?, ?> controlled = new IDCNotIterable(cache);
+      TestingUtil.replaceComponent(cache, InternalDataContainer.class, controlled, true);
+   }
+
+   static class IDCNotIterable extends AbstractDelegatingInternalDataContainer {
+      final InternalDataContainer<?, ?> current;
+
+      IDCNotIterable(Cache<?, ?> cache) {
+         this.current = TestingUtil.extractComponent(cache, InternalDataContainer.class);
+      }
+
+      @Override
+      protected InternalDataContainer<?, ?> delegate() {
+         return current;
+      }
+
+      @Override
+      public Iterator<InternalCacheEntry<?, ?>> iterator() {
+         throw new TestException("Should not call iterator");
+      }
+
+      @Override
+      public Iterator<InternalCacheEntry<?, ?>> iterator(IntSet segments) {
+         throw new TestException("Should not call iterator");
+      }
+
+      @Override
+      public Iterator<InternalCacheEntry<?, ?>> iteratorIncludingExpired() {
+         throw new TestException("Should not call iterator");
+      }
+
+      @Override
+      public Iterator<InternalCacheEntry<?, ?>> iteratorIncludingExpired(IntSet segments) {
+         throw new TestException("Should not call iterator");
+      }
+
+      @Override
+      public Publisher<InternalCacheEntry> publisher(int segment) {
+         throw new TestException("Should not call publisher");
+      }
+
+      @Override
+      public Publisher<InternalCacheEntry> publisher(IntSet segments) {
+         throw new TestException("Should not call publisher");
+      }
+   }
+}

--- a/core/src/test/java/org/infinispan/util/mocks/ControlledCommandFactory.java
+++ b/core/src/test/java/org/infinispan/util/mocks/ControlledCommandFactory.java
@@ -258,8 +258,8 @@ public class ControlledCommandFactory implements CommandsFactory {
    }
 
    @Override
-   public SizeCommand buildSizeCommand(long flagsBitSet) {
-      return actual.buildSizeCommand(flagsBitSet);
+   public SizeCommand buildSizeCommand(IntSet segments, long flagsBitSet) {
+      return actual.buildSizeCommand(segments, flagsBitSet);
    }
 
    @Override


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-9366

Optimizing for the cases where:

1. Store is shared
2. No store in use, no expired entries and `CACHE_MODE_LOCAL` is set
3. Store is private and `CACHE_MODE_LOCAL` is set

In such cases we can use the `size` method from the data container directly.