### PR TITLE
ISPN-14583 RESP endpoint should bundle flush calls to allow pipelining

### DIFF
--- a/server/resp/src/main/java/org/infinispan/server/resp/BaseRespDecoder.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/BaseRespDecoder.java
@@ -14,13 +14,95 @@ import io.netty.handler.codec.ByteToMessageDecoder;
 
 public abstract class BaseRespDecoder extends ByteToMessageDecoder {
    protected final static Log log = LogFactory.getLog(RespDecoder.class, Log.class);
+   protected final static int MINIMUM_BUFFER_SIZE;
    protected final Intrinsics.Resp2LongProcessor longProcessor = new Intrinsics.Resp2LongProcessor();
    protected RespRequestHandler requestHandler;
+
+   protected ByteBuf outboundBuffer;
+   // Variable to resume auto read when channel can be written to again. Some commands may resume themselves after
+   // flush and may not want to also resume on writability changes
+   protected boolean resumeAutoReadOnWritability;
+
+   static {
+      MINIMUM_BUFFER_SIZE = Integer.parseInt(System.getProperty("infinispan.resp.minimum-buffer-size", "4096"));
+   }
+
+   protected ByteBuf allocateBuffer(ChannelHandlerContext ctx, int size) {
+      if (outboundBuffer != null) {
+         if (outboundBuffer.writableBytes() > size) {
+            return outboundBuffer;
+         }
+         log.tracef("Writing buffer %s as request is larger than remaining", outboundBuffer);
+         ctx.write(outboundBuffer, ctx.voidPromise());
+      }
+      int allocatedSize = Math.max(size, MINIMUM_BUFFER_SIZE);
+      outboundBuffer = ctx.alloc().buffer(allocatedSize, allocatedSize);
+      return outboundBuffer;
+   }
+
+   private void flushBufferIfNeeded(ChannelHandlerContext ctx, boolean runOnEventLoop) {
+      if (outboundBuffer != null) {
+         log.tracef("Writing and flushing buffer %s", outboundBuffer);
+         if (runOnEventLoop) {
+            ctx.channel().eventLoop().execute(() -> {
+               ctx.writeAndFlush(outboundBuffer, ctx.voidPromise());
+               outboundBuffer = null;
+            });
+         } else {
+            ctx.writeAndFlush(outboundBuffer, ctx.voidPromise());
+            outboundBuffer = null;
+         }
+      }
+   }
+
+   @Override
+   public void channelRegistered(ChannelHandlerContext ctx) throws Exception {
+      ctx.channel().attr(RespRequestHandler.BYTE_BUF_POOL_ATTRIBUTE_KEY)
+            .set(size -> allocateBuffer(ctx, size));
+      super.channelRegistered(ctx);
+   }
 
    @Override
    public void channelUnregistered(ChannelHandlerContext ctx) throws Exception {
       super.channelUnregistered(ctx);
       requestHandler.handleChannelDisconnect(ctx);
+   }
+
+   @Override
+   public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
+      // We may disable auto read until a command completes or flush. This is useful because some operations may need
+      // do a flush and then resume auto read. If the flush caused writability change we don't want to resume twice
+      if (ctx.channel().config().isAutoRead()) {
+         flushBufferIfNeeded(ctx, false);
+      }
+      super.channelReadComplete(ctx);
+   }
+
+   @Override
+   public void channelWritabilityChanged(ChannelHandlerContext ctx) throws Exception {
+      if (resumeAutoReadOnWritability && ctx.channel().isWritable()) {
+         resumeAutoReadOnWritability = false;
+         // Schedule a read resume after we are done to prevent stack overflow
+         ctx.channel().eventLoop().execute(() -> attemptReadResume(ctx));
+      }
+      super.channelWritabilityChanged(ctx);
+   }
+
+   protected void attemptReadResume(ChannelHandlerContext ctx) {
+      log.tracef("Re-enabling auto read for channel %s as previous command is complete", ctx.channel());
+      ctx.channel().config().setAutoRead(true);
+      // If there is any readable bytes left before we paused make sure to try to decode, just in case
+      // if a pending message was read before we disabled auto read
+      ByteBuf buf = internalBuffer();
+      if (buf.isReadable()) {
+         log.tracef("Bytes available from previous read for channel %s, trying decode directly", ctx.channel());
+         // callDecode will call us until the ByteBuf is no longer consumed
+         callDecode(ctx, buf, List.of());
+         // It is possible the decode above filled our outbound buffer again, so we can only flush if auto read is still enabled
+         if (ctx.channel().config().isAutoRead()) {
+            flushBufferIfNeeded(ctx, false);
+         }
+      }
    }
 
    /**
@@ -40,6 +122,14 @@ public abstract class BaseRespDecoder extends ByteToMessageDecoder {
       CompletionStage<RespRequestHandler> stage = requestHandler.handleRequest(ctx, command, arguments);
       if (CompletionStages.isCompletedSuccessfully(stage)) {
          requestHandler = CompletionStages.join(stage);
+         if (outboundBuffer != null && outboundBuffer.readableBytes() > ctx.channel().bytesBeforeUnwritable()) {
+            log.tracef("Buffer will cause channel %s to be unwriteable - forcing flush", ctx.channel());
+            // Note the flush is done later after this task completes, since we don't want to resume reading yet
+            flushBufferIfNeeded(ctx, true);
+            ctx.channel().config().setAutoRead(false);
+            resumeAutoReadOnWritability = true;
+            return false;
+         }
          return true;
       }
       log.tracef("Disabling auto read for channel %s until previous command is complete", ctx.channel());
@@ -47,23 +137,15 @@ public abstract class BaseRespDecoder extends ByteToMessageDecoder {
       ctx.channel().config().setAutoRead(false);
       stage.whenComplete((handler, t) -> {
          assert ctx.channel().eventLoop().inEventLoop();
-         log.tracef("Re-enabling auto read for channel %s as previous command is complete", ctx.channel());
-         ctx.channel().config().setAutoRead(true);
          if (t != null) {
             exceptionCaught(ctx, t);
-         } else {
-            // Instate the new handler if there was no exception
-            requestHandler = handler;
+            return;
          }
-
-         // If there is any readable bytes left before we paused make sure to try to decode, just in case
-         // if a pending message was read before we disabled auto read
-         ByteBuf buf = internalBuffer();
-         if (buf.isReadable()) {
-            log.tracef("Bytes available from previous read for channel %s, trying decode directly", ctx.channel());
-            // callDecode will call us until the ByteBuf is no longer consumed
-            callDecode(ctx, buf, List.of());
-         }
+         // Instate the new handler if there was no exception
+         requestHandler = handler;
+         flushBufferIfNeeded(ctx, false);
+         // Schedule a read resume after we are done to prevent stack overflow
+         ctx.channel().eventLoop().execute(() -> attemptReadResume(ctx));
       });
       return false;
    }
@@ -71,7 +153,8 @@ public abstract class BaseRespDecoder extends ByteToMessageDecoder {
    @Override
    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
       log.unexpectedException(cause);
-      ctx.writeAndFlush(RespRequestHandler.stringToByteBuf("-ERR Server Error Encountered: " + cause.getMessage() + "\\r\\n", ctx.alloc()));
+      RespRequestHandler.stringToByteBuf("-ERR Server Error Encountered: " + cause.getMessage() + "\\r\\n", requestHandler.allocatorToUse);
+      flushBufferIfNeeded(ctx, false);
       ctx.close();
    }
 }

--- a/server/resp/src/main/java/org/infinispan/server/resp/ByteBufPool.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/ByteBufPool.java
@@ -1,0 +1,22 @@
+package org.infinispan.server.resp;
+
+import java.util.function.IntFunction;
+
+import io.netty.buffer.ByteBuf;
+
+@FunctionalInterface
+public interface ByteBufPool extends IntFunction<ByteBuf> {
+   /**
+    * This method will return a pooled ByteBuf.
+    * This buffer may already have bytes written to it.
+    * A caller should only ever write additional bytes to the buffer and not change it in any other way.
+    * <p>
+    * The returned ByteBuf should never be written as the decoder will handle this instead
+    *
+    * @param requiredSize The amount of bytes required to be writable into the ByteBuf
+    * @return a ByteBuf to write those bytes to
+    */
+   default ByteBuf acquire(int requiredSize) {
+      return apply(requiredSize);
+   }
+}

