### PR TITLE
ISPN-15701 JGroups: add option for non-blocking TCP and a new default…

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/parsing/Parser.java
+++ b/core/src/main/java/org/infinispan/configuration/parsing/Parser.java
@@ -1420,6 +1420,7 @@ public class Parser extends CacheParser {
          holder.addJGroupsStack(BuiltinJGroupsChannelConfigurator.EC2(reader.getProperties()));
          holder.addJGroupsStack(BuiltinJGroupsChannelConfigurator.GOOGLE(reader.getProperties()));
          holder.addJGroupsStack(BuiltinJGroupsChannelConfigurator.AZURE(reader.getProperties()));
+         holder.addJGroupsStack(BuiltinJGroupsChannelConfigurator.TUNNEL(reader.getProperties()));
       }
    }
 }

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/BuiltinJGroupsChannelConfigurator.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/BuiltinJGroupsChannelConfigurator.java
@@ -40,6 +40,10 @@ public class BuiltinJGroupsChannelConfigurator extends FileJGroupsChannelConfigu
       return loadBuiltIn("azure", "default-configs/default-jgroups-azure.xml", properties);
    }
 
+   public static BuiltinJGroupsChannelConfigurator TUNNEL(Properties properties) {
+      return loadBuiltIn("tunnel", "default-configs/default-jgroups-tunnel.xml", properties);
+   }
+
    private static BuiltinJGroupsChannelConfigurator loadBuiltIn(String name, String path, Properties properties) {
       try (InputStream xml = FileLookupFactory.newInstance().lookupFileStrict(path, BuiltinJGroupsChannelConfigurator.class.getClassLoader())) {
          return new BuiltinJGroupsChannelConfigurator(name, path, xml, properties);

--- a/core/src/main/resources/default-configs/default-jgroups-azure.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-azure.xml
@@ -4,7 +4,7 @@
 -->
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.2.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.3.xsd">
    <!-- jgroups.tcp.address is deprecated and will be removed, see ISPN-11867 -->
    <TCP bind_addr="${jgroups.bind.address,jgroups.tcp.address:SITE_LOCAL}"
         bind_port="${jgroups.bind.port,jgroups.tcp.port:7800}"
@@ -15,6 +15,7 @@
         linger="${jgroups.tcp.linger:-1}"
         bundler_type="${jgroups.bundler.type:transfer-queue}"
         bundler.max_size="${jgroups.bundler.max_size:64000}"
+        non_blocking_sends="${jgroups.non_blocking_sends:false}"
 
         thread_pool.min_threads="${jgroups.thread_pool.min_threads:0}"
         thread_pool.max_threads="${jgroups.thread_pool.max_threads:200}"

--- a/core/src/main/resources/default-configs/default-jgroups-ec2.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-ec2.xml
@@ -4,7 +4,7 @@
 -->
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.2.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.3.xsd">
    <!-- jgroups.tcp.address is deprecated and will be removed, see ISPN-11867 -->
    <TCP bind_addr="${jgroups.bind.address,jgroups.tcp.address:SITE_LOCAL}"
         bind_port="${jgroups.bind.port,jgroups.tcp.port:7800}"
@@ -15,6 +15,7 @@
         linger="${jgroups.tcp.linger:-1}"
         bundler_type="${jgroups.bundler.type:transfer-queue}"
         bundler.max_size="${jgroups.bundler.max_size:64000}"
+        non_blocking_sends="${jgroups.non_blocking_sends:false}"
 
         thread_pool.min_threads="${jgroups.thread_pool.min_threads:0}"
         thread_pool.max_threads="${jgroups.thread_pool.max_threads:200}"

--- a/core/src/main/resources/default-configs/default-jgroups-google.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-google.xml
@@ -4,7 +4,7 @@
 -->
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.2.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.3.xsd">
 
    <!-- jgroups.tcp.address is deprecated and will be removed, see ISPN-11867 -->
    <TCP bind_addr="${jgroups.bind.address,jgroups.tcp.address:SITE_LOCAL}"
@@ -16,6 +16,7 @@
         linger="${jgroups.tcp.linger:-1}"
         bundler_type="${jgroups.bundler.type:transfer-queue}"
         bundler.max_size="${jgroups.bundler.max_size:64000}"
+        non_blocking_sends="${jgroups.non_blocking_sends:false}"
 
         thread_pool.min_threads="${jgroups.thread_pool.min_threads:0}"
         thread_pool.max_threads="${jgroups.thread_pool.max_threads:200}"

--- a/core/src/main/resources/default-configs/default-jgroups-kubernetes.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-kubernetes.xml
@@ -4,7 +4,7 @@
 -->
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.2.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.3.xsd">
 
    <!-- jgroups.tcp.address is deprecated and will be removed, see ISPN-11867 -->
    <TCP bind_addr="${jgroups.bind.address,jgroups.tcp.address:SITE_LOCAL}"
@@ -18,6 +18,7 @@
         port_range="0"
         bundler_type="${jgroups.bundler.type:transfer-queue}"
         bundler.max_size="${jgroups.bundler.max_size:64000}"
+        non_blocking_sends="${jgroups.non_blocking_sends:false}"
 
         thread_pool.min_threads="${jgroups.thread_pool.min_threads:0}"
         thread_pool.max_threads="${jgroups.thread_pool.max_threads:200}"

--- a/core/src/main/resources/default-configs/default-jgroups-tcp.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-tcp.xml
@@ -1,6 +1,6 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.2.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.3.xsd">
    <!-- jgroups.tcp.address is deprecated and will be removed, see ISPN-11867 -->
    <TCP bind_addr="${jgroups.bind.address,jgroups.tcp.address:SITE_LOCAL}"
         bind_port="${jgroups.bind.port,jgroups.tcp.port:7800}"
@@ -11,6 +11,7 @@
         linger="${jgroups.tcp.linger:-1}"
         bundler_type="${jgroups.bundler.type:transfer-queue}"
         bundler.max_size="${jgroups.bundler.max_size:64000}"
+        non_blocking_sends="${jgroups.non_blocking_sends:false}"
 
         thread_pool.min_threads="${jgroups.thread_pool.min_threads:0}"
         thread_pool.max_threads="${jgroups.thread_pool.max_threads:200}"

--- a/core/src/main/resources/default-configs/default-jgroups-tunnel.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-tunnel.xml
@@ -1,35 +1,33 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.3.xsd">
-   <!-- jgroups.udp.address is deprecated and will be removed, see ISPN-11867 -->
-   <UDP bind_addr="${jgroups.bind.address,jgroups.udp.address:SITE_LOCAL}"
-        bind_port="${jgroups.bind.port,jgroups.udp.port:0}"
-        mcast_addr="${jgroups.mcast_addr:239.6.7.8}"
-        mcast_port="${jgroups.mcast_port:46655}"
-        tos="0"
-        ucast_send_buf_size="1m"
-        mcast_send_buf_size="1m"
-        ucast_recv_buf_size="20m"
-        mcast_recv_buf_size="25m"
-        ip_ttl="${jgroups.ip_ttl:2}"
-        thread_naming_pattern="pl"
-        diag.enabled="${jgroups.diag.enabled:false}"
-        bundler_type="${jgroups.bundler.type:transfer-queue}"
-        bundler.max_size="${jgroups.bundler.max_size:64000}"
+   <TUNNEL bind_addr="${jgroups.tunnel.address,jgroups.bind.address:SITE_LOCAL}"
+           bind_port="${jgroups.tunnel.port,jgroups.bind.port:0}"
+           diag.enabled="${jgroups.diag.enabled:false}"
 
-        thread_pool.min_threads="${jgroups.thread_pool.min_threads:0}"
-        thread_pool.max_threads="${jgroups.thread_pool.max_threads:200}"
-        thread_pool.keep_alive_time="60000"
+           thread_naming_pattern="pl"
+           linger="${jgroups.tcp.linger:-1}"
+           bundler_type="${jgroups.bundler.type:transfer-queue}"
+           bundler.max_size="${jgroups.bundler.max_size:64000}"
+           non_blocking_sends="${jgroups.non_blocking_sends:false}"
 
-        thread_pool.thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
-        use_virtual_threads="${jgroups.thread.virtual,org.infinispan.threads.virtual:false}"
+           thread_pool.min_threads="${jgroups.thread_pool.min_threads:0}"
+           thread_pool.max_threads="${jgroups.thread_pool.max_threads:200}"
+           thread_pool.keep_alive_time="60000"
+           thread_pool.thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
+
+           use_virtual_threads="${jgroups.thread.virtual,org.infinispan.threads.virtual:false}"
+
+           gossip_router_hosts="${jgroups.tunnel.hosts}"
+           heartbeat_interval="${jgroups.tunnel.heartbeat.interval:10000}"
+           heartbeat_timeout="${jgroups.tunnel.heartbeat.timeout:30000}"
    />
    <RED/>
    <PING num_discovery_runs="3"/>
    <MERGE3 min_interval="10000"
            max_interval="30000"
    />
-   <FD_SOCK2 offset="${jgroups.fd.port-offset:50000}"/>
+   <!-- FD_SOCK2 removed: TUNNEL is used in firewalled environment so FD_SOCK* won't work. -->
    <FD_ALL3/>
    <VERIFY_SUSPECT2 timeout="1000"/>
    <pbcast.NAKACK2 xmit_interval="100"

--- a/core/src/main/resources/schema/infinispan-config-15.0.xsd
+++ b/core/src/main/resources/schema/infinispan-config-15.0.xsd
@@ -5,7 +5,7 @@
            xmlns:jgroups="urn:org:jgroups"
            xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
-  <xs:import namespace="urn:org:jgroups" schemaLocation="http://www.jgroups.org/schema/jgroups-5.2.xsd"/>
+  <xs:import namespace="urn:org:jgroups" schemaLocation="http://www.jgroups.org/schema/jgroups-5.3.xsd"/>
 
   <xs:element name="infinispan" type="tns:infinispan">
     <xs:annotation>

--- a/core/src/test/java/org/infinispan/configuration/ConfigurationUnitTest.java
+++ b/core/src/test/java/org/infinispan/configuration/ConfigurationUnitTest.java
@@ -459,7 +459,7 @@ public class ConfigurationUnitTest extends AbstractInfinispanTest {
       Map<String, String> entities = new HashMap<>();
 
       public TestResolver() {
-         entities.put("urn:org:jgroups", "jgroups-5.2.xsd");
+         entities.put("urn:org:jgroups", "jgroups-5.3.xsd");
          entities.put("urn:jgroups:relay:1.0", "relay.xsd");
          entities.put("fork", "fork-stacks.xsd");
       }

--- a/core/src/test/resources/configs/all/15.0.xml
+++ b/core/src/test/resources/configs/all/15.0.xml
@@ -1,7 +1,7 @@
 <infinispan
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:infinispan:config:15.0 https://infinispan.org/schemas/infinispan-config-15.0.xsd
-                          urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.2.xsd"
+                          urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.3.xsd"
       xmlns="urn:infinispan:config:15.0"
       xmlns:ispn="urn:infinispan:config:15.0">
    <jgroups transport="org.infinispan.remoting.transport.jgroups.JGroupsTransport">

--- a/core/src/test/resources/configs/config-with-jgroups-stack.xml
+++ b/core/src/test/resources/configs/config-with-jgroups-stack.xml
@@ -2,7 +2,7 @@
 <infinispan
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:infinispan:config:${infinispan.core.schema.version} https://infinispan.org/schemas/infinispan-config-${infinispan.core.schema.version}.xsd
-                          urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.2.xsd"
+                          urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.3.xsd"
       xmlns="urn:infinispan:config:${infinispan.core.schema.version}">
    <jgroups>
       <!-- Inline definition -->

--- a/core/src/test/resources/configs/xsite/bridge.xml
+++ b/core/src/test/resources/configs/xsite/bridge.xml
@@ -1,6 +1,6 @@
 <config xmlns="urn:org:jgroups"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.2.xsd">
+      xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.3.xsd">
 
     <TCP bind_addr="127.0.0.1"
          recv_buf_size="20000000"

--- a/core/src/test/resources/configs/xsite/xsite-inline-test.xml
+++ b/core/src/test/resources/configs/xsite/xsite-inline-test.xml
@@ -2,7 +2,7 @@
 <infinispan
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="urn:infinispan:config:${infinispan.core.schema.version} https://infinispan.org/schemas/infinispan-config:${infinispan.core.schema.version}
-                            urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.2.xsd"
+                            urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.3.xsd"
         xmlns="urn:infinispan:config:${infinispan.core.schema.version}">
    <jgroups>
       <stack name="bridge">

--- a/core/src/test/resources/stacks/broken-tcp.xml
+++ b/core/src/test/resources/stacks/broken-tcp.xml
@@ -1,6 +1,6 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.2.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.3.xsd">
    <TCP
          bind_addr="${jgroups.bind.address,jgroups.tcp.address:127.0.0.1}"
          bind_port="${jgroups.bind.port,jgroups.tcp.port:7800}"

--- a/core/src/test/resources/stacks/tcp.xml
+++ b/core/src/test/resources/stacks/tcp.xml
@@ -1,6 +1,6 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.2.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.3.xsd">
    <!-- Disable the regular thread pool queue for tests so we can set a lower min_threads -->
    <TCP_NIO2
          bind_addr="${jgroups.bind.address,jgroups.tcp.address:127.0.0.1}"

--- a/core/src/test/resources/stacks/tcp_mping/tcp1.xml
+++ b/core/src/test/resources/stacks/tcp_mping/tcp1.xml
@@ -1,6 +1,6 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.2.xsd" >
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.3.xsd" >
    <TCP bind_addr="${jgroups.bind.address,jgroups.tcp.address:127.0.0.1}"
         bind_port="7800"
         port_range="30"

--- a/core/src/test/resources/stacks/tcp_mping/tcp2.xml
+++ b/core/src/test/resources/stacks/tcp_mping/tcp2.xml
@@ -1,6 +1,6 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.2.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.3.xsd">
    <TCP bind_addr="${jgroups.bind.address,jgroups.tcp.address:127.0.0.1}"
         bind_port="7800"
         port_range="30"

--- a/core/src/test/resources/stacks/udp.xml
+++ b/core/src/test/resources/stacks/udp.xml
@@ -1,6 +1,6 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.2.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.3.xsd">
    <UDP
          bind_addr="${jgroups.bind.address,jgroups.udp.address:SITE_LOCAL}"
          bind_port="${jgroups.bind.port,jgroups.udp.port:0}"

--- a/documentation/src/main/asciidoc/topics/attributes/community-attributes.adoc
+++ b/documentation/src/main/asciidoc/topics/attributes/community-attributes.adoc
@@ -128,7 +128,7 @@
 
 //JGroups
 :jgroups_docs: http://www.jgroups.org/manual4/index.html
-:jgroups_schema: http://www.jgroups.org/schema/jgroups-5.2.xsd
+:jgroups_schema: http://www.jgroups.org/schema/jgroups-5.3.xsd
 :jgroups_extras: https://github.com/jgroups-extras
 
 //Code tutorials

--- a/documentation/src/main/asciidoc/topics/ref_jgroups_default.adoc
+++ b/documentation/src/main/asciidoc/topics/ref_jgroups_default.adoc
@@ -38,6 +38,13 @@ endif::remote_caches[]
 |`azure`
 |Uses TCP for transport and `AZURE_PING` for discovery. Suitable for Microsoft Azure nodes where UDP multicast is not available. Requires additional dependencies.
 
+|`default-jgroups-tunnel.xml`
+|`tunnel`
+|Uses `TUNNEL` for transport.
+Suitable for environments where the {brandname} is behind a firewall and direct connection between {brandname} nodes is impossible.
+It requires an external and accessible service (http://jgroups.org/manual5/index.html#TUNNEL_Advanced[Gossip Router]) to redirect the traffic.
+It requires `jgroups.tunnel.hosts` property to be set in the format `host1[port],host2[port],...` with the Gossip Router(s) hosts and ports.
+
 |===
 
 [role="_additional-resources"]

--- a/graalvm/core/src/main/java/org/infinispan/graalvm/NativeMetadataProvider.java
+++ b/graalvm/core/src/main/java/org/infinispan/graalvm/NativeMetadataProvider.java
@@ -53,6 +53,7 @@ public class NativeMetadataProvider implements org.infinispan.commons.graalvm.Na
          "default-configs/default-jgroups-ec2\\.xml",
          "default-configs/default-jgroups-google\\.xml",
          "default-configs/default-jgroups-azure\\.xml",
+         "default-configs/default-jgroups-tunnel\\.xml",
          ClassConfigurator.MAGIC_NUMBER_FILE,
          ClassConfigurator.PROTOCOL_ID_FILE,
          Version.VERSION_FILE

--- a/hibernate/cache-commons/src/test/resources/2lc-test-tcp.xml
+++ b/hibernate/cache-commons/src/test/resources/2lc-test-tcp.xml
@@ -6,7 +6,7 @@
   -->
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.2.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.3.xsd">
    <TCP bind_addr="${jgroups.bind.address,jgroups.tcp.address:127.0.0.1}"
         bind_port="7800"
         diag.enabled="false"

--- a/quarkus/integration-tests/embedded/src/main/resources/stacks/broken-tcp.xml
+++ b/quarkus/integration-tests/embedded/src/main/resources/stacks/broken-tcp.xml
@@ -1,6 +1,6 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.2.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.3.xsd">
    <TCP
          bind_addr="${jgroups.bind.address,jgroups.tcp.address:127.0.0.1}"
          bind_port="${jgroups.bind.port,jgroups.tcp.port:7800}"

--- a/quarkus/integration-tests/embedded/src/main/resources/stacks/tcp.xml
+++ b/quarkus/integration-tests/embedded/src/main/resources/stacks/tcp.xml
@@ -1,6 +1,6 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.2.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.3.xsd">
    <!-- Disable the regular thread pool queue for tests so we can set a lower min_threads -->
    <TCP_NIO2
          bind_addr="${jgroups.bind.address,jgroups.tcp.address:127.0.0.1}"

--- a/quarkus/integration-tests/embedded/src/main/resources/stacks/tcp_mping/tcp1.xml
+++ b/quarkus/integration-tests/embedded/src/main/resources/stacks/tcp_mping/tcp1.xml
@@ -1,6 +1,6 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.2.xsd" >
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.3.xsd" >
    <TCP bind_addr="${jgroups.bind.address,jgroups.tcp.address:127.0.0.1}"
         bind_port="7800"
         port_range="30"

--- a/quarkus/integration-tests/embedded/src/main/resources/stacks/tcp_mping/tcp2.xml
+++ b/quarkus/integration-tests/embedded/src/main/resources/stacks/tcp_mping/tcp2.xml
@@ -1,6 +1,6 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.2.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.3.xsd">
    <TCP bind_addr="${jgroups.bind.address,jgroups.tcp.address:127.0.0.1}"
         bind_port="7800"
         port_range="30"

--- a/quarkus/integration-tests/embedded/src/main/resources/stacks/udp.xml
+++ b/quarkus/integration-tests/embedded/src/main/resources/stacks/udp.xml
@@ -1,6 +1,6 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.2.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.3.xsd">
    <UDP
          bind_addr="${jgroups.bind.address,jgroups.udp.address:SITE_LOCAL}"
          bind_port="${jgroups.bind.port,jgroups.udp.port:0}"

--- a/server/runtime/src/main/server/server/conf/infinispan-dev-mode.xml
+++ b/server/runtime/src/main/server/server/conf/infinispan-dev-mode.xml
@@ -2,7 +2,7 @@
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:infinispan:config:15.0 https://infinispan.org/schemas/infinispan-config-15.0.xsd
                             urn:infinispan:server:15.0 https://infinispan.org/schemas/infinispan-server-15.0.xsd
-                            urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.2.xsd"
+                            urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.3.xsd"
       xmlns="urn:infinispan:config:15.0"
       xmlns:ispn="urn:infinispan:config:15.0"
       xmlns:server="urn:infinispan:server:15.0">

--- a/server/runtime/src/main/server/server/conf/infinispan-xsite.xml
+++ b/server/runtime/src/main/server/server/conf/infinispan-xsite.xml
@@ -2,7 +2,7 @@
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:infinispan:config:15.0 https://infinispan.org/schemas/infinispan-config-15.0.xsd
                             urn:infinispan:server:15.0 https://infinispan.org/schemas/infinispan-server-15.0.xsd
-                            urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.2.xsd"
+                            urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.3.xsd"
       xmlns="urn:infinispan:config:15.0"
       xmlns:ispn="urn:infinispan:config:15.0"
       xmlns:server="urn:infinispan:server:15.0">

--- a/server/testdriver/junit5/src/test/resources/jgroups/xsite-stacks.xml
+++ b/server/testdriver/junit5/src/test/resources/jgroups/xsite-stacks.xml
@@ -1,6 +1,6 @@
 <jgroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="urn:infinispan:config:15.0 https://infinispan.org/schemas/infinispan-config-fragment-15.0.xsd
-                             urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.2.xsd"
+                             urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.3.xsd"
          xmlns="urn:infinispan:config:15.0"
          xmlns:ispn="urn:infinispan:config:15.0">
    <stack name="global" extends="tcp">

--- a/server/tests/src/test/resources/configuration/jgroups/authz-stacks.xml
+++ b/server/tests/src/test/resources/configuration/jgroups/authz-stacks.xml
@@ -1,6 +1,6 @@
 <jgroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="urn:infinispan:config:15.0 https://infinispan.org/schemas/infinispan-config-fragment-15.0.xsd
-            urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.2.xsd"
+            urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.3.xsd"
          xmlns="urn:infinispan:config:15.0"
          xmlns:ispn="urn:infinispan:config:15.0">
    <stack name="global" extends="tcp">

--- a/server/tests/src/test/resources/configuration/jgroups/xsite-stacks.xml
+++ b/server/tests/src/test/resources/configuration/jgroups/xsite-stacks.xml
@@ -1,6 +1,6 @@
 <jgroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="urn:infinispan:config:15.0 https://infinispan.org/schemas/infinispan-config-fragment-15.0.xsd
-                             urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.2.xsd"
+                             urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.3.xsd"
          xmlns="urn:infinispan:config:15.0"
          xmlns:ispn="urn:infinispan:config:15.0">
    <stack name="global" extends="tcp">

--- a/tools/src/test/resources/udp.xml
+++ b/tools/src/test/resources/udp.xml
@@ -1,6 +1,6 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.2.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.3.xsd">
    <UDP
          bind_addr="${jgroupd.bind.address,jgroups.udp.address:SITE_LOCAL}"
          bind_port="${jgroups.bind.port,jgroups.udp.port:0}"


### PR DESCRIPTION
… stack

* added non-blocking-sends option (disabled by default)
* added new stack with TUNNEL transport
* updated version in JGroups XML schema

https://issues.redhat.com/browse/ISPN-15701

It requires a manual backport for 14.x due to the schema version change. 