### PR TITLE
[14.0.x] ISPN-14814 ServerEventLogger blocks when creating a cache

### DIFF
--- a/server/runtime/src/main/java/org/infinispan/server/LifecycleCallbacks.java
+++ b/server/runtime/src/main/java/org/infinispan/server/LifecycleCallbacks.java
@@ -15,6 +15,7 @@ import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.marshall.protostream.impl.SerializationContextRegistry;
 import org.infinispan.registry.InternalCacheRegistry;
 import org.infinispan.server.logging.events.ServerEventLogger;
+import org.infinispan.util.concurrent.BlockingManager;
 import org.infinispan.util.logging.events.EventLogManager;
 import org.infinispan.util.logging.events.EventLogger;
 import org.infinispan.util.logging.events.EventLoggerNotifier;
@@ -42,8 +43,9 @@ public class LifecycleCallbacks implements ModuleLifecycle {
       internalCacheRegistry.registerInternalCache(ServerEventLogger.EVENT_LOG_CACHE, getTaskHistoryCacheConfiguration(cacheManager).build(),
             EnumSet.of(InternalCacheRegistry.Flag.PERSISTENT, InternalCacheRegistry.Flag.QUERYABLE));
       EventLoggerNotifier notifier = gcr.getComponent(EventLoggerNotifier.class);
+      BlockingManager blockingManager = gcr.getComponent(BlockingManager.class);
       // Install the new logger component
-      ServerEventLogger logger = new ServerEventLogger(cacheManager, gcr.getTimeService(), notifier);
+      ServerEventLogger logger = new ServerEventLogger(cacheManager, gcr.getTimeService(), notifier, blockingManager);
       oldEventLogger = gcr.getComponent(EventLogManager.class).replaceEventLogger(logger);
    }
 

--- a/server/runtime/src/main/java/org/infinispan/server/logging/events/ServerEventLogger.java
+++ b/server/runtime/src/main/java/org/infinispan/server/logging/events/ServerEventLogger.java
@@ -20,6 +20,7 @@ import org.infinispan.query.core.Search;
 import org.infinispan.query.dsl.Query;
 import org.infinispan.query.dsl.QueryFactory;
 import org.infinispan.remoting.transport.Address;
+import org.infinispan.util.concurrent.BlockingManager;
 import org.infinispan.util.concurrent.CompletionStages;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -45,19 +46,15 @@ public class ServerEventLogger implements EventLogger {
    private final EmbeddedCacheManager cacheManager;
    private final TimeService timeService;
    private final EventLoggerNotifier notifier;
+   private final BlockingManager blockingManager;
    private Cache<UUID, ServerEventImpl> eventCache;
 
-   public ServerEventLogger(EmbeddedCacheManager cacheManager, TimeService timeService, EventLoggerNotifier notifier) {
+   public ServerEventLogger(EmbeddedCacheManager cacheManager, TimeService timeService, EventLoggerNotifier notifier,
+                            BlockingManager blockingManager) {
       this.cacheManager = cacheManager;
       this.timeService = timeService;
       this.notifier = notifier;
-   }
-
-   private Cache<UUID, ServerEventImpl> getEventCache() {
-      if (eventCache == null) {
-         eventCache = cacheManager.getCache(EVENT_LOG_CACHE);
-      }
-      return eventCache;
+      this.blockingManager = blockingManager;
    }
 
    @Override
@@ -71,7 +68,23 @@ public class ServerEventLogger implements EventLogger {
    }
 
    void eventLog(ServerEventImpl event) {
-      getEventCache().putAsync(Util.threadLocalRandomUUID(), event)
+      if (eventCache == null) {
+         if (!cacheManager.isRunning(EVENT_LOG_CACHE)) {
+            // Cache is not running yet, we can't block this thread so offload blocking thread to log the message
+            blockingManager.runBlocking(() -> {
+               eventCache = cacheManager.getCache(EVENT_LOG_CACHE);
+               actualSend(eventCache, event);
+            }, "ServerEventLog");
+            return;
+         }
+         eventCache = cacheManager.getCache(EVENT_LOG_CACHE);
+      }
+
+      actualSend(eventCache, event);
+   }
+
+   void actualSend(Cache<UUID, ServerEventImpl> cache, ServerEventImpl event) {
+      eventCache.putAsync(Util.threadLocalRandomUUID(), event)
             .thenAccept(ignore -> CompletionStages.join(notifier.notifyEventLogged(event)));
    }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-14814

After a graceful shutdown, the node finishes recovering and logs the topology update. Since the event logger cache is created, it blocks the cache join, and it seems, also lead to a complete startup deadlock.