### PR TITLE
ISPN-14325 type pollution

### DIFF
--- a/build/configuration/pom.xml
+++ b/build/configuration/pom.xml
@@ -179,7 +179,7 @@
       <version.mockito_dep.bytebuddy>1.9.7</version.mockito_dep.bytebuddy>
       <version.mockito_dep.objenesis>2.6</version.mockito_dep.objenesis>
       <version.nashorn>15.4</version.nashorn>
-      <version.netty>4.1.82.Final</version.netty>
+      <version.netty>4.1.84.Final</version.netty>
       <version.netty.incubator.iouring>0.0.14.Final</version.netty.incubator.iouring>
       <version.okhttp>3.14.9</version.okhttp>
       <version.openjdk.jmh>1.23</version.openjdk.jmh>

--- a/commons/all/src/main/java/org/infinispan/commons/marshall/Ids.java
+++ b/commons/all/src/main/java/org/infinispan/commons/marshall/Ids.java
@@ -226,6 +226,8 @@ public interface Ids {
    Integer COMMAND_INVOCATION_ID = 154;
    Integer CACHE_ENTRY_GROUP_PREDICATE = 155;
 
+   Integer VISITABLE_COMMAND = 156;
+
    Integer COUNTER_CONFIGURATION = 2000; //from counter
    Integer COUNTER_STATE = 2001; //from counter
 }

--- a/core/src/main/java/org/infinispan/commands/SegmentSpecificCommand.java
+++ b/core/src/main/java/org/infinispan/commands/SegmentSpecificCommand.java
@@ -1,5 +1,6 @@
 package org.infinispan.commands;
 
+import org.infinispan.commands.write.AbstractDataWriteCommand;
 import org.infinispan.commons.util.SegmentAwareKey;
 import org.infinispan.distribution.ch.KeyPartitioner;
 
