### PR TITLE
ISPN-15309 Hot Rod client should use server key media-type to route r…

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/DataFormat.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/DataFormat.java
@@ -7,6 +7,7 @@ import org.infinispan.client.hotrod.configuration.RemoteCacheConfiguration;
 import org.infinispan.client.hotrod.impl.MarshallerRegistry;
 import org.infinispan.client.hotrod.logging.Log;
 import org.infinispan.client.hotrod.logging.LogFactory;
+import org.infinispan.client.hotrod.marshall.MediaTypeMarshaller;
 import org.infinispan.commons.configuration.ClassAllowList;
 import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.commons.marshall.AdaptiveBufferSizePredictor;
@@ -24,44 +25,135 @@ public final class DataFormat {
 
    private static final Log log = LogFactory.getLog(DataFormat.class, Log.class);
 
-   private final MediaType keyType;
-   private final MediaType valueType;
-   private final Marshaller keyMarshaller;
-   private final Marshaller valueMarshaller;
-
-   private MarshallerRegistry marshallerRegistry;
-   private Marshaller defaultMarshaller;
-   private boolean isObjectStorage;
-
    private final BufferSizePredictor keySizePredictor = new AdaptiveBufferSizePredictor();
    private final BufferSizePredictor valueSizePredictor = new AdaptiveBufferSizePredictor();
 
+   private final DataFormatImpl server;
+   private final DataFormatImpl client;
+   private MarshallerRegistry marshallerRegistry;
+   private Marshaller defaultMarshaller;
 
-   private DataFormat(MediaType keyType, MediaType valueType, Marshaller keyMarshaller, Marshaller valueMarshaller) {
-      this.keyType = keyType;
-      this.valueType = valueType;
-      this.keyMarshaller = keyMarshaller;
-      this.valueMarshaller = valueMarshaller;
+   private final class DataFormatImpl implements MediaTypeMarshaller {
+
+      private final MediaType keyType;
+      private final MediaType valueType;
+      private final Marshaller keyMarshaller;
+      private final Marshaller valueMarshaller;
+
+      private DataFormatImpl(MediaType keyType, MediaType valueType,
+                             Marshaller keyMarshaller, Marshaller valueMarshaller) {
+         this.keyType = keyType;
+         this.valueType = valueType;
+         this.keyMarshaller = keyMarshaller;
+         this.valueMarshaller = valueMarshaller;
+      }
+
+      public MediaType getKeyType() {
+         if (keyType != null) return keyType;
+         Marshaller marshaller = resolveKeyMarshaller();
+         return marshaller == null ? null : marshaller.mediaType();
+      }
+
+      public MediaType getValueType() {
+         if (valueType != null) return valueType;
+         Marshaller marshaller = resolveValueMarshaller();
+         return marshaller == null ? null : marshaller.mediaType();
+      }
+
+      private Marshaller resolveKeyMarshaller() {
+         if (keyMarshaller != null) return keyMarshaller;
+         if (keyType == null) return defaultMarshaller;
+
+         Marshaller forKeyType = marshallerRegistry.getMarshaller(keyType);
+         if (forKeyType != null) return forKeyType;
+         log.debugf("No marshaller registered for %s, using no-op marshaller", keyType);
+
+         return IdentityMarshaller.INSTANCE;
+      }
+
+      private Marshaller resolveValueMarshaller() {
+         if (valueMarshaller != null) return valueMarshaller;
+         if (valueType == null) return defaultMarshaller;
+
+         Marshaller forValueType = marshallerRegistry.getMarshaller(valueType);
+         if (forValueType != null) return forValueType;
+         log.debugf("No marshaller registered for %s, using no-op marshaller", valueType);
+
+         return IdentityMarshaller.INSTANCE;
+      }
+
+      public byte[] keyToBytes(Object key) {
+         Marshaller keyMarshaller = resolveKeyMarshaller();
+         return obj2bytes(keyMarshaller, key, keySizePredictor);
+      }
+
+      public byte[] valueToBytes(Object value) {
+         Marshaller valueMarshaller = resolveValueMarshaller();
+         return obj2bytes(valueMarshaller, value, valueSizePredictor);
+      }
+
+      @Override
+      public <T> T bytesToKey(byte[] bytes, ClassAllowList allowList) {
+         Marshaller keyMarshaller = resolveKeyMarshaller();
+         return bytes2obj(keyMarshaller, bytes, isObjectStorage(), allowList);
+      }
+
+      @Override
+      public <T> T bytesToValue(byte[] bytes, ClassAllowList allowList) {
+         Marshaller valueMarshaller = resolveValueMarshaller();
+         return bytes2obj(valueMarshaller, bytes, isObjectStorage(), allowList);
+      }
+
+      public boolean match(DataFormatImpl other) {
+         if (other == null) return false;
+
+         MediaType mt = getKeyType();
+         return mt != null && other.getKeyType() != null && mt.match(other.getKeyType());
+      }
+
+      @Override
+      public String toString() {
+         return "DataFormatImpl{" +
+               "keyType=" + keyType +
+               ", valueType=" + valueType +
+               ", keyMarshaller=" + keyMarshaller +
+               ", valueMarshaller=" + valueMarshaller +
+               '}';
+      }
+   }
+
+   private DataFormat(MediaType cKeyType, MediaType cValueType, Marshaller cKeyMarshaller, Marshaller cValueMarshaller,
+                      MediaType sKeyType, MediaType sValueType, Marshaller sKeyMarshaller, Marshaller sValueMarshaller) {
+      this.server = new DataFormatImpl(sKeyType, sValueType, sKeyMarshaller, sValueMarshaller);
+      this.client = new DataFormatImpl(cKeyType, cValueType, cKeyMarshaller, cValueMarshaller);
+   }
+
+   private DataFormat(MediaType cKeyType, MediaType cValueType, Marshaller cKeyMarshaller, Marshaller cValueMarshaller) {
+      this.server = null;
+      this.client = new DataFormatImpl(cKeyType, cValueType, cKeyMarshaller, cValueMarshaller);
    }
 
    public DataFormat withoutValueType() {
-      DataFormat dataFormat = new DataFormat(keyType, null, keyMarshaller, null);
+      DataFormat dataFormat;
+      if (server != null) {
+         dataFormat = new DataFormat(
+               client.keyType, null, client.keyMarshaller, null,
+               server.keyType, server.valueType, server.keyMarshaller, server.valueMarshaller);
+      } else {
+         dataFormat = new DataFormat(client.keyType, null, client.keyMarshaller, null);
+      }
+
       dataFormat.marshallerRegistry = this.marshallerRegistry;
       dataFormat.defaultMarshaller = this.defaultMarshaller;
-      dataFormat.isObjectStorage = this.isObjectStorage;
       return dataFormat;
    }
 
    public MediaType getKeyType() {
-      if (keyType != null) return keyType;
-      Marshaller marshaller = resolveKeyMarshaller();
-      return marshaller == null ? null : marshaller.mediaType();
+      return client.getKeyType();
    }
 
    public MediaType getValueType() {
-      if (valueType != null) return valueType;
-      Marshaller marshaller = resolveValueMarshaller();
-      return marshaller == null ? null : marshaller.mediaType();
+      return client.getValueType();
    }
 
    /**
@@ -71,12 +163,10 @@ public final class DataFormat {
    public void initialize(RemoteCacheManager remoteCacheManager, boolean serverObjectStorage) {
       this.marshallerRegistry = remoteCacheManager.getMarshallerRegistry();
       this.defaultMarshaller = remoteCacheManager.getMarshaller();
-      this.isObjectStorage = serverObjectStorage;
    }
 
    public void initialize(RemoteCacheManager remoteCacheManager, String cacheName, boolean serverObjectStorage) {
       this.marshallerRegistry = remoteCacheManager.getMarshallerRegistry();
-      this.isObjectStorage = serverObjectStorage;
       this.defaultMarshaller = remoteCacheManager.getMarshaller();
       RemoteCacheConfiguration remoteCacheConfiguration = remoteCacheManager.getConfiguration().remoteCaches().get(cacheName);
       if (remoteCacheConfiguration != null) {
@@ -93,30 +183,8 @@ public final class DataFormat {
       }
    }
 
-   private Marshaller resolveValueMarshaller() {
-      if (valueMarshaller != null) return valueMarshaller;
-      if (valueType == null) return defaultMarshaller;
-
-      Marshaller forValueType = marshallerRegistry.getMarshaller(valueType);
-      if (forValueType != null) return forValueType;
-      log.debugf("No marshaller registered for %s, using no-op marshaller", valueType);
-
-      return IdentityMarshaller.INSTANCE;
-   }
-
    public boolean isObjectStorage() {
-      return isObjectStorage;
-   }
-
-   private Marshaller resolveKeyMarshaller() {
-      if (keyMarshaller != null) return keyMarshaller;
-      if (keyType == null) return defaultMarshaller;
-
-      Marshaller forKeyType = marshallerRegistry.getMarshaller(keyType);
-      if (forKeyType != null) return forKeyType;
-      log.debugf("No marshaller registered for %s, using no-op marshaller", keyType);
-
-      return IdentityMarshaller.INSTANCE;
+      return server != null && server.keyType == MediaType.APPLICATION_OBJECT;
    }
 
    /**
@@ -128,8 +196,7 @@ public final class DataFormat {
    }
 
    public byte[] keyToBytes(Object key) {
-      Marshaller keyMarshaller = resolveKeyMarshaller();
-      return obj2bytes(keyMarshaller, key, keySizePredictor);
+      return client.keyToBytes(key);
    }
 
    /**
@@ -141,27 +208,39 @@ public final class DataFormat {
    }
 
    public byte[] valueToBytes(Object value) {
-      Marshaller valueMarshaller = resolveValueMarshaller();
-      return obj2bytes(valueMarshaller, value, valueSizePredictor);
+      return client.valueToBytes(value);
    }
 
    public <T> T keyToObj(byte[] bytes, ClassAllowList allowList) {
-      Marshaller keyMarshaller = resolveKeyMarshaller();
-      return bytes2obj(keyMarshaller, bytes, isObjectStorage, allowList);
+      return client.bytesToKey(bytes, allowList);
    }
 
    public <T> T valueToObj(byte[] bytes, ClassAllowList allowList) {
-      Marshaller valueMarshaller = resolveValueMarshaller();
-      return bytes2obj(valueMarshaller, bytes, isObjectStorage, allowList);
+      return client.bytesToValue(bytes, allowList);
+   }
+
+   public MediaTypeMarshaller server() {
+      if (server == null || server.match(client)) return null;
+
+      // If is an object storage, we hash the actual object to retrieve the segment.
+      // We return null so the client does not use anything from the server.
+      if (isObjectStorage()) return null;
+
+      // When the registry returns `null` means that the client DOES NOT have a marshaller capable of converting to
+      // the server key type. Therefore, we return null, so it will utilize the default and NOT convert the object.
+      // This could cause additional redirections on the server side and poor performance for the client.
+      return marshallerRegistry.getMarshaller(server.keyType) == null ? null : server;
+   }
+
+   public MediaTypeMarshaller client() {
+      return client;
    }
 
    @Override
    public String toString() {
       return "DataFormat{" +
-            "keyType=" + keyType +
-            ", valueType=" + valueType +
-            ", keyMarshaller=" + keyMarshaller +
-            ", valueMarshaller=" + valueMarshaller +
+            "client=" + client +
+            ", server=" + server +
             ", marshallerRegistry=" + marshallerRegistry +
             ", defaultMarshaller=" + defaultMarshaller +
             '}';
@@ -176,13 +255,22 @@ public final class DataFormat {
       private MediaType valueType;
       private Marshaller valueMarshaller;
       private Marshaller keyMarshaller;
+      private Builder serverDataFormat;
 
       public Builder from(DataFormat dataFormat) {
-         this.keyType = dataFormat.keyType;
-         this.valueType = dataFormat.valueType;
-         this.keyMarshaller = dataFormat.keyMarshaller;
-         this.valueMarshaller = dataFormat.valueMarshaller;
+         from(dataFormat.client);
+         if (dataFormat.server != null) {
+            this.serverDataFormat = new Builder();
+            this.serverDataFormat.from(dataFormat.server);
+         }
          return this;
+      }
+
+      private void from(DataFormatImpl impl) {
+         this.keyType = impl.keyType;
+         this.valueType = impl.valueType;
+         this.keyMarshaller = impl.keyMarshaller;
+         this.valueMarshaller = impl.valueMarshaller;
       }
 
       public Builder valueMarshaller(Marshaller valueMarshaller) {
@@ -205,7 +293,19 @@ public final class DataFormat {
          return this;
       }
 
+      public Builder serverDataFormat(Builder format) {
+         this.serverDataFormat = format;
+         return this;
+      }
+
       public DataFormat build() {
+         if (serverDataFormat != null) {
+            return new DataFormat(
+                  keyType, valueType, keyMarshaller, valueMarshaller,
+                  serverDataFormat.keyType, serverDataFormat.valueType, serverDataFormat.keyMarshaller, serverDataFormat.valueMarshaller
+            );
+         }
+
          return new DataFormat(keyType, valueType, keyMarshaller, valueMarshaller);
       }
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
@@ -551,7 +551,7 @@ public class RemoteCacheManager implements RemoteCacheContainer, Closeable, Remo
       synchronized (cacheName2RemoteCache) {
          startRemoteCache(remoteCache, forceReturnValue);
          RemoteCacheHolder holder = new RemoteCacheHolder(remoteCache, forceReturnValueOverride);
-         remoteCache.resolveStorage(pingResponse.isObjectStorage());
+         remoteCache.resolveStorage(pingResponse.getKeyMediaType(), pingResponse.getValueMediaType(), pingResponse.isObjectStorage());
          cacheName2RemoteCache.putIfAbsent(key, holder);
          return remoteCache;
       }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/DelegatingRemoteCache.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/DelegatingRemoteCache.java
@@ -340,11 +340,6 @@ public abstract class DelegatingRemoteCache<K, V> extends RemoteCacheSupport<K, 
    }
 
    @Override
-   public K keyAsObjectIfNeeded(Object key) {
-      return delegate.keyAsObjectIfNeeded(key);
-   }
-
-   @Override
    public byte[] keyToBytes(Object o) {
       return delegate.keyToBytes(o);
    }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/InternalRemoteCache.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/InternalRemoteCache.java
@@ -15,6 +15,7 @@ import org.infinispan.client.hotrod.configuration.Configuration;
 import org.infinispan.client.hotrod.impl.operations.OperationsFactory;
 import org.infinispan.client.hotrod.impl.operations.PingResponse;
 import org.infinispan.client.hotrod.impl.operations.RetryAwareCompletionStage;
+import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.commons.util.CloseableIterator;
 import org.infinispan.commons.util.IntSet;
 
@@ -46,6 +47,10 @@ public interface InternalRemoteCache<K, V> extends RemoteCache<K, V> {
 
    void resolveStorage(boolean objectStorage);
 
+   default void resolveStorage(MediaType key, MediaType value, boolean objectStorage) {
+      resolveStorage(objectStorage);
+   }
+
    @Override
    ClientStatistics clientStatistics();
 
@@ -57,8 +62,6 @@ public interface InternalRemoteCache<K, V> extends RemoteCache<K, V> {
    OperationsFactory getOperationsFactory();
 
    boolean isObjectStorage();
-
-   K keyAsObjectIfNeeded(Object key);
 
    byte[] keyToBytes(Object o);
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/RemoteCacheImpl.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/RemoteCacheImpl.java
@@ -59,6 +59,7 @@ import org.infinispan.client.hotrod.impl.query.RemoteQueryFactory;
 import org.infinispan.client.hotrod.logging.Log;
 import org.infinispan.client.hotrod.logging.LogFactory;
 import org.infinispan.client.hotrod.near.NearCacheService;
+import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.commons.time.TimeService;
 import org.infinispan.commons.util.CloseableIterator;
 import org.infinispan.commons.util.CloseableIteratorCollection;
@@ -183,7 +184,7 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> implements I
    public CompletableFuture<Boolean> removeWithVersionAsync(final K key, final long version) {
       assertRemoteCacheManagerIsStarted();
       RemoveIfUnmodifiedOperation<V> op = operationsFactory.newRemoveIfUnmodifiedOperation(
-            keyAsObjectIfNeeded(key), keyToBytes(key), version, dataFormat);
+            key, keyToBytes(key), version, dataFormat);
       return op.execute().thenApply(response -> response.getCode().isUpdated());
    }
 
@@ -195,7 +196,7 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> implements I
    public CompletableFuture<Boolean> replaceWithVersionAsync(K key, V newValue, long version, long lifespan, TimeUnit lifespanTimeUnit, long maxIdle, TimeUnit maxIdleTimeUnit) {
       assertRemoteCacheManagerIsStarted();
       ReplaceIfUnmodifiedOperation op = operationsFactory.newReplaceIfUnmodifiedOperation(
-            keyAsObjectIfNeeded(key), keyToBytes(key), valueToBytes(newValue), lifespan, lifespanTimeUnit, maxIdle, maxIdleTimeUnit, version, dataFormat);
+            key, keyToBytes(key), valueToBytes(newValue), lifespan, lifespanTimeUnit, maxIdle, maxIdleTimeUnit, version, dataFormat);
       return op.execute().thenApply(response -> response.getCode().isUpdated());
    }
 
@@ -247,7 +248,7 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> implements I
    public CompletableFuture<MetadataValue<V>> getWithMetadataAsync(K key) {
       assertRemoteCacheManagerIsStarted();
       GetWithMetadataOperation<V> op = operationsFactory.newGetWithMetadataOperation(
-            keyAsObjectIfNeeded(key), keyToBytes(key), dataFormat);
+            key, keyToBytes(key), dataFormat);
       return op.execute();
    }
 
@@ -255,7 +256,7 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> implements I
    public RetryAwareCompletionStage<MetadataValue<V>> getWithMetadataAsync(K key, SocketAddress preferredAddres) {
       assertRemoteCacheManagerIsStarted();
       GetWithMetadataOperation<V> op = operationsFactory.newGetWithMetadataOperation(
-            keyAsObjectIfNeeded(key), keyToBytes(key), dataFormat, preferredAddres);
+            key, keyToBytes(key), dataFormat, preferredAddres);
       return op.internalExecute();
    }
 
@@ -303,17 +304,12 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> implements I
    }
 
    @Override
-   public K keyAsObjectIfNeeded(Object key) {
-      return isObjectStorage ? (K) key : null;
-   }
-
-   @Override
    public CompletableFuture<V> putAsync(K key, V value, long lifespan, TimeUnit lifespanUnit, long maxIdleTime, TimeUnit maxIdleTimeUnit) {
       assertRemoteCacheManagerIsStarted();
       if (log.isTraceEnabled()) {
          log.tracef("About to add (K,V): (%s, %s) lifespan:%d, maxIdle:%d", key, value, lifespan, maxIdleTime);
       }
-      PutOperation<V> op = operationsFactory.newPutKeyValueOperation(keyAsObjectIfNeeded(key),
+      PutOperation<V> op = operationsFactory.newPutKeyValueOperation(key,
             keyToBytes(key), valueToBytes(value), lifespan, lifespanUnit, maxIdleTime, maxIdleTimeUnit, dataFormat);
       return op.execute();
    }
@@ -415,7 +411,7 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> implements I
    @Override
    public CompletableFuture<V> putIfAbsentAsync(K key, V value, long lifespan, TimeUnit lifespanUnit, long maxIdleTime, TimeUnit maxIdleTimeUnit) {
       assertRemoteCacheManagerIsStarted();
-      PutIfAbsentOperation<V> op = operationsFactory.newPutIfAbsentOperation(keyAsObjectIfNeeded(key),
+      PutIfAbsentOperation<V> op = operationsFactory.newPutIfAbsentOperation(key,
             keyToBytes(key), valueToBytes(value), lifespan, lifespanUnit, maxIdleTime, maxIdleTimeUnit, dataFormat);
       return op.execute();
    }
@@ -446,7 +442,7 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> implements I
    @Override
    public CompletableFuture<V> removeAsync(Object key) {
       assertRemoteCacheManagerIsStarted();
-      RemoveOperation<V> removeOperation = operationsFactory.newRemoveOperation(keyAsObjectIfNeeded(key), keyToBytes(key), dataFormat);
+      RemoveOperation<V> removeOperation = operationsFactory.newRemoveOperation(key, keyToBytes(key), dataFormat);
       // TODO: It sucks that you need the prev value to see if it works...
       // We need to find a better API for RemoteCache...
       return removeOperation.execute();
@@ -474,7 +470,7 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> implements I
    @Override
    public CompletableFuture<V> replaceAsync(K key, V value, long lifespan, TimeUnit lifespanUnit, long maxIdleTime, TimeUnit maxIdleTimeUnit) {
       assertRemoteCacheManagerIsStarted();
-      ReplaceOperation<V> op = operationsFactory.newReplaceOperation(keyAsObjectIfNeeded(key),
+      ReplaceOperation<V> op = operationsFactory.newReplaceOperation(key,
             keyToBytes(key), valueToBytes(value), lifespan, lifespanUnit, maxIdleTime, maxIdleTimeUnit, dataFormat);
       return op.execute();
    }
@@ -482,8 +478,7 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> implements I
    @Override
    public CompletableFuture<Boolean> containsKeyAsync(K key) {
       assertRemoteCacheManagerIsStarted();
-      ContainsKeyOperation op = operationsFactory.newContainsKeyOperation(
-            keyAsObjectIfNeeded(key), keyToBytes(key), dataFormat);
+      ContainsKeyOperation op = operationsFactory.newContainsKeyOperation(key, keyToBytes(key), dataFormat);
       return op.execute();
    }
 
@@ -604,7 +599,7 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> implements I
    public CompletableFuture<V> getAsync(Object key) {
       assertRemoteCacheManagerIsStarted();
       byte[] keyBytes = keyToBytes(key);
-      GetOperation<V> gco = operationsFactory.newGetKeyOperation(keyAsObjectIfNeeded(key), keyBytes, dataFormat);
+      GetOperation<V> gco = operationsFactory.newGetKeyOperation(key, keyBytes, dataFormat);
       CompletableFuture<V> result = gco.execute();
       if (log.isTraceEnabled()) {
          result.thenAccept(value -> log.tracef("For key(%s) returning %s", key, value));
@@ -710,6 +705,33 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> implements I
    public void resolveStorage(boolean objectStorage) {
       this.isObjectStorage = objectStorage;
       this.dataFormat.initialize(remoteCacheManager, name, isObjectStorage);
+   }
+
+   @Override
+   public void resolveStorage(MediaType key, MediaType value, boolean objectStorage) {
+      // Set the storage first and initialize the current data format.
+      // We need this to check if the key type match.
+      resolveStorage(objectStorage);
+
+      if (key != null && key != MediaType.APPLICATION_UNKNOWN && !dataFormat.getKeyType().match(key)) {
+         DataFormat.Builder server = DataFormat.builder()
+               .from(this.dataFormat)
+               .keyType(key)
+               .valueType(value);
+         this.dataFormat = DataFormat.builder()
+               .from(this.dataFormat)
+               .serverDataFormat(server)
+               .build();
+         resolveStorage(objectStorage);
+
+         // Now proceed and check if the server has an available marshaller.
+         // This means that the client DOES NOT have a marshaller capable of converting to the server key type.
+         // Therefore, it will utilize the default fallback and NOT convert the object.
+         // This could cause additional redirections on the server side and poor performance for the client.
+         if (remoteCacheManager.getMarshallerRegistry().getMarshaller(key) == null) {
+            log.serverKeyTypeNotRecognized(key);
+         }
+      }
    }
 
    @Override

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/StreamingRemoteCacheImpl.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/StreamingRemoteCacheImpl.java
@@ -6,6 +6,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.concurrent.TimeUnit;
 
+import org.infinispan.client.hotrod.DataFormat;
 import org.infinispan.client.hotrod.StreamingRemoteCache;
 import org.infinispan.client.hotrod.VersionedMetadata;
 import org.infinispan.client.hotrod.impl.operations.GetStreamOperation;
@@ -25,9 +26,16 @@ public class StreamingRemoteCacheImpl<K> implements StreamingRemoteCache<K> {
       this.cache = cache;
    }
 
+   private K keyAsObjectIfNeeded(K key) {
+      DataFormat df = cache.getDataFormat();
+      return df.isObjectStorage()
+            ? key
+            : null;
+   }
+
    @Override
    public <T extends InputStream & VersionedMetadata> T get(K key) {
-      GetStreamOperation op = cache.getOperationsFactory().newGetStreamOperation(cache.keyAsObjectIfNeeded(key), cache.keyToBytes(key), 0);
+      GetStreamOperation op = cache.getOperationsFactory().newGetStreamOperation(keyAsObjectIfNeeded(key), cache.keyToBytes(key), 0);
       return (T) await(op.execute());
    }
 
@@ -43,7 +51,7 @@ public class StreamingRemoteCacheImpl<K> implements StreamingRemoteCache<K> {
 
    @Override
    public OutputStream put(K key, long lifespan, TimeUnit lifespanUnit, long maxIdle, TimeUnit maxIdleUnit) {
-      PutStreamOperation op = cache.getOperationsFactory().newPutStreamOperation(cache.keyAsObjectIfNeeded(key), cache.keyToBytes(key), lifespan, lifespanUnit, maxIdle, maxIdleUnit);
+      PutStreamOperation op = cache.getOperationsFactory().newPutStreamOperation(keyAsObjectIfNeeded(key), cache.keyToBytes(key), lifespan, lifespanUnit, maxIdle, maxIdleUnit);
       return await(op.execute());
    }
 
@@ -59,7 +67,7 @@ public class StreamingRemoteCacheImpl<K> implements StreamingRemoteCache<K> {
 
    @Override
    public OutputStream putIfAbsent(K key, long lifespan, TimeUnit lifespanUnit, long maxIdle, TimeUnit maxIdleUnit) {
-      PutStreamOperation op = cache.getOperationsFactory().newPutIfAbsentStreamOperation(cache.keyAsObjectIfNeeded(key), cache.keyToBytes(key), lifespan, lifespanUnit, maxIdle, maxIdleUnit);
+      PutStreamOperation op = cache.getOperationsFactory().newPutIfAbsentStreamOperation(keyAsObjectIfNeeded(key), cache.keyToBytes(key), lifespan, lifespanUnit, maxIdle, maxIdleUnit);
       return await(op.execute());
    }
 
@@ -75,7 +83,7 @@ public class StreamingRemoteCacheImpl<K> implements StreamingRemoteCache<K> {
 
    @Override
    public OutputStream replaceWithVersion(K key, long version, long lifespan, TimeUnit lifespanUnit, long maxIdle, TimeUnit maxIdleUnit) {
-      PutStreamOperation op = cache.getOperationsFactory().newPutStreamOperation(cache.keyAsObjectIfNeeded(key), cache.keyToBytes(key), version, lifespan, lifespanUnit, maxIdle, maxIdleUnit);
+      PutStreamOperation op = cache.getOperationsFactory().newPutStreamOperation(keyAsObjectIfNeeded(key), cache.keyToBytes(key), version, lifespan, lifespanUnit, maxIdle, maxIdleUnit);
       return await(op.execute());
    }
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/ChannelFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/ChannelFactory.java
@@ -360,7 +360,7 @@ public class ChannelFactory {
                                                                byte[] cacheName, T operation) {
       CacheInfo cacheInfo = topologyInfo.getCacheInfo(wrapBytes(cacheName));
       if (cacheInfo != null && cacheInfo.getConsistentHash() != null) {
-         SocketAddress server = cacheInfo.getConsistentHash().getServer(key);
+         SocketAddress server = cacheInfo.getConsistentHash().getServer(operation.routingObject(key));
          if (server != null && (failedServers == null || !failedServers.contains(server))) {
             return fetchChannelAndInvoke(server, cacheName, operation);
          }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/ChannelOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/ChannelOperation.java
@@ -19,4 +19,8 @@ public interface ChannelOperation {
     * @param cause
     */
    void cancel(SocketAddress address, Throwable cause);
+
+   default Object routingObject(Object defaultObject) {
+      return defaultObject;
+   }
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/logging/Log.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/logging/Log.java
@@ -22,6 +22,7 @@ import org.infinispan.client.hotrod.exceptions.InvalidResponseException;
 import org.infinispan.client.hotrod.exceptions.TransportException;
 import org.infinispan.commons.CacheConfigurationException;
 import org.infinispan.commons.CacheListenerException;
+import org.infinispan.commons.dataconversion.MediaType;
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.Cause;
@@ -413,4 +414,7 @@ public interface Log extends BasicLogger {
    @Message(value = "Unexpected error while creating the tracing propagation context. Client context tracing will not be propagated.", id = 4115)
    void errorCreatingPropagationContext(@Cause Throwable throwable);
 
+   @LogMessage(level = WARN)
+   @Message(value = "Client cannot marshall the server's key media type ('%s'). This could cause poor performance.", id = 4116)
+   void serverKeyTypeNotRecognized(MediaType serverKeyType);
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/marshall/MediaTypeMarshaller.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/marshall/MediaTypeMarshaller.java
@@ -1,0 +1,65 @@
+package org.infinispan.client.hotrod.marshall;
+
+import org.infinispan.commons.configuration.ClassAllowList;
+import org.infinispan.commons.dataconversion.MediaType;
+
+/**
+ * A marshaller that takes the {@link MediaType} decision to marshall/unmarshall.
+ *
+ * @since 15.0
+ */
+public interface MediaTypeMarshaller {
+
+   /**
+    * The decided type for the key.
+    *
+    * @return The media type the marshaller uses for keys.
+    */
+   MediaType getKeyType();
+
+   /**
+    * The decided type for the values.
+    *
+    * @return The media type the marshaller uses for values.
+    */
+   MediaType getValueType();
+
+   /**
+    * Transforms the key object to the marshalled form.
+    * The marshalled format respects the define media type for the key.
+    *
+    * @param key: Key object to marshall.
+    * @return The byte array representation of the object in the decided key media type.
+    */
+
+   byte[] keyToBytes(Object key);
+
+   /**
+    * Transforms the value object to the marshalled form.
+    * The marshalled format respects the define media type for the value.
+    *
+    * @param value: Value object to marshall.
+    * @return The byte array representation of the object in the decided value media type.
+    */
+   byte[] valueToBytes(Object value);
+
+   /**
+    * Unmarshall the byte array into the object form.
+    * The unmarshalling follows the process by the decided key media type.
+    *
+    * @param bytes: Byte array to unmarshall.
+    * @param allowList: The allowed list of classes to use during unmarshalling.
+    * @return The object store in the byte array representation.
+    */
+   <T> T bytesToKey(byte[] bytes, ClassAllowList allowList);
+
+   /**
+    * Unmarshall the byte array into the object form.
+    * The unmarshalling follows the process by the decided value media type.
+    *
+    * @param bytes: Byte array to unmarshall.
+    * @param allowList: The allowed list of classes to use during unmarshalling.
+    * @return The object store in the byte array representation.
+    */
+   <T> T bytesToValue(byte[] bytes, ClassAllowList allowList);
+}

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/hash/ConsistentHashTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/hash/ConsistentHashTest.java
@@ -1,0 +1,136 @@
+package org.infinispan.client.hotrod.hash;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+import org.infinispan.Cache;
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.client.hotrod.configuration.Configuration;
+import org.infinispan.client.hotrod.impl.protocol.CodecHolder;
+import org.infinispan.client.hotrod.impl.transport.netty.ChannelFactory;
+import org.infinispan.client.hotrod.impl.transport.netty.ChannelOperation;
+import org.infinispan.client.hotrod.test.InternalRemoteCacheManager;
+import org.infinispan.client.hotrod.test.MultiHotRodServersTest;
+import org.infinispan.commons.dataconversion.MediaType;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.context.Flag;
+import org.infinispan.server.hotrod.HotRodServer;
+import org.testng.annotations.Test;
+
+@Test(groups = "functional", testName = "client.hotrod.hash.ConsistentHashTest")
+public class ConsistentHashTest extends MultiHotRodServersTest {
+
+   private static final int NUM_SERVERS = 3;
+
+   private MediaType keyType = null;
+
+   protected ConsistentHashTest withKeyType(MediaType keyType) {
+      this.keyType = keyType;
+      return this;
+   }
+
+   public void testKeysMapToCorrectSegment() {
+      RemoteCacheManager rcm = clients.get(0);
+      rcm.start();
+
+      Map<Object, SocketAddress> requests = new HashMap<>();
+      RemoteCache<Object, Object> cache = rcm.getCache();
+
+      for (int i = 0; i < 100; i++) {
+         Object keyValue = kv(i);
+         ((ControlledChannelFactory) rcm.getChannelFactory()).useOnFetch((server, op) -> {
+            requests.put(keyValue, server);
+         });
+         cache.put(keyValue, keyValue);
+      }
+
+      for (Map.Entry<Object, SocketAddress> entry : requests.entrySet()) {
+         int port = ((InetSocketAddress) entry.getValue()).getPort();
+         HotRodServer server = findServer(port);
+
+         Cache<Object, Object> c = server.getCacheManager()
+                     .getCache();
+
+         Object r = c.getAdvancedCache()
+               .withFlags(Flag.CACHE_MODE_LOCAL)
+               .get(entry.getKey());
+
+         assertThat(r).isEqualTo(entry.getKey());
+      }
+   }
+
+   private Object kv(int i) {
+      return String.valueOf(i);
+   }
+
+   private HotRodServer findServer(int port) {
+      for (HotRodServer server : servers) {
+         if (server.getAddress().getPort() == port)
+            return server;
+      }
+      throw new IllegalStateException("Server not found for port: " + port);
+   }
+
+   @Override
+   public Object[] factory() {
+      return new Object[] {
+            new ConsistentHashTest(),
+            new ConsistentHashTest().withKeyType(MediaType.APPLICATION_PROTOSTREAM),
+            new ConsistentHashTest().withKeyType(MediaType.APPLICATION_OBJECT),
+            new ConsistentHashTest().withKeyType(MediaType.TEXT_PLAIN),
+      };
+   }
+
+   @Override
+   protected String parameters() {
+      return " -- key-type=" + keyType;
+   }
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      createHotRodServers(NUM_SERVERS, getCacheConfiguration());
+   }
+
+   private ConfigurationBuilder getCacheConfiguration() {
+      ConfigurationBuilder builder = hotRodCacheConfiguration(getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false));
+      if (keyType != null) builder.encoding().key().mediaType(keyType);
+
+      // We want to ensure only a single copy exist and the client is sending to the correct owner.
+      builder.clustering().hash().numOwners(1);
+
+      return builder;
+   }
+
+   @Override
+   protected RemoteCacheManager createClient(int i) {
+      Configuration cfg = createHotRodClientConfigurationBuilder(server(i)).build();
+      return new InternalRemoteCacheManager(cfg, new ControlledChannelFactory(cfg));
+   }
+
+   private static class ControlledChannelFactory extends ChannelFactory {
+
+      private BiConsumer<SocketAddress, ChannelOperation> onFetch;
+
+      public ControlledChannelFactory(Configuration cfg) {
+         super(new CodecHolder(cfg.version().getCodec()));
+      }
+
+      public void useOnFetch(BiConsumer<SocketAddress, ChannelOperation> onFetch) {
+         this.onFetch = onFetch;
+      }
+
+      @Override
+      public <T extends ChannelOperation> T fetchChannelAndInvoke(SocketAddress server, T operation) {
+         if (onFetch != null) onFetch.accept(server, operation);
+         return super.fetchChannelAndInvoke(server, operation);
+      }
+   }
+}

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/MediaTypeMultiServerRemoteIteratorTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/MediaTypeMultiServerRemoteIteratorTest.java
@@ -1,0 +1,59 @@
+package org.infinispan.client.hotrod.impl.iteration;
+
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+
+import java.util.Map;
+
+import org.infinispan.commons.dataconversion.MediaType;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.testng.annotations.Test;
+
+@Test(groups = "functional", testName = "client.hotrod.iteration.MediaTypeMultiServerRemoteIteratorTest")
+public class MediaTypeMultiServerRemoteIteratorTest extends BaseMultiServerRemoteIteratorTest {
+
+   private static final int NUM_SERVERS = 3;
+
+   private MediaType key = null;
+
+   public MediaTypeMultiServerRemoteIteratorTest withKeyType(MediaType key) {
+      this.key = key;
+      return this;
+   }
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      createHotRodServers(NUM_SERVERS, getCacheConfiguration());
+   }
+
+   private ConfigurationBuilder getCacheConfiguration() {
+      ConfigurationBuilder builder = hotRodCacheConfiguration(getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false));
+      if (key != null) builder.encoding().key().mediaType(key);
+      return builder;
+   }
+
+   @Override
+   protected <T> Map.Entry<Object, T> convertEntry(Map.Entry<Object, ?> entry) {
+      return super.convertEntry(Map.entry(Integer.valueOf(entry.getKey().toString()), entry.getValue()));
+   }
+
+   @Override
+   protected <T> T convertKey(Object key) {
+      return super.convertKey(Integer.valueOf(key.toString()));
+   }
+
+   @Override
+   public Object[] factory() {
+      return new Object[] {
+            new MediaTypeMultiServerRemoteIteratorTest(),
+            new MediaTypeMultiServerRemoteIteratorTest().withKeyType(MediaType.APPLICATION_PROTOSTREAM),
+            new MediaTypeMultiServerRemoteIteratorTest().withKeyType(MediaType.TEXT_PLAIN),
+            new MediaTypeMultiServerRemoteIteratorTest().withKeyType(MediaType.APPLICATION_OBJECT),
+      };
+   }
+
+   @Override
+   protected String parameters() {
+      return "[key_type=" + key + "]";
+   }
+}

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/MultiServerDistRemoteIteratorTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/MultiServerDistRemoteIteratorTest.java
@@ -50,7 +50,11 @@ public class MultiServerDistRemoteIteratorTest extends BaseMultiServerRemoteIter
 
    private static class TestSegmentKeyTracker implements KeyTracker {
 
-      final IntSet finished = IntSets.mutableEmptySet();
+      final IntSet finished;
+
+      public TestSegmentKeyTracker(int size) {
+         this.finished = IntSets.concurrentSet(size);
+      }
 
       @Override
       public boolean track(byte[] key, short status, ClassAllowList allowList) {
@@ -71,7 +75,7 @@ public class MultiServerDistRemoteIteratorTest extends BaseMultiServerRemoteIter
    public void testSegmentFinishedCallback() {
       RemoteCache<Integer, AccountHS> cache = clients.get(0).getCache();
       populateCache(CACHE_SIZE, Util::newAccount, cache);
-      TestSegmentKeyTracker testSegmentKeyTracker = new TestSegmentKeyTracker();
+      TestSegmentKeyTracker testSegmentKeyTracker = new TestSegmentKeyTracker(60);
 
       Publisher<Map.Entry<Integer, AccountHS>> publisher = cache.publishEntries(null, null, null, 3);
       TestingUtil.replaceField(testSegmentKeyTracker, "segmentKeyTracker", publisher, RemotePublisher.class);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/Util.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/Util.java
@@ -75,7 +75,7 @@ class Util {
    static void assertKeysInSegment(Set<Map.Entry<Object, Object>> entries, Set<Integer> segments,
                                     Marshaller marshaller, Function<byte[], Integer> segmentCalculator) {
       entries.forEach(e -> {
-         Integer key = (Integer) e.getKey();
+         Object key = e.getKey();
          int segment = segmentCalculator.apply(toByteBuffer(key, marshaller));
          assertTrue(segments.contains(segment));
       });


### PR DESCRIPTION
…equest

https://issues.redhat.com/browse/ISPN-15309

* This changes the client to serialize again if the server media type does not match the client configuration.
* This fixes the iterator to convert the received key properly.

Basically, I made some changes to the `DataFormat` to keep track of the server's media type. Later, we decide whether to use the server's type when hashing the key to get the segment. In cases where the media types match, there is no need for this encoding.