### PR TITLE
[14.0] ISPN-14854 Fix IPv6 wildcard address used when detecting multi homing

### DIFF
--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/ServerAddress.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/ServerAddress.java
@@ -20,7 +20,7 @@ public interface ServerAddress {
    int getPort();
 
    static ServerAddress forAddress(String host, int port, boolean networkPrefixOverride) {
-      if ("0.0.0.0".equals(host) || "::0".equals(host)) {
+      if ("0.0.0.0".equals(host) || "0:0:0:0:0:0:0:0".equals(host)) {
          return new MultiHomedServerAddress(port, networkPrefixOverride);
       } else {
          return new SingleHomedServerAddress(host, port);


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-14854