--- a/server/resp/src/main/java/org/infinispan/server/resp/Resp3AuthHandler.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/Resp3AuthHandler.java
@@ -1,7 +1,5 @@
 package org.infinispan.server.resp;
 
-import static org.infinispan.server.resp.Resp3Handler.statusOK;
-
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
@@ -21,21 +19,21 @@ public class Resp3AuthHandler extends CacheRespRequestHandler {
    }
 
    @Override
-   public CompletionStage<RespRequestHandler> handleRequest(ChannelHandlerContext ctx, String type, List<byte[]> arguments) {
+   protected CompletionStage<RespRequestHandler> actualHandleRequest(ChannelHandlerContext ctx, String type, List<byte[]> arguments) {
       CompletionStage<Boolean> successStage = null;
       switch (type) {
          case "HELLO":
             byte[] respProtocolBytes = arguments.get(0);
             String version = new String(respProtocolBytes, CharsetUtil.UTF_8);
             if (!version.equals("3")) {
-               ctx.writeAndFlush(RespRequestHandler.stringToByteBuf("-NOPROTO sorry this protocol version is not supported\r\n", ctx.alloc()), ctx.voidPromise());
+               stringToByteBuf("-NOPROTO sorry this protocol version is not supported\r\n", allocatorToUse);
                break;
             }
 
             if (arguments.size() == 4) {
                successStage = performAuth(ctx, arguments.get(2), arguments.get(3));
             } else {
-               helloResponse(ctx);
+               helloResponse(ctx, allocatorToUse);
             }
             break;
          case "AUTH":
@@ -45,7 +43,7 @@ public class Resp3AuthHandler extends CacheRespRequestHandler {
             ctx.close();
             break;
          default:
-            if (isAuthorized()) super.handleRequest(ctx, type, arguments);
+            if (isAuthorized()) super.actualHandleRequest(ctx, type, arguments);
             else handleUnauthorized(ctx);
       }
 
@@ -78,33 +76,33 @@ public class Resp3AuthHandler extends CacheRespRequestHandler {
    private boolean handleAuthResponse(ChannelHandlerContext ctx, Subject subject) {
       assert ctx.channel().eventLoop().inEventLoop();
       if (subject == null) {
-         ctx.writeAndFlush(RespRequestHandler.stringToByteBuf("-ERR Client sent AUTH, but no password is set\r\n", ctx.alloc()), ctx.voidPromise());
+         stringToByteBuf("-ERR Client sent AUTH, but no password is set\r\n", allocatorToUse);
          return false;
       }
 
       cache = cache.withSubject(subject);
-      ctx.writeAndFlush(statusOK(), ctx.voidPromise());
+      Resp3Handler.OK_BICONSUMER.accept(null, allocatorToUse);
       return true;
    }
 
    private void handleUnauthorized(ChannelHandlerContext ctx) {
       assert ctx.channel().eventLoop().inEventLoop();
-      ctx.writeAndFlush(RespRequestHandler.stringToByteBuf("-WRONGPASS invalid username-password pair or user is disabled.\r\n", ctx.alloc()), ctx.voidPromise());
+      stringToByteBuf("-WRONGPASS invalid username-password pair or user is disabled.\r\n", allocatorToUse);
    }
 
    private boolean isAuthorized() {
       return this.getClass() != Resp3AuthHandler.class;
    }
 
-   private static void helloResponse(ChannelHandlerContext ctx) {
+   private static void helloResponse(ChannelHandlerContext ctx, ByteBufPool alloc) {
       String versionString = Version.getBrandVersion();
-      ctx.writeAndFlush(RespRequestHandler.stringToByteBuf("%7\r\n" +
+      RespRequestHandler.stringToByteBuf("%7\r\n" +
             "$6\r\nserver\r\n$15\r\nInfinispan RESP\r\n" +
             "$7\r\nversion\r\n$" + versionString.length() + "\r\n" + versionString + "\r\n" +
             "$5\r\nproto\r\n:3\r\n" +
             "$2\r\nid\r\n:184\r\n" +
             "$4\r\nmode\r\n$7\r\ncluster\r\n" +
             "$4\r\nrole\r\n$6\r\nmaster\r\n" +
-            "$7\r\nmodules\r\n*0\r\n", ctx.alloc()), ctx.voidPromise());
+            "$7\r\nmodules\r\n*0\r\n", alloc);
    }
 }

--- a/server/resp/src/main/java/org/infinispan/server/resp/Resp3Handler.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/Resp3Handler.java
@@ -9,101 +9,61 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
 
 import org.infinispan.Cache;
 import org.infinispan.commons.CacheException;
 import org.infinispan.commons.logging.LogFactory;
 import org.infinispan.server.core.logging.Log;
-import org.infinispan.server.core.transport.NativeTransport;
 import org.infinispan.util.concurrent.AggregateCompletionStage;
 import org.infinispan.util.concurrent.CompletionStages;
-import org.infinispan.util.function.TriConsumer;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
-import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.CharsetUtil;
 
 public class Resp3Handler extends Resp3AuthHandler {
    private static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass(), Log.class);
-   private static final ByteBuf OK;
-
-   static {
-      if (NativeTransport.USE_NATIVE_EPOLL || NativeTransport.USE_NATIVE_IOURING) {
-         OK = Unpooled.unreleasableBuffer(Unpooled.directBuffer(5, 5));
-      } else {
-         OK = Unpooled.unreleasableBuffer(Unpooled.buffer(5, 5));
-      }
-      OK.writeCharSequence("+OK\r\n", CharsetUtil.US_ASCII);
-   }
+   static final byte[] OK = "+OK\r\n".getBytes(StandardCharsets.US_ASCII);
 
    Resp3Handler(RespServer respServer) {
       super(respServer);
    }
 
-   // Returns a cached OK status that is retained for multiple uses
-   static ByteBuf statusOK() {
-      return OK.duplicate();
-   }
-
-   private static final TriConsumer<byte[], ChannelHandlerContext, Throwable> GET_TRICONSUMER = (innerValueBytes, innerCtx, t) -> {
-      if (t != null) {
-         log.trace("Exception encountered while performing GET", t);
-         handleThrowable(innerCtx, t);
-      } else if (innerValueBytes != null) {
-         ByteBuf buf = bytesToResult(innerValueBytes, innerCtx.alloc());
-         innerCtx.writeAndFlush(buf, innerCtx.voidPromise());
+   protected static final BiConsumer<byte[], ByteBufPool> GET_TRICONSUMER = (innerValueBytes, alloc) -> {
+      if (innerValueBytes != null) {
+         bytesToResult(innerValueBytes, alloc);
       } else {
-         innerCtx.writeAndFlush(RespRequestHandler.stringToByteBuf("$-1\r\n", innerCtx.alloc()), innerCtx.voidPromise());
+         stringToByteBuf("$-1\r\n", alloc);
       }
    };
 
-   private static final TriConsumer<byte[], ChannelHandlerContext, Throwable> SET_TRICONSUMER = (ignore, innerCtx, t) -> {
-      if (t != null) {
-         log.trace("Exception encountered while performing SET", t);
-         handleThrowable(innerCtx, t);
-      } else {
-         innerCtx.writeAndFlush(statusOK(), innerCtx.voidPromise());
-      }
-   };
+   protected static final BiConsumer<Object, ByteBufPool> OK_BICONSUMER = (ignore, alloc) ->
+         alloc.acquire(OK.length).writeBytes(OK);
 
-   private static final TriConsumer<Long, ChannelHandlerContext, Throwable> INCDEC_TRICONSUMER = (longValue, innerCtx, t) -> {
-      if (t != null) {
-         handleThrowable(innerCtx, t);
-      } else {
-         handleLongResult(innerCtx, longValue);
-      }
-   };
+   protected static final BiConsumer<Long, ByteBufPool> LONG_BICONSUMER = Resp3Handler::handleLongResult;
 
-   private static final TriConsumer<byte[], ChannelHandlerContext, Throwable> DELETE_TRICONSUMER = (prev, innerCtx, t) -> {
-      if (t != null) {
-         log.trace("Exception encountered while performing DEL", t);
-         handleThrowable(innerCtx, t);
-         return;
-      }
-      innerCtx.writeAndFlush(RespRequestHandler.stringToByteBuf(":" + (prev == null ? "0" : "1") +
-            "\r\n", innerCtx.alloc()), innerCtx.voidPromise());
-   };
+   protected static final BiConsumer<byte[], ByteBufPool> DELETE_BICONSUMER = (prev, alloc) ->
+         stringToByteBuf(":" + (prev == null ? "0" : "1") + "\r\n", alloc);
 
    @Override
-   public CompletionStage<RespRequestHandler> handleRequest(ChannelHandlerContext ctx, String type, List<byte[]> arguments) {
+   protected CompletionStage<RespRequestHandler> actualHandleRequest(ChannelHandlerContext ctx, String type, List<byte[]> arguments) {
       switch (type) {
          case "PING":
             if (arguments.size() == 0) {
-               ctx.writeAndFlush(RespRequestHandler.stringToByteBuf("$4\r\nPONG\r\n", ctx.alloc()), ctx.voidPromise());
+               stringToByteBuf("$4\r\nPONG\r\n", allocatorToUse);
                break;
             }
             // falls-through
          case "ECHO":
             byte[] argument = arguments.get(0);
-            ByteBuf bufferToWrite = RespRequestHandler.stringToByteBufWithExtra("$" + argument.length + "\r\n", ctx.alloc(), argument.length + 2);
+            ByteBuf bufferToWrite = stringToByteBufWithExtra("$" + argument.length + "\r\n", allocatorToUse, argument.length + 2);
             bufferToWrite.writeBytes(argument);
             bufferToWrite.writeByte('\r').writeByte('\n');
-            ctx.writeAndFlush(bufferToWrite, ctx.voidPromise());
             break;
          case "SET":
-            return stageToReturn(cache.putAsync(arguments.get(0), arguments.get(1)), ctx, SET_TRICONSUMER);
+            return stageToReturn(cache.putAsync(arguments.get(0), arguments.get(1)), ctx, OK_BICONSUMER);
          case "GET":
             byte[] keyBytes = arguments.get(0);
 
@@ -115,62 +75,57 @@ public class Resp3Handler extends Resp3AuthHandler {
          case "MSET":
             return performMset(ctx, cache, arguments);
          case "INCR":
-            return stageToReturn(counterIncOrDec(cache, arguments.get(0), true), ctx, INCDEC_TRICONSUMER);
+            return stageToReturn(counterIncOrDec(cache, arguments.get(0), true), ctx, LONG_BICONSUMER);
          case "DECR":
-            return stageToReturn(counterIncOrDec(cache, arguments.get(0), false), ctx, INCDEC_TRICONSUMER);
+            return stageToReturn(counterIncOrDec(cache, arguments.get(0), false), ctx, LONG_BICONSUMER);
          case "CONFIG":
             String getOrSet = new String(arguments.get(0), StandardCharsets.UTF_8);
             String name = new String(arguments.get(1), StandardCharsets.UTF_8);
 
             if ("GET".equalsIgnoreCase(getOrSet)) {
                if ("appendonly".equalsIgnoreCase(name)) {
-                  ctx.writeAndFlush(RespRequestHandler.stringToByteBuf("*2\r\n+" + name + "\r\n+no\r\n", ctx.alloc()), ctx.voidPromise());
+                  stringToByteBuf("*2\r\n+" + name + "\r\n+no\r\n", allocatorToUse);
                } else if (name.indexOf('*') != -1 || name.indexOf('?') != -1) {
-                  ctx.writeAndFlush(RespRequestHandler.stringToByteBuf("-ERR CONFIG blob pattern matching not implemented\r\n", ctx.alloc()), ctx.voidPromise());
+                  stringToByteBuf("-ERR CONFIG blob pattern matching not implemented\r\n", allocatorToUse);
                } else {
-                  ctx.writeAndFlush(RespRequestHandler.stringToByteBuf("*2\r\n+" + name + "\r\n+\r\n", ctx.alloc()), ctx.voidPromise());
+                  stringToByteBuf("*2\r\n+" + name + "\r\n+\r\n", allocatorToUse);
                }
             } else if ("SET".equalsIgnoreCase(getOrSet)) {
-               ctx.writeAndFlush(statusOK(), ctx.voidPromise());
+               OK_BICONSUMER.accept(null, allocatorToUse);
             } else {
-               ctx.writeAndFlush(RespRequestHandler.stringToByteBuf("-ERR CONFIG " + getOrSet + " not implemented\r\n", ctx.alloc()), ctx.voidPromise());
+               stringToByteBuf("-ERR CONFIG " + getOrSet + " not implemented\r\n", allocatorToUse);
             }
             break;
          case "INFO":
-            ctx.writeAndFlush(RespRequestHandler.stringToByteBuf("-ERR not implemented yet\r\n", ctx.alloc()), ctx.voidPromise());
+            stringToByteBuf("-ERR not implemented yet\r\n", allocatorToUse);
             break;
          case "PUBLISH":
             // TODO: should we return the # of subscribers on this node?
             // We use expiration to remove the event values eventually while preventing them during high periods of
             // updates
-            return stageToReturn(cache.putAsync(SubscriberHandler.keyToChannel(arguments.get(0)), arguments.get(1), 3, TimeUnit.SECONDS), ctx, (ignore, innerCtx, t) -> {
-               if (t != null) {
-                  log.trace("Exception encountered while performing PUBLISH", t);
-                  handleThrowable(innerCtx, t);
-               } else {
-                  innerCtx.writeAndFlush(RespRequestHandler.stringToByteBuf(":0\r\n", ctx.alloc()), innerCtx.voidPromise());
-               }
+            return stageToReturn(cache.putAsync(SubscriberHandler.keyToChannel(arguments.get(0)), arguments.get(1), 3, TimeUnit.SECONDS), ctx, (ignore, alloc) -> {
+               stringToByteBuf(":0\r\n", alloc);
             });
          case "SUBSCRIBE":
             SubscriberHandler subscriberHandler = new SubscriberHandler(respServer, this);
             return subscriberHandler.handleRequest(ctx, type, arguments);
          case "SELECT":
-            ctx.writeAndFlush(RespRequestHandler.stringToByteBuf("-ERR Select not supported in cluster mode\r\n", ctx.alloc()), ctx.voidPromise());
+            stringToByteBuf("-ERR Select not supported in cluster mode\r\n", allocatorToUse);
             break;
          case "READWRITE":
          case "READONLY":
             // We are always in read write allowing read from backups
-            ctx.writeAndFlush(statusOK(), ctx.voidPromise());
+            OK_BICONSUMER.accept(null, allocatorToUse);
             break;
          case "RESET":
-            ctx.writeAndFlush(RespRequestHandler.stringToByteBuf("+RESET\r\n", ctx.alloc()), ctx.voidPromise());
+            stringToByteBuf("+RESET\r\n", allocatorToUse);
             if (respServer.getConfiguration().authentication().enabled()) {
                return CompletableFuture.completedFuture(new Resp3AuthHandler(respServer));
             }
             break;
          case "COMMAND":
             if (!arguments.isEmpty()) {
-               ctx.writeAndFlush(RespRequestHandler.stringToByteBuf("-ERR COMMAND does not currently support arguments\r\n", ctx.alloc()), ctx.voidPromise());
+               stringToByteBuf("-ERR COMMAND does not currently support arguments\r\n", allocatorToUse);
                break;
             }
             StringBuilder commandBuilder = new StringBuilder();
@@ -196,10 +151,10 @@ public class Resp3Handler extends Resp3AuthHandler {
             addCommand(commandBuilder, "RESET", 1, 0, 0, 0);
             addCommand(commandBuilder, "QUIT", 1, 0, 0, 0);
             addCommand(commandBuilder, "COMMAND", -1, 0, 0, 0);
-            ctx.writeAndFlush(RespRequestHandler.stringToByteBuf(commandBuilder.toString(), ctx.alloc()), ctx.voidPromise());
+            stringToByteBuf(commandBuilder.toString(), allocatorToUse);
             break;
          default:
-            return super.handleRequest(ctx, type, arguments);
+            return super.actualHandleRequest(ctx, type, arguments);
       }
       return myStage;
    }
@@ -221,12 +176,13 @@ public class Resp3Handler extends Resp3AuthHandler {
 
    }
 
-   private static void handleLongResult(ChannelHandlerContext ctx, Long result) {
-      ctx.writeAndFlush(RespRequestHandler.stringToByteBuf(":" + result + "\r\n", ctx.alloc()), ctx.voidPromise());
+   protected static void handleLongResult(Long result, ByteBufPool alloc) {
+      // TODO: this can be optimized to avoid the String allocation
+      stringToByteBuf(":" + result + "\r\n", alloc);
    }
 
-   static void handleThrowable(ChannelHandlerContext ctx, Throwable t) {
-      ctx.writeAndFlush(RespRequestHandler.stringToByteBuf("-ERR" + t.getMessage() + "\r\n", ctx.alloc()), ctx.voidPromise());
+   protected static void handleThrowable(ByteBufPool alloc, Throwable t) {
+      stringToByteBuf("-ERR " + t.getMessage() + "\r\n", alloc);
    }
 
    private static CompletionStage<Long> counterIncOrDec(Cache<byte[], byte[]> cache, byte[] key, boolean increment) {
@@ -268,10 +224,10 @@ public class Resp3Handler extends Resp3AuthHandler {
       int keysToRemove = arguments.size();
       if (keysToRemove == 1) {
          byte[] keyBytes = arguments.get(0);
-         return stageToReturn(cache.removeAsync(keyBytes), ctx, DELETE_TRICONSUMER);
+         return stageToReturn(cache.removeAsync(keyBytes), ctx, DELETE_BICONSUMER);
       } else if (keysToRemove == 0) {
          // TODO: is this an error?
-         ctx.writeAndFlush(RespRequestHandler.stringToByteBuf(":0\r\n", ctx.alloc()), ctx.voidPromise());
+         stringToByteBuf(":0\r\n", allocatorToUse);
          return myStage;
       } else {
          AtomicInteger removes = new AtomicInteger();
@@ -284,13 +240,8 @@ public class Resp3Handler extends Resp3AuthHandler {
                      }
                   }));
          }
-         return stageToReturn(deleteStages.freeze(), ctx, (removals, innerCtx, t) -> {
-            if (t != null) {
-               log.trace("Exception encountered while performing multiple DEL", t);
-               handleThrowable(innerCtx, t);
-               return;
-            }
-            innerCtx.writeAndFlush(RespRequestHandler.stringToByteBuf(":" + removals.get() + "\r\n", innerCtx.alloc()), innerCtx.voidPromise());
+         return stageToReturn(deleteStages.freeze(), ctx, (removals, alloc) -> {
+            stringToByteBuf(":" + removals.get() + "\r\n", alloc);
          });
       }
    }
@@ -298,7 +249,7 @@ public class Resp3Handler extends Resp3AuthHandler {
    private CompletionStage<RespRequestHandler> performMget(ChannelHandlerContext ctx, Cache<byte[], byte[]> cache, List<byte[]> arguments) {
       int keysToRetrieve = arguments.size();
       if (keysToRetrieve == 0) {
-         ctx.writeAndFlush(RespRequestHandler.stringToByteBuf("*0\r\n", ctx.alloc()), ctx.voidPromise());
+         stringToByteBuf("*0\r\n", allocatorToUse);
          return myStage;
       }
       List<byte[]> results = Collections.synchronizedList(Arrays.asList(
@@ -328,16 +279,11 @@ public class Resp3Handler extends Resp3AuthHandler {
                   resultBytesSize.addAndGet(2);
                }));
       }
-      return stageToReturn(getStage.freeze(), ctx, (ignore, innerCtx, t) -> {
-         if (t != null) {
-            log.trace("Exception encountered while performing multiple GET", t);
-            handleThrowable(innerCtx, t);
-            return;
-         }
+      return stageToReturn(getStage.freeze(), ctx, (ignore, alloc) -> {
          int elements = results.size();
          // * + digit length (log10 + 1) + \r\n + accumulated bytes
          int byteAmount = 1 + (int) Math.log10(elements) + 1 + 2 + resultBytesSize.get();
-         ByteBuf byteBuf = innerCtx.alloc().buffer(byteAmount, byteAmount);
+         ByteBuf byteBuf = alloc.apply(byteAmount);
          byteBuf.writeCharSequence("*" + results.size(), CharsetUtil.US_ASCII);
          byteBuf.writeByte('\r');
          byteBuf.writeByte('\n');
@@ -354,7 +300,6 @@ public class Resp3Handler extends Resp3AuthHandler {
             byteBuf.writeByte('\n');
          }
          assert byteBuf.writerIndex() == byteAmount;
-         innerCtx.writeAndFlush(byteBuf, innerCtx.voidPromise());
       });
    }
 
@@ -362,7 +307,7 @@ public class Resp3Handler extends Resp3AuthHandler {
       int keyValuePairCount = arguments.size();
       if ((keyValuePairCount & 1) == 1) {
          log.tracef("Received: %s count for keys and values combined, should be even for MSET", keyValuePairCount);
-         ctx.writeAndFlush(RespRequestHandler.stringToByteBuf("-ERR Missing a value for a key" + "\r\n", ctx.alloc()), ctx.voidPromise());
+         stringToByteBuf("-ERR Missing a value for a key" + "\r\n", allocatorToUse);
          return myStage;
       }
       AggregateCompletionStage<Void> setStage = CompletionStages.aggregateCompletionStage();
@@ -371,13 +316,6 @@ public class Resp3Handler extends Resp3AuthHandler {
          byte[] valueBytes = arguments.get(i + 1);
          setStage.dependsOn(cache.putAsync(keyBytes, valueBytes));
       }
-      return stageToReturn(setStage.freeze(), ctx, (ignore, innerCtx, t) -> {
-         if (t != null) {
-            log.trace("Exception encountered while performing MSET", t);
-            handleThrowable(innerCtx, t);
-         } else {
-            innerCtx.writeAndFlush(statusOK(), innerCtx.voidPromise());
-         }
-      });
+      return stageToReturn(setStage.freeze(), ctx, OK_BICONSUMER);
    }
 }

--- a/server/resp/src/test/java/org/infinispan/server/resp/RespDecoderTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/RespDecoderTest.java
@@ -48,7 +48,7 @@ public class RespDecoderTest {
       queuedCommands = new ArrayDeque<>();
       RespRequestHandler myRespRequestHandler = new RespRequestHandler() {
          @Override
-         public CompletionStage<RespRequestHandler> handleRequest(ChannelHandlerContext ctx, String type, List<byte[]> arguments) {
+         protected CompletionStage<RespRequestHandler> actualHandleRequest(ChannelHandlerContext ctx, String type, List<byte[]> arguments) {
             queuedCommands.add(new Request(type, arguments));
             return myStage;
          }

--- a/server/resp/src/test/java/org/infinispan/server/resp/RespSingleNodeTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/RespSingleNodeTest.java
@@ -15,15 +15,18 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.infinispan.commons.test.Exceptions;
 import org.infinispan.commons.test.TestResourceTracker;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.server.resp.configuration.RespServerConfiguration;
 import org.infinispan.server.resp.configuration.RespServerConfigurationBuilder;
+import org.infinispan.server.resp.test.CommonRespTests;
 import org.infinispan.server.resp.test.RespTestingUtil;
 import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
@@ -346,5 +349,9 @@ public class RespSingleNodeTest extends SingleCacheManagerTest {
 
    protected RedisPubSubCommands<String, String> createPubSubConnection() {
       return client.connectPubSub().sync();
+   }
+
+   public void testPipeline() throws ExecutionException, InterruptedException, TimeoutException {
+      CommonRespTests.testPipeline(redisConnection);
    }
 }

--- a/server/resp/src/test/java/org/infinispan/server/resp/RespTwoNodeTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/RespTwoNodeTest.java
@@ -20,6 +20,7 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.distribution.DistributionTestHelper;
 import org.infinispan.interceptors.locking.ClusteringDependentLogic;
 import org.infinispan.server.resp.configuration.RespServerConfigurationBuilder;
+import org.infinispan.server.resp.test.CommonRespTests;
 import org.infinispan.server.resp.test.RespTestingUtil;
 import org.infinispan.test.Mocks;
 import org.infinispan.test.MultipleCacheManagersTest;
@@ -102,5 +103,9 @@ public class RespTwoNodeTest extends MultipleCacheManagersTest {
 
       RedisFuture<String> getFuture = redis.get(blockedKey);
       assertEquals("bar", getFuture.get(10, TimeUnit.SECONDS));
+   }
+
+   public void testPipeline() throws ExecutionException, InterruptedException, TimeoutException {
+      CommonRespTests.testPipeline(redisConnection1);
    }
 }

--- a/server/resp/src/test/java/org/infinispan/server/resp/test/CommonRespTests.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/test/CommonRespTests.java
@@ -1,0 +1,82 @@
+package org.infinispan.server.resp.test;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNull;
+
+import java.util.AbstractMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.async.RedisAsyncCommands;
+
+public class CommonRespTests {
+   public static void testPipeline(StatefulRedisConnection<String, String> redisConnection) throws ExecutionException,
+         InterruptedException, TimeoutException {
+      int commandCount = 35;
+      AtomicReference<Throwable> error = new AtomicReference<>();
+      AtomicInteger setCompleted = new AtomicInteger();
+      RedisAsyncCommands<String, String> redis = redisConnection.async();
+      for (int i = 0; i < commandCount; ++i) {
+         redis.set("key-" + i, "value-" + i).whenComplete((___, t) -> {
+            if (t != null) {
+               error.set(t);
+            }
+            setCompleted.incrementAndGet();
+         });
+      }
+      // This will effectively wait for all set commands above to be completed
+      redis.ping().get(10, TimeUnit.SECONDS);
+
+      Throwable throwable = error.get();
+      if (throwable != null) {
+         throw new AssertionError(throwable);
+      }
+
+      AtomicReferenceArray<Map.Entry<String, String>> atomicReferenceArray = new AtomicReferenceArray<>(commandCount + 1);
+      for (int i = 0; i < commandCount; ++i) {
+         String key = "key-" + i;
+
+         if (i == 13) {
+            redis.get("not-present")
+                  .whenComplete((v, t) -> {
+                     if (t != null) {
+                        error.set(t);
+                     } else {
+                        atomicReferenceArray.set(commandCount, new AbstractMap.SimpleEntry<>("key-" + commandCount, v));
+                     }
+                  });
+         }
+         int j = i;
+         redis.get(key).whenComplete((v, t) -> {
+            if (t != null) {
+               error.set(t);
+            } else {
+               atomicReferenceArray.set(j, new AbstractMap.SimpleEntry<>(key, v));
+            }
+         });
+      }
+
+      redis.ping().get(10, TimeUnit.SECONDS);
+
+      throwable = error.get();
+      if (throwable != null) {
+         throw new AssertionError(throwable);
+      }
+
+      for (int i = 0; i < atomicReferenceArray.length(); ++i) {
+         Map.Entry<String, String> entry = atomicReferenceArray.get(i);
+         assertEquals("key-" + i, entry.getKey());
+         if (i == commandCount) {
+            assertNull(entry.getValue());
+         } else {
+            assertEquals("value-" + i, entry.getValue());
+         }
+      }
+   }
+}

--- a/server/router/src/main/java/org/infinispan/server/router/router/impl/singleport/RespDetector.java
+++ b/server/router/src/main/java/org/infinispan/server/router/router/impl/singleport/RespDetector.java
@@ -54,7 +54,8 @@ public class RespDetector extends ByteToMessageDecoder {
 
    private void installRespHandler(ChannelHandlerContext ctx) {
       // We found the RESP handshake, let's do some pipeline surgery
-      ChannelHandlerAdapter dummyHandler = new ChannelHandlerAdapter() {};
+      ChannelHandlerAdapter dummyHandler = new ChannelHandlerAdapter() {
+      };
       ctx.pipeline().addAfter(NAME, "dummy", dummyHandler);
       ChannelHandler channelHandler = ctx.pipeline().removeLast();
       // Remove everything else
@@ -63,6 +64,8 @@ public class RespDetector extends ByteToMessageDecoder {
       }
       // Add the RESP server handler
       ctx.pipeline().addLast(respServer.getInitializer());
+      // Make sure to fire registered on the newly installed handlers
+      ctx.fireChannelRegistered();
       RouterLogger.SERVER.tracef("Detected RESP connection %s", ctx);
    }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-14583

This change makes it so that the Handler itself never writes to the context or channel directly. Instead, the various handlers can request a ByteBuf from a "pool" that can be a cached buffer for the given channel. This allows for pipelined commands to write to the same buffer before flushing either when the end of the pipeline is found or if the channel outbound buffer would be too full.

To support backpressure and having a client may not keep up we check for channel writability and will disable auto read if it is full and resume as necessary when the outbound buffer can be written to again.