### PR TITLE
ISPN-14491 Adding entries with putAll does not add metadata version -…

### DIFF
--- a/client/hotrod/src/test/java/org/infinispan/hotrod/HotRodAsyncCacheTest.java
+++ b/client/hotrod/src/test/java/org/infinispan/hotrod/HotRodAsyncCacheTest.java
@@ -165,7 +165,7 @@ public class HotRodAsyncCacheTest<K, V> extends AbstractAsyncCacheSingleServerTe
             .build();
       await(cache.putAll(entries, options));
 
-      final CacheEntryVersion cve = new CacheEntryVersionImpl(0);
+      final CacheEntryVersion cve = new CacheEntryVersionImpl(1);
       for (Map.Entry<K, V> entry : entries.entrySet()) {
          assertEntry(entry.getKey(), entry.getValue(), kvGenerator, await(cache.getEntry(entry.getKey())), options, cve);
       }
@@ -232,7 +232,7 @@ public class HotRodAsyncCacheTest<K, V> extends AbstractAsyncCacheSingleServerTe
             .stream().collect(Collectors.toMap(CacheEntry::key, e -> e));
 
       assertEquals(entries.size(), retrieved.size());
-      final CacheEntryVersion cve = new CacheEntryVersionImpl(0);
+      final CacheEntryVersion cve = new CacheEntryVersionImpl(1);
       MapKVHelper<K, V> helper = new MapKVHelper<>(entries, kvGenerator);
       for (Map.Entry<K, CacheEntry<K, V>> entry : retrieved.entrySet()) {
          V expected = helper.get(entry.getKey());

--- a/client/hotrod/src/test/java/org/infinispan/hotrod/HotRodMutinyCacheTest.java
+++ b/client/hotrod/src/test/java/org/infinispan/hotrod/HotRodMutinyCacheTest.java
@@ -165,7 +165,7 @@ public class HotRodMutinyCacheTest<K, V> extends AbstractMutinyCacheSingleServer
             .build();
       await(cache.putAll(entries, options));
 
-      final CacheEntryVersion cve = new CacheEntryVersionImpl(0);
+      final CacheEntryVersion cve = new CacheEntryVersionImpl(1);
       for (Map.Entry<K, V> entry : entries.entrySet()) {
          assertEntry(entry.getKey(), entry.getValue(), kvGenerator, await(cache.getEntry(entry.getKey())), options, cve);
       }
@@ -232,7 +232,7 @@ public class HotRodMutinyCacheTest<K, V> extends AbstractMutinyCacheSingleServer
             .stream().collect(Collectors.toMap(CacheEntry::key, e -> e));
 
       assertEquals(entries.size(), retrieved.size());
-      final CacheEntryVersion cve = new CacheEntryVersionImpl(0);
+      final CacheEntryVersion cve = new CacheEntryVersionImpl(1);
       MapKVHelper<K, V> helper = new MapKVHelper<>(entries, kvGenerator);
       for (Map.Entry<K, CacheEntry<K, V>> entry : retrieved.entrySet()) {
          V expected = helper.get(entry.getKey());

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/CacheRequestProcessor.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/CacheRequestProcessor.java
@@ -263,7 +263,7 @@ class CacheRequestProcessor extends BaseRequestProcessor {
          telemetryService.requestEnd(span);
       } else if (entry != null) {
          NumericVersion streamVersion = new NumericVersion(version);
-         if (entry.getMetadata().version().equals(streamVersion)) {
+         if (streamVersion.equals(entry.getMetadata().version())) {
             cache.replaceAsync(entry.getKey(), entry.getValue(), value, metadata)
                   .whenComplete((replaced, throwable2) -> {
                      if (throwable2 != null) {
@@ -403,7 +403,7 @@ class CacheRequestProcessor extends BaseRequestProcessor {
       } else if (entry != null) {
          byte[] prev = entry.getValue();
          NumericVersion streamVersion = new NumericVersion(version);
-         if (entry.getMetadata().version().equals(streamVersion)) {
+         if (streamVersion.equals(entry.getMetadata().version())) {
             cache.removeAsync(key, prev).whenComplete((removed, throwable2) -> {
                if (throwable2 != null) {
                   writeException(header, span, throwable2);
@@ -446,6 +446,7 @@ class CacheRequestProcessor extends BaseRequestProcessor {
       Object span = telemetryService.requestStart(HotRodOperation.PUT_ALL.name(), header.otherParams);
       ExtendedCacheInfo cacheInfo = server.getCacheInfo(header);
       AdvancedCache<byte[], byte[]> cache = server.cache(cacheInfo, header, subject);
+      metadata.version(cacheInfo.versionGenerator.generateNew());
       putAllInternal(header, cache, entries, metadata.build(), span);
    }
 


### PR DESCRIPTION
… following replaceWithVersion will end with a timeout

https://issues.redhat.com/browse/ISPN-14491

The issue because the entry was created with `putAll`, so the `version` is null during the check, causing an NPE. 
