### PR TITLE
Update Hibernate Search version to 6.2.0.Final

### DIFF
--- a/build/configuration/pom.xml
+++ b/build/configuration/pom.xml
@@ -138,7 +138,7 @@
       <version.groovy>2.4.8</version.groovy>
       <version.hamcrest>1.3</version.hamcrest>
       <version.hibernate.core>6.2.0.Final</version.hibernate.core>
-      <version.hibernate.search>6.2.0.CR1</version.hibernate.search>
+      <version.hibernate.search>6.2.0.Final</version.hibernate.search>
       <version.infinispan>15.0.0-SNAPSHOT</version.infinispan>
       <version.infinispan.arquillian>1.2.0.Beta3</version.infinispan.arquillian>
       <version.infinispan.doclets>1.4.0.Final</version.infinispan.doclets>


### PR DESCRIPTION
No Jira. Since it is trivial and we don't need to take track of it.