### PR TITLE
[14.0.x] Properly deprecate EmbeddedCacheManager#getTransport()

### DIFF
--- a/core/src/main/java/org/infinispan/manager/EmbeddedCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/EmbeddedCacheManager.java
@@ -282,6 +282,7 @@ public interface EmbeddedCacheManager extends CacheContainer, Listenable, Closea
    /**
     * @deprecated Since 10.0, please use {@link #getAddress()}, {@link #getMembers()}, {@link #getCoordinator()}
     */
+   @Deprecated(forRemoval = true)
    Transport getTransport();
 
    /**


### PR DESCRIPTION
Though already removed from main without proper notice. 

I am assuming here we don't need a Jira here, but let me know.