### PR TITLE
ISPN-13489 Exponential back-off does not work with multiple sites

### DIFF
--- a/core/src/main/java/org/infinispan/container/versioning/irac/DefaultIracTombstoneManager.java
+++ b/core/src/main/java/org/infinispan/container/versioning/irac/DefaultIracTombstoneManager.java
@@ -50,7 +50,6 @@ import org.infinispan.remoting.rpc.RpcManager;
 import org.infinispan.remoting.rpc.RpcOptions;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.remoting.transport.Transport;
-import org.infinispan.util.ExponentialBackOff;
 import org.infinispan.util.concurrent.AggregateCompletionStage;
 import org.infinispan.util.concurrent.BlockingManager;
 import org.infinispan.commons.util.concurrent.CompletableFutures;
@@ -141,7 +140,6 @@ public class DefaultIracTombstoneManager implements IracTombstoneManager {
       transport.checkCrossSiteAvailable();
       String localSiteName = transport.localSiteName();
       asyncBackups.removeIf(xSiteBackup -> localSiteName.equals(xSiteBackup.getSiteName()));
-      iracExecutor.setBackOff(ExponentialBackOff.NO_OP);
       iracExecutor.setExecutor(blockingManager.asExecutor(commandsFactory.getCacheName() + "-tombstone-cleanup"));
       stopped = false;
       scheduler.disabled = false;

--- a/core/src/main/java/org/infinispan/util/ExponentialBackOff.java
+++ b/core/src/main/java/org/infinispan/util/ExponentialBackOff.java
@@ -1,9 +1,11 @@
 package org.infinispan.util;
 
 import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 
 import org.infinispan.commons.util.Experimental;
 import org.infinispan.commons.util.concurrent.CompletableFutures;
+import org.infinispan.xsite.irac.IracXSiteBackup;
 
 /**
  * Interface to implement an exponential back-off algorithm that retries the request based on the result of the remote
@@ -33,6 +35,8 @@ public interface ExponentialBackOff {
          return CompletableFutures.completedNull();
       }
    };
+
+   Function<IracXSiteBackup, ExponentialBackOff> NO_OP_BUILDER = backup -> NO_OP;
 
    /**
     * Resets its state.

--- a/core/src/main/java/org/infinispan/xsite/irac/IracManagerKeyInfoImpl.java
+++ b/core/src/main/java/org/infinispan/xsite/irac/IracManagerKeyInfoImpl.java
@@ -61,6 +61,11 @@ public class IracManagerKeyInfoImpl implements IracManagerKeyInfo {
       return result;
    }
 
+   @Override
+   public String toString() {
+      return "IracManagerKeyInfoImpl{" + "segment=" + segment + ", key=" + key + ", owner=" + owner + '}';
+   }
+
    public static void writeTo(ObjectOutput output, IracManagerKeyInfo keyInfo) throws IOException {
       if (keyInfo == null) {
          output.writeObject(null);

--- a/core/src/main/java/org/infinispan/xsite/irac/IracManagerKeyState.java
+++ b/core/src/main/java/org/infinispan/xsite/irac/IracManagerKeyState.java
@@ -1,5 +1,9 @@
 package org.infinispan.xsite.irac;
 
+import java.util.Collection;
+
+import org.infinispan.xsite.XSiteBackup;
+
 /**
  * Keeps a key state for {@link IracManager}.
  * <p>
@@ -56,4 +60,23 @@ interface IracManagerKeyState extends IracManagerKeyInfo {
     */
    void discard();
 
+   /**
+    * Mark the given site as successfully received the current state.
+    *
+    * @param site: Site that received the state.
+    */
+   void successFor(XSiteBackup site);
+
+   /**
+    * Check if given site received this state.
+    *
+    * @param site: Site to verify.
+    * @return true if successfully sent, false otherwise.
+    */
+   boolean wasSuccessful(XSiteBackup site);
+
+   /**
+    * Check if all given sites have received this state.
+    */
+   boolean successfullySent(Collection<? extends XSiteBackup> sites);
 }

