### PR TITLE
ISPN-14593 A thread dump shuld be triggered in case of CacheBackpress…

### DIFF
--- a/commons/all/src/main/java/org/infinispan/commons/util/TimedThreadDump.java
+++ b/commons/all/src/main/java/org/infinispan/commons/util/TimedThreadDump.java
@@ -1,0 +1,45 @@
+package org.infinispan.commons.util;
+
+import java.util.concurrent.TimeUnit;
+
+import org.infinispan.commons.logging.Log;
+import org.infinispan.commons.logging.LogFactory;
+
+public class TimedThreadDump {
+   private static final Log log = LogFactory.getLog(TimedThreadDump.class);
+
+   private final long interval;
+   private long lastUse = 0;
+
+   private TimedThreadDump() {
+      this.interval = TimeUnit.SECONDS.toMillis(Long.getLong("infinispan.backpressure.dump.interval.sec", 60));
+   }
+
+   private static final TimedThreadDump INSTANCE = new TimedThreadDump();
+
+   public static TimedThreadDump instance() {
+      return INSTANCE;
+   }
+
+   public static boolean generateThreadDump() {
+      return instance().generateThreadDump(System.currentTimeMillis());
+   }
+
+   private boolean generateThreadDump(long millisTime) {
+      if (log.isTraceEnabled()) {
+         boolean dump;
+         synchronized (this) {
+            dump = lastUse + interval < millisTime;
+            if (dump) {
+               lastUse = millisTime;
+            }
+         }
+
+         if (dump) {
+            log.trace(Util.threadDump());
+            return true;
+         }
+      }
+      return false;
+   }
+}

--- a/commons/all/src/main/java/org/infinispan/commons/util/concurrent/CacheBackpressureFullException.java
+++ b/commons/all/src/main/java/org/infinispan/commons/util/concurrent/CacheBackpressureFullException.java
@@ -1,6 +1,7 @@
 package org.infinispan.commons.util.concurrent;
 
 import org.infinispan.commons.CacheException;
+import org.infinispan.commons.util.TimedThreadDump;
 
 /**
  * A {@link CacheException} that is thrown when the backpressure has been filled an unable to process the request. This
@@ -8,4 +9,8 @@ import org.infinispan.commons.CacheException;
  * high. This can be remedied by reducing the load or increasing the backpressure handling (usually buffering of some sort).
  */
 public class CacheBackpressureFullException extends CacheException {
+
+   public CacheBackpressureFullException() {
+      TimedThreadDump.generateThreadDump();
+   }
 }

--- a/commons/all/src/test/java/org/infinispan/commons/util/TimedThreadDumpTest.java
+++ b/commons/all/src/test/java/org/infinispan/commons/util/TimedThreadDumpTest.java
@@ -1,0 +1,19 @@
+package org.infinispan.commons.util;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TimedThreadDumpTest {
+
+   static {
+      Configurator.setLevel("org.infinispan.commons.util.TimedThreadDump", Level.TRACE);
+   }
+
+   @Test
+   public void dumpThreadsOnlyOnce() {
+      Assert.assertTrue(TimedThreadDump.generateThreadDump());
+      Assert.assertFalse(TimedThreadDump.generateThreadDump());
+   }
+}


### PR DESCRIPTION
…ureFullException

https://issues.redhat.com/browse/ISPN-14593

A tentative approach of generating a thread dump on a CacheBackpressureFullException. This implementation keeps track of the time of the last thread dump, by default 60 secs, and only dumps again after that. This would generate a dump **before** throwing an exception.