### PR TITLE
Avoid potential NullPointerException

### DIFF
--- a/core/src/main/java/org/infinispan/marshall/core/AbstractBytesObjectInput.java
+++ b/core/src/main/java/org/infinispan/marshall/core/AbstractBytesObjectInput.java
@@ -257,7 +257,7 @@ abstract public class AbstractBytesObjectInput implements ObjectInput {
    }
 
    private void checkPosLength(int len) throws EOFException {
-      if (len > 0 && pos + len > bytes.length) {
+      if (len > 0 && (bytes == null || pos + len > bytes.length)) {
          throw new EOFException();
       }
    }


### PR DESCRIPTION
Hi there, 

For an unknown reason (so far), I am in a case where the buffer is null.

It result in an NPE.

```
2024-03-07 14:19:31,682 ERROR [org.infinispan.CLUSTER] (jgroups-14,f4d5439b3910-35958) ISPN000474: Error processing request 0@918a36bef812-46695: java.lang.NullPointerException: Cannot read the array length because "this.bytes" is null
	at org.infinispan.marshall.core.AbstractBytesObjectInput.checkPosLength(AbstractBytesObjectInput.java:260)
	at org.infinispan.marshall.core.AbstractBytesObjectInput.readByte(AbstractBytesObjectInput.java:107)
	at org.infinispan.marshall.core.AbstractBytesObjectInput.readUnsignedByte(AbstractBytesObjectInput.java:113)
	at org.infinispan.marshall.core.GlobalMarshaller.readNullableObject(GlobalMarshaller.java:356)
	at org.infinispan.marshall.core.GlobalMarshaller.objectFromObjectInput(GlobalMarshaller.java:191)
	at org.infinispan.marshall.core.GlobalMarshaller.objectFromByteBuffer(GlobalMarshaller.java:220)
	at org.infinispan.remoting.transport.jgroups.JGroupsTransport.processRequest(JGroupsTransport.java:1536)
	at org.infinispan.remoting.transport.jgroups.JGroupsTransport.processMessage(JGroupsTransport.java:1476)
	at org.infinispan.remoting.transport.jgroups.JGroupsTransport$ChannelCallbacks.lambda$up$1(JGroupsTransport.java:1695)
	at java.base/java.lang.Iterable.forEach(Iterable.java:75)
	at org.infinispan.remoting.transport.jgroups.JGroupsTransport$ChannelCallbacks.up(JGroupsTransport.java:1687)
	at org.jgroups.JChannel.up(JChannel.java:749)
	at org.jgroups.stack.ProtocolStack.up(ProtocolStack.java:939)
	at org.jgroups.protocols.FRAG3.up(FRAG3.java:154)
	at org.jgroups.protocols.VERIFY_SUSPECT.up(VERIFY_SUSPECT.java:146)
	at org.jgroups.protocols.FailureDetection.up(FailureDetection.java:193)
	at org.jgroups.protocols.FRAG2.up(FRAG2.java:161)
	at org.jgroups.protocols.FlowControl.up(FlowControl.java:319)
	at org.jgroups.protocols.FlowControl.up(FlowControl.java:319)
	at org.jgroups.protocols.pbcast.GMS.up(GMS.java:859)
	at org.jgroups.protocols.pbcast.STABLE.up(STABLE.java:246)
	at org.jgroups.protocols.UNICAST3.up(UNICAST3.java:498)
	at org.jgroups.protocols.pbcast.NAKACK2.up(NAKACK2.java:722)
	at org.jgroups.protocols.VERIFY_SUSPECT2.up(VERIFY_SUSPECT2.java:119)
	at org.jgroups.protocols.FailureDetection.up(FailureDetection.java:193)
	at org.jgroups.stack.Protocol.up(Protocol.java:372)
	at org.jgroups.protocols.MERGE3.up(MERGE3.java:288)
	at org.jgroups.protocols.Discovery.up(Discovery.java:314)
	at org.jgroups.protocols.RED.up(RED.java:119)
	at org.jgroups.protocols.TP.passBatchUp(TP.java:1210)
	at org.jgroups.util.MaxOneThreadPerSender$BatchHandlerLoop.passBatchUp(MaxOneThreadPerSender.java:287)
	at org.jgroups.util.SubmitToThreadPool$BatchHandler.run(SubmitToThreadPool.java:157)
	at org.jgroups.util.MaxOneThreadPerSender$BatchHandlerLoop.run(MaxOneThreadPerSender.java:276)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
```

I propose this change to properly handle this case instead of an unhandled null pointer exception

I bet the issue comes from the underlying jgroup, but this will be a safer way to handle those data.

Let me know
