### PR TITLE
Ispn 15928 Unexpected attribute 'enabled-ciphersuites-tls13' in Redhat Datagrid 8.3.1

### DIFF
--- a/documentation/src/main/asciidoc/topics/json/server_ssl_identity_engine.json
+++ b/documentation/src/main/asciidoc/topics/json/server_ssl_identity_engine.json
@@ -12,8 +12,7 @@
             },
             "engine": {
               "enabled-protocols": ["TLSv1.3"],
-              "enabled-ciphersuites": "TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256",
-              "enabled-ciphersuites-tls13": "TLS_AES_256_GCM_SHA384"
+              "enabled-ciphersuites": "TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256"
             }
           }
         }

--- a/documentation/src/main/asciidoc/topics/proc_server_configuring_ssl_engine.adoc
+++ b/documentation/src/main/asciidoc/topics/proc_server_configuring_ssl_engine.adoc
@@ -25,7 +25,7 @@ Omitting the `enabled-protocols` attribute allows any TLS version.
 ----
 ====
 +
-. Configure {brandname} to use one or more cipher suites with the `enabled-ciphersuites` attribute (for TLSv1.2 and below) and the `enabled-ciphersuites-tls13` attribute (for TLSv1.3).
+. Configure {brandname} to use one or more cipher suites with the `enabled-ciphersuites` attribute (for TLSv1.3,TLSv1.2 and below) .
 +
 You must ensure that you set a cipher suite that supports any protocol features you plan to use; for example `HTTP/2 ALPN`.
 . Save the changes to your configuration.

--- a/documentation/src/main/asciidoc/topics/xml/server_ssl_identity_engine.xml
+++ b/documentation/src/main/asciidoc/topics/xml/server_ssl_identity_engine.xml
@@ -10,8 +10,8 @@
                       alias="server"/>
             <!-- Configures {brandname} Server to use specific TLS versions and cipher suites. -->
             <engine enabled-protocols="TLSv1.3 TLSv1.2"
-                    enabled-ciphersuites="TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256"
-                    enabled-ciphersuites-tls13="TLS_AES_256_GCM_SHA384"/>
+		    enabled-ciphersuites="TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256"/>
+                    
           </ssl>
         </server-identities>
       </security-realm>


### PR DESCRIPTION
Unexpected attribute 'enabled-ciphersuites-tls13' in Redhat Datagrid 8.3.1
The attribute is not present in Infinispan-server-13.0.xsd which is used in Redhat Datagrid 8.3.1 but present in Infinispan-server-14.0.xsd, therefore this needs a removal from the documentation.

https://issues.redhat.com/browse/ISPN-15928