### PR TITLE
ISPN-14100 REST keys operation cache value should match all

### DIFF
--- a/server/rest/src/main/java/org/infinispan/rest/CacheKeyInputStream.java
+++ b/server/rest/src/main/java/org/infinispan/rest/CacheKeyInputStream.java
@@ -43,7 +43,9 @@ public class CacheKeyInputStream extends InputStream {
    }
 
    private byte[] escape(byte[] content) {
-      return ("\"" + new String(content, UTF_8) + "\"").getBytes(UTF_8);
+      String stringified = new String(content, UTF_8);
+      String escaped = stringified.replaceAll("\"", "\\\\\"");
+      return ("\"" + escaped + "\"").getBytes(UTF_8);
    }
 
    @Override

--- a/server/rest/src/main/java/org/infinispan/rest/resources/CacheResourceV2.java
+++ b/server/rest/src/main/java/org/infinispan/rest/resources/CacheResourceV2.java
@@ -12,6 +12,7 @@ import static org.infinispan.commons.dataconversion.MediaType.APPLICATION_JSON_T
 import static org.infinispan.commons.dataconversion.MediaType.APPLICATION_OCTET_STREAM;
 import static org.infinispan.commons.dataconversion.MediaType.APPLICATION_XML;
 import static org.infinispan.commons.dataconversion.MediaType.APPLICATION_YAML;
+import static org.infinispan.commons.dataconversion.MediaType.MATCH_ALL;
 import static org.infinispan.commons.dataconversion.MediaType.TEXT_EVENT_STREAM;
 import static org.infinispan.commons.dataconversion.MediaType.TEXT_PLAIN;
 import static org.infinispan.rest.framework.Method.DELETE;
@@ -361,7 +362,7 @@ public class CacheResourceV2 extends BaseCacheResource implements ResourceHandle
       int batch = batchParam == null || batchParam.isEmpty() ? STREAM_BATCH_SIZE : Integer.parseInt(batchParam);
       int limit = limitParam == null || limitParam.isEmpty() ? -1 : Integer.parseInt(limitParam);
 
-      Cache<?, ?> cache = invocationHelper.getRestCacheManager().getCache(cacheName, TEXT_PLAIN, TEXT_PLAIN, request);
+      Cache<?, ?> cache = invocationHelper.getRestCacheManager().getCache(cacheName, TEXT_PLAIN, MATCH_ALL, request);
       if (cache == null)
          return notFoundResponseFuture();
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-14100

Instead of using `TEXT_PLAIN` to retrieve a cache, which, IIUC converts the values, we use `MATCH_ALL`. Also adding a test with different media-types and minor fix in the string escape.