@@ -33,6 +34,10 @@ public interface SegmentSpecificCommand {
     * @return the segment value to use.
     */
    static int extractSegment(ReplicableCommand command, Object key, KeyPartitioner keyPartitioner) {
+      // To reduce type pollution we first check for AbstractDataWriteCommand
+      if (command instanceof AbstractDataWriteCommand) {
+         return ((AbstractDataWriteCommand) command).getSegment();
+      }
       if (command instanceof SegmentSpecificCommand) {
          return ((SegmentSpecificCommand) command).getSegment();
       }

--- a/core/src/main/java/org/infinispan/commands/SegmentSpecificCommand.java
+++ b/core/src/main/java/org/infinispan/commands/SegmentSpecificCommand.java
@@ -1,6 +1,6 @@
 package org.infinispan.commands;
 
-import org.infinispan.commands.write.AbstractDataWriteCommand;
+import org.infinispan.commands.read.AbstractDataCommand;
 import org.infinispan.commons.util.SegmentAwareKey;
 import org.infinispan.distribution.ch.KeyPartitioner;
 
@@ -34,9 +34,9 @@ public interface SegmentSpecificCommand {
     * @return the segment value to use.
     */
    static int extractSegment(ReplicableCommand command, Object key, KeyPartitioner keyPartitioner) {
-      // To reduce type pollution we first check for AbstractDataWriteCommand
-      if (command instanceof AbstractDataWriteCommand) {
-         return ((AbstractDataWriteCommand) command).getSegment();
+      // To reduce type pollution we first check for AbstractDataCommand
+      if (command instanceof AbstractDataCommand) {
+         return ((AbstractDataCommand) command).getSegment();
       }
       if (command instanceof SegmentSpecificCommand) {
          return ((SegmentSpecificCommand) command).getSegment();

--- a/core/src/main/java/org/infinispan/commands/SegmentSpecificCommand.java
+++ b/core/src/main/java/org/infinispan/commands/SegmentSpecificCommand.java
@@ -44,6 +44,17 @@ public interface SegmentSpecificCommand {
       return keyPartitioner.getSegment(key);
    }
 
+   static int extractSegment(Object command, Object key, KeyPartitioner keyPartitioner) {
+      // To reduce type pollution we first check for AbstractDataCommand
+      if (command instanceof AbstractDataCommand) {
+         return ((AbstractDataCommand) command).getSegment();
+      }
+      if (command instanceof SegmentSpecificCommand) {
+         return ((SegmentSpecificCommand) command).getSegment();
+      }
+      return keyPartitioner.getSegment(key);
+   }
+
    /**
     * Create an {@link SegmentAwareKey} instance with the key and its segment.
     * <p>

--- a/core/src/main/java/org/infinispan/commands/read/AbstractDataCommand.java
+++ b/core/src/main/java/org/infinispan/commands/read/AbstractDataCommand.java
@@ -1,20 +1,19 @@
 package org.infinispan.commands.read;
 
-import static org.infinispan.commons.util.EnumUtil.prettyPrintBitSet;
 import static org.infinispan.commons.util.Util.toStr;
 
 import java.util.Objects;
 
+import org.infinispan.commands.AbstractTopologyAffectedCommand;
 import org.infinispan.commands.DataCommand;
 import org.infinispan.commands.SegmentSpecificCommand;
-import org.infinispan.context.Flag;
 
 /**
  * @author Mircea.Markus@jboss.com
  * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2011 Red Hat Inc.
  * @since 4.0
  */
-public abstract class AbstractDataCommand implements DataCommand, SegmentSpecificCommand {
+public abstract class AbstractDataCommand extends AbstractTopologyAffectedCommand implements DataCommand, SegmentSpecificCommand {
    protected Object key;
    private long flags;
    // These 2 ints have to stay next to each other to ensure they are aligned together
@@ -99,9 +98,5 @@ public abstract class AbstractDataCommand implements DataCommand, SegmentSpecifi
    @Override
    public boolean isReturnValueExpected() {
       return true;
-   }
-
-   protected final String printFlags() {
-      return prettyPrintBitSet(flags, Flag.class);
    }
 }

--- a/core/src/main/java/org/infinispan/commands/read/SizeCommand.java
+++ b/core/src/main/java/org/infinispan/commands/read/SizeCommand.java
@@ -8,7 +8,7 @@ import java.util.concurrent.CompletionStage;
 import org.infinispan.commands.FlagAffectedCommand;
 import org.infinispan.commands.TopologyAffectedCommand;
 import org.infinispan.commands.Visitor;
-import org.infinispan.commands.remote.BaseRpcCommand;
+import org.infinispan.commands.remote.BaseTopologyRpcCommand;
 import org.infinispan.commons.util.EnumUtil;
 import org.infinispan.commons.util.IntSet;
 import org.infinispan.context.InvocationContext;
@@ -25,10 +25,9 @@ import org.infinispan.util.ByteString;
  * @author <a href="http://gleamynode.net/">Trustin Lee</a>
  * @since 4.0
  */
-public class SizeCommand extends BaseRpcCommand implements FlagAffectedCommand, TopologyAffectedCommand {
+public class SizeCommand extends BaseTopologyRpcCommand implements FlagAffectedCommand, TopologyAffectedCommand {
    public static final byte COMMAND_ID = 61;
 
-   private int topologyId = -1;
    private long flags = EnumUtil.EMPTY_BIT_SET;
    private IntSet segments;
 
@@ -37,17 +36,19 @@ public class SizeCommand extends BaseRpcCommand implements FlagAffectedCommand, 
          IntSet segments,
          long flags
    ) {
-      super(cacheName);
+      this(cacheName);
       setFlagsBitSet(flags);
       this.segments = segments;
    }
 
    public SizeCommand(ByteString name) {
-      super(name);
+      super(name, EnumUtil.EMPTY_BIT_SET);
    }
 
    // Only here for CommandIdUniquenessTest
-   private SizeCommand() { super(null); }
+   private SizeCommand() {
+      this(null);
+   }
 
    @Override
    public Object acceptVisitor(InvocationContext ctx, Visitor visitor) throws Throwable {

--- a/core/src/main/java/org/infinispan/commands/remote/BaseTopologyRpcCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/BaseTopologyRpcCommand.java
@@ -8,11 +8,11 @@ import org.infinispan.util.ByteString;
 /**
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
-public abstract class BaseClusteredReadCommand extends BaseRpcCommand implements TopologyAffectedCommand {
+public abstract class BaseTopologyRpcCommand extends BaseRpcCommand implements TopologyAffectedCommand {
    protected int topologyId = -1;
    private long flags;
 
-   protected BaseClusteredReadCommand(ByteString cacheName, long flagBitSet) {
+   protected BaseTopologyRpcCommand(ByteString cacheName, long flagBitSet) {
       super(cacheName);
       this.flags = flagBitSet;
    }

--- a/core/src/main/java/org/infinispan/commands/remote/ClusteredGetAllCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/ClusteredGetAllCommand.java
@@ -29,7 +29,7 @@ import org.infinispan.util.logging.LogFactory;
  *
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
-public class ClusteredGetAllCommand<K, V> extends BaseClusteredReadCommand {
+public class ClusteredGetAllCommand<K, V> extends BaseTopologyRpcCommand {
    public static final byte COMMAND_ID = 46;
    private static final Log log = LogFactory.getLog(ClusteredGetAllCommand.class);
 
@@ -38,7 +38,7 @@ public class ClusteredGetAllCommand<K, V> extends BaseClusteredReadCommand {
 
 
    ClusteredGetAllCommand() {
-      super(null, EnumUtil.EMPTY_BIT_SET);
+      this(null);
    }
 
    public ClusteredGetAllCommand(ByteString cacheName) {

--- a/core/src/main/java/org/infinispan/commands/remote/ClusteredGetCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/ClusteredGetCommand.java
@@ -36,7 +36,7 @@ import org.infinispan.util.logging.LogFactory;
  * @author Mircea.Markus@jboss.com
  * @since 4.0
  */
-public class ClusteredGetCommand extends BaseClusteredReadCommand implements SegmentSpecificCommand {
+public class ClusteredGetCommand extends BaseTopologyRpcCommand implements SegmentSpecificCommand {
 
    public static final byte COMMAND_ID = 16;
    private static final Log log = LogFactory.getLog(ClusteredGetCommand.class);
@@ -47,7 +47,7 @@ public class ClusteredGetCommand extends BaseClusteredReadCommand implements Seg
    private Integer segment;
 
    private ClusteredGetCommand() {
-      super(null, EnumUtil.EMPTY_BIT_SET); // For command id uniqueness test
+      this(null); // For command id uniqueness test
    }
 
    public ClusteredGetCommand(ByteString cacheName) {

--- a/core/src/main/java/org/infinispan/commands/remote/SingleRpcCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/SingleRpcCommand.java
@@ -6,7 +6,6 @@ import java.io.ObjectOutput;
 import java.util.Objects;
 import java.util.concurrent.CompletionStage;
 
-import org.infinispan.commands.ReplicableCommand;
 import org.infinispan.commands.VisitableCommand;
 import org.infinispan.commands.write.AbstractDataWriteCommand;
 import org.infinispan.context.InvocationContext;
@@ -100,7 +99,7 @@ public class SingleRpcCommand extends BaseRpcCommand {
             '}';
    }
 
-   public ReplicableCommand getCommand() {
+   public VisitableCommand getCommand() {
       return command;
    }
 

--- a/core/src/main/java/org/infinispan/commands/remote/recovery/TxCompletionNotificationCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/recovery/TxCompletionNotificationCommand.java
@@ -11,8 +11,10 @@ import java.util.Set;
 import java.util.concurrent.CompletionStage;
 
 import org.infinispan.commands.TopologyAffectedCommand;
-import org.infinispan.commands.remote.BaseRpcCommand;
+import org.infinispan.commands.remote.BaseTopologyRpcCommand;
 import org.infinispan.commons.tx.XidImpl;
+import org.infinispan.commons.util.EnumUtil;
+import org.infinispan.commons.util.concurrent.CompletableFutures;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.distribution.LocalizedCacheTopology;
 import org.infinispan.factories.ComponentRegistry;
@@ -24,7 +26,6 @@ import org.infinispan.transaction.impl.TransactionTable;
 import org.infinispan.transaction.xa.GlobalTransaction;
 import org.infinispan.transaction.xa.recovery.RecoveryManager;
 import org.infinispan.util.ByteString;
-import org.infinispan.commons.util.concurrent.CompletableFutures;
 import org.infinispan.util.concurrent.locks.LockManager;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -35,7 +36,7 @@ import org.infinispan.util.logging.LogFactory;
  * @author Mircea.Markus@jboss.com
  * @since 5.0
  */
-public class TxCompletionNotificationCommand extends BaseRpcCommand implements TopologyAffectedCommand {
+public class TxCompletionNotificationCommand extends BaseTopologyRpcCommand implements TopologyAffectedCommand {
    private static final Log log = LogFactory.getLog(TxCompletionNotificationCommand.class);
 
    public static final int COMMAND_ID = 22;
@@ -43,26 +44,25 @@ public class TxCompletionNotificationCommand extends BaseRpcCommand implements T
    private XidImpl xid;
    private long internalId;
    private GlobalTransaction gtx;
-   private int topologyId = -1;
 
    @SuppressWarnings("unused")
    private TxCompletionNotificationCommand() {
-      super(null); // For command id uniqueness test
+      this(null); // For command id uniqueness test
    }
 
    public TxCompletionNotificationCommand(XidImpl xid, GlobalTransaction gtx, ByteString cacheName) {
-      super(cacheName);
+      this(cacheName);
       this.xid = xid;
       this.gtx = gtx;
    }
 
    public TxCompletionNotificationCommand(long internalId, ByteString cacheName) {
-      super(cacheName);
+      this(cacheName);
       this.internalId = internalId;
    }
 
    public TxCompletionNotificationCommand(ByteString cacheName) {
-      super(cacheName);
+      super(cacheName, EnumUtil.EMPTY_BIT_SET);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/commands/statetransfer/AbstractStateTransferCommand.java
+++ b/core/src/main/java/org/infinispan/commands/statetransfer/AbstractStateTransferCommand.java
@@ -5,7 +5,8 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 
 import org.infinispan.commands.TopologyAffectedCommand;
-import org.infinispan.commands.remote.BaseRpcCommand;
+import org.infinispan.commands.remote.BaseTopologyRpcCommand;
+import org.infinispan.commons.util.EnumUtil;
 import org.infinispan.commons.util.IntSet;
 import org.infinispan.commons.util.IntSetsExternalization;
 import org.infinispan.util.ByteString;
@@ -16,14 +17,14 @@ import org.infinispan.util.ByteString;
  * @author Ryan Emerson
  * @since 11.0
  */
-abstract class AbstractStateTransferCommand extends BaseRpcCommand implements TopologyAffectedCommand {
+abstract class AbstractStateTransferCommand extends BaseTopologyRpcCommand implements TopologyAffectedCommand {
 
    private final byte commandId;
    protected int topologyId;
    protected IntSet segments;
 
    AbstractStateTransferCommand(byte commandId, ByteString cacheName) {
-      super(cacheName);
+      super(cacheName, EnumUtil.EMPTY_BIT_SET);
       this.commandId = commandId;
    }
 

--- a/core/src/main/java/org/infinispan/commands/statetransfer/StateResponseCommand.java
+++ b/core/src/main/java/org/infinispan/commands/statetransfer/StateResponseCommand.java
@@ -8,14 +8,15 @@ import java.util.Collection;
 import java.util.concurrent.CompletionStage;
 
 import org.infinispan.commands.TopologyAffectedCommand;
-import org.infinispan.commands.remote.BaseRpcCommand;
+import org.infinispan.commands.remote.BaseTopologyRpcCommand;
 import org.infinispan.commons.marshall.MarshallUtil;
+import org.infinispan.commons.util.EnumUtil;
+import org.infinispan.commons.util.concurrent.CompletableFutures;
 import org.infinispan.conflict.impl.StateReceiver;
 import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.statetransfer.StateChunk;
 import org.infinispan.statetransfer.StateConsumer;
 import org.infinispan.util.ByteString;
-import org.infinispan.commons.util.concurrent.CompletableFutures;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -25,16 +26,11 @@ import org.infinispan.util.logging.LogFactory;
  * @author anistor@redhat.com
  * @since 5.2
  */
-public class StateResponseCommand extends BaseRpcCommand implements TopologyAffectedCommand {
+public class StateResponseCommand extends BaseTopologyRpcCommand implements TopologyAffectedCommand {
 
    private static final Log log = LogFactory.getLog(StateResponseCommand.class);
 
    public static final byte COMMAND_ID = 20;
-
-   /**
-    * The topology id of the sender at send time.
-    */
-   private int topologyId;
 
    /**
     * A collections of state chunks to be transferred.
@@ -54,16 +50,16 @@ public class StateResponseCommand extends BaseRpcCommand implements TopologyAffe
    private boolean pushTransfer;
 
    private StateResponseCommand() {
-      super(null);  // for command id uniqueness test
+      this(null);  // for command id uniqueness test
    }
 
    public StateResponseCommand(ByteString cacheName) {
-      super(cacheName);
+      super(cacheName, EnumUtil.EMPTY_BIT_SET);
    }
 
    public StateResponseCommand(ByteString cacheName, int topologyId, Collection<StateChunk> stateChunks,
                                boolean applyState, boolean pushTransfer) {
-      super(cacheName);
+      this(cacheName);
       this.topologyId = topologyId;
       this.stateChunks = stateChunks;
       this.applyState = applyState;
@@ -91,16 +87,6 @@ public class StateResponseCommand extends BaseRpcCommand implements TopologyAffe
    @Override
    public boolean isReturnValueExpected() {
       return false;
-   }
-
-   @Override
-   public int getTopologyId() {
-      return topologyId;
-   }
-
-   @Override
-   public void setTopologyId(int topologyId) {
-      this.topologyId = topologyId;
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/commands/statetransfer/StateTransferGetListenersCommand.java
+++ b/core/src/main/java/org/infinispan/commands/statetransfer/StateTransferGetListenersCommand.java
@@ -8,7 +8,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import org.infinispan.commands.TopologyAffectedCommand;
-import org.infinispan.commands.remote.BaseRpcCommand;
+import org.infinispan.commands.remote.BaseTopologyRpcCommand;
+import org.infinispan.commons.util.EnumUtil;
 import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.notifications.cachelistener.cluster.ClusterListenerReplicateCallable;
 import org.infinispan.statetransfer.StateProvider;
@@ -20,11 +21,9 @@ import org.infinispan.util.ByteString;
  * @author Ryan Emerson
  * @since 11.0
  */
-public class StateTransferGetListenersCommand extends BaseRpcCommand implements TopologyAffectedCommand {
+public class StateTransferGetListenersCommand extends BaseTopologyRpcCommand implements TopologyAffectedCommand {
 
    public static final byte COMMAND_ID = 118;
-
-   private int topologyId;
 
    // For command id uniqueness test only
    public StateTransferGetListenersCommand() {
@@ -32,11 +31,11 @@ public class StateTransferGetListenersCommand extends BaseRpcCommand implements 
    }
 
    public StateTransferGetListenersCommand(ByteString cacheName) {
-      super(cacheName);
+      super(cacheName, EnumUtil.EMPTY_BIT_SET);
    }
 
    public StateTransferGetListenersCommand(ByteString cacheName, int topologyId) {
-      super(cacheName);
+      this(cacheName);
       this.topologyId = topologyId;
    }
 
@@ -45,16 +44,6 @@ public class StateTransferGetListenersCommand extends BaseRpcCommand implements 
       StateProvider stateProvider = registry.getStateTransferManager().getStateProvider();
       Collection<ClusterListenerReplicateCallable<Object, Object>> listeners = stateProvider.getClusterListenersToInstall();
       return CompletableFuture.completedFuture(listeners);
-   }
-
-   @Override
-   public int getTopologyId() {
-      return topologyId;
-   }
-
-   @Override
-   public void setTopologyId(int topologyId) {
-      this.topologyId = topologyId;
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/commands/tx/AbstractTransactionBoundaryCommand.java
+++ b/core/src/main/java/org/infinispan/commands/tx/AbstractTransactionBoundaryCommand.java
@@ -6,6 +6,7 @@ import java.io.ObjectOutput;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
+import org.infinispan.commands.AbstractTopologyAffectedCommand;
 import org.infinispan.context.InvocationContextFactory;
 import org.infinispan.context.impl.RemoteTxInvocationContext;
 import org.infinispan.factories.ComponentRegistry;
@@ -24,27 +25,16 @@ import org.infinispan.util.logging.LogFactory;
  * @author Mircea.Markus@jboss.com
  * @since 4.0
  */
-public abstract class AbstractTransactionBoundaryCommand implements TransactionBoundaryCommand {
+public abstract class AbstractTransactionBoundaryCommand extends AbstractTopologyAffectedCommand implements TransactionBoundaryCommand {
 
    private static final Log log = LogFactory.getLog(AbstractTransactionBoundaryCommand.class);
 
    protected GlobalTransaction globalTx;
    protected final ByteString cacheName;
    private Address origin;
-   private int topologyId = -1;
 
    public AbstractTransactionBoundaryCommand(ByteString cacheName) {
       this.cacheName = cacheName;
-   }
-
-   @Override
-   public int getTopologyId() {
-      return topologyId;
-   }
-
-   @Override
-   public void setTopologyId(int topologyId) {
-      this.topologyId = topologyId;
    }
 
    @Override
@@ -126,7 +116,7 @@ public abstract class AbstractTransactionBoundaryCommand implements TransactionB
    public String toString() {
       return "gtx=" + globalTx +
             ", cacheName='" + cacheName + '\'' +
-            ", topologyId=" + topologyId +
+            ", topologyId=" + getTopologyId() +
             '}';
    }
 

--- a/core/src/main/java/org/infinispan/context/impl/AbstractInvocationContextFactory.java
+++ b/core/src/main/java/org/infinispan/context/impl/AbstractInvocationContextFactory.java
@@ -1,9 +1,8 @@
 package org.infinispan.context.impl;
 
-import org.infinispan.commands.DataCommand;
 import org.infinispan.commands.VisitableCommand;
+import org.infinispan.commands.read.AbstractDataCommand;
 import org.infinispan.commands.write.ClearCommand;
-import org.infinispan.commands.write.InvalidateCommand;
 import org.infinispan.commands.write.PutMapCommand;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.context.InvocationContext;
@@ -27,7 +26,8 @@ public abstract class AbstractInvocationContextFactory implements InvocationCont
    @Override
    public InvocationContext createRemoteInvocationContextForCommand(
          VisitableCommand cacheCommand, Address origin) {
-      if (cacheCommand instanceof DataCommand && !(cacheCommand instanceof InvalidateCommand)) {
+      // Use abstract class to avoid type pollution
+      if (cacheCommand instanceof AbstractDataCommand) {
          return new SingleKeyNonTxInvocationContext(origin);
       } else if (cacheCommand instanceof PutMapCommand) {
          return new NonTxInvocationContext(((PutMapCommand) cacheCommand).getMap().size(), origin);

--- a/core/src/main/java/org/infinispan/interceptors/distribution/BaseDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/BaseDistributionInterceptor.java
@@ -23,7 +23,7 @@ import org.infinispan.commands.read.AbstractDataCommand;
 import org.infinispan.commands.read.GetAllCommand;
 import org.infinispan.commands.read.GetCacheEntryCommand;
 import org.infinispan.commands.read.GetKeyValueCommand;
-import org.infinispan.commands.remote.BaseClusteredReadCommand;
+import org.infinispan.commands.remote.BaseTopologyRpcCommand;
 import org.infinispan.commands.remote.ClusteredGetCommand;
 import org.infinispan.commands.write.AbstractDataWriteCommand;
 import org.infinispan.commands.write.ClearCommand;
@@ -32,6 +32,7 @@ import org.infinispan.commands.write.ValueMatcher;
 import org.infinispan.commands.write.WriteCommand;
 import org.infinispan.commons.time.TimeService;
 import org.infinispan.commons.util.ArrayCollector;
+import org.infinispan.commons.util.concurrent.CompletableFutures;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.container.entries.InternalCacheValue;
@@ -65,7 +66,6 @@ import org.infinispan.remoting.transport.impl.SingletonMapResponseCollector;
 import org.infinispan.remoting.transport.impl.VoidResponseCollector;
 import org.infinispan.statetransfer.OutdatedTopologyException;
 import org.infinispan.transaction.xa.GlobalTransaction;
-import org.infinispan.commons.util.concurrent.CompletableFutures;
 import org.infinispan.util.CacheTopologyUtil;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -784,7 +784,7 @@ public abstract class BaseDistributionInterceptor extends ClusteringInterceptor 
       public ReplicableCommand apply(Address target) {
          List<Object> targetKeys = requestedKeys.get(target);
          assert !targetKeys.isEmpty();
-         BaseClusteredReadCommand getCommand = cf.buildClusteredGetAllCommand(targetKeys, flags, gtx);
+         BaseTopologyRpcCommand getCommand = cf.buildClusteredGetAllCommand(targetKeys, flags, gtx);
          getCommand.setTopologyId(topologyId);
          return getCommand;
       }

--- a/core/src/main/java/org/infinispan/interceptors/distribution/TriangleDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/TriangleDistributionInterceptor.java
@@ -47,6 +47,7 @@ import org.infinispan.commands.write.RemoveCommand;
 import org.infinispan.commands.write.ReplaceCommand;
 import org.infinispan.commands.write.WriteCommand;
 import org.infinispan.commons.util.InfinispanCollections;
+import org.infinispan.commons.util.concurrent.CompletableFutures;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.FlagBitSets;
@@ -67,7 +68,6 @@ import org.infinispan.statetransfer.StateTransferInterceptor;
 import org.infinispan.util.CacheTopologyUtil;
 import org.infinispan.util.TriangleFunctionsUtil;
 import org.infinispan.util.concurrent.CommandAckCollector;
-import org.infinispan.commons.util.concurrent.CompletableFutures;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -429,7 +429,7 @@ public class TriangleDistributionInterceptor extends BaseDistributionInterceptor
       CacheEntry entry = context.lookupEntry(command.getKey());
       if (entry == null) {
          if (command.loadType() == OWNER) {
-            return asyncInvokeNext(context, command, remoteGetSingleKey(context, command, command.getKey(), true));
+            return asyncInvokeNext(context, command, remoteGetSingleKey(context, command, command.getKey(), true, command.getFlagsBitSet()));
          }
          entryFactory.wrapExternalEntry(context, command.getKey(), null, false, true);
       }

--- a/core/src/main/java/org/infinispan/marshall/core/BytesObjectOutput.java
+++ b/core/src/main/java/org/infinispan/marshall/core/BytesObjectOutput.java
@@ -154,66 +154,55 @@ final class BytesObjectOutput implements ObjectOutput {
 
    @Override
    public void writeUTF(String s) {
-      int startPos = skipIntSize();
+      int strlen = s.length();
+      int startPos = pos;
+      // First optimize for 1 - 127 case
+      ensureCapacity(strlen + 4);
+      // Note this will be overwritten if not all 1 - 127 characters below
+      writeIntDirect(strlen, startPos);
+
       int localPos = pos; /* avoid getfield opcode */
       byte[] localBuf = bytes; /* avoid getfield opcode */
 
-      int strlen = s.length();
-      int c = 0;
+      localPos += 4;
 
-      int i=0;
-      for (i=0; i<strlen; i++) {
+      int c;
+      int i;
+      for (i = 0; i < strlen; i++) {
          c = s.charAt(i);
-         if (!((c >= 0x0001) && (c <= 0x007F))) break;
+         if (c > 127) break;
 
-         if(localPos == bytes.length) {
-            pos = localPos;
-            ensureCapacity(1);
-            localBuf = bytes;
-         }
          localBuf[localPos++] = (byte) c;
       }
 
-      for (;i < strlen; i++){
+      // Means we completed with all latin characters
+      if (i == strlen) {
+         pos = localPos;
+         return;
+      }
+
+      // Resize the rest assuming worst case of 3 bytes
+      ensureCapacity((strlen - i) * 3);
+
+      localPos = pos; /* avoid getfield opcode */
+      localBuf = bytes; /* avoid getfield opcode */
+
+      for (; i < strlen; i++) {
          c = s.charAt(i);
          if ((c >= 0x0001) && (c <= 0x007F)) {
-            if(localPos == bytes.length) {
-               pos = localPos;
-               ensureCapacity(1);
-               localBuf = bytes;
-            }
             localBuf[localPos++] = (byte) c;
 
          } else if (c > 0x07FF) {
-            if(localPos+3 >= bytes.length) {
-               pos = localPos;
-               ensureCapacity(3);
-               localBuf = bytes;
-            }
-
             localBuf[localPos++] = (byte) (0xE0 | ((c >> 12) & 0x0F));
-            localBuf[localPos++] = (byte) (0x80 | ((c >>  6) & 0x3F));
+            localBuf[localPos++] = (byte) (0x80 | ((c >> 6) & 0x3F));
             localBuf[localPos++] = (byte) (0x80 | (c & 0x3F));
          } else {
-            if(localPos + 2 >= bytes.length) {
-               pos = localPos;
-               ensureCapacity(2);
-               localBuf = bytes;
-            }
-
-            localBuf[localPos++] = (byte) (0xC0 | ((c >>  6) & 0x1F));
+            localBuf[localPos++] = (byte) (0xC0 | ((c >> 6) & 0x1F));
             localBuf[localPos++] = (byte) (0x80 | (c & 0x3F));
          }
       }
       pos = localPos;
       writeIntDirect(localPos - 4 - startPos, startPos);
-   }
-
-   private int skipIntSize() {
-      ensureCapacity(4);
-      int count = pos;
-      pos +=4;
-      return count;
    }
 
    private void writeIntDirect(int intValue, int index) {

--- a/core/src/main/java/org/infinispan/marshall/core/InternalExternalizers.java
+++ b/core/src/main/java/org/infinispan/marshall/core/InternalExternalizers.java
@@ -76,6 +76,7 @@ import org.infinispan.marshall.exts.ReplicableCommandExternalizer;
 import org.infinispan.marshall.exts.ThrowableExternalizer;
 import org.infinispan.marshall.exts.TriangleAckExternalizer;
 import org.infinispan.marshall.exts.UuidExternalizer;
+import org.infinispan.marshall.exts.VisitableCommandExternalizer;
 import org.infinispan.metadata.EmbeddedMetadata;
 import org.infinispan.metadata.impl.InternalMetadataImpl;
 import org.infinispan.notifications.cachelistener.cluster.ClusterEvent;
@@ -132,6 +133,8 @@ final class InternalExternalizers {
       // Add the stateful externalizer first
       ReplicableCommandExternalizer ext = new ReplicableCommandExternalizer(cmdFactory, gcr);
       addInternalExternalizer(ext, exts);
+      VisitableCommandExternalizer visitExt = new VisitableCommandExternalizer(cmdFactory, gcr);
+      addInternalExternalizer(visitExt, exts);
 
       // Add the rest of stateless externalizers
       addInternalExternalizer(new AcceptAllKeyValueFilter.Externalizer(), exts);

--- a/core/src/main/java/org/infinispan/marshall/exts/ReplicableCommandExternalizer.java
+++ b/core/src/main/java/org/infinispan/marshall/exts/ReplicableCommandExternalizer.java
@@ -10,19 +10,6 @@ import org.infinispan.commands.AbstractTopologyAffectedCommand;
 import org.infinispan.commands.RemoteCommandsFactory;
 import org.infinispan.commands.ReplicableCommand;
 import org.infinispan.commands.TopologyAffectedCommand;
-import org.infinispan.commands.functional.ReadOnlyKeyCommand;
-import org.infinispan.commands.functional.ReadOnlyManyCommand;
-import org.infinispan.commands.functional.ReadWriteKeyCommand;
-import org.infinispan.commands.functional.ReadWriteKeyValueCommand;
-import org.infinispan.commands.functional.ReadWriteManyCommand;
-import org.infinispan.commands.functional.ReadWriteManyEntriesCommand;
-import org.infinispan.commands.functional.TxReadOnlyKeyCommand;
-import org.infinispan.commands.functional.TxReadOnlyManyCommand;
-import org.infinispan.commands.functional.WriteOnlyKeyCommand;
-import org.infinispan.commands.functional.WriteOnlyKeyValueCommand;
-import org.infinispan.commands.functional.WriteOnlyManyCommand;
-import org.infinispan.commands.functional.WriteOnlyManyEntriesCommand;
-import org.infinispan.commands.read.GetKeyValueCommand;
 import org.infinispan.commands.remote.BaseTopologyRpcCommand;
 import org.infinispan.commands.remote.CacheRpcCommand;
 import org.infinispan.commands.topology.CacheAvailabilityUpdateCommand;
@@ -37,21 +24,8 @@ import org.infinispan.commands.topology.RebalanceStartCommand;
 import org.infinispan.commands.topology.RebalanceStatusRequestCommand;
 import org.infinispan.commands.topology.TopologyUpdateCommand;
 import org.infinispan.commands.topology.TopologyUpdateStableCommand;
-import org.infinispan.commands.write.ClearCommand;
-import org.infinispan.commands.write.ComputeCommand;
-import org.infinispan.commands.write.ComputeIfAbsentCommand;
-import org.infinispan.commands.write.EvictCommand;
-import org.infinispan.commands.write.InvalidateCommand;
-import org.infinispan.commands.write.InvalidateL1Command;
-import org.infinispan.commands.write.IracPutKeyValueCommand;
-import org.infinispan.commands.write.PutKeyValueCommand;
-import org.infinispan.commands.write.PutMapCommand;
-import org.infinispan.commands.write.RemoveCommand;
-import org.infinispan.commands.write.RemoveExpiredCommand;
-import org.infinispan.commands.write.ReplaceCommand;
 import org.infinispan.commons.marshall.AbstractExternalizer;
 import org.infinispan.commons.util.Util;
-import org.infinispan.expiration.impl.TouchCommand;
 import org.infinispan.factories.GlobalComponentRegistry;
 import org.infinispan.manager.impl.ReplicableManagerFunctionCommand;
 import org.infinispan.manager.impl.ReplicableRunnableCommand;
@@ -142,26 +116,12 @@ public class ReplicableCommandExternalizer extends AbstractExternalizer<Replicab
    @Override
    public Set<Class<? extends ReplicableCommand>> getTypeClasses() {
       Set<Class<? extends ReplicableCommand>> coreCommands = Util.asSet(
-            GetKeyValueCommand.class,
-            ClearCommand.class, EvictCommand.class,
-            InvalidateCommand.class, InvalidateL1Command.class,
-            PutKeyValueCommand.class,
-            PutMapCommand.class, RemoveCommand.class, RemoveExpiredCommand.class,
-            ReplaceCommand.class,
-            ComputeCommand.class, ComputeIfAbsentCommand.class,
-            ReadOnlyKeyCommand.class, ReadOnlyManyCommand.class,
-            ReadWriteKeyCommand.class, ReadWriteKeyValueCommand.class,
-            WriteOnlyKeyCommand.class, WriteOnlyKeyValueCommand.class,
-            WriteOnlyManyCommand.class, WriteOnlyManyEntriesCommand.class,
-            ReadWriteManyCommand.class, ReadWriteManyEntriesCommand.class,
-            TxReadOnlyKeyCommand.class, TxReadOnlyManyCommand.class,
             ReplicableRunnableCommand.class, ReplicableManagerFunctionCommand.class,
             HeartBeatCommand.class, CacheStatusRequestCommand.class, RebalancePhaseConfirmCommand.class,
             TopologyUpdateCommand.class, RebalancePolicyUpdateCommand.class,
             RebalanceStartCommand.class, RebalanceStatusRequestCommand.class,
             CacheShutdownCommand.class, CacheShutdownRequestCommand.class, TopologyUpdateStableCommand.class,
             CacheJoinCommand.class, CacheLeaveCommand.class, CacheAvailabilityUpdateCommand.class,
-            IracPutKeyValueCommand.class, TouchCommand.class,
             XSiteViewNotificationCommand.class);
       // Search only those commands that replicable and not cache specific replicable commands
       Collection<Class<? extends ReplicableCommand>> moduleCommands = globalComponentRegistry.getModuleProperties().moduleOnlyReplicableCommands();

--- a/core/src/main/java/org/infinispan/reactive/publisher/impl/commands/batch/NextPublisherCommand.java
+++ b/core/src/main/java/org/infinispan/reactive/publisher/impl/commands/batch/NextPublisherCommand.java
@@ -5,27 +5,28 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.concurrent.CompletionStage;
 
-import org.infinispan.commands.TopologyAffectedCommand;
-import org.infinispan.commands.remote.BaseRpcCommand;
+import org.infinispan.commands.remote.BaseTopologyRpcCommand;
+import org.infinispan.commons.util.EnumUtil;
 import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.reactive.publisher.impl.PublisherHandler;
 import org.infinispan.util.ByteString;
 
-public class  NextPublisherCommand extends BaseRpcCommand implements TopologyAffectedCommand {
+public class NextPublisherCommand extends BaseTopologyRpcCommand {
    public static final byte COMMAND_ID = 25;
 
    private String requestId;
-   private int topologyId = -1;
 
    // Only here for CommandIdUniquenessTest
-   private NextPublisherCommand() { super(null); }
+   private NextPublisherCommand() {
+      this(null);
+   }
 
    public NextPublisherCommand(ByteString cacheName) {
-      super(cacheName);
+      super(cacheName, EnumUtil.EMPTY_BIT_SET);
    }
 
    public NextPublisherCommand(ByteString cacheName, String requestId) {
-      super(cacheName);
+      this(cacheName);
       this.requestId = requestId;
    }
 
@@ -33,16 +34,6 @@ public class  NextPublisherCommand extends BaseRpcCommand implements TopologyAff
    public CompletionStage<?> invokeAsync(ComponentRegistry componentRegistry) throws Throwable {
       PublisherHandler publisherHandler = componentRegistry.getPublisherHandler().running();
       return publisherHandler.getNext(requestId);
-   }
-
-   @Override
-   public int getTopologyId() {
-      return topologyId;
-   }
-
-   @Override
-   public void setTopologyId(int topologyId) {
-      this.topologyId = topologyId;
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/reactive/publisher/impl/commands/reduction/ReductionPublisherRequestCommand.java
+++ b/core/src/main/java/org/infinispan/reactive/publisher/impl/commands/reduction/ReductionPublisherRequestCommand.java
@@ -10,7 +10,7 @@ import java.util.function.Function;
 
 import org.infinispan.commands.TopologyAffectedCommand;
 import org.infinispan.commands.functional.functions.InjectableComponent;
-import org.infinispan.commands.remote.BaseRpcCommand;
+import org.infinispan.commands.remote.BaseTopologyRpcCommand;
 import org.infinispan.commons.marshall.MarshallUtil;
 import org.infinispan.commons.util.EnumUtil;
 import org.infinispan.commons.util.IntSet;
@@ -24,9 +24,10 @@ import org.infinispan.util.ByteString;
 
 /**
  * Stream request command that is sent to remote nodes handle execution of remote intermediate and terminal operations.
+ *
  * @param <K> the key type
  */
-public class ReductionPublisherRequestCommand<K> extends BaseRpcCommand implements TopologyAffectedCommand {
+public class ReductionPublisherRequestCommand<K> extends BaseTopologyRpcCommand implements TopologyAffectedCommand {
    public static final byte COMMAND_ID = 31;
 
    private boolean parallelStream;
@@ -38,29 +39,20 @@ public class ReductionPublisherRequestCommand<K> extends BaseRpcCommand implemen
    private boolean entryStream;
    private Function transformer;
    private Function finalizer;
-   private int topologyId = -1;
-
-   @Override
-   public int getTopologyId() {
-      return topologyId;
-   }
-
-   @Override
-   public void setTopologyId(int topologyId) {
-      this.topologyId = topologyId;
-   }
 
    // Only here for CommandIdUniquenessTest
-   private ReductionPublisherRequestCommand() { super(null); }
+   private ReductionPublisherRequestCommand() {
+      this(null);
+   }
 
    public ReductionPublisherRequestCommand(ByteString cacheName) {
-      super(cacheName);
+      super(cacheName, EnumUtil.EMPTY_BIT_SET);
    }
 
    public ReductionPublisherRequestCommand(ByteString cacheName, boolean parallelStream, DeliveryGuarantee deliveryGuarantee,
          IntSet segments, Set<K> keys, Set<K> excludedKeys, long explicitFlags, boolean entryStream,
          Function transformer, Function finalizer) {
-      super(cacheName);
+      this(cacheName);
       this.parallelStream = parallelStream;
       this.deliveryGuarantee = deliveryGuarantee;
       this.segments = segments;

--- a/core/src/main/java/org/infinispan/remoting/inboundhandler/BasePerCacheInboundInvocationHandler.java
+++ b/core/src/main/java/org/infinispan/remoting/inboundhandler/BasePerCacheInboundInvocationHandler.java
@@ -6,13 +6,15 @@ import static org.infinispan.util.logging.Log.CLUSTER;
 
 import java.util.concurrent.CompletableFuture;
 
-import org.infinispan.commands.ReplicableCommand;
+import org.infinispan.commands.AbstractTopologyAffectedCommand;
 import org.infinispan.commands.TopologyAffectedCommand;
+import org.infinispan.commands.VisitableCommand;
 import org.infinispan.commands.remote.CacheRpcCommand;
 import org.infinispan.commands.remote.ClusteredGetAllCommand;
 import org.infinispan.commands.remote.ClusteredGetCommand;
 import org.infinispan.commands.remote.SingleRpcCommand;
 import org.infinispan.commons.CacheException;
+import org.infinispan.commons.util.concurrent.CompletableFutures;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.factories.annotations.ComponentName;
@@ -30,7 +32,6 @@ import org.infinispan.statetransfer.OutdatedTopologyException;
 import org.infinispan.statetransfer.StateTransferLock;
 import org.infinispan.util.concurrent.BlockingRunnable;
 import org.infinispan.util.concurrent.BlockingTaskAwareExecutorService;
-import org.infinispan.commons.util.concurrent.CompletableFutures;
 import org.infinispan.util.concurrent.CompletionStages;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -63,8 +64,10 @@ public abstract class BasePerCacheInboundInvocationHandler implements PerCacheIn
    private volatile int firstTopologyAsMember = Integer.MAX_VALUE;
 
    private static int extractCommandTopologyId(SingleRpcCommand command) {
-      ReplicableCommand innerCmd = command.getCommand();
-      if (innerCmd instanceof TopologyAffectedCommand) {
+      VisitableCommand innerCmd = command.getCommand();
+      if (innerCmd instanceof AbstractTopologyAffectedCommand) {
+         return ((AbstractTopologyAffectedCommand) innerCmd).getTopologyId();
+      } else if (innerCmd instanceof TopologyAffectedCommand) {
          return ((TopologyAffectedCommand) innerCmd).getTopologyId();
       }
       return NO_TOPOLOGY_COMMAND;

--- a/core/src/main/java/org/infinispan/remoting/inboundhandler/InboundInvocationHandler.java
+++ b/core/src/main/java/org/infinispan/remoting/inboundhandler/InboundInvocationHandler.java
@@ -1,6 +1,7 @@
 package org.infinispan.remoting.inboundhandler;
 
 import org.infinispan.commands.ReplicableCommand;
+import org.infinispan.commands.remote.CacheRpcCommand;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.xsite.XSiteReplicateCommand;
 
@@ -16,19 +17,30 @@ public interface InboundInvocationHandler {
    /**
     * Handles the {@link org.infinispan.commands.ReplicableCommand} from other node belonging to local site.
     *
-    * @param origin  the sender {@link org.infinispan.remoting.transport.Address}
+    * @param origin the sender {@link org.infinispan.remoting.transport.Address}
     * @param command the {@link org.infinispan.commands.ReplicableCommand} to handler
-    * @param reply   the return value is passed to this object in order to be sent back to the origin
-    * @param order   the {@link org.infinispan.remoting.inboundhandler.DeliverOrder} in which the command was sent
+    * @param reply the return value is passed to this object in order to be sent back to the origin
+    * @param order the {@link org.infinispan.remoting.inboundhandler.DeliverOrder} in which the command was sent
     */
    void handleFromCluster(Address origin, ReplicableCommand command, Reply reply, DeliverOrder order);
 
    /**
+    * @param origin
+    * @param command
+    * @param reply
+    * @param order
+    */
+   default void handleFromCluster(Address origin, CacheRpcCommand command, Reply reply, DeliverOrder order) {
+      handleFromCluster(origin, (ReplicableCommand) command, reply, order);
+   }
+
+   /**
     * Handles the {@link org.infinispan.commands.ReplicableCommand} from remote site.
-    * @param origin  the sender site
+    *
+    * @param origin the sender site
     * @param command the {@link org.infinispan.commands.ReplicableCommand} to handle
-    * @param reply   the return value is passed to this object in order to be sent back to the origin
-    * @param order   the {@link DeliverOrder} in which the command was sent
+    * @param reply the return value is passed to this object in order to be sent back to the origin
+    * @param order the {@link DeliverOrder} in which the command was sent
     */
    void handleFromRemoteSite(String origin, XSiteReplicateCommand<?> command, Reply reply, DeliverOrder order);
 }

--- a/core/src/main/java/org/infinispan/statetransfer/StateTransferInterceptor.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateTransferInterceptor.java
@@ -2,6 +2,7 @@ package org.infinispan.statetransfer;
 
 import java.util.concurrent.CompletionStage;
 
+import org.infinispan.commands.AbstractTopologyAffectedCommand;
 import org.infinispan.commands.TopologyAffectedCommand;
 import org.infinispan.commands.VisitableCommand;
 import org.infinispan.commands.control.LockControlCommand;
@@ -203,7 +204,11 @@ public class StateTransferInterceptor extends BaseStateTransferInterceptor {
     */
    private Object handleTxCommand(TxInvocationContext ctx, TransactionBoundaryCommand command) {
       if (log.isTraceEnabled()) log.tracef("handleTxCommand for command %s, origin %s", command, getOrigin(ctx));
-      updateTopologyId(command);
+      if (command instanceof AbstractTopologyAffectedCommand) {
+         updateTopologyId((AbstractTopologyAffectedCommand) command);
+      } else {
+         updateTopologyId(command);
+      }
 
       return invokeNextAndHandle(ctx, command, handleTxReturn);
    }
@@ -260,7 +265,11 @@ public class StateTransferInterceptor extends BaseStateTransferInterceptor {
    private Object handleTxWriteCommand(InvocationContext ctx, WriteCommand command) {
       if (log.isTraceEnabled()) log.tracef("handleTxWriteCommand for command %s, origin %s", command, ctx.getOrigin());
 
-      updateTopologyId(command);
+      if (command instanceof AbstractTopologyAffectedCommand) {
+         updateTopologyId((AbstractTopologyAffectedCommand) command);
+      } else {
+         updateTopologyId(command);
+      }
       return invokeNextAndHandle(ctx, command, handleTxWriteReturn);
    }
 
@@ -300,9 +309,14 @@ public class StateTransferInterceptor extends BaseStateTransferInterceptor {
     * the {@code CACHE_MODE_LOCAL} flag.
     */
    private Object handleNonTxWriteCommand(InvocationContext ctx, WriteCommand command) {
-      if (log.isTraceEnabled()) log.tracef("handleNonTxWriteCommand for command %s, topology id %d", command, command.getTopologyId());
+      if (log.isTraceEnabled())
+         log.tracef("handleNonTxWriteCommand for command %s, topology id %d", command, command.getTopologyId());
 
-      updateTopologyId(command);
+      if (command instanceof AbstractTopologyAffectedCommand) {
+         updateTopologyId((AbstractTopologyAffectedCommand) command);
+      } else {
+         updateTopologyId(command);
+      }
 
       // Only catch OutdatedTopologyExceptions on the originator
       if (!ctx.isOriginLocal()) {
@@ -359,7 +373,11 @@ public class StateTransferInterceptor extends BaseStateTransferInterceptor {
                                                 VisitableCommand command, Address origin) {
       if (log.isTraceEnabled()) log.tracef("handleTopologyAffectedCommand for command %s, origin %s", command, origin);
 
-      updateTopologyId((TopologyAffectedCommand) command);
+      if (command instanceof AbstractTopologyAffectedCommand) {
+         updateTopologyId((AbstractTopologyAffectedCommand) command);
+      } else {
+         updateTopologyId((TopologyAffectedCommand) command);
+      }
       return invokeNext(ctx, command);
    }
 

--- a/core/src/main/java/org/infinispan/util/CacheTopologyUtil.java
+++ b/core/src/main/java/org/infinispan/util/CacheTopologyUtil.java
@@ -27,12 +27,13 @@ public enum CacheTopologyUtil {
    public static LocalizedCacheTopology checkTopology(TopologyAffectedCommand command, LocalizedCacheTopology current) {
       int currentTopologyId = current.getTopologyId();
       int cmdTopology = command.getTopologyId();
+      // Do this check before the cast to prevent type pollution as this method touches a lot of commands
+      if (cmdTopology < 0 || currentTopologyId == cmdTopology) {
+         return current;
+      }
       if (command instanceof FlagAffectedCommand && (((FlagAffectedCommand) command).hasAnyFlag(SKIP_TOPOLOGY_FLAGS))) {
          return current;
       }
-      if (cmdTopology >= 0 && currentTopologyId != cmdTopology) {
-         throw OutdatedTopologyException.RETRY_NEXT_TOPOLOGY;
-      }
-      return current;
+      throw OutdatedTopologyException.RETRY_NEXT_TOPOLOGY;
    }
 }

--- a/core/src/main/java/org/infinispan/util/CacheTopologyUtil.java
+++ b/core/src/main/java/org/infinispan/util/CacheTopologyUtil.java
@@ -1,5 +1,6 @@
 package org.infinispan.util;
 
+import org.infinispan.commands.AbstractTopologyAffectedCommand;
 import org.infinispan.commands.FlagAffectedCommand;
 import org.infinispan.commands.TopologyAffectedCommand;
 import org.infinispan.context.impl.FlagBitSets;
@@ -32,6 +33,15 @@ public enum CacheTopologyUtil {
          return current;
       }
       if (command instanceof FlagAffectedCommand && (((FlagAffectedCommand) command).hasAnyFlag(SKIP_TOPOLOGY_FLAGS))) {
+         return current;
+      }
+      throw OutdatedTopologyException.RETRY_NEXT_TOPOLOGY;
+   }
+
+   public static LocalizedCacheTopology checkTopology(AbstractTopologyAffectedCommand command, LocalizedCacheTopology current) {
+      int currentTopologyId = current.getTopologyId();
+      int cmdTopology = command.getTopologyId();
+      if (cmdTopology < 0 || currentTopologyId == cmdTopology || command.hasAnyFlag(SKIP_TOPOLOGY_FLAGS)) {
          return current;
       }
       throw OutdatedTopologyException.RETRY_NEXT_TOPOLOGY;

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -1536,7 +1536,7 @@ public interface Log extends BasicLogger {
 
    @LogMessage(level = ERROR)
    @Message(value = "Error sending response for request %d@%s, command %s", id = 440)
-   void errorSendingResponse(long requestId, org.jgroups.Address origin, ReplicableCommand command);
+   void errorSendingResponse(long requestId, org.jgroups.Address origin, Object command);
 
    @Message(value = "Unsupported async cache mode '%s' for transactional caches", id = 441)
    CacheConfigurationException unsupportedAsyncCacheMode(CacheMode cacheMode);

--- a/core/src/test/java/org/infinispan/tx/EntryWrappingInterceptorDoesNotBlockTest.java
+++ b/core/src/test/java/org/infinispan/tx/EntryWrappingInterceptorDoesNotBlockTest.java
@@ -19,7 +19,7 @@ import java.util.stream.Stream;
 import javax.transaction.Transaction;
 
 import org.infinispan.Cache;
-import org.infinispan.commands.remote.BaseClusteredReadCommand;
+import org.infinispan.commands.remote.BaseTopologyRpcCommand;
 import org.infinispan.commands.remote.ClusteredGetCommand;
 import org.infinispan.commands.remote.recovery.TxCompletionNotificationCommand;
 import org.infinispan.commands.statetransfer.StateResponseCommand;
@@ -152,7 +152,7 @@ public class EntryWrappingInterceptorDoesNotBlockTest extends MultipleCacheManag
       // The PrepareCommand attempts to load moving keys, and we allow the request to be sent
       // but block receiving the responses. Here we'll intercept only the first remote get because the second one
       // is not fired until the first is received (implementation inefficiency).
-      ControlledRpcManager.SentRequest firstRemoteGet = crm2.expectCommand(BaseClusteredReadCommand.class).send();
+      ControlledRpcManager.SentRequest firstRemoteGet = crm2.expectCommand(BaseTopologyRpcCommand.class).send();
 
       // The topmost interceptor gets the InvocationStage from the PrepareCommand and verifies
       // that it is not completed yet (as we are waiting for the remote gets). Receiving the invocation stage
@@ -163,7 +163,7 @@ public class EntryWrappingInterceptorDoesNotBlockTest extends MultipleCacheManag
       // Receiving the responses for one remote get triggers the next remote get, so complete them in parallel
       firstRemoteGet.expectAllResponses().receiveAsync();
       for (int i = 1; i < expectRemoteGets; ++i) {
-         crm2.expectCommand(BaseClusteredReadCommand.class).send().receiveAll();
+         crm2.expectCommand(BaseTopologyRpcCommand.class).send().receiveAll();
       }
 
       sentPrepare.expectAllResponses().receiveAsync();


### PR DESCRIPTION
This fixes the type pollution issues found when running benchmarks against embedded ISPN with LOCAL, REPL, DIST non tx caches.  Note this PR only affects embedded more, there are more with client/server mode that will have to be addressed in a separate PR.

The report can be found here https://gist.github.com/wburns/d37ec537b739b09c210a2c17a22c8a85

1. The write commands are now prioritizing using AbstractDataWriteCommand when possible.
2. Any single key segment command should extend AbstractDataCommand if possible to prevent type pollution.
3. Any command that implements TopologyAffectedCommand should extend AbstractTopologyAffectedCommand when possible to not pollute the interface types for various topology methods.
4. Separated Visitable and Replicable command to prevent Visitable commands from polluting the cache every time
5. Updated netty as it has a fix that we have with our decoders