### PR TITLE
ISPN-16031 Lock SIFS directories to avoid shared usage between instances

### DIFF
--- a/commons/all/src/main/java/org/infinispan/commons/util/concurrent/FileSystemLock.java
+++ b/commons/all/src/main/java/org/infinispan/commons/util/concurrent/FileSystemLock.java
@@ -1,0 +1,140 @@
+package org.infinispan.commons.util.concurrent;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.file.Path;
+
+import org.infinispan.commons.util.Util;
+
+import net.jcip.annotations.GuardedBy;
+import net.jcip.annotations.ThreadSafe;
+
+/**
+ * A simplified global lock backed by the file system.
+ * <p>
+ * This implementation allows to control the access to external resource between different virtual machines. A file
+ * is created to control access, where subsequent tries do not succeed acquiring the lock as long as the file exists.
+ * </p>
+ * <p>
+ * <b>Warning:</b> This implementation <b>does not</b> have the semantics of a traditional {@link java.util.concurrent.locks.Lock}.
+ * Does <b>not</b> provide memory or visibility guarantees following the JMM.
+ * </p>
+ *
+ * @since 15.0
+ */
+@ThreadSafe
+public class FileSystemLock {
+
+   private final Path directory;
+   private final String name;
+
+   @GuardedBy("this")
+   private FileOutputStream globalLockFile;
+
+   @GuardedBy("this")
+   private FileLock globalLock;
+
+   /**
+    * Creates new instance of the lock.
+    * <p>
+    * Creates a new file in the provided directory utilizing the lock's name.
+    * </p>
+    *
+    * @param directory: Root directory to create the lock files.
+    * @param name: Uniquely identify the file name. If the names conflict, it means the lock is already held.
+    */
+   public FileSystemLock(Path directory, String name) {
+      this.directory = directory;
+      this.name = name;
+   }
+
+   /**
+    * Tries to acquire the global lock.
+    * <p>
+    * Creates a file in the provided directory with the lock's name. If the file already exists, the lock is held
+    * by another instance. The instance is not necessarily in the same virtual machine.
+    * </p>
+    *
+    * @return <code>true</code> if acquired the lock, <code>false</code>, otherwise.
+    * @throws IOException: In case of failures creating the file.
+    * @see FileChannel#lock() Check the thrown exceptions.
+    */
+   public synchronized boolean tryLock() throws IOException {
+      File lockFile = getLockFile();
+      if (lockFile.exists())
+         return false;
+
+      return acquireGlobalLock(lockFile);
+   }
+
+   /**
+    * Unlocks the current instance if holding the global lock.
+    * <p>
+    * This method only has an effect if the lock is hold by this instance. Effectively, the underlying file is deleted.
+    * </p>
+    */
+   public synchronized void unlock() {
+      if (globalLockFile != null) {
+         if (globalLock != null && globalLock.isValid())
+            Util.close(globalLock);
+
+         globalLock = null;
+         Util.close(globalLockFile);
+         getLockFile().delete();
+      }
+   }
+
+   /**
+    * Unsafely forces the current instance to hold the lock.
+    *
+    * <p>
+    * This method bypasses the existing lock mechanism to delete the underlying file and acquire ownership over it.
+    * <b>Use this method with caution!</b> This method is useful in cases of hard crashes of the virtual machine where
+    * the lock was not released prior to shutdown.
+    * </p>
+    *
+    * @throws IOException: In case of I/O errors while acquiring the lock.
+    * @see #tryLock() Exceptions list.
+    */
+   public synchronized void unsafeLock() throws IOException {
+      boolean retry;
+      do {
+         getLockFile().delete();
+         retry = !tryLock();
+      } while (retry);
+   }
+
+   /**
+    * Check whether the current instance holds the global lock.
+    *
+    * @return <code>true</code> in case the lock is held, <code>false</code>, otherwise.
+    */
+   public synchronized boolean isAcquired() {
+      return globalLock != null && globalLock.isValid();
+   }
+
+   private File getLockFile() {
+      return directory.resolve(lockFileName()).toFile();
+   }
+
+   private boolean acquireGlobalLock(File lockFile) throws IOException {
+      assert Thread.holdsLock(this);
+
+      lockFile.getParentFile().mkdirs();
+      globalLockFile = new FileOutputStream(lockFile);
+      globalLock = globalLockFile.getChannel().tryLock();
+      return globalLock.isValid();
+   }
+
+   private String lockFileName() {
+      return String.format("%s.lck", name);
+   }
+
+   @Override
+   public String toString() {
+      return "FileSystemLock{directory=" + directory + ", file=" + lockFileName() + "}";
+   }
+}

