### PR TITLE
Docs fix, remove option to update index schema from the console

### DIFF
--- a/documentation/src/main/asciidoc/topics/proc_indexing_update_index_schema.adoc
+++ b/documentation/src/main/asciidoc/topics/proc_indexing_update_index_schema.adoc
@@ -23,7 +23,7 @@ remoteCacheManager.administration().updateIndexSchema("MyCache");
 +
 [TIP]
 ====
-For remote caches, you can update index schema from the {brandname} Console or using the link:{rest_docs}#rest_v2_query_updateIndexSchema[REST API].
+For remote caches, you can update index schema using the link:{rest_docs}#rest_v2_query_updateIndexSchema[REST API].
 ====
 
 .Additional resources


### PR DESCRIPTION
Small docs update. It's not possible to update index schema from the console.
fyi @andyuk1986 