### PR TITLE
ISPN-15424 Remove inherited versionx properties to facilitate Dependabot

### DIFF
--- a/archetypes/server-task/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/server-task/src/main/resources/archetype-resources/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.kohsuke.metainf-services</groupId>
             <artifactId>metainf-services</artifactId>
-            <version>${versionx.org.kohsuke.metainf-services.metainf-services}</version>
+            <version>${version.metainf-services}</version>
         </dependency>
     </dependencies>
 

--- a/archetypes/store/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/store/src/main/resources/archetype-resources/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>org.kohsuke.metainf-services</groupId>
             <artifactId>metainf-services</artifactId>
-            <version>${versionx.org.kohsuke.metainf-services.metainf-services}</version>
+            <version>${version.metainf-services}</version>
         </dependency>
     </dependencies>
 

--- a/build/component-processor/pom.xml
+++ b/build/component-processor/pom.xml
@@ -54,7 +54,7 @@
                   <path>
                      <groupId>org.kohsuke.metainf-services</groupId>
                      <artifactId>metainf-services</artifactId>
-                     <version>${versionx.org.kohsuke.metainf-services.metainf-services}</version>
+                     <version>${version.metainf-services}</version>
                   </path>
                </annotationProcessorPaths>
             </configuration>

--- a/build/configuration/pom.xml
+++ b/build/configuration/pom.xml
@@ -205,11 +205,9 @@
       <version.quarkus>3.6.2</version.quarkus>
       <version.graalvm>23.0.1</version.graalvm>
       <version.jandex>3.1.6</version.jandex>
-      <version.quarkus.opentelemetry>1.30.1</version.quarkus.opentelemetry>
-      <version.quarkus.opentelemetry.alpha>1.30.0-alpha</version.quarkus.opentelemetry.alpha>
 
-      <version.opentelemetry>${version.quarkus.opentelemetry}</version.opentelemetry>
-      <version.opentelemetry.alpha>${version.quarkus.opentelemetry.alpha}</version.opentelemetry.alpha>
+      <version.opentelemetry>1.30.1</version.opentelemetry>
+      <version.opentelemetry.alpha>1.30.0-alpha</version.opentelemetry.alpha>
 
       <version.smallrye-mutiny>2.2.0</version.smallrye-mutiny>
       <!-- Spring 6, Spring Boot 3 versions -->
@@ -225,7 +223,7 @@
       <version.checkstyle.maven-plugin>3.3.0</version.checkstyle.maven-plugin>
       <version.native.maven.plugin>0.9.22</version.native.maven.plugin>
       <version.maven>3.8.2</version.maven>
-      <version.maven.antlr3>${version.antlr3}</version.maven.antlr3>
+      <version.maven.antlr3>3.5.2</version.maven.antlr3>
       <version.maven.antrun>3.1.0</version.maven.antrun>
       <version.maven.buildhelper>3.4.0</version.maven.buildhelper>
       <version.maven.bundle>4.2.1</version.maven.bundle>

--- a/client/hotrod/pom.xml
+++ b/client/hotrod/pom.xml
@@ -121,7 +121,7 @@
       <dependency>
          <groupId>org.junit.jupiter</groupId>
          <artifactId>junit-jupiter-params</artifactId>
-         <version>${versionx.junit.junit5}</version>
+         <version>${version.junit5}</version>
          <scope>test</scope>
       </dependency>
       <dependency>

--- a/graalvm/client-hotrod/pom.xml
+++ b/graalvm/client-hotrod/pom.xml
@@ -113,7 +113,7 @@
       <dependency>
          <groupId>org.junit.platform</groupId>
          <artifactId>junit-platform-suite</artifactId>
-         <version>${versionx.junit.platform}</version>
+         <version>${version.junit.platform}</version>
          <scope>test</scope>
       </dependency>
       <dependency>

--- a/graalvm/core/pom.xml
+++ b/graalvm/core/pom.xml
@@ -75,7 +75,7 @@
       <dependency>
          <groupId>org.junit.platform</groupId>
          <artifactId>junit-platform-launcher</artifactId>
-         <version>${versionx.junit.platform}</version>
+         <version>${version.junit.platform}</version>
          <scope>test</scope>
       </dependency>
    </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -229,16 +229,9 @@
       <jboss.modules.settings.xml.url>file://${infinispan.root}/maven-settings.xml</jboss.modules.settings.xml.url>
 
       <!-- dependencies version -->
-      <versionx.ant-contrib.ant-contrib>${version.ant-contrib}</versionx.ant-contrib.ant-contrib>
       <versionx.com.amazonaws>1.12.621</versionx.com.amazonaws>
       <versionx.org.infinispan.memcached-client>1.2.1</versionx.org.infinispan.memcached-client>
-      <versionx.org.bouncycastle>${version.bouncycastle}</versionx.org.bouncycastle>
       <versionx.com.clearspring.analytics.stream>2.2.0</versionx.com.clearspring.analytics.stream>
-      <versionx.com.fasterxml.jackson.core.jackson-annotations>${version.jackson}</versionx.com.fasterxml.jackson.core.jackson-annotations>
-      <versionx.com.fasterxml.jackson.core.jackson-core>${version.jackson}</versionx.com.fasterxml.jackson.core.jackson-core>
-      <versionx.com.fasterxml.jackson.core.jackson-databind>${version.jackson.databind}</versionx.com.fasterxml.jackson.core.jackson-databind>
-      <versionx.com.fasterxml.jackson.modules.jackson-modules-java8>${version.jackson}</versionx.com.fasterxml.jackson.modules.jackson-modules-java8>
-      <versionx.com.github.ben-manes.caffeine.caffeine>${version.caffeine}</versionx.com.github.ben-manes.caffeine.caffeine>
       <versionx.com.google.errorprone.error_prone_annotations>2.1.3</versionx.com.google.errorprone.error_prone_annotations>
       <versionx.com.google.guava.guava>32.1.1-jre</versionx.com.google.guava.guava>
       <versionx.com.google.testing.compile>0.18</versionx.com.google.testing.compile>
@@ -250,55 +243,19 @@
       <versionx.com.postgresqldatabase.postgresql>42.4.3</versionx.com.postgresqldatabase.postgresql>
       <versionx.com.oracle.ojdbc.ojdbc8>19.3.0.0</versionx.com.oracle.ojdbc.ojdbc8>
       <versionx.com.squareup.protoparser>4.0.3</versionx.com.squareup.protoparser>
