### PR TITLE
ISPN-14571 Propagate errors in REST chunked response

### DIFF
--- a/client/rest-client/src/main/java/org/infinispan/client/rest/impl/okhttp/RestClientOkHttp.java
+++ b/client/rest-client/src/main/java/org/infinispan/client/rest/impl/okhttp/RestClientOkHttp.java
@@ -116,6 +116,8 @@ public class RestClientOkHttp implements RestClient {
             } else {
                builder.protocols(Arrays.asList(Protocol.HTTP_2, Protocol.HTTP_1_1));
             }
+            // OkHttp might retry infinitely on HTTP/2.
+            builder.retryOnConnectionFailure(false);
             break;
       }
 

--- a/server/rest/src/main/java/org/infinispan/rest/stream/CacheChunkedStream.java
+++ b/server/rest/src/main/java/org/infinispan/rest/stream/CacheChunkedStream.java
@@ -6,7 +6,6 @@ import java.util.Objects;
 import org.infinispan.commons.marshall.WrappedByteArray;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
-import org.reactivestreams.Publisher;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
@@ -17,6 +16,7 @@ import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import io.reactivex.rxjava3.subscribers.DefaultSubscriber;
+import org.reactivestreams.Publisher;
 
 public abstract class CacheChunkedStream<T> {
    protected static final Log logger = LogFactory.getLog(CacheChunkedStream.class);
@@ -114,6 +114,7 @@ public abstract class CacheChunkedStream<T> {
             pendingBuffer = null;
          }
          cancel();
+         ctx.close();
       }
 
       @Override


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-14571

It doesn't seem the nicest way. If an error happens midway through writing the chunked response (key and entries), we cancel the stream, write HTTP last content, and add a trailer header with the exception message.