### PR TITLE
ISPN-14641 MULTI + ISPN-14643 EXEC

### DIFF
--- a/server/resp/src/main/java/org/infinispan/server/resp/Consumers.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/Consumers.java
@@ -91,10 +91,10 @@ public final class Consumers {
    };
 
    public static final BiConsumer<List, ByteBufPool> LMPOP_BICONSUMER = (res, alloc) -> {
-      Resp3Handler.handleArrayPrefix(2, alloc);
+      Resp3Handler.writeArrayPrefix(2, alloc);
       Resp3Handler.handleBulkResult((byte[])res.get(0), alloc);
       Collection<byte[]> values = (Collection<byte[]>)res.get(1);
-      Resp3Handler.handleArrayPrefix(values.size(), alloc);
+      Resp3Handler.writeArrayPrefix(values.size(), alloc);
       for (byte[] val : values) {
          Resp3Handler.handleBulkResult(val, alloc);
       }
@@ -102,17 +102,17 @@ public final class Consumers {
 
    private static void handleIdxArray(LCSResponse res, ByteBufPool alloc) {
       // return idx. it's a 4 items array
-      Resp3Handler.handleArrayPrefix(4, alloc);
+      Resp3Handler.writeArrayPrefix(4, alloc);
       Resp3Handler.handleBulkResult("matches", alloc);
-      Resp3Handler.handleArrayPrefix(res.idx.size(), alloc);
+      Resp3Handler.writeArrayPrefix(res.idx.size(), alloc);
       for (var match : res.idx) {
          // 2 positions + optional length
          var size = match.length > 4 ? 3 : 2;
-         Resp3Handler.handleArrayPrefix(size, alloc);
-         Resp3Handler.handleArrayPrefix(2, alloc);
+         Resp3Handler.writeArrayPrefix(size, alloc);
+         Resp3Handler.writeArrayPrefix(2, alloc);
          Resp3Handler.handleLongResult(match[0], alloc);
          Resp3Handler.handleLongResult(match[1], alloc);
-         Resp3Handler.handleArrayPrefix(2, alloc);
+         Resp3Handler.writeArrayPrefix(2, alloc);
          Resp3Handler.handleLongResult(match[2], alloc);
          Resp3Handler.handleLongResult(match[3], alloc);
          if (size == 3) {

--- a/server/resp/src/main/java/org/infinispan/server/resp/Consumers.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/Consumers.java
@@ -9,6 +9,7 @@ import java.util.function.BiConsumer;
 
 import static org.infinispan.server.resp.RespConstants.CRLF_STRING;
 import static org.infinispan.server.resp.RespConstants.OK;
+import static org.infinispan.server.resp.RespConstants.QUEUED_REPLY;
 
 /**
  * Utility class with Consumers
@@ -23,6 +24,9 @@ public final class Consumers {
 
    public static final BiConsumer<Object, ByteBufPool> OK_BICONSUMER = (ignore, alloc) -> alloc.acquire(OK.length)
          .writeBytes(OK);
+
+   public static final BiConsumer<Object, ByteBufPool> QUEUED_BICONSUMER = (ignore, alloc) -> alloc.acquire(QUEUED_REPLY.length)
+         .writeBytes(QUEUED_REPLY);
 
    public static final BiConsumer<Long, ByteBufPool> LONG_BICONSUMER = Resp3Handler::handleLongResult;
 

--- a/server/resp/src/main/java/org/infinispan/server/resp/Resp3Handler.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/Resp3Handler.java
@@ -160,7 +160,7 @@ public class Resp3Handler extends Resp3AuthHandler {
       }
    }
 
-   protected static void handleArrayPrefix(int size, ByteBufPool alloc) {
+   public static void writeArrayPrefix(int size, ByteBufPool alloc) {
       allocAndWriteLengthPrefix('*', size, alloc, 0);
    }
 

--- a/server/resp/src/main/java/org/infinispan/server/resp/RespConstants.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/RespConstants.java
@@ -14,4 +14,5 @@ public interface RespConstants {
 
    byte[] OK = "+OK\r\n".getBytes(StandardCharsets.US_ASCII);
    byte[] NIL = "$-1\r\n".getBytes(StandardCharsets.US_ASCII);
+   byte[] QUEUED_REPLY = "+QUEUED\r\n".getBytes(StandardCharsets.US_ASCII);
 }

--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/Commands.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/Commands.java
@@ -1,5 +1,9 @@
 package org.infinispan.server.resp.commands;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import org.infinispan.server.resp.RespCommand;
 import org.infinispan.server.resp.commands.cluster.CLUSTER;
 import org.infinispan.server.resp.commands.connection.AUTH;
@@ -98,10 +102,7 @@ import org.infinispan.server.resp.commands.string.SET;
 import org.infinispan.server.resp.commands.string.SETRANGE;
 import org.infinispan.server.resp.commands.string.STRALGO;
 import org.infinispan.server.resp.commands.string.STRLEN;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import org.infinispan.server.resp.commands.tx.MULTI;
 
 /**
  * @since 15.0
@@ -125,7 +126,7 @@ public final class Commands {
       ALL_COMMANDS[7] = new RespCommand[]{new HELLO(), new HGET(), new HSET(), new HLEN(), new HEXISTS(), new HDEL(), new HMGET(), new HKEYS(), new HVALS(), new HSCAN(), new HGETALL(), new HMSET(), new HINCRBY(), new HINCRBYFLOAT(), new HRANDFIELD()};
       ALL_COMMANDS[8] = new RespCommand[]{new INCR(), new INCRBY(), new INCRBYFLOAT(), new INFO()};
       ALL_COMMANDS[11] = new RespCommand[]{new LINDEX(), new LINSERT(), new LPUSH(), new LPUSHX(), new LPOP(), new LRANGE(), new LLEN(), new LPOS(), new LREM(), new LSET(), new LTRIM(), new LMOVE(), new LMPOP() };
-      ALL_COMMANDS[12] = new RespCommand[]{new MGET(), new MSET(), new MODULE(), new MEMORY()};
+      ALL_COMMANDS[12] = new RespCommand[]{new MGET(), new MSET(), new MULTI(), new MODULE(), new MEMORY()};
       ALL_COMMANDS[15] = new RespCommand[]{new PUBLISH(), new PING(), new PSUBSCRIBE(), new PUNSUBSCRIBE(), new PTTL(), new PEXPIRETIME()};
       ALL_COMMANDS[16] = new RespCommand[]{new QUIT()};
       ALL_COMMANDS[17] = new RespCommand[]{new RPUSH(), new RPUSHX(), new RPOP(), new RESET(), new READWRITE(), new READONLY(), new RPOPLPUSH() };

--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/Commands.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/Commands.java
@@ -102,6 +102,7 @@ import org.infinispan.server.resp.commands.string.SET;
 import org.infinispan.server.resp.commands.string.SETRANGE;
 import org.infinispan.server.resp.commands.string.STRALGO;
 import org.infinispan.server.resp.commands.string.STRLEN;
+import org.infinispan.server.resp.commands.tx.EXEC;
 import org.infinispan.server.resp.commands.tx.MULTI;
 
 /**
@@ -119,7 +120,7 @@ public final class Commands {
       ALL_COMMANDS[2] = new RespCommand[]{new CONFIG(), new COMMAND(), new CLUSTER(), new CLIENT() };
       // DEL should always be first here
       ALL_COMMANDS[3] = new RespCommand[]{new DEL(), new DECR(), new DECRBY(), new DBSIZE()};
-      ALL_COMMANDS[4] = new RespCommand[]{new ECHO(), new EXISTS(), new EXPIRE(), new EXPIREAT(), new EXPIRETIME()};
+      ALL_COMMANDS[4] = new RespCommand[]{new ECHO(), new EXISTS(), new EXPIRE(), new EXPIREAT(), new EXPIRETIME(), new EXEC()};
       ALL_COMMANDS[5] = new RespCommand[]{new FLUSHDB(), new FLUSHALL()};
       // GET should always be first here
       ALL_COMMANDS[6] = new RespCommand[]{new GET(), new GETDEL(), new GETEX(), new GETRANGE()};

--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/TransactionResp3Command.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/TransactionResp3Command.java
@@ -1,0 +1,14 @@
+package org.infinispan.server.resp.commands;
+
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
+import org.infinispan.server.resp.RespRequestHandler;
+import org.infinispan.server.resp.tx.RespTransactionHandler;
+
+import io.netty.channel.ChannelHandlerContext;
+
+public interface TransactionResp3Command {
+
+   CompletionStage<RespRequestHandler> perform(RespTransactionHandler handler, ChannelHandlerContext ctx, List<byte[]> arguments);
+}

--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/connection/QUIT.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/connection/QUIT.java
@@ -1,21 +1,24 @@
 package org.infinispan.server.resp.commands.connection;
 
-import io.netty.channel.ChannelHandlerContext;
-import org.infinispan.server.resp.commands.AuthResp3Command;
-import org.infinispan.server.resp.commands.PubSubResp3Command;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
 import org.infinispan.server.resp.Resp3AuthHandler;
 import org.infinispan.server.resp.RespCommand;
 import org.infinispan.server.resp.RespRequestHandler;
 import org.infinispan.server.resp.SubscriberHandler;
+import org.infinispan.server.resp.commands.AuthResp3Command;
+import org.infinispan.server.resp.commands.PubSubResp3Command;
+import org.infinispan.server.resp.commands.TransactionResp3Command;
+import org.infinispan.server.resp.tx.RespTransactionHandler;
 
-import java.util.List;
-import java.util.concurrent.CompletionStage;
+import io.netty.channel.ChannelHandlerContext;
 
 /**
  * @link https://redis.io/commands/quit/
  * @since 14.0
  */
-public class QUIT extends RespCommand implements AuthResp3Command, PubSubResp3Command {
+public class QUIT extends RespCommand implements AuthResp3Command, PubSubResp3Command, TransactionResp3Command {
 
    public QUIT() {
       super(1, 0, 0, 0);
@@ -34,5 +37,11 @@ public class QUIT extends RespCommand implements AuthResp3Command, PubSubResp3Co
                                                                 List<byte[]> arguments) {
       handler.removeAllListeners();
       return handler.resp3Handler().handleRequest(ctx, this, arguments);
+   }
+
+   @Override
+   public CompletionStage<RespRequestHandler> perform(RespTransactionHandler handler, ChannelHandlerContext ctx, List<byte[]> arguments) {
+      handler.dropTransaction();
+      return handler.respServer().newHandler().handleRequest(ctx, this, arguments);
    }
 }

--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/tx/EXEC.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/tx/EXEC.java
@@ -1,0 +1,74 @@
+package org.infinispan.server.resp.commands.tx;
+
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
+import org.infinispan.commons.util.concurrent.CompletableFutures;
+import org.infinispan.server.resp.Consumers;
+import org.infinispan.server.resp.Resp3Handler;
+import org.infinispan.server.resp.RespCommand;
+import org.infinispan.server.resp.RespErrorUtil;
+import org.infinispan.server.resp.RespRequestHandler;
+import org.infinispan.server.resp.commands.Resp3Command;
+import org.infinispan.server.resp.commands.TransactionResp3Command;
+import org.infinispan.server.resp.tx.RespTransactionHandler;
+import org.infinispan.server.resp.tx.TransactionCommand;
+import org.infinispan.util.concurrent.CompletionStages;
+
+import io.netty.channel.ChannelHandlerContext;
+
+/**
+ * `<code>EXEC</code>` command.
+ * <p>
+ * Retrieves the queued commands from the handler and executes them serially. If the handler returns a <code>null</code>
+ * list, the transaction is aborted. The user installed a watch for a key, and the value was updated.
+ * <p>
+ * This implementation executes the operations outside a transaction context on the Infinispan level. Another user can
+ * see the state changing before the queue finishes. Even though Redis does not have the concept of commit/rollback,
+ * which means that everything is applied, the current implementation provides a weaker isolation level.
+ *
+ * @since 15.0
+ * @see <a href="https://redis.io/commands/exec">Redis Documentation</a>
+ * @author José Bolina
+ */
+public class EXEC extends RespCommand implements Resp3Command, TransactionResp3Command {
+
+   public EXEC() {
+      super(1, 0, 0, 0);
+   }
+
+   @Override
+   public CompletionStage<RespRequestHandler> perform(Resp3Handler handler, ChannelHandlerContext ctx, List<byte[]> arguments) {
+      RespErrorUtil.customError("EXEC without MULTI", handler.allocator());
+      return handler.myStage();
+   }
+
+   @Override
+   public CompletionStage<RespRequestHandler> perform(RespTransactionHandler handler, ChannelHandlerContext ctx, List<byte[]> arguments) {
+      Resp3Handler next = handler.respServer().newHandler();
+      List<TransactionCommand> commands = handler.performingOperations();
+
+      // Using WATCH and keys changed. Abort transaction.
+      if (commands == null) {
+         return handler.stageToReturn(CompletableFutures.completedNull(), ctx, ignore -> {
+            Consumers.GET_BICONSUMER.accept(null, handler.allocator());
+            return next;
+         });
+      }
+
+      Resp3Handler.writeArrayPrefix(commands.size(), handler.allocator());
+      return next.stageToReturn(orderlyExecution(next, ctx, commands, 0, CompletableFutures.completedNull()), ctx, ignore -> next);
+   }
+
+   private CompletionStage<?> orderlyExecution(Resp3Handler handler, ChannelHandlerContext ctx,
+                                               List<TransactionCommand> commands, int index,
+                                               CompletionStage<?> current) {
+      if (index == commands.size()) {
+         return current;
+      }
+
+      TransactionCommand command = commands.get(index);
+      return CompletionStages.handleAndCompose(current, (r, ignore) ->
+            orderlyExecution(handler, ctx, commands, index + 1, command.perform(handler, ctx)));
+   }
+}

--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/tx/MULTI.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/tx/MULTI.java
@@ -18,18 +18,19 @@ import io.netty.channel.ChannelHandlerContext;
 /**
  * `<code>MULTI</code>` command.
  * <p>
- * This command marks the start of a transaction block. Subsequent commands will be queued for execution, and always
- * replying with a {@link org.infinispan.server.resp.RespConstants#QUEUED_REPLY} response. The commands are verified
- * for errors, such as number of arguments, and an error is returned instead. Although, the transaction is not aborted.
+ * This command marks the start of a transaction block. Subsequent operations are queued for later execution and receive
+ * a {@link org.infinispan.server.resp.RespConstants#QUEUED_REPLY} response. Each operation is verified for errors,
+ * for example, the number of arguments. Flawed operations receive the corresponding error reply and are discarded.
+ * Although, these errors do not abort the transaction.
  * <p>
- * Sending "nested" MULTI commands is not accepted, that is, sending a MULTI command while inside a transaction. Again,
- * this does not abort the transaction, but returns an error.
+ * Sending "nested" MULTI commands is not accepted, i.e., sending a MULTI command when already in a MULTI context.
+ * Again, this does not abort the transaction but returns an error.
  * <p>
- * Redis also does not include a rollback command. Instead, the user can send a DISCARD command to abort the transaction.
- * This means the queued commands are discarded and the transaction context ends. Another commands with a similar
- * behavior are the {@link org.infinispan.server.resp.commands.connection.QUIT} and the subscription commands
- * {@link org.infinispan.server.resp.commands.pubsub.SUBSCRIBE} and {@link org.infinispan.server.resp.commands.pubsub.PSUBSCRIBE}.
- * The subscription commands drop the queued commands and enter into pub-sub mode.
+ * Redis also does not include a rollback command. Instead, the user can send a DISCARD command to abort the transaction,
+ * clearing the queued commands and exiting the transaction context. Other commands with similar behavior are
+ * {@link org.infinispan.server.resp.commands.connection.QUIT}, {@link org.infinispan.server.resp.commands.pubsub.SUBSCRIBE},
+ * and {@link org.infinispan.server.resp.commands.pubsub.PSUBSCRIBE}. The subscription commands drop the queued commands
+ * and enter pub-sub mode.
  *
  * @since 15.0
  * @see <a href="https://redis.io/commands/multi/">Redis documentation</a>

--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/tx/MULTI.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/tx/MULTI.java
@@ -1,0 +1,56 @@
+package org.infinispan.server.resp.commands.tx;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import org.infinispan.server.resp.Consumers;
+import org.infinispan.server.resp.Resp3Handler;
+import org.infinispan.server.resp.RespCommand;
+import org.infinispan.server.resp.RespErrorUtil;
+import org.infinispan.server.resp.RespRequestHandler;
+import org.infinispan.server.resp.commands.Resp3Command;
+import org.infinispan.server.resp.commands.TransactionResp3Command;
+import org.infinispan.server.resp.tx.RespTransactionHandler;
+
+import io.netty.channel.ChannelHandlerContext;
+
+/**
+ * `<code>MULTI</code>` command.
+ * <p>
+ * This command marks the start of a transaction block. Subsequent commands will be queued for execution, and always
+ * replying with a {@link org.infinispan.server.resp.RespConstants#QUEUED_REPLY} response. The commands are verified
+ * for errors, such as number of arguments, and an error is returned instead. Although, the transaction is not aborted.
+ * <p>
+ * Sending "nested" MULTI commands is not accepted, that is, sending a MULTI command while inside a transaction. Again,
+ * this does not abort the transaction, but returns an error.
+ * <p>
+ * Redis also does not include a rollback command. Instead, the user can send a DISCARD command to abort the transaction.
+ * This means the queued commands are discarded and the transaction context ends. Another commands with a similar
+ * behavior are the {@link org.infinispan.server.resp.commands.connection.QUIT} and the subscription commands
+ * {@link org.infinispan.server.resp.commands.pubsub.SUBSCRIBE} and {@link org.infinispan.server.resp.commands.pubsub.PSUBSCRIBE}.
+ * The subscription commands drop the queued commands and enter into pub-sub mode.
+ *
+ * @since 15.0
+ * @see <a href="https://redis.io/commands/multi/">Redis documentation</a>
+ * @see <a href="https://redis.io/docs/interact/transactions/">Redis transactions documentation</a>
+ * @author José Bolina
+ */
+public class MULTI extends RespCommand implements Resp3Command, TransactionResp3Command {
+
+   public MULTI() {
+      super(1, 0, 0, 0);
+   }
+
+   @Override
+   public CompletionStage<RespRequestHandler> perform(Resp3Handler handler, ChannelHandlerContext ctx, List<byte[]> arguments) {
+      Consumers.OK_BICONSUMER.accept(null, handler.allocator());
+      return CompletableFuture.completedFuture(new RespTransactionHandler(handler.respServer()));
+   }
+
+   @Override
+   public CompletionStage<RespRequestHandler> perform(RespTransactionHandler handler, ChannelHandlerContext ctx, List<byte[]> arguments) {
+      RespErrorUtil.customError("MULTI calls can not be nested", handler.allocator());
+      return handler.myStage();
+   }
+}

--- a/server/resp/src/main/java/org/infinispan/server/resp/tx/RespTransactionHandler.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/tx/RespTransactionHandler.java
@@ -1,0 +1,88 @@
+package org.infinispan.server.resp.tx;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
+import org.infinispan.commons.logging.LogFactory;
+import org.infinispan.server.resp.CacheRespRequestHandler;
+import org.infinispan.server.resp.Consumers;
+import org.infinispan.server.resp.RespCommand;
+import org.infinispan.server.resp.RespErrorUtil;
+import org.infinispan.server.resp.RespRequestHandler;
+import org.infinispan.server.resp.RespServer;
+import org.infinispan.server.resp.SubscriberHandler;
+import org.infinispan.server.resp.commands.TransactionResp3Command;
+import org.infinispan.server.resp.commands.pubsub.PSUBSCRIBE;
+import org.infinispan.server.resp.commands.pubsub.SUBSCRIBE;
+import org.infinispan.server.resp.logging.Log;
+
+import io.netty.channel.ChannelHandlerContext;
+
+/**
+ * Handles the commands while in the transaction state.
+ * <p>
+ * The transaction state is entered when the {@link org.infinispan.server.resp.commands.tx.MULTI} command is received
+ * and exited when the EXEC or DISCARD command is received. Additional commands that change the handler include the
+ * quit and subscribe commands.
+ * <p>
+ * The handler will queue all commands and copy the arguments received.
+ *
+ * @see <a href="https://redis.io/docs/interact/transactions/">Redis transactions documentation</a>
+ * @author José Bolina
+ */
+public class RespTransactionHandler extends CacheRespRequestHandler {
+
+   private static final Log log = LogFactory.getLog(RespTransactionHandler.class, Log.class);
+   private final List<TransactionCommand> queued;
+
+   public RespTransactionHandler(RespServer respServer) {
+      super(respServer);
+      this.queued = new ArrayList<>();
+   }
+
+   @Override
+   protected CompletionStage<RespRequestHandler> actualHandleRequest(ChannelHandlerContext ctx, RespCommand command, List<byte[]> arguments) {
+      initializeIfNecessary(ctx);
+      // Subscribe commands discard the queue and enter into pub-sub. See: https://github.com/redis/redis/pull/9928
+      // Doing specific checks here instead of implementing on the commands, so we can update this later, if necessary.
+      if (command instanceof SUBSCRIBE || command instanceof PSUBSCRIBE) {
+         dropTransaction();
+         SubscriberHandler subscriberHandler = new SubscriberHandler(respServer(), respServer().newHandler());
+         return subscriberHandler.handleRequest(ctx, command, arguments);
+      }
+
+      // Transaction commands take precedence and are not queued.
+      // We need to verify how commands like WATCH are handled from within a transaction.
+      if (command instanceof TransactionResp3Command) {
+         TransactionResp3Command tx = (TransactionResp3Command) command;
+         return tx.perform(this, ctx, arguments);
+      }
+
+      // Queued commands need to be parsed for syntax errors. Redis verify the number of arguments.
+      // This method already writes any error message to the socket.
+      if (!isCommandValid(command, arguments)) return myStage();
+
+      queued.add(new TransactionCommand(command, Collections.unmodifiableList(arguments)));
+      return stageToReturn(myStage(), ctx, Consumers.QUEUED_BICONSUMER);
+   }
+
+   @Override
+   public void handleChannelDisconnect(ChannelHandlerContext ctx) {
+      dropTransaction();
+   }
+
+   private boolean isCommandValid(RespCommand command, List<byte[]> arguments) {
+      if (!command.hasValidNumberOfArguments(arguments)) {
+         RespErrorUtil.wrongArgumentNumber(command, allocator());
+         return false;
+      }
+
+      return true;
+   }
+
+   public void dropTransaction() {
+      queued.clear();
+   }
+}

--- a/server/resp/src/main/java/org/infinispan/server/resp/tx/TransactionCommand.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/tx/TransactionCommand.java
@@ -1,23 +1,25 @@
 package org.infinispan.server.resp.tx;
 
 import java.util.List;
+import java.util.concurrent.CompletionStage;
 
+import org.infinispan.server.resp.Resp3Handler;
 import org.infinispan.server.resp.RespCommand;
-class TransactionCommand {
+import org.infinispan.server.resp.RespRequestHandler;
+
+import io.netty.channel.ChannelHandlerContext;
+
+public class TransactionCommand {
 
    private final RespCommand command;
    private final List<byte[]> arguments;
 
-   public TransactionCommand(RespCommand command, List<byte[]> arguments) {
+   TransactionCommand(RespCommand command, List<byte[]> arguments) {
       this.command = command;
       this.arguments = arguments;
    }
 
-   public RespCommand getCommand() {
-      return command;
-   }
-
-   public List<byte[]> getArguments() {
-      return arguments;
+   public CompletionStage<RespRequestHandler> perform(Resp3Handler handler, ChannelHandlerContext ctx) {
+      return handler.handleRequest(ctx, command, arguments);
    }
 }

--- a/server/resp/src/main/java/org/infinispan/server/resp/tx/TransactionCommand.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/tx/TransactionCommand.java
@@ -1,0 +1,23 @@
+package org.infinispan.server.resp.tx;
+
+import java.util.List;
+
+import org.infinispan.server.resp.RespCommand;
+class TransactionCommand {
+
+   private final RespCommand command;
+   private final List<byte[]> arguments;
+
+   public TransactionCommand(RespCommand command, List<byte[]> arguments) {
+      this.command = command;
+      this.arguments = arguments;
+   }
+
+   public RespCommand getCommand() {
+      return command;
+   }
+
+   public List<byte[]> getArguments() {
+      return arguments;
+   }
+}

--- a/server/resp/src/test/java/org/infinispan/server/resp/TransactionOperationsTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/TransactionOperationsTest.java
@@ -1,0 +1,48 @@
+package org.infinispan.server.resp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.concurrent.TimeUnit;
+
+import org.testng.annotations.Test;
+
+import io.lettuce.core.RedisCommandExecutionException;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.sync.RedisCommands;
+
+@Test(groups = "functional", testName = "server.resp.TransactionOperationsTest")
+public class TransactionOperationsTest extends SingleNodeRespBaseTest {
+
+   @Test
+   public void testStartTxAndQueueCommands() throws Exception {
+      StatefulRedisConnection<String, String> multi = client.connect();
+      RedisCommands<String, String> redis = multi.sync();
+
+      assertThat(redis.multi()).isEqualTo("OK");
+      assertThat(multi.isMulti()).isTrue();
+
+      for (int i = 0; i < 10; i++) {
+         // Lettuce returns `null` instead of QUEUED.
+         assertThat(redis.set("k" + i, "v" + i)).isNull();
+      }
+
+      // TODO: use EXEC to apply
+      multi.closeAsync().get(10, TimeUnit.SECONDS);
+   }
+
+   @Test
+   public void testStartNestedTx() throws Exception {
+      StatefulRedisConnection<String, String> multi = client.connect();
+      RedisCommands<String, String> redis = multi.sync();
+
+      assertThat(redis.multi()).isEqualTo("OK");
+      assertThat(multi.isMulti()).isTrue();
+
+      assertThatThrownBy(redis::multi)
+            .isInstanceOf(RedisCommandExecutionException.class)
+            .hasMessage("ERR MULTI calls can not be nested");
+
+      multi.closeAsync().get(10, TimeUnit.SECONDS);
+   }
+}

--- a/server/resp/src/test/java/org/infinispan/server/resp/TransactionOperationsTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/TransactionOperationsTest.java
@@ -8,6 +8,7 @@ import java.util.concurrent.TimeUnit;
 import org.testng.annotations.Test;
 
 import io.lettuce.core.RedisCommandExecutionException;
+import io.lettuce.core.TransactionResult;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.sync.RedisCommands;
 
@@ -16,19 +17,67 @@ public class TransactionOperationsTest extends SingleNodeRespBaseTest {
 
    @Test
    public void testStartTxAndQueueCommands() throws Exception {
-      StatefulRedisConnection<String, String> multi = client.connect();
-      RedisCommands<String, String> redis = multi.sync();
+      int numCommands = 20;
+      RedisCommands<String, String> redis = redisConnection.sync();
 
       assertThat(redis.multi()).isEqualTo("OK");
-      assertThat(multi.isMulti()).isTrue();
+      assertThat(redisConnection.isMulti()).isTrue();
 
-      for (int i = 0; i < 10; i++) {
+      for (int i = 0; i < numCommands; i++) {
          // Lettuce returns `null` instead of QUEUED.
          assertThat(redis.set("k" + i, "v" + i)).isNull();
       }
 
-      // TODO: use EXEC to apply
-      multi.closeAsync().get(10, TimeUnit.SECONDS);
+      assertThat(redis.exec())
+            .hasSize(numCommands)
+            .allMatch("OK"::equals);
+      assertThat(redisConnection.isMulti()).isFalse();
+
+      for (int i = 0; i < numCommands; i++) {
+         assertThat(redis.get("k" + i)).isEqualTo("v" + i);
+      }
+   }
+
+   @Test
+   public void testExecWithoutMulti() {
+      RedisCommands<String, String> redis = redisConnection.sync();
+      assertThat(redisConnection.isMulti()).isFalse();
+      assertThatThrownBy(redis::exec)
+            .isInstanceOf(RedisCommandExecutionException.class)
+            .hasMessage("ERR EXEC without MULTI");
+   }
+
+   @Test
+   public void testEmptyTransaction() {
+      RedisCommands<String, String> redis = redisConnection.sync();
+
+      assertThat(redis.multi()).isEqualTo("OK");
+      assertThat(redisConnection.isMulti()).isTrue();
+      assertThat(redis.exec()).isEmpty();
+      assertThat(redisConnection.isMulti()).isFalse();
+   }
+
+   @Test
+   public void testTransactionWithError() {
+      RedisCommands<String, String> redis = redisConnection.sync();
+
+      assertThat(redis.multi()).isEqualTo("OK");
+      assertThat(redisConnection.isMulti()).isTrue();
+
+      redis.set("tx-err-k1", "v1");
+      redis.hlen("tx-err-k1");
+      redis.set("tx-err-k2", "v2");
+
+      TransactionResult result = redis.exec();
+      assertThat(result.<String>get(0)).isEqualTo("OK");
+      assertThat(result.<Throwable>get(1))
+            .hasMessage("ERRWRONGTYPE Operation against a key holding the wrong kind of value");
+      assertThat(result.<String>get(2)).isEqualTo("OK");
+
+      assertThat(redisConnection.isMulti()).isFalse();
+
+      assertThat(redis.get("tx-err-k1")).isEqualTo("v1");
+      assertThat(redis.get("tx-err-k2")).isEqualTo("v2");
    }
 
    @Test

--- a/server/tests/src/test/java/org/infinispan/server/functional/resp/RespTransactionTest.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/resp/RespTransactionTest.java
@@ -1,0 +1,49 @@
+package org.infinispan.server.functional.resp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.vertx.core.Vertx;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.redis.client.RedisAPI;
+
+public class RespTransactionTest extends AbstractRespTest {
+
+   @Test
+   public void testStartTxAndExecuteOperations(Vertx vertx, VertxTestContext ctx) {
+      // Using STANDALONE mode here.
+      RedisAPI server0 = createDirectConnection(0, vertx);
+      RedisAPI server1 = createDirectConnection(1, vertx);
+
+      server0.multi()
+            .onFailure(ctx::failNow)
+            .compose(reply -> server0.set(List.of("tx-k1", "v1")))
+            .compose(reply -> server0.set(List.of("tx-k2", "v2")))
+            .compose(reply -> server0.get("tx-k2"))
+            .compose(reply -> {
+               ctx.verify(() -> assertThat(reply.toString()).isEqualTo("QUEUED"));
+
+               // The transaction context exist only in the server0.
+               // Redirecting the connection to a different server will not work.
+               return server1.exec();
+            })
+            .recover(r -> {
+               ctx.verify(() -> assertThat(r.toString()).isEqualTo("ERR EXEC without MULTI"));
+
+               // Execute on the correct server.
+               return server0.exec();
+            })
+            .onComplete(ctx.succeeding(reply -> {
+               ctx.verify(() -> {
+                  assertThat(reply).hasSize(3);
+                  assertThat(reply.get(0).toString()).isEqualTo("OK");
+                  assertThat(reply.get(1).toString()).isEqualTo("OK");
+                  assertThat(reply.get(2).toString()).isEqualTo("v2");
+               });
+               ctx.completeNow();
+            }));
+   }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-14641
https://issues.redhat.com/browse/ISPN-14643

This was the easy part. Working fine in a single node/STANDALONE. This way, we have a few things already:

* The commands are in memory, not tolerating restarts;
* TX could be half-applied if crashing mid-way EXEC;
* Executing the queued commands has a read uncommitted isolation.

Going to CLUSTER mode becomes more difficult. We lose the transaction context, as it is bound to a channel. We can start a discussion about how we want to handle all this. But for now, we have at least the basics in.