### PR TITLE
ISPN-13944 Log remote IP in DEBUG message for a REST connection closi…

### DIFF
--- a/server/rest/src/main/java/org/infinispan/rest/RestRequestHandler.java
+++ b/server/rest/src/main/java/org/infinispan/rest/RestRequestHandler.java
@@ -167,7 +167,7 @@ public class RestRequestHandler extends BaseHttpRequestHandler {
       } else if (e instanceof Errors.NativeIoException) {
          // Native IO exceptions happen on HAProxy disconnect. It sends RST instead of FIN, which cases
          // a Netty IO Exception. The only solution is to ignore it, just like Tomcat does.
-         logger.debug("Native IO Exception", e);
+         logger.debugf(e, "Native IO Exception from %s", ctx.channel().remoteAddress());
          ctx.close();
       } else if (!ctx.channel().isActive() && e instanceof IllegalStateException &&
                  e.getMessage().equals("ssl is null")) {


### PR DESCRIPTION
…ng abnormally

https://issues.redhat.com/browse/ISPN-13944

Message:

```text
09:13:13,111 DEBUG (non-blocking-thread-PipelineInitializationTest-NodeA-p2-t1:[]) [RestRequestHandler] Native IO Exception from /127.0.0.1:52620
io.netty.channel.unix.Errors$NativeIoException: readAddress(..) failed: Connection reset by peer
```

Triggered with:

```java
public void shouldTriggerRST() throws IOException {
    Socket socket = new Socket(InetAddress.getLocalHost(), restServer.getPort());
    socket.setSoLinger(true, 0);
    assertTrue(socket.isConnected(), "Client not connected!");
    socket.close();
}
```