### PR TITLE
ISPN-13216 Client should not close server connection after timeout

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/SocketTimeoutFailureRetryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/SocketTimeoutFailureRetryTest.java
@@ -64,8 +64,10 @@ public class SocketTimeoutFailureRetryTest extends AbstractRetryTest {
       interceptor.delayNextRequest(delay);
 
       assertEquals(0, remoteCacheManager.getChannelFactory().getRetries());
+      int connectionsBefore = channelFactory.getNumActive() + channelFactory.getNumIdle();
       assertEquals("v1", remoteCache.get(key));
       assertEquals(1, remoteCacheManager.getChannelFactory().getRetries());
+      assertEquals(connectionsBefore, channelFactory.getNumActive() + channelFactory.getNumIdle());
 
       delay.complete(null);
    }


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-13216

* Changing to not close the socket when handling a
`SocketTimeoutException`.

* To facilitate testing the property
`ChannelPool#connectionFailureListener` is now package-private, so we
can intercept the call in the test and verify the socket is not closed. Not sure
how I feel about this.