### PR TITLE
ISPN-15304 Virtual Threads improvements

### DIFF
--- a/commons-test/src/main/java/org/infinispan/commons/test/ThreadLeakChecker.java
+++ b/commons-test/src/main/java/org/infinispan/commons/test/ThreadLeakChecker.java
@@ -89,6 +89,13 @@ public class ThreadLeakChecker {
                       "|OkHttp Http2Connection" +
                       // The mysql driver uses a daemon thread to check for connection leaks
                       "|mysql-cj-abandoned-connection-cleanup" +
+                      // virtual threads - thread pools
+                      "|ForkJoinPool" +
+                      "|Write-Updater" +
+                      "|Write-Poller" +
+                      "|VirtualThread-unparker"+
+                      "|Read-Updater"+
+                      "|Read-Poller"+
                       ").*");
    private static final String ARQUILLIAN_CONSOLE_CONSUMER =
       "org.jboss.as.arquillian.container.CommonManagedDeployableContainer$ConsoleConsumer";

--- a/commons/all/src/main/java/org/infinispan/commons/jdkspecific/ThreadCreator.java
+++ b/commons/all/src/main/java/org/infinispan/commons/jdkspecific/ThreadCreator.java
@@ -1,5 +1,8 @@
 package org.infinispan.commons.jdkspecific;
 
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+
 import org.infinispan.commons.logging.Log;
 import org.infinispan.commons.util.Util;
 
