### PR TITLE
[14.0.x] ISPN-15304 Virtual Threads improvements

### DIFF
--- a/commons/all/src/main/java/org/infinispan/commons/jdkspecific/ThreadCreator.java
+++ b/commons/all/src/main/java/org/infinispan/commons/jdkspecific/ThreadCreator.java
@@ -1,5 +1,8 @@
 package org.infinispan.commons.jdkspecific;
 
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+
 import org.infinispan.commons.logging.Log;
 import org.infinispan.commons.util.Util;
 
@@ -8,11 +11,15 @@ import org.infinispan.commons.util.Util;
  * @since 11.0
  **/
 public class ThreadCreator {
-   static org.infinispan.commons.spi.ThreadCreator INSTANCE = getInstance();
+   private static final org.infinispan.commons.spi.ThreadCreator INSTANCE = getInstance();
+
+   public static boolean useVirtualThreads() {
+      return Boolean.getBoolean("org.infinispan.threads.virtual");
+   }
 
    private static org.infinispan.commons.spi.ThreadCreator getInstance() {
       try {
-         if (Boolean.getBoolean("org.infinispan.threads.virtual")) {
+         if (useVirtualThreads()) {
             org.infinispan.commons.spi.ThreadCreator instance = Util.getInstance("org.infinispan.commons.jdk21.ThreadCreatorImpl", ThreadCreator.class.getClassLoader());
             Log.CONTAINER.infof("Virtual threads support enabled");
             return instance;
@@ -24,8 +31,12 @@ public class ThreadCreator {
    }
 
 
-   public static Thread createThread(ThreadGroup threadGroup, Runnable target, boolean lightweight) {
-      return INSTANCE.createThread(threadGroup, target, lightweight);
+   public static Thread createThread(ThreadGroup threadGroup, Runnable target, boolean useVirtualThread) {
+      return INSTANCE.createThread(threadGroup, target, useVirtualThread);
+   }
+
+   public static Optional<ExecutorService> createBlockingExecutorService() {
+      return INSTANCE.newVirtualThreadPerTaskExecutor();
    }
 
    static class ThreadCreatorImpl implements org.infinispan.commons.spi.ThreadCreator {
@@ -33,6 +44,11 @@ public class ThreadCreator {
       @Override
       public Thread createThread(ThreadGroup threadGroup, Runnable target, boolean lightweight) {
          return new Thread(threadGroup, target);
+      }
+
+      @Override
+      public Optional<ExecutorService> newVirtualThreadPerTaskExecutor() {
+         return Optional.empty();
       }
    }
 }

--- a/commons/jdk21/src/main/java/org/infinispan/commons/jdk21/ThreadCreatorImpl.java
+++ b/commons/jdk21/src/main/java/org/infinispan/commons/jdk21/ThreadCreatorImpl.java
@@ -1,17 +1,26 @@
 package org.infinispan.commons.jdk21;
 
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
 /**
  * @author Tristan Tarrant &lt;tristan@infinispan.org&gt;
  * @since 11.0
  **/
 public class ThreadCreatorImpl implements org.infinispan.commons.spi.ThreadCreator {
 
-   public Thread createThread(ThreadGroup group, Runnable runnable, boolean lightweight) {
-      if (lightweight) {
+   public Thread createThread(ThreadGroup group, Runnable runnable, boolean useVirtualThreads) {
+      if (useVirtualThreads) {
          return Thread.ofVirtual().unstarted(runnable);
       } else {
          return new Thread(group, runnable);
       }
+   }
+
+   @Override
+   public Optional<ExecutorService> newVirtualThreadPerTaskExecutor() {
+      return Optional.of(Executors.newVirtualThreadPerTaskExecutor());
    }
 
 }

--- a/commons/spi/src/main/java/org/infinispan/commons/spi/ThreadCreator.java
+++ b/commons/spi/src/main/java/org/infinispan/commons/spi/ThreadCreator.java
@@ -1,8 +1,13 @@
 package org.infinispan.commons.spi;
 
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+
 /**
  * @since 15.0
  **/
 public interface ThreadCreator {
    Thread createThread(ThreadGroup threadGroup, Runnable target, boolean lightweight);
+
+   Optional<ExecutorService> newVirtualThreadPerTaskExecutor();
 }

--- a/core/src/main/java/org/infinispan/factories/threads/DefaultThreadFactory.java
+++ b/core/src/main/java/org/infinispan/factories/threads/DefaultThreadFactory.java
@@ -29,6 +29,7 @@ public class DefaultThreadFactory implements ThreadFactory {
    private String node;
    private String component;
    private ClassLoader classLoader;
+   private boolean useVirtualThreads = ThreadCreator.useVirtualThreads();
 
    /**
     * Construct a new instance.  The access control context of the calling thread will be the one used to create
@@ -95,6 +96,10 @@ public class DefaultThreadFactory implements ThreadFactory {
       return initialPriority;
    }
 
+   public void useVirtualThread(boolean useVirtualThreads) {
+      this.useVirtualThreads = useVirtualThreads;
+   }
+
    @Override
    public Thread newThread(final Runnable target) {
       return createThread(target);
@@ -111,7 +116,7 @@ public class DefaultThreadFactory implements ThreadFactory {
       return thread;
    }
 
-   private final Thread actualThreadCreate(ThreadGroup threadGroup, Runnable target) {
-      return ThreadCreator.createThread(threadGroup, target, true);
+   private Thread actualThreadCreate(ThreadGroup threadGroup, Runnable target) {
+      return ThreadCreator.createThread(threadGroup, target, useVirtualThreads);
    }
 }

--- a/core/src/main/java/org/infinispan/factories/threads/EnhancedQueueExecutorFactory.java
+++ b/core/src/main/java/org/infinispan/factories/threads/EnhancedQueueExecutorFactory.java
@@ -2,19 +2,20 @@ package org.infinispan.factories.threads;
 
 import static org.infinispan.commons.logging.Log.CONFIG;
 
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
 import org.infinispan.commons.executors.NonBlockingResource;
+import org.infinispan.commons.jdkspecific.ThreadCreator;
 import org.infinispan.commons.util.concurrent.BlockingRejectedExecutionHandler;
 import org.jboss.threads.EnhancedQueueExecutor;
-import org.jboss.threads.management.ManageableThreadPoolExecutorService;
 
 /**
  * Executor Factory used for blocking executors which utilizes {@link EnhancedQueueExecutor} internally.
  * @author wburns
  */
-public class EnhancedQueueExecutorFactory extends AbstractThreadPoolExecutorFactory<ManageableThreadPoolExecutorService> {
+public class EnhancedQueueExecutorFactory extends AbstractThreadPoolExecutorFactory<ExecutorService> {
    protected EnhancedQueueExecutorFactory(int maxThreads, int coreThreads, int queueLength, long keepAlive) {
       super(maxThreads, coreThreads, queueLength, keepAlive);
    }
@@ -26,23 +27,25 @@ public class EnhancedQueueExecutorFactory extends AbstractThreadPoolExecutorFact
    }
 
    @Override
-   public ManageableThreadPoolExecutorService createExecutor(ThreadFactory factory) {
+   public ExecutorService createExecutor(ThreadFactory factory) {
       if (factory instanceof NonBlockingResource) {
          throw new IllegalStateException("Executor factory configured to be blocking and received a thread" +
                " factory that creates non-blocking threads!");
       }
-      EnhancedQueueExecutor.Builder builder = new EnhancedQueueExecutor.Builder();
-      builder.setThreadFactory(factory);
-      builder.setCorePoolSize(coreThreads);
-      builder.setMaximumPoolSize(maxThreads);
-      builder.setGrowthResistance(0.0f);
-      builder.setMaximumQueueSize(queueLength);
-      builder.setKeepAliveTime(keepAlive, TimeUnit.MILLISECONDS);
+      return ThreadCreator.createBlockingExecutorService().orElseGet(() -> {
+         EnhancedQueueExecutor.Builder builder = new EnhancedQueueExecutor.Builder();
+         builder.setThreadFactory(factory);
+         builder.setCorePoolSize(coreThreads);
+         builder.setMaximumPoolSize(maxThreads);
+         builder.setGrowthResistance(0.0f);
+         builder.setMaximumQueueSize(queueLength);
+         builder.setKeepAliveTime(keepAlive, TimeUnit.MILLISECONDS);
 
-      EnhancedQueueExecutor enhancedQueueExecutor = builder.build();
-      enhancedQueueExecutor.setHandoffExecutor(task ->
-         BlockingRejectedExecutionHandler.getInstance().rejectedExecution(task, enhancedQueueExecutor));
-      return enhancedQueueExecutor;
+         EnhancedQueueExecutor enhancedQueueExecutor = builder.build();
+         enhancedQueueExecutor.setHandoffExecutor(task ->
+               BlockingRejectedExecutionHandler.getInstance().rejectedExecution(task, enhancedQueueExecutor));
+         return enhancedQueueExecutor;
+      });
    }
 
    @Override

--- a/core/src/main/resources/default-configs/default-jgroups-azure.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-azure.xml
@@ -20,6 +20,7 @@
         thread_pool.keep_alive_time="60000"
 
         thread_pool.thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
+        use_virtual_threads="${jgroups.thread.virtual,org.infinispan.threads.virtual:false}"
    />
    <RED/>
    <azure.AZURE_PING storage_account_name="${jboss.jgroups.azure_ping.storage_account_name}"

--- a/core/src/main/resources/default-configs/default-jgroups-ec2.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-ec2.xml
@@ -20,6 +20,7 @@
         thread_pool.keep_alive_time="60000"
 
         thread_pool.thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
+        use_virtual_threads="${jgroups.thread.virtual,org.infinispan.threads.virtual:false}"
    />
    <RED/>
    <aws.S3_PING region_name="${jgroups.s3.region_name}"

--- a/core/src/main/resources/default-configs/default-jgroups-google.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-google.xml
@@ -21,6 +21,7 @@
         thread_pool.keep_alive_time="60000"
 
         thread_pool.thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
+        use_virtual_threads="${jgroups.thread.virtual,org.infinispan.threads.virtual:false}"
    />
    <RED/>
    <org.jgroups.protocols.google.GOOGLE_PING2

--- a/core/src/main/resources/default-configs/default-jgroups-kubernetes.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-kubernetes.xml
@@ -23,6 +23,7 @@
         thread_pool.keep_alive_time="60000"
 
         thread_pool.thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
+        use_virtual_threads="${jgroups.thread.virtual,org.infinispan.threads.virtual:false}"
    />
    <RED/>
    <dns.DNS_PING dns_query="${jgroups.dns.query}"

--- a/core/src/main/resources/default-configs/default-jgroups-tcp.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-tcp.xml
@@ -16,6 +16,7 @@
         thread_pool.keep_alive_time="60000"
 
         thread_pool.thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
+        use_virtual_threads="${jgroups.thread.virtual,org.infinispan.threads.virtual:false}"
    />
    <RED/>
    <MPING mcast_addr="${jgroups.mcast_addr:239.6.7.8}"

--- a/core/src/main/resources/default-configs/default-jgroups-udp.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-udp.xml
@@ -22,6 +22,7 @@
         thread_pool.keep_alive_time="60000"
 
         thread_pool.thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
+        use_virtual_threads="${jgroups.thread.virtual,org.infinispan.threads.virtual:false}"
    />
    <RED/>
    <PING num_discovery_runs="3"/>

--- a/core/src/test/java/org/infinispan/test/AbstractInfinispanTest.java
+++ b/core/src/test/java/org/infinispan/test/AbstractInfinispanTest.java
@@ -38,6 +38,7 @@ import javax.transaction.TransactionManager;
 
 import org.infinispan.commons.api.BasicCache;
 import org.infinispan.commons.api.BasicCacheContainer;
+import org.infinispan.commons.jdkspecific.ThreadCreator;
 import org.infinispan.commons.test.ExceptionRunnable;
 import org.infinispan.commons.test.TestNGLongTestsHook;
 import org.infinispan.commons.test.TestResourceTracker;
@@ -89,10 +90,11 @@ public abstract class AbstractInfinispanTest {
    protected static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
 
    private final ThreadFactory defaultThreadFactory = getTestThreadFactory("ForkThread");
-   private final ThreadPoolExecutor testExecutor = new ThreadPoolExecutor(0, Integer.MAX_VALUE,
-                                                                          60L, TimeUnit.SECONDS,
-                                                                          new SynchronousQueue<>(),
-                                                                          defaultThreadFactory);
+   private final ExecutorService testExecutor = ThreadCreator.createBlockingExecutorService()
+         .orElseGet(() -> new ThreadPoolExecutor(0, Integer.MAX_VALUE,
+               60L, TimeUnit.SECONDS,
+               new SynchronousQueue<>(),
+               defaultThreadFactory));
    public static final TimeService TIME_SERVICE = new EmbeddedTimeService();
 
    public static class OrderByInstance implements IMethodInterceptor {
@@ -196,10 +198,12 @@ public abstract class AbstractInfinispanTest {
 
    @AfterMethod
    protected final void checkThreads() {
-      int activeTasks = testExecutor.getActiveCount();
-      if (activeTasks != 0) {
-         log.errorf("There were %d active tasks found in the test executor service for class %s", activeTasks,
-                    getClass().getSimpleName());
+      if (testExecutor instanceof ThreadPoolExecutor) {
+         int activeTasks = ((ThreadPoolExecutor) testExecutor).getActiveCount();
+         if (activeTasks != 0) {
+            log.errorf("There were %d active tasks found in the test executor service for class %s", activeTasks,
+                  getClass().getSimpleName());
+         }
       }
    }
 

--- a/core/src/test/resources/configs/config-with-jgroups-stack.xml
+++ b/core/src/test/resources/configs/config-with-jgroups-stack.xml
@@ -12,6 +12,7 @@
               sock_conn_timeout="300" bundler_type="transfer-queue"
               thread_pool.min_threads="0" thread_pool.max_threads="25" thread_pool.keep_alive_time="5000"
               thread_pool.thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
+              use_virtual_threads="${jgroups.thread.virtual,org.infinispan.threads.virtual:false}"
               xmlns="urn:org:jgroups"/>
          <RED/>
             <MPING break_on_coord_rsp="true"

--- a/core/src/test/resources/configs/xsite/bridge.xml
+++ b/core/src/test/resources/configs/xsite/bridge.xml
@@ -14,6 +14,7 @@
          thread_pool.keep_alive_time="5000"
 
          thread_pool.thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
+         use_virtual_threads="${jgroups.thread.virtual,org.infinispan.threads.virtual:false}"
     />
     <RED/>
 

--- a/core/src/test/resources/stacks/tcp.xml
+++ b/core/src/test/resources/stacks/tcp.xml
@@ -18,6 +18,7 @@
          thread_pool.keep_alive_time="60000"
 
          thread_pool.thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
+         use_virtual_threads="${jgroups.thread.virtual,org.infinispan.threads.virtual:false}"
          />
    <RED/>
 

--- a/core/src/test/resources/stacks/tcp_mping/tcp1.xml
+++ b/core/src/test/resources/stacks/tcp_mping/tcp1.xml
@@ -14,6 +14,7 @@
         thread_pool.keep_alive_time="5000"
 
         thread_pool.thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
+        use_virtual_threads="${jgroups.thread.virtual,org.infinispan.threads.virtual:false}"
    />
    <RED/>
 

--- a/core/src/test/resources/stacks/tcp_mping/tcp2.xml
+++ b/core/src/test/resources/stacks/tcp_mping/tcp2.xml
@@ -14,6 +14,7 @@
         thread_pool.keep_alive_time="5000"
 
         thread_pool.thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
+        use_virtual_threads="${jgroups.thread.virtual,org.infinispan.threads.virtual:false}"
    />
    <RED/>
 

--- a/core/src/test/resources/stacks/udp.xml
+++ b/core/src/test/resources/stacks/udp.xml
@@ -23,6 +23,7 @@
          thread_pool.keep_alive_time="60000"
 
          thread_pool.thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
+         use_virtual_threads="${jgroups.thread.virtual,org.infinispan.threads.virtual:false}"
    />
    <RED/>
 

--- a/hibernate/cache-commons/src/test/resources/2lc-test-tcp.xml
+++ b/hibernate/cache-commons/src/test/resources/2lc-test-tcp.xml
@@ -20,6 +20,7 @@
         thread_pool.keep_alive_time="60000"
 
         thread_pool.thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
+        use_virtual_threads="${jgroups.thread.virtual,org.infinispan.threads.virtual:false}"
    />
    <RED/>
 

--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,7 @@
       <!-- unstable and stress because we can have them inside a functional class, for example -->
       <defaultExcludedTestNGGroups>unstable,stress</defaultExcludedTestNGGroups>
       <defaultTestNGGroups>functional,unit,xsite,arquillian</defaultTestNGGroups>
+      <org.infinispan.tests.threads.virtual>false</org.infinispan.tests.threads.virtual>
       <dir.ispn>../</dir.ispn>
       <dir.jacoco>${session.executionRootDirectory}/jacoco/</dir.jacoco>
       <dir.jacoco.merged>../jacoco/merged/</dir.jacoco.merged>
@@ -2289,6 +2290,7 @@
                      <infinispan.module-suffix>${infinispan.module-suffix}</infinispan.module-suffix>
                      <ansi.strip>${ansi.strip}</ansi.strip>
                      <com.arjuna.ats.arjuna.common.propertiesFile>test-jbossts-properties.xml</com.arjuna.ats.arjuna.common.propertiesFile>
+                     <org.infinispan.threads.virtual>${org.infinispan.tests.threads.virtual}</org.infinispan.threads.virtual>
                   </systemPropertyVariables>
                   <rerunFailingTestsCount>${rerunFailingTestsCount}</rerunFailingTestsCount>
                   <argLine>${forkJvmArgs} ${testjvm.jdkSpecificArgs}</argLine>
@@ -2515,6 +2517,15 @@
                      <failIfNoMatch>false</failIfNoMatch>
                   </configuration>
                </execution>
+               <execution>
+                  <id>get-cpu-count</id>
+                  <goals>
+                     <goal>cpu-count</goal>
+                  </goals>
+                  <configuration>
+                     <cpuCount>system.numCores</cpuCount>
+                  </configuration>
+               </execution>
             </executions>
          </plugin>
          <plugin>
@@ -2689,6 +2700,7 @@
                   <!-- this is picked up in log4j2.xml, which adds it to each module's log file name-->
                   <infinispan.module-suffix>${infinispan.module-suffix}</infinispan.module-suffix>
                   <ansi.strip>${ansi.strip}</ansi.strip>
+                  <org.infinispan.threads.virtual>${org.infinispan.tests.threads.virtual}</org.infinispan.threads.virtual>
                </systemPropertyVariables>
                <trimStackTrace>false</trimStackTrace>
                <argLine>${forkJvmArgs} ${testjvm.jdkSpecificArgs} -Djdk.attach.allowAttachSelf=true</argLine>
@@ -3445,6 +3457,16 @@
          <modules>
             <module>server/insights</module>
          </modules>
+      </profile>
+      <profile>
+         <id>vthreads-tests</id>
+         <activation>
+            <activeByDefault>false</activeByDefault>
+         </activation>
+         <properties>
+            <org.infinispan.tests.threads.virtual>true</org.infinispan.tests.threads.virtual>
+            <infinispan.test.parallel.threads>${system.numCores}</infinispan.test.parallel.threads>
+         </properties>
       </profile>
    </profiles>
 </project>

--- a/server/core/src/main/java/org/infinispan/server/core/factories/NettyEventLoopFactory.java
+++ b/server/core/src/main/java/org/infinispan/server/core/factories/NettyEventLoopFactory.java
@@ -30,6 +30,11 @@ public class NettyEventLoopFactory extends AbstractComponentFactory implements A
                globalConfiguration.transport().nodeName(), shortened(KnownComponentNames.NON_BLOCKING_EXECUTOR));
       }
 
+      if (threadFactory instanceof DefaultThreadFactory) {
+         //not supported at the moment
+         ((DefaultThreadFactory) threadFactory).useVirtualThread(false);
+      }
+
       ThreadPoolExecutorFactory<?> tpef = globalConfiguration.nonBlockingThreadPool().threadPoolFactory();
       int threadAmount = tpef instanceof NonBlockingThreadPoolExecutorFactory ?
             ((NonBlockingThreadPoolExecutorFactory) tpef).maxThreads() :

--- a/server/testdriver/junit5/src/test/resources/jgroups/xsite-stacks.xml
+++ b/server/testdriver/junit5/src/test/resources/jgroups/xsite-stacks.xml
@@ -49,6 +49,7 @@
            thread_pool.keep_alive_time="60000"
 
            thread_pool.thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
+           use_virtual_threads="${jgroups.thread.virtual,org.infinispan.threads.virtual:false}"
            ispn:stack.combine="REPLACE"
       />
       <MERGE3 min_interval="1000" max_interval="5000" ispn:stack.combine="REPLACE"/>

--- a/server/tests/src/test/resources/configuration/jgroups/xsite-stacks.xml
+++ b/server/tests/src/test/resources/configuration/jgroups/xsite-stacks.xml
@@ -49,6 +49,7 @@
            thread_pool.keep_alive_time="60000"
 
            thread_pool.thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
+           use_virtual_threads="${jgroups.thread.virtual,org.infinispan.threads.virtual:false}"
            ispn:stack.combine="REPLACE"
       />
       <MERGE3 min_interval="1000" max_interval="5000" ispn:stack.combine="REPLACE"/>


### PR DESCRIPTION
* Enable JGroups virtual threads with org.infinispan.threads.virtual or jgroups.thread.virtual
* Create VirtualThreadPerTaskExecutor for blocking thread pool
* Do not use virtual threads in Netty event loop

https://issues.redhat.com/browse/ISPN-15304