### PR TITLE
[10.1.x] ISPN-13229 LocalPublisherManagerImpl doesn't clean up changeListener …

### DIFF
--- a/core/src/main/java/org/infinispan/reactive/publisher/impl/LocalPublisherManagerImpl.java
+++ b/core/src/main/java/org/infinispan/reactive/publisher/impl/LocalPublisherManagerImpl.java
@@ -49,7 +49,6 @@ import io.reactivex.Flowable;
 import io.reactivex.Maybe;
 import io.reactivex.Scheduler;
 import io.reactivex.functions.Predicate;
-import io.reactivex.internal.functions.Functions;
 import io.reactivex.parallel.ParallelFlowable;
 import io.reactivex.processors.FlowableProcessor;
 import io.reactivex.processors.UnicastProcessor;

--- a/core/src/main/java/org/infinispan/reactive/publisher/impl/LocalPublisherManagerImpl.java
+++ b/core/src/main/java/org/infinispan/reactive/publisher/impl/LocalPublisherManagerImpl.java
@@ -34,6 +34,7 @@ import org.infinispan.factories.annotations.Start;
 import org.infinispan.factories.impl.ComponentRef;
 import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
+import org.infinispan.reactive.RxJavaInterop;
 import org.infinispan.reactive.publisher.impl.commands.reduction.PublisherResult;
 import org.infinispan.reactive.publisher.impl.commands.reduction.SegmentPublisherResult;
 import org.infinispan.stream.StreamMarshalling;


### PR DESCRIPTION
Backporting the fix for Memory leak issue in 10.1.x release.