### PR TITLE
ISPN-14886 + ISPN-14885 Client connection information and RESP CLIENT ID|INFO|LIST|SETNAME|GETNAME|SETINFO

### DIFF
--- a/cli/src/main/java/org/infinispan/cli/commands/rest/Connections.java
+++ b/cli/src/main/java/org/infinispan/cli/commands/rest/Connections.java
@@ -1,0 +1,58 @@
+package org.infinispan.cli.commands.rest;
+
+import java.util.concurrent.CompletionStage;
+
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.CommandResult;
+import org.aesh.command.GroupCommandDefinition;
+import org.aesh.command.option.Option;
+import org.infinispan.cli.activators.ConnectionActivator;
+import org.infinispan.cli.commands.CliCommand;
+import org.infinispan.cli.impl.ContextAwareCommandInvocation;
+import org.infinispan.cli.resources.Resource;
+import org.infinispan.client.rest.RestClient;
+import org.infinispan.client.rest.RestResponse;
+
+/**
+ * @since 15.0
+ **/
+@GroupCommandDefinition(name = Connections.CMD, description = "Performs operations on connections", activator = ConnectionActivator.class, groupCommands = {Connections.Ls.class})
+public class Connections extends CliCommand {
+
+   public static final String CMD = "connections";
+
+   @Option(shortName = 'h', hasValue = false, overrideRequired = true)
+   protected boolean help;
+
+   @Override
+   public boolean isHelp() {
+      return help;
+   }
+
+   @Override
+   public CommandResult exec(ContextAwareCommandInvocation invocation) {
+      // This command serves only to wrap the sub-commands
+      invocation.println(invocation.getHelpInfo());
+      return CommandResult.FAILURE;
+   }
+
+   @CommandDefinition(name = "ls", description = "Lists connections", activator = ConnectionActivator.class)
+   public static class Ls extends RestCliCommand {
+
+      @Option(shortName = 'g', hasValue = false, overrideRequired = true)
+      protected boolean global;
+
+      @Option(shortName = 'h', hasValue = false, overrideRequired = true)
+      protected boolean help;
+
+      @Override
+      public boolean isHelp() {
+         return help;
+      }
+
+      @Override
+      protected CompletionStage<RestResponse> exec(ContextAwareCommandInvocation invocation, RestClient client, Resource resource) {
+         return client.server().listConnections(global);
+      }
+   }
+}

--- a/cli/src/main/java/org/infinispan/cli/commands/rest/Server.java
+++ b/cli/src/main/java/org/infinispan/cli/commands/rest/Server.java
@@ -21,7 +21,7 @@ import org.kohsuke.MetaInfServices;
  * @since 11.0
  **/
 @MetaInfServices(Command.class)
