### PR TITLE
ISPN-15241 fix property name to connection-pooling

### DIFF
--- a/documentation/src/main/asciidoc/topics/ref_server_realm_ldap.adoc
+++ b/documentation/src/main/asciidoc/topics/ref_server_realm_ldap.adoc
@@ -26,6 +26,12 @@ credential:: Corresponds to the password associated with the principal mentioned
 The principal for LDAP connections must have necessary privileges to perform LDAP queries and access specific attributes.
 ====
 
+[TIP]
+====
+Enabling `connection-pooling` significantly improves the performance of authentication to LDAP servers.
+The connection pooling mechanism is provided by the JDK. For more information see link:https://docs.oracle.com/javase/jndi/tutorial/ldap/connect/config.html[Connection Pooling Configuration] and link:https://docs.oracle.com/javase/tutorial/jndi/ldap/pool.html[Java Tutorials: Pooling].
+====
+
 == LDAP realm user authentication methods
 Configure the user authentication method in the LDAP realm.
 

--- a/server/runtime/src/main/resources/schema/infinispan-server-15.0.xsd
+++ b/server/runtime/src/main/resources/schema/infinispan-server-15.0.xsd
@@ -1377,7 +1377,7 @@
             </xs:documentation>
          </xs:annotation>
       </xs:attribute>
-      <xs:attribute type="xs:boolean" name="enable-connection-pooling" default="false">
+      <xs:attribute type="xs:boolean" name="connection-pooling" default="false">
          <xs:annotation>
             <xs:documentation>
                Enables connection pooling.


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-15241 
Fix property name in the schema

@pruivo fixing an old bug. Could you elaborate about its implications?
