### PR TITLE
[14.0.x]docs fixes, typos, grammar, asciidoc syntax

### DIFF
--- a/documentation/src/main/asciidoc/topics/con_performance_data_consistency.adoc
+++ b/documentation/src/main/asciidoc/topics/con_performance_data_consistency.adoc
@@ -15,7 +15,7 @@ The main performance concern for enabling transactions is finding the balance be
 
 .Write locks with transactions
 
-Configuring the wrong locking mode can negatively the performance of your transactions.
+Configuring the wrong locking mode can negatively affect the performance of your transactions.
 The right locking mode depends on whether your {brandname} deployment has a high or low rate of contention for keys.
 
 For workloads with low rates of contention, where two or more transactions are not likely to write to the same key simultaneously, optimistic locking offers the best performance.

--- a/documentation/src/main/asciidoc/topics/con_restarting_clusters.adoc
+++ b/documentation/src/main/asciidoc/topics/con_restarting_clusters.adoc
@@ -2,7 +2,7 @@
 = Shutdown and restart of {brandname} clusters
 Prevent data loss and ensure consistency of your cluster by properly shutting down and restarting nodes.
 
-[descrete]
+[discrete]
 == Cluster shutdown
 {brandname} recommends using the `shutdown cluster` command to stop all nodes in a cluster while saving cluster state and persisting all data in the cache.
 You can use the `shutdown cluster` command also for clusters with a single node.

--- a/documentation/src/main/asciidoc/topics/transactions.adoc
+++ b/documentation/src/main/asciidoc/topics/transactions.adoc
@@ -31,9 +31,6 @@ If you're running {brandname} in WildFly 11 or later, this should be your defaul
 This is a lookup class that locate transaction managers in the most popular Java EE application servers.
 If no transaction manager can be found, it defaults on the `EmbeddedTransactionManager`.
 
-WARN: `DummyTransactionManagerLookup` has been deprecated in 9.0 and it will be removed in the future.
-Use `EmbeddedTransactionManagerLookup` instead.
-
 Once initialized, the `TransactionManager` can also be obtained from the `Cache` itself:
 
 [source,java]


### PR DESCRIPTION
miscellaneous docs fixes

-     fix asciidoc syntax
-     typo
-     remove warning about DummyTransactionManagerLookup deprecation

backports #10887 