### PR TITLE
ISPN-15494 Near cache with invalidation fails to start in Spring Boot

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/logging/Log.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/logging/Log.java
@@ -420,4 +420,8 @@ public interface Log extends BasicLogger {
    @LogMessage(level = WARN)
    @Message(value = "Client cannot marshall the server's key media type ('%s'). This could cause poor performance.", id = 4116)
    void serverKeyTypeNotRecognized(MediaType serverKeyType);
+
+   @LogMessage(level = WARN)
+   @Message(value = "Cache '%s' with marshaller %s does not handle server storage type '%s'. Configure the cache or default marshaller.", id = 4117)
+   void invalidateNearDefaultMarshallerMismatch(String cacheName, Class<?> clazz, MediaType serverKeyType);
 }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/ClusterNearCacheMarshallingTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/ClusterNearCacheMarshallingTest.java
@@ -3,29 +3,36 @@ package org.infinispan.client.hotrod.near;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
 
+import java.util.stream.Stream;
+
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.configuration.NearCacheMode;
 import org.infinispan.client.hotrod.test.MultiHotRodServersTest;
 import org.infinispan.commons.dataconversion.MediaType;
+import org.infinispan.commons.marshall.JavaSerializationMarshaller;
 import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.commons.marshall.ProtoStreamMarshaller;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.jboss.marshalling.commons.GenericJBossMarshaller;
+import org.infinispan.test.TestingUtil;
 import org.testng.annotations.Test;
 
 @Test(groups = "functional", testName = "client.hotrod.event.ClusteredListenerMarshallerTest")
 public class ClusterNearCacheMarshallingTest extends MultiHotRodServersTest {
 
+   private static final String SERVER_DEFINED_CACHE = "other-cache";
    private Class<? extends Marshaller> marshaller;
    private MediaType storeType;
+   private boolean bloomFilter;
 
    public ClusterNearCacheMarshallingTest() { }
 
-   protected ClusterNearCacheMarshallingTest(Class<? extends Marshaller> marshaller, MediaType storeType) {
+   protected ClusterNearCacheMarshallingTest(Class<? extends Marshaller> marshaller, MediaType storeType, boolean bloomFilter) {
       this.marshaller = marshaller;
       this.storeType = storeType;
+      this.bloomFilter = bloomFilter;
    }
 
    @Override
@@ -35,17 +42,29 @@ public class ClusterNearCacheMarshallingTest extends MultiHotRodServersTest {
       createHotRodServers(2, serverCfg);
 
       waitForClusterToForm();
+
+      org.infinispan.configuration.cache.ConfigurationBuilder cb = new org.infinispan.configuration.cache.ConfigurationBuilder();
+      cb.encoding().key().mediaType(MediaType.APPLICATION_OCTET_STREAM_TYPE);
+      cb.encoding().value().mediaType(MediaType.APPLICATION_OCTET_STREAM_TYPE);
+      TestingUtil.defineConfiguration(manager(0), SERVER_DEFINED_CACHE, cb.build());
    }
 
    @Override
    protected org.infinispan.client.hotrod.configuration.ConfigurationBuilder createHotRodClientConfigurationBuilder(String host, int serverPort) {
       org.infinispan.client.hotrod.configuration.ConfigurationBuilder cb = super.createHotRodClientConfigurationBuilder(host, serverPort);
       if (marshaller != null) cb.marshaller(marshaller);
+      cb.nearCache().mode(NearCacheMode.INVALIDATED).maxEntries(100);
       cb.remoteCache("").nearCacheMode(NearCacheMode.INVALIDATED)
             .nearCacheMaxEntries(2)
-            .nearCacheUseBloomFilter(true);
+            .nearCacheUseBloomFilter(bloomFilter);
       cb.connectionPool().maxActive(1);
       return cb;
+   }
+
+   public void testServerDefinedCache() {
+      RemoteCacheManager cacheManager = client(0);
+      assertThat(cacheManager.getCache(SERVER_DEFINED_CACHE)).isNotNull();
+      assertThat(cacheManager.getCache()).isNotNull();
    }
 
    public void testRemoteWriteOnLocal() {
@@ -71,17 +90,20 @@ public class ClusterNearCacheMarshallingTest extends MultiHotRodServersTest {
 
    @Override
    public Object[] factory() {
-      return new Object[] {
-            new ClusterNearCacheMarshallingTest(null, null),
-            new ClusterNearCacheMarshallingTest(GenericJBossMarshaller.class, MediaType.APPLICATION_JBOSS_MARSHALLING),
-            new ClusterNearCacheMarshallingTest(ProtoStreamMarshaller.class, MediaType.APPLICATION_PROTOSTREAM),
-            new ClusterNearCacheMarshallingTest(ProtoStreamMarshaller.class, null),
-            new ClusterNearCacheMarshallingTest(GenericJBossMarshaller.class, null),
-      };
+      return Stream.of(true, false)
+            .flatMap(bloomFilter -> Stream.of(
+                  new ClusterNearCacheMarshallingTest(null, null, bloomFilter),
+                  new ClusterNearCacheMarshallingTest(GenericJBossMarshaller.class, MediaType.APPLICATION_JBOSS_MARSHALLING, bloomFilter),
+                  new ClusterNearCacheMarshallingTest(ProtoStreamMarshaller.class, MediaType.APPLICATION_PROTOSTREAM, bloomFilter),
+                  new ClusterNearCacheMarshallingTest(ProtoStreamMarshaller.class, null, bloomFilter),
+                  new ClusterNearCacheMarshallingTest(GenericJBossMarshaller.class, null, bloomFilter),
+                  new ClusterNearCacheMarshallingTest(JavaSerializationMarshaller.class, null, bloomFilter)
+            ))
+            .toArray();
    }
 
    @Override
    protected String parameters() {
-      return String.format("(marshaller=%s, mediaType=%s", (marshaller != null ? marshaller.getSimpleName() : "null"), storeType);
+      return String.format("(marshaller=%s, mediaType=%s, bloomFilter=%b", (marshaller != null ? marshaller.getSimpleName() : "null"), storeType, bloomFilter);
    }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-15494

Updated for the invalidated near cache instances. We check if the MANAGER marshaller handles the server type and only then proceed with the usual flow. Either we register the listener and set the data format or the inverse.

If the marshaller is compatible with the server type, we exchange the type information when installing the listener. See, this might hide bugs that bite back during runtime! During runtime, when executing some key-based operation against the server, an exception is thrown because it is not possible to convert between types, failing later instead of during start-up. We also log a warning message.

Note that it would be a similar behavior to before we added #11337.

Internal caches, where the user won't interact directly through HR (resp), should be fine.