@@ -8,11 +11,15 @@ import org.infinispan.commons.util.Util;
  * @since 11.0
  **/
 public class ThreadCreator {
-   static org.infinispan.commons.spi.ThreadCreator INSTANCE = getInstance();
+   private static final org.infinispan.commons.spi.ThreadCreator INSTANCE = getInstance();
+
+   public static boolean useVirtualThreads() {
+      return Boolean.getBoolean("org.infinispan.threads.virtual");
+   }
 
    private static org.infinispan.commons.spi.ThreadCreator getInstance() {
       try {
-         if (Boolean.getBoolean("org.infinispan.threads.virtual")) {
+         if (useVirtualThreads()) {
             org.infinispan.commons.spi.ThreadCreator instance = Util.getInstance("org.infinispan.commons.jdk21.ThreadCreatorImpl", ThreadCreator.class.getClassLoader());
             Log.CONTAINER.infof("Virtual threads support enabled");
             return instance;
@@ -24,8 +31,12 @@ public class ThreadCreator {
    }
 
 
-   public static Thread createThread(ThreadGroup threadGroup, Runnable target, boolean lightweight) {
-      return INSTANCE.createThread(threadGroup, target, lightweight);
+   public static Thread createThread(ThreadGroup threadGroup, Runnable target, boolean useVirtualThread) {
+      return INSTANCE.createThread(threadGroup, target, useVirtualThread);
+   }
+
+   public static Optional<ExecutorService> createBlockingExecutorService() {
+      return INSTANCE.newVirtualThreadPerTaskExecutor();
    }
 
    static class ThreadCreatorImpl implements org.infinispan.commons.spi.ThreadCreator {
@@ -33,6 +44,11 @@ public class ThreadCreator {
       @Override
       public Thread createThread(ThreadGroup threadGroup, Runnable target, boolean lightweight) {
          return new Thread(threadGroup, target);
+      }
+
+      @Override
+      public Optional<ExecutorService> newVirtualThreadPerTaskExecutor() {
+         return Optional.empty();
       }
    }
 }

--- a/commons/jdk21/src/main/java/org/infinispan/commons/jdk21/ThreadCreatorImpl.java
+++ b/commons/jdk21/src/main/java/org/infinispan/commons/jdk21/ThreadCreatorImpl.java
@@ -1,17 +1,26 @@
 package org.infinispan.commons.jdk21;
 
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
 /**
  * @author Tristan Tarrant &lt;tristan@infinispan.org&gt;
  * @since 11.0
  **/
 public class ThreadCreatorImpl implements org.infinispan.commons.spi.ThreadCreator {
 
-   public Thread createThread(ThreadGroup group, Runnable runnable, boolean lightweight) {
-      if (lightweight) {
+   public Thread createThread(ThreadGroup group, Runnable runnable, boolean useVirtualThreads) {
+      if (useVirtualThreads) {
          return Thread.ofVirtual().unstarted(runnable);
       } else {
          return new Thread(group, runnable);
       }
+   }
+
+   @Override
+   public Optional<ExecutorService> newVirtualThreadPerTaskExecutor() {
+      return Optional.of(Executors.newVirtualThreadPerTaskExecutor());
    }
 
 }

--- a/commons/spi/src/main/java/org/infinispan/commons/spi/ThreadCreator.java
+++ b/commons/spi/src/main/java/org/infinispan/commons/spi/ThreadCreator.java
@@ -1,8 +1,13 @@
 package org.infinispan.commons.spi;
 
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+
 /**
  * @since 15.0
  **/
 public interface ThreadCreator {
    Thread createThread(ThreadGroup threadGroup, Runnable target, boolean lightweight);
+
+   Optional<ExecutorService> newVirtualThreadPerTaskExecutor();
 }

--- a/core/src/main/java/org/infinispan/factories/threads/DefaultThreadFactory.java
+++ b/core/src/main/java/org/infinispan/factories/threads/DefaultThreadFactory.java
@@ -29,6 +29,7 @@ public class DefaultThreadFactory implements ThreadFactory {
    private String node;
    private String component;
    private ClassLoader classLoader;
+   private boolean useVirtualThreads = ThreadCreator.useVirtualThreads();
 
    /**
     * Construct a new instance.  The access control context of the calling thread will be the one used to create
@@ -94,6 +95,10 @@ public class DefaultThreadFactory implements ThreadFactory {
       return initialPriority;
    }
 
+   public void useVirtualThread(boolean useVirtualThreads) {
+      this.useVirtualThreads = useVirtualThreads;
+   }
+
    @Override
    public Thread newThread(final Runnable target) {
       return createThread(target);
@@ -110,7 +115,7 @@ public class DefaultThreadFactory implements ThreadFactory {
       return thread;
    }
 
-   private final Thread actualThreadCreate(ThreadGroup threadGroup, Runnable target) {
-      return ThreadCreator.createThread(threadGroup, target, true);
+   private Thread actualThreadCreate(ThreadGroup threadGroup, Runnable target) {
+      return ThreadCreator.createThread(threadGroup, target, useVirtualThreads);
    }
 }

--- a/core/src/main/resources/default-configs/default-jgroups-azure.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-azure.xml
@@ -20,6 +20,7 @@
         thread_pool.keep_alive_time="60000"
 
         thread_pool.thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
+        use_virtual_threads="${jgroups.thread.virtual,org.infinispan.threads.virtual:false}"
    />
    <RED/>
    <azure.AZURE_PING storage_account_name="${jboss.jgroups.azure_ping.storage_account_name}"

--- a/core/src/main/resources/default-configs/default-jgroups-ec2.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-ec2.xml
@@ -20,6 +20,7 @@
         thread_pool.keep_alive_time="60000"
 
         thread_pool.thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
+        use_virtual_threads="${jgroups.thread.virtual,org.infinispan.threads.virtual:false}"
    />
    <RED/>
    <aws.S3_PING region_name="${jgroups.s3.region_name}"

--- a/core/src/main/resources/default-configs/default-jgroups-google.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-google.xml
@@ -21,6 +21,7 @@
         thread_pool.keep_alive_time="60000"
 
         thread_pool.thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
+        use_virtual_threads="${jgroups.thread.virtual,org.infinispan.threads.virtual:false}"
    />
    <RED/>
    <org.jgroups.protocols.google.GOOGLE_PING2

--- a/core/src/main/resources/default-configs/default-jgroups-kubernetes.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-kubernetes.xml
@@ -23,6 +23,7 @@
         thread_pool.keep_alive_time="60000"
 
         thread_pool.thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
+        use_virtual_threads="${jgroups.thread.virtual,org.infinispan.threads.virtual:false}"
    />
    <RED/>
    <dns.DNS_PING dns_query="${jgroups.dns.query}"

--- a/core/src/main/resources/default-configs/default-jgroups-tcp.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-tcp.xml
@@ -16,6 +16,7 @@
         thread_pool.keep_alive_time="60000"
 
         thread_pool.thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
+        use_virtual_threads="${jgroups.thread.virtual,org.infinispan.threads.virtual:false}"
    />
    <RED/>
    <MPING mcast_addr="${jgroups.mcast_addr:239.6.7.8}"

--- a/core/src/main/resources/default-configs/default-jgroups-udp.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-udp.xml
@@ -22,6 +22,7 @@
         thread_pool.keep_alive_time="60000"
 
         thread_pool.thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
+        use_virtual_threads="${jgroups.thread.virtual,org.infinispan.threads.virtual:false}"
    />
    <RED/>
    <PING num_discovery_runs="3"/>

--- a/core/src/test/resources/configs/config-with-jgroups-stack.xml
+++ b/core/src/test/resources/configs/config-with-jgroups-stack.xml
@@ -12,6 +12,7 @@
               sock_conn_timeout="300" bundler_type="transfer-queue"
               thread_pool.min_threads="0" thread_pool.max_threads="25" thread_pool.keep_alive_time="5000"
               thread_pool.thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
+              use_virtual_threads="${jgroups.thread.virtual,org.infinispan.threads.virtual:false}"
               xmlns="urn:org:jgroups"/>
          <RED/>
             <MPING break_on_coord_rsp="true"

--- a/core/src/test/resources/configs/xsite/bridge.xml
+++ b/core/src/test/resources/configs/xsite/bridge.xml
@@ -14,6 +14,7 @@
          thread_pool.keep_alive_time="5000"
 
          thread_pool.thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
+         use_virtual_threads="${jgroups.thread.virtual,org.infinispan.threads.virtual:false}"
     />
     <RED/>
 

--- a/core/src/test/resources/stacks/tcp.xml
+++ b/core/src/test/resources/stacks/tcp.xml
@@ -18,6 +18,7 @@
          thread_pool.keep_alive_time="60000"
 
          thread_pool.thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
+         use_virtual_threads="${jgroups.thread.virtual,org.infinispan.threads.virtual:false}"
          />
    <RED/>
 

--- a/core/src/test/resources/stacks/tcp_mping/tcp1.xml
+++ b/core/src/test/resources/stacks/tcp_mping/tcp1.xml
@@ -14,6 +14,7 @@
         thread_pool.keep_alive_time="5000"
 
         thread_pool.thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
+        use_virtual_threads="${jgroups.thread.virtual,org.infinispan.threads.virtual:false}"
    />
    <RED/>
 

--- a/core/src/test/resources/stacks/tcp_mping/tcp2.xml
+++ b/core/src/test/resources/stacks/tcp_mping/tcp2.xml
@@ -14,6 +14,7 @@
         thread_pool.keep_alive_time="5000"
 
         thread_pool.thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
+        use_virtual_threads="${jgroups.thread.virtual,org.infinispan.threads.virtual:false}"
    />
    <RED/>
 

--- a/core/src/test/resources/stacks/udp.xml
+++ b/core/src/test/resources/stacks/udp.xml
@@ -23,6 +23,7 @@
          thread_pool.keep_alive_time="60000"
 
          thread_pool.thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
+         use_virtual_threads="${jgroups.thread.virtual,org.infinispan.threads.virtual:false}"
    />
    <RED/>
 

--- a/hibernate/cache-commons/src/test/resources/2lc-test-tcp.xml
+++ b/hibernate/cache-commons/src/test/resources/2lc-test-tcp.xml
@@ -20,6 +20,7 @@
         thread_pool.keep_alive_time="60000"
 
         thread_pool.thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
+        use_virtual_threads="${jgroups.thread.virtual,org.infinispan.threads.virtual:false}"
    />
    <RED/>
 

--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,7 @@
       <!-- unstable and stress because we can have them inside a functional class, for example -->
       <defaultExcludedTestNGGroups>unstable,stress</defaultExcludedTestNGGroups>
       <defaultTestNGGroups>functional,unit,xsite,arquillian</defaultTestNGGroups>
+      <org.infinispan.tests.threads.virtual>false</org.infinispan.tests.threads.virtual>
       <dir.ispn>../</dir.ispn>
       <dir.jacoco>${session.executionRootDirectory}/jacoco/</dir.jacoco>
       <dir.jacoco.merged>../jacoco/merged/</dir.jacoco.merged>
@@ -2136,6 +2137,7 @@
                      <infinispan.module-suffix>${infinispan.module-suffix}</infinispan.module-suffix>
                      <ansi.strip>${ansi.strip}</ansi.strip>
                      <com.arjuna.ats.arjuna.common.propertiesFile>test-jbossts-properties.xml</com.arjuna.ats.arjuna.common.propertiesFile>
+                     <org.infinispan.threads.virtual>${org.infinispan.tests.threads.virtual}</org.infinispan.threads.virtual>
                   </systemPropertyVariables>
                   <rerunFailingTestsCount>${rerunFailingTestsCount}</rerunFailingTestsCount>
                   <argLine>${forkJvmArgs} ${testjvm.jdkSpecificArgs}</argLine>
@@ -2366,6 +2368,15 @@
                      <failIfNoMatch>false</failIfNoMatch>
                   </configuration>
                </execution>
+               <execution>
+                  <id>get-cpu-count</id>
+                  <goals>
+                     <goal>cpu-count</goal>
+                  </goals>
+                  <configuration>
+                     <cpuCount>system.numCores</cpuCount>
+                  </configuration>
+               </execution>
             </executions>
          </plugin>
          <plugin>
@@ -2521,6 +2532,7 @@
                   <!-- this is picked up in log4j2.xml, which adds it to each module's log file name-->
                   <infinispan.module-suffix>${infinispan.module-suffix}</infinispan.module-suffix>
                   <ansi.strip>${ansi.strip}</ansi.strip>
+                  <org.infinispan.threads.virtual>${org.infinispan.tests.threads.virtual}</org.infinispan.threads.virtual>
                </systemPropertyVariables>
                <trimStackTrace>false</trimStackTrace>
                <argLine>${forkJvmArgs} ${testjvm.jdkSpecificArgs} -Djdk.attach.allowAttachSelf=true</argLine>
@@ -3232,6 +3244,16 @@
          <modules>
             <module>server/insights</module>
          </modules>
+      </profile>
+      <profile>
+         <id>vthreads-tests</id>
+         <activation>
+            <activeByDefault>false</activeByDefault>
+         </activation>
+         <properties>
+            <org.infinispan.tests.threads.virtual>true</org.infinispan.tests.threads.virtual>
+            <infinispan.test.parallel.threads>${system.numCores}</infinispan.test.parallel.threads>
+         </properties>
       </profile>
    </profiles>
 </project>

--- a/quarkus/integration-tests/embedded/src/main/resources/embedded.xml
+++ b/quarkus/integration-tests/embedded/src/main/resources/embedded.xml
@@ -15,6 +15,7 @@
               sock_conn_timeout="300" bundler_type="transfer-queue"
               thread_pool.min_threads="0" thread_pool.max_threads="25" thread_pool.keep_alive_time="5000"
               thread_pool.thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
+              use_virtual_threads="${jgroups.thread.virtual,org.infinispan.threads.virtual:false}"
               xmlns="urn:org:jgroups"/>
          <RED/>
          <MPING bind_addr="127.0.0.1" break_on_coord_rsp="true"

--- a/quarkus/integration-tests/embedded/src/main/resources/stacks/tcp.xml
+++ b/quarkus/integration-tests/embedded/src/main/resources/stacks/tcp.xml
@@ -18,6 +18,7 @@
          thread_pool.keep_alive_time="60000"
 
          thread_pool.thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
+         use_virtual_threads="${jgroups.thread.virtual,org.infinispan.threads.virtual:false}"
    />
    <RED/>
 

--- a/quarkus/integration-tests/embedded/src/main/resources/stacks/tcp_mping/tcp1.xml
+++ b/quarkus/integration-tests/embedded/src/main/resources/stacks/tcp_mping/tcp1.xml
@@ -14,6 +14,7 @@
         thread_pool.keep_alive_time="5000"
 
         thread_pool.thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
+        use_virtual_threads="${jgroups.thread.virtual,org.infinispan.threads.virtual:false}"
    />
    <RED/>
 

--- a/quarkus/integration-tests/embedded/src/main/resources/stacks/tcp_mping/tcp2.xml
+++ b/quarkus/integration-tests/embedded/src/main/resources/stacks/tcp_mping/tcp2.xml
@@ -14,6 +14,7 @@
         thread_pool.keep_alive_time="5000"
 
         thread_pool.thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
+        use_virtual_threads="${jgroups.thread.virtual,org.infinispan.threads.virtual:false}"
    />
    <RED/>
 

--- a/quarkus/integration-tests/embedded/src/main/resources/stacks/udp.xml
+++ b/quarkus/integration-tests/embedded/src/main/resources/stacks/udp.xml
@@ -23,6 +23,7 @@
          thread_pool.keep_alive_time="60000"
 
          thread_pool.thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
+         use_virtual_threads="${jgroups.thread.virtual,org.infinispan.threads.virtual:false}"
    />
    <RED/>
 

--- a/server/core/src/main/java/org/infinispan/server/core/factories/NettyEventLoopFactory.java
+++ b/server/core/src/main/java/org/infinispan/server/core/factories/NettyEventLoopFactory.java
@@ -30,6 +30,11 @@ public class NettyEventLoopFactory extends AbstractComponentFactory implements A
                globalConfiguration.transport().nodeName(), shortened(KnownComponentNames.NON_BLOCKING_EXECUTOR));
       }
 
+      if (threadFactory instanceof DefaultThreadFactory) {
+         //not supported at the moment
+         ((DefaultThreadFactory) threadFactory).useVirtualThread(false);
+      }
+
       ThreadPoolExecutorFactory<?> tpef = globalConfiguration.nonBlockingThreadPool().threadPoolFactory();
       int threadAmount = tpef instanceof NonBlockingThreadPoolExecutorFactory ?
             ((NonBlockingThreadPoolExecutorFactory) tpef).maxThreads() :

--- a/server/testdriver/junit5/src/test/resources/jgroups/xsite-stacks.xml
+++ b/server/testdriver/junit5/src/test/resources/jgroups/xsite-stacks.xml
@@ -49,6 +49,7 @@
            thread_pool.keep_alive_time="60000"
 
            thread_pool.thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
+           use_virtual_threads="${jgroups.thread.virtual,org.infinispan.threads.virtual:false}"
            ispn:stack.combine="REPLACE"
       />
       <MERGE3 min_interval="1000" max_interval="5000" ispn:stack.combine="REPLACE"/>

--- a/server/tests/src/test/resources/configuration/jgroups/xsite-stacks.xml
+++ b/server/tests/src/test/resources/configuration/jgroups/xsite-stacks.xml
@@ -49,6 +49,7 @@
            thread_pool.keep_alive_time="60000"
 
            thread_pool.thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
+           use_virtual_threads="${jgroups.thread.virtual,org.infinispan.threads.virtual:false}"
            ispn:stack.combine="REPLACE"
       />
       <MERGE3 min_interval="1000" max_interval="5000" ispn:stack.combine="REPLACE"/>


### PR DESCRIPTION
* Enable JGroups virtual threads with org.infinispan.threads.virtual or jgroups.thread.virtual
* Create VirtualThreadPerTaskExecutor for blocking thread pool
* Do not use virtual threads in Netty event loop

@tristantarrant @wburns opened for later discussion :+1: 

https://issues.redhat.com/browse/ISPN-15304