### PR TITLE
Increase Jenkins timeout to 2.5 hours

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 2, unit: 'HOURS')
+        timeout(time: 150, unit: 'MINUTES')
         timestamps()
         buildDiscarder(logRotator(numToKeepStr: '100', daysToKeepStr: '61'))
     }


### PR DESCRIPTION
We can't use 2.5 hours as Jenkins rounds down to 2 hours.