### PR TITLE
ISPN-14740 Do not persist empty metadata

### DIFF
--- a/core/src/main/java/org/infinispan/functional/impl/MetaParamsInternalMetadata.java
+++ b/core/src/main/java/org/infinispan/functional/impl/MetaParamsInternalMetadata.java
@@ -54,7 +54,10 @@ public final class MetaParamsInternalMetadata implements InternalMetadata, MetaP
       if (counterConfiguration != null) {
          params.add(new CounterConfigurationMetaParam(counterConfiguration));
       }
-      params.add(MetaParam.MetaUpdateCreationTime.of(updateCreationTimestamp));
+      // Default is always true, so no need to set the param unless it is false
+      if (!updateCreationTimestamp) {
+         params.add(MetaParam.MetaUpdateCreationTime.of(false));
+      }
    }
 
    private MetaParamsInternalMetadata(MetaParams params) {

--- a/core/src/main/java/org/infinispan/marshall/persistence/impl/MarshalledEntryFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/marshall/persistence/impl/MarshalledEntryFactoryImpl.java
@@ -63,7 +63,11 @@ public class MarshalledEntryFactoryImpl implements MarshallableEntryFactory {
    @Override
    public MarshallableEntry create(Object key, Object value, Metadata metadata, PrivateMetadata internalMetadata,
          long created, long lastUsed) {
-      return new MarshallableEntryImpl<>(key, value, metadata, internalMetadata, created, lastUsed, marshaller);
+      PrivateMetadata privateMetadataToUse = internalMetadata != null && !internalMetadata.isEmpty() ? internalMetadata : null;
+      if (metadata == null || metadata.isEmpty()) {
+         return new MarshallableEntryImpl<>(key, value, null, privateMetadataToUse, -1, -1, marshaller);
+      }
+      return new MarshallableEntryImpl<>(key, value, metadata, privateMetadataToUse, created, lastUsed, marshaller);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/metadata/EmbeddedMetadata.java
+++ b/core/src/main/java/org/infinispan/metadata/EmbeddedMetadata.java
@@ -67,6 +67,11 @@ public class EmbeddedMetadata implements Metadata {
    }
 
    @Override
+   public boolean isEmpty() {
+      return version == null;
+   }
+
+   @Override
    public Metadata.Builder builder() {
       return new Builder().version(version);
    }
@@ -206,6 +211,11 @@ public class EmbeddedMetadata implements Metadata {
       }
 
       @Override
+      public boolean isEmpty() {
+         return super.isEmpty() && lifespan < 0 && maxIdle < 0;
+      }
+
+      @Override
       public boolean equals(Object o) {
          if (this == o) return true;
          if (o == null || getClass() != o.getClass()) return false;
@@ -257,6 +267,11 @@ public class EmbeddedMetadata implements Metadata {
       }
 
       @Override
+      public boolean isEmpty() {
+         return super.isEmpty() && lifespan < 0;
+      }
+
+      @Override
       public boolean equals(Object o) {
          if (this == o) return true;
          if (o == null || getClass() != o.getClass()) return false;
@@ -298,6 +313,11 @@ public class EmbeddedMetadata implements Metadata {
       @Override
       public long maxIdle() {
          return maxIdle;
+      }
+
+      @Override
+      public boolean isEmpty() {
+         return super.isEmpty() && maxIdle < 0;
       }
 
       @Override

--- a/core/src/main/java/org/infinispan/metadata/Metadata.java
+++ b/core/src/main/java/org/infinispan/metadata/Metadata.java
@@ -56,6 +56,15 @@ public interface Metadata {
    }
 
    /**
+    * Returns whether this metadata is effectively empty, that is that persisting or replicating it to another
+    * node would be no different then sending a null metadata object.
+    * @return if this metadata has no actual data to store
+    */
+   default boolean isEmpty() {
+      return false;
+   }
+
+   /**
     * Returns an instance of {@link Builder} which can be used to build
     * new instances of {@link Metadata} instance which are full copies of
     * this {@link Metadata}.

--- a/core/src/main/java/org/infinispan/metadata/impl/InternalMetadataImpl.java
+++ b/core/src/main/java/org/infinispan/metadata/impl/InternalMetadataImpl.java
@@ -63,6 +63,11 @@ public class InternalMetadataImpl implements InternalMetadata {
    }
 
    @Override
+   public boolean isEmpty() {
+      return actual.isEmpty();
+   }
+
+   @Override
    public Builder builder() {
       return new InternalBuilder(actual, created, lastUsed);
    }

--- a/core/src/main/java/org/infinispan/metadata/impl/L1Metadata.java
+++ b/core/src/main/java/org/infinispan/metadata/impl/L1Metadata.java
@@ -35,6 +35,11 @@ public class L1Metadata implements Metadata {
    }
 
    @Override
+   public boolean isEmpty() {
+      return metadata.isEmpty();
+   }
+
+   @Override
    public Metadata.Builder builder() {
       return metadata.builder();
    }

--- a/core/src/test/java/org/infinispan/persistence/CacheLoaderFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/persistence/CacheLoaderFunctionalTest.java
@@ -659,7 +659,7 @@ public class CacheLoaderFunctionalTest extends AbstractInfinispanTest {
             found = true;
          }
          if (load != null) {
-            testStoredEntry(load.getValue(), value, load.getMetadata().lifespan(), lifespan, "Store", key);
+            testStoredEntry(load.getValue(), value, load.getMetadata() == null ? -1 : load.getMetadata().lifespan(), lifespan, "Store", key);
             found = true;
          }
          assertTrue("Key not found.", found);
@@ -690,7 +690,7 @@ public class CacheLoaderFunctionalTest extends AbstractInfinispanTest {
             found = true;
          }
          if (load != null) {
-            testStoredEntry(load.getValue(), value, load.getMetadata().lifespan(), lifespan, "Store", key);
+            testStoredEntry(load.getValue(), value, load.getMetadata() == null ? -1 : load.getMetadata().lifespan(), lifespan, "Store", key);
             found = true;
          }
          assertTrue("Key not found.", found);

--- a/core/src/test/java/org/infinispan/persistence/WriteSkewCacheLoaderFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/persistence/WriteSkewCacheLoaderFunctionalTest.java
@@ -68,7 +68,7 @@ public class WriteSkewCacheLoaderFunctionalTest extends SingleCacheManagerTest {
       assertStoredEntry(icv.getValue(), value, icv.getLifespan(), lifespanMillis, "Cache", key);
       assertNotNull("For :" + icv, icv.getInternalMetadata().entryVersion());
       MarshallableEntry<?, ?> load = store.loadEntry(key);
-      assertStoredEntry(load.getValue(), value, load.getMetadata().lifespan(), lifespanMillis, "Store", key);
+      assertStoredEntry(load.getValue(), value, load.getMetadata() == null ? -1 : load.getMetadata().lifespan(), lifespanMillis, "Store", key);
       assertNotNull("For :" + load, load.getInternalMetadata().entryVersion());
    }
 

--- a/core/src/test/java/org/infinispan/persistence/sifs/SoftIndexFileStoreRestartTest.java
+++ b/core/src/test/java/org/infinispan/persistence/sifs/SoftIndexFileStoreRestartTest.java
@@ -51,8 +51,8 @@ public class SoftIndexFileStoreRestartTest extends BaseDistStoreTest<Integer, St
                         .add(new SoftIndexFileStoreRestartTest().fileSize(10_000).cacheMode(type))
                         .add(new SoftIndexFileStoreRestartTest().fileSize(320_000).cacheMode(type))
                         .add(new SoftIndexFileStoreRestartTest().fileSize(2_000_000).cacheMode(type))
-                        .add(new SoftIndexFileStoreRestartTest().fileSize(DataConfiguration.MAX_FILE_SIZE.getDefaultValue()).cacheMode(type)
-                        ).build()
+                        .add(new SoftIndexFileStoreRestartTest().fileSize(DataConfiguration.MAX_FILE_SIZE.getDefaultValue()).cacheMode(type))
+                        .build()
             ).toArray();
    }
 
@@ -191,7 +191,9 @@ public class SoftIndexFileStoreRestartTest extends BaseDistStoreTest<Integer, St
 
    @Test(dataProvider = "booleans")
    public void testRestartWithEntryUpdatedMultipleTimes(boolean leafOrNode) throws Throwable {
-      int size = 10;
+      // Current serialized size is 54 bytes, so this number has to be large enough to cause a file to fill to
+      // actually compact something
+      int size = 20;
       String key = "compaction";
       // We want to test both a leaf and node storage on the root node
       int extraInserts = leafOrNode ? size : size * 256;

--- a/server/memcached/src/main/java/org/infinispan/server/memcached/MemcachedMetadata.java
+++ b/server/memcached/src/main/java/org/infinispan/server/memcached/MemcachedMetadata.java
@@ -35,6 +35,11 @@ public class MemcachedMetadata extends EmbeddedMetadata.EmbeddedLifespanExpirabl
    }
 
    @Override
+   public boolean isEmpty() {
+      return super.isEmpty() && flags == 0;
+   }
+
+   @Override
    public Metadata.Builder builder() {
       return new Builder()
             .flags(flags)


### PR DESCRIPTION
* PersistenceManager won't pass metadata with no expiration or version

https://issues.redhat.com/browse/ISPN-14740

Reworked this to not change the in memory persistence and instead now we just ignore the metadata when passing to a store. 

This saves approximately 40 bytes per entry and avoids serializing the metadata to protostream. 

This change is the equivalent to https://github.com/infinispan/infinispan/blob/main/core/src/main/java/org/infinispan/container/impl/InternalEntryFactoryImpl.java#L88 which avoids the allocation in memory.