### PR TITLE
ISPN-14693 Enhance cluster start/restart for administration

### DIFF
--- a/cli/src/main/java/org/infinispan/cli/commands/rest/Cluster.java
+++ b/cli/src/main/java/org/infinispan/cli/commands/rest/Cluster.java
@@ -1,0 +1,93 @@
+package org.infinispan.cli.commands.rest;
+
+import java.util.Map;
+import java.util.concurrent.CompletionStage;
+
+import org.aesh.command.Command;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.CommandException;
+import org.aesh.command.CommandResult;
+import org.aesh.command.GroupCommandDefinition;
+import org.aesh.command.impl.internal.ProcessedOption;
+import org.aesh.command.option.Option;
+import org.aesh.command.option.OptionGroup;
+import org.aesh.command.parser.OptionParser;
+import org.aesh.command.parser.OptionParserException;
+import org.aesh.parser.ParsedLineIterator;
+import org.infinispan.cli.activators.ConnectionActivator;
+import org.infinispan.cli.commands.CliCommand;
+import org.infinispan.cli.impl.ContextAwareCommandInvocation;
+import org.infinispan.cli.resources.Resource;
+import org.infinispan.client.rest.RestClient;
+import org.infinispan.client.rest.RestResponse;
+import org.kohsuke.MetaInfServices;
+
+/**
+ * @author José Bolina
+ * @since 15.0
+ */
+@MetaInfServices(Command.class)
+@GroupCommandDefinition(name = "cluster", description = "Execute cluster related operations.", activator = ConnectionActivator.class, groupCommands = {Cluster.Start.class})
+public class Cluster extends CliCommand {
+
+   @Option(shortName = 'h', hasValue = false, overrideRequired = true)
+   protected boolean help;
+
+   @Override
+   protected boolean isHelp() {
+      return help;
+   }
+
+   @Override
+   protected CommandResult exec(ContextAwareCommandInvocation invocation) throws CommandException {
+      invocation.println(invocation.getHelpInfo());
+      return CommandResult.FAILURE;
+   }
+
+   @CommandDefinition(name = "start", description = "SSH into the servers and starts one or more server instances.", activator = ConnectionActivator.class)
+   public static class Start extends RestCliCommand {
+
+      @Option(shortName = 'u', description = "Specifies the username to use for SSH.")
+      String username;
+
+      @OptionGroup(name = "H", shortName = 'H', description = "Specifies the host to SSH into and custom parameters.", parser = HostAndArgumentsParser.class)
+      Map<String, String> hostsAndArguments;
+
+      @Option(shortName = 'h', hasValue = false, overrideRequired = true)
+      protected boolean help;
+
+      @Override
+      protected boolean isHelp() {
+         return help;
+      }
+
+      @Override
+      protected CompletionStage<RestResponse> exec(ContextAwareCommandInvocation invocation, RestClient client,
+                                                   Resource resource) throws Exception {
+         return client.cluster().start(username, hostsAndArguments);
+      }
+
+      private static final class HostAndArgumentsParser implements OptionParser {
+
+         @Override
+         public void parse(ParsedLineIterator iterator, ProcessedOption currOption) throws OptionParserException {
+            // Copied from `AeshOptionParser#processProperty`.
+            String word = currOption.isLongNameUsed() ? iterator.pollWord().substring(2) : iterator.pollWord().substring(1);
+            String name = currOption.isLongNameUsed() ? currOption.name() : currOption.shortName();
+
+            // Originally, this would enforce the `=` sign.
+            if (word.length() < (1 + name.length()))
+               throw new OptionParserException("Option "+currOption.getDisplayName()+", must be part of a property");
+
+            if (!word.contains("=")) currOption.addProperty(word.substring(name.length()), "");
+            else {
+               String propertyName = word.substring(name.length(), word.indexOf("="));
+               String value = word.substring(word.indexOf("=") + 1);
+
+               // Originally, this would require value to be non-empty.
+               currOption.addProperty(propertyName, value);
+            }
+         }
+      }
+   }
+}

