### PR TITLE
ISPN-13648 Schema evolution with respect to indices without downtime

### DIFF
--- a/build/configuration/pom.xml
+++ b/build/configuration/pom.xml
@@ -139,7 +139,7 @@
       <version.hamcrest>1.3</version.hamcrest>
       <version.hibernate53.core>5.3.22.Final</version.hibernate53.core>
       <version.hibernate.core>6.0.1.Final</version.hibernate.core>
-      <version.hibernate.search>6.1.4.Final</version.hibernate.search>
+      <version.hibernate.search>6.1.5.Final</version.hibernate.search>
       <version.infinispan>14.0.0-SNAPSHOT</version.infinispan>
       <version.infinispan.arquillian>1.2.0.Beta3</version.infinispan.arquillian>
       <version.infinispan.doclets>1.4.0.Final</version.infinispan.doclets>

--- a/cli/src/main/java/org/infinispan/cli/commands/rest/Index.java
+++ b/cli/src/main/java/org/infinispan/cli/commands/rest/Index.java
@@ -79,6 +79,26 @@ public class Index extends CliCommand {
       }
    }
 
+   @CommandDefinition(name = "update-schema", description = "Update index schema for a given cache.", activator = ConnectionActivator.class)
+   public static class UpdateIndex extends RestCliCommand {
+
+      @Argument(description = "Specifies which cache to update its index schema.", completer = CacheCompleter.class, required = true)
+      String cache;
+
+      @Option(shortName = 'h', hasValue = false, overrideRequired = true)
+      protected boolean help;
+
+      @Override
+      public boolean isHelp() {
+         return help;
+      }
+
+      @Override
+      protected CompletionStage<RestResponse> exec(ContextAwareCommandInvocation invocation, RestClient client, Resource resource) {
+         return client.cache(cache).updateIndexSchema();
+      }
+   }
+
    @CommandDefinition(name = "stats", description = "Displays indexing and search statistics for a cache.", activator = ConnectionActivator.class)
    public static class Stats extends RestCliCommand {
 

--- a/cli/src/main/resources/help/index.adoc
+++ b/cli/src/main/resources/help/index.adoc
@@ -31,7 +31,7 @@ Reindexes a cache.
 Clears a cache index.
 
 `index update-schema mycache` +
-Update index schema for the given cache
+Updates the index schema for a cache.
 
 `index stats mycache` +
 Shows indexing and search statistics for a cache.

--- a/cli/src/main/resources/help/index.adoc
+++ b/cli/src/main/resources/help/index.adoc
@@ -14,6 +14,8 @@ SYNOPSIS
 
 *index clear* 'cache-name'
 
+*index update-schema* 'cache-name'
+
 *index stats* 'cache-name'
 
 *index clear-stats* 'cache-name'
@@ -27,6 +29,9 @@ Reindexes a cache.
 
 `index clear mycache` +
 Clears a cache index.
+
+`index update-schema mycache` +
+Update index schema for the given cache
 
 `index stats mycache` +
 Shows indexing and search statistics for a cache.

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManagerAdmin.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManagerAdmin.java
@@ -102,4 +102,14 @@ public interface RemoteCacheManagerAdmin extends CacheContainerAdmin<RemoteCache
     * @throws HotRodClientException
     */
    void reindexCache(String name) throws HotRodClientException;
+
+   /**
+    * Update the index schema state for the given cache,
+    * the cache engine is hot restarted so that index persisted or not persisted state will be preserved.
+    *
+    * @param cacheName the name of the cache on which the index schema will be updated
+    * @throws HotRodClientException
+    */
+   void updateIndexSchema(String cacheName) throws HotRodClientException;
+
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/RemoteCacheManagerAdminImpl.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/RemoteCacheManagerAdminImpl.java
@@ -119,6 +119,11 @@ public class RemoteCacheManagerAdminImpl implements RemoteCacheManagerAdmin {
    }
 
    @Override
+   public void updateIndexSchema(String name) throws HotRodClientException {
+      await(operationsFactory.newAdminOperation("@@cache@updateindexschema", Collections.singletonMap(CACHE_NAME, string(name))).execute());
+   }
+
+   @Override
    public void createTemplate(String name, BasicConfiguration configuration) {
       Map<String, byte[]> params = new HashMap<>(2);
       params.put(CACHE_NAME, string(name));

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/admin/RemoteCacheAdminTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/admin/RemoteCacheAdminTest.java
@@ -285,6 +285,27 @@ public class RemoteCacheAdminTest extends MultiHotRodServersTest {
       client(0).administration().removeCache(cacheName);
    }
 
+   public void updateIndexSchemaTest(Method m) {
+      String cacheName = m.getName();
+      // Create the cache
+      client(0).administration().withFlags(CacheContainerAdmin.AdminFlag.VOLATILE).createCache(cacheName, "template");
+      RemoteCache<String, Transaction> cache = client(0).getCache(cacheName);
+      verifyQuery(cache, 0);
+      Transaction tx = new TransactionPB();
+      tx.setId(1);
+      tx.setAccountId(777);
+      tx.setAmount(500);
+      tx.setDate(new Date(1));
+      tx.setDescription("February rent");
+      tx.setLongDescription("February rent");
+      tx.setNotes("card was not present");
+      cache.put("tx", tx);
+      verifyQuery(cache, 1);
+      client(0).administration().updateIndexSchema(cacheName);
+      verifyQuery(cache, 1);
+      client(0).administration().removeCache(cacheName);
+   }
+
    private void verifyQuery(RemoteCache<String, Transaction> cache, int count) {
       List<User> users = Search.getQueryFactory(cache)
                                .<User>create("from sample_bank_account.Transaction where longDescription:'RENT'")

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/admin/SchemaIndexUpdateTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/admin/SchemaIndexUpdateTest.java
@@ -1,0 +1,136 @@
+package org.infinispan.client.hotrod.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.infinispan.commons.dataconversion.MediaType.APPLICATION_PROTOSTREAM_TYPE;
+import static org.infinispan.configuration.cache.IndexStorage.LOCAL_HEAP;
+
+import java.util.List;
+
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.Search;
+import org.infinispan.client.hotrod.annotation.model.Model;
+import org.infinispan.client.hotrod.annotation.model.ModelA;
+import org.infinispan.client.hotrod.annotation.model.ModelB;
+import org.infinispan.client.hotrod.annotation.model.SchemaA;
+import org.infinispan.client.hotrod.annotation.model.SchemaB;
+import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
+import org.infinispan.client.hotrod.test.SingleHotRodServerTest;
+import org.infinispan.commons.marshall.ProtoStreamMarshaller;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.query.dsl.Query;
+import org.infinispan.query.remote.client.ProtobufMetadataManagerConstants;
+import org.infinispan.server.core.admin.embeddedserver.EmbeddedServerAdminOperationHandler;
+import org.infinispan.server.hotrod.HotRodServer;
+import org.infinispan.server.hotrod.configuration.HotRodServerConfigurationBuilder;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.Test;
+
+@Test(groups = "functional", testName = "client.hotrod.admin.SchemaIndexUpdateTest")
+public class SchemaIndexUpdateTest extends SingleHotRodServerTest {
+
+   private static final String CACHE_NAME = "models";
+
+   private final ProtoStreamMarshaller schemaEvolutionClientMarshaller = new ProtoStreamMarshaller();
+
+   /**
+    * Configure server side (embedded) cache
+    *
+    * @return the embedded cache manager
+    * @throws Exception
+    */
+   @Override
+   protected EmbeddedCacheManager createCacheManager() throws Exception {
+      ConfigurationBuilder builder = new ConfigurationBuilder();
+      builder
+            .encoding()
+               .mediaType(APPLICATION_PROTOSTREAM_TYPE)
+            .indexing()
+               .enable()
+               .storage(LOCAL_HEAP)
+               .addIndexedEntity("model.Model");
+
+      EmbeddedCacheManager cacheManager = TestCacheManagerFactory.createServerModeCacheManager();
+      cacheManager.defineConfiguration(CACHE_NAME, builder.build());
+
+      return cacheManager;
+   }
+
+   /**
+    * Configure the server, enabling the admin operations
+    *
+    * @return the HotRod server
+    */
+   @Override
+   protected HotRodServer createHotRodServer() {
+      HotRodServerConfigurationBuilder serverBuilder = new HotRodServerConfigurationBuilder();
+      serverBuilder.adminOperationsHandler(new EmbeddedServerAdminOperationHandler());
+
+      return HotRodClientTestingUtil.startHotRodServer(cacheManager, serverBuilder);
+   }
+
+   /**
+    * Configure client side (remote) cache
+    *
+    * @param host The used host name
+    * @param serverPort The used server port
+    * @return the HotRod client configuration
+    */
+   @Override
+   protected org.infinispan.client.hotrod.configuration.ConfigurationBuilder createHotRodClientConfigurationBuilder(String host, int serverPort) {
+      org.infinispan.client.hotrod.configuration.ConfigurationBuilder builder = HotRodClientTestingUtil.newRemoteConfigurationBuilder();
+      builder.addServer()
+            .host(host)
+            .port(serverPort)
+            .addContextInitializer(SchemaA.INSTANCE)
+            .marshaller(schemaEvolutionClientMarshaller);
+      return builder;
+   }
+
+   @Test
+   public void test() {
+      RemoteCache<Integer, Model> cache = remoteCacheManager.getCache(CACHE_NAME);
+
+      cache.put(1, new ModelA("Fabio"));
+
+      Query<Model> query = Search.getQueryFactory(cache).create("from model.Model where original is not null");
+      List<Model> result = query.execute().list();
+
+      assertThat(result).extracting("original").containsExactly("Fabio");
+      assertThat(result).hasOnlyElementsOfType(ModelA.class);
+
+      updateSchemaIndex(); // test target
+
+      cache.put(2, new ModelB("Silvia", "Silvia"));
+
+      query = Search.getQueryFactory(cache).create("from model.Model where original is not null");
+      result = query.execute().list();
+
+      assertThat(result).extracting("original").containsExactly("Fabio", "Silvia");
+      assertThat(result).hasOnlyElementsOfType(ModelB.class);
+
+      query = Search.getQueryFactory(cache).create("from model.Model where different is not null");
+      result = query.execute().list();
+
+      assertThat(result).extracting("different").containsExactly("Silvia");
+      assertThat(result).hasOnlyElementsOfType(ModelB.class);
+   }
+
+   private void updateSchemaIndex() {
+      SchemaB schema = SchemaB.INSTANCE;
+
+      // Register proto schema && entity marshaller on client side
+      schema.registerSchema(schemaEvolutionClientMarshaller.getSerializationContext());
+      schema.registerMarshallers(schemaEvolutionClientMarshaller.getSerializationContext());
+
+      // Register proto schema on server side
+      RemoteCache<String, String> metadataCache = remoteCacheManager
+            .getCache(ProtobufMetadataManagerConstants.PROTOBUF_METADATA_CACHE_NAME);
+      metadataCache.put(schema.getProtoFileName(), schema.getProtoFile());
+
+      // reindexCache would make this test working as well,
+      // the difference is that with updateIndexSchema the index state (Lucene directories) is not touched,
+      // if the schema change is not retro-compatible reindexCache is required
+      remoteCacheManager.administration().updateIndexSchema(CACHE_NAME);
+   }
+}

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/annotation/model/Model.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/annotation/model/Model.java
@@ -1,0 +1,4 @@
+package org.infinispan.client.hotrod.annotation.model;
+
+public interface Model {
+}

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/annotation/model/ModelA.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/annotation/model/ModelA.java
@@ -1,0 +1,25 @@
+package org.infinispan.client.hotrod.annotation.model;
+
+import org.infinispan.api.annotations.indexing.Basic;
+import org.infinispan.api.annotations.indexing.Indexed;
+import org.infinispan.protostream.annotations.ProtoFactory;
+import org.infinispan.protostream.annotations.ProtoField;
+import org.infinispan.protostream.annotations.ProtoName;
+
+@Indexed
+@ProtoName("Model")
+public class ModelA implements Model {
+
+   private String original;
+
+   @ProtoFactory
+   public ModelA(String original) {
+      this.original = original;
+   }
+
+   @ProtoField(value = 1)
+   @Basic
+   public String getOriginal() {
+      return original;
+   }
+}

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/annotation/model/ModelB.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/annotation/model/ModelB.java
@@ -1,0 +1,36 @@
+package org.infinispan.client.hotrod.annotation.model;
+
+import org.infinispan.api.annotations.indexing.Basic;
+import org.infinispan.api.annotations.indexing.Indexed;
+import org.infinispan.protostream.annotations.ProtoFactory;
+import org.infinispan.protostream.annotations.ProtoField;
+import org.infinispan.protostream.annotations.ProtoName;
+
+@Indexed
+@ProtoName("Model")
+public class ModelB implements Model {
+
+   @Deprecated
+   public String original;
+
+   public String different;
+
+   @ProtoFactory
+   public ModelB(String original, String different) {
+      this.original = original;
+      this.different = different;
+   }
+
+   @Deprecated
+   @ProtoField(value = 1)
+   @Basic
+   public String getOriginal() {
+      return original;
+   }
+
+   @ProtoField(value = 2)
+   @Basic
+   public String getDifferent() {
+      return different;
+   }
+}

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/annotation/model/SchemaA.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/annotation/model/SchemaA.java
@@ -1,0 +1,11 @@
+package org.infinispan.client.hotrod.annotation.model;
+
+import org.infinispan.protostream.GeneratedSchema;
+import org.infinispan.protostream.annotations.AutoProtoSchemaBuilder;
+
+@AutoProtoSchemaBuilder(includeClasses = ModelA.class, schemaFileName = "model-schema.proto", schemaPackageName = "model")
+public interface SchemaA extends GeneratedSchema {
+
+   SchemaA INSTANCE = new SchemaAImpl();
+
+}

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/annotation/model/SchemaB.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/annotation/model/SchemaB.java
@@ -1,0 +1,11 @@
+package org.infinispan.client.hotrod.annotation.model;
+
+import org.infinispan.protostream.GeneratedSchema;
+import org.infinispan.protostream.annotations.AutoProtoSchemaBuilder;
+
+@AutoProtoSchemaBuilder(includeClasses = ModelB.class, schemaFileName = "model-schema.proto", schemaPackageName = "model")
+public interface SchemaB extends GeneratedSchema {
+
+   SchemaB INSTANCE = new SchemaBImpl();
+
+}

--- a/client/rest-client/src/main/java/org/infinispan/client/rest/RestCacheClient.java
+++ b/client/rest-client/src/main/java/org/infinispan/client/rest/RestCacheClient.java
@@ -434,6 +434,11 @@ public interface RestCacheClient {
    CompletionStage<RestResponse> clearIndex();
 
    /**
+    * Update index schema for the current cache.
+    */
+   CompletionStage<RestResponse> updateIndexSchema();
+
+   /**
     * Obtain statistics about queries.
     *
     * @deprecated Use {@link #searchStats()} instead.

--- a/client/rest-client/src/main/java/org/infinispan/client/rest/impl/okhttp/RestCacheClientOkHttp.java
+++ b/client/rest-client/src/main/java/org/infinispan/client/rest/impl/okhttp/RestCacheClientOkHttp.java
@@ -481,6 +481,11 @@ public class RestCacheClientOkHttp implements RestCacheClient {
    }
 
    @Override
+   public CompletionStage<RestResponse> updateIndexSchema() {
+      return executeIndexOperation("updateSchema", false);
+   }
+
+   @Override
    public CompletionStage<RestResponse> queryStats() {
       return executeSearchStatOperation("query", null);
    }

--- a/counter/src/main/java/org/infinispan/counter/EmbeddedCounterManagerFactory.java
+++ b/counter/src/main/java/org/infinispan/counter/EmbeddedCounterManagerFactory.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import org.infinispan.commons.IllegalLifecycleStateException;
 import org.infinispan.counter.api.CounterManager;
 import org.infinispan.factories.impl.BasicComponentRegistry;
+import org.infinispan.factories.impl.ComponentRef;
 import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.manager.EmbeddedCacheManager;
 
@@ -29,9 +30,13 @@ public final class EmbeddedCounterManagerFactory {
       if (cacheManager.getStatus() != ComponentStatus.RUNNING)
          throw new IllegalLifecycleStateException();
 
-      return SecurityActions.getGlobalComponentRegistry(cacheManager)
-                            .getComponent(BasicComponentRegistry.class)
-                            .getComponent(CounterManager.class)
-                            .running();
+      ComponentRef<CounterManager> component = SecurityActions.getGlobalComponentRegistry(cacheManager)
+            .getComponent(BasicComponentRegistry.class)
+            .getComponent(CounterManager.class);
+      if (component == null) {
+         return null;
+      }
+
+      return component.running();
    }
 }

--- a/counter/src/main/java/org/infinispan/counter/impl/CounterModuleLifecycle.java
+++ b/counter/src/main/java/org/infinispan/counter/impl/CounterModuleLifecycle.java
@@ -31,6 +31,7 @@ import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.factories.GlobalComponentRegistry;
 import org.infinispan.factories.annotations.InfinispanModule;
 import org.infinispan.factories.impl.BasicComponentRegistry;
+import org.infinispan.factories.impl.ComponentRef;
 import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.interceptors.impl.EntryWrappingInterceptor;
 import org.infinispan.jmx.CacheManagerJmxRegistration;
@@ -128,7 +129,12 @@ public class CounterModuleLifecycle implements ModuleLifecycle {
 
       log.debug("Register EmbeddedCounterManager");
       // required to instantiate and start the EmbeddedCounterManager.
-      CounterManager cm = bcr.getComponent(CounterManager.class).wired();
+      ComponentRef<CounterManager> component = bcr.getComponent(CounterManager.class);
+      if ( component == null ) {
+         return;
+      }
+
+      CounterManager cm = component.wired();
       if (globalConfiguration.jmx().enabled()) {
          try {
             CacheManagerJmxRegistration jmxRegistration = bcr.getComponent(CacheManagerJmxRegistration.class).running();

--- a/query/src/main/java/org/infinispan/query/backend/QueryInterceptor.java
+++ b/query/src/main/java/org/infinispan/query/backend/QueryInterceptor.java
@@ -402,6 +402,11 @@ public final class QueryInterceptor extends DDAsyncInterceptor {
    }
 
    CompletableFuture<?> processChange(InvocationContext ctx, FlagAffectedCommand command, Object storedKey, Object storedOldValue, Object storedNewValue) {
+      if (searchMapping.isRestarting()) {
+         log.mappingIsRestarting();
+         return CompletableFutures.completedNull();
+      }
+
       int segment = SegmentSpecificCommand.extractSegment(command, storedKey, keyPartitioner);
       Object key = extractKey(storedKey);
       Object oldValue = storedOldValue == UNKNOWN ? UNKNOWN : extractValue(storedOldValue);

--- a/query/src/main/java/org/infinispan/query/impl/LifecycleManager.java
+++ b/query/src/main/java/org/infinispan/query/impl/LifecycleManager.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -309,7 +310,7 @@ public class LifecycleManager implements ModuleLifecycle {
          SearchMappingBuilder builder = commonBuilding.builder(SearchMappingBuilder.introspector(MethodHandles.lookup()));
          builder.setEntityLoader(new EntityLoader<>(cache, queryStatistics));
          builder.addEntityTypes(types);
-         searchMapping = builder.build();
+         searchMapping = builder.build(Optional.empty());
          cr.registerComponent(searchMapping, SearchMapping.class);
       }
 

--- a/query/src/main/java/org/infinispan/query/logging/Log.java
+++ b/query/src/main/java/org/infinispan/query/logging/Log.java
@@ -183,5 +183,9 @@ public interface Log extends org.infinispan.query.core.impl.Log {
    @Message(value = "Cannot index entry since the search mapping failed to initialize.", id = 14055)
    CacheException searchMappingUnavailable();
 
+   @LogMessage(level = WARN)
+   @Message(value = "The indexing engine is restarting, index updates will be skipped for the current data changes.", id = 14059)
+   void mappingIsRestarting();
+
    // !!!!!! When adding anything new here please check the last used id in org.infinispan.query.core.impl.Log !!!!!!
 }

--- a/query/src/main/java/org/infinispan/search/mapper/mapping/SearchMapping.java
+++ b/query/src/main/java/org/infinispan/search/mapper/mapping/SearchMapping.java
@@ -74,9 +74,17 @@ public interface SearchMapping extends AutoCloseable {
    Set<Class<?>> allIndexedEntityJavaClasses();
 
    /**
-    * Releases all used resources (IO, threads) and restarts from the mapping configuration.
+    * Releases all used resources (IO, threads)
+    * and restarts from the mapping configuration.
     */
    default void reload() {
+   }
+
+   /**
+    * Releases some used resources (e.g.: threads), preserving some others (e.g.: IO)
+    * and restarts from the mapping configuration.
+    */
+   default void restart() {
    }
 
    /**

--- a/query/src/main/java/org/infinispan/search/mapper/mapping/SearchMapping.java
+++ b/query/src/main/java/org/infinispan/search/mapper/mapping/SearchMapping.java
@@ -43,6 +43,10 @@ public interface SearchMapping extends AutoCloseable {
 
    boolean isClose();
 
+   default boolean isRestarting() {
+      return false;
+   }
+
    SearchSession getMappingSession();
 
    SearchIndexer getSearchIndexer();

--- a/query/src/main/java/org/infinispan/search/mapper/mapping/SearchMappingBuilder.java
+++ b/query/src/main/java/org/infinispan/search/mapper/mapping/SearchMappingBuilder.java
@@ -3,6 +3,7 @@ package org.infinispan.search.mapper.mapping;
 import java.lang.invoke.MethodHandles;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import org.hibernate.search.engine.cfg.ConfigurationPropertySource;
@@ -115,7 +116,7 @@ public final class SearchMappingBuilder {
       return this;
    }
 
-   public SearchMapping build() {
+   public SearchMapping build(Optional<SearchIntegration> previousIntegration) {
       SearchIntegrationEnvironment.Builder envBuilder = SearchIntegrationEnvironment.builder(propertySource, propertyChecker);
       if (classLoaderService != null) {
          envBuilder.classResolver(classLoaderService);
@@ -128,7 +129,10 @@ public final class SearchMappingBuilder {
       SearchMapping mapping;
       SearchIntegration integration;
       try {
-         SearchIntegration.Builder integrationBuilder = SearchIntegration.builder(environment);
+         SearchIntegration.Builder integrationBuilder = (previousIntegration.isPresent()) ?
+               previousIntegration.get().restartBuilder(environment) :
+               SearchIntegration.builder(environment);
+
          integrationBuilder.addMappingInitiator(mappingKey, mappingInitiator);
          integrationPartialBuildState = integrationBuilder.prepareBuild();
 

--- a/query/src/main/java/org/infinispan/search/mapper/mapping/impl/InfinispanMapping.java
+++ b/query/src/main/java/org/infinispan/search/mapper/mapping/impl/InfinispanMapping.java
@@ -204,6 +204,10 @@ public class InfinispanMapping extends AbstractPojoMappingImplementor<SearchMapp
       return new EntityReferenceImpl(typeContext.typeIdentifier(), typeContext.name(), identifier);
    }
 
+   public SearchIntegration getIntegration() {
+      return integration;
+   }
+
    public void setIntegration(SearchIntegration integration) {
       this.integration = integration;
    }

--- a/query/src/test/java/org/infinispan/query/helper/SearchMappingHelper.java
+++ b/query/src/test/java/org/infinispan/query/helper/SearchMappingHelper.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import org.infinispan.search.mapper.mapping.SearchMapping;
 import org.infinispan.search.mapper.mapping.SearchMappingBuilder;
@@ -30,6 +31,6 @@ public class SearchMappingHelper {
       return SearchMapping.builder(introspector, null, Collections.emptyList())
                    .setProperties(properties)
                    .addEntityTypes(new HashSet<>(Arrays.asList(types)))
-                   .build();
+                   .build(Optional.empty());
    }
 }

--- a/server/core/src/main/java/org/infinispan/server/core/admin/embeddedserver/CacheUpdateIndexSchemaTask.java
+++ b/server/core/src/main/java/org/infinispan/server/core/admin/embeddedserver/CacheUpdateIndexSchemaTask.java
@@ -14,10 +14,10 @@ import org.infinispan.search.mapper.mapping.SearchMapping;
 import org.infinispan.server.core.admin.AdminServerTask;
 
 /**
- * Admin operation to reindex a cache
+ * Administrative operation to update the index schema for a cache with the following parameters:
  * Parameters:
  * <ul>
- *    <li><strong>name</strong> the name of the cache to reindex</li>
+ *    <li><strong>name</strong> specifies the cache for which its index schema will be updated.</li>
  *    <li><strong>flags</strong> unused</li>
  * </ul>
  *

--- a/server/core/src/main/java/org/infinispan/server/core/admin/embeddedserver/CacheUpdateIndexSchemaTask.java
+++ b/server/core/src/main/java/org/infinispan/server/core/admin/embeddedserver/CacheUpdateIndexSchemaTask.java
@@ -1,0 +1,58 @@
+package org.infinispan.server.core.admin.embeddedserver;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.infinispan.Cache;
+import org.infinispan.commons.api.CacheContainerAdmin;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.query.impl.ComponentRegistryUtils;
+import org.infinispan.search.mapper.mapping.SearchMapping;
+import org.infinispan.server.core.admin.AdminServerTask;
+
+/**
+ * Admin operation to reindex a cache
+ * Parameters:
+ * <ul>
+ *    <li><strong>name</strong> the name of the cache to reindex</li>
+ *    <li><strong>flags</strong> unused</li>
+ * </ul>
+ *
+ * @author Fabio Massimo Ercoli
+ * @since 14.0
+ */
+public class CacheUpdateIndexSchemaTask extends AdminServerTask<Void> {
+   private static final Set<String> PARAMETERS = Collections.singleton("name");
+
+   @Override
+   public String getTaskContextName() {
+      return "cache";
+   }
+
+   @Override
+   public String getTaskOperationName() {
+      return "updateindexschema";
+   }
+
+   @Override
+   public Set<String> getParameters() {
+      return PARAMETERS;
+   }
+
+   @Override
+   protected Void execute(EmbeddedCacheManager cacheManager, Map<String, List<String>> parameters, EnumSet<CacheContainerAdmin.AdminFlag> adminFlags) {
+      if(!adminFlags.isEmpty())
+         throw new UnsupportedOperationException();
+
+      String name = requireParameter(parameters, "name");
+      Cache<Object, Object> cache = cacheManager.getCache(name);
+
+      SearchMapping searchMapping = ComponentRegistryUtils.getSearchMapping(cache);
+      searchMapping.restart();
+
+      return null;
+   }
+}

--- a/server/core/src/main/java/org/infinispan/server/core/admin/embeddedserver/EmbeddedServerAdminOperationHandler.java
+++ b/server/core/src/main/java/org/infinispan/server/core/admin/embeddedserver/EmbeddedServerAdminOperationHandler.java
@@ -17,6 +17,7 @@ public class EmbeddedServerAdminOperationHandler extends AdminOperationsHandler 
             new CacheNamesTask(),
             new CacheRemoveTask(),
             new CacheReindexTask(),
+            new CacheUpdateIndexSchemaTask(),
             new TemplateCreateTask(),
             new TemplateRemoveTask(),
             new TemplateNamesTask()

--- a/server/runtime/src/main/java/org/infinispan/server/tasks/admin/ServerAdminOperationsHandler.java
+++ b/server/runtime/src/main/java/org/infinispan/server/tasks/admin/ServerAdminOperationsHandler.java
@@ -6,6 +6,7 @@ import org.infinispan.server.core.admin.AdminServerTask;
 import org.infinispan.server.core.admin.embeddedserver.CacheNamesTask;
 import org.infinispan.server.core.admin.embeddedserver.CacheReindexTask;
 import org.infinispan.server.core.admin.embeddedserver.CacheRemoveTask;
+import org.infinispan.server.core.admin.embeddedserver.CacheUpdateIndexSchemaTask;
 import org.infinispan.server.core.admin.embeddedserver.TemplateCreateTask;
 import org.infinispan.server.core.admin.embeddedserver.TemplateRemoveTask;
 
@@ -30,6 +31,7 @@ public class ServerAdminOperationsHandler extends AdminOperationsHandler {
                new CacheNamesTask(),
                new CacheRemoveTask(),
                new CacheReindexTask(),
+               new CacheUpdateIndexSchemaTask(),
                new LoggingSetTask(),
                new LoggingRemoveTask(),
                new TemplateCreateTask(),


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-13648

I added [this commit](https://github.com/infinispan/infinispan/pull/10114/commits/5dd6f794a2646f8777e1039f9b0b2569b7069e8c), since with it I'm not still be able to run HotRod tests on indexes from the IDE.