### PR TITLE
Add backporting GH actions

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -1,0 +1,31 @@
+name: Automated Backporting
+
+on:
+  pull_request_target:
+    types:
+      - closed
+    branches:
+      - main
+
+jobs:
+  create_backport:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - if: contains(github.event.pull_request.labels.*.name, '13.0.x')
+        name: 13.0.x Backport
+        uses: kiegroup/git-backporting@main
+        with:
+          target-branch: 13.0.x
+          pull-request: ${{ github.event.pull_request.url }}
+          auth: ${{ secrets.GITHUB_TOKEN }}
+          no-squash: true
+
+      - if: contains(github.event.pull_request.labels.*.name, '14.0.x')
+        name: 14.0.x Backport
+        uses: kiegroup/git-backporting@main
+        with:
+          target-branch: 14.0.x
+          pull-request: ${{ github.event.pull_request.url }}
+          auth: ${{ secrets.GITHUB_TOKEN }}
+          no-squash: true

--- a/.github/workflows/backport_reaper.yaml
+++ b/.github/workflows/backport_reaper.yaml
@@ -1,0 +1,19 @@
+name: Backport branch reaper
+
+on:
+  pull_request_target:
+    types:
+      - closed
+    branches:
+      - '*.0.x'
+
+jobs:
+  remove_backport_branch:
+    if: startsWith(github.event.pull_request.head.ref, 'bp-')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete PR head branches
+        uses: dawidd6/action-delete-branch@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          numbers: ${{github.event.pull_request.number}}


### PR DESCRIPTION
Once merged to the `main` branch, plus those we want to be eligible for backports, it's possible for contributors to add a label corresponding to the backport branch, e.g. "14.0.x", and the commits from this PR will automatically be backported to said branch once this PR has been merged. A backport branch is created in the `infinispan/infinispan` repository, which is then deleted when the backport PR is closed/merged.