--- a/core/src/main/java/org/infinispan/xsite/irac/IracResponseCollector.java
+++ b/core/src/main/java/org/infinispan/xsite/irac/IracResponseCollector.java
@@ -1,136 +1,106 @@
 package org.infinispan.xsite.irac;
 
 import java.util.ArrayList;
-import java.util.BitSet;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.function.BiConsumer;
 
 import org.infinispan.commons.util.IntSet;
-import org.infinispan.commons.util.IntSets;
-import org.infinispan.util.concurrent.CountDownRunnable;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 import org.infinispan.xsite.status.DefaultTakeOfflineManager;
 
-import net.jcip.annotations.GuardedBy;
-
 /**
  * A response collector for an asynchronous cross site requests.
  * <p>
- * Multiple keys are batched together in a single requests. The remote site sends a {@link BitSet} back where if bit
+ * Multiple keys are batched together in a single requests. The remote site sends a {@link IntSet} back where if bit
  * {@code n} is set, it means the {@code n}th key in the batch failed to be applied (example, lock failed to be
  * acquired), and it needs to be retried.
  * <p>
  * If an {@link Exception} is received (example, timed-out waiting for the remote site ack), it assumes all keys in the
  * batch aren't applied, and they are retried.
  * <p>
- * When all responses (or exceptions) are received, {@link IracResponseCompleted#onResponseCompleted(IracBatchSendResult,
- * Collection)} is invoked with the global result in {@link IracBatchSendResult} and a collection with all the
- * successfully applied keys. Also, the {@link CompletableFuture} returned by {@link #freeze()} is completed (completed
- * value not relevant, and it is never completed exceptionally).
+ * When the response (or exception) is received, {@link IracResponseCompleted#onResponseCompleted(IracBatchSendResult, Collection)} is invoked with the global result in {@link IracBatchSendResult} and a collection
+ * with all the successfully applied keys. Once the listener finishes execution, the {@link CompletableFuture} completes
+ * (completed value not relevant, and it is never completed exceptionally).
  *
  * @author Pedro Ruivo
  * @since 12
  */
