### PR TITLE
ISPN-15942 Add JGroups probe and gossip router scripts

### DIFF
--- a/server/runtime/src/main/server/bin/gossip-router.sh
+++ b/server/runtime/src/main/server/bin/gossip-router.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+LOADER_CLASS=org.infinispan.server.loader.Loader
+MAIN_CLASS=org.jgroups.stack.GossipRouter
+ARGUMENTS=
+PROCESS_NAME=${infinispan.brand.short-name}-gossip-router
+
+PROGNAME=$(basename "$0")
+DIRNAME=$(dirname "$0")
+
+. "$DIRNAME/common.sh"
+
+while true; do
+   # Execute the JVM in the background
+   eval \"$JAVA\" $JAVA_OPTS \
+      -Dvisualvm.display.name=$PROCESS_NAME \
+      -Djava.util.logging.manager=org.infinispan.server.loader.LogManager \
+      -Dlog4j.configurationFile="$DIRNAME/gossiprouter.log4j2.xml" \
+      -Dinfinispan.server.home.path=\""$ISPN_HOME"\" \
+      -classpath \""$CLASSPATH"\" "$LOADER_CLASS" "$MAIN_CLASS" "$ARGUMENTS" "&"
+   GR_PID=$!
+   # Trap common signals and relay them to the server process
+   trap "kill -HUP  $GR_PID" HUP
+   trap "kill -TERM $GR_PID" INT
+   trap "kill -QUIT $GR_PID" QUIT
+   trap "kill -PIPE $GR_PID" PIPE
+   trap "kill -TERM $GR_PID" TERM
+   # Wait until the background process exits
+   WAIT_STATUS=128
+   while [ "$WAIT_STATUS" -ge 128 ]; do
+      wait $GR_PID 2>/dev/null
+      WAIT_STATUS=$?
+      if [ "$WAIT_STATUS" -gt 128 ]; then
+         SIGNAL=`expr $WAIT_STATUS - 128`
+         SIGNAL_NAME=`kill -l $SIGNAL`
+         echo "*** Gossip Router process ($GR_PID) received $SIGNAL_NAME signal ***" >&2
+      fi
+   done
+   if [ "$WAIT_STATUS" -lt 127 ]; then
+      ISPN_STATUS=$WAIT_STATUS
+   else
+      ISPN_STATUS=0
+   fi
+   if [ "$ISPN_STATUS" -ne 10 ]; then
+         # Wait for a complete shudown
+         wait $GR_PID 2>/dev/null
+   fi
+   if [ "$ISPN_STATUS" -eq 10 ]; then
+      echo "Restarting Gossip Router..."
+   else
+      exit $ISPN_STATUS
+   fi
+done

--- a/server/runtime/src/main/server/bin/gossiprouter.log4j2.xml
+++ b/server/runtime/src/main/server/bin/gossiprouter.log4j2.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration name="InfinispanGossipRouterConfig" monitorInterval="60">
+   <Appenders>
+      <!-- Colored output on the console -->
+      <Console name="STDOUT">
+         <PatternLayout
+               pattern="%highlight{%d{HH:mm:ss,SSS} %-5p [%c{1}] %m%throwable}{INFO=normal, DEBUG=normal, TRACE=normal}%n"/>
+      </Console>
+      <File name="FILE" createOnDemand="true"
+            fileName="gossiprouter.log">
+         <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p (%t) [%c{1}] %m%throwable%n"/>
+      </File>
+   </Appenders>
+
+   <Loggers>
+      <Root level="INFO">
+         <AppenderRef ref="STDOUT" level="INFO"/>
+         <!-- AppenderRef ref="FILE" level="DEBUG"/ -->
+      </Root>
+   </Loggers>
+</Configuration>

--- a/server/runtime/src/main/server/bin/probe.sh
+++ b/server/runtime/src/main/server/bin/probe.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+LOADER_CLASS=org.infinispan.server.loader.Loader
+MAIN_CLASS=org.jgroups.tests.Probe
+ARGUMENTS=
+PROCESS_NAME=${infinispan.brand.short-name}-probe
+
+PROGNAME=$(basename "$0")
+DIRNAME=$(dirname "$0")
+
+. "$DIRNAME/common.sh"
+
+eval \"$JAVA\" $JAVA_OPTS \
+  -Dvisualvm.display.name=$PROCESS_NAME \
+  -Djava.util.logging.manager=org.infinispan.server.loader.LogManager \
+  -Dinfinispan.server.home.path=\""$ISPN_HOME"\" \
+  -classpath \""$CLASSPATH"\" "$LOADER_CLASS" "$MAIN_CLASS" "$ARGUMENTS"


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-15942

Basic script to start the Gossip Router. Used by `TUNNEL` or `TCPGOSSIP` protocols.
```
$ ./bin/gossip-router.sh  -dump_msgs all


GossipRouter started in 335 ms listening on 0.0.0.0:12001
added pedro-desktop-31820 (127.0.0.1:58674) to group cluster
dst=null src=pedro-desktop-31820 (54 bytes): hdrs= PING: [GET_MBRS_REQ cluster=cluster initial_discovery=true], TP: [cluster=cluster]
dst=null src=pedro-desktop-31820 (54 bytes): hdrs= PING: [GET_MBRS_REQ cluster=cluster initial_discovery=true], TP: [cluster=cluster]
dst=null src=pedro-desktop-31820 (54 bytes): hdrs= PING: [GET_MBRS_REQ cluster=cluster initial_discovery=true], TP: [cluster=cluster]
```

And probe, if diagnostic is enabled
```
$ ./bin/probe.sh

#1 (90 bytes):
GossipRouter [addr=127.0.1.1:12001, cluster=GossipRouter, version=5.3.4.Final (Zoncolan)]

#2 (164 bytes):
pedro-desktop-31820 (ip=127.0.0.1:58674)
view=[pedro-desktop-31820|0] (1) [pedro-desktop-31820]
cluster=cluster
version=5.3.4.Final (Zoncolan) (java 21.0.2+13-LTS)

2 responses (2 matches, 0 non matches)
```