### PR TITLE
[14.x] ISPN-14476: Bump JGroups to 5.2.12.Final

### DIFF
--- a/build/configuration/pom.xml
+++ b/build/configuration/pom.xml
@@ -167,7 +167,7 @@
       <version.jboss.shrinkwrap.descriptors>2.0.0</version.jboss.shrinkwrap.descriptors>
       <version.jboss.shrinkwrap.resolver>3.1.3</version.jboss.shrinkwrap.resolver>
       <version.jcip-annotations>1.0</version.jcip-annotations>
-      <version.jgroups>5.2.10.Final</version.jgroups>
+      <version.jgroups>5.2.12.Final</version.jgroups>
       <version.jgroups.raft>1.0.10.Final</version.jgroups.raft>
       <version.jsr107>1.1.0</version.jsr107>
       <version.junit>4.13.2</version.junit>


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-14476

Backport of https://github.com/infinispan/infinispan/pull/10599