### PR TITLE
ISPN-15175 Don't filter out META-INF/MANIFEST.MF and META-INF/licenses.xml in object-filter pom.xml

### DIFF
--- a/object-filter/pom.xml
+++ b/object-filter/pom.xml
@@ -124,15 +124,6 @@
                            <exclude>org.infinispan:infinispan-component-annotations:</exclude>
                         </excludes>
                      </artifactSet>
-                     <filters>
-                        <filter>
-                           <artifact>*:*</artifact>
-                           <excludes>
-                              <exclude>META-INF/MANIFEST.MF</exclude>
-                              <exclude>META-INF/licenses.xml</exclude>
-                           </excludes>
-                        </filter>
-                     </filters>
                      <relocations>
                         <relocation>
                            <pattern>org.antlr.runtime</pattern>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ISPN-15175

ISPN-15175 Don't filter out META-INF/MANIFEST.MF and META-INF/licenses.xml in object-filter pom.xml