### PR TITLE
ISPN-15342 Custom Keycloak images may not have admin console enabled

### DIFF
--- a/server/tests/src/test/java/org/infinispan/server/test/core/KeyCloakServerExtension.java
+++ b/server/tests/src/test/java/org/infinispan/server/test/core/KeyCloakServerExtension.java
@@ -71,9 +71,9 @@ public class KeyCloakServerExtension implements AfterAllCallback, BeforeAllCallb
             .withFixedExposedPort(14568, 8443)
             .withEnv(environment)
             .withCopyFileToContainer(MountableFile.forHostPath(keycloakImport.getAbsolutePath()), keycloakImport.getPath())
-            .withFileSystemBind(keycloakDirectory.getPath(), "/etc/x509/https")
+            .withCopyFileToContainer(MountableFile.forHostPath(keycloakDirectory.getPath()), "/etc/x509/https")
             //.waitingFor(Wait.forHttp("/").forPort(14567))
-            .waitingFor(Wait.forLogMessage(".*WFLYSRV0051.*",1))
+            .waitingFor(Wait.forLogMessage(".*WFLYSRV0025.*",1))
             .withLogConsumer(new JBossLoggingConsumer(LogFactory.getLog(testClass)));
       container.start();
    }


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-15342

The PR changes the server extension to wait on server startup rather then admin console.

Additional change to server extension is to copy the certificates to the container rather then mounting them through volume as original approach may result in inaccessible files from the container due to insufficient access rights.