### PR TITLE
ISPN-15402 JGroups Raft 1.0.12.Final

### DIFF
--- a/build/configuration/pom.xml
+++ b/build/configuration/pom.xml
@@ -164,7 +164,7 @@
       <version.jboss.shrinkwrap>1.2.6</version.jboss.shrinkwrap>
       <version.jcip-annotations>1.0</version.jcip-annotations>
       <version.jgroups>5.3.0.Final</version.jgroups>
-      <version.jgroups.raft>1.0.11.Final</version.jgroups.raft>
+      <version.jgroups.raft>1.0.12.Final</version.jgroups.raft>
       <version.jsr107>1.1.0</version.jsr107>
       <version.junit>4.13.2</version.junit>
       <version.junit.platform>1.9.3</version.junit.platform>


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-15402

Supersedes #11604.

Bump org.jgroups:jgroups-raft from 1.0.11.Final to 1.0.12.Final

Bumps [org.jgroups:jgroups-raft](https://github.com/jgroups-extras/jgroups-raft) from 1.0.11.Final to 1.0.12.Final.
- [Commits](https://github.com/jgroups-extras/jgroups-raft/compare/jgroups-raft-1.0.11.Final...jgroups-raft-1.0.12.Final)

---
updated-dependencies:
- dependency-name: org.jgroups:jgroups-raft dependency-type: direct:production update-type: version-update:semver-patch ...