### PR TITLE
ISPN-13813 Hot Rod client uses "greater than" for comparison but topology ID resets on full cluster restart

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/ChannelFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/ChannelFactory.java
@@ -322,7 +322,7 @@ public class ChannelFactory {
 
          // Only accept the update if it's from the current age and the topology id is greater than the current one
          // Relies on TopologyInfo.switchCluster() to update the topologyAge for caches first
-         if (responseTopologyAge == cacheInfo.getTopologyAge() && responseTopologyId > cacheInfo.getTopologyId()) {
+         if (responseTopologyAge == cacheInfo.getTopologyAge() && responseTopologyId != cacheInfo.getTopologyId()) {
             List<InetSocketAddress> addressList = Arrays.asList(addresses);
             HOTROD.newTopology(responseTopologyId, responseTopologyAge, addresses.length, addressList);
             CacheInfo newCacheInfo;
@@ -330,7 +330,7 @@ public class ChannelFactory {
                SegmentConsistentHash consistentHash =
                      createConsistentHash(segmentOwners, hashFunctionVersion, cacheInfo.getCacheName());
                newCacheInfo = cacheInfo.withNewHash(responseTopologyAge, responseTopologyId, addressList,
-                                                       consistentHash, segmentOwners.length);
+                     consistentHash, segmentOwners.length);
             } else {
                newCacheInfo = cacheInfo.withNewServers(responseTopologyAge, responseTopologyId, addressList);
             }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HotRodServerStartStopTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HotRodServerStartStopTest.java
@@ -4,11 +4,19 @@ import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killRemo
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
 import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertNull;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.Arrays;
 
 import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.server.hotrod.HotRodServer;
+import org.infinispan.server.hotrod.configuration.HotRodServerConfigurationBuilder;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
@@ -19,8 +27,20 @@ import org.testng.annotations.Test;
  */
 @Test(testName = "client.hotrod.HotRodServerStartStopTest", groups = "functional")
 public class HotRodServerStartStopTest extends MultipleCacheManagersTest {
+
+   private static int randomPort() {
+      try {
+         ServerSocket socket = new ServerSocket(0);
+         return socket.getLocalPort();
+      } catch (IOException e) {
+         return 56001;
+      }
+   }
+
+   private final static int FIRST_SERVER_PORT = randomPort();
    private HotRodServer hotRodServer1;
    private HotRodServer hotRodServer2;
+   private HotRodServer hotRodServer3;
 
    @AfterMethod
    @Override
@@ -33,12 +53,11 @@ public class HotRodServerStartStopTest extends MultipleCacheManagersTest {
             getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false));
       addClusterEnabledCacheManager(builder);
       addClusterEnabledCacheManager(builder);
+      addClusterEnabledCacheManager(builder);
 
-      hotRodServer1 = HotRodClientTestingUtil.startHotRodServer(manager(0));
+      hotRodServer1 = HotRodClientTestingUtil.startHotRodServer(manager(0), FIRST_SERVER_PORT, new HotRodServerConfigurationBuilder());
       hotRodServer2 = HotRodClientTestingUtil.startHotRodServer(manager(1));
-
-      assert manager(0).getCache() != null;
-      assert manager(1).getCache() != null;
+      hotRodServer3 = HotRodClientTestingUtil.startHotRodServer(manager(2));
 
       waitForClusterToForm();
    }
@@ -51,13 +70,34 @@ public class HotRodServerStartStopTest extends MultipleCacheManagersTest {
       RemoteCache<Object, Object> remoteCache = remoteCacheManager.getCache();
       remoteCache.put("k", "v");
       assertEquals("v", remoteCache.get("k"));
-      killRemoteCacheManager(remoteCacheManager);
-   }
 
-   @Test (dependsOnMethods = "testTouchServer")
-   public void testHrServerStop() {
-      killServers(hotRodServer1, hotRodServer2);
+      CacheTopologyInfo info = remoteCache.getCacheTopologyInfo();
+      Integer prevTop = info.getTopologyId();
+
+      killServers(hotRodServer1, hotRodServer2, hotRodServer3);
+
+      Arrays.stream(managers()).forEach(EmbeddedCacheManager::stop);
+      cacheManagers.clear();
+
       hotRodServer1 = null;
       hotRodServer2 = null;
+      hotRodServer3 = null;
+
+      ConfigurationBuilder builder = hotRodCacheConfiguration(
+            getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false));
+      addClusterEnabledCacheManager(builder);
+
+      hotRodServer1 = HotRodClientTestingUtil.startHotRodServer(manager(0), FIRST_SERVER_PORT, new HotRodServerConfigurationBuilder());
+
+      // data was loss on restart
+      assertNull(remoteCache.get("k1"));
+
+      if (prevTop != null) {
+         assertFalse("Topology is still the same: " + prevTop, prevTop.equals(remoteCache.getCacheTopologyInfo().getTopologyId()));
+      }
+
+      killRemoteCacheManager(remoteCacheManager);
+      killServers(hotRodServer1);
+      hotRodServer1 = null;
    }
 }

