### PR TITLE
Always provide cache.memory.used stat

### DIFF
--- a/spring/spring-boot/embedded/src/main/java/org/infinispan/spring/starter/embedded/actuator/InfinispanCacheMeterBinder.java
+++ b/spring/spring-boot/embedded/src/main/java/org/infinispan/spring/starter/embedded/actuator/InfinispanCacheMeterBinder.java
@@ -84,13 +84,11 @@ public class InfinispanCacheMeterBinder extends CacheMeterBinder {
             .tags(getTagsWithCacheName())
             .description("Number of entries currently in the cache, excluding passivated entries")
             .register(registry);
-
-      if (cache.getCacheConfiguration().memory().evictionStrategy().isEnabled()) {
-         Gauge.builder("cache.memory.used", cache, cache -> cache.getAdvancedCache().getStats().getDataMemoryUsed())
-               .tags(getTagsWithCacheName())
-               .description("Provides how much memory the current eviction algorithm estimates is in use for data")
-               .register(registry);
-      }
+      
+      Gauge.builder("cache.memory.used", cache, cache -> cache.getAdvancedCache().getStats().getDataMemoryUsed())
+            .tags(getTagsWithCacheName())
+            .description("Provides how much memory the current eviction algorithm estimates is in use for data")
+            .register(registry);
 
       Gauge.builder("cache.memory.offHeap", cache, cache -> cache.getAdvancedCache().getStats().getOffHeapMemoryUsed())
             .tags(getTagsWithCacheName())


### PR DESCRIPTION
Always provide cache.memory.used stat and not only when eviction is enabled.

This provides information that can be helpful in managing cache configuration even when eviction is not enabled