### PR TITLE
[14.0] Backport circus

### DIFF
--- a/cli/src/main/java/org/infinispan/cli/commands/kubernetes/Shell.java
+++ b/cli/src/main/java/org/infinispan/cli/commands/kubernetes/Shell.java
@@ -25,7 +25,7 @@ import org.aesh.readline.terminal.formatting.TerminalString;
 import org.infinispan.cli.commands.CLI;
 import org.infinispan.cli.commands.CliCommand;
 import org.infinispan.cli.impl.ContextAwareCommandInvocation;
-import org.infinispan.cli.impl.DefaultShell;
+import org.infinispan.cli.impl.KubeShell;
 import org.infinispan.cli.impl.KubernetesContext;
 import org.infinispan.cli.logging.Messages;
 import org.infinispan.commons.util.Util;
@@ -161,7 +161,7 @@ public class Shell extends CliCommand {
          args.add("-c");
          args.add(connection.toString());
          Messages.CLI.debugf("cli %s", args);
-         CLI.main(new DefaultShell(), args.toArray(new String[0]), System.getProperties(), false);
+         CLI.main(new KubeShell(), args.toArray(new String[0]), System.getProperties(), false);
          return CommandResult.SUCCESS;
       } catch (Throwable t) {
          TerminalString error = new TerminalString(Util.getRootCause(t).getLocalizedMessage(), new TerminalColor(Color.RED, Color.DEFAULT, Color.Intensity.BRIGHT));

--- a/cli/src/main/java/org/infinispan/cli/impl/CliShell.java
+++ b/cli/src/main/java/org/infinispan/cli/impl/CliShell.java
@@ -1,0 +1,15 @@
+package org.infinispan.cli.impl;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+import org.aesh.readline.tty.terminal.TerminalConnection;
+
+/**
+ * @since 14.0
+ **/
+public class CliShell extends AeshDelegatingShell {
+   public CliShell() throws IOException {
+      super(new TerminalConnection(Charset.defaultCharset(), System.in, System.out));
+   }
+}

--- a/cli/src/main/java/org/infinispan/cli/impl/KubeShell.java
+++ b/cli/src/main/java/org/infinispan/cli/impl/KubeShell.java
@@ -10,9 +10,9 @@ import org.aesh.readline.tty.terminal.TerminalConnection;
 import org.aesh.readline.util.Parser;
 import org.aesh.terminal.utils.ANSI;
 
-public class DefaultShell extends AeshDelegatingShell {
+public class KubeShell extends AeshDelegatingShell {
 
-   public DefaultShell() throws IOException {
+   public KubeShell() throws IOException {
       super(new TerminalConnection(Charset.defaultCharset(), System.in, System.out));
    }
 

--- a/cli/src/main/java/org/infinispan/cli/impl/StreamShell.java
+++ b/cli/src/main/java/org/infinispan/cli/impl/StreamShell.java
@@ -1,0 +1,104 @@
+package org.infinispan.cli.impl;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.PrintStream;
+
+import org.aesh.command.shell.Shell;
+import org.aesh.readline.Prompt;
+import org.aesh.readline.terminal.Key;
+import org.aesh.readline.util.Parser;
+import org.aesh.terminal.tty.Size;
+import org.infinispan.commons.util.Util;
+
+/**
+ * @since 14.0
+ **/
+public class StreamShell implements Shell {
+   private final BufferedReader in;
+   private final PrintStream out;
+
+   public StreamShell() {
+      this(System.in, System.out);
+   }
+
+   public StreamShell(InputStream in, PrintStream out) {
+      this.in = new BufferedReader(new InputStreamReader(in));
+      this.out = out;
+   }
+
+   @Override
+   public void write(String msg, boolean paging) {
+      out.print(msg);
+   }
+
+   @Override
+   public void writeln(String msg, boolean paging) {
+      out.println(msg);
+   }
+
+   @Override
+   public void write(int[] cp) {
+      out.print(Parser.fromCodePoints(cp));
+      out.flush();
+   }
+
+   @Override
+   public void write(char c) {
+      out.print(c);
+   }
+
+   @Override
+   public String readLine() throws InterruptedException {
+      try {
+         String line = in.readLine();
+         if (line == null) {
+            Util.close(in);
+         }
+         return line;
+      } catch (IOException e) {
+         return null;
+      }
+   }
+
+   @Override
+   public String readLine(Prompt prompt) throws InterruptedException {
+      return readLine();
+   }
+
+   @Override
+   public Key read() throws InterruptedException {
+      try {
+         int input = in.read();
+         return Key.getKey(new int[]{input});
+      } catch (IOException e) {
+         throw new RuntimeException(e);
+      }
+   }
+
+   @Override
+   public Key read(Prompt prompt) throws InterruptedException {
+      return read();
+   }
+
+   @Override
+   public boolean enableAlternateBuffer() {
+      return false;
+   }
+
+   @Override
+   public boolean enableMainBuffer() {
+      return false;
+   }
+
+   @Override
+   public Size size() {
+      return new Size(0, 0);
+   }
+
+   @Override
+   public void clear() {
+   }
+}

--- a/cli/src/main/java/org/infinispan/cli/logging/Messages.java
+++ b/cli/src/main/java/org/infinispan/cli/logging/Messages.java
@@ -200,8 +200,8 @@ public interface Messages {
    @Message(value = "Filter rule '%s' is not in the format [ACCEPT|REJECT]/{CIDR}")
    IllegalArgumentException illegalFilterRule(String rule);
 
-   @Message(value = "Error executing line %d: '%s'")
-   CommandException batchError(int lineNumber, String line, @Cause Throwable t);
+   @Message(value = "Error executing file: %s, line %d: '%s'")
+   CommandException batchError(String file, int lineNumber, String line, @Cause Throwable t);
 
    @Message("Option '%s' requires option '%s'")
    RequiredOptionException requiresAllOf(String option1, String option2);

--- a/cli/src/test/java/org/infinispan/cli/CliPipeTest.java
+++ b/cli/src/test/java/org/infinispan/cli/CliPipeTest.java
@@ -1,0 +1,47 @@
+package org.infinispan.cli;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import org.infinispan.cli.commands.CLI;
+import org.infinispan.cli.impl.StreamShell;
+import org.infinispan.commons.test.CommonsTestingUtil;
+import org.infinispan.commons.test.Eventually;
+import org.infinispan.commons.util.Util;
+import org.junit.ComparisonFailure;
+import org.junit.Test;
+
+/**
+ * @since 14.0
+ **/
+public class CliPipeTest {
+   @Test
+   public void testCliBatchPipe() throws IOException, InterruptedException {
+      File workingDir = new File(CommonsTestingUtil.tmpDirectory(CliPipeTest.class));
+      Util.recursiveFileRemove(workingDir);
+      workingDir.mkdirs();
+      Properties properties = new Properties(System.getProperties());
+      properties.put("cli.dir", workingDir.getAbsolutePath());
+
+      PipedOutputStream pipe = new PipedOutputStream();
+      ByteArrayOutputStream out = new ByteArrayOutputStream();
+      StreamShell shell = new StreamShell(new PipedInputStream(pipe), new PrintStream(out));
+      Thread thread = new Thread(() -> CLI.main(shell, new String[]{"-f", "-"}, properties));
+      thread.start();
+      PrintWriter pw = new PrintWriter(pipe, true);
+      pw.println("echo Piped");
+      Eventually.eventually(
+            () -> new ComparisonFailure("Expected output was not equal to expected string after timeout", "Piped", out.toString(StandardCharsets.UTF_8)),
+            () -> out.toString(StandardCharsets.UTF_8).startsWith("Piped"), 10_000, 50, TimeUnit.MILLISECONDS);
+      pw.close();
+      thread.join();
+   }
+}

--- a/commons/all/src/main/java/org/infinispan/commons/configuration/io/ConfigurationWriter.java
+++ b/commons/all/src/main/java/org/infinispan/commons/configuration/io/ConfigurationWriter.java
@@ -46,7 +46,7 @@ public interface ConfigurationWriter extends AutoCloseable {
       }
 
       public ConfigurationWriter build() {
-         switch (type.toString()) {
+         switch (type.getTypeSubtype()) {
             case MediaType.APPLICATION_XML_TYPE:
                return new XmlConfigurationWriter(writer, prettyPrint, clearTextSecrets);
             case MediaType.APPLICATION_YAML_TYPE:

--- a/server/rest/src/main/java/org/infinispan/rest/resources/BackupManagerResource.java
+++ b/server/rest/src/main/java/org/infinispan/rest/resources/BackupManagerResource.java
@@ -79,7 +79,8 @@ class BackupManagerResource {
       if (existingStatus != BackupManager.Status.NOT_FOUND)
          return responseFuture(CONFLICT);
 
-      Json json = Json.read(request.contents().asString());
+      String body = request.contents().asString();
+      Json json = body.length() > 0 ? Json.read(body) : Json.object();
       Json dirJson = json.at(DIR_KEY);
       Path workingDir = dirJson == null ? null : Paths.get(dirJson.asString());
       if (workingDir != null && !Files.isDirectory(workingDir))

--- a/server/rest/src/test/java/org/infinispan/rest/resources/CacheResourceV2Test.java
+++ b/server/rest/src/test/java/org/infinispan/rest/resources/CacheResourceV2Test.java
@@ -363,6 +363,9 @@ public class CacheResourceV2Test extends AbstractRestResourceTest {
       Configuration xmlConfig = registry.parse(cache1Xml).getCurrentConfigurationBuilder().build();
       assertEquals(1200000, xmlConfig.clustering().l1().lifespan());
       assertEquals(60500, xmlConfig.clustering().stateTransfer().timeout());
+
+      response = client.cache("cache1").configuration("application/xml; q=0.9");
+      assertThat(response).isOk();
    }
 
    @Test

--- a/server/runtime/src/main/java/org/infinispan/server/Server.java
+++ b/server/runtime/src/main/java/org/infinispan/server/Server.java
@@ -686,7 +686,7 @@ public class Server implements ServerManagement, AutoCloseable {
       Path home = serverHome.toPath();
       Path root = serverRoot.toPath();
       ProcessBuilder builder = new ProcessBuilder();
-      builder.command("sh", "-c", home.resolve(reportFile).toString(), Long.toString(pid), root.toString());
+      builder.command("sh", "-c", String.format("%s %s %s", home.resolve(reportFile), pid, root));
       return blockingManager.supplyBlocking(() -> {
          try {
             Process process = builder.start();

--- a/server/runtime/src/main/java/org/infinispan/server/configuration/endpoint/EndpointsConfigurationBuilder.java
+++ b/server/runtime/src/main/java/org/infinispan/server/configuration/endpoint/EndpointsConfigurationBuilder.java
@@ -43,8 +43,8 @@ public class EndpointsConfigurationBuilder implements Builder<EndpointsConfigura
    }
 
    public EndpointConfigurationBuilder addEndpoint(String socketBindingName) {
-      if (endpoints.containsKey(socketBindingName)) {
-         throw Server.log.endpointSocketBindingConflict(socketBindingName);
+      if (endpoints.remove(socketBindingName) != null) {
+         Server.log.endpointSocketBindingOverride(socketBindingName);
       }
       EndpointConfigurationBuilder builder = new EndpointConfigurationBuilder(server, socketBindingName);
       endpoints.put(socketBindingName, builder);

--- a/server/runtime/src/main/java/org/infinispan/server/logging/Log.java
+++ b/server/runtime/src/main/java/org/infinispan/server/logging/Log.java
@@ -177,8 +177,9 @@ public interface Log extends BasicLogger {
    @Message(value = "HotRod lazy-retrieval has been deprecated and will be removed in a future version with no direct replacement", id = 80044)
    void warnHotRodLazyRetrievalDeprecated();
 
-   @Message(value = "Cannot have multiple endpoints bound to the same socket binding '%s'", id = 80045)
-   CacheConfigurationException endpointSocketBindingConflict(String name);
+   @LogMessage(level = Logger.Level.WARN)
+   @Message(value = "Overriding existing endpoint on socket-binding '%s'", id = 80045)
+   void endpointSocketBindingOverride(String name);
 
    @Message(value = "Unknown credential store '%s'", id = 80046)
    IllegalArgumentException unknownCredentialStore(String store);

--- a/server/tests/src/test/java/org/infinispan/server/cli/CliIT.java
+++ b/server/tests/src/test/java/org/infinispan/server/cli/CliIT.java
@@ -172,7 +172,7 @@ public class CliIT {
       AeshTestShell shell = new AeshTestShell();
       CLI.main(shell, new String[]{"-f", getCliResource("batch-error.cli").getPath()}, properties);
       shell.assertContains("Hi CLI running on " + System.getProperty("os.arch"));
-      shell.assertContains("Error executing line 2");
+      shell.assertContains("batch-error.cli, line 2");
    }
 
    @Test


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-14256 Fix the CLI batch test
https://issues.redhat.com/browse/ISPN-14315 ConfigurationWriter should ignore media type parameters
https://issues.redhat.com/browse/ISPN-14316 Correctly pass arguments to report script
https://issues.redhat.com/browse/ISPN-14317 Server Backup creation should work even without JSON content
https://issues.redhat.com/browse/ISPN-14327 Allow overriding server endpoint