--- a/commons/all/src/main/java/org/infinispan/commons/util/ImmutableListCopy.java
+++ b/commons/all/src/main/java/org/infinispan/commons/util/ImmutableListCopy.java
@@ -233,9 +233,7 @@ public class ImmutableListCopy<E> extends AbstractList<E> implements Immutables.
 
    @Override
    public int hashCode() {
-      int result = super.hashCode();
-      result = 31 * result + Arrays.hashCode(elements);
-      return result;
+      return Arrays.hashCode(elements);
    }
 
    @SuppressWarnings("rawtypes")

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/HotRodServer.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/HotRodServer.java
@@ -34,6 +34,7 @@ import org.infinispan.commons.logging.LogFactory;
 import org.infinispan.commons.marshall.Externalizer;
 import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.commons.marshall.SerializeWith;
+import org.infinispan.commons.time.TimeService;
 import org.infinispan.commons.util.ServiceFinder;
 import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.CacheMode;
@@ -123,6 +124,7 @@ public class HotRodServer extends AbstractProtocolServer<HotRodServerConfigurati
    private ClientCounterManagerNotificationManager clientCounterNotificationManager;
    private HotRodAccessLogging accessLogging = new HotRodAccessLogging();
    private ScheduledExecutorService scheduledExecutor;
+   private TimeService timeService;
 
    public HotRodServer() {
       super("HotRod");
@@ -138,6 +140,10 @@ public class HotRodServer extends AbstractProtocolServer<HotRodServerConfigurati
 
    public Marshaller getMarshaller() {
       return marshaller;
+   }
+
+   public TimeService getTimeService() {
+      return timeService;
    }
 
    byte[] query(AdvancedCache<byte[], byte[]> cache, byte[] query) {
@@ -320,10 +326,12 @@ public class HotRodServer extends AbstractProtocolServer<HotRodServerConfigurati
       topologyChangeListener = new ReAddMyAddressListener(addressCache, clusterAddress, address);
       addressCache.addListener(topologyChangeListener);
 
+      timeService = SecurityActions.getGlobalComponentRegistry(cacheManager).getTimeService();
+
       // Map cluster address to server endpoint address
       log.debugf("Map %s cluster address with %s server endpoint in address cache", clusterAddress, address);
       addressCache.getAdvancedCache().withFlags(Flag.IGNORE_RETURN_VALUES)
-                  .put(clusterAddress, address);
+            .put(clusterAddress, address);
    }
 
    private void defineTopologyCacheConfig(EmbeddedCacheManager cacheManager) {

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/HotRodVersion.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/HotRodVersion.java
@@ -79,6 +79,6 @@ public enum HotRodVersion {
    }
 
    public static VersionedEncoder getEncoder(byte version) {
-      return new Encoder2x();
+      return Encoder2x.instance();
    }
 }

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/SecurityActions.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/SecurityActions.java
@@ -98,4 +98,8 @@ final class SecurityActions {
          return cache;
       }
    }
+
+   static String getSystemProperty(String propertyName) {
+      return doPrivileged(() -> System.getProperty(propertyName));
+   }
 }

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/logging/Log.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/logging/Log.java
@@ -3,6 +3,7 @@ package org.infinispan.server.hotrod.logging;
 import static org.jboss.logging.Logger.Level.ERROR;
 import static org.jboss.logging.Logger.Level.WARN;
 
