### PR TITLE
ISPN-15104 Global RemoteCacheManager for remote store

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/AuthenticationConfiguration.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/AuthenticationConfiguration.java
@@ -52,4 +52,15 @@ public class AuthenticationConfiguration {
       return clientSubject;
    }
 
+   @Override
+   public String toString() {
+      return "AuthenticationConfiguration{" +
+            "enabled=" + enabled +
+            ", callbackHandler=" + callbackHandler +
+            ", clientSubject=" + clientSubject +
+            ", saslMechanism='" + saslMechanism + '\'' +
+            ", saslProperties=" + saslProperties +
+            ", serverName='" + serverName + '\'' +
+            '}';
+   }
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/SecurityConfiguration.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/SecurityConfiguration.java
@@ -24,4 +24,11 @@ public class SecurityConfiguration {
       return ssl;
    }
 
+   @Override
+   public String toString() {
+      return "SecurityConfiguration{" +
+            "authentication=" + authentication +
+            ", ssl=" + ssl +
+            '}';
+   }
 }

--- a/documentation/src/main/asciidoc/topics/json/persistence_remote_store_shared.json
+++ b/documentation/src/main/asciidoc/topics/json/persistence_remote_store_shared.json
@@ -1,0 +1,21 @@
+{
+  "infinispan": {
+    "remote-cache-containers": [
+      {
+        "uri": "hotrod://one,two:12111?max-active=10&exhausted-action=CREATE_NEW"
+      }
+    ],
+    "cache-container": {
+      "caches": {
+        "mycache": {
+          "distributed-cache": {
+            "remote-store": {
+              "cache": "mycache",
+              "raw-values": "true"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/documentation/src/main/asciidoc/topics/ref_cache_store_remote.adoc
+++ b/documentation/src/main/asciidoc/topics/ref_cache_store_remote.adoc
@@ -9,6 +9,18 @@ If you configure remote cache stores as shared you cannot preload data.
 In other words if `shared="true"` in your configuration then you must set `preload="false"`.
 ====
 
+.Shared remote cache containers
+
+Each remote cache store creates a dedicated remote cache manager. In case there are multiple remote stores connecting
+to the same server, this wastes resources. Use the `remote-cache-containers` configuration to create shared remote
+cache managers and reference them by name within your `remote-store` definitions.
+
+[TIP]
+====
+If there is only a single `remote-cache-container`, it will be used by default by all remote cache stores which
+don't specify one explicitly.
+====
+
 .Segmentation
 
 `RemoteStore` supports segmentation and can publish keys and entries by
@@ -26,7 +38,34 @@ case, you should disable segmentation for `RemoteStore`.
 ====
 
 [discrete]
-== Remote cache store configuration
+== Remote cache store configuration with shared remote containers
+
+.XML
+[source,xml,options="nowrap",subs=attributes+,role="primary"]
+----
+include::xml/persistence_remote_store_shared.xml[]
+----
+
+.JSON
+[source,json,options="nowrap",subs=attributes+,role="secondary"]
+----
+include::json/persistence_remote_store_shared.json[]
+----
+
+.YAML
+[source,yaml,options="nowrap",subs=attributes+,role="secondary"]
+----
+include::yaml/persistence_remote_store_shared.yaml[]
+----
+
+.ConfigurationBuilder
+[source,java,options="nowrap",subs=attributes+,role="secondary"]
+----
+include::code_examples/ConfigRemoteStore.java[]
+----
+
+[discrete]
+== Remote cache store configuration with private remote container
 
 .XML
 [source,xml,options="nowrap",subs=attributes+,role="primary"]

--- a/documentation/src/main/asciidoc/topics/xml/persistence_remote_store_shared.xml
+++ b/documentation/src/main/asciidoc/topics/xml/persistence_remote_store_shared.xml
@@ -1,0 +1,17 @@
+<infinispan>
+
+    <remote-cache-containers>
+        <remote-cache-container uri="hotrod://one,two:12111?max-active=10&amp;exhausted-action=CREATE_NEW"/>
+    </remote-cache-containers>
+
+    <cache-container>
+        <distributed-cache>
+            <persistence>
+                <remote-store xmlns="urn:infinispan:config:store:remote:{schemaversion}"
+                              cache="mycache"
+                              raw-values="true"
+                />
+            </persistence>
+        </distributed-cache>
+    </cache-container>
+</infinispan>

--- a/documentation/src/main/asciidoc/topics/yaml/persistence_remote_store_shared.yaml
+++ b/documentation/src/main/asciidoc/topics/yaml/persistence_remote_store_shared.yaml
@@ -1,0 +1,17 @@
+infinispan:
+  remoteCacheContainers:
+    - uri: "hotrod://one,two:12111?max-active=10&exhausted-action=CREATE_NEW"
+  cacheContainer:
+    caches:
+      mycache:
+        distributedCache:
+          remoteStore:
+            cache: "mycache"
+            rawValues: "true"
+            remoteServer:
+              - host: "one"
+                port: "12111"
+              - host: "two"
+            connectionPool:
+              maxActive: "10"
+              exhaustedAction: "CREATE_NEW"

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/LifecycleCallbacks.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/LifecycleCallbacks.java
@@ -6,7 +6,9 @@ import org.infinispan.commons.marshall.AdvancedExternalizer;
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.factories.GlobalComponentRegistry;
 import org.infinispan.factories.annotations.InfinispanModule;
+import org.infinispan.factories.impl.BasicComponentRegistry;
 import org.infinispan.lifecycle.ModuleLifecycle;
+import org.infinispan.persistence.remote.global.GlobalRemoteContainers;
 import org.infinispan.persistence.remote.upgrade.AddSourceRemoteStoreTask;
 import org.infinispan.persistence.remote.upgrade.CheckRemoteStoreTask;
 import org.infinispan.persistence.remote.upgrade.DisconnectRemoteStoreTask;
@@ -22,6 +24,8 @@ public class LifecycleCallbacks implements ModuleLifecycle {
 
    @Override
    public void cacheManagerStarting(GlobalComponentRegistry gcr, GlobalConfiguration globalCfg) {
+      BasicComponentRegistry bcr = gcr.getComponent(BasicComponentRegistry.class);
+      bcr.getComponent(GlobalRemoteContainers.class).running();
       Map<Integer, AdvancedExternalizer<?>> externalizerMap = globalCfg.serialization().advancedExternalizers();
       externalizerMap.put(ExternalizerIds.MIGRATION_TASK, new MigrationTask.Externalizer());
       externalizerMap.put(ExternalizerIds.REMOVED_FILTER, new RemovedFilter.Externalizer());

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/LifecycleCallbacks.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/LifecycleCallbacks.java
@@ -6,7 +6,6 @@ import org.infinispan.commons.marshall.AdvancedExternalizer;
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.factories.GlobalComponentRegistry;
 import org.infinispan.factories.annotations.InfinispanModule;
-import org.infinispan.factories.impl.BasicComponentRegistry;
 import org.infinispan.lifecycle.ModuleLifecycle;
 import org.infinispan.persistence.remote.global.GlobalRemoteContainers;
 import org.infinispan.persistence.remote.upgrade.AddSourceRemoteStoreTask;
@@ -24,8 +23,7 @@ public class LifecycleCallbacks implements ModuleLifecycle {
 
    @Override
    public void cacheManagerStarting(GlobalComponentRegistry gcr, GlobalConfiguration globalCfg) {
-      BasicComponentRegistry bcr = gcr.getComponent(BasicComponentRegistry.class);
-      bcr.getComponent(GlobalRemoteContainers.class).running();
+      gcr.getComponent(GlobalRemoteContainers.class);
       Map<Integer, AdvancedExternalizer<?>> externalizerMap = globalCfg.serialization().advancedExternalizers();
       externalizerMap.put(ExternalizerIds.MIGRATION_TASK, new MigrationTask.Externalizer());
       externalizerMap.put(ExternalizerIds.REMOVED_FILTER, new RemovedFilter.Externalizer());

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/AbstractRemoteStoreConfigurationChildBuilder.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/AbstractRemoteStoreConfigurationChildBuilder.java
@@ -88,6 +88,11 @@ public abstract class AbstractRemoteStoreConfigurationChildBuilder<S> extends Ab
    }
 
    @Override
+   public RemoteStoreConfigurationBuilder remoteCacheContainer(String name) {
+      return builder.remoteCacheContainer(name);
+   }
+
+   @Override
    public RemoteStoreConfigurationBuilder remoteCacheName(String remoteCacheName) {
       return builder.remoteCacheName(remoteCacheName);
    }

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/Attribute.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/Attribute.java
@@ -34,6 +34,7 @@ public enum Attribute {
    MAX_WAIT("max-wait"),
    MIN_EVICTABLE_IDLE_TIME("min-evictable-idle-time"),
    MIN_IDLE("min-idle"),
+   NAME("name"),
    /**
     * @deprecated Since 12.0, will be removed in 15.0
     */
@@ -47,6 +48,7 @@ public enum Attribute {
    PROTOCOL_VERSION("protocol-version"),
    RAW_VALUES("raw-values"),
    REALM("realm"),
+   REMOTE_CACHE_CONTAINER("remote-cache-container"),
    REMOTE_CACHE_NAME("cache"),
    SASL_MECHANISM("sasl-mechanism"),
    SERVER_NAME("server-name"),

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/Element.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/Element.java
@@ -29,7 +29,8 @@ public enum Element {
    SERVERS("servers"),
    REMOTE_SERVER("remote-server"),
    TRUSTSTORE("truststore"),
-   ;
+   REMOTE_CACHE_CONTAINER("remote-cache-container"),
+   REMOTE_CACHE_CONTAINERS("remote-cache-containers");
 
    private final String name;
 

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/RemoteStoreConfiguration.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/RemoteStoreConfiguration.java
@@ -7,7 +7,6 @@ import org.infinispan.client.hotrod.impl.ConfigurationProperties;
 import org.infinispan.client.hotrod.impl.transport.tcp.RoundRobinBalancingStrategy;
 import org.infinispan.commons.configuration.BuiltBy;
 import org.infinispan.commons.configuration.ConfigurationFor;
-import org.infinispan.commons.configuration.attributes.Attribute;
 import org.infinispan.commons.configuration.attributes.AttributeDefinition;
 import org.infinispan.commons.configuration.attributes.AttributeSet;
 import org.infinispan.configuration.cache.AbstractStoreConfiguration;
@@ -37,6 +36,7 @@ public class RemoteStoreConfiguration extends AbstractStoreConfiguration<RemoteS
    static final AttributeDefinition<String> MARSHALLER = AttributeDefinition.builder(org.infinispan.persistence.remote.configuration.Attribute.MARSHALLER, null, String.class).immutable().build();
    static final AttributeDefinition<ProtocolVersion> PROTOCOL_VERSION = AttributeDefinition.builder(org.infinispan.persistence.remote.configuration.Attribute.PROTOCOL_VERSION, ProtocolVersion.DEFAULT_PROTOCOL_VERSION)
          .immutable().build();
+   static final AttributeDefinition<String> REMOTE_CACHE_CONTAINER = AttributeDefinition.builder(org.infinispan.persistence.remote.configuration.Attribute.REMOTE_CACHE_CONTAINER, "").immutable().build();
    static final AttributeDefinition<String> REMOTE_CACHE_NAME = AttributeDefinition.builder(org.infinispan.persistence.remote.configuration.Attribute.REMOTE_CACHE_NAME, "").immutable().build();
 
    static final AttributeDefinition<String> URI = AttributeDefinition.builder(org.infinispan.persistence.remote.configuration.Attribute.URI, null, String.class).immutable()
@@ -47,44 +47,18 @@ public class RemoteStoreConfiguration extends AbstractStoreConfiguration<RemoteS
 
    public static AttributeSet attributeDefinitionSet() {
       return new AttributeSet(RemoteStoreConfiguration.class, AbstractStoreConfiguration.attributeDefinitionSet(), BALANCING_STRATEGY, CONNECTION_TIMEOUT, FORCE_RETURN_VALUES,
-            HOTROD_WRAPPING, RAW_VALUES, KEY_SIZE_ESTIMATE, MARSHALLER, PROTOCOL_VERSION, REMOTE_CACHE_NAME, SOCKET_TIMEOUT, TCP_NO_DELAY, VALUE_SIZE_ESTIMATE, URI);
+            HOTROD_WRAPPING, RAW_VALUES, KEY_SIZE_ESTIMATE, MARSHALLER, PROTOCOL_VERSION, REMOTE_CACHE_CONTAINER, REMOTE_CACHE_NAME, SOCKET_TIMEOUT, TCP_NO_DELAY, VALUE_SIZE_ESTIMATE, URI);
    }
 
-   private final Attribute<String> balancingStrategy;
-   private final Attribute<Long> connectionTimeout;
-   private final Attribute<Boolean> forceReturnValues;
-   private final Attribute<Boolean> hotRodWrapping;
-   private final Attribute<Boolean> rawValues;
-   private final Attribute<Integer> keySizeEstimate;
-   private final Attribute<Integer> valueSizeEstimate;
-   private final Attribute<String> marshaller;
-   private final Attribute<ProtocolVersion> protocolVersion;
-   private final Attribute<String> remoteCacheName;
-   private final Attribute<String> uri;
-   private final Attribute<Long> socketTimeout;
-   private final Attribute<Boolean> tcpNoDelay;
    private final ConnectionPoolConfiguration connectionPool;
    private final ExecutorFactoryConfiguration asyncExecutorFactory;
    private final SecurityConfiguration security;
-   private List<RemoteServerConfiguration> servers;
+   private final List<RemoteServerConfiguration> servers;
 
    public RemoteStoreConfiguration(AttributeSet attributes, AsyncStoreConfiguration async,
                                    ExecutorFactoryConfiguration asyncExecutorFactory, ConnectionPoolConfiguration connectionPool,
                                    SecurityConfiguration security, List<RemoteServerConfiguration> servers) {
       super(Element.REMOTE_STORE, attributes, async);
-      balancingStrategy = attributes.attribute(BALANCING_STRATEGY);
-      connectionTimeout = attributes.attribute(CONNECTION_TIMEOUT);
-      forceReturnValues = attributes.attribute(FORCE_RETURN_VALUES);
-      hotRodWrapping = attributes.attribute(HOTROD_WRAPPING);
-      rawValues = attributes.attribute(RAW_VALUES);
-      keySizeEstimate = attributes.attribute(KEY_SIZE_ESTIMATE);
-      valueSizeEstimate = attributes.attribute(VALUE_SIZE_ESTIMATE);
-      marshaller = attributes.attribute(MARSHALLER);
-      protocolVersion = attributes.attribute(PROTOCOL_VERSION);
-      remoteCacheName = attributes.attribute(REMOTE_CACHE_NAME);
-      uri = attributes.attribute(URI);
-      socketTimeout = attributes.attribute(SOCKET_TIMEOUT);
-      tcpNoDelay = attributes.attribute(TCP_NO_DELAY);
       this.asyncExecutorFactory = asyncExecutorFactory;
       this.connectionPool = connectionPool;
       this.security = security;
@@ -92,7 +66,7 @@ public class RemoteStoreConfiguration extends AbstractStoreConfiguration<RemoteS
    }
 
    public String uri() {
-      return uri.get();
+      return attributes.attribute(URI).get();
    }
 
    public ExecutorFactoryConfiguration asyncExecutorFactory() {
@@ -100,7 +74,7 @@ public class RemoteStoreConfiguration extends AbstractStoreConfiguration<RemoteS
    }
 
    public String balancingStrategy() {
-      return balancingStrategy.get();
+      return attributes.attribute(BALANCING_STRATEGY).get();
    }
 
    public ConnectionPoolConfiguration connectionPool() {
@@ -108,11 +82,11 @@ public class RemoteStoreConfiguration extends AbstractStoreConfiguration<RemoteS
    }
 
    public long connectionTimeout() {
-      return connectionTimeout.get();
+      return attributes.attribute(CONNECTION_TIMEOUT).get();
    }
 
    public boolean forceReturnValues() {
-      return forceReturnValues.get();
+      return attributes.attribute(FORCE_RETURN_VALUES).get();
    }
 
    /**
@@ -120,7 +94,7 @@ public class RemoteStoreConfiguration extends AbstractStoreConfiguration<RemoteS
     */
    @Deprecated
    public boolean hotRodWrapping() {
-      return hotRodWrapping.get();
+      return attributes.attribute(RAW_VALUES).get();
    }
 
    /**
@@ -128,15 +102,15 @@ public class RemoteStoreConfiguration extends AbstractStoreConfiguration<RemoteS
     */
    @Deprecated
    public int keySizeEstimate() {
-      return keySizeEstimate.get();
+      return attributes.attribute(KEY_SIZE_ESTIMATE).get();
    }
 
    public String marshaller() {
-      return marshaller.get();
+      return attributes.attribute(MARSHALLER).get();
    }
 
    public ProtocolVersion protocol() {
-      return protocolVersion.get();
+      return attributes.attribute(PROTOCOL_VERSION).get();
    }
 
    /**
@@ -144,11 +118,15 @@ public class RemoteStoreConfiguration extends AbstractStoreConfiguration<RemoteS
     */
    @Deprecated
    public boolean rawValues() {
-      return rawValues.get();
+      return attributes.attribute(RAW_VALUES).get();
+   }
+
+   public String remoteCacheContainer() {
+      return attributes.attribute(REMOTE_CACHE_CONTAINER).get();
    }
 
    public String remoteCacheName() {
-      return remoteCacheName.get();
+      return attributes.attribute(REMOTE_CACHE_NAME).get();
    }
 
    public List<RemoteServerConfiguration> servers() {
@@ -156,11 +134,11 @@ public class RemoteStoreConfiguration extends AbstractStoreConfiguration<RemoteS
    }
 
    public long socketTimeout() {
-      return socketTimeout.get();
+     return attributes.attribute(SOCKET_TIMEOUT).get();
    }
 
    public boolean tcpNoDelay() {
-      return tcpNoDelay.get();
+      return attributes.attribute(TCP_NO_DELAY).get();
    }
 
    /**
@@ -176,7 +154,7 @@ public class RemoteStoreConfiguration extends AbstractStoreConfiguration<RemoteS
     */
    @Deprecated
    public int valueSizeEstimate() {
-      return valueSizeEstimate.get();
+      return attributes.attribute(VALUE_SIZE_ESTIMATE).get();
    }
 
    public SecurityConfiguration security() {

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/RemoteStoreConfigurationChildBuilder.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/RemoteStoreConfigurationChildBuilder.java
@@ -79,6 +79,11 @@ public interface RemoteStoreConfigurationChildBuilder<S> extends StoreConfigurat
    RemoteStoreConfigurationBuilder rawValues(boolean rawValues);
 
    /**
+    * Specifies the name of a shared remote cache container to use, instead of creating a dedicated instance.
+    */
+   RemoteStoreConfigurationBuilder remoteCacheContainer(String name);
+
+   /**
     * The name of the remote cache in the remote infinispan cluster, to which to connect to. If
     * unspecified, the default cache will be used
     */

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/RemoteStoreConfigurationParser.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/RemoteStoreConfigurationParser.java
@@ -14,7 +14,6 @@ import org.infinispan.configuration.parsing.ConfigurationParser;
 import org.infinispan.configuration.parsing.Namespace;
 import org.infinispan.configuration.parsing.ParseUtils;
 import org.infinispan.configuration.parsing.Parser;
-import org.infinispan.configuration.parsing.ParserScope;
 import org.infinispan.persistence.remote.configuration.global.RemoteContainerConfigurationBuilder;
 import org.infinispan.persistence.remote.configuration.global.RemoteContainersConfigurationBuilder;
 import org.kohsuke.MetaInfServices;
@@ -41,18 +40,13 @@ public class RemoteStoreConfigurationParser implements ConfigurationParser {
 
    @Override
    public void readElement(final ConfigurationReader reader, final ConfigurationBuilderHolder holder) {
-      if (holder.inScope(ParserScope.GLOBAL)) {
-         parseGlobalScope(reader, holder);
-      } else if (holder.inScope(ParserScope.CACHE)) {
-         parseCacheScope(reader, holder);
-      } else {
-         throw coreLog.invalidScope(ParserScope.GLOBAL.name(), holder.getScope());
-      }
-   }
-
-   private void parseGlobalScope(ConfigurationReader reader, ConfigurationBuilderHolder holder) {
+      ConfigurationBuilder builder = holder.getCurrentConfigurationBuilder();
       Element element = Element.forName(reader.getLocalName());
       switch (element) {
+         case REMOTE_STORE: {
+            parseRemoteStore(reader, builder.persistence(), holder.getClassLoader());
+            break;
+         }
          case REMOTE_CACHE_CONTAINERS: {
             parseRemoteContainers(reader, holder);
             break;
@@ -82,23 +76,27 @@ public class RemoteStoreConfigurationParser implements ConfigurationParser {
       RemoteContainersConfigurationBuilder containersBuilder = holder.getGlobalConfigurationBuilder().addModule(RemoteContainersConfigurationBuilder.class);
       String name = reader.getAttributeValue(Attribute.NAME);
       RemoteContainerConfigurationBuilder builder = containersBuilder.addRemoteContainer(name != null ? name : "");
-      ParseUtils.parseAttributes(reader, builder);
-      ParseUtils.requireNoContent(reader);
-   }
 
-   private void parseCacheScope(ConfigurationReader reader, ConfigurationBuilderHolder holder) {
-      ConfigurationBuilder builder = holder.getCurrentConfigurationBuilder();
-
-      Element element = Element.forName(reader.getLocalName());
-      switch (element) {
-         case REMOTE_STORE: {
-            parseRemoteStore(reader, builder.persistence(), holder.getClassLoader());
-            break;
-         }
-         default: {
-            throw ParseUtils.unexpectedElement(reader);
+      for (int i = 0; i < reader.getAttributeCount(); i++) {
+         ParseUtils.requireNoNamespaceAttribute(reader, i);
+         String value = reader.getAttributeValue(i);
+         Attribute attribute = Attribute.forName(reader.getAttributeName(i));
+         switch (attribute) {
+            case NAME: {
+               // Set during creation of the builder.
+               continue;
+            }
+            case URI:
+               builder.uri(value);
+               break;
+            default: {
+               throw ParseUtils.unexpectedAttribute(reader, i);
+            }
          }
       }
+
+      ParseUtils.parseAttributes(reader, builder);
+      builder.properties(Parser.parseProperties(reader, Element.REMOTE_CACHE_CONTAINER));
    }
 
    private void parseRemoteStore(final ConfigurationReader reader, PersistenceConfigurationBuilder persistenceBuilder,

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/global/RemoteContainerConfiguration.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/global/RemoteContainerConfiguration.java
@@ -1,8 +1,12 @@
 package org.infinispan.persistence.remote.configuration.global;
 
+import static org.infinispan.commons.configuration.AbstractTypedPropertiesConfiguration.PROPERTIES;
+
 import org.infinispan.commons.configuration.attributes.AttributeDefinition;
 import org.infinispan.commons.configuration.attributes.AttributeSet;
 import org.infinispan.commons.configuration.attributes.ConfigurationElement;
+import org.infinispan.commons.util.Immutables;
+import org.infinispan.commons.util.TypedProperties;
 import org.infinispan.persistence.remote.configuration.Attribute;
 import org.infinispan.persistence.remote.configuration.Element;
 
@@ -12,9 +16,14 @@ import org.infinispan.persistence.remote.configuration.Element;
 public class RemoteContainerConfiguration extends ConfigurationElement<RemoteContainerConfiguration> {
    static final AttributeDefinition<String> NAME = AttributeDefinition.builder(Attribute.NAME, "", String.class).immutable().build();
    static final AttributeDefinition<String> URI = AttributeDefinition.builder(Attribute.URI, null, String.class).immutable().build();
+   private final org.infinispan.commons.configuration.attributes.Attribute<TypedProperties> properties;
 
    protected RemoteContainerConfiguration(AttributeSet attributes, ConfigurationElement<?>... children) {
       super(Element.REMOTE_CACHE_CONTAINER, attributes, children);
+      this.properties = attributes.attribute(PROPERTIES);
+      if (properties.isModified()) {
+         properties.set(Immutables.immutableTypedProperties(properties.get()));
+      }
    }
 
    public static AttributeSet attributeSet() {
@@ -27,5 +36,9 @@ public class RemoteContainerConfiguration extends ConfigurationElement<RemoteCon
 
    public String uri() {
       return attributes.attribute(URI).get();
+   }
+
+   public TypedProperties properties() {
+      return properties.get();
    }
 }

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/global/RemoteContainerConfiguration.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/global/RemoteContainerConfiguration.java
@@ -1,0 +1,31 @@
+package org.infinispan.persistence.remote.configuration.global;
+
+import org.infinispan.commons.configuration.attributes.AttributeDefinition;
+import org.infinispan.commons.configuration.attributes.AttributeSet;
+import org.infinispan.commons.configuration.attributes.ConfigurationElement;
+import org.infinispan.persistence.remote.configuration.Attribute;
+import org.infinispan.persistence.remote.configuration.Element;
+
+/**
+ * @since 15.0
+ **/
+public class RemoteContainerConfiguration extends ConfigurationElement<RemoteContainerConfiguration> {
+   static final AttributeDefinition<String> NAME = AttributeDefinition.builder(Attribute.NAME, "", String.class).immutable().build();
+   static final AttributeDefinition<String> URI = AttributeDefinition.builder(Attribute.URI, null, String.class).immutable().build();
+
+   protected RemoteContainerConfiguration(AttributeSet attributes, ConfigurationElement<?>... children) {
+      super(Element.REMOTE_CACHE_CONTAINER, attributes, children);
+   }
+
+   public static AttributeSet attributeSet() {
+      return new AttributeSet(RemoteContainerConfiguration.class, NAME, URI);
+   }
+
+   public String name() {
+      return attributes.attribute(NAME).get();
+   }
+
+   public String uri() {
+      return attributes.attribute(URI).get();
+   }
+}

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/global/RemoteContainerConfigurationBuilder.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/global/RemoteContainerConfigurationBuilder.java
@@ -1,11 +1,16 @@
 package org.infinispan.persistence.remote.configuration.global;
 
+import static org.infinispan.commons.configuration.AbstractTypedPropertiesConfiguration.PROPERTIES;
 import static org.infinispan.persistence.remote.configuration.global.RemoteContainerConfiguration.NAME;
 import static org.infinispan.persistence.remote.configuration.global.RemoteContainerConfiguration.URI;
 
+import java.util.Properties;
+
+import org.infinispan.commons.configuration.AbstractTypedPropertiesConfiguration;
 import org.infinispan.commons.configuration.Builder;
 import org.infinispan.commons.configuration.Combine;
 import org.infinispan.commons.configuration.attributes.AttributeSet;
+import org.infinispan.commons.util.TypedProperties;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 
 /**
@@ -15,8 +20,10 @@ public class RemoteContainerConfigurationBuilder implements Builder<RemoteContai
 
    private final AttributeSet attributes;
 
-   public RemoteContainerConfigurationBuilder(GlobalConfigurationBuilder builder) {
-      this.attributes = RemoteContainerConfiguration.attributeSet();
+   public RemoteContainerConfigurationBuilder(GlobalConfigurationBuilder builder, String name) {
+      this.attributes = new AttributeSet(RemoteContainerConfiguration.class,
+            AbstractTypedPropertiesConfiguration.attributeSet(), NAME, URI);
+      attributes.attribute(NAME).set(name);
    }
 
    @Override
@@ -35,13 +42,13 @@ public class RemoteContainerConfigurationBuilder implements Builder<RemoteContai
       return attributes;
    }
 
-   public RemoteContainerConfigurationBuilder name(String name) {
-      attributes.attribute(NAME).set(name);
+   public RemoteContainerConfigurationBuilder uri(String uri) {
+      attributes.attribute(URI).set(uri);
       return this;
    }
 
-   public RemoteContainerConfigurationBuilder uri(String uri) {
-      attributes.attribute(URI).set(uri);
+   public RemoteContainerConfigurationBuilder properties(Properties properties) {
+      attributes.attribute(PROPERTIES).set(TypedProperties.toTypedProperties(properties));
       return this;
    }
 }

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/global/RemoteContainerConfigurationBuilder.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/global/RemoteContainerConfigurationBuilder.java
@@ -1,0 +1,47 @@
+package org.infinispan.persistence.remote.configuration.global;
+
+import static org.infinispan.persistence.remote.configuration.global.RemoteContainerConfiguration.NAME;
+import static org.infinispan.persistence.remote.configuration.global.RemoteContainerConfiguration.URI;
+
+import org.infinispan.commons.configuration.Builder;
+import org.infinispan.commons.configuration.Combine;
+import org.infinispan.commons.configuration.attributes.AttributeSet;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+
+/**
+ * @since 15.0
+ **/
+public class RemoteContainerConfigurationBuilder implements Builder<RemoteContainerConfiguration> {
+
+   private final AttributeSet attributes;
+
+   public RemoteContainerConfigurationBuilder(GlobalConfigurationBuilder builder) {
+      this.attributes = RemoteContainerConfiguration.attributeSet();
+   }
+
+   @Override
+   public RemoteContainerConfiguration create() {
+      return new RemoteContainerConfiguration(attributes.protect());
+   }
+
+   @Override
+   public Builder<?> read(RemoteContainerConfiguration template, Combine combine) {
+      this.attributes.read(template.attributes(), combine);
+      return this;
+   }
+
+   @Override
+   public AttributeSet attributes() {
+      return attributes;
+   }
+
+   public RemoteContainerConfigurationBuilder name(String name) {
+      attributes.attribute(NAME).set(name);
+      return this;
+   }
+
+   public RemoteContainerConfigurationBuilder uri(String uri) {
+      attributes.attribute(URI).set(uri);
+      return this;
+   }
+}

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/global/RemoteContainersConfiguration.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/global/RemoteContainersConfiguration.java
@@ -1,0 +1,30 @@
+package org.infinispan.persistence.remote.configuration.global;
+
+import java.util.Map;
+
+import org.infinispan.client.hotrod.TransportFactory;
+import org.infinispan.commons.configuration.BuiltBy;
+import org.infinispan.configuration.serializing.SerializedWith;
+
+/**
+ * @since 15.0
+ **/
+@BuiltBy(RemoteContainersConfigurationBuilder.class)
+@SerializedWith(RemoteContainersConfigurationSerializer.class)
+public class RemoteContainersConfiguration {
+   private final Map<String, RemoteContainerConfiguration> containers;
+   private final TransportFactory transportFactory;
+
+   public RemoteContainersConfiguration(Map<String, RemoteContainerConfiguration> containers, TransportFactory transportFactory) {
+      this.containers = containers;
+      this.transportFactory = transportFactory;
+   }
+
+   public Map<String, RemoteContainerConfiguration> configurations() {
+      return containers;
+   }
+
+   public TransportFactory transportFactory() {
+      return transportFactory;
+   }
+}

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/global/RemoteContainersConfigurationBuilder.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/global/RemoteContainersConfigurationBuilder.java
@@ -23,7 +23,7 @@ public class RemoteContainersConfigurationBuilder implements Builder<RemoteConta
    }
 
    public RemoteContainerConfigurationBuilder addRemoteContainer(String name) {
-      return builders.computeIfAbsent(name, __ -> new RemoteContainerConfigurationBuilder(global));
+      return builders.computeIfAbsent(name, __ -> new RemoteContainerConfigurationBuilder(global, name));
    }
 
    public RemoteContainersConfigurationBuilder transportFactory(TransportFactory transportFactory) {

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/global/RemoteContainersConfigurationBuilder.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/global/RemoteContainersConfigurationBuilder.java
@@ -1,0 +1,51 @@
+package org.infinispan.persistence.remote.configuration.global;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.infinispan.client.hotrod.TransportFactory;
+import org.infinispan.commons.configuration.Builder;
+import org.infinispan.commons.configuration.Combine;
+import org.infinispan.commons.configuration.attributes.AttributeSet;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+
+/**
+ * @since 15.0
+ **/
+public class RemoteContainersConfigurationBuilder implements Builder<RemoteContainersConfiguration> {
+   private final GlobalConfigurationBuilder global;
+   private final Map<String, RemoteContainerConfigurationBuilder> builders = new HashMap<>();
+   private TransportFactory transportFactory = TransportFactory.DEFAULT;
+
+   public RemoteContainersConfigurationBuilder(GlobalConfigurationBuilder global) {
+      this.global = global;
+   }
+
+   public RemoteContainerConfigurationBuilder addRemoteContainer(String name) {
+      return builders.computeIfAbsent(name, __ -> new RemoteContainerConfigurationBuilder(global));
+   }
+
+   public RemoteContainersConfigurationBuilder transportFactory(TransportFactory transportFactory) {
+      this.transportFactory = transportFactory;
+      return this;
+   }
+
+   @Override
+   public RemoteContainersConfiguration create() {
+      Map<String, RemoteContainerConfiguration> containers = builders.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().create()));
+      return new RemoteContainersConfiguration(containers, transportFactory);
+   }
+
+   @Override
+   public Builder<?> read(RemoteContainersConfiguration template, Combine combine) {
+
+      return null;
+   }
+
+   @Override
+   public AttributeSet attributes() {
+      return AttributeSet.EMPTY;
+   }
+
+}

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/global/RemoteContainersConfigurationSerializer.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/global/RemoteContainersConfigurationSerializer.java
@@ -1,0 +1,28 @@
+package org.infinispan.persistence.remote.configuration.global;
+
+import static org.infinispan.persistence.remote.configuration.RemoteStoreConfigurationParser.NAMESPACE;
+import static org.infinispan.persistence.remote.configuration.RemoteStoreConfigurationParser.PREFIX;
+
+import org.infinispan.commons.configuration.io.ConfigurationWriter;
+import org.infinispan.commons.util.Version;
+import org.infinispan.configuration.serializing.ConfigurationSerializer;
+import org.infinispan.persistence.remote.configuration.Element;
+
+public class RemoteContainersConfigurationSerializer
+      implements ConfigurationSerializer<RemoteContainersConfiguration> {
+
+   @Override
+   public void serialize(ConfigurationWriter writer, RemoteContainersConfiguration configuration) {
+      if (!configuration.configurations().isEmpty()) {
+         String xmlns = NAMESPACE + Version.getMajorMinor();
+         writer.writeStartElement(PREFIX, xmlns, Element.REMOTE_CACHE_CONTAINERS);
+         writer.writeNamespace(PREFIX, xmlns);
+         configuration.configurations().values().forEach(c -> {
+            writer.writeStartElement(PREFIX, xmlns, Element.REMOTE_CACHE_CONTAINER);
+            c.attributes().write(writer);
+            writer.writeEndElement();
+         });
+         writer.writeEndElement();
+      }
+   }
+}

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/global/GlobalRemoteContainers.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/global/GlobalRemoteContainers.java
@@ -3,6 +3,7 @@ package org.infinispan.persistence.remote.global;
 import java.util.concurrent.CompletionStage;
 
 import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
 
@@ -10,11 +11,11 @@ import org.infinispan.factories.scopes.Scopes;
  * GlobalRemoteContainer.
  *
  * @author Tristan Tarrant
- * @since 8.1
+ * @since 15.0
  */
 @Scope(Scopes.GLOBAL)
 public interface GlobalRemoteContainers {
 
-   CompletionStage<RemoteCacheManager> cacheContainer(String name);
+   CompletionStage<RemoteCacheManager> cacheContainer(String name, Marshaller marshaller);
 
 }

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/global/GlobalRemoteContainers.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/global/GlobalRemoteContainers.java
@@ -1,0 +1,20 @@
+package org.infinispan.persistence.remote.global;
+
+import java.util.concurrent.CompletionStage;
+
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.factories.scopes.Scope;
+import org.infinispan.factories.scopes.Scopes;
+
+/**
+ * GlobalRemoteContainer.
+ *
+ * @author Tristan Tarrant
+ * @since 8.1
+ */
+@Scope(Scopes.GLOBAL)
+public interface GlobalRemoteContainers {
+
+   CompletionStage<RemoteCacheManager> cacheContainer(String name);
+
+}

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/internal/GlobalRemoteContainersImpl.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/internal/GlobalRemoteContainersImpl.java
@@ -1,0 +1,55 @@
+package org.infinispan.persistence.remote.internal;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletionStage;
+
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfiguration;
+import org.infinispan.factories.annotations.Inject;
+import org.infinispan.factories.annotations.Start;
+import org.infinispan.factories.annotations.Stop;
+import org.infinispan.factories.scopes.Scope;
+import org.infinispan.factories.scopes.Scopes;
+import org.infinispan.persistence.remote.configuration.global.RemoteContainerConfiguration;
+import org.infinispan.persistence.remote.configuration.global.RemoteContainersConfiguration;
+import org.infinispan.persistence.remote.global.GlobalRemoteContainers;
+import org.infinispan.util.concurrent.BlockingManager;
+
+/**
+ * @since 15.0
+ **/
+@Scope(Scopes.GLOBAL)
+public class GlobalRemoteContainersImpl implements GlobalRemoteContainers {
+
+   @Inject
+   GlobalConfiguration globalConfiguration;
+
+   @Inject
+   BlockingManager blockingManager;
+
+   private final Map<String, CompletionStage<RemoteCacheManager>> remoteContainers = new HashMap<>();
+
+   @Start
+   public void start() {
+      RemoteContainersConfiguration configuration = globalConfiguration.module(RemoteContainersConfiguration.class);
+      if (configuration != null) {
+         for (Map.Entry<String, RemoteContainerConfiguration> e : configuration.configurations().entrySet()) {
+            ConfigurationBuilder builder = new ConfigurationBuilder();
+            builder.uri(e.getValue().uri()).transportFactory(configuration.transportFactory());
+            remoteContainers.put(e.getKey(), blockingManager.supplyBlocking(() -> new RemoteCacheManager(builder.build()), "RemoteContainer-create"));
+         }
+      }
+   }
+
+   @Stop
+   public void stop() {
+      remoteContainers.values().forEach(c -> c.thenAccept(RemoteCacheManager::stop));
+   }
+
+   @Override
+   public CompletionStage<RemoteCacheManager> cacheContainer(String name) {
+      return remoteContainers.get(name);
+   }
+}

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/internal/GlobalRemoteContainersImpl.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/internal/GlobalRemoteContainersImpl.java
@@ -1,11 +1,19 @@
 package org.infinispan.persistence.remote.internal;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.client.hotrod.configuration.Configuration;
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
+import org.infinispan.client.hotrod.impl.HotRodURI;
+import org.infinispan.commons.logging.LogFactory;
+import org.infinispan.commons.marshall.Marshaller;
+import org.infinispan.commons.util.concurrent.CompletableFutures;
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
@@ -15,6 +23,7 @@ import org.infinispan.factories.scopes.Scopes;
 import org.infinispan.persistence.remote.configuration.global.RemoteContainerConfiguration;
 import org.infinispan.persistence.remote.configuration.global.RemoteContainersConfiguration;
 import org.infinispan.persistence.remote.global.GlobalRemoteContainers;
+import org.infinispan.persistence.remote.logging.Log;
 import org.infinispan.util.concurrent.BlockingManager;
 
 /**
@@ -23,33 +32,132 @@ import org.infinispan.util.concurrent.BlockingManager;
 @Scope(Scopes.GLOBAL)
 public class GlobalRemoteContainersImpl implements GlobalRemoteContainers {
 
+   private static final org.infinispan.commons.logging.Log log = LogFactory.getLog(GlobalRemoteContainersImpl.class);
+
    @Inject
    GlobalConfiguration globalConfiguration;
 
    @Inject
    BlockingManager blockingManager;
 
-   private final Map<String, CompletionStage<RemoteCacheManager>> remoteContainers = new HashMap<>();
+   private final Map<String, CompletionStage<RemoteCacheManager>> remoteContainers = new ConcurrentHashMap<>();
 
    @Start
    public void start() {
       RemoteContainersConfiguration configuration = globalConfiguration.module(RemoteContainersConfiguration.class);
       if (configuration != null) {
          for (Map.Entry<String, RemoteContainerConfiguration> e : configuration.configurations().entrySet()) {
-            ConfigurationBuilder builder = new ConfigurationBuilder();
-            builder.uri(e.getValue().uri()).transportFactory(configuration.transportFactory());
-            remoteContainers.put(e.getKey(), blockingManager.supplyBlocking(() -> new RemoteCacheManager(builder.build()), "RemoteContainer-create"));
+            remoteContainers.put(e.getKey(), CompletableFutures.completedNull());
          }
       }
    }
 
    @Stop
    public void stop() {
-      remoteContainers.values().forEach(c -> c.thenAccept(RemoteCacheManager::stop));
+      remoteContainers.values().forEach(c -> c.thenApply(this::stop));
+   }
+
+   private Void stop(RemoteCacheManager rcm) {
+      if (rcm != null) rcm.stop();
+      return null;
+   }
+
+   private void remoteCacheManagerShutdown(String name) {
+      remoteContainers.computeIfPresent(name, (key, prev) -> prev.thenApply(ignore -> null));
    }
 
    @Override
-   public CompletionStage<RemoteCacheManager> cacheContainer(String name) {
-      return remoteContainers.get(name);
+   public CompletionStage<RemoteCacheManager> cacheContainer(String name, Marshaller marshaller) {
+      CompletionStage<RemoteCacheManager> cs = remoteContainers.computeIfPresent(name, (k, cf) ->
+            cf.thenCompose(prev -> {
+               if (prev != null && ((RefCountedRemoteCacheManager) prev).incrementReference()) {
+                  return CompletableFuture.completedFuture(prev);
+               }
+               return createCacheManager(name, marshaller);
+            }));
+
+      if (cs == null) {
+         return CompletableFuture.failedFuture(Log.CONFIG.unknownRemoteCacheManagerContainer(name));
+      }
+
+      return cs.thenApply(rcm -> {
+         Marshaller inUse = rcm.getConfiguration().marshaller();
+         if (!inUse.equals(marshaller)) throw Log.CONFIG.shouldUseSameMarshallerWithContainer(inUse, marshaller);
+         return rcm;
+      });
+   }
+
+   private CompletionStage<RemoteCacheManager> createCacheManager(String name, Marshaller marshaller) {
+      RemoteContainersConfiguration configuration = globalConfiguration.module(RemoteContainersConfiguration.class);
+      if (configuration != null) {
+         RemoteContainerConfiguration rcc = configuration.configurations().get(name);
+
+         if (rcc == null)
+            return CompletableFuture.failedFuture(new IllegalStateException("No configuration defined for container " + name));
+
+         ConfigurationBuilder builder = !rcc.uri().isEmpty()
+               ? HotRodURI.create(rcc.uri()).toConfigurationBuilder()
+               : new ConfigurationBuilder();
+
+         builder.marshaller(marshaller);
+
+         Properties propertiesToUse;
+         Properties actualProperties = rcc.properties();
+         if (!actualProperties.contains("blocking")) {
+            // Need to make a copy to not change the actual configuration properties
+            propertiesToUse = new Properties();
+            propertiesToUse.putAll(actualProperties);
+            // Make sure threads are marked as non blocking if user didn't specify
+            propertiesToUse.put("blocking", "false");
+         } else {
+            propertiesToUse = actualProperties;
+         }
+         builder.withProperties(propertiesToUse);
+
+         return blockingManager.supplyBlocking(() -> new RefCountedRemoteCacheManager(name, builder.build()), "RemoteContainer-create");
+      }
+      return CompletableFuture.failedFuture(new IllegalStateException("No remote container configuration defined"));
+   }
+
+   /**
+    * Count the number of references to the {@link RemoteCacheManager}.
+    * <p>
+    * The shutdown only happens after the number of references reaches zero. Which also removes the class
+    * from the {@link GlobalRemoteContainersImpl#remoteContainers}.
+    */
+   private class RefCountedRemoteCacheManager extends RemoteCacheManager {
+
+      private final String name;
+      private final AtomicInteger references;
+
+      public RefCountedRemoteCacheManager(String name, Configuration configuration) {
+         super(configuration);
+         this.name = name;
+         this.references = new AtomicInteger(1);
+      }
+
+      @Override
+      public void stop() {
+         if (references.decrementAndGet() == 0) {
+            super.stop();
+            remoteCacheManagerShutdown(name);
+         }
+      }
+
+      public boolean incrementReference() {
+         int curr = references.get();
+
+         // Probably won't iterate (much), as the incrementReference is invoked from within the compute method.
+         // This could conflict with a concurrent stop.
+         while (curr > 0) {
+            if (references.compareAndSet(curr, curr + 1)) {
+               return true;
+            }
+            curr = references.get();
+         }
+
+         log.warnf("Remote cache manager '%s' was shutdown before acquiring, a new one will be created", name);
+         return false;
+      }
    }
 }

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/internal/RemoteContainersComponentFactory.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/internal/RemoteContainersComponentFactory.java
@@ -1,0 +1,22 @@
+package org.infinispan.persistence.remote.internal;
+
+import static org.infinispan.util.logging.Log.CONTAINER;
+
+import org.infinispan.factories.AbstractComponentFactory;
+import org.infinispan.factories.AutoInstantiableFactory;
+import org.infinispan.factories.annotations.DefaultFactoryFor;
+import org.infinispan.persistence.remote.global.GlobalRemoteContainers;
+
+/**
+ * @since 15.0
+ */
+@DefaultFactoryFor(classes = GlobalRemoteContainers.class)
+public class RemoteContainersComponentFactory extends AbstractComponentFactory implements AutoInstantiableFactory {
+
+   @Override
+   public Object construct(String componentName) {
+      if (componentName.equals(GlobalRemoteContainers.class.getName()))
+         return new GlobalRemoteContainersImpl();
+      throw CONTAINER.factoryCannotConstructComponent(componentName);
+   }
+}

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/logging/Log.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/logging/Log.java
@@ -8,6 +8,7 @@ import org.infinispan.client.hotrod.ProtocolVersion;
 import org.infinispan.commons.CacheConfigurationException;
 import org.infinispan.commons.CacheException;
 import org.infinispan.commons.dataconversion.MediaType;
+import org.infinispan.commons.marshall.Marshaller;
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.Cause;
@@ -63,4 +64,10 @@ public interface Log extends BasicLogger {
 
    @Message(value = "The RemoteCacheStore must specify either an existing remote-cache-container or provide a URI/server list", id = 10013)
    CacheConfigurationException remoteStoreWithoutContainer();
+
+   @Message(value = "All stores referencing the same manager must use the same marshaller, actual is %s but provided was %s", id = 10014)
+   CacheConfigurationException shouldUseSameMarshallerWithContainer(Marshaller inUse, Marshaller provided);
+
+   @Message(value = "The remote cache container with name '%s' was not found", id = 10015)
+   CacheConfigurationException unknownRemoteCacheManagerContainer(String name);
 }

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/logging/Log.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/logging/Log.java
@@ -60,4 +60,7 @@ public interface Log extends BasicLogger {
 
    @Message(value = "The RemoteCacheStore cannot be segmented when grouping is enabled", id = 10012)
    CacheConfigurationException segmentationNotSupportedWithGroups();
+
+   @Message(value = "The RemoteCacheStore must specify either an existing remote-cache-container or provide a URI/server list", id = 10013)
+   CacheConfigurationException remoteStoreWithoutContainer();
 }

--- a/persistence/remote/src/main/resources/schema/infinispan-cachestore-remote-config-15.0.xsd
+++ b/persistence/remote/src/main/resources/schema/infinispan-cachestore-remote-config-15.0.xsd
@@ -37,6 +37,13 @@
             </xs:annotation>
           </xs:element>
         </xs:sequence>
+        <xs:attribute name="remote-cache-container" type="remote-cache-container" default="">
+          <xs:annotation>
+            <xs:documentation>
+              The name of the remote cache container to use.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="socket-timeout" type="xs:long" default="${RemoteStore.socketTimeout}">
           <xs:annotation>
             <xs:documentation>
@@ -388,12 +395,21 @@
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="uri" use="required">
+    <xs:attribute name="uri" type="xs:anyURI" use="required">
       <xs:annotation>
         <xs:documentation>
           A Hot Rod URI.
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>
+    <xs:sequence>
+      <xs:element name="property" type="config:property" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>
+            Add key/value property pair to this remote cache configuration. The configuration are applied during the Hot Rod client creation.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
   </xs:complexType>
 </xs:schema>

--- a/persistence/remote/src/main/resources/schema/infinispan-cachestore-remote-config-15.0.xsd
+++ b/persistence/remote/src/main/resources/schema/infinispan-cachestore-remote-config-15.0.xsd
@@ -6,6 +6,8 @@
   <xs:import namespace="urn:infinispan:config:15.0"
              schemaLocation="https://infinispan.org/schemas/infinispan-config-15.0.xsd" />
 
+  <xs:element name="remote-cache-containers" type="tns:remote-cache-containers"/>
+
   <xs:element name="remote-store" type="tns:remote-store"/>
 
   <xs:complexType name="remote-store">
@@ -368,4 +370,30 @@
     </xs:complexContent>
   </xs:complexType>
 
+  <xs:complexType name="remote-cache-containers">
+    <xs:unique name="remote-cache-container-unique">
+      <xs:selector xpath="./tns:remote-cache-container" />
+      <xs:field xpath="@name" />
+    </xs:unique>
+    <xs:sequence>
+      <xs:element name="remote-cache-container" type="tns:remote-cache-container" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="remote-cache-container">
+    <xs:attribute name="name" default="">
+      <xs:annotation>
+        <xs:documentation>
+          The name of this remote cache container.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="uri" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          A Hot Rod URI.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
 </xs:schema>

--- a/persistence/remote/src/test/java/org/infinispan/persistence/remote/RemoteStoreConfigTest.java
+++ b/persistence/remote/src/test/java/org/infinispan/persistence/remote/RemoteStoreConfigTest.java
@@ -31,9 +31,9 @@ public class RemoteStoreConfigTest extends AbstractInfinispanTest {
    public static final String STORE_CACHE_NAME = "RemoteStoreConfigTest";
    private EmbeddedCacheManager cacheManager;
    private HotRodServer hotRodServer;
-   private String cacheLoaderConfig;
-   private String storeCacheName;
-   private int port;
+   private final String cacheLoaderConfig;
+   private final String storeCacheName;
+   private final int port;
 
    public RemoteStoreConfigTest(String cacheLoaderConfig, String storeCacheName, int port) {
       super();

--- a/persistence/remote/src/test/java/org/infinispan/persistence/remote/RemoteStoreConfigTest.java
+++ b/persistence/remote/src/test/java/org/infinispan/persistence/remote/RemoteStoreConfigTest.java
@@ -29,10 +29,10 @@ public class RemoteStoreConfigTest extends AbstractInfinispanTest {
    private static final int PORT = 19711;
    public static final String CACHE_LOADER_CONFIG = "remote-cl-config.xml";
    public static final String STORE_CACHE_NAME = "RemoteStoreConfigTest";
-   private EmbeddedCacheManager cacheManager;
+   protected EmbeddedCacheManager cacheManager;
    private HotRodServer hotRodServer;
    private final String cacheLoaderConfig;
-   private final String storeCacheName;
+   protected final String storeCacheName;
    private final int port;
 
    public RemoteStoreConfigTest(String cacheLoaderConfig, String storeCacheName, int port) {

--- a/persistence/remote/src/test/java/org/infinispan/persistence/remote/RemoteStoreConfigWithContainersTest.java
+++ b/persistence/remote/src/test/java/org/infinispan/persistence/remote/RemoteStoreConfigWithContainersTest.java
@@ -1,0 +1,15 @@
+package org.infinispan.persistence.remote;
+
+import org.testng.annotations.Test;
+
+@Test(testName = "persistence.remote.RemoteStoreConfigWithContainersTest", groups = "functional")
+public class RemoteStoreConfigWithContainersTest extends RemoteStoreConfigTest {
+
+   private static final int PORT = 19811;
+   public static final String CACHE_LOADER_CONFIG = "remotestore-with-containers.xml";
+   public static final String STORE_CACHE_NAME = "RemoteStoreWithDefaultContainer";
+
+   public RemoteStoreConfigWithContainersTest() {
+      super(CACHE_LOADER_CONFIG, STORE_CACHE_NAME, PORT);
+   }
+}

--- a/persistence/remote/src/test/java/org/infinispan/persistence/remote/RemoteStoreConfigWithContainersTest.java
+++ b/persistence/remote/src/test/java/org/infinispan/persistence/remote/RemoteStoreConfigWithContainersTest.java
@@ -1,5 +1,9 @@
 package org.infinispan.persistence.remote;
 
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 
 @Test(testName = "persistence.remote.RemoteStoreConfigWithContainersTest", groups = "functional")
@@ -7,9 +11,37 @@ public class RemoteStoreConfigWithContainersTest extends RemoteStoreConfigTest {
 
    private static final int PORT = 19811;
    public static final String CACHE_LOADER_CONFIG = "remotestore-with-containers.xml";
-   public static final String STORE_CACHE_NAME = "RemoteStoreWithDefaultContainer";
+   public static final String DEFAULT_STORE_CACHE_NAME = "RemoteStoreWithDefaultContainer";
+   public static final String ALTERNATIVE_STORE_CACHE_NAME = "RemoteStoreWithNamedContainer";
 
-   public RemoteStoreConfigWithContainersTest() {
-      super(CACHE_LOADER_CONFIG, STORE_CACHE_NAME, PORT);
+   protected RemoteStoreConfigWithContainersTest(String cacheName) {
+      super(CACHE_LOADER_CONFIG, cacheName, PORT);
+   }
+
+   @BeforeClass
+   @Override
+   public void startUp() {
+      super.startUp();
+      switch (storeCacheName) {
+         case ALTERNATIVE_STORE_CACHE_NAME:
+            cacheManager.createCache(DEFAULT_STORE_CACHE_NAME, hotRodCacheConfiguration().build());
+            break;
+         case DEFAULT_STORE_CACHE_NAME:
+            cacheManager.createCache(ALTERNATIVE_STORE_CACHE_NAME, hotRodCacheConfiguration().build());
+            break;
+      }
+   }
+
+   @Factory
+   protected static Object[] factory() {
+      return new Object[] {
+            new RemoteStoreConfigWithContainersTest(DEFAULT_STORE_CACHE_NAME),
+            new RemoteStoreConfigWithContainersTest(ALTERNATIVE_STORE_CACHE_NAME),
+      };
+   }
+
+   @Override
+   protected String parameters() {
+      return "[cache=" + storeCacheName + "]";
    }
 }

--- a/persistence/remote/src/test/java/org/infinispan/persistence/remote/configuration/XmlFileParsingTest.java
+++ b/persistence/remote/src/test/java/org/infinispan/persistence/remote/configuration/XmlFileParsingTest.java
@@ -25,7 +25,7 @@ public class XmlFileParsingTest extends AbstractInfinispanTest {
       TestingUtil.killCacheManagers(cacheManager);
    }
 
-   public void testRemoteCacheStore() throws Exception {
+   public void testRemoteCacheStore() {
       String config = TestingUtil.wrapXMLWithSchema(
             "<cache-container default-cache=\"default\">" +
             "   <local-cache name=\"default\">\n" +

--- a/persistence/remote/src/test/java/org/infinispan/persistence/remote/shared/RemoteSharedCacheManagerSSLTest.java
+++ b/persistence/remote/src/test/java/org/infinispan/persistence/remote/shared/RemoteSharedCacheManagerSSLTest.java
@@ -1,0 +1,98 @@
+package org.infinispan.persistence.remote.shared;
+
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+
+import java.util.Properties;
+
+import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
+import org.infinispan.commons.test.security.TestCertificates;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.cache.PersistenceConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.persistence.remote.RemoteStoreFunctionalTest;
+import org.infinispan.persistence.remote.configuration.RemoteStoreConfigurationBuilder;
+import org.infinispan.persistence.remote.configuration.global.RemoteContainersConfigurationBuilder;
+import org.infinispan.server.core.security.simple.SimpleSaslAuthenticator;
+import org.infinispan.server.hotrod.HotRodServer;
+import org.infinispan.server.hotrod.configuration.HotRodServerConfigurationBuilder;
+import org.infinispan.server.hotrod.test.HotRodTestingUtil;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+@Test(testName = "persistence.remote.shared.RemoteSharedCacheManagerSSLTest", groups = "functional")
+public class RemoteSharedCacheManagerSSLTest extends RemoteStoreFunctionalTest {
+
+   private static final String REMOTE_CONTAINER_NAME = "shared-remote-container";
+
+   private EmbeddedCacheManager localCacheManager;
+   private HotRodServer hrServer;
+
+   @BeforeClass
+   protected void setupBefore() {
+      localCacheManager = TestCacheManagerFactory.createCacheManager(hotRodCacheConfiguration());
+
+      SimpleSaslAuthenticator ssa = new SimpleSaslAuthenticator();
+      HotRodServerConfigurationBuilder serverBuilder = HotRodTestingUtil.getDefaultHotRodConfiguration();
+      serverBuilder
+            .ssl()
+            .enable()
+            .requireClientAuth(true)
+            .keyStoreFileName(TestCertificates.certificate("server"))
+            .keyStorePassword(TestCertificates.KEY_PASSWORD)
+            .keyAlias("server")
+            .trustStoreFileName(TestCertificates.certificate("trust"))
+            .trustStorePassword(TestCertificates.KEY_PASSWORD);
+      serverBuilder
+            .authentication()
+            .enable()
+            .sasl()
+            .serverName("localhost")
+            .addAllowedMech("EXTERNAL")
+            .authenticator(ssa);
+
+      hrServer = HotRodClientTestingUtil.startHotRodServer(localCacheManager, serverBuilder);
+   }
+
+   @AfterClass
+   protected void tearDown() {
+      HotRodClientTestingUtil.killServers(hrServer);
+      localCacheManager.stop();
+   }
+
+   @Override
+   protected EmbeddedCacheManager createCacheManager(boolean start, GlobalConfigurationBuilder global, ConfigurationBuilder cb) {
+      // We configure all the security properties to work correctly.
+      // See: https://docs.jboss.org/infinispan/15.0/apidocs/org/infinispan/client/hotrod/configuration/package-summary.html
+      Properties properties = new Properties();
+      properties.setProperty("infinispan.client.hotrod.use_ssl", "true");
+      properties.setProperty("infinispan.client.hotrod.key_store_file_name", TestCertificates.certificate("client"));
+      properties.setProperty("infinispan.client.hotrod.key_store_password", new String(TestCertificates.KEY_PASSWORD));
+      properties.setProperty("infinispan.client.hotrod.trust_store_file_name", TestCertificates.certificate("ca"));
+      properties.setProperty("infinispan.client.hotrod.trust_store_password", new String(TestCertificates.KEY_PASSWORD));
+      properties.setProperty("infinispan.client.hotrod.ssl_hostname_validation", "false");
+      properties.setProperty("infinispan.client.hotrod.use_auth", "true");
+      properties.setProperty("infinispan.client.hotrod.sasl_mechanism", "EXTERNAL");
+
+      RemoteContainersConfigurationBuilder rccb = global.addModule(RemoteContainersConfigurationBuilder.class);
+      rccb.addRemoteContainer(REMOTE_CONTAINER_NAME)
+            .uri(String.format("hotrod://localhost:%d", hrServer.getPort()))
+            .properties(properties);
+      return super.createCacheManager(start, global, cb);
+   }
+
+   @Override
+   protected PersistenceConfigurationBuilder createCacheStoreConfig(PersistenceConfigurationBuilder persistence,
+                                                                    String cacheName, boolean preload) {
+      persistence
+            .addStore(RemoteStoreConfigurationBuilder.class)
+            .remoteCacheName("")
+            .preload(preload)
+            // local cache encoding is object where as server is protostream so we can't be segmented
+            .segmented(false)
+            .remoteCacheContainer(REMOTE_CONTAINER_NAME);
+      return persistence;
+   }
+}

--- a/persistence/remote/src/test/java/org/infinispan/persistence/remote/shared/RemoteStoreSharedCacheManagerTest.java
+++ b/persistence/remote/src/test/java/org/infinispan/persistence/remote/shared/RemoteStoreSharedCacheManagerTest.java
@@ -1,0 +1,82 @@
+package org.infinispan.persistence.remote.shared;
+
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.test.TestingUtil.withCacheManager;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.infinispan.Cache;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.persistence.manager.PersistenceManager;
+import org.infinispan.persistence.remote.RemoteStore;
+import org.infinispan.server.hotrod.HotRodServer;
+import org.infinispan.server.hotrod.test.HotRodTestingUtil;
+import org.infinispan.test.AbstractInfinispanTest;
+import org.infinispan.test.CacheManagerCallable;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+@Test(groups = "functional", testName = "persistence.remote.shared.RemoteStoreSharedCacheManagerTest")
+public class RemoteStoreSharedCacheManagerTest extends AbstractInfinispanTest {
+
+   private static final int PORT = 19721;
+   private static final String CACHE_NAME = "remote-cache-name";
+   private static final String CONFIG_PATH = "remotestore-shared-container.xml";
+   private HotRodServer hotRodServer;
+   private EmbeddedCacheManager storeCacheManager;
+
+   @BeforeClass
+   protected void setup() {
+      storeCacheManager = TestCacheManagerFactory.createCacheManager();
+      storeCacheManager.createCache(CACHE_NAME, hotRodCacheConfiguration().build());
+      hotRodServer = HotRodTestingUtil.startHotRodServer(storeCacheManager, PORT);
+   }
+
+   @AfterClass
+   protected void tearDown() {
+      HotRodClientTestingUtil.killServers(hotRodServer);
+      hotRodServer = null;
+      TestingUtil.killCacheManagers(storeCacheManager);
+      storeCacheManager = null;
+   }
+
+   @Test
+   public void testOperationsSharedStore() throws Exception {
+      withCacheManager(new CacheManagerCallable(TestCacheManagerFactory.fromXml(CONFIG_PATH)) {
+         @Override
+         public void call() {
+            Cache<Object, Object> c0 = cm.getCache("RemoteStoreWithDefaultContainer");
+            Cache<Object, Object> c1 = cm.getCache("AnotherRemoteStore");
+
+            c0.put("k", "v");
+            assertEquals(c1.get("k"), "v");
+
+            List<RemoteStore> rs0 = new ArrayList<>(extractRemoteStore(c0));
+            List<RemoteStore> rs1 = new ArrayList<>(extractRemoteStore(c1));
+
+            assertEquals(rs0.size(), 1);
+            assertEquals(rs0.size(), rs1.size());
+
+            RemoteCacheManager rcm0 = TestingUtil.extractField(rs0.get(0), "remoteCacheManager");
+            RemoteCacheManager rcm1 = TestingUtil.extractField(rs1.get(0), "remoteCacheManager");
+
+            assertSame(rcm0, rcm1);
+         }
+      });
+   }
+
+   private Set<RemoteStore> extractRemoteStore(Cache<Object, Object> cache) {
+      PersistenceManager pm = cache.getAdvancedCache().getComponentRegistry()
+            .getComponent(PersistenceManager.class);
+      return pm.getStores(RemoteStore.class);
+   }
+}

--- a/persistence/remote/src/test/java/org/infinispan/persistence/remote/shared/RemoteStoreSharedManagerFunctionalTest.java
+++ b/persistence/remote/src/test/java/org/infinispan/persistence/remote/shared/RemoteStoreSharedManagerFunctionalTest.java
@@ -1,0 +1,59 @@
+package org.infinispan.persistence.remote.shared;
+
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+
+import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.cache.PersistenceConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.persistence.remote.RemoteStoreFunctionalTest;
+import org.infinispan.persistence.remote.configuration.RemoteStoreConfigurationBuilder;
+import org.infinispan.persistence.remote.configuration.global.RemoteContainersConfigurationBuilder;
+import org.infinispan.server.hotrod.HotRodServer;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+@Test(testName = "persistence.remote.shared.RemoteStoreSharedManagerFunctionalTest", groups = "functional")
+public class RemoteStoreSharedManagerFunctionalTest extends RemoteStoreFunctionalTest {
+
+   private EmbeddedCacheManager localCacheManager;
+   private HotRodServer hrServer;
+
+   @BeforeClass
+   public void setupBefore() {
+      localCacheManager = TestCacheManagerFactory.createCacheManager(hotRodCacheConfiguration());
+      hrServer = HotRodClientTestingUtil.startHotRodServer(localCacheManager);
+   }
+
+   @AfterClass
+   public void tearDown() {
+      HotRodClientTestingUtil.killServers(hrServer);
+      localCacheManager.stop();
+   }
+
+   @Override
+   protected EmbeddedCacheManager createCacheManager(boolean start, GlobalConfigurationBuilder global, ConfigurationBuilder cb) {
+      RemoteContainersConfigurationBuilder rccb = global.addModule(RemoteContainersConfigurationBuilder.class);
+      rccb.addRemoteContainer("shared-container")
+            .uri(String.format("hotrod://localhost:%d", hrServer.getPort()));
+      rccb.addRemoteContainer("alternative")
+            .uri(String.format("hotrod://localhost:%d", hrServer.getPort()));
+      return super.createCacheManager(start, global, cb);
+   }
+
+   @Override
+   protected PersistenceConfigurationBuilder createCacheStoreConfig(PersistenceConfigurationBuilder persistence,
+                                                                    String cacheName, boolean preload) {
+      persistence
+            .addStore(RemoteStoreConfigurationBuilder.class)
+            .remoteCacheName("")
+            .preload(preload)
+            // local cache encoding is object where as server is protostream so we can't be segmented
+            .segmented(false)
+            .remoteCacheContainer("shared-container");
+      return persistence;
+   }
+}

--- a/persistence/remote/src/test/java/org/infinispan/persistence/remote/upgrade/HotRodUpgradeContainerSSLTest.java
+++ b/persistence/remote/src/test/java/org/infinispan/persistence/remote/upgrade/HotRodUpgradeContainerSSLTest.java
@@ -1,0 +1,62 @@
+package org.infinispan.persistence.remote.upgrade;
+
+import java.util.Properties;
+
+import org.infinispan.commons.test.security.TestCertificates;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.persistence.remote.configuration.global.RemoteContainersConfigurationBuilder;
+import org.testng.annotations.Test;
+
+@Test(testName = "upgrade.hotrod.HotRodUpgradeContainerSSLTest", groups = "functional")
+public class HotRodUpgradeContainerSSLTest extends HotRodUpgradeWithSSLTest {
+
+   private static final String CONTAINER_NAME_OLD = "old-ssl-container-name";
+   private static final String CONTAINER_NAME_TEST = "test-ssl-container-name";
+
+   @Override
+   protected TestCluster configureTargetCluster() {
+      Properties properties = new Properties();
+      properties.setProperty("infinispan.client.hotrod.async_executor_factory", "org.infinispan.executors.DefaultExecutorFactory");
+      properties.setProperty("infinispan.client.hotrod.use_ssl", "true");
+      properties.setProperty("infinispan.client.hotrod.key_store_file_name", TestCertificates.certificate("client"));
+      properties.setProperty("infinispan.client.hotrod.key_store_password", new String(TestCertificates.KEY_PASSWORD));
+      properties.setProperty("infinispan.client.hotrod.key_store_type", "JKS");
+      properties.setProperty("infinispan.client.hotrod.trust_store_file_name", TestCertificates.certificate("ca"));
+      properties.setProperty("infinispan.client.hotrod.trust_store_password", new String(TestCertificates.KEY_PASSWORD));
+      properties.setProperty("infinispan.client.hotrod.trust_store_type", "JKS");
+      properties.setProperty("infinispan.client.hotrod.ssl_hostname_validation", "false");
+
+      return new TestCluster.Builder().setName("targetCluster").setNumMembers(2)
+            .withHotRodBuilder(getHotRodServerBuilder())
+            .cache()
+            .name(TEST_CACHE)
+            .remotePort(sourceCluster.getHotRodPort())
+            .useRemoteContainer(CONTAINER_NAME_TEST)
+            .remoteProtocolVersion(NEW_PROTOCOL_VERSION)
+            .cache()
+            .name(OLD_CACHE)
+            .remotePort(sourceCluster.getHotRodPort())
+            .useRemoteContainer(CONTAINER_NAME_OLD)
+            .remoteProtocolVersion(OLD_PROTOCOL_VERSION)
+            .build(() -> {
+               GlobalConfigurationBuilder global = new GlobalConfigurationBuilder();
+               RemoteContainersConfigurationBuilder rccb = global.addModule(RemoteContainersConfigurationBuilder.class);
+
+               Properties old = new Properties();
+               old.putAll(properties);
+               old.setProperty("infinispan.client.hotrod.protocol_version", OLD_PROTOCOL_VERSION.toString());
+               rccb.addRemoteContainer(CONTAINER_NAME_OLD)
+                     .uri(String.format("hotrods://localhost:%d", sourceCluster.getHotRodPort()))
+                     .properties(old);
+
+               Properties test = new Properties();
+               test.putAll(properties);
+               test.setProperty("infinispan.client.hotrod.protocol_version", NEW_PROTOCOL_VERSION.toString());
+               rccb.addRemoteContainer(CONTAINER_NAME_TEST)
+                     .uri(String.format("hotrods://localhost:%d", sourceCluster.getHotRodPort()))
+                     .properties(test);
+
+               return global;
+            }, properties);
+   }
+}

--- a/persistence/remote/src/test/java/org/infinispan/persistence/remote/upgrade/HotRodUpgradeContainerStoreTest.java
+++ b/persistence/remote/src/test/java/org/infinispan/persistence/remote/upgrade/HotRodUpgradeContainerStoreTest.java
@@ -1,0 +1,36 @@
+package org.infinispan.persistence.remote.upgrade;
+
+import java.util.Properties;
+
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.persistence.dummy.DummyInMemoryStoreConfigurationBuilder;
+import org.infinispan.persistence.remote.configuration.global.RemoteContainersConfigurationBuilder;
+import org.infinispan.util.concurrent.IsolationLevel;
+import org.testng.annotations.Test;
+
+@Test(testName = "upgrade.hotrod.HotRodUpgradeContainerStoreTest", groups = "functional")
+public class HotRodUpgradeContainerStoreTest extends HotRodUpgradeWithStoreTest {
+
+   private static final String CONTAINER_NAME = "upgrade-container-name";
+
+   @Override
+   protected TestCluster configureTargetCluster() {
+      ConfigurationBuilder targetStoreBuilder = new ConfigurationBuilder();
+      targetStoreBuilder.clustering().cacheMode(CacheMode.DIST_SYNC)
+            .locking().isolationLevel(IsolationLevel.REPEATABLE_READ)
+            .persistence().addStore(DummyInMemoryStoreConfigurationBuilder.class).shared(true).storeName("targetStore");
+
+      return new TestCluster.Builder().setName("targetCluster").setNumMembers(2)
+            .cache().name(CACHE_NAME).remotePort(sourceCluster.getHotRodPort()).useRemoteContainer(CONTAINER_NAME)
+            .configuredWith(targetStoreBuilder)
+            .build(() -> {
+               GlobalConfigurationBuilder global = new GlobalConfigurationBuilder();
+               RemoteContainersConfigurationBuilder rccb = global.addModule(RemoteContainersConfigurationBuilder.class);
+               rccb.addRemoteContainer(CONTAINER_NAME)
+                     .uri(String.format("hotrod://localhost:%d", sourceCluster.getHotRodPort()));
+               return global;
+            }, new Properties());
+   }
+}

--- a/persistence/remote/src/test/java/org/infinispan/persistence/remote/upgrade/HotRodUpgradeContainersEncodingsTest.java
+++ b/persistence/remote/src/test/java/org/infinispan/persistence/remote/upgrade/HotRodUpgradeContainersEncodingsTest.java
@@ -1,0 +1,38 @@
+package org.infinispan.persistence.remote.upgrade;
+
+import java.util.Properties;
+
+import org.infinispan.configuration.cache.StorageType;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.persistence.remote.configuration.global.RemoteContainersConfigurationBuilder;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+
+@Test(groups = "functional", testName = "upgrade.hotrod.HotRodUpgradeContainersEncodingsTest")
+public class HotRodUpgradeContainersEncodingsTest extends HotRodUpgradeEncodingsTest {
+
+   private static final String CONTAINER_NAME = "encoding-container-name";
+
+   @Factory
+   @Override
+   public Object[] factory() {
+      return new Object[] {
+            new HotRodUpgradeContainersEncodingsTest().withStorage(StorageType.HEAP),
+            new HotRodUpgradeContainersEncodingsTest().withStorage(StorageType.OFF_HEAP),
+      };
+   }
+
+   @Override
+   protected TestCluster configureTargetCluster() {
+      return new TestCluster.Builder().setName("targetCluster").setNumMembers(2)
+            .cache().name(CACHE_NAME).remotePort(sourceCluster.getHotRodPort())
+            .useRemoteContainer(CONTAINER_NAME).configuredWith(getConfigurationBuilder())
+            .build(() -> {
+               GlobalConfigurationBuilder global = new GlobalConfigurationBuilder();
+               RemoteContainersConfigurationBuilder rccb = global.addModule(RemoteContainersConfigurationBuilder.class);
+               rccb.addRemoteContainer(CONTAINER_NAME)
+                     .uri(String.format("hotrod://localhost:%d", sourceCluster.getHotRodPort()));
+               return global;
+            }, new Properties());
+   }
+}

--- a/persistence/remote/src/test/resources/remotestore-shared-container.xml
+++ b/persistence/remote/src/test/resources/remotestore-shared-container.xml
@@ -11,26 +11,24 @@
       <local-cache name="RemoteStoreWithDefaultContainer">
          <persistence>
             <remote-store xmlns="urn:infinispan:config:store:remote:${infinispan.core.schema.version}"
-                          cache="RemoteStoreWithDefaultContainer"
+                          cache="remote-cache-name"
                           segmented="false"/>
          </persistence>
       </local-cache>
 
-      <local-cache name="RemoteStoreWithNamedContainer">
+      <local-cache name="AnotherRemoteStore">
          <persistence>
             <remote-store xmlns="urn:infinispan:config:store:remote:${infinispan.core.schema.version}"
-                          cache="RemoteStoreWithNamedContainer"
-                          remote-cache-container="alternative"
+                          cache="remote-cache-name"
                           segmented="false"/>
          </persistence>
       </local-cache>
    </cache-container>
 
    <remote-cache-containers xmlns="urn:infinispan:config:store:remote:${infinispan.core.schema.version}">
-      <remote-cache-container uri="hotrod://127.0.0.1:19811"/>
-      <remote-cache-container uri="hotrod://127.0.0.1:19811" name="alternative">
-         <property name="socket-timeout">20000</property>
-         <property name="connect-timeout">20000</property>
+      <remote-cache-container uri="hotrod://127.0.0.1:19721">
+         <property name="connect-timeout">10000</property>
+         <property name="socket-timeout">10000</property>
       </remote-cache-container>
    </remote-cache-containers>
 

--- a/persistence/remote/src/test/resources/remotestore-with-containers.xml
+++ b/persistence/remote/src/test/resources/remotestore-with-containers.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<infinispan
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="urn:infinispan:config:${infinispan.core.schema.version} https://infinispan.org/schemas/infinispan-config-${infinispan.core.schema.version}.xsd
+                          urn:infinispan:config:store:remote:${infinispan.core.schema.version} https://infinispan.org/schemas/infinispan-cachestore-remote-config-${infinispan.core.schema.version}.xsd"
+      xmlns="urn:infinispan:config:${infinispan.core.schema.version}"
+      xmlns:remote="urn:infinispan:config:store:remote:${infinispan.core.schema.version}" >
+
+   <remote-cache-containers xmlns="urn:infinispan:config:store:remote:${infinispan.core.schema.version}">
+      <remote-cache-container uri="hotrod://127.0.0.1:19811"/>
+      <remote-cache-container uri="hotrod://127.0.0.1:19811" name="alternative"/>
+   </remote-cache-containers>
+
+   <!-- Default cache named to preserve old default cache name -->
+   <cache-container default-cache="RemoteStoreWithDefaultContainer">
+      <local-cache name="RemoteStoreWithDefaultContainer">
+         <persistence>
+            <remote-store xmlns="urn:infinispan:config:store:remote:${infinispan.core.schema.version}"
+                          cache="RemoteStoreWithDefaultContainer"
+                          segmented="false"/>
+         </persistence>
+      </local-cache>
+
+      <local-cache name="RemoteStoreWithNamedContainer">
+         <persistence>
+            <remote-store xmlns="urn:infinispan:config:store:remote:${infinispan.core.schema.version}"
+                          cache="RemoteStoreWithDefaultContainer"
+                          remote-cache-container="alternative"
+                          segmented="false"/>
+         </persistence>
+      </local-cache>
+   </cache-container>
+
+</infinispan>


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-15104

* Includes the new configuration to create a remote-cache-container
* I am using the marshaller from the first RCS that requests the RCM. If multiple RCS with different marshallers point to the same remote-cache-container could create an issue. I added a verification to limit here, and only create if the marshallers are the same.