### PR TITLE
ISPN-14233 REST API makes it possible to download any server report

### DIFF
--- a/client/rest-client/src/main/java/org/infinispan/client/rest/RestServerClient.java
+++ b/client/rest-client/src/main/java/org/infinispan/client/rest/RestServerClient.java
@@ -45,6 +45,8 @@ public interface RestServerClient {
     */
    CompletionStage<RestResponse> report();
 
+   CompletionStage<RestResponse> report(String node);
+
    CompletionStage<RestResponse> ignoreCache(String cacheManagerName, String cacheName);
 
    CompletionStage<RestResponse> unIgnoreCache(String cacheManagerName, String cacheName);

--- a/client/rest-client/src/main/java/org/infinispan/client/rest/impl/okhttp/RestServerClientOkHttp.java
+++ b/client/rest-client/src/main/java/org/infinispan/client/rest/impl/okhttp/RestServerClientOkHttp.java
@@ -71,6 +71,11 @@ public class RestServerClientOkHttp implements RestServerClient {
    }
 
    @Override
+   public CompletionStage<RestResponse> report(String node) {
+      return client.execute(baseServerURL, "report", node);
+   }
+
+   @Override
    public CompletionStage<RestResponse> ignoreCache(String cacheManagerName, String cacheName) {
       return ignoreCacheOp(cacheManagerName, cacheName, "POST");
    }

--- a/documentation/src/main/asciidoc/topics/ref_rest_servers.adoc
+++ b/documentation/src/main/asciidoc/topics/ref_rest_servers.adoc
@@ -145,10 +145,18 @@ GET /rest/v2/server/threads
 [id='rest_v2_server_report']
 = Getting Diagnostic Reports for {brandname} Servers
 Retrieve aggregated reports for {brandname} Servers with `GET` requests.
+To retrieve the report for the requested server:
 
 [source,options="nowrap",subs=attributes+]
 ----
 GET /rest/v2/server/report
+----
+
+To retrieve the report of another server in the cluster, reference the node by name:
+
+[source,options="nowrap",subs=attributes+]
+----
+GET /rest/v2/server/report/{nodeName}
 ----
 
 {brandname} responds with a `tar.gz` archive that contains an aggregated report

--- a/server/core/src/main/java/org/infinispan/server/core/ServerStateManager.java
+++ b/server/core/src/main/java/org/infinispan/server/core/ServerStateManager.java
@@ -29,4 +29,6 @@ public interface ServerStateManager extends Lifecycle {
    CompletableFuture<Void> setConnectorIpFilterRule(String name, Collection<IpSubnetFilterRule> filterRule);
 
    CompletableFuture<Void> clearConnectorIpFilterRules(String name);
+
+   ServerManagement managedServer();
 }

--- a/server/core/src/test/java/org/infinispan/server/core/DummyServerStateManager.java
+++ b/server/core/src/test/java/org/infinispan/server/core/DummyServerStateManager.java
@@ -62,6 +62,11 @@ public class DummyServerStateManager implements ServerStateManager {
    }
 
    @Override
+   public ServerManagement managedServer() {
+      return null;
+   }
+
+   @Override
    public void start() {
    }
 

--- a/server/runtime/src/main/java/org/infinispan/server/state/ServerStateManagerImpl.java
+++ b/server/runtime/src/main/java/org/infinispan/server/state/ServerStateManagerImpl.java
@@ -32,6 +32,7 @@ import org.infinispan.protostream.annotations.ProtoTypeId;
 import org.infinispan.security.AuthorizationPermission;
 import org.infinispan.server.Server;
 import org.infinispan.server.core.ProtocolServer;
+import org.infinispan.server.core.ServerManagement;
 import org.infinispan.server.core.ServerStateManager;
 import org.infinispan.server.core.transport.CompositeChannelMatcher;
 import org.infinispan.server.core.transport.IpFilterRuleChannelMatcher;
@@ -142,6 +143,11 @@ public final class ServerStateManagerImpl implements ServerStateManager {
    public CompletableFuture<Void> clearConnectorIpFilterRules(String name) {
       SecurityActions.checkPermission(cacheManager, AuthorizationPermission.ADMIN);
       return cache.putAsync(new ScopedState(CONNECTOR_IPFILTER_SCOPE, name), new IpFilterRules()).thenApply(v -> null);
+   }
+
+   @Override
+   public ServerManagement managedServer() {
+      return server;
    }
 
    private void updateLocalIgnoredCaches(IgnoredCaches ignored) {


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-14233

~Returning something like:~

```json
[
   {
      "node_name":"ClusterResourceTest-NodeA",
      "transport":{
         "io-threads":6,
         "receive-buffer-size":0,
         "global-connections":1,
         "total-bytes-read":707,
         "port":38567,
         "pending-tasks":0,
         "total-bytes-written":1501,
         "host":"localhost",
         "send-buffer-size":0,
         "local-connections":1
      }
   },
   {
      "node_name":"ClusterResourceTest-NodeB",
      "transport":{
         "io-threads":6,
         "receive-buffer-size":0,
         "global-connections":1,
         "total-bytes-read":0,
         "port":46363,
         "pending-tasks":0,
         "total-bytes-written":0,
         "host":"localhost",
         "send-buffer-size":0,
         "local-connections":0
      }
   }
]
```

---
Updated:

Added an endpoint that receives a node name and downloads the referenced node's report.
