### PR TITLE
ISPN-14689 Handle RESP SET optional arguments

### DIFF
--- a/server/resp/src/main/java/org/infinispan/server/resp/Util.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/Util.java
@@ -1,0 +1,54 @@
+package org.infinispan.server.resp;
+
+public class Util {
+   private Util() { }
+
+   /**
+    * Checks if target is equal to expected. This method is case-insensitive and only works with ASCII characters.
+    * The characters on expected must be in uppercase.
+    *
+    * @param expected: Upper case ASCII characters.
+    * @param target: ASCII characters to verify.
+    * @return true if target is equal to expected, false otherwise.
+    */
+   public static boolean isAsciiBytesEquals(byte[] expected, byte[] target) {
+      if (expected.length != target.length) return false;
+
+      for (int i = 0; i < expected.length; i++) {
+         assert isAsciiUppercase(expected[i]) : "Expected byte is not uppercase ASCII";
+         assert isAsciiChar(target[i]) : "Target byte is not ASCII";
+
+         byte l = target[i];
+         byte r = expected[i];
+         if (l != r && l != (r - 32)) return false;
+      }
+      return true;
+   }
+
+   /**
+    * Checks if target is equal to expected. This method is case-insensitive and only works with ASCII characters.
+    * The expected char must be in uppercase.
+    *
+    * @param expected: Upper case ASCII character.
+    * @param actual: ASCII character to verify.
+    * @return true if actual is equal to expected, false otherwise.
+    */
+   public static boolean caseInsensitiveAsciiCheck(char expected, byte actual) {
+      assert isAsciiUppercase((byte) expected) : "Expected byte is not uppercase ASCII";
+      assert isAsciiChar(actual) : "Target byte is not ASCII";
+
+      return expected == actual || expected == (actual - 32);
+   }
+
+   public static boolean isAsciiChar(byte b) {
+      return isAsciiLowercase(b) || isAsciiUppercase(b);
+   }
+
+   public static boolean isAsciiUppercase(byte b) {
+      return b >= 65 && b <= 90;
+   }
+
+   public static boolean isAsciiLowercase(byte b) {
+      return b >= 97 && b <= 122;
+   }
+}

--- a/server/resp/src/main/java/org/infinispan/server/resp/operation/RespExpiration.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/operation/RespExpiration.java
@@ -1,0 +1,62 @@
+package org.infinispan.server.resp.operation;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+
+import org.infinispan.server.resp.Util;
+
+public enum RespExpiration {
+   EX {
+      @Override
+      protected long convert(long value) {
+         return TimeUnit.SECONDS.toMillis(value);
+      }
+   },
+   PX {
+      @Override
+      protected long convert(long value) {
+         return value;
+      }
+   },
+   EXAT {
+      @Override
+      protected long convert(long value) {
+         return (value - Instant.now().getEpochSecond()) * 1000;
+      }
+   },
+   PXAT {
+      @Override
+      protected long convert(long value) {
+         return value - Instant.now().toEpochMilli();
+      }
+   };
+
+   public static final byte[] EXAT_BYTES = "EXAT".getBytes(StandardCharsets.US_ASCII);
+   public static final byte[] PXAT_BYTES = "PXAT".getBytes(StandardCharsets.US_ASCII);
+
+   protected abstract long convert(long value);
+
+   public static RespExpiration valueOf(byte[] type) {
+      if (type.length == 2) {
+         if (!Util.caseInsensitiveAsciiCheck('X', type[1]))
+            throw new IllegalArgumentException("Invalid expiration type");
+
+         switch (type[0]) {
+            case 'E':
+            case 'e':
+               return EX;
+            case 'P':
+            case 'p':
+               return PX;
+         }
+      }
+
+      if (type.length == 4) {
+         if (Util.isAsciiBytesEquals(EXAT_BYTES, type)) return EXAT;
+         if (Util.isAsciiBytesEquals(PXAT_BYTES, type)) return PXAT;
+      }
+
+      throw new IllegalArgumentException("Invalid expiration type");
+   }
+}