-      <versionx.com.thoughtworks.xstream.xstream>${version.xstream}</versionx.com.thoughtworks.xstream.xstream>
       <versionx.commons-dbcp.commons-dbcp>1.4</versionx.commons-dbcp.commons-dbcp>
       <versionx.commons-io.commons-io>2.8.0</versionx.commons-io.commons-io>
       <versionx.commons-logging.commons-logging>1.2</versionx.commons-logging.commons-logging>
-      <versionx.io.fabric8.kubernetes-client>${version.fabric8.kubernetes-client}</versionx.io.fabric8.kubernetes-client>
-      <versionx.io.netty.netty-buffer>${version.netty}</versionx.io.netty.netty-buffer>
-      <versionx.io.netty.netty-codec>${version.netty}</versionx.io.netty.netty-codec>
-      <versionx.io.netty.netty-codec-http>${version.netty}</versionx.io.netty.netty-codec-http>
-      <versionx.io.netty.netty-codec-http2>${version.netty}</versionx.io.netty.netty-codec-http2>
-      <versionx.io.netty.netty-common>${version.netty}</versionx.io.netty.netty-common>
-      <versionx.io.netty.netty-handler>${version.netty}</versionx.io.netty.netty-handler>
-      <versionx.io.netty.netty-resolver>${version.netty}</versionx.io.netty.netty-resolver>
-      <versionx.io.netty.netty-resolver-dns>${version.netty}</versionx.io.netty.netty-resolver-dns>
-      <versionx.io.netty.netty-transport>${version.netty}</versionx.io.netty.netty-transport>
-      <versionx.io.netty.netty-transport-native-epoll>${version.netty}</versionx.io.netty.netty-transport-native-epoll>
-      <versionx.io.netty.netty-transport-native-unix-common>${version.netty}</versionx.io.netty.netty-transport-native-unix-common>
-      <versionx.io.reactivex.rxjava3.rxjava>${version.rxjava}</versionx.io.reactivex.rxjava3.rxjava>
       <versionx.javax.activation.activation>1.1.1</versionx.javax.activation.activation>
       <versionx.javax.annotation.javax.annotation-api>1.3.2</versionx.javax.annotation.javax.annotation-api>
-      <versionx.javax.cache.cache-api>${version.javax.cache}</versionx.javax.cache.cache-api>
-      <versionx.javax.cache.cache-tests>${version.javax.cache}</versionx.javax.cache.cache-tests>
       <versionx.javax.inject.javax.inject>1</versionx.javax.inject.javax.inject>
-      <versionx.junit.junit>${version.junit}</versionx.junit.junit>
-      <versionx.junit.platform>${version.junit.platform}</versionx.junit.platform>
-      <versionx.junit.junit5>${version.junit5}</versionx.junit.junit5>
       <versionx.net.spy.spymemcached>2.12.1</versionx.net.spy.spymemcached>
-      <versionx.org.aesh.aesh>${version.aesh}</versionx.org.aesh.aesh>
-      <versionx.org.aesh.readline>${version.aesh-readline}</versionx.org.aesh.readline>
       <versionx.org.antlr.antlr-runtime>3.5.2</versionx.org.antlr.antlr-runtime>
-      <versionx.org.apache.ant.ant>${version.ant}</versionx.org.apache.ant.ant>
       <versionx.org.apache.avro.avro>1.11.3</versionx.org.apache.avro.avro>
-      <versionx.org.apache.commons.commons-compress>${version.commons.compress}</versionx.org.apache.commons.commons-compress>
       <versionx.org.apache.commons.commons-lang3>3.14.0</versionx.org.apache.commons.commons-lang3>
       <versionx.org.apache.commons.commons-math>2.2</versionx.org.apache.commons.commons-math>
       <versionx.org.apache.directory.server.apacheds>2.0.0-M24</versionx.org.apache.directory.server.apacheds>
       <versionx.org.apache.mina.mina>2.0.22</versionx.org.apache.mina.mina>
-      <versionx.org.apache.logging.log4j.log4j-api>${version.log4j}</versionx.org.apache.logging.log4j.log4j-api>
-      <versionx.org.apache.logging.log4j.log4j-core>${version.log4j}</versionx.org.apache.logging.log4j.log4j-core>
-      <versionx.org.apache.logging.log4j.log4j-slf4j-impl>${version.log4j}</versionx.org.apache.logging.log4j.log4j-slf4j-impl>
-      <versionx.org.apache.logging.log4j.log4j-jul>${version.log4j}</versionx.org.apache.logging.log4j.log4j-jul>
-      <versionx.org.apache.lucene.lucene-analyzers-common>${version.lucene}</versionx.org.apache.lucene.lucene-analyzers-common>
-      <versionx.org.apache.lucene.lucene-core>${version.lucene}</versionx.org.apache.lucene.lucene-core>
-      <versionx.org.apache.lucene.lucene-facet>${version.lucene}</versionx.org.apache.lucene.lucene-facet>
-      <versionx.org.apache.lucene.lucene-grouping>${version.lucene}</versionx.org.apache.lucene.lucene-grouping>
-      <versionx.org.apache.lucene.lucene-join>${version.lucene}</versionx.org.apache.lucene.lucene-join>
-      <versionx.org.apache.lucene.lucene-misc>${version.lucene}</versionx.org.apache.lucene.lucene-misc>
-      <versionx.org.apache.lucene.lucene-queryparser>${version.lucene}</versionx.org.apache.lucene.lucene-queryparser>
-      <versionx.org.apache.maven.maven-core>${version.maven}</versionx.org.apache.maven.maven-core>
-      <versionx.org.apache.maven.maven-plugin-api>${version.maven}</versionx.org.apache.maven.maven-plugin-api>
       <versionx.org.apache.maven.plugin-tools.maven-plugin-annotations>3.6.4</versionx.org.apache.maven.plugin-tools.maven-plugin-annotations>
       <versionx.org.aspectj.aspectjweaver>1.8.1</versionx.org.aspectj.aspectjweaver>
       <versionx.org.assertj.assertj-core>3.24.1</versionx.org.assertj.assertj-core>
@@ -306,87 +263,31 @@
       <versionx.org.codehaus.mojo.versions-maven-plugin>2.7</versionx.org.codehaus.mojo.versions-maven-plugin>
       <versionx.org.codehaus.mojo.xml-maven-plugin>1.0.2</versionx.org.codehaus.mojo.xml-maven-plugin>
       <versionx.org.dom4j.dom4j>2.1.3</versionx.org.dom4j.dom4j>
