### PR TITLE
Explicitly set xmx for windows native builds to prevent OOM

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -51,7 +51,7 @@ jobs:
         name: Build native executable
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
-          mvnw.cmd -V install -s maven-settings.xml -Pdistribution -Pnative -Pwindows -am -pl quarkus/cli
+          mvnw.cmd -V install -s maven-settings.xml -Pdistribution -Pnative -Pwindows -am -pl quarkus/cli -Dquarkus.native.native-image-xmx=5G
         shell: cmd
 
       - if: ${{ matrix.os != 'windows-2022' }}


### PR DESCRIPTION
Windows GH action runners get 7GB of RAM, attempting to limit the amount of memory available to the windows build in order to avoid OOM.

https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners