### PR TITLE
ISPN-15070 RESP cache cannot be configured as a simple cache

### DIFF
--- a/core/src/main/java/org/infinispan/factories/ComponentRegistry.java
+++ b/core/src/main/java/org/infinispan/factories/ComponentRegistry.java
@@ -98,7 +98,7 @@ public class ComponentRegistry extends AbstractComponentRegistry {
    private ComponentRef<InternalConflictManager> conflictManager;
    private ComponentRef<DistributionManager> distributionManager;
    private ComponentRef<InternalDataContainer> internalDataContainer;
-   private ComponentRef<InternalEntryFactory> internalEntryFactory;
+   protected ComponentRef<InternalEntryFactory> internalEntryFactory;
    private ComponentRef<InvocationContextFactory> invocationContextFactory;
    private ComponentRef<IracManager> iracManager;
    private ComponentRef<IracVersionGenerator> iracVersionGenerator;

--- a/core/src/main/java/org/infinispan/factories/InternalCacheFactory.java
+++ b/core/src/main/java/org/infinispan/factories/InternalCacheFactory.java
@@ -23,6 +23,7 @@ import org.infinispan.commons.util.EnumUtil;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.container.impl.InternalDataContainer;
+import org.infinispan.container.impl.InternalEntryFactory;
 import org.infinispan.context.Flag;
 import org.infinispan.context.impl.FlagBitSets;
 import org.infinispan.context.impl.ImmutableContext;
@@ -486,11 +487,13 @@ public class InternalCacheFactory<K, V> {
       protected void bootstrapComponents() {
          registerComponent(new ClusterEventManagerStub<K, V>(), ClusterEventManager.class);
          registerComponent(new PassivationManagerStub(), PassivationManager.class);
+         registerComponent(new InternalCacheFactory<>(), InternalCacheFactory.class);
       }
 
       @Override
       public void cacheComponents() {
          getOrCreateComponent(InternalExpirationManager.class);
+         internalEntryFactory = basicComponentRegistry.getComponent(InternalEntryFactory.class);
       }
    }
 }

--- a/core/src/main/java/org/infinispan/functional/impl/ReadOnlyMapImpl.java
+++ b/core/src/main/java/org/infinispan/functional/impl/ReadOnlyMapImpl.java
@@ -27,10 +27,10 @@ import org.infinispan.util.logging.LogFactory;
  * @since 8.0
  */
 @Experimental