-public class IracResponseCollector implements Runnable {
+public class IracResponseCollector extends CompletableFuture<Void> implements BiConsumer<IntSet, Throwable> {
 
    private static final Log log = LogFactory.getLog(IracResponseCollector.class);
-   private static final AtomicReferenceFieldUpdater<IracResponseCollector, IracBatchSendResult> RESULT_UPDATED = AtomicReferenceFieldUpdater.newUpdater(IracResponseCollector.class, IracBatchSendResult.class, "result");
-
-   private volatile IracBatchSendResult result = IracBatchSendResult.OK;
-   private volatile boolean exceptionReceived;
-   @GuardedBy("failedKeys")
-   private final IntSet failedKeys;
+   private final IracXSiteBackup backup;
    private final String cacheName;
    private final Collection<IracManagerKeyState> batch;
    private final IracResponseCompleted listener;
-   private final CountDownRunnable countDownRunnable;
-   private final CompletableFuture<Void> completableFuture = new CompletableFuture<>();
 
-   public IracResponseCollector(String cacheName, Collection<IracManagerKeyState> batch, IracResponseCompleted listener) {
+   public IracResponseCollector(String cacheName, IracXSiteBackup backup, Collection<IracManagerKeyState> batch, IracResponseCompleted listener) {
       this.cacheName = cacheName;
+      this.backup = backup;
       this.batch = batch;
       this.listener = listener;
-      countDownRunnable = new CountDownRunnable(this);
-      failedKeys = IntSets.mutableEmptySet(batch.size());
-   }
-
-   public void dependsOn(IracXSiteBackup backup, CompletionStage<? extends IntSet> request) {
-      countDownRunnable.increment();
-      request.whenComplete((bitSet, throwable) -> onResponse(backup, bitSet, throwable));
-   }
-
-   public CompletionStage<Void> freeze() {
-      countDownRunnable.freeze();
-      return completableFuture;
-   }
-
-   private void onResponse(IracXSiteBackup backup, IntSet rspIntSet, Throwable throwable) {
-      boolean trace = log.isTraceEnabled();
-      try {
-         if (throwable != null) {
-            exceptionReceived = true;
-            if (DefaultTakeOfflineManager.isCommunicationError(throwable)) {
-               //in case of communication error, we need to back-off.
-               RESULT_UPDATED.set(this, IracBatchSendResult.BACK_OFF_AND_RETRY);
-            } else if (result == IracBatchSendResult.OK) {
-               //don't overwrite communication errors
-               RESULT_UPDATED.compareAndSet(this, IracBatchSendResult.OK, IracBatchSendResult.RETRY);
-            }
-            if (backup.logExceptions()) {
-               log.warnXsiteBackupFailed(cacheName, backup.getSiteName(), throwable);
-            } else if (trace) {
-               log.tracef(throwable, "[IRAC] Encountered issues while backing up data for cache %s to site %s", cacheName, backup.getSiteName());
-            }
-         } else {
-            if (trace) {
-               log.tracef("[IRAC] Received response from site %s (%d missing): %s", backup.getSiteName(), countDownRunnable.missing(), rspIntSet);
-            }
-            mergeIntSetResult(rspIntSet);
-            // if some keys failed to apply, we need to retry.
-            if (!rspIntSet.isEmpty() && result == IracBatchSendResult.OK) {
-               RESULT_UPDATED.compareAndSet(this, IracBatchSendResult.OK, IracBatchSendResult.RETRY);
-            }
-         }
-      } finally {
-         countDownRunnable.decrement();
-      }
    }
 
    @Override
-   public void run() {
-      if (exceptionReceived) {
+   public void accept(IntSet rspIntSet, Throwable throwable) {
+      boolean trace = log.isTraceEnabled();
+      if (throwable != null) {
+         IracBatchSendResult result;
+         if (DefaultTakeOfflineManager.isCommunicationError(throwable)) {
+            //in case of communication error, we need to back-off.
+            backup.enableBackOff();
+            result = IracBatchSendResult.BACK_OFF_AND_RETRY;
+         } else {
+            //don't overwrite communication errors
+            backup.resetBackOff();
+            result = IracBatchSendResult.RETRY;
+         }
+         if (backup.logExceptions()) {
+            log.warnXsiteBackupFailed(cacheName, backup.getSiteName(), throwable);
+         } else if (trace) {
+            log.tracef(throwable, "[IRAC] Encountered issues while backing up data for cache %s to site %s", cacheName, backup.getSiteName());
+         }
+
          batch.forEach(IracManagerKeyState::retry);
-         listener.onResponseCompleted(result, Collections.emptyList());
-         completableFuture.complete(null);
+         notifyAndComplete(result, Collections.emptyList());
          return;
       }
-      Collection<IracManagerKeyState> successfulSent = new ArrayList<>(batch.size());
-      int index = 0;
-      for (IracManagerKeyState state : batch) {
-         if (hasKeyFailed(index)) {
-            state.retry();
-         } else if (state.done()) {
-            successfulSent.add(state);
+
+      if (trace) {
+         log.tracef("[IRAC] Received response from site %s for cache %s: %s", backup.getSiteName(), cacheName, rspIntSet);
+      }
+
+      backup.resetBackOff();
+
+      // Everything is good.
+      if (rspIntSet == null || rspIntSet.isEmpty()) {
+         for (IracManagerKeyState state : batch) {
+            state.successFor(backup);
          }
+         notifyAndComplete(IracBatchSendResult.OK, batch);
+         return;
       }
+
+      // Handle failed keys.
+      int index = 0;
+      List<IracManagerKeyState> successfulSent = new ArrayList<>(batch.size());
+      for (IracManagerKeyState state : batch) {
+         if (rspIntSet.contains(index++)) {
+            state.retry();
+            continue;
+         }
+         state.successFor(backup);
+         successfulSent.add(state);
+      }
+      notifyAndComplete(IracBatchSendResult.RETRY, successfulSent);
+   }
+
+   private void notifyAndComplete(IracBatchSendResult result, Collection<IracManagerKeyState> successfulSent) {
       listener.onResponseCompleted(result, successfulSent);
-      completableFuture.complete(null);
-   }
-
-   private void mergeIntSetResult(IntSet rsp) {
-      synchronized (failedKeys) {
-         failedKeys.addAll(rsp);
-      }
-   }
-
-   private boolean hasKeyFailed(int index) {
-      synchronized (failedKeys) {
-         return failedKeys.contains(index);
-      }
+      complete(null);
    }
 
    @FunctionalInterface

--- a/core/src/main/java/org/infinispan/xsite/irac/IracXSiteBackup.java
+++ b/core/src/main/java/org/infinispan/xsite/irac/IracXSiteBackup.java
@@ -2,24 +2,71 @@ package org.infinispan.xsite.irac;
 
 import org.infinispan.configuration.cache.BackupConfiguration;
 import org.infinispan.configuration.cache.BackupFailurePolicy;
+import org.infinispan.util.ExponentialBackOff;
 import org.infinispan.xsite.XSiteBackup;
+
+import net.jcip.annotations.GuardedBy;
 
 /**
  * Extends {@link XSiteBackup} class with logging configuration.
  *
  * @since 14.0
  */
-public class IracXSiteBackup extends XSiteBackup {
+public class IracXSiteBackup extends XSiteBackup implements Runnable {
 
    private final boolean logExceptions;
+
+   @GuardedBy("this")
+   private ExponentialBackOff backOff;
+
+   @GuardedBy("this")
+   private boolean backOffEnabled;
+
+   @GuardedBy("this")
+   private Runnable afterBackOff = () -> {};
 
    public IracXSiteBackup(String siteName, boolean sync, long timeout, boolean logExceptions) {
       super(siteName, sync, timeout);
       this.logExceptions = logExceptions;
+      this.backOff = ExponentialBackOff.NO_OP;
+      this.backOffEnabled = false;
    }
 
    public boolean logExceptions() {
       return logExceptions;
+   }
+
+   public synchronized void enableBackOff() {
+      if (backOffEnabled) return;
+
+      backOffEnabled = true;
+      backOff.asyncBackOff().thenRun(this);
+   }
+
+   synchronized void useBackOff(ExponentialBackOff backOff, Runnable after) {
+      this.backOff = backOff;
+      this.afterBackOff = after;
+   }
+
+   public synchronized boolean isBackOffEnabled() {
+      return backOffEnabled;
+   }
+
+   synchronized void resetBackOff() {
+      backOffEnabled = false;
+      backOff.reset();
+      afterBackOff.run();
+   }
+
+   @Override
+   public synchronized void run() {
+      backOffEnabled = false;
+      afterBackOff.run();
+   }
+
+   @Override
+   public String toString() {
+      return super.toString() + (isBackOffEnabled() ? " [backoff-enabled]" : "");
    }
 
    public static IracXSiteBackup fromBackupConfiguration(BackupConfiguration backupConfiguration) {

--- a/core/src/test/java/org/infinispan/xsite/irac/ControlledExponentialBackOff.java
+++ b/core/src/test/java/org/infinispan/xsite/irac/ControlledExponentialBackOff.java
@@ -1,0 +1,84 @@
+package org.infinispan.xsite.irac;
+
+import static org.testng.AssertJUnit.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.BlockingDeque;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+
+import org.infinispan.util.ExponentialBackOff;
+import org.testng.AssertJUnit;
+
+public class ControlledExponentialBackOff implements ExponentialBackOff {
+
+   private String name;
+   private final BlockingDeque<Event> backOffEvents;
+   private volatile CompletableFuture<Void> backOff = new CompletableFuture<>();
+
+   ControlledExponentialBackOff() {
+      backOffEvents = new LinkedBlockingDeque<>();
+   }
+
+   ControlledExponentialBackOff(String name) {
+      this();
+      this.name = name;
+   }
+
+   @Override
+   public void reset() {
+      backOffEvents.add(Event.RESET);
+   }
+
+   @Override
+   public CompletionStage<Void> asyncBackOff() {
+      CompletionStage<Void> stage = backOff;
+      // add to the event after getting the completable future
+      backOffEvents.add(Event.BACK_OFF);
+      return stage;
+   }
+
+   void release() {
+      backOff.complete(null);
+      this.backOff = new CompletableFuture<>();
+   }
+
+   void cleanupEvents() {
+      backOffEvents.clear();
+   }
+
+   void eventually(String message, Event... expected) {
+      List<Event> events = new ArrayList<>(Arrays.asList(expected));
+      while (!events.isEmpty()) {
+         Event current = null;
+         try {
+            current = backOffEvents.poll(30, TimeUnit.SECONDS);
+         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            AssertJUnit.fail(e.getMessage());
+         }
+         assertTrue("At " + name + ": " + message + " Expected " + events + ", current " + current, events.contains(current));
+         events.remove(current);
+      }
+   }
+
+   void containsOnly(String message, Event event) {
+      while (!backOffEvents.isEmpty()) {
+         eventually(message, event);
+      }
+   }
+
+   void assertNoEvents() {
+      assertTrue("At " + name + ": Expected no events, found: " + backOffEvents, backOffEvents.isEmpty());
+   }
+
+   enum Event {
+      BACK_OFF,
+      RESET
+   }
+
+}

--- a/core/src/test/java/org/infinispan/xsite/irac/ControlledTransport.java
+++ b/core/src/test/java/org/infinispan/xsite/irac/ControlledTransport.java
@@ -1,0 +1,89 @@
+package org.infinispan.xsite.irac;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+
+import org.infinispan.commons.CacheConfigurationException;
+import org.infinispan.remoting.transport.AbstractDelegatingTransport;
+import org.infinispan.remoting.transport.Transport;
+import org.infinispan.remoting.transport.XSiteResponse;
+import org.infinispan.xsite.XSiteBackup;
+import org.infinispan.xsite.XSiteReplicateCommand;
+
+public class ControlledTransport extends AbstractDelegatingTransport {
+
+   volatile Supplier<Throwable> throwableSupplier = () -> null;
+   private final String local;
+   private final Collection<String> connectedSites;
+   private final Collection<String> disconnectedSites;
+
+   ControlledTransport(Transport actual,
+                       String local,
+                       Collection<String> connectedSites,
+                       Collection<String> disconnectedSites) {
+      super(actual);
+      this.local = local;
+      this.connectedSites = connectedSites;
+      this.disconnectedSites = disconnectedSites;
+   }
+
+   ControlledTransport(Transport actual, String local, Collection<String> disconnectedSites) {
+      this(actual, local, Collections.singleton(local), disconnectedSites);
+   }
+
+   @Override
+   public void start() {
+      //already started
+   }
+
+   @Override
+   public <O> XSiteResponse<O> backupRemotely(XSiteBackup backup, XSiteReplicateCommand<O> rpcCommand) {
+      Throwable t = null;
+      if (disconnectedSites.contains(backup.getSiteName())) t = throwableSupplier.get();
+      ControlledXSiteResponse<O> response = new ControlledXSiteResponse<>(backup, t);
+      response.complete();
+      return response;
+   }
+
+   @Override
+   public void checkCrossSiteAvailable() throws CacheConfigurationException {
+      //no-op == it is available
+   }
+
+   @Override
+   public String localSiteName() {
+      return local;
+   }
+
+   @Override
+   public Set<String> getSitesView() {
+      return Set.copyOf(connectedSites);
+   }
+
+   private static class ControlledXSiteResponse<T> extends CompletableFuture<T> implements XSiteResponse<T> {
+
+      private final XSiteBackup backup;
+      private final Throwable result;
+
+      private ControlledXSiteResponse(XSiteBackup backup, Throwable result) {
+         this.backup = backup;
+         this.result = result;
+      }
+
+      @Override
+      public void whenCompleted(XSiteResponseCompleted listener) {
+         listener.onCompleted(backup, System.currentTimeMillis(), 0, result);
+      }
+
+      void complete() {
+         if (result == null) {
+            complete(null);
+         } else {
+            completeExceptionally(result);
+         }
+      }
+   }
+}

--- a/core/src/test/java/org/infinispan/xsite/irac/Irac3SitesExponentialBackOffTest.java
+++ b/core/src/test/java/org/infinispan/xsite/irac/Irac3SitesExponentialBackOffTest.java
@@ -1,0 +1,164 @@
+package org.infinispan.xsite.irac;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+import org.infinispan.Cache;
+import org.infinispan.commons.CacheException;
+import org.infinispan.configuration.cache.BackupConfiguration;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.remoting.transport.Transport;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.xsite.AbstractMultipleSitesTest;
+import org.jgroups.UnreachableException;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Functional test for exponential back-off with IRAC.
+ * </p>
+ * This test uses 3 sites with a cluster of size 1 for simplification. We issue all commands from site 1,
+ * which has sites 2 and 3 as backups. The requests from 1 -> 2 will complete on the first try,
+ * whereas 1 -> 3 will need the back-off to kick in.
+ * </p>
+ * We verify that the back-off only retries the failed operations. We have the same verifications as
+ * {@link IracExponentialBackOffTest}.
+ *
+ * @author Jose Bolina
+ * @since 15.0
+ */
+@Test(groups = "functional", testName = "xsite.irac.Irac3SitesExponentialBackOffTest")
+public class Irac3SitesExponentialBackOffTest extends AbstractMultipleSitesTest {
+   private static final int N_SITES = 3;
+   private static final int CLUSTER_SIZE = 1;
+   private static final Supplier<Throwable> NO_EXCEPTION = () -> null;
+   private final Map<String, ControlledExponentialBackOff> backOffMap = new ConcurrentHashMap<>();
+   private volatile ControlledTransport transport;
+
+
+   @Override
+   protected ConfigurationBuilder defaultConfigurationForSite(int siteIndex) {
+      ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false);
+      for (int i = 0; i < N_SITES; ++i) {
+         if (i == siteIndex) {
+            //don't add our site as backup.
+            continue;
+         }
+         builder.sites()
+               .addBackup()
+               .site(siteName(i))
+               .strategy(BackupConfiguration.BackupStrategy.ASYNC);
+      }
+      return builder;
+   }
+
+   @Override
+   protected int defaultNumberOfSites() {
+      return N_SITES;
+   }
+
+   @Override
+   protected int defaultNumberOfNodes() {
+      return CLUSTER_SIZE;
+   }
+
+   @Override
+   protected void afterSitesCreated() {
+      Cache<String, String> c = cache(siteName(0), 0);
+      Collection<String> connected = Arrays.asList(siteName(0), siteName(1));
+      Collection<String> disconnected = Collections.singletonList(siteName(2));
+
+      transport = TestingUtil.wrapGlobalComponent(manager(c), Transport.class,
+            actual -> new ControlledTransport(actual, siteName(0), connected, disconnected), true);
+      DefaultIracManager iracManager = (DefaultIracManager) TestingUtil.extractComponent(c, IracManager.class);
+      iracManager.setBackOff(backup -> backOffMap.computeIfAbsent(backup.getSiteName(), ControlledExponentialBackOff::new));
+   }
+
+   @AfterMethod(alwaysRun = true)
+   public void resetStateAfterTest() {
+      backOffMap.values().forEach(ControlledExponentialBackOff::release);
+
+      Cache<String, String> c = cache(siteName(0), 0);
+      DefaultIracManager iracManager = (DefaultIracManager) TestingUtil.extractComponent(c, IracManager.class);
+      eventually(iracManager::isEmpty);
+      backOffMap.values().forEach(ControlledExponentialBackOff::cleanupEvents);
+      backOffMap.values().forEach(ControlledExponentialBackOff::assertNoEvents);
+   }
+
+   public void testSimulatedTimeout(Method method) {
+      doTest(method, () -> log.requestTimedOut(1, siteName(2), "some time"));
+   }
+
+   public void testSimulatedUnreachableException(Method method) {
+      doTest(method, () -> new UnreachableException(null));
+   }
+
+   public void testSiteUnreachable(Method method) {
+      doTest(method, () -> log.remoteNodeSuspected(null));
+   }
+
+   public void testNoBackoffOnOtherException(Method method) {
+      transport.throwableSupplier = CacheException::new;
+      Cache<String, String> c = cache(siteName(0), 0);
+
+      final String key = TestingUtil.k(method);
+      final String value = TestingUtil.v(method);
+
+      c.put(key, value);
+
+      // Since no back off applied, both issues a reset. One backup succeeds and another fails.
+      backOffMap.get(siteName(1)).eventually("Both reset with CacheException.", ControlledExponentialBackOff.Event.RESET);
+      backOffMap.get(siteName(2)).eventually("Both reset with CacheException.", ControlledExponentialBackOff.Event.RESET);
+
+      //with "normal" exception, the protocol will keep trying to send the request
+      //we need to let it have a successful request otherwise it will fill the queue with RESET events.
+      //it is possible that between the prev check and changing this, that already happened.
+      transport.throwableSupplier = NO_EXCEPTION;
+
+      DefaultIracManager iracManager = (DefaultIracManager) TestingUtil.extractComponent(c, IracManager.class);
+      eventually(iracManager::isEmpty);
+
+      // Only the backup that failed issued an event now, so only RESET event here (could be more than one).
+      backOffMap.get(siteName(1)).assertNoEvents();
+      backOffMap.get(siteName(2)).containsOnly("Only one that failed reset.", ControlledExponentialBackOff.Event.RESET);
+
+      // Back off not applied.
+      backOffMap.values().forEach(ControlledExponentialBackOff::assertNoEvents);
+   }
+
+   private void doTest(Method method, Supplier<Throwable> throwableSupplier) {
+      Cache<String, String> c = cache(siteName(0), 0);
+      transport.throwableSupplier = throwableSupplier;
+
+      final String key = TestingUtil.k(method);
+      final String value = TestingUtil.v(method);
+
+      c.put(key, value);
+
+      // With 2 backups, one succeeds and another fails.
+      backOffMap.get(siteName(1)).eventually("Backoff event on first try.", ControlledExponentialBackOff.Event.RESET);
+      backOffMap.get(siteName(2)).eventually("Backoff event on first try.", ControlledExponentialBackOff.Event.BACK_OFF);
+
+      // Release will trigger the backoff to the failed site.
+      backOffMap.get(siteName(2)).release();
+
+      // Only one site sends the keys, so only a single event here.
+      backOffMap.get(siteName(2)).eventually("Backoff event after release.", ControlledExponentialBackOff.Event.BACK_OFF);
+
+      // Operation now should succeed.
+      transport.throwableSupplier = NO_EXCEPTION;
+      backOffMap.get(siteName(2)).release();
+
+      // The operation finally succeeds, since only one backup was failing we have only one event.
+      backOffMap.get(siteName(2)).eventually("All operations should succeed.", ControlledExponentialBackOff.Event.RESET);
+
+      // No other event was issued.
+      backOffMap.values().forEach(ControlledExponentialBackOff::assertNoEvents);
+   }
+}

--- a/core/src/test/java/org/infinispan/xsite/irac/ManualIracManager.java
+++ b/core/src/test/java/org/infinispan/xsite/irac/ManualIracManager.java
@@ -13,6 +13,7 @@ import org.infinispan.Cache;
 import org.infinispan.commons.util.IntSet;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.test.TestingUtil;
+import org.infinispan.xsite.XSiteBackup;
 import org.infinispan.xsite.statetransfer.XSiteState;
 
 /**
@@ -205,6 +206,20 @@ public class ManualIracManager extends ControlledIracManager {
       @Override
       public void discard() {
 
+      }
+
+      @Override
+      public void successFor(XSiteBackup site) {
+      }
+
+      @Override
+      public boolean wasSuccessful(XSiteBackup site) {
+         return false;
+      }
+
+      @Override
+      public boolean successfullySent(Collection<? extends XSiteBackup> sites) {
+         return false;
       }
    }
 }

--- a/core/src/test/java/org/infinispan/xsite/offline/AsyncOfflineTest.java
+++ b/core/src/test/java/org/infinispan/xsite/offline/AsyncOfflineTest.java
@@ -53,7 +53,7 @@ public class AsyncOfflineTest extends AbstractXSiteTest {
       defineCache(NYC, cacheName, getNYCOrSFOConfiguration());
 
       for (int i = 0; i < NUM_NODES; ++i) {
-         iracManager(LON, cacheName, i).setBackOff(ExponentialBackOff.NO_OP);
+         iracManager(LON, cacheName, i).setBackOff(ExponentialBackOff.NO_OP_BUILDER);
       }
 
       String key = method.getName() + "-key";
@@ -73,7 +73,7 @@ public class AsyncOfflineTest extends AbstractXSiteTest {
       defineCache(SFO, cacheName, getNYCOrSFOConfiguration());
 
       for (int i = 0; i < NUM_NODES; ++i) {
-         iracManager(LON, cacheName, i).setBackOff(ExponentialBackOff.NO_OP);
+         iracManager(LON, cacheName, i).setBackOff(ExponentialBackOff.NO_OP_BUILDER);
       }
 
       String key = method.getName() + "-key";
@@ -103,7 +103,7 @@ public class AsyncOfflineTest extends AbstractXSiteTest {
       defineCache(SFO, cacheName, getNYCOrSFOConfiguration());
 
       for (int i = 0; i < NUM_NODES; ++i) {
-         iracManager(LON, cacheName, i).setBackOff(ExponentialBackOff.NO_OP);
+         iracManager(LON, cacheName, i).setBackOff(ExponentialBackOff.NO_OP_BUILDER);
       }
 
       String key = method.getName() + "-key";

--- a/core/src/test/java/org/infinispan/xsite/offline/AsyncTimeBasedOfflineTest.java
+++ b/core/src/test/java/org/infinispan/xsite/offline/AsyncTimeBasedOfflineTest.java
@@ -43,7 +43,7 @@ public class AsyncTimeBasedOfflineTest extends AbstractXSiteTest {
 
       //disable exponential back-off to avoid messing the times
       for (int i = 0; i < NUM_NODES; ++i) {
-         iracManager(LON, cacheName, i).setBackOff(ExponentialBackOff.NO_OP);
+         iracManager(LON, cacheName, i).setBackOff(ExponentialBackOff.NO_OP_BUILDER);
       }
 
       String key = method.getName() + "-key";


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-13489

I've created `CompletableFuture`, which can be retried multiple times. We have the back-off for the whole `DefaultIracManager#run` and a back-off per operation issued to the remote sites. Both follow the same retry policy.

At first, I was trying to use the same thread for the retries with the `WithinThreadExecutor`, but it started to block too much stuff. Because of the way I've created the `RetryableCompletionStage`, where the `onComplete` calls the `retry`, which calls the `onComplete`. So suggestions are really welcome.