### PR TITLE
ISPN-9366 Cache.size optimizations (pt. 2)

### DIFF
--- a/core/src/main/java/org/infinispan/cache/impl/CacheImpl.java
+++ b/core/src/main/java/org/infinispan/cache/impl/CacheImpl.java
@@ -491,7 +491,7 @@ public class CacheImpl<K, V> implements AdvancedCache<K, V> {
    }
 
    final int size(long explicitFlags) {
-      SizeCommand command = commandsFactory.buildSizeCommand(explicitFlags);
+      SizeCommand command = commandsFactory.buildSizeCommand(null, explicitFlags);
       long size = invocationHelper.invoke(invocationContextFactory.createInvocationContext(false, UNBOUNDED), command);
       return size > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) size;
    }
@@ -502,7 +502,7 @@ public class CacheImpl<K, V> implements AdvancedCache<K, V> {
    }
 
    final CompletableFuture<Long> sizeAsync(long explicitFlags) {
-      SizeCommand command = commandsFactory.buildSizeCommand(explicitFlags);
+      SizeCommand command = commandsFactory.buildSizeCommand(null, explicitFlags);
       return invocationHelper.invokeAsync(invocationContextFactory.createInvocationContext(false, UNBOUNDED), command);
    }
 

--- a/core/src/main/java/org/infinispan/commands/CommandsFactory.java
+++ b/core/src/main/java/org/infinispan/commands/CommandsFactory.java
@@ -269,7 +269,7 @@ public interface CommandsFactory {
     * @param flagsBitSet Command flags provided by cache
     * @return a SizeCommand
     */
-   SizeCommand buildSizeCommand(long flagsBitSet);
+   SizeCommand buildSizeCommand(IntSet segments, long flagsBitSet);
 
    /**
     * Builds a GetKeyValueCommand

--- a/core/src/main/java/org/infinispan/commands/CommandsFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/commands/CommandsFactoryImpl.java
@@ -245,8 +245,8 @@ public class CommandsFactoryImpl implements CommandsFactory {
    }
 
    @Override
-   public SizeCommand buildSizeCommand(long flagsBitSet) {
-      return new SizeCommand(flagsBitSet);
+   public SizeCommand buildSizeCommand(IntSet segments, long flagsBitSet) {
+      return new SizeCommand(cacheName, segments, flagsBitSet);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/commands/RemoteCommandsFactory.java
+++ b/core/src/main/java/org/infinispan/commands/RemoteCommandsFactory.java
@@ -30,6 +30,7 @@ import org.infinispan.commands.irac.IracUpdateVersionCommand;
 import org.infinispan.commands.module.ModuleCommandFactory;
 import org.infinispan.commands.read.GetCacheEntryCommand;
 import org.infinispan.commands.read.GetKeyValueCommand;
+import org.infinispan.commands.read.SizeCommand;
 import org.infinispan.commands.remote.CacheRpcCommand;
 import org.infinispan.commands.remote.CheckTransactionRpcCommand;
 import org.infinispan.commands.remote.ClusteredGetAllCommand;
@@ -498,6 +499,9 @@ public class RemoteCommandsFactory {
                break;
             case IracPutManyCommand.COMMAND_ID:
                command = new IracPutManyCommand(cacheName);
+               break;
+            case SizeCommand.COMMAND_ID:
+               command = new SizeCommand(cacheName);
                break;
             default:
                throw new CacheException("Unknown command id " + id + "!");

--- a/core/src/main/java/org/infinispan/commands/read/SizeCommand.java
+++ b/core/src/main/java/org/infinispan/commands/read/SizeCommand.java
@@ -1,8 +1,21 @@
 package org.infinispan.commands.read;
 
-import org.infinispan.commands.VisitableCommand;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.concurrent.CompletionStage;
+
+import org.infinispan.commands.FlagAffectedCommand;
+import org.infinispan.commands.TopologyAffectedCommand;
 import org.infinispan.commands.Visitor;
+import org.infinispan.commands.remote.BaseRpcCommand;
+import org.infinispan.commons.util.EnumUtil;
+import org.infinispan.commons.util.IntSet;
 import org.infinispan.context.InvocationContext;
+import org.infinispan.context.InvocationContextFactory;
+import org.infinispan.factories.ComponentRegistry;
+import org.infinispan.interceptors.AsyncInterceptorChain;
+import org.infinispan.util.ByteString;
 
 /**
  * Command to calculate the size of the cache
@@ -12,10 +25,29 @@ import org.infinispan.context.InvocationContext;
  * @author <a href="http://gleamynode.net/">Trustin Lee</a>
  * @since 4.0
  */
-public class SizeCommand extends AbstractLocalCommand implements VisitableCommand {
-   public SizeCommand(long flags) {
+public class SizeCommand extends BaseRpcCommand implements FlagAffectedCommand, TopologyAffectedCommand {
+   public static final byte COMMAND_ID = 61;
+
+   private int topologyId = -1;
+   private long flags = EnumUtil.EMPTY_BIT_SET;
+   private IntSet segments;
+
+   public SizeCommand(
+         ByteString cacheName,
+         IntSet segments,
+         long flags
+   ) {
+      super(cacheName);
       setFlagsBitSet(flags);
+      this.segments = segments;
    }
+
+   public SizeCommand(ByteString name) {
+      super(name);
+   }
+
+   // Only here for CommandIdUniquenessTest
+   private SizeCommand() { super(null); }
 
    @Override
    public Object acceptVisitor(InvocationContext ctx, Visitor visitor) throws Throwable {
@@ -23,7 +55,70 @@ public class SizeCommand extends AbstractLocalCommand implements VisitableComman
    }
 
    @Override
+   public CompletionStage<?> invokeAsync(ComponentRegistry registry) throws Throwable {
+      InvocationContextFactory icf = registry.getInvocationContextFactory().running();
+      InvocationContext ctx = icf.createRemoteInvocationContextForCommand(this, getOrigin());
+      AsyncInterceptorChain invoker = registry.getInterceptorChain().running();
+      return invoker.invokeAsync(ctx, this);
+   }
+
+   @Override
+   public LoadType loadType() {
+      return LoadType.DONT_LOAD;
+   }
+
+   @Override
+   public byte getCommandId() {
+      return COMMAND_ID;
+   }
+
+   @Override
+   public boolean isReturnValueExpected() {
+      return true;
+   }
+
+   @Override
+   public int getTopologyId() {
+      return topologyId;
+   }
+
+   @Override
+   public void setTopologyId(int topologyId) {
+      this.topologyId = topologyId;
+   }
+
+   @Override
+   public long getFlagsBitSet() {
+      return flags;
+   }
+
+   @Override
+   public void setFlagsBitSet(long bitSet) {
+      this.flags = bitSet;
+   }
+
+   public IntSet getSegments() {
+      return segments;
+   }
+
+   @Override
+   public void writeTo(ObjectOutput output) throws IOException {
+      output.writeLong(flags);
+      output.writeObject(segments);
+   }
+
+   @Override
+   public void readFrom(ObjectInput input) throws IOException, ClassNotFoundException {
+      setFlagsBitSet(input.readLong());
+      segments = (IntSet) input.readObject();
+   }
+
+   @Override
    public String toString() {
-      return "SizeCommand{}";
+      return "SizeCommand{" +
+            "topologyId=" + topologyId +
+            ", flags=" + flags +
+            ", segments=" + segments +
+            '}';
    }
 }

--- a/core/src/main/java/org/infinispan/container/impl/InternalDataContainer.java
+++ b/core/src/main/java/org/infinispan/container/impl/InternalDataContainer.java
@@ -139,7 +139,7 @@ public interface InternalDataContainer<K, V> extends DataContainer<K, V> {
       int size = 0;
       // We have to loop through and count the entries
       for (Iterator<InternalCacheEntry<K, V>> iter = iterator(segments); iter.hasNext(); ) {
-         iter.next();
+         if (iter.next().getValue() == null) continue;
          if (++size == Integer.MAX_VALUE) return Integer.MAX_VALUE;
       }
       return size;

--- a/core/src/main/java/org/infinispan/factories/ComponentRegistry.java
+++ b/core/src/main/java/org/infinispan/factories/ComponentRegistry.java
@@ -88,6 +88,7 @@ public class ComponentRegistry extends AbstractComponentRegistry {
    private ComponentRef<BackupSender> backupSender;
    private ComponentRef<BlockingManager> blockingManager;
    private ComponentRef<ClusterPublisherManager> clusterPublisherManager;
+   private ComponentRef<ClusterPublisherManager> localClusterPublisherManager;
    private ComponentRef<BiasManager> biasManager;
    private ComponentRef<CacheNotifier> cacheNotifier;
    private ComponentRef<ClusterCacheNotifier> clusterCacheNotifier;
@@ -376,6 +377,7 @@ public class ComponentRegistry extends AbstractComponentRegistry {
       backupSender = basicComponentRegistry.getComponent(BackupSender.class);
       blockingManager = basicComponentRegistry.getComponent(BlockingManager.class);
       clusterPublisherManager = basicComponentRegistry.getComponent(ClusterPublisherManager.class);
+      localClusterPublisherManager = basicComponentRegistry.getComponent(PublisherManagerFactory.LOCAL_CLUSTER_PUBLISHER, ClusterPublisherManager.class);
       takeOfflineManager = basicComponentRegistry.getComponent(TakeOfflineManager.class);
       cache = basicComponentRegistry.getComponent(AdvancedCache.class);
       cacheNotifier = basicComponentRegistry.getComponent(CacheNotifier.class);
@@ -446,6 +448,10 @@ public class ComponentRegistry extends AbstractComponentRegistry {
 
    public ComponentRef<ClusterPublisherManager> getClusterPublisherManager() {
       return clusterPublisherManager;
+   }
+
+   public ComponentRef<ClusterPublisherManager> getLocalClusterPublisherManager() {
+      return localClusterPublisherManager;
    }
 
    public ComponentRef<TakeOfflineManager> getTakeOfflineManager() {

--- a/core/src/main/java/org/infinispan/interceptors/impl/CacheLoaderInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/CacheLoaderInterceptor.java
@@ -283,6 +283,7 @@ public class CacheLoaderInterceptor<K, V> extends JmxStatsCommandInterceptor imp
       CompletionStage<Long> sizeStage = trySizeOptimization(command.getFlagsBitSet());
       return asyncValue(sizeStage).thenApply(ctx, command, (rCtx, rCommand, rv) -> {
          if ((Long) rv == -1) {
+            rCommand.addFlags(FlagBitSets.SKIP_SIZE_OPTIMIZATION);
             return super.visitSizeCommand(rCtx, rCommand);
          }
          return rv;

--- a/core/src/main/java/org/infinispan/interceptors/impl/CallInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/CallInterceptor.java
@@ -67,6 +67,8 @@ import org.infinispan.commands.write.ValueMatcher;
 import org.infinispan.commons.reactive.RxJavaInterop;
 import org.infinispan.commons.time.TimeService;
 import org.infinispan.commons.util.IntSet;
+import org.infinispan.commons.util.IntSets;
+import org.infinispan.configuration.cache.Configurations;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.container.entries.ExpiryHelper;
 import org.infinispan.container.entries.InternalCacheEntry;
@@ -139,9 +141,8 @@ public class CallInterceptor extends BaseAsyncInterceptor implements Visitor {
    @Inject InternalEntryFactory internalEntryFactory;
    @Inject KeyPartitioner keyPartitioner;
    @Inject GroupManager groupManager;
-   @Inject ClusterPublisherManager clusterPublisherManager;
    @ComponentName(PublisherManagerFactory.LOCAL_CLUSTER_PUBLISHER)
-   @Inject ClusterPublisherManager localClusterPublisherManager;
+   @Inject ClusterPublisherManager<?, ?> localClusterPublisherManager;
    @Inject ComponentRegistry componentRegistry;
 
    // Internally we always deal with an unwrapped cache, so don't unwrap per invocation
@@ -604,16 +605,31 @@ public class CallInterceptor extends BaseAsyncInterceptor implements Visitor {
 
    @Override
    public Object visitSizeCommand(InvocationContext ctx, SizeCommand command) throws Throwable {
-      ClusterPublisherManager managerToUse;
-      if (command.hasAnyFlag(FlagBitSets.CACHE_MODE_LOCAL)) {
-         managerToUse = localClusterPublisherManager;
-      } else {
-         managerToUse = clusterPublisherManager;
+      long size = trySizeOptimization(ctx, command);
+      if (size >= 0) {
+         return size;
       }
 
-      return asyncValue(managerToUse.keyReduction(false, null, null, ctx,
-            command.getFlagsBitSet(), DeliveryGuarantee.EXACTLY_ONCE, PublisherReducers.count(),
-            PublisherReducers.add()));
+      return asyncValue(localClusterPublisherManager.keyReduction(false, command.getSegments(), null,
+            ctx, command.getFlagsBitSet(), DeliveryGuarantee.EXACTLY_ONCE, PublisherReducers.count(), PublisherReducers.add()));
+   }
+
+   private long trySizeOptimization(InvocationContext ctx, SizeCommand command) {
+      if (command.hasAnyFlag(FlagBitSets.SKIP_SIZE_OPTIMIZATION)
+            || (ctx != null && ctx.lookedUpEntriesCount() > 0)) {
+         return -1;
+      }
+
+      IntSet segments = command.getSegments();
+      if (segments == null) {
+         int maxSegments = 1;
+         if (Configurations.needSegments(cacheConfiguration)) {
+            maxSegments = cacheConfiguration.clustering().hash().numSegments();
+         }
+         segments = IntSets.immutableRangeSet(maxSegments);
+      }
+
+      return dataContainer.size(segments);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/marshall/exts/CacheRpcCommandExternalizer.java
+++ b/core/src/main/java/org/infinispan/marshall/exts/CacheRpcCommandExternalizer.java
@@ -18,6 +18,7 @@ import org.infinispan.commands.irac.IracTombstoneRemoteSiteCheckCommand;
 import org.infinispan.commands.irac.IracTombstoneStateResponseCommand;
 import org.infinispan.commands.irac.IracTouchKeyCommand;
 import org.infinispan.commands.irac.IracUpdateVersionCommand;
+import org.infinispan.commands.read.SizeCommand;
 import org.infinispan.commands.remote.CacheRpcCommand;
 import org.infinispan.commands.remote.CheckTransactionRpcCommand;
 import org.infinispan.commands.remote.ClusteredGetAllCommand;
@@ -111,6 +112,7 @@ public final class CacheRpcCommandExternalizer extends AbstractExternalizer<Cach
             PutMapBackupWriteCommand.class,
             MultiEntriesFunctionalBackupWriteCommand.class,
             MultiKeyFunctionalBackupWriteCommand.class,
+            SizeCommand.class,
             BackupNoopCommand.class,
             InvalidateVersionsCommand.class,
             RevokeBiasCommand.class, RenewBiasCommand.class, ReductionPublisherRequestCommand.class,

--- a/core/src/main/java/org/infinispan/persistence/manager/PersistenceManager.java
+++ b/core/src/main/java/org/infinispan/persistence/manager/PersistenceManager.java
@@ -208,6 +208,20 @@ public interface PersistenceManager extends Lifecycle {
        return size(AccessMode.BOTH);
    }
 
+   default CompletionStage<Long> size(IntSet segments) {
+      return size(AccessMode.BOTH, segments);
+   }
+
+   /**
+    * Returns the count of how many entries are persisted in the given segments. If no store can handle the request
+    * for the given mode a value of <b>-1</b> is returned instead.
+    *
+    * @param predicate whether a loader can be used
+    * @param segments segments to check
+    * @return size or -1 if size couldn't be computed
+    */
+   CompletionStage<Long> size(Predicate<? super StoreConfiguration> predicate, IntSet segments);
+
    /**
     * Returns the count of how many entries are persisted. If no store can handle the request for the given mode a
     * value of <b>-1</b> is returned instead.

--- a/core/src/main/java/org/infinispan/persistence/support/DelegatingPersistenceManager.java
+++ b/core/src/main/java/org/infinispan/persistence/support/DelegatingPersistenceManager.java
@@ -237,6 +237,11 @@ public class DelegatingPersistenceManager implements PersistenceManager, Lifecyc
    }
 
    @Override
+   public CompletionStage<Long> size(Predicate<? super StoreConfiguration> predicate, IntSet segments) {
+      return persistenceManager.size(predicate, segments);
+   }
+
+   @Override
    public CompletionStage<Void> writeToAllNonTxStores(MarshallableEntry marshalledEntry, int segment,
                                                       Predicate<? super StoreConfiguration> predicate) {
       return persistenceManager.writeToAllNonTxStores(marshalledEntry, segment, predicate);

--- a/core/src/main/java/org/infinispan/reactive/publisher/impl/ClusterPublisherManager.java
+++ b/core/src/main/java/org/infinispan/reactive/publisher/impl/ClusterPublisherManager.java
@@ -94,4 +94,6 @@ public interface ClusterPublisherManager<K, V> {
    <R> SegmentPublisherSupplier<R> entryPublisher(IntSet segments, Set<K> keysToInclude, InvocationContext invocationContext,
          long explicitFlags, DeliveryGuarantee deliveryGuarantee, int batchSize,
          Function<? super Publisher<CacheEntry<K, V>>, ? extends Publisher<R>> transformer);
+
+   CompletionStage<Long> sizePublisher(IntSet segments, InvocationContext ctx, long flags);
 }

--- a/core/src/main/java/org/infinispan/reactive/publisher/impl/LocalClusterPublisherManagerImpl.java
+++ b/core/src/main/java/org/infinispan/reactive/publisher/impl/LocalClusterPublisherManagerImpl.java
@@ -205,4 +205,9 @@ public class LocalClusterPublisherManagerImpl<K, V> implements ClusterPublisherM
          }
       };
    }
+
+   @Override
+   public CompletionStage<Long> sizePublisher(IntSet segments, InvocationContext ctx, long flags) {
+      return localPublisherManager.sizePublisher(segments, flags);
+   }
 }

--- a/core/src/main/java/org/infinispan/reactive/publisher/impl/LocalPublisherManager.java
+++ b/core/src/main/java/org/infinispan/reactive/publisher/impl/LocalPublisherManager.java
@@ -129,4 +129,6 @@ public interface LocalPublisherManager<K, V> {
     * @param lostSegments the segments that are being removed from this node
     */
    void segmentsLost(IntSet lostSegments);
+
+   CompletionStage<Long> sizePublisher(IntSet segments, long flags);
 }

--- a/core/src/main/java/org/infinispan/reactive/publisher/impl/LocalPublisherManagerImpl.java
+++ b/core/src/main/java/org/infinispan/reactive/publisher/impl/LocalPublisherManagerImpl.java
@@ -21,6 +21,7 @@ import org.infinispan.cache.impl.InvocationHelper;
 import org.infinispan.commands.CommandsFactory;
 import org.infinispan.commands.read.EntrySetCommand;
 import org.infinispan.commands.read.KeySetCommand;
+import org.infinispan.commands.read.SizeCommand;
 import org.infinispan.commons.util.EnumUtil;
 import org.infinispan.commons.util.IntSet;
 import org.infinispan.commons.util.IntSets;
@@ -34,6 +35,7 @@ import org.infinispan.container.entries.NullCacheEntry;
 import org.infinispan.context.Flag;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.InvocationContextFactory;
+import org.infinispan.context.impl.FlagBitSets;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.distribution.LocalizedCacheTopology;
 import org.infinispan.distribution.ch.KeyPartitioner;
@@ -383,6 +385,14 @@ public class LocalPublisherManagerImpl<K, V> implements LocalPublisherManager<K,
          log.tracef("Notifying listeners of lost segments %s", lostSegments);
       }
       changeListener.forEach(lostSegments::forEach);
+   }
+
+   @Override
+   public CompletionStage<Long> sizePublisher(IntSet segments, long flags) {
+      SizeCommand command = commandsFactory.buildSizeCommand(
+            segments, EnumUtil.mergeBitSets(flags, FlagBitSets.CACHE_MODE_LOCAL));
+      InvocationContext ctx = invocationContextFactory.createInvocationContext(false, UNBOUNDED);
+      return CompletableFuture.completedFuture(invocationHelper.running().invoke(ctx, command));
    }
 
    private static Function<Object, PublisherResult<Object>> ignoreSegmentsFunction = value ->

--- a/core/src/test/java/org/infinispan/util/mocks/ControlledCommandFactory.java
+++ b/core/src/test/java/org/infinispan/util/mocks/ControlledCommandFactory.java
@@ -259,8 +259,8 @@ public class ControlledCommandFactory implements CommandsFactory {
    }
 
    @Override
-   public SizeCommand buildSizeCommand(long flagsBitSet) {
-      return actual.buildSizeCommand(flagsBitSet);
+   public SizeCommand buildSizeCommand(IntSet segments, long flagsBitSet) {
+      return actual.buildSizeCommand(segments, flagsBitSet);
    }
 
    @Override


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-9366

* Created a method for the size in the Publisher* interface and classes.

* We query locally for the size and issue request to some of the remote
targets to do the same. With the returned value we sum everything.

* Change ComponentRegistry to create the LocalClusterPublisherManager,
only needed so the component is already started when used.

This relates to #10042 