### PR TITLE
ISPN-14418 CLI/REST command to recover an incomplete cluster if it ca…

### DIFF
--- a/cli/src/main/java/org/infinispan/cli/commands/Batch.java
+++ b/cli/src/main/java/org/infinispan/cli/commands/Batch.java
@@ -26,6 +26,7 @@ import org.infinispan.cli.commands.rest.Shutdown;
 import org.infinispan.cli.commands.rest.Site;
 import org.infinispan.cli.commands.rest.Stats;
 import org.infinispan.cli.commands.rest.Task;
+import org.infinispan.cli.commands.rest.Topology;
 import org.infinispan.cli.impl.ExitCodeResultHandler;
 
 /**
@@ -74,6 +75,7 @@ import org.infinispan.cli.impl.ExitCodeResultHandler;
             Stats.class,
             Site.class,
             Task.class,
+            Topology.class,
             User.class,
             Version.class
       }, resultHandler = ExitCodeResultHandler.class)

--- a/cli/src/main/java/org/infinispan/cli/commands/CLI.java
+++ b/cli/src/main/java/org/infinispan/cli/commands/CLI.java
@@ -61,6 +61,7 @@ import org.infinispan.cli.commands.rest.Server;
 import org.infinispan.cli.commands.rest.Shutdown;
 import org.infinispan.cli.commands.rest.Site;
 import org.infinispan.cli.commands.rest.Task;
+import org.infinispan.cli.commands.rest.Topology;
 import org.infinispan.cli.completers.ContextAwareCompleterInvocationProvider;
 import org.infinispan.cli.connection.RegexHostnameVerifier;
 import org.infinispan.cli.impl.AeshDelegatingShell;
@@ -133,6 +134,7 @@ import org.wildfly.security.keystore.KeyStoreUtil;
             Shutdown.class,
             Site.class,
             Task.class,
+            Topology.class,
             User.class,
             Version.class
       }, resultHandler = ExitCodeResultHandler.class)

--- a/cli/src/main/java/org/infinispan/cli/commands/rest/Topology.java
+++ b/cli/src/main/java/org/infinispan/cli/commands/rest/Topology.java
@@ -1,0 +1,63 @@
+package org.infinispan.cli.commands.rest;
+
+import java.util.concurrent.CompletionStage;
+
+import org.aesh.command.Command;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.CommandException;
+import org.aesh.command.CommandResult;
+import org.aesh.command.GroupCommandDefinition;
+import org.aesh.command.option.Argument;
+import org.aesh.command.option.Option;
+import org.infinispan.cli.activators.ConnectionActivator;
+import org.infinispan.cli.commands.CliCommand;
+import org.infinispan.cli.completers.CacheCompleter;
+import org.infinispan.cli.impl.ContextAwareCommandInvocation;
+import org.infinispan.cli.resources.CacheResource;
+import org.infinispan.cli.resources.Resource;
+import org.infinispan.client.rest.RestClient;
+import org.infinispan.client.rest.RestResponse;
+import org.kohsuke.MetaInfServices;
+
+@MetaInfServices(Command.class)
+@GroupCommandDefinition(name = "topology", description = "Manages the cluster topology.",
+      activator = ConnectionActivator.class, groupCommands = {Topology.SetStable.class})
+public class Topology extends CliCommand {
+
+   @Option(shortName = 'h', hasValue = false, overrideRequired = true)
+   protected boolean help;
+
+   @Override
+   protected boolean isHelp() {
+      return help;
+   }
+
+   @Override
+   protected CommandResult exec(ContextAwareCommandInvocation invocation) throws CommandException {
+      invocation.println(invocation.getHelpInfo());
+      return CommandResult.FAILURE;
+   }
+
+   @CommandDefinition(name = "set-stable", description = "Set the current topology as stable.", activator = ConnectionActivator.class)
+   public static class SetStable extends RestCliCommand {
+
+      @Option(shortName = 'h', hasValue = false, overrideRequired = true)
+      protected boolean help;
+
+      @Option(shortName = 'f', hasValue = false, overrideRequired = true)
+      protected boolean force;
+
+      @Argument(description = "The cache name to mark topology stable.", completer = CacheCompleter.class)
+      String cacheName;
+
+      @Override
+      protected boolean isHelp() {
+         return help;
+      }
+
+      @Override
+      protected CompletionStage<RestResponse> exec(ContextAwareCommandInvocation invocation, RestClient client, Resource resource) throws Exception {
+         return client.cache(cacheName != null ? cacheName : CacheResource.cacheName(resource)).markTopologyStable(force);
+      }
+   }
+}

--- a/client/rest-client/src/main/java/org/infinispan/client/rest/RestCacheClient.java
+++ b/client/rest-client/src/main/java/org/infinispan/client/rest/RestCacheClient.java
@@ -561,4 +561,9 @@ public interface RestCacheClient {
     * Sets the Cache's Avaialability
     */
    CompletionStage<RestResponse> setAvailability(String availability);
