### PR TITLE
ISPN-14323 Get command blocks in text/plain caches

### DIFF
--- a/server/resp/src/main/java/org/infinispan/server/resp/Resp3AuthHandler.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/Resp3AuthHandler.java
@@ -8,7 +8,6 @@ import java.util.concurrent.CompletionStage;
 
 import javax.security.auth.Subject;
 
-import org.infinispan.AdvancedCache;
 import org.infinispan.commons.util.Version;
 import org.infinispan.commons.util.concurrent.CompletableFutures;
 
@@ -17,12 +16,8 @@ import io.netty.util.CharsetUtil;
 
 public class Resp3AuthHandler extends RespRequestHandler {
 
-   protected final RespServer respServer;
-   protected AdvancedCache<byte[], byte[]> cache;
-
    public Resp3AuthHandler(RespServer server) {
-      this.respServer = server;
-      this.cache = server.getCache();
+      super(server);
    }
 
    @Override

--- a/server/resp/src/main/java/org/infinispan/server/resp/RespRequestHandler.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/RespRequestHandler.java
@@ -8,6 +8,8 @@ import java.util.concurrent.Executor;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
+import org.infinispan.AdvancedCache;
+import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.commons.util.concurrent.CompletableFutures;
 import org.infinispan.util.concurrent.CompletionStages;
 
@@ -18,6 +20,14 @@ import io.netty.channel.ChannelHandlerContext;
 
 public abstract class RespRequestHandler {
    protected final CompletionStage<RespRequestHandler> myStage = CompletableFuture.completedStage(this);
+   protected final RespServer respServer;
+   protected AdvancedCache<byte[], byte[]> cache;
+
+   protected RespRequestHandler(RespServer respServer) {
+      this.respServer = respServer;
+      this.cache = respServer.getCache()
+            .withMediaType(MediaType.APPLICATION_OCTET_STREAM, MediaType.APPLICATION_OCTET_STREAM);
+   }
 
    /**
     * Handles the RESP request returning a stage that when complete notifies the command has completed as well as

--- a/server/resp/src/test/java/org/infinispan/server/resp/RespMediaTypesTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/RespMediaTypesTest.java
@@ -1,0 +1,71 @@
+package org.infinispan.server.resp;
+
+import static org.infinispan.server.resp.test.RespTestingUtil.createClient;
+import static org.infinispan.server.resp.test.RespTestingUtil.startServer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.infinispan.commons.dataconversion.MediaType;
+import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.server.resp.configuration.RespServerConfiguration;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+
+@Test(groups = "functional", testName = "server.resp.RespMediaTypesTest")
+public class RespMediaTypesTest extends RespSingleNodeTest {
+
+   private MediaType keyType;
+   private MediaType valueType;
+
+   @Override
+   protected EmbeddedCacheManager createCacheManager() {
+      cacheManager = createTestCacheManager();
+      Configuration configuration = new ConfigurationBuilder()
+            .encoding()
+            .key().mediaType(keyType.toString())
+            .encoding()
+            .value().mediaType(valueType.toString())
+            .build();
+      RespServerConfiguration serverConfiguration = serverConfiguration().build();
+      cacheManager.defineConfiguration(serverConfiguration.defaultCacheName(), configuration);
+      server = startServer(cacheManager, serverConfiguration);
+      client = createClient(30000, server.getPort());
+      redisConnection = client.connect();
+      cache = cacheManager.getCache(server.getConfiguration().defaultCacheName());
+      return cacheManager;
+   }
+
+   private RespMediaTypesTest withKeyType(MediaType type) {
+      this.keyType = type;
+      return this;
+   }
+
+   private RespMediaTypesTest withValueType(MediaType type) {
+      this.valueType = type;
+      return this;
+   }
+
+   @Factory
+   public Object[] factory() {
+      List<RespMediaTypesTest> instances = new ArrayList<>();
+      MediaType[] types = new MediaType[] {
+            MediaType.APPLICATION_OCTET_STREAM,
+            MediaType.APPLICATION_OBJECT,
+            MediaType.TEXT_PLAIN,
+      };
+      for (MediaType key : types) {
+         for (MediaType value : types) {
+            instances.add(new RespMediaTypesTest().withKeyType(key).withValueType(value));
+         }
+      }
+      return instances.toArray();
+   }
+
+   @Override
+   protected String parameters() {
+      return String.format("[key=%s, type=%s]", keyType, valueType);
+   }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-14323

The problem was that the current implementation assumed the cache media types, so some methods failed with type casting. I've changed to handle different media types. I guess that another approach would be to not accept custom configurations.

Also, the random bytes prefix seems to affect when the value was transformed, so I changed it to be a readable value (resp|). 