### PR TITLE
Test embedded protobuf-encoded indexed cache

### DIFF
--- a/query/src/test/java/org/infinispan/query/encoding/ProtobufEncodedIndexedCacheTest.java
+++ b/query/src/test/java/org/infinispan/query/encoding/ProtobufEncodedIndexedCacheTest.java
@@ -1,0 +1,52 @@
+package org.infinispan.query.encoding;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.infinispan.configuration.cache.IndexStorage.LOCAL_HEAP;
+
+import org.infinispan.commons.api.CacheContainerAdmin;
+import org.infinispan.commons.dataconversion.MediaType;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.query.Search;
+import org.infinispan.query.dsl.Query;
+import org.infinispan.query.dsl.QueryFactory;
+import org.infinispan.query.dsl.QueryResult;
+import org.infinispan.query.model.Book;
+import org.infinispan.query.model.Game;
+import org.infinispan.test.SingleCacheManagerTest;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.Test;
+
+@Test(groups = "functional", testName = "org.infinispan.query.encoding.ProtobufEncodedIndexedCacheTest")
+public class ProtobufEncodedIndexedCacheTest extends SingleCacheManagerTest {
+
+   @Override
+   protected EmbeddedCacheManager createCacheManager() throws Exception {
+      ConfigurationBuilder builder = getDefaultStandaloneCacheConfig(false);
+      builder
+            .encoding()
+               .mediaType(MediaType.APPLICATION_PROTOSTREAM_TYPE)
+            .indexing()
+               .enable()
+               .storage(LOCAL_HEAP)
+               .addIndexedEntity("Game");
+
+      EmbeddedCacheManager cacheManager = TestCacheManagerFactory.createCacheManager(Game.GameSchema.INSTANCE, null);
+      cache = cacheManager.administration()
+            .withFlags(CacheContainerAdmin.AdminFlag.VOLATILE)
+            .getOrCreateCache("default", builder.build());
+      return cacheManager;
+   }
+
+   @Test
+   public void test() {
+      cache.put(1, new Game("Civilization 1", "The best video game of all time!")); // according to the contributor
+
+      QueryFactory factory = Search.getQueryFactory(cache);
+      Query<Book> query = factory.create("from Game where description : 'game'");
+      QueryResult<Book> result = query.execute();
+
+      assertThat(result.hitCount()).hasValue(1L);
+      assertThat(result.list()).extracting("name").contains("Civilization 1");
+   }
+}

--- a/query/src/test/java/org/infinispan/query/model/Game.java
+++ b/query/src/test/java/org/infinispan/query/model/Game.java
@@ -1,0 +1,41 @@
+package org.infinispan.query.model;
+
+import org.hibernate.search.engine.backend.types.Projectable;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.KeywordField;
+import org.infinispan.protostream.GeneratedSchema;
+import org.infinispan.protostream.annotations.AutoProtoSchemaBuilder;
+import org.infinispan.protostream.annotations.ProtoFactory;
+import org.infinispan.protostream.annotations.ProtoField;
+
+@Indexed(index = "play")
+public class Game {
+
+   @KeywordField(projectable = Projectable.YES)
+   private String name;
+
+   @FullTextField
+   private String description;
+
+   @ProtoFactory
+   public Game(String name, String description) {
+      this.name = name;
+      this.description = description;
+   }
+
+   @ProtoField(1)
+   public String getName() {
+      return name;
+   }
+
+   @ProtoField(2)
+   public String getDescription() {
+      return description;
+   }
+
+   @AutoProtoSchemaBuilder(includeClasses = Game.class)
+   public interface GameSchema extends GeneratedSchema {
+      GameSchema INSTANCE = new GameSchemaImpl();
+   }
+}


### PR DESCRIPTION
I didn't create an issue for this.
I would like to add this test to make clear that even if we're in the embedded mode if we use a Protobuf-encoded indexed cache, the entities there are not the mapped Java classes, but the mapped ProtocolBuffer messages.

Draft => I still need to check something