-      <versionx.org.glassfish.jaxb.jaxb-runtime>${version.glassfish.jaxb}</versionx.org.glassfish.jaxb.jaxb-runtime>
-      <versionx.org.hamcrest.hamcrest-core>${version.hamcrest}</versionx.org.hamcrest.hamcrest-core>
-      <versionx.org.hamcrest.hamcrest-library>${version.hamcrest}</versionx.org.hamcrest.hamcrest-library>
-      <versionx.org.hibernate.hibernate-core>${version.hibernate.core}</versionx.org.hibernate.hibernate-core>
-      <versionx.org.hibernate.search.hibernate-search-backend-lucene>${version.hibernate.search}</versionx.org.hibernate.search.hibernate-search-backend-lucene>
-      <versionx.org.hibernate.search.hibernate-search-mapper-pojo-base>${version.hibernate.search}</versionx.org.hibernate.search.hibernate-search-mapper-pojo-base>
-      <versionx.org.jacoco.org.jacoco.agent>${version.jacoco}</versionx.org.jacoco.org.jacoco.agent>
       <versionx.org.javassist.javassist>3.29.1-GA</versionx.org.javassist.javassist>
       <versionx.org.jboss.arquillian.container.arquillian-weld-embedded>3.0.2.Final</versionx.org.jboss.arquillian.container.arquillian-weld-embedded>
-      <versionx.org.jboss.arquillian.junit.arquillian-junit-container>${version.arquillian}</versionx.org.jboss.arquillian.junit.arquillian-junit-container>
-      <versionx.org.jboss.arquillian.testng.arquillian-testng-container>${version.arquillian}</versionx.org.jboss.arquillian.testng.arquillian-testng-container>
-      <versionx.org.jboss.arquillian.testenricher.arquillian-testenricher-cdi>${version.arquillian}</versionx.org.jboss.arquillian.testenricher.arquillian-testenricher-cdi>
-      <versionx.org.jboss.arquillian.container.arquillian-container-spi>${version.arquillian}</versionx.org.jboss.arquillian.container.arquillian-container-spi>
-      <versionx.org.jboss.byteman.byteman>${version.byteman}</versionx.org.jboss.byteman.byteman>
-      <versionx.org.jboss.byteman.byteman-bmunit>${version.byteman}</versionx.org.jboss.byteman.byteman-bmunit>
-      <versionx.org.jboss.byteman.byteman-install>${version.byteman}</versionx.org.jboss.byteman.byteman-install>
-      <versionx.org.jboss.byteman.byteman-submit>${version.byteman}</versionx.org.jboss.byteman.byteman-submit>
       <versionx.org.jboss.jboss-common-core>2.2.16.GA</versionx.org.jboss.jboss-common-core>
       <versionx.org.jboss.jboss-transaction-spi>8.0.0.Final</versionx.org.jboss.jboss-transaction-spi>
-      <versionx.org.jboss.logging.jboss-logging>${version.jboss.logging}</versionx.org.jboss.logging.jboss-logging>
       <versionx.org.jboss.logging.jboss-logging-processor>2.2.1.Final</versionx.org.jboss.logging.jboss-logging-processor>
-      <versionx.org.jboss.marshalling.jboss-marshalling>${version.jboss.marshalling}</versionx.org.jboss.marshalling.jboss-marshalling>
-      <versionx.org.jboss.marshalling.jboss-marshalling-river>${version.jboss.marshalling}</versionx.org.jboss.marshalling.jboss-marshalling-river>
-      <versionx.org.jboss.naming.jnp-client>${version.jboss.naming}</versionx.org.jboss.naming.jnp-client>
-      <versionx.org.jboss.naming.jnpserver>${version.jboss.naming}</versionx.org.jboss.naming.jnpserver>
-      <versionx.org.jboss.security.jboss-negotiation-extras>${version.jboss.security}</versionx.org.jboss.security.jboss-negotiation-extras>
-      <versionx.org.jboss.shrinkwrap>${version.jboss.shrinkwrap}</versionx.org.jboss.shrinkwrap>
       <versionx.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec>2.0.0.Final</versionx.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec>
       <versionx.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>2.0.0.Final</versionx.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>
       <versionx.org.jboss.spec.jboss-jakartaee-8.0>1.0.1.Final</versionx.org.jboss.spec.jboss-jakartaee-8.0>
       <versionx.org.jboss.threads.jboss-threads>3.5.0.Final</versionx.org.jboss.threads.jboss-threads>
       <versionx.org.jboss.weld.se.weld-se-core>5.1.0.Final</versionx.org.jboss.weld.se.weld-se-core>
-      <versionx.org.jboss.weld.weld-core-impl>${versionx.org.jboss.weld.se.weld-se-core}</versionx.org.jboss.weld.weld-core-impl>
+      <versionx.org.jboss.weld.weld-core-impl>5.1.0.Final</versionx.org.jboss.weld.weld-core-impl>
       <versionx.org.jboss.weld.weld-api>5.0.SP3</versionx.org.jboss.weld.weld-api>
       <versionx.org.jgroups.aws.jgroups-aws>2.0.1.Final</versionx.org.jgroups.aws.jgroups-aws>
       <versionx.org.jgroups.azure.jgroups-azure>2.0.2.Final</versionx.org.jgroups.azure.jgroups-azure>
-      <versionx.org.jgroups.jgroups>${version.jgroups}</versionx.org.jgroups.jgroups>
-      <versionx.org.jgroups.jgroups-raft>${version.jgroups.raft}</versionx.org.jgroups.jgroups-raft>
       <versionx.org.jgroups.kubernetes.jgroups-kubernetes>2.0.1.Final</versionx.org.jgroups.kubernetes.jgroups-kubernetes>
       <versionx.org.jsoup>1.15.3</versionx.org.jsoup>
-      <versionx.org.kohsuke.metainf-services.metainf-services>${version.metainf-services}</versionx.org.kohsuke.metainf-services.metainf-services>
-      <versionx.org.latencyutils.LatencyUtils>${version.latencyutils}</versionx.org.latencyutils.LatencyUtils>
       <versionx.org.mariadb.jdbc>2.7.3</versionx.org.mariadb.jdbc>
