### PR TITLE
ISPN-14720 RESP endpoint should be able to parse commands as enum

### DIFF
--- a/server/resp/src/main/java/org/infinispan/server/resp/BaseRespDecoder.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/BaseRespDecoder.java
@@ -114,7 +114,7 @@ public abstract class BaseRespDecoder extends ByteToMessageDecoder {
     * @param arguments the arguments provided to the command. The list should not be retained as it is reused
     * @return boolean whether the decoder can read more bytes or must wait
     */
-   protected boolean handleCommandAndArguments(ChannelHandlerContext ctx, String command, List<byte[]> arguments) {
+   protected boolean handleCommandAndArguments(ChannelHandlerContext ctx, RespCommand command, List<byte[]> arguments) {
       if (log.isTraceEnabled()) {
          log.tracef("Received command: %s with arguments %s for %s", command, Util.toStr(arguments), ctx.channel());
       }

--- a/server/resp/src/main/java/org/infinispan/server/resp/Resp3AuthHandler.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/Resp3AuthHandler.java
@@ -19,10 +19,10 @@ public class Resp3AuthHandler extends CacheRespRequestHandler {
    }
 
    @Override
-   protected CompletionStage<RespRequestHandler> actualHandleRequest(ChannelHandlerContext ctx, String type, List<byte[]> arguments) {
+   protected CompletionStage<RespRequestHandler> actualHandleRequest(ChannelHandlerContext ctx, RespCommand type, List<byte[]> arguments) {
       CompletionStage<Boolean> successStage = null;
       switch (type) {
-         case "HELLO":
+         case HELLO:
             byte[] respProtocolBytes = arguments.get(0);
             String version = new String(respProtocolBytes, CharsetUtil.UTF_8);
             if (!version.equals("3")) {
@@ -36,10 +36,10 @@ public class Resp3AuthHandler extends CacheRespRequestHandler {
                helloResponse(ctx, allocatorToUse);
             }
             break;
-         case "AUTH":
+         case AUTH:
             successStage = performAuth(ctx, arguments.get(0), arguments.get(1));
             break;
-         case "QUIT":
+         case QUIT:
             ctx.close();
             break;
          default:

--- a/server/resp/src/main/java/org/infinispan/server/resp/RespCommand.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/RespCommand.java
@@ -1,0 +1,98 @@
+package org.infinispan.server.resp;
+
+import java.nio.charset.StandardCharsets;
+
+import io.netty.buffer.ByteBuf;
+
+public enum RespCommand {
+   GET,
+   SET,
+   INCR,
+   DECR,
+   DEL,
+   MSET,
+   MGET,
+   PUBLISH,
+   PING,
+   PSUBSCRIBE,
+   PUNSUBSCRIBE,
+   SUBSCRIBE,
+   UNSUBSCRIBE,
+   RESET,
+   COMMAND,
+   ECHO,
+   HELLO,
+   AUTH,
+   CONFIG,
+   INFO,
+   READWRITE,
+   READONLY,
+   SELECT,
+   QUIT;
+
+   private final byte[] bytes;
+
+   RespCommand() {
+      this.bytes = name().getBytes(StandardCharsets.US_ASCII);
+   }
+
+   private static final RespCommand[][] indexedRespCommand;
+
+   static {
+      indexedRespCommand = new RespCommand[26][];
+      // Just manual for now, but we may want to dynamically do this with ordinal determining what order within
+      // a sub array the commands are placed
+      indexedRespCommand[0] = new RespCommand[]{AUTH};
+      indexedRespCommand[2] = new RespCommand[]{CONFIG, COMMAND};
+      indexedRespCommand[3] = new RespCommand[]{DECR, DEL};
+      indexedRespCommand[4] = new RespCommand[]{ECHO};
+      indexedRespCommand[6] = new RespCommand[]{GET};
+      indexedRespCommand[7] = new RespCommand[]{HELLO};
+      indexedRespCommand[8] = new RespCommand[]{INCR, INFO};
+      indexedRespCommand[12] = new RespCommand[]{MGET, MSET};
+      indexedRespCommand[15] = new RespCommand[]{PUBLISH, PING, PSUBSCRIBE, PUNSUBSCRIBE};
+      indexedRespCommand[16] = new RespCommand[]{QUIT};
+      indexedRespCommand[17] = new RespCommand[]{RESET, READWRITE, READONLY};
+      indexedRespCommand[18] = new RespCommand[]{SET, SUBSCRIBE, SELECT};
+      indexedRespCommand[20] = new RespCommand[]{UNSUBSCRIBE};
+   }
+
+   public static RespCommand fromByteBuf(ByteBuf buf, int commandLength) {
+      if (buf.readableBytes() < commandLength + 2) {
+         return null;
+      }
+      int readOffset = buf.readerIndex();
+      // We already asserted we have enough bytes, just mark them as read now, since we have to possibly read the
+      // bytes multiple times to check for various commands
+      buf.readerIndex(readOffset + commandLength + 2);
+      byte b = buf.getByte(readOffset);
+      byte ignoreCase = b >= 97 ? (byte) (b - 97) : (byte) (b - 65);
+      if (ignoreCase < 0 || ignoreCase > 25) {
+         return null;
+      }
+      RespCommand[] target = indexedRespCommand[ignoreCase];
+      if (target == null) {
+         return null;
+      }
+      for (RespCommand possible : target) {
+         byte[] possibleBytes = possible.bytes;
+         if (commandLength == possibleBytes.length) {
+            boolean matches = true;
+            // Already checked first byte, so skip that one
+            for (int i = 1; i < possibleBytes.length; ++i) {
+               byte upperByte = possibleBytes[i];
+               byte targetByte = buf.getByte(readOffset + i);
+               if (upperByte == targetByte || upperByte + 22 == targetByte) {
+                  continue;
+               }
+               matches = false;
+               break;
+            }
+            if (matches) {
+               return possible;
+            }
+         }
+      }
+      return null;
+   }
+}

--- a/server/resp/src/main/java/org/infinispan/server/resp/RespRequestHandler.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/RespRequestHandler.java
@@ -32,8 +32,12 @@ public abstract class RespRequestHandler {
       }
    }
 
-   public final CompletionStage<RespRequestHandler> handleRequest(ChannelHandlerContext ctx, String type, List<byte[]> arguments) {
+   public final CompletionStage<RespRequestHandler> handleRequest(ChannelHandlerContext ctx, RespCommand type, List<byte[]> arguments) {
       initializeIfNecessary(ctx);
+      if (type == null) {
+         stringToByteBuf("-ERR unknown command\r\n", allocatorToUse);
+         return myStage;
+      }
       return actualHandleRequest(ctx, type, arguments);
    }
 
@@ -53,8 +57,8 @@ public abstract class RespRequestHandler {
     * @param arguments The remaining arguments to the command
     * @return stage that when complete returns the new handler to instate. This stage <b>must</b> be completed on the event loop
     */
-   protected CompletionStage<RespRequestHandler> actualHandleRequest(ChannelHandlerContext ctx, String type, List<byte[]> arguments) {
-      if ("QUIT".equals(type)) {
+   protected CompletionStage<RespRequestHandler> actualHandleRequest(ChannelHandlerContext ctx, RespCommand type, List<byte[]> arguments) {
+      if (type == RespCommand.QUIT) {
          ctx.close();
          return myStage;
       }

--- a/server/resp/src/main/java/org/infinispan/server/resp/SubscriberHandler.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/SubscriberHandler.java
@@ -115,11 +115,11 @@ public class SubscriberHandler extends CacheRespRequestHandler {
    }
 
    @Override
-   protected CompletionStage<RespRequestHandler> actualHandleRequest(ChannelHandlerContext ctx, String type, List<byte[]> arguments) {
+   protected CompletionStage<RespRequestHandler> actualHandleRequest(ChannelHandlerContext ctx, RespCommand type, List<byte[]> arguments) {
       initializeIfNecessary(ctx);
 
       switch (type) {
-         case "SUBSCRIBE":
+         case SUBSCRIBE:
             AggregateCompletionStage<Void> aggregateCompletionStage = CompletionStages.aggregateCompletionStage();
             for (byte[] keyChannel : arguments) {
                if (log.isTraceEnabled()) {
@@ -135,7 +135,7 @@ public class SubscriberHandler extends CacheRespRequestHandler {
                }
             }
             return sendSubscriptions(ctx, aggregateCompletionStage.freeze(), arguments, true);
-         case "UNSUBSCRIBE":
+         case UNSUBSCRIBE:
             aggregateCompletionStage = CompletionStages.aggregateCompletionStage();
             if (arguments.size() == 0) {
                return unsubscribeAll(ctx);
@@ -149,16 +149,16 @@ public class SubscriberHandler extends CacheRespRequestHandler {
                }
             }
             return sendSubscriptions(ctx, aggregateCompletionStage.freeze(), arguments, false);
-         case "PING":
+         case PING:
             // Note we don't return the handler and just use it to handle the ping - we assume stage is always complete
             handler.handleRequest(ctx, type, arguments);
             break;
-         case "RESET":
-         case "QUIT":
+         case RESET:
+         case QUIT:
             removeAllListeners();
             return handler.handleRequest(ctx, type, arguments);
-         case "PSUBSCRIBE":
-         case "PUNSUBSCRIBE":
+         case PSUBSCRIBE:
+         case PUNSUBSCRIBE:
             RespRequestHandler.stringToByteBuf("-ERR not implemented yet\r\n", allocatorToUse);
             break;
          default:

--- a/server/resp/src/main/resources/resp.gr
+++ b/server/resp/src/main/resources/resp.gr
@@ -56,9 +56,9 @@ root request
      execute
    ;
 
-command returns String switch singleByte
-   : { BULK_STRING }? bulkString[longProcessor] { bulkString }
-   | { SIMPLE_STRING }? simpleString { simpleString }
+command returns RespCommand switch singleByte
+   : { BULK_STRING }? bulkCommand[longProcessor]
+   | { SIMPLE_STRING }? simpleCommand
    | { throw new UnsupportedOperationException("Type not supported: " + singleByte); }
    ;
 number: readNumber[longProcessor] { readNumber -= 1; };

--- a/server/resp/src/test/java/org/infinispan/server/resp/RespDecoderTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/RespDecoderTest.java
@@ -33,10 +33,10 @@ public class RespDecoderTest {
    Queue<Request> queuedCommands;
 
    static class Request {
-      private final String command;
+      private final RespCommand command;
       private final List<byte[]> arguments;
 
-      Request(String command, List<byte[]> arguments) {
+      Request(RespCommand command, List<byte[]> arguments) {
          this.command = command;
          // Make a copy, because the decoder may reuse the list
          this.arguments = new ArrayList<>(arguments);
@@ -48,7 +48,7 @@ public class RespDecoderTest {
       queuedCommands = new ArrayDeque<>();
       RespRequestHandler myRespRequestHandler = new RespRequestHandler() {
          @Override
-         protected CompletionStage<RespRequestHandler> actualHandleRequest(ChannelHandlerContext ctx, String type, List<byte[]> arguments) {
+         protected CompletionStage<RespRequestHandler> actualHandleRequest(ChannelHandlerContext ctx, RespCommand type, List<byte[]> arguments) {
             queuedCommands.add(new Request(type, arguments));
             return myStage;
          }
@@ -63,7 +63,7 @@ public class RespDecoderTest {
 
    @Test
    public void testMixtureOfTypes() {
-      String commandName = "ALLTYPES";
+      String commandName = RespCommand.PSUBSCRIBE.toString();
       String minValueStr = String.valueOf(Long.MIN_VALUE);
       ByteBuf buffer = Unpooled.copiedBuffer("*6\r\n+" + commandName + "\r\n$3\r\nkey\r\n+value\r\n:23\r\n$5\r\nworks\r\n:" + minValueStr + "\r\n", StandardCharsets.US_ASCII);
       channel.writeInbound(buffer);
@@ -72,7 +72,7 @@ public class RespDecoderTest {
 
       Request req = queuedCommands.poll();
       assertNotNull(req);
-      assertEquals(commandName, req.command);
+      assertEquals(RespCommand.PSUBSCRIBE, req.command);
       List<byte[]> arguments = req.arguments;
       assertEquals(5, arguments.size());
 


### PR DESCRIPTION
Changes command parsing from reading a byte[] that is then converted to a String to instead read the bytes directly and take assumptions since all these commands are ASCII characters a-zA-Z. Instead we now have a 2D indexing the outer array by the first character of the command, so that we only have to check for a subset of commands. Also we verify length of the array first to avoid doing any byte comparisons unless the command actually has the same number of bytes. This also prevents any allocations for the command and will allow us to put properties on the arguments such as minimum and maximum arguments, security and other things in the enum itself.

Results from benchmark with these changes in https://github.com/infinispan/infinispan-benchmarks/pull/15 ( average time per invocation in us/op) Lower is better

Benchmark    |                    (decoder) | (messageCount) | Score  
--------------|:-----:|:-----:|-----------:
MyBenchmark.testGetPerf            |CURRENT         |    N/A  |0.795 
MyBenchmark.testGetPerf             |   NEW            | N/A  | 0.731
MyBenchmark.testGetPipelinePerf |   CURRENT    |           2  |1.205 
MyBenchmark.testGetPipelinePerf   |     NEW         |      2  |1.188 
MyBenchmark.testGetPipelinePerf  |  CURRENT     |         25  |6.990 
MyBenchmark.testGetPipelinePerf    |    NEW          |    25  |  5.516 
MyBenchmark.testSetPerf            |CURRENT            | N/A  |  0.832 
MyBenchmark.testSetPerf             |   NEW             |N/A  |  0.779
MyBenchmark.testSetPipelinePerf |   CURRENT               |2  |1.314 
MyBenchmark.testSetPipelinePerf   |     NEW               |2  |1.247
MyBenchmark.testSetPipelinePerf  |  CURRENT              |25 |7.812 
MyBenchmark.testSetPipelinePerf    |    NEW              |25  |6.994

