### PR TITLE
ISPN-12350 Persistent UUIDs are only used for initial consistent hash

### DIFF
--- a/commons/all/src/main/java/org/infinispan/commons/marshall/Ids.java
+++ b/commons/all/src/main/java/org/infinispan/commons/marshall/Ids.java
@@ -226,6 +226,9 @@ public interface Ids {
    Integer COMMAND_INVOCATION_ID = 154;
    Integer CACHE_ENTRY_GROUP_PREDICATE = 155;
 
+   Integer SYNC_CONSISTENT_HASH = 156;
+   Integer HASHING_MEMBER = 157;
+
    Integer COUNTER_CONFIGURATION = 2000; //from counter
    Integer COUNTER_STATE = 2001; //from counter
 }

--- a/core/src/main/java/org/infinispan/distribution/Member.java
+++ b/core/src/main/java/org/infinispan/distribution/Member.java
@@ -1,0 +1,107 @@
+package org.infinispan.distribution;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.Collections;
+import java.util.Set;
+
+import net.jcip.annotations.Immutable;
+import org.infinispan.commons.marshall.Ids;
+import org.infinispan.commons.marshall.InstanceReusingAdvancedExternalizer;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.topology.PersistentUUID;
+
+/**
+ * Represents a single node during the hashing steps.
+ * <p/>
+ * For each node, it contains the {@link Address}, the node's {@link PersistentUUID} provided by the
+ * {@link org.infinispan.topology.PersistentUUIDManager}, and the node's capacity factor.
+ *
+ * @author José Bolina
+ * @since 14.0
+ */
+@Immutable
+public class Member {
+
+   private final Address address;
+   private final PersistentUUID uuid;
+   private final float capacityFactor;
+
+   public Member(Address address, PersistentUUID uuid, float capacityFactor) {
+      this.address = address;
+      this.uuid = uuid;
+      this.capacityFactor = capacityFactor;
+   }
+
+   public Address address() {
+      return address;
+   }
+
+   public PersistentUUID uuid() {
+      return uuid;
+   }
+
+   public float capacityFactor() {
+      return capacityFactor;
+   }
+
+   @Override
+   public boolean equals(final Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      Member that = (Member) o;
+
+      return address().equals(that.address)
+            && capacityFactor == that.capacityFactor;
+   }
+
+   @Override
+   public int hashCode() {
+      int result = Math.round(capacityFactor);
+      result = 31 * result + address.hashCode();
+      return result;
+   }
+
+   @Override
+   public String toString() {
+      return "Member{" +
+            "address=" + address +
+            ", uuid=" + uuid +
+            ", capacityFactor=" + capacityFactor +
+            '}';
+   }
+
+   public static final class Externalizer extends InstanceReusingAdvancedExternalizer<Member> {
+
+      public Externalizer() {
+         super(false);
+      }
+
+      @Override
+      public Integer getId() {
+         return Ids.HASHING_MEMBER;
+      }
+
+      @Override
+      public Set<Class<? extends Member>> getTypeClasses() {
+         return Collections.singleton(Member.class);
+      }
+
+      @Override
+      public void doWriteObject(ObjectOutput output, Member member) throws IOException {
+         output.writeObject(member.address);
+         output.writeObject(member.uuid);
+         output.writeFloat(member.capacityFactor);
+      }
+
+      @Override
+      public Member doReadObject(ObjectInput input) throws IOException, ClassNotFoundException {
+         Address address = (Address) input.readObject();
+         PersistentUUID uuid = (PersistentUUID) input.readObject();
+         float capacityFactor = input.readFloat();
+         return new Member(address, uuid, capacityFactor);
+      }
+   }
+}