-      <versionx.org.mockito.mockito-core>${version.mockito}</versionx.org.mockito.mockito-core>
       <versionx.org.objectweb.howl.howl>1.0.1-1</versionx.org.objectweb.howl.howl>
-      <versionx.org.openjdk.jmh.jmh-core>${version.openjdk.jmh}</versionx.org.openjdk.jmh.jmh-core>
-      <versionx.org.openjdk.jmh.jmh-generator-annprocess>${version.openjdk.jmh}</versionx.org.openjdk.jmh.jmh-generator-annprocess>
-      <versionx.org.openjdk.nashorn>${version.nashorn}</versionx.org.openjdk.nashorn>
       <versionx.org.postgresql>42.4.3</versionx.org.postgresql>
-      <versionx.org.picketlink.picketlink-api>${version.picketlink}</versionx.org.picketlink.picketlink-api>
-      <versionx.org.reactivestreams.reactive-streams>${version.reactivestreams}</versionx.org.reactivestreams.reactive-streams>
-      <versionx.org.rocksdb.rocksdbjni>${version.rocksdb}</versionx.org.rocksdb.rocksdbjni>
-      <versionx.org.springframework.boot.spring-boot-starter>${version.spring.boot}</versionx.org.springframework.boot.spring-boot-starter>
-      <versionx.org.springframework.boot.spring-boot-starter-security>${version.spring.boot}</versionx.org.springframework.boot.spring-boot-starter-security>
-      <versionx.org.springframework.boot.spring-boot-starter-test>${version.spring.boot}</versionx.org.springframework.boot.spring-boot-starter-test>
-      <versionx.org.springframework.boot.spring-boot-starter-web>${version.spring.boot}</versionx.org.springframework.boot.spring-boot-starter-web>
-      <versionx.org.springframework.boot.spring-boot-starter-log4j2>${version.spring.boot}</versionx.org.springframework.boot.spring-boot-starter-log4j2>
-      <versionx.org.springframework.boot.spring-boot-configuration-processor>${version.spring.boot}</versionx.org.springframework.boot.spring-boot-configuration-processor>
-      <versionx.org.springframework.boot.spring-boot-starter-actuator>${version.spring.boot}</versionx.org.springframework.boot.spring-boot-starter-actuator>
-      <versionx.org.springframework.boot.spring-boot-autoconfigure-processor>${version.spring.boot}</versionx.org.springframework.boot.spring-boot-autoconfigure-processor>
-      <versionx.org.springframework.session.spring-session>${version.spring.session}</versionx.org.springframework.session.spring-session>
-      <versionx.org.springframework.spring-beans>${version.spring}</versionx.org.springframework.spring-beans>
-      <versionx.org.springframework.spring-context>${version.spring}</versionx.org.springframework.spring-context>
-      <versionx.org.springframework.spring-context-support>${version.spring}</versionx.org.springframework.spring-context-support>
-      <versionx.org.springframework.spring-core>${version.spring}</versionx.org.springframework.spring-core>
-      <versionx.org.springframework.spring-expression>${version.spring}</versionx.org.springframework.spring-expression>
-      <versionx.org.springframework.spring-jdbc>${version.spring}</versionx.org.springframework.spring-jdbc>
-      <versionx.org.springframework.spring-test>${version.spring}</versionx.org.springframework.spring-test>
-      <versionx.org.springframework.spring-tx>${version.spring}</versionx.org.springframework.spring-tx>
       <versionx.org.testcontainers.testcontainers>1.19.3</versionx.org.testcontainers.testcontainers>
       <versionx.com.github.docker-java>3.3.0</versionx.com.github.docker-java>
-      <versionx.micrometer>${version.micrometer}</versionx.micrometer>
       <versionx.org.testng.testng>6.14.3</versionx.org.testng.testng>
       <versionx.org.twdata.maven.mojo-executor>2.4.0</versionx.org.twdata.maven.mojo-executor>
       <versionx.org.wildfly.common.wildfly-common>1.5.4.Final-format-001</versionx.org.wildfly.common.wildfly-common>
       <versionx.org.wildfly.maven.plugins.licenses-plugin>2.3.0.Final</versionx.org.wildfly.maven.plugins.licenses-plugin>
-      <versionx.org.wildfly.openssl.natives>${version.org.wildfly.openssl.natives}</versionx.org.wildfly.openssl.natives>
-      <versionx.org.wildfly.openssl.wildfly-openssl-linux-x86_64>${version.org.wildfly.openssl.natives.linux_x86_64}</versionx.org.wildfly.openssl.wildfly-openssl-linux-x86_64>
-      <versionx.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>${version.org.wildfly.openssl.natives.macos_x86_64}</versionx.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
-      <versionx.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives.windows_x86_64}</versionx.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-      <versionx.org.wildfly.security.wildfly-elytron>${version.org.wildfly.elytron}</versionx.org.wildfly.security.wildfly-elytron>
       <versionx.org.xerial>3.41.2.2</versionx.org.xerial>
       <versionx.software.amazon.ion.java>1.0.2</versionx.software.amazon.ion.java>
       <versionx.sun.jdk.jconsole>jdk</versionx.sun.jdk.jconsole>
@@ -407,7 +308,7 @@
          <dependency>
             <groupId>ant-contrib</groupId>
             <artifactId>ant-contrib</artifactId>
-            <version>${versionx.ant-contrib.ant-contrib}</version>
+            <version>${version.ant-contrib}</version>
             <scope>test</scope>
          </dependency>
          <dependency>
@@ -433,12 +334,12 @@
          <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15to18</artifactId>
-            <version>${versionx.org.bouncycastle}</version>
+            <version>${version.bouncycastle}</version>
          </dependency>
          <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>${versionx.org.bouncycastle}</version>
+            <version>${version.bouncycastle}</version>
          </dependency>
          <dependency>
             <groupId>com.clearspring.analytics</groupId>
@@ -454,32 +355,32 @@
          <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${versionx.com.fasterxml.jackson.core.jackson-annotations}</version>
+            <version>${version.jackson}</version>
          </dependency>
          <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>${versionx.com.fasterxml.jackson.core.jackson-core}</version>
+            <version>${version.jackson}</version>
          </dependency>
          <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${versionx.com.fasterxml.jackson.core.jackson-databind}</version>
+            <version>${version.jackson}</version>
          </dependency>
          <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jdk8</artifactId>
-            <version>${versionx.com.fasterxml.jackson.modules.jackson-modules-java8}</version>
+            <version>${version.jackson}</version>
          </dependency>
          <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>${versionx.com.fasterxml.jackson.core.jackson-databind}</version>
