### PR TITLE
Dependabot auto merge

### DIFF
--- a/.github/workflows/dependabot_pull_request.yml
+++ b/.github/workflows/dependabot_pull_request.yml
@@ -38,39 +38,21 @@ jobs:
           RUNNER_DEBUG: "1"
 
       - name: Add comment to PR
-        uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: '${{ env.JIRA_ISSUE_URL }}'
-            })
+        run: gh pr comment ${{ github.event.pull_request.number }} --body ${{ env.JIRA_ISSUE_URL }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update PR Title main
         if: ${{ github.base_ref == 'main' }}
-        uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.pulls.update({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: ${{ github.event.pull_request.number }},
-              title: '${{ env.JIRA_ISSUE_KEY }} ${{ github.event.pull_request.title }}'
-            })
+        run: gh pr edit ${{ github.event.pull_request.number }} --title "${{ env.JIRA_ISSUE_KEY }} ${{ github.event.pull_request.title }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update PR Title 14.0.x
         if: ${{ github.base_ref == '14.0.x' }}
-        uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.pulls.update({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: ${{ github.event.pull_request.number }},
-              title: '[14.0.x] ${{ env.JIRA_ISSUE_KEY }} ${{ github.event.pull_request.title }}'
-            })
+        run: gh pr edit ${{ github.event.pull_request.number }} --title "[14.0.x] ${{ env.JIRA_ISSUE_KEY }} ${{ github.event.pull_request.title }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set PR Milestone
         id: milestone

--- a/.github/workflows/dependabot_pull_request.yml
+++ b/.github/workflows/dependabot_pull_request.yml
@@ -71,3 +71,20 @@ jobs:
               pull_number: ${{ github.event.pull_request.number }},
               title: '[14.0.x] ${{ env.JIRA_ISSUE_KEY }} ${{ github.event.pull_request.title }}'
             })
+
+      - name: Set PR Milestone
+        id: milestone
+        run: |
+          sudo apt-get install xmlstarlet
+          MVN_VERSION=$(xmlstarlet sel -t -m _:project -v _:version pom.xml)
+          export MAJOR_VERSION=${MVN_VERSION%.*.*}
+          gh pr edit ${{ github.event.pull_request.number }} --milestone "$(./bin/jira/get_milestone.sh)"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PROJECT_KEY: ISPN
+          TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+
+      - name: Approve PR for auto-merge
+        run: gh pr merge --auto --rebase ${{ github.event.pull_request.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull_request_open.yml
+++ b/.github/workflows/pull_request_open.yml
@@ -39,3 +39,15 @@ jobs:
           ISSUE_KEY: ${{ env.ISSUE_KEY }}
           TOKEN: ${{ secrets.JIRA_API_TOKEN }}
           TRANSITION: Code Review
+
+      - name: Set PR Milestone
+        id: milestone
+        run: |
+          sudo apt-get install xmlstarlet
+          MVN_VERSION=$(xmlstarlet sel -t -m _:project -v _:version pom.xml)
+          export MAJOR_VERSION=${MVN_VERSION%.*.*}
+          gh pr edit ${{ github.event.pull_request.number }} --milestone "$(./bin/jira/get_milestone.sh)"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PROJECT_KEY: ISPN
+          TOKEN: ${{ secrets.JIRA_API_TOKEN }}

--- a/bin/jira/get_milestone.sh
+++ b/bin/jira/get_milestone.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# A script to update a Jira tickets linked Pull Requests
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "${SCRIPT_DIR}/common.sh"
+
+requiredEnv TOKEN PROJECT_KEY MAJOR_VERSION
+
+VERSIONS_URL="${API_URL}/project/${PROJECT_KEY}/versions"
+
+# Return the oldest unreleased version for the project
+curl ${VERSIONS_URL} \
+  | jq -r ".[] | select(.released==false) | select(.name | startswith(\"${MAJOR_VERSION}\")) | .name" \
+  | sort -V \
+  | head -n1


### PR DESCRIPTION
I have configured the GH rulesets so that PRs to the `main` and `14.0.x` branch require the relevant tests to pass before a PR can automatically be merged. Once this PR is is in, all we need to do is enable the "auto-merge" feature for this repository.

Once "auto-merge" is enabled, all Dependabot PRs will automatically be merged once the Jenkins and GH action CI has successfully run. A single test failure will prevent automatic merging and will require a manual review from a member of the team.

As part of this PR I have also added an automation so that PRs have a default milestone set. The rules for this are as follows:

- The maven version in the root pom is used to determine the major version of the release
- Jira is queried to return all unreleased releases for said major
- The oldest unreleased version is then used as the gh Milestone value

A caveat of ^ approach is that `CR1` is sorted to be older than `Dev11` as this is non-standard semantic versioning.