--- a/server/resp/src/main/java/org/infinispan/server/resp/operation/SetOperation.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/operation/SetOperation.java
@@ -1,0 +1,219 @@
+package org.infinispan.server.resp.operation;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+
+import org.infinispan.AdvancedCache;
+import org.infinispan.container.entries.CacheEntry;
+import org.infinispan.server.resp.Util;
+import org.infinispan.server.resp.response.SetResponse;
+import org.infinispan.util.concurrent.CompletionStages;
+
+public class SetOperation {
+
+   private static final byte[] GET_BYTES = "GET".getBytes(StandardCharsets.US_ASCII);
+   private static final byte[] NX_BYTES = "NX".getBytes(StandardCharsets.US_ASCII);
+   private static final byte[] XX_BYTES = "XX".getBytes(StandardCharsets.US_ASCII);
+   private static final byte[] KEEP_TTL_BYTES = "KEEPTTL".getBytes(StandardCharsets.US_ASCII);
+   private static final CompletionStage<SetResponse> MISSING_ARGUMENTS = CompletableFuture.failedFuture(new IllegalStateException("Missing arguments"));
+
+   public static CompletionStage<SetResponse> performOperation(AdvancedCache<byte[], byte[]> cache, List<byte[]> arguments) {
+      try {
+         if (arguments.size() < 2) return MISSING_ARGUMENTS;
+
+         SetOperationOptions options = new SetOperationOptions(arguments);
+         if (options.operationType == XX_BYTES) {
+            return performOperationWithXX(cache, options);
+         }
+
+         CompletionStage<byte[]> cacheOperation;
+         if (options.isKeepingTtl()) {
+            cacheOperation =  cache.getCacheEntryAsync(options.key)
+                  .thenCompose(e -> performOperation(cache, options, e != null ? extractCurrentTTL(e) : -1));
+         } else {
+            cacheOperation = performOperation(cache, options, options.expirationMs);
+         }
+
+         if (CompletionStages.isCompletedSuccessfully(cacheOperation)) {
+            return CompletableFuture.completedFuture(parseResponse(options, CompletionStages.join(cacheOperation)));
+         }
+
+         return cacheOperation.thenApply(v -> parseResponse(options, v));
+      } catch (Exception e) {
+         return CompletableFuture.failedFuture(e);
+      }
+   }
+
+   private static CompletionStage<byte[]> performOperation(AdvancedCache<byte[], byte[]> cache, SetOperationOptions options, long expiration) {
+      byte[] key = options.key;
+      byte[] value = options.value;
+      return options.operationType == null
+            ? cache.putAsync(key, value, expiration, TimeUnit.MILLISECONDS)
+            : cache.putIfAbsentAsync(key, value, expiration, TimeUnit.MILLISECONDS);
+   }
+
+   private static SetResponse parseResponse(SetOperationOptions options, byte[] v) {
+      return options.operationType == null
+            ? new SetResponse(v, options.isReturningPrevious())
+            : new SetResponse(v, options.isReturningPrevious(), v == null);
+   }
+
+   private static CompletionStage<SetResponse> performOperationWithXX(AdvancedCache<byte[], byte[]> cache, SetOperationOptions options) {
+      byte[] key = options.key;
+      byte[] value = options.value;
+      return cache.getCacheEntryAsync(key)
+            .thenCompose(e -> {
+               if (e == null || e.isNull()) {
+                  return CompletableFuture.completedFuture(new SetResponse(null, options.isReturningPrevious(), false));
+               }
+
+               long exp = -1;
+               if (options.isKeepingTtl()) {
+                  exp = extractCurrentTTL(e);
+               }
+
+               byte[] prev = e.getValue();
+               return cache.replaceAsync(key, prev, value, exp, TimeUnit.MILLISECONDS)
+                     .thenApply(b -> new SetResponse(prev, options.isReturningPrevious(), b));
+            });
+   }
+
+   private static long extractCurrentTTL(CacheEntry<?, ?> entry) {
+      long lifespan = entry.getLifespan();
+      long delta = Instant.now().toEpochMilli() - entry.getCreated();
+      return lifespan - delta;
+   }
+
+   private static class SetOperationOptions {
+      private final List<byte[]> arguments;
+      private byte[] key;
+      private byte[] value;
+      private long expirationMs;
+      private boolean keepTtl;
+      private boolean setAndReturnPrevious;
+      private byte[] operationType;
+
+      public SetOperationOptions(List<byte[]> arguments) {
+         this.arguments = arguments;
+         this.key = null;
+         this.value = null;
+         this.expirationMs = -1;
+         this.keepTtl = false;
+         this.setAndReturnPrevious = false;
+         this.operationType = null;
+         parseAndLoadOptions();
+      }
+
+      public void withKey(byte[] key) {
+         this.key = key;
+      }
+
+      public void withValue(byte[] value) {
+         this.value = value;
+      }
+
+      public void withReturnPrevious() {
+         this.setAndReturnPrevious = true;
+      }
+
+      public void withExpiration(long expirationMs) {
+         this.expirationMs = expirationMs;
+      }
+
+      public void withOperationType(byte[] operationType) {
+         this.operationType = operationType;
+      }
+
+      public void withKeepTtl() {
+         this.keepTtl = true;
+      }
+
+      public boolean isKeepingTtl() {
+         return this.keepTtl;
+      }
+
+      public boolean isReturningPrevious() {
+         return this.setAndReturnPrevious;
+      }
+
+      public boolean isUsingExpiration() {
+         return expirationMs > 0 || isKeepingTtl();
+      }
+
+      private void parseAndLoadOptions() {
+         withKey(arguments.get(0));
+         withValue(arguments.get(1));
+
+         // Bellow here we parse the optional arguments for the SET command:
+         //
+         // * `GET`: return the previous value with this key or nil;
+         // * `NX` or `XX`: putIfAbsent or putIfPresent. Returns nil if failed, if `GET` is present, it takes precedence.
+         //
+         // And expiration related parameters:
+         //
+         // `EX` seconds: TTL in seconds;
+         // `PX` milliseconds: TTL in ms;
+         // `EXAT` timestamp: Unix time for key expiration, seconds;
+         // `PXAT` timestamp: Unix time for key expiration, milliseconds;
+         // `KEEPTTL`: keep the key current TTL.
+         //
+         // Each of the time arguments are exclusive, only one is present at a time.
+         // All these arguments can be in any order. Expiration must be followed by the proper value.
+         for (int i = 2; i < arguments.size(); i++) {
+            byte[] arg = arguments.get(i);
+
+            // `NX`, `XX` or expiration.
+            if (arg.length == 2 || arg.length == 4) {
+               switch (arg[0]) {
+                  case 'N':
+                  case 'n':
+                     if (!Util.caseInsensitiveAsciiCheck('X', arg[1])) break;
+                     if (operationType != null) throw new IllegalArgumentException("NX and XX options are mutually exclusive");
+                     withOperationType(NX_BYTES);
+                     continue;
+                  case 'X':
+                  case 'x':
+                     if (!Util.caseInsensitiveAsciiCheck('X', arg[1])) break;
+                     if (operationType != null) throw new IllegalArgumentException("NX and XX options are mutually exclusive");
+                     withOperationType(XX_BYTES);
+                     continue;
+                  case 'E':
+                  case 'P':
+                  case 'e':
+                  case 'p':
+                     // Throws an exception if invalid.
+                     RespExpiration expiration = RespExpiration.valueOf(arg);
+                     if (isUsingExpiration()) throw new IllegalArgumentException("Only one expiration option should be used on SET");
+                     if (isKeepingTtl()) throw new IllegalArgumentException("KEEPTTL and EX/PX/EXAT/PXAT are mutually exclusive");
+                     if (i + 1 > arguments.size()) throw new IllegalArgumentException("No argument accompanying expiration");
+
+                     withExpiration(expiration.convert(Long.parseLong(new String(arguments.get(i + 1), StandardCharsets.US_ASCII))));
+                     i++;
+                     continue;
+               }
+
+               throw new IllegalArgumentException("Unknown argument for SET operation");
+            }
+
+            // `GET` argument.
+            if (arg.length == 3 && Util.isAsciiBytesEquals(GET_BYTES, arg)) {
+               withReturnPrevious();
+               continue;
+            }
+
+            // `KEEPTTL` argument.
+            if (arg.length == 7 && Util.isAsciiBytesEquals(KEEP_TTL_BYTES, arg)) {
+               if (isUsingExpiration()) throw new IllegalArgumentException("KEEPTTL and EX/PX/EXAT/PXAT are mutually exclusive");
+               withKeepTtl();
+               continue;
+            }
+
+            throw new IllegalArgumentException("Unknown argument for SET operation");
+         }
+      }
+   }
+}

