### PR TITLE
ISPN-15523 Restore procedure performance regression

### DIFF
--- a/server/tests/src/test/java/org/infinispan/server/functional/BackupManagerIT.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/BackupManagerIT.java
@@ -419,6 +419,13 @@ public class BackupManagerIT extends AbstractMultiClusterIT {
       RestResponse getResponse = backupAndDownload.apply(client);
       String fileName = getResponse.header("Content-Disposition").split("=")[1];
 
+      // Copy the returned zip bytes to the local working dir
+      File backupZip = new File(WORKING_DIR, fileName);
+      try (InputStream is = getResponse.bodyAsStream()) {
+         Files.copy(is, backupZip.toPath(), StandardCopyOption.REPLACE_EXISTING);
+      }
+      getResponse.close();
+
       // Delete the backup from the server
       try (RestResponse deleteResponse = delete.apply(client)) {
          assertEquals(204, deleteResponse.status());
@@ -435,13 +442,6 @@ public class BackupManagerIT extends AbstractMultiClusterIT {
       // Start the target cluster
       startTargetCluster();
       client = target.getClient();
-
-      // Copy the returned zip bytes to the local working dir
-      File backupZip = new File(WORKING_DIR, fileName);
-      try (InputStream is = getResponse.bodyAsStream()) {
-         Files.copy(is, backupZip.toPath(), StandardCopyOption.REPLACE_EXISTING);
-      }
-      getResponse.close();
 
       if (syncToServer) {
          backupZip = new File(target.driver.syncFilesToServer(0, backupZip.getAbsolutePath()));
@@ -534,7 +534,7 @@ public class BackupManagerIT extends AbstractMultiClusterIT {
       assertStatusAndBodyEquals(OK, Long.toString(expectedValue), client.counter(name).get());
    }
 
-   private void assertNoServerBackupFilesExist(Cluster cluster) {
+   static void assertNoServerBackupFilesExist(Cluster cluster) {
       for (int i = 0; i < 2; i++) {
          cluster.driver.syncFilesFromServer(i, "data");
          Path root = cluster.driver.getRootDir().toPath();

--- a/server/tests/src/test/java/org/infinispan/server/functional/LargeBackupManagerIT.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/LargeBackupManagerIT.java
@@ -1,0 +1,135 @@
+package org.infinispan.server.functional;
+
+import static org.infinispan.client.rest.RestResponseInfo.ACCEPTED;
+import static org.infinispan.client.rest.RestResponseInfo.CREATED;
+import static org.infinispan.client.rest.RestResponseInfo.NO_CONTENT;
+import static org.infinispan.client.rest.RestResponseInfo.OK;
+import static org.infinispan.functional.FunctionalTestUtils.await;
+import static org.infinispan.server.functional.BackupManagerIT.assertNoServerBackupFilesExist;
+import static org.infinispan.server.test.core.Common.assertStatus;
+import static org.infinispan.server.test.core.Common.assertStatusAndBodyEquals;
+import static org.infinispan.server.test.core.Common.awaitResponse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.UUID;
+
+import org.infinispan.client.rest.RestCacheClient;
+import org.infinispan.client.rest.RestClient;
+import org.infinispan.client.rest.RestContainerClient;
+import org.infinispan.client.rest.RestResponse;
+import org.infinispan.commons.test.CommonsTestingUtil;
+import org.infinispan.commons.util.Util;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class LargeBackupManagerIT extends AbstractMultiClusterIT {
+
+   private static final File WORKING_DIR = new File(CommonsTestingUtil.tmpDirectory(LargeBackupManagerIT.class));
+   private final String name = "testManagerBackupUploadLargeCache";
+   private final String cacheName = "cache1";
+   private final int size = 35_000;
+
+   @BeforeAll
+   public static void setup() {
+      WORKING_DIR.mkdirs();
+   }
+
+   @AfterAll
+   public static void teardown() {
+      Util.recursiveFileRemove(WORKING_DIR);
+   }
+
+   @Test
+   public void testManagerBackupUploadLargeCache() throws Exception {
+      // Start the source cluster
+      startSourceCluster();
+      RestClient client = source.getClient();
+
+      // Populate the source container
+      populateContainer(client);
+
+      // Perform the backup and download
+      RestResponse getResponse = backupAndDownload(client);
+      String fileName = getResponse.header("Content-Disposition").split("=")[1];
+
+      // Copy the returned zip bytes to the local working dir
+      File backupZip = new File(WORKING_DIR, fileName);
+      try (InputStream is = getResponse.bodyAsStream()) {
+         Files.copy(is, backupZip.toPath(), StandardCopyOption.REPLACE_EXISTING);
+      }
+      getResponse.close();
+
+      // Delete the backup from the server
+      try (RestResponse deleteResponse = await(client.container().deleteBackup(name))) {
+         assertEquals(204, deleteResponse.status());
+      }
+
+      // Ensure that all of the backup files have been deleted from the source cluster
+      // We must wait for a short period time here to ensure that the returned entity has actually been removed from the filesystem
+      Thread.sleep(50);
+      assertNoServerBackupFilesExist(source);
+
+      // Shutdown the source cluster
+      stopSourceCluster();
+
+      // Start the target cluster
+      startTargetCluster();
+      client = target.getClient();
+
+      // Upload the backup to the target cluster
+      try (RestResponse restoreResponse = restore(backupZip, client)) {
+         assertEquals(201, restoreResponse.status(), restoreResponse.body());
+      }
+
+      // Assert that all content has been restored as expected, connecting to the second node in the cluster to ensure
+      // that configurations and caches are restored cluster-wide
+      assertTargetContent(target.getClient(1));
+
+      // Ensure that the backup files have been deleted from the target cluster
+      assertNoServerBackupFilesExist(target);
+      stopTargetCluster();
+   }
+
+   private void populateContainer(RestClient client) {
+      ConfigurationBuilder builder = new ConfigurationBuilder();
+      builder.clustering().cacheMode(CacheMode.DIST_SYNC);
+      createCache(cacheName, builder, client);
+
+      RestCacheClient cache = client.cache(cacheName);
+      for (int i = 0; i < size; i++) {
+         assertStatus(NO_CONTENT, cache.put("Key-" + i, UUID.randomUUID().toString()));
+      }
+      assertEquals(size, getCacheSize(cacheName, client));
+   }
+
+   private RestResponse backupAndDownload(RestClient client) {
+      RestContainerClient cm = client.container();
+      assertStatus(ACCEPTED, cm.createBackup(name));
+      return awaitResponse(() -> cm.getBackup(name, false), ACCEPTED, OK);
+   }
+
+   private RestResponse restore(File zip, RestClient client) {
+      RestContainerClient cm = client.container();
+      assertStatus(ACCEPTED, cm.restore(name, zip));
+      long start = System.currentTimeMillis();
+      return awaitResponse(() -> {
+         if (System.currentTimeMillis() - start > 10_000)
+            fail("Failed to complete restore procedure on time");
+
+         return cm.getRestore(name);
+      }, ACCEPTED, CREATED);
+   }
+
+   private void assertTargetContent(RestClient client) {
+      RestCacheClient cache = client.cache(cacheName);
+      assertStatusAndBodyEquals(OK, Integer.toString(size), cache.size());
+   }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-15523

Batch requests while restoring the cache and using a Flowable so we have control more easily. For comparison, with the tests I did for the Jira:

14.0.7.Final takes around 1:30s.
```log
2024-01-23 18:30:20,102 INFO  (jgroups-13,node-0) [org.infinispan.server.core.backup.BackupManagerImpl] ISPN005045: Starting restore 'reproducer2' of 'backup.zip'
2024-01-23 18:31:48,750 INFO  (non-blocking-thread-node-0-p2-t11) [org.infinispan.server.core.backup.BackupManagerImpl] ISPN005046: Restore 'reproducer2' complete
```

14.0.22.Final takes around 4 min.
```log
2024-01-23 18:46:03,516 INFO  (jgroups-7,node-0) [org.infinispan.server.core.backup.BackupManagerImpl] ISPN005045: Starting restore 'reproducer2' of 'backup.zip'
2024-01-23 18:50:12,590 INFO  (non-blocking-thread-node-0-p2-t6) [org.infinispan.server.core.backup.BackupManagerImpl] ISPN005046: Restore 'reproducer2' complete
```

This version takes almost 15s.
```log
2024-03-05 20:34:29,051 INFO  (jgroups-6,node-0) [org.infinispan.server.core.backup.BackupManagerImpl] ISPN005045: Starting restore 'reproducer2' of '/home/jbolina/backup.zip'
2024-03-05 20:34:43,793 INFO  (non-blocking-thread-node-0-p2-t2) [org.infinispan.server.core.backup.BackupManagerImpl] ISPN005046: Restore 'reproducer2' complete
```

I created another class for the test instead of adding the method to `BackupManagerIT` so it can run in parallel. That test takes around 1:30s to complete here, likely more on CI. If you prefer I can change it to the stress group.