### PR TITLE
ISPN-13725 Revert changes on InfinispanRuleBasicTest

### DIFF
--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/api/HotRodTestClientDriver.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/api/HotRodTestClientDriver.java
@@ -1,7 +1,5 @@
 package org.infinispan.server.test.api;
 
-import java.util.function.Consumer;
-
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
@@ -22,14 +20,12 @@ public class HotRodTestClientDriver extends BaseTestClientDriver<HotRodTestClien
    private ConfigurationBuilder clientConfiguration;
    private int port = 11222;
 
-   public HotRodTestClientDriver(TestServer testServer, TestClient testClient,
-                                 Consumer<ConfigurationBuilder> additionalConfigurations) {
+   public HotRodTestClientDriver(TestServer testServer, TestClient testClient) {
       this.testServer = testServer;
       this.testClient = testClient;
 
       ConfigurationBuilder builder = new ConfigurationBuilder();
       builder.maxRetries(1).connectionPool().maxActive(1);
-      additionalConfigurations.accept(builder);
       applyDefaultConfiguration(builder);
       this.clientConfiguration = builder;
    }

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/core/TestClient.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/core/TestClient.java
@@ -7,12 +7,10 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Consumer;
 
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.RemoteCounterManagerFactory;
-import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
 import org.infinispan.client.hotrod.exceptions.HotRodClientException;
 import org.infinispan.client.hotrod.multimap.MultimapCacheManager;
 import org.infinispan.client.hotrod.multimap.RemoteMultimapCacheManagerFactory;
@@ -56,11 +54,7 @@ public class TestClient {
    }
 
    public HotRodTestClientDriver hotrod() {
-      return hotrod(configurationBuilder -> {});
-   }
-
-   public HotRodTestClientDriver hotrod(Consumer<ConfigurationBuilder> additionalConfigurations) {
-      return new HotRodTestClientDriver(testServer, this, additionalConfigurations);
+      return new HotRodTestClientDriver(testServer, this);
    }
 
    public RestTestClientDriver rest() {

--- a/server/testdriver/junit4/src/main/java/org/infinispan/server/test/junit4/InfinispanServerTestMethodRule.java
+++ b/server/testdriver/junit4/src/main/java/org/infinispan/server/test/junit4/InfinispanServerTestMethodRule.java
@@ -2,7 +2,6 @@ package org.infinispan.server.test.junit4;
 
 import net.spy.memcached.MemcachedClient;
 import org.infinispan.client.hotrod.RemoteCacheManager;
-import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
 import org.infinispan.client.rest.RestClient;
 import org.infinispan.client.rest.configuration.RestClientConfigurationBuilder;
 import org.infinispan.counter.api.CounterManager;
@@ -15,7 +14,6 @@ import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
 import java.util.Objects;
-import java.util.function.Consumer;
 
 /**
  * @author Tristan Tarrant &lt;tristan@infinispan.org&gt;
@@ -37,10 +35,6 @@ public class InfinispanServerTestMethodRule implements TestRule, TestClientDrive
    @Override
    public HotRodTestClientDriver hotrod() {
       return testClient.hotrod();
-   }
-
-   public HotRodTestClientDriver hotrod(Consumer<ConfigurationBuilder> additionalConfigurations) {
-      return testClient.hotrod(additionalConfigurations);
    }
 
    @Override

--- a/server/testdriver/junit4/src/test/java/org/infinispan/server/test/junit4/InfinispanRuleBasicTest.java
+++ b/server/testdriver/junit4/src/test/java/org/infinispan/server/test/junit4/InfinispanRuleBasicTest.java
@@ -2,7 +2,6 @@ package org.infinispan.server.test.junit4;
 
 import static org.junit.Assert.assertEquals;
 
-import org.infinispan.client.hotrod.ProtocolVersion;
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.configuration.cache.CacheMode;
 import org.junit.ClassRule;
@@ -19,12 +18,7 @@ public class InfinispanRuleBasicTest {
    @Test
    public void testSingleServer() {
       RemoteCache<String, String> cache = SERVER_TEST
-            // TODO this test uses the latest public image container version
-            //  see ContainerInfinispanServerDriver
-            //  At this very moment we don't have any supporting the #PROTOCOL_VERSION_40
-            //  we can remove this downgrade, when the new version of Infinispan container
-            //  (supporting the protocol 40) is published!
-            .hotrod(builder -> builder.version(ProtocolVersion.PROTOCOL_VERSION_31))
+            .hotrod()
             .withCacheMode(CacheMode.DIST_SYNC).create();
 
       cache.put("k1", "v1");


### PR DESCRIPTION
We don't need to force the client to use HotRod 3.1 anymore, a 4.0 client can work with a 3.1 server thanks to the version negotiation