### PR TITLE
ISPN-15930 SoftIndexFileStore locking inconsistent on clear and publi…

### DIFF
--- a/core/src/main/java/org/infinispan/persistence/sifs/Compactor.java
+++ b/core/src/main/java/org/infinispan/persistence/sifs/Compactor.java
@@ -419,7 +419,7 @@ class Compactor {
                nextExpirationTime = -1;
             }
 
-            nonBlockingManager.complete(stageRequest, null);
+            completeFuture(stageRequest);
          } else {
             log.tracef("Ignoring compaction request for %s as compactor is being cleared", stageRequest);
             completeFuture(stageRequest);

--- a/core/src/main/java/org/infinispan/persistence/sifs/Log.java
+++ b/core/src/main/java/org/infinispan/persistence/sifs/Log.java
@@ -92,4 +92,12 @@ public interface Log extends BasicLogger {
    @LogMessage(level = Logger.Level.WARN)
    @Message(value = "Compaction skipping a corrupted entry for key %s, at %s:%s|%s that doesn't have enough bytes for header %s", id = 29022)
    void compactedFileNotLongEnough(byte[] key, int file, long offset, long fileSize, EntryHeader record);
+
+   @LogMessage(level = Logger.Level.FATAL)
+   @Message(value = "Error encountered with index, SIFS may not operate properly.", id = 29023)
+   void fatalIndexError(@Cause Throwable t);
+
+   @LogMessage(level = Logger.Level.WARN)
+   @Message(value = "Clear encountered an exception, size stats for future invocations may be incorrect", id = 29024)
+   void clearError(@Cause Throwable t);
 }


### PR DESCRIPTION
…sh methods

https://issues.redhat.com/browse/ISPN-15930

Switched to StampedLock since it does not tie the lock state to the invoking thread, allowing us to unlock from a different thread which is required for the publish and clear methods.

Change clear and publish method to retain the lock until the operation is completed, the latter only retains the lock while iterating over a given segment at a time.

Added clear and iteration forks to the SoftIndexFileStressTest for validation.