### PR TITLE
ISPN-15857 Allow to configure DNS record type for DNS_PING with a Java property

### DIFF
--- a/core/src/main/resources/default-configs/default-jgroups-kubernetes.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-kubernetes.xml
@@ -29,6 +29,7 @@
    />
    <RED/>
    <dns.DNS_PING dns_query="${jgroups.dns.query}"
+                 dns_record_type="${jgroups.dns.record:A}"
                  num_discovery_runs="3"
    />
    <MERGE3 min_interval="10000"

--- a/documentation/src/main/asciidoc/topics/ref_jgroups_extras_properties.adoc
+++ b/documentation/src/main/asciidoc/topics/ref_jgroups_extras_properties.adoc
@@ -92,4 +92,9 @@ System properties for `DNS_PING`.
 | No default value.
 | Required
 
+| `jgroups.dns.record`
+| Sets the DNS record type.
+| A
+| Optional
+
 |===


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-15857

My setup is a set of Keycloak 18.0.2 clusters in an environment with nomad and consul. We're using DNS_PING with SRV records for a long time now and the JGroups setup is pretty simple:

```
JGROUPS_DISCOVERY_PROTOCOL=dns.DNS_PING
JGROUPS_DISCOVERY_PROPERTIES="dns_query="${dns_query}",dns_record_type="SRV""
JGROUPS_TRANSPORT_STACK="tcp"
```

When migrating this to Keycloak 23.0.7, I found that the dns_record_type separated with a comma is not supported anymore. After a lot of experimenting and a [PR on JGroups](https://github.com/belaban/JGroups/pull/776), I managed to use SRV records again with this infinispan configuration for jgroups:

```
<infinispan
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="urn:infinispan:config:14.0 http://www.infinispan.org/schemas/infinispan-config-14.0.xsd"
        xmlns="urn:infinispan:config:14.0">

    <jgroups>
        <stack name="dns-ping" extends="kubernetes">
            <dns.DNS_PING dns_query="${jgroups.dns.query}"
                          dns_record_type="${jgroups.dns.record:A}"
            />
        </stack>
    </jgroups>

    <cache-container name="keycloak">
        <transport lock-timeout="60000" stack="dns-ping"/>
        ...
```

and some Java properties:

```
KC_CACHE=ispn
JAVA_OPTS_APPEND="-Djgroups.dns.query=${dns_query} -Djgroups.dns.record=SRV
```

I hope you find this PR useful and I'm happy about feedback.