### PR TITLE
ISPN-15432 Make stable topology recovery more robust

### DIFF
--- a/core/src/main/java/org/infinispan/statetransfer/InboundTransferTask.java
+++ b/core/src/main/java/org/infinispan/statetransfer/InboundTransferTask.java
@@ -245,7 +245,7 @@ public class InboundTransferTask {
             if (segments.contains(segmentId)) {
                unfinishedSegments.remove(segmentId);
                if (unfinishedSegments.isEmpty()) {
-                  log.debugf("Finished receiving state for segments %s", segments);
+                  log.debugf("Finished receiving state for %s with segments %s", cacheName, segments);
                   isCompleted = true;
                }
             }

--- a/core/src/test/java/org/infinispan/globalstate/AbstractGlobalStateRestartTest.java
+++ b/core/src/test/java/org/infinispan/globalstate/AbstractGlobalStateRestartTest.java
@@ -80,6 +80,7 @@ public abstract class AbstractGlobalStateRestartTest extends MultipleCacheManage
       ConfigurationBuilder config = new ConfigurationBuilder();
       applyCacheManagerClusteringConfiguration(id, config);
       config.persistence().addSingleFileStore().location(stateDirectory).fetchPersistentState(true);
+      config.clustering().stateTransfer().timeout(90, TimeUnit.SECONDS);
       EmbeddedCacheManager manager = addClusterEnabledCacheManager(global, null);
       manager.defineConfiguration(CACHE_NAME, config.build());
    }


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-15432

I suspect the issue is caused because the tests also invoke `LocalTopologyManager.stableTopologyCompletion` to wait, and that causes the store to be cleared twice. It was cleared once by the internal workings and another time by the test.

I updated it so the method can be invoked without clearing the stores every time.