### PR TITLE
ISPN-15181 Deadlock when creating caches with a zero-capacity node an…

### DIFF
--- a/core/src/main/java/org/infinispan/globalstate/impl/GlobalConfigurationStateListener.java
+++ b/core/src/main/java/org/infinispan/globalstate/impl/GlobalConfigurationStateListener.java
@@ -15,6 +15,7 @@ import org.infinispan.notifications.cachelistener.event.CacheEntryCreatedEvent;
 import org.infinispan.notifications.cachelistener.event.CacheEntryModifiedEvent;
 import org.infinispan.notifications.cachelistener.event.CacheEntryRemovedEvent;
 import org.infinispan.commons.util.concurrent.CompletableFutures;
+import org.infinispan.security.actions.SecurityActions;
 
 /**
  * Listens to events on the global state cache and manages cache configuration creation / removal accordingly
@@ -41,10 +42,16 @@ public class GlobalConfigurationStateListener {
 
       String name = event.getKey().getName();
       CacheState state = event.getValue();
+      if (CACHE_SCOPE.equals(scope)) {
+         CompletionStage<Void> cs = gcm.createCacheLocally(name, state);
+         // zero capacity nodes have to wait for a non-zero capacity node to start the cache.
+         // prevent the cache creating to blocking the listener invocation
+         return isZeroCapacityNode()
+               ? CompletableFutures.completedNull()
+               : cs;
+      }
 
-      return CACHE_SCOPE.equals(scope) ?
-            gcm.createCacheLocally(name, state) :
-            gcm.createTemplateLocally(name, state);
+      return gcm.createTemplateLocally(name, state);
    }
 
    @CacheEntryModified
@@ -79,5 +86,9 @@ public class GlobalConfigurationStateListener {
          CONTAINER.debugf("Removing template %s because it was removed from global state", name);
          return gcm.removeTemplateLocally(name);
       }
+   }
+
+   private boolean isZeroCapacityNode() {
+      return SecurityActions.getGlobalComponentRegistry(gcm.cacheManager).getGlobalConfiguration().isZeroCapacityNode();
    }
 }

--- a/core/src/main/java/org/infinispan/topology/CacheJoinInfo.java
+++ b/core/src/main/java/org/infinispan/topology/CacheJoinInfo.java
@@ -141,6 +141,7 @@ public class CacheJoinInfo {
             ", cacheMode=" + cacheMode +
             ", persistentUUID=" + persistentUUID +
             ", persistentStateChecksum=" + persistentStateChecksum +
+            ", capacityFactor=" + getCapacityFactor() +
             '}';
    }
 

--- a/core/src/main/java/org/infinispan/topology/ClusterCacheStatus.java
+++ b/core/src/main/java/org/infinispan/topology/ClusterCacheStatus.java
@@ -745,6 +745,7 @@ public class ClusterCacheStatus implements AvailabilityStrategyContext {
       if (joinInfo.getCapacityFactor() != 0f || getCurrentTopology() != null)
          return CompletableFutures.completedNull();
 
+      log.tracef("Waiting on initial topology for %s with %s", joinInfo, getCurrentTopology());
       // Creating the initial topology requires at least one node with a non-zero capacity factor
       return hasInitialTopologyFuture.newConditionStage(ccs -> ccs.getCurrentTopology() != null,
                                                         () -> new TimeoutException("Timed out waiting for initial cache topology"),

--- a/core/src/test/java/org/infinispan/distribution/ZeroCapacityAdministrationTest.java
+++ b/core/src/test/java/org/infinispan/distribution/ZeroCapacityAdministrationTest.java
@@ -1,15 +1,22 @@
 package org.infinispan.distribution;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Fail.fail;
 import static org.infinispan.commons.test.CommonsTestingUtil.tmpDirectory;
+import static org.infinispan.globalstate.GlobalConfigurationManager.CONFIG_STATE_CACHE_NAME;
+import static org.infinispan.globalstate.impl.GlobalConfigurationManagerImpl.CACHE_SCOPE;
 import static org.testng.AssertJUnit.assertNotNull;
 
 import java.nio.file.Paths;
 
+import org.infinispan.Cache;
 import org.infinispan.commons.util.Util;
+import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.globalstate.ConfigurationStorage;
+import org.infinispan.globalstate.ScopedState;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.testng.annotations.Test;
@@ -45,6 +52,38 @@ public class ZeroCapacityAdministrationTest extends MultipleCacheManagersTest {
       zeroCapacityNode.administration().createTemplate("zero-template", config);
       assertNotNull(node1.getCache("zero-cache"));
       assertNotNull(node1.getCacheConfiguration("zero-template"));
+   }
+
+   public void testCreateNewClusteredCacheFromZeroToRemote() {
+      Configuration config = new ConfigurationBuilder()
+            .clustering().cacheMode(CacheMode.DIST_SYNC)
+            .build();
+
+      // The join command is sent to the coordinator.
+      assertThat(node1.isCoordinator()).isTrue();
+
+      // Make sure this will trigger a remote call to create the cache.
+      int tries = 0;
+      String cacheName = "another-cache";
+      ScopedState ss = new ScopedState(CACHE_SCOPE, cacheName);
+      while (!DistributionTestHelper.isFirstOwner(node1.getCache(CONFIG_STATE_CACHE_NAME), ss)) {
+         if (tries > 50) fail("Exceeded attempts to find configuration mapping to remote");
+
+         cacheName = "another-cache-" + tries++;
+         ss = new ScopedState(CACHE_SCOPE, cacheName);
+      }
+
+      try {
+         Cache<?, ?> cache = zeroCapacityNode.administration().getOrCreateCache(cacheName, config);
+         assertNotNull(cache);
+      } catch (Throwable t) {
+         // Needed so the cache creation is unblocked by the non-zero capacity node in order to clean up the test.
+         node1.administration().getOrCreateCache(cacheName, config);
+         fail("Failed creating clustered cache from node zero", t.getCause());
+      }
+
+      assertNotNull(node1.getCache(cacheName));
+      assertNotNull(node1.getCacheConfiguration(cacheName));
    }
 
    private GlobalConfigurationBuilder statefulGlobalBuilder(String stateDirectory) {


### PR DESCRIPTION
…d a single stateful node

https://issues.redhat.com/browse/ISPN-15181

I changed to delay the cache local creation if there is a remote request to create the same cache. We return a completed future, though, so the listener can proceed.

If we had a way to handle events async/sync dynamically, the solution could be better. Also, I didn't want to modify the zero capacity nodes' join as that has a wider effect, which I am somewhat unfamiliar with.


