### PR TITLE
ISPN-14125 Preloader can execute multiple times

### DIFF
--- a/core/src/main/java/org/infinispan/container/entries/ForwardingCacheEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/ForwardingCacheEntry.java
@@ -2,6 +2,7 @@ package org.infinispan.container.entries;
 
 import org.infinispan.container.DataContainer;
 import org.infinispan.metadata.Metadata;
+import org.infinispan.metadata.impl.PrivateMetadata;
 
 /**
  * A class designed to forward all method invocations for a CacheEntry to the provided delegate.  This
@@ -140,5 +141,10 @@ public abstract class ForwardingCacheEntry<K, V> implements CacheEntry<K, V> {
    @Override
    public int hashCode() {
       return delegate().hashCode();
+   }
+
+   @Override
+   public PrivateMetadata getInternalMetadata() {
+      return delegate().getInternalMetadata();
    }
 }

--- a/core/src/main/java/org/infinispan/interceptors/impl/CallInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/CallInterceptor.java
@@ -187,6 +187,11 @@ public class CallInterceptor extends BaseAsyncInterceptor implements Visitor {
          e.setCreated(internalMetadata.created());
          e.setLastUsed(internalMetadata.lastUsed());
       }
+
+      if (command.getInternalMetadata() != null) {
+         e.setInternalMetadata(command.getInternalMetadata());
+      }
+
       Object prevValue = e.getValue();
       if (!valueMatcher.matches(prevValue, null, newValue)) {
          command.fail();

--- a/core/src/main/java/org/infinispan/metadata/impl/PrivateMetadata.java
+++ b/core/src/main/java/org/infinispan/metadata/impl/PrivateMetadata.java
@@ -27,16 +27,19 @@ public final class PrivateMetadata {
    /**
     * A cached empty {@link PrivateMetadata}.
     */
-   private static final PrivateMetadata EMPTY = new PrivateMetadata(null, null);
+   private static final PrivateMetadata EMPTY = new PrivateMetadata(null, null, false);
 
    @ProtoField(1)
    final IracMetadata iracMetadata;
 
    private final IncrementableEntryVersion entryVersion;
 
