### PR TITLE
ISPN-13903 CME for a joining node with xsite

### DIFF
--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
@@ -184,7 +184,7 @@ public class JGroupsTransport implements Transport, ChannelListener {
    private final Condition viewUpdateCondition = viewUpdateLock.newCondition();
    private final ThreadPoolProbeHandler probeHandler;
    private final ChannelCallbacks channelCallbacks = new ChannelCallbacks();
-   private final Map<JChannel, Set<Object>> clusters = new HashMap<>();
+   private final Map<JChannel, Set<Object>> clusters = new ConcurrentHashMap<>();
    protected boolean connectChannel = true, disconnectChannel = true, closeChannel = true;
    protected TypedProperties props;
    protected JChannel channel;


### PR DESCRIPTION
ConcurrentModificationException happens when cross-site replication and
metrics are enabled because both channels start at the same time.

https://issues.redhat.com/browse/ISPN-13903