### PR TITLE
ISPN-14290 fix ldap yaml config example

### DIFF
--- a/documentation/src/main/asciidoc/topics/yaml/server_ldap_realm.yaml
+++ b/documentation/src/main/asciidoc/topics/yaml/server_ldap_realm.yaml
@@ -6,12 +6,12 @@ server:
           url: 'ldap://my-ldap-server:10389'
           principal: 'uid=admin,ou=People,dc=infinispan,dc=org'
           credential: strongPassword
-          connectionTimeout': '3000'
-          readTimeout': '30000'
-          connectionPooling': true
-          referralMode': ignore
-          pageSize': '30'
-          directVerification': true
+          connectionTimeout: '3000'
+          readTimeout: '30000'
+          connectionPooling: true
+          referralMode: ignore
+          pageSize: '30'
+          directVerification: true
           identityMapping:
             rdnIdentifier: uid
             searchDn: 'ou=People,dc=infinispan,dc=org'


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-14290
Remove apostrophe from the ldap config example

Needs backport to 14.0.x and 13.0.x