### PR TITLE
ISPN-15167 Upgrade JGroups to 5.2.19.Final

### DIFF
--- a/build/configuration/pom.xml
+++ b/build/configuration/pom.xml
@@ -163,7 +163,7 @@
       <version.jboss.security>3.0.6.Final</version.jboss.security>
       <version.jboss.shrinkwrap>1.2.6</version.jboss.shrinkwrap>
       <version.jcip-annotations>1.0</version.jcip-annotations>
-      <version.jgroups>5.2.18.Final</version.jgroups>
+      <version.jgroups>5.2.19.Final</version.jgroups>
       <version.jgroups.raft>1.0.11.Final</version.jgroups.raft>
       <version.jsr107>1.1.0</version.jsr107>
       <version.junit>4.13.2</version.junit>


### PR DESCRIPTION
Contains only a single fix that may improve test suite stability (TCP_NIO2 is used by default)
* JGRP-2727 - TCP_NIO2: Discovery fails due to NoConnectionPendingException...

https://issues.redhat.com/browse/ISPN-15167