### PR TITLE
ISPN-15282 Handle varying numeric precision in SQL store

### DIFF
--- a/core/src/test/java/org/infinispan/test/TestDataSCI.java
+++ b/core/src/test/java/org/infinispan/test/TestDataSCI.java
@@ -9,6 +9,7 @@ import org.infinispan.test.data.BrokenMarshallingPojo;
 import org.infinispan.test.data.CountMarshallingPojo;
 import org.infinispan.test.data.DelayedMarshallingPojo;
 import org.infinispan.test.data.Key;
+import org.infinispan.test.data.Numerics;
 import org.infinispan.test.data.Person;
 import org.infinispan.test.data.Sex;
 import org.infinispan.test.data.Value;
@@ -26,6 +27,7 @@ import org.infinispan.xsite.irac.IracCustomConflictTest;
             Person.class,
             Sex.class,
             Value.class,
+            Numerics.class,
             IracCustomConflictTest.MySortedSet.class,
             ExpirationFunctionalTest.NoEquals.class,
       },

--- a/core/src/test/java/org/infinispan/test/data/Numerics.java
+++ b/core/src/test/java/org/infinispan/test/data/Numerics.java
@@ -1,0 +1,73 @@
+package org.infinispan.test.data;
+
+import java.util.Objects;
+
+import org.infinispan.protostream.annotations.ProtoFactory;
+import org.infinispan.protostream.annotations.ProtoField;
+
+public class Numerics {
+
+   public Numerics() { }
+
+   @ProtoFactory
+   public Numerics(int keyColumn, long simpleLong, float simpleFloat, double simpleDouble) {
+      this.keyColumn = keyColumn;
+      this.simpleLong = simpleLong;
+      this.simpleFloat = simpleFloat;
+      this.simpleDouble = simpleDouble;
+   }
+
+   @ProtoField(number = 1, defaultValue = "0")
+   int keyColumn;
+
+   @ProtoField(number = 2, defaultValue = "0")
+   long simpleLong;
+
+   @ProtoField(number = 3, defaultValue = "0")
+   float simpleFloat;
+
+   @ProtoField(number = 4, defaultValue = "0")
+   double simpleDouble;
+
+   public int simpleInt() {
+      return keyColumn;
+   }
+
+   public long simpleLong() {
+      return simpleLong;
+   }
+
+   public float simpleFloat() {
+      return simpleFloat;
+   }
+
+   public double simpleDouble() {
+      return simpleDouble;
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      Numerics numerics = (Numerics) o;
+      return keyColumn == numerics.keyColumn
+            && simpleLong == numerics.simpleLong
+            && Float.compare(simpleFloat, numerics.simpleFloat) == 0
+            && Double.compare(simpleDouble, numerics.simpleDouble) == 0;
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hash(keyColumn, simpleLong, simpleFloat, simpleDouble);
+   }
+
+   @Override
+   public String toString() {
+      return "Numerics{" +
+            "keyColumn=" + keyColumn +
+            ", simpleLong=" + simpleLong +
+            ", simpleFloat=" + simpleFloat +
+            ", simpleDouble=" + simpleDouble +
+            '}';
+   }
+}

--- a/persistence/sql/src/main/java/org/infinispan/persistence/sql/QueriesJdbcStore.java
+++ b/persistence/sql/src/main/java/org/infinispan/persistence/sql/QueriesJdbcStore.java
@@ -97,8 +97,9 @@ public class QueriesJdbcStore<K, V> extends AbstractSchemaJdbcStore<K, V, Querie
             for (int i = 1; i <= rsMetadata.getColumnCount(); ++i) {
                int columnType = rsMetadata.getColumnType(i);
                String name = rsMetadata.getColumnName(i);
+               int precision = rsMetadata.getPrecision(i);
                int scale = rsMetadata.getScale(i);
-               int actualType = typeWeUse(columnType, rsMetadata.getColumnTypeName(i), scale);
+               int actualType = typeWeUse(columnType, rsMetadata.getColumnTypeName(i), precision, scale);
                ProtostreamFieldType type = ProtostreamFieldType.from(actualType);
                String lowerCaseName = name.toLowerCase();
                // Make sure to reuse same parameter instance just with different offset

--- a/persistence/sql/src/main/java/org/infinispan/persistence/sql/TableJdbcStore.java
+++ b/persistence/sql/src/main/java/org/infinispan/persistence/sql/TableJdbcStore.java
@@ -134,8 +134,9 @@ public class TableJdbcStore<K, V> extends AbstractSchemaJdbcStore<K, V, TableJdb
          while (rs.next()) {
             String name = rs.getString("COLUMN_NAME");
             int sqlColumnType = rs.getInt("DATA_TYPE");
+            int precision = rs.getInt("COLUMN_SIZE");
             int scale = rs.getInt("DECIMAL_DIGITS");
-            int actualType = typeWeUse(sqlColumnType, rs.getString("TYPE_NAME"), scale);
+            int actualType = typeWeUse(sqlColumnType, rs.getString("TYPE_NAME"), precision, scale);
 
             ProtostreamFieldType schemaType = ProtostreamFieldType.from(actualType);
             boolean isPrimary = primaryKeyList.contains(name.toUpperCase());


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-15282

Added a test for SQL store to check the different numeric types. But two notes:

SQLite has "flexible typing" or something like that, which makes it complicated [1]. We have only a few data types, and when an inconsistent behavior using the JDBC implementation. For example, a `simpleLong` column needs to be defined as `INTEGER`. Extracting the column information from the `DatabaseMetaData` yields `INTEGER (2000000000, 0)` but through the `ResultSetMetaData` and the query yields only `INTEGER` without precision or scale. That's why I skip the test for query + SQLite.

Second, the `Numerics` class does not include `byte` or `short` because Protostream seems unable to parse it right now to/from JSON.

[1]: https://www.sqlite.org/datatype3.html