+
+   /**
+    * Force the current cache topology as the stable if not running.
+    */
+   CompletionStage<RestResponse> markTopologyStable(boolean force);
 }

--- a/client/rest-client/src/main/java/org/infinispan/client/rest/impl/okhttp/RestCacheClientOkHttp.java
+++ b/client/rest-client/src/main/java/org/infinispan/client/rest/impl/okhttp/RestCacheClientOkHttp.java
@@ -652,4 +652,13 @@ public class RestCacheClientOkHttp implements RestCacheClient {
                   .url(cacheUrl + "?action=set-availability&availability=" + availability)
       );
    }
+
+   @Override
+   public CompletionStage<RestResponse> markTopologyStable(boolean force) {
+      return client.execute(
+            new Request.Builder()
+                  .post(EMPTY_BODY)
+                  .url(cacheUrl + "?action=initialize&force=" + force)
+      );
+   }
 }

--- a/core/src/main/java/org/infinispan/commands/topology/TopologyUpdateStableCommand.java
+++ b/core/src/main/java/org/infinispan/commands/topology/TopologyUpdateStableCommand.java
@@ -32,6 +32,7 @@ public class TopologyUpdateStableCommand extends AbstractCacheControlCommand {
    private int rebalanceId;
    private int topologyId;
    private int viewId;
+   private boolean topologyRestored;
 
    // For CommandIdUniquenessTest only
    public TopologyUpdateStableCommand() {
@@ -48,11 +49,12 @@ public class TopologyUpdateStableCommand extends AbstractCacheControlCommand {
       this.actualMembers = cacheTopology.getActualMembers();
       this.persistentUUIDs = cacheTopology.getMembersPersistentUUIDs();
       this.viewId = viewId;
+      this.topologyRestored = cacheTopology.wasTopologyRestoredFromState();
    }
 
    @Override
    public CompletionStage<?> invokeAsync(GlobalComponentRegistry gcr) throws Throwable {
-      CacheTopology topology = new CacheTopology(topologyId, rebalanceId, currentCH, pendingCH,
+      CacheTopology topology = new CacheTopology(topologyId, rebalanceId, topologyRestored, currentCH, pendingCH,
             CacheTopology.Phase.NO_REBALANCE, actualMembers, persistentUUIDs);
       return gcr.getLocalTopologyManager()
             .handleStableTopologyUpdate(cacheName, topology, origin, viewId);
@@ -80,6 +82,7 @@ public class TopologyUpdateStableCommand extends AbstractCacheControlCommand {
       output.writeInt(topologyId);
       output.writeInt(rebalanceId);
       output.writeInt(viewId);
+      output.writeBoolean(topologyRestored);
    }
 
    @Override
@@ -92,6 +95,7 @@ public class TopologyUpdateStableCommand extends AbstractCacheControlCommand {
       topologyId = input.readInt();
       rebalanceId = input.readInt();
       viewId = input.readInt();
+      topologyRestored = input.readBoolean();
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/distribution/ch/ConsistentHash.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/ConsistentHash.java
@@ -129,6 +129,16 @@ public interface ConsistentHash {
    }
 
    /**
+    * Same as {@link #remapAddresses(UnaryOperator)} but skip missing members.
+    *
+    * @param remapper: the remapper which given an address replaces it with another one
+    * @return the remapped ConsistentHash
+    */
+   default ConsistentHash remapAddressRemoveMissing(UnaryOperator<Address> remapper) {
+      throw new UnsupportedOperationException();
+   }
+
+   /**
     * The capacity factor of each member. Determines the relative capacity of each node compared to the others.
     * If {@code null}, all the members are assumed to have a capacity factor of 1.
     */

--- a/core/src/main/java/org/infinispan/distribution/ch/impl/AbstractConsistentHash.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/impl/AbstractConsistentHash.java
@@ -165,22 +165,28 @@ public abstract class AbstractConsistentHash implements ConsistentHash {
       }
    }
 
-   protected Map<Address, Float> remapCapacityFactors(UnaryOperator<Address> remapper) {
+   protected Map<Address, Float> remapCapacityFactors(UnaryOperator<Address> remapper, boolean allowMissing) {
       Map<Address, Float> remappedCapacityFactors = null;
       if (capacityFactors != null) {
          remappedCapacityFactors = new HashMap<>(members.size());
          for(int i=0; i < members.size(); i++) {
-            remappedCapacityFactors.put(remapper.apply(members.get(i)), capacityFactors[i]);
+            Address a = remapper.apply(members.get(i));
+            if (a == null) {
+               if (allowMissing) continue;
+               return null;
+            }
+            remappedCapacityFactors.put(a, capacityFactors[i]);
          }
       }
       return remappedCapacityFactors;
    }
 
-   protected List<Address> remapMembers(UnaryOperator<Address> remapper) {
+   protected List<Address> remapMembers(UnaryOperator<Address> remapper, boolean allowMissing) {
       List<Address> remappedMembers = new ArrayList<>(members.size());
       for(Iterator<Address> i = members.iterator(); i.hasNext(); ) {
          Address a = remapper.apply(i.next());
          if (a == null) {
+            if (allowMissing) continue;
             return null;
          }
          remappedMembers.add(a);

--- a/core/src/main/java/org/infinispan/topology/ClusterTopologyManager.java
+++ b/core/src/main/java/org/infinispan/topology/ClusterTopologyManager.java
@@ -86,6 +86,8 @@ public interface ClusterTopologyManager {
 
    CompletionStage<Void> handleShutdownRequest(String cacheName) throws Exception;
 
+   boolean useCurrentTopologyAsStable(String cacheName, boolean force);
+
    /**
     * Sets the id of the initial topology in given cache. This is necessary when using entry versions
     * that contain topology id; had we started with topology id 1, newer versions would not be recognized properly.

--- a/core/src/main/java/org/infinispan/topology/ClusterTopologyManagerImpl.java
+++ b/core/src/main/java/org/infinispan/topology/ClusterTopologyManagerImpl.java
@@ -733,6 +733,17 @@ public class ClusterTopologyManagerImpl implements ClusterTopologyManager {
       return cacheStatus.shutdownCache();
    }
 
+   @Override
+   public boolean useCurrentTopologyAsStable(String cacheName, boolean force) {
+      ClusterCacheStatus status = cacheStatusMap.get(cacheName);
+      if (status == null) return false;
+      if (!status.setCurrentTopologyAsStable(force)) return false;
+
+      // We are sure this one is completed.
+      status.forceRebalance();
+      return true;
+   }
+
    public static boolean distLostDataCheck(ConsistentHash stableCH, List<Address> newMembers) {
       for (int i = 0; i < stableCH.getNumSegments(); i++) {
          if (!InfinispanCollections.containsAny(newMembers, stableCH.locateOwnersForSegment(i)))

--- a/core/src/main/java/org/infinispan/topology/LocalTopologyManagerImpl.java
+++ b/core/src/main/java/org/infinispan/topology/LocalTopologyManagerImpl.java
@@ -1,9 +1,9 @@
 package org.infinispan.topology;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.infinispan.commons.util.concurrent.CompletableFutures.completedNull;
 import static org.infinispan.factories.KnownComponentNames.NON_BLOCKING_EXECUTOR;
 import static org.infinispan.factories.KnownComponentNames.TIMEOUT_SCHEDULE_EXECUTOR;
-import static org.infinispan.commons.util.concurrent.CompletableFutures.completedNull;
 import static org.infinispan.util.concurrent.CompletionStages.handleAndCompose;
 import static org.infinispan.util.logging.Log.CLUSTER;
 import static org.infinispan.util.logging.Log.CONFIG;
@@ -23,6 +23,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 
 import org.infinispan.commands.ReplicableCommand;
 import org.infinispan.commands.topology.CacheAvailabilityUpdateCommand;
@@ -35,6 +36,7 @@ import org.infinispan.commands.topology.RebalanceStatusRequestCommand;
 import org.infinispan.commons.IllegalLifecycleStateException;
 import org.infinispan.commons.time.TimeService;
 import org.infinispan.commons.util.Version;
+import org.infinispan.commons.util.concurrent.CompletableFutures;
 import org.infinispan.configuration.cache.StoreConfiguration;
 import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.distribution.ch.ConsistentHashFactory;
@@ -64,16 +66,15 @@ import org.infinispan.remoting.transport.impl.VoidResponseCollector;
 import org.infinispan.remoting.transport.jgroups.SuspectException;
 import org.infinispan.util.concurrent.ActionSequencer;
 import org.infinispan.util.concurrent.BlockingManager;
-import org.infinispan.commons.util.concurrent.CompletableFutures;
 import org.infinispan.util.concurrent.CompletionStages;
 import org.infinispan.util.concurrent.TimeoutException;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
-
-import net.jcip.annotations.GuardedBy;
 import org.infinispan.util.logging.events.EventLogCategory;
 import org.infinispan.util.logging.events.EventLogManager;
 import org.infinispan.util.logging.events.EventLogger;
+
+import net.jcip.annotations.GuardedBy;
 
 /**
  * The {@code LocalTopologyManager} implementation.
@@ -425,6 +426,7 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager, GlobalSta
 
       List<PersistentUUID> persistentUUIDs = persistentUUIDManager.mapAddresses(cacheTopology.getActualMembers());
       CacheTopology unionTopology = new CacheTopology(cacheTopology.getTopologyId(), cacheTopology.getRebalanceId(),
+                                                      cacheTopology.wasTopologyRestoredFromState(),
                                                       currentCH, pendingCH, unionCH, cacheTopology.getPhase(),
                                                       cacheTopology.getActualMembers(), persistentUUIDs);
       boolean updateAvailabilityModeFirst = availabilityMode != AvailabilityMode.AVAILABLE;
@@ -527,6 +529,7 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager, GlobalSta
             registerPersistentUUID(newCacheTopology);
             CacheTopology resetTopology = new CacheTopology(newCacheTopology.getTopologyId() - 1,
                                                             newCacheTopology.getRebalanceId() - 1,
+                                                            newCacheTopology.wasTopologyRestoredFromState(),
                                                             newCacheTopology.getCurrentCH(), null,
                                                             CacheTopology.Phase.NO_REBALANCE,
                                                             newCacheTopology.getActualMembers(), persistentUUIDManager
@@ -561,7 +564,6 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager, GlobalSta
          CacheTopology stableTopology = cacheStatus.getStableTopology();
          if (stableTopology == null || stableTopology.getTopologyId() < newStableTopology.getTopologyId()) {
             log.tracef("Updating stable topology for cache %s: %s", cacheName, newStableTopology);
-            //System.out.printf("[%s] Updating stable topology for cache %s: %s\n", transport.getAddress(), cacheName, newStableTopology);
             cacheStatus.setStableTopology(newStableTopology);
             if (newStableTopology != null && cacheStatus.getJoinInfo().getPersistentUUID() != null) {
                // Don't use the current CH state for the next restart
@@ -636,7 +638,7 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager, GlobalSta
       CacheTopologyHandler handler = cacheStatus.getHandler();
       ConsistentHash unionCH = cacheStatus.getJoinInfo().getConsistentHashFactory().union(
             cacheTopology.getCurrentCH(), cacheTopology.getPendingCH());
-      CacheTopology newTopology = new CacheTopology(cacheTopology.getTopologyId(), cacheTopology.getRebalanceId(),
+      CacheTopology newTopology = new CacheTopology(cacheTopology.getTopologyId(), cacheTopology.getRebalanceId(), cacheTopology.wasTopologyRestoredFromState(),
                                                     cacheTopology.getCurrentCH(), cacheTopology.getPendingCH(), unionCH,
                                                     cacheTopology.getPhase(),
                                                     cacheTopology.getActualMembers(),
@@ -724,7 +726,7 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager, GlobalSta
             return;
          }
 
-         if (!lcs.isStableTopologyRestored()) {
+         if (!lcs.isTopologyRestored()) {
             log.debugf("Not changing rebalance for cache '%s' without stable topology", cacheName);
             return;
          }
@@ -790,8 +792,16 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager, GlobalSta
          if (!recovered) {
             ComponentRegistry cr = gcr.getNamedComponentRegistry(cacheName);
             PersistenceManager pm;
+
             if (cr != null && (pm = cr.getComponent(PersistenceManager.class)) != null) {
-               return pm.clearAllStores(PersistenceManager.AccessMode.PRIVATE.and(StoreConfiguration::purgeOnStartup));
+               Predicate<StoreConfiguration> predicate = PersistenceManager.AccessMode.PRIVATE;
+
+               // If the cache did not recover completely from state, we force a cleanup.
+               // Otherwise, it only cleans if it was configured.
+               if (!cacheStatus.needRecovery()) {
+                  predicate = predicate.and(StoreConfiguration::purgeOnStartup);
+               }
+               return pm.clearAllStores(predicate);
             }
          }
 
@@ -802,7 +812,7 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager, GlobalSta
    @Override
    public void assertTopologyStable(String cacheName) {
       LocalCacheStatus cacheStatus = runningCaches.get(cacheName);
-      if (cacheStatus != null && !cacheStatus.isStableTopologyRestored()) {
+      if (cacheStatus != null && !cacheStatus.isTopologyRestored()) {
          List<Address> members;
          if ((members = clusterTopologyManager.currentJoiners(cacheName)) == null) {
             members = cacheStatus.knownMembers();
@@ -911,7 +921,9 @@ class LocalCacheStatus {
    void setStableTopology(CacheTopology stableTopology) {
       this.stableTopology = stableTopology;
       partitionHandlingManager.onTopologyUpdate(currentTopology);
-      if (stableTopology != null) stable.complete(true);
+      if (stableTopology != null) {
+         stable.complete(stableTopology.wasTopologyRestoredFromState());
+      }
    }
 
    List<Address> knownMembers() {
@@ -926,8 +938,8 @@ class LocalCacheStatus {
       return stable;
    }
 
-   boolean isStableTopologyRestored() {
-      return (stable.isDone() && stableTopology != null) || !needRecovery();
+   boolean isTopologyRestored() {
+      return (stable.isDone() && stableTopology != null) || stableMembersSize < 0;
    }
 
    boolean needRecovery() {

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -2362,6 +2362,10 @@ public interface Log extends BasicLogger {
    @LogMessage(level = INFO)
    @Message(value = "Flushed ACL Cache", id = 692)
    void flushedACLCache();
+
    @Message(value = "Dangling lock file '%s' in persistent global state, probably left behind by an unclean shutdown. ", id = 693)
    CacheConfigurationException globalStateLockFilePresent(File lockFile);
+
+   @Message(value = "Cache '%s' has number of owners %d but is missing too many members (%d/%d) to reinstall topology", id = 694)
+   MissingMembersException missingTooManyMembers(String cacheName, int owners, int missing, int total);
 }

--- a/core/src/test/java/org/infinispan/globalstate/ThreeNodeTopologyReinstallTest.java
+++ b/core/src/test/java/org/infinispan/globalstate/ThreeNodeTopologyReinstallTest.java
@@ -1,0 +1,187 @@
+package org.infinispan.globalstate;
+
+import static org.infinispan.commons.test.CommonsTestingUtil.tmpDirectory;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertTrue;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.infinispan.Cache;
+import org.infinispan.commons.test.Exceptions;
+import org.infinispan.commons.util.concurrent.CompletableFutures;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.factories.GlobalComponentRegistry;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.remoting.transport.jgroups.JGroupsAddress;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.topology.MissingMembersException;
+import org.infinispan.topology.PersistentUUID;
+import org.infinispan.util.concurrent.AggregateCompletionStage;
+import org.infinispan.util.concurrent.CompletionStages;
+import org.testng.annotations.Test;
+
+@Test(testName = "globalstate.ThreeNodeTopologyReinstallTest", groups = "functional")
+public class ThreeNodeTopologyReinstallTest extends AbstractGlobalStateRestartTest {
+
+   private CacheMode cacheMode;
+
+   private int getNumOwners() {
+      return getClusterSize() - 1;
+   }
+
+   @Override
+   protected int getClusterSize() {
+      return 3;
+   }
+
+   @Override
+   protected void applyCacheManagerClusteringConfiguration(ConfigurationBuilder config) {
+      config.clustering().cacheMode(cacheMode).hash().numOwners(getNumOwners());
+   }
+
+   @Override
+   protected void applyCacheManagerClusteringConfiguration(String id, ConfigurationBuilder config) {
+      applyCacheManagerClusteringConfiguration(config);
+      config.persistence().addSoftIndexFileStore()
+            .dataLocation(tmpDirectory(this.getClass().getSimpleName(), id, "data"))
+            .indexLocation(tmpDirectory(this.getClass().getSimpleName(), id, "index"));
+   }
+
+   public void testReinstallTopologyByForce() throws Exception {
+      executeTestRestart(true);
+   }
+
+   public void testReinstallTopologySafely() throws Exception {
+      executeTestRestart(false);
+   }
+
+   private void executeTestRestart(boolean force) throws Exception {
+      boolean possibleDataLoss = !cacheMode.isReplicated() && force;
+      Map<JGroupsAddress, PersistentUUID> addressMappings = createInitialCluster();
+
+      // Shutdown the cache cluster-wide
+      cache(0, CACHE_NAME).shutdown();
+      TestingUtil.killCacheManagers(this.cacheManagers);
+
+      // Verify that the cache state file exists for all participants.
+      for (int i = 0; i < getClusterSize(); i++) {
+         String persistentLocation = manager(i).getCacheManagerConfiguration().globalState().persistentLocation();
+         File[] listFiles = new File(persistentLocation).listFiles((dir, name) -> name.equals(CACHE_NAME + ".state"));
+         assertEquals(Arrays.toString(listFiles), 1, listFiles.length);
+      }
+      this.cacheManagers.clear();
+
+      // Partially recreate the cluster while trying to reinstall topology.
+      int i = 0;
+      for (; i < (getClusterSize() - getNumOwners()); i++) {
+         createStatefulCacheManager(Character.toString((char) ('A' + i)), false);
+         TestingUtil.blockUntilViewsReceived(15000, getCaches(CACHE_NAME));
+         GlobalComponentRegistry gcr = TestingUtil.extractGlobalComponentRegistry(manager(i));
+         Exceptions.expectException(MissingMembersException.class,
+               "ISPN000694: Cache 'testCache' has number of owners \\d but is missing too many members \\(\\d\\/3\\) to reinstall topology$",
+               () -> gcr.getClusterTopologyManager().useCurrentTopologyAsStable(CACHE_NAME, false));
+      }
+
+      // Since we didn't force the installation, operations still fail.
+      assertOperationsFail();
+
+      if (!force) {
+         createStatefulCacheManager(Character.toString((char) ('A' + i++)), false);
+         TestingUtil.blockUntilViewsReceived(15000, getCaches(CACHE_NAME));
+      }
+
+      // Now we install the topology.
+      for (int j = 0; j < cacheManagers.size(); j++) {
+         EmbeddedCacheManager ecm = manager(j);
+         if (ecm.isCoordinator()) {
+            TestingUtil.extractGlobalComponentRegistry(manager(0))
+                  .getClusterTopologyManager()
+                  .useCurrentTopologyAsStable(CACHE_NAME, force);
+            break;
+         }
+      }
+
+      // Wait topology installation.
+      AggregateCompletionStage<Void> topologyInstall = CompletionStages.aggregateCompletionStage();
+      for (int j = 0; j < cacheManagers.size(); j++) {
+         GlobalComponentRegistry gcr = TestingUtil.extractGlobalComponentRegistry(manager(j));
+         topologyInstall.dependsOn(gcr.getLocalTopologyManager().stableTopologyCompletion(CACHE_NAME));
+      }
+      CompletableFutures.uncheckedAwait(topologyInstall.freeze().toCompletableFuture(), 30, TimeUnit.SECONDS);
+
+      if (possibleDataLoss) {
+         // Varying the cache configuration and if forcing the topology, we can lose data.
+         for (int j = 0; j < cacheManagers.size(); j++) {
+            assertFalse(cache(j, CACHE_NAME).isEmpty());
+            assertTrue(cache(j, CACHE_NAME).size() < DATA_SIZE);
+         }
+      } else {
+         // In some cases, it is possible to recover all the data.
+         checkData();
+      }
+
+      // Now we add the missing members back.
+      for (; i < getClusterSize(); i++) {
+         createStatefulCacheManager(Character.toString((char) ('A' + i)), false);
+      }
+
+      // This will create the cache, and trigger the join operation for the new managers.
+      TestingUtil.blockUntilViewsReceived(30000, getCaches(CACHE_NAME));
+
+      // Wait topology again, just to make sure.
+      topologyInstall = CompletionStages.aggregateCompletionStage();
+      for (int j = 0; j < cacheManagers.size(); j++) {
+         GlobalComponentRegistry gcr = TestingUtil.extractGlobalComponentRegistry(manager(j));
+         topologyInstall.dependsOn(gcr.getLocalTopologyManager().stableTopologyCompletion(CACHE_NAME));
+      }
+      CompletableFutures.uncheckedAwait(topologyInstall.freeze().toCompletableFuture(), 30, TimeUnit.SECONDS);
+
+      checkClusterRestartedCorrectly(addressMappings);
+      waitForClusterToForm(CACHE_NAME);
+
+      if (possibleDataLoss) {
+         for (int j = 0; j < getClusterSize(); j++) {
+            assertFalse(cache(j, CACHE_NAME).isEmpty());
+            assertTrue(cache(j, CACHE_NAME).size() < DATA_SIZE);
+         }
+      } else {
+         checkData();
+      }
+   }
+
+   private void assertOperationsFail() {
+      for (int i = 0; i < cacheManagers.size(); i++) {
+         for (int v = 0; v < DATA_SIZE; v++) {
+            final Cache<Object, Object> cache = cache(i, CACHE_NAME);
+            String key = String.valueOf(v);
+            // Always returns null. Message about not stable yet is logged.
+            Exceptions.expectException(MissingMembersException.class,
+                  "ISPN000689: Recovering cache 'testCache' but there are missing members, known members \\[.*\\] of a total of 3$",
+                  () -> cache.get(key));
+         }
+      }
+   }
+
+   private ThreeNodeTopologyReinstallTest withCacheMode(CacheMode mode) {
+      this.cacheMode = mode;
+      return this;
+   }
+
+   @Override
+   public Object[] factory() {
+      return new Object[]{
+            new ThreeNodeTopologyReinstallTest().withCacheMode(CacheMode.DIST_SYNC),
+            new ThreeNodeTopologyReinstallTest().withCacheMode(CacheMode.REPL_SYNC),
+      };
+   }
+
+   @Override
+   protected String parameters() {
+      return String.format("[cacheMode=%s]", cacheMode);
+   }
+}

--- a/documentation/src/main/asciidoc/stories/assembly_cli_cache_operations.adoc
+++ b/documentation/src/main/asciidoc/stories/assembly_cli_cache_operations.adoc
@@ -10,6 +10,7 @@ include::{topics}/proc_cli_adding_entries.adoc[leveloffset=+1]
 include::{topics}/proc_cli_deleting_entries.adoc[leveloffset=+1]
 include::{topics}/proc_cli_dropping_caches.adoc[leveloffset=+1]
 include::{topics}/proc_cli_rebalancing_caches.adoc[leveloffset=+1]
+include::{topics}/proc_cli_set_topology_caches.adoc[leveloffset=+1]
 
 // Restore the parent context.
 ifdef::parent-context[:context: {parent-context}]

--- a/documentation/src/main/asciidoc/topics/con_restarting_clusters.adoc
+++ b/documentation/src/main/asciidoc/topics/con_restarting_clusters.adoc
@@ -12,8 +12,15 @@ To prevent inconsistencies or data loss, {brandname} restricts access to the dat
 Additionally, {brandname} disables cluster rebalancing and prevents local cache stores purging on startup.
 
 During the cluster recovery process, the coordinator node logs messages for each new node joining, indicating which nodes are available and which are still missing.
-Other nodes in the {brandname} cluster have the view from the time they join. +
-You can monitor availability of caches using the {brandname} Console or REST API.
+Other nodes in the {brandname} cluster have the view from the time they join. You can monitor availability of caches using the {brandname} Console or REST API.
+
+However, in cases where waiting for all nodes is not necessary nor desired, it is possible to set a cache available with the current topology.
+This approach is possible through the CLI, see below, or the REST API.
+
+[IMPORTANT]
+====
+Manually installing a topology can lead to data loss, only perform this operation if the initial topology cannot be recreated.
+====
 
 [discrete]
 == Server shutdown

--- a/documentation/src/main/asciidoc/topics/proc_cli_set_topology_caches.adoc
+++ b/documentation/src/main/asciidoc/topics/proc_cli_set_topology_caches.adoc
@@ -1,0 +1,31 @@
+[id='cli-set-topology-caches_{context}']
+= Set a Stable Topology
+
+By default, after a cluster shutdown, {brandname} waits for all nodes to join the cluster and restore the topology.
+However, we offer a CLI command to mark the current topology stable for a specific cache.
+
+.Procedure
+
+. Create a CLI connection to {brandname}.
+. Do one of the following:
++
+* Set the current topology as stable for the given cache.
++
+[source,options="nowrap",subs=attributes+]
+----
+topology set-stable cacheName
+----
++
+* If the current topology is missing more nodes than the number of owners, the force flag is necessary to confirm the operation.
++
+[source,options="nowrap",subs=attributes+]
+----
+topology set-stable cacheName -f
+----
+
+For more information about the [command]`topology set-stable` command, run [command]`topology set-stable -h`.
+
+[IMPORTANT]
+====
+Manually installing a topology can lead to data loss, only perform this operation if the initial topology cannot be recreated.
+====

--- a/documentation/src/main/asciidoc/topics/ref_rest_caches.adoc
+++ b/documentation/src/main/asciidoc/topics/ref_rest_caches.adoc
@@ -656,3 +656,30 @@ POST /rest/v2/caches/{cacheName}?action=set-availability&availability={AVAILABIL
 
 [NOTE]
 You can set the availability of internal caches but this is subject to change in future {brandname} versions.
+
+[id='rest_v2_caches_set_topology_stable']
+= Set a Stable Topology
+By default, after a cluster shutdown, {brandname} waits for all nodes to join the cluster and restore the topology.
+However, it is possible to define the current cluster topology as stable for a specific cache using the REST operation.
+
+[source,options="nowrap",subs=attributes+]
+----
+POST /rest/v2/caches/{cacheName}?action=initialize&force={FORCE}
+----
+
+.Request Parameters
+
+|===
+|Parameter |Required or Optional |Value
+
+|`force`
+|OPTIONAL
+|true or false.
+|===
+
+* `force` is required when the number of missing nodes in the current topology is greater or equal to the number of owners.
+
+[IMPORTANT]
+====
+Manually installing a topology can lead to data loss, only perform this operation if the initial topology cannot be recreated.
+====

--- a/server/rest/src/main/java/org/infinispan/rest/resources/CacheResourceV2.java
+++ b/server/rest/src/main/java/org/infinispan/rest/resources/CacheResourceV2.java
@@ -118,6 +118,7 @@ import org.infinispan.security.AuditContext;
 import org.infinispan.security.AuthorizationPermission;
 import org.infinispan.security.actions.SecurityActions;
 import org.infinispan.stats.Stats;
+import org.infinispan.topology.ClusterTopologyManager;
 import org.infinispan.topology.LocalTopologyManager;
 import org.infinispan.upgrade.RollingUpgradeManager;
 
@@ -218,6 +219,11 @@ public class CacheResourceV2 extends BaseCacheResource implements ResourceHandle
             .invocation().methods(POST).path("/v2/caches/{cacheName}").withAction("disable-rebalancing")
             .permission(AuthorizationPermission.ADMIN).name("DISABLE REBALANCE").auditContext(AuditContext.CACHE)
             .handleWith(r -> setRebalancing(false, r))
+
+            // Restore after a shutdown
+            .invocation().method(POST).path("/v2/caches/{cacheName}").withAction("initialize")
+            .permission(AuthorizationPermission.ADMIN).name("Initialize cache").auditContext(AuditContext.CACHE)
+            .handleWith(this::reinitializeCache)
 
             .create();
    }
@@ -954,6 +960,42 @@ public class CacheResourceV2 extends BaseCacheResource implements ResourceHandle
          }
          return builder.build();
       }, invocationHelper.getExecutor());
+   }
+
+   private CompletionStage<RestResponse> reinitializeCache(RestRequest request) {
+      boolean force = Boolean.parseBoolean(request.getParameter("force"));
+      NettyRestResponse.Builder builder = new NettyRestResponse.Builder();
+      EmbeddedCacheManager ecm = invocationHelper.getProtocolServer().getCacheManager();
+      if (!ecm.isCoordinator()) {
+         builder.status(BAD_REQUEST);
+         builder.entity(Json.make("Node not coordinator, request at " + ecm.getCoordinator()));
+         return CompletableFuture.completedFuture(builder.build());
+      }
+
+      GlobalComponentRegistry gcr = SecurityActions.getGlobalComponentRegistry(ecm);
+      ClusterTopologyManager ctm = gcr.getClusterTopologyManager();
+      LocalTopologyManager ltm = gcr.getLocalTopologyManager();
+      if (ctm == null || ltm == null) {
+         builder.status(BAD_REQUEST);
+         return CompletableFuture.completedFuture(builder.build());
+      }
+
+      builder.status(NO_CONTENT);
+      String cache = request.variables().get("cacheName");
+      InternalCacheRegistry internalRegistry = gcr.getComponent(InternalCacheRegistry.class);
+      if (ecm.isRunning(cache)) return CompletableFuture.completedFuture(builder.build());
+      if (internalRegistry.isInternalCache(cache)) return CompletableFuture.completedFuture(builder.build());
+
+      return CompletableFuture.supplyAsync(() -> {
+         if (!ctm.useCurrentTopologyAsStable(cache, force))
+            return CompletableFuture.completedFuture(builder.build());
+
+         // We wait for the topology to be installed.
+         return ltm.stableTopologyCompletion(cache)
+             .thenApply(ignore -> builder.build());
+      }, invocationHelper.getExecutor())
+          .thenCompose(Function.identity())
+          .thenApply(Function.identity());
    }
 
    private static class CacheFullDetail implements JsonSerialization {


### PR DESCRIPTION
…n not recover after 'shutdown cluster'

https://issues.redhat.com/browse/ISPN-14418

I am already opening this so we can start reviewing and decide a CLI command for this operation.

We restore only one cache at a time. We throw an exception if the current topology is missing more or equal to `numOwners`. We create a topology with the current members, and caches that initialize will apply `purgeOnStartup` if configured. 

Points of attention:

* Forcing initialization could lead to data loss;
* Applying operations after forcing initialization could lead to inconsistencies.

The recommendation is to use `purgeOnStartup`, or once we always purge by default :grin:.

