### PR TITLE
ISPN-15467 FootprintIT failures

### DIFF
--- a/server/tests/src/test/java/org/infinispan/server/footprint/FootprintIT.java
+++ b/server/tests/src/test/java/org/infinispan/server/footprint/FootprintIT.java
@@ -30,8 +30,8 @@ public class FootprintIT {
    private static final int LOADED_CLASS_COUNT_UPPER_BOUND = 11_200;
    private static final long HEAP_USAGE_LOWER_BOUND = 23_000_000L;
    private static final long HEAP_USAGE_UPPER_BOUND = 25_000_000L;
-   private static final long DISK_USAGE_LOWER_BOUND = 86_000_000L;
-   private static final long DISK_USAGE_UPPER_BOUND = 87_000_000L;
+   private static final long DISK_USAGE_LOWER_BOUND = 86_500_000L;
+   private static final long DISK_USAGE_UPPER_BOUND = 87_500_000L;
    public static final String HEAP_DUMP = "footprint.hprof";
 
    @RegisterExtension


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-15467

Increasing the bound. Comparing the files we traverse in the tests, there is an addition of `micrometer-commons-1.12.2.jar` with size `47343` and `micrometer-observation-1.12.2.jar` with size `71751`. And the `micrometer-core-1.12.2.jar` has size `882586` (1.9.2 was 657113), and `micrometer-registry-prometheus-1.12.2.jar` has `43651` (1.9.2 was 40972).

We have other dependencies, including our code, increasing a few Kb or bytes.