### PR TITLE
ISPN-15377 SoftIndexFileStore index by cache segment

### DIFF
--- a/commons/all/src/main/java/org/infinispan/commons/reactive/RxJavaInterop.java
+++ b/commons/all/src/main/java/org/infinispan/commons/reactive/RxJavaInterop.java
@@ -8,6 +8,8 @@ import org.reactivestreams.Publisher;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.functions.Consumer;
 import io.reactivex.rxjava3.functions.Function;
+import io.reactivex.rxjava3.processors.AsyncProcessor;
+import io.reactivex.rxjava3.processors.FlowableProcessor;
 
 /**
  * Static factory class that provides methods to obtain commonly used instances for interoperation between RxJava
@@ -54,9 +56,25 @@ public class RxJavaInterop {
       return (Consumer) emptyConsumer;
    }
 
+   /**
+    * Returns a {@link FlowableProcessor} that is already complete and will ignore any value submitted to it and will
+    * immediately cancel any subscriptions it receives.
+    * @return processor that is completed
+    * @param <R> user value type
+    */
+   public static <R> FlowableProcessor<R> completedFlowableProcessor() {
+      return (FlowableProcessor<R>) completeFlowableProcessor;
+   }
+
    private static final Function<Object, Object> identityFunction = i -> i;
    private static final Consumer<Object> emptyConsumer = ignore -> { };
    private static final Function<Map.Entry<Object, Object>, Object> entryToKeyFunction = Map.Entry::getKey;
    private static final Function<Map.Entry<Object, Object>, Object> entryToValueFunction = Map.Entry::getValue;
    private static final Function<? super Throwable, Publisher<?>> wrapThrowable = t -> Flowable.error(Util.rewrapAsCacheException(t));
+   private static final FlowableProcessor<Object> completeFlowableProcessor;
+
+   static {
+      completeFlowableProcessor = AsyncProcessor.create();
+      completeFlowableProcessor.onComplete();
+   }
 }

--- a/core/src/main/java/org/infinispan/configuration/parsing/CacheParser.java
+++ b/core/src/main/java/org/infinispan/configuration/parsing/CacheParser.java
@@ -1105,7 +1105,8 @@ public class CacheParser implements ConfigurationParser {
                break;
             }
             case SEGMENTS:
-               builder.indexSegments(ParseUtils.parseInt(reader, i, value));
+               ParseUtils.removedSince(reader, 15, 0);
+               ignoreAttribute(reader, i);
                break;
             case INDEX_QUEUE_LENGTH:
                builder.indexQueueLength(ParseUtils.parseInt(reader, i, value));

