### PR TITLE
ISPN-14813 Memached backpressure support

### DIFF
--- a/server/memcached/src/main/java/org/infinispan/server/memcached/ByteBufPool.java
+++ b/server/memcached/src/main/java/org/infinispan/server/memcached/ByteBufPool.java
@@ -1,0 +1,22 @@
+package org.infinispan.server.memcached;
+
+import java.util.function.IntFunction;
+
+import io.netty.buffer.ByteBuf;
+
+@FunctionalInterface
+public interface ByteBufPool extends IntFunction<ByteBuf> {
+   /**
+    * This method will return a pooled ByteBuf.
+    * This buffer may already have bytes written to it.
+    * A caller should only ever write additional bytes to the buffer and not change it in any other way.
+    * <p>
+    * The returned ByteBuf should never be written as the decoder will handle this instead
+    *
+    * @param requiredSize The amount of bytes required to be writable into the ByteBuf
+    * @return a ByteBuf to write those bytes to
+    */
+   default ByteBuf acquire(int requiredSize) {
+      return apply(requiredSize);
+   }
+}

--- a/server/memcached/src/main/java/org/infinispan/server/memcached/MemcachedAutoDetector.java
+++ b/server/memcached/src/main/java/org/infinispan/server/memcached/MemcachedAutoDetector.java
@@ -33,7 +33,10 @@ public class MemcachedAutoDetector extends ProtocolDetector {
       byte b = in.getByte(in.readerIndex());
       trimPipeline(ctx);
       MemcachedProtocol protocol = b == BinaryConstants.MAGIC_REQ ? MemcachedProtocol.BINARY : MemcachedProtocol.TEXT;
-      ctx.pipeline().replace(this, "decoder", ((MemcachedServer) server).getDecoder(protocol));
+
+      MemcachedBaseDecoder decoder = (MemcachedBaseDecoder) ((MemcachedServer) server).getDecoder(protocol);
+      ctx.pipeline().replace(this, "decoder", decoder);
+      ((MemcachedServer) server).installMemcachedInboundHandler(ctx.channel(), decoder);
       // Make sure to fire registered on the newly installed handlers
       ctx.fireChannelRegistered();
       Log.SERVER.tracef("Detected %s connection", protocol);

--- a/server/memcached/src/main/java/org/infinispan/server/memcached/MemcachedBaseDecoder.java
+++ b/server/memcached/src/main/java/org/infinispan/server/memcached/MemcachedBaseDecoder.java
@@ -137,18 +137,27 @@ public abstract class MemcachedBaseDecoder extends ByteToMessageDecoder {
       map.put(MemcachedStats.MemcachedStatsKeys.GET_MISSES, ParseUtil.writeAsciiLong(stats.getMisses()));
       map.put(MemcachedStats.MemcachedStatsKeys.DELETE_MISSES, ParseUtil.writeAsciiLong(stats.getRemoveMisses()));
       map.put(MemcachedStats.MemcachedStatsKeys.DELETE_HITS, ParseUtil.writeAsciiLong(stats.getRemoveHits()));
-      map.put(MemcachedStats.MemcachedStatsKeys.INCR_MISSES, ParseUtil.writeAsciiLong(INCR_MISSES.get(statistics)));
-      map.put(MemcachedStats.MemcachedStatsKeys.INCR_HITS, ParseUtil.writeAsciiLong(INCR_HITS.get(statistics)));
-      map.put(MemcachedStats.MemcachedStatsKeys.DECR_MISSES, ParseUtil.writeAsciiLong(DECR_MISSES.get(statistics)));
-      map.put(MemcachedStats.MemcachedStatsKeys.DECR_HITS, ParseUtil.writeAsciiLong(DECR_HITS.get(statistics)));
-      map.put(MemcachedStats.MemcachedStatsKeys.CAS_MISSES, ParseUtil.writeAsciiLong(CAS_MISSES.get(statistics)));
-      map.put(MemcachedStats.MemcachedStatsKeys.CAS_HITS, ParseUtil.writeAsciiLong(CAS_HITS.get(statistics)));
-      map.put(MemcachedStats.MemcachedStatsKeys.CAS_BADVAL, ParseUtil.writeAsciiLong(CAS_BADVAL.get(statistics)));
+
+      if (statsEnabled) {
+         map.put(MemcachedStats.MemcachedStatsKeys.INCR_MISSES, ParseUtil.writeAsciiLong(INCR_MISSES.get(statistics)));
+         map.put(MemcachedStats.MemcachedStatsKeys.INCR_HITS, ParseUtil.writeAsciiLong(INCR_HITS.get(statistics)));
+         map.put(MemcachedStats.MemcachedStatsKeys.DECR_MISSES, ParseUtil.writeAsciiLong(DECR_MISSES.get(statistics)));
+         map.put(MemcachedStats.MemcachedStatsKeys.DECR_HITS, ParseUtil.writeAsciiLong(DECR_HITS.get(statistics)));
+         map.put(MemcachedStats.MemcachedStatsKeys.CAS_MISSES, ParseUtil.writeAsciiLong(CAS_MISSES.get(statistics)));
+         map.put(MemcachedStats.MemcachedStatsKeys.CAS_HITS, ParseUtil.writeAsciiLong(CAS_HITS.get(statistics)));
+         map.put(MemcachedStats.MemcachedStatsKeys.CAS_BADVAL, ParseUtil.writeAsciiLong(CAS_BADVAL.get(statistics)));
+      }
+
       map.put(MemcachedStats.MemcachedStatsKeys.AUTH_CMDS, ParseUtil.ZERO); // Unsupported
       map.put(MemcachedStats.MemcachedStatsKeys.AUTH_ERRORS, ParseUtil.ZERO); // Unsupported
       //TODO: Evictions are measured by evict calls, but not by nodes are that are expired after the entry's lifespan has expired.
       map.put(MemcachedStats.MemcachedStatsKeys.EVICTIONS, ParseUtil.writeAsciiLong(stats.getEvictions()));
+
       NettyTransport transport = server.getTransport();
+      if (transport == null) {
+         transport = (NettyTransport) server.getEnclosingProtocolServer().getTransport();
+      }
+
       map.put(MemcachedStats.MemcachedStatsKeys.BYTES_READ, ParseUtil.writeAsciiLong(transport.getTotalBytesRead()));
       map.put(MemcachedStats.MemcachedStatsKeys.BYTES_WRITTEN, ParseUtil.writeAsciiLong(transport.getTotalBytesWritten()));
       map.put(MemcachedStats.MemcachedStatsKeys.CURR_CONNECTIONS, ParseUtil.writeAsciiLong(transport.getNumberOfLocalConnections()));

--- a/server/memcached/src/main/java/org/infinispan/server/memcached/MemcachedChannelInitializer.java
+++ b/server/memcached/src/main/java/org/infinispan/server/memcached/MemcachedChannelInitializer.java
@@ -1,0 +1,35 @@
+package org.infinispan.server.memcached;
+
+import org.infinispan.server.core.transport.NettyInitializer;
+import org.infinispan.server.memcached.configuration.MemcachedProtocol;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelInboundHandler;
+
+public class MemcachedChannelInitializer implements NettyInitializer {
+
+   private final MemcachedServer memcachedServer;
+   private final MemcachedProtocol protocol;
+
+   public MemcachedChannelInitializer(MemcachedServer memcachedServer) {
+      this(memcachedServer, null);
+   }
+
+   public MemcachedChannelInitializer(MemcachedServer server, MemcachedProtocol protocol) {
+      this.memcachedServer = server;
+      this.protocol = protocol;
+   }
+
+   @Override
+   public void initializeChannel(Channel ch) {
+      ChannelInboundHandler cih = protocol == null
+            ? memcachedServer.getDecoder()
+            : memcachedServer.getDecoder(protocol);
+
+      ch.pipeline().addLast("decoder", cih);
+      if (cih instanceof MemcachedBaseDecoder) {
+         MemcachedBaseDecoder decoder = (MemcachedBaseDecoder) cih;
+         memcachedServer.installMemcachedInboundHandler(ch, decoder);
+      }
+   }
+}

--- a/server/memcached/src/main/java/org/infinispan/server/memcached/MemcachedInboundAdapter.java
+++ b/server/memcached/src/main/java/org/infinispan/server/memcached/MemcachedInboundAdapter.java
@@ -1,0 +1,217 @@
+package org.infinispan.server.memcached;
+
+import java.util.concurrent.CompletionStage;
+
+import org.infinispan.server.memcached.logging.Log;
+import org.infinispan.server.memcached.logging.MemcachedAccessLogging;
+import org.infinispan.util.concurrent.CompletionStages;
+import org.infinispan.util.logging.LogFactory;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelProgressiveFuture;
+import io.netty.channel.ChannelProgressiveFutureListener;
+import io.netty.channel.ChannelProgressivePromise;
+import io.netty.util.AttributeKey;
+
+public class MemcachedInboundAdapter extends ChannelInboundHandlerAdapter {
+
+   static final AttributeKey<ByteBufPool> ALLOCATOR_KEY = AttributeKey.valueOf("allocator");
+   protected final static int MINIMUM_BUFFER_SIZE;
+
+   protected final static Log log = LogFactory.getLog(MemcachedInboundAdapter.class, Log.class);
+
+   private final MemcachedBaseDecoder decoder;
+
+   protected ByteBuf outbound;
+   protected ChannelProgressivePromise progressive;
+
+   private long progressiveStart;
+   private long progressiveEnd;
+
+   // Variable to resume auto read when channel can be written to again. Some commands may resume themselves after
+   // flush and may not want to also resume on writability changes
+   protected boolean resumeAutoReadOnWritability;
+
+   static {
+      MINIMUM_BUFFER_SIZE = Integer.parseInt(System.getProperty("infinispan.memcached.minimum-buffer-size", "4096"));
+   }
+
+   public MemcachedInboundAdapter(MemcachedBaseDecoder decoder) {
+      this.decoder = decoder;
+   }
+
+   public static ByteBufPool getAllocator(ChannelHandlerContext ctx) {
+      ByteBufPool allocator = ctx.channel().attr(ALLOCATOR_KEY).get();
+      if (allocator == null) throw new IllegalStateException("Context does not have a buffer allocator");
+      return allocator;
+   }
+
+   private void flushBufferIfNeeded(ChannelHandlerContext ctx, boolean runOnEventLoop, MemcachedResponse res) {
+      if (outbound != null) {
+         if (runOnEventLoop) {
+            ctx.channel().eventLoop().execute(() -> {
+               if (res != null && progressive != null) {
+                  res.flushed(ctx.writeAndFlush(outbound));
+               } else {
+                  ctx.writeAndFlush(outbound, ctx.voidPromise());
+                  notifyPendingResponses(ctx);
+               }
+               outbound = null;
+            });
+         } else {
+            if (res != null && progressive != null) {
+               res.flushed(ctx.writeAndFlush(outbound));
+            } else {
+               ctx.writeAndFlush(outbound, ctx.voidPromise());
+               notifyPendingResponses(ctx);
+            }
+            outbound = null;
+         }
+      }
+   }
+
+   public void flushBufferIfNeeded(ChannelHandlerContext ctx) {
+      assert ctx.channel().eventLoop().inEventLoop();
+
+      flushBufferIfNeeded(ctx, false, null);
+   }
+
+   private void notifyPendingResponses(ChannelHandlerContext ctx) {
+      assert ctx.channel().eventLoop().inEventLoop();
+      if (progressive == null) return;
+
+      progressive.tryProgress(progressiveStart, progressiveEnd);
+      progressiveStart = progressiveEnd;
+   }
+
+   private ByteBuf allocateBuffer(ChannelHandlerContext ctx, int size) {
+      if (outbound != null) {
+         if (outbound.writableBytes() > size) {
+            return outbound;
+         }
+         ctx.write(outbound, ctx.voidPromise());
+      }
+      int allocatedSize = Math.max(size, MINIMUM_BUFFER_SIZE);
+      outbound = ctx.alloc().buffer(allocatedSize, allocatedSize);
+      return outbound;
+   }
+
+   private void resumeAutoRead(ChannelHandlerContext ctx) {
+      ctx.channel().config().setAutoRead(true);
+      decoder.resumeRead();
+   }
+
+   public void handleExceptionally(ChannelHandlerContext ctx, MemcachedResponse response) {
+      assert !response.isSuccessful();
+
+      ByteBufPool allocator = ctx.channel().attr(ALLOCATOR_KEY).get();
+      response.writeFailure(allocator);
+      registerResponseForLater(response);
+   }
+
+   @Override
+   public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
+      ctx.channel().attr(ALLOCATOR_KEY).set(size -> allocateBuffer(ctx, size));
+      progressive = MemcachedAccessLogging.isEnabled() ? ctx.newProgressivePromise() : null;
+      super.handlerAdded(ctx);
+   }
+
+   @Override
+   public void channelUnregistered(ChannelHandlerContext ctx) throws Exception {
+      if (progressive != null)
+         progressive.setFailure(new IllegalStateException("Channel unregistered"));
+      super.channelUnregistered(ctx);
+   }
+
+   @Override
+   public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
+      if (ctx.channel().config().isAutoRead()) {
+         flushBufferIfNeeded(ctx);
+      }
+      super.channelReadComplete(ctx);
+   }
+
+   @Override
+   public void channelWritabilityChanged(ChannelHandlerContext ctx) throws Exception {
+      if (resumeAutoReadOnWritability && ctx.channel().isWritable()) {
+         resumeAutoReadOnWritability = false;
+         resumeAutoRead(ctx);
+      }
+      super.channelWritabilityChanged(ctx);
+   }
+
+   @Override
+   public void channelRead(ChannelHandlerContext ctx, Object msg) {
+      if (msg == null) return;
+      handleResponse(ctx, (MemcachedResponse) msg);
+   }
+
+   @Override
+   public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+      log.unexpectedException(cause);
+      if (ctx.channel().isOpen()) flushBufferIfNeeded(ctx);
+      ctx.close();
+   }
+
+   private void handleResponse(ChannelHandlerContext ctx, MemcachedResponse res) {
+      CompletionStage<?> cs = res.getResponse();
+      if (CompletionStages.isCompletedSuccessfully(cs)) {
+         Object result = CompletionStages.join(cs);
+         res.writeResponse(result, ctx.channel().attr(ALLOCATOR_KEY).get());
+         if (outbound != null && outbound.readableBytes() > ctx.channel().bytesBeforeUnwritable()) {
+            flushBufferIfNeeded(ctx, true, res);
+            ctx.channel().config().setAutoRead(false);
+            resumeAutoReadOnWritability = true;
+            return;
+         }
+         registerResponseForLater(res);
+         return;
+      }
+
+      ctx.channel().config().setAutoRead(false);
+      cs.whenCompleteAsync((obj, t) -> {
+         assert ctx.channel().eventLoop().inEventLoop();
+
+         ByteBufPool allocator = ctx.channel().attr(ALLOCATOR_KEY).get();
+         if (t != null) {
+            res.writeFailure(t, allocator);
+            flushBufferIfNeeded(ctx, false, res);
+            return;
+         }
+
+         res.writeResponse(obj, allocator);
+         flushBufferIfNeeded(ctx, false, res);
+         resumeAutoRead(ctx);
+      }, ctx.channel().eventLoop());
+   }
+
+   private void registerResponseForLater(MemcachedResponse res) {
+      if (progressive != null) {
+         progressiveEnd++;
+         progressive = progressive.addListener(new MemcachedProgressiveListener(res, progressive));
+      }
+   }
+
+   private static class MemcachedProgressiveListener implements ChannelProgressiveFutureListener {
+      private final MemcachedResponse res;
+      private final ChannelProgressivePromise promise;
+
+      private MemcachedProgressiveListener(MemcachedResponse res, ChannelProgressivePromise promise) {
+         this.res = res;
+         this.promise = promise;
+      }
+
+      @Override
+      public void operationProgressed(ChannelProgressiveFuture future, long progress, long total) {
+         res.flushed(future.channel().newSucceededFuture());
+         promise.removeListener(this);
+      }
+
+      @Override
+      public void operationComplete(ChannelProgressiveFuture future) {
+         res.flushed(future);
+      }
+   }
+}

