### PR TITLE
ISPN-15659 Hot Rod Client RemoteCache#computeAsync() can lose the result of remapping processing when executed concurrently against a new entry

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/RemoteCacheImpl.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/RemoteCacheImpl.java
@@ -343,7 +343,7 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> implements I
             if (oldValue != null) {
                doneStage = replaceWithVersionAsync(key, newValue, version, lifespan, lifespanUnit, maxIdle, maxIdleUnit);
             } else {
-               doneStage = putIfAbsentAsync(key, newValue, lifespan, lifespanUnit, maxIdle, maxIdleUnit)
+               doneStage = withFlags(Flag.FORCE_RETURN_VALUE).putIfAbsentAsync(key, newValue, lifespan, lifespanUnit, maxIdle, maxIdleUnit)
                      .thenApply(Objects::isNull);
             }
          } else {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/RemoteCacheImpl.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/RemoteCacheImpl.java
@@ -343,7 +343,7 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> implements I
             if (oldValue != null) {
                doneStage = replaceWithVersionAsync(key, newValue, version, lifespan, lifespanUnit, maxIdle, maxIdleUnit);
             } else {
-               doneStage = withFlags(Flag.FORCE_RETURN_VALUE).putIfAbsentAsync(key, newValue, lifespan, lifespanUnit, maxIdle, maxIdleUnit)
+               doneStage = putIfAbsentAsync(key, newValue, lifespan, lifespanUnit, maxIdle, maxIdleUnit, Flag.FORCE_RETURN_VALUE)
                      .thenApply(Objects::isNull);
             }
          } else {
@@ -410,9 +410,14 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> implements I
 
    @Override
    public CompletableFuture<V> putIfAbsentAsync(K key, V value, long lifespan, TimeUnit lifespanUnit, long maxIdleTime, TimeUnit maxIdleTimeUnit) {
+      return putIfAbsentAsync(key, value, lifespan, lifespanUnit, maxIdleTime, maxIdleTimeUnit, (Flag[]) null);
+   }
+
+   private CompletableFuture<V> putIfAbsentAsync(K key, V value, long lifespan, TimeUnit lifespanUnit, long maxIdleTime, TimeUnit maxIdleTimeUnit, Flag ... flags) {
       assertRemoteCacheManagerIsStarted();
       PutIfAbsentOperation<V> op = operationsFactory.newPutIfAbsentOperation(key,
             keyToBytes(key), valueToBytes(value), lifespan, lifespanUnit, maxIdleTime, maxIdleTimeUnit, dataFormat);
+      op.header().addFlags(flags);
       return op.execute();
    }
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/HeaderParams.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/HeaderParams.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.infinispan.client.hotrod.DataFormat;
+import org.infinispan.client.hotrod.Flag;
 import org.infinispan.client.hotrod.impl.ClientTopology;
 
 /**
@@ -17,7 +18,7 @@ public class HeaderParams {
    final short opCode;
    final short opRespCode;
    byte[] cacheName;
-   final int flags;
+   int flags;
    final byte txMarker;
    final AtomicReference<ClientTopology> clientTopology;
    final long messageId;
@@ -72,6 +73,16 @@ public class HeaderParams {
 
    public int flags() {
       return flags;
+   }
+
+   public void addFlags(Flag ... flags) {
+      if (flags == null) return;
+
+      for (Flag flag : flags) {
+         if (flag == null) continue;
+
+         this.flags |= flag.getFlagInt();
+      }
    }
 
    public AtomicReference<ClientTopology> getClientTopology() {


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-15659