### PR TITLE
ISPN-13834 Create single REST endpoint for all container events

### DIFF
--- a/core/src/main/java/org/infinispan/security/actions/AddCacheManagerListenerAsyncAction.java
+++ b/core/src/main/java/org/infinispan/security/actions/AddCacheManagerListenerAsyncAction.java
@@ -1,0 +1,26 @@
+package org.infinispan.security.actions;
+
+import java.util.concurrent.CompletionStage;
+
+import org.infinispan.manager.EmbeddedCacheManager;
+
+/**
+ * CacheManagerAddListenerAction.
+ *
+ * @since 14.0
+ */
+public class AddCacheManagerListenerAsyncAction extends AbstractEmbeddedCacheManagerAction<CompletionStage<Void>> {
+
+   private final Object listener;
+
+   public AddCacheManagerListenerAsyncAction(EmbeddedCacheManager cacheManager, Object listener) {
+      super(cacheManager);
+      this.listener = listener;
+   }
+
+   @Override
+   public CompletionStage<Void> run() {
+      return cacheManager.addListenerAsync(listener);
+   }
+
+}

--- a/core/src/main/java/org/infinispan/security/actions/AddLoggerListenerAsyncAction.java
+++ b/core/src/main/java/org/infinispan/security/actions/AddLoggerListenerAsyncAction.java
@@ -1,0 +1,25 @@
+package org.infinispan.security.actions;
+
+import java.util.concurrent.CompletionStage;
+
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.util.logging.events.EventLogManager;
+
+/**
+ * Add logger listener action.
+ *
+ * @since 14.0
+ */
+public class AddLoggerListenerAsyncAction extends AbstractEmbeddedCacheManagerAction<CompletionStage<Void>> {
+   private final Object listener;
+
+   public AddLoggerListenerAsyncAction(EmbeddedCacheManager cacheManager, Object listener) {
+      super(cacheManager);
+      this.listener = listener;
+   }
+
+   @Override
+   public CompletionStage<Void> run() {
+      return EventLogManager.getEventLogger(cacheManager).addListenerAsync(listener);
+   }
+}

--- a/core/src/main/java/org/infinispan/topology/LocalTopologyManagerImpl.java
+++ b/core/src/main/java/org/infinispan/topology/LocalTopologyManagerImpl.java
@@ -542,8 +542,8 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager, GlobalSta
          return CompletableFutures.completedNull();
       }
 
