### PR TITLE
[14.0] ISPN-14784 Only use -Djava.security.manager=allow since JDK 17

### DIFF
--- a/integrationtests/security-manager-it/pom.xml
+++ b/integrationtests/security-manager-it/pom.xml
@@ -68,7 +68,7 @@
                   <usedefaultlisteners>false</usedefaultlisteners>
                   <listener>${testNGListeners}</listener>
                </properties>
-               <argLine>${forkJvmArgs} ${testjvm.jdkSpecificArgs} -Djava.security.manager=allow</argLine>
+               <argLine>${forkJvmArgs} ${testjvm.jdkSpecificArgs} ${testjvm.javaSecurityManager}</argLine>
                <dependenciesToScan>
                   <!-- TestNGSuiteChecksTest -->
                   <dependency>org.infinispan:infinispan-commons-test</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,7 @@
          --add-modules=java.se
       </testjvm.jigsawArgs>
       <testjvm.blockHoundRedefinitionArgs/>
+      <testjvm.javaSecurityManager>-Djava.security.manager=allow</testjvm.javaSecurityManager>
       <testjvm.jdkSpecificArgs>${testjvm.jigsawArgs} -Dnet.bytebuddy.experimental=true ${testjvm.blockHoundRedefinitionArgs}</testjvm.jdkSpecificArgs>
       <testjvm.extraArgs/>
       <forkJvmArgs>-Xmx1G ${testjvm.commonArgs} ${testjvm.jdkSpecificArgs} ${testjvm.extraArgs}</forkJvmArgs>
@@ -3011,6 +3012,7 @@
             <!-- Unset all JDK-specific properties -->
             <testjvm.jigsawArgs/>
             <testjvm.blockHoundRedefinitionArgs/>
+            <testjvm.javaSecurityManager/>
             <!-- Also unset the aggregate property, just in case -->
             <testjvm.jdkSpecificArgs/>
          </properties>


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-14784