+            <version>${version.jackson}</version>
          </dependency>
          <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
-            <version>${versionx.com.github.ben-manes.caffeine.caffeine}</version>
+            <version>${version.caffeine}</version>
             <exclusions>
                <exclusion>
                   <groupId>org.checkerframework</groupId>
@@ -560,12 +461,12 @@
          <dependency>
             <groupId>com.thoughtworks.xstream</groupId>
             <artifactId>xstream</artifactId>
-            <version>${versionx.com.thoughtworks.xstream.xstream}</version>
+            <version>${version.xstream}</version>
          </dependency>
          <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>${versionx.org.apache.commons.commons-compress}</version>
+            <version>${version.commons.compress}</version>
          </dependency>
          <dependency>
             <groupId>org.apache.sshd</groupId>
@@ -602,7 +503,7 @@
          <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client</artifactId>
-            <version>${versionx.io.fabric8.kubernetes-client}</version>
+            <version>${version.fabric8.kubernetes-client}</version>
          </dependency>
          <dependency>
             <groupId>io.mashona</groupId>
@@ -690,69 +591,69 @@
          <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-buffer</artifactId>
-            <version>${versionx.io.netty.netty-buffer}</version>
+            <version>${version.netty}</version>
          </dependency>
          <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec</artifactId>
-            <version>${versionx.io.netty.netty-codec}</version>
+            <version>${version.netty}</version>
          </dependency>
          <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http</artifactId>
-            <version>${versionx.io.netty.netty-codec-http}</version>
+            <version>${version.netty}</version>
          </dependency>
          <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http2</artifactId>
-            <version>${versionx.io.netty.netty-codec-http2}</version>
+            <version>${version.netty}</version>
          </dependency>
          <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-common</artifactId>
-            <version>${versionx.io.netty.netty-common}</version>
+            <version>${version.netty}</version>
          </dependency>
          <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
-            <version>${versionx.io.netty.netty-handler}</version>
+            <version>${version.netty}</version>
          </dependency>
          <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-resolver</artifactId>
-            <version>${versionx.io.netty.netty-resolver}</version>
+            <version>${version.netty}</version>
          </dependency>
          <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-resolver-dns</artifactId>
-            <version>${versionx.io.netty.netty-resolver-dns}</version>
+            <version>${version.netty}</version>
          </dependency>
          <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport</artifactId>
-            <version>${versionx.io.netty.netty-transport}</version>
+            <version>${version.netty}</version>
          </dependency>
          <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-epoll</artifactId>
-            <version>${versionx.io.netty.netty-transport-native-epoll}</version>
+            <version>${version.netty}</version>
          </dependency>
          <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-epoll</artifactId>
-            <version>${versionx.io.netty.netty-transport-native-epoll}</version>
+            <version>${version.netty}</version>
             <classifier>linux-x86_64</classifier>
          </dependency>
          <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-epoll</artifactId>
-            <version>${versionx.io.netty.netty-transport-native-epoll}</version>
+            <version>${version.netty}</version>
             <classifier>linux-aarch_64</classifier>
          </dependency>
          <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-unix-common</artifactId>
-            <version>${versionx.io.netty.netty-transport-native-unix-common}</version>
+            <version>${version.netty}</version>
          </dependency>
          <dependency>
             <groupId>io.netty.incubator</groupId>
@@ -774,7 +675,7 @@
          <dependency>
             <groupId>io.reactivex.rxjava3</groupId>
             <artifactId>rxjava</artifactId>
-            <version>${versionx.io.reactivex.rxjava3.rxjava}</version>
+            <version>${version.rxjava}</version>
          </dependency>
          <dependency>
             <groupId>io.lettuce</groupId>
@@ -817,18 +718,18 @@
          <dependency>
             <groupId>javax.cache</groupId>
             <artifactId>cache-api</artifactId>
-            <version>${versionx.javax.cache.cache-api}</version>
+            <version>${version.javax.cache}</version>
          </dependency>
          <dependency>
             <groupId>javax.cache</groupId>
             <artifactId>cache-tests</artifactId>
-            <version>${versionx.javax.cache.cache-tests}</version>
+            <version>${version.javax.cache}</version>
             <scope>test</scope>
          </dependency>
          <dependency>
             <groupId>javax.cache</groupId>
             <artifactId>cache-tests</artifactId>
-            <version>${versionx.javax.cache.cache-tests}</version>
+            <version>${version.javax.cache}</version>
             <scope>test</scope>
             <classifier>tests</classifier>
          </dependency>
@@ -845,25 +746,25 @@
          <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${versionx.junit.junit}</version>
+            <version>${version.junit}</version>
             <scope>test</scope>
          </dependency>
          <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${versionx.junit.junit5}</version>
+            <version>${version.junit5}</version>
             <scope>test</scope>
          </dependency>
          <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${versionx.junit.junit5}</version>
+            <version>${version.junit5}</version>
             <scope>test</scope>
          </dependency>
          <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
-            <version>${versionx.junit.junit5}</version>
+            <version>${version.junit5}</version>
          </dependency>
          <dependency>
             <groupId>org.junit.support</groupId>
@@ -890,12 +791,12 @@
          <dependency>
             <groupId>org.aesh</groupId>
             <artifactId>aesh</artifactId>
-            <version>${versionx.org.aesh.aesh}</version>
+            <version>${version.aesh}</version>
          </dependency>
          <dependency>
             <groupId>org.aesh</groupId>
             <artifactId>readline</artifactId>
-            <version>${versionx.org.aesh.readline}</version>
+            <version>${version.aesh-readline}</version>
          </dependency>
          <dependency>
             <groupId>org.antlr</groupId>
@@ -905,7 +806,7 @@
          <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
-            <version>${versionx.org.apache.ant.ant}</version>
+            <version>${version.ant}</version>
             <scope>provided</scope>
          </dependency>
          <!-- Dependency of org.hibernate:hibernate-search-serialization-avro. Overwrite version to 1.9.1 -->
@@ -947,73 +848,73 @@
          <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>${versionx.org.apache.logging.log4j.log4j-api}</version>
+            <version>${version.log4j}</version>
             <scope>provided</scope>
          </dependency>
          <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>${versionx.org.apache.logging.log4j.log4j-core}</version>