-      eventLogger.info(EventLogCategory.LIFECYCLE, MESSAGES.cacheRebalanceStart(
-            cacheTopology.getMembers(), cacheTopology.getPhase(), cacheTopology.getTopologyId()));
+      eventLogger.context(cacheName)
+            .info(EventLogCategory.LIFECYCLE, MESSAGES.cacheRebalanceStart(cacheTopology.getMembers(), cacheTopology.getPhase(), cacheTopology.getTopologyId()));
       return withView(viewId, cacheStatus.getJoinInfo().getTimeout(), MILLISECONDS)
             .thenCompose(ignored -> orderOnCache(cacheName, () -> {
                return doHandleRebalance(viewId, cacheStatus, cacheTopology, cacheName, sender);
@@ -557,11 +557,12 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager, GlobalSta
                   // Ignore errors when the cache is shutting down
                   if (!(t instanceof IllegalLifecycleStateException)) {
                      log.rebalanceStartError(cacheName, throwable);
-                     eventLogger.error(EventLogCategory.LIFECYCLE, MESSAGES.rebalanceFinishedWithFailure(
-                           members, topologyId, t));
+                     eventLogger.context(cacheName)
+                           .error(EventLogCategory.LIFECYCLE, MESSAGES.rebalanceFinishedWithFailure(members, topologyId, t));
                   }
                } else {
-                  eventLogger.info(EventLogCategory.LIFECYCLE, MESSAGES.rebalanceFinished(members, topologyId));
+                  eventLogger.context(cacheName)
+                        .info(EventLogCategory.LIFECYCLE, MESSAGES.rebalanceFinished(members, topologyId));
                }
 
                return null;

--- a/core/src/main/java/org/infinispan/util/logging/events/impl/BaseEventLog.java
+++ b/core/src/main/java/org/infinispan/util/logging/events/impl/BaseEventLog.java
@@ -20,7 +20,7 @@ public class BaseEventLog implements EventLog {
    protected final String scope;
 
    public BaseEventLog(Instant when, EventLogLevel level, EventLogCategory category, String message, String detail,
-                       String who, String context, String scope) {
+                       String context, String who, String scope) {
       this.when = when;
       this.level = level;
       this.category = category;

--- a/core/src/main/java/org/infinispan/util/logging/events/impl/DecoratedEventLogger.java
+++ b/core/src/main/java/org/infinispan/util/logging/events/impl/DecoratedEventLogger.java
@@ -44,8 +44,8 @@ public class DecoratedEventLogger implements EventLogger {
 
    protected void addLogsToBuilder(StringBuilder sb) {
       if (context != null) sb.append(MESSAGES.eventLogContext(context));
-      if (scope != null) sb.append(MESSAGES.eventLogContext(scope));
-      if (who != null) sb.append(MESSAGES.eventLogContext(who));
+      if (scope != null) sb.append(MESSAGES.eventLogScope(scope));
+      if (who != null) sb.append(MESSAGES.eventLogWho(who));
    }
 
    @Override

--- a/documentation/src/main/asciidoc/topics/ref_rest_cache_managers.adoc
+++ b/documentation/src/main/asciidoc/topics/ref_rest_cache_managers.adoc
@@ -499,3 +499,17 @@ GET /rest/v2/container/config?action=listen
 |OPTIONAL
 |Sets the required format to return content. Supported formats are `application/yaml`, `application/json` and `application/xml`. The default is `application/yaml`. See link:#rest_accept[Accept] for more information.
 |===
+
+[id='rest_v2_container_listen']
+= Listening to container events
+
+Receive events from the container using https://html.spec.whatwg.org/multipage/server-sent-events.html[Server-Sent Events].
+The emitted events come from logged information, so each event contains an identifier associated with the message.
+The `event` value will be `lifecycle-event`. The `data` has the logged information, which includes the `message`,
+`category`, `level`, `timestamp`, `owner`, `context`, and `scope`, some of which may be empty.
+Currently, we expose only `LIFECYCLE` events.
+
+[source,options="nowrap",subs=attributes+]
+----
+GET /rest/v2/container?action=listen
+----

--- a/server/rest/src/main/java/org/infinispan/rest/resources/SecurityActions.java
+++ b/server/rest/src/main/java/org/infinispan/rest/resources/SecurityActions.java
@@ -2,6 +2,7 @@ package org.infinispan.rest.resources;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.concurrent.CompletionStage;
 
 import org.infinispan.AdvancedCache;
 import org.infinispan.configuration.cache.Configuration;
@@ -15,6 +16,8 @@ import org.infinispan.rest.InvocationHelper;
 import org.infinispan.rest.framework.RestRequest;
 import org.infinispan.security.AuthorizationPermission;
 import org.infinispan.security.Security;
+import org.infinispan.security.actions.AddCacheManagerListenerAsyncAction;
+import org.infinispan.security.actions.AddLoggerListenerAsyncAction;
 import org.infinispan.security.actions.GetCacheComponentRegistryAction;
 import org.infinispan.security.actions.GetCacheConfigurationAction;
 import org.infinispan.security.actions.GetCacheConfigurationFromManagerAction;
@@ -71,6 +74,14 @@ final class SecurityActions {
 
    static <K, V> ComponentRegistry getComponentRegistry(AdvancedCache<K, V> cache) {
       return doPrivileged(new GetCacheComponentRegistryAction(cache));
+   }
+
+   static CompletionStage<Void> addLoggerListenerAsync(EmbeddedCacheManager ecm, Object listener) {
+      return doPrivileged(new AddLoggerListenerAsyncAction(ecm, listener));
+   }
+
+   static CompletionStage<Void> addListenerAsync(EmbeddedCacheManager cacheManager, Object listener) {
+      return doPrivileged(new AddCacheManagerListenerAsyncAction(cacheManager, listener));
    }
 
    static void checkPermission(InvocationHelper invocationHelper, RestRequest request, AuthorizationPermission permission) {

--- a/server/rest/src/test/java/org/infinispan/rest/resources/SSEListener.java
+++ b/server/rest/src/test/java/org/infinispan/rest/resources/SSEListener.java
@@ -37,6 +37,10 @@ public class SSEListener implements RestEventListener {
       this.events.add(new KeyValuePair<>(type, data));
    }
 
+   public boolean await(long timeout, TimeUnit unit) throws InterruptedException {
+      return openLatch.await(timeout, unit);
+   }
+
    public void expectEvent(String type, String subString) throws InterruptedException {
       KeyValuePair<String, String> event = events.poll(10, TimeUnit.SECONDS);
       assertNotNull(event);

--- a/server/rest/src/test/java/org/infinispan/rest/resources/WeakSSEListener.java
+++ b/server/rest/src/test/java/org/infinispan/rest/resources/WeakSSEListener.java
@@ -1,0 +1,71 @@
+package org.infinispan.rest.resources;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.infinispan.commons.util.ByRef;
+import org.infinispan.test.TestException;
+import org.infinispan.util.KeyValuePair;
+
+/**
+ * A listener for SSE without ordering restriction.
+ */
+public class WeakSSEListener extends SSEListener {
+   private final ConcurrentMap<String, List<String>> backup = new ConcurrentHashMap<>();
+
+   public void expectEvent(String type, String subString) throws InterruptedException {
+      CompletableFuture<Void> waitEvent = CompletableFuture.supplyAsync(() -> {
+         ByRef.Boolean contains = new ByRef.Boolean(false);
+         backup.computeIfPresent(type, (k, v) -> {
+            int index = -1;
+            for (int i = 0; i < v.size() && !contains.get(); i++) {
+               if (v.get(i).contains(subString)) {
+                  contains.set(true);
+                  index = i;
+                  break;
+               }
+            }
+
+            if (index >= 0) v.remove(index);
+            return v;
+         });
+
+         while (!contains.get()) {
+            try {
+               KeyValuePair<String, String> event = events.poll(10, TimeUnit.SECONDS);
+               assert event != null : "No event received";
+
+               if (type.equals(event.getKey()) && event.getValue().contains(subString)) {
+                  contains.set(true);
+                  break;
+               } else {
+                  backup.compute(event.getKey(), (k, v) -> {
+                     if (v == null) v = new ArrayList<>();
+
+                     v.add(event.getValue());
+                     return v;
+                  });
+               }
+            } catch (InterruptedException e) {
+               Thread.currentThread().interrupt();
+               throw new TestException(e);
+            }
+         }
+
+         assert contains.get() : "Should contain event with: " + subString;
+         return null;
+      });
+
+      try {
+         waitEvent.get(10, TimeUnit.SECONDS);
+      } catch (ExecutionException | TimeoutException e) {
+         throw new TestException(e);
+      }
+   }
+}

--- a/server/runtime/src/main/java/org/infinispan/server/logging/events/ServerEventImpl.java
+++ b/server/runtime/src/main/java/org/infinispan/server/logging/events/ServerEventImpl.java
@@ -25,7 +25,7 @@ public final class ServerEventImpl extends BaseEventLog {
    }
 
    ServerEventImpl(Instant when, EventLogLevel level, EventLogCategory category, String message, String detail, String context, String who, String scope) {
-      super(when, level, category, message, detail, who, context, scope);
+      super(when, level, category, message, detail, context, who, scope);
    }
 
    ServerEventImpl(Instant when, EventLogLevel level, EventLogCategory category, String message) {

--- a/server/runtime/src/test/java/org/infinispan/server/configuration/ServerEventLoggerTest.java
+++ b/server/runtime/src/test/java/org/infinispan/server/configuration/ServerEventLoggerTest.java
@@ -39,7 +39,6 @@ import org.infinispan.test.MultiCacheManagerCallable;
 import org.infinispan.test.TestException;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
-import org.infinispan.topology.LocalTopologyManagerImpl;
 import org.infinispan.util.concurrent.CompletionStages;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -166,8 +165,9 @@ public class ServerEventLoggerTest {
 
                // There are rebalance events, must be an even number of events.
                events = getLatestEvents(-1, eventLogger, EventLogCategory.LIFECYCLE, null);
+               final String cacheName = cms[0].getCache().getName();
                Predicate<EventLog> predicate = e -> e.getContext().isPresent()
-                     && e.getContext().get().equals(LocalTopologyManagerImpl.class.getName());
+                     && e.getContext().get().equals(cacheName);
                assertTrue(events.stream().anyMatch(predicate));
                assertEquals(0, events.stream().filter(predicate).count() & 1);
             }


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-13834

* Created an endpoint to listen for lifecycle events at
`/rest/v2/container?action=listen`. The old endpoint still exists. We
listen for logs produced with the `ServerEventLogger`.

* The current endpoint only publishes events logged with LIFECYCLE
category.

* Currently we only publish the event in the JSON format. We need more
work to handle properly the `Accept` HTTP header.

* Currently we publish all events received by the logger. There is room
for future improvement to listen only events for the node which is
serving the request.