### PR TITLE
Fix deploy without compiling sources

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -160,7 +160,7 @@ pipeline {
             steps {
                 script {
                     if (!env.BRANCH_NAME.startsWith('PR-')) {
-                        sh "$MAVEN_HOME/bin/mvn deploy -B -V -e -Pdistribution -Pcommunity-release -DdeployServerZip=true -Dmaven.main.skip=true -Dmaven.test.skip=true"
+                        sh "$MAVEN_HOME/bin/mvn deploy -B -V -e -Pdistribution -Pcommunity-release -DdeployServerZip=true -Dmaven.main.skip=true -Dmaven.test.skip=true -Dcheckstyle.skip=true"
                     }
                 }
             }

--- a/build/configuration/pom.xml
+++ b/build/configuration/pom.xml
@@ -339,6 +339,7 @@
                   <configuration>
                      <skip>${maven.javadoc.skip}</skip>
                      <detectOfflineLinks>false</detectOfflineLinks>
+                     <sourcepath>src/main/java:target/generated-sources</sourcepath>
                   </configuration>
                </plugin>
                <plugin>


### PR DESCRIPTION
* maven-javadoc-plugin is unable to find "target/generated-sources" when maven.main.skip is true
* test jars are not deployed because of maven.test.skip is interpreted by  maven-jar-plugin