### PR TITLE
[13.0.x] ISPN-13813 Hot Rod client uses "greater than" for comparison but topo…

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/ChannelFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/ChannelFactory.java
@@ -322,7 +322,7 @@ public class ChannelFactory {
 
          // Only accept the update if it's from the current age and the topology id is greater than the current one
          // Relies on TopologyInfo.switchCluster() to update the topologyAge for caches first
-         if (responseTopologyAge == cacheInfo.getTopologyAge() && responseTopologyId > cacheInfo.getTopologyId()) {
+         if (responseTopologyAge == cacheInfo.getTopologyAge() && responseTopologyId != cacheInfo.getTopologyId()) {
             List<InetSocketAddress> addressList = Arrays.asList(addresses);
             HOTROD.newTopology(responseTopologyId, responseTopologyAge, addresses.length, addressList);
             CacheInfo newCacheInfo;
@@ -330,7 +330,7 @@ public class ChannelFactory {
                SegmentConsistentHash consistentHash =
                      createConsistentHash(segmentOwners, hashFunctionVersion, cacheInfo.getCacheName());
                newCacheInfo = cacheInfo.withNewHash(responseTopologyAge, responseTopologyId, addressList,
-                                                       consistentHash, segmentOwners.length);
+                     consistentHash, segmentOwners.length);
             } else {
                newCacheInfo = cacheInfo.withNewServers(responseTopologyAge, responseTopologyId, addressList);
             }


### PR DESCRIPTION
…logy ID resets on full cluster restart

* Only backports the client