### PR TITLE
ISPN-15143 Utilise Junit5 TestNG engine to run tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -133,13 +133,14 @@ pipeline {
 
         stage('Tests') {
             steps {
-                sh "$MAVEN_HOME/bin/mvn verify -B -V -e -Dmaven.test.failure.ignore=true -Dansi.strip=true -Pnative $ALT_TEST_BUILD"
-
+                sh "$MAVEN_HOME/bin/mvn verify -B -V -e -DrerunFailingTestsCount=2 -Dmaven.test.failure.ignore=true -Dansi.strip=true -Pnative $ALT_TEST_BUILD"
+                // Remove any default TestNG report files as this will result in tests being counted twice by Jenkins statistics
+                sh "rm -rf **/target/*-reports*/**/TEST-TestSuite.xml"
                 // TODO Add StabilityTestDataPublisher after https://issues.jenkins-ci.org/browse/JENKINS-42610 is fixed
                 // Capture target/surefire-reports/*.xml, target/failsafe-reports/*.xml,
                 // target/failsafe-reports-embedded/*.xml, target/failsafe-reports-remote/*.xml
                 junit testResults: '**/target/*-reports*/**/TEST-*.xml',
-                    testDataPublishers: [[$class: 'ClaimTestDataPublisher']],
+                    testDataPublishers: [[$class: 'ClaimTestDataPublisher'],[$class: 'JUnitFlakyTestDataPublisher']],
                     healthScaleFactor: 100, allowEmptyResults: true
 
                 // Workaround for SUREFIRE-1426: Fail the build if there a fork crashed

--- a/anchored-keys/pom.xml
+++ b/anchored-keys/pom.xml
@@ -75,8 +75,18 @@
             <artifactId>metainf-services</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
+            <groupId>org.junit.support</groupId>
+            <artifactId>testng-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/archetypes/pom.xml
+++ b/archetypes/pom.xml
@@ -27,8 +27,20 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
+            <groupId>org.junit.support</groupId>
+            <artifactId>testng-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/build/configuration/pom.xml
+++ b/build/configuration/pom.xml
@@ -195,6 +195,7 @@
       <version.rocksdb>7.1.2</version.rocksdb>
       <version.rxjava>3.1.4</version.rxjava>
       <version.sshd>2.10.0</version.sshd>
+      <version.testng.engine>1.0.4</version.testng.engine>
 
       <!-- these versions must be kept in sync with ${version.micrometer}: -->
       <version.io.prometheus>0.15.0</version.io.prometheus>

--- a/cdi/embedded/pom.xml
+++ b/cdi/embedded/pom.xml
@@ -92,6 +92,10 @@
                     <forkCount>1</forkCount>
                     <parallel>none</parallel>
                     <groups>${defaultTestGroup}</groups>
+                    <properties>
+                        <usedefaultlisteners>false</usedefaultlisteners>
+                        <listener>${testNGListeners}</listener>
+                    </properties>
                    <dependenciesToScan>
                       <!-- TestNGSuiteChecksTest -->
                       <dependency>org.infinispan:infinispan-commons-test</dependency>

--- a/cdi/remote/pom.xml
+++ b/cdi/remote/pom.xml
@@ -112,6 +112,10 @@
                     <forkCount>1</forkCount>
                     <parallel>none</parallel>
                     <groups>${defaultTestGroup}</groups>
+                    <properties>
+                        <usedefaultlisteners>false</usedefaultlisteners>
+                        <listener>${testNGListeners}</listener>
+                    </properties>
                    <dependenciesToScan>
                       <dependency>org.infinispan:infinispan-commons-test</dependency>
                    </dependenciesToScan>

--- a/client/hotrod-client/pom.xml
+++ b/client/hotrod-client/pom.xml
@@ -225,8 +225,20 @@
       </dependency>
 
       <dependency>
-         <groupId>org.testng</groupId>
-         <artifactId>testng</artifactId>
+         <groupId>org.junit.support</groupId>
+         <artifactId>testng-engine</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-api</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-engine</artifactId>
          <scope>test</scope>
       </dependency>
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/BaseIterationFailOverTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/BaseIterationFailOverTest.java
@@ -1,5 +1,8 @@
 package org.infinispan.client.hotrod.impl.iteration;
 
+import static org.infinispan.client.hotrod.impl.iteration.Util.extractKeys;
+import static org.infinispan.client.hotrod.impl.iteration.Util.populateCache;
+import static org.infinispan.client.hotrod.impl.iteration.Util.rangeAsSet;
 import static org.testng.AssertJUnit.assertEquals;
 
 import java.util.ArrayList;
@@ -21,7 +24,7 @@ import org.testng.annotations.Test;
  * @author gustavonalle
  * @since 8.0
  */
-public abstract class BaseIterationFailOverTest extends MultiHotRodServersTest implements AbstractRemoteIteratorTest {
+public abstract class BaseIterationFailOverTest extends MultiHotRodServersTest {
 
    protected final int SERVERS = 3;
 
@@ -48,7 +51,7 @@ public abstract class BaseIterationFailOverTest extends MultiHotRodServersTest i
       int cacheSize = 1_000;
       int batch = 17;
       RemoteCache<Integer, AccountHS> cache = clients.get(0).getCache();
-      populateCache(cacheSize, this::newAccount, cache);
+      populateCache(cacheSize, Util::newAccount, cache);
 
       List<Map.Entry<Object, Object>> entries = new ArrayList<>();
       CloseableIterator<Map.Entry<Object, Object>> iterator = cache.retrieveEntries(null, null, batch);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/BaseMultiServerRemoteIteratorTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/BaseMultiServerRemoteIteratorTest.java
@@ -1,5 +1,15 @@
 package org.infinispan.client.hotrod.impl.iteration;
 
+import static org.infinispan.client.hotrod.impl.iteration.Util.assertForAll;
+import static org.infinispan.client.hotrod.impl.iteration.Util.assertKeysInSegment;
+import static org.infinispan.client.hotrod.impl.iteration.Util.extractEntries;
+import static org.infinispan.client.hotrod.impl.iteration.Util.extractKeys;
+import static org.infinispan.client.hotrod.impl.iteration.Util.extractValues;
+import static org.infinispan.client.hotrod.impl.iteration.Util.newAccount;
+import static org.infinispan.client.hotrod.impl.iteration.Util.populateCache;
+import static org.infinispan.client.hotrod.impl.iteration.Util.rangeAsSet;
+import static org.infinispan.client.hotrod.impl.iteration.Util.setOf;
+import static org.infinispan.client.hotrod.impl.iteration.Util.toByteBuffer;
 import static org.testng.Assert.assertTrue;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
@@ -45,7 +55,7 @@ import org.testng.annotations.Test;
  * @since 8.0
  */
 @Test(groups = "functional")
-public abstract class BaseMultiServerRemoteIteratorTest extends MultiHotRodServersTest implements AbstractRemoteIteratorTest {
+public abstract class BaseMultiServerRemoteIteratorTest extends MultiHotRodServersTest {
 
    public static final int CACHE_SIZE = 20;
 
@@ -70,7 +80,7 @@ public abstract class BaseMultiServerRemoteIteratorTest extends MultiHotRodServe
       int maximumBatchSize = 120;
       RemoteCache<Integer, AccountHS> cache = clients.get(0).getCache();
 
-      populateCache(CACHE_SIZE, this::newAccount, cache);
+      populateCache(CACHE_SIZE, org.infinispan.client.hotrod.impl.iteration.Util::newAccount, cache);
       Set<Integer> expectedKeys = rangeAsSet(0, CACHE_SIZE);
 
       for (int batch = 1; batch < maximumBatchSize; batch += 10) {
@@ -134,7 +144,7 @@ public abstract class BaseMultiServerRemoteIteratorTest extends MultiHotRodServe
    @Test
    public void testFilterBySegment() {
       RemoteCache<Integer, AccountHS> cache = clients.get(0).getCache();
-      populateCache(CACHE_SIZE, this::newAccount, cache);
+      populateCache(CACHE_SIZE, org.infinispan.client.hotrod.impl.iteration.Util::newAccount, cache);
 
       CacheTopologyInfo cacheTopologyInfo = cache.getCacheTopologyInfo();
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/MultiServerDistRemoteIteratorTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/MultiServerDistRemoteIteratorTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.client.hotrod.impl.iteration;
 
+import static org.infinispan.client.hotrod.impl.iteration.Util.populateCache;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
 import static org.testng.AssertJUnit.assertEquals;
 
@@ -69,7 +70,7 @@ public class MultiServerDistRemoteIteratorTest extends BaseMultiServerRemoteIter
 
    public void testSegmentFinishedCallback() {
       RemoteCache<Integer, AccountHS> cache = clients.get(0).getCache();
-      populateCache(CACHE_SIZE, this::newAccount, cache);
+      populateCache(CACHE_SIZE, Util::newAccount, cache);
       TestSegmentKeyTracker testSegmentKeyTracker = new TestSegmentKeyTracker();
 
       Publisher<Map.Entry<Integer, AccountHS>> publisher = cache.publishEntries(null, null, null, 3);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/MultiServerObjectStoreTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/MultiServerObjectStoreTest.java
@@ -1,5 +1,7 @@
 package org.infinispan.client.hotrod.impl.iteration;
 
+import static org.infinispan.client.hotrod.impl.iteration.Util.extractEntries;
+import static org.infinispan.client.hotrod.impl.iteration.Util.populateCache;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
 import static org.testng.AssertJUnit.assertEquals;
 
@@ -14,7 +16,7 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.testng.annotations.Test;
 
 @Test(groups = "functional", testName = "client.hotrod.iteration.MultiServerObjectStoreTest")
-public class MultiServerObjectStoreTest extends MultiHotRodServersTest implements AbstractRemoteIteratorTest {
+public class MultiServerObjectStoreTest extends MultiHotRodServersTest {
 
    private static final int NUM_SERVERS = 2;
    private static final int CACHE_SIZE = 10;

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/ProtobufRemoteIteratorIndexingTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/ProtobufRemoteIteratorIndexingTest.java
@@ -1,5 +1,9 @@
 package org.infinispan.client.hotrod.impl.iteration;
 
+import static org.infinispan.client.hotrod.impl.iteration.Util.assertForAll;
+import static org.infinispan.client.hotrod.impl.iteration.Util.extractEntries;
+import static org.infinispan.client.hotrod.impl.iteration.Util.extractKeys;
+import static org.infinispan.client.hotrod.impl.iteration.Util.populateCache;
 import static org.infinispan.configuration.cache.IndexStorage.LOCAL_HEAP;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
 import static org.testng.Assert.assertEquals;
@@ -26,7 +30,7 @@ import org.testng.annotations.Test;
  * @since 9.1
  */
 @Test(groups = "functional", testName = "client.hotrod.iteration.ProtobufRemoteIteratorIndexingTest")
-public class ProtobufRemoteIteratorIndexingTest extends MultiHotRodServersTest implements AbstractRemoteIteratorTest {
+public class ProtobufRemoteIteratorIndexingTest extends MultiHotRodServersTest {
 
    private static final int NUM_NODES = 2;
    private static final int CACHE_SIZE = 10;
@@ -49,7 +53,7 @@ public class ProtobufRemoteIteratorIndexingTest extends MultiHotRodServersTest i
    public void testSimpleIteration() {
       RemoteCache<Integer, AccountPB> cache = clients.get(0).getCache();
 
-      populateCache(CACHE_SIZE, this::newAccountPB, cache);
+      populateCache(CACHE_SIZE, Util::newAccountPB, cache);
 
       List<AccountPB> results = new ArrayList<>();
       cache.retrieveEntries(null, null, CACHE_SIZE).forEachRemaining(e -> results.add((AccountPB) e.getValue()));
@@ -59,7 +63,7 @@ public class ProtobufRemoteIteratorIndexingTest extends MultiHotRodServersTest i
 
    public void testFilteredIterationWithQuery() {
       RemoteCache<Integer, AccountPB> remoteCache = clients.get(0).getCache();
-      populateCache(CACHE_SIZE, this::newAccountPB, remoteCache);
+      populateCache(CACHE_SIZE, Util::newAccountPB, remoteCache);
       QueryFactory queryFactory = Search.getQueryFactory(remoteCache);
 
       int lowerId = 5;

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/ProtobufRemoteIteratorTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/ProtobufRemoteIteratorTest.java
@@ -1,5 +1,12 @@
 package org.infinispan.client.hotrod.impl.iteration;
 
+import static org.infinispan.client.hotrod.impl.iteration.Util.assertForAll;
+import static org.infinispan.client.hotrod.impl.iteration.Util.assertKeysInSegment;
+import static org.infinispan.client.hotrod.impl.iteration.Util.extractEntries;
+import static org.infinispan.client.hotrod.impl.iteration.Util.extractKeys;
+import static org.infinispan.client.hotrod.impl.iteration.Util.extractValues;
+import static org.infinispan.client.hotrod.impl.iteration.Util.populateCache;
+import static org.infinispan.client.hotrod.impl.iteration.Util.rangeAsSet;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
 import static org.testng.Assert.assertEquals;
 
@@ -35,7 +42,7 @@ import org.testng.annotations.Test;
  * @since 8.0
  */
 @Test(groups = "functional", testName = "client.hotrod.iteration.ProtobufRemoteIteratorTest")
-public class ProtobufRemoteIteratorTest extends MultiHotRodServersTest implements AbstractRemoteIteratorTest {
+public class ProtobufRemoteIteratorTest extends MultiHotRodServersTest {
 
    private static final int NUM_NODES = 2;
    private static final int CACHE_SIZE = 10;
@@ -57,7 +64,7 @@ public class ProtobufRemoteIteratorTest extends MultiHotRodServersTest implement
    public void testSimpleIteration() {
       RemoteCache<Integer, AccountPB> cache = clients.get(0).getCache();
 
-      populateCache(CACHE_SIZE, this::newAccountPB, cache);
+      populateCache(CACHE_SIZE, Util::newAccountPB, cache);
 
       List<AccountPB> results = new ArrayList<>();
       cache.retrieveEntries(null, null, CACHE_SIZE).forEachRemaining(e -> results.add((AccountPB) e.getValue()));
@@ -84,7 +91,7 @@ public class ProtobufRemoteIteratorTest extends MultiHotRodServersTest implement
 
       RemoteCache<Integer, AccountPB> cache = clients.get(0).getCache();
 
-      populateCache(CACHE_SIZE, this::newAccountPB, cache);
+      populateCache(CACHE_SIZE, Util::newAccountPB, cache);
 
       Set<Integer> segments = rangeAsSet(1, 30);
       Set<Entry<Object, Object>> results = new HashSet<>();
@@ -101,7 +108,7 @@ public class ProtobufRemoteIteratorTest extends MultiHotRodServersTest implement
 
    public void testFilteredIterationWithQuery() {
       RemoteCache<Integer, AccountPB> remoteCache = clients.get(0).getCache();
-      populateCache(CACHE_SIZE, this::newAccountPB, remoteCache);
+      populateCache(CACHE_SIZE, Util::newAccountPB, remoteCache);
       QueryFactory queryFactory = Search.getQueryFactory(remoteCache);
 
       int lowerId = 5;

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/SegmentFilteredFailOverTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/SegmentFilteredFailOverTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.client.hotrod.impl.iteration;
 
+import static org.infinispan.client.hotrod.impl.iteration.Util.populateCache;
 import static org.testng.Assert.assertEquals;
 
 import java.util.Map.Entry;
@@ -25,7 +26,7 @@ public class SegmentFilteredFailOverTest extends DistFailOverRemoteIteratorTest 
    @Override
    public void testFailOver() throws InterruptedException {
       RemoteCache<Integer, AccountHS> remoteCache = clients.get(0).getCache();
-      populateCache(ENTRIES, this::newAccount, remoteCache);
+      populateCache(ENTRIES, Util::newAccount, remoteCache);
 
       Cache<Object, Object> cache = caches().get(0);
       int totalSegments = cache.getCacheConfiguration().clustering().hash().numSegments();

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/SingleServerRemoteIteratorTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/SingleServerRemoteIteratorTest.java
@@ -1,5 +1,11 @@
 package org.infinispan.client.hotrod.impl.iteration;
 
+import static org.infinispan.client.hotrod.impl.iteration.Util.assertForAll;
+import static org.infinispan.client.hotrod.impl.iteration.Util.extractKeys;
+import static org.infinispan.client.hotrod.impl.iteration.Util.extractValues;
+import static org.infinispan.client.hotrod.impl.iteration.Util.populateCache;
+import static org.infinispan.client.hotrod.impl.iteration.Util.rangeAsSet;
+import static org.infinispan.client.hotrod.impl.iteration.Util.setOf;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
 import static org.testng.Assert.assertFalse;
 import static org.testng.AssertJUnit.assertEquals;
@@ -31,7 +37,7 @@ import org.testng.annotations.Test;
  * @since 8.0
  */
 @Test(groups = "functional", testName = "client.hotrod.iteration.SingleServerRemoteIteratorTest")
-public class SingleServerRemoteIteratorTest extends SingleHotRodServerTest implements AbstractRemoteIteratorTest {
+public class SingleServerRemoteIteratorTest extends SingleHotRodServerTest {
 
    public static final String FILTER_CONVERTER_FACTORY_NAME = "even-accounts-descriptions";
 
@@ -132,7 +138,7 @@ public class SingleServerRemoteIteratorTest extends SingleHotRodServerTest imple
       RemoteCache<Integer, AccountHS> cache = remoteCacheManager.getCache();
 
       int cacheSize = 50;
-      populateCache(cacheSize, this::newAccount, cache);
+      populateCache(cacheSize, Util::newAccount, cache);
 
       Set<Entry<Object, Object>> entries = new HashSet<>();
 
@@ -165,7 +171,7 @@ public class SingleServerRemoteIteratorTest extends SingleHotRodServerTest imple
       RemoteCache<Integer, AccountHS> cache = remoteCacheManager.getCache();
 
       int cacheSize = 50;
-      populateCache(cacheSize, this::newAccount, cache);
+      populateCache(cacheSize, Util::newAccount, cache);
 
       Set<Entry<Object, Object>> entries = new HashSet<>();
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/Util.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/Util.java
@@ -23,22 +23,21 @@ import org.infinispan.query.dsl.embedded.testdomain.hsearch.AccountHS;
  * @author gfernandes
  * @since 8.0
  */
-@SuppressWarnings("unchecked")
-public interface AbstractRemoteIteratorTest {
+class Util {
 
-   default <T> Set<T> setOf(T... values) {
+   static <T> Set<T> setOf(T... values) {
       return Stream.of(values).collect(Collectors.toSet());
    }
 
-   default <T> void populateCache(int numElements, Function<Integer, T> supplier, RemoteCache<Integer, T> remoteCache) {
+   static <T> void populateCache(int numElements, Function<Integer, T> supplier, RemoteCache<Integer, T> remoteCache) {
       IntStream.range(0, numElements).parallel().forEach(i -> remoteCache.put(i, supplier.apply(i)));
    }
 
-   default <T> void assertForAll(Collection<T> elements, Predicate<? super T> condition) {
+   static <T> void assertForAll(Collection<T> elements, Predicate<? super T> condition) {
       assertTrue(elements.stream().allMatch(condition));
    }
 
-   default AccountHS newAccount(int id) {
+   static AccountHS newAccount(int id) {
       AccountHS account = new AccountHS();
       account.setId(id);
       account.setDescription("description for " + id);
@@ -46,7 +45,7 @@ public interface AbstractRemoteIteratorTest {
       return account;
    }
 
-   default AccountPB newAccountPB(int id) {
+   static AccountPB newAccountPB(int id) {
       AccountPB account = new AccountPB();
       account.setId(id);
       account.setDescription("description for " + id);
@@ -54,26 +53,26 @@ public interface AbstractRemoteIteratorTest {
       return account;
    }
 
-   default Set<Integer> rangeAsSet(int minimum, int maximum) {
+   static Set<Integer> rangeAsSet(int minimum, int maximum) {
       return IntStream.range(minimum, maximum).boxed().collect(Collectors.toSet());
    }
 
-   default <K> Set<K> extractKeys(Collection<Map.Entry<Object, Object>> entries) {
+   static <K> Set<K> extractKeys(Collection<Map.Entry<Object, Object>> entries) {
       return entries.stream().map(e -> (K) e.getKey()).collect(Collectors.toSet());
    }
 
-   default <V> Set<V> extractValues(Collection<Map.Entry<Object, Object>> entries) {
+   static <V> Set<V> extractValues(Collection<Map.Entry<Object, Object>> entries) {
       return entries.stream().map(e -> (V) e.getValue()).collect(Collectors.toSet());
    }
 
-   default byte[] toByteBuffer(Object key, Marshaller marshaller) {
+   static byte[] toByteBuffer(Object key, Marshaller marshaller) {
       try {
          return marshaller.objectToByteBuffer(key);
       } catch (Exception ignored) { }
       return null;
    }
 
-   default void assertKeysInSegment(Set<Map.Entry<Object, Object>> entries, Set<Integer> segments,
+   static void assertKeysInSegment(Set<Map.Entry<Object, Object>> entries, Set<Integer> segments,
                                     Marshaller marshaller, Function<byte[], Integer> segmentCalculator) {
       entries.forEach(e -> {
          Integer key = (Integer) e.getKey();
@@ -82,7 +81,7 @@ public interface AbstractRemoteIteratorTest {
       });
    }
 
-   default <K,V> Set<Map.Entry<K, V>> extractEntries(CloseableIterator<Map.Entry<Object, Object>> iterator) {
+   static <K,V> Set<Map.Entry<K, V>> extractEntries(CloseableIterator<Map.Entry<Object, Object>> iterator) {
       Set<Map.Entry<K, V>> entries = new HashSet<>();
       try {
          while (iterator.hasNext()) {

--- a/client/infinispan-key-value-store-hotrod/pom.xml
+++ b/client/infinispan-key-value-store-hotrod/pom.xml
@@ -35,8 +35,20 @@
 
       <!-- Test dependencies -->
       <dependency>
-         <groupId>org.testng</groupId>
-         <artifactId>testng</artifactId>
+         <groupId>org.junit.support</groupId>
+         <artifactId>testng-engine</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-api</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-engine</artifactId>
          <scope>test</scope>
       </dependency>
 

--- a/cloudevents-integration/pom.xml
+++ b/cloudevents-integration/pom.xml
@@ -88,8 +88,18 @@
          <artifactId>metainf-services</artifactId>
       </dependency>
       <dependency>
-         <groupId>org.testng</groupId>
-         <artifactId>testng</artifactId>
+         <groupId>org.junit.support</groupId>
+         <artifactId>testng-engine</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-api</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-engine</artifactId>
          <scope>test</scope>
       </dependency>
    </dependencies>

--- a/commons-test/pom.xml
+++ b/commons-test/pom.xml
@@ -24,11 +24,13 @@
          <artifactId>jboss-logging</artifactId>
          <scope>provided</scope>
       </dependency>
+
       <dependency>
          <groupId>junit</groupId>
          <artifactId>junit</artifactId>
          <scope>provided</scope>
       </dependency>
+
       <dependency>
          <groupId>org.testng</groupId>
          <artifactId>testng</artifactId>

--- a/commons-test/src/main/java/org/infinispan/commons/test/PolarionJUnitTest.java
+++ b/commons-test/src/main/java/org/infinispan/commons/test/PolarionJUnitTest.java
@@ -1,0 +1,59 @@
+package org.infinispan.commons.test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.testng.ITestResult;
+
+public class PolarionJUnitTest {
+
+   public enum Status {SUCCESS, FLAKY, FAILURE, ERROR, SKIPPED}
+
+   final String name;
+   final String clazz;
+   final List<Throwable> failures = Collections.synchronizedList(new ArrayList<>());
+   final AtomicInteger successes =  new AtomicInteger();
+   final AtomicLong elapsedTime = new AtomicLong();
+
+   volatile Status status = Status.ERROR;
+
+   public PolarionJUnitTest(String name, String clazz) {
+      this(name, clazz, null);
+   }
+
+   public PolarionJUnitTest(String name, String clazz, Throwable t) {
+      this.name = name;
+      this.clazz = clazz;
+      if (t != null) {
+         this.failures.add(t);
+         this.status = Status.FAILURE;
+      }
+   }
+
+   void add(ITestResult tr) {
+      switch (tr.getStatus()) {
+         case ITestResult.SUCCESS:
+            status = failures.isEmpty() ? Status.SUCCESS : Status.FLAKY;
+            successes.incrementAndGet();
+            break;
+         case ITestResult.FAILURE:
+            failures.add(tr.getThrowable());
+            status = Status.FAILURE;
+            break;
+         case ITestResult.SKIP:
+         case ITestResult.SUCCESS_PERCENTAGE_FAILURE:
+            status = Status.SKIPPED;
+            break;
+         default:
+            status = Status.ERROR;
+      }
+      elapsedTime.addAndGet(tr.getEndMillis() - tr.getStartMillis());
+   }
+
+   long elapsedTime() {
+      return elapsedTime.get();
+   }
+}

--- a/commons-test/src/main/java/org/infinispan/commons/test/PolarionJUnitXMLReporter.java
+++ b/commons-test/src/main/java/org/infinispan/commons/test/PolarionJUnitXMLReporter.java
@@ -2,9 +2,7 @@ package org.infinispan.commons.test;
 
 import java.io.File;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -12,19 +10,14 @@ import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import javax.xml.stream.XMLStreamException;
+import java.util.stream.Collectors;
 
 import org.testng.ISuite;
 import org.testng.ISuiteListener;
-import org.testng.ISuiteResult;
 import org.testng.ITestContext;
-import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
 import org.testng.annotations.Test;
-import org.testng.collections.Maps;
 import org.testng.internal.IResultListener2;
-import org.testng.internal.Utils;
 
 /**
  * A JUnit XML report generator for Polarion based on the JUnitXMLReporter
@@ -33,12 +26,13 @@ import org.testng.internal.Utils;
  */
 public class PolarionJUnitXMLReporter implements IResultListener2, ISuiteListener {
    public static final Pattern DUPLICATE_TESTS_MODULE_PATTERN = Pattern.compile(".*-(embedded|remote|v\\d+)");
+
    /**
     * keep lists of all the results
     */
-   private AtomicInteger m_numFailed = new AtomicInteger(0);
-   private AtomicInteger m_numSkipped = new AtomicInteger(0);
-   private Map<String, List<ITestResult>> m_allTests = Collections.synchronizedMap(new TreeMap<>());
+   private static final AtomicInteger m_numFailed = new AtomicInteger(0);
+   private static final AtomicInteger m_numSkipped = new AtomicInteger(0);
+   private static final Map<String, PolarionJUnitTest> m_allTests = Collections.synchronizedMap(new TreeMap<>());
 
    /**
     * @see org.testng.IConfigurationListener2#beforeConfiguration(ITestResult)
@@ -108,7 +102,6 @@ public class PolarionJUnitXMLReporter implements IResultListener2, ISuiteListene
     */
    @Override
    public void onStart(ISuite suite) {
-      resetAll();
    }
 
    /**
@@ -116,7 +109,7 @@ public class PolarionJUnitXMLReporter implements IResultListener2, ISuiteListene
     */
    @Override
    public void onFinish(ISuite suite) {
-      generateReport(suite);
+      generateReport();
    }
 
    /**
@@ -145,139 +138,26 @@ public class PolarionJUnitXMLReporter implements IResultListener2, ISuiteListene
    /**
     * generate the XML report given what we know from all the test results
     */
-   private void generateReport(ISuite suite) {
-      // Get elapsed time for testsuite element
-      long elapsedTime = 0;
-      long testCount = 0;
-      for (List<ITestResult> testResults : m_allTests.values()) {
-         for (ITestResult tr : testResults) {
-            elapsedTime += (tr.getEndMillis() - tr.getStartMillis());
-            //            if (tr.getMethod().getConstructorOrMethod().getMethod().getAnnotation(Test.class) != null) {
-            //               testCount += tr.getMethod().getConstructorOrMethod().getMethod().getAnnotation(Test.class)
-            //                     .invocationCount();
-            //            } else {
-            testCount++;
-            //            }
-         }
-      }
+   private void generateReport() {
+      synchronized (m_allTests) {
+         // Get elapsed time for testsuite element
+         long elapsedTime = m_allTests.values().stream().mapToLong(PolarionJUnitTest::elapsedTime).sum();
+         long testCount = m_allTests.values().size();
 
-      PolarionJUnitXMLWriter writer = null;
-      try {
-         String outputDir = suite.getOutputDirectory().replaceAll(".Surefire suite", "");
-         String baseName = String.format("TEST-%s.xml", getSuiteName(suite));
-         File outputFile = new File(outputDir, baseName);
-         writer = new PolarionJUnitXMLWriter(outputFile);
-         writer.start(getModuleSuffix(), testCount, m_numSkipped.get(), m_numFailed.get(), elapsedTime, true);
-
-         // TODO Also write a report based on suite.getAllInvokedMethod() and check for differences
-         writeTestResults(writer, m_allTests.values());
-      } catch (Exception e) {
-         System.err.println("Error writing test report");
-         e.printStackTrace(System.err);
-      } finally {
-         try {
-            if (writer != null) {
-               writer.close();
-            }
-         } catch (Exception e) {
-            System.err.println("Error writing test report");
-            e.printStackTrace(System.err);
-         }
-      }
-   }
-
-   private void writeTestResults(PolarionJUnitXMLWriter document, Collection<List<ITestResult>> results)
-      throws XMLStreamException {
-      synchronized (results) {
-         for (List<ITestResult> testResults : results) {
-            boolean hasFailures = false;
-            // A single test method might have multiple invocations
-            for (ITestResult tr : testResults) {
-               if (!tr.isSuccess()) {
-                  hasFailures = true;
-                  // Report all failures
-                  writeTestCase(document, tr);
-               }
-            }
-            if (!hasFailures) {
-               // If there were no failures, report a single success
-               writeTestCase(document, testResults.get(0));
+         String outputDir = String.format("%s/surefire-reports", System.getProperty("build.directory"));
+         Map<String, List<PolarionJUnitTest>> testsByClass = m_allTests.values().stream().collect(Collectors.groupingBy(p -> p.clazz));
+         for (Map.Entry<String, List<PolarionJUnitTest>> entry : testsByClass.entrySet()) {
+            File outputFile = new File(outputDir, String.format("TEST-%s.xml", entry.getKey()));
+            try (PolarionJUnitXMLWriter writer = new PolarionJUnitXMLWriter(outputFile)){
+               writer.start(entry.getKey(), testCount, m_numSkipped.get(), m_numFailed.get(), elapsedTime, true);
+               for (PolarionJUnitTest testCase : entry.getValue())
+                  writer.writeTestCase(testCase);
+            } catch (Exception e) {
+               System.err.printf("Error writing test report '%s'\n", outputFile.getName());
+               e.printStackTrace(System.err);
             }
          }
       }
-   }
-
-   private void writeTestCase(PolarionJUnitXMLWriter writer, ITestResult tr) throws XMLStreamException {
-      String className = tr.getTestClass().getRealClass().getName();
-      String testName = testName(tr);
-      long elapsedTimeMillis = tr.getEndMillis() - tr.getStartMillis();
-      PolarionJUnitXMLWriter.Status status = translateStatus(tr);
-      Throwable throwable = tr.getThrowable();
-      if (throwable != null) {
-         writer.writeTestCase(testName, className, elapsedTimeMillis, status, Utils.shortStackTrace(throwable, true),
-                              throwable.getClass().getName(), throwable.getMessage());
-      } else {
-         writer.writeTestCase(testName, className, elapsedTimeMillis, status, null, null, null);
-      }
-   }
-
-   private PolarionJUnitXMLWriter.Status translateStatus(ITestResult tr) {
-      switch (tr.getStatus()) {
-         case ITestResult.FAILURE:
-            return PolarionJUnitXMLWriter.Status.FAILURE;
-         case ITestResult.SUCCESS:
-            return PolarionJUnitXMLWriter.Status.SUCCESS;
-         case ITestResult.SUCCESS_PERCENTAGE_FAILURE:
-         case ITestResult.SKIP:
-            return PolarionJUnitXMLWriter.Status.SKIPPED;
-         default:
-            return PolarionJUnitXMLWriter.Status.ERROR;
-      }
-   }
-
-   /**
-    * Reset all member variables for next test.
-    */
-   private void resetAll() {
-      m_allTests = Collections.synchronizedMap(Maps.newHashMap());
-      m_numFailed.set(0);
-      m_numSkipped.set(0);
-   }
-
-   private String getSuiteName(ISuite suite) {
-      String name = getModuleSuffix();
-      Collection<ISuiteResult> suiteResults = suite.getResults().values();
-      if (suiteResults.size() == 1) {
-         ITestNGMethod[] testMethods = suiteResults.iterator().next().getTestContext().getAllTestMethods();
-         if (testMethods.length > 0) {
-            Class<?> testClass = testMethods[0].getConstructorOrMethod().getDeclaringClass();
-            // If only one test class executed, then use that as the filename
-            String className = testClass.getName();
-            // If only one test package executed, then use that as the filename
-            String packageName = testClass.getPackage().getName();
-            boolean oneTestClass = true;
-            boolean oneTestPackage = true;
-            for (ITestNGMethod method : testMethods) {
-               if (!method.getConstructorOrMethod().getDeclaringClass().getName().equals(className)) {
-                  oneTestClass = false;
-               }
-               if (!method.getConstructorOrMethod().getDeclaringClass().getPackage().getName().equals(packageName)) {
-                  oneTestPackage = false;
-               }
-            }
-            if (oneTestClass) {
-               name = className;
-            } else {
-               if (oneTestPackage) {
-                  name = packageName;
-               }
-            }
-         } else {
-            System.err.println(
-                  "[" + this.getClass().getSimpleName() + "] Test suite '" + name + "' results have no test methods");
-         }
-      }
-      return name;
    }
 
    private String testName(ITestResult res) {
@@ -347,21 +227,22 @@ public class PolarionJUnitXMLReporter implements IResultListener2, ISuiteListene
       // Need fully qualified name to guarantee uniqueness in the results map
       String instanceName = tr.getInstanceName();
       String key = instanceName + "." + testName(tr);
+      PolarionJUnitTest meta;
       if (m_allTests.containsKey(key)) {
-         if (tr.getMethod().getCurrentInvocationCount() == 1 && tr.isSuccess()) {
+         meta = m_allTests.get(key);
+         // Guard against duplicate test names across test instances whilst supporting TestNG invocationCount
+         if (meta.successes.get() > tr.getMethod().getCurrentInvocationCount()) {
             System.err.println("[" + this.getClass().getSimpleName() + "] Test case '" + key
                   + "' already exists in the results");
             tr.setStatus(ITestResult.FAILURE);
             tr.setThrowable(new IllegalStateException("Duplicate test: " + key));
          }
-
-         List<ITestResult> itrList = m_allTests.get(key);
-         itrList.add(tr);
-         m_allTests.put(key, itrList);
       } else {
-         ArrayList<ITestResult> itrList = new ArrayList<>();
-         itrList.add(tr);
-         m_allTests.put(key, itrList);
+         String testName = testName(tr);
+         String className = tr.getTestClass().getRealClass().getName();
+         meta = new PolarionJUnitTest(testName, className);
       }
+      meta.add(tr);
+      m_allTests.put(key, meta);
    }
 }

--- a/commons-test/src/main/java/org/infinispan/commons/test/RunningTestsRegistry.java
+++ b/commons-test/src/main/java/org/infinispan/commons/test/RunningTestsRegistry.java
@@ -8,7 +8,6 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.lang.management.LockInfo;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MonitorInfo;
@@ -80,12 +79,7 @@ class RunningTestsRegistry {
          String property = System.getProperty("infinispan.modulesuffix");
          String moduleName = property != null ? property.substring(1) : "";
          writer.start(moduleName, 1, 0, 1, 0, false);
-
-         StringWriter exceptionWriter = new StringWriter();
-         exception.printStackTrace(new PrintWriter(exceptionWriter));
-         writer.writeTestCase("Timeout", testName, 0, PolarionJUnitXMLWriter.Status.FAILURE,
-                              exceptionWriter.toString(), exception.getClass().getName(), exception.getMessage());
-
+         writer.writeTestCase(new PolarionJUnitTest("Timeout", testName, exception));
          writer.close();
       } catch (Exception e) {
          throw new RuntimeException("Error reporting thread leaks", e);

--- a/commons-test/src/main/java/org/infinispan/commons/test/ThreadLeakChecker.java
+++ b/commons-test/src/main/java/org/infinispan/commons/test/ThreadLeakChecker.java
@@ -2,8 +2,6 @@ package org.infinispan.commons.test;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -237,14 +235,8 @@ public class ThreadLeakChecker {
                LeakException exception = new LeakException("Leaked thread: " + leakInfo.thread.getName(),
                                                            leakInfo.stacktrace);
                exception.setStackTrace(leakInfo.thread.getStackTrace());
-
                TestSuiteProgress.fakeTestFailure(testName + ".ThreadLeakChecker", exception);
-
-               StringWriter exceptionWriter = new StringWriter();
-               exception.printStackTrace(new PrintWriter(exceptionWriter));
-               writer.writeTestCase("ThreadLeakChecker", testName, 0, PolarionJUnitXMLWriter.Status.FAILURE,
-                                    exceptionWriter.toString(), exception.getClass().getName(), exception.getMessage());
-
+               writer.writeTestCase(new PolarionJUnitTest("ThreadLeakChecker", testName, exception));
                leakInfo.markReported();
             }
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -118,8 +118,20 @@
       </dependency>
 
       <dependency>
-         <groupId>org.testng</groupId>
-         <artifactId>testng</artifactId>
+         <groupId>org.junit.support</groupId>
+         <artifactId>testng-engine</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-api</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-engine</artifactId>
          <scope>test</scope>
       </dependency>
 
@@ -228,14 +240,6 @@
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
-            <dependencies>
-               <!-- Explicit dependency on surefire-testng to help builds without access to Maven Central -->
-               <dependency>
-                  <groupId>org.apache.maven.surefire</groupId>
-                  <artifactId>surefire-testng</artifactId>
-                  <version>${version.maven.surefire}</version>
-               </dependency>
-            </dependencies>
             <configuration>
                <dependenciesToScan>
                   <!-- TestNGSuiteChecksTest -->

--- a/core/src/test/java/org/infinispan/test/AbstractInfinispanTest.java
+++ b/core/src/test/java/org/infinispan/test/AbstractInfinispanTest.java
@@ -119,6 +119,7 @@ public abstract class AbstractInfinispanTest {
                }
                String parameters = ((AbstractInfinispanTest) instance).parameters();
                if (parameters != null) {
+                  parameters = parameters.replaceAll("[-.\\+*?\\[^\\]$(){}=!<>|:\\\\]", "\\\\$0");
                   for (IMethodInstance method : instanceAndMethods.getValue()) {
                      // TestNG calls intercept twice (bug?) so this prevents adding the parameters two times
                      if (method.getMethod() instanceof NamedTestMethod) {

--- a/core/src/test/java/org/infinispan/test/FeaturesListener.java
+++ b/core/src/test/java/org/infinispan/test/FeaturesListener.java
@@ -16,6 +16,9 @@ public class FeaturesListener implements IMethodInterceptor {
 
    @Override
    public List<IMethodInstance> intercept(List<IMethodInstance> methods, ITestContext context) {
+      if (methods.isEmpty())
+         return methods;
+
       Object instance = methods.get(0).getMethod().getInstance();
       Features features = new Features(instance.getClass().getClassLoader());
       AbstractInfinispanTest.FeatureCondition featureCondition = instance.getClass().getAnnotation(AbstractInfinispanTest.FeatureCondition.class);

--- a/core/src/test/java/org/infinispan/util/CoreTestBlockHoundIntegration.java
+++ b/core/src/test/java/org/infinispan/util/CoreTestBlockHoundIntegration.java
@@ -2,11 +2,10 @@ package org.infinispan.util;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 
 import org.infinispan.commons.IllegalLifecycleStateException;
 import org.infinispan.commons.internal.CommonsBlockHoundIntegration;
+import org.infinispan.commons.test.PolarionJUnitTest;
 import org.infinispan.commons.test.PolarionJUnitXMLWriter;
 import org.infinispan.commons.test.TestResourceTracker;
 import org.infinispan.commons.test.TestSuiteProgress;
@@ -130,12 +129,7 @@ public class CoreTestBlockHoundIntegration implements BlockHoundIntegration {
          String property = System.getProperty("infinispan.modulesuffix");
          String moduleName = property != null ? property.substring(1) : "";
          writer.start(moduleName, 1, 0, 1, 0, false);
-
-         StringWriter exceptionWriter = new StringWriter();
-         throwable.printStackTrace(new PrintWriter(exceptionWriter));
-         writer.writeTestCase(type, testName, 0, PolarionJUnitXMLWriter.Status.FAILURE,
-               exceptionWriter.toString(), throwable.getClass().getName(), throwable.getMessage());
-
+         writer.writeTestCase(new PolarionJUnitTest(type, testName, throwable));
          writer.close();
       } catch (Exception e) {
          throw new RuntimeException("Error reporting " + type, e);

--- a/counter/pom.xml
+++ b/counter/pom.xml
@@ -108,8 +108,18 @@
             <artifactId>metainf-services</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
+            <groupId>org.junit.support</groupId>
+            <artifactId>testng-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/gridfs/pom.xml
+++ b/gridfs/pom.xml
@@ -75,8 +75,18 @@
             <artifactId>metainf-services</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
+            <groupId>org.junit.support</groupId>
+            <artifactId>testng-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/integrationtests/cdi-weld-se-it/pom.xml
+++ b/integrationtests/cdi-weld-se-it/pom.xml
@@ -47,8 +47,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
+            <groupId>org.junit.support</groupId>
+            <artifactId>testng-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/integrationtests/endpoints-interop-it/pom.xml
+++ b/integrationtests/endpoints-interop-it/pom.xml
@@ -101,8 +101,18 @@
          <scope>test</scope>
       </dependency>
       <dependency>
-         <groupId>org.testng</groupId>
-         <artifactId>testng</artifactId>
+         <groupId>org.junit.support</groupId>
+         <artifactId>testng-engine</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-api</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-engine</artifactId>
          <scope>test</scope>
       </dependency>
       <dependency>

--- a/integrationtests/jboss-marshalling-it/pom.xml
+++ b/integrationtests/jboss-marshalling-it/pom.xml
@@ -101,8 +101,18 @@
          <scope>test</scope>
       </dependency>
       <dependency>
-         <groupId>org.testng</groupId>
-         <artifactId>testng</artifactId>
+         <groupId>org.junit.support</groupId>
+         <artifactId>testng-engine</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-api</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-engine</artifactId>
          <scope>test</scope>
       </dependency>
    </dependencies>

--- a/jboss-marshalling/pom.xml
+++ b/jboss-marshalling/pom.xml
@@ -55,8 +55,20 @@
         </dependency>
 
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
+            <groupId>org.junit.support</groupId>
+            <artifactId>testng-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/lock/pom.xml
+++ b/lock/pom.xml
@@ -82,10 +82,19 @@
             <artifactId>blockhound</artifactId>
             <optional>true</optional>
         </dependency>
-
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
+            <groupId>org.junit.support</groupId>
+            <artifactId>testng-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/multimap/pom.xml
+++ b/multimap/pom.xml
@@ -51,8 +51,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
+            <groupId>org.junit.support</groupId>
+            <artifactId>testng-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/persistence/jdbc-common/pom.xml
+++ b/persistence/jdbc-common/pom.xml
@@ -23,9 +23,22 @@
          <artifactId>protostream-processor</artifactId>
       </dependency>
 
+
       <dependency>
-         <groupId>org.testng</groupId>
-         <artifactId>testng</artifactId>
+         <groupId>org.junit.support</groupId>
+         <artifactId>testng-engine</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-api</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-engine</artifactId>
          <scope>test</scope>
       </dependency>
 

--- a/persistence/jdbc/pom.xml
+++ b/persistence/jdbc/pom.xml
@@ -28,9 +28,22 @@
          <artifactId>infinispan-cachestore-jdbc-common</artifactId>
       </dependency>
 
+
       <dependency>
-         <groupId>org.testng</groupId>
-         <artifactId>testng</artifactId>
+         <groupId>org.junit.support</groupId>
+         <artifactId>testng-engine</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-api</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-engine</artifactId>
          <scope>test</scope>
       </dependency>
 

--- a/persistence/remote/pom.xml
+++ b/persistence/remote/pom.xml
@@ -96,8 +96,18 @@
          <optional>true</optional>
       </dependency>
       <dependency>
-         <groupId>org.testng</groupId>
-         <artifactId>testng</artifactId>
+         <groupId>org.junit.support</groupId>
+         <artifactId>testng-engine</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-api</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-engine</artifactId>
          <scope>test</scope>
       </dependency>
       <dependency>

--- a/persistence/rocksdb/pom.xml
+++ b/persistence/rocksdb/pom.xml
@@ -34,10 +34,19 @@
          <artifactId>blockhound</artifactId>
          <optional>true</optional>
       </dependency>
-
       <dependency>
-         <groupId>org.testng</groupId>
-         <artifactId>testng</artifactId>
+         <groupId>org.junit.support</groupId>
+         <artifactId>testng-engine</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-api</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-engine</artifactId>
          <scope>test</scope>
       </dependency>
       <dependency>

--- a/persistence/sql/pom.xml
+++ b/persistence/sql/pom.xml
@@ -40,9 +40,22 @@
          <scope>test</scope>
       </dependency>
 
+
       <dependency>
-         <groupId>org.testng</groupId>
-         <artifactId>testng</artifactId>
+         <groupId>org.junit.support</groupId>
+         <artifactId>testng-engine</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-api</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-engine</artifactId>
          <scope>test</scope>
       </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,7 @@
       <dir.jacoco>${session.executionRootDirectory}/jacoco/</dir.jacoco>
       <dir.jacoco.merged>../jacoco/merged/</dir.jacoco.merged>
       <dir.jacoco.report>../jacoco/report/</dir.jacoco.report>
+      <rerunFailingTestsCount>0</rerunFailingTestsCount>
       <testjvm.commonArgs>-XX:+UseG1GC -XX:-TieredCompilation -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${user.dir} -Djboss.modules.settings.xml.url=${jboss.modules.settings.xml.url}</testjvm.commonArgs>
       <!--
         java.lang, java.util, java.io, java.lang.invoke, java.lang, reflect, java.util.concurrent, java.time:
@@ -819,6 +820,12 @@
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
             <version>${versionx.junit.junit5}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.junit.support</groupId>
+            <artifactId>testng-engine</artifactId>
+            <version>${version.testng.engine}</version>
+            <scope>test</scope>
          </dependency>
          <dependency>
             <groupId>com.mysql</groupId>
@@ -2120,6 +2127,7 @@
                      <ansi.strip>${ansi.strip}</ansi.strip>
                      <com.arjuna.ats.arjuna.common.propertiesFile>test-jbossts-properties.xml</com.arjuna.ats.arjuna.common.propertiesFile>
                   </systemPropertyVariables>
+                  <rerunFailingTestsCount>${rerunFailingTestsCount}</rerunFailingTestsCount>
                   <argLine>${forkJvmArgs} ${testjvm.jdkSpecificArgs}</argLine>
                   <!-- Use TCP for plugin <-> fork JVM communication -->
                   <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
@@ -2466,6 +2474,16 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
+               <properties>
+                  <configurationParameters>
+                     testng.excludedGroups = ${defaultExcludedTestNGGroups}
+                     testng.groups = ${defaultTestNGGroups}
+                     testng.listeners = ${testNGListeners}
+                     testng.useDefaultListeners = false
+                     testng.parallel = tests
+                     testng.threadCount = ${infinispan.test.parallel.threads}
+                  </configurationParameters>
+               </properties>
                <parallel>tests</parallel>
                <threadCount>${infinispan.test.parallel.threads}</threadCount>
                <forkCount>1</forkCount>
@@ -2473,6 +2491,7 @@
                <groups>${defaultTestNGGroups}</groups>
                <excludedGroups>${defaultExcludedTestNGGroups}</excludedGroups>
                <useFile>false</useFile>
+               <rerunFailingTestsCount>${rerunFailingTestsCount}</rerunFailingTestsCount>
                <systemPropertyVariables>
                   <infinispan.cluster.stack>${infinispan.cluster.stack}</infinispan.cluster.stack>
                   <jgroups.bind_addr>127.0.0.1</jgroups.bind_addr>
@@ -2494,17 +2513,30 @@
                   <ansi.strip>${ansi.strip}</ansi.strip>
                </systemPropertyVariables>
                <trimStackTrace>false</trimStackTrace>
-               <properties>
-                  <!-- Deactivate the default listeners which may cause OOME. Jenkins uses the surefire generated XML file. -->
-                  <usedefaultlisteners>false</usedefaultlisteners>
-                  <listener>${testNGListeners}</listener>
-               </properties>
                <argLine>${forkJvmArgs} ${testjvm.jdkSpecificArgs} -Djdk.attach.allowAttachSelf=true</argLine>
                <!-- Use TCP for plugin <-> fork JVM communication -->
                <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
                <!-- Disable modular classpath -->
                <useModulePath>false</useModulePath>
             </configuration>
+         </plugin>
+         <!-- Maven plugin that scans the test output of Surefire for flaky tests and writes test output files for just the flaky tests.
+         Allows flaky tests to be highlighted in Jenkins test failure summary -->
+         <plugin>
+            <groupId>io.zeebe</groupId>
+            <artifactId>flaky-test-extractor-maven-plugin</artifactId>
+            <version>2.1.1</version>
+            <executions>
+               <execution>
+                  <phase>post-integration-test</phase>
+                  <goals>
+                     <goal>extract-flaky-tests</goal>
+                  </goals>
+                  <configuration>
+                     <failBuild>false</failBuild>
+                  </configuration>
+               </execution>
+            </executions>
          </plugin>
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>

--- a/query-core/pom.xml
+++ b/query-core/pom.xml
@@ -82,8 +82,20 @@
         </dependency>
 
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
+            <groupId>org.junit.support</groupId>
+            <artifactId>testng-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/query/pom.xml
+++ b/query/pom.xml
@@ -105,9 +105,22 @@
          <scope>test</scope>
       </dependency>
 
+
       <dependency>
-         <groupId>org.testng</groupId>
-         <artifactId>testng</artifactId>
+         <groupId>org.junit.support</groupId>
+         <artifactId>testng-engine</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-api</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-engine</artifactId>
          <scope>test</scope>
       </dependency>
 

--- a/remote-query/remote-query-server/pom.xml
+++ b/remote-query/remote-query-server/pom.xml
@@ -98,9 +98,22 @@
          <optional>true</optional>
       </dependency>
 
+
       <dependency>
-         <groupId>org.testng</groupId>
-         <artifactId>testng</artifactId>
+         <groupId>org.junit.support</groupId>
+         <artifactId>testng-engine</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-api</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-engine</artifactId>
          <scope>test</scope>
       </dependency>
    </dependencies>

--- a/server/core/pom.xml
+++ b/server/core/pom.xml
@@ -162,8 +162,18 @@
          <scope>test</scope>
       </dependency>
       <dependency>
-         <groupId>org.testng</groupId>
-         <artifactId>testng</artifactId>
+         <groupId>org.junit.support</groupId>
+         <artifactId>testng-engine</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-api</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-engine</artifactId>
          <scope>test</scope>
       </dependency>
    </dependencies>

--- a/server/hotrod/pom.xml
+++ b/server/hotrod/pom.xml
@@ -73,8 +73,18 @@
          <scope>test</scope>
       </dependency>
       <dependency>
-         <groupId>org.testng</groupId>
-         <artifactId>testng</artifactId>
+         <groupId>org.junit.support</groupId>
+         <artifactId>testng-engine</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-api</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-engine</artifactId>
          <scope>test</scope>
       </dependency>
    </dependencies>

--- a/server/memcached/pom.xml
+++ b/server/memcached/pom.xml
@@ -41,8 +41,18 @@
          <scope>test</scope>
       </dependency>
       <dependency>
-         <groupId>org.testng</groupId>
-         <artifactId>testng</artifactId>
+         <groupId>org.junit.support</groupId>
+         <artifactId>testng-engine</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-api</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-engine</artifactId>
          <scope>test</scope>
       </dependency>
       <dependency>

--- a/server/resp/pom.xml
+++ b/server/resp/pom.xml
@@ -46,9 +46,20 @@
          <artifactId>lettuce-core</artifactId>
          <scope>test</scope>
       </dependency>
+
       <dependency>
-         <groupId>org.testng</groupId>
-         <artifactId>testng</artifactId>
+         <groupId>org.junit.support</groupId>
+         <artifactId>testng-engine</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-api</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-engine</artifactId>
          <scope>test</scope>
       </dependency>
       <dependency>

--- a/server/rest/pom.xml
+++ b/server/rest/pom.xml
@@ -134,11 +134,24 @@
          <scope>test</scope>
       </dependency>
 
-       <dependency>
-         <groupId>org.testng</groupId>
-         <artifactId>testng</artifactId>
+      <dependency>
+         <groupId>org.junit.support</groupId>
+         <artifactId>testng-engine</artifactId>
          <scope>test</scope>
       </dependency>
+
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-api</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-engine</artifactId>
+         <scope>test</scope>
+      </dependency>
+
       <dependency>
          <groupId>org.antlr</groupId>
          <artifactId>antlr-runtime</artifactId>

--- a/server/rest/src/test/java/org/infinispan/rest/tracing/OpenTelemetryClient.java
+++ b/server/rest/src/test/java/org/infinispan/rest/tracing/OpenTelemetryClient.java
@@ -30,6 +30,9 @@ public class OpenTelemetryClient {
             .addSpanProcessor(spanProcessor);
 
       tracerProvider = builder.build();
+      // JUnit5 TestNG engine creates two instances of test class, so we must explicitly reset GlobalOpenTelemetry to
+      // prevent an IllegalStateException on the second invocation.
+      GlobalOpenTelemetry.resetForTest();
       openTelemetry = OpenTelemetrySdk.builder()
             .setTracerProvider(tracerProvider)
             .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))

--- a/server/router/pom.xml
+++ b/server/router/pom.xml
@@ -116,9 +116,20 @@
             <artifactId>wildfly-openssl-macosx-x86_64</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
+            <groupId>org.junit.support</groupId>
+            <artifactId>testng-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/server/testdriver/junit4/pom.xml
+++ b/server/testdriver/junit4/pom.xml
@@ -37,8 +37,18 @@
          <scope>compile</scope>
       </dependency>
       <dependency>
-         <groupId>org.testng</groupId>
-         <artifactId>testng</artifactId>
+         <groupId>org.junit.support</groupId>
+         <artifactId>testng-engine</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-api</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-engine</artifactId>
          <scope>test</scope>
       </dependency>
    </dependencies>

--- a/spring/spring6/spring6-common/pom.xml
+++ b/spring/spring6/spring6-common/pom.xml
@@ -60,8 +60,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
+            <groupId>org.junit.support</groupId>
+            <artifactId>testng-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/spring/spring6/spring6-embedded/pom.xml
+++ b/spring/spring6/spring6-embedded/pom.xml
@@ -75,12 +75,6 @@
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-commons-test</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.testng</groupId>
-                    <artifactId>testng</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.infinispan</groupId>
@@ -146,8 +140,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
+            <groupId>org.junit.support</groupId>
+            <artifactId>testng-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/spring/spring6/spring6-remote/pom.xml
+++ b/spring/spring6/spring6-remote/pom.xml
@@ -133,8 +133,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
+            <groupId>org.junit.support</groupId>
+            <artifactId>testng-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/tasks/manager/pom.xml
+++ b/tasks/manager/pom.xml
@@ -47,9 +47,22 @@
          <optional>true</optional>
       </dependency>
 
+
       <dependency>
-         <groupId>org.testng</groupId>
-         <artifactId>testng</artifactId>
+         <groupId>org.junit.support</groupId>
+         <artifactId>testng-engine</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-api</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-engine</artifactId>
          <scope>test</scope>
       </dependency>
    </dependencies>

--- a/tasks/scripting/pom.xml
+++ b/tasks/scripting/pom.xml
@@ -52,8 +52,20 @@
       </dependency>
 
       <dependency>
-         <groupId>org.testng</groupId>
-         <artifactId>testng</artifactId>
+         <groupId>org.junit.support</groupId>
+         <artifactId>testng-engine</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-api</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-engine</artifactId>
          <scope>test</scope>
       </dependency>
    </dependencies>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -89,9 +89,22 @@
          <scope>provided</scope>
       </dependency>
 
+
       <dependency>
-         <groupId>org.testng</groupId>
-         <artifactId>testng</artifactId>
+         <groupId>org.junit.support</groupId>
+         <artifactId>testng-engine</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-api</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-engine</artifactId>
          <scope>test</scope>
       </dependency>
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-15143

The CDI integration tests still utilise vanilla TestNG as it's necessary to convert the tests to utilise `org.jboss.arquillian.junit5` in order for them to work with JUnit 5 as expected.

@tristantarrant  I haven't applied `rerunFailingTestsCount` yet. What value do we think is acceptable, 2/3? I think higher than that and we're potentially ignoring tests that are definitely too flaky to be acceptabble.
