### PR TITLE
ISPN-15735 Report flaky infinispan tests to Jira

### DIFF
--- a/bin/jira/add_comment.sh
+++ b/bin/jira/add_comment.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# A script to update a Jira tickets linked Pull Requests
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "${SCRIPT_DIR}/common.sh"
+
+requiredEnv TOKEN ISSUE_KEY COMMENT
+
+ISSUE_URL="${API_URL}/issue/${ISSUE_KEY}/comment"
+PAYLOAD="{\"body\":${COMMENT}}"
+
+curl -X POST ${ISSUE_URL} --data "${PAYLOAD}"

--- a/bin/jira/add_fix_version.sh
+++ b/bin/jira/add_fix_version.sh
@@ -19,6 +19,4 @@ cat << EOF | tee update-jira.json
 }
 EOF
 
-${CURL} -X PUT ${API_URL}/issue/${ISSUE_KEY} \
-  -H @headers \
-  --data @update-jira.json
+curl -X PUT ${API_URL}/issue/${ISSUE_KEY} --data @update-jira.json

--- a/bin/jira/add_pull_request.sh
+++ b/bin/jira/add_pull_request.sh
@@ -6,7 +6,7 @@ source "${SCRIPT_DIR}/common.sh"
 requiredEnv TOKEN ISSUE_KEY PULL_REQUEST
 
 ISSUE_URL="${API_URL}/issue/${ISSUE_KEY}"
-ISSUE=$(${CURL} -H @headers ${ISSUE_URL} | jq .)
+ISSUE=$(curl ${ISSUE_URL} | jq .)
 EXISTING_PRS=$(echo ${ISSUE} | jq .fields.customfield_12310220)
 
 if [[ ${EXISTING_PRS} == *"${PULL_REQUEST}"* ]]; then
@@ -27,6 +27,4 @@ cat << EOF | tee update-jira.json
 }
 EOF
 
-${CURL} -X PUT ${ISSUE_URL} \
-  -H @headers \
-  --data @update-jira.json
+curl -X PUT ${ISSUE_URL} --data @update-jira.json

--- a/bin/jira/assign_issue.sh
+++ b/bin/jira/assign_issue.sh
@@ -5,6 +5,4 @@ source "${SCRIPT_DIR}/common.sh"
 
 requiredEnv TOKEN ISSUE_KEY ASSIGNEE
 
-${CURL} -X PUT ${API_URL}/issue/${ISSUE_KEY}/assignee \
-  -H @headers \
-  --data "{\"name\":\"${ASSIGNEE}\"}"
+curl -X PUT ${API_URL}/issue/${ISSUE_KEY}/assignee --data "{\"name\":\"${ASSIGNEE}\"}"

--- a/bin/jira/common.sh
+++ b/bin/jira/common.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 set -e -o pipefail
+shopt -s expand_aliases
 
-CURL="curl --no-progress-meter --fail-with-body"
+
 if [[ "$RUNNER_DEBUG" == "1" ]]; then
   set -x
