### PR TITLE
ISPN-15068 RESP Server should always use OCTET key media type storage

### DIFF
--- a/server/resp/src/main/java/org/infinispan/server/resp/RespServer.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/RespServer.java
@@ -85,7 +85,7 @@ public class RespServer extends AbstractProtocolServer<RespServerConfiguration> 
             builder.encoding().value().mediaType(configuredValueType);
          }
          cacheManager.defineConfiguration(configuration.defaultCacheName(), builder.build());
-      } else if (!explicitConfiguration.encoding().keyDataType().mediaType().equals(MediaType.APPLICATION_OCTET_STREAM)) {
+      } else if (!MediaType.APPLICATION_OCTET_STREAM.equals(explicitConfiguration.encoding().keyDataType().mediaType())) {
          throw CONFIG.respCacheKeyMediaTypeSupplied(cacheName, explicitConfiguration.encoding().keyDataType().mediaType());
       }
       super.startInternal();


### PR DESCRIPTION
* Handle case where key encoding is not defined

https://issues.redhat.com/browse/ISPN-15068