### PR TITLE
ISPN-15089 Skip cache manager loading configuration

### DIFF
--- a/core/src/main/java/org/infinispan/globalstate/impl/GlobalConfigurationManagerImpl.java
+++ b/core/src/main/java/org/infinispan/globalstate/impl/GlobalConfigurationManagerImpl.java
@@ -155,7 +155,7 @@ public class GlobalConfigurationManagerImpl implements GlobalConfigurationManage
                .thenCompose(r -> {
                   if (r instanceof CacheState) {
                      Configuration remoteConf = buildConfiguration(name, ((CacheState) r).getConfiguration(), false);
-                     ensurePersistenceCompatibility(name, remoteConf);
+                     ensurePersistenceCompatibility(name, configuration, remoteConf);
                      return createCacheLocally(name, (CacheState) r);
                   }
                   return CompletableFutures.completedNull();
@@ -175,8 +175,12 @@ public class GlobalConfigurationManagerImpl implements GlobalConfigurationManage
 
    private void ensurePersistenceCompatibility(String name, Configuration configuration) {
       Configuration staticConfiguration = cacheManager.getCacheConfiguration(name);
-      if (staticConfiguration != null && !staticConfiguration.matches(configuration))
-         throw CONFIG.incompatiblePersistedConfiguration(name, configuration, staticConfiguration);
+      ensurePersistenceCompatibility(name, staticConfiguration, configuration);
+   }
+
+   private void ensurePersistenceCompatibility(String name, Configuration existing, Configuration other) {
+      if (existing != null && !existing.matches(other))
+         throw CONFIG.incompatiblePersistedConfiguration(name, other, existing);
    }
 
    private void assertNameLength(String name) {


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-15089

Otherwise, the `cacheManager#getCacheConfiguration(String)` does a check with the authorizer and throws a lack of permission. Since we already have the configuration we're trying to load, we don't need to reload it again.