### PR TITLE
ISPN-13984 Upgrade JGroups to 5.2.3.Final and Raft to 1.0.9.Final

### DIFF
--- a/build/configuration/pom.xml
+++ b/build/configuration/pom.xml
@@ -163,8 +163,8 @@
       <version.jboss.shrinkwrap.descriptors>2.0.0</version.jboss.shrinkwrap.descriptors>
       <version.jboss.shrinkwrap.resolver>3.1.3</version.jboss.shrinkwrap.resolver>
       <version.jcip-annotations>1.0</version.jcip-annotations>
-      <version.jgroups>5.2.2.Final</version.jgroups>
-      <version.jgroups.raft>1.0.8.Final</version.jgroups.raft>
+      <version.jgroups>5.2.3.Final</version.jgroups>
+      <version.jgroups.raft>1.0.9.Final</version.jgroups.raft>
       <version.jsr107>1.1.0</version.jsr107>
       <version.junit>4.13.2</version.junit>
       <version.junit5>5.8.2</version.junit5>

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsRaftManager.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsRaftManager.java
@@ -28,8 +28,8 @@ import org.jgroups.protocols.raft.InMemoryLog;
 import org.jgroups.protocols.raft.NO_DUPES;
 import org.jgroups.protocols.raft.RAFT;
 import org.jgroups.protocols.raft.REDIRECT;
-import org.jgroups.protocols.raft.StateMachine;
 import org.jgroups.raft.RaftHandle;
+import org.jgroups.raft.StateMachine;
 import org.jgroups.stack.ProtocolStack;
 
 /**

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsStateMachineAdapter.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsStateMachineAdapter.java
@@ -8,7 +8,7 @@ import org.infinispan.commons.io.ByteBuffer;
 import org.infinispan.commons.io.ByteBufferImpl;
 import org.infinispan.commons.util.Util;
 import org.infinispan.remoting.transport.raft.RaftStateMachine;
-import org.jgroups.protocols.raft.StateMachine;
+import org.jgroups.raft.StateMachine;
 
 /**
  * An adapter that converts JGroups {@link StateMachine} calls to {@link  RaftStateMachine}.
@@ -24,7 +24,8 @@ class JGroupsStateMachineAdapter<T extends RaftStateMachine> implements StateMac
    }
 
    @Override
-   public byte[] apply(byte[] data, int offset, int length) throws Exception {
+   public byte[] apply(byte[] data, int offset, int length, boolean serialize_response) throws Exception {
+      // serialize_response ignored.
       ByteBuffer buffer = stateMachine.apply(ByteBufferImpl.create(data, offset, length));
       return buffer == null ? Util.EMPTY_BYTE_ARRAY : buffer.trim();
    }


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-13984

JGroups 5.2.3.Final isn't available in Maven Central yet. It may take a couple of days to sync because of Jboss Repo issues.