+            <version>${version.log4j}</version>
             <scope>provided</scope>
          </dependency>
          <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>${versionx.org.apache.logging.log4j.log4j-slf4j-impl}</version>
+            <version>${version.log4j}</version>
             <scope>provided</scope>
          </dependency>
          <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-jul</artifactId>
-            <version>${versionx.org.apache.logging.log4j.log4j-jul}</version>
+            <version>${version.log4j}</version>
             <scope>provided</scope>
          </dependency>
          <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-analyzers-common</artifactId>
-            <version>${versionx.org.apache.lucene.lucene-analyzers-common}</version>
+            <version>${version.lucene}</version>
          </dependency>
          <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-core</artifactId>
-            <version>${versionx.org.apache.lucene.lucene-core}</version>
+            <version>${version.lucene}</version>
          </dependency>
          <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-facet</artifactId>
-            <version>${versionx.org.apache.lucene.lucene-facet}</version>
+            <version>${version.lucene}</version>
          </dependency>
          <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-grouping</artifactId>
-            <version>${versionx.org.apache.lucene.lucene-grouping}</version>
+            <version>${version.lucene}</version>
          </dependency>
          <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-join</artifactId>
-            <version>${versionx.org.apache.lucene.lucene-join}</version>
+            <version>${version.lucene}</version>
          </dependency>
          <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-misc</artifactId>
-            <version>${versionx.org.apache.lucene.lucene-misc}</version>
+            <version>${version.lucene}</version>
          </dependency>
          <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-queryparser</artifactId>
-            <version>${versionx.org.apache.lucene.lucene-queryparser}</version>
+            <version>${version.lucene}</version>
          </dependency>
          <!-- Bump maven-core version. Dependency of org.twdata.maven:mojo-executor -->
          <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
-            <version>${versionx.org.apache.maven.maven-core}</version>
+            <version>${version.maven}</version>
             <scope>provided</scope>
          </dependency>
          <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>${versionx.org.apache.maven.maven-plugin-api}</version>
+            <version>${version.maven}</version>
             <scope>provided</scope>
          </dependency>
          <dependency>
@@ -1043,7 +944,7 @@
          <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
-            <version>${versionx.org.glassfish.jaxb.jaxb-runtime}</version>
+            <version>${version.glassfish.jaxb}</version>
          </dependency>
          <dependency>
             <groupId>org.glassfish</groupId>
@@ -1058,44 +959,44 @@
          <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
-            <version>${versionx.org.hamcrest.hamcrest-core}</version>
+            <version>${version.hamcrest}</version>
          </dependency>
          <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
-            <version>${versionx.org.hamcrest.hamcrest-library}</version>
+            <version>${version.hamcrest}</version>
             <scope>test</scope>
          </dependency>
          <dependency>
             <groupId>org.hibernate.orm</groupId>
             <artifactId>hibernate-core</artifactId>
-            <version>${versionx.org.hibernate.hibernate-core}</version>
+            <version>${version.hibernate.core}</version>
          </dependency>
          <dependency>
             <groupId>org.hibernate.orm</groupId>
             <artifactId>hibernate-testing</artifactId>
-            <version>${versionx.org.hibernate.hibernate-core}</version>
+            <version>${version.hibernate.core}</version>
          </dependency>
          <dependency>
             <groupId>org.hibernate.orm</groupId>
             <artifactId>hibernate-jpamodelgen</artifactId>
-            <version>${versionx.org.hibernate.hibernate-core}</version>
+            <version>${version.hibernate.core}</version>
             <scope>test</scope>
          </dependency>
          <dependency>
             <groupId>org.hibernate.search</groupId>
             <artifactId>hibernate-search-backend-lucene</artifactId>
-            <version>${versionx.org.hibernate.search.hibernate-search-backend-lucene}</version>
+            <version>${version.hibernate.search}</version>
          </dependency>
          <dependency>
             <groupId>org.hibernate.search</groupId>
             <artifactId>hibernate-search-mapper-pojo-base</artifactId>
-            <version>${versionx.org.hibernate.search.hibernate-search-mapper-pojo-base}</version>
+            <version>${version.hibernate.search}</version>
          </dependency>
          <dependency>
             <groupId>org.hibernate.search</groupId>
             <artifactId>hibernate-search-v5migrationhelper-engine</artifactId>
-            <version>${versionx.org.hibernate.search.hibernate-search-mapper-pojo-base}</version>
+            <version>${version.hibernate.search}</version>
          </dependency>
          <dependency>
             <groupId>org.hibernate.lucene-jbossmodules</groupId>
@@ -1400,7 +1301,7 @@
          <dependency>
             <groupId>org.jacoco</groupId>
             <artifactId>org.jacoco.agent</artifactId>
-            <version>${versionx.org.jacoco.org.jacoco.agent}</version>
+            <version>${version.jacoco}</version>
             <scope>test</scope>
             <classifier>runtime</classifier>
          </dependency>
@@ -1429,55 +1330,55 @@
          <dependency>
             <groupId>org.jboss.arquillian.junit</groupId>
             <artifactId>arquillian-junit-container</artifactId>
-            <version>${versionx.org.jboss.arquillian.junit.arquillian-junit-container}</version>
+            <version>${version.arquillian}</version>
          </dependency>
          <dependency>
             <groupId>org.jboss.arquillian.testng</groupId>
             <artifactId>arquillian-testng-container</artifactId>
-            <version>${versionx.org.jboss.arquillian.testng.arquillian-testng-container}</version>
+            <version>${version.arquillian}</version>
             <scope>test</scope>
          </dependency>
          <dependency>
             <groupId>org.jboss.arquillian.testenricher</groupId>
             <artifactId>arquillian-testenricher-cdi-jakarta</artifactId>
-            <version>${versionx.org.jboss.arquillian.testenricher.arquillian-testenricher-cdi}</version>
+            <version>${version.arquillian}</version>
             <scope>test</scope>
          </dependency>
          <dependency>
             <groupId>org.jboss.arquillian.container</groupId>
             <artifactId>arquillian-container-spi</artifactId>
-            <version>${versionx.org.jboss.arquillian.container.arquillian-container-spi}</version>
+            <version>${version.arquillian}</version>
             <scope>test</scope>
          </dependency>
          <dependency>
             <groupId>org.jboss.byteman</groupId>
             <artifactId>byteman</artifactId>