+import java.net.SocketAddress;
 import java.util.Set;
 
 import org.infinispan.commons.CacheConfigurationException;
@@ -111,4 +112,8 @@ public interface Log extends BasicLogger {
 
    @Message(value = "Invalid mech '%s'", id = 28028)
    IllegalArgumentException invalidMech(String mech);
+
+   @LogMessage(level = WARN)
+   @Message(value = "Client %s keeps providing outdated topology %s", id = 28029)
+   void clientNotUpdatingTopology(SocketAddress socketAddress, int topologyId);
 }

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodDistributionTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodDistributionTest.java
@@ -26,7 +26,6 @@ import org.infinispan.server.hotrod.test.HotRodTestingUtil;
 import org.infinispan.server.hotrod.test.TestResponse;
 import org.infinispan.server.hotrod.test.TestSizeResponse;
 import org.infinispan.test.TestingUtil;
-import org.infinispan.topology.ClusterCacheStatus;
 import org.testng.annotations.Test;
 
 /**
@@ -71,10 +70,11 @@ public class HotRodDistributionTest extends HotRodMultiNodeTest {
 
       resp = client2.put(k(m), 0, 0, v(m, "v2-"), INTELLIGENCE_TOPOLOGY_AWARE, 0);
       assertStatus(resp, Success);
-      assertTopologyReceived(resp.topologyResponse, servers(), currentServerTopologyId());
+      int serverClientTopologyId = currentServerTopologyId();
+      assertTopologyReceived(resp.topologyResponse, servers(), serverClientTopologyId);
 
       resp = client1.put(k(m), 0, 0, v(m, "v3-"), INTELLIGENCE_TOPOLOGY_AWARE,
-                         ClusterCacheStatus.INITIAL_TOPOLOGY_ID + 2 * nodeCount());
+            serverClientTopologyId);
       assertStatus(resp, Success);
       assertEquals(resp.topologyResponse, null);
       assertSuccess(client2.get(k(m), 0), v(m, "v3-"));
@@ -115,8 +115,7 @@ public class HotRodDistributionTest extends HotRodMultiNodeTest {
          log.trace("New server stopped");
       }
 
-      resp = client2.put(k(m), 0, 0, v(m, "v8-"), INTELLIGENCE_HASH_DISTRIBUTION_AWARE,
-                         ClusterCacheStatus.INITIAL_TOPOLOGY_ID + 2 * nodeCount());
+      resp = client2.put(k(m), 0, 0, v(m, "v8-"), INTELLIGENCE_HASH_DISTRIBUTION_AWARE, 0);
       assertStatus(resp, Success);
       assertHashTopology20Received(resp.topologyResponse, servers(), cacheName(), currentServerTopologyId());
 

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/test/HotRodTestingUtil.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/test/HotRodTestingUtil.java
@@ -34,6 +34,7 @@ import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.container.entries.CacheEntry;
+import org.infinispan.distribution.DistributionManager;
 import org.infinispan.distribution.LocalizedCacheTopology;
 import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.manager.DefaultCacheManager;
@@ -48,6 +49,7 @@ import org.infinispan.server.hotrod.configuration.HotRodServerConfigurationBuild
 import org.infinispan.server.hotrod.logging.Log;
 import org.infinispan.server.hotrod.transport.TestHandlersChannelInitializer;
 import org.infinispan.server.hotrod.transport.TimeoutEnabledChannelInitializer;
+import org.infinispan.test.TestingUtil;
 import org.infinispan.util.KeyValuePair;
 
 import io.netty.channel.Channel;
@@ -306,7 +308,8 @@ public class HotRodTestingUtil {
    }
 
    public static int getServerTopologyId(EmbeddedCacheManager cm, String cacheName) {
-      return cm.getCache(cacheName).getAdvancedCache().getRpcManager().getTopologyId();
+      return TestingUtil.extractComponent(cm.getCache(cacheName), DistributionManager.class).getCacheTopology()
+            .getReadConsistentHash().hashCode();
    }
 
    public static void killClient(HotRodClient client) {


### PR DESCRIPTION
Hot Rod client uses "greater than" for comparison but topology ID resets on full cluster restart

https://issues.redhat.com/browse/ISPN-13813
https://issues.redhat.com/browse/ISPN-13833