--- a/client/rest-client/src/main/java/org/infinispan/client/rest/RestClusterClient.java
+++ b/client/rest-client/src/main/java/org/infinispan/client/rest/RestClusterClient.java
@@ -2,6 +2,7 @@ package org.infinispan.client.rest;
 
 import java.io.File;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -18,6 +19,8 @@ public interface RestClusterClient {
     * Shuts down the specified servers
     */
    CompletionStage<RestResponse> stop(List<String> server);
+
+   CompletionStage<RestResponse> start(String username, Map<String, String> serverAndArguments);
 
    /**
     * Creates a backup file containing the content of all containers in the cluster.

--- a/client/rest-client/src/main/java/org/infinispan/client/rest/impl/okhttp/RestClusterClientOkHttp.java
+++ b/client/rest-client/src/main/java/org/infinispan/client/rest/impl/okhttp/RestClusterClientOkHttp.java
@@ -1,20 +1,22 @@
 package org.infinispan.client.rest.impl.okhttp;
 
-import static org.infinispan.client.rest.impl.okhttp.RestClientOkHttp.EMPTY_BODY;
-
 import java.io.File;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletionStage;
 
+import okhttp3.MultipartBody;
+import okhttp3.Request;
+import okhttp3.RequestBody;
 import org.infinispan.client.rest.RestClusterClient;
 import org.infinispan.client.rest.RestResponse;
 import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.commons.dataconversion.internal.Json;
 
-import okhttp3.MultipartBody;
-import okhttp3.Request;
-import okhttp3.RequestBody;
+import static org.infinispan.client.rest.impl.okhttp.RestClientOkHttp.EMPTY_BODY;
 
 /**
  * @author Tristan Tarrant &lt;tristan@infinispan.org&gt;
@@ -43,6 +45,29 @@ public class RestClusterClientOkHttp implements RestClusterClient {
          sb.append("&server=");
          sb.append(server);
       }
+      builder.post(EMPTY_BODY).url(sb.toString());
+      return client.execute(builder);
+   }
+
+   @Override
+   public CompletionStage<RestResponse> start(String username, Map<String, String> serverAndArguments) {
+      Request.Builder builder = new Request.Builder();
+      StringBuilder sb = new StringBuilder(baseClusterURL);
+      sb.append("?action=start");
+      if (username != null) {
+         sb.append("&user=");
+         sb.append(username);
+      }
+      serverAndArguments.forEach((server, arguments) -> {
+         sb.append("&server=");
+         sb.append(server);
+         if (!arguments.isEmpty()) {
+            sb.append("&param.");
+            sb.append(server);
+            sb.append("=");
+            sb.append(URLEncoder.encode(arguments, StandardCharsets.UTF_8));
+         }
+      });
       builder.post(EMPTY_BODY).url(sb.toString());
       return client.execute(builder);
    }

--- a/server/core/src/main/java/org/infinispan/server/core/ServerManagement.java
+++ b/server/core/src/main/java/org/infinispan/server/core/ServerManagement.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
-
 import javax.sql.DataSource;
 
 import org.infinispan.commons.configuration.io.ConfigurationWriter;
@@ -26,6 +25,8 @@ public interface ServerManagement {
    void serverStop(List<String> servers);
 
    void clusterStop();
+
+   void serverStart(String username, Map<String, String> serverAndArguments);
 
    void containerStop();
 

--- a/server/core/src/test/java/org/infinispan/server/core/DummyServerManagement.java
+++ b/server/core/src/test/java/org/infinispan/server/core/DummyServerManagement.java
@@ -38,6 +38,9 @@ public class DummyServerManagement implements ServerManagement {
    }
 
    @Override
+   public void serverStart(String username, Map<String, String> serverAndArguments) { }
+
+   @Override
    public void containerStop() {
    }
 

--- a/server/runtime/src/main/server/bin/start.sh
+++ b/server/runtime/src/main/server/bin/start.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+DIRNAME=$(dirname "$0")
+
+# Setup ISPN_HOME
+ISPN_HOME=$(cd "$DIRNAME/.." > /dev/null || exit; pwd)
+
+USER_NAME=$(whoami)
+SERVERS=""
+ADDITIONAL_ARGS=()
+IDX=-1
+
+for arg in "$@"
+do
+  case "$arg" in
+  --user=*)
+    USER_NAME="${arg#*=}"
+    ;;
+  --server=*)
+    IDX=$((IDX+1))
+    ADDITIONAL_ARGS[$IDX]=""
+    SERVERS="$SERVERS ${arg#*=}"
+    ;;
+  *)
+    ADDITIONAL_ARGS[$IDX]="${ADDITIONAL_ARGS[$IDX]} $arg"
+    ;;
+  esac
+done
+
+if [ "x$SERVERS" = "x" ]; then
+  echo "No servers arguments specified" >&2
+  exit 1
+fi
+
+IDX=0
+for server in $SERVERS; do
+  SCRIPT="$ISPN_HOME/bin/server.sh"
+  if [ "x${ADDITIONAL_ARGS[$IDX]}" != "x" ]; then
+    SCRIPT="$SCRIPT ${ADDITIONAL_ARGS[$IDX]}"
+  fi
+  # We want this expanded on the client side.
+  ssh -f -n -q "$USER_NAME@$server" "$SCRIPT"
+  IDX=$((IDX+1))
+done


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-14693

So, this approach uses a bash script to SSH into each given host and start the server. At this point, this is only handling Linux. This has some requirements:

1. The client must be able to connect to the server without a password prompt. This can be done with the keys already prepared beforehand and pushed to the server's authorized_keys;
2. The server must be in the `known_host` on the client. We could add it automatically with `ssh-keyscan` or by removing the host check. 
3. The server folder has the same location on every server.

Since we can start multiple servers, passing custom options to each is a bit tricky (and maybe dangerous, passing arguments directly into the remote node shell). I changed the `server.sh` to persist the options so we can use it in future restarts.

The CLI option has the format:

```text
cluster start -h 10.0.0.1,10.0.0.2,10.0.0.3 -u ssh_user --restore-arguments
```

The `-h` is the hosts list to SSH into, `-u` is the SSH use and fallback to the authenticated username, and `--restore-arguments` will use the same arguments of the last `sever.sh` execution. The host list is required. The restore option is the way I found to use the arguments on each server when starting.

I tried to create something to start a cluster automatically, but keeping track of the host list is not easy, even more, when they could change on each restart. So I only added the option with an explicit list. We could expand this in the future with the suggestions of the named cluster.

The tests are also not so easy, even with the containers. We would need to generate the keys, copy that to every container, and install and prepare the SSH server.

Let me know what you think, if it's feasible, or back to the drawing board, I can turn this into a draft.