### PR TITLE
ISPN-15070 RESP cache cannot be configured as a simple cache

### DIFF
--- a/core/src/main/java/org/infinispan/factories/ComponentRegistry.java
+++ b/core/src/main/java/org/infinispan/factories/ComponentRegistry.java
@@ -98,7 +98,7 @@ public class ComponentRegistry extends AbstractComponentRegistry {
    private ComponentRef<InternalConflictManager> conflictManager;
    private ComponentRef<DistributionManager> distributionManager;
    private ComponentRef<InternalDataContainer> internalDataContainer;
-   private ComponentRef<InternalEntryFactory> internalEntryFactory;
+   protected ComponentRef<InternalEntryFactory> internalEntryFactory;
    private ComponentRef<InvocationContextFactory> invocationContextFactory;
    private ComponentRef<IracManager> iracManager;
    private ComponentRef<IracVersionGenerator> iracVersionGenerator;

--- a/core/src/main/java/org/infinispan/factories/InternalCacheFactory.java
+++ b/core/src/main/java/org/infinispan/factories/InternalCacheFactory.java
@@ -23,6 +23,7 @@ import org.infinispan.commons.util.EnumUtil;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.container.impl.InternalDataContainer;
+import org.infinispan.container.impl.InternalEntryFactory;
 import org.infinispan.context.Flag;
 import org.infinispan.context.impl.FlagBitSets;
 import org.infinispan.context.impl.ImmutableContext;
@@ -486,11 +487,13 @@ public class InternalCacheFactory<K, V> {
       protected void bootstrapComponents() {
          registerComponent(new ClusterEventManagerStub<K, V>(), ClusterEventManager.class);
          registerComponent(new PassivationManagerStub(), PassivationManager.class);
+         registerComponent(new InternalCacheFactory<>(), InternalCacheFactory.class);
       }
 
       @Override
       public void cacheComponents() {
          getOrCreateComponent(InternalExpirationManager.class);
+         internalEntryFactory = basicComponentRegistry.getComponent(InternalEntryFactory.class);
       }
    }
 }

--- a/server/resp/src/test/java/org/infinispan/server/resp/RespSingleNodeTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/RespSingleNodeTest.java
@@ -30,10 +30,13 @@ import java.util.stream.Stream;
 
 import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.commons.test.Exceptions;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.server.resp.commands.Commands;
 import org.infinispan.server.resp.test.CommonRespTests;
 import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 
 import io.lettuce.core.ExpireArgs;
@@ -62,6 +65,37 @@ import io.lettuce.core.pubsub.api.sync.RedisPubSubCommands;
  */
 @Test(groups = "functional", testName = "server.resp.RespSingleNodeTest")
 public class RespSingleNodeTest extends SingleNodeRespBaseTest {
+
+   private CacheMode cacheMode;
+   private boolean simpleCache;
+
+   @Factory
+   public Object[] factory() {
+      return new Object[]{
+            new RespSingleNodeTest().cacheMode(CacheMode.LOCAL),
+            new RespSingleNodeTest().simpleCache()
+      };
+   }
+
+   RespSingleNodeTest cacheMode(CacheMode cacheMode) {
+      this.cacheMode = cacheMode;
+      return this;
+   }
+
+   RespSingleNodeTest simpleCache() {
+      this.cacheMode = CacheMode.LOCAL;
+      this.simpleCache = true;
+      return this;
+   }
+
+   @Override
+   protected void amendConfiguration(ConfigurationBuilder configurationBuilder) {
+      if (simpleCache) {
+         configurationBuilder.clustering().cacheMode(CacheMode.LOCAL).simpleCache(true);
+      } else {
+         configurationBuilder.clustering().cacheMode(cacheMode);
+      }
+   }
 
    @Test
    public void testSetMultipleOptions() {

--- a/server/resp/src/test/java/org/infinispan/server/resp/SingleNodeRespBaseTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/SingleNodeRespBaseTest.java
@@ -47,9 +47,14 @@ public abstract class SingleNodeRespBaseTest extends SingleCacheManagerTest {
       TestCacheManagerFactory.amendGlobalConfiguration(globalBuilder, new TransportFlags());
       ConfigurationBuilder builder = new ConfigurationBuilder();
       builder.clustering().hash().keyPartitioner(new CRC16HashFunctionPartitioner()).numSegments(256);
+      amendConfiguration(builder);
       EmbeddedCacheManager cacheManager = TestCacheManagerFactory.newDefaultCacheManager(true, globalBuilder, builder);
       TestingUtil.replaceComponent(cacheManager, TimeService.class, timeService, true);
       return cacheManager;
+   }
+
+   protected void amendConfiguration(ConfigurationBuilder configurationBuilder) {
+
    }
 
    protected RespServerConfigurationBuilder serverConfiguration() {


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-15070

This allows for most commands to work, however things like LCS and TYPE are not working still.