--- a/commons/all/src/test/java/org/infinispan/commons/util/FileSystemLockTest.java
+++ b/commons/all/src/test/java/org/infinispan/commons/util/FileSystemLockTest.java
@@ -1,0 +1,96 @@
+package org.infinispan.commons.util;
+
+import static org.infinispan.commons.test.CommonsTestingUtil.tmpDirectory;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.infinispan.commons.util.concurrent.FileSystemLock;
+import org.junit.After;
+import org.junit.Test;
+
+public class FileSystemLockTest {
+
+   @After
+   public void afterEach() {
+      Util.recursiveFileRemove(tmpDirectory(directoryName()));
+   }
+
+   @Test
+   public void testLockAndUnlock() throws Exception {
+      String path = tmpDirectory(directoryName());
+
+      FileSystemLock lock = new FileSystemLock(Paths.get(path), "test-1");
+
+      assertTrue(lock.tryLock());
+      assertTrue(lock.isAcquired());
+
+      assertFalse(lock.tryLock());
+
+      lock.unlock();
+      assertFalse(lock.isAcquired());
+   }
+
+   @Test
+   public void testMultipleThreads() throws Exception {
+      String path = tmpDirectory(directoryName());
+      ExecutorService executor = Executors.newFixedThreadPool(4);
+      try {
+         List<CompletableFuture<?>> futures = new ArrayList<>();
+
+         CyclicBarrier barrier = new CyclicBarrier(5);
+         ByRef.Integer counter = new ByRef.Integer(0);
+         FileSystemLock lock = new FileSystemLock(Paths.get(path), "test-2");
+
+         for (int i = 0; i < 4; i++) {
+            futures.add(CompletableFuture.supplyAsync(() -> {
+               try {
+                  barrier.await(10, TimeUnit.SECONDS);
+                  if (lock.tryLock()) {
+                     counter.inc();
+                  }
+               } catch (Exception e) {
+                  throw new RuntimeException(e);
+               }
+               return null;
+            }, executor));
+         }
+
+         barrier.await(10, TimeUnit.SECONDS);
+         futures.forEach(CompletableFuture::join);
+
+         assertEquals(1, counter.get());
+
+         // Assert it is still locked.
+         assertFalse(lock.tryLock());
+         lock.unlock();
+      } finally {
+         executor.shutdown();
+      }
+   }
+
+   @Test
+   public void testUnsafeLocking() throws Exception {
+      String path = tmpDirectory(directoryName());
+
+      FileSystemLock lock = new FileSystemLock(Paths.get(path), "test-3");
+
+      assertTrue(lock.tryLock());
+      assertTrue(lock.isAcquired());
+
+      lock.unsafeLock();
+   }
+
+   private static String directoryName() {
+      return FileSystemLockTest.class.getSimpleName();
+   }
+}

--- a/core/src/main/java/org/infinispan/persistence/sifs/Log.java
+++ b/core/src/main/java/org/infinispan/persistence/sifs/Log.java
@@ -3,6 +3,7 @@ package org.infinispan.persistence.sifs;
 import java.io.IOException;
 
 import org.infinispan.commons.CacheConfigurationException;
+import org.infinispan.commons.util.concurrent.FileSystemLock;
 import org.infinispan.persistence.spi.PersistenceException;
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
@@ -100,4 +101,7 @@ public interface Log extends BasicLogger {
    @LogMessage(level = Logger.Level.WARN)
    @Message(value = "Clear encountered an exception, size stats for future invocations may be incorrect", id = 29024)
    void clearError(@Cause Throwable t);
+
+   @Message(value = "Failed acquiring lock '%s' for SIFS", id = 29025)
+   PersistenceException failedAcquiringLockFile(@Cause Throwable cause, FileSystemLock lock);
 }

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -31,6 +31,7 @@ import org.infinispan.commons.marshall.AdvancedExternalizer;
 import org.infinispan.commons.marshall.MarshallingException;
 import org.infinispan.commons.util.IntSet;
 import org.infinispan.commons.util.TypedProperties;
+import org.infinispan.commons.util.concurrent.FileSystemLock;
 import org.infinispan.configuration.cache.BackupFailurePolicy;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.Configuration;
