### PR TITLE
ISPN-13871 Prometheus metrics exported incorrectly

### DIFF
--- a/server/tests/src/test/java/org/infinispan/server/functional/RestMetricsResource.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/RestMetricsResource.java
@@ -54,6 +54,7 @@ public class RestMetricsResource {
          checkIsOpenmetrics(response.contentType());
          String metricsText = response.getBody();
          assertTrue(metricsText.contains("# TYPE vendor_" + metricName + " gauge\n"));
+         assertTrue(metricsText.contains("vendor_" + metricName + "{cache=\"" + SERVER_TEST.getMethodName()));
       }
    }
 
@@ -84,7 +85,8 @@ public class RestMetricsResource {
       RestClient client = SERVER_TEST.rest().create();
       RestMetricsClient metricsClient = client.metrics();
 
-      String metricName = "cache_manager_default_cache_" + SERVER_TEST.getMethodName() + "_statistics_stores";
+      String cacheName = SERVER_TEST.getMethodName();
+      String metricName = String.format("cache_manager_default_cache_%s_statistics_stores{cache=\"%s\"", cacheName, cacheName);
       int NUM_PUTS = 10;
 
       try (RestResponse response = sync(metricsClient.metrics())) {
@@ -185,7 +187,8 @@ public class RestMetricsResource {
       RestClient client = SERVER_TEST.rest().create();
       RestMetricsClient metricsClient = client.metrics();
 
-      String metricName = "cache_manager_default_cache_" + SERVER_TEST.getMethodName() + "_statistics_stores";
+      String cacheName = SERVER_TEST.getMethodName();
+      String metricName = String.format("cache_manager_default_cache_%s_statistics_stores{cache=\"%s\"", cacheName, cacheName);
 
       try (RestResponse response = sync(metricsClient.metricsMetadata())) {
          assertEquals(200, response.getStatus());


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-13871

Always using the cache name as label. Previously only one of the caches is exported, in this approach we have that metrics are exported:

```text
# HELP vendor_cache_manager_default_cache_some_name_statistics_stores Number of cache attribute put operations
# TYPE vendor_cache_manager_default_cache_some_name_statistics_stores gauge
vendor_cache_manager_default_cache_some_name_statistics_stores{cache="some-name",node="jbolina-35119",} 0.0
vendor_cache_manager_default_cache_some_name_statistics_stores{cache="some/name",node="jbolina-35119",} 0.0
```

That would only happen in edge cases where the cache names differ only by non-alphanumerical characters. The [docs](https://prometheus.io/docs/practices/instrumentation/#do-not-overuse-labels) states to not overuse labels, but I guess that is ok for our case.