### PR TITLE
ISPN-15467 FootprintIT failures

### DIFF
--- a/server/tests/src/test/java/org/infinispan/server/footprint/FootprintIT.java
+++ b/server/tests/src/test/java/org/infinispan/server/footprint/FootprintIT.java
@@ -30,8 +30,8 @@ public class FootprintIT {
    private static final int LOADED_CLASS_COUNT_UPPER_BOUND = 11_200;
    private static final long HEAP_USAGE_LOWER_BOUND = 23_000_000L;
    private static final long HEAP_USAGE_UPPER_BOUND = 25_000_000L;
-   private static final long DISK_USAGE_LOWER_BOUND = 86_500_000L;
-   private static final long DISK_USAGE_UPPER_BOUND = 87_500_000L;
+   private static final long DISK_USAGE_LOWER_BOUND = 87_000_000L;
+   private static final long DISK_USAGE_UPPER_BOUND = 88_000_000L;
    public static final String HEAP_DUMP = "footprint.hprof";
 
    @RegisterExtension


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-15467

The bump was too small. It was fixed on the PR, but when it got merged, it started falling again.
Comparing the PR run and main, the changes seem:

* commons-math3, 3.2 -> 3.6.1, 1692782 -> 2213560
* jmh, 1.23 -> 1.37, 515717 -> 552986
* wildfly-elytron-http-util, 2.2.2.Final -> 2.2.3.Final, 29558 -> 32405

And a few of our modules:

* infinispan-remote-query-client, PR #11695 -> main version,  34006 -> 42489

And some increases on our objectfilter and cli modules.

