### PR TITLE
[14.0] ISPN-TEST Use different cache names

### DIFF
--- a/server/rest/src/test/java/org/infinispan/rest/search/EmbeddedRestSearchTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/search/EmbeddedRestSearchTest.java
@@ -23,4 +23,9 @@ public class EmbeddedRestSearchTest extends SingleNodeLocalIndexTest {
    protected boolean isServerMode() {
       return false;
    }
+
+   @Override
+   protected String cacheName() {
+      return "search-rest-embedded-search";
+   }
 }

--- a/server/rest/src/test/java/org/infinispan/rest/search/IndexedRestOffHeapSearchTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/search/IndexedRestOffHeapSearchTest.java
@@ -16,6 +16,11 @@ import org.testng.annotations.Test;
 public class IndexedRestOffHeapSearchTest extends BaseRestSearchTest {
 
    @Override
+   protected String cacheName() {
+      return "search-rest-indexed-off-heap";
+   }
+
+   @Override
    protected ConfigurationBuilder getConfigBuilder() {
       ConfigurationBuilder configurationBuilder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC);
       configurationBuilder.indexing().enable().storage(LOCAL_HEAP)

--- a/server/rest/src/test/java/org/infinispan/rest/search/IndexedRestSearchTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/search/IndexedRestSearchTest.java
@@ -26,6 +26,11 @@ import org.testng.annotations.Test;
 public class IndexedRestSearchTest extends BaseRestSearchTest {
 
    @Override
+   protected String cacheName() {
+      return "search-rest-indexed";
+   }
+
+   @Override
    protected ConfigurationBuilder getConfigBuilder() {
       ConfigurationBuilder configurationBuilder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC);
       configurationBuilder.indexing()

--- a/server/rest/src/test/java/org/infinispan/rest/search/NonIndexedPojoQueryTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/search/NonIndexedPojoQueryTest.java
@@ -26,6 +26,11 @@ public class NonIndexedPojoQueryTest extends BaseRestSearchTest {
    }
 
    @Override
+   protected String cacheName() {
+      return "search-rest-non-indexed-pojo";
+   }
+
+   @Override
    protected void createCacheManagers() throws Exception {
       super.createCacheManagers();
       cacheManagers.forEach(cm -> cm.getClassAllowList().addRegexps("org.infinispan.rest.search.entity.*"));

--- a/server/rest/src/test/java/org/infinispan/rest/search/NonIndexedRestOffHeapSearch.java
+++ b/server/rest/src/test/java/org/infinispan/rest/search/NonIndexedRestOffHeapSearch.java
@@ -20,4 +20,9 @@ public class NonIndexedRestOffHeapSearch extends BaseRestSearchTest {
       configurationBuilder.memory().storageType(StorageType.OFF_HEAP);
       return configurationBuilder;
    }
+
+   @Override
+   protected String cacheName() {
+      return "search-rest-non-indexed-off-heap";
+   }
 }

--- a/server/rest/src/test/java/org/infinispan/rest/search/NonIndexedRestSearchTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/search/NonIndexedRestSearchTest.java
@@ -17,4 +17,9 @@ public class NonIndexedRestSearchTest extends BaseRestSearchTest {
       configurationBuilder.encoding().mediaType(MediaType.APPLICATION_PROTOSTREAM);
       return configurationBuilder;
    }
+
+   @Override
+   protected String cacheName() {
+      return "search-rest-non-indexed";
+   }
 }

--- a/server/rest/src/test/java/org/infinispan/rest/search/NonSharedIndexSearchTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/search/NonSharedIndexSearchTest.java
@@ -16,6 +16,11 @@ import org.testng.annotations.Test;
 public class NonSharedIndexSearchTest extends BaseRestSearchTest {
 
    @Override
+   protected String cacheName() {
+      return "search-rest-non-shared-indexed";
+   }
+
+   @Override
    protected ConfigurationBuilder getConfigBuilder() {
       ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC);
       builder.indexing().enable()

--- a/server/rest/src/test/java/org/infinispan/rest/search/SingleNodeLocalIndexTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/search/SingleNodeLocalIndexTest.java
@@ -28,4 +28,9 @@ public class SingleNodeLocalIndexTest extends BaseRestSearchTest {
    protected int getNumNodes() {
       return 1;
    }
+
+   @Override
+   protected String cacheName() {
+      return "search-rest-single-node-local";
+   }
 }


### PR DESCRIPTION
Some of these tests can be executed in parallel, resulting in possible clustered locks used for mass-indexing contention, that are based on cache name.

Backport of #11416