### PR TITLE
[14.0] ISPN-15041 Preserve stack traces to caller to simplify debugging

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/Util.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/Util.java
@@ -77,12 +77,14 @@ public class Util {
    }
 
    protected static RuntimeException rewrap(ExecutionException e) {
-      if (e.getCause() instanceof HotRodClientException) {
-         return new HotRodClientException(e);
-      } else if (e.getCause() instanceof CacheException) {
-         return new CacheException(e);
+      Throwable cause = e.getCause();
+      if (cause instanceof HotRodClientException) {
+         cause.setStackTrace(e.getStackTrace());
+         return (HotRodClientException) cause;
+      } else if (cause instanceof CacheException) {
+         return new CacheException(cause);
       } else {
-         return new TransportException(e.getCause(), null);
+         return new TransportException(cause, null);
       }
    }
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/Util.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/Util.java
@@ -78,9 +78,9 @@ public class Util {
 
    protected static RuntimeException rewrap(ExecutionException e) {
       if (e.getCause() instanceof HotRodClientException) {
-         return (HotRodClientException) e.getCause();
+         return new HotRodClientException(e);
       } else if (e.getCause() instanceof CacheException) {
-         return (CacheException) e.getCause();
+         return new CacheException(e);
       } else {
          return new TransportException(e.getCause(), null);
       }

--- a/client/hotrod/src/main/java/org/infinispan/hotrod/impl/Util.java
+++ b/client/hotrod/src/main/java/org/infinispan/hotrod/impl/Util.java
@@ -77,9 +77,9 @@ public class Util {
 
    protected static RuntimeException rewrap(ExecutionException e) {
       if (e.getCause() instanceof HotRodClientException) {
-         return (HotRodClientException) e.getCause();
+         return new HotRodClientException(e);
       } else if (e.getCause() instanceof CacheException) {
-         return (CacheException) e.getCause();
+         return new CacheException(e);
       } else {
          return new TransportException(e.getCause(), null);
       }

--- a/client/hotrod/src/main/java/org/infinispan/hotrod/impl/Util.java
+++ b/client/hotrod/src/main/java/org/infinispan/hotrod/impl/Util.java
@@ -76,12 +76,14 @@ public class Util {
    }
 
    protected static RuntimeException rewrap(ExecutionException e) {
-      if (e.getCause() instanceof HotRodClientException) {
-         return new HotRodClientException(e);
-      } else if (e.getCause() instanceof CacheException) {
-         return new CacheException(e);
+      Throwable cause = e.getCause();
+      if (cause instanceof HotRodClientException) {
+         cause.setStackTrace(e.getStackTrace());
+         return (HotRodClientException) cause;
+      } else if (cause instanceof CacheException) {
+         return new CacheException(cause);
       } else {
-         return new TransportException(e.getCause(), null);
+         return new TransportException(cause, null);
       }
    }
 


### PR DESCRIPTION
This backports this fix from the main branch to 14.x

The original PR is #11111

(cherry picked from commit 8c0d352b46babc51c571b45b5770d23656b42ea5)