### PR TITLE
ISPN-15872 View change during a cache join can lead to not replicatin…

### DIFF
--- a/core/src/main/java/org/infinispan/commands/topology/CacheJoinCommand.java
+++ b/core/src/main/java/org/infinispan/commands/topology/CacheJoinCommand.java
@@ -36,6 +36,10 @@ public class CacheJoinCommand extends AbstractCacheControlCommand {
       this.viewId = viewId;
    }
 
+   public String getCacheName() {
+      return cacheName;
+   }
+
    @Override
    public CompletionStage<?> invokeAsync(GlobalComponentRegistry gcr) throws Throwable {
       return gcr.getClusterTopologyManager()

--- a/core/src/main/java/org/infinispan/topology/LocalTopologyManagerImpl.java
+++ b/core/src/main/java/org/infinispan/topology/LocalTopologyManagerImpl.java
@@ -280,8 +280,10 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager, GlobalSta
 
    private CompletionStage<CacheTopology> handleJoinResponse(String cacheName, LocalCacheStatus cacheStatus,
                                                             CacheStatusResponse initialStatus) {
+      log.debugf("Cache %s received join response %s", cacheName, initialStatus);
+      CacheTopology ct = getJoinTopology(initialStatus);
       int viewId = transport.getViewId();
-      return doHandleTopologyUpdate(cacheName, initialStatus.getCacheTopology(), initialStatus.getAvailabilityMode(),
+      return doHandleTopologyUpdate(cacheName, ct, initialStatus.getAvailabilityMode(),
                                     viewId, transport.getCoordinator(), cacheStatus)
                    .thenCompose(applied -> {
                       if (!applied) {
@@ -298,7 +300,24 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager, GlobalSta
                       return doHandleStableTopologyUpdate(cacheName, initialStatus.getStableTopology(), viewId,
                                                           transport.getCoordinator(), cacheStatus);
                    })
-                   .thenApply(ignored -> initialStatus.getCacheTopology());
+                  .thenApply(ignored -> ct);
+   }
+
+   private CacheTopology getJoinTopology(CacheStatusResponse response) {
+      // First, try to utilize the coordinator topology *before* the join.
+      CacheTopology ct = response.getCacheTopology();
+      if (ct == null)
+         return null;
+
+      // If the join receives a topology already in rebalance AND it is counted towards the current members, utilize the stable topology.
+      // This scenario could happen when the node retries the join operation due to a view change when received the response.
+      // Counting itself as a member *during* the join would cause the node to be identified as a state donor in the state transfer.
+      // However, since the node is joining, it does not have any state to donate. Instead, utilize the stable topology to bootstrap.
+      // During this processing, a lock is held to this cache, and the rebalance message should be received *after* the join completes.
+      if (ct.getPhase() != CacheTopology.Phase.NO_REBALANCE && ct.getActualMembers().contains(transport.getAddress()))
+         return response.getStableTopology();
+
+      return ct;
    }
 
    private int getNumberMembersFromState(String cacheName, CacheJoinInfo joinInfo) {
@@ -706,8 +725,10 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager, GlobalSta
 
    private CompletionStage<Void> withView(int viewId, long timeout, TimeUnit timeUnit) {
       CompletableFuture<Void> viewFuture = transport.withView(viewId);
+      // Generate here to keep the stack trace.
+      Throwable t = CLUSTER.timeoutWaitingForView(viewId, transport.getViewId());
       ScheduledFuture<Boolean> cancelTask = timeoutExecutor.schedule(
-            () -> viewFuture.completeExceptionally(CLUSTER.timeoutWaitingForView(viewId, transport.getViewId())),
+            () -> viewFuture.completeExceptionally(t),
             timeout, timeUnit);
       viewFuture.whenComplete((v, throwable) -> cancelTask.cancel(false));
       return viewFuture;

--- a/core/src/test/java/org/infinispan/commands/CommandIdUniquenessTest.java
+++ b/core/src/test/java/org/infinispan/commands/CommandIdUniquenessTest.java
@@ -10,6 +10,7 @@ import java.util.TreeMap;
 
 import org.infinispan.commons.util.ClassFinder;
 import org.infinispan.test.AbstractInfinispanTest;
+import org.infinispan.test.Mocks;
 import org.testng.annotations.Test;
 
 @Test(groups = "unit", testName = "commands.CommandIdUniquenessTest")
@@ -19,7 +20,7 @@ public class CommandIdUniquenessTest extends AbstractInfinispanTest {
       SortedMap<Byte, String> cmdIds = new TreeMap<Byte, String>();
 
       for (Class<?> c : commands) {
-         if (!c.isInterface() && !Modifier.isAbstract(c.getModifiers()) && !LocalCommand.class.isAssignableFrom(c)) {
+         if (!c.isInterface() && !Modifier.isAbstract(c.getModifiers()) && !LocalCommand.class.isAssignableFrom(c) && !c.getName().contains(Mocks.class.getName())) {
             log.infof("Testing %s", c.getSimpleName());
             Constructor<?>[] declaredCtors = c.getDeclaredConstructors();
             Constructor<?> constructor = null;

--- a/core/src/test/java/org/infinispan/topology/ClusterTopologyViewChangesTest.java
+++ b/core/src/test/java/org/infinispan/topology/ClusterTopologyViewChangesTest.java
@@ -5,7 +5,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.IntStream;
 
+import org.infinispan.Cache;
 import org.infinispan.commands.topology.RebalanceStatusRequestCommand;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
@@ -21,6 +23,8 @@ import org.testng.annotations.Test;
 @CleanupAfterMethod
 @Test(testName = "topology.ClusterTopologyViewChangesTest", groups = "functional")
 public class ClusterTopologyViewChangesTest extends MultipleCacheManagersTest {
+
+   private final int dataSize = 100;
 
 
    @Override
@@ -56,7 +60,7 @@ public class ClusterTopologyViewChangesTest extends MultipleCacheManagersTest {
       executeJoinTest(-1);
    }
 
-   public void nodeLeftDuringCacheWithRebalanceDisabled() throws Exception {
+   public void nodeLeftDuringCacheJoinWithRebalanceDisabled() throws Exception {
       waitForClusterToForm();
       TestingUtil.extractGlobalComponentRegistry(findCoordinator())
             .getClusterTopologyManager()
@@ -70,12 +74,16 @@ public class ClusterTopologyViewChangesTest extends MultipleCacheManagersTest {
       waitForClusterToForm();
       TestingUtil.extractGlobalComponentRegistry(findCoordinator())
             .getClusterTopologyManager()
-            .setRebalancingEnabled(false);
+            .setRebalancingEnabled(false)
+            .toCompletableFuture().get(10, TimeUnit.SECONDS);
 
       executeJoinTest(findCoordinatorIndex());
    }
 
    private void executeJoinTest(int nodeToStop) throws Exception {
+      // First step, populate the cache.
+      populateCache();
+
       CheckPoint checkPoint = new CheckPoint();
       AtomicBoolean onlyOnce = new AtomicBoolean(true);
 
@@ -109,8 +117,32 @@ public class ClusterTopologyViewChangesTest extends MultipleCacheManagersTest {
       EmbeddedCacheManager joiner = joining.get(10, TimeUnit.SECONDS);
 
       // Assert the joiner has the same status as the coordinator.
+      boolean rebalanced = TestingUtil.extractGlobalComponentRegistry(joiner).getClusterTopologyManager().isRebalancingEnabled();
       assertThat(TestingUtil.extractGlobalComponentRegistry(findCoordinator()).getClusterTopologyManager().isRebalancingEnabled())
-            .isEqualTo(TestingUtil.extractGlobalComponentRegistry(joiner).getClusterTopologyManager().isRebalancingEnabled());
+            .isEqualTo(rebalanced);
+
+      // Assert data on all caches if rebalance enabled.
+      if (rebalanced) assertCacheData();
+   }
+
+   private void populateCache() {
+      Cache<String, String> cache = cache(0);
+      IntStream.range(0, dataSize).parallel()
+            .forEach(i -> cache.put("key-" + i, "value-" + i));
+   }
+
+   private void assertCacheData() {
+      for (int m = 0; m < managers().length; m++) {
+         Cache<String, String> cache = cache(m);
+         int size = cache.size();
+         assertThat(size)
+               .withFailMessage(String.format("Cache %d has %d/%d entries", m, size, dataSize))
+               .isEqualTo(dataSize);
+
+         for (int i = 0; i < dataSize; i++) {
+            assertThat(cache.get("key-" + i)).isEqualTo("value-" + i);
+         }
+      }
    }
 
    private EmbeddedCacheManager findCoordinator() {

--- a/core/src/test/java/org/infinispan/topology/TopologyUnorderedJoinTest.java
+++ b/core/src/test/java/org/infinispan/topology/TopologyUnorderedJoinTest.java
@@ -1,0 +1,148 @@
+package org.infinispan.topology;
+
+import static org.infinispan.test.Mocks.AFTER_INVOCATION;
+import static org.infinispan.test.Mocks.AFTER_RELEASE;
+import static org.infinispan.test.Mocks.BEFORE_INVOCATION;
+import static org.infinispan.test.Mocks.BEFORE_RELEASE;
+
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.IntStream;
+
+import org.assertj.core.api.SoftAssertions;
+import org.infinispan.Cache;
+import org.infinispan.commands.topology.CacheJoinCommand;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.test.Mocks;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.CheckPoint;
+import org.testng.annotations.Test;
+
+@Test(testName = "topology.TopologyUnorderedJoinTest", groups = "functional")
+public class TopologyUnorderedJoinTest extends MultipleCacheManagersTest {
+
+   private final int dataSize = 100;
+   private final String cacheName = "testCache";
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      createCluster(defaultGlobalConfig(), defaultCacheConfig(), 2);
+      for (EmbeddedCacheManager manager : managers()) {
+         defineConfiguration(manager);
+      }
+   }
+
+   private GlobalConfigurationBuilder defaultGlobalConfig() {
+      GlobalConfigurationBuilder gcb = GlobalConfigurationBuilder.defaultClusteredBuilder();
+      gcb.transport().distributedSyncTimeout(15, TimeUnit.SECONDS);
+      return gcb;
+   }
+
+   private ConfigurationBuilder defaultCacheConfig() {
+      ConfigurationBuilder cb = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false);
+      cb.clustering().stateTransfer().timeout(30, TimeUnit.SECONDS);
+      return cb;
+   }
+
+   private EmbeddedCacheManager addNewMember() {
+      return addClusterEnabledCacheManager(defaultGlobalConfig(), defaultCacheConfig());
+   }
+
+   private void defineConfiguration(EmbeddedCacheManager ecm) {
+      ecm.defineConfiguration(cacheName, defaultCacheConfig().build());
+   }
+
+   public void testDelayJoinResponseAfterRebalanceStart() throws Exception {
+      // Create the cache on the initial two nodes and populate.
+      waitForClusterToForm(cacheName);
+      populateCache();
+
+      // Replace to block on the join request.
+      // We allow the request to process, and unlock only after another node joins and the view updates.
+      AtomicBoolean onlyOnce = new AtomicBoolean(true);
+      CheckPoint joinPoint =  Mocks.blockInboundGlobalCommandExecution(findCoordinator(), rc -> {
+         if (rc instanceof CacheJoinCommand cjc) {
+            return cjc.getCacheName().equals(cacheName) && onlyOnce.getAndSet(false);
+         }
+         return false;
+      });
+
+      // Add new node.
+      // We add an interceptor to the rebalance start command to the joiner.
+      EmbeddedCacheManager joiner = addNewMember();
+      defineConfiguration(joiner);
+
+      // Request cache asynchronously, since we block the initial commands.
+      Future<Cache<String, String>> future = fork(() -> joiner.getCache(cacheName));
+
+      // We allow the join request to process.
+      joinPoint.awaitStrict(BEFORE_INVOCATION, 10, TimeUnit.SECONDS);
+      joinPoint.trigger(BEFORE_RELEASE);
+
+      // Wait the join to process on the coordinator and the rebalance request arrive at the joiner.
+      joinPoint.awaitStrict(AFTER_INVOCATION, 10, TimeUnit.SECONDS);
+
+      // New node joins, this causes the view to update.
+      // No need to request the cache now, this is enough to cause a view change.
+      EmbeddedCacheManager ecm = addNewMember();
+      defineConfiguration(ecm);
+
+      // Wait view is installed on all nodes.
+      // Since the view is global, we can utilize the default cache instead here.
+      // This way, we don't block with the second joiner also creating the cache.
+      TestingUtil.blockUntilViewsReceived(15_000, caches());
+
+      // Release the join on the coordinator.
+      // The joiner will receive a response and retry.
+      joinPoint.trigger(AFTER_RELEASE);
+
+      // Wait to the state transfer to finish.
+      // This also creates the cache on the second joiner.
+      waitForClusterToForm(cacheName);
+      future.get(10, TimeUnit.SECONDS);
+
+      // Assert the data is available from all nodes.
+      assertCacheData();
+   }
+
+   private void populateCache() {
+      Cache<String, String> cache = cache(0, cacheName);
+      IntStream.range(0, dataSize).parallel()
+            .forEach(i -> cache.put("key-" + i, "value-" + i));
+   }
+
+   private void assertCacheData() {
+      // Use soft assertions to check all caches and all values.
+      SoftAssertions sa = new SoftAssertions();
+      for (int m = 0; m < managers().length; m++) {
+         Cache<String, String> cache = cache(m, cacheName);
+         int size = cache.size();
+         sa.assertThat(size)
+               .withFailMessage(String.format("Cache %d has %d/%d entries", m, size, dataSize))
+               .isEqualTo(dataSize);
+
+         for (int i = 0; i < dataSize; i++) {
+            sa.assertThat(cache.get("key-" + i)).isEqualTo("value-" + i);
+         }
+      }
+
+      sa.assertAll();
+   }
+
+   private EmbeddedCacheManager findCoordinator() {
+      return manager(findCoordinatorIndex());
+   }
+
+   private int findCoordinatorIndex() {
+      for (int i = 0; i < managers().length; i++) {
+         if (manager(i).isCoordinator()) return i;
+      }
+
+      throw new IllegalStateException("Coordinator node not found");
+   }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-15872

…g data

Basically, because of the view change, the joiner retries the request and receives the topology in rebalance. The topology in rebalance has the pending consistent hash that includes the joiner. This causes the state transfer to mistakenly use the joiner as a state donor, causing some entries to not replicate in the state transfer.

The fix is to choose the appropriate topology when handling the join response. We can not use a topology which includes the joiner. We change this when handling the response because it is at a point we know the node is still joining and doesn't have any state.