### PR TITLE
ISPN-14084 MergePolicyCustomTest - Inbound transfer was cancelled

### DIFF
--- a/core/src/main/java/org/infinispan/conflict/impl/StateReceiverImpl.java
+++ b/core/src/main/java/org/infinispan/conflict/impl/StateReceiverImpl.java
@@ -245,12 +245,12 @@ public class StateReceiverImpl<K, V> implements StateReceiver<K, V> {
             // requestState() has not run yet, so we create the future first
             future = new CompletableFuture<>();
          }
-         transferTaskMap.forEach((address, inboundTransferTask) -> inboundTransferTask.cancel());
          if (throwable != null) {
             future.completeExceptionally(throwable);
          } else {
             future.cancel(true);
          }
+         transferTaskMap.forEach((address, inboundTransferTask) -> inboundTransferTask.cancel());
          clear();
       }
 

--- a/core/src/main/java/org/infinispan/statetransfer/InboundTransferTask.java
+++ b/core/src/main/java/org/infinispan/statetransfer/InboundTransferTask.java
@@ -118,7 +118,6 @@ public class InboundTransferTask {
     * @return a {@code CompletableFuture} that completes when the transfer is done.
     */
    public CompletionStage<Void> requestSegments() {
-      Address address = rpcManager.getAddress();
       return startTransfer(applyState ?
             segments -> commandsFactory.buildStateTransferStartCommand(topologyId, segments) :
             segments -> commandsFactory.buildConflictResolutionStartCommand(topologyId, segments));


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-14084

~An initial PR trying to debug the problem. At this point I am trying to use the CI to debug the problem.~

After some debugging, there are some cases when a rehash event is issued during the tests. The rehash listener will start canceling all current segment transfers and complete the future with a `CacheException`. Since the `InboundTransferTask`s are canceled before completing the future, the `InboundTransferTask`'s callback would invoke `cancel` again, which could lead the future completion with a `CancellationException` instead of the `CacheException`.

I only moved to first complete the future and only then cancel the tasks.
Also, includes a change to the `DefaultConflictManager`, because, in the scenario above, the `CancellationException` is wrapped in a `CompletionException`. I've changed it so we can handle this case too.

I did not find out why the rehash event happened in the test. I've run the CI multiple times, but the problem did not occur.



