### PR TITLE
ISPN-14849 ChannelLookupTest is failing

### DIFF
--- a/core/src/test/java/org/infinispan/remoting/jgroups/ChannelLookupTest.java
+++ b/core/src/test/java/org/infinispan/remoting/jgroups/ChannelLookupTest.java
@@ -5,7 +5,7 @@ import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.AssertJUnit.assertNotNull;
-import static org.testng.AssertJUnit.assertNotSame;
+import static org.testng.AssertJUnit.assertSame;
 import static org.testng.AssertJUnit.assertTrue;
 
 import java.util.Collections;
@@ -60,7 +60,7 @@ public class ChannelLookupTest extends AbstractInfinispanTest {
          Transport t = gcr.getComponent(Transport.class);
          assertNotNull(t);
          assertTrue(t instanceof JGroupsTransport);
-         assertNotSame(JChannel.class, ((JGroupsTransport) t).getChannel().getClass());
+         assertSame(mockChannel, ((JGroupsTransport) t).getChannel());
       } finally {
          TestingUtil.killCacheManagers(cm);
       }


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-14849

Mockito originally had a `.getClass()` like `class org.jgroups.JChannel$MockitoMock$iXlEc4Js` and after the update, it is `class org.jgroups.JChannel`.