### PR TITLE
ISPN-14645 Final string commands pending

### DIFF
--- a/documentation/src/main/asciidoc/topics/ref_redis_commands.adoc
+++ b/documentation/src/main/asciidoc/topics/ref_redis_commands.adoc
@@ -100,6 +100,9 @@ The {brandname} RESP endpoint implements the following Redis commands:
 | link:https://redis.io/commands/getrange[GETRANGE]
 |
 
+| link:https://redis.io/commands/getset[GETSET]
+| Deprecated. Use the `SET` command with the appropriate flags.
+
 | link:https://redis.io/commands/hdel[HDEL]
 |
 
@@ -215,6 +218,9 @@ for concurrent operations or failures unless the resp cache is configured to use
 | link:https://redis.io/commands/mset[MSET]
 |
 
+| link:https://redis.io/commands/msetnx[MSETNX]
+|
+
 | link:https://redis.io/commands/multi[MULTI] [[multi_command]]
 | The current implementation has a relaxed isolation level. Redis offers serializable transactions, but {{brandname}}
 provides a read-uncommitted isolation.
@@ -225,11 +231,11 @@ provides a read-uncommitted isolation.
 | link:https://redis.io/commands/pexpiretime[PEXPIRETIME]
 |
 
-| link:https://redis.io/commands/msetnx[MSETNX]
-|
-
 | link:https://redis.io/commands/ping[PING]
 |
+
+| link:https://redis.io/commands/psetex[PSETEX]
+| Deprecated. Utilize `SET` with the appropriate flags.
 
 | link:https://redis.io/commands/psubscribe[PSUBSCRIBE]
 |
@@ -294,6 +300,12 @@ provides a read-uncommitted isolation.
 | link:https://redis.io/commands/set[SET]
 |
 
+| link:https://redis.io/commands/setex[SETEX]
+| Deprecated. Use the `SET` command with the appropriate flags.
+
+| link:https://redis.io/commands/setnx[SETNX]
+| Deprecated. Use the `SET` command with the appropriate flags.
+
 | link:https://redis.io/commands/set[SETRANGE]
 |
 
@@ -332,6 +344,9 @@ provides a read-uncommitted isolation.
 
 | link:https://redis.io/commands/strlen[STRLEN]
 |
+
+| link:https://redis.io/commands/substr[SUBSTR]
+| Deprecated. Use the `GETRANGE` command.
 
 | link:https://redis.io/commands/subscribe[SUBSCRIBE]
 |

