### PR TITLE
ISPN-13053 Enable XML configuration to support "name-as-tags" again

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/global/GlobalMetricsConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/global/GlobalMetricsConfiguration.java
@@ -11,10 +11,10 @@ import org.infinispan.commons.configuration.attributes.AttributeSet;
  */
 public class GlobalMetricsConfiguration {
 
-   public static final AttributeDefinition<Boolean> GAUGES = AttributeDefinition.builder("gauges", true).immutable().build();
-   public static final AttributeDefinition<Boolean> HISTOGRAMS = AttributeDefinition.builder("histograms", false).immutable().build();
-   public static final AttributeDefinition<String> PREFIX = AttributeDefinition.builder("prefix", "").immutable().build();
-   public static final AttributeDefinition<Boolean> NAMES_AS_TAGS = AttributeDefinition.builder("namesAsTags", false).immutable().build();
+   public static final AttributeDefinition<Boolean> GAUGES = AttributeDefinition.builder(org.infinispan.configuration.parsing.Attribute.GAUGES, true).immutable().build();
+   public static final AttributeDefinition<Boolean> HISTOGRAMS = AttributeDefinition.builder(org.infinispan.configuration.parsing.Attribute.HISTOGRAMS, false).immutable().build();
+   public static final AttributeDefinition<String> PREFIX = AttributeDefinition.builder(org.infinispan.configuration.parsing.Attribute.PREFIX, "").immutable().build();
+   public static final AttributeDefinition<Boolean> NAMES_AS_TAGS = AttributeDefinition.builder(org.infinispan.configuration.parsing.Attribute.NAMES_AS_TAGS, false).immutable().build();
    public static final AttributeDefinition<Boolean> ACCURATE_SIZE = AttributeDefinition.builder(org.infinispan.configuration.parsing.Attribute.ACCURATE_SIZE, false).build();
 
    static AttributeSet attributeDefinitionSet() {

--- a/core/src/main/java/org/infinispan/configuration/parsing/Attribute.java
+++ b/core/src/main/java/org/infinispan/configuration/parsing/Attribute.java
@@ -126,7 +126,7 @@ public enum Attribute {
     MODULE,
     NAME,
     NAMES,
-    NAMES_AS_TAGS("namesAsTags"),
+    NAMES_AS_TAGS,
     NON_BLOCKING_EXECUTOR,
     NOTIFICATIONS,
     ON_REHASH("onRehash"),

--- a/core/src/main/resources/schema/infinispan-config-15.0.xsd
+++ b/core/src/main/resources/schema/infinispan-config-15.0.xsd
@@ -748,10 +748,10 @@
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="namesAsTags" type="xs:boolean" default="${GlobalMetrics.namesAsTags}">
+    <xs:attribute name="names-as-tags" type="xs:boolean" default="${GlobalMetrics.namesAsTags}">
       <xs:annotation>
         <xs:documentation>
-          Put the cache manager and cache name in tags rather then include them in the metric name.
+          Put the cache manager and cache name in tags rather than include them in the metric name.
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>

--- a/core/src/test/resources/configs/all/15.0.xml
+++ b/core/src/test/resources/configs/all/15.0.xml
@@ -123,7 +123,7 @@
             <regex>org.infinispan.test.data.*</regex>
          </allow-list>
       </serialization>
-      <metrics gauges="true" histograms="true" accurate-size="true"/>
+      <metrics gauges="true" histograms="true" accurate-size="true" names-as-tags="true" />
       <jmx enabled="true" domain="my-domain" mbean-server-lookup="org.infinispan.jmx.CustomMBeanServerPropertiesTest$TestLookup">
          <property name="key">value</property>
       </jmx>


### PR DESCRIPTION
This fixes https://issues.redhat.com/browse/ISPN-13053

As the tag name was broken for several versions, I opted to rename the tag to follow the usual XML naming convention of other attribute being "kebab-case". Please advise if you think differently. 

The test case which tests that the parsing of the XML works is `UnifiedXmlFileParsingTest#testParseAndConstructUnifiedXmlFile`. Once I added the "nameAsTags" to the "15.0.xml" file it turned red. After the changes it is now green again.
