### PR TITLE
ISPN-15738 Avoid individual GET by Key in distributed query aggregation

### DIFF
--- a/query/src/main/java/org/infinispan/query/clustered/ClusteredQueryInvoker.java
+++ b/query/src/main/java/org/infinispan/query/clustered/ClusteredQueryInvoker.java
@@ -58,8 +58,7 @@ final class ClusteredQueryInvoker {
 
       Map<Address, BitSet> split = partitioner.split();
       SegmentsClusteredQueryCommand localCommand = new SegmentsClusteredQueryCommand(cache.getName(), operation, split.get(myAddress));
-      // invoke on own node
-      CompletionStage<QueryResponse> localResponse = localInvoke(localCommand);
+      // sends the request remotely first
       List<CompletableFuture<QueryResponse>> futureRemoteResponses = split.entrySet().stream()
             .filter(e -> !e.getKey().equals(myAddress)).map(e -> {
                Address address = e.getKey();
@@ -68,6 +67,9 @@ final class ClusteredQueryInvoker {
                return rpcManager.invokeCommand(address, cmd, SingleResponseCollector.validOnly(),
                                                rpcManager.getSyncRpcOptions()).toCompletableFuture();
             }).map(a -> a.thenApply(r -> (QueryResponse) r.getResponseValue())).collect(Collectors.toList());
+
+      // then, invoke on own node
+      CompletionStage<QueryResponse> localResponse = localInvoke(localCommand);
 
       List<QueryResponse> results = new ArrayList<>();
       try {

--- a/query/src/main/java/org/infinispan/query/clustered/DistributedEntryIterator.java
+++ b/query/src/main/java/org/infinispan/query/clustered/DistributedEntryIterator.java
@@ -16,10 +16,10 @@ import org.infinispan.remoting.transport.Address;
  */
 class DistributedEntryIterator<K, V> extends DistributedIterator<EntityEntry<K, V>> {
 
-   DistributedEntryIterator(LocalQueryStatistics queryStatistics, Sort sort, int fetchSize, int resultSize,
+   DistributedEntryIterator(LocalQueryStatistics queryStatistics, Sort sort, int resultSize,
                             int maxResults, int firstResult, Map<Address, NodeTopDocs> topDocsResponses,
                             AdvancedCache<?, ?> cache) {
-      super(queryStatistics, sort, fetchSize, resultSize, maxResults, firstResult, topDocsResponses, cache);
+      super(queryStatistics, sort, resultSize, maxResults, firstResult, topDocsResponses, cache);
    }
 
    @Override

--- a/query/src/main/java/org/infinispan/query/clustered/DistributedIndexedQueryImpl.java
+++ b/query/src/main/java/org/infinispan/query/clustered/DistributedIndexedQueryImpl.java
@@ -97,7 +97,7 @@ public final class DistributedIndexedQueryImpl<E> extends IndexedQueryImpl<E> {
                aggregation.displayGroupFirst(), luceneSort);
       }
 
-      return new DistributedIterator<>(queryStatistics, luceneSort, maxResults, resultSize, maxResults,
+      return new DistributedIterator<>(queryStatistics, luceneSort, resultSize, maxResults,
             firstResult, topDocsResponses, cache);
    }
 
@@ -115,7 +115,7 @@ public final class DistributedIndexedQueryImpl<E> extends IndexedQueryImpl<E> {
       }
 
       return new DistributedEntryIterator<>(queryStatistics, queryDefinition.getSearchQueryBuilder().getLuceneSort(),
-            maxResults, resultSize, maxResults, firstResult, topDocsResponses, cache);
+            resultSize, maxResults, firstResult, topDocsResponses, cache);
    }
 
    // number of results of each node of cluster

--- a/query/src/test/java/org/infinispan/query/maxresult/DistributedMaxResultTest.java
+++ b/query/src/test/java/org/infinispan/query/maxresult/DistributedMaxResultTest.java
@@ -1,0 +1,55 @@
+package org.infinispan.query.maxresult;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.infinispan.configuration.cache.IndexStorage.LOCAL_HEAP;
+
+import org.infinispan.Cache;
+import org.infinispan.commons.api.query.Query;
+import org.infinispan.commons.api.query.QueryResult;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.query.model.Game;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.testng.annotations.Test;
+
+@Test(groups = "functional", testName = "query.maxresult.DistributedMaxResultTest")
+public class DistributedMaxResultTest extends MultipleCacheManagersTest {
+
+   private Cache<Integer, Game> node1;
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      ConfigurationBuilder config = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false);
+      config
+            .clustering()
+               .hash().numOwners(2)
+               .stateTransfer().chunkSize(100)
+            .indexing().enable()
+               .storage(LOCAL_HEAP)
+               .addIndexedEntity("org.infinispan.query.model.Game")
+            .query().defaultMaxResults(50);
+
+      createClusteredCaches(2, config);
+      node1 = cache(0);
+      cache(1);
+   }
+
+   public void executeSmokeTest() {
+      for (int i = 1; i <= 110; i++) {
+         node1.put(i, new Game("Game " + i, "This is the game " + i + "# of a series"));
+      }
+
+      Query<Game> query = node1.query("from org.infinispan.query.model.Game");
+      QueryResult<Game> result = query.execute();
+
+      assertThat(result.count().value()).isEqualTo(110);
+      assertThat(result.list()).hasSize(50); // use custom default
+
+      query = node1.query("from org.infinispan.query.model.Game");
+      query.maxResults(200); // raise it
+      result = query.execute();
+
+      assertThat(result.count().value()).isEqualTo(110);
+      assertThat(result.list()).hasSize(110);
+   }
+}


### PR DESCRIPTION
Use getAll to fetch multiple keys in a single RPC request. The batch is the same as the chunk-size for state transfer.

https://issues.redhat.com/browse/ISPN-15738