### PR TITLE
ISPN-14018 Compatibility between new HR version with old versions

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec40.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec40.java
@@ -39,7 +39,6 @@ public class Codec40 extends Codec31 {
 
    private void writeOtherParams(ByteBuf buf, Map<String, byte[]> parameters) {
       if (parameters == null) {
-         ByteBufUtil.writeVInt(buf, 0);
          return;
       }
 

--- a/server/hotrod/src/main/resources/hotrod.gr
+++ b/server/hotrod/src/main/resources/hotrod.gr
@@ -11,6 +11,7 @@ constants org.infinispan.server.hotrod.HotRodConstants;
 // methods vInt, vLong, array, byte...
 intrinsics org.infinispan.server.hotrod.Intrinsics;
 
+import java.lang.Integer;
 import java.time.Instant;
 import java.time.temporal.Temporal;
 import java.util.Collections;
@@ -114,11 +115,15 @@ mediaTypeDescription returns MediaType switch mediaTypeDefinition
    ;
 
 otherParams returns Map<String, byte[]>
-: { version >= VERSION_40 }? otherParamsRev
+: { version >= VERSION_40 }? otherParamsNum { otherParamsRev }
    | { null }
    ;
 
-otherParamsNum: vInt;
+otherParamsSize: vInt;
+otherParamsNum returns int
+   : otherParamsSize { (otherParamsSize != Integer.MIN_VALUE) && (otherParamsSize > 0) }? otherParamsSize
+   | { 0 }
+   ;
 otherParamName: string;
 otherParamValue: array;
 otherParamsRev returns Map<String, byte[]>


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-14018

I've tried to make the additional parameters optional. Without this, if we send a request without the parameters the HR 4.0 is unable to parse the headers correctly. With this change we can make the ping operation tracing optional and enable tracing after the protocol is negotiated.