-  CURL="${CURL} --verbose"
+  CURL_VERBOSE="--verbose"
 fi
 
 function requiredEnv() {
@@ -16,10 +17,7 @@ function requiredEnv() {
   done
 }
 
+alias curl="curl ${CURL_VERBOSE} --no-progress-meter --fail-with-body -H 'Authorization: Bearer ${TOKEN}' -H 'Content-Type: application/json'"
+
 BASE_URL=https://issues.redhat.com
 API_URL=${BASE_URL}/rest/api/2
-
-cat << EOF | tee headers
-Authorization: Bearer ${TOKEN}
-Content-Type: application/json
-EOF

--- a/bin/jira/track_flaky_tests.sh
+++ b/bin/jira/track_flaky_tests.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+set -e
+# A script to track flaky tests in Jira
+# Requires xmlstarlet and jq to be installed
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "${SCRIPT_DIR}/common.sh"
+
+requiredEnv TOKEN PROJECT_KEY TYPE JENKINS_JOB_URL FLAKY_TEST_GLOB
+
+PROJECT=$(curl $API_URL/project/${PROJECT_KEY})
+PROJECT_ID=$(echo ${PROJECT} | jq -r .id)
+ISSUE_TYPE_ID=$(echo ${PROJECT} | jq -r ".issueTypes[] | select(.name==\"${TYPE}\").id")
+
+shopt -s nullglob globstar
+TESTS=(${FLAKY_TEST_GLOB})
+for TEST in "${TESTS[@]}"; do
+  TEST_CLASS=$(xmlstarlet sel --template --value-of '/testsuite/testcase/@classname' ${TEST})
+  TEST_NAME=$(xmlstarlet sel --template --value-of '/testsuite/testcase/@name' ${TEST})
+  TEST_NAME=${TEST_NAME% (Flaky Test)}
+  TEST_NAME_NO_PARAMS=${TEST_NAME%%\\*}
+  STACK_TRACE=$(xmlstarlet sel --template --value-of '/testsuite/testcase/failure' ${TEST})
+
+  # Create Issue for Test Class+TestName
+  SUMMARY="Flaky test: ${TEST_CLASS}#${TEST_NAME_NO_PARAMS}"
+  echo ${SUMMARY}
+  JQL="project = ${PROJECT_KEY} AND summary ~ '${SUMMARY}'"
+  # Search issues for existing Jira issue
+  ISSUES="$(curl ${API_URL}/search -G --data-urlencode "jql=${JQL}")"
+  TOTAL_ISSUES=$(echo "${ISSUES}" | jq -r .total)
+  if [ ${TOTAL_ISSUES} -gt 1 ]; then
+    echo "Multiple Jiras found in '${PROJECT_KEY}' with summary ~ '${SUMMARY}'"
+    exit 1
+  fi
+
+  if [ ${TOTAL_ISSUES} == 0 ]; then
+    echo "Existing Jira not found, creating a new one"
+    cat << EOF | tee create-jira.json
+    {
+      "fields": {
+        "project": {
+          "id": "${PROJECT_ID}"
+        },
+        "summary": "${SUMMARY}",
+        "issuetype": {
+          "id": "${ISSUE_TYPE_ID}"
+        },
+        "labels": [
+          "flaky-test"
+        ]
+      }
+    }
+EOF
+    # We retry on error here as for some reason the Jira server occasionally responds with 400 errors
+    export ISSUE_KEY=$(curl --retry 5 --retry-all-errors --data @create-jira.json $API_URL/issue | jq -r .key)
+  else
+    export ISSUE_KEY=$(echo "${ISSUES}" | jq -r '.issues[0].key')
+    # Re-open the issue if it was previously resolved
+    TRANSITION="New" ${SCRIPT_DIR}/transition.sh
+  fi
+
+  COMMENT=$(
+  cat << EOF
+  h1. ${TEST_NAME}
+  [Jenkins Job|${JENKINS_JOB_URL}]
+  {code:java}
+  ${STACK_TRACE}
+  {code}
+EOF
+  )
+  export COMMENT=$(echo "${COMMENT}" | jq -sR)
+
+  # Add details of flaky failure as a new Jira comment
+  ${SCRIPT_DIR}/add_comment.sh
+done

--- a/bin/jira/transition.sh
+++ b/bin/jira/transition.sh
@@ -6,8 +6,8 @@ source "${SCRIPT_DIR}/common.sh"
 requiredEnv TOKEN ISSUE_KEY TRANSITION
 
 TRANSITIONS_URL="${API_URL}/issue/${ISSUE_KEY}/transitions"
-TRANSITIONS=$(${CURL} -H @headers ${TRANSITIONS_URL} | jq .)
-TRANSITION_ID=$(echo ${TRANSITIONS} | jq -r ".transitions[] | select(.name==\"${TRANSITION}\").id")
+TRANSITIONS=$(curl ${TRANSITIONS_URL} | jq .)
+TRANSITION_ID=$(echo "${TRANSITIONS}" | jq -r ".transitions[] | select(.name==\"${TRANSITION}\").id")
 
 cat << EOF | tee update-jira.json
 {
@@ -17,6 +17,4 @@ cat << EOF | tee update-jira.json
 }
 EOF
 
-${CURL} -X POST "${TRANSITIONS_URL}" \
-  -H @headers \
-  --data @update-jira.json
+curl -X POST "${TRANSITIONS_URL}" --data @update-jira.json

--- a/bin/jira/upsert.sh
+++ b/bin/jira/upsert.sh
@@ -5,16 +5,13 @@ source "${SCRIPT_DIR}/common.sh"
 
 requiredEnv TOKEN PROJECT_KEY ASSIGNEE PULL_REQUEST SUMMARY TYPE
 
-PROJECT=$(${CURL} -H @headers $API_URL/project/${PROJECT_KEY})
+PROJECT=$(curl $API_URL/project/${PROJECT_KEY})
 PROJECT_ID=$(echo ${PROJECT} | jq -r .id)
 ISSUE_TYPE_ID=$(echo ${PROJECT} | jq -r ".issueTypes[] | select(.name==\"${TYPE}\").id")
 
 JQL="project = ${PROJECT_KEY} AND summary ~ '${SUMMARY}'"
 # Search issues for existing Jira issue
-ISSUES=$(${CURL} ${API_URL}/search \
--G --data-urlencode "jql=${JQL}" \
--H @headers
-)
+ISSUES=$(curl ${API_URL}/search -G --data-urlencode "jql=${JQL}")
 TOTAL_ISSUES=$(echo ${ISSUES} | jq -r .total)
 if [ ${TOTAL_ISSUES} -gt 1 ]; then
   echo "Multiple Jiras found in '${PROJECT}' with summary ~ '${SUMMARY}'"
@@ -40,7 +37,7 @@ elif [ ${TOTAL_ISSUES} == 0 ]; then
   }
 EOF
   # We retry on error here as for some reason the Jira server occasionally responds with 400 errors
-  ISSUE_KEY=$(${CURL} --retry 5 --retry-all-errors -H @headers --data @create-jira.json $API_URL/issue | jq -r .key)
+  ISSUE_KEY=$(curl --retry 5 --retry-all-errors --data @create-jira.json $API_URL/issue | jq -r .key)
 else
   export ISSUE_KEY=$(echo ${ISSUES} | jq -r .issues[0].key)
   export ASSIGNEE PULL_REQUEST


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-15735

Example Run: https://ci.infinispan.org/job/Infinispan/job/PR-12026/36/, reports green as only one flaky test encountered and Jira created https://issues.redhat.com/browse/ISPN-15778

Every time a flaky test is encountered on a CI run a Jira will be created for the corresponding test method, or re-used if it already exists. A comment is then added to the Jira containing the test method and parameters (if any), a link to the offending CI job and the stacktrace reported by the test failure.

I would like to keep debug logging enabled for a little while as without it it's almost impossible to figure when things have gone wrong.