### PR TITLE
ISPN-13873 Handle Accept header to serialize the events

### DIFF
--- a/commons/all/src/main/java/org/infinispan/commons/configuration/io/xml/XmlConfigurationWriter.java
+++ b/commons/all/src/main/java/org/infinispan/commons/configuration/io/xml/XmlConfigurationWriter.java
@@ -233,7 +233,9 @@ public class XmlConfigurationWriter extends AbstractConfigurationWriter {
          writer.write(' ');
          writer.write(rename ? naming.convert(name) : name);
          writer.write("=\"");
-         writer.write(value.replaceAll("&", "&amp;"));
+         if (value != null) {
+            writer.write(value.replaceAll("&", "&amp;"));
+         }
          writer.write('"');
       } catch (IOException e) {
          throw new ConfigurationWriterException(e);

--- a/commons/all/src/main/java/org/infinispan/commons/configuration/io/yaml/YamlConfigurationWriter.java
+++ b/commons/all/src/main/java/org/infinispan/commons/configuration/io/yaml/YamlConfigurationWriter.java
@@ -155,9 +155,13 @@ public class YamlConfigurationWriter extends AbstractConfigurationWriter {
          }
          array = false;
          writer.write(rename ? naming.convert(name) : name);
-         writer.write(": \"");
-         writer.write(value);
-         writer.write('"');
+         if (value != null) {
+            writer.write(": \"");
+            writer.write(value);
+            writer.write('"');
+         } else {
+            writer.write(": ~");
+         }
          nl();
       } catch (IOException e) {
          throw new ConfigurationWriterException(e);

--- a/core/src/main/java/org/infinispan/configuration/parsing/ParserRegistry.java
+++ b/core/src/main/java/org/infinispan/configuration/parsing/ParserRegistry.java
@@ -40,6 +40,7 @@ import org.infinispan.commons.util.Version;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.configuration.serializing.ConfigurationHolder;
+import org.infinispan.configuration.serializing.ConfigurationSerializer;
 import org.infinispan.configuration.serializing.CoreConfigurationSerializer;
 
 /**
@@ -283,9 +284,12 @@ public class ParserRegistry implements NamespaceMappingParser {
     * @param configurations a map of named configurations
     */
    public void serialize(ConfigurationWriter writer, GlobalConfiguration globalConfiguration, Map<String, Configuration> configurations) {
+      serializeWith(writer, new CoreConfigurationSerializer(), new ConfigurationHolder(globalConfiguration, configurations));
+   }
+
+   public <T> void serializeWith(ConfigurationWriter writer, ConfigurationSerializer<T> serializer, T t) {
       writer.writeStartDocument();
-      CoreConfigurationSerializer serializer = new CoreConfigurationSerializer();
-      serializer.serialize(writer, new ConfigurationHolder(globalConfiguration, configurations));
+      serializer.serialize(writer, t);
       writer.writeEndDocument();
    }
 

--- a/core/src/main/java/org/infinispan/util/logging/events/EventLogSerializer.java
+++ b/core/src/main/java/org/infinispan/util/logging/events/EventLogSerializer.java
@@ -1,0 +1,39 @@
+package org.infinispan.util.logging.events;
+
+import java.util.Optional;
+
+import org.infinispan.commons.configuration.io.ConfigurationWriter;
+import org.infinispan.configuration.serializing.ConfigurationSerializer;
+
+/**
+ * @since 14.0
+ */
+public class EventLogSerializer implements ConfigurationSerializer<EventLog> {
+
+   @Override
+   public void serialize(ConfigurationWriter writer, EventLog event) {
+      writer.writeStartElement("log");
+      writer.writeAttribute("category", event.getCategory().name());
+
+      writer.writeStartElement("content");
+      writer.writeAttribute("level", event.getLevel().name());
+      writer.writeAttribute("message", event.getMessage());
+      writer.writeAttribute("detail", unwrap(event.getDetail()));
+      writer.writeEndElement();
+
+      writer.writeStartElement("meta");
+      writer.writeAttribute("instant", event.getWhen().toString());
+      writer.writeAttribute("context", unwrap(event.getContext()));
+      writer.writeAttribute("scope", unwrap(event.getScope()));
+      writer.writeAttribute("who", unwrap(event.getWho()));
+      // `meta` object
+      writer.writeEndElement();
+
+      // `log` object
+      writer.writeEndElement();
+   }
+
+   private String unwrap(Optional<String> optional) {
+      return optional.orElse(null);
+   }
+}

--- a/core/src/test/java/org/infinispan/util/EventLogSerializerTest.java
+++ b/core/src/test/java/org/infinispan/util/EventLogSerializerTest.java
@@ -1,0 +1,121 @@
+package org.infinispan.util;
+
+import static org.testng.AssertJUnit.assertEquals;
+
+import java.io.StringWriter;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.infinispan.commons.configuration.io.ConfigurationWriter;
+import org.infinispan.commons.dataconversion.MediaType;
+import org.infinispan.test.AbstractInfinispanTest;
+import org.infinispan.util.logging.events.EventLog;
+import org.infinispan.util.logging.events.EventLogCategory;
+import org.infinispan.util.logging.events.EventLogLevel;
+import org.infinispan.util.logging.events.EventLogSerializer;
+import org.testng.annotations.Test;
+
+@Test(testName = "util.EventLogSerializerTest", groups = "unit")
+public class EventLogSerializerTest extends AbstractInfinispanTest {
+   private static final String JSON_TEMPLATE = "{\n  \"log\" : {\n"
+         + "    \"category\" : \"CLUSTER\",\n    \"content\" : {\n      \"level\" : \"INFO\",\n"
+         + "      \"message\" : \"%s\",\n      \"detail\" : \"%s\"\n    },\n    \"meta\" : {\n"
+         + "      \"instant\" : \"%s\",\n      \"context\" : \"%s\",\n      \"scope\" : null,\n"
+         + "      \"who\" : null\n    }\n  }\n}";
+   private static final String XML_TEMPLATE = "<?xml version=\"1.0\"?>\n"
+         + "<log category=\"CLUSTER\">\n"
+         + "    <content level=\"INFO\" message=\"%s\" detail=\"%s\"/>\n"
+         + "    <meta instant=\"%s\" context=\"%s\" scope=\"\" who=\"\"/>\n"
+         + "</log>\n";
+   private static final String YAML_TEMPLATE = "log: \n  category: \"CLUSTER\"\n"
+         + "  content: \n    level: \"INFO\"\n    message: \"%s\"\n    detail: \"%s\"\n"
+         + "  meta: \n    instant: \"%s\"\n    context: \"%s\"\n    scope: ~\n"
+         + "    who: ~\n";
+
+   private final EventLogSerializer serializer = new EventLogSerializer();
+
+   public void testJsonSerialization() {
+      EventLog log = new TestEventLog();
+      String expected = String.format(JSON_TEMPLATE, log.getMessage(), log.getDetail().get(), log.getWhen(), log.getContext().get());
+      String actual = serialize(log, MediaType.APPLICATION_JSON);
+      assertEquals(expected, actual);
+   }
+
+   public void testXmlSerialization() {
+      EventLog log = new TestEventLog();
+      String expected = String.format(XML_TEMPLATE, log.getMessage(), log.getDetail().get(), log.getWhen(), log.getContext().get());
+      String actual = serialize(log, MediaType.APPLICATION_XML);
+      assertEquals(expected, actual);
+   }
+
+   public void testYamlSerialization() {
+      EventLog log = new TestEventLog();
+      String expected = String.format(YAML_TEMPLATE, log.getMessage(), log.getDetail().get(), log.getWhen(), log.getContext().get());
+      String actual = serialize(log, MediaType.APPLICATION_YAML);
+      assertEquals(expected, actual);
+   }
+
+   private String serialize(EventLog log, MediaType type) {
+      StringWriter sw = new StringWriter();
+      try (ConfigurationWriter cw = ConfigurationWriter.to(sw).withType(type).build()) {
+         cw.writeStartDocument();
+         serializer.serialize(cw, log);
+         cw.writeEndDocument();
+      }
+
+      return sw.toString();
+   }
+
+   private static class TestEventLog implements EventLog {
+      private final Instant now = Instant.now();
+      private final String message = UUID.randomUUID().toString();
+      private final String detail = UUID.randomUUID().toString();
+      private final String context = UUID.randomUUID().toString();
+
+      @Override
+      public Instant getWhen() {
+         return now;
+      }
+
+      @Override
+      public EventLogLevel getLevel() {
+         return EventLogLevel.INFO;
+      }
+
+      @Override
+      public String getMessage() {
+         return message;
+      }
+
+      @Override
+      public EventLogCategory getCategory() {
+         return EventLogCategory.CLUSTER;
+      }
+
+      @Override
+      public Optional<String> getDetail() {
+         return Optional.of(detail);
+      }
+
+      @Override
+      public Optional<String> getWho() {
+         return Optional.empty();
+      }
+
+      @Override
+      public Optional<String> getContext() {
+         return Optional.of(context);
+      }
+
+      @Override
+      public Optional<String> getScope() {
+         return Optional.empty();
+      }
+
+      @Override
+      public int compareTo(EventLog eventLog) {
+         return eventLog.getWhen().compareTo(getWhen());
+      }
+   }
+}

--- a/documentation/src/main/asciidoc/topics/ref_rest_cache_managers.adoc
+++ b/documentation/src/main/asciidoc/topics/ref_rest_cache_managers.adoc
@@ -513,3 +513,13 @@ Currently, we expose only `LIFECYCLE` events.
 ----
 GET /rest/v2/container?action=listen
 ----
+
+.Headers
+
+|===
+|Header |Required or Optional |Parameter
+
+|`Accept`
+|OPTIONAL
+|Sets the required format to return content. Supported formats are `application/yaml`, `application/json` and `application/xml`. The default is `application/yaml`. See link:#rest_accept[Accept] for more information.
+|===

--- a/server/rest/src/test/java/org/infinispan/rest/resources/SSEListener.java
+++ b/server/rest/src/test/java/org/infinispan/rest/resources/SSEListener.java
@@ -8,6 +8,7 @@ import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 import org.infinispan.client.rest.RestEventListener;
 import org.infinispan.client.rest.RestResponse;
@@ -20,6 +21,7 @@ import org.infinispan.util.logging.LogFactory;
  * @since 13.0
  **/
 public class SSEListener implements RestEventListener {
+   protected static final Consumer<KeyValuePair<String, String>> NO_OP = ignore -> {};
    private static final Log log = LogFactory.getLog(SSEListener.class);
 
    BlockingDeque<KeyValuePair<String, String>> events = new LinkedBlockingDeque<>();
@@ -42,9 +44,14 @@ public class SSEListener implements RestEventListener {
    }
 
    public void expectEvent(String type, String subString) throws InterruptedException {
+      expectEvent(type, subString, NO_OP);
+   }
+
+   public void expectEvent(String type, String subString, Consumer<KeyValuePair<String, String>> consumer) throws InterruptedException {
       KeyValuePair<String, String> event = events.poll(10, TimeUnit.SECONDS);
       assertNotNull(event);
       assertEquals(type, event.getKey());
       assertTrue(event.getValue().contains(subString));
+      consumer.accept(event);
    }
 }

--- a/server/tests/src/test/java/org/infinispan/server/functional/RestContainerListenerTest.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/RestContainerListenerTest.java
@@ -1,0 +1,149 @@
+package org.infinispan.server.functional;
+
+import static org.infinispan.rest.assertion.ResponseAssertion.assertThat;
+import static org.infinispan.server.test.core.Common.HTTP_PROTOCOLS;
+import static org.junit.Assert.assertTrue;
+
+import java.io.Closeable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.infinispan.client.rest.RestClient;
+import org.infinispan.client.rest.configuration.Protocol;
+import org.infinispan.client.rest.configuration.RestClientConfigurationBuilder;
+import org.infinispan.commons.dataconversion.MediaType;
+import org.infinispan.commons.dataconversion.internal.Json;
+import org.infinispan.rest.resources.WeakSSEListener;
+import org.infinispan.server.test.junit4.InfinispanServerRule;
+import org.infinispan.server.test.junit4.InfinispanServerTestMethodRule;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.testcontainers.shaded.org.yaml.snakeyaml.Yaml;
+
+/**
+ * Listen the container endpoint and test different serializations.
+ *
+ * @since 14.0
+ */
+@RunWith(Parameterized.class)
+public class RestContainerListenerTest {
+
+   @ClassRule
+   public static InfinispanServerRule SERVERS = ClusteredIT.SERVERS;
+   private final Protocol protocol;
+   private final AcceptSerialization serialization;
+
+   @Rule
+   public InfinispanServerTestMethodRule SERVER_TEST = new InfinispanServerTestMethodRule(SERVERS);
+
+   @Parameterized.Parameters(name = "{0}-{1}")
+   public static Collection<Object[]> data() {
+      List<Object[]> params = new ArrayList<>(HTTP_PROTOCOLS.size());
+      for (Protocol protocol : HTTP_PROTOCOLS) {
+         for (AcceptSerialization serialization : AcceptSerialization.values()) {
+            params.add(new Object[]{protocol, serialization});
+         }
+      }
+      return params;
+   }
+
+   public RestContainerListenerTest(Protocol protocol, AcceptSerialization serialization) {
+      this.protocol = protocol;
+      this.serialization = serialization;
+   }
+
+   @Test
+   public void testSSECluster() throws Exception {
+      RestClientConfigurationBuilder builder = new RestClientConfigurationBuilder();
+      builder.protocol(protocol);
+      RestClient client = SERVER_TEST.rest().withClientConfiguration(builder).create();
+      WeakSSEListener sseListener = new WeakSSEListener();
+      Map<String, String> headers = Collections.singletonMap("Accept", serialization.header());
+
+      try (Closeable ignored = client.raw().listen("/rest/v2/container?action=listen", headers, sseListener)) {
+         assertTrue(sseListener.await(10, TimeUnit.SECONDS));
+
+         assertThat(client.cache("caching-listen").createWithTemplate("org.infinispan.DIST_SYNC")).isOk();
+
+         sseListener.expectEvent("create-cache", "caching-listen");
+         sseListener.expectEvent("lifecycle-event", "ISPN100002", pair -> {
+            assertTrue("Not a " + serialization.header() + ": " + pair.getValue(), serialization.isAccepted(pair.getValue()));
+         });
+         sseListener.expectEvent("lifecycle-event", "ISPN100010", pair -> {
+            assertTrue("Not a " + serialization.header() + ": " + pair.getValue(), serialization.isAccepted(pair.getValue()));
+         });
+
+         assertThat(client.cache("caching-listen").delete()).isOk();
+         sseListener.expectEvent("remove-cache", "caching-listen");
+      }
+   }
+
+   private enum AcceptSerialization {
+      JSON {
+         @Override
+         public String header() {
+            return MediaType.APPLICATION_JSON_TYPE;
+         }
+
+         @Override
+         public boolean isAccepted(String s) {
+            Json json = Json.read(s);
+            if (!(json.isObject() && json.has("log"))) return false;
+
+            Json log = json.at("log");
+            if (!(log.has("content") && log.has("meta") && log.has("category"))) return false;
+
+            Json content = log.at("content");
+            Json meta = log.at("meta");
+            return content.has("level") && content.has("message") && content.has("detail")
+                  && meta.has("context") && meta.has("scope") && meta.has("who") && meta.has("instant");
+         }
+      },
+      YAML {
+         @Override
+         public String header() {
+            return MediaType.APPLICATION_YAML_TYPE;
+         }
+
+         @Override
+         @SuppressWarnings("unchecked")
+         public boolean isAccepted(String s) {
+            Yaml yaml = new Yaml();
+            LinkedHashMap<String, LinkedHashMap> ev = yaml.load(s);
+            if (!(ev != null && ev.containsKey("log"))) return false;
+
+            LinkedHashMap<String, LinkedHashMap> log = ev.get("log");
+            if (!(log.containsKey("content") && log.containsKey("meta") && log.containsKey("category"))) return false;
+
+            LinkedHashMap<String, String> content = log.get("content");
+            LinkedHashMap<String, String> meta = log.get("meta");
+            return content.containsKey("level") && content.containsKey("message") && content.containsKey("detail")
+                  && meta.containsKey("context") && meta.containsKey("scope") && meta.containsKey("who") && meta.containsKey("instant");
+         }
+      },
+      XML {
+         @Override
+         public String header() {
+            return MediaType.APPLICATION_XML_TYPE;
+         }
+
+         @Override
+         public boolean isAccepted(String content) {
+            return content.startsWith("<?xml version=\"1.0\"?>\n<log category=")
+                  && content.endsWith("</log>");
+         }
+      };
+
+      public abstract String header();
+
+      public abstract boolean isAccepted(String content);
+   }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-13873

* Created an `EventLog` serializer using the
`ConfigurationSerializer` interface.

I am using the stuff that we already have to serialize configuration, since that can handle the `EventLog` object, but pretty much all of the serialization classes have `Configuration` in the name.

Now we have:

```json
{
  "log" : {
    "instant" : "2022-07-26T11:33:08.666580Z",
    "category" : "LIFECYCLE",
    "content" : {
      "level" : "INFO",
      "message" : "ISPN100010: Finished rebalance with members [jbolina-34174, jbolina-58560], topology id 2"
    },
    "additional" : {
      "context" : "caching-listen",
      "scope" : "jbolina-58560",
      "detail" : null,
      "who" : null
    }
  }
}
```

```yaml
log: 
  instant: "2022-07-26T11:11:22.912906Z"
  category: "LIFECYCLE"
  content: 
    level: "INFO"
    message: "ISPN100002: Starting rebalance with members [jbolina-9736, jbolina-46792], phase READ_OLD_WRITE_ALL, topology id 2"
  additional: 
    context: "caching-listen"
    scope: "jbolina-9736"
    detail: ~
    who: ~
```

```xml
<?xml version="1.0"?>
<log instant="2022-07-26T11:31:07.318201Z" category="LIFECYCLE">
    <content level="INFO" message="ISPN100002: Starting rebalance with members [jbolina-23979, jbolina-17669], phase READ_OLD_WRITE_ALL, topology id 2"/>
    <additional context="caching-listen" scope="jbolina-23979" detail="" who=""/>
</log>
```

Want to check with you all first. This is changes the object format for the log, currently is:

```json
{
  "message":"ISPN100002: Starting rebalance with members [jbolina-29050, jbolina-38947], phase READ_OLD_WRITE_ALL, topology id 2",
  "category":"LIFECYCLE",
  "level":"INFO",
  "time":1658846192341,
  "owner":"",
  "context":"caching-listen",
  "scope":"jbolina-38947"
}
```

Do we keep the format that is currently used or it is OK to change it? 