### PR TITLE
Fix javadoc that TransportConfigurationBuilder does not use object instance

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/global/TransportConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/global/TransportConfigurationBuilder.java
@@ -138,10 +138,6 @@ public class TransportConfigurationBuilder extends AbstractGlobalConfigurationBu
     * Class that represents a network transport. Must implement
     * org.infinispan.remoting.transport.Transport
     *
-    * NOTE: Currently Infinispan will not use the object instance, but instead instantiate a new
-    * instance of the class. Therefore, do not expect any state to survive, and provide a no-args
-    * constructor to any instance.
-    *
     * @param transport transport instance
     */
    public TransportConfigurationBuilder transport(Transport transport) {


### PR DESCRIPTION
Fix javadoc that TransportConfigurationBuilder does not use object instance