### PR TITLE
IPSN-14801 Data Distribution metrics REST API is broken for secured c…

### DIFF
--- a/server/rest/src/main/java/org/infinispan/rest/cachemanager/RestCacheManager.java
+++ b/server/rest/src/main/java/org/infinispan/rest/cachemanager/RestCacheManager.java
@@ -235,7 +235,7 @@ public class RestCacheManager<V> {
       checkCachePermission(ac, request.getSubject(), AuthorizationPermission.MONITOR);
       DistributionManager dm = SecurityActions.getDistributionManager(ac);
       if (dm == null) {
-         CacheDistributionInfo local = CacheDistributionInfo.resolve(instance.getCache(cacheName).getAdvancedCache());
+         CacheDistributionInfo local = CacheDistributionInfo.resolve(ac, instance.getCacheManagerInfo());
          return CompletableFuture.completedFuture(Collections.singletonList(local));
       }
 

--- a/server/rest/src/main/java/org/infinispan/rest/distribution/CacheDistributionInfo.java
+++ b/server/rest/src/main/java/org/infinispan/rest/distribution/CacheDistributionInfo.java
@@ -69,8 +69,12 @@ public class CacheDistributionInfo implements JsonSerialization, NodeDataDistrib
    }
 
    public static CacheDistributionInfo resolve(AdvancedCache<?, ?> cache) {
-      final Stats stats = cache.getStats();
       final CacheManagerInfo manager = cache.getCacheManager().getCacheManagerInfo();
+      return resolve(cache, manager);
+   }
+
+   public static CacheDistributionInfo resolve(AdvancedCache<?, ?> cache, CacheManagerInfo manager) {
+      final Stats stats = cache.getStats();
       long inMemory = stats.getApproximateEntriesInMemory();
       long total = stats.getApproximateEntries();
       return new CacheDistributionInfo(manager.getNodeName(), manager.getPhysicalAddressesRaw(), inMemory, total,

--- a/server/tests/src/test/java/org/infinispan/server/security/authorization/AbstractAuthorization.java
+++ b/server/tests/src/test/java/org/infinispan/server/security/authorization/AbstractAuthorization.java
@@ -141,9 +141,18 @@ public abstract class AbstractAuthorization {
    }
 
    @Test
+   public void testRestLocalCacheDistribution() {
+      restCreateAuthzLocalCache("admin", "observer", "deployer", "application", "writer", "reader", "monitor");
+      actualTestCacheDistribution();
+   }
+
+   @Test
    public void testRestCacheDistribution() {
       restCreateAuthzCache("admin", "observer", "deployer", "application", "writer", "reader", "monitor");
+      actualTestCacheDistribution();
+   }
 
+   private void actualTestCacheDistribution() {
       for (TestUser type : EnumSet.of(TestUser.ADMIN, TestUser.MONITOR)) {
          RestCacheClient cache = getServerTest().rest().withClientConfiguration(restBuilders.get(type)).get().cache(getServerTest().getMethodName());
          assertStatus(OK, cache.distribution());
@@ -817,8 +826,16 @@ public abstract class AbstractAuthorization {
    }
 
    private RestClient restCreateAuthzCache(String... explicitRoles) {
+      return restCreateAuthzCache(CacheMode.DIST_SYNC, explicitRoles);
+   }
+
+   private RestClient restCreateAuthzLocalCache(String... explicitRoles) {
+      return restCreateAuthzCache(CacheMode.LOCAL, explicitRoles);
+   }
+
+   private RestClient restCreateAuthzCache(CacheMode mode, String... explicitRoles) {
       org.infinispan.configuration.cache.ConfigurationBuilder builder = new org.infinispan.configuration.cache.ConfigurationBuilder();
-      AuthorizationConfigurationBuilder authorizationConfigurationBuilder = builder.clustering().cacheMode(CacheMode.DIST_SYNC).security().authorization().enable();
+      AuthorizationConfigurationBuilder authorizationConfigurationBuilder = builder.clustering().cacheMode(mode).security().authorization().enable();
       if (explicitRoles != null) {
          for (String role : explicitRoles) {
             authorizationConfigurationBuilder.role(role);


### PR DESCRIPTION
…aches

https://issues.redhat.com/browse/ISPN-14801

The issue happened with local caches, which also lacked some test coverage.