### PR TITLE
[14.0.x]ISPN-14267-14 fix docs formatting 

### DIFF
--- a/documentation/src/main/asciidoc/titles/embedding/stories.adoc
+++ b/documentation/src/main/asciidoc/titles/embedding/stories.adoc
@@ -3,6 +3,7 @@
 
 include::{stories}/assembly_configuring_maven_repository.adoc[leveloffset=+1]
 include::{stories}/assembly_creating_embedded_caches.adoc[leveloffset=+1]
+include::{stories}/assembly_authorization_embedded.adoc[leveloffset=+1]
 include::{stories}/assembly_configuring_statistics_jmx.adoc[leveloffset=+1]
 include::{stories}/assembly_setting_up_clusters.adoc[leveloffset=+1]
 include::{stories}/assembly_clustered_locks.adoc[leveloffset=+1]

--- a/documentation/src/main/asciidoc/topics/proc_cli_statistics.adoc
+++ b/documentation/src/main/asciidoc/topics/proc_cli_statistics.adoc
@@ -9,7 +9,7 @@ Use the [command]`stats` command either from the context of a resource that prov
 ----
 stats
 ----
-+
+
 [source,json,options="nowrap",subs=attributes+]
 ----
 include::json/cli_stats_container.json[]
@@ -19,7 +19,7 @@ include::json/cli_stats_container.json[]
 ----
 stats /containers/default/caches/mycache
 ----
-+
+
 [source,json,options="nowrap",subs=attributes+]
 ----
 include::json/cli_stats_cache.json[]

--- a/documentation/src/main/asciidoc/topics/proc_enabling_jmx_port.adoc
+++ b/documentation/src/main/asciidoc/topics/proc_enabling_jmx_port.adoc
@@ -22,6 +22,7 @@ Users must have `controlRole` with read/write access or the `monitorRole` with r
 
 .Procedure
 Start {brandname} Server with a remote JMX port enabled using one of the following ways:
+
 * Enable remote JMX through port `9999`.
 +
 [source,options="nowrap",subs=attributes+]


### PR DESCRIPTION
Backports #10421
https://issues.redhat.com/browse/ISPN-14267 
fixes docs formatting
includes rbac content in the embedded guide