### PR TITLE
[14.0] ISPN-14738 RESP endpoint commands don't require previous value

### DIFF
--- a/core/src/main/java/org/infinispan/marshall/persistence/impl/MarshalledEntryFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/marshall/persistence/impl/MarshalledEntryFactoryImpl.java
@@ -63,7 +63,8 @@ public class MarshalledEntryFactoryImpl implements MarshallableEntryFactory {
    @Override
    public MarshallableEntry create(Object key, Object value, Metadata metadata, PrivateMetadata internalMetadata,
          long created, long lastUsed) {
-      return new MarshallableEntryImpl<>(key, value, metadata, internalMetadata, created, lastUsed, marshaller);
+      return new MarshallableEntryImpl<>(key, value, metadata == EmbeddedMetadata.EMPTY ? null : metadata,
+            internalMetadata, created, lastUsed, marshaller);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/metadata/EmbeddedMetadata.java
+++ b/core/src/main/java/org/infinispan/metadata/EmbeddedMetadata.java
@@ -137,7 +137,7 @@ public class EmbeddedMetadata implements Metadata {
          else if (hasLifespan)
             return new EmbeddedLifespanExpirableMetadata(toMillis(lifespan, lifespanUnit), version);
          else if (hasMaxIdle)
-            return new EmbeddedMaxIdleExpirableMetadata(toMillis(maxIdle, lifespanUnit), version);
+            return new EmbeddedMaxIdleExpirableMetadata(toMillis(maxIdle, maxIdleUnit), version);
          else if (version == null)
             return EmbeddedMetadata.EMPTY;
          else

--- a/core/src/main/java/org/infinispan/metadata/EmbeddedMetadata.java
+++ b/core/src/main/java/org/infinispan/metadata/EmbeddedMetadata.java
@@ -138,16 +138,18 @@ public class EmbeddedMetadata implements Metadata {
             return new EmbeddedLifespanExpirableMetadata(toMillis(lifespan, lifespanUnit), version);
          else if (hasMaxIdle)
             return new EmbeddedMaxIdleExpirableMetadata(toMillis(maxIdle, lifespanUnit), version);
+         else if (version == null)
+            return EmbeddedMetadata.EMPTY;
          else
             return new EmbeddedMetadata(version);
       }
 
       protected boolean hasLifespan() {
-         return lifespan != null;
+         return lifespan != null && lifespan >= 0;
       }
 
       protected boolean hasMaxIdle() {
-         return maxIdle != null;
+         return maxIdle != null && maxIdle >= 0;
       }
 
       @Override

--- a/core/src/test/java/org/infinispan/persistence/CacheLoaderFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/persistence/CacheLoaderFunctionalTest.java
@@ -31,6 +31,7 @@ import org.infinispan.context.Flag;
 import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.marshall.persistence.impl.MarshalledEntryUtil;
+import org.infinispan.metadata.Metadata;
 import org.infinispan.persistence.dummy.DummyInMemoryStore;
 import org.infinispan.persistence.dummy.DummyInMemoryStoreConfigurationBuilder;
 import org.infinispan.persistence.spi.MarshallableEntry;
@@ -659,7 +660,8 @@ public class CacheLoaderFunctionalTest extends AbstractInfinispanTest {
             found = true;
          }
          if (load != null) {
-            testStoredEntry(load.getValue(), value, load.getMetadata().lifespan(), lifespan, "Store", key);
+            Metadata metadata = load.getMetadata();
+            testStoredEntry(load.getValue(), value, metadata != null ? metadata.lifespan() : -1, lifespan, "Store", key);
             found = true;
          }
          assertTrue("Key not found.", found);
@@ -690,7 +692,8 @@ public class CacheLoaderFunctionalTest extends AbstractInfinispanTest {
             found = true;
          }
          if (load != null) {
-            testStoredEntry(load.getValue(), value, load.getMetadata().lifespan(), lifespan, "Store", key);
+            Metadata metadata = load.getMetadata();
+            testStoredEntry(load.getValue(), value, metadata != null ? metadata.lifespan() : -1, lifespan, "Store", key);
             found = true;
          }
          assertTrue("Key not found.", found);

--- a/core/src/test/java/org/infinispan/persistence/WriteSkewCacheLoaderFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/persistence/WriteSkewCacheLoaderFunctionalTest.java
@@ -17,6 +17,7 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.container.DataContainer;
 import org.infinispan.container.entries.InternalCacheValue;
 import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.metadata.Metadata;
 import org.infinispan.persistence.dummy.DummyInMemoryStore;
 import org.infinispan.persistence.dummy.DummyInMemoryStoreConfigurationBuilder;
 import org.infinispan.persistence.spi.MarshallableEntry;
@@ -68,7 +69,8 @@ public class WriteSkewCacheLoaderFunctionalTest extends SingleCacheManagerTest {
       assertStoredEntry(icv.getValue(), value, icv.getLifespan(), lifespanMillis, "Cache", key);
       assertNotNull("For :" + icv, icv.getInternalMetadata().entryVersion());
       MarshallableEntry<?, ?> load = store.loadEntry(key);
-      assertStoredEntry(load.getValue(), value, load.getMetadata().lifespan(), lifespanMillis, "Store", key);
+      Metadata metadata = load.getMetadata();
+      assertStoredEntry(load.getValue(), value, metadata != null ? metadata.lifespan() : -1, lifespanMillis, "Store", key);
       assertNotNull("For :" + load, load.getInternalMetadata().entryVersion());
    }
 

--- a/core/src/test/java/org/infinispan/persistence/sifs/SoftIndexFileStoreFileStatsTest.java
+++ b/core/src/test/java/org/infinispan/persistence/sifs/SoftIndexFileStoreFileStatsTest.java
@@ -148,7 +148,7 @@ public class SoftIndexFileStoreFileStatsTest extends SingleCacheManagerTest {
       try {
          cache.put("k1", "v1", 2, TimeUnit.MILLISECONDS);
 
-         for (int i = 2; i < 22; ++i) {
+         for (int i = 2; i < 40; ++i) {
             cache.put("k" + i, "v" + 2);
          }
 

--- a/core/src/test/java/org/infinispan/persistence/sifs/SoftIndexFileStoreRestartTest.java
+++ b/core/src/test/java/org/infinispan/persistence/sifs/SoftIndexFileStoreRestartTest.java
@@ -191,7 +191,9 @@ public class SoftIndexFileStoreRestartTest extends BaseDistStoreTest<Integer, St
 
    @Test(dataProvider = "booleans")
    public void testRestartWithEntryUpdatedMultipleTimes(boolean leafOrNode) throws Throwable {
-      int size = 10;
+      // Current serialized size is 54 bytes, so this number has to be large enough to cause a file to fill to
+      // actually compact something
+      int size = 20;
       String key = "compaction";
       // We want to test both a leaf and node storage on the root node
       int extraInserts = leafOrNode ? size : size * 256;


### PR DESCRIPTION
* Add IGNORE_RETURN_VALUES flag as well

https://issues.redhat.com/browse/ISPN-14738