@@ -1737,7 +1738,7 @@ public interface Log extends BasicLogger {
    CacheConfigurationException managerConfigurationStorageUnavailable();
 
    @Message(value = "Cannot acquire lock '%s' for persistent global state", id = 512)
-   CacheConfigurationException globalStateCannotAcquireLockFile(@Cause Throwable cause, File lockFile);
+   CacheConfigurationException globalStateCannotAcquireLockFile(@Cause Throwable cause, FileSystemLock lockFile);
 
    @Message(value = "Exception based eviction requires a transactional cache that doesn't allow for 1 phase commit or synchronizations", id = 513)
    CacheConfigurationException exceptionBasedEvictionOnlySupportedInTransactionalCaches();
@@ -2359,7 +2360,7 @@ public interface Log extends BasicLogger {
    void flushedACLCache();
 
    @Message(value = "Dangling lock file '%s' in persistent global state, probably left behind by an unclean shutdown. ", id = 693)
-   CacheConfigurationException globalStateLockFilePresent(File lockFile);
+   CacheConfigurationException globalStateLockFilePresent(FileSystemLock lockFile);
 
    @Message(value = "Cache '%s' has number of owners %d but is missing too many members (%d/%d) to reinstall topology", id = 694)
    MissingMembersException missingTooManyMembers(String cacheName, int owners, int missing, int total);

--- a/core/src/test/java/org/infinispan/persistence/sifs/SoftIndexFileStoreLockingTest.java
+++ b/core/src/test/java/org/infinispan/persistence/sifs/SoftIndexFileStoreLockingTest.java
@@ -1,0 +1,108 @@
+package org.infinispan.persistence.sifs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.AssertJUnit.assertEquals;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+
+import org.infinispan.Cache;
+import org.infinispan.commons.test.CommonsTestingUtil;
+import org.infinispan.commons.test.Exceptions;
+import org.infinispan.commons.util.Util;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.cache.PersistenceConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.manager.EmbeddedCacheManagerStartupException;
+import org.infinispan.persistence.spi.PersistenceException;
+import org.infinispan.test.SingleCacheManagerTest;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+@Test(groups = "functional", testName = "persistence.sifs.SoftIndexFileStoreLockingTest")
+public class SoftIndexFileStoreLockingTest extends SingleCacheManagerTest {
+
+   private static final String CACHE_NAME = "locking-test-cache";
+   protected String tmpDirectory;
+
+   @AfterClass(alwaysRun = true, dependsOnMethods = "destroyAfterClass")
+   protected void clearTempDir() throws IOException {
+      try {
+         SoftIndexFileStoreTestUtils.StatsValue statsValue = SoftIndexFileStoreTestUtils.readStatsFile(tmpDirectory, CACHE_NAME, log);
+         long dataDirectorySize = SoftIndexFileStoreTestUtils.dataDirectorySize(tmpDirectory, CACHE_NAME);
+
+         assertEquals(dataDirectorySize, statsValue.getStatsSize());
+      } finally {
+         Util.recursiveFileRemove(tmpDirectory);
+      }
+   }
+
+   @Override
+   protected EmbeddedCacheManager createCacheManager() throws Exception {
+      tmpDirectory = CommonsTestingUtil.tmpDirectory(getClass());
+      GlobalConfigurationBuilder global = new GlobalConfigurationBuilder();
+      global.globalState().persistentLocation(CommonsTestingUtil.tmpDirectory(this.getClass()));
+      global.cacheContainer().security().authorization().enable();
+      EmbeddedCacheManager ecm = TestCacheManagerFactory.newDefaultCacheManager(false, global, new ConfigurationBuilder());
+      TestingUtil.defineConfiguration(ecm, CACHE_NAME, createCacheConfiguration().build());
+      return ecm;
+   }
+
+   protected PersistenceConfigurationBuilder createCacheStoreConfig(PersistenceConfigurationBuilder persistence, String cacheName, boolean preload) {
+      persistence
+            .addSoftIndexFileStore()
+            .dataLocation(Paths.get(tmpDirectory, "data").toString())
+            .indexLocation(Paths.get(tmpDirectory, "index").toString())
+            .maxFileSize(1000)
+            .async().enabled(true)
+            .purgeOnStartup(false).preload(preload)
+            // Effectively disable reaper for tests
+            .expiration().wakeUpInterval(Long.MAX_VALUE);
+      return persistence;
+   }
+
+   private ConfigurationBuilder createCacheConfiguration() {
+      ConfigurationBuilder cb = TestCacheManagerFactory.getDefaultCacheConfiguration(false);
+      createCacheStoreConfig(cb.persistence(), CACHE_NAME, false);
+      return cb;
+   }
+
+   public void testOverlappingCacheManagers() throws Throwable {
+      // Get the cache with the default cache manager created by the test.
+      Cache<String, Object> c1 = cacheManager.getCache(CACHE_NAME);
+      c1.put("key", "value");
+
+      // Create another cache manager utilizing the same configuration.
+      // This will cause both CM to utilize the same directory to store data.
+      EmbeddedCacheManager ecm = createCacheManager();
+
+      // It is not possible to retrieve the running cache.
+      Exceptions.expectException("ISPN029025: Failed acquiring lock .*", () -> ecm.getCache(CACHE_NAME),
+            EmbeddedCacheManagerStartupException.class, PersistenceException.class);
+      TestingUtil.killCacheManagers(ecm);
+
+      // The original cache still works properly.
+      assertThat(c1.get("key")).isEqualTo("value");
+   }
+
+   public void testStartStopDifferentCacheManagers() throws Throwable {
+      // Acquire the cache with the cache manager created by the test.
+      Cache<String, Object> c1 = cacheManager.getCache(CACHE_NAME);
+      c1.put("key", "value");
+
+      // Stop the manager and release the file lock.
+      TestingUtil.killCacheManagers(cacheManager);
+
+      // Create another CM.
+      // This time it is possible to retrieve the running cache instance.
+      EmbeddedCacheManager ecm = createCacheManager();
+      c1 = ecm.getCache(CACHE_NAME);
+
+      // The data still present.
+      assertThat(c1.get("key")).isEqualTo("value");
+      TestingUtil.killCacheManagers(ecm);
+   }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-16031

Create a global lock backed by the file system to control concurrent usage of files within and between virtual machines.

When creating the cache, an exception is thrown in case the current cache is not the unique owner of the cache data directory.

See, this change might mean a change in behavior for some applications. But it affects misconfigured embedded applications only.