### PR TITLE
ISPN-14541 Note about marshalling circular objects

### DIFF
--- a/documentation/src/main/asciidoc/topics/con_protobuf_encoding.adoc
+++ b/documentation/src/main/asciidoc/topics/con_protobuf_encoding.adoc
@@ -12,6 +12,12 @@ The following example shows a Protobuf message that describes a `Person` object:
 include::protobuf/personalshopper.proto[]
 ----
 
+[NOTE]
+====
+Protobuf does not support circular objects.
+Use Java serialization or JBoss Marshalling to marshall circular objects.
+====
+
 [discrete]
 == Interoperability
 

--- a/documentation/src/main/asciidoc/topics/json/off_heap_memory.json
+++ b/documentation/src/main/asciidoc/topics/json/off_heap_memory.json
@@ -1,7 +1,7 @@
 {
   "replicated-cache" : {
     "memory" : {
-      "storage" : "OBJECT",
+      "storage" : "OFF_HEAP",
       "max-count" : "500"
     }
   }


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-14541 & https://issues.redhat.com/browse/ISPN-14540
needs backport to 14.0.x
Docs:

Protobuf does not support circular objects
Fix config example