-            <version>${versionx.org.jboss.byteman.byteman}</version>
+            <version>${version.byteman}</version>
             <scope>test</scope>
          </dependency>
          <dependency>
             <groupId>org.jboss.byteman</groupId>
             <artifactId>byteman-bmunit</artifactId>
-            <version>${versionx.org.jboss.byteman.byteman-bmunit}</version>
+            <version>${version.byteman}</version>
             <scope>test</scope>
          </dependency>
          <!-- for some reason, without byteman-install and byteman-submit declared here, the hibernate cache module fails to compile... -->
          <dependency>
             <groupId>org.jboss.byteman</groupId>
             <artifactId>byteman-install</artifactId>
-            <version>${versionx.org.jboss.byteman.byteman-install}</version>
+            <version>${version.byteman}</version>
             <scope>test</scope>
          </dependency>
          <dependency>
             <groupId>org.jboss.byteman</groupId>
             <artifactId>byteman-submit</artifactId>
-            <version>${versionx.org.jboss.byteman.byteman-submit}</version>
+            <version>${version.byteman}</version>
             <scope>test</scope>
          </dependency>
          <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
-            <version>${versionx.org.jboss.logging.jboss-logging}</version>
+            <version>${version.jboss.logging}</version>
          </dependency>
          <dependency>
             <groupId>org.jboss.logging</groupId>
@@ -1489,23 +1390,23 @@
          <dependency>
             <groupId>org.jboss.marshalling</groupId>
             <artifactId>jboss-marshalling</artifactId>
-            <version>${versionx.org.jboss.marshalling.jboss-marshalling}</version>
+            <version>${version.jboss.marshalling}</version>
          </dependency>
          <dependency>
             <groupId>org.jboss.marshalling</groupId>
             <artifactId>jboss-marshalling-river</artifactId>
-            <version>${versionx.org.jboss.marshalling.jboss-marshalling-river}</version>
+            <version>${version.jboss.marshalling}</version>
          </dependency>
          <dependency>
             <groupId>org.jboss.naming</groupId>
             <artifactId>jnp-client</artifactId>
-            <version>${versionx.org.jboss.naming.jnp-client}</version>
+            <version>${version.jboss.naming}</version>
             <scope>test</scope>
          </dependency>
          <dependency>
             <groupId>org.jboss.naming</groupId>
             <artifactId>jnpserver</artifactId>
-            <version>${versionx.org.jboss.naming.jnpserver}</version>
+            <version>${version.jboss.naming}</version>
             <scope>test</scope>
          </dependency>
          <dependency>
@@ -1517,12 +1418,12 @@
          <dependency>
             <groupId>org.jboss.security</groupId>
             <artifactId>jboss-negotiation-extras</artifactId>
-            <version>${versionx.org.jboss.security.jboss-negotiation-extras}</version>
+            <version>${version.jboss.security}</version>
          </dependency>
          <dependency>
             <groupId>org.jboss.shrinkwrap</groupId>
             <artifactId>shrinkwrap-impl-base</artifactId>
-            <version>${versionx.org.jboss.shrinkwrap}</version>
+            <version>${version.jboss.shrinkwrap}</version>
          </dependency>
          <dependency>
             <groupId>org.jboss.spec</groupId>
@@ -1575,7 +1476,7 @@
          <dependency>
             <groupId>org.jgroups</groupId>
             <artifactId>jgroups</artifactId>
-            <version>${versionx.org.jgroups.jgroups}</version>
+            <version>${version.jgroups}</version>
             <exclusions>
                <exclusion>
                   <groupId>org.jboss.byteman</groupId>
@@ -1586,7 +1487,7 @@
          <dependency>
             <groupId>org.jgroups</groupId>
             <artifactId>jgroups-raft</artifactId>
-            <version>${versionx.org.jgroups.jgroups-raft}</version>
+            <version>${version.jgroups.raft}</version>
             <exclusions>
                <exclusion>
                   <groupId>*</groupId>
@@ -1618,14 +1519,14 @@
          <dependency>
             <groupId>org.kohsuke.metainf-services</groupId>
             <artifactId>metainf-services</artifactId>
-            <version>${versionx.org.kohsuke.metainf-services.metainf-services}</version>
+            <version>${version.metainf-services}</version>
             <!-- compile-only dependency -->
             <scope>provided</scope>
          </dependency>
          <dependency>
             <groupId>org.latencyutils</groupId>
             <artifactId>LatencyUtils</artifactId>
-            <version>${versionx.org.latencyutils.LatencyUtils}</version>
+            <version>${version.latencyutils}</version>
             <scope>test</scope>
          </dependency>
          <dependency>
@@ -1648,7 +1549,7 @@
          <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>${versionx.org.mockito.mockito-core}</version>
+            <version>${version.mockito}</version>
             <scope>test</scope>
          </dependency>
          <dependency>
@@ -1660,19 +1561,19 @@
          <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-core</artifactId>
-            <version>${versionx.org.openjdk.jmh.jmh-core}</version>
+            <version>${version.openjdk.jmh}</version>
             <scope>test</scope>
          </dependency>
          <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-generator-annprocess</artifactId>
-            <version>${versionx.org.openjdk.jmh.jmh-generator-annprocess}</version>
+            <version>${version.openjdk.jmh}</version>
             <scope>test</scope>
          </dependency>
          <dependency>
             <groupId>org.openjdk.nashorn</groupId>
             <artifactId>nashorn-core</artifactId>
-            <version>${versionx.org.openjdk.nashorn}</version>
+            <version>${version.nashorn}</version>
          </dependency>
          <dependency>
             <groupId>org.postgresql</groupId>
@@ -1683,65 +1584,65 @@
          <dependency>
             <groupId>org.reactivestreams</groupId>
             <artifactId>reactive-streams</artifactId>
-            <version>${versionx.org.reactivestreams.reactive-streams}</version>
+            <version>${version.reactivestreams}</version>
          </dependency>
          <dependency>
             <groupId>org.rocksdb</groupId>
             <artifactId>rocksdbjni</artifactId>
-            <version>${versionx.org.rocksdb.rocksdbjni}</version>
+            <version>${version.rocksdb}</version>
          </dependency>
          <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-beans</artifactId>
-            <version>${versionx.org.springframework.spring-beans}</version>
+            <version>${version.spring}</version>
             <scope>provided</scope>
          </dependency>
          <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
-            <version>${versionx.org.springframework.spring-context}</version>
+            <version>${version.spring}</version>
             <scope>provided</scope>
          </dependency>
          <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context-support</artifactId>
