### PR TITLE
ISPN-15406-The TLS v1.2 and v1.3 supported ciphers Updated 

### DIFF
--- a/documentation/src/main/asciidoc/topics/json/server_ssl_identity_engine.json
+++ b/documentation/src/main/asciidoc/topics/json/server_ssl_identity_engine.json
@@ -12,8 +12,8 @@
             },
             "engine": {
               "enabled-protocols": ["TLSv1.3"],
-              "enabled-ciphersuites": "TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256",
-              "enabled-ciphersuites-tls13": "TLS_AES_256_GCM_SHA384"
+              "enabled-ciphersuites": "TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA256",
+              "enabled-ciphersuites-tls13": "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256"
             }
           }
         }

--- a/documentation/src/main/asciidoc/topics/xml/server_ssl_identity_engine.xml
+++ b/documentation/src/main/asciidoc/topics/xml/server_ssl_identity_engine.xml
@@ -10,8 +10,8 @@
                       alias="server"/>
             <!-- Configures {brandname} Server to use specific TLS versions and cipher suites. -->
             <engine enabled-protocols="TLSv1.3 TLSv1.2"
-                    enabled-ciphersuites="TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256"
-                    enabled-ciphersuites-tls13="TLS_AES_256_GCM_SHA384"/>
+                    enabled-ciphersuites="TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA256"
+                    enabled-ciphersuites-tls13="TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256"/>
           </ssl>
         </server-identities>
       </security-realm>


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-15406

The TLS v1.3 ciphers should be separated by colon
The TLS v1.2 ciphers should be updated in the enabled-ciphers section 
