### PR TITLE
ISPN-15373 Enable insight profile is community release profile is dis…

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -163,7 +163,7 @@ pipeline {
             steps {
                 script {
                     if (!env.BRANCH_NAME.startsWith('PR-')) {
-                        sh "$MAVEN_HOME/bin/mvn deploy -B -V -e -Pdistribution -Pcommunity-release -DdeployServerZip=true -DskipTests -Dcheckstyle.skip=true"
+                        sh "$MAVEN_HOME/bin/mvn deploy -B -V -e -Pdistribution -Drelease-mode=upstream -DdeployServerZip=true -DskipTests -Dcheckstyle.skip=true"
                     }
                 }
             }

--- a/Jenkinsfile-release
+++ b/Jenkinsfile-release
@@ -67,7 +67,7 @@ pipeline {
 
         stage('Deploy') {
             steps {
-                sh "$MAVEN_HOME/bin/mvn -B -V -Pcommunity-release -Pdistribution -DskipTests clean deploy -Dinfinispan.brand.version=${version}"
+                sh "$MAVEN_HOME/bin/mvn -B -V -Drelease-mode=upstream -Pdistribution -DskipTests clean deploy -Dinfinispan.brand.version=${version}"
             }
         }
 

--- a/build/configuration/pom.xml
+++ b/build/configuration/pom.xml
@@ -261,6 +261,10 @@
 
       <!-- configuration properties -->
       <org.infinispan.attachServerZip>false</org.infinispan.attachServerZip>
+      <!-- empty by default, means no profiles for upstream or downstream release are enabled. -->
+      <!-- upstream: enables profiles for community release -->
+      <!-- downstream: enables profiles for downstream/product release -->
+      <release-mode/>
    </properties>
 
    <build>
@@ -332,7 +336,10 @@
       <profile>
          <id>community-release</id>
          <activation>
-            <activeByDefault>false</activeByDefault>
+            <property>
+               <name>release-mode</name>
+               <value>upstream</value>
+            </property>
          </activation>
          <build>
             <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -3296,6 +3296,12 @@
       </profile>
       <profile>
          <id>insights</id>
+         <activation>
+            <property>
+               <name>release-mode</name>
+               <value>downstream</value>
+            </property>
+         </activation>
          <modules>
             <module>server/insights</module>
          </modules>

--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -100,7 +100,10 @@
         <profile>
             <id>community-release</id>
             <activation>
-                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>release-mode</name>
+                    <value>upstream</value>
+                </property>
             </activation>
             <build>
                 <plugins>

--- a/server/runtime/pom.xml
+++ b/server/runtime/pom.xml
@@ -545,7 +545,10 @@
       <profile>
          <id>community</id>
          <activation>
-            <activeByDefault>true</activeByDefault>
+            <property>
+               <name>release-mode</name>
+               <value>!downstream</value>
+            </property>
          </activation>
          <dependencies>
             <dependency>
@@ -568,6 +571,12 @@
       </profile>
       <profile>
          <id>insights</id>
+         <activation>
+            <property>
+               <name>release-mode</name>
+               <value>downstream</value>
+            </property>
+         </activation>
          <dependencies>
             <dependency>
                <groupId>org.infinispan</groupId>

--- a/server/tests/pom.xml
+++ b/server/tests/pom.xml
@@ -251,6 +251,12 @@
       </profile>
       <profile>
          <id>insights</id>
+         <activation>
+            <property>
+               <name>release-mode</name>
+               <value>downstream</value>
+            </property>
+         </activation>
          <dependencies>
             <dependency>
                <groupId>org.infinispan</groupId>


### PR DESCRIPTION
…abled

A manual backport for 14.0.x is required.

https://issues.redhat.com/browse/ISPN-15373

The idea is `release-mode` is set to `upstream` for Infinispan releases and set to `downstream` for datagrid releases. Use this property to enable or disable profiles. 