### PR TITLE
Fix classes name for the code generation

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/IndexNormalizerTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/IndexNormalizerTest.java
@@ -31,7 +31,7 @@ public class IndexNormalizerTest extends SingleHotRodServerTest {
 
    @Override
    protected SerializationContextInitializer contextInitializer() {
-      return Book.Schema.INSTANCE;
+      return Book.BookSchema.INSTANCE;
    }
 
    @Test

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/MultipleIndexFieldAnnotationsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/MultipleIndexFieldAnnotationsTest.java
@@ -38,7 +38,7 @@ public class MultipleIndexFieldAnnotationsTest extends SingleHotRodServerTest {
 
    @Override
    protected SerializationContextInitializer contextInitializer() {
-      return Color.Schema.INSTANCE;
+      return Color.ColorSchema.INSTANCE;
    }
 
    @Test

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/testdomain/protobuf/Book.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/testdomain/protobuf/Book.java
@@ -23,7 +23,7 @@ public class Book {
    }
 
    @AutoProtoSchemaBuilder(includeClasses = Book.class)
-   public interface Schema extends GeneratedSchema {
-      Schema INSTANCE = new SchemaImpl();
+   public interface BookSchema extends GeneratedSchema {
+      BookSchema INSTANCE = new BookSchemaImpl();
    }
 }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/testdomain/protobuf/Color.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/testdomain/protobuf/Color.java
@@ -61,7 +61,7 @@ public class Color {
    }
 
    @AutoProtoSchemaBuilder(includeClasses = Color.class)
-   public interface Schema extends GeneratedSchema {
-      Schema INSTANCE = new SchemaImpl();
+   public interface ColorSchema extends GeneratedSchema {
+      ColorSchema INSTANCE = new ColorSchemaImpl();
    }
 }


### PR DESCRIPTION
Quick fix renaming the classes to avoid conflict in the generated code. Suppose it was introduced because the conflicting class (Schema) was added in different PRs #10037 and #10041.

https://issues.redhat.com/browse/ISPN-13816