### PR TITLE
ISPN-14129 Memory used by a node and cache in the distribution endpoint

### DIFF
--- a/documentation/src/main/asciidoc/topics/json/rest_full_cache_data_distribution.json
+++ b/documentation/src/main/asciidoc/topics/json/rest_full_cache_data_distribution.json
@@ -5,7 +5,8 @@
       "127.0.0.1:44175"
     ],
     "memory_entries": 0,
-    "total_entries": 0
+    "total_entries": 0,
+    "memory_used": 528512
   },
   {
     "node_name":"NodeB",
@@ -13,6 +14,7 @@
       "127.0.0.1:44187"
     ],
     "memory_entries": 0,
-    "total_entries": 0
+    "total_entries": 0,
+    "memory_used": 528512
   }
 ]

--- a/documentation/src/main/asciidoc/topics/ref_rest_caches.adoc
+++ b/documentation/src/main/asciidoc/topics/ref_rest_caches.adoc
@@ -177,6 +177,7 @@ Each element in the list represents a node. The properties are:
 * `node_addresses` is a list with all the node's physical addresses.
 * `memory_entries` the number of entries the node holds in memory belonging to the cache.
 * `total_entries` the number of entries the node has in memory and disk belonging to the cache.
+* `memory_used` the value in bytes the eviction algorithm estimates the cache occupies. Returns -1 if eviction is not enabled.
 
 [id='rest_v2_cache_mutable_attributes']
 = Retrieving all mutable cache configuration attributes

--- a/server/rest/proto.lock
+++ b/server/rest/proto.lock
@@ -77,6 +77,17 @@
                     "value": "0"
                   }
                 ]
+              },
+              {
+                "id": 5,
+                "name": "memoryUsed",
+                "type": "int64",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "0"
+                  }
+                ]
               }
             ]
           },

--- a/server/rest/src/main/java/org/infinispan/rest/distribution/CacheDistributionInfo.java
+++ b/server/rest/src/main/java/org/infinispan/rest/distribution/CacheDistributionInfo.java
@@ -20,13 +20,15 @@ public class CacheDistributionInfo implements JsonSerialization, NodeDataDistrib
    private final List<String> addresses;
    private final long memoryEntries;
    private final long totalEntries;
+   private final long memoryUsed;
 
    @ProtoFactory
-   public CacheDistributionInfo(String name, List<String> addresses, long memoryEntries, long totalEntries) {
+   public CacheDistributionInfo(String name, List<String> addresses, long memoryEntries, long totalEntries, long memoryUsed) {
       this.name = name;
       this.addresses = addresses;
       this.memoryEntries = memoryEntries;
       this.totalEntries = totalEntries;
+      this.memoryUsed = memoryUsed;
    }
 
    @ProtoField(1)
@@ -51,13 +53,19 @@ public class CacheDistributionInfo implements JsonSerialization, NodeDataDistrib
       return totalEntries;
    }
 
+   @ProtoField(value = 5, defaultValue = "0")
+   public long memoryUsed() {
+      return memoryUsed;
+   }
+
    @Override
    public Json toJson() {
       return Json.object()
             .set("node_name", name)
             .set("node_addresses", Json.array(addresses.toArray()))
             .set("memory_entries", memoryEntries)
-            .set("total_entries", totalEntries);
+            .set("total_entries", totalEntries)
+            .set("memory_used", memoryUsed);
    }
 
    public static CacheDistributionInfo resolve(AdvancedCache<?, ?> cache) {
@@ -65,6 +73,7 @@ public class CacheDistributionInfo implements JsonSerialization, NodeDataDistrib
       final CacheManagerInfo manager = cache.getCacheManager().getCacheManagerInfo();
       long inMemory = stats.getApproximateEntriesInMemory();
       long total = stats.getApproximateEntries();
-      return new CacheDistributionInfo(manager.getNodeName(), manager.getPhysicalAddressesRaw(), inMemory, total);
+      return new CacheDistributionInfo(manager.getNodeName(), manager.getPhysicalAddressesRaw(), inMemory, total,
+            stats.getDataMemoryUsed());
    }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-14129

Using the same value exposed in the stats.