### PR TITLE
ISPN-14566 Implement RESP access logging

### DIFF
--- a/server/resp/src/main/java/org/infinispan/server/resp/CacheRespRequestHandler.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/CacheRespRequestHandler.java
@@ -4,11 +4,10 @@ import org.infinispan.AdvancedCache;
 import org.infinispan.commons.dataconversion.MediaType;
 
 public class CacheRespRequestHandler extends RespRequestHandler {
-   protected final RespServer respServer;
    protected AdvancedCache<byte[], byte[]> cache;
 
    protected CacheRespRequestHandler(RespServer respServer) {
-      this.respServer = respServer;
+      super(respServer);
       setCache(respServer.getCache()
             .withMediaType(MediaType.APPLICATION_OCTET_STREAM, MediaType.APPLICATION_OCTET_STREAM));
    }
@@ -19,9 +18,5 @@ public class CacheRespRequestHandler extends RespRequestHandler {
 
    protected void setCache(AdvancedCache<byte[], byte[]> cache) {
       this.cache = cache;
-   }
-
-   public RespServer respServer() {
-      return respServer;
    }
 }

--- a/server/resp/src/main/java/org/infinispan/server/resp/RespRequestHandler.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/RespRequestHandler.java
@@ -16,10 +16,15 @@ import io.netty.util.AttributeKey;
 
 public abstract class RespRequestHandler {
    protected final CompletionStage<RespRequestHandler> myStage = CompletableFuture.completedFuture(this);
+   protected final RespServer respServer;
 
    public static final AttributeKey<ByteBufPool> BYTE_BUF_POOL_ATTRIBUTE_KEY = AttributeKey.newInstance("buffer-pool");
 
    ByteBufPool allocatorToUse;
+
+   protected RespRequestHandler(RespServer server) {
+      this.respServer = server;
+   }
 
    protected void initializeIfNecessary(ChannelHandlerContext ctx) {
       if (allocatorToUse == null) {
@@ -28,6 +33,10 @@ public abstract class RespRequestHandler {
          }
          allocatorToUse = ctx.channel().attr(BYTE_BUF_POOL_ATTRIBUTE_KEY).get();
       }
+   }
+
+   public RespServer respServer() {
+      return respServer;
    }
 
    public CompletionStage<RespRequestHandler> myStage() {

--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/string/MSET.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/string/MSET.java
@@ -25,7 +25,7 @@ public class MSET extends RespCommand implements Resp3Command {
    private static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass(), Log.class);
 
    public MSET() {
-      super(-3, 1, 1, 2);
+      super(-3, 1, -1, 2);
    }
 
    @Override

--- a/server/resp/src/main/java/org/infinispan/server/resp/logging/AccessData.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/logging/AccessData.java
@@ -1,0 +1,86 @@
+package org.infinispan.server.resp.logging;
+
+import java.time.temporal.Temporal;
+
+import org.infinispan.security.Security;
+import org.infinispan.server.core.transport.ConnectionMetadata;
+import org.infinispan.server.resp.RespCommand;
+
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import net.jcip.annotations.Immutable;
+
+/**
+ * Access data from a single request.
+ * <p>
+ * Maintain the information about one request, start and finishing times, affected keys, request and response size,
+ * and failure cause, if any. All the data collected is final, only pending a flush to the access log.
+ * <p>
+ * When access logging is enabled, each request instantiates a new object.
+ */
+@Immutable
+public class AccessData {
+   private final Temporal start;
+   private final byte[][] keys;
+   private final int requestBytes;
+   private final int responseBytes;
+   private final String principalName;
+   private final String operation;
+   private final Throwable throwable;
+
+   private AccessData(Temporal start,
+                      byte[][] keys,
+                      int requestBytes,
+                      int responseBytes,
+                      String principalName,
+                      String operation,
+                      Throwable throwable) {
+      this.start = start;
+      this.keys = keys;
+      this.requestBytes = requestBytes;
+      this.responseBytes = responseBytes;
+      this.principalName = principalName;
+      this.operation = operation;
+      this.throwable = throwable;
+   }
+
+   static AccessData create(ChannelHandlerContext ctx, RespCommand req, Temporal start, byte[][] keys,
+                            int requestBytes, int responseBytes, Throwable throwable) {
+      ConnectionMetadata metadata = ConnectionMetadata.getInstance(ctx.channel());
+      String principalName = Security.getSubjectUserPrincipalName(metadata.subject());
+
+      return new AccessData(start, keys, requestBytes, responseBytes, principalName, req.getName(), throwable);
+   }
+
+   public void log(ChannelFuture future) {
+      if (throwable == null) {
+         RespAccessLogger.success(future, this);
+      } else {
+         RespAccessLogger.failure(future, this, throwable);
+      }
+   }
+
+   public Temporal start() {
+      return start;
+   }
+
+   public byte[][] keys() {
+      return keys;
+   }
+
+   public int requestBytes() {
+      return requestBytes;
+   }
+
+   public int responseBytes() {
+      return responseBytes;
+   }
+
+   public String principalName() {
+      return principalName;
+   }
+
+   public String operation() {
+      return operation;
+   }
+}

--- a/server/resp/src/main/java/org/infinispan/server/resp/logging/AccessLoggerManager.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/logging/AccessLoggerManager.java
@@ -1,0 +1,130 @@
+package org.infinispan.server.resp.logging;
+
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.function.IntConsumer;
+
+import org.infinispan.commons.time.TimeService;
+import org.infinispan.server.resp.RespCommand;
+import org.infinispan.util.concurrent.CompletionStages;
+
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelProgressiveFuture;
+import io.netty.channel.ChannelProgressiveFutureListener;
+import io.netty.channel.ChannelProgressivePromise;
+
+/**
+ * Handle the access log.
+ * <p>
+ * Keeps track of pending operations and pushes them to the access log. Some operations are not flushed directly
+ * because of the pipelining, so the manager keeps them with {@link ChannelProgressivePromise}. Once the buffer is
+ * flushed, the {@link ChannelProgressivePromise} advances the indexes and flushes the pending operations to the
+ * access log.
+ * <p>
+ * The manager tracks data of only one active operation at a time. The current active operation is then flushed or
+ * registered to do so later. This approach fits with the way we handle the commands on the
+ * {@link org.infinispan.server.resp.RespHandler}.
+ * <p>
+ * <b>Thread safety</b>: This implementation is <b>not</b> thread-safe. It assumes all invocations come from the same
+ * thread to track, register, and flush operations.
+ *
+ * @since 15.0
+ */
+public class AccessLoggerManager implements IntConsumer {
+   private final ChannelProgressivePromise promise;
+   private final Tracker tracker;
+   private long start;
+   private long end;
+
+   public AccessLoggerManager(ChannelHandlerContext ctx, TimeService timeService) {
+      this.promise = ctx.newProgressivePromise();
+      this.tracker = new Tracker(ctx, timeService);
+   }
+
+   public void track(RespCommand req, List<byte[]> arguments) {
+      // Unknown command.
+      if (req == null) return;
+
+      tracker.track(req, arguments);
+   }
+
+   public void flush(ChannelHandlerContext ctx, ChannelFuture future, CompletionStage<?> pending) {
+      assert ctx.channel().eventLoop().inEventLoop() : "Flush must happen from event loop";
+
+      if (end > start) {
+         final long s = start;
+         final long e = end;
+         future.addListener(ignore -> {
+            promise.tryProgress(s, e);
+         });
+         start = end;
+      }
+
+      if (pending != null) logCompleted(future, pending);
+   }
+
+   public void register(CompletionStage<?> res) {
+      if (CompletionStages.isCompletedSuccessfully(res)) {
+         registerFinishedOperation(null);
+         return;
+      }
+
+      res.whenComplete((ignore, t) -> registerFinishedOperation(t));
+   }
+
+   public void close() {
+      promise.setSuccess();
+   }
+
+   private void logCompleted(ChannelFuture future, CompletionStage<?> pending) {
+      if (CompletionStages.isCompletedSuccessfully(pending)) {
+         AccessData data = tracker.done(null);
+         if (data != null) data.log(future);
+         return;
+      }
+
+      pending.whenComplete((ignore, t) -> {
+         AccessData data = tracker.done(t);
+         if (data != null) data.log(future);
+      });
+   }
+
+   private void registerFinishedOperation(Throwable t) {
+      AccessData data = tracker.done(t);
+
+      if (data == null)
+         throw new IllegalStateException("No operation tracked!");
+
+      promise.addListener(new LogProgressiveListener(data, end++));
+   }
+
+   @Override
+   public void accept(int value) {
+      // Bytes requested to buffer allocator.
+      tracker.increaseBytesRequested(value);
+   }
+
+   private static class LogProgressiveListener implements ChannelProgressiveFutureListener {
+      private final AccessData data;
+      private final long offset;
+
+      private LogProgressiveListener(AccessData data, long offset) {
+         this.data = data;
+         this.offset = offset;
+      }
+
+      @Override
+      public void operationProgressed(ChannelProgressiveFuture future, long progress, long total) {
+         if (offset >= progress && offset <= total) {
+            data.log(future.channel().newSucceededFuture());
+            future.removeListener(this);
+         }
+      }
+
+      @Override
+      public void operationComplete(ChannelProgressiveFuture future) {
+         data.log(future);
+      }
+   }
+}

--- a/server/resp/src/main/java/org/infinispan/server/resp/logging/RespAccessLogger.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/logging/RespAccessLogger.java
@@ -1,0 +1,81 @@
+package org.infinispan.server.resp.logging;
+
+import java.net.InetSocketAddress;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import org.infinispan.commons.util.Util;
+import org.infinispan.util.logging.LogFactory;
+import org.jboss.logging.Logger;
+import org.jboss.logging.MDC;
+
+import io.netty.channel.ChannelFuture;
+
+public class RespAccessLogger {
+
+   public final static Logger log = LogFactory.getLogger("RESP_ACCESS_LOG");
+
+   public static boolean isEnabled() {
+      return log.isTraceEnabled();
+   }
+
+   static void success(ChannelFuture future, AccessData data) {
+      log(future, data, "OK");
+   }
+
+   static void failure(ChannelFuture future, AccessData data, Throwable throwable) {
+      log(future, data, throwable.getMessage());
+   }
+
+   private static void log(ChannelFuture future, AccessData data, String status) {
+      String remoteAddress = ((InetSocketAddress) future.channel().remoteAddress()).getHostString();
+      if (future.isDone()) {
+         log(remoteAddress, data, status);
+         return;
+      }
+      future.addListener(f -> log(remoteAddress, data, status));
+   }
+
+   private static void log(String remoteAddress, AccessData data, String status) {
+      long duration;
+      if (data.start() == null) {
+         duration = -1;
+      } else {
+         duration = ChronoUnit.MILLIS.between(data.start(), Instant.now());
+      }
+
+      MDC.clear();
+      MDC.put("address", remoteAddress);
+      MDC.put("user", parameter(data.principalName()));
+      MDC.put("method", parameter(data.operation()));
+      MDC.put("protocol", "RESP");
+      MDC.put("status", parameter(status));
+      MDC.put("responseSize", data.responseBytes());
+      MDC.put("requestSize", data.requestBytes());
+      MDC.put("duration", duration);
+      log.tracef("/%s", parameter(data.keys()));
+   }
+
+   private static String parameter(Object obj) {
+      if (obj == null || obj instanceof String && ((String) obj).isEmpty()) {
+         return "-";
+      }
+
+      if (obj instanceof byte[]) {
+         return Util.printArray((byte[]) obj);
+      }
+
+      if (obj instanceof byte[][]) {
+         boolean wrote = false;
+         StringBuilder builder = new StringBuilder("[");
+         for (byte[] b : (byte[][]) obj) {
+            wrote = true;
+            builder.append(Util.printArray(b)).append(",");
+         }
+         if (wrote) builder.deleteCharAt(builder.length() - 1);
+         return builder.append("]").toString();
+      }
+
+      return obj.toString();
+   }
+}

--- a/server/resp/src/main/java/org/infinispan/server/resp/logging/Tracker.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/logging/Tracker.java
@@ -1,0 +1,77 @@
+package org.infinispan.server.resp.logging;
+
+import java.time.temporal.Temporal;
+import java.util.List;
+
+import org.infinispan.commons.time.TimeService;
+import org.infinispan.server.resp.RespCommand;
+
+import io.netty.channel.ChannelHandlerContext;
+
+/**
+ * Tracker for a single command.
+ * <p>
+ * One instance tracks one request at a time. One instance can be reutilized indefinitely for subsequent requests within
+ * the same {@link ChannelHandlerContext} but never for interleaving requests.
+ * <p>
+ * A request starts with a call to {@link #track(RespCommand, List)}, storing data about time, request size, and
+ * affected keys. The tracker is updated when the {@link org.infinispan.server.resp.ByteBufPool} needs to allocate more
+ * bytes for a response. The request stops tracking on the {@link #done(Throwable)}, generating an instance of
+ * {@link AccessData}.
+ * <p>
+ *
+ */
+public class Tracker {
+   private final TimeService timeService;
+   private final ChannelHandlerContext ctx;
+   private byte[][] keys;
+   private Temporal start;
+   private int bytesRequested;
+   private int requestSize;
+   private RespCommand req;
+
+   public Tracker(ChannelHandlerContext ctx, TimeService timeService) {
+      this.timeService = timeService;
+      this.ctx = ctx;
+   }
+
+   /**
+    * Starts tracking the request.
+    * <p>
+    * Only one request is tracked at a time. If this method is called while another request is being tracked, an
+    * {@link IllegalStateException} is thrown.
+    *
+    * @param req: The current request to track.
+    * @param arguments: The request arguments.
+    * @throws IllegalStateException if another request is being tracked.
+    */
+   public void track(RespCommand req, List<byte[]> arguments) {
+      if (start != null) throw new IllegalStateException("Interleaving command not allowed!");
+
+      start = timeService.instant();
+      bytesRequested = 0;
+      keys = req.extractKeys(arguments);
+      requestSize = req.size(arguments);
+      this.req = req;
+   }
+
+   public void increaseBytesRequested(int bytes) {
+      bytesRequested += bytes;
+   }
+
+   /**
+    * Stops tracking the request.
+    * <p>
+    * If this method is called while no request is being tracked, {@code null} is returned.
+    *
+    * @param throwable: If the request failed, the exception that caused the failure.
+    * @return An instance of {@link AccessData} if a request was being tracked, {@code null} otherwise.
+    */
+   public AccessData done(Throwable throwable) {
+      if (start == null) return null;
+
+      AccessData ad = AccessData.create(ctx, req, start, keys, requestSize, bytesRequested, throwable);
+      start = null;
+      return ad;
+   }
+}

--- a/server/resp/src/test/java/org/infinispan/server/resp/RespDecoderTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/RespDecoderTest.java
@@ -46,7 +46,7 @@ public class RespDecoderTest {
    @BeforeClass
    public void beforeClass() {
       queuedCommands = new ArrayDeque<>();
-      RespRequestHandler myRespRequestHandler = new RespRequestHandler() {
+      RespRequestHandler myRespRequestHandler = new RespRequestHandler(null) {
          @Override
          protected CompletionStage<RespRequestHandler> actualHandleRequest(ChannelHandlerContext ctx, RespCommand type, List<byte[]> arguments) {
             queuedCommands.add(new Request(type, arguments));

--- a/server/resp/src/test/java/org/infinispan/server/resp/logging/RespAccessLoggingTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/logging/RespAccessLoggingTest.java
@@ -1,0 +1,83 @@
+package org.infinispan.server.resp.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+import org.infinispan.commons.test.TestResourceTracker;
+import org.infinispan.commons.test.skip.StringLogAppender;
+import org.infinispan.server.resp.SingleNodeRespBaseTest;
+import org.testng.annotations.Test;
+
+import io.lettuce.core.api.sync.RedisCommands;
+
+@Test(groups = "functional", testName = "server.resp.logging.RespAccessLoggingTest")
+public class RespAccessLoggingTest extends SingleNodeRespBaseTest {
+
+   public static final String LOG_FORMAT = "%X{address} %X{user} [%d{dd/MMM/yyyy:HH:mm:ss Z}] \"%X{method} %m %X{protocol}\" %X{status} %X{requestSize} %X{responseSize} %X{duration}";
+   StringLogAppender logAppender;
+   private String testShortName;
+
+   @Override
+   protected void setup() throws Exception {
+      testShortName = TestResourceTracker.getCurrentTestShortName();
+
+      logAppender = new StringLogAppender(RespAccessLogger.log.getName(),
+            Level.TRACE,
+            t -> t.getName().startsWith("non-blocking-thread-" + testShortName),
+            PatternLayout.newBuilder().withPattern(LOG_FORMAT).build());
+      logAppender.install();
+      assertThat(RespAccessLogger.isEnabled()).isTrue();
+      super.setup();
+   }
+
+   @Override
+   protected void teardown() {
+      logAppender.uninstall();
+      super.teardown();
+   }
+
+   @Test
+   public void testAccessLogg() {
+      int size = 10;
+      RedisCommands<String, String> redis = redisConnection.sync();
+
+      for (int i = 0; i < size; i ++) {
+         redis.set("key" + i, "value" + i);
+      }
+
+      // INFO has a big response.
+      redis.info();
+
+      // MGET uses multiple keys.
+      redis.mget("key1", "key2", "key3");
+
+      // MSET uses multiple keys with values.
+      redis.mset(Map.of("k1", "v1", "k2", "v2", "k3", "v3"));
+
+      server.getTransport().stop();
+
+      assertThat(logAppender.getLog(0))
+            .matches("^127\\.0\\.0\\.1 - \\[\\d+/\\w+/\\d+:\\d+:\\d+:\\d+ [+-]?\\d*] \"HELLO /\\[] RESP\" OK \\d+ \\d+ \\d+$");
+
+      for (int i = 1; i <= size; i ++) {
+         String logLine = logAppender.getLog(i);
+         assertThat(logLine)
+               .matches("^127\\.0\\.0\\.1 - \\[\\d+/\\w+/\\d+:\\d+:\\d+:\\d+ [+-]?\\d*] \"SET /\\[\\[B0x\\w+] RESP\" OK \\d+ \\d+ \\d+$");
+      }
+
+      assertThat(logAppender.getLog(size + 1))
+            // INFO writes more than 4K data to the buffer
+            .matches("^127\\.0\\.0\\.1 - \\[\\d+/\\w+/\\d+:\\d+:\\d+:\\d+ [+-]?\\d*] \"INFO /\\[] RESP\" OK \\d+ 4\\d{3} \\d+$");
+
+      assertThat(logAppender.getLog(size + 2))
+            // We invoke MGET with 3 keys.
+            .matches("^127\\.0\\.0\\.1 - \\[\\d+/\\w+/\\d+:\\d+:\\d+:\\d+ [+-]?\\d*] \"MGET /\\[?(\\[B0x\\w+[,\\]]){3} RESP\" OK \\d+ \\d+ \\d+$");
+
+      assertThat(logAppender.getLog(size + 3))
+            // We invoke MSET with 3 keys.
+            .matches("^127\\.0\\.0\\.1 - \\[\\d+/\\w+/\\d+:\\d+:\\d+:\\d+ [+-]?\\d*] \"MSET /\\[?(\\[B0x\\w+[,\\]]){3} RESP\" OK \\d+ \\d+ \\d+$");
+   }
+}

--- a/server/runtime/src/main/server/server/conf/log4j2.xml
+++ b/server/runtime/src/main/server/server/conf/log4j2.xml
@@ -75,6 +75,16 @@
       </Policies>
       <PatternLayout pattern="${accessLogPattern}"/>
     </RollingFile>
+
+    <!-- Rolling RESP access log, disabled by default -->
+    <RollingFile name="RESP-ACCESS-FILE" createOnDemand="true"
+                 fileName="${path}/resp-access.log"
+                 filePattern="${path}/resp-access.log.%i">
+      <Policies>
+        <SizeBasedTriggeringPolicy size="100 MB" />
+      </Policies>
+      <PatternLayout pattern="${accessLogPattern}"/>
+    </RollingFile>
   </Appenders>
 
   <Loggers>
@@ -112,6 +122,11 @@
     <!-- Set to TRACE to enable access logging for Memcached requests -->
     <Logger name="org.infinispan.MEMCACHED_ACCESS_LOG" additivity="false" level="INFO">
       <AppenderRef ref="MEMCACHED-ACCESS-FILE"/>
+    </Logger>
+
+    <!-- Set to TRACE to enable access logging for RESP requests -->
+    <Logger name="org.infinispan.RESP_ACCESS_LOG" additivity="false" level="INFO">
+      <AppenderRef ref="RESP-ACCESS-FILE"/>
     </Logger>
   </Loggers>
 </Configuration>


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-14566

I wanted to get this one out of the way already.

Running with memtier to compare the main and this branch with the access log disabled, the performance holds. A small snippet from the log:

```text
127.0.0.1 admin [25/Aug/2023:11:49:08 -0300] "GET /[[B0x6D656D746965722D393939] RESP" OK 27 9009 0
127.0.0.1 admin [25/Aug/2023:11:49:08 -0300] "SET /[[B0x6D656D746965722D343235] RESP" OK 9030 5 0
127.0.0.1 admin [25/Aug/2023:11:49:08 -0300] "GET /[[B0x6D656D746965722D343135] RESP" OK 27 5 0
```

GET with a hit, SET, and GET with a miss. Memtier is running with a 9K data size.

I think the time interval at the end is small and goes to 0.