### PR TITLE
Add no-downtime scenarios for index attributes migration

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/evolution/model/BaseModelIndexAttributesChangedEntity.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/evolution/model/BaseModelIndexAttributesChangedEntity.java
@@ -1,0 +1,50 @@
+package org.infinispan.client.hotrod.evolution.model;
+
+import org.infinispan.api.annotations.indexing.Basic;
+import org.infinispan.api.annotations.indexing.Indexed;
+import org.infinispan.api.annotations.indexing.Keyword;
+import org.infinispan.api.annotations.indexing.Text;
+import org.infinispan.client.hotrod.annotation.model.Model;
+import org.infinispan.protostream.GeneratedSchema;
+import org.infinispan.protostream.annotations.AutoProtoSchemaBuilder;
+import org.infinispan.protostream.annotations.ProtoField;
+import org.infinispan.protostream.annotations.ProtoName;
+
+@Indexed
+@ProtoName("Model") // L
+public class BaseModelIndexAttributesChangedEntity implements Model {
+
+    @ProtoField(number = 1)
+    @Basic
+    public Integer entityVersion;
+
+    @ProtoField(number = 2)
+    @Basic
+    public String id;
+
+    @ProtoField(number = 3)
+    @Basic
+    public Integer number;
+
+    @ProtoField(number = 4)
+    @Basic(projectable = true, sortable = true, aggregable = true)
+    public String name;
+
+    @ProtoField(number = 5)
+    @Keyword
+    public String normalizedField;
+
+    @ProtoField(number = 6)
+    @Text(analyzer = "keyword")
+    public String analyzedField;
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @AutoProtoSchemaBuilder(includeClasses = BaseModelIndexAttributesChangedEntity.class, schemaFileName = "evolution-schema.proto", schemaPackageName = "evolution")
+    public interface BaseModelIndexAttributesChangedEntitySchema extends GeneratedSchema {
+        BaseModelIndexAttributesChangedEntitySchema INSTANCE = new BaseModelIndexAttributesChangedEntitySchemaImpl();
+    }
+}

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/evolution/model/BaseModelIndexAttributesEntity.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/evolution/model/BaseModelIndexAttributesEntity.java
@@ -1,0 +1,50 @@
+package org.infinispan.client.hotrod.evolution.model;
+
+import org.infinispan.api.annotations.indexing.Basic;
+import org.infinispan.api.annotations.indexing.Indexed;
+import org.infinispan.api.annotations.indexing.Keyword;
+import org.infinispan.api.annotations.indexing.Text;
+import org.infinispan.client.hotrod.annotation.model.Model;
+import org.infinispan.protostream.GeneratedSchema;
+import org.infinispan.protostream.annotations.AutoProtoSchemaBuilder;
+import org.infinispan.protostream.annotations.ProtoField;
+import org.infinispan.protostream.annotations.ProtoName;
+
+@Indexed
+@ProtoName("Model") // K
+public class BaseModelIndexAttributesEntity implements Model {
+
+    @ProtoField(number = 1)
+    @Basic(projectable = true)
+    public Integer entityVersion;
+
+    @ProtoField(number = 2)
+    @Basic(sortable = true)
+    public String id;
+
+    @ProtoField(number = 3)
+    @Basic(aggregable = true)
+    public Integer number;
+
+    @ProtoField(number = 4)
+    @Basic()
+    public String name;
+
+    @ProtoField(number = 5)
+    @Keyword(normalizer = "lowercase")
+    public String normalizedField;
+
+    @ProtoField(number = 6)
+    @Text()
+    public String analyzedField;
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @AutoProtoSchemaBuilder(includeClasses = BaseModelIndexAttributesEntity.class, schemaFileName = "evolution-schema.proto", schemaPackageName = "evolution")
+    public interface BaseModelIndexAttributesEntitySchema extends GeneratedSchema {
+        BaseModelIndexAttributesEntitySchema INSTANCE = new BaseModelIndexAttributesEntitySchemaImpl();
+    }
+}

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/evolution/model/ModelUtils.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/evolution/model/ModelUtils.java
@@ -123,6 +123,32 @@ public class ModelUtils {
         };
     }
 
+    public static Function<Integer, Model> createBaseModelIndexAttributesEntity(int version) {
+        return i -> {
+            BaseModelIndexAttributesEntity m = new BaseModelIndexAttributesEntity();
+            m.entityVersion = version;
+            m.id = String.valueOf((8 * ID_VERSION_OFFSET) + i);
+            m.number = i;
+            m.name = "modelK # " + i;
+            m.normalizedField = "modelK # lowercase NORMALIZED field " + i;
+            m.analyzedField = "modelK # standard ANALYZED field " + i;
+            return m;
+        };
+    }
+
+    public static Function<Integer, Model> createBaseModelIndexAttributesChangedEntity(int version) {
+        return i -> {
+            BaseModelIndexAttributesChangedEntity m = new BaseModelIndexAttributesChangedEntity();
+            m.entityVersion = version;
+            m.id = String.valueOf((9 * ID_VERSION_OFFSET) + i);
+            m.number = i;
+            m.name = "modelL # " + i;
+            m.normalizedField = "modelL # NORMALIZED field " + i;
+            m.analyzedField = "modelL # keyword ANALYZED field " + i;
+            return m;
+        };
+    }
+
     public static void createModelEntities(RemoteCache<String, Model> cache, int number, Function<Integer, Model> modelProducer) {
         for (int i = 0; i < number; i++) {
             Model m = modelProducer.apply(i);


### PR DESCRIPTION
This PR adds index attributes migration scenarios with regards of no-downtime into the testsuite. 

- changing `projectable`, `sortable`, `aggregable` from `true` to `false` and vice versa
- changing a normalizer/analyzer  

CC: @fax4ever @mhajas 