### PR TITLE
ISPN-12912 Data Distribution endpoint for caches

### DIFF
--- a/server/rest/src/main/java/org/infinispan/rest/cachemanager/SecurityActions.java
+++ b/server/rest/src/main/java/org/infinispan/rest/cachemanager/SecurityActions.java
@@ -12,15 +12,19 @@ import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.factories.GlobalComponentRegistry;
+import org.infinispan.manager.ClusterExecutor;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.notifications.Listenable;
+import org.infinispan.security.AuthorizationManager;
 import org.infinispan.security.Security;
 import org.infinispan.security.actions.AddCacheManagerListenerAction;
+import org.infinispan.security.actions.GetCacheAuthorizationManagerAction;
 import org.infinispan.security.actions.GetCacheComponentRegistryAction;
 import org.infinispan.security.actions.GetCacheConfigurationAction;
 import org.infinispan.security.actions.GetCacheDistributionManagerAction;
 import org.infinispan.security.actions.GetCacheEntryAsyncAction;
 import org.infinispan.security.actions.GetCacheManagerConfigurationAction;
+import org.infinispan.security.actions.GetClusterExecutorAction;
 import org.infinispan.security.actions.GetGlobalComponentRegistryAction;
 import org.infinispan.security.actions.RemoveListenerAsyncAction;
 
@@ -75,5 +79,13 @@ final class SecurityActions {
 
    static GlobalConfiguration getCacheManagerConfiguration(EmbeddedCacheManager cacheManager) {
       return doPrivileged(new GetCacheManagerConfigurationAction(cacheManager));
+   }
+
+   static ClusterExecutor getClusterExecutor(EmbeddedCacheManager cacheManager) {
+      return doPrivileged(new GetClusterExecutorAction(cacheManager));
+   }
+
+   static AuthorizationManager getCacheAuthorizationManager(final AdvancedCache<?, ?> cache) {
+      return doPrivileged(new GetCacheAuthorizationManagerAction(cache));
    }
 }

--- a/server/tests/src/test/java/org/infinispan/server/security/authorization/AbstractAuthorization.java
+++ b/server/tests/src/test/java/org/infinispan/server/security/authorization/AbstractAuthorization.java
@@ -123,6 +123,40 @@ public abstract class AbstractAuthorization {
       RestCacheClient adminCache = getServerTest().rest().withClientConfiguration(restBuilders.get(TestUser.ADMIN)).withCacheMode(CacheMode.DIST_SYNC).create().cache(getServerTest().getMethodName());
       sync(adminCache.put("k", "v"));
       assertEquals("v", sync(adminCache.get("k")).getBody());
+
+      assertStatus(OK, adminCache.distribution());
+   }
+
+   @Test
+   public void testRestCacheDistribution() {
+      restCreateAuthzCache("admin", "observer", "deployer", "application", "writer", "reader", "monitor");
+
+      for (TestUser type : EnumSet.of(TestUser.ADMIN, TestUser.MONITOR)) {
+         RestCacheClient cache = getServerTest().rest().withClientConfiguration(restBuilders.get(type)).get().cache(getServerTest().getMethodName());
+         assertStatus(OK, cache.distribution());
+      }
+
+      // Types with no access.
+      for (TestUser type: EnumSet.complementOf(EnumSet.of(TestUser.ANONYMOUS, TestUser.ADMIN, TestUser.MONITOR))) {
+         RestCacheClient cache = getServerTest().rest().withClientConfiguration(restBuilders.get(type)).get().cache(getServerTest().getMethodName());
+         assertStatus(FORBIDDEN, cache.distribution());
+      }
+   }
+
+   @Test
+   public void testStats() {
+      restCreateAuthzCache("admin", "observer", "deployer", "application", "writer", "reader", "monitor");
+
+      for (TestUser type : EnumSet.of(TestUser.ADMIN, TestUser.MONITOR)) {
+         RestCacheClient cache = getServerTest().rest().withClientConfiguration(restBuilders.get(type)).get().cache(getServerTest().getMethodName());
+         assertStatus(OK, cache.stats());
+      }
+
+      // Types with no access.
+      for (TestUser type: EnumSet.complementOf(EnumSet.of(TestUser.ANONYMOUS, TestUser.ADMIN, TestUser.MONITOR))) {
+         RestCacheClient cache = getServerTest().rest().withClientConfiguration(restBuilders.get(type)).get().cache(getServerTest().getMethodName());
+         assertStatus(FORBIDDEN, cache.stats());
+      }
    }
 
    @Test


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12192

Should have used the security action to retrieve the executor.