### PR TITLE
ISPN-13846 Creating cache with name more than 256 characters long fails

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/global/CacheContainerConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/global/CacheContainerConfiguration.java
@@ -1,9 +1,12 @@
 package org.infinispan.configuration.global;
 
+import static org.infinispan.util.logging.Log.CONFIG;
+
 import org.infinispan.commons.configuration.attributes.Attribute;
 import org.infinispan.commons.configuration.attributes.AttributeDefinition;
 import org.infinispan.commons.configuration.attributes.AttributeSet;
 import org.infinispan.commons.util.Features;
+import org.infinispan.util.ByteString;
 
 /*
  * @since 10.0
@@ -12,7 +15,12 @@ class CacheContainerConfiguration {
 
    private static final String ZERO_CAPACITY_NODE_FEATURE = "zero-capacity-node";
 
-   static final AttributeDefinition<String> DEFAULT_CACHE = AttributeDefinition.builder("defaultCache", null, String.class).immutable().build();
+   static final AttributeDefinition<String> DEFAULT_CACHE = AttributeDefinition.builder("defaultCache", null, String.class).immutable()
+         .validator(value -> {
+            if (value != null && !ByteString.isValid(value)) {
+               throw CONFIG.invalidNameSize(value);
+            }
+         }).build();
    static final AttributeDefinition<String> NAME = AttributeDefinition.builder("name", "DefaultCacheManager").immutable().build();
    static final AttributeDefinition<Boolean> STATISTICS = AttributeDefinition.builder("statistics", false).immutable().build();
    static final AttributeDefinition<Boolean> ZERO_CAPACITY_NODE = AttributeDefinition.builder("zeroCapacityNode", Boolean.FALSE).immutable().build();

--- a/core/src/main/java/org/infinispan/configuration/global/CacheContainerConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/global/CacheContainerConfigurationBuilder.java
@@ -225,6 +225,13 @@ public class CacheContainerConfigurationBuilder extends AbstractGlobalConfigurat
 
    public void validate() {
       List<RuntimeException> validationExceptions = new ArrayList<>();
+
+      try {
+         attributes.validate();
+      } catch (RuntimeException e) {
+         validationExceptions.add(e);
+      }
+
       Arrays.asList(
             metrics,
             jmx,

--- a/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
@@ -7,7 +7,6 @@ import static org.infinispan.util.logging.Log.CONTAINER;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -89,6 +88,7 @@ import org.infinispan.security.impl.SecureCacheImpl;
 import org.infinispan.stats.CacheContainerStats;
 import org.infinispan.stats.impl.CacheContainerStatsImpl;
 import org.infinispan.topology.LocalTopologyManager;
+import org.infinispan.util.ByteString;
 import org.infinispan.util.CyclicDependencyException;
 import org.infinispan.util.DependencyGraph;
 import org.infinispan.commons.util.concurrent.CompletableFutures;
@@ -443,7 +443,7 @@ public class DefaultCacheManager implements EmbeddedCacheManager {
       assertIsNotTerminated();
       if (name == null || configurations == null)
          throw new NullPointerException("Null arguments not allowed");
-      if (name.getBytes(StandardCharsets.UTF_8).length > 255)
+      if (!ByteString.isValid(name))
          throw CONFIG.invalidNameSize(name);
 
       Configuration existing = configurationManager.getConfiguration(name, false);

--- a/core/src/main/java/org/infinispan/util/ByteString.java
+++ b/core/src/main/java/org/infinispan/util/ByteString.java
@@ -24,6 +24,7 @@ import org.infinispan.protostream.annotations.ProtoTypeId;
 public final class ByteString implements Comparable<ByteString> {
    private static final Charset CHARSET = StandardCharsets.UTF_8;
    private static final ByteString EMPTY = new ByteString(Util.EMPTY_BYTE_ARRAY);
+   private static final int MAX_LENGTH = 255;
    private transient String s;
    private transient final int hash;
 
@@ -32,7 +33,7 @@ public final class ByteString implements Comparable<ByteString> {
 
    @ProtoFactory
    ByteString(byte[] bytes) {
-      if (bytes.length > 255) {
+      if (bytes.length > MAX_LENGTH) {
          throw new IllegalArgumentException("ByteString must be less than 256 bytes");
       }
       this.bytes = bytes;
@@ -44,6 +45,10 @@ public final class ByteString implements Comparable<ByteString> {
          return EMPTY;
       else
          return new ByteString(s.getBytes(CHARSET));
+   }
+
+   public static boolean isValid(String s) {
+      return s.getBytes(CHARSET).length <= MAX_LENGTH;
    }
 
    public static ByteString emptyString() {

--- a/core/src/test/java/org/infinispan/globalstate/GlobalStateTest.java
+++ b/core/src/test/java/org/infinispan/globalstate/GlobalStateTest.java
@@ -12,7 +12,6 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.Writer;
 import java.lang.reflect.Method;
-import java.util.concurrent.CompletionException;
 
 import org.infinispan.commons.CacheConfigurationException;
 import org.infinispan.commons.api.CacheContainerAdmin;
@@ -257,7 +256,7 @@ public class GlobalStateTest extends AbstractInfinispanTest {
                CacheConfigurationException.class);
          expectException(exceptionMessage,
                () -> cm.administration().getOrCreateTemplate(cacheName, configuration),
-               CompletionException.class, CacheConfigurationException.class);
+               CacheConfigurationException.class);
       } finally {
          TestingUtil.killCacheManagers(cm);
       }


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-13846


A follow-up of #10068 to make clear that the limitation originates from `ByteString`.