### PR TITLE
ISPN-14897 Avoid allocating strings for parsing int/long in resp

### DIFF
--- a/server/memcached/src/main/java/org/infinispan/server/memcached/MemcachedBaseDecoder.java
+++ b/server/memcached/src/main/java/org/infinispan/server/memcached/MemcachedBaseDecoder.java
@@ -9,6 +9,7 @@ import static org.infinispan.server.memcached.MemcachedStats.INCR_HITS;
 import static org.infinispan.server.memcached.MemcachedStats.INCR_MISSES;
 import static org.infinispan.server.memcached.binary.BinaryConstants.MAX_EXPIRATION;
 
+import java.nio.charset.StandardCharsets;
 import java.time.temporal.Temporal;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -85,46 +86,46 @@ public abstract class MemcachedBaseDecoder extends ByteToMessageDecoder {
 
    protected abstract void send(Header header, CompletionStage<?> response, GenericFutureListener<? extends Future<? super Void>> listener);
 
-   protected Map<String, String> statsMap() {
+   protected Map<byte[], byte[]> statsMap() {
       Stats stats = cache.getAdvancedCache().getStats();
-      Map<String, String> map = new LinkedHashMap<>(35);
-      map.put("pid", Long.toString(ProcessHandle.current().pid()));
-      map.put("uptime", Long.toString(stats.getTimeSinceStart()));
-      map.put("time", Long.toString(TimeUnit.MILLISECONDS.toSeconds(timeService.wallClockTime())));
-      map.put("version", cache.getVersion());
-      map.put("pointer_size", "0"); // Unsupported
-      map.put("rusage_user", "0"); // Unsupported
-      map.put("rusage_system", "0"); // Unsupported
-      map.put("curr_items", Long.toString(stats.getApproximateEntries()));
-      map.put("total_items", Long.toString(stats.getStores()));
-      map.put("bytes", "0"); // Unsupported
-      map.put("cmd_get", Long.toString(stats.getRetrievals()));
-      map.put("cmd_set", Long.toString(stats.getStores()));
-      map.put("get_hits", Long.toString(stats.getHits()));
-      map.put("get_misses", Long.toString(stats.getMisses()));
-      map.put("delete_misses", Long.toString(stats.getRemoveMisses()));
-      map.put("delete_hits", Long.toString(stats.getRemoveHits()));
-      map.put("incr_misses", Long.toString(INCR_MISSES.get(statistics)));
-      map.put("incr_hits", Long.toString(INCR_HITS.get(statistics)));
-      map.put("decr_misses", Long.toString(DECR_MISSES.get(statistics)));
-      map.put("decr_hits", Long.toString(DECR_HITS.get(statistics)));
-      map.put("cas_misses", Long.toString(CAS_MISSES.get(statistics)));
-      map.put("cas_hits", Long.toString(CAS_HITS.get(statistics)));
-      map.put("cas_badval", Long.toString(CAS_BADVAL.get(statistics)));
-      map.put("auth_cmds", "0"); // Unsupported
-      map.put("auth_errors", "0"); // Unsupported
+      Map<byte[], byte[]> map = new LinkedHashMap<>(35);
+      map.put(MemcachedStats.MemcachedStatsKeys.PID, ParseUtil.writeAsciiLong(ProcessHandle.current().pid()));
+      map.put(MemcachedStats.MemcachedStatsKeys.UPTIME, ParseUtil.writeAsciiLong(stats.getTimeSinceStart()));
+      map.put(MemcachedStats.MemcachedStatsKeys.TIME, ParseUtil.writeAsciiLong(TimeUnit.MILLISECONDS.toSeconds(timeService.wallClockTime())));
+      map.put(MemcachedStats.MemcachedStatsKeys.VERSION, cache.getVersion().getBytes(StandardCharsets.US_ASCII));
+      map.put(MemcachedStats.MemcachedStatsKeys.POINTER_SIZE, ParseUtil.ZERO); // Unsupported
+      map.put(MemcachedStats.MemcachedStatsKeys.RUSAGE_USER, ParseUtil.ZERO); // Unsupported
+      map.put(MemcachedStats.MemcachedStatsKeys.RUSAGE_SYSTEM, ParseUtil.ZERO); // Unsupported
+      map.put(MemcachedStats.MemcachedStatsKeys.CURR_ITEMS, ParseUtil.writeAsciiLong(stats.getApproximateEntries()));
+      map.put(MemcachedStats.MemcachedStatsKeys.TOTAL_ITEMS, ParseUtil.writeAsciiLong(stats.getStores()));
+      map.put(MemcachedStats.MemcachedStatsKeys.BYTES, ParseUtil.ZERO); // Unsupported
+      map.put(MemcachedStats.MemcachedStatsKeys.CMD_GET, ParseUtil.writeAsciiLong(stats.getRetrievals()));
+      map.put(MemcachedStats.MemcachedStatsKeys.CMD_SET, ParseUtil.writeAsciiLong(stats.getStores()));
+      map.put(MemcachedStats.MemcachedStatsKeys.GET_HITS, ParseUtil.writeAsciiLong(stats.getHits()));
+      map.put(MemcachedStats.MemcachedStatsKeys.GET_MISSES, ParseUtil.writeAsciiLong(stats.getMisses()));
+      map.put(MemcachedStats.MemcachedStatsKeys.DELETE_MISSES, ParseUtil.writeAsciiLong(stats.getRemoveMisses()));
+      map.put(MemcachedStats.MemcachedStatsKeys.DELETE_HITS, ParseUtil.writeAsciiLong(stats.getRemoveHits()));
+      map.put(MemcachedStats.MemcachedStatsKeys.INCR_MISSES, ParseUtil.writeAsciiLong(INCR_MISSES.get(statistics)));
+      map.put(MemcachedStats.MemcachedStatsKeys.INCR_HITS, ParseUtil.writeAsciiLong(INCR_HITS.get(statistics)));
+      map.put(MemcachedStats.MemcachedStatsKeys.DECR_MISSES, ParseUtil.writeAsciiLong(DECR_MISSES.get(statistics)));
+      map.put(MemcachedStats.MemcachedStatsKeys.DECR_HITS, ParseUtil.writeAsciiLong(DECR_HITS.get(statistics)));
+      map.put(MemcachedStats.MemcachedStatsKeys.CAS_MISSES, ParseUtil.writeAsciiLong(CAS_MISSES.get(statistics)));
+      map.put(MemcachedStats.MemcachedStatsKeys.CAS_HITS, ParseUtil.writeAsciiLong(CAS_HITS.get(statistics)));
+      map.put(MemcachedStats.MemcachedStatsKeys.CAS_BADVAL, ParseUtil.writeAsciiLong(CAS_BADVAL.get(statistics)));
+      map.put(MemcachedStats.MemcachedStatsKeys.AUTH_CMDS, ParseUtil.ZERO); // Unsupported
+      map.put(MemcachedStats.MemcachedStatsKeys.AUTH_ERRORS, ParseUtil.ZERO); // Unsupported
       //TODO: Evictions are measured by evict calls, but not by nodes are that are expired after the entry's lifespan has expired.
-      map.put("evictions", Long.toString(stats.getEvictions()));
+      map.put(MemcachedStats.MemcachedStatsKeys.EVICTIONS, ParseUtil.writeAsciiLong(stats.getEvictions()));
       NettyTransport transport = server.getTransport();
-      map.put("bytes_read", Long.toString(transport.getTotalBytesRead()));
-      map.put("bytes_written", Long.toString(transport.getTotalBytesWritten()));
-      map.put("curr_connections", Long.toString(transport.getNumberOfLocalConnections()));
-      map.put("total_connections", Long.toString(transport.getNumberOfGlobalConnections()));
-      map.put("threads", "0"); // TODO: Through netty?
-      map.put("connection_structures", "0"); // Unsupported
-      map.put("limit_maxbytes", "0"); // Unsupported
-      map.put("conn_yields", "0"); // Unsupported
-      map.put("reclaimed", "0"); // Unsupported
+      map.put(MemcachedStats.MemcachedStatsKeys.BYTES_READ, ParseUtil.writeAsciiLong(transport.getTotalBytesRead()));
+      map.put(MemcachedStats.MemcachedStatsKeys.BYTES_WRITTEN, ParseUtil.writeAsciiLong(transport.getTotalBytesWritten()));
+      map.put(MemcachedStats.MemcachedStatsKeys.CURR_CONNECTIONS, ParseUtil.writeAsciiLong(transport.getNumberOfLocalConnections()));
+      map.put(MemcachedStats.MemcachedStatsKeys.TOTAL_CONNECTIONS, ParseUtil.writeAsciiLong(transport.getNumberOfGlobalConnections()));
+      map.put(MemcachedStats.MemcachedStatsKeys.THREADS, ParseUtil.ZERO); // TODO: Through netty?
+      map.put(MemcachedStats.MemcachedStatsKeys.CONNECTION_STRUCTURES, ParseUtil.ZERO); // Unsupported
+      map.put(MemcachedStats.MemcachedStatsKeys.LIMIT_MAXBYTES, ParseUtil.ZERO); // Unsupported
+      map.put(MemcachedStats.MemcachedStatsKeys.CONN_YIELDS, ParseUtil.ZERO); // Unsupported
+      map.put(MemcachedStats.MemcachedStatsKeys.RECLAIMED, ParseUtil.ZERO); // Unsupported
       return map;
    }
 

--- a/server/memcached/src/main/java/org/infinispan/server/memcached/MemcachedStats.java
+++ b/server/memcached/src/main/java/org/infinispan/server/memcached/MemcachedStats.java
@@ -2,6 +2,7 @@ package org.infinispan.server.memcached;
 
 import static java.util.concurrent.atomic.AtomicLongFieldUpdater.newUpdater;
 
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 /**
@@ -22,4 +23,44 @@ public class MemcachedStats {
    private volatile long casMisses = 0;
    private volatile long casHits = 0;
    private volatile long casBadval = 0;
+
+
+   public static class MemcachedStatsKeys {
+
+      public static final byte[] PID = "pid".getBytes(StandardCharsets.US_ASCII);
+      public static final byte[] UPTIME = "uptime".getBytes(StandardCharsets.US_ASCII);
+      public static final byte[] TIME = "time".getBytes(StandardCharsets.US_ASCII);
+      public static final byte[] VERSION = "version".getBytes(StandardCharsets.US_ASCII);
+      public static final byte[] POINTER_SIZE = "pointer_size".getBytes(StandardCharsets.US_ASCII);
+      public static final byte[] RUSAGE_USER = "rusage_user".getBytes(StandardCharsets.US_ASCII);
+      public static final byte[] RUSAGE_SYSTEM = "rusage_system".getBytes(StandardCharsets.US_ASCII);
+      public static final byte[] CURR_ITEMS = "curr_items".getBytes(StandardCharsets.US_ASCII);
+      public static final byte[] TOTAL_ITEMS = "total_items".getBytes(StandardCharsets.US_ASCII);
+      public static final byte[] BYTES = "bytes".getBytes(StandardCharsets.US_ASCII);
+      public static final byte[] CMD_GET = "cmd_get".getBytes(StandardCharsets.US_ASCII);
+      public static final byte[] CMD_SET = "cmd_set".getBytes(StandardCharsets.US_ASCII);
+      public static final byte[] GET_HITS = "get_hits".getBytes(StandardCharsets.US_ASCII);
+      public static final byte[] GET_MISSES = "get_misses".getBytes(StandardCharsets.US_ASCII);
+      public static final byte[] DELETE_MISSES = "delete_misses".getBytes(StandardCharsets.US_ASCII);
+      public static final byte[] DELETE_HITS = "delete_hits".getBytes(StandardCharsets.US_ASCII);
+      public static final byte[] INCR_MISSES = "incr_misses".getBytes(StandardCharsets.US_ASCII);
+      public static final byte[] INCR_HITS = "incr_hits".getBytes(StandardCharsets.US_ASCII);
+      public static final byte[] DECR_MISSES = "decr_misses".getBytes(StandardCharsets.US_ASCII);
+      public static final byte[] DECR_HITS = "decr_hits".getBytes(StandardCharsets.US_ASCII);
+      public static final byte[] CAS_MISSES = "cas_misses".getBytes(StandardCharsets.US_ASCII);
+      public static final byte[] CAS_HITS = "cas_hits".getBytes(StandardCharsets.US_ASCII);
+      public static final byte[] CAS_BADVAL = "cas_badval".getBytes(StandardCharsets.US_ASCII);
+      public static final byte[] AUTH_CMDS = "auth_cmds".getBytes(StandardCharsets.US_ASCII);
+      public static final byte[] AUTH_ERRORS = "auth_errors".getBytes(StandardCharsets.US_ASCII);
+      public static final byte[] EVICTIONS = "evictions".getBytes(StandardCharsets.US_ASCII);
+      public static final byte[] BYTES_READ = "bytes_read".getBytes(StandardCharsets.US_ASCII);
+      public static final byte[] BYTES_WRITTEN = "bytes_written".getBytes(StandardCharsets.US_ASCII);
+      public static final byte[] CURR_CONNECTIONS = "curr_connections".getBytes(StandardCharsets.US_ASCII);
+      public static final byte[] TOTAL_CONNECTIONS = "total_connections".getBytes(StandardCharsets.US_ASCII);
+      public static final byte[] THREADS = "threads".getBytes(StandardCharsets.US_ASCII);
+      public static final byte[] CONNECTION_STRUCTURES = "connection_structures".getBytes(StandardCharsets.US_ASCII);
+      public static final byte[] LIMIT_MAXBYTES = "limit_maxbytes".getBytes(StandardCharsets.US_ASCII);
+      public static final byte[] CONN_YIELDS = "conn_yields".getBytes(StandardCharsets.US_ASCII);
+      public static final byte[] RECLAIMED = "reclaimed".getBytes(StandardCharsets.US_ASCII);
+   }
 }

--- a/server/memcached/src/main/java/org/infinispan/server/memcached/ParseUtil.java
+++ b/server/memcached/src/main/java/org/infinispan/server/memcached/ParseUtil.java
@@ -1,0 +1,126 @@
+package org.infinispan.server.memcached;
+
+public class ParseUtil {
+
+   private ParseUtil() { }
+
+   static final byte[] DigitTens = {
+         '0', '0', '0', '0', '0', '0', '0', '0', '0', '0',
+         '1', '1', '1', '1', '1', '1', '1', '1', '1', '1',
+         '2', '2', '2', '2', '2', '2', '2', '2', '2', '2',
+         '3', '3', '3', '3', '3', '3', '3', '3', '3', '3',
+         '4', '4', '4', '4', '4', '4', '4', '4', '4', '4',
+         '5', '5', '5', '5', '5', '5', '5', '5', '5', '5',
+         '6', '6', '6', '6', '6', '6', '6', '6', '6', '6',
+         '7', '7', '7', '7', '7', '7', '7', '7', '7', '7',
+         '8', '8', '8', '8', '8', '8', '8', '8', '8', '8',
+         '9', '9', '9', '9', '9', '9', '9', '9', '9', '9',
+   };
+
+   static final byte[] DigitOnes = {
+         '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+         '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+         '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+         '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+         '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+         '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+         '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+         '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+         '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+         '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+   };
+
+   public static byte[] ZERO = new byte[] { '0' };
+
+   public static long readLong(byte[] in) {
+      if (in == null || in.length == 0)
+         throw new NumberFormatException("Empty argument");
+
+      boolean negative = false;
+      int i = 0;
+      if (in[0] < '0') {
+         if ((in[0] != '-' && in[0] != '+') || in.length == 1)
+            throw new NumberFormatException("Invalid character: " + in[0]);
+
+         negative = true;
+         i = 1;
+      }
+
+      long result;
+
+      byte b = in[i++];
+      if (b < '0' || b > '9')
+         throw new NumberFormatException("Invalid character: " + b);
+      result = (b - 48);
+
+      for (; i < in.length; i++) {
+         b = in[i];
+         if (b < '0' || b > '9')
+            throw new NumberFormatException("Invalid character: " + b);
+
+         result = (result << 3) + (result << 1) + (b - 48);
+      }
+      return negative ? -result : result;
+   }
+
+   public static int readInt(byte[] in) {
+      long v = readLong(in);
+      if (v > Integer.MAX_VALUE || v < Integer.MIN_VALUE) {
+         throw new NumberFormatException("Invalid integer: " + v);
+      }
+      return (int)v;
+   }
+
+
+   public static byte[] writeAsciiLong(long in) {
+      if (in == 0) return ZERO;
+
+      int numberDigits = stringSize(in);
+      int writerIndex = numberDigits;
+      boolean negative = in < 0;
+      byte[] out = new byte[numberDigits];
+
+      if (!negative) {
+         in = -in;
+      }
+
+      long q;
+      int r;
+      while (in <= -100) {
+         q = in / 100;
+         r = (int)((q * 100) - in);
+         in = q;
+         out[--writerIndex] = DigitOnes[r];
+         out[--writerIndex] = DigitTens[r];
+      }
+
+      q = in / 10;
+      r = (int)((q * 10) - in);
+      out[--writerIndex] = (byte) ('0' + r);
+
+      if (q < 0) {
+         out[--writerIndex] = (byte) ('0' - q);
+      }
+
+      if (negative) {
+         out[0] = '-';
+      }
+
+      return out;
+   }
+
+   private static int stringSize(long x) {
+      int d = 1;
+      if (x >= 0) {
+         d = 0;
+         x = -x;
+      }
+      int p = -10;
+      for (int i = 1; i < 10; i++) {
+         if (x > p)
+            return i + d;
+         p = 10 * p;
+      }
+      return 10 + d;
+   }
+}

--- a/server/memcached/src/main/java/org/infinispan/server/memcached/binary/BinaryDecoder.java
+++ b/server/memcached/src/main/java/org/infinispan/server/memcached/binary/BinaryDecoder.java
@@ -91,7 +91,7 @@ abstract class BinaryDecoder extends MemcachedBaseDecoder {
       return buf;
    }
 
-   protected ByteBuf response(BinaryHeader header, MemcachedStatus status, String number) {
+   protected ByteBuf response(BinaryHeader header, MemcachedStatus status, long number) {
       ByteBuf buf = channel.alloc().buffer(32);
       buf.writeByte(MAGIC_RES);
       buf.writeByte(header.op.opCode());
@@ -102,7 +102,7 @@ abstract class BinaryDecoder extends MemcachedBaseDecoder {
       buf.writeInt(8);
       buf.writeInt(header.opaque);
       buf.writeLong(header.cas);
-      buf.writeLong(Long.parseLong(number));
+      buf.writeLong(number);
       return buf;
    }
 

--- a/server/memcached/src/main/java/org/infinispan/server/memcached/text/TextIntrinsics.java
+++ b/server/memcached/src/main/java/org/infinispan/server/memcached/text/TextIntrinsics.java
@@ -95,7 +95,7 @@ public class TextIntrinsics {
       if (s == null) {
          return 0;
       } else if (s.isReadable()) {
-         return Integer.parseUnsignedInt(s.toString(US_ASCII));
+         return parseUnsignedInt(s);
       } else {
          consumeLine(buf);
          throw new IllegalArgumentException("Expected number");
@@ -191,5 +191,27 @@ public class TextIntrinsics {
       }
       buf.resetReaderIndex();
       return false;
+   }
+
+   public static long parseLong(ByteBuf s) {
+      byte first = s.readByte();
+      long result = first == '+' ? 0 : first - 48;
+      while (s.isReadable()) {
+         byte b = s.readByte();
+         if (b < '0' || b > '9')
+            throw new NumberFormatException("Invalid character: " + b);
+
+         result = (result << 3) + (result << 1) + (b - 48);
+      }
+      return result;
+   }
+
+   public static int parseUnsignedInt(ByteBuf s) {
+      long v = parseLong(s);
+      // From Integer.parseUnsignedInt.
+      if ((v & 0xffff_ffff_0000_0000L) != 0L) {
+         throw new NumberFormatException("Value exceeds range of unsigned int: " + v);
+      }
+      return (int)v;
    }
 }

--- a/server/resp/src/main/java/org/infinispan/server/resp/ByteBufferUtils.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/ByteBufferUtils.java
@@ -59,6 +59,17 @@ public final class ByteBufferUtils {
       return buffer;
    }
 
+   public static ByteBuf writeLong(long result, ByteBufPool alloc) {
+      // : + number of digits + \r\n
+      int size = 1 + stringSize(result) + 2;
+      ByteBuf buffer = alloc.acquire(size);
+      buffer.writeByte(':');
+      setIntChars(result, size - 3, buffer);
+      buffer.writeByte('\r')
+            .writeByte('\n');
+      return buffer;
+   }
+
    public static ByteBuf bytesToResult(Collection<byte[]> results, ByteBufPool alloc) {
       int resultBytesSize = 0;
       for (byte[] result: results) {
@@ -104,9 +115,10 @@ public final class ByteBufferUtils {
    // This code is a modified version of Integer.toString to write the underlying bytes directly to the ByteBuffer
    // instead of creating a String around a byte[]
 
-   protected static int setIntChars(int i, int index, ByteBuf buf) {
+   protected static int setIntChars(long i, int index, ByteBuf buf) {
       int writeIndex = buf.writerIndex();
-      int q, r;
+      long q;
+      int r;
       int charPos = index;
 
       boolean negative = i < 0;
@@ -117,7 +129,7 @@ public final class ByteBufferUtils {
       // Generate two digits per iteration
       while (i <= -100) {
          q = i / 100;
-         r = (q * 100) - i;
+         r = (int)((q * 100) - i);
          i = q;
          buf.setByte(writeIndex + --charPos, DigitOnes[r]);
          buf.setByte(writeIndex + --charPos, DigitTens[r]);
@@ -125,7 +137,7 @@ public final class ByteBufferUtils {
 
       // We know there are at most two digits left at this point.
       q = i / 10;
-      r = (q * 10) - i;
+      r = (int)((q * 10) - i);
       buf.setByte(writeIndex + --charPos, (byte) ('0' + r));
 
       // Whatever left is the remaining digit.
@@ -140,7 +152,7 @@ public final class ByteBufferUtils {
       return charPos;
    }
 
-   private static int stringSize(int x) {
+   private static int stringSize(long x) {
       int d = 1;
       if (x >= 0) {
          d = 0;

--- a/server/resp/src/main/java/org/infinispan/server/resp/Resp3Handler.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/Resp3Handler.java
@@ -45,14 +45,13 @@ public class Resp3Handler extends Resp3AuthHandler {
       return super.actualHandleRequest(ctx, type, arguments);
    }
 
-   protected static void handleLongResult(Long result, ByteBufPool alloc) {
-      // TODO: this can be optimized to avoid the String allocation
-      ByteBufferUtils.stringToByteBuf(":" + result + CRLF, alloc);
+   protected static void handleLongResult(long result, ByteBufPool alloc) {
+      ByteBufferUtils.writeLong(result, alloc);
    }
 
-   protected static void handleDoubleResult(Double result, ByteBufPool alloc) {
+   protected static void handleDoubleResult(double result, ByteBufPool alloc) {
       // TODO: this can be optimized to avoid the String allocation
-      handleBulkResult(result.toString(), alloc);
+      handleBulkResult(Double.toString(result), alloc);
    }
 
    public static void handleBulkResult(CharSequence result, ByteBufPool alloc) {

--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/ArgumentUtils.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/ArgumentUtils.java
@@ -1,7 +1,5 @@
 package org.infinispan.server.resp.commands;
 
-import java.nio.charset.StandardCharsets;
-
 /**
  * Utility class to transform byte[] arguments.
  *
@@ -12,11 +10,41 @@ public final class ArgumentUtils {
    private ArgumentUtils() {
 
    }
+
    public static long toLong(byte[] argument) {
-      return Long.parseLong(new String(argument, StandardCharsets.US_ASCII));
+      if (argument == null || argument.length == 0)
+         throw new NumberFormatException("Empty argument");
+
+      boolean negative = false;
+      int i = 0;
+      if (argument[0] < '0') {
+         if ((argument[0] != '-' && argument[0] != '+') || argument.length == 1)
+            throw new NumberFormatException("Invalid character: " + argument[0]);
+
+         negative = true;
+         i = 1;
+      }
+
+      long result;
+      byte b = argument[i++];
+      if (b < '0' || b > '9')
+         throw new NumberFormatException("Invalid character: " + b);
+
+      result = (b - 48);
+      for (; i < argument.length; i++) {
+         b = argument[i];
+         if (b < '0' || b > '9')
+            throw new NumberFormatException("Invalid character: " + b);
+
+         result = (result << 3) + (result << 1) + (b - 48);
+      }
+      return negative ? -result : result;
    }
 
    public static int toInt(byte[] argument) {
-      return Integer.parseInt(new String(argument, StandardCharsets.US_ASCII));
+      long v = toLong(argument);
+      if (v > Integer.MAX_VALUE || v < Integer.MIN_VALUE)
+         throw new NumberFormatException("Value out of range: " + v);
+      return (int) v;
    }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-14897

Some numbers are available on https://github.com/infinispan/infinispan-benchmarks/pull/19 for the `byte[]` -> `long`.