### PR TITLE
Build images automatically on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,11 +10,18 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
+      images: ${{ steps.images.outputs.images }}
       upload_url: ${{ steps.release.outputs.upload_url }}
 
     steps:
       - name: Checkout Source
         uses: actions/checkout@v4
+
+      - id: images
+        run: |
+          BRANCH=${{ github.ref_name }}
+          MAJOR=${BRANCH%.*.*.*}
+          [ "${MAJOR}" -ge "15" ] && echo "images=true" >> ${GITHUB_OUTPUT} || true
 
       - id: release
         name: Create Release
@@ -25,6 +32,16 @@ jobs:
           tag_name: ${{github.ref_name}}
           release_name: ${{github.ref_name}}
           prerelease: ${{ !contains(github.ref_name, '.Final') }}
+
+  images:
+    needs: release
+    if: needs.release.outputs.images == 'true'
+    uses: infinispan/infinispan-images/.github/workflows/release.yml@main
+    with:
+      # TODO set the branch accordingly once we branch for 16.0.x
+      branch: main
+      repository: infinispan/infinispan-images
+      ispnVersion: ${{ github.ref_name }}
 
   server-upload:
     needs: release


### PR DESCRIPTION
With this change Images will automatically be created when tags for majors >= 15 are pushed. When we fork for 16, we'll need to adjust the logic slightly so that the correct image branch is checked out.

I also added the following commit to the infinispan-images repo: https://github.com/infinispan/infinispan-images/commit/b5697d5647c87bdfceeac0b41ff20fcee56f0447