### PR TITLE
ISPN-14428 size() and keySet() are not reliable and return fuzzy results

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/iteration/RemotePublisher.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/iteration/RemotePublisher.java
@@ -5,6 +5,7 @@ import static org.infinispan.client.hotrod.logging.Log.HOTROD;
 import java.lang.invoke.MethodHandles;
 import java.net.SocketAddress;
 import java.util.AbstractMap;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -55,7 +56,7 @@ public class RemotePublisher<K, E> implements Publisher<Map.Entry<K, E>> {
       if (segments == null) {
          if (segmentConsistentHash != null) {
             int maxSegment = segmentConsistentHash.getNumSegments();
-            this.segments = IntSets.mutableEmptySet(maxSegment);
+            this.segments = IntSets.concurrentSet(maxSegment);
             for (int i = 0; i < maxSegment; ++i) {
                this.segments.set(i);
             }
@@ -63,7 +64,7 @@ public class RemotePublisher<K, E> implements Publisher<Map.Entry<K, E>> {
             this.segments = null;
          }
       } else {
-         this.segments = IntSets.mutableCopyFrom(segments);
+         this.segments = IntSets.concurrentCopyFrom(IntSets.from(segments), Collections.max(segments) + 1);
       }
       this.batchSize = batchSize;
       this.metadata = metadata;

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/SegmentKeyTrackerTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/SegmentKeyTrackerTest.java
@@ -1,0 +1,46 @@
+package org.infinispan.client.hotrod.impl.iteration;
+
+import static org.infinispan.client.hotrod.impl.protocol.HotRodConstants.NO_ERROR_STATUS;
+import static org.testng.AssertJUnit.assertTrue;
+
+import java.net.SocketAddress;
+import java.util.Set;
+
+import org.infinispan.client.hotrod.DataFormat;
+import org.infinispan.client.hotrod.impl.consistenthash.SegmentConsistentHash;
+import org.infinispan.commons.configuration.ClassAllowList;
+import org.infinispan.commons.dataconversion.MediaType;
+import org.infinispan.commons.marshall.IdentityMarshaller;
+import org.infinispan.commons.test.Exceptions;
+import org.infinispan.commons.util.IntSet;
+import org.infinispan.commons.util.IntSets;
+import org.testng.annotations.Test;
+
+@Test(groups = "functional", testName = "client.hotrod.SegmentKeyTrackerTest")
+public class SegmentKeyTrackerTest {
+
+   public void testNoDuplication() {
+      SocketAddress[][] segmentOwners = new SocketAddress[0][0];
+      SegmentConsistentHash ch = new SegmentConsistentHash();
+      ch.init(segmentOwners, 2);
+      DataFormat df = DataFormat.builder()
+            .keyType(MediaType.APPLICATION_OBJECT)
+            .keyMarshaller(IdentityMarshaller.INSTANCE)
+            .build();
+
+      KeyTracker tracker = new SegmentKeyTracker(df, ch, Set.of(0, 1));
+
+      // Belongs to segment 0
+      byte[] key = new byte[] { 0b0, 0b1 };
+      IntSet completed = IntSets.from(Set.of(0));
+
+      assertTrue(tracker.track(key, NO_ERROR_STATUS, new ClassAllowList()));
+      tracker.segmentsFinished(completed);
+      Exceptions.expectException(IllegalStateException.class, () ->
+            tracker.track(key, NO_ERROR_STATUS, new ClassAllowList()));
+
+      // Belongs to another segment.
+      byte[] anotherKey = new byte[] { 0b1, 0b0, 0b1 };
+      assertTrue(tracker.track(anotherKey, NO_ERROR_STATUS, new ClassAllowList()));
+   }
+}

--- a/client/hotrod/src/main/java/org/infinispan/hotrod/impl/iteration/RemotePublisher.java
+++ b/client/hotrod/src/main/java/org/infinispan/hotrod/impl/iteration/RemotePublisher.java
@@ -5,6 +5,7 @@ import static org.infinispan.hotrod.impl.logging.Log.HOTROD;
 import java.lang.invoke.MethodHandles;
 import java.net.SocketAddress;
 import java.util.AbstractMap;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -57,7 +58,7 @@ public class RemotePublisher<K, E> implements Publisher<CacheEntry<K, E>> {
       if (segments == null) {
          if (segmentConsistentHash != null) {
             int maxSegment = segmentConsistentHash.getNumSegments();
-            this.segments = IntSets.mutableEmptySet(maxSegment);
+            this.segments = IntSets.concurrentSet(maxSegment);
             for (int i = 0; i < maxSegment; ++i) {
                this.segments.set(i);
             }
@@ -65,7 +66,7 @@ public class RemotePublisher<K, E> implements Publisher<CacheEntry<K, E>> {
             this.segments = null;
          }
       } else {
-         this.segments = IntSets.mutableCopyFrom(segments);
+         this.segments = IntSets.concurrentCopyFrom(IntSets.from(segments), Collections.max(segments) + 1);
       }
       this.batchSize = batchSize;
       this.metadata = metadata;

--- a/commons/all/src/main/java/org/infinispan/commons/util/ConcurrentSmallIntSet.java
+++ b/commons/all/src/main/java/org/infinispan/commons/util/ConcurrentSmallIntSet.java
@@ -66,7 +66,7 @@ class ConcurrentSmallIntSet implements IntSet {
 
    private void checkBounds(int index) {
       if (index >= array.length()) {
-         throw new IllegalArgumentException("Provided integer was larger than originally initialized size");
+         throw new IllegalArgumentException("Provided integer " + index + " was larger than originally initialized size " + array.length());
       }
    }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-14428

A couple of things here:

* Key tracker allows duplicates;
* The IntSet keeping track segments not completed;

The latter I guess is a visibility issue. We have only a single outstanding request for each target, but we have a concurrency of # of target servers. We update by removing the completed segments when a response is received, and the flowable uses the segment again to request the not completed. Not sure how to create a test for this, tough.

A log from a local execution:

```
18:18:42.200 INFO [org.jabolina.playground.TestHotRodClient] (1) SIZE: 10
18:18:42.200 INFO [org.infinispan.client.hotrod.impl.iteration.RemotePublisher] (15) [HotRod-client-async-pool-1-1] Segments left to process are {60-62 79-91 103-107 113-115 117-122 187-202 205 209-216 218-234 238-249} <--- Causes a request for these segments again.
18:18:42.202 INFO [org.infinispan.client.hotrod.impl.iteration.RemotePublisher] (18) [HotRod-client-async-pool-1-4] Segments left to process are {} <--- After receiving the segments.
18:18:42.202 INFO [org.jabolina.playground.TestHotRodClient] (1) KEYS [10]: [test4, test3, test1, test6, test9, test7, test2, test8, test5, test10, test6]
18:18:42.202 INFO [org.jabolina.playground.TestHotRodClient] (1) FOUND 10 KEYS
```
