### PR TITLE
ISPN-15760 Flaky test: org.infinispan.topology.ClusterTopologyViewCha…

### DIFF
--- a/core/src/main/java/org/infinispan/commands/topology/CacheStatusRequestCommand.java
+++ b/core/src/main/java/org/infinispan/commands/topology/CacheStatusRequestCommand.java
@@ -3,9 +3,14 @@ package org.infinispan.commands.topology;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import org.infinispan.factories.GlobalComponentRegistry;
+import org.infinispan.topology.ManagerStatusResponse;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
 
 /**
  * The coordinator is requesting information about the running caches.
@@ -15,6 +20,7 @@ import org.infinispan.factories.GlobalComponentRegistry;
  */
 public class CacheStatusRequestCommand extends AbstractCacheControlCommand {
 
+   private final static Log log = LogFactory.getLog(CacheStatusRequestCommand.class);
    public static final byte COMMAND_ID = 96;
 
    private int viewId;
@@ -31,6 +37,11 @@ public class CacheStatusRequestCommand extends AbstractCacheControlCommand {
 
    @Override
    public CompletionStage<?> invokeAsync(GlobalComponentRegistry gcr) throws Throwable {
+      if (!gcr.isLocalTopologyManagerRunning()) {
+         log.debug("Reply with empty status request because topology manager not running");
+         return CompletableFuture.completedFuture(new ManagerStatusResponse(Collections.emptyMap(), true));
+      }
+
       return gcr.getLocalTopologyManager()
             .handleStatusRequest(viewId);
    }


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-15760

…ngesTest#coordinatorLeftDuringCacheJoin


The original backport #11932 has this change. The issue happens because this command is still possibly blocked.