### PR TITLE
[14.0.x] ISPN-14573 AbstractAuthorization.testRestServerNodeReport is failing

### DIFF
--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/core/ContainerInfinispanServerDriver.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/core/ContainerInfinispanServerDriver.java
@@ -238,6 +238,7 @@ public class ContainerInfinispanServerDriver extends AbstractInfinispanServerDri
          builder
                .copy("lib", serverPathFrom("lib"))
                .user("root")
+               .run("microdnf update && microdnf install tar && microdnf clean all")
                .run("chown", "-R", IMAGE_USER, INFINISPAN_SERVER_HOME)
                .run("chmod", "-R", "g+rw", INFINISPAN_SERVER_HOME)
                .user(IMAGE_USER);


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-14573

Backporting the changes to the container and report method, but 14.0.x doesn't seem to have the failing test.