-public final class ReadOnlyMapImpl<K, V> extends AbstractFunctionalMap<K, V> implements ReadOnlyMap<K, V> {
+public class ReadOnlyMapImpl<K, V> extends AbstractFunctionalMap<K, V> implements ReadOnlyMap<K, V> {
    private static final Log log = LogFactory.getLog(ReadOnlyMapImpl.class);
 
-   private ReadOnlyMapImpl(Params params, FunctionalMapImpl<K, V> functionalMap) {
+   ReadOnlyMapImpl(Params params, FunctionalMapImpl<K, V> functionalMap) {
       super(params, functionalMap);
    }
 
@@ -39,6 +39,9 @@ public final class ReadOnlyMapImpl<K, V> extends AbstractFunctionalMap<K, V> imp
    }
 
    private static <K, V> ReadOnlyMap<K, V> create(Params params, FunctionalMapImpl<K, V> functionalMap) {
+      if (functionalMap.cache().getCacheConfiguration().simpleCache()) {
+         return new SimpleReadOnlyMapImpl<>(params, functionalMap);
+      }
       return new ReadOnlyMapImpl<>(params, functionalMap);
    }
 

--- a/core/src/main/java/org/infinispan/functional/impl/ReadWriteMapImpl.java
+++ b/core/src/main/java/org/infinispan/functional/impl/ReadWriteMapImpl.java
@@ -28,10 +28,10 @@ import org.infinispan.util.logging.LogFactory;
  * @since 8.0
  */
 @Experimental
-public final class ReadWriteMapImpl<K, V> extends AbstractFunctionalMap<K, V> implements ReadWriteMap<K, V> {
+public class ReadWriteMapImpl<K, V> extends AbstractFunctionalMap<K, V> implements ReadWriteMap<K, V> {
    private static final Log log = LogFactory.getLog(ReadWriteMapImpl.class);
 
-   private ReadWriteMapImpl(Params params, FunctionalMapImpl<K, V> functionalMap) {
+   ReadWriteMapImpl(Params params, FunctionalMapImpl<K, V> functionalMap) {
       super(params, functionalMap);
    }
 
@@ -40,6 +40,9 @@ public final class ReadWriteMapImpl<K, V> extends AbstractFunctionalMap<K, V> im
    }
 
    private static <K, V> ReadWriteMap<K, V> create(Params params, FunctionalMapImpl<K, V> functionalMap) {
+      if (functionalMap.cache().getCacheConfiguration().simpleCache()) {
+         return new SimpleReadWriteMapImpl<>(params, functionalMap);
+      }
       return new ReadWriteMapImpl<>(params, functionalMap);
    }
 

--- a/core/src/main/java/org/infinispan/functional/impl/SimpleReadOnlyMapImpl.java
+++ b/core/src/main/java/org/infinispan/functional/impl/SimpleReadOnlyMapImpl.java
@@ -1,0 +1,91 @@
+package org.infinispan.functional.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+import org.infinispan.commons.util.Experimental;
+import org.infinispan.commons.util.concurrent.CompletableFutures;
+import org.infinispan.container.entries.InternalCacheEntry;
+import org.infinispan.context.impl.ImmutableContext;
+import org.infinispan.functional.EntryView;
+import org.infinispan.functional.Traversable;
+import org.infinispan.notifications.cachelistener.CacheNotifier;
+import org.infinispan.util.concurrent.CompletionStages;
+
+/**
+ * A {@link ReadOnlyMapImpl} that works with a simple cache.
+ *
+ * @since 15.0
+ * @author José Bolina
+ * @see ReadOnlyMapImpl
+ */
+@Experimental
+public class SimpleReadOnlyMapImpl<K, V> extends ReadOnlyMapImpl<K, V> {
+   private static final String KEY_CANNOT_BE_NULL = "Key cannot be null";
+   private static final String FUNCTION_CANNOT_BE_NULL = "Function cannot be null";
+
+   private final CacheNotifier<K, V> notifier;
+
+
+   SimpleReadOnlyMapImpl(Params params, FunctionalMapImpl<K, V> functionalMap) {
+      super(params, functionalMap);
+      this.notifier = functionalMap.cache.getComponentRegistry().getComponent(CacheNotifier.class);
+   }
+
+   @Override
+   public <R> CompletableFuture<R> eval(K key, Function<EntryView.ReadEntryView<K, V>, R> f) {
+      try {
+         return internalEval(key, f);
+      } catch (Throwable t) {
+         return CompletableFuture.failedFuture(t);
+      }
+   }
+
+   @Override
+   public <R> Traversable<R> evalMany(Set<? extends K> keys, Function<EntryView.ReadEntryView<K, V>, R> f) {
+      List<R> results = new ArrayList<>(keys.size());
+      for (K key : keys) {
+         // Everything is local, CF is always complete.
+         CompletableFuture<R> cf = eval(key, f);
+         assert cf.isDone() : "eval() returned an incomplete CF";
+
+         R r = CompletionStages.join(cf);
+         results.add(r);
+      }
+      return Traversables.of(results.stream());
+   }
+
+   private <R> CompletableFuture<R> internalEval(K key, Function<EntryView.ReadEntryView<K, V>, R> f) {
+      Objects.requireNonNull(key, KEY_CANNOT_BE_NULL);
+      Objects.requireNonNull(f, FUNCTION_CANNOT_BE_NULL);
+
+      InternalCacheEntry<K, V> ice = fmap.cache.getDataContainer().peek(key);
+      boolean notify = false;
+      EntryView.ReadEntryView<K, V> view;
+      if (ice == null || ice.isNull()) {
+         view = EntryViews.noValue(key);
+      } else {
+         view = EntryViews.readOnly(ice);
+         notify = true;
+      }
+
+      if (notify && hasListeners())
+         CompletionStages.join(notifier.notifyCacheEntryVisited(ice.getKey(), ice.getValue(), true, ImmutableContext.INSTANCE, null));
+
+      R r = EntryViews.snapshot(f.apply(view));
+
+      if (notify && hasListeners())
+         CompletionStages.join(notifier.notifyCacheEntryVisited(ice.getKey(), ice.getValue(), false, ImmutableContext.INSTANCE, null));
+
+      if (r == null) return CompletableFutures.completedNull();
+      return CompletableFuture.completedFuture(r);
+   }
+
+   private boolean hasListeners() {
+      return !notifier.getListeners().isEmpty();
+   }
+}

--- a/core/src/main/java/org/infinispan/functional/impl/SimpleReadWriteMapImpl.java
+++ b/core/src/main/java/org/infinispan/functional/impl/SimpleReadWriteMapImpl.java
@@ -1,0 +1,232 @@
+package org.infinispan.functional.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import org.infinispan.commons.util.ByRef;
+import org.infinispan.commons.util.Experimental;
+import org.infinispan.commons.util.concurrent.CompletableFutures;
+import org.infinispan.container.entries.InternalCacheEntry;
+import org.infinispan.container.entries.MVCCEntry;
+import org.infinispan.container.entries.ReadCommittedEntry;
+import org.infinispan.container.impl.InternalEntryFactory;
+import org.infinispan.context.impl.ImmutableContext;
+import org.infinispan.expiration.impl.InternalExpirationManager;
+import org.infinispan.functional.EntryView;
+import org.infinispan.functional.Param;
+import org.infinispan.functional.Traversable;
+import org.infinispan.metadata.Metadata;
+import org.infinispan.metadata.impl.PrivateMetadata;
+import org.infinispan.notifications.cachelistener.CacheNotifier;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryExpired;
+import org.infinispan.util.concurrent.CompletionStages;
+
+/**
+ * A {@link ReadWriteMapImpl} that works with a simple cache.
+ *
+ * @since 15.0
+ * @author José Bolina
+ * @see ReadWriteMapImpl
+ */
+@Experimental
+public class SimpleReadWriteMapImpl<K, V> extends ReadWriteMapImpl<K, V> {
+   private static final String KEY_CANNOT_BE_NULL = "Key cannot be null";
+   private static final String FUNCTION_CANNOT_BE_NULL = "Function cannot be null";
+
+   private final InternalExpirationManager<K, V> expirationManager;
+   private final CacheNotifier<K, V> notifier;
+
+   public SimpleReadWriteMapImpl(Params params, FunctionalMapImpl<K, V> functionalMap) {
+      super(params, functionalMap);
+      this.expirationManager = functionalMap.cache.getComponentRegistry().getComponent(InternalExpirationManager.class);
+      this.notifier = functionalMap.cache.getComponentRegistry().getComponent(CacheNotifier.class);
+   }
+
+   @Override
+   public <R> CompletableFuture<R> eval(K key, Function<EntryView.ReadWriteEntryView<K, V>, R> f) {
+      return eval(key, null, (ignore, v) -> f.apply(v));
+   }
+
+   @Override
+   public <T, R> CompletableFuture<R> eval(K key, T argument, BiFunction<T, EntryView.ReadWriteEntryView<K, V>, R> f) {
+      K storageKey = storageKey(key);
+      InternalCacheEntry<K, V> ice = fmap.cache.getDataContainer().peek(storageKey);
+      if (ice == null || !ice.canExpire()) {
+         try {
+            R result = evalInternal(storageKey, argument, f);
+            return result == null
+                  ? CompletableFutures.completedNull()
+                  : CompletableFuture.completedFuture(result);
+         } catch (Throwable t) {
+            return CompletableFuture.failedFuture(t);
+         }
+      }
+
+      int segment = fmap.keyPartitioner.getSegment(storageKey);
+      CompletionStage<Boolean> expiration = expirationManager.handlePossibleExpiration(ice, segment, true);
+      assert expiration.toCompletableFuture().isDone() : "Expiration should be done";
+      boolean expired = CompletionStages.join(expiration);
+
+      if (expired && notifier.hasListener(CacheEntryExpired.class)) {
+         CompletionStages.join(notifier.notifyCacheEntryExpired(ice.getKey(), ice.getValue(), ice.getMetadata(), ImmutableContext.INSTANCE));
+      }
+
+      try {
+         InternalCacheEntry<K, V> entry = !expired ? ice : null;
+         R result = evalInternal(key, argument, f, entry);
+         return result == null
+               ? CompletableFutures.completedNull()
+               : CompletableFuture.completedFuture(result);
+      } catch (Throwable t) {
+         return CompletableFuture.failedFuture(t);
+      }
+   }
+
+   @Override
+   public <T, R> Traversable<R> evalMany(Map<? extends K, ? extends T> arguments, BiFunction<T, EntryView.ReadWriteEntryView<K, V>, R> f) {
+      // Since we're in a simple cache, everything is local!
+      List<R> results = new ArrayList<>(arguments.size());
+      for (Map.Entry<? extends K, ? extends T> me : arguments.entrySet()) {
+         CompletableFuture<R> cf = eval(me.getKey(), me.getValue(), f);
+         assert cf.isDone() : "eval() returned an incomplete CompletableFuture";
+
+         results.add(CompletionStages.join(cf));
+      }
+
+      return Traversables.of(results.stream());
+   }
+
+   @Override
+   public <R> Traversable<R> evalMany(Set<? extends K> keys, Function<EntryView.ReadWriteEntryView<K, V>, R> f) {
+      List<R> results = new ArrayList<>(keys.size());
+      BiFunction<?, EntryView.ReadWriteEntryView<K, V>, R> bf = (ignore, v) -> f.apply(v);
+      for (K key : keys) {
+         CompletableFuture<R> cf = eval(key, null, bf);
+         assert cf.isDone() : "eval() returned an incomplete CompletableFuture";
+
+         results.add(CompletionStages.join(cf));
+      }
+
+      return Traversables.of(results.stream());
+   }
+
+   @Override
+   public <R> Traversable<R> evalAll(Function<EntryView.ReadWriteEntryView<K, V>, R> f) {
+      return evalMany(fmap.cache.keySet(), f);
+   }
+
+   private boolean isStatisticsEnabled() {
+      return !params.containsAll(Param.StatisticsMode.SKIP);
+   }
+
+   private boolean hasListeners() {
+      return !notifier.getListeners().isEmpty();
+   }
+
+   private <R, T> R evalInternal(K key, T argument, BiFunction<T, EntryView.ReadWriteEntryView<K, V>, R> f) {
+      Objects.requireNonNull(key, KEY_CANNOT_BE_NULL);
+      Objects.requireNonNull(f, FUNCTION_CANNOT_BE_NULL);
+      ByRef<R> result = new ByRef<>(null);
+      ByRef<EntryHolder<K, V>> holder = new ByRef<>(null);
+      fmap.cache.getDataContainer().compute(key, (k, oldEntry, factory) ->
+            compute(key, argument, f, oldEntry, factory, result, holder));
+      handleNotifications(key, holder.get());
+      return result.get();
+   }
+
+   private <R, T> R evalInternal(K key, T argument, BiFunction<T, EntryView.ReadWriteEntryView<K, V>, R> f, InternalCacheEntry<K, V> override) {
+      Objects.requireNonNull(key, KEY_CANNOT_BE_NULL);
+      Objects.requireNonNull(f, FUNCTION_CANNOT_BE_NULL);
+      ByRef<R> result = new ByRef<>(null);
+      ByRef<EntryHolder<K, V>> holder = new ByRef<>(null);
+      fmap.cache.getDataContainer().compute(key, (k, ignore, factory) ->
+            compute(key, argument, f, override, factory, result, holder));
+      handleNotifications(key, holder.get());
+      return result.get();
+   }
+
+   private void handleNotifications(K key, EntryHolder<K, V> holder) {
+      if (holder == null) return;
+
+      InternalCacheEntry<K, V> oldEntry = holder.before;
+      MVCCEntry<K, V> e = holder.after;
+
+      if (hasListeners()) {
+         if (oldEntry == null) {
+            CompletionStages.join(notifier.notifyCacheEntryCreated(key, e.getValue(), e.getOldMetadata(), false, ImmutableContext.INSTANCE, null));
+         } else {
+            CompletionStages.join(notifier.notifyCacheEntryModified(key, e.getValue(), e.getMetadata(), oldEntry.getValue(), oldEntry.getMetadata(), false, ImmutableContext.INSTANCE, null));
+         }
+      }
+   }
+
+   private <R, T> InternalCacheEntry<K, V> compute(K key, T argument, BiFunction<T, EntryView.ReadWriteEntryView<K, V>, R> f,
+                                                   InternalCacheEntry<K, V> oldEntry, InternalEntryFactory factory,
+                                                   ByRef<R> result, ByRef<EntryHolder<K, V>> holder) {
+      MVCCEntry<K, V> e = extractEntry(oldEntry, key);
+      EntryViews.AccessLoggingReadWriteView<K, V> view =  EntryViews.readWrite(e, fmap.cache.getKeyDataConversion(), fmap.cache.getValueDataConversion());
+      result.set(EntryViews.snapshot(f.apply(argument, view)));
+
+      if (!e.isChanged()) return oldEntry;
+
+      if (hasListeners()) {
+         if (oldEntry == null) {
+            holder.set(new EntryHolder<>(null, e));
+            CompletionStages.join(notifier.notifyCacheEntryCreated(key, e.getValue(), e.getOldMetadata(), true, ImmutableContext.INSTANCE, null));
+         } else {
+            holder.set(new EntryHolder<>(oldEntry, e));
+            CompletionStages.join(notifier.notifyCacheEntryModified(key, e.getValue(), e.getMetadata(), oldEntry.getValue(), oldEntry.getMetadata(), true, ImmutableContext.INSTANCE, null));
+         }
+      }
+
+      return oldEntry == null
+            ? factory.create(e)
+            : factory.update(oldEntry, e.getValue(), e.getMetadata());
+   }
+
+   @SuppressWarnings("unchecked")
+   private K storageKey(K key) {
+      return (K) fmap.cache.getKeyDataConversion().toStorage(key);
+   }
+
+   private MVCCEntry<K, V> extractEntry(InternalCacheEntry<K, V> ice, K key) {
+      if (ice == null) {
+         return new ReadCommittedEntry<>(key, null, null);
+      }
+
+      return createWrapped(key, ice);
+   }
+
+   private MVCCEntry<K, V> createWrapped(K key, InternalCacheEntry<K, V> ice) {
+      V value;
+      Metadata metadata;
+      PrivateMetadata internalMetadata;
+      synchronized (ice) {
+         value = ice.getValue();
+         metadata = ice.getMetadata();
+         internalMetadata = ice.getInternalMetadata();
+      }
+      MVCCEntry<K, V> mvccEntry = new ReadCommittedEntry<>(key, value, metadata);
+      mvccEntry.setInternalMetadata(internalMetadata);
+      mvccEntry.setCreated(ice.getCreated());
+      mvccEntry.setLastUsed(ice.getLastUsed());
+      return mvccEntry;
+   }
+
+   private static class EntryHolder<K, V> {
+      private final InternalCacheEntry<K, V> before;
+      private final MVCCEntry<K, V> after;
+
+      private EntryHolder(InternalCacheEntry<K, V> before, MVCCEntry<K, V> after) {
+         this.before = before;
+         this.after = after;
+      }
+   }
+}

--- a/server/resp/src/main/java/org/infinispan/server/resp/operation/LCSOperation.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/operation/LCSOperation.java
@@ -2,7 +2,9 @@ package org.infinispan.server.resp.operation;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -11,6 +13,8 @@ import org.infinispan.AdvancedCache;
 import org.infinispan.server.resp.response.LCSResponse;
 
 public class LCSOperation {
+
+   private static final byte[] EMPTY_ARRAY = new byte[0];
    private static final CompletionStage<LCSResponse> MISSING_ARGUMENTS = CompletableFuture
          .failedFuture(new IllegalStateException("Missing arguments"));
 
@@ -22,18 +26,34 @@ public class LCSOperation {
       lcsCtx.cache = cache;
       return lcsCtx.cache.getAllAsync(Set.of(lcsCtx.key1, lcsCtx.key2))
             .thenApply((m) -> {
-               var v1 = m.get(lcsCtx.key1);
-               var v2 = m.get(lcsCtx.key2);
+               if (m.size() < 2) {
+                  lcsCtx.result = new LCSResponse();
+                  lcsCtx.result.lcs = EMPTY_ARRAY;
+               }
+
+               var v1 = findValue(m, lcsCtx.key1);
+               var v2 = findValue(m, lcsCtx.key2);
                if (v1 == null || v2 == null) {
                   lcsCtx.result = new LCSResponse();
-                  lcsCtx.result.lcs = new byte[0];
+                  lcsCtx.result.lcs = EMPTY_ARRAY;
                }
+
                lcsCtx.lcsLength(v1, v2);
                if (!lcsCtx.justLen) {
                   lcsCtx.backtrack(v1, v2);
                }
                return lcsCtx.result;
             });
+   }
+
+   private static byte[] findValue(Map<byte[], byte[]> values, byte[] key) {
+      assert values.size() == 2;
+      for (Map.Entry<byte[], byte[]> entry : values.entrySet()) {
+         if (Arrays.equals(entry.getKey(), key)) {
+            return entry.getValue();
+         }
+      }
+      return null;
    }
 
    protected static class LCSOperationContext {
@@ -109,11 +129,12 @@ public class LCSOperation {
                      throw new IllegalArgumentException("ERR syntax error");
                   this.minMatchLen = Long.parseLong(new String(arguments.get(i + 1), StandardCharsets.US_ASCII));
                   i++;
+                  continue;
                case "WITHMATCHLEN":
                   if (this.matchLen)
                      throw new IllegalArgumentException(
                            "ERR If you want both the length and indexes, please just use IDX.");
-                  matchLen = true && idx; // matchLen useless without idx
+                  matchLen = idx; // matchLen useless without idx
                   continue;
             }
             throw new IllegalArgumentException("Unknown argument for LCS operation");
@@ -157,7 +178,7 @@ public class LCSOperation {
          }
          while (i > 0 && j > 0) {
             if (aStr[i - 1] == bStr[j - 1]) { // On match, save char and move up-left
-            matching = true;
+               matching = true;
                if (!this.idx) {
                   this.result.lcs[m--] = aStr[i - 1];
                }

--- a/server/resp/src/test/java/org/infinispan/server/resp/RespAuthSingleNodeTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/RespAuthSingleNodeTest.java
@@ -13,6 +13,7 @@ import org.infinispan.server.resp.authentication.RespAuthenticator;
 import org.infinispan.server.resp.configuration.RespServerConfigurationBuilder;
 import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 
 import io.lettuce.core.RedisCommandExecutionException;
@@ -92,5 +93,20 @@ public class RespAuthSingleNodeTest extends RespSingleNodeTest {
       public boolean isClientCertAuthEnabled() {
          return false;
       }
+   }
+
+   @Factory
+   @Override
+   public Object[] factory() {
+      return new Object[] {
+            new RespAuthSingleNodeTest(),
+            new RespAuthSingleNodeTest().simpleCache(),
+      };
+   }
+
+   @Override
+   RespSingleNodeTest simpleCache() {
+      super.simpleCache();
+      return this;
    }
 }

--- a/server/resp/src/test/java/org/infinispan/server/resp/RespMediaTypesTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/RespMediaTypesTest.java
@@ -58,6 +58,6 @@ public class RespMediaTypesTest extends RespSingleNodeTest {
 
    @Override
    protected String parameters() {
-      return "[value=" + valueType + "]";
+      return super.parameters() + " + " + "[value=" + valueType + "]";
    }
 }

--- a/server/resp/src/test/java/org/infinispan/server/resp/RespSimpleCacheTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/RespSimpleCacheTest.java
@@ -1,0 +1,139 @@
+package org.infinispan.server.resp;
+
+import static io.lettuce.core.ScoredValue.just;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.infinispan.server.resp.test.RespTestingUtil.assertWrongType;
+
+import java.util.Map;
+
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+
+import io.lettuce.core.ZAddArgs;
+import io.lettuce.core.api.sync.RedisCommands;
+
+@Test(groups = "functional", testName = "server.resp.RespSimpleCacheTest")
+public class RespSimpleCacheTest extends SingleNodeRespBaseTest {
+
+   protected CacheMode cacheMode = CacheMode.LOCAL;
+   protected boolean simpleCache;
+
+   @Factory
+   public Object[] factory() {
+      return new Object[] {
+            new RespSimpleCacheTest(),
+            new RespSimpleCacheTest().simpleCache(),
+      };
+   }
+
+   protected RespSimpleCacheTest simpleCache() {
+      this.cacheMode = CacheMode.LOCAL;
+      this.simpleCache = true;
+      return this;
+   }
+
+   @Override
+   protected String parameters() {
+      return "[simpleCache=" + simpleCache + ", cacheMode=" + cacheMode + "]";
+   }
+
+   @Override
+   protected void amendConfiguration(ConfigurationBuilder builder) {
+      if (simpleCache) {
+         builder.clustering().cacheMode(CacheMode.LOCAL).simpleCache(true);
+      } else {
+         builder.clustering().cacheMode(cacheMode);
+      }
+   }
+
+   public void testSetGetDelete() {
+      RedisCommands<String, String> redis = redisConnection.sync();
+      redis.set("k1", "v1");
+      String v = redis.get("k1");
+      assertThat(v).isEqualTo("v1");
+
+      redis.del("k1");
+
+      assertThat(redis.get("k1")).isNull();
+      assertThat(redis.get("something")).isNull();
+   }
+
+   public void testHashStructureOperations() {
+      RedisCommands<String, String> redis = redisConnection.sync();
+
+      assertThat(redis.hdel("not-existent", "unknown")).isEqualTo(0);
+      assertThat(redis.hgetall("not-existent")).isEmpty();
+
+      Map<String, String> map = Map.of("key1", "value1", "key2", "value2", "key3", "value3");
+      assertThat(redis.hset("HSET", map)).isEqualTo(3);
+
+      // Updating some keys should return 0.
+      assertThat(redis.hset("HSET", Map.of("key1", "other-value1"))).isEqualTo(0);
+
+      // Mixing update and new keys.
+      assertThat(redis.hset("HSET", Map.of("key2", "other-value2", "key4", "value4"))).isEqualTo(1);
+
+      assertThat(redis.hget("HSET", "key1")).isEqualTo("other-value1");
+      assertThat(redis.hget("HSET", "unknown")).isNull();
+      assertThat(redis.hget("UNKNOWN", "unknown")).isNull();
+      assertThat(redis.hgetall("HSET"))
+            .containsAllEntriesOf(
+                  Map.of("key1", "other-value1",
+                        "key2", "other-value2",
+                        "key3", "value3",
+                        "key4", "value4"));
+
+      assertWrongType(() -> redis.set("plain", "string"), () -> redis.hmset("plain", Map.of("k1", "v1")));
+      assertWrongType(() -> {}, () -> redis.hget("plain", "k1"));
+   }
+
+   public void testSortedSetOperations() {
+      RedisCommands<String, String> redis = redisConnection.sync();
+
+      assertThat(redis.zcard("not_existing")).isEqualTo(0);
+      assertThat(redis.zadd("people", ZAddArgs.Builder.ch(),
+            just(18.9, "fabio"),
+            just(21.9, "marc")))
+            .isEqualTo(2);
+      assertThat(redis.zcard("people")).isEqualTo(2);
+      assertThat(redis.zrangeWithScores("people", 0, -1))
+            .containsExactly(just(18.9, "fabio"), just(21.9, "marc"));
+      assertWrongType(() -> redis.set("another", "tristan"), () ->  redis.zcard("another"));
+   }
+
+   public void testListOperations() {
+      RedisCommands<String, String> redis = redisConnection.sync();
+
+      long result = redis.rpush("people", "tristan");
+      assertThat(result).isEqualTo(1);
+
+      result = redis.rpush("people", "william");
+      assertThat(result).isEqualTo(2);
+
+      result = redis.rpush("people", "william", "jose", "pedro");
+      assertThat(result).isEqualTo(5);
+      assertThat(redis.lrange("people", 0, 4)).containsExactly("tristan", "william", "william", "jose", "pedro");
+
+      assertWrongType(() -> redis.set("leads", "tristan"), () ->  redis.rpush("leads", "william"));
+   }
+
+   public void testSetOperations() {
+      RedisCommands<String, String> redis = redisConnection.sync();
+      String key = "sadd";
+      Long newValue = redis.sadd(key, "1", "2", "3");
+      assertThat(newValue.longValue()).isEqualTo(3L);
+      newValue = redis.sadd(key, "4", "5");
+      assertThat(newValue.longValue()).isEqualTo(2L);
+      newValue = redis.sadd(key, "5", "6");
+      assertThat(newValue.longValue()).isEqualTo(1L);
+
+      // SADD on an existing key that contains a String, not a Set!
+      // Set a String Command
+      assertWrongType(() -> redis.set("leads", "tristan"), () ->  redis.sadd("leads", "william"));
+      // SADD on an existing key that contains a List, not a Set!
+      // Create a List
+      assertWrongType(() -> redis.lpush("listleads", "tristan"), () ->  redis.sadd("listleads", "william"));
+   }
+}

--- a/server/resp/src/test/java/org/infinispan/server/resp/SingleNodeRespBaseTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/SingleNodeRespBaseTest.java
@@ -49,9 +49,14 @@ public abstract class SingleNodeRespBaseTest extends SingleCacheManagerTest {
       ConfigurationBuilder builder = new ConfigurationBuilder();
       builder.encoding().key().mediaType(MediaType.APPLICATION_OCTET_STREAM);
       builder.clustering().hash().keyPartitioner(new CRC16HashFunctionPartitioner()).numSegments(256);
+      amendConfiguration(builder);
       EmbeddedCacheManager cacheManager = TestCacheManagerFactory.newDefaultCacheManager(true, globalBuilder, builder);
       TestingUtil.replaceComponent(cacheManager, TimeService.class, timeService, true);
       return cacheManager;
+   }
+
+   protected void amendConfiguration(ConfigurationBuilder configurationBuilder) {
+
    }
 
    protected RespServerConfigurationBuilder serverConfiguration() {

--- a/server/resp/src/test/java/org/infinispan/server/resp/operation/OperationTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/operation/OperationTest.java
@@ -9,14 +9,26 @@ import org.testng.annotations.Test;
 
 @Test(groups = "unit", testName = "server.resp.operation.OperationTest")
 public class OperationTest {
-@Test
-public void testLcs() {
-    byte[] val1 =    "ohmytext".getBytes(StandardCharsets.US_ASCII);
-    byte[] val2 =    "mynewtext".getBytes(StandardCharsets.US_ASCII);
+   @Test
+   public void testLcs() {
+      byte[] val1 = "ohmytext".getBytes(StandardCharsets.US_ASCII);
+      byte[] val2 = "mynewtext".getBytes(StandardCharsets.US_ASCII);
 
-    var lcsOpts = new LCSOperation.LCSOperationContext(val1, val2,false, false, false, 0);
-    lcsOpts.lcsLength(val1, val2);
-    lcsOpts.backtrack(val1, val2);
-    assertThat(lcsOpts.getResult().lcs).isEqualTo(new byte[] {'m','y','t','e','x','t'});
-}
+      var lcsOpts = new LCSOperation.LCSOperationContext(val1, val2, false, false, false, 0);
+      lcsOpts.lcsLength(val1, val2);
+      lcsOpts.backtrack(val1, val2);
+      assertThat(lcsOpts.getResult().lcs).isEqualTo(new byte[]{'m', 'y', 't', 'e', 'x', 't'});
+   }
+
+   @Test
+   public void testLcsMinMatch() {
+      byte[] val1 = "ohmytext".getBytes(StandardCharsets.US_ASCII);
+      byte[] val2 = "mynewtext".getBytes(StandardCharsets.US_ASCII);
+
+      var lcsOpts = new LCSOperation.LCSOperationContext(val1, val2, false, true, false, 4);
+      lcsOpts.lcsLength(val1, val2);
+      lcsOpts.backtrack(val1, val2);
+      assertThat(lcsOpts.getResult().idx).containsExactly(new long[]{4, 7, 5, 8});
+      assertThat(lcsOpts.getResult().len).isEqualTo(6);
+   }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-15070
https://issues.redhat.com/browse/ISPN-15094

Maybe not the correct name for the JIRA, but this adds an implementation for the functional map that works with a simple cache. We follow the same idea from `SimpleCacheImpl` to directly access the data container and execute the operations. This still lacks proper stats collection.

This allows configuring a simple cache for resp and using all the data structures, too.