### PR TITLE
[14.x] ISPN-15738 Avoid individual GET by Key in distributed query aggregation

### DIFF
--- a/query/src/main/java/org/infinispan/query/clustered/ClusteredQueryInvoker.java
+++ b/query/src/main/java/org/infinispan/query/clustered/ClusteredQueryInvoker.java
@@ -65,12 +65,12 @@ final class ClusteredQueryInvoker {
                BitSet segments = e.getValue();
                SegmentsClusteredQueryCommand cmd = new SegmentsClusteredQueryCommand(cache.getName(), operation, segments);
                return rpcManager.invokeCommand(address, cmd, SingleResponseCollector.validOnly(),
-                                               rpcManager.getSyncRpcOptions()).toCompletableFuture();
+                     rpcManager.getSyncRpcOptions()).toCompletableFuture();
             }).map(a -> a.thenApply(r -> (QueryResponse) r.getResponseValue())).collect(Collectors.toList());
 
       // then, invoke on own node
       CompletionStage<QueryResponse> localResponse = localInvoke(localCommand);
-      
+
       List<QueryResponse> results = new ArrayList<>();
       try {
          results.add(await(localResponse.toCompletableFuture()));

--- a/query/src/main/java/org/infinispan/query/clustered/DistributedEntryIterator.java
+++ b/query/src/main/java/org/infinispan/query/clustered/DistributedEntryIterator.java
@@ -15,30 +15,14 @@ import org.infinispan.remoting.transport.Address;
  */
 class DistributedEntryIterator<K, V> extends DistributedIterator<Map.Entry<K, V>> {
 
-   DistributedEntryIterator(LocalQueryStatistics queryStatistics, Sort sort, int fetchSize, int resultSize,
+   DistributedEntryIterator(LocalQueryStatistics queryStatistics, Sort sort, int resultSize,
                             int maxResults, int firstResult, Map<Address, NodeTopDocs> topDocsResponses,
                             AdvancedCache<?, ?> cache) {
-      super(queryStatistics, sort, fetchSize, resultSize, maxResults, firstResult, topDocsResponses, cache);
+      super(queryStatistics, sort, resultSize, maxResults, firstResult, topDocsResponses, cache);
    }
 
    @Override
    protected Map.Entry<K, V> decorate(Object key, Object value) {
-      return new Map.Entry<K, V>() {
-
-         @Override
-         public K getKey() {
-            return (K) key;
-         }
-
-         @Override
-         public V getValue() {
-            return (V) value;
-         }
-
-         @Override
-         public V setValue(V value) {
-            throw new UnsupportedOperationException("Entry is immutable");
-         }
-      };
+      return Map.entry((K) key, (V) value);
    }
 }

--- a/query/src/main/java/org/infinispan/query/clustered/DistributedIndexedQueryImpl.java
+++ b/query/src/main/java/org/infinispan/query/clustered/DistributedIndexedQueryImpl.java
@@ -2,7 +2,6 @@ package org.infinispan.query.clustered;
 
 import static java.util.Spliterators.spliteratorUnknownSize;
 import static java.util.stream.StreamSupport.stream;
-
 import static org.infinispan.query.logging.Log.CONTAINER;
 
 import java.util.Collections;
@@ -96,7 +95,7 @@ public final class DistributedIndexedQueryImpl<E> extends IndexedQueryImpl<E> {
                aggregation.displayGroupFirst(), luceneSort);
       }
 
-      return new DistributedIterator<>(queryStatistics, luceneSort, maxResults, resultSize, maxResults,
+      return new DistributedIterator<>(queryStatistics, luceneSort, resultSize, maxResults,
             firstResult, topDocsResponses, cache);
    }
 
@@ -114,7 +113,7 @@ public final class DistributedIndexedQueryImpl<E> extends IndexedQueryImpl<E> {
       }
 
       return new DistributedEntryIterator<>(queryStatistics, queryDefinition.getSearchQueryBuilder().getLuceneSort(),
-            maxResults, resultSize, maxResults, firstResult, topDocsResponses, cache);
+              resultSize, maxResults, firstResult, topDocsResponses, cache);
    }
 
    // number of results of each node of cluster

--- a/query/src/main/java/org/infinispan/query/clustered/DistributedIterator.java
+++ b/query/src/main/java/org/infinispan/query/clustered/DistributedIterator.java
@@ -1,23 +1,28 @@
 package org.infinispan.query.clustered;
 
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TopFieldDocs;
 import org.infinispan.AdvancedCache;
