### PR TITLE
ISPN-13943 Don't implicitly enable the RESP connector if realm does n…

### DIFF
--- a/server/core/src/main/java/org/infinispan/server/core/configuration/ProtocolServerConfigurationBuilder.java
+++ b/server/core/src/main/java/org/infinispan/server/core/configuration/ProtocolServerConfigurationBuilder.java
@@ -154,6 +154,10 @@ public abstract class ProtocolServerConfigurationBuilder<T extends ProtocolServe
       return this.self();
    }
 
+   public boolean implicitConnector() {
+      return attributes.attribute(IMPLICIT_CONNECTOR).get();
+   }
+
    @Override
    public void validate() {
       ssl.validate();


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-13943

Fixes TLSWithoutAuthenticationIT and CertWithoutAuthenticationIT failures