### PR TITLE
[11.0.x] ISPN-15239 HotRod client repeatedly retries iteration operation against failed server after removal from topology

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/iteration/RemoteInnerPublisherHandler.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/iteration/RemoteInnerPublisherHandler.java
@@ -1,6 +1,7 @@
 package org.infinispan.client.hotrod.impl.iteration;
 
 import java.lang.invoke.MethodHandles;
+import java.net.ConnectException;
 import java.net.SocketAddress;
 import java.util.List;
 import java.util.Map;
@@ -112,7 +113,7 @@ class RemoteInnerPublisherHandler<K, E> extends AbstractAsyncPublisherHandler<Ma
 
    @Override
    protected void handleThrowableInResponse(Throwable t, Map.Entry<SocketAddress, IntSet> target) {
-      if (t instanceof TransportException || t instanceof RemoteIllegalLifecycleStateException) {
+      if (t instanceof TransportException || t instanceof RemoteIllegalLifecycleStateException || t instanceof ConnectException) {
          log.throwableDuringPublisher(t);
          if (log.isTraceEnabled()) {
             IntSet targetSegments = target.getValue();

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/iteration/RemotePublisher.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/iteration/RemotePublisher.java
@@ -132,6 +132,7 @@ public class RemotePublisher<K, E> implements Publisher<Map.Entry<K, E>> {
                int batchSize = (this.batchSize / actualTargets.size()) + 1;
                return Flowable.fromIterable(actualTargets.entrySet())
                      .map(entry -> {
+                        log.tracef("Requesting next for: %s", entry);
                         RemoteInnerPublisherHandler<K, E> innerHandler = new RemoteInnerPublisherHandler<>(this,
                               batchSize, () -> null, entry);
                         return innerHandler.startPublisher();

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/SslTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/SslTest.java
@@ -3,23 +3,25 @@ package org.infinispan.client.hotrod;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
 import static org.testng.AssertJUnit.assertEquals;
 
-import java.io.IOException;
+import javax.net.ssl.SSLHandshakeException;
 
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
 import org.infinispan.client.hotrod.configuration.SslConfigurationBuilder;
 import org.infinispan.client.hotrod.exceptions.TransportException;
 import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
+import org.infinispan.commons.test.Exceptions;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.server.hotrod.HotRodServer;
 import org.infinispan.server.hotrod.configuration.HotRodServerConfigurationBuilder;
 import org.infinispan.server.hotrod.test.HotRodTestingUtil;
-import org.infinispan.commons.test.Exceptions;
 import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 import org.testng.annotations.Test;
+
+import io.netty.handler.codec.DecoderException;
 
 /**
  * @author Adrian Brock
@@ -138,7 +140,7 @@ public class SslTest extends SingleCacheManagerTest {
 
    // Note: with Netty this started to throw SSLException instead of SSLHandshakeException
    public void testClientAuthWithAnonClient() throws Exception {
-      Exceptions.expectExceptionNonStrict(TransportException.class, IOException.class, () -> initServerAndClient(true, true, true, false, false));
+      Exceptions.expectExceptionNonStrict(TransportException.class, DecoderException.class, SSLHandshakeException.class, () -> initServerAndClient(true, true, true, false, false));
    }
 
    public void testClientAuthAltCertPassword() throws Exception {

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/BaseIterationFailOverTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/BaseIterationFailOverTest.java
@@ -42,7 +42,7 @@ public abstract class BaseIterationFailOverTest extends MultiHotRodServersTest i
    @Override
    protected int maxRetries() {
       // We kill one node in many tests - let it failover in that case
-      return 1;
+      return 2;
    }
 
    @Test(groups = "functional")

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/BaseIterationFailOverTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/BaseIterationFailOverTest.java
@@ -3,6 +3,7 @@ package org.infinispan.client.hotrod.impl.iteration;
 import static org.testng.AssertJUnit.assertEquals;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -11,6 +12,7 @@ import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
 import org.infinispan.client.hotrod.test.MultiHotRodServersTest;
 import org.infinispan.commons.util.CloseableIterator;
+import org.infinispan.commons.util.CloseableIteratorSet;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.protostream.SerializationContextInitializer;
 import org.infinispan.query.dsl.embedded.DslSCI;
@@ -63,6 +65,24 @@ public abstract class BaseIterationFailOverTest extends MultiHotRodServersTest i
          Map.Entry<Object, Object> next = iterator.next();
          entries.add(next);
 
+      }
+
+      assertEquals(cacheSize, entries.size());
+
+      Set<Integer> keys = extractKeys(entries);
+      assertEquals(rangeAsSet(0, cacheSize), keys);
+   }
+
+   @Test(groups = "functional")
+   public void testServerLeaveButIterateTwice() throws InterruptedException {
+      testFailOver();
+      int cacheSize = 1_000;
+
+      RemoteCache<Integer, AccountHS> cache = clients.get(0).getCache();
+      Collection<Map.Entry<Object, Object>> entries = new ArrayList<>();
+      CloseableIteratorSet<Map.Entry<Integer, AccountHS>> iterator = cache.entrySet();
+      for (Map.Entry<Integer, AccountHS> entry : iterator) {
+         entries.add((Map.Entry) entry);
       }
 
       assertEquals(cacheSize, entries.size());


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ISPN-15239

This is a backport of : https://github.com/infinispan/infinispan/pull/11422 to `11.0.x` branch for EAP 7.4.z