### PR TITLE
Run Operator Upgrade tests against branch server build

### DIFF
--- a/.github/workflows/operator_upgrade.yaml
+++ b/.github/workflows/operator_upgrade.yaml
@@ -1,0 +1,79 @@
+name: Operator Upgrade Tests
+
+on:
+  push:
+    branches:
+      - main
+      - '*.0.x'
+  pull_request:
+    branches:
+      - main
+      - '*.0.x'
+
+jobs:
+  image:
+    runs-on: ubuntu-latest
+
+    steps:
+      - if: ${{ github.event_name != 'pull_request' }}
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref_name }}
+          repository: infinispan/infinispan-images
+
+      - if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.base_ref }}
+          repository: infinispan/infinispan-images
+
+      - uses: actions/checkout@v3
+        with:
+          path: server
+
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          java-version: '21'
+          distribution: 'oracle'
+          cache: maven
+
+      - name: Build Infinispan
+        working-directory: server
+        run:  |
+          ./mvnw -s maven-settings.xml install -DskipTests -am -pl server/runtime
+          SERVER_VERSION=$(./mvnw -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
+          cd server/runtime/target
+          zip -r ${GITHUB_WORKSPACE}/server.zip infinispan-server-${SERVER_VERSION}
+
+      - name: Install CEKit
+        uses: cekit/actions-setup-cekit@v1.1.5
+
+      - name: Create Dockerfile
+        run: |
+          SERVER_OVERRIDE="{\"artifacts\":[{\"name\":\"server\",\"path\":\"${GITHUB_WORKSPACE}/server.zip\"}]}"
+          cekit -v --descriptor server-openjdk.yaml build --overrides '{'version': '${{ github.sha }}'}' --overrides ${SERVER_OVERRIDE} --dry-run docker
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build Image
+        run: |
+          cat target/image/Dockerfile
+          docker buildx build --load -t localhost:5001/server:${{ github.sha }} target/image
+          docker save localhost:5001/server:${{ github.sha }} > /tmp/operand-image.tar
+
+      - name: Upload
+        uses: actions/upload-artifact@v3
+        with:
+          name: operand-image
+          path: /tmp/operand-image.tar
+
+  tests:
+    needs: image
+    uses: infinispan/infinispan-operator/.github/workflows/upgrade_tests.yaml@main
+    with:
+      operand: localhost:5001/server:${{ github.sha }}
+      operandArtifact: operand-image
+      ref: main
+      repository: infinispan/infinispan-operator


### PR DESCRIPTION
@tristantarrant There's some overlap here with the "Image required" logic in the Jenkinsfile which we could probably replace with a purely GH action implementation, but given that the Jenkins solution works and hasn't ever changed, it's probably not worth changing.