--- a/core/src/main/java/org/infinispan/distribution/ch/ConsistentHash.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/ConsistentHash.java
@@ -47,6 +47,11 @@ public interface ConsistentHash {
    int getNumSegments();
 
    /**
+    * @return the number of owners each segment have.
+    */
+   int getNumOwners();
+
+   /**
     * Should return the addresses of the nodes used to create this consistent hash.
     *
     * @return set of node addresses.

--- a/core/src/main/java/org/infinispan/distribution/ch/impl/DefaultConsistentHash.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/impl/DefaultConsistentHash.java
@@ -146,6 +146,7 @@ public class DefaultConsistentHash extends AbstractConsistentHash {
       return segmentOwners[segmentId].get(0);
    }
 
+   @Override
    public int getNumOwners() {
       return numOwners;
    }

--- a/core/src/main/java/org/infinispan/distribution/ch/impl/ReplicatedConsistentHash.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/impl/ReplicatedConsistentHash.java
@@ -173,6 +173,7 @@ public class ReplicatedConsistentHash implements ConsistentHash {
       return primaryOwners.length;
    }
 
+   @Override
    public int getNumOwners() {
       return membersWithState.size();
    }

--- a/core/src/main/java/org/infinispan/distribution/ch/impl/ScatteredConsistentHash.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/impl/ScatteredConsistentHash.java
@@ -135,7 +135,8 @@ public class ScatteredConsistentHash extends AbstractConsistentHash {
       return segmentOwners[segmentId];
    }
 
-   private int getNumOwners() {
+   @Override
+   public int getNumOwners() {
       return 1;
    }
 

--- a/core/src/main/java/org/infinispan/distribution/ch/impl/SyncConsistentHash.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/impl/SyncConsistentHash.java
@@ -1,0 +1,304 @@
+package org.infinispan.distribution.ch.impl;
+
+import static org.infinispan.distribution.ch.impl.ConsistentHashPersistenceConstants.STATE_CONSISTENT_HASH;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
+
+import net.jcip.annotations.Immutable;
+import org.infinispan.commons.marshall.Ids;
+import org.infinispan.commons.marshall.InstanceReusingAdvancedExternalizer;
+import org.infinispan.commons.util.Immutables;
+import org.infinispan.distribution.Member;
+import org.infinispan.distribution.ch.ConsistentHash;
+import org.infinispan.globalstate.ScopedPersistentState;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.topology.PersistentUUID;
+
+/**
+ * An immutable {@link ConsistentHash}.
+ * <p/>
+ * This hash keep the association between the node's {@link Address} and {@link PersistentUUID}, which we use
+ * when creating the hash to distribute the segments between the nodes.
+ * <p/>
+ * This hash will delegate its operations to {@link DefaultConsistentHash}, where we implement only some methods
+ * to be sure we propagate the members.
+ *
+ * @author José Bolina
+ * @since 14.0
+ * @see DefaultConsistentHash
+ */
+@Immutable
+public class SyncConsistentHash implements ConsistentHash {
+   private static final String STATE_ASSOCIATION_ADDRESS_INDEX = "association.%d.uuid";
+
+   private final List<Member> members;
+   private final DefaultConsistentHash delegate;
+
+   public SyncConsistentHash(int numOwners, int numSegments, List<Member> members, List<Member>[] owners) {
+      this(members, numOwners, numSegments, collectOwners(owners));
+   }
+
+   public SyncConsistentHash(List<Member> members, int numOwners, int numSegments, List<Address>[] owners) {
+      this(members, new DefaultConsistentHash(numOwners, numSegments, collectAddresses(members),
+            collectCapacityFactors(members), owners));
+   }
+
+   SyncConsistentHash(ScopedPersistentState state) {
+      DefaultConsistentHash delegate = new DefaultConsistentHash(state);
+      List<Member> members = readState(state, delegate);
+      this.delegate = delegate;
+      this.members = Immutables.immutableListCopy(members);
+   }
+
+   private SyncConsistentHash(Collection<Member> members, DefaultConsistentHash delegate) {
+      this.members = Immutables.immutableListConvert(members);
+      this.delegate = delegate;
+   }
+
+   @Override
+   public int getNumSegments() {
+      return delegate.getNumSegments();
+   }
+
+   @Override
+   public int getNumOwners() {
+      return delegate.getNumOwners();
+   }
+
+   @Override
+   public List<Address> getMembers() {
+      return delegate.getMembers();
+   }
+
+   public List<Member> completeMembers() {
+      return members;
+   }
+
+   @Override
+   public List<Address> locateOwnersForSegment(int segmentId) {
+      return delegate.locateOwnersForSegment(segmentId);
+   }
+
+   @Override
+   public Address locatePrimaryOwnerForSegment(int segmentId) {
+      return delegate.locatePrimaryOwnerForSegment(segmentId);
+   }
+
+   @Override
+   public Set<Integer> getSegmentsForOwner(Address owner) {
+      return delegate.getSegmentsForOwner(owner);
+   }
+
+   @Override
+   public Set<Integer> getPrimarySegmentsForOwner(Address owner) {
+      return delegate.getPrimarySegmentsForOwner(owner);
+   }
+
+   @Override
+   public String getRoutingTableAsString() {
+      return delegate.getRoutingTableAsString();
+   }
+
+   @Override
+   public void toScopedState(ScopedPersistentState state) {
+      delegate.toScopedState(state);
+      state.setProperty(STATE_CONSISTENT_HASH, this.getClass().getName());
+      Map<Address, PersistentUUID> association = collectPersistentUuid(members);
+      for (int i = 0; i < delegate.members.size(); i++) {
+         PersistentUUID uuid = association.get(delegate.members.get(i));
+         String stringified = uuid != null ? uuid.toString() : "";
+         state.setProperty(String.format(STATE_ASSOCIATION_ADDRESS_INDEX, i), stringified);
+      }
+   }
+
+   @Override
+   public ConsistentHash remapAddresses(UnaryOperator<Address> remapper) {
+      DefaultConsistentHash remappedDelegate = (DefaultConsistentHash) delegate.remapAddresses(remapper);
+
+      if (remappedDelegate == null) return null;
+
+      List<Member> remappedMembers = new ArrayList<>(members.size());
+      Map<Address, PersistentUUID> association = collectPersistentUuid(members);
+      for (Member member: members) {
+         PersistentUUID previousUuid = association.get(member.address());
+         Address remappedAddress = remapper.apply(member.address());
+         Member remappedMember = new Member(remappedAddress, previousUuid, member.capacityFactor());
+         remappedMembers.add(remappedMember);
+      }
+
+      return new SyncConsistentHash(remappedMembers, remappedDelegate);
+   }
+
+   @Override
+   public Map<Address, Float> getCapacityFactors() {
+      return delegate.getCapacityFactors();
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      SyncConsistentHash that = (SyncConsistentHash) o;
+      return delegate.equals(that.delegate)
+            && members.equals(that.members);
+   }
+
+   @Override
+   public int hashCode() {
+      return delegate.hashCode();
+   }
+
+   @Override
+   public String toString() {
+      StringBuilder sb = new StringBuilder("SyncConsistentHash{");
+      sb.append("associations=[");
+      boolean first = true;
+      Map<Address, PersistentUUID> association = collectPersistentUuid(members);
+      for (Map.Entry<Address, PersistentUUID> entry: association.entrySet()) {
+         if (first) {
+            first = false;
+         } else {
+            sb.append(", ");
+         }
+
+         sb.append("(")
+               .append(entry.getKey())
+               .append(", ")
+               .append(entry.getValue())
+               .append(")");
+      }
+
+      sb.append("]")
+            .append(", delegate=")
+            .append(delegate.toString())
+            .append("}");
+      return sb.toString();
+   }
+
+   public SyncConsistentHash union(SyncConsistentHash other) {
+      DefaultConsistentHash delegateUnion = delegate.union(other.delegate);
+
+      Set<Member> unionMembers = new HashSet<>();
+      unionMembers.addAll(members);
+      unionMembers.addAll(other.members);
+
+      return new SyncConsistentHash(unionMembers, delegateUnion);
+   }
+
+   private static List<Address> collectAddresses(List<Member> members) {
+      return members.stream().map(Member::address).collect(Collectors.toList());
+   }
+
+   private static Map<Address, Float> collectCapacityFactors(List<Member> members) {
+      return members.stream().collect(Collectors.toMap(Member::address, Member::capacityFactor));
+   }
+
+   private static Map<Address, PersistentUUID> collectPersistentUuid(List<Member> members) {
+      return members.stream()
+            .filter(m -> m.uuid() != null)
+            .collect(Collectors.toMap(Member::address, Member::uuid));
+   }
+
+   private static List<Member> readState(ScopedPersistentState state, DefaultConsistentHash delegate) {
+      List<Address> addresses = delegate.getMembers();
+      Map<Address, Float> capacityFactors = delegate.getCapacityFactors();
+      List<Member> members = new ArrayList<>(addresses.size());
+
+      for (int i = 0; i < addresses.size(); i++) {
+         String stringified = state.getProperty(String.format(STATE_ASSOCIATION_ADDRESS_INDEX, i));
+         Address address = addresses.get(i);
+         float capacity = capacityFactors.getOrDefault(address, 1.0f);
+         PersistentUUID uuid = stringified.isEmpty() ? null : PersistentUUID.fromString(stringified);
+         Member member = new Member(address, uuid, capacity);
+         members.add(member);
+      }
+
+      return members;
+   }
+
+   public static List<Address>[] collectOwners(List<Member>[] memberOwners) {
+      List<Address>[] segmentOwners = new List[memberOwners.length];
+      for (int i = 0; i < memberOwners.length; i++) {
+         Address[] owners = new Address[memberOwners[i].size()];
+         for (int j = 0; j < memberOwners[i].size(); j++) {
+            Member member = memberOwners[i].get(j);
+            owners[j] = member.address();
+         }
+         segmentOwners[i] = Immutables.immutableListWrap(owners);
+      }
+      return segmentOwners;
+   }
+
+   public static class Externalizer extends InstanceReusingAdvancedExternalizer<SyncConsistentHash> {
+
+      @Override
+      public Integer getId() {
+         return Ids.SYNC_CONSISTENT_HASH;
+      }
+
+      @Override
+      public Set<Class<? extends SyncConsistentHash>> getTypeClasses() {
+         return Collections.singleton(SyncConsistentHash.class);
+      }
+
+      @Override
+      public void doWriteObject(ObjectOutput output, SyncConsistentHash sync) throws IOException {
+         output.writeInt(sync.getNumSegments());
+         output.writeInt(sync.delegate.getNumOwners());
+         output.writeObject(sync.members);
+
+         Map<Address, Member> grouped = sync.members.stream().collect(Collectors.toMap(Member::address, Function.identity()));
+         Map<Member, Integer> indexed = getMemberIndexMap(sync.members);
+         for (int i = 0; i < sync.getNumSegments(); i++) {
+            List<Address> owners = sync.locateOwnersForSegment(i);
+            output.writeInt(owners.size());
+            for (Address owner: owners) {
+               output.writeInt(indexed.get(grouped.get(owner)));
+            }
+         }
+      }
+
+      @Override
+      @SuppressWarnings("unchecked")
+      public SyncConsistentHash doReadObject(ObjectInput input) throws IOException, ClassNotFoundException {
+         int numSegments = input.readInt();
+         int numOwners = input.readInt();
+         List<Member> members = (List<Member>) input.readObject();
+
+         List<Member>[] segmentOwners = new List[numSegments];
+         for (int i = 0; i < numSegments; i++) {
+            int size = input.readInt();
+            Member[] owners = new Member[size];
+            for (int j = 0; j < size; j++) {
+               int index = input.readInt();
+               owners[j] = members.get(index);
+            }
+            segmentOwners[i] = Immutables.immutableListWrap(owners);
+         }
+
+         return new SyncConsistentHash(numOwners, numSegments, members, segmentOwners);
+      }
+
+      private HashMap<Member, Integer> getMemberIndexMap(List<Member> members) {
+         HashMap<Member, Integer> memberIndexes = new HashMap<>(members.size());
+         for (int i = 0; i < members.size(); i++) {
+            memberIndexes.put(members.get(i), i);
+         }
+         return memberIndexes;
+      }
+   }
+}

--- a/core/src/main/java/org/infinispan/marshall/core/InternalExternalizers.java
+++ b/core/src/main/java/org/infinispan/marshall/core/InternalExternalizers.java
@@ -38,12 +38,14 @@ import org.infinispan.container.entries.metadata.MetadataTransientMortalCacheVal
 import org.infinispan.container.versioning.NumericVersion;
 import org.infinispan.container.versioning.SimpleClusteredVersion;
 import org.infinispan.context.Flag;
+import org.infinispan.distribution.Member;
 import org.infinispan.distribution.ch.impl.DefaultConsistentHash;
 import org.infinispan.distribution.ch.impl.DefaultConsistentHashFactory;
 import org.infinispan.distribution.ch.impl.ReplicatedConsistentHash;
 import org.infinispan.distribution.ch.impl.ReplicatedConsistentHashFactory;
 import org.infinispan.distribution.ch.impl.ScatteredConsistentHash;
 import org.infinispan.distribution.ch.impl.ScatteredConsistentHashFactory;
+import org.infinispan.distribution.ch.impl.SyncConsistentHash;
 import org.infinispan.distribution.ch.impl.SyncConsistentHashFactory;
 import org.infinispan.distribution.ch.impl.SyncReplicatedConsistentHashFactory;
 import org.infinispan.distribution.ch.impl.TopologyAwareConsistentHashFactory;
@@ -154,6 +156,8 @@ final class InternalExternalizers {
       addInternalExternalizer(new CollectionExternalizer(), exts);
       addInternalExternalizer(new CompositeKeyValueFilter.Externalizer(), exts); // TODO: Untested in core
       addInternalExternalizer(new DefaultConsistentHash.Externalizer(), exts);
+      addInternalExternalizer(new SyncConsistentHash.Externalizer(), exts);
+      addInternalExternalizer(new Member.Externalizer(), exts);
       addInternalExternalizer(new DefaultConsistentHashFactory.Externalizer(), exts); // TODO: Untested in core
       addInternalExternalizer(new DoubleSummaryStatisticsExternalizer(), exts);
       addInternalExternalizer(new EmbeddedMetadata.Externalizer(), exts);

--- a/core/src/test/java/org/infinispan/distribution/ch/SyncConsistentHashFactoryKeyDistributionTest.java
+++ b/core/src/test/java/org/infinispan/distribution/ch/SyncConsistentHashFactoryKeyDistributionTest.java
@@ -57,7 +57,7 @@ public class SyncConsistentHashFactoryKeyDistributionTest extends AbstractInfini
    // percentiles to print
    public static final double[] PERCENTILES = { .999 };
 
-   protected ConsistentHashFactory<DefaultConsistentHash> createFactory() {
+   protected ConsistentHashFactory createFactory() {
       return new SyncConsistentHashFactory();
    }
 
@@ -132,7 +132,7 @@ public class SyncConsistentHashFactoryKeyDistributionTest extends AbstractInfini
       int distIndex = 0;
       ConsistentHashFactory<DefaultConsistentHash> chf = createFactory();
       for (int i = 0; i < LOOPS; i++) {
-         DefaultConsistentHash ch = chf.create(numOwners, numSegments, members, null);
+         ConsistentHash ch = chf.create(numOwners, numSegments, members, null);
          OwnershipStatistics stats = new OwnershipStatistics(ch, ch.getMembers());
          assertEquals(numSegments * numOwners, stats.sumOwned());
          for (Address node : ch.getMembers()) {
@@ -160,14 +160,14 @@ public class SyncConsistentHashFactoryKeyDistributionTest extends AbstractInfini
       double[] largestRatio = new double[LOOPS];
       int distIndex = 0;
 
-      ConsistentHashFactory<DefaultConsistentHash> chf = createFactory();
-      DefaultConsistentHash ch = chf.create(numOwners, numSegments, members, null);
+      ConsistentHashFactory<ConsistentHash> chf = createFactory();
+      ConsistentHash ch = chf.create(numOwners, numSegments, members, null);
 
       // loop leave/join and rebalance
       for (int i = 0; i < LOOPS; i++) {
          // leave
          members.remove(0);
-         DefaultConsistentHash rebalancedCH = chf.updateMembers(ch, members, null);
+         ConsistentHash rebalancedCH = chf.updateMembers(ch, members, null);
          ch = chf.rebalance(rebalancedCH);
          // join
          Address joiner = createSingleAddress(numNodes + i);
@@ -250,7 +250,7 @@ public class SyncConsistentHashFactoryKeyDistributionTest extends AbstractInfini
       return new IndexedJGroupsAddress(UUID.randomUUID(), nodeIndex);
    }
 
-   protected double getSegmentsPerNodesMinMaxRatio(DefaultConsistentHash ch) {
+   protected double getSegmentsPerNodesMinMaxRatio(ConsistentHash ch) {
       int max = 0;
       int min = Integer.MAX_VALUE;
       for (Address addr : ch.getMembers()) {

--- a/core/src/test/java/org/infinispan/distribution/ch/TopologyAwareSyncConsistentHashFactoryKeyDistributionTest.java
+++ b/core/src/test/java/org/infinispan/distribution/ch/TopologyAwareSyncConsistentHashFactoryKeyDistributionTest.java
@@ -37,7 +37,7 @@ public class TopologyAwareSyncConsistentHashFactoryKeyDistributionTest extends S
    }
 
    @Override
-   protected ConsistentHashFactory<DefaultConsistentHash> createFactory() {
+   protected ConsistentHashFactory createFactory() {
       return new TopologyAwareSyncConsistentHashFactory();
    }
 

--- a/core/src/test/java/org/infinispan/distribution/topologyaware/TopologyAwareSyncConsistentHashFactoryTest.java
+++ b/core/src/test/java/org/infinispan/distribution/topologyaware/TopologyAwareSyncConsistentHashFactoryTest.java
@@ -5,7 +5,6 @@ import static org.testng.Assert.assertTrue;
 import java.util.List;
 
 import org.infinispan.distribution.ch.ConsistentHashFactory;
-import org.infinispan.distribution.ch.impl.DefaultConsistentHash;
 import org.infinispan.distribution.ch.impl.TopologyAwareSyncConsistentHashFactory;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.util.logging.Log;
@@ -23,7 +22,7 @@ public class TopologyAwareSyncConsistentHashFactoryTest extends TopologyAwareCon
    private final Log log = LogFactory.getLog(TopologyAwareSyncConsistentHashFactoryTest.class);
 
    @Override
-   protected ConsistentHashFactory<DefaultConsistentHash> createConsistentHashFactory() {
+   protected ConsistentHashFactory createConsistentHashFactory() {
       return new TopologyAwareSyncConsistentHashFactory();
    }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12350

We need to use the `PersistentUUID` while hashing the node's address. Initially, I was going to only pass the converting method from `PersistentUUIDManager` in all `ConsistentHashFactory` uses, but soon enough, I realized that was not a good approach.

To propagate the `PersistentUUID` and be ready to use it during the hash, I created the `Member` class and the `SyncConsistentHash`. The `Member` only wraps the values together. The `SyncConsistentHash` keep the `Member` objects, serializing and transferring as needed, and other operations it delegates to the `DefaultConsistentHash`.

In the `ConsistentHashFactory`, I kept the existing methods, and the new ones will delegate to the already existing ones. `ClusterCacheStatus` is using the added methods.

The `SyncConsistentHash` serializes the `UUID`, so it may be that we have a larger serialized object here when compared with `DefaultConsistentHash`. From the `SyncConsistentHashFactoryTest`, we also can see that it may move more segments.

I was definitely struggling with this one. So any review or inputs is really appreciated.