### PR TITLE
[14.0] ISPN-14477 Tests for concurrent Spring session access

### DIFF
--- a/spring/spring5/spring5-common/src/main/java/org/infinispan/spring/common/session/SessionUpdateRemappingFunctionProtoAdapter.java
+++ b/spring/spring5/spring5-common/src/main/java/org/infinispan/spring/common/session/SessionUpdateRemappingFunctionProtoAdapter.java
@@ -4,6 +4,8 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.infinispan.commons.marshall.ProtoStreamTypeIds;
@@ -33,11 +35,15 @@ public class SessionUpdateRemappingFunctionProtoAdapter {
       if (maxInactiveSeconds != null) {
          function.setMaxInactiveInterval(Duration.ofSeconds(maxInactiveSeconds));
       }
-      function.setDelta(attributes.stream().collect(Collectors.toMap(SessionAttribute::getName, SessionAttribute::getValue)));
+      Map<String,Object> delta = new HashMap<>();
+      for (SessionAttribute attribute : attributes) {
+         delta.put(attribute.getName(), attribute.getValue());
+      }
+      function.setDelta(delta);
       return function;
    }
 
-   @ProtoField(number = 1, defaultValue = "0")
+   @ProtoField(number = 1)
    Instant getLastAccessedTime(SessionUpdateRemappingFunction function) {
       return function.getLastAccessedTime();
    }

--- a/spring/spring5/spring5-embedded/src/test/java/org/infinispan/spring/embedded/session/InfinispanEmbeddedSessionRepositoryTest.java
+++ b/spring/spring5/spring5-embedded/src/test/java/org/infinispan/spring/embedded/session/InfinispanEmbeddedSessionRepositoryTest.java
@@ -80,8 +80,8 @@ public class InfinispanEmbeddedSessionRepositoryTest extends InfinispanSessionRe
    }
 
    @Override
-   public void testSavingSession() throws Exception {
-      super.testSavingSession();
+   public void testSavingNewSession() throws Exception {
+      super.testSavingNewSession();
    }
 
    @Override

--- a/spring/spring5/spring5-remote/src/test/java/org/infinispan/spring/remote/session/InfinispanRemoteSessionRepositoryTest.java
+++ b/spring/spring5/spring5-remote/src/test/java/org/infinispan/spring/remote/session/InfinispanRemoteSessionRepositoryTest.java
@@ -95,8 +95,8 @@ public class InfinispanRemoteSessionRepositoryTest extends InfinispanSessionRepo
    }
 
    @Override
-   public void testSavingSession() throws Exception {
-      super.testSavingSession();
+   public void testSavingNewSession() throws Exception {
+      super.testSavingNewSession();
    }
 
    @Override

--- a/spring/spring6/spring6-common/src/main/java/org/infinispan/spring/common/session/SessionUpdateRemappingFunctionProtoAdapter.java
+++ b/spring/spring6/spring6-common/src/main/java/org/infinispan/spring/common/session/SessionUpdateRemappingFunctionProtoAdapter.java
@@ -11,6 +11,8 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -33,11 +35,15 @@ public class SessionUpdateRemappingFunctionProtoAdapter {
       if (maxInactiveSeconds != null) {
          function.setMaxInactiveInterval(Duration.ofSeconds(maxInactiveSeconds));
       }
-      function.setDelta(attributes.stream().collect(Collectors.toMap(SessionAttribute::getName, SessionAttribute::getValue)));
+      Map<String,Object> delta = new HashMap<>();
+      for (SessionAttribute attribute : attributes) {
+         delta.put(attribute.getName(), attribute.getValue());
+      }
+      function.setDelta(delta);
       return function;
    }
 
-   @ProtoField(number = 1, defaultValue = "0")
+   @ProtoField(number = 1)
    Instant getLastAccessedTime(SessionUpdateRemappingFunction function) {
       return function.getLastAccessedTime();
    }

--- a/spring/spring6/spring6-embedded/src/test/java/org/infinispan/spring/embedded/session/InfinispanEmbeddedProtostreamSessionRepositoryTest.java
+++ b/spring/spring6/spring6-embedded/src/test/java/org/infinispan/spring/embedded/session/InfinispanEmbeddedProtostreamSessionRepositoryTest.java
@@ -85,8 +85,8 @@ public class InfinispanEmbeddedProtostreamSessionRepositoryTest extends Infinisp
    }
 
    @Override
-   public void testSavingSession() throws Exception {
-      super.testSavingSession();
+   public void testSavingNewSession() throws Exception {
+      super.testSavingNewSession();
    }
 
    @Override

--- a/spring/spring6/spring6-embedded/src/test/java/org/infinispan/spring/embedded/session/InfinispanEmbeddedSessionRepositoryTest.java
+++ b/spring/spring6/spring6-embedded/src/test/java/org/infinispan/spring/embedded/session/InfinispanEmbeddedSessionRepositoryTest.java
@@ -85,8 +85,8 @@ public class InfinispanEmbeddedSessionRepositoryTest extends InfinispanSessionRe
    }
 
    @Override
-   public void testSavingSession() throws Exception {
-      super.testSavingSession();
+   public void testSavingNewSession() throws Exception {
+      super.testSavingNewSession();
    }
 
    @Override

--- a/spring/spring6/spring6-remote/src/test/java/org/infinispan/spring/remote/session/InfinispanRemoteProtostreamSessionRepositoryTest.java
+++ b/spring/spring6/spring6-remote/src/test/java/org/infinispan/spring/remote/session/InfinispanRemoteProtostreamSessionRepositoryTest.java
@@ -100,8 +100,8 @@ public class InfinispanRemoteProtostreamSessionRepositoryTest extends Infinispan
    }
 
    @Override
-   public void testSavingSession() throws Exception {
-      super.testSavingSession();
+   public void testSavingNewSession() throws Exception {
+      super.testSavingNewSession();
    }
 
    @Override

--- a/spring/spring6/spring6-remote/src/test/java/org/infinispan/spring/remote/session/InfinispanRemoteSessionRepositoryTest.java
+++ b/spring/spring6/spring6-remote/src/test/java/org/infinispan/spring/remote/session/InfinispanRemoteSessionRepositoryTest.java
@@ -100,8 +100,8 @@ public class InfinispanRemoteSessionRepositoryTest extends InfinispanSessionRepo
    }
 
    @Override
-   public void testSavingSession() throws Exception {
-      super.testSavingSession();
+   public void testSavingNewSession() throws Exception {
+      super.testSavingNewSession();
    }
 
    @Override


### PR DESCRIPTION
Added more tests to cover the change tracking in `InfinispanSession`. Specifically, ensure that the session attributes, max inactive duration and last accessed time are updated in the Infinispan cache if they are changed. Also, added tests for the various FlushMode and SaveMode settings.

Fixed a `NullPointerException` in `SessionUpdateRemappingFunctionProtoAdapter` which occurred when a session attribute was removed, i.e. the `SessionAttribute` value was null.

Fixed a serialisation issue `SessionUpdateRemappingFunctionProtoAdapter` which caused the last accessed time to be set to the epoch value if the session's last accessed time hadn't been changed.