### PR TITLE
ISPN-15943 SIFS during stop may not index puts that don't error

### DIFF
--- a/core/src/main/java/org/infinispan/persistence/sifs/NonBlockingSoftIndexFileStore.java
+++ b/core/src/main/java/org/infinispan/persistence/sifs/NonBlockingSoftIndexFileStore.java
@@ -458,7 +458,7 @@ public class NonBlockingSoftIndexFileStore<K, V> implements NonBlockingStore<K, 
    public CompletionStage<Void> stop() {
       return blockingManager.runBlocking(() -> {
          try {
-            logAppender.stop();
+            CompletionStages.join(logAppender.stop());
             compactor.stopOperations();
             compactor = null;
             CompletionStages.join(index.stop());


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-15943

I had to change the test to be a little flaky as it can't wait anymore as the fix now delays the stop until any log operation is fully completed.