--- a/server/memcached/src/main/java/org/infinispan/server/memcached/binary/BinaryDecoder.java
+++ b/server/memcached/src/main/java/org/infinispan/server/memcached/binary/BinaryDecoder.java
@@ -28,10 +28,15 @@ import io.netty.util.concurrent.GenericFutureListener;
  **/
 abstract class BinaryDecoder extends MemcachedBaseDecoder {
 
-   protected BinaryHeader singleHeader = new BinaryHeader();
+   private final BinaryHeader singleHeader = new BinaryHeader();
 
    protected BinaryDecoder(MemcachedServer server, Subject subject) {
       super(server, subject, server.getCache().getAdvancedCache().withMediaType(MediaType.APPLICATION_OCTET_STREAM, server.getConfiguration().clientEncoding()));
+   }
+
+   // Used by the generated decoder.
+   public BinaryHeader acquireHeader() {
+      return singleHeader;
    }
 
    @Override

--- a/server/memcached/src/main/java/org/infinispan/server/memcached/binary/BinaryHeader.java
+++ b/server/memcached/src/main/java/org/infinispan/server/memcached/binary/BinaryHeader.java
@@ -8,12 +8,13 @@ import org.infinispan.server.memcached.logging.Header;
  * @since 15.0
  **/
 public class BinaryHeader extends Header {
-   private final Object key;
-   final BinaryCommand op;
-   final int opaque;
-   long cas;
 
-   BinaryHeader(Temporal requestStart, int requestBytes, String principalName, Object key, BinaryCommand op, int opaque, long cas) {
+   private Object key;
+   private BinaryCommand op;
+   private int opaque;
+   private long cas;
+
+   private BinaryHeader(Temporal requestStart, int requestBytes, String principalName, Object key, BinaryCommand op, int opaque, long cas) {
       super(requestStart, requestBytes, principalName);
       this.key = key;
       this.op = op;
@@ -21,8 +22,8 @@ public class BinaryHeader extends Header {
       this.cas = cas;
    }
 
-   BinaryHeader(BinaryHeader h) {
-      this(h.requestStart, h.requestBytes, h.principalName, h.key, h.op, h.opaque, h.cas);
+   BinaryHeader() {
+      this(null, -1, null, null, null, -1, -1);
    }
 
    @Override
@@ -38,5 +39,33 @@ public class BinaryHeader extends Header {
    @Override
    public String getProtocol() {
       return "MCBIN";
+   }
+
+
+   public BinaryHeader replace(Temporal requestStart, int requestBytes, String principalName, Object key, BinaryCommand op, int opaque, long cas) {
+      this.requestStart = requestStart;
+      this.requestBytes = requestBytes;
+      this.principalName = principalName;
+      this.key = key;
+      this.op = op;
+      this.opaque = opaque;
+      this.cas = cas;
+      return this;
+   }
+
+   public BinaryCommand getCommand() {
+      return op;
+   }
+
+   public int getOpaque() {
+      return opaque;
+   }
+
+   public long getCas() {
+      return cas;
+   }
+
+   public void setCas(long cas) {
+      this.cas = cas;
    }
 }

--- a/server/memcached/src/main/java/org/infinispan/server/memcached/logging/Header.java
+++ b/server/memcached/src/main/java/org/infinispan/server/memcached/logging/Header.java
@@ -6,9 +6,9 @@ import java.time.temporal.Temporal;
  * @since 15.0
  **/
 public abstract class Header {
-   protected final Temporal requestStart;
-   protected final int requestBytes;
-   protected final String principalName;
+   protected Temporal requestStart;
+   protected int requestBytes;
+   protected String principalName;
 
    protected Header(Temporal requestStart, int requestBytes, String principalName) {
       this.requestStart = requestStart;

--- a/server/memcached/src/main/java/org/infinispan/server/memcached/logging/Log.java
+++ b/server/memcached/src/main/java/org/infinispan/server/memcached/logging/Log.java
@@ -1,6 +1,7 @@
 package org.infinispan.server.memcached.logging;
 
 import static org.jboss.logging.Logger.Level.ERROR;
+import static org.jboss.logging.Logger.Level.WARN;
 
 import org.infinispan.commons.CacheConfigurationException;
 import org.jboss.logging.BasicLogger;
@@ -30,4 +31,8 @@ public interface Log extends BasicLogger {
 
    @Message(value = "Cannot enable Memcached text-protocol detection when authentication is disabled", id = 11002)
    CacheConfigurationException cannotDetectMemcachedTextWithoutAuthentication();
+
+   @LogMessage(level = WARN)
+   @Message(value = "Received an unexpected exception.", id = 11003)
+   void unexpectedException(@Cause Throwable cause);
 }

--- a/server/memcached/src/main/java/org/infinispan/server/memcached/text/TextDecoder.java
+++ b/server/memcached/src/main/java/org/infinispan/server/memcached/text/TextDecoder.java
@@ -7,6 +7,7 @@ import javax.security.auth.Subject;
 import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.server.core.transport.ConnectionMetadata;
 import org.infinispan.server.memcached.MemcachedBaseDecoder;
+import org.infinispan.server.memcached.MemcachedResponse;
 import org.infinispan.server.memcached.MemcachedServer;
 import org.infinispan.server.memcached.logging.Header;
 
@@ -18,25 +19,42 @@ import io.netty.util.concurrent.GenericFutureListener;
  * @since 15.0
  **/
 abstract class TextDecoder extends MemcachedBaseDecoder {
+
+   protected TokenReader reader;
+
    protected TextDecoder(MemcachedServer server, Subject subject) {
       super(server, subject, server.getCache().getAdvancedCache().withMediaType(MediaType.TEXT_PLAIN, server.getConfiguration().clientEncoding()));
    }
 
    @Override
-   public void handlerAdded(ChannelHandlerContext ctx) {
+   public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
       super.handlerAdded(ctx);
-      ConnectionMetadata metadata = ConnectionMetadata.getInstance(channel);
+
+      // It can exceed the 256 for large values, so we don't have a max capacity.
+      this.reader = new TokenReader(ctx.alloc().buffer(256));
+      ConnectionMetadata metadata = ConnectionMetadata.getInstance(ctx.channel());
       metadata.subject(subject);
       metadata.protocolVersion("MCTXT");
    }
 
    @Override
-   public void send(Header header, CompletionStage<?> response) {
-      new TextResponse(current, channel).queueResponse(accessLogging ? header : null, response);
+   public void channelUnregistered(ChannelHandlerContext ctx) throws Exception {
+      super.channelUnregistered(ctx);
+      if (this.reader != null) reader.release();
    }
 
    @Override
-   public void send(Header header, CompletionStage<?> response, GenericFutureListener<? extends Future<? super Void>> listener) {
-      new TextResponse(current, channel).queueResponse(accessLogging ? header : null, response, listener);
+   protected MemcachedResponse failedResponse(Header header, Throwable t) {
+      return new TextResponse(t, header);
+   }
+
+   @Override
+   protected MemcachedResponse send(Header header, CompletionStage<?> response) {
+      return new TextResponse(response, header, null);
+   }
+
+   @Override
+   protected MemcachedResponse send(Header header, CompletionStage<?> response, GenericFutureListener<? extends Future<? super Void>> listener) {
+      return new TextResponse(response, header, listener);
    }
 }

--- a/server/memcached/src/main/java/org/infinispan/server/memcached/text/TextHeader.java
+++ b/server/memcached/src/main/java/org/infinispan/server/memcached/text/TextHeader.java
@@ -21,6 +21,7 @@ public class TextHeader extends Header {
 
    @Override
    public Object getKey() {
+      if (key == null) return null;
       return new String(key, StandardCharsets.US_ASCII);
    }
 

--- a/server/memcached/src/main/java/org/infinispan/server/memcached/text/TokenReader.java
+++ b/server/memcached/src/main/java/org/infinispan/server/memcached/text/TokenReader.java
@@ -1,0 +1,78 @@
+package org.infinispan.server.memcached.text;
+
+import java.util.BitSet;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.util.ByteProcessor;
+
+/**
+ * Reads the next token from the buffer, accepting only valid characters. If a non-valid character is found, the
+ * buffer is consumed to the end of the line and an {@link IllegalArgumentException} is thrown.
+ */
+public class TokenReader implements ByteProcessor {
+
+   private final ByteBuf output;
+   private BitSet token;
+   private boolean found;
+   private int bytesRead = 0;
+
+   public TokenReader(ByteBuf output) {
+      this.output = output;
+   }
+
+   public void release() {
+      output.release();
+   }
+
+   public TokenReader forToken(BitSet token) {
+      found = false;
+      bytesRead = 0;
+      output.resetReaderIndex().resetWriterIndex();
+      this.token = token;
+      return this;
+   }
+
+   public ByteBuf output() {
+      if (output.writerIndex() == 0) return null;
+      return output.resetReaderIndex();
+   }
+
+   public int readBytesSize() {
+      return bytesRead;
+   }
+
+   @Override
+   public boolean process(byte b) throws Exception {
+      if (found) return false;
+
+      // A full buffer means the Memcached limit was reached.
+      // This validation is done elsewhere, we can stop iterating.
+      if (!output.isWritable()) return false;
+
+      bytesRead++;
+
+      // Found a space, means we found the complete token.
+      // We go one byte ahead to skip the space.
+      if (b == 32) {
+         found = true;
+         return true;
+      }
+
+      if (b == 10) return false;
+      if (b == 13) {
+         // If it has data, minus 1 and stop iterating;
+         if (output.writerIndex() > 0) {
+            bytesRead--;
+            return false;
+         }
+         return true;
+      }
+
+      if (!token.get(b & 0xFF)) {
+         return false;
+      }
+
+      output.writeByte(b);
+      return true;
+   }
+}

--- a/server/memcached/src/main/resources/memcache-binary-auth.gr
+++ b/server/memcached/src/main/resources/memcache-binary-auth.gr
@@ -45,7 +45,7 @@ root request
 header returns BinaryHeader
    : { magic != MAGIC_REQ }? { throw new IllegalStateException("Error reading magic byte or message id: " + magic); }
    | { deadEnd = false } op keyLength extrasLength dataType vbucketId totalBodyLength opaque cas valueLength
-     { singleHeader.replace(requestStart, requestBytes, principalName, key, opCode, opaque, cas) }
+     { acquireHeader().replace(requestStart, requestBytes, principalName, key, opCode, opaque, cas) }
    ;
 
 magic: byte;

--- a/server/memcached/src/main/resources/memcache-binary-auth.gr
+++ b/server/memcached/src/main/resources/memcache-binary-auth.gr
@@ -45,7 +45,7 @@ root request
 header returns BinaryHeader
    : { magic != MAGIC_REQ }? { throw new IllegalStateException("Error reading magic byte or message id: " + magic); }
    | { deadEnd = false } op keyLength extrasLength dataType vbucketId totalBodyLength opaque cas valueLength
-     { new BinaryHeader(requestStart, requestBytes, principalName, key, opCode, opaque, cas) }
+     { singleHeader.replace(requestStart, requestBytes, principalName, key, opCode, opaque, cas) }
    ;
 
 magic: byte;
@@ -76,10 +76,10 @@ value returns byte[]
 
 parameters switch op
 // Operations
-   : { SASL_LIST_MECHS }? { saslListMechs(header) }
-   | { SASL_AUTH }? key value { saslAuth(header, key, value) }
-   | { SASL_STEP }? key value { saslStep(header, key, value) }
-   | { CONFIG_GET }? key { config(header, key) }
+   : { SASL_LIST_MECHS }? { if (out.add(saslListMechs(header))) { state=0; return false;} }
+   | { SASL_AUTH }? key value { if (out.add(saslAuth(header, key, value))) { state=0; return false;} }
+   | { SASL_STEP }? key value { if (out.add(saslStep(header, key, value))) { state=0; return false;} }
+   | { CONFIG_GET }? key { if (out.add(config(header, key))) { state=0; return false;} }
 // Unknown
    | { throw new IllegalArgumentException("Unknown operation " + op); }
    ;

--- a/server/memcached/src/main/resources/memcache-binary-op.gr
+++ b/server/memcached/src/main/resources/memcache-binary-op.gr
@@ -30,14 +30,26 @@ init {
 exceptionally {
    log.trace("Parsing error", t);
    state = 0;
+   exceptionCaught(header, t);
 }
 
 deadend {
    if (!deadEnd) {
       log.tracef("Invalid state of parsing");
+      exceptionCaught(header, new IllegalStateException("Dead end processing request"));
       deadEnd = true;
    }
    state = 0;
+}
+
+beforedecode {
+   // We cannot read more than one command at a time
+   if (!ctx.channel().config().isAutoRead()) {
+      log.tracef("Auto read was disabled, not reading next bytes yet");
+      return;
+   } else {
+      log.tracef("Auto read was enabled, reading next bytes");
+   }
 }
 
 // this is the root
@@ -50,7 +62,7 @@ root request
 header returns BinaryHeader
    : { magic != MAGIC_REQ }? { throw new IllegalStateException("Error reading magic byte or message id: " + magic); }
    | { deadEnd = false } op keyLength extrasLength dataType vbucketId totalBodyLength opaque cas valueLength
-     { new BinaryHeader(requestStart, requestBytes, principalName, key, opCode, opaque, cas) }
+     { singleHeader.replace(requestStart, requestBytes, principalName, key, opCode, opaque, cas) }
    ;
 
 magic: byte;
@@ -88,40 +100,40 @@ value returns byte[]
 
 parameters switch op
 // Operations
-   : { GET }? key { get(header, key, false) }
-   | { GETQ }? key { get(header, key, true) }
-   | { GETK }? key { get(header, key, false) }
-   | { GETKQ }? key { get(header, key, true) }
-   | { SET }? flags expiration key value { set(header, key, value, flags, expiration, false) }
-   | { SETQ }? flags expiration key value { set(header, key, value, flags, expiration, true) }
-   | { ADD }? flags expiration key value { add(header, key, value, flags, expiration, false) }
-   | { ADDQ }? flags expiration key value { add(header, key, value, flags, expiration, true) }
-   | { REPLACE }? flags expiration key value { replace(header, key, value, flags, expiration, false) }
-   | { REPLACEQ }? flags expiration key value { replace(header, key, value, flags, expiration, true) }
-   | { DELETE }? key { delete(header, key, false) }
-   | { DELETEQ }? key { delete(header, key, true) }
-   | { INCREMENT }? delta initial expiration key { increment(header, key, delta, initial, expiration, false) }
-   | { INCREMENTQ }? delta initial expiration key { increment(header, key, delta, initial, expiration, true) }
-   | { DECREMENT }? delta initial expiration key { increment(header, key, -delta, initial, expiration, false) }
-   | { DECREMENTQ }? delta initial expiration key { increment(header, key, -delta, initial, expiration, true) }
-   | { QUIT }? { quit(header, false) }
+   : { GET }? key { if (out.add(get(header, key, false))) { state=0; return false; } }
+   | { GETQ }? key { if (out.add(get(header, key, true))) { state=0; return false; } }
+   | { GETK }? key { if (out.add(get(header, key, false))) { state=0; return false; } }
+   | { GETKQ }? key { if (out.add(get(header, key, true))) { state=0; return false; } }
+   | { SET }? flags expiration key value { if (out.add(set(header, key, value, flags, expiration, false))) { state=0; return false; } }
+   | { SETQ }? flags expiration key value { if (out.add(set(header, key, value, flags, expiration, true))) { state=0; return false; } }
+   | { ADD }? flags expiration key value { if (out.add(add(header, key, value, flags, expiration, false))) { state=0; return false; } }
+   | { ADDQ }? flags expiration key value { if (out.add(add(header, key, value, flags, expiration, true))) { state=0; return false; } }
+   | { REPLACE }? flags expiration key value { if (out.add(replace(header, key, value, flags, expiration, false))) { state=0; return false; } }
+   | { REPLACEQ }? flags expiration key value { if (out.add(replace(header, key, value, flags, expiration, true))) { state=0; return false; } }
+   | { DELETE }? key { if (out.add(delete(header, key, false))) { state=0; return false; } }
+   | { DELETEQ }? key { if (out.add(delete(header, key, true))) { state=0; return false; } }
+   | { INCREMENT }? delta initial expiration key { if (out.add(increment(header, key, delta, initial, expiration, false))) { state=0; return false; } }
+   | { INCREMENTQ }? delta initial expiration key { if (out.add(increment(header, key, delta, initial, expiration, true))) { state=0; return false; } }
+   | { DECREMENT }? delta initial expiration key { if (out.add(increment(header, key, -delta, initial, expiration, false))) { state=0; return false; } }
+   | { DECREMENTQ }? delta initial expiration key { if (out.add(increment(header, key, -delta, initial, expiration, true))) { state=0; return false; } }
+   | { QUIT }? { if (out.add(quit(header, false))) { state=0; return false; } }
    | { QUITQ }? { quit(header, true) }
-   | { FLUSH }? expiration { flush(header, expiration, false) }
+   | { FLUSH }? expiration { if (out.add(flush(header, expiration, false))) { state=0; return false; } }
    | { FLUSHQ }? expiration { flush(header, expiration, true) }
-   | { NO_OP }? { noop(header) }
-   | { VERSION }? { version(header) }
-   | { APPEND }? key value { append(header, key, value, false) }
-   | { APPENDQ }? key value { append(header, key, value, true) }
-   | { PREPEND }? key value { prepend(header, key, value, false) }
-   | { PREPENDQ }? key value { prepend(header, key, value, true) }
-   | { VERBOSITY }? verbosity { verbosityLevel(header, verbosity) }
-   | { TOUCH }? expiration key { touch(header, key, expiration) }
-   | { GAT }? expiration key { gat(header, key, expiration, false) }
-   | { GATQ }? expiration key { gat(header, key, expiration, true) }
-   | { GATK }? expiration key { gat(header, key, expiration, false) }
-   | { GATKQ }? expiration key { gat(header, key, expiration, true) }
-   | { STAT }? key { stat(header, key) }
-   | { CONFIG_GET }? key { config(header, key) }
+   | { NO_OP }? { if (out.add(noop(header))) { state=0; return false; } }
+   | { VERSION }? { if (out.add(version(header))) { state=0; return false; } }
+   | { APPEND }? key value { if (out.add(append(header, key, value, false))) { state=0; return false; } }
+   | { APPENDQ }? key value { if (out.add(append(header, key, value, true))) { state=0; return false; } }
+   | { PREPEND }? key value { if (out.add(prepend(header, key, value, false))) { state=0; return false; } }
+   | { PREPENDQ }? key value { if (out.add(prepend(header, key, value, true))) { state=0; return false; } }
+   | { VERBOSITY }? verbosity { if (out.add(verbosityLevel(header, verbosity))) { state=0; return false; } }
+   | { TOUCH }? expiration key { if (out.add(touch(header, key, expiration))) { state=0; return false; } }
+   | { GAT }? expiration key { if (out.add(gat(header, key, expiration, false))) { state=0; return false; } }
+   | { GATQ }? expiration key { if (out.add(gat(header, key, expiration, true))) { state=0; return false; } }
+   | { GATK }? expiration key { if (out.add(gat(header, key, expiration, false))) { state=0; return false; } }
+   | { GATKQ }? expiration key { if (out.add(gat(header, key, expiration, true))) { state=0; return false; } }
+   | { STAT }? key { if (out.add(stat(header, key))) { state=0; return false; } }
+   | { CONFIG_GET }? key { if (out.add(config(header, key))) { state=0; return false; } }
 // Unknown
    | { throw new IllegalArgumentException("Unknown operation " + op); }
    ;

--- a/server/memcached/src/main/resources/memcache-binary-op.gr
+++ b/server/memcached/src/main/resources/memcache-binary-op.gr
@@ -62,7 +62,7 @@ root request
 header returns BinaryHeader
    : { magic != MAGIC_REQ }? { throw new IllegalStateException("Error reading magic byte or message id: " + magic); }
    | { deadEnd = false } op keyLength extrasLength dataType vbucketId totalBodyLength opaque cas valueLength
-     { singleHeader.replace(requestStart, requestBytes, principalName, key, opCode, opaque, cas) }
+     { acquireHeader().replace(requestStart, requestBytes, principalName, key, opCode, opaque, cas) }
    ;
 
 magic: byte;

--- a/server/memcached/src/main/resources/memcache-text-auth.gr
+++ b/server/memcached/src/main/resources/memcache-text-auth.gr
@@ -39,11 +39,11 @@ root request
    : command_name { requestStart = Instant.now(); } parameters
    ;
 
-key: text_key;
-command_name: command;
-exptime: long_number;
-flags: int_number;
-vsize: int_number;
+key: text_key[reader];
+command_name: command[reader];
+exptime: long_number[reader];
+flags: int_number[reader];
+vsize: int_number[reader];
 value returns byte[]
    : { vsize > 0 }? fixedArray[vsize]
    | { org.infinispan.commons.util.Util.EMPTY_BYTE_ARRAY }

--- a/server/memcached/src/main/resources/memcache-text-op.gr
+++ b/server/memcached/src/main/resources/memcache-text-op.gr
@@ -28,69 +28,79 @@ init {
    }
 
    private TextHeader getHeader() {
-      return new TextHeader(requestBytes, requestStart, principalName, key, command_name);
+      return accessLogging ? new TextHeader(requestBytes, requestStart, principalName, key, command_name) : null;
    }
 }
 
 exceptionally {
    state = 0;
-   send(getHeader(), CompletableFuture.failedFuture(t));
+   exceptionCaught(getHeader(), t);
 }
 
 deadend {
    if (!deadEnd) {
-      send(getHeader(), CompletableFuture.failedFuture(new IllegalStateException()));
+      exceptionCaught(getHeader(), new IllegalStateException("Dead end processing request"));
       deadEnd = true;
    }
    state = 0;
+}
+
+beforedecode {
+   // We cannot read more than one command at a time
+   if (!ctx.channel().config().isAutoRead()) {
+      log.tracef("Auto read was disabled, not reading next bytes yet");
+      return;
+   } else {
+      log.tracef("Auto read was enabled, reading next bytes");
+   }
 }
 
 root request
    : command_name { requestStart = Instant.now(); } parameters
    ;
 
-key: text_key;
-keys: text_key_list;
-command_name: command;
-exptime: int_number;
-flags: int_number;
-vsize: int_number;
+key: text_key[reader];
+keys: text_key_list[reader];
+command_name: command[reader];
+exptime: int_number[reader];
+flags: int_number[reader];
+vsize: int_number[reader];
 value returns byte[]
    : { vsize > 0 }? fixedArray[vsize]
    | { org.infinispan.commons.util.Util.EMPTY_BYTE_ARRAY }
    ;
-cas_unique: long_number;
+cas_unique: long_number[reader];
 eol: short;
-delta: text;
+delta: text[reader];
 noreply: eowc;
-varargs: text_list;
+varargs: text_list[reader];
 
 parameters switch command_name
 // Operations
-   : { set }? key flags exptime vsize noreply value eol { set(getHeader(), key, value, flags, exptime, noreply) }
-   | { add }? key flags exptime vsize noreply value eol { add(getHeader(), key, value, flags, exptime, noreply) }
-   | { replace }? key flags exptime vsize noreply value eol { replace(getHeader(), key, value, flags, exptime, noreply) }
-   | { delete }? key noreply { delete(getHeader(), key, noreply) }
-   | { append }? key flags exptime vsize noreply value eol { concat(getHeader(), key, value, flags, exptime, noreply, true) }
-   | { prepend }? key flags exptime vsize noreply value eol { concat(getHeader(), key, value, flags, exptime, noreply, false) }
-   | { cas }? key flags exptime vsize cas_unique noreply value eol { cas(getHeader(), key, value, flags, exptime, cas_unique, noreply) }
-   | { get }? keys { get(getHeader(), keys, false) }
-   | { gets }? keys { get(getHeader(), keys, true) }
-   | { incr }? key delta noreply { incr(getHeader(), key, delta, noreply, true) }
-   | { decr }? key delta noreply { incr(getHeader(), key, delta, noreply, false) }
-   | { touch }? key exptime noreply { touch(getHeader(), key, exptime, noreply) }
-   | { gat }? exptime keys { gat(getHeader(), exptime, keys, false) }
-   | { gats }? exptime keys { gat(getHeader(), exptime, keys, true) }
-   | { flush_all }? varargs { flush_all(getHeader(), varargs) }
-   | { version }? eol { version(getHeader()) }
+   : { set }? key flags exptime vsize noreply value eol { if (out.add(set(getHeader(), key, value, flags, exptime, noreply))) { state = 0; return false; } }
+   | { add }? key flags exptime vsize noreply value eol { if (out.add(add(getHeader(), key, value, flags, exptime, noreply))) { state = 0; return false; } }
+   | { replace }? key flags exptime vsize noreply value eol { if (out.add(replace(getHeader(), key, value, flags, exptime, noreply))) { state = 0; return false; } }
+   | { delete }? key noreply { if (out.add(delete(getHeader(), key, noreply))) { state = 0; return false; } }
+   | { append }? key flags exptime vsize noreply value eol { if (out.add(concat(getHeader(), key, value, flags, exptime, noreply, true))) { state = 0; return false; } }
+   | { prepend }? key flags exptime vsize noreply value eol { if (out.add(concat(getHeader(), key, value, flags, exptime, noreply, false))) { state = 0; return false; } }
+   | { cas }? key flags exptime vsize cas_unique noreply value eol { if (out.add(cas(getHeader(), key, value, flags, exptime, cas_unique, noreply))) { state = 0; return false; } }
+   | { get }? keys { if (out.add(get(getHeader(), keys, false))) { state = 0; return false; } }
+   | { gets }? keys { if (out.add(get(getHeader(), keys, true))) { state = 0; return false; } }
+   | { incr }? key delta noreply { if (out.add(incr(getHeader(), key, delta, noreply, true))) { state = 0; return false; } }
+   | { decr }? key delta noreply { if (out.add(incr(getHeader(), key, delta, noreply, false))) { state = 0; return false; } }
+   | { touch }? key exptime noreply { if (out.add(touch(getHeader(), key, exptime, noreply))) { state = 0; return false; } }
+   | { gat }? exptime keys { if (out.add(gat(getHeader(), exptime, keys, false))) { state = 0; return false; } }
+   | { gats }? exptime keys { if (out.add(gat(getHeader(), exptime, keys, true))) { state = 0; return false; } }
+   | { flush_all }? varargs { if (out.add(flush_all(getHeader(), varargs))) { state = 0; return false; } }
+   | { version }? eol { if (out.add(version(getHeader()))) { state = 0; return false; } }
    | { quit }? eol { quit(getHeader()) }
-   | { stats }? keys { stats(getHeader(), keys) }
-   | { mg }? key varargs { mg(getHeader(), key, varargs) }
-   | { ms }? key vsize varargs value eol { ms(getHeader(), key, value, varargs) }
-   | { md }? key varargs { md(getHeader(), key, varargs) }
-   | { ma }? key varargs { ma(getHeader(), key, varargs) }
-   | { mn }? eol { mn(getHeader()) }
-   | { me }? key varargs { me(getHeader(), key, varargs) }
+   | { stats }? keys { if (out.add(stats(getHeader(), keys))) { state = 0; return false; } }
+   | { mg }? key varargs { if (out.add(mg(getHeader(), key, varargs))) { state = 0; return false; } }
+   | { ms }? key vsize varargs value eol { if (out.add(ms(getHeader(), key, value, varargs))) { state = 0; return false; } }
+   | { md }? key varargs { if (out.add(md(getHeader(), key, varargs))) { state = 0; return false; } }
+   | { ma }? key varargs { if (out.add(ma(getHeader(), key, varargs))) { state = 0; return false; } }
+   | { mn }? eol { if (out.add(mn(getHeader()))) { state = 0; return false; } }
+   | { me }? key varargs { if (out.add(me(getHeader(), key, varargs))) { state = 0; return false; } }
 // Unknown
    | { throw new IllegalArgumentException("Unknown command " + command_name); }
    ;

--- a/server/memcached/src/test/java/org/infinispan/server/memcached/binary/MemcachedBinaryReplicationTest.java
+++ b/server/memcached/src/test/java/org/infinispan/server/memcached/binary/MemcachedBinaryReplicationTest.java
@@ -1,0 +1,147 @@
+package org.infinispan.server.memcached.binary;
+
+import static org.infinispan.test.TestingUtil.k;
+import static org.infinispan.test.TestingUtil.v;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.server.memcached.configuration.MemcachedProtocol;
+import org.infinispan.server.memcached.test.MemcachedMultiNodeTest;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.Test;
+
+import net.spy.memcached.CASResponse;
+import net.spy.memcached.CASValue;
+import net.spy.memcached.internal.OperationFuture;
+
+@Test(groups = "functional", testName = "server.memcached.binary.MemcachedBinaryReplicationTest")
+public class MemcachedBinaryReplicationTest extends MemcachedMultiNodeTest {
+
+   @Override
+   protected EmbeddedCacheManager createCacheManager(int index) {
+      ConfigurationBuilder builder = new ConfigurationBuilder();
+      builder.clustering().cacheMode(CacheMode.REPL_SYNC);
+      return TestCacheManagerFactory.createClusteredCacheManager(
+            GlobalConfigurationBuilder.defaultClusteredBuilder().defaultCacheName(cacheName),
+            builder);
+   }
+
+   @Override
+   protected MemcachedProtocol getProtocol() {
+      return MemcachedProtocol.BINARY;
+   }
+
+   public void testReplicatedSet(Method m) throws InterruptedException, ExecutionException, TimeoutException {
+      OperationFuture<Boolean> f = clients.get(0).set(k(m), 0, v(m));
+      assertTrue(f.get(timeout, TimeUnit.SECONDS));
+      assertEquals(clients.get(0).get(k(m)), v(m));
+   }
+
+   public void testReplicatedGetMultipleKeys(Method m) throws InterruptedException, ExecutionException,
+         TimeoutException {
+      OperationFuture<Boolean> f1 = clients.get(0).set(k(m, "k1-"), 0, v(m, "v1-"));
+      OperationFuture<Boolean> f2 = clients.get(0).set(k(m, "k2-"), 0, v(m, "v2-"));
+      OperationFuture<Boolean> f3 = clients.get(0).set(k(m, "k3-"), 0, v(m, "v3-"));
+      assertTrue(f1.get(timeout, TimeUnit.SECONDS));
+      assertTrue(f2.get(timeout, TimeUnit.SECONDS));
+      assertTrue(f3.get(timeout, TimeUnit.SECONDS));
+      List<String> keys = Arrays.asList(k(m, "k1-"), k(m, "k2-"), k(m, "k3-"));
+      Map<String, Object> ret = clients.get(1).getBulk(keys);
+      assertEquals(ret.get(k(m, "k1-")), v(m, "v1-"));
+      assertEquals(ret.get(k(m, "k2-")), v(m, "v2-"));
+      assertEquals(ret.get(k(m, "k3-")), v(m, "v3-"));
+   }
+
+   public void testReplicatedAdd(Method m) throws InterruptedException, ExecutionException, TimeoutException {
+      OperationFuture<Boolean> f = clients.get(0).add(k(m), 0, v(m));
+      assertTrue(f.get(timeout, TimeUnit.SECONDS));
+      assertEquals(clients.get(1).get(k(m)), v(m));
+   }
+
+   public void testReplicatedReplace(Method m) throws InterruptedException, ExecutionException, TimeoutException {
+      OperationFuture<Boolean> f = clients.get(0).add(k(m), 0, v(m));
+      assertTrue(f.get(timeout, TimeUnit.SECONDS));
+      assertEquals(clients.get(1).get(k(m)), v(m));
+      f = clients.get(1).replace(k(m), 0, v(m, "v1-"));
+      assertTrue(f.get(timeout, TimeUnit.SECONDS));
+      assertEquals(clients.get(0).get(k(m)), v(m, "v1-"));
+   }
+
+   public void testReplicatedAppend(Method m) throws InterruptedException, ExecutionException, TimeoutException {
+      OperationFuture<Boolean> f = clients.get(0).add(k(m), 0, v(m));
+      assertTrue(f.get(timeout, TimeUnit.SECONDS));
+      assertEquals(clients.get(1).get(k(m)), v(m));
+      f = clients.get(1).append(0, k(m), v(m, "v1-"));
+      assertTrue(f.get(timeout, TimeUnit.SECONDS));
+      String expected = v(m) + v(m, "v1-");
+      assertEquals(clients.get(0).get(k(m)), expected);
+   }
+
+   public void testReplicatedPrepend(Method m) throws InterruptedException, ExecutionException, TimeoutException {
+      OperationFuture<Boolean> f = clients.get(0).add(k(m), 0, v(m));
+      assertTrue(f.get(timeout, TimeUnit.SECONDS));
+      assertEquals(clients.get(1).get(k(m)), v(m));
+      f = clients.get(1).prepend(0, k(m), v(m, "v1-"));
+      assertTrue(f.get(timeout, TimeUnit.SECONDS));
+      String expected = v(m, "v1-") + v(m);
+      assertEquals(clients.get(0).get(k(m)), expected);
+   }
+
+   public void testReplicatedGets(Method m) throws InterruptedException, ExecutionException, TimeoutException {
+      OperationFuture<Boolean> f = clients.get(0).set(k(m), 0, v(m));
+      assertTrue(f.get(timeout, TimeUnit.SECONDS));
+      CASValue<Object> value = clients.get(1).gets(k(m));
+      assertEquals(value.getValue(), v(m));
+      assertTrue(value.getCas() != 0);
+   }
+
+   public void testReplicatedCasExists(Method m) throws InterruptedException, ExecutionException, TimeoutException {
+      OperationFuture<Boolean> f = clients.get(0).set(k(m), 0, v(m));
+      assertTrue(f.get(timeout, TimeUnit.SECONDS));
+      CASValue<Object> value = clients.get(1).gets(k(m));
+      assertEquals(value.getValue(), v(m));
+      assertTrue(value.getCas() != 0);
+      long old = value.getCas();
+      CASResponse resp = clients.get(1).cas(k(m), value.getCas(), v(m, "v1-"));
+      value = clients.get(0).gets(k(m));
+      assertEquals(value.getValue(), v(m, "v1-"));
+      assertTrue(value.getCas() != 0);
+      assertTrue(value.getCas() != old);
+      resp = clients.get(0).cas(k(m), old, v(m, "v2-"));
+      assertEquals(resp, CASResponse.EXISTS);
+      resp = clients.get(1).cas(k(m), value.getCas(), v(m, "v2-"));
+      assertEquals(resp, CASResponse.OK);
+   }
+
+   public void testReplicatedDelete(Method m) throws InterruptedException, ExecutionException, TimeoutException {
+      OperationFuture<Boolean> f = clients.get(0).set(k(m), 0, v(m));
+      assertTrue(f.get(timeout, TimeUnit.SECONDS));
+      f = clients.get(1).delete(k(m));
+      assertTrue(f.get(timeout, TimeUnit.SECONDS));
+   }
+
+   public void testReplicatedIncrement(Method m) throws InterruptedException, ExecutionException, TimeoutException {
+      OperationFuture<Boolean> f = clients.get(0).set(k(m), 0, "1");
+      assertTrue(f.get(timeout, TimeUnit.SECONDS));
+      assertEquals(clients.get(1).incr(k(m), 1), 2);
+   }
+
+   public void testReplicatedDecrement(Method m) throws InterruptedException, ExecutionException, TimeoutException {
+      OperationFuture<Boolean> f = clients.get(0).set(k(m), 0, "1");
+      assertTrue(f.get(timeout, TimeUnit.SECONDS));
+      assertEquals(clients.get(1).decr(k(m), 1), 0);
+   }
+
+}

--- a/server/memcached/src/test/java/org/infinispan/server/memcached/test/MemcachedFunctionalTest.java
+++ b/server/memcached/src/test/java/org/infinispan/server/memcached/test/MemcachedFunctionalTest.java
@@ -29,6 +29,7 @@ import org.infinispan.server.memcached.MemcachedServer;
 import org.infinispan.server.memcached.configuration.MemcachedProtocol;
 import org.infinispan.server.memcached.configuration.MemcachedServerConfigurationBuilder;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.Test;
 
 import net.spy.memcached.CASResponse;
 import net.spy.memcached.CASValue;
@@ -37,6 +38,7 @@ import net.spy.memcached.internal.OperationFuture;
 /**
  * Tests Memcached protocol functionality against Infinispan Memcached server.
  */
+@Test(groups = "functional", testName = "server.memcached.test.MemcachedFunctionalTest")
 public abstract class MemcachedFunctionalTest extends MemcachedSingleNodeTest {
 
    public void testSetBasic(Method m) throws InterruptedException, ExecutionException, TimeoutException {

--- a/server/memcached/src/test/java/org/infinispan/server/memcached/text/MemcachedStatsTest.java
+++ b/server/memcached/src/test/java/org/infinispan/server/memcached/text/MemcachedStatsTest.java
@@ -101,7 +101,7 @@ public class MemcachedStatsTest extends MemcachedSingleNodeTest {
       assertEquals(stats.getVal1().get("version"), Version.getVersion());
    }
 
-   public void testTodoStats() {
+   public void testConnStats() {
       Triple<Map<String, String>, Integer, Integer> stats = getStats(-1, -1);
       assertEquals(stats.getVal1().get("curr_connections"), "1");
       assertEquals(stats.getVal1().get("total_connections"), "1");


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-14813

Most of the changes are based on #10934 and #11006.

I ran locally using the `memtier_benchmark`. If anyone is interested in running, I ran with the configuration `memtier_benchmark -p 11222 -4 -P memcache_binary -d 9000 -R --pipeline=10 --test-time=60`, varying the protocol with `memcache_binary` and `memcache_text`, and running one time to warm up and another to collect the info, additionally:

```
4         Threads
50        Connections per thread
60        Seconds
```

Comparison with `--pipeline=1`: https://gist.github.com/jabolina/99ea2e4d8317f36ad12d445bc57672a9
Comparison with `--pipeline=10`: https://gist.github.com/jabolina/6db34b4e1afce874ff7247a9ea9625d3

We can see that `pipeline=1` performs slightly worse but performs better with `pipeline=10`.

I am opening for CI to run, and if anyone wants to take a look already. I am going to check allocations, although I expect a behavior similar to main.