--- a/server/resp/src/main/java/org/infinispan/server/resp/response/SetResponse.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/response/SetResponse.java
@@ -1,0 +1,30 @@
+package org.infinispan.server.resp.response;
+
+public class SetResponse {
+
+   private final byte[] value;
+   private final boolean returnValue;
+   private final boolean success;
+
+   public SetResponse(byte[] value, boolean returnValue) {
+      this(value, returnValue, true);
+   }
+
+   public SetResponse(byte[] value, boolean returnValue, boolean success) {
+      this.value = value;
+      this.returnValue = returnValue;
+      this.success = success;
+   }
+
+   public byte[] value() {
+      return value;
+   }
+
+   public boolean isReturnValue() {
+      return returnValue;
+   }
+
+   public boolean isSuccess() {
+      return success;
+   }
+}

--- a/server/resp/src/test/java/org/infinispan/server/resp/test/RespTestingUtil.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/test/RespTestingUtil.java
@@ -1,6 +1,7 @@
 package org.infinispan.server.resp.test;
 
 import java.time.Duration;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.infinispan.commons.dataconversion.MediaType;
@@ -88,7 +89,7 @@ public class RespTestingUtil {
 
       static UniquePortThreadLocal INSTANCE = new UniquePortThreadLocal();
 
-      private static final AtomicInteger uniqueAddr = new AtomicInteger(16211);
+      private static final AtomicInteger uniqueAddr = new AtomicInteger(1600 + ThreadLocalRandom.current().nextInt(1024));
 
       @Override
       protected Integer initialValue() {


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-14689

For reference: https://redis.io/commands/set/

At this stage, I didn't try to introduce any optimization. We could do something with the string allocation with the parameters, but that might cover only a few cases where they are used.

The point of attention here is the `KEEPTTL` option. I am not sure if I am handling it correctly. I retrieve the entry, calculate the time passed from creation, and decrease that from the original TTL. There might be cases, just before the entry expires, and we set a negative TTL, making the entry immortal.