### PR TITLE
ISPN-13931 SoftIndexFileStore is increasing the size of the data folder

### DIFF
--- a/commons-test/src/main/java/org/infinispan/commons/lambda/NamedLambdas.java
+++ b/commons-test/src/main/java/org/infinispan/commons/lambda/NamedLambdas.java
@@ -13,6 +13,10 @@ public class NamedLambdas {
       return new NamedPredicate(description, predicate);
    }
 
+   public static Runnable of(String description, Runnable runnable) {
+      return new NamedRunnable(description, runnable);
+   }
+
    private static class NamedPredicate<T> implements Predicate<T> {
 
       private String description;
@@ -67,6 +71,27 @@ public class NamedLambdas {
       @Override
       public BiConsumer<T, U> andThen(BiConsumer<? super T, ? super U> after) {
          return this.biConsumer.andThen(after);
+      }
+
+      @Override
+      public String toString() {
+         return this.description;
+      }
+   }
+
+   private static class NamedRunnable implements Runnable {
+
+      private final String description;
+      private final Runnable runnable;
+
+      private NamedRunnable(String description, Runnable runnable) {
+         this.description = description;
+         this.runnable = runnable;
+      }
+
+      @Override
+      public void run() {
+         runnable.run();
       }
 
       @Override

--- a/core/src/main/java/org/infinispan/persistence/sifs/IndexNode.java
+++ b/core/src/main/java/org/infinispan/persistence/sifs/IndexNode.java
@@ -713,6 +713,10 @@ class IndexNode {
                   if (log.isTraceEnabled()) {
                      log.trace(String.format("Updating num records for %d:%d to %d", oldLeafNode.file, oldLeafNode.offset, numRecords));
                   }
+                  if (recordChange == RecordChange.INCREASE_FOR_OLD) {
+                     // Mark old files as freed for compactor when rebuilding index
+                     segment.getCompactor().free(file, size);
+                  }
                   // We don't need to update the file as the file and position are the same, only the numRecords
                   // has been updated for REMOVED
                   file = oldLeafNode.file;

--- a/core/src/main/java/org/infinispan/persistence/sifs/IndexRequest.java
+++ b/core/src/main/java/org/infinispan/persistence/sifs/IndexRequest.java
@@ -56,8 +56,8 @@ class IndexRequest extends CompletableFuture<Object> {
       return new IndexRequest(Type.DROPPED, segment, Objects.requireNonNull(key), serializedKey, -1, -1, -1, prevFile, prevOffset);
    }
 
-   public static IndexRequest foundOld(int segment, Object key, ByteBuffer serializedKey, int prevFile, int prevOffset) {
-      return new IndexRequest(Type.FOUND_OLD, segment, Objects.requireNonNull(key), serializedKey, -1, -1, -1, prevFile, prevOffset);
+   public static IndexRequest foundOld(int segment, Object key, ByteBuffer serializedKey, int file, int offset, int size) {
+      return new IndexRequest(Type.FOUND_OLD, segment, Objects.requireNonNull(key), serializedKey, file, offset, size, -1, -1);
    }
 
    public static IndexRequest clearRequest() {

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -2327,4 +2327,7 @@ public interface Log extends BasicLogger {
 
    @Message(value = "Cannot persist RAFT data as global state is disabled", id = 673)
    CacheConfigurationException raftGlobalStateDisabled();
+
+   @Message(value = "There was an error when resetting the SIFS index for cache %s", id = 674)
+   PersistenceException issueEncounteredResettingIndex(String cacheName, @Cause Throwable t);
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-13931

Persist the file stats upon shutdown so upon restart we know what the previous free space was.

The test passes however there is still an issue with the case when the stats file is not present that the free space is not read in properly afaik. I am still trying to fix this last part, as it is required for migration of existing directories and should clean those up if they have old files lying around.