+import org.infinispan.commons.time.TimeService;
 import org.infinispan.commons.util.CloseableIterator;
-import org.infinispan.encoding.DataConversion;
 import org.infinispan.query.core.stats.impl.LocalQueryStatistics;
 import org.infinispan.remoting.transport.Address;
 
 /**
  * Iterates on the results of a distributed query returning the values. Subclasses can customize this by overriding the
- * {@link #decorate} method.
+ * {@link #decorate(Object, Object)} method.
  *
  * @param <T> The return type of the iterator
  * @author Israel Lacerra &lt;israeldl@gmail.com&gt;
@@ -27,13 +32,10 @@ import org.infinispan.remoting.transport.Address;
  */
 class DistributedIterator<T> implements CloseableIterator<T> {
 
-   private final AdvancedCache<?, ?> cache;
-   private final DataConversion keyDataConversion;
+   private final AdvancedCache<Object, Object> cache;
 
    private int currentIndex = -1;
 
-   // todo [anistor] seems we are ignoring fetchSize https://issues.jboss.org/browse/ISPN-9506
-   private final int fetchSize;
    private final int resultSize;
    private final int maxResults;
    private final int firstResult;
@@ -42,16 +44,18 @@ class DistributedIterator<T> implements CloseableIterator<T> {
    private final TopDocs mergedResults;
    private final LocalQueryStatistics queryStatistics;
 
-   DistributedIterator(LocalQueryStatistics queryStatistics, Sort sort, int fetchSize, int resultSize, int maxResults,
+   private int valueIndex;
+   private final int batchSize;
+   private final List<T> values;
+
+   DistributedIterator(LocalQueryStatistics queryStatistics, Sort sort, int resultSize, int maxResults,
                        int firstResult, Map<Address, NodeTopDocs> topDocsResponses, AdvancedCache<?, ?> cache) {
       this.queryStatistics = queryStatistics;
-      this.fetchSize = fetchSize;
       this.resultSize = resultSize;
       this.maxResults = maxResults;
       this.firstResult = firstResult;
-      this.cache = cache;
-      this.keyDataConversion = cache.getKeyDataConversion();
-      final int parallels = topDocsResponses.size();
+      this.cache = (AdvancedCache<Object, Object>) cache;
+      int parallels = topDocsResponses.size();
       this.partialResults = new NodeTopDocs[parallels];
       boolean isFieldDocs = expectTopFieldDocs(topDocsResponses);
       TopDocs[] partialTopDocs = isFieldDocs ? new TopFieldDocs[parallels] : new TopDocs[parallels];
@@ -67,9 +71,11 @@ class DistributedIterator<T> implements CloseableIterator<T> {
       } else {
          mergedResults = TopDocs.merge(firstResult, maxResults, partialTopDocs, true);
       }
+      batchSize = Math.min(maxResults, cache.getCacheConfiguration().clustering().stateTransfer().chunkSize());
+      values = new ArrayList<>(batchSize);
    }
 
-   private boolean expectTopFieldDocs(Map<Address, NodeTopDocs> topDocsResponses) {
+   private static boolean expectTopFieldDocs(Map<Address, NodeTopDocs> topDocsResponses) {
       Iterator<NodeTopDocs> it = topDocsResponses.values().iterator();
       if (it.hasNext()) {
          return it.next().topDocs instanceof TopFieldDocs;
@@ -88,6 +94,69 @@ class DistributedIterator<T> implements CloseableIterator<T> {
          throw new NoSuchElementException();
       }
 
+      // hasNext populate the values if returns true
+      assert !values.isEmpty();
+      assert valueIndex < values.size();
+
+      return values.get(valueIndex++);
+   }
+
+   /**
+    * Extension point for subclasses.
+    */
+   protected T decorate(Object key, Object value) {
+      return (T) value;
+   }
+
+   @Override
+   public final boolean hasNext() {
+      if (valueIndex == values.size()) {
+         fetchBatch();
+      }
+      return valueIndex < values.size();
+   }
+
+   private void fetchBatch() {
+      // keep the order
+      Set<Object> keys = new LinkedHashSet<>(batchSize);
+      values.clear();
+      valueIndex = 0;
+      for (int i = 0; i < batchSize; ++i) {
+         if (!hasMoreKeys()) {
+            break;
+         }
+         Object key = nextKey();
+         if (key != null) {
+            keys.add(cache.getKeyDataConversion().fromStorage(key));
+         }
+      }
+
+      if (keys.isEmpty()) {
+         return;
+      }
+
+      if (!queryStatistics.isEnabled()) {
+         getAllAndStore(keys);
+         return;
+      }
+
+      TimeService timeService = cache.getComponentRegistry().getTimeService();
+      long start = timeService.time();
+      getAllAndStore(keys);
+      queryStatistics.entityLoaded(timeService.timeDuration(start, TimeUnit.NANOSECONDS));
+   }
+
+   private void getAllAndStore(Set<Object> keys) {
+      Map<Object, Object> map = cache.getAll(keys);
+      keys.stream().map(key -> decorate(key, map.get(key))).forEach(values::add);
+   }
+
+   private boolean hasMoreKeys() {
+      int nextIndex = currentIndex + 1;
+      return firstResult + nextIndex < resultSize && nextIndex < maxResults;
+   }
+
+   private Object nextKey() {
       currentIndex++;
 
       ScoreDoc scoreDoc = mergedResults.scoreDocs[currentIndex];
@@ -106,31 +175,10 @@ class DistributedIterator<T> implements CloseableIterator<T> {
 
       int pos = partialPositionNext[index]++;
 
-      Object[] keys = nodeTopDocs.keys;
-      if (keys == null || keys.length == 0) {
-         return (T) nodeTopDocs.projections[pos];
+      if (nodeTopDocs.keys == null || nodeTopDocs.keys.length == 0) {
+         values.add((T) nodeTopDocs.projections[pos]);
+         return null;
       }
-
-      long start = queryStatistics.isEnabled() ? System.nanoTime() : 0;
-
-      Object key = keyDataConversion.fromStorage(keys[pos]);
-      T value = (T) cache.get(key);
-
-      if (queryStatistics.isEnabled()) queryStatistics.entityLoaded(System.nanoTime() - start);
-
-      return decorate(key, value);
-   }
-
-   /**
-    * Extension point for subclasses.
-    */
-   protected T decorate(Object key, Object value) {
-      return (T) value;
-   }
-
-   @Override
-   public final boolean hasNext() {
-      int nextIndex = currentIndex + 1;
-      return firstResult + nextIndex < resultSize && nextIndex < maxResults;
+      return nodeTopDocs.keys[pos];
    }
 }

--- a/query/src/test/java/org/infinispan/query/maxresult/DistributedMaxResultTest.java
+++ b/query/src/test/java/org/infinispan/query/maxresult/DistributedMaxResultTest.java
@@ -1,0 +1,58 @@
+package org.infinispan.query.maxresult;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.infinispan.configuration.cache.IndexStorage.LOCAL_HEAP;
+
+import org.infinispan.Cache;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.query.Search;
+import org.infinispan.query.dsl.Query;
+import org.infinispan.query.dsl.QueryFactory;
+import org.infinispan.query.dsl.QueryResult;
+import org.infinispan.query.model.Game;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.testng.annotations.Test;
+
+@Test(groups = "functional", testName = "query.maxresult.DistributedMaxResultTest")
+public class DistributedMaxResultTest extends MultipleCacheManagersTest {
+
+   private Cache<Integer, Game> node1;
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      ConfigurationBuilder config = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false);
+      config
+            .clustering()
+               .hash().numOwners(2)
+               .stateTransfer().chunkSize(100)
+            .indexing().enable()
+               .storage(LOCAL_HEAP)
+               .addIndexedEntity("org.infinispan.query.model.Game")
+            .query().defaultMaxResults(50);
+
+      createClusteredCaches(2, config);
+      node1 = cache(0);
+      cache(1);
+   }
+
+   public void executeSmokeTest() {
+      for (int i = 1; i <= 110; i++) {
+         node1.put(i, new Game("Game " + i, "This is the game " + i + "# of a series"));
+      }
+
+      QueryFactory factory = Search.getQueryFactory(node1);
+      Query<Game> query = factory.create("from org.infinispan.query.model.Game");
+      QueryResult<Game> result = query.execute();
+
+      assertThat(result.hitCount()).hasValue(110);
+      assertThat(result.list()).hasSize(50); // use custom default
+
+      query = factory.create("from org.infinispan.query.model.Game");
+      query.maxResults(200); // raise it
+      result = query.execute();
+
+      assertThat(result.hitCount()).hasValue(110);
+      assertThat(result.list()).hasSize(110);
+   }
+}


### PR DESCRIPTION
Use getAll to fetch multiple keys in a single RPC request. The batch is the same as the chunk-size for state transfer.

https://issues.redhat.com/browse/ISPN-15738