### PR TITLE
ISPN-14832 Hot Rod client issues

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/ChannelFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/ChannelFactory.java
@@ -202,22 +202,26 @@ public class ChannelFactory {
             .option(ChannelOption.SO_KEEPALIVE, configuration.tcpKeepAlive())
             .option(ChannelOption.TCP_NODELAY, configuration.tcpNoDelay())
             .option(ChannelOption.SO_RCVBUF, 1024576);
-      int maxConnections = configuration.connectionPool().maxActive();
-      if (maxConnections < 0) {
-         maxConnections = Integer.MAX_VALUE;
-      }
       ChannelInitializer channelInitializer = createChannelInitializer(address, bootstrap);
       bootstrap.handler(channelInitializer);
-      ChannelPool pool = new ChannelPool(bootstrap.config().group().next(), address, channelInitializer,
-            configuration.connectionPool().exhaustedAction(), this::onConnectionEvent,
-            configuration.connectionPool().maxWait(), maxConnections,
-            configuration.connectionPool().maxPendingRequests());
+      ChannelPool pool = createChannelPool(bootstrap, channelInitializer, address);
       channelInitializer.setChannelPool(pool);
       return pool;
    }
 
    public ChannelInitializer createChannelInitializer(SocketAddress address, Bootstrap bootstrap) {
       return new ChannelInitializer(bootstrap, address, operationsFactory, configuration, this);
+   }
+
+   protected ChannelPool createChannelPool(Bootstrap bootstrap, ChannelInitializer channelInitializer, SocketAddress address) {
+      int maxConnections = configuration.connectionPool().maxActive();
+      if (maxConnections < 0) {
+         maxConnections = Integer.MAX_VALUE;
+      }
+      return new ChannelPool(bootstrap.config().group().next(), address, channelInitializer,
+            configuration.connectionPool().exhaustedAction(), this::onConnectionEvent,
+            configuration.connectionPool().maxWait(), maxConnections,
+            configuration.connectionPool().maxPendingRequests());
    }
 
    protected final OperationsFactory getOperationsFactory() {
@@ -300,7 +304,8 @@ public class ChannelFactory {
             : fetchChannelAndInvoke(server, operation);
    }
 
-   private <T extends ChannelOperation> T fetchChannelAndInvoke(SocketAddress preferred, byte[] cacheName, T operation) {
+   // Package-private for testing purposes.
+   <T extends ChannelOperation> T fetchChannelAndInvoke(SocketAddress preferred, byte[] cacheName, T operation) {
       boolean suspect;
       lock.readLock().lock();
       try {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/HeaderDecoder.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/HeaderDecoder.java
@@ -90,11 +90,6 @@ public class HeaderDecoder extends HintedReplayingDecoder<HeaderDecoder.State> {
                   case CACHE_ENTRY_EXPIRED_EVENT_RESPONSE:
                      if (codec.allowOperationsAndEvents()) {
                         operation = messageId == 0 ? null : incomplete.get(messageId);
-                     } else if (incomplete.size() == 1) {
-                        operation = incomplete.values().iterator().next();
-                        messageId = operation.header().messageId();
-                     } else if (incomplete.size() > 1) {
-                        throw new IllegalStateException("Too many incomplete operations: " + incomplete);
                      } else {
                         operation = null;
                         messageId = 0;

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/transport/netty/CloseBeforeEnqueuingTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/transport/netty/CloseBeforeEnqueuingTest.java
@@ -1,0 +1,172 @@
+package org.infinispan.client.hotrod.impl.transport.netty;
+
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.testng.AssertJUnit.assertTrue;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import org.infinispan.client.hotrod.DataFormat;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.client.hotrod.configuration.Configuration;
+import org.infinispan.client.hotrod.impl.ClientTopology;
+import org.infinispan.client.hotrod.impl.operations.RetryOnFailureOperation;
+import org.infinispan.client.hotrod.impl.protocol.CodecHolder;
+import org.infinispan.client.hotrod.retry.AbstractRetryTest;
+import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
+import org.infinispan.client.hotrod.test.InternalRemoteCacheManager;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.test.fwk.CleanupAfterMethod;
+import org.testng.annotations.Test;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+
+@CleanupAfterMethod
+@Test(testName = "client.hotrod.impl.transport.netty.CloseBeforeEnqueuingTest", groups = "functional")
+public class CloseBeforeEnqueuingTest extends AbstractRetryTest {
+
+   @Override
+   protected ConfigurationBuilder getCacheConfig() {
+      ConfigurationBuilder builder = hotRodCacheConfiguration(
+            getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false));
+      builder.clustering().hash().numOwners(1);
+      return builder;
+   }
+
+   protected RemoteCacheManager createRemoteCacheManager(int port) {
+      org.infinispan.client.hotrod.configuration.ConfigurationBuilder builder =
+            HotRodClientTestingUtil.newRemoteConfigurationBuilder();
+      amendRemoteCacheManagerConfiguration(builder);
+      builder
+            .forceReturnValues(true)
+            .connectionTimeout(5)
+            .connectionPool().maxActive(1) // This ensures that only one server is active at a time
+            .addServer().host("127.0.0.1").port(port);
+      Configuration configuration = builder.build();
+      RemoteCacheManager remoteCacheManager = new InternalRemoteCacheManager(configuration, new CustomChannelFactory(configuration));
+      remoteCacheManager.start();
+      return remoteCacheManager;
+   }
+
+   public void testClosingAndEnqueueing() throws Exception {
+      ChannelFactory channelFactory = remoteCacheManager.getChannelFactory();
+      InetSocketAddress address = InetSocketAddress.createUnresolved(hotRodServer1.getHost(), hotRodServer1.getPort());
+
+      CountDownLatch operationLatch = new CountDownLatch(1);
+      AtomicReference<Channel> channelRef = new AtomicReference<>();
+      ExecutorService operationsExecutor = Executors.newSingleThreadExecutor();
+
+      NoopRetryingOperation firstOperation = new NoopRetryingOperation(0, channelFactory, remoteCacheManager.getConfiguration(),
+            channelRef, operationLatch);
+      operationsExecutor.submit(() -> channelFactory.fetchChannelAndInvoke(address, firstOperation));
+
+      eventually(() -> channelRef.get() != null);
+      Channel channel = channelRef.get();
+
+      assertTrue(channelFactory instanceof CustomChannelFactory);
+
+      AtomicBoolean closedServer = new AtomicBoolean(false);
+      ((CustomChannelFactory) channelFactory).setExecuteInstead(() -> {
+         HotRodClientTestingUtil.killServers(hotRodServer1);
+         eventually(() -> !channel.isActive());
+         eventually(() -> channelFactory.getNumActive(address) == 0);
+         return !closedServer.compareAndSet(false, true);
+      });
+
+      operationLatch.countDown();
+      NoopRetryingOperation secondOperation = new NoopRetryingOperation(0, channelFactory, remoteCacheManager.getConfiguration(),
+            channelRef, null);
+      operationsExecutor.submit(() -> channelFactory.fetchChannelAndInvoke(address, secondOperation));
+      secondOperation.get(10, TimeUnit.SECONDS);
+      operationsExecutor.shutdownNow();
+   }
+
+   private static class NoopRetryingOperation extends RetryOnFailureOperation<Void> {
+      private final AtomicReference<Channel> channelRef;
+      private final CountDownLatch firstOp;
+      private final int id;
+
+      protected NoopRetryingOperation(int nbr, ChannelFactory channelFactory, Configuration cfg,
+                                      AtomicReference<Channel> channelRef, CountDownLatch firstOp) {
+         super((short) 0, (short) 0, null, channelFactory, null,
+               new AtomicReference<>(new ClientTopology(-1, cfg.clientIntelligence())), 0, cfg,
+               DataFormat.builder().build(), null);
+         this.channelRef = channelRef;
+         this.firstOp = firstOp;
+         this.id = nbr;
+      }
+
+      @Override
+      public void acceptResponse(ByteBuf buf, short status, HeaderDecoder decoder) {
+         complete(null);
+      }
+
+      @Override
+      protected void executeOperation(Channel channel) {
+         if (channelRef.compareAndSet(null, channel)) {
+            try {
+               scheduleRead(channel);
+               firstOp.await();
+            } catch (InterruptedException e) {
+               completeExceptionally(e);
+            }
+            assert isDone() : "Should be done";
+            return;
+         }
+
+         complete(null);
+      }
+
+      @Override
+      public String toString() {
+         return "id = " + id;
+      }
+   }
+
+   private static class CustomChannelFactory extends ChannelFactory {
+
+      private final Configuration configuration;
+      private Supplier<Boolean> executeInstead;
+
+      public CustomChannelFactory(Configuration cfg) {
+         super(new CodecHolder(cfg.version().getCodec()));
+         this.configuration = cfg;
+         this.executeInstead = null;
+      }
+
+      public void setExecuteInstead(Supplier<Boolean> supplier) {
+         this.executeInstead = supplier;
+      }
+
+      @Override
+      protected ChannelPool createChannelPool(Bootstrap bootstrap, ChannelInitializer channelInitializer, SocketAddress address) {
+         int maxConnections = configuration.connectionPool().maxActive();
+         if (maxConnections < 0) {
+            maxConnections = Integer.MAX_VALUE;
+         }
+         return new ChannelPool(bootstrap.config().group().next(), address, channelInitializer,
+               configuration.connectionPool().exhaustedAction(), this::onConnectionEvent,
+               configuration.connectionPool().maxWait(), maxConnections,
+               configuration.connectionPool().maxPendingRequests()) {
+
+            @Override
+            boolean executeDirectlyIfPossible(ChannelOperation callback) {
+               if (executeInstead != null && !executeInstead.get()) {
+                  return false;
+               }
+               return super.executeDirectlyIfPossible(callback);
+            }
+         };
+      }
+   }
+}

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/transport/netty/CrashMidOperationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/transport/netty/CrashMidOperationTest.java
@@ -1,9 +1,11 @@
 package org.infinispan.client.hotrod.impl.transport.netty;
 
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.testng.AssertJUnit.assertTrue;
 
 import java.net.ConnectException;
 import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -12,31 +14,23 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.infinispan.client.hotrod.DataFormat;
 import org.infinispan.client.hotrod.configuration.Configuration;
+import org.infinispan.client.hotrod.exceptions.TransportException;
 import org.infinispan.client.hotrod.impl.ClientTopology;
 import org.infinispan.client.hotrod.impl.operations.RetryOnFailureOperation;
 import org.infinispan.client.hotrod.retry.AbstractRetryTest;
 import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
+import org.infinispan.commons.test.Exceptions;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.test.fwk.CleanupAfterMethod;
-import org.infinispan.util.concurrent.AggregateCompletionStage;
-import org.infinispan.util.concurrent.CompletionStages;
 import org.testng.annotations.Test;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 
 @CleanupAfterMethod
-@Test(groups = "functional", testName = "client.hotrod.impl.transport.netty.ChannelPoolTest")
-public class ChannelPoolTest extends AbstractRetryTest {
-
-   private int retries = 0;
-
-   public ChannelPoolTest() {}
-
-   public ChannelPoolTest(int nbrOfServers) {
-      this.nbrOfServers = nbrOfServers;
-   }
+@Test(testName = "client.hotrod.impl.transport.netty.CrashMidOperationTest", groups = "functional")
+public class CrashMidOperationTest extends AbstractRetryTest {
 
    @Override
    protected ConfigurationBuilder getCacheConfig() {
@@ -48,67 +42,52 @@ public class ChannelPoolTest extends AbstractRetryTest {
 
    @Override
    protected void amendRemoteCacheManagerConfiguration(org.infinispan.client.hotrod.configuration.ConfigurationBuilder builder) {
-      builder.maxRetries(retries);
+      builder.maxRetries(0);
    }
 
-   public void testClosingSockAndKillingServerFinishesOperations() throws Exception {
-      doTest(true);
-   }
-
-   public void testClosingSockAndKeepingServerFinishesOperations() throws Exception {
-      doTest(false);
-   }
-
-   private void doTest(boolean killServer) throws Exception {
+   public void killServerMidOperation() throws Exception {
       ChannelFactory channelFactory = remoteCacheManager.getChannelFactory();
       InetSocketAddress address = InetSocketAddress.createUnresolved(hotRodServer1.getHost(), hotRodServer1.getPort());
-      AggregateCompletionStage<Void> pendingOperations = CompletionStages.aggregateCompletionStage();
+
+      CountDownLatch operationLatch = new CountDownLatch(1);
       AtomicReference<Channel> channelRef = new AtomicReference<>();
+      ExecutorService operationsExecutor = Executors.newFixedThreadPool(2);
 
-      CountDownLatch firstOp = new CountDownLatch(1);
-      ExecutorService operationsExecutor = Executors.newFixedThreadPool(2); // The fist operation blocks.
-
-      for (int i = 0; i < 10; i++) {
-         NoopRetryingOperation op = new NoopRetryingOperation(i, channelFactory, remoteCacheManager.getConfiguration(), channelRef, firstOp);
-         operationsExecutor.submit(() -> channelFactory.fetchChannelAndInvoke(address, op));
-         pendingOperations.dependsOn(op);
-      }
+      NoopRetryingOperation firstOperation = new NoopRetryingOperation(0, channelFactory, remoteCacheManager.getConfiguration(),
+            channelRef, operationLatch);
+      operationsExecutor.submit(() -> channelFactory.fetchChannelAndInvoke(address, firstOperation));
 
       eventually(() -> channelRef.get() != null);
       Channel channel = channelRef.get();
 
-      if (killServer) HotRodClientTestingUtil.killServers(hotRodServer1);
-      channel.close().awaitUninterruptibly();
+      HotRodClientTestingUtil.killServers(hotRodServer1);
+      eventually(() -> !channel.isActive());
 
-      // The first one completes successfully on server1.
-      firstOp.countDown();
+      eventually(firstOperation::isDone);
+      Exceptions.expectExecutionException(TransportException.class, firstOperation);
 
-      if (nbrOfServers == 1 && killServer) {
-         assertConnectException(pendingOperations);
-         operationsExecutor.shutdown();
-         return;
-      }
-
-      if (retries == 0 && killServer) {
-         assertConnectException(pendingOperations);
-         operationsExecutor.shutdown();
-         return;
-      }
-
-      pendingOperations.freeze().toCompletableFuture().get(10, TimeUnit.SECONDS);
-      operationsExecutor.shutdown();
-   }
-
-   private void assertConnectException(AggregateCompletionStage<Void> ops) {
+      // Since the first operation failed midway execution, we don't know if the server has failed or only the channel.
+      // The second operation will try to connect and fail, and then update the failed list.
+      NoopRetryingOperation secondOperation = new NoopRetryingOperation(1, channelFactory, remoteCacheManager.getConfiguration(),
+            channelRef, operationLatch);
+      channelFactory.fetchChannelAndInvoke(address, remoteCache.getName().getBytes(StandardCharsets.UTF_8), secondOperation);
+      eventually(secondOperation::isDone);
       try {
-         ops.freeze().toCompletableFuture().get(10, TimeUnit.SECONDS);
-      } catch (Exception e) {
-         Throwable cause = e.getCause();
-         if (cause instanceof ConnectException) {
-            return;
-         }
-         throw new AssertionError("Expected ConnectException, but got " + cause, cause);
+         secondOperation.get(10, TimeUnit.SECONDS);
+      } catch (Throwable t) {
+         assertTrue(t.getCause() instanceof ConnectException);
       }
+
+      // We only release the latch now, but notice that all the other operations were able to finish.
+      operationLatch.countDown();
+
+      // The failed list was update, the next operation should succeed.
+      NoopRetryingOperation thirdOperation = new NoopRetryingOperation(2, channelFactory, remoteCacheManager.getConfiguration(),
+            channelRef, operationLatch);
+      channelFactory.fetchChannelAndInvoke(address, remoteCache.getName().getBytes(StandardCharsets.UTF_8), thirdOperation);
+      eventually(thirdOperation::isDone);
+      thirdOperation.get(10, TimeUnit.SECONDS);
+      operationsExecutor.shutdown();
    }
 
    private static class NoopRetryingOperation extends RetryOnFailureOperation<Void> {
@@ -135,13 +114,20 @@ public class ChannelPoolTest extends AbstractRetryTest {
       protected void executeOperation(Channel channel) {
          if (channelRef.compareAndSet(null, channel)) {
             try {
+               scheduleRead(channel);
                firstOp.await();
-               complete(null);
             } catch (InterruptedException e) {
                completeExceptionally(e);
             }
-         } else {
+            assert isDone() : "Should be done";
+            return;
+         }
+
+         try {
+            firstOp.await();
             complete(null);
+         } catch (InterruptedException e) {
+            completeExceptionally(e);
          }
       }
 
@@ -149,25 +135,5 @@ public class ChannelPoolTest extends AbstractRetryTest {
       public String toString() {
          return "id = " + id;
       }
-   }
-
-   private ChannelPoolTest withRetries(int retries) {
-      this.retries = retries;
-      return this;
-   }
-
-   @Override
-   protected String parameters() {
-      return "[retries=" + retries + ", nbrServers=" + nbrOfServers + "]";
-   }
-
-   @Override
-   public Object[] factory() {
-      return new Object[] {
-            new ChannelPoolTest().withRetries(0),
-            new ChannelPoolTest(1).withRetries(0),
-            new ChannelPoolTest().withRetries(10),
-            new ChannelPoolTest(1).withRetries(10),
-      };
    }
 }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/AbstractRetryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/AbstractRetryTest.java
@@ -82,12 +82,12 @@ public abstract class AbstractRetryTest extends HitsAwareCacheManagersTest {
    protected RemoteCacheManager createRemoteCacheManager(int port) {
       org.infinispan.client.hotrod.configuration.ConfigurationBuilder builder =
          HotRodClientTestingUtil.newRemoteConfigurationBuilder();
-      amendRemoteCacheManagerConfiguration(builder);
       builder
          .forceReturnValues(true)
          .connectionTimeout(5)
-         .connectionPool().maxActive(1) //this ensures that only one server is active at a time
-         .addServer().host("127.0.0.1").port(port);
+         .connectionPool().maxActive(1); //this ensures that only one server is active at a time
+      amendRemoteCacheManagerConfiguration(builder);
+      builder.addServer().host("127.0.0.1").port(port);
       return new InternalRemoteCacheManager(builder.build());
    }
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/AbstractRetryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/AbstractRetryTest.java
@@ -34,7 +34,7 @@ public abstract class AbstractRetryTest extends HitsAwareCacheManagersTest {
 
    protected int nbrOfServers = 3;
 
-   RemoteCacheImpl<Object, Object> remoteCache;
+   protected RemoteCacheImpl<Object, Object> remoteCache;
    protected RemoteCacheManager remoteCacheManager;
    protected ChannelFactory channelFactory;
    protected ConfigurationBuilder config;

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/ClientListenerFailoverBusyTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/ClientListenerFailoverBusyTest.java
@@ -1,0 +1,170 @@
+package org.infinispan.client.hotrod.retry;
+
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+
+import java.net.InetSocketAddress;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.infinispan.AdvancedCache;
+import org.infinispan.client.hotrod.ProtocolVersion;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.client.hotrod.annotation.ClientCacheEntryModified;
+import org.infinispan.client.hotrod.annotation.ClientListener;
+import org.infinispan.client.hotrod.event.ClientCacheEntryModifiedEvent;
+import org.infinispan.client.hotrod.impl.protocol.Codec25;
+import org.infinispan.client.hotrod.impl.transport.netty.ChannelRecord;
+import org.infinispan.client.hotrod.test.NoopChannelOperation;
+import org.infinispan.commands.write.PutKeyValueCommand;
+import org.infinispan.commons.test.annotation.TestForIssue;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.context.InvocationContext;
+import org.infinispan.interceptors.DDAsyncInterceptor;
+import org.infinispan.test.fwk.CleanupAfterMethod;
+import org.infinispan.util.concurrent.AggregateCompletionStage;
+import org.infinispan.util.concurrent.CompletionStages;
+import org.testng.annotations.Test;
+
+import io.netty.channel.Channel;
+
+@TestForIssue(jiraKey = "ISPN-14846")
+@CleanupAfterMethod
+@Test(groups = "functional", testName = "client.hotrod.retry.ClientListenerFailoverBusyTest")
+public class ClientListenerFailoverBusyTest extends AbstractRetryTest {
+
+   private static final int MAX_PENDING_REQUESTS = 10;
+
+   {
+      nbrOfServers = 1;
+   }
+
+   @Override
+   protected ConfigurationBuilder getCacheConfig() {
+      ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false);
+      return hotRodCacheConfiguration(builder);
+   }
+
+   @Override
+   protected RemoteCacheManager createClient() {
+      RemoteCacheManager rcm = super.createClient();
+      rcm.getChannelFactory().setNegotiatedCodec(new Codec25());
+      return rcm;
+   }
+
+   @Override
+   protected void amendRemoteCacheManagerConfiguration(org.infinispan.client.hotrod.configuration.ConfigurationBuilder builder) {
+      builder.version(ProtocolVersion.PROTOCOL_VERSION_25)
+            // We need maxActive=2 because protocol version is 2.5.
+            // The listener never releases its channel to the pool.
+            .connectionPool().maxActive(2)
+
+            // Necessary so the listener reuses the channel.
+            .maxPendingRequests(MAX_PENDING_REQUESTS + 1);
+   }
+
+   public void testWithASingleOperation() throws Exception {
+      testListenerWithSlowServer(1);
+   }
+
+   public void testWithMultipleOperations() throws Exception {
+      testListenerWithSlowServer(MAX_PENDING_REQUESTS);
+   }
+
+   private void testListenerWithSlowServer(int numberOfOperations) throws Exception {
+      AdvancedCache<?, ?> cache = cacheToHit(1);
+      InetSocketAddress address = InetSocketAddress.createUnresolved(hotRodServer1.getHost(), hotRodServer1.getPort());
+
+      // We acquire the channel. This will be the same channel for the listener.
+      Channel channel = channelFactory.fetchChannelAndInvoke(address, new NoopChannelOperation()).get(10, TimeUnit.SECONDS);
+
+      // Release channel back to the pool so listener can use it.
+      ChannelRecord.of(channel).release(channel);
+
+      Listener listener = new Listener();
+      remoteCache.addClientListener(listener);
+
+      ExecutorService executor = Executors.newScheduledThreadPool(numberOfOperations);
+      CyclicBarrier barrier = new CyclicBarrier(numberOfOperations + 1);
+      CountDownLatch latch = new CountDownLatch(1);
+      DelayedInterceptor interceptor = new DelayedInterceptor(latch, barrier, executor);
+
+      cache.getAsyncInterceptorChain().addInterceptor(interceptor, 1);
+
+      // We issue all of these operations which do not complete until the latch is released.
+      AggregateCompletionStage<?> operations = CompletionStages.aggregateCompletionStage();
+      for (int i = 0; i < numberOfOperations; i++) {
+         operations.dependsOn(remoteCache.putAsync(1, "v" + i));
+      }
+
+      // Await all the operations reach the interceptor.
+      barrier.await(10, TimeUnit.SECONDS);
+
+      int eventsBeforeFailover = listener.getReceived();
+
+      // Now close the listener channel, so it failover to the channel with put operations.
+      channel.close().awaitUninterruptibly();
+      eventually(() -> channelFactory.getNumActive() == 1);
+
+      try {
+         // We release the latch so operations complete, in the same channel the listener is using.
+         latch.countDown();
+         operations.freeze().toCompletableFuture().get(10, TimeUnit.SECONDS);
+
+         // If numberOfOperations == 1 we only create the entry, we do not generate events from updates.
+         if (numberOfOperations > 1)
+            eventually(() -> listener.getReceived() > eventsBeforeFailover);
+      } finally {
+         cache.getAsyncInterceptorChain().removeInterceptor(DelayedInterceptor.class);
+         executor.shutdown();
+      }
+   }
+
+
+   @ClientListener
+   private static class Listener {
+
+      private final AtomicInteger count = new AtomicInteger(0);
+
+      @ClientCacheEntryModified
+      public void handleModifiedEvent(ClientCacheEntryModifiedEvent<?> ignore) {
+         count.incrementAndGet();
+      }
+
+      int getReceived() {
+         return count.intValue();
+      }
+   }
+
+   public static class DelayedInterceptor extends DDAsyncInterceptor {
+      private final CountDownLatch latch;
+      private final CyclicBarrier barrier;
+      private final ExecutorService executor;
+
+      public DelayedInterceptor(CountDownLatch latch, CyclicBarrier barrier, ExecutorService executor) {
+         this.latch = latch;
+         this.barrier = barrier;
+         this.executor = executor;
+      }
+
+      @Override
+      public Object visitPutKeyValueCommand(InvocationContext ctx, PutKeyValueCommand command) throws Throwable {
+         CompletableFuture<Object> cf = new CompletableFuture<>();
+         executor.submit(() -> {
+            try {
+               barrier.await();
+               latch.await();
+               cf.complete(super.visitPutKeyValueCommand(ctx, command));
+            } catch (Throwable e) {
+               cf.completeExceptionally(e);
+            }
+         });
+         return asyncValue(cf);
+      }
+   }
+}

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/DistributionRetryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/DistributionRetryTest.java
@@ -159,6 +159,7 @@ public class DistributionRetryTest extends AbstractRetryTest {
 
       log.info("About to stop Hot Rod server 2");
       HotRodClientTestingUtil.killServers(hotRodServer2);
+      eventually(() -> !channel.isActive());
 
       return key;
    }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/test/InternalRemoteCacheManager.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/test/InternalRemoteCacheManager.java
@@ -16,6 +16,7 @@ import org.infinispan.client.hotrod.impl.transport.netty.TestChannelFactory;
 public class InternalRemoteCacheManager extends RemoteCacheManager {
 
    private final boolean testReplay;
+   private ChannelFactory customChannelFactory;
 
    public InternalRemoteCacheManager(boolean testReplay, Configuration configuration) {
       super(configuration, true);
@@ -25,6 +26,11 @@ public class InternalRemoteCacheManager extends RemoteCacheManager {
    public InternalRemoteCacheManager(Configuration configuration) {
       super(configuration, true);
       this.testReplay = true;
+   }
+
+   public InternalRemoteCacheManager(Configuration configuration, ChannelFactory customChannelFactory) {
+      this(configuration, false);
+      this.customChannelFactory = customChannelFactory;
    }
 
    public InternalRemoteCacheManager(Configuration configuration, boolean start) {
@@ -47,6 +53,7 @@ public class InternalRemoteCacheManager extends RemoteCacheManager {
 
    @Override
    public ChannelFactory createChannelFactory() {
+      if (customChannelFactory != null) return customChannelFactory;
       if (testReplay) return new TestChannelFactory(new CodecHolder(getConfiguration().version().getCodec()));
       return super.createChannelFactory();
    }

--- a/client/hotrod/src/main/java/org/infinispan/hotrod/impl/transport/netty/ChannelPool.java
+++ b/client/hotrod/src/main/java/org/infinispan/hotrod/impl/transport/netty/ChannelPool.java
@@ -74,6 +74,32 @@ class ChannelPool {
          callback.cancel(address, new RejectedExecutionException("Pool was terminated"));
          return;
       }
+
+      // We could acquire an active channel and submit the callback.
+      if (executeDirectlyIfPossible(callback)) return;
+
+      // wait action
+      if (maxWait > 0) {
+         TimeoutCallback timeoutCallback = new TimeoutCallback(callback);
+         timeoutCallback.timeoutFuture = executor.schedule(timeoutCallback, maxWait, TimeUnit.MILLISECONDS);
+         callback = timeoutCallback;
+      }
+
+      // Between the check time and adding the callback to the queue, we could have a channel available.
+      // Let's just try again.
+      if (!executeOrEnqueue(callback)) {
+         boolean remove = false;
+         try {
+            remove = executeDirectlyIfPossible(callback);
+         } finally {
+            if (remove) {
+               callbacks.remove(callback);
+            }
+         }
+      }
+   }
+
+   boolean executeDirectlyIfPossible(ChannelOperation callback) {
       Channel channel;
       int fullChannelsSeen = 0;
       while ((channel = channels.pollFirst()) != null) {
@@ -90,8 +116,7 @@ class ChannelPool {
                break;
             }
          }
-         activateChannel(channel, callback, false);
-         return;
+         return activateChannel(channel, callback, false);
       }
       int current = created.get();
       while (current < maxConnections) {
@@ -100,7 +125,7 @@ class ChannelPool {
             if (log.isTraceEnabled()) log.tracef("[%s] Creating new channel, created = %d, active = %d", address, current + 1, currentActive);
             // create new connection and apply callback
             createAndInvoke(callback);
-            return;
+            return true;
          }
          current = created.get();
       }
@@ -115,16 +140,16 @@ class ChannelPool {
             int currentActive = active.incrementAndGet();
             if (log.isTraceEnabled()) log.tracef("[%s] Creating new channel, created = %d, active = %d", address, currentCreated, currentActive);
             createAndInvoke(callback);
-            return;
+            return true;
          default:
             throw new IllegalArgumentException(String.valueOf(exhaustedAction));
       }
-      // wait action
-      if (maxWait > 0) {
-         TimeoutCallback timeoutCallback = new TimeoutCallback(callback);
-         timeoutCallback.timeoutFuture = executor.schedule(timeoutCallback, maxWait, TimeUnit.MILLISECONDS);
-         callback = timeoutCallback;
-      }
+
+      return false;
+   }
+
+   private boolean executeOrEnqueue(ChannelOperation callback) {
+      Channel channel;
       // To prevent adding channel and callback concurrently we'll synchronize all additions
       // TODO: completely lock-free algorithm would be better
       long stamp = lock.writeLock();
@@ -135,7 +160,7 @@ class ChannelPool {
             if (channel == null) {
                if (log.isTraceEnabled()) log.tracef("[%s] No channel available, adding callback to the queue %s", address, callback);
                callbacks.addLast(callback);
-               return;
+               return false;
             } else if (channel.isActive()) {
                break;
             }
@@ -143,7 +168,7 @@ class ChannelPool {
       } finally {
          lock.unlockWrite(stamp);
       }
-      activateChannel(channel, callback, false);
+      return activateChannel(channel, callback, false);
    }
 
    private void createAndInvoke(ChannelOperation callback) {
@@ -251,8 +276,8 @@ class ChannelPool {
       connectionFailureListener.accept( this, idle ? ChannelEventType.CLOSED_IDLE : ChannelEventType.CLOSED_ACTIVE);
    }
 
-   private void activateChannel(Channel channel, ChannelOperation callback, boolean useExecutor) {
-      assert channel.isActive() : "Channel " + channel + " is not active";
+   private boolean activateChannel(Channel channel, ChannelOperation callback, boolean useExecutor) {
+      if (!channel.isActive()) return false;
       int currentActive = active.incrementAndGet();
       if (log.isTraceEnabled()) log.tracef("[%s] Activated record %s, created = %d, active = %d", address, channel, created.get(), currentActive);
       ChannelRecord record = ChannelRecord.of(channel);
@@ -276,6 +301,7 @@ class ChannelPool {
             throw t;
          }
       }
+      return true;
    }
 
    private void discardChannel(Channel channel) {

--- a/client/hotrod/src/main/java/org/infinispan/hotrod/impl/transport/netty/HeaderDecoder.java
+++ b/client/hotrod/src/main/java/org/infinispan/hotrod/impl/transport/netty/HeaderDecoder.java
@@ -91,11 +91,6 @@ public class HeaderDecoder extends HintedReplayingDecoder<HeaderDecoder.State> {
                   case CACHE_ENTRY_EXPIRED_EVENT_RESPONSE:
                      if (codec.allowOperationsAndEvents()) {
                         operation = messageId == 0 ? null : incomplete.get(messageId);
-                     } else if (incomplete.size() == 1) {
-                        operation = incomplete.values().iterator().next();
-                        messageId = operation.header().messageId();
-                     } else if (incomplete.size() > 1) {
-                        throw new IllegalStateException("Too many incomplete operations: " + incomplete);
                      } else {
                         operation = null;
                         messageId = 0;


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-14831
https://issues.redhat.com/browse/ISPN-14832
https://issues.redhat.com/browse/ISPN-14846

The biggest issue here is that there is a narrow window in which an operation might be enqueued but never executed. Happening when before enqueueing the operation, the channel closes and finishes all pending operations, then this operation remains in the queue.

The fix retries acquiring a channel from the pool if available. I needed to move the code around to test that.

The second commit here is regarding the flaky DistributionRetryTest with retry=0. It might happen that after killing the server, the channel is still created successfully to become inactive later. The change in the test waits for the channel with the server to become inactive before proceeding. It also includes a test that kills the server during the operation execution.

---

Updated:

The third issue triggers when using Hot Rod version < 2.8. If the client failover to a channel with registered operations, these operations might fail when the listener receives an event.