-@GroupCommandDefinition(name = "server", description = "Obtains information about the server", activator = ConnectionActivator.class, groupCommands = {Connector.class, DataSource.class, Server.Report.class, Server.HeapDump.class})
+@GroupCommandDefinition(name = "server", description = "Obtains information about the server", activator = ConnectionActivator.class, groupCommands = {Connector.class, DataSource.class, Server.Report.class, Server.HeapDump.class, Connections.class})
 public class Server extends CliCommand {
 
    @Option(shortName = 'h', hasValue = false, overrideRequired = true)

--- a/cli/src/main/java/org/infinispan/cli/connection/rest/RestConnector.java
+++ b/cli/src/main/java/org/infinispan/cli/connection/rest/RestConnector.java
@@ -11,6 +11,7 @@ import org.infinispan.cli.connection.Connector;
 import org.infinispan.cli.impl.SSLContextSettings;
 import org.infinispan.client.rest.configuration.RestClientConfigurationBuilder;
 import org.infinispan.client.rest.configuration.SslConfigurationBuilder;
+import org.infinispan.commons.util.Version;
 import org.kohsuke.MetaInfServices;
 
 /**
@@ -60,6 +61,7 @@ public class RestConnector implements Connector {
                }
             }
          }
+         builder.header("User-Agent", Version.getBrandName()+" CLI " + Version.getBrandVersion());
          return new RestConnection(builder);
       } catch (Throwable e) {
          return null;

--- a/cli/src/main/resources/help/server.adoc
+++ b/cli/src/main/resources/help/server.adoc
@@ -21,6 +21,8 @@ SYNOPSIS
 
 *server heap-dump* [--live]
 
+*server connections ls* [--global]
+
 *server connector ls*
 
 *server connector describe* 'connector-name'
@@ -55,6 +57,10 @@ Obtains a server report, including information about network, threads, memory, e
 
 `server heap-dump` +
 Generates a JVM heap dump in the server data directory, returning the name of the generated file.
+
+`server connections ls` +
+Lists all active client connections to the server. The `--global` argument will return connections from all cluster
+members.
 
 `server connector ls` +
 Lists all available connectors on the server.

--- a/client/rest-client/src/main/java/org/infinispan/client/rest/RestServerClient.java
+++ b/client/rest-client/src/main/java/org/infinispan/client/rest/RestServerClient.java
@@ -55,6 +55,8 @@ public interface RestServerClient {
 
    RestLoggingClient logging();
 
+   CompletionStage<RestResponse> listConnections(boolean global);
+
    CompletionStage<RestResponse> connectorNames();
 
    CompletionStage<RestResponse> connector(String name);

--- a/client/rest-client/src/main/java/org/infinispan/client/rest/configuration/RestClientConfiguration.java
+++ b/client/rest-client/src/main/java/org/infinispan/client/rest/configuration/RestClientConfiguration.java
@@ -95,6 +95,7 @@ public class RestClientConfiguration {
       properties.setProperty(RestClientConfigurationProperties.TCP_NO_DELAY, tcpNoDelay());
       properties.setProperty(RestClientConfigurationProperties.TCP_KEEP_ALIVE, tcpKeepAlive());
       properties.setProperty(RestClientConfigurationProperties.CONTEXT_PATH, contextPath());
+      properties.setProperty(RestClientConfigurationProperties.USER_AGENT, headers.get("User-Agent"));
 
       StringBuilder servers = new StringBuilder();
       for (ServerConfiguration server : servers()) {

--- a/client/rest-client/src/main/java/org/infinispan/client/rest/configuration/RestClientConfigurationBuilder.java
+++ b/client/rest-client/src/main/java/org/infinispan/client/rest/configuration/RestClientConfigurationBuilder.java
@@ -14,6 +14,7 @@ import org.infinispan.client.rest.RestURI;
 import org.infinispan.commons.configuration.Builder;
 import org.infinispan.commons.configuration.attributes.AttributeSet;
 import org.infinispan.commons.util.TypedProperties;
+import org.infinispan.commons.util.Version;
 
 /**
  * <p>ConfigurationBuilder used to generate immutable {@link RestClientConfiguration} objects.
@@ -45,6 +46,7 @@ public class RestClientConfigurationBuilder implements RestClientConfigurationCh
    public RestClientConfigurationBuilder() {
       this.security = new SecurityConfigurationBuilder(this);
       this.servers = new ArrayList<>();
+      this.headers.put("User-Agent", Version.getBrandName() + "/" + Version.getVersion());
    }
 
    @Override
@@ -226,7 +228,6 @@ public class RestClientConfigurationBuilder implements RestClientConfigurationCh
       this.security.read(template.security());
       this.headers.clear();
       this.headers.putAll(template.headers());
-
       return this;
    }
 }

--- a/client/rest-client/src/main/java/org/infinispan/client/rest/configuration/RestClientConfigurationProperties.java
+++ b/client/rest-client/src/main/java/org/infinispan/client/rest/configuration/RestClientConfigurationProperties.java
@@ -3,6 +3,7 @@ package org.infinispan.client.rest.configuration;
 import java.util.Properties;
 
 import org.infinispan.commons.util.TypedProperties;
+import org.infinispan.commons.util.Version;
 
 /**
  * Encapsulate all config properties here
@@ -22,6 +23,7 @@ public class RestClientConfigurationProperties {
    public static final String PROTOCOL = ICR + "protocol";
    public static final String SO_TIMEOUT = ICR + "socket_timeout";
    public static final String CONNECT_TIMEOUT = ICR + "connect_timeout";
+   public static final String USER_AGENT = Version.printVersion();
 
    // Encryption properties
    public static final String USE_SSL = ICR + "use_ssl";

--- a/client/rest-client/src/main/java/org/infinispan/client/rest/impl/okhttp/RestClientOkHttp.java
+++ b/client/rest-client/src/main/java/org/infinispan/client/rest/impl/okhttp/RestClientOkHttp.java
@@ -261,7 +261,7 @@ public class RestClientOkHttp implements RestClient {
    }
 
    CompletionStage<RestResponse> execute(Request.Builder builder) {
-      configuration.headers().forEach((name, value) -> builder.header(name, value));
+      configuration.headers().forEach(builder::header);
       Request request = builder.build();
       log.tracef("Request %s", request);
       CompletableFuture<RestResponse> response = new CompletableFuture<>();

--- a/client/rest-client/src/main/java/org/infinispan/client/rest/impl/okhttp/RestServerClientOkHttp.java
+++ b/client/rest-client/src/main/java/org/infinispan/client/rest/impl/okhttp/RestServerClientOkHttp.java
@@ -103,6 +103,11 @@ public class RestServerClientOkHttp implements RestServerClient {
    }
 
    @Override
+   public CompletionStage<RestResponse> listConnections(boolean global) {
+      return client.execute(baseServerURL, "connections?global=" + global);
+   }
+
+   @Override
    public CompletionStage<RestResponse> connectorNames() {
       return client.execute(baseServerURL, "connectors");
    }

--- a/commons/all/src/main/java/org/infinispan/commons/dataconversion/internal/Json.java
+++ b/commons/all/src/main/java/org/infinispan/commons/dataconversion/internal/Json.java
@@ -27,6 +27,7 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.text.CharacterIterator;
 import java.text.StringCharacterIterator;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -1194,6 +1195,8 @@ public class Json implements java.io.Serializable {
          else if (anything instanceof Enum) {
             return factory().string(anything.toString());
          } else if (anything instanceof MediaType) {
+            return factory().string(anything.toString());
+         } else if (anything instanceof Instant) {
             return factory().string(anything.toString());
          } else if (anything.getClass().isArray()) {
             Class<?> comp = anything.getClass().getComponentType();

--- a/documentation/src/main/asciidoc/topics/json/rest_server_connections_response.json
+++ b/documentation/src/main/asciidoc/topics/json/rest_server_connections_response.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": 2,
+    "name": "flower",
+    "created": "2023-05-18T14:54:37.882566188Z",
+    "principal": "admin",
+    "local-address": "/127.0.0.1:11222",
+    "remote-address": "/127.0.0.1:58230",
+    "protocol-version": "RESP3",
+    "client-library": null,
+    "client-version": null,
+    "ssl-application-protocol": "http/1.1",
+    "ssl-cipher-suite": "TLS_AES_256_GCM_SHA384",
+    "ssl-protocol": "TLSv1.3"
+  },
+  {
+    "id": 0,
+    "name": null,
+    "created": "2023-05-18T14:54:07.727775875Z",
+    "principal": "admin",
+    "local-address": "/127.0.0.1:11222",
+    "remote-address": "/127.0.0.1:35716",
+    "protocol-version": "HTTP/1.1",
+    "client-library": "Infinispan CLI 15.0.0-SNAPSHOT",
+    "client-version": null,
+    "ssl-application-protocol": "http/1.1",
+    "ssl-cipher-suite": "TLS_AES_256_GCM_SHA384",
+    "ssl-protocol": "TLSv1.3"
+  }
+]

--- a/documentation/src/main/asciidoc/topics/ref_rest_servers.adoc
+++ b/documentation/src/main/asciidoc/topics/ref_rest_servers.adoc
@@ -174,3 +174,29 @@ POST /rest/v2/server?action=stop
 ----
 
 {brandname} responds with `204 (No Content)` and then stops running.
+
+[id='rest_v2_server_connections']
+= Retrieving Client Connection Information
+List information about clients connected to {brandname} Servers with `GET` requests.
+
+[source,options="nowrap",subs=attributes+]
+----
+GET /rest/v2/server/connections
+----
+
+{brandname} responds with details about all active client connections in JSON format as in the following example:
+
+[source,json,options="nowrap",subs=attributes+]
+----
+include::json/rest_server_connections_response.json[]
+----
+
+.Request Parameters
+
+|===
+|Parameter |Required or Optional |Value
+
+|`global`
+|OPTIONAL
+| `true`: will collect connections from all servers in the cluster
+|===

--- a/server/core/src/main/java/org/infinispan/server/core/ServerStateManager.java
+++ b/server/core/src/main/java/org/infinispan/server/core/ServerStateManager.java
@@ -5,6 +5,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import org.infinispan.commons.api.Lifecycle;
+import org.infinispan.commons.dataconversion.internal.Json;
 import org.infinispan.server.core.transport.IpSubnetFilterRule;
 
 /**
@@ -29,6 +30,8 @@ public interface ServerStateManager extends Lifecycle {
    CompletableFuture<Void> setConnectorIpFilterRule(String name, Collection<IpSubnetFilterRule> filterRule);
 
    CompletableFuture<Void> clearConnectorIpFilterRules(String name);
+
+   CompletableFuture<Json> listConnections();
 
    ServerManagement managedServer();
 }

--- a/server/core/src/main/java/org/infinispan/server/core/transport/ConnectionMetadata.java
+++ b/server/core/src/main/java/org/infinispan/server/core/transport/ConnectionMetadata.java
@@ -1,0 +1,103 @@
+package org.infinispan.server.core.transport;
+
+import java.net.SocketAddress;
+import java.time.Instant;
+
+import javax.security.auth.Subject;
+
+import io.netty.channel.Channel;
+import io.netty.util.AttributeKey;
+
+/**
+ * @since 15.0
+ **/
+public class ConnectionMetadata {
+   static final AttributeKey<ConnectionMetadata> METADATA = AttributeKey.newInstance("METADATA");
+   private final Channel channel;
+   private long id;
+   private Subject subject;
+   private String clientName;
+   private String clientLibName;
+   private String clientLibVersion;
+   private String protocolVersion;
+   private Instant created;
+
+   public static ConnectionMetadata getInstance(Channel channel) {
+      ConnectionMetadata existing = channel.attr(METADATA).get();
+      if (existing == null) {
+         ConnectionMetadata metadata = new ConnectionMetadata(channel);
+         existing = channel.attr(METADATA).setIfAbsent(metadata);
+         return existing == null ? metadata : existing;
+      } else {
+         return existing;
+      }
+   }
+
+   private ConnectionMetadata(Channel channel) {
+      this.channel = channel;
+   }
+
+   public void id(long id) {
+      this.id = id;
+   }
+
+   public long id() {
+      return id;
+   }
+
+   public Subject subject() {
+      return subject;
+   }
+
+   public SocketAddress localAddress() {
+      return channel.localAddress();
+   }
+
+   public SocketAddress remoteAddress() {
+      return channel.remoteAddress();
+   }
+
+   public String clientName() {
+      return clientName;
+   }
+
+   public String clientLibraryName() {
+      return clientLibName;
+   }
+
+   public String clientLibraryVersion() {
+      return clientLibVersion;
+   }
+
+   public String protocolVersion() {
+      return protocolVersion;
+   }
+
+   public void clientLibraryName(String name) {
+      this.clientLibName = name;
+   }
+
+   public void clientLibraryVersion(String version) {
+      this.clientLibVersion = version;
+   }
+
+   public void clientName(String name) {
+      this.clientName = name;
+   }
+
+   public void created(Instant timestamp) {
+      this.created = timestamp;
+   }
+
+   public Instant created() {
+      return created;
+   }
+
+   public void subject(Subject subject) {
+      this.subject = subject;
+   }
+
+   public void protocolVersion(String version) {
+      this.protocolVersion = version;
+   }
+}

--- a/server/core/src/main/java/org/infinispan/server/core/transport/NettyTransport.java
+++ b/server/core/src/main/java/org/infinispan/server/core/transport/NettyTransport.java
@@ -348,6 +348,11 @@ public class NettyTransport implements Transport {
       return closed;
    }
 
+   @Override
+   public ChannelGroup getAcceptedChannels() {
+      return acceptedChannels;
+   }
+
    private Class<? extends ServerChannel> getServerSocketChannel() {
       Class<? extends ServerChannel> channel = NativeTransport.serverSocketChannelClass();
       log.createdSocketChannel(channel.getName(), configuration.toString());

--- a/server/core/src/main/java/org/infinispan/server/core/transport/Transport.java
+++ b/server/core/src/main/java/org/infinispan/server/core/transport/Transport.java
@@ -2,6 +2,7 @@ package org.infinispan.server.core.transport;
 
 import java.util.concurrent.CompletionStage;
 
+import io.netty.channel.group.ChannelGroup;
 import io.netty.channel.group.ChannelMatcher;
 
 /**
@@ -43,4 +44,6 @@ public interface Transport {
    int getNumberOfGlobalConnections();
 
    CompletionStage<Void> closeChannels(ChannelMatcher channelMatcher);
+
+   ChannelGroup getAcceptedChannels();
 }

--- a/server/core/src/test/java/org/infinispan/server/core/DummyServerStateManager.java
+++ b/server/core/src/test/java/org/infinispan/server/core/DummyServerStateManager.java
@@ -5,6 +5,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.infinispan.commons.dataconversion.internal.Json;
 import org.infinispan.server.core.transport.IpSubnetFilterRule;
 
 /**
@@ -59,6 +60,11 @@ public class DummyServerStateManager implements ServerStateManager {
    @Override
    public CompletableFuture<Void> clearConnectorIpFilterRules(String name) {
       return CompletableFuture.completedFuture(null);
+   }
+
+   @Override
+   public CompletableFuture<Json> listConnections() {
+      return CompletableFuture.completedFuture(Json.array());
    }
 
    @Override

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/Authentication.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/Authentication.java
@@ -11,6 +11,7 @@ import org.infinispan.commons.logging.LogFactory;
 import org.infinispan.server.core.configuration.SaslAuthenticationConfiguration;
 import org.infinispan.server.core.security.sasl.SaslAuthenticator;
 import org.infinispan.server.core.security.sasl.SubjectSaslServer;
+import org.infinispan.server.core.transport.ConnectionMetadata;
 import org.infinispan.server.core.transport.SaslQopHandler;
 import org.infinispan.server.hotrod.configuration.HotRodServerConfiguration;
 import org.infinispan.server.hotrod.logging.Log;
@@ -99,7 +100,8 @@ public class Authentication extends BaseRequestProcessor {
       // Obtaining the subject might be expensive, so do it before sending the final server challenge, otherwise the
       // client might send another operation before this is complete
       subject = (Subject) saslServer.getNegotiatedProperty(SubjectSaslServer.SUBJECT);
-
+      ConnectionMetadata metadata = ConnectionMetadata.getInstance(channel);
+      metadata.subject(subject);
       // Finally we setup the QOP handler if required
       String qop = (String) saslServer.getNegotiatedProperty(Sasl.QOP);
       if ("auth-int".equals(qop) || "auth-conf".equals(qop)) {

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/CacheRequestProcessor.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/CacheRequestProcessor.java
@@ -24,6 +24,7 @@ import org.infinispan.context.Flag;
 import org.infinispan.metadata.Metadata;
 import org.infinispan.reactive.publisher.impl.DeliveryGuarantee;
 import org.infinispan.security.actions.SecurityActions;
+import org.infinispan.server.core.transport.ConnectionMetadata;
 import org.infinispan.server.hotrod.HotRodServer.ExtendedCacheInfo;
 import org.infinispan.server.hotrod.logging.Log;
 import org.infinispan.server.hotrod.tracing.HotRodTelemetryService;
@@ -55,6 +56,8 @@ class CacheRequestProcessor extends BaseRequestProcessor {
       if (!header.cacheName.isEmpty()) {
          server.cache(server.getCacheInfo(header), header, subject);
       }
+      ConnectionMetadata metadata = ConnectionMetadata.getInstance(channel);
+      metadata.protocolVersion(HotRodVersion.forVersion(header.version).toString());
       writeResponse(header, header.encoder().pingResponse(header, server, channel, OperationStatus.Success));
    }
 
@@ -69,7 +72,7 @@ class CacheRequestProcessor extends BaseRequestProcessor {
          ClusterCacheStats clusterCacheStats =
                SecurityActions.getCacheComponentRegistry(cache).getComponent(ClusterCacheStats.class);
          ByteBuf buf = header.encoder().statsResponse(header, server, channel, stats, server.getTransport(),
-                                                      clusterCacheStats);
+               clusterCacheStats);
          writeResponse(header, buf);
       } catch (Throwable t) {
          writeException(header, t);

--- a/server/memcached/src/main/java/org/infinispan/server/memcached/binary/BinaryDecoder.java
+++ b/server/memcached/src/main/java/org/infinispan/server/memcached/binary/BinaryDecoder.java
@@ -10,12 +10,14 @@ import javax.security.auth.Subject;
 
 import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.commons.util.Util;
+import org.infinispan.server.core.transport.ConnectionMetadata;
 import org.infinispan.server.memcached.MemcachedBaseDecoder;
 import org.infinispan.server.memcached.MemcachedServer;
 import org.infinispan.server.memcached.MemcachedStatus;
 import org.infinispan.server.memcached.logging.Header;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 
@@ -26,6 +28,14 @@ abstract class BinaryDecoder extends MemcachedBaseDecoder {
 
    protected BinaryDecoder(MemcachedServer server, Subject subject) {
       super(server, subject, server.getCache().getAdvancedCache().withMediaType(MediaType.APPLICATION_OCTET_STREAM, server.getConfiguration().clientEncoding()));
+   }
+
+   @Override
+   public void handlerAdded(ChannelHandlerContext ctx) {
+      super.handlerAdded(ctx);
+      ConnectionMetadata metadata = ConnectionMetadata.getInstance(channel);
+      metadata.subject(subject);
+      metadata.protocolVersion("MCBIN");
    }
 
    protected void config(BinaryHeader header, byte[] key) {

--- a/server/memcached/src/main/java/org/infinispan/server/memcached/text/TextDecoder.java
+++ b/server/memcached/src/main/java/org/infinispan/server/memcached/text/TextDecoder.java
@@ -5,10 +5,12 @@ import java.util.concurrent.CompletionStage;
 import javax.security.auth.Subject;
 
 import org.infinispan.commons.dataconversion.MediaType;
+import org.infinispan.server.core.transport.ConnectionMetadata;
 import org.infinispan.server.memcached.MemcachedBaseDecoder;
 import org.infinispan.server.memcached.MemcachedServer;
 import org.infinispan.server.memcached.logging.Header;
 
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 
@@ -18,6 +20,14 @@ import io.netty.util.concurrent.GenericFutureListener;
 abstract class TextDecoder extends MemcachedBaseDecoder {
    protected TextDecoder(MemcachedServer server, Subject subject) {
       super(server, subject, server.getCache().getAdvancedCache().withMediaType(MediaType.TEXT_PLAIN, server.getConfiguration().clientEncoding()));
+   }
+
+   @Override
+   public void handlerAdded(ChannelHandlerContext ctx) {
+      super.handlerAdded(ctx);
+      ConnectionMetadata metadata = ConnectionMetadata.getInstance(channel);
+      metadata.subject(subject);
+      metadata.protocolVersion("MCTXT");
    }
 
    @Override

--- a/server/resp/src/main/java/org/infinispan/server/resp/Resp3AuthHandler.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/Resp3AuthHandler.java
@@ -8,6 +8,7 @@ import javax.security.auth.Subject;
 import javax.security.sasl.SaslException;
 
 import org.infinispan.commons.util.concurrent.CompletableFutures;
+import org.infinispan.server.core.transport.ConnectionMetadata;
 import org.infinispan.server.resp.authentication.RespAuthenticator;
 import org.infinispan.server.resp.commands.AuthResp3Command;
 
@@ -77,7 +78,8 @@ public class Resp3AuthHandler extends CacheRespRequestHandler {
          ByteBufferUtils.stringToByteBuf("-ERR Client sent AUTH, but no password is set\r\n", allocatorToUse);
          return false;
       }
-
+      ConnectionMetadata metadata = ConnectionMetadata.getInstance(ctx.channel());
+      metadata.subject(subject);
       setCache(cache.withSubject(subject));
       Consumers.OK_BICONSUMER.accept(null, allocatorToUse);
       return true;

--- a/server/resp/src/main/java/org/infinispan/server/resp/RespChannelInitializer.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/RespChannelInitializer.java
@@ -1,5 +1,6 @@
 package org.infinispan.server.resp;
 
+import org.infinispan.server.core.transport.ConnectionMetadata;
 import org.infinispan.server.core.transport.NettyInitializer;
 
 import io.netty.channel.Channel;
@@ -25,6 +26,8 @@ public class RespChannelInitializer implements NettyInitializer {
 
    @Override
    public void initializeChannel(Channel ch) {
+      ConnectionMetadata metadata = ConnectionMetadata.getInstance(ch);
+      metadata.protocolVersion("RESP3");
       ChannelPipeline pipeline = ch.pipeline();
       RespRequestHandler initialHandler;
       if (respServer.getConfiguration().authentication().enabled()) {

--- a/server/resp/src/main/java/org/infinispan/server/resp/Util.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/Util.java
@@ -1,5 +1,7 @@
 package org.infinispan.server.resp;
 
+import java.nio.charset.StandardCharsets;
+
 public class Util {
    private Util() { }
 
@@ -50,5 +52,9 @@ public class Util {
 
    public static boolean isAsciiLowercase(byte b) {
       return b >= 97 && b <= 122;
+   }
+
+   public static String utf8(byte[] b) {
+      return new String(b, StandardCharsets.UTF_8);
    }
 }

--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/Commands.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/Commands.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.infinispan.server.resp.RespCommand;
 import org.infinispan.server.resp.commands.cluster.CLUSTER;
 import org.infinispan.server.resp.commands.connection.AUTH;
+import org.infinispan.server.resp.commands.connection.CLIENT;
 import org.infinispan.server.resp.commands.connection.COMMAND;
 import org.infinispan.server.resp.commands.connection.DBSIZE;
 import org.infinispan.server.resp.commands.connection.ECHO;
@@ -66,7 +67,7 @@ public final class Commands {
       // NOTE that the order within the sub array matters, commands we want to have the lowest latency should be first
       // in this array as they are looked up sequentially for matches
       ALL_COMMANDS[0] = new RespCommand[]{new APPEND(), new AUTH()};
-      ALL_COMMANDS[2] = new RespCommand[]{new CONFIG(), new COMMAND(), new CLUSTER()};
+      ALL_COMMANDS[2] = new RespCommand[]{new CONFIG(), new COMMAND(), new CLUSTER(), new CLIENT() };
       // DEL should always be first here
       ALL_COMMANDS[3] = new RespCommand[]{new DEL(), new DECR(), new DECRBY(), new DBSIZE()};
       ALL_COMMANDS[4] = new RespCommand[]{new ECHO(), new EXISTS()};

--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/connection/CLIENT.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/connection/CLIENT.java
@@ -1,0 +1,130 @@
+package org.infinispan.server.resp.commands.connection;
+
+import static org.infinispan.server.resp.Resp3Handler.handleBulkResult;
+import static org.infinispan.server.resp.Util.utf8;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
+import org.infinispan.security.AuthorizationPermission;
+import org.infinispan.security.Security;
+import org.infinispan.server.core.transport.ConnectionMetadata;
+import org.infinispan.server.core.transport.NettyTransport;
+import org.infinispan.server.resp.ByteBufferUtils;
+import org.infinispan.server.resp.Consumers;
+import org.infinispan.server.resp.Resp3Handler;
+import org.infinispan.server.resp.RespCommand;
+import org.infinispan.server.resp.RespRequestHandler;
+import org.infinispan.server.resp.commands.Resp3Command;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.group.ChannelGroup;
+import io.netty.channel.group.ChannelMatcher;
+
+/**
+ * <a href="https://redis.io/commands/client/">CLIENT</a> *
+ *
+ * @since 15.0
+ */
+public class CLIENT extends RespCommand implements Resp3Command {
+   public CLIENT() {
+      super(-2, 0, 0, 0);
+   }
+
+   @Override
+   public CompletionStage<RespRequestHandler> perform(Resp3Handler handler, ChannelHandlerContext ctx,
+                                                      List<byte[]> arguments) {
+      String subcommand = utf8(arguments.get(0)).toUpperCase();
+      ConnectionMetadata metadata = ConnectionMetadata.getInstance(ctx.channel());
+      switch (subcommand) {
+         case "CACHING":
+         case "UNPAUSE":
+         case "PAUSE":
+         case "NO-EVICT":
+         case "KILL":
+         case "NO-TOUCH":
+         case "GETREDIR":
+         case "UNBLOCK":
+         case "REPLY":
+            ByteBufferUtils.stringToByteBuf("-ERR unsupported command\r\n", handler.allocator());
+            break;
+         case "SETINFO":
+            for (int i = 1; i < arguments.size(); i++) {
+               String name = utf8(arguments.get(i));
+               switch (name.toUpperCase()) {
+                  case "LIB-NAME":
+                     metadata.clientLibraryName(utf8(arguments.get(++i)));
+                     break;
+                  case "LIB-VER":
+                     metadata.clientLibraryVersion(utf8(arguments.get(++i)));
+                     break;
+                  default:
+                     ByteBufferUtils.stringToByteBuf("-ERR unsupported attribute " + name + "\r\n", handler.allocator());
+                     return handler.myStage();
+               }
+            }
+            break;
+         case "SETNAME":
+            metadata.clientName(utf8(arguments.get(1)));
+            Consumers.OK_BICONSUMER.accept(null, handler.allocator());
+            break;
+         case "GETNAME":
+            handleBulkResult(metadata.clientName(), handler.allocator());
+            break;
+         case "ID":
+            Consumers.LONG_BICONSUMER.accept(metadata.id(), handler.allocator());
+            break;
+         case "INFO": {
+            StringBuilder sb = new StringBuilder();
+            addInfo(sb, metadata);
+            handleBulkResult(sb, handler.allocator());
+            break;
+         }
+         case "LIST": {
+            handler.checkPermission(AuthorizationPermission.ADMIN);
+            StringBuilder sb = new StringBuilder();
+            ChannelMatcher matcher = handler.respServer().getChannelMatcher();
+            NettyTransport transport = handler.respServer().getTransport();
+            if (transport == null) {
+               transport = (NettyTransport) handler.respServer().getEnclosingProtocolServer().getTransport();
+            }
+            ChannelGroup channels = transport.getAcceptedChannels();
+            channels.forEach(ch -> {
+               if (matcher.matches(ch)) {
+                  addInfo(sb, ConnectionMetadata.getInstance(ch));
+               }
+            });
+            handleBulkResult(sb, handler.allocator());
+            break;
+         }
+         case "TRACKING":
+            ByteBufferUtils.stringToByteBuf("-ERR client tracking not supported\r\n", handler.allocator());
+            break;
+         case "TRACKINGINFO":
+            ByteBufferUtils.stringToByteBuf("*0\r\n", handler.allocator());
+            break;
+      }
+      return handler.myStage();
+   }
+
+   private void addInfo(StringBuilder sb, ConnectionMetadata metadata) {
+      sb.append("id=");
+      sb.append(metadata.id());
+      sb.append(" addr=");
+      sb.append(metadata.remoteAddress());
+      sb.append(" laddr=");
+      sb.append(metadata.localAddress());
+      sb.append(" name=");
+      String name = metadata.clientName();
+      if (name != null) {
+         sb.append(name);
+      }
+      sb.append(" age=");
+      sb.append(Duration.between(metadata.created(), Instant.now()).getSeconds());
+      sb.append(" user=");
+      sb.append(Security.getSubjectUserPrincipalName(metadata.subject()));
+      sb.append("\n");
+   }
+}

--- a/server/resp/src/test/java/org/infinispan/server/resp/RespServerTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/RespServerTest.java
@@ -36,7 +36,7 @@ public class RespServerTest extends AbstractInfinispanTest {
       config.expiration().lifespan(10);
       Stoppable.useCacheManager(TestCacheManagerFactory.createCacheManager(config), cm ->
             Stoppable.useServer(new RespServer(), ms -> {
-               ms.start(new RespServerConfigurationBuilder().defaultCacheName(cm.getCacheManagerConfiguration().defaultCacheName().get()).build(), cm);
+               ms.start(new RespServerConfigurationBuilder().port(0).defaultCacheName(cm.getCacheManagerConfiguration().defaultCacheName().get()).build(), cm);
                assertEquals(10, ms.getCache().getCacheConfiguration().expiration().lifespan());
             }));
    }

--- a/server/rest/src/test/java/org/infinispan/rest/logging/RestAccessLoggingTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/logging/RestAccessLoggingTest.java
@@ -68,6 +68,6 @@ public class RestAccessLoggingTest extends SingleCacheManagerTest {
 
       String logline = logAppender.getLog(0);
 
-      assertTrue(logline, logline.matches("^127\\.0\\.0\\.1 - \\[\\d+/\\w+/\\d+:\\d+:\\d+:\\d+ [+-]?\\d+] \"PUT /rest/v2/caches/default/key HTTP/1\\.1\" 404 \\d+ \\d+ \\d+ okhttp/\\p{Graph}+$"));
+      assertTrue(logline, logline.matches("^127\\.0\\.0\\.1 - \\[\\d+/\\w+/\\d+:\\d+:\\d+:\\d+ [+-]?\\d+] \"PUT /rest/v2/caches/default/key HTTP/1\\.1\" 404 \\d+ \\d+ \\d+ Infinispan/\\p{Graph}+$"));
    }
 }

--- a/server/tests/src/test/java/org/infinispan/server/security/authorization/RESTAuthorizationTest.java
+++ b/server/tests/src/test/java/org/infinispan/server/security/authorization/RESTAuthorizationTest.java
@@ -261,6 +261,9 @@ public class RESTAuthorizationTest extends BaseTest {
       assertStatus(OK, client.server().memory());
       assertStatus(OK, client.server().env());
       assertStatus(OK, client.server().configuration());
+      String connections = assertStatus(OK, client.server().listConnections(true));
+      Json json = Json.read(connections);
+      assertTrue(json.isArray());
    }
 
    @Test


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-14886
https://issues.redhat.com/browse/ISPN-14885

This PR includes two commits: the first one introduces connection metadata to the protocol servers, by attaching a number of attributes to the channel. There is also a new REST API `/rest/v2/server/connections` which lists all active connections

The second commit implements a number of RESP CLIENT subcommands which rely on the above functionality