### PR TITLE
ISPN-14329 Availability of caches should be prevented until a cluster…

### DIFF
--- a/core/src/main/java/org/infinispan/factories/GlobalComponentRegistry.java
+++ b/core/src/main/java/org/infinispan/factories/GlobalComponentRegistry.java
@@ -8,6 +8,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledExecutorService;
@@ -281,6 +282,11 @@ public class GlobalComponentRegistry extends AbstractComponentRegistry {
    @Override
    protected void postStart() {
       modulesManagerStarted();
+   }
+
+   @Override
+   protected CompletionStage<Void> delayStart() {
+      return null;
    }
 
    private void modulesManagerStarting() {

--- a/core/src/main/java/org/infinispan/health/HealthStatus.java
+++ b/core/src/main/java/org/infinispan/health/HealthStatus.java
@@ -23,6 +23,13 @@ public enum HealthStatus {
    HEALTHY,
 
    /**
+    * The given entity is still initializing.
+    *
+    * <p>This can happen when the entity does not have the time to completely initialize or when it is recovering after a cluster shutdown.</p>
+    */
+   INITIALIZING,
+
+   /**
     * Given entity is healthy but a rebalance is in progress.
     */
    HEALTHY_REBALANCING,

--- a/core/src/main/java/org/infinispan/health/impl/CacheHealthImpl.java
+++ b/core/src/main/java/org/infinispan/health/impl/CacheHealthImpl.java
@@ -4,6 +4,7 @@ import org.infinispan.distribution.DistributionManager;
 import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.health.CacheHealth;
 import org.infinispan.health.HealthStatus;
+import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.partitionhandling.AvailabilityMode;
 import org.infinispan.partitionhandling.impl.PartitionHandlingManager;
 
@@ -22,6 +23,8 @@ class CacheHealthImpl implements CacheHealth {
 
    @Override
    public HealthStatus getStatus() {
+      if (cr.getStatus() == ComponentStatus.INITIALIZING) return HealthStatus.INITIALIZING;
+
       PartitionHandlingManager partitionHandlingManager = cr.getComponent(PartitionHandlingManager.class);
       if (!isComponentHealthy() || partitionHandlingManager.getAvailabilityMode() == AvailabilityMode.DEGRADED_MODE) {
          return HealthStatus.DEGRADED;

--- a/core/src/main/java/org/infinispan/interceptors/impl/InvocationContextInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/InvocationContextInterceptor.java
@@ -28,6 +28,7 @@ import org.infinispan.interceptors.BaseAsyncInterceptor;
 import org.infinispan.interceptors.InvocationExceptionFunction;
 import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.statetransfer.OutdatedTopologyException;
+import org.infinispan.topology.LocalTopologyManager;
 import org.infinispan.transaction.WriteSkewException;
 import org.infinispan.transaction.impl.AbstractCacheTransaction;
 import org.infinispan.transaction.impl.TransactionTable;
@@ -99,6 +100,9 @@ public class InvocationContextInterceptor extends BaseAsyncInterceptor {
             if (stoppingAndNotAllowed(status, ctx)) {
                throw CONTAINER.cacheIsStopping(getCacheNamePrefix());
             }
+         case INITIALIZING:
+            LocalTopologyManager ltm = componentRegistry.getComponent(LocalTopologyManager.class);
+            if (ltm != null) ltm.assertTopologyStable(componentRegistry.getCacheName());
          default:
             // Allow the command to run
       }

--- a/core/src/main/java/org/infinispan/lifecycle/ComponentStatus.java
+++ b/core/src/main/java/org/infinispan/lifecycle/ComponentStatus.java
@@ -56,7 +56,6 @@ public enum ComponentStatus {
          case INSTANTIATED:
          case TERMINATED:
          case STOPPING:
-         case INITIALIZING:
             return false;
          default:
             return true;

--- a/core/src/main/java/org/infinispan/marshall/exts/ThrowableExternalizer.java
+++ b/core/src/main/java/org/infinispan/marshall/exts/ThrowableExternalizer.java
@@ -25,6 +25,7 @@ import org.infinispan.remoting.transport.jgroups.SuspectException;
 import org.infinispan.statetransfer.AllOwnersLostException;
 import org.infinispan.statetransfer.OutdatedTopologyException;
 import org.infinispan.topology.CacheJoinException;
+import org.infinispan.topology.MissingMembersException;
 import org.infinispan.transaction.WriteSkewException;
 import org.infinispan.transaction.xa.InvalidTransactionException;
 import org.infinispan.util.UserRaisedFunctionalException;
@@ -72,6 +73,7 @@ public class ThrowableExternalizer implements AdvancedExternalizer<Throwable> {
    private static final short TIMEOUT = 23;
    private static final short USER_RAISED_FUNCTIONAL = 24;
    private static final short WRITE_SKEW = 25;
+   private static final short MISSING_MEMBERS = 26;
    private final Map<Class<?>, Short> numbers = new HashMap<>(24);
 
    public ThrowableExternalizer() {
@@ -100,6 +102,7 @@ public class ThrowableExternalizer implements AdvancedExternalizer<Throwable> {
       numbers.put(UserRaisedFunctionalException.class, USER_RAISED_FUNCTIONAL);
       numbers.put(WriteSkewException.class, WRITE_SKEW);
       numbers.put(OutdatedTopologyException.class, OUTDATED_TOPOLOGY);
+      numbers.put(MissingMembersException.class, MISSING_MEMBERS);
    }
 
    @Override
@@ -138,6 +141,7 @@ public class ThrowableExternalizer implements AdvancedExternalizer<Throwable> {
          case SUSPECT:
             writeMessageAndCause(out, t);
             break;
+         case MISSING_MEMBERS:
          case CACHE_UNREACHABLE:
          case CONTAINER_FULL:
          case DEADLOCK_DETECTED:
@@ -229,6 +233,9 @@ public class ThrowableExternalizer implements AdvancedExternalizer<Throwable> {
             Throwable[] suppressed = MarshallUtil.unmarshallArray(in, Util::throwableArray);
             Object key = in.readObject();
             return addSuppressed(new WriteSkewException(msg, t, key), suppressed);
+         case MISSING_MEMBERS:
+            msg = MarshallUtil.unmarshallString(in);
+            return new MissingMembersException(msg);
          default:
             return readGenericThrowable(in);
       }

--- a/core/src/main/java/org/infinispan/persistence/manager/PersistenceManagerImpl.java
+++ b/core/src/main/java/org/infinispan/persistence/manager/PersistenceManagerImpl.java
@@ -266,7 +266,9 @@ public class PersistenceManagerImpl implements PersistenceManager {
             // This relies upon visibility guarantees of reactive streams for publishing map values
             .doOnNext(stores::add)
             .delay(status -> {
-               if (status.config.purgeOnStartup()) {
+               // Caches that need state transfer will clear the store *after* the stable
+               // topology is restored, if needed.
+               if (!configuration.clustering().cacheMode().needsStateTransfer() && status.config.purgeOnStartup()) {
                   return Flowable.fromCompletable(Completable.fromCompletionStage(status.store.clear()));
                }
                return Flowable.empty();

--- a/core/src/main/java/org/infinispan/persistence/sifs/Compactor.java
+++ b/core/src/main/java/org/infinispan/persistence/sifs/Compactor.java
@@ -135,7 +135,7 @@ class Compactor implements Consumer<Object> {
    boolean addFreeFile(int file, int expectedSize, int freeSize, long expirationTime, boolean canScheduleCompaction) {
       int fileSize = (int) fileProvider.getFileSize(file);
       if (fileSize != expectedSize) {
-         log.tracef("Unable to add file %s as it its size %s does not match expected %s, index may be dirty", fileSize, expectedSize);
+         log.tracef("Unable to add file %s as it its size %s does not match expected %s, index may be dirty", file, fileSize, expectedSize);
          return false;
       }
       Stats stats = new Stats(fileSize, freeSize, expirationTime);

--- a/core/src/main/java/org/infinispan/reactive/publisher/impl/ClusterPublisherManagerImpl.java
+++ b/core/src/main/java/org/infinispan/reactive/publisher/impl/ClusterPublisherManagerImpl.java
@@ -987,7 +987,7 @@ public class ClusterPublisherManagerImpl<K, V> implements ClusterPublisherManage
        */
       private <E> Flowable<E> getValuesFlowable(BiFunction<InnerPublisherSubscription.InnerPublisherSubscriptionBuilder<K, I, R>, Map.Entry<Address, IntSet>, Publisher<E>> subToFlowableFunction) {
          return Flowable.defer(() -> {
-            if (!componentRegistry.getStatus().allowInvocations()) {
+            if (!componentRegistry.getStatus().allowInvocations() && !componentRegistry.getStatus().startingUp()) {
                return Flowable.error(new IllegalLifecycleStateException());
             }
             LocalizedCacheTopology topology = distributionManager.getCacheTopology();

--- a/core/src/main/java/org/infinispan/topology/CacheStatusResponse.java
+++ b/core/src/main/java/org/infinispan/topology/CacheStatusResponse.java
@@ -4,12 +4,16 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 import org.infinispan.commons.marshall.AbstractExternalizer;
+import org.infinispan.commons.marshall.MarshallUtil;
 import org.infinispan.marshall.core.Ids;
 import org.infinispan.partitionhandling.AvailabilityMode;
+import org.infinispan.remoting.transport.Address;
 
 /**
 * @author Dan Berindei
@@ -20,13 +24,15 @@ public class CacheStatusResponse implements Serializable {
    private final CacheTopology cacheTopology;
    private final CacheTopology stableTopology;
    private final AvailabilityMode availabilityMode;
+   private final List<Address> current;
 
    public CacheStatusResponse(CacheJoinInfo cacheJoinInfo, CacheTopology cacheTopology, CacheTopology stableTopology,
-         AvailabilityMode availabilityMode) {
+                              AvailabilityMode availabilityMode, List<Address> current) {
       this.cacheJoinInfo = cacheJoinInfo;
       this.cacheTopology = cacheTopology;
       this.stableTopology = stableTopology;
       this.availabilityMode = availabilityMode;
+      this.current = current;
    }
 
    public CacheJoinInfo getCacheJoinInfo() {
@@ -48,6 +54,10 @@ public class CacheStatusResponse implements Serializable {
       return availabilityMode;
    }
 
+   public List<Address> joinedMembers() {
+      return current;
+   }
+
    @Override
    public String toString() {
       return "StatusResponse{" +
@@ -64,6 +74,7 @@ public class CacheStatusResponse implements Serializable {
          output.writeObject(cacheStatusResponse.cacheTopology);
          output.writeObject(cacheStatusResponse.stableTopology);
          output.writeObject(cacheStatusResponse.availabilityMode);
+         MarshallUtil.marshallCollection(cacheStatusResponse.current, output);
       }
 
       @Override
@@ -72,7 +83,8 @@ public class CacheStatusResponse implements Serializable {
          CacheTopology cacheTopology = (CacheTopology) unmarshaller.readObject();
          CacheTopology stableTopology = (CacheTopology) unmarshaller.readObject();
          AvailabilityMode availabilityMode = (AvailabilityMode) unmarshaller.readObject();
-         return new CacheStatusResponse(cacheJoinInfo, cacheTopology, stableTopology, availabilityMode);
+         List<Address> current = MarshallUtil.unmarshallCollection(unmarshaller, ArrayList::new);
+         return new CacheStatusResponse(cacheJoinInfo, cacheTopology, stableTopology, availabilityMode, current);
       }
 
       @Override

--- a/core/src/main/java/org/infinispan/topology/ClusterTopologyManager.java
+++ b/core/src/main/java/org/infinispan/topology/ClusterTopologyManager.java
@@ -1,5 +1,6 @@
 package org.infinispan.topology;
 
+import java.util.List;
 import java.util.concurrent.CompletionStage;
 
 import org.infinispan.factories.scopes.Scope;
@@ -31,6 +32,12 @@ public interface ClusterTopologyManager {
          return this == COORDINATOR || this == RECOVERING_CLUSTER;
       }
    }
+
+   /**
+    * Returns the list of nodes that joined the cache with the given {@code cacheName} if the current
+    * node is the coordinator. If the node is not the coordinator, the method returns null.
+    */
+   List<Address> currentJoiners(String cacheName);
 
    /**
     * Signals that a new member is joining the cache.

--- a/core/src/main/java/org/infinispan/topology/ClusterTopologyManagerImpl.java
+++ b/core/src/main/java/org/infinispan/topology/ClusterTopologyManagerImpl.java
@@ -199,6 +199,14 @@ public class ClusterTopologyManagerImpl implements ClusterTopologyManager {
    }
 
    @Override
+   public List<Address> currentJoiners(String cacheName) {
+      if (!getStatus().isCoordinator()) return null;
+
+      ClusterCacheStatus status = cacheStatusMap.get(cacheName);
+      return status != null ? status.getExpectedMembers() : null;
+   }
+
+   @Override
    public CompletionStage<CacheStatusResponse> handleJoin(String cacheName, Address joiner, CacheJoinInfo joinInfo,
                                                           int joinerViewId) {
       CompletionStage<Void> viewStage;
@@ -326,7 +334,7 @@ public class ClusterTopologyManagerImpl implements ClusterTopologyManager {
                Map<Address, CacheStatusResponse> cacheResponses =
                      responsesByCache.computeIfAbsent(cacheName, k -> new HashMap<>());
                cacheResponses.put(sender, new CacheStatusResponse(info, cacheTopology, stableTopology,
-                                                                  csr.getAvailabilityMode()));
+                                                                  csr.getAvailabilityMode(), csr.joinedMembers()));
             }
          }
          return null;

--- a/core/src/main/java/org/infinispan/topology/LocalTopologyManager.java
+++ b/core/src/main/java/org/infinispan/topology/LocalTopologyManager.java
@@ -129,4 +129,18 @@ public interface LocalTopologyManager {
     */
    CompletionStage<Void> handleCacheShutdown(String cacheName);
 
+   /**
+    * Returns a {@link CompletionStage} that completes when the cache with the name {@code cacheName} has a
+    * stable topology. Returns null if the cache does not exist.
+    */
+   CompletionStage<Void> stableTopologyCompletion(String cacheName);
+
+   /**
+    * Asserts the cache with the given name has a stable topology installed.
+    *
+    * @param cacheName: The cache name to search.
+    * @throws MissingMembersException: Thrown when the cache does not have a stable topology.
+    */
+   default void assertTopologyStable(String cacheName) { }
+
 }

--- a/core/src/main/java/org/infinispan/topology/MissingMembersException.java
+++ b/core/src/main/java/org/infinispan/topology/MissingMembersException.java
@@ -1,0 +1,16 @@
+package org.infinispan.topology;
+
+import org.infinispan.commons.CacheException;
+
+/**
+ * Thrown when members are missing after a cluster shutdown.
+ *
+ * A cluster misses members after the cluster shutdown and a restart, and some previous members did not join again.
+ *
+ * @since 15.0
+ */
+public class MissingMembersException extends CacheException {
+  public MissingMembersException(String msg) {
+    super(msg);
+  }
+}

--- a/core/src/main/java/org/infinispan/util/CoreBlockHoundIntegration.java
+++ b/core/src/main/java/org/infinispan/util/CoreBlockHoundIntegration.java
@@ -152,6 +152,7 @@ public class CoreBlockHoundIntegration implements BlockHoundIntegration {
       builder.allowBlockingCallsInside(ClusterTopologyManagerImpl.class.getName(), "initCacheStatusIfAbsent");
       builder.allowBlockingCallsInside(LocalTopologyManagerImpl.class.getName(), "writeCHState");
       builder.allowBlockingCallsInside(LocalTopologyManagerImpl.class.getName(), "deleteCHState");
+      builder.allowBlockingCallsInside(LocalTopologyManagerImpl.class.getName(), "getNumberMembersFromState");
 
       // This can block if there is a store otherwise it won't block
       builder.allowBlockingCallsInside(CacheMgmtInterceptor.class.getName(), "getNumberOfEntries");

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -54,6 +54,7 @@ import org.infinispan.remoting.transport.Address;
 import org.infinispan.remoting.transport.jgroups.SuspectException;
 import org.infinispan.topology.CacheJoinException;
 import org.infinispan.topology.CacheTopology;
+import org.infinispan.topology.MissingMembersException;
 import org.infinispan.transaction.WriteSkewException;
 import org.infinispan.transaction.impl.LocalTransaction;
 import org.infinispan.transaction.xa.GlobalTransaction;
@@ -2367,4 +2368,10 @@ public interface Log extends BasicLogger {
    @LogMessage(level = WARN)
    @Message(value = "Attribute '%s' of element '%s' has been deprecated since schema version %d.%d. Refer to the upgrade guide", id = 688)
    void attributeDeprecated(String name, String element, int major, int minor);
+
+   @LogMessage(level = WARN)
+   @Message(value = "Recovering cache '%s' but there are missing members, known members %s of a total of %s", id = 689)
+   void recoverFromStateMissingMembers(String cacheName, List<Address> members, int total);
+
+   MissingMembersException recoverFromStateMissingMembers(String cacheName, List<Address> members, String total);
 }

--- a/core/src/test/java/org/infinispan/globalstate/ThreeNodeGlobalStatePartialRestartTest.java
+++ b/core/src/test/java/org/infinispan/globalstate/ThreeNodeGlobalStatePartialRestartTest.java
@@ -1,0 +1,252 @@
+package org.infinispan.globalstate;
+
+import static org.infinispan.commons.test.CommonsTestingUtil.tmpDirectory;
+import static org.testng.AssertJUnit.assertEquals;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Map;
+
+import org.infinispan.Cache;
+import org.infinispan.commons.test.Exceptions;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.cache.StoreConfigurationBuilder;
+import org.infinispan.distribution.ch.ConsistentHash;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.partitionhandling.PartitionHandling;
+import org.infinispan.remoting.transport.jgroups.JGroupsAddress;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.topology.MissingMembersException;
+import org.infinispan.topology.PersistentUUID;
+import org.infinispan.topology.PersistentUUIDManager;
+import org.testng.annotations.Test;
+
+@Test(testName = "globalstate.ThreeNodeGlobalStatePartialRestartTest", groups = "functional")
+public class ThreeNodeGlobalStatePartialRestartTest extends AbstractGlobalStateRestartTest {
+
+   private PartitionHandling handling;
+   private CacheMode cacheMode;
+   private boolean purge;
+
+   @Override
+   protected int getClusterSize() {
+      return 3;
+   }
+
+   @Override
+   protected void applyCacheManagerClusteringConfiguration(ConfigurationBuilder config) {
+      config.clustering().cacheMode(cacheMode).hash().numOwners(getClusterSize() - 1);
+      config.clustering().partitionHandling().whenSplit(handling);
+   }
+
+   @Override
+   protected void applyCacheManagerClusteringConfiguration(String id, ConfigurationBuilder config) {
+      applyCacheManagerClusteringConfiguration(config);
+
+      StoreConfigurationBuilder scb = config.persistence().addSoftIndexFileStore()
+          .dataLocation(tmpDirectory(this.getClass().getSimpleName(), id, "data"))
+          .indexLocation(tmpDirectory(this.getClass().getSimpleName(), id, "index"));
+      scb.purgeOnStartup(purge);
+   }
+
+   public void testClusterDelayedJoiners() throws Exception {
+      Map<JGroupsAddress, PersistentUUID> addressMappings = createInitialCluster();
+
+      ConsistentHash oldConsistentHash = advancedCache(0, CACHE_NAME).getDistributionManager().getWriteConsistentHash();
+
+      // Shutdown the cache cluster-wide
+      cache(0, CACHE_NAME).shutdown();
+      TestingUtil.killCacheManagers(this.cacheManagers);
+
+      // Verify that the cache state file exists
+      for (int i = 0; i < getClusterSize(); i++) {
+         String persistentLocation = manager(i).getCacheManagerConfiguration().globalState().persistentLocation();
+         File[] listFiles = new File(persistentLocation).listFiles((dir, name) -> name.equals(CACHE_NAME + ".state"));
+         assertEquals(Arrays.toString(listFiles), 1, listFiles.length);
+      }
+      this.cacheManagers.clear();
+
+      // Partially recreate the cluster
+      for (int i = 0; i < getClusterSize() - 1; i++) {
+         createStatefulCacheManager(Character.toString((char) ('A' + i)), false);
+      }
+
+      TestingUtil.blockUntilViewsReceived(30000, getCaches(CACHE_NAME));
+
+      assertOperationsFail();
+
+      // The last pending member joins.
+      createStatefulCacheManager(Character.toString((char) ('A' + getClusterSize() - 1)), false);
+
+      // Healthy cluster
+      waitForClusterToForm(CACHE_NAME);
+
+      checkClusterRestartedCorrectly(addressMappings);
+      checkData();
+
+      ConsistentHash newConsistentHash =
+            advancedCache(0, CACHE_NAME).getDistributionManager().getWriteConsistentHash();
+      PersistentUUIDManager persistentUUIDManager = TestingUtil.extractGlobalComponent(manager(0), PersistentUUIDManager.class);
+      assertEquivalent(addressMappings, oldConsistentHash, newConsistentHash, persistentUUIDManager);
+   }
+
+   public void testConnectAndDisconnectDuringRestart() throws Exception {
+      Map<JGroupsAddress, PersistentUUID> addressMappings = createInitialCluster();
+
+      ConsistentHash oldConsistentHash = advancedCache(0, CACHE_NAME).getDistributionManager().getWriteConsistentHash();
+
+      // Shutdown the cache cluster-wide
+      cache(0, CACHE_NAME).shutdown();
+      TestingUtil.killCacheManagers(this.cacheManagers);
+
+      // Verify that the cache state file exists for all participants.
+      for (int i = 0; i < getClusterSize(); i++) {
+         String persistentLocation = manager(i).getCacheManagerConfiguration().globalState().persistentLocation();
+         File[] listFiles = new File(persistentLocation).listFiles((dir, name) -> name.equals(CACHE_NAME + ".state"));
+         assertEquals(Arrays.toString(listFiles), 1, listFiles.length);
+      }
+      this.cacheManagers.clear();
+
+      // Partially recreate the cluster.
+      for (int i = 0; i < getClusterSize() - 1; i++) {
+         createStatefulCacheManager(Character.toString((char) ('A' + i)), false);
+      }
+
+      TestingUtil.blockUntilViewsReceived(30000, getCaches(CACHE_NAME));
+      assertOperationsFail();
+
+      // Stop one of the caches and assert the files are still here.
+      EmbeddedCacheManager left = cacheManagers.remove(1);
+      TestingUtil.killCacheManagers(left);
+      String persistentLocation = left.getCacheManagerConfiguration().globalState().persistentLocation();
+      File[] listFiles = new File(persistentLocation).listFiles((dir, name) -> name.equals(CACHE_NAME + ".state"));
+      assertEquals(Arrays.toString(listFiles), 1, listFiles.length);
+
+      // Assert we are still unable to execute operations.
+      assertOperationsFail();
+
+      // Create the missing member instead of the one that left.
+      createStatefulCacheManager(Character.toString((char) ('A' + getClusterSize() - 1)), false);
+      TestingUtil.blockUntilViewsReceived(30000, getCaches(CACHE_NAME));
+
+      // Assert we are still unable to execute operations.
+      assertOperationsFail();
+
+      // The missing restart again.
+      createStatefulCacheManager(Character.toString((char) ('A' + 1)), false);
+
+      // Healthy cluster
+      waitForClusterToForm(CACHE_NAME);
+
+      checkClusterRestartedCorrectly(addressMappings);
+      checkData();
+
+      ConsistentHash newConsistentHash =
+          advancedCache(0, CACHE_NAME).getDistributionManager().getWriteConsistentHash();
+      PersistentUUIDManager persistentUUIDManager = TestingUtil.extractGlobalComponent(manager(0), PersistentUUIDManager.class);
+      assertEquivalent(addressMappings, oldConsistentHash, newConsistentHash, persistentUUIDManager);
+   }
+
+   public void testClusterWithRestartsDuringPartitioning() throws Exception {
+      Map<JGroupsAddress, PersistentUUID> addressMappings = createInitialCluster();
+
+      ConsistentHash oldConsistentHash = advancedCache(0, CACHE_NAME).getDistributionManager().getWriteConsistentHash();
+
+      // Shutdown the cache cluster-wide
+      cache(0, CACHE_NAME).shutdown();
+      TestingUtil.killCacheManagers(this.cacheManagers);
+
+      // Verify that the cache state file exists for all participants.
+      for (int i = 0; i < getClusterSize(); i++) {
+         String persistentLocation = manager(i).getCacheManagerConfiguration().globalState().persistentLocation();
+         File[] listFiles = new File(persistentLocation).listFiles((dir, name) -> name.equals(CACHE_NAME + ".state"));
+         assertEquals(Arrays.toString(listFiles), 1, listFiles.length);
+      }
+      this.cacheManagers.clear();
+
+      // Partially recreate the cluster.
+      for (int i = 0; i < getClusterSize() - 1; i++) {
+         createStatefulCacheManager(Character.toString((char) ('A' + i)), false);
+      }
+
+      TestingUtil.blockUntilViewsReceived(30000, getCaches(CACHE_NAME));
+
+      assertOperationsFail();
+
+      // Shutdown the malformed cluster.
+      cache(0, CACHE_NAME).shutdown();
+      TestingUtil.killCacheManagers(this.cacheManagers);
+
+      // Verify that the cache state file exists.
+      // Since the topology was never restored, the state files should be present.
+      for (int i = 0; i < getClusterSize() - 1; i++) {
+         String persistentLocation = manager(i).getCacheManagerConfiguration().globalState().persistentLocation();
+         File[] listFiles = new File(persistentLocation).listFiles((dir, name) -> name.equals(CACHE_NAME + ".state"));
+         assertEquals("Node " + i + " wrong files: " + Arrays.toString(listFiles), 1, listFiles.length);
+      }
+      this.cacheManagers.clear();
+
+      // Recreate the complete cluster now.
+      for (int i = 0; i < getClusterSize(); i++) {
+         createStatefulCacheManager(Character.toString((char) ('A' + i)), false);
+      }
+
+      // Healthy cluster
+      waitForClusterToForm(CACHE_NAME);
+
+      checkClusterRestartedCorrectly(addressMappings);
+      checkData();
+
+      ConsistentHash newConsistentHash =
+            advancedCache(0, CACHE_NAME).getDistributionManager().getWriteConsistentHash();
+      PersistentUUIDManager persistentUUIDManager = TestingUtil.extractGlobalComponent(manager(0), PersistentUUIDManager.class);
+      assertEquivalent(addressMappings, oldConsistentHash, newConsistentHash, persistentUUIDManager);
+   }
+
+   private void assertOperationsFail() {
+      for (int i = 0; i < cacheManagers.size(); i++) {
+         for (int v = 0; v < DATA_SIZE; v++) {
+            final Cache<Object, Object> cache = cache(i, CACHE_NAME);
+            String key = String.valueOf(v);
+            // Always returns null. Message about not stable yet is logged.
+            Exceptions.expectException(MissingMembersException.class,
+                "ISPN000689: Recovering cache 'testCache' but there are missing members, known members \\[.*\\] of a total of 3$",
+                () -> cache.get(key));
+         }
+      }
+   }
+
+   public ThreeNodeGlobalStatePartialRestartTest withPartitionHandling(PartitionHandling handling) {
+      this.handling = handling;
+      return this;
+   }
+
+   public ThreeNodeGlobalStatePartialRestartTest withCacheMode(CacheMode mode) {
+      this.cacheMode = mode;
+      return this;
+   }
+
+   public ThreeNodeGlobalStatePartialRestartTest purgeOnStartup(boolean purge) {
+      this.purge = purge;
+      return this;
+   }
+
+   @Override
+   public Object[] factory() {
+      return Arrays.stream(PartitionHandling.values())
+            .filter(ph -> ph != PartitionHandling.ALLOW_READ_WRITES)
+            .flatMap(ph -> Arrays.stream(new Object[] {
+                  new ThreeNodeGlobalStatePartialRestartTest().withCacheMode(CacheMode.DIST_SYNC).withPartitionHandling(ph),
+                  new ThreeNodeGlobalStatePartialRestartTest().withCacheMode(CacheMode.DIST_SYNC).withPartitionHandling(ph).purgeOnStartup(true),
+                  new ThreeNodeGlobalStatePartialRestartTest().withCacheMode(CacheMode.REPL_SYNC).withPartitionHandling(ph).purgeOnStartup(true),
+                  new ThreeNodeGlobalStatePartialRestartTest().withCacheMode(CacheMode.REPL_SYNC).withPartitionHandling(ph),
+            }))
+            .toArray();
+   }
+
+   @Override
+   protected String parameters() {
+      return String.format("[cacheMode=%s, ph=%s, purge=%b]", cacheMode, handling, purge);
+   }
+}

--- a/core/src/test/java/org/infinispan/partitionhandling/impl/PreferAvailabilityStrategyTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/impl/PreferAvailabilityStrategyTest.java
@@ -115,7 +115,7 @@ public class PreferAvailabilityStrategyTest extends AbstractInfinispanTest {
    public void testSinglePartitionOnlyJoiners() {
       // There's no cache topology, so the first cache topology is created with the joiners
       List<Address> joiners = asList(A, B);
-      CacheStatusResponse response = new CacheStatusResponse(DIST_INFO, null, null, AVAILABLE);
+      CacheStatusResponse response = new CacheStatusResponse(DIST_INFO, null, null, AVAILABLE, joiners);
       Map<Address, CacheStatusResponse> statusResponses = mapOf(A, response, B, response);
 
       when(context.getCacheName()).thenReturn(CACHE_NAME);
@@ -133,7 +133,7 @@ public class PreferAvailabilityStrategyTest extends AbstractInfinispanTest {
       List<Address> mergeMembers = asList(B, C);
       TestClusterCacheStatus cacheA = start(DIST_INFO, A);
       CacheStatusResponse responseB = availableResponse(B, cacheA);
-      CacheStatusResponse responseC = new CacheStatusResponse(DIST_INFO, null, null, AVAILABLE);
+      CacheStatusResponse responseC = new CacheStatusResponse(DIST_INFO, null, null, AVAILABLE, List.of(B));
       Map<Address, CacheStatusResponse> statusResponses = mapOf(B, responseB, C, responseC);
 
       when(context.getCacheName()).thenReturn(CACHE_NAME);
@@ -521,7 +521,7 @@ public class PreferAvailabilityStrategyTest extends AbstractInfinispanTest {
 
    private CacheStatusResponse availableResponse(Address a, TestClusterCacheStatus cacheStatus) {
       return new CacheStatusResponse(cacheStatus.joinInfo(a), cacheStatus.topology(), cacheStatus.stableTopology(),
-                                     AVAILABLE);
+                                     AVAILABLE, asList(A, B, C));
    }
 
    @Override

--- a/core/src/test/java/org/infinispan/topology/MockLocalTopologyManager.java
+++ b/core/src/test/java/org/infinispan/topology/MockLocalTopologyManager.java
@@ -42,7 +42,7 @@ class MockLocalTopologyManager implements LocalTopologyManager {
 
    public void init(CacheJoinInfo joinInfo, CacheTopology topology, CacheTopology stableTopology,
                     AvailabilityMode availabilityMode) {
-      this.status = new CacheStatusResponse(joinInfo, topology, stableTopology, availabilityMode);
+      this.status = new CacheStatusResponse(joinInfo, topology, stableTopology, availabilityMode, Collections.emptyList());
    }
 
    public void verifyTopology(CacheTopology topology, int topologyId, List<Address> currentMembers,
@@ -94,7 +94,7 @@ class MockLocalTopologyManager implements LocalTopologyManager {
    public CompletionStage<Void> handleTopologyUpdate(String cacheName, CacheTopology cacheTopology, AvailabilityMode availabilityMode,
                                                      int viewId, Address sender) {
       status = new CacheStatusResponse(status.getCacheJoinInfo(), cacheTopology,
-                                       status.getStableTopology(), availabilityMode);
+                                       status.getStableTopology(), availabilityMode, status.joinedMembers());
       topologies.add(cacheTopology);
       return CompletableFutures.completedNull();
    }
@@ -102,14 +102,14 @@ class MockLocalTopologyManager implements LocalTopologyManager {
    @Override
    public CompletionStage<Void> handleStableTopologyUpdate(String cacheName, CacheTopology cacheTopology, Address sender, int viewId) {
       status = new CacheStatusResponse(status.getCacheJoinInfo(), status.getCacheTopology(),
-                                       cacheTopology, status.getAvailabilityMode());
+                                       cacheTopology, status.getAvailabilityMode(), status.joinedMembers());
       return CompletableFutures.completedNull();
    }
 
    @Override
    public CompletionStage<Void> handleRebalance(String cacheName, CacheTopology cacheTopology, int viewId, Address sender) {
       status = new CacheStatusResponse(status.getCacheJoinInfo(), cacheTopology,
-                                       status.getStableTopology(), status.getAvailabilityMode());
+                                       status.getStableTopology(), status.getAvailabilityMode(), status.joinedMembers());
       topologies.add(cacheTopology);
       return CompletableFutures.completedNull();
    }
@@ -172,5 +172,10 @@ class MockLocalTopologyManager implements LocalTopologyManager {
     @Override
    public CompletionStage<Void> handleCacheShutdown(String cacheName) {
       throw new UnsupportedOperationException();
+   }
+
+   @Override
+   public CompletionStage<Void> stableTopologyCompletion(String cacheName) {
+      return CompletableFutures.completedNull();
    }
 }

--- a/core/src/test/java/org/infinispan/util/AbstractControlledLocalTopologyManager.java
+++ b/core/src/test/java/org/infinispan/util/AbstractControlledLocalTopologyManager.java
@@ -190,4 +190,8 @@ public abstract class AbstractControlledLocalTopologyManager implements LocalTop
       return delegate.handleCacheShutdown(cacheName);
    }
 
+   @Override
+   public CompletionStage<Void> stableTopologyCompletion(String cacheName) {
+      return CompletableFutures.completedNull();
+   }
 }

--- a/server/rest/src/main/java/org/infinispan/rest/RestRequestHandler.java
+++ b/server/rest/src/main/java/org/infinispan/rest/RestRequestHandler.java
@@ -30,6 +30,7 @@ import org.infinispan.rest.framework.LookupResult;
 import org.infinispan.rest.framework.Method;
 import org.infinispan.rest.logging.Log;
 import org.infinispan.rest.logging.RestAccessLoggingHandler;
+import org.infinispan.topology.MissingMembersException;
 import org.infinispan.util.logging.LogFactory;
 
 import io.netty.channel.ChannelFutureListener;
@@ -83,7 +84,7 @@ public class RestRequestHandler extends SimpleChannelInboundHandler<FullHttpRequ
       } else if (cause instanceof NoSuchElementException) {
          if (getLogger().isTraceEnabled()) getLogger().tracef("Request failed: %s", cause);
          errorResponse = new NettyRestResponse.Builder().status(NOT_FOUND).entity(unwrapExceptionMessage(cause)).build();
-      } else if (cause instanceof CacheConfigurationException || cause instanceof IllegalArgumentException || cause instanceof EncodingException || cause instanceof Json.MalformedJsonException) {
+      } else if (cause instanceof CacheConfigurationException || cause instanceof IllegalArgumentException || cause instanceof EncodingException || cause instanceof Json.MalformedJsonException || cause instanceof MissingMembersException) {
          if (getLogger().isTraceEnabled()) getLogger().tracef("Request failed: %s", cause);
          errorResponse = new NettyRestResponse.Builder().status(BAD_REQUEST).entity(unwrapExceptionMessage(cause)).build();
       } else {

--- a/server/rest/src/main/java/org/infinispan/rest/cachemanager/RestCacheManager.java
+++ b/server/rest/src/main/java/org/infinispan/rest/cachemanager/RestCacheManager.java
@@ -26,6 +26,7 @@ import org.infinispan.distribution.DistributionInfo;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.distribution.LocalizedCacheTopology;
 import org.infinispan.encoding.impl.StorageConfigurationManager;
+import org.infinispan.factories.GlobalComponentRegistry;
 import org.infinispan.manager.ClusterExecutor;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.manager.EmbeddedCacheManagerAdmin;
@@ -46,6 +47,7 @@ import org.infinispan.security.AuthorizationPermission;
 import org.infinispan.security.Security;
 import org.infinispan.security.impl.Authorizer;
 import org.infinispan.server.core.CacheInfo;
+import org.infinispan.topology.LocalTopologyManager;
 import org.infinispan.util.KeyValuePair;
 import org.infinispan.util.concurrent.CompletionStages;
 import org.infinispan.util.function.SerializableFunction;
@@ -117,6 +119,10 @@ public class RestCacheManager<V> {
 
    private void checkCacheAvailable(String cacheName) {
       if (!instance.isRunning(cacheName)) {
+         GlobalComponentRegistry gcr = SecurityActions.getGlobalComponentRegistry(instance);
+         LocalTopologyManager ltm = gcr.getLocalTopologyManager();
+         if (ltm != null) ltm.assertTopologyStable(cacheName);
+
          throw logger.cacheNotFound(cacheName);
       } else if (icr.isInternalCache(cacheName)) {
          if (icr.isPrivateCache(cacheName)) {

--- a/server/rest/src/main/java/org/infinispan/rest/resources/ContainerResource.java
+++ b/server/rest/src/main/java/org/infinispan/rest/resources/ContainerResource.java
@@ -341,11 +341,17 @@ public class ContainerResource implements ResourceHandler {
       if (ignoredCaches.contains(cacheName)) {
          cacheInfo.status = "IGNORED";
       } else {
-         if(cacheHealth != HealthStatus.FAILED) {
-            Cache<?, ?> cache = restCacheManager.getCache(cacheName, request);
-            cacheInfo.status = cache.getStatus().toString();
-         } else {
-            cacheInfo.status = ComponentStatus.FAILED.toString();
+         switch (cacheHealth) {
+            case FAILED:
+               cacheInfo.status = ComponentStatus.FAILED.toString();
+               break;
+            case INITIALIZING:
+               cacheInfo.status = ComponentStatus.INITIALIZING.toString();
+               break;
+            default:
+               Cache<?, ?> cache = restCacheManager.getCache(cacheName, request);
+               cacheInfo.status = cache.getStatus().toString();
+               break;
          }
       }
 


### PR DESCRIPTION
… is complete after "shutdown cluster"

https://issues.redhat.com/browse/ISPN-14329
https://issues.redhat.com/browse/ISPN-14414

After the cluster shutdown, the nodes must wait for the complete recovery before accepting commands. We keep the cache's registry as `INITIALIZING` until all nodes join back and the restoration of a stable topology. We do this if the cache has a non-shared store without purging on start.

We log and return an exception with the current members. We can't say the missing member's address for sure, as we only have the persistent UUID.

With the test we added, the log message is:

```text
11:19:12,840 WARN  (jgroups-7,ThreeNodeGlobalStatePartialRestartTest-NodeF:[]) [o.i.t.ClusterCacheStatus] ISPN000681: Recovering cache testCache missing members, currently have [ThreeNodeGlobalStatePartialRestartTest-NodeF, ThreeNodeGlobalStatePartialRestartTest-NodeG] of a total of 3
```

We still need a way to send commands and force the cache to start, even if that means data loss. And handle the inconsistent behavior from reports. That's follow-up work.

But I also wanted to gather some reviews/comments on the approach here (and see how CI behaves). There is also the option to block the cache creation until the cluster is back or receives a manual intervention.

