### PR TITLE
ISPN-14036 Server restart if a cache with SQL store is configured wit…

### DIFF
--- a/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
@@ -545,7 +545,12 @@ public class DefaultCacheManager implements EmbeddedCacheManager {
          try {
             return (Cache<K, V>) cacheFuture.join();
          } catch (CompletionException e) {
-            throw ((CacheException) e.getCause());
+            caches.computeIfPresent(cacheName, (k, v) -> {
+               if (v == cacheFuture) {
+                  return null;
+               }
+               return v;
+            });
          }
       }
 

--- a/persistence/sql/src/test/java/org/infinispan/persistence/sql/QueriesJdbcStoreFunctionalTest.java
+++ b/persistence/sql/src/test/java/org/infinispan/persistence/sql/QueriesJdbcStoreFunctionalTest.java
@@ -96,7 +96,7 @@ public class QueriesJdbcStoreFunctionalTest extends AbstractSQLStoreFunctionalTe
                .upsert(manager.getUpsertStatement(Collections.singletonList(KEY_COLUMN),
                      Arrays.asList(KEY_COLUMN, "name", "street")))
                .delete("DELETE FROM " + tableName + " WHERE " + KEY_COLUMN + " = :" + KEY_COLUMN);
-      } else if (cacheName.toUpperCase().startsWith("TESTEMBEDDEDKEY")) {
+      } else if (cacheName.toUpperCase().startsWith("TESTEMBEDDED")) {
          storeBuilder.keyColumns("name");
          storeBuilder.queriesJdbcConfigurationBuilder()
                .select("SELECT name, STREET, city, ZIP, picture, sex, birthdate FROM " + tableName + " WHERE name = :name")


### PR DESCRIPTION
…h a schema but the schema is missing

https://issues.redhat.com/browse/ISPN-14036

This is more of a draft, so we can discuss possible solutions. The one I have here is the simpler way I've found to be able to re-create the cache if it failed to be created before. But I feel this one has more implications, and I am not seeing them. The design of not clearing if an exception happened and always throwing it afterward was deliberate.

Another approach I could think of is for us to focus explicitly on the schema loading. If the schema does not exist, we do not throw an exception. Instead, we create the cache, but it does not execute operations until the schema is loaded. This one will need more changes, though.