### PR TITLE
ISPN-15357 Unable to enable rebalancing after cluster scale up

### DIFF
--- a/core/src/main/java/org/infinispan/topology/CacheStatusResponse.java
+++ b/core/src/main/java/org/infinispan/topology/CacheStatusResponse.java
@@ -20,6 +20,9 @@ import org.infinispan.remoting.transport.Address;
 * @since 7.0
 */
 public class CacheStatusResponse implements Serializable {
+
+   private static final CacheStatusResponse EMPTY = new CacheStatusResponse(null, null, null, null, null);
+
    private final CacheJoinInfo cacheJoinInfo;
    private final CacheTopology cacheTopology;
    private final CacheTopology stableTopology;
@@ -33,6 +36,18 @@ public class CacheStatusResponse implements Serializable {
       this.stableTopology = stableTopology;
       this.availabilityMode = availabilityMode;
       this.current = current;
+   }
+
+   public static CacheStatusResponse empty() {
+      return EMPTY;
+   }
+
+   public boolean isEmpty() {
+      return cacheJoinInfo == null
+            && cacheTopology == null
+            && stableTopology == null
+            && availabilityMode == null
+            && current == null;
    }
 
    public CacheJoinInfo getCacheJoinInfo() {

--- a/core/src/main/java/org/infinispan/topology/ClusterTopologyManagerImpl.java
+++ b/core/src/main/java/org/infinispan/topology/ClusterTopologyManagerImpl.java
@@ -24,6 +24,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
@@ -55,6 +56,7 @@ import org.infinispan.factories.annotations.Stop;
 import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
 import org.infinispan.globalstate.GlobalStateManager;
+import org.infinispan.globalstate.GlobalStateProvider;
 import org.infinispan.globalstate.ScopedPersistentState;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.notifications.cachemanagerlistener.CacheManagerNotifier;
@@ -90,7 +92,9 @@ import net.jcip.annotations.GuardedBy;
  * @since 5.2
  */
 @Scope(Scopes.GLOBAL)
-public class ClusterTopologyManagerImpl implements ClusterTopologyManager {
+public class ClusterTopologyManagerImpl implements ClusterTopologyManager, GlobalStateProvider {
+
+   private static final String GLOBAL_REBALANCE_STATE = "global_rebalance";
 
    public static final int INITIAL_CONNECTION_ATTEMPTS = 10;
    public static final int CLUSTER_RECOVERY_ATTEMPTS = 10;
@@ -114,6 +118,7 @@ public class ClusterTopologyManagerImpl implements ClusterTopologyManager {
    @Inject EventLogManager eventLogManager;
    @Inject PersistentUUIDManager persistentUUIDManager;
    @Inject TimeService timeService;
+   @Inject GlobalStateManager globalStateManager;
 
    private TopologyManagementHelper helper;
    private ConditionFuture<ClusterTopologyManagerImpl> joinViewFuture;
@@ -129,9 +134,33 @@ public class ClusterTopologyManagerImpl implements ClusterTopologyManager {
    private AtomicInteger recoveryAttemptCount = new AtomicInteger();
 
    // The global rebalancing status
-   private boolean globalRebalancingEnabled = true;
+   // Initial state is NOT_RECOVERED, changing after reading from the local state or retrieving from the coordinator.
+   private final AtomicReference<GlobalRebalanceStatus> globalRebalancingEnabled = new AtomicReference<>(GlobalRebalanceStatus.NOT_RECOVERED);
 
    private EventLoggerViewListener viewListener;
+
+   private enum GlobalRebalanceStatus {
+      NOT_RECOVERED,
+      ENABLED,
+      DISABLED;
+
+      boolean isEnabled() {
+         return this != DISABLED;
+      }
+
+      static GlobalRebalanceStatus fromBoolean(boolean enabled) {
+         return enabled ? ENABLED : DISABLED;
+      }
+   }
+
+   @Start
+   public void preStart() {
+      // Registration must happen *before* global state start.
+      if (globalStateManager != null) {
+         globalStateManager.registerStateProvider(this);
+      }
+   }
+
 
    @Start
    public void start() {
@@ -144,12 +173,13 @@ public class ClusterTopologyManagerImpl implements ClusterTopologyManager {
       // The listener already missed the initial view
       handleClusterView(false, transport.getViewId());
 
-      globalRebalancingEnabled = join(fetchRebalancingStatusFromCoordinator(INITIAL_CONNECTION_ATTEMPTS));
+      boolean coordinatorRebalance = join(fetchRebalancingStatusFromCoordinator(INITIAL_CONNECTION_ATTEMPTS));
+      globalRebalancingEnabled.set(GlobalRebalanceStatus.fromBoolean(coordinatorRebalance));
    }
 
    private CompletionStage<Boolean> fetchRebalancingStatusFromCoordinator(int attempts) {
       if (transport.isCoordinator()) {
-         return CompletableFutures.completedTrue();
+         return CompletableFuture.completedFuture(isRebalancingEnabled());
       }
       ReplicableCommand command = new RebalanceStatusRequestCommand();
       Address coordinator = transport.getCoordinator();
@@ -311,6 +341,19 @@ public class ClusterTopologyManagerImpl implements ClusterTopologyManager {
       return CompletableFutures.completedNull();
    }
 
+   @Override
+   public void prepareForPersist(ScopedPersistentState globalState) {
+      GlobalRebalanceStatus grs = globalRebalancingEnabled.get();
+      globalState.setProperty(GLOBAL_REBALANCE_STATE, String.valueOf(grs.isEnabled()));
+   }
+
+   @Override
+   public void prepareForRestore(ScopedPersistentState globalState) {
+      String status = globalState.getProperty(GLOBAL_REBALANCE_STATE);
+      GlobalRebalanceStatus grs = GlobalRebalanceStatus.fromBoolean(status == null || Boolean.parseBoolean(status));
+      globalRebalancingEnabled.compareAndExchange(GlobalRebalanceStatus.NOT_RECOVERED, grs);
+   }
+
    private static class CacheStatusResponseCollector extends ValidResponseCollector<CacheStatusResponseCollector> {
       private final Map<String, Map<Address, CacheStatusResponse>> responsesByCache = new HashMap<>();
       private final List<Address> suspectedMembers = new ArrayList<>();
@@ -443,7 +486,8 @@ public class ClusterTopologyManagerImpl implements ClusterTopologyManager {
                   return;
                }
                clusterManagerStatus = ClusterManagerStatus.COORDINATOR;
-               globalRebalancingEnabled = responseCollector.getRebalancingEnabled();
+               GlobalRebalanceStatus grs = GlobalRebalanceStatus.fromBoolean(responseCollector.getRebalancingEnabled());
+               globalRebalancingEnabled.set(grs);
             } finally {
                releaseUpdateLock();
             }
@@ -641,7 +685,7 @@ public class ClusterTopologyManagerImpl implements ClusterTopologyManager {
 
    @Override
    public boolean isRebalancingEnabled() {
-      return globalRebalancingEnabled;
+      return globalRebalancingEnabled.get().isEnabled();
    }
 
    @Override
@@ -672,15 +716,15 @@ public class ClusterTopologyManagerImpl implements ClusterTopologyManager {
    @Override
    public CompletionStage<Void> setRebalancingEnabled(boolean enabled) {
       if (enabled) {
-         if (!globalRebalancingEnabled) {
+         if (!isRebalancingEnabled()) {
             CLUSTER.rebalancingEnabled();
          }
       } else {
-         if (globalRebalancingEnabled) {
+         if (isRebalancingEnabled()) {
             CLUSTER.rebalancingSuspended();
          }
       }
-      globalRebalancingEnabled = enabled;
+      globalRebalancingEnabled.set(GlobalRebalanceStatus.fromBoolean(enabled));
       cacheStatusMap.values().forEach(ClusterCacheStatus::startQueuedRebalance);
       return CompletableFutures.completedNull();
    }

--- a/core/src/test/java/org/infinispan/globalstate/ThreeNodeDistGlobalStateRestartTest.java
+++ b/core/src/test/java/org/infinispan/globalstate/ThreeNodeDistGlobalStateRestartTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.globalstate;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertTrue;
 
@@ -12,6 +13,7 @@ import org.infinispan.factories.GlobalComponentRegistry;
 import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.remoting.transport.jgroups.JGroupsAddress;
 import org.infinispan.test.TestingUtil;
+import org.infinispan.topology.LocalTopologyManager;
 import org.infinispan.topology.PersistentUUID;
 import org.testng.annotations.Test;
 
@@ -50,6 +52,20 @@ public class ThreeNodeDistGlobalStateRestartTest extends AbstractGlobalStateRest
       restartWithoutGracefulShutdown();
    }
 
+   public void testAddMemberAfterRecover() throws Throwable {
+      shutdownAndRestart(-1, false);
+      createStatefulCacheManager(Character.toString('@'), true);
+      waitForClusterToForm(CACHE_NAME);
+
+      // Ensure that the cache contains the right data.
+      // Use the extraneous member to check.
+      int index = getClusterSize();
+      assertEquals(DATA_SIZE, cache(index, CACHE_NAME).size());
+      for (int i = 0; i < DATA_SIZE; i++) {
+         assertEquals(cache(index, CACHE_NAME).get(String.valueOf(i)), String.valueOf(i));
+      }
+   }
+
    public void testDisableRebalanceRestartEnableRebalance() throws Throwable {
       Map<JGroupsAddress, PersistentUUID> addressMappings = createInitialCluster();
       ConsistentHash oldConsistentHash = advancedCache(0, CACHE_NAME).getDistributionManager().getWriteConsistentHash();
@@ -69,7 +85,10 @@ public class ThreeNodeDistGlobalStateRestartTest extends AbstractGlobalStateRest
          cache(i, CACHE_NAME);
       }
 
-      GlobalComponentRegistry.of(manager(0)).getLocalTopologyManager().setRebalancingEnabled(true);
+      LocalTopologyManager ltm = GlobalComponentRegistry.of(manager(0)).getLocalTopologyManager();
+      assertThat(ltm.isRebalancingEnabled()).isFalse();
+
+      ltm.setRebalancingEnabled(true);
 
       // Last missing.
       cache(getClusterSize() - 1, CACHE_NAME);

--- a/core/src/test/java/org/infinispan/topology/AbstractStatefulCluster.java
+++ b/core/src/test/java/org/infinispan/topology/AbstractStatefulCluster.java
@@ -1,0 +1,82 @@
+package org.infinispan.topology;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.infinispan.commons.test.CommonsTestingUtil.tmpDirectory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+import org.infinispan.commons.util.Util;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.test.MultipleCacheManagersTest;
+
+public abstract class AbstractStatefulCluster extends MultipleCacheManagersTest {
+
+   protected int clusterSize = 3;
+   protected String cacheName = "clusterTestCache";
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      Util.recursiveFileRemove(tmpDirectory(this.getClass().getSimpleName()));
+      createStatefulCacheManager(true);
+   }
+
+   protected void createStatefulCacheManager(boolean clear) {
+      for (int i = 0; i < clusterSize; i++) {
+         createStatefulCacheManager(clear, Character.toString('A' + i));
+      }
+   }
+
+   protected void createStatefulCacheManager(boolean clear, String id) {
+      String stateDirectory = tmpDirectory(this.getClass().getSimpleName(), id);
+      if (clear) Util.recursiveFileRemove(stateDirectory);
+
+      GlobalConfigurationBuilder global = GlobalConfigurationBuilder.defaultClusteredBuilder();
+      global.globalState().enable().persistentLocation(stateDirectory);
+
+      EmbeddedCacheManager ecm = addClusterEnabledCacheManager(global, null);
+
+      ConfigurationBuilder builder = createCacheConfig(id);
+      if (builder != null) {
+         ecm.defineConfiguration(cacheName, builder.build());
+      }
+   }
+
+   protected ConfigurationBuilder createCacheConfig(String id) {
+      return null;
+   }
+
+   protected final void assertClusterStateFiles() throws IOException {
+      assertClusterStateFiles(null);
+   }
+
+   protected final void assertClusterStateFiles(String cacheName) throws IOException {
+      for (int i = 0; i < clusterSize; i++) {
+         assertClusterStateFiles(manager(i), cacheName);
+      }
+   }
+
+   protected final void assertClusterStateFiles(EmbeddedCacheManager ecm, String cacheName) throws IOException {
+      String persistentLocation = ecm.getCacheManagerConfiguration().globalState().persistentLocation();
+
+      boolean globalState = false;
+      boolean cacheState = cacheName == null;
+
+      try (Stream<Path> s = Files.list(Path.of(persistentLocation))) {
+         Path[] paths = s.toArray(Path[]::new);
+
+
+         for (Path p : paths) {
+            globalState |= p.endsWith("___global.state");
+            cacheState |= p.endsWith(cacheName + ".state");
+         }
+      }
+
+      assertThat(globalState).as("Global state present for " + ecm.getAddress()).isTrue();
+      assertThat(cacheState).as(cacheName + " state present for " + ecm.getAddress()).isTrue();
+   }
+}

--- a/core/src/test/java/org/infinispan/topology/ClusterTopologyStatefulTest.java
+++ b/core/src/test/java/org/infinispan/topology/ClusterTopologyStatefulTest.java
@@ -1,0 +1,117 @@
+package org.infinispan.topology;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.infinispan.commons.test.CommonsTestingUtil.tmpDirectory;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.infinispan.commons.util.Util;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.TestingUtil;
+import org.testng.annotations.Test;
+
+@Test(testName = "topology.ClusterTopologyStatefulTest", groups = "functional")
+public class ClusterTopologyStatefulTest extends MultipleCacheManagersTest {
+
+   private final int clusterSize = 3;
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      Util.recursiveFileRemove(tmpDirectory(this.getClass().getSimpleName()));
+      createStatefulCacheManager(true);
+   }
+
+   protected void createStatefulCacheManager(boolean clear) {
+      for (int i = 0; i < clusterSize; i++) {
+         createStatefulCacheManager(clear, Character.toString('A' + i));
+      }
+   }
+
+   protected void createStatefulCacheManager(boolean clear, String id) {
+      String stateDirectory = tmpDirectory(this.getClass().getSimpleName(), id);
+      if (clear) Util.recursiveFileRemove(stateDirectory);
+
+      GlobalConfigurationBuilder global = GlobalConfigurationBuilder.defaultClusteredBuilder();
+      global.globalState().enable().persistentLocation(stateDirectory);
+
+      addClusterEnabledCacheManager(global, null);
+   }
+
+   private Condition allNodesHaveRebalanceDisabled() {
+      return () -> Arrays.stream(managers())
+            .map(ecm -> TestingUtil.extractGlobalComponent(manager(0), ClusterTopologyManager.class))
+            .noneMatch(ClusterTopologyManager::isRebalancingEnabled);
+   }
+
+   private Supplier<String> dumpClusterGlobalRebalanceStatus() {
+      return () -> Arrays.stream(managers())
+            .map(ecm -> Map.entry(ecm, TestingUtil.extractGlobalComponent(manager(0), ClusterTopologyManager.class)))
+            .map(entry -> String.format("%s is rebalance enabled? %b", entry.getKey().getAddress(), entry.getValue().isRebalancingEnabled()))
+            .collect(Collectors.joining(System.lineSeparator()));
+   }
+
+   private void disableRebalanceAndShutdown() throws Exception {
+      ClusterTopologyManager ctm = TestingUtil.extractGlobalComponent(manager(0), ClusterTopologyManager.class);
+
+      // Disable rebalance globally.
+      ctm.setRebalancingEnabled(false).toCompletableFuture().get(10, TimeUnit.SECONDS);
+
+      // Assert that eventually the whole cluster has rebalance disabled.
+      eventually(dumpClusterGlobalRebalanceStatus(), allNodesHaveRebalanceDisabled());
+
+      // Shutdown everything. This will generate the state file.
+      TestingUtil.killCacheManagers(this.cacheManagers);
+
+      // Verify all managers have a global state file.
+      for (int i = 0; i < clusterSize; i++) {
+         String persistentLocation = manager(i).getCacheManagerConfiguration().globalState().persistentLocation();
+         try (Stream<Path> s = Files.list(Path.of(persistentLocation))) {
+            assertThat(s.filter(p -> p.endsWith("___global.state"))).isNotEmpty();
+         }
+      }
+      this.cacheManagers.clear();
+   }
+
+   public void testRebalanceAfterRestart() throws Exception {
+      disableRebalanceAndShutdown();
+
+      // Recreate the cluster.
+      createStatefulCacheManager(false);
+
+      // All nodes should start with global rebalance disabled.
+      assertThat(allNodesHaveRebalanceDisabled().isSatisfied())
+            .as(dumpClusterGlobalRebalanceStatus())
+            .isTrue();
+   }
+
+   public void testOnlyCoordinatorKeepsGlobalState() throws Exception {
+      disableRebalanceAndShutdown();
+
+      // Now we create only the coordinator. The coordinator restore with the global state.
+      createStatefulCacheManager(false, "A");
+
+      // Assert the coordinator has restored the state.
+      assertThat(allNodesHaveRebalanceDisabled().isSatisfied())
+            .as(dumpClusterGlobalRebalanceStatus())
+            .isTrue();
+
+      // Now we restore the remaining nodes. Note that they do not keep the global state.
+      // These nodes must recover the rebalance status from the coordinator A.
+      for (int i = 1; i < clusterSize; i++) {
+         createStatefulCacheManager(true, Character.toString('A' + i));
+      }
+
+      // All nodes should start with global rebalance disabled.
+      assertThat(allNodesHaveRebalanceDisabled().isSatisfied())
+            .as(dumpClusterGlobalRebalanceStatus())
+            .isTrue();
+   }
+}

--- a/core/src/test/java/org/infinispan/topology/StatefulShutdownDuringJoinTest.java
+++ b/core/src/test/java/org/infinispan/topology/StatefulShutdownDuringJoinTest.java
@@ -1,0 +1,162 @@
+package org.infinispan.topology;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.infinispan.commons.test.CommonsTestingUtil.tmpDirectory;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+
+import java.nio.file.Paths;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.assertj.core.api.Assertions;
+import org.infinispan.Cache;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.test.Mocks;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.CheckPoint;
+import org.infinispan.test.fwk.CleanupAfterMethod;
+import org.testng.annotations.Test;
+
+@CleanupAfterMethod
+@Test(testName = "topology.StatefulShutdownDuringJoinTest", groups = "functional")
+public class StatefulShutdownDuringJoinTest extends AbstractStatefulCluster {
+
+   {
+      clusterSize = 2;
+   }
+
+   private final int dataSize = 100;
+
+   @Override
+   protected ConfigurationBuilder createCacheConfig(String id) {
+      String stateDirectory = tmpDirectory(this.getClass().getSimpleName(), id);
+      ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false);
+
+      // We want persistence so data survive through restarts.
+      builder.persistence().addSoftIndexFileStore()
+            .dataLocation(Paths.get(stateDirectory, "data").toString())
+            .indexLocation(Paths.get(stateDirectory, "index").toString());
+      return builder;
+   }
+
+   private void shutdownBeforeJoiningComplete() throws Exception {
+      // Causes node A to join.
+      // This would create the cache status and persist the state on shutdown.
+      Cache<Object, Object> c0 = manager(0).getCache(cacheName);
+
+      assertThat(manager(0).isCoordinator()).isTrue();
+
+      // Cache is operating normally.
+      fillData(c0);
+
+      // Checkpoint to intercept the mock invocations during the join.
+      CheckPoint checkPoint = new CheckPoint();
+      ClusterTopologyManager originalCtm = TestingUtil.extractGlobalComponent(manager(0), ClusterTopologyManager.class);
+      ClusterTopologyManager spyCtm = spy(originalCtm);
+      doAnswer(ivk -> {
+         Object o = ivk.callRealMethod();
+         checkPoint.trigger(Mocks.AFTER_INVOCATION);
+         checkPoint.awaitStrict(Mocks.AFTER_RELEASE, 5, TimeUnit.SECONDS);
+         return o;
+      }).when(spyCtm).handleJoin(eq(cacheName), any(), any(), anyInt());
+
+      // We only replace one way. We'll shut down this manager later.
+      TestingUtil.replaceComponent(manager(0), ClusterTopologyManager.class, spyCtm, true);
+
+      // Asynchronous call to wait. This would block until the cache join request finishes.
+      Future<Void> create = fork(() -> waitForClusterToForm(cacheName));
+
+      // Wait until the node join is PROCESSED but not yet REPLIED.
+      checkPoint.awaitStrict(Mocks.AFTER_INVOCATION, 10, TimeUnit.SECONDS);
+
+      // Node B still haven't joined.
+      assertThat(create.isDone()).isFalse();
+
+      // Shutdown everything. This should create the state files.
+      // Since node B haven't joined, the operation will fail on B but succeed on A.
+      c0.shutdown();
+
+      // Kill all the managers to recreate cluster.
+      // Observe that we NEVER released the checkpoint, it times out.
+      // That is, the cache was shutdown before the join response is received, the topology was never updated and only
+      // one of the nodes succeeded writing the state to file.
+      TestingUtil.killCacheManagers(managers());
+      eventually(create::isDone, 10, TimeUnit.SECONDS);
+   }
+
+   public void testRestartStatelessCoordinator() throws Exception {
+      // Shutdown before node B joins node A.
+      // This causes node A to have a state file and node B does not.
+      shutdownBeforeJoiningComplete();
+
+      // All nodes should have a state file.
+      assertClusterStateFiles();
+
+      // But only node A has the state file for the cache.
+      assertClusterStateFiles(manager(0), cacheName);
+      cacheManagers.clear();
+
+      // Now we create the cluster backwards. Node B will be the coordinator.
+      // This will cause the node B, which doesn't have the cache state to be the coordinator.
+      createStatefulCacheManager(false, "B");
+      assertThat(manager(0).isCoordinator()).isTrue();
+
+      // Retrieve cache to create only on node B first.
+      Cache<Object, Object> c1 = manager(0).getCache(cacheName);
+      c1.put("k-0", "v1");
+
+      // We now create node A again. Since it has a persistent state, the join will fail.
+      createStatefulCacheManager(false, "A");
+      Assertions.assertThatThrownBy(() -> waitForClusterToForm(cacheName))
+            .rootCause()
+            .isInstanceOf(CacheJoinException.class)
+            .hasMessageStartingWith("ISPN000408:");
+
+      // Check it is still operational. This is on node B.
+      assertThat(c1.get("k-0")).isEqualTo("v1");
+      assertThat(c1.size()).isOne();
+   }
+
+   public void testRestartStatefulCoordinatorAndStatelessBackup() throws Exception {
+      // Shutdown before node B joins node A.
+      // This causes node A to have a state file and node B does not.
+      shutdownBeforeJoiningComplete();
+
+      // All nodes should have a state file.
+      assertClusterStateFiles();
+
+      // But only node A has the state file for the cache.
+      assertClusterStateFiles(manager(0), cacheName);
+      cacheManagers.clear();
+
+      // First, start the coordinator. This node has a state file for the cache.
+      createStatefulCacheManager(false, "A");
+      assertThat(manager(0).isCoordinator()).isTrue();
+
+      // We now start the backup node, which does not have a state file.
+      createStatefulCacheManager(false, "B");
+      waitForClusterToForm(cacheName);
+
+      // The data still present.
+      // We check with the backup node cache.
+      assertData(manager(1).getCache(cacheName));
+   }
+
+   private void fillData(Cache<Object, Object> cache) {
+      for (int i = 0; i < dataSize; i++) {
+         cache.put("k-" + i, "v-" + i);
+      }
+   }
+
+   private void assertData(Cache<Object, Object> cache) {
+      assertThat(cache.size()).isEqualTo(dataSize);
+      for (int i = 0; i < dataSize; i++) {
+         assertThat(cache.get("k-" + i)).isEqualTo("v-" + i);
+      }
+   }
+}

--- a/server/tests/src/test/java/org/infinispan/server/resilience/GracefulShutdownRestartIT.java
+++ b/server/tests/src/test/java/org/infinispan/server/resilience/GracefulShutdownRestartIT.java
@@ -1,9 +1,9 @@
 package org.infinispan.server.resilience;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.infinispan.server.test.core.Common.assertStatus;
 import static org.infinispan.server.test.core.Common.sync;
 import static org.infinispan.server.test.core.TestSystemPropertyNames.INFINISPAN_TEST_SERVER_CONTAINER_VOLUME_REQUIRED;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.concurrent.TimeUnit;
 
@@ -43,26 +43,57 @@ public class GracefulShutdownRestartIT {
       builder.clustering().cacheMode(CacheMode.DIST_SYNC).persistence().addSingleFileStore().segmented(false);
       RemoteCache<Object, Object> hotRod = SERVER.hotrod().withServerConfiguration(builder).create();
 
-      for (int i = 0; i < 100; i++) {
-         hotRod.put(String.format("k%03d", i), String.format("v%03d", i));
-      }
+      populateCache(hotRod);
 
       RestClientConfigurationBuilder restClientBuilder = new RestClientConfigurationBuilder()
             .socketTimeout(RestClientConfigurationProperties.DEFAULT_SO_TIMEOUT * 60)
             .connectionTimeout(RestClientConfigurationProperties.DEFAULT_CONNECT_TIMEOUT * 60);
       RestClient rest = SERVER.rest().withClientConfiguration(restClientBuilder).get();
-      sync(rest.cluster().stop(), 5, TimeUnit.MINUTES).close();
-      ContainerInfinispanServerDriver serverDriver = (ContainerInfinispanServerDriver) SERVER.getServerDriver();
-      Eventually.eventually(
-            "Cluster did not shutdown within timeout",
-            () -> (!serverDriver.isRunning(0) && !serverDriver.isRunning(1)),
-            serverDriver.getTimeout(), 1, TimeUnit.SECONDS);
+      shutdownAndRestart(rest);
 
-      serverDriver.restartCluster();
+      assertCacheData(hotRod);
+   }
 
-      for (int i = 0; i < 100; i++) {
-         assertEquals(String.format("v%03d", i), hotRod.get(String.format("k%03d", i)));
+   @Test
+   public void testRebalanceAndRestart() {
+      ConfigurationBuilder builder = new ConfigurationBuilder();
+      builder.clustering().cacheMode(CacheMode.DIST_SYNC).persistence().addSoftIndexFileStore();
+      RemoteCache<Object, Object> hotRod = SERVER.hotrod().withServerConfiguration(builder).create();
+
+      populateCache(hotRod);
+
+      // Create the REST client to issue admin commands.
+      RestClientConfigurationBuilder restClientBuilder = new RestClientConfigurationBuilder()
+            .socketTimeout(RestClientConfigurationProperties.DEFAULT_SO_TIMEOUT * 60)
+            .connectionTimeout(RestClientConfigurationProperties.DEFAULT_CONNECT_TIMEOUT * 60);
+      RestClient rest = SERVER.rest().withClientConfiguration(restClientBuilder).get();
+
+      // First, we disable rebalance cluster-wide.
+      assertStatus(204, rest.cacheManager("default").disableRebalancing());
+
+      // We get the cache details to assert it is in fact disabled.
+      try (RestResponse res = sync(rest.cache(hotRod.getName()).details())) {
+         Json body = Json.read(res.body());
+         assertThat(body.at("rebalancing_enabled").asBoolean()).isFalse();
       }
+
+      // Then we execute the graceful shutdown and restart the cluster.
+      shutdownAndRestart(rest);
+
+      // After the restart, rebalance is still disabled.
+      try (RestResponse res = sync(rest.cache(hotRod.getName()).details())) {
+         Json body = Json.read(res.body());
+         assertThat(body.at("rebalancing_enabled").asBoolean()).isFalse();
+      }
+
+      // We enable rebalance again after restart.
+      assertStatus(204, rest.cacheManager("default").enableRebalancing());
+
+      // Assert all nodes back.
+      assertHealthyCluster(rest);
+
+      // All data still available.
+      assertCacheData(hotRod);
    }
 
    @Test
@@ -71,9 +102,7 @@ public class GracefulShutdownRestartIT {
       builder.clustering().cacheMode(CacheMode.DIST_SYNC);
       RemoteCache<Object, Object> hotRod = SERVER.hotrod().withServerConfiguration(builder).create();
 
-      for (int i = 0; i < 100; i++) {
-         hotRod.put(String.format("k%03d", i), String.format("v%03d", i));
-      }
+      populateCache(hotRod);
 
       ContainerInfinispanServerDriver serverDriver = (ContainerInfinispanServerDriver) SERVER.getServerDriver();
 
@@ -106,16 +135,44 @@ public class GracefulShutdownRestartIT {
       serverDriver.restart(1);
 
       // All data still available.
-      for (int i = 0; i < 100; i++) {
-         assertEquals(String.format("v%03d", i), hotRod.get(String.format("k%03d", i)));
-      }
+      assertCacheData(hotRod);
 
       // After the node joining again, it should be healthy.
-      try (RestResponse res = sync(rest.cacheManager("default").health())) {
-         Json body = Json.read(res.body());
-         Json clusterHealth = body.at("cluster_health");
-         assertThat(clusterHealth.at("health_status").asString()).isEqualTo("HEALTHY");
-         assertThat(clusterHealth.at("number_of_nodes").asInteger()).isEqualTo(2);
+      assertHealthyCluster(rest);
+   }
+
+   private void shutdownAndRestart(RestClient rest) {
+      sync(rest.cluster().stop(), 5, TimeUnit.MINUTES).close();
+      ContainerInfinispanServerDriver serverDriver = (ContainerInfinispanServerDriver) SERVER.getServerDriver();
+      Eventually.eventually(
+            "Cluster did not shutdown within timeout",
+            () -> (!serverDriver.isRunning(0) && !serverDriver.isRunning(1)),
+            serverDriver.getTimeout(), 1, TimeUnit.SECONDS);
+
+      serverDriver.restartCluster();
+   }
+
+   private void populateCache(RemoteCache<Object, Object> hotRod) {
+      for (int i = 0; i < 100; i++) {
+         hotRod.put(String.format("k%03d", i), String.format("v%03d", i));
+      }
+   }
+
+   private void assertCacheData(RemoteCache<Object, Object> hotRod) {
+      for (int i = 0; i < 100; i++) {
+         assertThat(hotRod.get(String.format("k%03d", i)))
+               .isEqualTo(String.format("v%03d", i));
+      }
+   }
+
+   private void assertHealthyCluster(RestClient rest) {
+      try (RestResponse response = sync(rest.cacheManager("default").health())) {
+         Json body = Json.read(response.body());
+         assertThat(body.at("cluster_health")).isNotNull();
+
+         Json health = body.at("cluster_health");
+         assertThat(health.at("health_status").asString()).isEqualTo("HEALTHY");
+         assertThat(health.at("number_of_nodes").asInteger()).isEqualTo(2);
       }
    }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-15357

There are a few moving parts here that I can break into smaller PRs if you prefer.

The first thing is persisting the global rebalance status. Previously, we could disable rebalance, but if the complete cluster is shut down, that information is lost, and it would restart with it enabled. It could survive during a rolling upgrade, with nodes retrieving the status from the coordinator. Now, we save the information to the persistent state. The node first reads it from the local state and later retrieves it from the coordinator.

The second part handles the join requests when nodes have a persistent state.

The easy part, which makes more sense to include, is a stateless joiner with a stateful coordinator *before* the cluster is recovered. Currently, the joiner will receive an exception because the cluster is not recovered, which ultimately can cause the node start process to fail. We need to keep that, as operations should only happen after the recovery, but the joiner has no clue when the recovery process is done and when it is safe to join. With the change, the joiner receives a specific status response and delays the join until the coordinator sends a stable topology request. This means the cluster finished the recovery, and the node can join successfully.

The other possibility is a stateless coordinator with a stateful joiner. Originally, that returns an exception to the join request. The current implementation accepts the stateful node joining, but it causes the joiner to clear *all* the storage data. I am still debating if that's ideal. The issues boil down to concurrent membership changes, i.e., concurrently starting a cluster, adding a node during a cache shutdown, etc. Some of these could be avoided, for example, during an update to install the fresh node later, but for others, I am not so sure it can be controlled.

Let me know what you think.