--- a/server/resp/src/main/java/org/infinispan/server/resp/Consumers.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/Consumers.java
@@ -75,6 +75,14 @@ public final class Consumers {
    public static final BiConsumer<byte[], ByteBufPool> DELETE_BICONSUMER = (prev, alloc) ->
          ByteBufferUtils.stringToByteBufAscii(":" + (prev == null ? "0" : "1") + CRLF_STRING, alloc);
 
+   public static final BiConsumer<Boolean, ByteBufPool> BOOLEAN_BICONSUMER = (res, alloc) -> {
+      if (res) {
+         LONG_BICONSUMER.accept(1L, alloc);
+      } else {
+         LONG_BICONSUMER.accept(0L, alloc);
+      }
+   };
+
    public static final BiConsumer<SetResponse, ByteBufPool> SET_BICONSUMER = (res, alloc) -> {
       // The set operation has three return options, with a precedence:
       //

--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/Commands.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/Commands.java
@@ -134,6 +134,7 @@ import org.infinispan.server.resp.commands.string.GET;
 import org.infinispan.server.resp.commands.string.GETDEL;
 import org.infinispan.server.resp.commands.string.GETEX;
 import org.infinispan.server.resp.commands.string.GETRANGE;
+import org.infinispan.server.resp.commands.string.GETSET;
 import org.infinispan.server.resp.commands.string.INCR;
 import org.infinispan.server.resp.commands.string.INCRBY;
 import org.infinispan.server.resp.commands.string.INCRBYFLOAT;
@@ -171,7 +172,7 @@ public final class Commands {
       ALL_COMMANDS[4] = new RespCommand[]{new ECHO(), new EXISTS(), new EXPIRE(), new EXPIREAT(), new EXPIRETIME(), new EXEC()};
       ALL_COMMANDS[5] = new RespCommand[]{new FLUSHDB(), new FLUSHALL()};
       // GET should always be first here
-      ALL_COMMANDS[6] = new RespCommand[]{new GET(), new GETDEL(), new GETEX(), new GETRANGE()};
+      ALL_COMMANDS[6] = new RespCommand[]{new GET(), new GETDEL(), new GETEX(), new GETRANGE(), new GETSET()};
       ALL_COMMANDS[7] = new RespCommand[]{new HELLO(), new HGET(), new HSET(), new HLEN(), new HEXISTS(), new HDEL(), new HMGET(), new HKEYS(), new HVALS(), new HSCAN(), new HGETALL(), new HMSET(), new HINCRBY(), new HINCRBYFLOAT(), new HRANDFIELD()};
       ALL_COMMANDS[8] = new RespCommand[]{new INCR(), new INCRBY(), new INCRBYFLOAT(), new INFO()};
       ALL_COMMANDS[10] = new RespCommand[]{new KEYS()};

--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/Commands.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/Commands.java
@@ -148,6 +148,7 @@ import org.infinispan.server.resp.commands.string.SETNX;
 import org.infinispan.server.resp.commands.string.SETRANGE;
 import org.infinispan.server.resp.commands.string.STRALGO;
 import org.infinispan.server.resp.commands.string.STRLEN;
+import org.infinispan.server.resp.commands.string.SUBSTR;
 import org.infinispan.server.resp.commands.tx.DISCARD;
 import org.infinispan.server.resp.commands.tx.EXEC;
 import org.infinispan.server.resp.commands.tx.MULTI;
@@ -183,7 +184,7 @@ public final class Commands {
       ALL_COMMANDS[16] = new RespCommand[]{new QUIT()};
       ALL_COMMANDS[17] = new RespCommand[]{new RPUSH(), new RPUSHX(), new RPOP(), new RESET(), new READWRITE(), new READONLY(), new RPOPLPUSH(), new RENAME(), new RENAMENX() };
       // SET should always be first here
-      ALL_COMMANDS[18] = new RespCommand[]{new SET(), new SETEX(), new SETNX(), new SMEMBERS(), new SISMEMBER(), new SADD(), new STRLEN(), new SMOVE(), new SCARD(), new SINTER(), new SINTERSTORE(), new SINTERCARD(), new SUNION(), new SUNIONSTORE(), new SPOP(), new SRANDMEMBER(), new SREM(), new SDIFF(), new SDIFFSTORE(), new SUBSCRIBE(), new SELECT(), new STRALGO(), new SCAN(), new SSCAN(), new SETRANGE(), new SORT(), new SORT_RO()};
+      ALL_COMMANDS[18] = new RespCommand[]{new SET(), new SETEX(), new SETNX(), new SMEMBERS(), new SISMEMBER(), new SADD(), new STRLEN(), new SMOVE(), new SCARD(), new SINTER(), new SINTERSTORE(), new SINTERCARD(), new SUNION(), new SUNIONSTORE(), new SPOP(), new SRANDMEMBER(), new SREM(), new SDIFF(), new SDIFFSTORE(), new SUBSCRIBE(), new SELECT(), new STRALGO(), new SCAN(), new SSCAN(), new SETRANGE(), new SORT(), new SORT_RO(), new SUBSTR()};
       ALL_COMMANDS[19] = new RespCommand[]{new TTL(), new TYPE(), new TOUCH(), new TIME() };
       ALL_COMMANDS[20] = new RespCommand[]{new UNSUBSCRIBE(), new UNWATCH()};
       ALL_COMMANDS[22] = new RespCommand[]{new WATCH()};

--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/Commands.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/Commands.java
@@ -141,6 +141,7 @@ import org.infinispan.server.resp.commands.string.INCRBYFLOAT;
 import org.infinispan.server.resp.commands.string.MGET;
 import org.infinispan.server.resp.commands.string.MSET;
 import org.infinispan.server.resp.commands.string.MSETNX;
+import org.infinispan.server.resp.commands.string.PSETEX;
 import org.infinispan.server.resp.commands.string.SET;
 import org.infinispan.server.resp.commands.string.SETEX;
 import org.infinispan.server.resp.commands.string.SETNX;
@@ -178,7 +179,7 @@ public final class Commands {
       ALL_COMMANDS[10] = new RespCommand[]{new KEYS()};
       ALL_COMMANDS[11] = new RespCommand[]{new LINDEX(), new LINSERT(), new LPUSH(), new LPUSHX(), new LPOP(), new LRANGE(), new LLEN(), new LPOS(), new LREM(), new LSET(), new LTRIM(), new LMOVE(), new LMPOP() };
       ALL_COMMANDS[12] = new RespCommand[]{new MGET(), new MSET(), new MSETNX(), new MULTI(), new MODULE(), new MEMORY()};
-      ALL_COMMANDS[15] = new RespCommand[]{new PUBLISH(), new PING(), new PSUBSCRIBE(), new PUNSUBSCRIBE(), new PTTL(), new PEXPIRETIME(), new PERSIST(), new PFADD()};
+      ALL_COMMANDS[15] = new RespCommand[]{new PUBLISH(), new PING(), new PSUBSCRIBE(), new PUNSUBSCRIBE(), new PTTL(), new PEXPIRETIME(), new PERSIST(), new PFADD(), new PSETEX()};
       ALL_COMMANDS[16] = new RespCommand[]{new QUIT()};
       ALL_COMMANDS[17] = new RespCommand[]{new RPUSH(), new RPUSHX(), new RPOP(), new RESET(), new READWRITE(), new READONLY(), new RPOPLPUSH(), new RENAME(), new RENAMENX() };
       // SET should always be first here

--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/Commands.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/Commands.java
@@ -141,6 +141,7 @@ import org.infinispan.server.resp.commands.string.MGET;
 import org.infinispan.server.resp.commands.string.MSET;
 import org.infinispan.server.resp.commands.string.MSETNX;
 import org.infinispan.server.resp.commands.string.SET;
+import org.infinispan.server.resp.commands.string.SETEX;
 import org.infinispan.server.resp.commands.string.SETRANGE;
 import org.infinispan.server.resp.commands.string.STRALGO;
 import org.infinispan.server.resp.commands.string.STRLEN;
@@ -179,7 +180,7 @@ public final class Commands {
       ALL_COMMANDS[16] = new RespCommand[]{new QUIT()};
       ALL_COMMANDS[17] = new RespCommand[]{new RPUSH(), new RPUSHX(), new RPOP(), new RESET(), new READWRITE(), new READONLY(), new RPOPLPUSH(), new RENAME(), new RENAMENX() };
       // SET should always be first here
-      ALL_COMMANDS[18] = new RespCommand[]{new SET(), new SMEMBERS(), new SISMEMBER(), new SADD(), new STRLEN(), new SMOVE(), new SCARD(), new SINTER(), new SINTERSTORE(), new SINTERCARD(), new SUNION(), new SUNIONSTORE(), new SPOP(), new SRANDMEMBER(), new SREM(), new SDIFF(), new SDIFFSTORE(), new SUBSCRIBE(), new SELECT(), new STRALGO(), new SCAN(), new SSCAN(), new SETRANGE(), new SORT(), new SORT_RO()};
+      ALL_COMMANDS[18] = new RespCommand[]{new SET(), new SETEX(), new SMEMBERS(), new SISMEMBER(), new SADD(), new STRLEN(), new SMOVE(), new SCARD(), new SINTER(), new SINTERSTORE(), new SINTERCARD(), new SUNION(), new SUNIONSTORE(), new SPOP(), new SRANDMEMBER(), new SREM(), new SDIFF(), new SDIFFSTORE(), new SUBSCRIBE(), new SELECT(), new STRALGO(), new SCAN(), new SSCAN(), new SETRANGE(), new SORT(), new SORT_RO()};
       ALL_COMMANDS[19] = new RespCommand[]{new TTL(), new TYPE(), new TOUCH(), new TIME() };
       ALL_COMMANDS[20] = new RespCommand[]{new UNSUBSCRIBE(), new UNWATCH()};
       ALL_COMMANDS[22] = new RespCommand[]{new WATCH()};

--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/Commands.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/Commands.java
@@ -142,6 +142,7 @@ import org.infinispan.server.resp.commands.string.MSET;
 import org.infinispan.server.resp.commands.string.MSETNX;
 import org.infinispan.server.resp.commands.string.SET;
 import org.infinispan.server.resp.commands.string.SETEX;
+import org.infinispan.server.resp.commands.string.SETNX;
 import org.infinispan.server.resp.commands.string.SETRANGE;
 import org.infinispan.server.resp.commands.string.STRALGO;
 import org.infinispan.server.resp.commands.string.STRLEN;
@@ -180,7 +181,7 @@ public final class Commands {
       ALL_COMMANDS[16] = new RespCommand[]{new QUIT()};
       ALL_COMMANDS[17] = new RespCommand[]{new RPUSH(), new RPUSHX(), new RPOP(), new RESET(), new READWRITE(), new READONLY(), new RPOPLPUSH(), new RENAME(), new RENAMENX() };
       // SET should always be first here
-      ALL_COMMANDS[18] = new RespCommand[]{new SET(), new SETEX(), new SMEMBERS(), new SISMEMBER(), new SADD(), new STRLEN(), new SMOVE(), new SCARD(), new SINTER(), new SINTERSTORE(), new SINTERCARD(), new SUNION(), new SUNIONSTORE(), new SPOP(), new SRANDMEMBER(), new SREM(), new SDIFF(), new SDIFFSTORE(), new SUBSCRIBE(), new SELECT(), new STRALGO(), new SCAN(), new SSCAN(), new SETRANGE(), new SORT(), new SORT_RO()};
+      ALL_COMMANDS[18] = new RespCommand[]{new SET(), new SETEX(), new SETNX(), new SMEMBERS(), new SISMEMBER(), new SADD(), new STRLEN(), new SMOVE(), new SCARD(), new SINTER(), new SINTERSTORE(), new SINTERCARD(), new SUNION(), new SUNIONSTORE(), new SPOP(), new SRANDMEMBER(), new SREM(), new SDIFF(), new SDIFFSTORE(), new SUBSCRIBE(), new SELECT(), new STRALGO(), new SCAN(), new SSCAN(), new SETRANGE(), new SORT(), new SORT_RO()};
       ALL_COMMANDS[19] = new RespCommand[]{new TTL(), new TYPE(), new TOUCH(), new TIME() };
       ALL_COMMANDS[20] = new RespCommand[]{new UNSUBSCRIBE(), new UNWATCH()};
       ALL_COMMANDS[22] = new RespCommand[]{new WATCH()};

--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/string/GETRANGE.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/string/GETRANGE.java
@@ -48,6 +48,8 @@ public class GETRANGE extends RespCommand implements Resp3Command {
    }
 
    private byte[] subrange(byte[] arr, int begin, int end) {
+      if (arr == null) return Util.EMPTY_BYTE_ARRAY;
+
       // Deal with negative
       if (begin < 0) {
          begin = Math.max(0, arr.length + begin);

--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/string/GETSET.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/string/GETSET.java
@@ -1,0 +1,35 @@
+package org.infinispan.server.resp.commands.string;
+
+import static org.infinispan.server.resp.operation.SetOperation.GET_BYTES;
+
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
+import org.infinispan.server.resp.Resp3Handler;
+import org.infinispan.server.resp.RespRequestHandler;
+
+import io.netty.channel.ChannelHandlerContext;
+
+/**
+ * `<code>GETSET key value</code>` command.
+ * <p>
+ * This command is deprecated. The alternative is `<code>SET key value GET</code>`.
+ * </p>
+ * @since 15.0
+ * @author José Bolina
+ * @see SET
+ * @see <a href="https://redis.io/commands/getset/">Redis documentation</a>.
+ */
+public class GETSET extends SET {
+
+   public GETSET() {
+      super(3, 1, 1, 1);
+   }
+
+   @Override
+   public CompletionStage<RespRequestHandler> perform(Resp3Handler handler, ChannelHandlerContext ctx, List<byte[]> arguments) {
+      byte[] key = arguments.get(0);
+      byte[] value = arguments.get(1);
+      return super.perform(handler, ctx, List.of(key, value, GET_BYTES));
+   }
+}

--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/string/PSETEX.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/string/PSETEX.java
@@ -1,0 +1,37 @@
+package org.infinispan.server.resp.commands.string;
+
+import static org.infinispan.server.resp.operation.RespExpiration.PX_BYTES;
+
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
+import org.infinispan.server.resp.Resp3Handler;
+import org.infinispan.server.resp.RespRequestHandler;
+
+import io.netty.channel.ChannelHandlerContext;
+
+/**
+ * `<code>PSETEX key milliseconds value</code>` command.
+ * <p>
+ * This command is deprecated. The alternative is `<code>SET key value PX milliseconds</code>`.
+ * </p>
+ *
+ * @since 15.0
+ * @author José Bolina
+ * @see SET
+ * @see <a href="https://redis.io/commands/psetex/">Redis documentation</a>.
+ */
+public class PSETEX extends SET {
+
+   public PSETEX() {
+      super(4, 1, 1, 1);
+   }
+
+   @Override
+   public CompletionStage<RespRequestHandler> perform(Resp3Handler handler, ChannelHandlerContext ctx, List<byte[]> arguments) {
+      byte[] key = arguments.get(0);
+      byte[] milliseconds = arguments.get(1);
+      byte[] value = arguments.get(2);
+      return super.perform(handler, ctx, List.of(key, value, PX_BYTES, milliseconds));
+   }
+}

--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/string/SET.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/string/SET.java
@@ -18,7 +18,11 @@ import io.netty.channel.ChannelHandlerContext;
  */
 public class SET extends RespCommand implements Resp3Command {
    public SET() {
-      super(-3, 1, 1, 1);
+      this(-3, 1, 1, 1);
+   }
+
+   protected SET(int arity, int firstKeyPos, int lastKeyPos, int steps) {
+      super(arity, firstKeyPos, lastKeyPos, steps);
    }
 
    @Override
@@ -27,7 +31,7 @@ public class SET extends RespCommand implements Resp3Command {
                                                       List<byte[]> arguments) {
       if (arguments.size() != 2) {
          return handler
-               .stageToReturn(SetOperation.performOperation(handler.cache(), arguments, handler.respServer().getTimeService()), ctx,
+               .stageToReturn(SetOperation.performOperation(handler.cache(), arguments, handler.respServer().getTimeService(), getName()), ctx,
                      Consumers.SET_BICONSUMER);
       }
       return handler.stageToReturn(

--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/string/SETEX.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/string/SETEX.java
@@ -1,0 +1,36 @@
+package org.infinispan.server.resp.commands.string;
+
+import static org.infinispan.server.resp.operation.RespExpiration.EX_BYTES;
+
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
+import org.infinispan.server.resp.Resp3Handler;
+import org.infinispan.server.resp.RespRequestHandler;
+
+import io.netty.channel.ChannelHandlerContext;
+
+/**
+ * `<code>SETEX key seconds value</code>` command.
+ * <p>
+ * As of Redis 2.6.2, this command is deprecated. Applications should utilize `<code>SET key value EX seconds</code>`.
+ * </p>
+ *
+ * @since 15.0
+ * @author José Bolina
+ * @see <a href="https://redis.io/commands/setex/">Redis documentation</a>.
+ */
+public class SETEX extends SET {
+
+   public SETEX() {
+      super(4, 1, 1, 1);
+   }
+
+   @Override
+   public CompletionStage<RespRequestHandler> perform(Resp3Handler handler, ChannelHandlerContext ctx, List<byte[]> arguments) {
+      byte[] key = arguments.get(0);
+      byte[] seconds = arguments.get(1);
+      byte[] value = arguments.get(2);
+      return super.perform(handler, ctx, List.of(key, value, EX_BYTES, seconds));
+   }
+}

--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/string/SETNX.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/string/SETNX.java
@@ -1,0 +1,44 @@
+package org.infinispan.server.resp.commands.string;
+
+import static org.infinispan.server.resp.operation.SetOperation.NX_BYTES;
+
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
+import org.infinispan.server.resp.Consumers;
+import org.infinispan.server.resp.Resp3Handler;
+import org.infinispan.server.resp.RespCommand;
+import org.infinispan.server.resp.RespRequestHandler;
+import org.infinispan.server.resp.commands.Resp3Command;
+import org.infinispan.server.resp.operation.SetOperation;
+import org.infinispan.server.resp.response.SetResponse;
+
+import io.netty.channel.ChannelHandlerContext;
+
+/**
+ * `<code>SETNX key value</code>` command.
+ * <p>
+ * This command is deprecated. The alternative is `<code>SET key value NX</code>`.
+ * </p>
+ *
+ * @since 15.0
+ * @author José Bolina
+ * @see SET
+ * @see <a href="https://redis.io/commands/setnx/">Redis documentation</a>.
+ */
+public class SETNX extends RespCommand implements Resp3Command {
+
+   public SETNX() {
+      super(3, 1, 1, 1);
+   }
+
+   @Override
+   public CompletionStage<RespRequestHandler> perform(Resp3Handler handler, ChannelHandlerContext ctx, List<byte[]> arguments) {
+      byte[] key = arguments.get(0);
+      byte[] value = arguments.get(1);
+
+      // Despite the recommended command to replace, the return of SETNX is a boolean instead of an OK.
+      CompletionStage<SetResponse> cs = SetOperation.performOperation(handler.cache(), List.of(key, value, NX_BYTES), handler.respServer().getTimeService(), getName());
+      return handler.stageToReturn(cs, ctx, (res, alloc) -> Consumers.BOOLEAN_BICONSUMER.accept(res.isSuccess(), alloc));
+   }
+}

--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/string/SUBSTR.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/string/SUBSTR.java
@@ -1,0 +1,14 @@
+package org.infinispan.server.resp.commands.string;
+
+/**
+ * `<code>SUBSTR key start end</code>` command.
+ * <p>
+ * This command is deprecated. The recommended alternative is `<code>GETRANGE key start end</code>`.
+ * </p>
+ *
+ * @since 15.0
+ * @author José Bolina
+ * @see GETRANGE
+ * @see <a href="https://redis.io/commands/substr/">Redis documentation</a>.
+ */
+public class SUBSTR extends GETRANGE { }

--- a/server/resp/src/main/java/org/infinispan/server/resp/operation/RespExpiration.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/operation/RespExpiration.java
@@ -33,6 +33,7 @@ public enum RespExpiration {
    };
 
    public static final byte[] EX_BYTES = "EX".getBytes(StandardCharsets.US_ASCII);
+   public static final byte[] PX_BYTES = "PX".getBytes(StandardCharsets.US_ASCII);
    public static final byte[] EXAT_BYTES = "EXAT".getBytes(StandardCharsets.US_ASCII);
    public static final byte[] PXAT_BYTES = "PXAT".getBytes(StandardCharsets.US_ASCII);
 

--- a/server/resp/src/main/java/org/infinispan/server/resp/operation/RespExpiration.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/operation/RespExpiration.java
@@ -32,6 +32,7 @@ public enum RespExpiration {
       }
    };
 
+   public static final byte[] EX_BYTES = "EX".getBytes(StandardCharsets.US_ASCII);
    public static final byte[] EXAT_BYTES = "EXAT".getBytes(StandardCharsets.US_ASCII);
    public static final byte[] PXAT_BYTES = "PXAT".getBytes(StandardCharsets.US_ASCII);
 

--- a/server/resp/src/main/java/org/infinispan/server/resp/operation/SetOperation.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/operation/SetOperation.java
@@ -17,7 +17,7 @@ import org.infinispan.util.concurrent.CompletionStages;
 public class SetOperation {
 
    private static final byte[] GET_BYTES = "GET".getBytes(StandardCharsets.US_ASCII);
-   private static final byte[] NX_BYTES = "NX".getBytes(StandardCharsets.US_ASCII);
+   public static final byte[] NX_BYTES = "NX".getBytes(StandardCharsets.US_ASCII);
    private static final byte[] XX_BYTES = "XX".getBytes(StandardCharsets.US_ASCII);
    private static final byte[] KEEP_TTL_BYTES = "KEEPTTL".getBytes(StandardCharsets.US_ASCII);
    private static final CompletionStage<SetResponse> MISSING_ARGUMENTS = CompletableFuture.failedFuture(new IllegalStateException("Missing arguments"));

--- a/server/resp/src/main/java/org/infinispan/server/resp/operation/SetOperation.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/operation/SetOperation.java
@@ -16,7 +16,7 @@ import org.infinispan.util.concurrent.CompletionStages;
 
 public class SetOperation {
 
-   private static final byte[] GET_BYTES = "GET".getBytes(StandardCharsets.US_ASCII);
+   public static final byte[] GET_BYTES = "GET".getBytes(StandardCharsets.US_ASCII);
    public static final byte[] NX_BYTES = "NX".getBytes(StandardCharsets.US_ASCII);
    private static final byte[] XX_BYTES = "XX".getBytes(StandardCharsets.US_ASCII);
    private static final byte[] KEEP_TTL_BYTES = "KEEPTTL".getBytes(StandardCharsets.US_ASCII);

--- a/server/resp/src/test/java/org/infinispan/server/resp/StringCommandsTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/StringCommandsTest.java
@@ -549,11 +549,24 @@ public class StringCommandsTest extends SingleNodeRespBaseTest {
       assertThat(redis.get("key")).isEqualTo("another");
    }
 
+   @Test
    public void testGetsetCounter() {
       RedisCommands<String, String> redis = redisConnection.sync();
 
       assertThat(redis.incr("counter")).isEqualTo(1);
       assertThat(redis.getset("counter", "0")).isEqualTo("1");
       assertThat(redis.get("counter")).isEqualTo("0");
+   }
+
+   @Test
+   public void testPsetex() {
+      RedisCommands<String, String> redis = redisConnection.sync();
+
+      assertThat(redis.psetex("key", 1000, "value")).isEqualTo("OK");
+      assertThat(redis.pttl("key")).isEqualTo(1000);
+
+      ((ControlledTimeService) timeService).advance(1001);
+      assertThat(redis.get("key")).isNull();
+
    }
 }

--- a/server/resp/src/test/java/org/infinispan/server/resp/StringCommandsTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/StringCommandsTest.java
@@ -512,4 +512,21 @@ public class StringCommandsTest extends SingleNodeRespBaseTest {
       results = redis.mget("k4", "k5", "k6");
       assertThat(results).containsExactlyElementsOf(expected);
    }
+
+   @Test
+   public void testSetex() {
+      RedisCommands<String, String> redis = redisConnection.sync();
+
+      assertThatThrownBy(() -> redis.setex("key", -30, "value"))
+            .isInstanceOf(RedisCommandExecutionException.class)
+            .hasMessage("ERR invalid expire time in 'SETEX' command");
+
+      assertThat(redisConnection.isOpen()).isTrue();
+
+      assertThat(redis.setex("key", 1, "value")).isEqualTo("OK");
+      assertThat(redis.ttl("key")).isEqualTo(1);
+
+      ((ControlledTimeService) timeService).advance(2_000);
+      assertThat(redis.get("key")).isNull();
+   }
 }

--- a/server/resp/src/test/java/org/infinispan/server/resp/StringCommandsTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/StringCommandsTest.java
@@ -369,6 +369,8 @@ public class StringCommandsTest extends SingleNodeRespBaseTest {
       assertThat(redis.getrange(key, 0, 0)).isEqualTo("");
       // End before beginning
       assertThat(redis.getrange(key, 3, 2)).isEqualTo("");
+      // Non-existent entry
+      assertThat(redis.getrange("something", 0, 10)).isEqualTo("");
    }
 
    @Test

--- a/server/resp/src/test/java/org/infinispan/server/resp/StringCommandsTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/StringCommandsTest.java
@@ -539,4 +539,21 @@ public class StringCommandsTest extends SingleNodeRespBaseTest {
 
       assertThat(redis.get("key")).isEqualTo("value");
    }
+
+   @Test
+   public void testGetset() {
+      RedisCommands<String, String> redis = redisConnection.sync();
+
+      assertThat(redis.getset("key", "value")).isNull();
+      assertThat(redis.getset("key", "another")).isEqualTo("value");
+      assertThat(redis.get("key")).isEqualTo("another");
+   }
+
+   public void testGetsetCounter() {
+      RedisCommands<String, String> redis = redisConnection.sync();
+
+      assertThat(redis.incr("counter")).isEqualTo(1);
+      assertThat(redis.getset("counter", "0")).isEqualTo("1");
+      assertThat(redis.get("counter")).isEqualTo("0");
+   }
 }

--- a/server/resp/src/test/java/org/infinispan/server/resp/StringCommandsTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/StringCommandsTest.java
@@ -529,4 +529,14 @@ public class StringCommandsTest extends SingleNodeRespBaseTest {
       ((ControlledTimeService) timeService).advance(2_000);
       assertThat(redis.get("key")).isNull();
    }
+
+   @Test
+   public void testSetnx() {
+      RedisCommands<String, String> redis = redisConnection.sync();
+
+      assertThat(redis.setnx("key", "value")).isTrue();
+      assertThat(redis.setnx("key", "another-value")).isFalse();
+
+      assertThat(redis.get("key")).isEqualTo("value");
+   }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-14656
https://issues.redhat.com/browse/ISPN-14657
https://issues.redhat.com/browse/ISPN-14651
https://issues.redhat.com/browse/ISPN-14655
https://issues.redhat.com/browse/ISPN-14660

This should close https://issues.redhat.com/browse/ISPN-14645.

Also, the `SUBSTR` is not covered in tests. Lettuce doesn't even have that command. Looking at the command documentation, they use `GETRANGE` instead of `SUBSTR` to show the examples.