--- a/core/src/main/java/org/infinispan/persistence/sifs/EntryInfo.java
+++ b/core/src/main/java/org/infinispan/persistence/sifs/EntryInfo.java
@@ -5,15 +5,13 @@ package org.infinispan.persistence.sifs;
  */
 public class EntryInfo extends EntryPosition {
    public final int numRecords;
-   public final int cacheSegment;
 
-   public EntryInfo(int file, int offset, int numRecords, int cacheSegment) {
+   public EntryInfo(int file, int offset, int numRecords) {
       super(file, offset);
       this.numRecords = numRecords;
-      this.cacheSegment = cacheSegment;
    }
 
    public String toString() {
-      return String.format("[%d:%d] containing %d records in segment %d", file, offset, numRecords, cacheSegment);
+      return String.format("[%d:%d] containing %d records", file, offset, numRecords);
    }
 }

--- a/core/src/main/java/org/infinispan/persistence/sifs/Index.java
+++ b/core/src/main/java/org/infinispan/persistence/sifs/Index.java
@@ -22,11 +22,15 @@ import java.util.concurrent.atomic.AtomicLongArray;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Function;
 
 import org.infinispan.commons.io.UnsignedNumeric;
+import org.infinispan.commons.reactive.RxJavaInterop;
 import org.infinispan.commons.time.TimeService;
 import org.infinispan.commons.util.IntSet;
+import org.infinispan.commons.util.IntSets;
 import org.infinispan.commons.util.concurrent.CompletableFutures;
+import org.infinispan.executors.LimitedExecutor;
 import org.infinispan.util.concurrent.AggregateCompletionStage;
 import org.infinispan.util.concurrent.CompletionStages;
 import org.infinispan.util.concurrent.NonBlockingManager;
@@ -38,6 +42,7 @@ import io.reactivex.rxjava3.functions.Consumer;
 import io.reactivex.rxjava3.processors.FlowableProcessor;
 import io.reactivex.rxjava3.processors.UnicastProcessor;
 import io.reactivex.rxjava3.schedulers.Schedulers;
+import net.jcip.annotations.GuardedBy;
 
 /**
  * Keeps the entry positions persisted in a file. It consists of couple of segments, each for one modulo-range of key's
@@ -60,18 +65,28 @@ class Index {
    private static final int INDEX_FILE_HEADER_SIZE = 34;
 
    private final NonBlockingManager nonBlockingManager;
-   private final FileProvider fileProvider;
+   private final FileProvider dataFileProvider;
+   private final FileProvider indexFileProvider;
    private final Path indexDir;
    private final Compactor compactor;
    private final int minNodeSize;
    private final int maxNodeSize;
    private final ReadWriteLock lock = new ReentrantReadWriteLock();
+   @GuardedBy("lock")
    private final Segment[] segments;
+   @GuardedBy("lock")
+   private final FlowableProcessor<IndexRequest>[] flowableProcessors;
    private final TimeService timeService;
    private final File indexSizeFile;
    public final AtomicLongArray sizePerSegment;
 
-   private final FlowableProcessor<IndexRequest>[] flowableProcessors;
+   private final TemporaryTable temporaryTable;
+
+   private final Executor executor;
+
+   private final Throwable END_EARLY = new Throwable("SIFS Index stopping");
+   // This is used to signal that a segment is not currently being used
+   private final Segment emptySegment;
 
    private final IndexNode.OverwriteHook movedHook = new IndexNode.OverwriteHook() {
       @Override
@@ -108,49 +123,54 @@ class Index {
       }
    };
 
-   public Index(NonBlockingManager nonBlockingManager, FileProvider fileProvider, Path indexDir, int segments,
-                int cacheSegments, int minNodeSize, int maxNodeSize, TemporaryTable temporaryTable, Compactor compactor,
-                TimeService timeService) throws IOException {
+   public Index(NonBlockingManager nonBlockingManager, FileProvider dataFileProvider, Path indexDir, int cacheSegments,
+                int minNodeSize, int maxNodeSize, TemporaryTable temporaryTable, Compactor compactor,
+                TimeService timeService, Executor executor, int maxOpenFiles) throws IOException {
       this.nonBlockingManager = nonBlockingManager;
-      this.fileProvider = fileProvider;
+      this.dataFileProvider = dataFileProvider;
       this.compactor = compactor;
       this.timeService = timeService;
       this.indexDir = indexDir;
       this.minNodeSize = minNodeSize;
       this.maxNodeSize = maxNodeSize;
       this.sizePerSegment = new AtomicLongArray(cacheSegments);
-      indexDir.toFile().mkdirs();
+      this.indexFileProvider = new FileProvider(indexDir, maxOpenFiles, "index.", Integer.MAX_VALUE);
       this.indexSizeFile = new File(indexDir.toFile(), "index-count");
 
-      this.segments = new Segment[segments];
-      this.flowableProcessors = new FlowableProcessor[segments];
-      for (int i = 0; i < segments; ++i) {
-         UnicastProcessor<IndexRequest> flowableProcessor = UnicastProcessor.create();
-         Segment segment = new Segment(this, i, temporaryTable);
+      this.segments = new Segment[cacheSegments];
+      this.flowableProcessors = new FlowableProcessor[cacheSegments];
 
-         this.segments[i] = segment;
-         // It is possible to write from multiple threads
-         this.flowableProcessors[i] = flowableProcessor.toSerialized();
-      }
+      this.temporaryTable = temporaryTable;
+      // Limits the amount of concurrent updates we do to the underlying indices to be based on the number of cache
+      // segments. Note that this uses blocking threads so this number is still limited by that as well
+      int concurrency = Math.max(cacheSegments >> 4, 1);
+      this.executor = new LimitedExecutor("sifs-index", executor, concurrency);
+      this.emptySegment = new Segment(this, -1, temporaryTable);
+      this.emptySegment.complete(null);
    }
 
    private boolean checkForExistingIndexSizeFile() {
-      int storeSegments = flowableProcessors.length;
       int cacheSegments = sizePerSegment.length();
       boolean validCount = false;
       try (RandomAccessFile indexCount = new RandomAccessFile(indexSizeFile, "r")) {
-         int storeSegmentsCount = UnsignedNumeric.readUnsignedInt(indexCount);
          int cacheSegmentsCount = UnsignedNumeric.readUnsignedInt(indexCount);
-         if (storeSegmentsCount == storeSegments && cacheSegmentsCount == cacheSegments) {
+         if (cacheSegmentsCount == cacheSegments) {
             for (int i = 0; i < sizePerSegment.length(); ++i) {
                long value = UnsignedNumeric.readUnsignedLong(indexCount);
+               if (value < 0) {
+                  log.tracef("Found an invalid size for a segment, assuming index is a different format");
+                  return false;
+               }
                sizePerSegment.set(i, value);
             }
 
-            validCount = true;
+            if (indexCount.read() != -1) {
+               log.tracef("Previous index file has more bytes than desired, assuming index is a different format");
+            } else {
+               validCount = true;
+            }
          } else {
-            log.tracef("Previous index file store segments " + storeSegmentsCount + " doesn't match configured" +
-                  " store segments " + storeSegments + " or index file cache segments " + cacheSegmentsCount + " doesn't match configured" +
+            log.tracef("Previous index file cache segments " + cacheSegmentsCount + " doesn't match configured" +
                   " cache segments " + cacheSegments);
          }
       } catch (IOException e) {
@@ -162,19 +182,16 @@ class Index {
       return validCount;
    }
 
-   public static byte[] toIndexKey(int cacheSegment, org.infinispan.commons.io.ByteBuffer buffer) {
-      return toIndexKey(cacheSegment, buffer.getBuf(), buffer.getOffset(), buffer.getLength());
+   public static byte[] toIndexKey(org.infinispan.commons.io.ByteBuffer buffer) {
+      return toIndexKey(buffer.getBuf(), buffer.getOffset(), buffer.getLength());
    }
 
-   static byte[] toIndexKey(int cacheSegment, byte[] bytes) {
-      return toIndexKey(cacheSegment, bytes, 0, bytes.length);
-   }
-
-   static byte[] toIndexKey(int cacheSegment, byte[] bytes, int offset, int length) {
-      int segmentBytes = UnsignedNumeric.sizeUnsignedInt(cacheSegment);
-      byte[] indexKey = new byte[length + segmentBytes];
-      UnsignedNumeric.writeUnsignedInt(indexKey, 0, cacheSegment);
-      System.arraycopy(bytes, 0, indexKey, segmentBytes + offset, length);
+   static byte[] toIndexKey(byte[] bytes, int offset, int length) {
+      if (offset == 0 && length == bytes.length) {
+         return bytes;
+      }
+      byte[] indexKey = new byte[length];
+      System.arraycopy(bytes, 0, indexKey, 0, length);
 
       return indexKey;
    }
@@ -233,21 +250,20 @@ class Index {
     * Get record or null if expired
     */
    public EntryRecord getRecord(Object key, int cacheSegment, org.infinispan.commons.io.ByteBuffer serializedKey) throws IOException {
-      return getRecord(key, cacheSegment, toIndexKey(cacheSegment, serializedKey), IndexNode.ReadOperation.GET_RECORD);
+      return getRecord(key, cacheSegment, toIndexKey(serializedKey), IndexNode.ReadOperation.GET_RECORD);
    }
 
    /**
     * Get record (even if expired) or null if not present
     */
    public EntryRecord getRecordEvenIfExpired(Object key, int cacheSegment, byte[] serializedKey) throws IOException {
-      return getRecord(key, cacheSegment, toIndexKey(cacheSegment, serializedKey), IndexNode.ReadOperation.GET_EXPIRED_RECORD);
+      return getRecord(key, cacheSegment, serializedKey, IndexNode.ReadOperation.GET_EXPIRED_RECORD);
    }
 
    private EntryRecord getRecord(Object key, int cacheSegment, byte[] indexKey, IndexNode.ReadOperation readOperation) throws IOException {
-      int segment = (key.hashCode() & Integer.MAX_VALUE) % segments.length;
       lock.readLock().lock();
       try {
-         return IndexNode.applyOnLeaf(segments[segment], cacheSegment, indexKey, segments[segment].rootReadLock(), readOperation);
+         return IndexNode.applyOnLeaf(segments[cacheSegment], cacheSegment, indexKey, segments[cacheSegment].rootReadLock(), readOperation);
       } finally {
          lock.readLock().unlock();
       }
@@ -257,10 +273,9 @@ class Index {
     * Get position or null if expired
     */
    public EntryPosition getPosition(Object key, int cacheSegment, org.infinispan.commons.io.ByteBuffer serializedKey) throws IOException {
-      int segment = (key.hashCode() & Integer.MAX_VALUE) % segments.length;
       lock.readLock().lock();
       try {
-         return IndexNode.applyOnLeaf(segments[segment], cacheSegment, toIndexKey(cacheSegment, serializedKey), segments[segment].rootReadLock(), IndexNode.ReadOperation.GET_POSITION);
+         return IndexNode.applyOnLeaf(segments[cacheSegment], cacheSegment, toIndexKey(serializedKey), segments[cacheSegment].rootReadLock(), IndexNode.ReadOperation.GET_POSITION);
       } finally {
          lock.readLock().unlock();
       }
@@ -270,10 +285,9 @@ class Index {
     * Get position + numRecords, without expiration
     */
    public EntryInfo getInfo(Object key, int cacheSegment, byte[] serializedKey) throws IOException {
-      int segment = (key.hashCode() & Integer.MAX_VALUE) % segments.length;
       lock.readLock().lock();
       try {
-         return IndexNode.applyOnLeaf(segments[segment], cacheSegment, toIndexKey(cacheSegment, serializedKey), segments[segment].rootReadLock(), IndexNode.ReadOperation.GET_INFO);
+         return IndexNode.applyOnLeaf(segments[cacheSegment], cacheSegment, serializedKey, segments[cacheSegment].rootReadLock(), IndexNode.ReadOperation.GET_INFO);
       } finally {
          lock.readLock().unlock();
       }
@@ -285,6 +299,10 @@ class Index {
       try {
          AggregateCompletionStage<Void> stage = CompletionStages.aggregateCompletionStage();
          for (FlowableProcessor<IndexRequest> processor : flowableProcessors) {
+            // Ignore already completed as we used this to signal that we don't own that segment anymore
+            if (processor == RxJavaInterop.<IndexRequest>completedFlowableProcessor()) {
+               continue;
+            }
             IndexRequest clearRequest = IndexRequest.clearRequest();
             processor.onNext(clearRequest);
             stage.dependsOn(clearRequest);
@@ -299,8 +317,7 @@ class Index {
    }
 
    public CompletionStage<Object> handleRequest(IndexRequest indexRequest) {
-      int processor = (indexRequest.getKey().hashCode() & Integer.MAX_VALUE) % segments.length;
-      flowableProcessors[processor].onNext(indexRequest);
+      flowableProcessors[indexRequest.getSegment()].onNext(indexRequest);
       return indexRequest;
    }
 
@@ -320,7 +337,7 @@ class Index {
       ensureRunOnLast(() -> {
          // After all indexes have ensured they have processed all requests - the last one will delete the file
          // This guarantees that the index can't see an outdated value
-         fileProvider.deleteFile(fileId);
+         dataFileProvider.deleteFile(fileId);
          compactor.releaseStats(fileId);
       });
    }
@@ -337,11 +354,11 @@ class Index {
 
       // After all SIFS segments are complete we write the size
       return aggregateCompletionStage.freeze().thenRun(() -> {
+         indexFileProvider.stop();
          try {
             // Create the file first as it should not be present as we deleted during startup
             indexSizeFile.createNewFile();
             try (FileOutputStream indexCountStream = new FileOutputStream(indexSizeFile)) {
-               UnsignedNumeric.writeUnsignedInt(indexCountStream, segments.length);
                UnsignedNumeric.writeUnsignedInt(indexCountStream, this.sizePerSegment.length());
                for (int i = 0; i < sizePerSegment.length(); ++i) {
                   UnsignedNumeric.writeUnsignedLong(indexCountStream, sizePerSegment.get(i));
@@ -359,7 +376,7 @@ class Index {
                   int file = entry.getKey();
                   int total = entry.getValue().getTotal();
                   if (total == -1) {
-                     total = (int) fileProvider.getFileSize(file);
+                     total = (int) dataFileProvider.getFileSize(file);
                   }
                   int free = entry.getValue().getFree();
                   buffer.putInt(file);
@@ -403,19 +420,25 @@ class Index {
       return maxSeqId;
    }
 
-   public void start(Executor executor) {
-      for (int i = 0; i < segments.length; ++i) {
-         Segment segment = segments[i];
-         flowableProcessors[i]
-               .observeOn(Schedulers.from(executor))
-               .subscribe(segment, t -> {
-                  log.error("Error encountered with index, SIFS may not operate properly.", t);
-                  segment.completeExceptionally(t);
-               }, segment);
-      }
+   public void start() {
+      addSegments(IntSets.immutableRangeSet(segments.length));
+   }
+
+   static boolean read(FileProvider.Handle handle, ByteBuffer buffer, long offset) throws IOException {
+      assert buffer.hasRemaining();
+      int read = 0;
+      do {
+         int newRead = handle.read(buffer, offset + read);
+         if (newRead < 0) {
+            return false;
+         }
+         read += newRead;
+      } while (buffer.hasRemaining());
+      return true;
    }
 
    static boolean read(FileChannel channel, ByteBuffer buffer) throws IOException {
+      assert buffer.hasRemaining();
       do {
          int read = channel.read(buffer);
          if (read < 0) {
@@ -425,7 +448,17 @@ class Index {
       return true;
    }
 
+   private static long write(FileProvider.Handle handle, ByteBuffer buffer, long offset) throws IOException {
+      assert buffer.hasRemaining();
+      long write = 0;
+      while (buffer.hasRemaining()) {
+         write += handle.write(buffer, offset + write);
+      }
+      return write;
+   }
+
    private static void write(FileChannel indexFile, ByteBuffer buffer) throws IOException {
+      assert buffer.hasRemaining();
       do {
          int written = indexFile.write(buffer);
          if (written < 0) {
@@ -434,69 +467,161 @@ class Index {
       } while (buffer.position() < buffer.limit());
    }
 
+   public CompletionStage<Void> addSegments(IntSet addedSegments) {
+      // Since actualAddSegments doesn't block we try a quick write lock acquisition to possibly avoid context change
+      if (lock.writeLock().tryLock()) {
+         try {
+            actualAddSegments(addedSegments);
+         } finally {
+            lock.writeLock().unlock();
+         }
+         return CompletableFutures.completedNull();
+      }
+      return CompletableFuture.runAsync(() -> {
+         lock.writeLock().lock();
+         try {
+            actualAddSegments(addedSegments);
+         } finally {
+            lock.writeLock().unlock();
+         }
+      }, executor);
+   }
+
+   private void actualAddSegments(IntSet addedSegments) {
+      for (PrimitiveIterator.OfInt segmentIter = addedSegments.iterator(); segmentIter.hasNext(); ) {
+         int i = segmentIter.nextInt();
+
+         // Segment is already running, don't do anything
+         if (segments[i] != null && segments[i] != emptySegment) {
+            continue;
+         }
+
+         UnicastProcessor<IndexRequest> flowableProcessor = UnicastProcessor.create(false);
+         Segment segment = new Segment(this, i, temporaryTable);
+
+         // Note we do not load the segments here as we only have to load them on startup and not if segments are
+         // added at runtime
+         this.segments[i] = segment;
+         // It is possible to write from multiple threads
+         this.flowableProcessors[i] = flowableProcessor.toSerialized();
+
+         flowableProcessors[i]
+               .observeOn(Schedulers.from(executor))
+               .subscribe(segment, t -> {
+                  if (t != END_EARLY)
+                     log.error("Error encountered with index, SIFS may not operate properly.", t);
+                  segment.completeExceptionally(t);
+               }, segment);
+      }
+   }
+   public CompletionStage<Void> removeSegments(IntSet addedSegments) {
+      return CompletableFuture.supplyAsync(() -> {
+         int addedCount = addedSegments.size();
+         List<Segment> removedSegments = new ArrayList<>(addedCount);
+         List<FlowableProcessor<IndexRequest>> removedFlowables = new ArrayList<>(addedCount);
+         // We hold the lock as short as possible just to swap the segments and processors to empty ones
+         lock.writeLock().lock();
+         try {
+            for (PrimitiveIterator.OfInt iter = addedSegments.iterator(); iter.hasNext(); ) {
+               int i = iter.nextInt();
+               removedSegments.add(segments[i]);
+               segments[i] = emptySegment;
+               removedFlowables.add(flowableProcessors[i]);
+               flowableProcessors[i] = RxJavaInterop.completedFlowableProcessor();
+            }
+         } finally {
+            lock.writeLock().unlock();
+         }
+         // We would love to do this outside of this stage asynchronously but unfortunately we can't say we have
+         // removed the segments until the segment file is deleted
+         AggregateCompletionStage<Void> stage = CompletionStages.aggregateCompletionStage();
+         // We need to iterate through the entire indexes to update free space for compactor
+         // Then we need to delete the segment
+         for (int i = 0; i < addedCount; i++) {
+            removedFlowables.get(i).onComplete();
+            Segment segment = removedSegments.get(i);
+            stage.dependsOn(segment
+                  .thenRun(segment::delete));
+         }
+         return stage.freeze();
+      }, executor).thenCompose(Function.identity());
+   }
+
    static class Segment extends CompletableFuture<Void> implements Consumer<IndexRequest>, Action {
       final Index index;
       private final TemporaryTable temporaryTable;
       private final TreeMap<Short, List<IndexSpace>> freeBlocks = new TreeMap<>();
       private final ReadWriteLock rootLock = new ReentrantReadWriteLock();
-      private final FileChannel indexFile;
-      private long indexFileSize;
+      private final int id;
+      private long indexFileSize = INDEX_FILE_HEADER_SIZE;
 
       private volatile IndexNode root;
 
-      private Segment(Index index, int id, TemporaryTable temporaryTable) throws IOException {
+      private Segment(Index index, int id, TemporaryTable temporaryTable) {
          this.index = index;
          this.temporaryTable = temporaryTable;
 
-         File indexFileFile = new File(index.indexDir.toFile(), "index." + id);
-         this.indexFile = new RandomAccessFile(indexFileFile, "rw").getChannel();
+         this.id = id;
 
          // Just to init to empty
          root = IndexNode.emptyWithLeaves(this);
       }
 
+      public int getId() {
+         return id;
+      }
+
       boolean load() throws IOException {
          int segmentMax = temporaryTable.getSegmentMax();
-         indexFile.position(0);
-         ByteBuffer buffer = ByteBuffer.allocate(INDEX_FILE_HEADER_SIZE);
-         boolean loaded;
-         if (indexFile.size() >= INDEX_FILE_HEADER_SIZE && read(indexFile, buffer)
-               && buffer.getInt(0) == GRACEFULLY && buffer.getInt(4) == segmentMax) {
-            long rootOffset = buffer.getLong(8);
-            short rootOccupied = buffer.getShort(16);
-            long freeBlocksOffset = buffer.getLong(18);
-            root = new IndexNode(this, rootOffset, rootOccupied);
-            loadFreeBlocks(freeBlocksOffset);
-            indexFileSize = freeBlocksOffset;
-            loaded = true;
-         } else {
-            this.indexFile.truncate(0);
-            root = IndexNode.emptyWithLeaves(this);
-            loaded = false;
-            // reserve space for shutdown
-            indexFileSize = INDEX_FILE_HEADER_SIZE;
-         }
-         buffer.putInt(0, DIRTY);
-         buffer.position(0);
-         buffer.limit(4);
-         indexFile.position(0);
-         write(indexFile, buffer);
+         FileProvider.Handle handle = index.indexFileProvider.getFile(id);
+         try (handle) {
+            ByteBuffer buffer = ByteBuffer.allocate(INDEX_FILE_HEADER_SIZE);
+            boolean loaded;
+            if (handle.getFileSize() >= INDEX_FILE_HEADER_SIZE && read(handle, buffer, 0)
+                  && buffer.getInt(0) == GRACEFULLY && buffer.getInt(4) == segmentMax) {
+               long rootOffset = buffer.getLong(8);
+               short rootOccupied = buffer.getShort(16);
+               long freeBlocksOffset = buffer.getLong(18);
+               root = new IndexNode(this, rootOffset, rootOccupied);
+               loadFreeBlocks(freeBlocksOffset);
+               indexFileSize = freeBlocksOffset;
+               loaded = true;
+            } else {
+               handle.truncate(0);
+               root = IndexNode.emptyWithLeaves(this);
+               loaded = false;
+               // reserve space for shutdown
+               indexFileSize = INDEX_FILE_HEADER_SIZE;
+            }
+            buffer.putInt(0, DIRTY);
+            buffer.position(0);
+            buffer.limit(4);
+            write(handle, buffer, 0);
 
-         return loaded;
+            return loaded;
+         }
+      }
+
+      void delete() {
+         // Empty segment is negative, so there is no file
+         if (id >= 0) {
+            index.indexFileProvider.deleteFile(id);
+         }
       }
 
       void reset() throws IOException {
-         this.indexFile.truncate(0);
-         root = IndexNode.emptyWithLeaves(this);
-         // reserve space for shutdown
-         indexFileSize = INDEX_FILE_HEADER_SIZE;
-         ByteBuffer buffer = ByteBuffer.allocate(INDEX_FILE_HEADER_SIZE);
-         buffer.putInt(0, DIRTY);
-         buffer.position(0);
-         buffer.limit(4);
-         indexFile.position(0);
+         try (FileProvider.Handle handle = index.indexFileProvider.getFile(id)) {
+            handle.truncate(0);
+            root = IndexNode.emptyWithLeaves(this);
+            // reserve space for shutdown
+            indexFileSize = INDEX_FILE_HEADER_SIZE;
+            ByteBuffer buffer = ByteBuffer.allocate(INDEX_FILE_HEADER_SIZE);
+            buffer.putInt(0, DIRTY);
+            buffer.position(0);
+            buffer.limit(4);
 
-         write(indexFile, buffer);
+            write(handle, buffer, 0);
+         }
       }
 
       @Override
@@ -507,7 +632,9 @@ class Index {
          switch (request.getType()) {
             case CLEAR:
                root = IndexNode.emptyWithLeaves(this);
-               indexFile.truncate(0);
+               try (FileProvider.Handle handle = index.indexFileProvider.getFile(id)) {
+                  handle.truncate(0);
+               }
                indexFileSize = INDEX_FILE_HEADER_SIZE;
                freeBlocks.clear();
                index.nonBlockingManager.complete(request, null);
@@ -554,42 +681,44 @@ class Index {
          try {
             IndexSpace rootSpace = allocateIndexSpace(root.length());
             root.store(rootSpace);
-            indexFile.position(indexFileSize);
-            ByteBuffer buffer = ByteBuffer.allocate(4);
-            buffer.putInt(0, freeBlocks.size());
-            write(indexFile, buffer);
-            for (Map.Entry<Short, List<IndexSpace>> entry : freeBlocks.entrySet()) {
-               List<IndexSpace> list = entry.getValue();
-               int requiredSize = 8 + list.size() * 10;
-               buffer = buffer.capacity() < requiredSize ? ByteBuffer.allocate(requiredSize) : buffer;
-               buffer.position(0);
-               buffer.limit(requiredSize);
-               // TODO: change this to short
-               buffer.putInt(entry.getKey());
-               buffer.putInt(list.size());
-               for (IndexSpace space : list) {
-                  buffer.putLong(space.offset);
-                  buffer.putShort(space.length);
+            try (FileProvider.Handle handle = index.indexFileProvider.getFile(id)) {
+               ByteBuffer buffer = ByteBuffer.allocate(4);
+               buffer.putInt(0, freeBlocks.size());
+               long offset = indexFileSize;
+               offset += write(handle, buffer, offset);
+               for (Map.Entry<Short, List<IndexSpace>> entry : freeBlocks.entrySet()) {
+                  List<IndexSpace> list = entry.getValue();
+                  int requiredSize = 8 + list.size() * 10;
+                  buffer = buffer.capacity() < requiredSize ? ByteBuffer.allocate(requiredSize) : buffer;
+                  buffer.position(0);
+                  buffer.limit(requiredSize);
+                  // TODO: change this to short
+                  buffer.putInt(entry.getKey());
+                  buffer.putInt(list.size());
+                  for (IndexSpace space : list) {
+                     buffer.putLong(space.offset);
+                     buffer.putShort(space.length);
+                  }
+                  buffer.flip();
+                  offset += write(handle, buffer, offset);
                }
+               int headerWithoutMagic = INDEX_FILE_HEADER_SIZE - 4;
+               buffer = buffer.capacity() < headerWithoutMagic ? ByteBuffer.allocate(headerWithoutMagic) : buffer;
+               buffer.position(0);
+               // we need to set limit ahead, otherwise the putLong could throw IndexOutOfBoundsException
+               buffer.limit(headerWithoutMagic);
+               buffer.putInt(index.segments.length);
+               buffer.putLong(rootSpace.offset);
+               buffer.putShort(rootSpace.length);
+               buffer.putLong(indexFileSize);
                buffer.flip();
-               write(indexFile, buffer);
+               write(handle, buffer, 4);
+
+               buffer.position(0);
+               buffer.limit(4);
+               buffer.putInt(0, GRACEFULLY);
+               write(handle, buffer, 0);
             }
-            int headerWithoutMagic = INDEX_FILE_HEADER_SIZE - 8;
-            buffer = buffer.capacity() < headerWithoutMagic ? ByteBuffer.allocate(headerWithoutMagic) : buffer;
-            buffer.position(0);
-            // we need to set limit ahead, otherwise the putLong could throw IndexOutOfBoundsException
-            buffer.limit(headerWithoutMagic);
-            buffer.putLong(0, rootSpace.offset);
-            buffer.putShort(8, rootSpace.length);
-            buffer.putLong(10, indexFileSize);
-            indexFile.position(8);
-            write(indexFile, buffer);
-            buffer.position(0);
-            buffer.limit(8);
-            buffer.putInt(0, GRACEFULLY);
-            buffer.putInt(4, temporaryTable.getSegmentMax());
-            indexFile.position(0);
-            write(indexFile, buffer);
 
             complete(null);
          } catch (Throwable t) {
@@ -598,48 +727,62 @@ class Index {
       }
 
       private void loadFreeBlocks(long freeBlocksOffset) throws IOException {
-         indexFile.position(freeBlocksOffset);
          ByteBuffer buffer = ByteBuffer.allocate(8);
          buffer.limit(4);
-         if (!read(indexFile, buffer)) {
-            throw new IOException("Cannot read free blocks lists!");
-         }
-         int numLists = buffer.getInt(0);
-         for (int i = 0; i < numLists; ++i) {
-            buffer.position(0);
-            buffer.limit(8);
-            if (!read(indexFile, buffer)) {
+         long offset = freeBlocksOffset;
+         try (FileProvider.Handle handle = index.indexFileProvider.getFile(id)) {
+            if (!read(handle, buffer, offset)) {
                throw new IOException("Cannot read free blocks lists!");
             }
-            // TODO: change this to short
-            int blockLength = buffer.getInt(0);
-            assert blockLength <= Short.MAX_VALUE;
-            int listSize = buffer.getInt(4);
-            // Ignore any free block that had no entries as it adds time complexity to our lookup
-            if (listSize > 0) {
-               int requiredSize = 10 * listSize;
-               buffer = buffer.capacity() < requiredSize ? ByteBuffer.allocate(requiredSize) : buffer;
+            offset += 4;
+            int numLists = buffer.getInt(0);
+            for (int i = 0; i < numLists; ++i) {
                buffer.position(0);
-               buffer.limit(requiredSize);
-               if (!read(indexFile, buffer)) {
+               buffer.limit(8);
+               if (!read(handle, buffer, offset)) {
                   throw new IOException("Cannot read free blocks lists!");
                }
-               buffer.flip();
-               ArrayList<IndexSpace> list = new ArrayList<>(listSize);
-               for (int j = 0; j < listSize; ++j) {
-                  list.add(new IndexSpace(buffer.getLong(), buffer.getShort()));
+               offset += 8;
+               // TODO: change this to short
+               int blockLength = buffer.getInt(0);
+               assert blockLength <= Short.MAX_VALUE;
+               int listSize = buffer.getInt(4);
+               // Ignore any free block that had no entries as it adds time complexity to our lookup
+               if (listSize > 0) {
+                  int requiredSize = 10 * listSize;
+                  buffer = buffer.capacity() < requiredSize ? ByteBuffer.allocate(requiredSize) : buffer;
+                  buffer.position(0);
+                  buffer.limit(requiredSize);
+                  if (!read(handle, buffer, offset)) {
+                     throw new IOException("Cannot read free blocks lists!");
+                  }
+                  offset += requiredSize;
+                  buffer.flip();
+                  ArrayList<IndexSpace> list = new ArrayList<>(listSize);
+                  for (int j = 0; j < listSize; ++j) {
+                     list.add(new IndexSpace(buffer.getLong(), buffer.getShort()));
+                  }
+                  freeBlocks.put((short) blockLength, list);
                }
-               freeBlocks.put((short) blockLength, list);
             }
          }
       }
 
-      public FileChannel getIndexFile() {
-         return indexFile;
+      public FileProvider.Handle getIndexFile() throws IOException {
+         return index.indexFileProvider.getFile(id);
+      }
+
+      public void forceIndexIfOpen(boolean metaData) throws IOException {
+         FileProvider.Handle handle = index.indexFileProvider.getFileIfOpen(id);
+         if (handle != null) {
+            try (handle) {
+               handle.force(metaData);
+            }
+         }
       }
 
       public FileProvider getFileProvider() {
-         return index.fileProvider;
+         return index.dataFileProvider;
       }
 
       public Compactor getCompactor() {
@@ -701,8 +844,8 @@ class Index {
             freeBlocks.computeIfAbsent(length, k -> new ArrayList<>()).add(new IndexSpace(offset, length));
          } else {
             indexFileSize -= length;
-            try {
-               indexFile.truncate(indexFileSize);
+            try (FileProvider.Handle handle = index.indexFileProvider.getFile(id)) {
+               handle.truncate(indexFileSize);
             } catch (IOException e) {
                log.cannotTruncateIndex(e);
             }
@@ -754,7 +897,7 @@ class Index {
    }
 
    <V> Flowable<EntryRecord> publish(IntSet cacheSegments, boolean loadValues) {
-      return Flowable.fromArray(segments)
-            .concatMap(segment -> segment.root.publish(cacheSegments, loadValues));
+      return Flowable.fromIterable(cacheSegments)
+            .concatMap(segment -> segments[segment].root.publish(segment, loadValues));
    }
 }

--- a/core/src/main/java/org/infinispan/persistence/sifs/IndexNode.java
+++ b/core/src/main/java/org/infinispan/persistence/sifs/IndexNode.java
@@ -3,7 +3,6 @@ package org.infinispan.persistence.sifs;
 import java.io.IOException;
 import java.lang.ref.SoftReference;
 import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -14,13 +13,9 @@ import java.util.List;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.stream.Collectors;
 
-import org.infinispan.commons.io.ByteBufferImpl;
-import org.infinispan.commons.io.UnsignedNumeric;
 import org.infinispan.commons.time.TimeService;
 import org.infinispan.commons.util.ByRef;
-import org.infinispan.commons.util.IntSet;
 import org.infinispan.commons.util.Util;
 import org.infinispan.reactive.FlowableCreate;
 import org.infinispan.util.logging.LogFactory;
@@ -56,8 +51,8 @@ class IndexNode {
    // Prefix length (short) + keyNode length (short) + flag (byte)
    private static final int INNER_NODE_HEADER_SIZE = 5;
    private static final int INNER_NODE_REFERENCE_SIZE = 10;
-   // File size (int), Offset (int), numRecords (int), Cache Segment (int)
-   private static final int LEAF_NODE_REFERENCE_SIZE = 16;
+   // File size (int), Offset (int), numRecords (int)
+   private static final int LEAF_NODE_REFERENCE_SIZE = 12;
 
    public static final int RESERVED_SPACE
          = INNER_NODE_HEADER_SIZE + 2 * Math.max(INNER_NODE_REFERENCE_SIZE, LEAF_NODE_REFERENCE_SIZE);
@@ -86,7 +81,10 @@ class IndexNode {
       this.offset = offset;
       this.occupiedSpace = occupiedSpace;
 
-      ByteBuffer buffer = loadBuffer(segment.getIndexFile(), offset, occupiedSpace);
+      ByteBuffer buffer;
+      try (FileProvider.Handle handle = segment.getIndexFile()) {
+         buffer = loadBuffer(handle, offset, occupiedSpace);
+      }
 
       prefix = new byte[buffer.getShort()];
       buffer.get(prefix);
@@ -106,7 +104,7 @@ class IndexNode {
       if ((flags & HAS_LEAVES) != 0) {
          leafNodes = new LeafNode[numKeyParts + 1];
          for (int i = 0; i < numKeyParts + 1; ++i) {
-            leafNodes[i] = new LeafNode(buffer.getInt(), buffer.getInt(), buffer.getInt(), buffer.getInt());
+            leafNodes[i] = new LeafNode(buffer.getInt(), buffer.getInt(), buffer.getInt());
          }
       } else if ((flags & HAS_NODES) != 0) {
          innerNodes = new InnerNode[numKeyParts + 1];
@@ -122,14 +120,14 @@ class IndexNode {
       }
    }
 
-   private static ByteBuffer loadBuffer(FileChannel indexFile, long offset, int occupiedSpace) throws IOException {
+   private static ByteBuffer loadBuffer(FileProvider.Handle indexFile, long offset, int occupiedSpace) throws IOException {
       ByteBuffer buffer = ByteBuffer.allocate(occupiedSpace);
       int read = 0;
       do {
          int nowRead = indexFile.read(buffer, offset + read);
          if (nowRead < 0) {
             throw new IOException("Cannot read record [" + offset + ":" + occupiedSpace + "] (already read "
-                  + read + "), file size is " + indexFile.size());
+                  + read + "), file size is " + indexFile.getFileSize());
          }
          read += nowRead;
       } while (read < occupiedSpace);
@@ -219,12 +217,13 @@ class IndexNode {
             buffer.putInt(leafNode.file);
             buffer.putInt(leafNode.offset);
             buffer.putInt(leafNode.numRecords);
-            buffer.putInt(leafNode.cacheSegment);
          }
       }
       assert buffer.position() == buffer.limit() : "Buffer position: " + buffer.position() + " limit: " + buffer.limit();
       buffer.flip();
-      segment.getIndexFile().write(buffer, offset);
+      try (FileProvider.Handle handle = segment.getIndexFile()) {
+         handle.write(buffer, offset);
+      }
 
       if (log.isTraceEnabled()) {
          log.tracef("Persisted %08x (length %d, %d %s) to %d:%d", System.identityHashCode(this), length(),
@@ -251,21 +250,21 @@ class IndexNode {
    public enum ReadOperation {
       GET_RECORD {
          @Override
-         protected EntryRecord apply(LeafNode leafNode, org.infinispan.commons.io.ByteBuffer key, FileProvider fileProvider, TimeService timeService) throws IOException, IndexNodeOutdatedException {
+         protected EntryRecord apply(LeafNode leafNode, byte[] key, FileProvider fileProvider, TimeService timeService) throws IOException, IndexNodeOutdatedException {
             return leafNode.loadRecord(fileProvider, key, timeService);
          }
       },
       GET_EXPIRED_RECORD {
          @Override
-         protected EntryRecord apply(LeafNode leafNode, org.infinispan.commons.io.ByteBuffer key, FileProvider fileProvider, TimeService timeService) throws IOException, IndexNodeOutdatedException {
+         protected EntryRecord apply(LeafNode leafNode, byte[] key, FileProvider fileProvider, TimeService timeService) throws IOException, IndexNodeOutdatedException {
             return leafNode.loadRecord(fileProvider, key, null);
          }
       },
       GET_POSITION {
          @Override
-         protected EntryPosition apply(LeafNode leafNode, org.infinispan.commons.io.ByteBuffer key, FileProvider fileProvider, TimeService timeService) throws IOException, IndexNodeOutdatedException {
+         protected EntryPosition apply(LeafNode leafNode, byte[] key, FileProvider fileProvider, TimeService timeService) throws IOException, IndexNodeOutdatedException {
             EntryRecord hak = leafNode.loadHeaderAndKey(fileProvider);
-            if (entryKeyEqualsBuffer(hak, key)) {
+            if (Arrays.equals(hak.getKey(), key)) {
                if (hak.getHeader().expiryTime() > 0 && hak.getHeader().expiryTime() <= timeService.wallClockTime()) {
                   if (log.isTraceEnabled()) {
                      log.tracef("Found node on %d:%d but it is expired", leafNode.file, leafNode.offset);
@@ -283,9 +282,9 @@ class IndexNode {
       },
       GET_INFO {
          @Override
-         protected EntryInfo apply(LeafNode leafNode, org.infinispan.commons.io.ByteBuffer key, FileProvider fileProvider, TimeService timeService) throws IOException, IndexNodeOutdatedException {
+         protected EntryInfo apply(LeafNode leafNode, byte[] key, FileProvider fileProvider, TimeService timeService) throws IOException, IndexNodeOutdatedException {
             EntryRecord hak = leafNode.loadHeaderAndKey(fileProvider);
-            if (entryKeyEqualsBuffer(hak, key)) {
+            if (Arrays.equals(hak.getKey(), key)) {
                log.tracef("Found matching leafNode %s", leafNode);
                return leafNode;
             } else {
@@ -297,7 +296,7 @@ class IndexNode {
          }
       };
 
-      protected abstract <T> T apply(LeafNode leafNode, org.infinispan.commons.io.ByteBuffer key, FileProvider fileProvider, TimeService timeService) throws IOException, IndexNodeOutdatedException;
+      protected abstract <T> T apply(LeafNode leafNode, byte[] key, FileProvider fileProvider, TimeService timeService) throws IOException, IndexNodeOutdatedException;
    }
 
    public static <T> T applyOnLeaf(Index.Segment segment, int cacheSegment, byte[] indexKey, Lock rootLock, ReadOperation operation) throws IOException {
@@ -325,9 +324,8 @@ class IndexNode {
                return null;
             }
             int insertionPoint = node.getInsertionPoint(indexKey);
-            int cacheSegmentBytesSize = UnsignedNumeric.sizeUnsignedInt(cacheSegment);
-            return operation.apply(node.leafNodes[insertionPoint], ByteBufferImpl.create(indexKey, cacheSegmentBytesSize, indexKey.length - cacheSegmentBytesSize),
-                  segment.getFileProvider(), segment.getTimeService());
+            return operation.apply(node.leafNodes[insertionPoint], indexKey, segment.getFileProvider(),
+                  segment.getTimeService());
          } catch (IndexNodeOutdatedException e) {
             try {
                if (attempts > 10) {
@@ -392,7 +390,9 @@ class IndexNode {
 
       buffer.flip();
 
-      this.segment.getIndexFile().write(buffer, offset);
+      try (FileProvider.Handle handle = this.segment.getIndexFile()) {
+         handle.write(buffer, offset);
+      }
    }
 
    private static IndexNode findParentNode(IndexNode root, byte[] indexKey, Deque<Path> stack) throws IOException {
@@ -411,8 +411,8 @@ class IndexNode {
    public static void setPosition(IndexNode root, IndexRequest request, OverwriteHook overwriteHook, RecordChange recordChange) throws IOException {
       int cacheSegment = request.getSegment();
 
-      // TODO: maybe we can optimize not copying this?
-      byte[] indexKey = Index.toIndexKey(cacheSegment, request.getSerializedKey());
+      // TODO: maybe we can optimize not copying this when Buffer has an offset or using portion of data
+      byte[] indexKey = Index.toIndexKey(request.getSerializedKey());
 
       Deque<Path> stack = new ArrayDeque<>();
       IndexNode node = findParentNode(root, indexKey, stack);
@@ -446,7 +446,7 @@ class IndexNode {
                   }
                } else {
                   newRoot = IndexNode.emptyWithInnerNodes(root.segment).copyWith(0, 0, result.newNodes);
-                  root.segment.getIndexFile().force(false);
+                  root.segment.forceIndexIfOpen(false);
                   if (log.isTraceEnabled()) {
                      log.tracef("Setting new root %08x (index has grown)", System.identityHashCode(newRoot));
                   }
@@ -643,7 +643,7 @@ class IndexNode {
       } else {
          for (LeafNode leafNode : leafNodes) {
             EntryRecord hak = leafNode.loadHeaderAndKey(segment.getFileProvider());
-            if (hak.getKey() != null) return Index.toIndexKey(leafNode.cacheSegment, hak.getKey());
+            if (hak.getKey() != null) return hak.getKey();
          }
       }
       return null;
@@ -658,7 +658,7 @@ class IndexNode {
       } else {
          for (int i = leafNodes.length - 1; i >= 0; --i) {
             EntryRecord hak = leafNodes[i].loadHeaderAndKey(segment.getFileProvider());
-            if (hak.getKey() != null) return Index.toIndexKey(leafNodes[i].cacheSegment, hak.getKey());
+            if (hak.getKey() != null) return hak.getKey();
          }
       }
       return null;
@@ -676,7 +676,7 @@ class IndexNode {
       if (leafNodes.length == 0) {
          overwriteHook.setOverwritten(request, cacheSegment, false, -1, -1);
          if (overwriteHook.check(request, -1, -1)) {
-            return new IndexNode(segment, prefix, keyParts, new LeafNode[]{new LeafNode(file, offset, 1, cacheSegment)});
+            return new IndexNode(segment, prefix, keyParts, new LeafNode[]{new LeafNode(file, offset, 1)});
          } else {
             segment.getCompactor().free(file, size);
             return this;
@@ -710,7 +710,7 @@ class IndexNode {
       } catch (IndexNodeOutdatedException e) {
          throw new IllegalStateException("Index cannot be outdated for segment updater thread", e);
       }
-      byte[] oldIndexKey = Index.toIndexKey(oldLeafNode.cacheSegment, hak.getKey());
+      byte[] oldIndexKey = hak.getKey();
       int keyComp = compare(oldIndexKey, indexKey);
       Object objectKey = request.getKey();
       if (keyComp == 0) {
@@ -740,7 +740,7 @@ class IndexNode {
                }
                lock.writeLock().lock();
                try {
-                  leafNodes[insertPart] = new LeafNode(file, offset, numRecords, cacheSegment);
+                  leafNodes[insertPart] = new LeafNode(file, offset, numRecords);
                } finally {
                   lock.writeLock().unlock();
                }
@@ -799,55 +799,36 @@ class IndexNode {
             System.arraycopy(leafNodes, 0, newLeafNodes, 0, insertPart + 1);
             System.arraycopy(leafNodes, insertPart + 1, newLeafNodes, insertPart + 2, leafNodes.length - insertPart - 1);
             log.tracef("Creating new leafNode for %s at %d:%d", objectKey, file, offset);
-            newLeafNodes[insertPart + 1] = new LeafNode(file, offset, 1, cacheSegment);
+            newLeafNodes[insertPart + 1] = new LeafNode(file, offset, 1);
          } else {
             newKeyParts[insertPart] = substring(oldIndexKey, newPrefix.length, -keyComp);
             System.arraycopy(leafNodes, 0, newLeafNodes, 0, insertPart);
             System.arraycopy(leafNodes, insertPart, newLeafNodes, insertPart + 1, leafNodes.length - insertPart);
             log.tracef("Creating new leafNode for %s at %d:%d", objectKey, file, offset);
-            newLeafNodes[insertPart] = new LeafNode(file, offset, 1, cacheSegment);
+            newLeafNodes[insertPart] = new LeafNode(file, offset, 1);
          }
       }
       return new IndexNode(segment, newPrefix, newKeyParts, newLeafNodes);
    }
 
-   private int getIterationPoint(byte[] key, int cacheSegment) {
-      int comp = compare(key, prefix, prefix.length);
-      int insertionPoint;
-      if (comp > 0) {
-         insertionPoint = 0;
-      } else if (comp < 0) {
-         insertionPoint = keyParts.length;
-      } else {
-         byte[] keyPostfix = substring(key, prefix.length, key.length);
-         insertionPoint = Arrays.binarySearch(keyParts, keyPostfix, REVERSED_COMPARE_TO);
-         if (insertionPoint < 0) {
-            insertionPoint = -insertionPoint - 1;
-         } else {
-            int cacheSegmentToUse = cacheSegment < 0 ? UnsignedNumeric.readUnsignedInt(key, 0) : cacheSegment;
-            if (UnsignedNumeric.sizeUnsignedInt(cacheSegmentToUse) < key.length) {
-               // When the length is bigger than a cache segment, that means the index prefix is a specific key and if it
-               // is equal we have to skip two spaces
-               // Example:
-               // KeyParts
-               // 84 = {byte[12]@9221} [-100, 1, -104, 1, 2, -118, 1, 5, 10, 3, 40, -71]
-               // 85 = {byte[12]@9222} [-100, 1, -104, 1, 2, -118, 1, 5, 10, 3, 40, -60]
-               // 86 = {byte[13]@9223} [-100, 1, -104, 1, 2, -118, 1, 5, 10, 3, 40, -60, 14]
-               // 87 = {byte[12]@9224} [-100, 1, -104, 1, 2, -118, 1, 5, 10, 3, 40, -54]
-               // 88 = {byte[12]@9225} [-100, 1, -104, 1, 2, -118, 1, 5, 10, 3, 40, -48]
-               // Segment Prefix
-               //     {byte[13]        [-100, 1, -104, 1, 2, -118, 1, 5, 10, 3, 40, -60, 14]
-               // The actual value is stored at 87 in this case per `getInsertionPoint` so we need to skip to 88
-               // CacheSegment is -1 for an innerNode because we have to find where in the leaf node the value is
-               // CacheSegment is > 0 for a leafNode
-               insertionPoint += cacheSegment < 0 ? 1 : 2;
-            }
-         }
-      }
-      return insertionPoint;
+   private int getInsertionPoint(byte[] key) {
+      return getInsertionPoint(key, false);
    }
 
-   private int getInsertionPoint(byte[] key) {
+   /**
+    * Finds where an entry would be inserted into the node. It will be 0th position if this key is before the prefix and
+    * the length of the array if it does not start with the given prefix.
+    * <p>
+    * When the prefix matches the first bytes of the key the point returned will be where either the key is or the key
+    * before where it would belong if the key is not present.
+    * <p>
+    * It is possible to instead always return the next position that is greater than the key by passing <b>true</b> for
+    * <b>addExtraOnPrefixMatch</b>. This can be useful to find the next key after a given one for doing iteration.
+    * @param key the key to find its position in the nodes
+    * @param addExtraOnPrefixMatch whether the returned position is always greater than the provided key
+    * @return the position in the nodes
+    */
+   private int getInsertionPoint(byte[] key, boolean addExtraOnPrefixMatch) {
       int comp = compare(key, prefix, prefix.length);
       int insertionPoint;
       if (comp > 0) {
@@ -858,9 +839,9 @@ class IndexNode {
          byte[] keyPostfix = substring(key, prefix.length, key.length);
          insertionPoint = Arrays.binarySearch(keyParts, keyPostfix, REVERSED_COMPARE_TO);
          if (insertionPoint < 0) {
-            insertionPoint = -insertionPoint - 1;
+            insertionPoint = -insertionPoint - 1 + (addExtraOnPrefixMatch ? 1 : 0);
          } else {
-            insertionPoint++; // identical elements must go to the right
+            insertionPoint += addExtraOnPrefixMatch ? 2 : 1; // identical elements must go to the right
          }
       }
 
@@ -1117,8 +1098,8 @@ class IndexNode {
       private static final LeafNode[] EMPTY_ARRAY = new LeafNode[0];
       private volatile SoftReference<EntryRecord> keyReference;
 
-      LeafNode(int file, int offset, int numRecords, int cacheSegment) {
-         super(file, offset, numRecords, cacheSegment);
+      LeafNode(int file, int offset, int numRecords) {
+         super(file, offset, numRecords);
       }
 
       public EntryRecord loadHeaderAndKey(FileProvider fileProvider) throws IOException, IndexNodeOutdatedException {
@@ -1162,7 +1143,7 @@ class IndexNode {
          return headerAndKey;
       }
 
-      public EntryRecord loadRecord(FileProvider fileProvider, org.infinispan.commons.io.ByteBuffer key, TimeService timeService) throws IOException, IndexNodeOutdatedException {
+      public EntryRecord loadRecord(FileProvider fileProvider, byte[] key, TimeService timeService) throws IOException, IndexNodeOutdatedException {
          FileProvider.Handle handle = fileProvider.getFile(file);
          int readOffset = offset < 0 ? ~offset : offset;
          if (handle == null) {
@@ -1171,7 +1152,7 @@ class IndexNode {
          try {
             boolean trace = log.isTraceEnabled();
             EntryRecord headerAndKey = getHeaderAndKey(fileProvider, handle);
-            if (key != null && !entryKeyEqualsBuffer(headerAndKey, key)) {
+            if (key != null && !Arrays.equals(headerAndKey.getKey(), key)) {
                if (trace) {
                   log.trace("Key on " + file + ":" + readOffset + " not matched.");
                }
@@ -1211,7 +1192,7 @@ class IndexNode {
       for (int i = 0; i <= keyParts.length; ++i) {
          sb.append('\n');
          if (leafNodes != null && i < leafNodes.length) {
-            sb.append(" [").append(leafNodes[i].file).append(':').append(leafNodes[i].offset).append(':').append(leafNodes[i].cacheSegment).append("] ");
+            sb.append(" [").append(leafNodes[i].file).append(':').append(leafNodes[i].offset).append("] ");
          } else {
             sb.append(" [").append(innerNodes[i].offset).append(':').append(innerNodes[i].length).append("] ");
          }
@@ -1223,69 +1204,53 @@ class IndexNode {
       return sb.toString();
    }
 
-   Flowable<EntryRecord> publish(IntSet cacheSegments, boolean loadValues) {
+   Flowable<EntryRecord> publish(int cacheSegment, boolean loadValues) {
       long currentTime = segment.getTimeService().wallClockTime();
 
-      int cacheSegmentSize = cacheSegments.size();
-      if (cacheSegmentSize == 0) {
-         return Flowable.empty();
-      }
-
-      // Needs defer as we mutate the deque so publisher can be subscribed to multiple times
+      // Needs defer as we mutate the lastRetrievedKey so inner publisher can be subscribed to multiple times
       return Flowable.defer(() -> {
-         // First sort all the cacheSegments by their unsigned numeric byte[] values.
-         // This allows us to start at the left most node, and we can iterate within the nodes if the cacheSegments are
-         // contiguous in the data
-         Deque<byte[]> sortedSegmentPrefixes = cacheSegments.intStream()
-               .filter(cacheSegment -> segment.index.sizePerSegment.get(cacheSegment) != 0)
-               .mapToObj(cacheSegment -> {
-                  byte[] segmentPrefix = new byte[UnsignedNumeric.sizeUnsignedInt(cacheSegment)];
-                  UnsignedNumeric.writeUnsignedInt(segmentPrefix, 0, cacheSegment);
-                  return segmentPrefix;
-               }).sorted(REVERSED_COMPARE_TO)
-               .collect(Collectors.toCollection(ArrayDeque::new));
-         if (sortedSegmentPrefixes.isEmpty()) {
+         if (segment.index.sizePerSegment.get(cacheSegment) == 0) {
             return Flowable.empty();
          }
+         ByRef<byte[]> lastRetrievedKey = new ByRef<>(Util.EMPTY_BYTE_ARRAY);
 
          return new FlowableCreate<>(emitter -> {
-            // Set to true in 3 different cases: cacheSegment didn't map to next entry, emitter has no more requests or cancelled
+            // Set to true in 2 different cases: emitter has no more requests or cancelled
             ByRef.Boolean done = new ByRef.Boolean(false);
             do {
                // Reset so we can loop
                done.set(false);
-               recursiveNode(this, segment, sortedSegmentPrefixes, emitter, loadValues, currentTime, new ByRef.Boolean(false), done, false);
+               recursiveNode(this, segment, lastRetrievedKey, emitter, loadValues, currentTime, new ByRef.Boolean(false), done);
                // This handles two of the done cases - in which case we can't continue
                if (emitter.requested() == 0 || emitter.isCancelled()) {
                   return;
                }
-            } while (done.get() && !sortedSegmentPrefixes.isEmpty());
+            } while (done.get() && lastRetrievedKey.get() != null);
             emitter.onComplete();
          }, BackpressureStrategy.ERROR);
       });
    }
 
-   void recursiveNode(IndexNode node, Index.Segment segment, Deque<byte[]> segmentPrefixes, FlowableEmitter<EntryRecord> emitter,
-         boolean loadValues, long currentTime, ByRef.Boolean foundData, ByRef.Boolean done, boolean firstNodeAttempted) throws IOException {
+   void recursiveNode(IndexNode node, Index.Segment segment, ByRef<byte[]> lastRetrievedKey, FlowableEmitter<EntryRecord> emitter,
+         boolean loadValues, long currentTime, ByRef.Boolean foundData, ByRef.Boolean done) throws IOException {
       Lock readLock = node.lock.readLock();
       readLock.lock();
       try {
          byte[] previousKey = null;
-         int previousSegment = -1;
          if (node.innerNodes != null) {
-            final int point = foundData.get() ? 0 : node.getIterationPoint(segmentPrefixes.getFirst(), -1);
+            byte[] lastKey = lastRetrievedKey.get();
+            final int point = foundData.get() ? 0 : node.getInsertionPoint(lastKey, false);
             // Need to search all inner nodes starting from that point until we hit the last entry for the segment
-            for (int i = point; !segmentPrefixes.isEmpty() && i < node.innerNodes.length && !done.get(); ++i) {
-               recursiveNode(node.innerNodes[i].getIndexNode(segment), segment, segmentPrefixes, emitter, loadValues,
-                     currentTime, foundData, done, i == point);
+            for (int i = point; i < node.innerNodes.length && !done.get(); ++i) {
+               recursiveNode(node.innerNodes[i].getIndexNode(segment), segment, lastRetrievedKey, emitter, loadValues,
+                     currentTime, foundData, done);
             }
          } else if (node.leafNodes != null) {
             int suggestedIteration;
-            byte[] segmentPrefix = segmentPrefixes.getFirst();
-            int cacheSegment = UnsignedNumeric.readUnsignedInt(segmentPrefix, 0);
+            byte[] lastKey = lastRetrievedKey.get();
             boolean firstData = !foundData.get();
             if (firstData) {
-               suggestedIteration = node.getIterationPoint(segmentPrefix, cacheSegment);
+               suggestedIteration = node.getInsertionPoint(lastKey, lastKey.length != 0);
                foundData.set(true);
             } else {
                suggestedIteration = 0;
@@ -1293,39 +1258,6 @@ class IndexNode {
 
             for (int i = suggestedIteration; i < node.leafNodes.length; ++i) {
                LeafNode leafNode = node.leafNodes[i];
-               if (leafNode.cacheSegment != cacheSegment) {
-                  // The suggestion may be off by 1 if the page index prefix is longer than the segment but equal
-                  if (i == suggestedIteration && firstData
-                        && segmentPrefix.length == UnsignedNumeric.sizeUnsignedInt(cacheSegment)) {
-
-                     // No entry for the given segment, make sure to try next segment
-                     if (i != node.leafNodes.length - 1
-                           && (i == node.keyParts.length ||
-                           (i < node.keyParts.length &&
-                                 compare(node.keyParts[i], segmentPrefix, Math.min(segmentPrefix.length, node.keyParts[i].length)) == 0)))
-                        continue;
-
-                     // The cache segment does not map to the current innerNode, we are at the end of the leafNodes,
-                     // and this is the first innerNode attempted. We need to also check the first leaf of the next innerNode if present.
-                     if (i == node.leafNodes.length - 1 && firstNodeAttempted) {
-                        return;
-                     }
-                  }
-                  segmentPrefixes.removeFirst();
-
-                  // If the data maps to the next segment in our ordered queue, we can continue reading,
-                  // otherwise we end and the retry will kick in
-                  segmentPrefix = segmentPrefixes.peekFirst();
-                  if (segmentPrefix != null) {
-                     cacheSegment = UnsignedNumeric.readUnsignedInt(segmentPrefix, 0);
-                  }
-                  // Next cacheSegment doesn't match either, thus we have to retry with the next prefix
-                  // Note that if segmentPrefix is null above, this will always be true
-                  if (leafNode.cacheSegment != cacheSegment) {
-                     done.set(true);
-                     return;
-                  }
-               }
 
                EntryRecord record;
                try {
@@ -1339,9 +1271,7 @@ class IndexNode {
                } catch (IndexNodeOutdatedException e) {
                   // Current key was outdated, we have to try from the previous entry we saw (note it is skipped)
                   if (previousKey != null) {
-                     byte[] currentIndexKey = Index.toIndexKey(previousSegment, previousKey);
-                     segmentPrefixes.removeFirst();
-                     segmentPrefixes.addFirst(currentIndexKey);
+                     lastRetrievedKey.set(previousKey);
                   }
                   done.set(true);
                   return;
@@ -1350,13 +1280,12 @@ class IndexNode {
                if (record != null && record.getHeader().valueLength() > 0) {
                   // It is possible that the very first looked up entry was a previously seen value and if so
                   // we must skip it if it is equal to not return it twice.
-                  // The current segmentPrefix will match the element's key bytes excluding the segment bytes
                   if (firstData && i == suggestedIteration) {
                      int keyLength = record.getHeader().keyLength();
-                     int lengthDiff = segmentPrefix.length - keyLength;
-                     if (lengthDiff > 0) {
+                     int lengthDiff = lastKey.length - keyLength;
+                     if (lengthDiff == 0) {
                         byte[] keyArray = record.getKey();
-                        if (Util.arraysEqual(keyArray, 0, keyArray.length, segmentPrefix, lengthDiff, segmentPrefix.length)) {
+                        if (Arrays.equals(keyArray, lastKey)) {
                            continue;
                         }
                      }
@@ -1368,9 +1297,7 @@ class IndexNode {
                      if (emitter.requested() == 0) {
                         // Store the current key as the next prefix when we can't retrieve more values, so
                         // the next request will get the next value after this one
-                        byte[] currentIndexKey = Index.toIndexKey(cacheSegment, record.getKey());
-                        segmentPrefixes.removeFirst();
-                        segmentPrefixes.addFirst(currentIndexKey);
+                        lastRetrievedKey.set(record.getKey());
                         done.set(true);
                         return;
                      } else if (emitter.isCancelled()) {
@@ -1380,16 +1307,13 @@ class IndexNode {
                   }
 
                   previousKey = record.getKey();
-                  previousSegment = cacheSegment;
                }
             }
 
             // We are continuing with the next innerNode, save the previous key, just in case we get an outdated
             // exception on the first entry
             if (previousKey != null) {
-               byte[] currentIndexKey = Index.toIndexKey(previousSegment, previousKey);
-               segmentPrefixes.removeFirst();
-               segmentPrefixes.addFirst(currentIndexKey);
+               lastRetrievedKey.set(previousKey);
             }
          }
       } finally {

--- a/core/src/main/java/org/infinispan/persistence/sifs/configuration/IndexConfiguration.java
+++ b/core/src/main/java/org/infinispan/persistence/sifs/configuration/IndexConfiguration.java
@@ -30,6 +30,10 @@ public class IndexConfiguration extends ConfigurationElement<IndexConfiguration>
       attributes.attribute(INDEX_LOCATION).set(location);
    }
 
+   /**
+    * This is no longer used as we create an index file per cache segment instead
+    */
+   @Deprecated(since = "15.0", forRemoval = true)
    public int indexSegments() {
       return attributes.attribute(INDEX_SEGMENTS).get();
    }

--- a/core/src/main/java/org/infinispan/persistence/sifs/configuration/SoftIndexFileStoreConfiguration.java
+++ b/core/src/main/java/org/infinispan/persistence/sifs/configuration/SoftIndexFileStoreConfiguration.java
@@ -43,6 +43,10 @@ public class SoftIndexFileStoreConfiguration extends AbstractStoreConfiguration<
       return index.indexLocation();
    }
 
+   /**
+    * This is no longer used as we create an index file per cache segment instead
+    */
+   @Deprecated(since = "15.0", forRemoval = true)
    public int indexSegments() {
       return index.indexSegments();
    }
@@ -67,6 +71,15 @@ public class SoftIndexFileStoreConfiguration extends AbstractStoreConfiguration<
       return data.syncWrites();
    }
 
+   /**
+    * The maximum number of files that will be open at a given time for all the data and index files, which does
+    * not include compactor and current log file (which will always be 2).
+    * Note that the number of data files is effectively unlimited, where as we have an index file per segment.
+    * <p>
+    * Index files will reserve 1/10th of the open files, with a minimum value of 1 and a maximum equal to the
+    * number of cache segments.
+    * @return How many open files SIFS will utilize
+    */
    public int openFilesLimit() {
       return attributes.attribute(OPEN_FILES_LIMIT).get();
    }

--- a/core/src/main/resources/schema/infinispan-config-15.0.xsd
+++ b/core/src/main/resources/schema/infinispan-config-15.0.xsd
@@ -2098,7 +2098,8 @@
         <xs:attribute name="open-files-limit" type="xs:int" default="${SoftIndexFileStore.open-files-limit}">
           <xs:annotation>
             <xs:documentation>
-              Max number of data files opened for reading (current log file, compaction output and index segments are not included here).
+              Max number of data and index files opened for reading (current log file and compaction output are not included here - always uses one each).
+              Index files will use 1/10th of list limit with a minimum of 1 and a maximum equal to the number of cache segments.
             </xs:documentation>
           </xs:annotation>
         </xs:attribute>
@@ -2158,7 +2159,8 @@
     <xs:attribute name="segments" type="xs:int" default="${Index.segments}">
       <xs:annotation>
         <xs:documentation>
-          Specifies the number of index segment files.
+          Deprecated since 15.0 which ignores the property.
+          This value is ignored as we create an index file per cache segment instead.
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>

--- a/core/src/test/java/org/infinispan/persistence/sifs/SoftIndexFileStoreRestartTest.java
+++ b/core/src/test/java/org/infinispan/persistence/sifs/SoftIndexFileStoreRestartTest.java
@@ -28,7 +28,6 @@ import org.infinispan.persistence.support.WaitDelegatingNonBlockingStore;
 import org.infinispan.test.Mocks;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.CheckPoint;
-import org.infinispan.util.concurrent.CompletionStages;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
@@ -249,12 +248,15 @@ public class SoftIndexFileStoreRestartTest extends BaseDistStoreTest<Integer, St
 
       createCacheManagers();
 
+      assertEquals("value-" + (size - 1), cache(0, cacheName).get(key));
+
       WaitDelegatingNonBlockingStore store = TestingUtil.getFirstStoreWait(cache(0, cacheName));
 
       Compactor compactor = TestingUtil.extractField(store.delegate(), "compactor");
 
       // Force compaction for the previous file
-      CompletionStages.join(compactor.forceCompactionForAllNonLogFiles());
+      compactor.forceCompactionForAllNonLogFiles()
+            .toCompletableFuture().get(10, TimeUnit.SECONDS);
 
       assertEquals("value-" + (size - 1), cache(0, cacheName).get(key));
 

--- a/core/src/test/java/org/infinispan/persistence/sifs/SoftIndexFileStoreTest.java
+++ b/core/src/test/java/org/infinispan/persistence/sifs/SoftIndexFileStoreTest.java
@@ -62,11 +62,11 @@ public class SoftIndexFileStoreTest extends BaseNonBlockingStoreTest {
 
    @Override
    protected Configuration buildConfig(ConfigurationBuilder configurationBuilder) {
+      configurationBuilder.clustering().hash().numSegments(1);
       return configurationBuilder.persistence()
             .addSoftIndexFileStore()
             .dataLocation(Paths.get(tmpDirectory, "data").toString())
             .indexLocation(Paths.get(tmpDirectory, "index").toString())
-            .indexSegments(1)
             .maxFileSize(1000)
             .build();
    }


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-15377
https://issues.redhat.com/browse/ISPN-15395

This PR changes SIFS to create an index file per cache segment instead of its own idea of a segment. This allows for iteration code to be simplified as well as no longer requiring every key to be prepended with the segment information. It also should reduce time complexity of looking up keys as the key space would be divided by the number of cache segments already.

This will also shave off 4 bytes off every entry in the index as well since we no longer have to store the segment information with the key itself.