### PR TITLE
Docs: Use setup mvn action in docs sync workflow

### DIFF
--- a/.github/workflows/sync_docs.yml
+++ b/.github/workflows/sync_docs.yml
@@ -18,12 +18,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up JDK 17
-      uses: actions/setup-java@v2
+    - name: Setup Maven
+      uses: s4u/setup-maven-action@v1.7.0
       with:
-        java-version: '17'
-        distribution: 'temurin'
-        cache: maven
+        java-version: 17
+        maven-version: 3.9.0
 
     - name: Build docs with Maven
       run: mvn install -Pdistribution -pl documentation -am -s maven-settings.xml


### PR DESCRIPTION
The action to sync core docs to the website is broken. This PR fixes that by using the following action: https://github.com/marketplace/actions/setup-maven-action

Tested here: https://github.com/oraNod/infinispan/actions/runs/5078958486/jobs/9124105364#step:4:36550

Requires backport to 14.0.x.

