### PR TITLE
ISPN-15239 HotRod client repeatedly retries iteration operation again…

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/iteration/RemoteInnerPublisherHandler.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/iteration/RemoteInnerPublisherHandler.java
@@ -1,6 +1,7 @@
 package org.infinispan.client.hotrod.impl.iteration;
 
 import java.lang.invoke.MethodHandles;
+import java.net.ConnectException;
 import java.net.SocketAddress;
 import java.util.List;
 import java.util.Map;
@@ -112,7 +113,7 @@ class RemoteInnerPublisherHandler<K, E> extends AbstractAsyncPublisherHandler<Ma
 
    @Override
    protected void handleThrowableInResponse(Throwable t, Map.Entry<SocketAddress, IntSet> target) {
-      if (t instanceof TransportException || t instanceof RemoteIllegalLifecycleStateException) {
+      if (t instanceof TransportException || t instanceof RemoteIllegalLifecycleStateException || t instanceof ConnectException) {
          log.throwableDuringPublisher(t);
          if (log.isTraceEnabled()) {
             IntSet targetSegments = target.getValue();

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/iteration/RemotePublisher.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/iteration/RemotePublisher.java
@@ -130,6 +130,7 @@ public class RemotePublisher<K, E> implements Publisher<Map.Entry<K, E>> {
                int batchSize = (this.batchSize / actualTargets.size()) + 1;
                return Flowable.fromIterable(actualTargets.entrySet())
                      .map(entry -> {
+                        log.tracef("Requesting next for: %s", entry);
                         RemoteInnerPublisherHandler<K, E> innerHandler = new RemoteInnerPublisherHandler<>(this,
                               batchSize, () -> null, entry);
                         return innerHandler.startPublisher();

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/BaseIterationFailOverTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/BaseIterationFailOverTest.java
@@ -6,6 +6,7 @@ import static org.infinispan.client.hotrod.impl.iteration.Util.rangeAsSet;
 import static org.testng.AssertJUnit.assertEquals;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -14,6 +15,7 @@ import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
 import org.infinispan.client.hotrod.test.MultiHotRodServersTest;
 import org.infinispan.commons.util.CloseableIterator;
+import org.infinispan.commons.util.CloseableIteratorSet;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.protostream.SerializationContextInitializer;
 import org.infinispan.query.dsl.embedded.DslSCI;
@@ -66,6 +68,24 @@ public abstract class BaseIterationFailOverTest extends MultiHotRodServersTest {
          Map.Entry<Object, Object> next = iterator.next();
          entries.add(next);
 
+      }
+
+      assertEquals(cacheSize, entries.size());
+
+      Set<Integer> keys = extractKeys(entries);
+      assertEquals(rangeAsSet(0, cacheSize), keys);
+   }
+
+   @Test(groups = "functional")
+   public void testServerLeaveButIterateTwice() throws InterruptedException {
+      testFailOver();
+      int cacheSize = 1_000;
+
+      RemoteCache<Integer, AccountHS> cache = clients.get(0).getCache();
+      Collection<Map.Entry<Object, Object>> entries = new ArrayList<>();
+      CloseableIteratorSet<Map.Entry<Integer, AccountHS>> iterator = cache.entrySet();
+      for (Map.Entry<Integer, AccountHS> entry : iterator) {
+         entries.add((Map.Entry) entry);
       }
 
       assertEquals(cacheSize, entries.size());

--- a/client/hotrod/src/main/java/org/infinispan/hotrod/impl/iteration/RemoteInnerPublisherHandler.java
+++ b/client/hotrod/src/main/java/org/infinispan/hotrod/impl/iteration/RemoteInnerPublisherHandler.java
@@ -1,6 +1,7 @@
 package org.infinispan.hotrod.impl.iteration;
 
 import java.lang.invoke.MethodHandles;
+import java.net.ConnectException;
 import java.net.SocketAddress;
 import java.util.List;
 import java.util.Map;
@@ -113,7 +114,7 @@ class RemoteInnerPublisherHandler<K, E> extends AbstractAsyncPublisherHandler<Ma
 
    @Override
    protected void handleThrowableInResponse(Throwable t, Map.Entry<SocketAddress, IntSet> target) {
-      if (t instanceof TransportException || t instanceof RemoteIllegalLifecycleStateException) {
+      if (t instanceof TransportException || t instanceof RemoteIllegalLifecycleStateException || t instanceof ConnectException) {
          log.throwableDuringPublisher(t);
          if (log.isTraceEnabled()) {
             IntSet targetSegments = target.getValue();


### PR DESCRIPTION
…st failed server after removal from topology

https://issues.redhat.com/browse/ISPN-15239

Looking at the logs, the iteration operation starts and calculates the segment owners, and then the topology updates. So, I updated the exception handling part.