-   private PrivateMetadata(IracMetadata iracMetadata, IncrementableEntryVersion entryVersion) {
+   private final boolean isPreloaded;
+
+   private PrivateMetadata(IracMetadata iracMetadata, IncrementableEntryVersion entryVersion, boolean isPreloaded) {
       this.iracMetadata = iracMetadata;
       this.entryVersion = entryVersion;
+      this.isPreloaded = isPreloaded;
    }
 
    /**
@@ -67,11 +70,11 @@ public final class PrivateMetadata {
    static PrivateMetadata protoFactory(IracMetadata iracMetadata, NumericVersion numericVersion,
          SimpleClusteredVersion clusteredVersion) {
       IncrementableEntryVersion entryVersion = numericVersion == null ? clusteredVersion : numericVersion;
-      return newInstance(iracMetadata, entryVersion);
+      return newInstance(iracMetadata, entryVersion, false);
    }
 
-   private static PrivateMetadata newInstance(IracMetadata iracMetadata, IncrementableEntryVersion entryVersion) {
-      return iracMetadata == null && entryVersion == null ? EMPTY : new PrivateMetadata(iracMetadata, entryVersion);
+   private static PrivateMetadata newInstance(IracMetadata iracMetadata, IncrementableEntryVersion entryVersion, boolean isPreloaded) {
+      return iracMetadata == null && entryVersion == null ? EMPTY : new PrivateMetadata(iracMetadata, entryVersion, isPreloaded);
    }
 
    /**
@@ -138,10 +141,15 @@ public final class PrivateMetadata {
       return entryVersion instanceof SimpleClusteredVersion ? (SimpleClusteredVersion) entryVersion : null;
    }
 
+   public boolean isPreloaded() {
+      return isPreloaded;
+   }
+
    public static class Builder {
 
       private IracMetadata iracMetadata;
       private IncrementableEntryVersion entryVersion;
+      private boolean isPreloaded;
 
       public Builder() {
       }
@@ -149,13 +157,14 @@ public final class PrivateMetadata {
       private Builder(PrivateMetadata metadata) {
          this.iracMetadata = metadata.iracMetadata;
          this.entryVersion = metadata.entryVersion;
+         this.isPreloaded = metadata.isPreloaded;
       }
 
       /**
        * @return A new instance of {@link PrivateMetadata}.
        */
       public PrivateMetadata build() {
-         return newInstance(iracMetadata, entryVersion);
+         return newInstance(iracMetadata, entryVersion, isPreloaded);
       }
 
       /**
@@ -177,6 +186,16 @@ public final class PrivateMetadata {
        */
       public Builder entryVersion(IncrementableEntryVersion entryVersion) {
          this.entryVersion = entryVersion;
+         return this;
+      }
+
+      /**
+       * Mark that the entry is preloaded.
+       *
+       * @return This instance.
+       */
+      public Builder preloadedEntry() {
+         this.isPreloaded = true;
          return this;
       }
 

--- a/core/src/main/java/org/infinispan/persistence/manager/PreloadStatus.java
+++ b/core/src/main/java/org/infinispan/persistence/manager/PreloadStatus.java
@@ -1,0 +1,43 @@
+package org.infinispan.persistence.manager;
+
+/**
+ * Identifies {@link PreloadManager}'s current status.
+ *
+ * @since 14.0
+ */
+public enum PreloadStatus {
+
+   /**
+    * The initial status when instantiated.
+    * This status represents a {@link PreloadManager} that never loaded any data. Once the manager loads data, this
+    * status is never reached again.
+    */
+   NOT_RUNNING,
+
+   /**
+    * Represents a {@link PreloadManager} that is currently loading data. The manager moves to this status before
+    * loading data and proceeds to the next status after removing older entries.
+    */
+
+   RUNNING,
+
+   /**
+    * Represents a {@link PreloadManager} that finished loading and removing older entries successfully.
+    */
+   COMPLETE_LOAD,
+
+   /**
+    * Represents a {@link PreloadManager} that was unable to load the whole data. This happens when a cache configured
+    * with a maximum number of entries is not filled. For example, the underlying storage has fewer entries.
+    */
+   PARTIAL_LOAD,
+
+   /**
+    * Represents a {@link PreloadManager} that failed either during load or during deletion of older entries.
+    */
+   FAILED_LOAD;
+
+   public boolean fullyPreloaded() {
+      return this == COMPLETE_LOAD;
+   }
+}

--- a/core/src/main/java/org/infinispan/scattered/impl/ScatteredPreloadManager.java
+++ b/core/src/main/java/org/infinispan/scattered/impl/ScatteredPreloadManager.java
@@ -31,8 +31,8 @@ public class ScatteredPreloadManager extends PreloadManager {
    @Inject ClusterTopologyManager clusterTopologyManager;
 
    @Override
-   public void start() {
-      super.start();
+   public void blockingPreload() {
+      super.blockingPreload();
 
       initTopologyId();
    }

--- a/core/src/main/java/org/infinispan/transaction/impl/WriteSkewHelper.java
+++ b/core/src/main/java/org/infinispan/transaction/impl/WriteSkewHelper.java
@@ -72,7 +72,8 @@ public class WriteSkewHelper {
             int segment = SegmentSpecificCommand.extractSegment(c, k, keyPartitioner);
             if (ksl.performCheckOnSegment(segment)) {
                CacheEntry<?, ?> cacheEntry = context.lookupEntry(k);
-               if (!(cacheEntry instanceof VersionedRepeatableReadEntry)) {
+               PrivateMetadata metadata = cacheEntry.getInternalMetadata();
+               if (!(cacheEntry instanceof VersionedRepeatableReadEntry) || metadata.isPreloaded()) {
                   continue;
                }
                VersionedRepeatableReadEntry entry = (VersionedRepeatableReadEntry) cacheEntry;

--- a/core/src/test/java/org/infinispan/persistence/manager/PreloadManagerTest.java
+++ b/core/src/test/java/org/infinispan/persistence/manager/PreloadManagerTest.java
@@ -1,0 +1,117 @@
+package org.infinispan.persistence.manager;
+
+import static org.infinispan.commons.test.Exceptions.expectException;
+import static org.infinispan.functional.FunctionalTestUtils.await;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertTrue;
+
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import io.reactivex.rxjava3.core.Flowable;
+import org.infinispan.AdvancedCache;
+import org.infinispan.commons.time.ControlledTimeService;
+import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.configuration.cache.MemoryConfiguration;
+import org.infinispan.configuration.cache.TransactionConfiguration;
+import org.infinispan.factories.impl.ComponentRef;
+import org.infinispan.test.AbstractInfinispanTest;
+import org.infinispan.test.RunningComponentRef;
+import org.infinispan.test.fwk.CheckPoint;
+import org.infinispan.transaction.TransactionMode;
+import org.testng.annotations.Test;
+
+@Test(groups = "unit", testName = "persistence.PreloadManagerTest")
+public class PreloadManagerTest extends AbstractInfinispanTest {
+
+   private final ExecutorService preloadExecutor =
+         Executors.newSingleThreadExecutor(getTestThreadFactory("PreloadManager"));
+
+   public void testNoConcurrentLoad() throws Exception {
+      PreloadManager manager = new PreloadManager();
+      PersistenceManager persistenceManager = mock(PersistenceManager.class);
+      CheckPoint checkPoint = new CheckPoint();
+
+      waitForPublisherCall(checkPoint, persistenceManager);
+
+      manager.nonBlockingExecutor = preloadExecutor;
+      manager.persistenceManager = persistenceManager;
+      manager.timeService = new ControlledTimeService();
+      manager.configuration = mockConfiguration();
+      manager.cache = mockedCache();
+
+      Future<Void> initial = fork(manager::blockingPreload);
+      checkPoint.awaitStrict("preload_starting", 10, TimeUnit.SECONDS);
+
+      assertFalse(manager.isFullyPreloaded());
+      assertEquals(PreloadStatus.RUNNING, manager.currentStatus());
+
+      CompletionStage<Void> second = manager.preload();
+      expectException(CompletionException.class, IllegalStateException.class,
+            "Preloader already running",
+            () -> await(second.toCompletableFuture()));
+
+      checkPoint.trigger("preload_starting_proceed");
+      initial.get(10, TimeUnit.SECONDS);
+
+      assertTrue(manager.isFullyPreloaded());
+      assertEquals(PreloadStatus.COMPLETE_LOAD, manager.currentStatus());
+   }
+
+   public void testFailedLoading() {
+      PreloadManager manager = new PreloadManager();
+      PersistenceManager persistenceManager = mock(PersistenceManager.class);
+
+      manager.nonBlockingExecutor = preloadExecutor;
+      manager.persistenceManager = persistenceManager;
+      manager.timeService = new ControlledTimeService();
+      manager.configuration = mockConfiguration();
+      manager.cache = mockedCache();
+
+      when(persistenceManager.preloadPublisher())
+            .thenAnswer(ivk -> Flowable.error(new RuntimeException("Failed loading data")));
+
+      expectException(CompletionException.class, RuntimeException.class,
+            "Failed loading data", manager::blockingPreload);
+
+      assertFalse(manager.isFullyPreloaded());
+      assertEquals(PreloadStatus.FAILED_LOAD, manager.currentStatus());
+   }
+
+   private void waitForPublisherCall(CheckPoint checkPoint, PersistenceManager manager) {
+      when(manager.preloadPublisher()).thenAnswer(ivk -> {
+         checkPoint.trigger("preload_starting");
+         checkPoint.awaitStrict("preload_starting_proceed", 10, TimeUnit.SECONDS);
+         return Flowable.empty();
+      });
+   }
+
+   private ComponentRef<AdvancedCache<?, ?>> mockedCache() {
+      AdvancedCache<Object, Object> cache = mock(AdvancedCache.class);
+      when(cache.getName()).thenReturn("PreloadManagerTest");
+      when(cache.withStorageMediaType()).thenReturn(cache);
+      when(cache.getKeyDataConversion()).thenReturn(null);
+      when(cache.getValueDataConversion()).thenReturn(null);
+
+      return new RunningComponentRef<>("SomeMockName", AdvancedCache.class, cache);
+   }
+
+   private Configuration mockConfiguration() {
+      Configuration configuration = mock(Configuration.class);
+      MemoryConfiguration memConf = mock(MemoryConfiguration.class);
+      TransactionConfiguration transactionConf = mock(TransactionConfiguration.class);
+
+      when(memConf.isEvictionEnabled()).thenReturn(false);
+      when(transactionConf.transactionMode()).thenReturn(TransactionMode.NON_TRANSACTIONAL);
+      when(configuration.transaction()).thenReturn(transactionConf);
+      when(configuration.memory()).thenReturn(memConf);
+      return configuration;
+   }
+}

--- a/core/src/test/java/org/infinispan/xsite/irac/persistence/IracMetadataStoreTest.java
+++ b/core/src/test/java/org/infinispan/xsite/irac/persistence/IracMetadataStoreTest.java
@@ -278,7 +278,7 @@ public class IracMetadataStoreTest extends AbstractXSiteTest {
    private void preload() {
       for (Cache<String, String> cache : this.<String, String>caches(LON)) {
          PreloadManager pm = TestingUtil.extractComponent(cache, PreloadManager.class);
-         pm.start();
+         pm.blockingPreload();
       }
    }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-14125

Enabling `PreloadManager` to run more than once.
We add a versioning to the manager, so it can keep track of loaded versions. When the entry is loaded, it is associated with a numeric version equal to the manager's. We also mark it as an entry loaded. After loading all the entries we remove the ones with an older version.