### PR TITLE
Automatically create Jira tickets for dependabot upgrades

### DIFF
--- a/.github/actions/create-jira/action.yaml
+++ b/.github/actions/create-jira/action.yaml
@@ -1,0 +1,57 @@
+name: Create Jira Ticket
+description: Create Jira Ticket
+
+inputs:
+  token:
+    description: 'The Jira bearer token used to authenticate'
+    required: true
+  project:
+    description: 'The name of the Jira Projec to create the issue for'
+    required: true
+  summary:
+    description: 'The Jira summary'
+    required: true
+  type:
+    description: 'The type of Jira to create'
+    required: true
+  description:
+    description: 'The Jira description'
+  pullRequest:
+    description: 'The url of a Pull Request to be added to the Jira ticket'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Create Jira Ticket
+      shell: bash
+      run: |
+        BASE_URL=https://issues.redhat.com
+        API_URL=${BASE_URL}/rest/api/2/
+
+        cat << EOF > headers
+        Authorization: Bearer ${{ inputs.token }}
+        Content-Type: application/json
+        EOF
+
+        PROJECT=$(curl -H @headers $API_URL/project/${{ inputs.project }})
+        PROJECT_ID=$(echo ${PROJECT} | jq -r .id)
+        ISSUE_TYPE_ID=$(echo ${PROJECT} | jq -r '.issueTypes[] | select(.name=="${{ inputs.type }}").id')
+
+        cat << EOF > create-jira.json
+        {
+          "fields": {
+            "project": {
+              "id": "${PROJECT_ID}"
+            },
+            "summary": "${{ inputs.summary }}",
+            "description": "${{ inputs.description }}",
+            "customfield_12310220": "${{ inputs.pullRequest }}",
+            "issuetype": {
+              "id": "${ISSUE_TYPE_ID}"
+            }
+          }
+        }
+        EOF
+
+        JIRA_KEY=$(curl -H @headers --data @create-jira.json $API_URL/issue | jq -r .key)
+        echo "JIRA_TICKET_URL=${BASE_URL}/browse/${JIRA_KEY}" >> $GITHUB_ENV

--- a/.github/workflows/dependabot_jira.yml
+++ b/.github/workflows/dependabot_jira.yml
@@ -1,0 +1,29 @@
+name: Dependabot Jira
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+
+jobs:
+  create_jira:
+    name: Dependabot Jira
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.id == 27856297 #id dependabot user
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Extract Jira Summary
+        run: echo SUMMARY=$(echo ${{ github.event.pull_request.title }} | grep -oP '(?<=Bump )(.*)(?=from)|(?<=to )(.*)' | tr -d '\n') >> $GITHUB_ENV
+
+      - name: Create Jira Ticket
+        uses: ./.github/actions/create-jira
+        with:
+          token: ${{ secrets.JIRA_API_TOKEN }}
+          project: ISPN
+          summary: ${{ env.SUMMARY }}
+          type: Component Upgrade
+          pullRequest: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
This will automatically create a Jira ticket for all dependabot PRs, link the PR to the ticket and then add the Jira URL as a comment on the PR itself.

Example Jira ticket: https://issues.redhat.com/browse/ISPN-15414

I'll create a different workflow for the backport branches, as we'll need to update an existing Jira instead of creating a new one.