-            <version>${versionx.org.springframework.spring-context-support}</version>
+            <version>${version.spring}</version>
             <scope>test</scope>
          </dependency>
          <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
-            <version>${versionx.org.springframework.spring-core}</version>
+            <version>${version.spring}</version>
             <scope>provided</scope>
          </dependency>
          <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-expression</artifactId>
-            <version>${versionx.org.springframework.spring-expression}</version>
+            <version>${version.spring}</version>
             <scope>provided</scope>
          </dependency>
          <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-jdbc</artifactId>
-            <version>${versionx.org.springframework.spring-jdbc}</version>
+            <version>${version.spring}</version>
             <scope>test</scope>
          </dependency>
          <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
-            <version>${versionx.org.springframework.spring-test}</version>
+            <version>${version.spring}</version>
             <scope>test</scope>
          </dependency>
          <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-tx</artifactId>
-            <version>${versionx.org.springframework.spring-tx}</version>
+            <version>${version.spring}</version>
             <scope>provided</scope>
          </dependency>
          <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
-            <version>${versionx.org.springframework.boot.spring-boot-starter}</version>
+            <version>${version.spring.boot}</version>
             <scope>test</scope>
             <exclusions>
                <exclusion>
@@ -1755,25 +1656,25 @@
          <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-log4j2</artifactId>
-            <version>${versionx.org.springframework.boot.spring-boot-starter-log4j2}</version>
+            <version>${version.spring.boot}</version>
             <scope>test</scope>
          </dependency>
          <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
-            <version>${versionx.org.springframework.boot.spring-boot-starter-security}</version>
+            <version>${version.spring.boot}</version>
             <scope>test</scope>
          </dependency>
          <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
-            <version>${versionx.org.springframework.boot.spring-boot-starter-test}</version>
+            <version>${version.spring.boot}</version>
             <scope>test</scope>
          </dependency>
          <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <version>${versionx.org.springframework.boot.spring-boot-starter-web}</version>
+            <version>${version.spring.boot}</version>
             <scope>test</scope>
          </dependency>
          <dependency>
@@ -1785,31 +1686,31 @@
          <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
-            <version>${versionx.org.springframework.boot.spring-boot-configuration-processor}</version>
+            <version>${version.spring.boot}</version>
             <scope>provided</scope>
          </dependency>
          <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
-            <version>${versionx.org.springframework.boot.spring-boot-starter-actuator}</version>
+            <version>${version.spring.boot}</version>
             <scope>provided</scope>
          </dependency>
          <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-autoconfigure-processor</artifactId>
-            <version>${versionx.org.springframework.boot.spring-boot-autoconfigure-processor}</version>
+            <version>${version.spring.boot}</version>
             <scope>provided</scope>
          </dependency>
          <dependency>
             <groupId>org.springframework.session</groupId>
             <artifactId>spring-session-core</artifactId>
-            <version>${versionx.org.springframework.session.spring-session}</version>
+            <version>${version.spring.session}</version>
             <scope>provided</scope>
          </dependency>
          <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-test</artifactId>
-            <version>${versionx.micrometer}</version>
+            <version>${version.micrometer}</version>
             <scope>test</scope>
          </dependency>
          <dependency>
@@ -1841,17 +1742,17 @@
          <dependency>
             <groupId>org.wildfly.openssl</groupId>
             <artifactId>wildfly-openssl-linux-x86_64</artifactId>
-            <version>${versionx.org.wildfly.openssl.wildfly-openssl-linux-x86_64}</version>
+            <version>${version.org.wildfly.openssl.natives.linux_x86_64}</version>
          </dependency>
          <dependency>
             <groupId>org.wildfly.openssl</groupId>
             <artifactId>wildfly-openssl-macosx-x86_64</artifactId>
-            <version>${versionx.org.wildfly.openssl.wildfly-openssl-macosx-x86_64}</version>
+            <version>${version.org.wildfly.openssl.natives.macos_x86_64}</version>
          </dependency>
          <dependency>
             <groupId>org.wildfly.openssl</groupId>
             <artifactId>wildfly-openssl-windows-x86_64</artifactId>
-            <version>${versionx.org.wildfly.openssl.wildfly-openssl-windows-x86_64}</version>
+            <version>${version.org.wildfly.openssl.natives.windows_x86_64}</version>
          </dependency>
          <!-- transitive dependency! force this version everywhere -->
          <dependency>

--- a/quarkus/integration-tests/server/pom.xml
+++ b/quarkus/integration-tests/server/pom.xml
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-suite</artifactId>
-            <version>${versionx.junit.platform}</version>
+            <version>${version.junit.platform}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/server/testdriver/junit5/pom.xml
+++ b/server/testdriver/junit5/pom.xml
@@ -24,25 +24,25 @@
       <dependency>
          <groupId>org.junit.jupiter</groupId>
          <artifactId>junit-jupiter-api</artifactId>
-         <version>${versionx.junit.junit5}</version>
+         <version>${version.junit5}</version>
          <scope>compile</scope>
       </dependency>
       <dependency>
          <groupId>org.junit.jupiter</groupId>
          <artifactId>junit-jupiter-engine</artifactId>
-         <version>${versionx.junit.junit5}</version>
+         <version>${version.junit5}</version>
          <scope>compile</scope>
       </dependency>
       <dependency>
          <groupId>org.junit.platform</groupId>
          <artifactId>junit-platform-launcher</artifactId>
-         <version>${versionx.junit.platform}</version>
+         <version>${version.junit.platform}</version>
          <scope>compile</scope>
       </dependency>
       <dependency>
          <groupId>org.junit.platform</groupId>
          <artifactId>junit-platform-suite-api</artifactId>
-         <version>${versionx.junit.platform}</version>
+         <version>${version.junit.platform}</version>
          <scope>compile</scope>
       </dependency>
       <dependency>

--- a/server/tests/pom.xml
+++ b/server/tests/pom.xml
@@ -52,7 +52,7 @@
       <dependency>
          <groupId>org.junit.platform</groupId>
          <artifactId>junit-platform-suite</artifactId>
-         <version>${versionx.junit.platform}</version>
+         <version>${version.junit.platform}</version>
          <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-15424

@pruivo I've only removed the `versionx` properties that inherited from another `version.*` property as I believe these are the only properties Dependabot has an issue with.

Let me know if there's an issue with this approach of if you want me to convert all of the remaining `versionx.*` properties.