### PR TITLE
ISPN-15018 temporary remove programmatic mapping of entities docs

### DIFF
--- a/documentation/src/main/asciidoc/stories/assembly_query_embedded.adoc
+++ b/documentation/src/main/asciidoc/stories/assembly_query_embedded.adoc
@@ -9,7 +9,7 @@ Indexing and querying are both done on top of Java objects.
 
 include::{topics}/proc_query_querying_embedded_caches.adoc[leveloffset=+1]
 include::{topics}/ref_query_entity_mapping_annotations.adoc[leveloffset=+1]
-include::{topics}/ref_query_programmatic_entity_mapping.adoc[leveloffset=+1]
+//include::{topics}/ref_query_programmatic_entity_mapping.adoc[leveloffset=+1]
 
 // Restore the parent context.
 ifdef::parent-context[:context: {parent-context}]


### PR DESCRIPTION
needs backport to 14
https://issues.redhat.com/browse/ISPN-15018 
Temporary removal of content that is not supported. 