### PR TITLE
ISPN-12224 Cluster in a confusing state after restarted from graceful…

### DIFF
--- a/core/src/main/java/org/infinispan/partitionhandling/PartitionHandling.java
+++ b/core/src/main/java/org/infinispan/partitionhandling/PartitionHandling.java
@@ -18,5 +18,14 @@ public enum PartitionHandling {
    /**
     * Allow entries on each partition to diverge, with conflicts resolved during merge.
     */
-   ALLOW_READ_WRITES
+   ALLOW_READ_WRITES {
+      @Override
+      public AvailabilityMode startingAvailability() {
+         return AvailabilityMode.AVAILABLE;
+      }
+   };
+
+   public AvailabilityMode startingAvailability() {
+      return AvailabilityMode.DEGRADED_MODE;
+   }
 }

--- a/core/src/test/java/org/infinispan/globalstate/ThreeNodeGlobalStatePartialRestartTest.java
+++ b/core/src/test/java/org/infinispan/globalstate/ThreeNodeGlobalStatePartialRestartTest.java
@@ -235,7 +235,6 @@ public class ThreeNodeGlobalStatePartialRestartTest extends AbstractGlobalStateR
    @Override
    public Object[] factory() {
       return Arrays.stream(PartitionHandling.values())
-            .filter(ph -> ph != PartitionHandling.ALLOW_READ_WRITES)
             .flatMap(ph -> Arrays.stream(new Object[] {
                   new ThreeNodeGlobalStatePartialRestartTest().withCacheMode(CacheMode.DIST_SYNC).withPartitionHandling(ph),
                   new ThreeNodeGlobalStatePartialRestartTest().withCacheMode(CacheMode.DIST_SYNC).withPartitionHandling(ph).purgeOnStartup(true),


### PR DESCRIPTION
… shutdown - no hint for waiting on complete restarted

https://issues.redhat.com/browse/ISPN-12224

* Follow the partition policy when missing members after graceful shutdown;
* Only clear persistent state after successfully recovering after a graceful shutdown;