### PR TITLE
ISPN-16057 Restore 3rd party integration tests for Wildfly and Tomcat

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -145,7 +145,7 @@ pipeline {
         stage('Tests') {
             steps {
                 timeout(time: 135, unit: 'MINUTES') {
-                    sh "$MAVEN_HOME/bin/mvn verify -B -e -DrerunFailingTestsCount=2 -Dmaven.test.failure.ignore=true -Dansi.strip=true -Pnative $ALT_TEST_BUILD"
+                    sh "$MAVEN_HOME/bin/mvn verify -s maven-settings.xml -B -e -DrerunFailingTestsCount=2 -Dmaven.test.failure.ignore=true -Dansi.strip=true -Pnative $ALT_TEST_BUILD"
                 }
                 // Remove any default TestNG report files as this will result in tests being counted twice by Jenkins statistics
                 sh "rm -rf **/target/*-reports*/**/TEST-TestSuite.xml"

--- a/build/configuration/pom.xml
+++ b/build/configuration/pom.xml
@@ -113,6 +113,10 @@
       <maven.snapshots.repo.id>ossrh</maven.snapshots.repo.id>
       <maven.snapshots.repo.url>https://s01.oss.sonatype.org/content/repositories/snapshots</maven.snapshots.repo.url>
 
+      <!-- org.wildfly / org.jboss.eap -->
+      <appserver.groupId>org.wildfly</appserver.groupId>
+      <appserver.version>32.0.0.Final</appserver.version>
+
       <!-- Java source/target version -->
       <maven.min.version>3.9.0</maven.min.version>
       <jdk.min.version>17</jdk.min.version>
@@ -163,6 +167,8 @@
       <version.jboss.narayana>7.0.1.Final</version.jboss.narayana>
       <version.jboss.security>3.0.6.Final</version.jboss.security>
       <version.jboss.shrinkwrap>1.2.6</version.jboss.shrinkwrap>
+      <version.jboss.shrinkwrap.descriptors>2.0.0</version.jboss.shrinkwrap.descriptors>
+      <version.jboss.shrinkwrap.resolver>3.3.0</version.jboss.shrinkwrap.resolver>
       <version.jcip-annotations>1.0</version.jcip-annotations>
       <version.jgroups>5.3.6.Final</version.jgroups>
       <version.jgroups.raft>1.0.13.Final</version.jgroups.raft>
@@ -181,6 +187,7 @@
       <version.netty>4.1.109.Final</version.netty>
       <version.netty.incubator.iouring>0.0.25.Final</version.netty.incubator.iouring>
       <version.openjdk.jmh>1.37</version.openjdk.jmh>
+      <version.org.wildfly.arquillian>5.0.1.Final</version.org.wildfly.arquillian>
       <version.org.wildfly.elytron>2.4.1.Final</version.org.wildfly.elytron>
       <version.ow2.asm>9.7</version.ow2.asm>
       <version.picketbox>5.0.3.Final</version.picketbox>
@@ -240,13 +247,15 @@
       <version.maven.shade>3.5.3</version.maven.shade>
       <version.maven.source>3.3.1</version.maven.source>
       <version.maven.surefire>3.2.5</version.maven.surefire>
+      <version.org.jboss.galleon>6.0.1.Final</version.org.jboss.galleon>
+      <version.org.wildfly.galleon-plugins>7.0.0.Final</version.org.wildfly.galleon-plugins>
       <version.sonatype.nexus-staging-plugin>1.6.13</version.sonatype.nexus-staging-plugin>
       <version.eclipse.transformer>0.5.0</version.eclipse.transformer>
       <!-- overwrite version in jboss-parent -->
       <version.pmd.plugin>3.21.2</version.pmd.plugin>
       <version.owasp-dependency-check-plugin>9.0.10</version.owasp-dependency-check-plugin>
       <version.spotbugs.plugin>4.8.5.0</version.spotbugs.plugin>
-      <version.weld-servlet>2.4.8.Final</version.weld-servlet>
+      <version.weld-servlet>5.1.2.Final</version.weld-servlet>
       <version.deploy.plugin>3.1.1</version.deploy.plugin>
 
       <!-- versionx -->

--- a/integrationtests/server-integration/pom.xml
+++ b/integrationtests/server-integration/pom.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.infinispan</groupId>
+        <artifactId>infinispan-integrationtests-parent</artifactId>
+        <version>15.0.4-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <properties>
+        <resources.dir>${basedir}/src/test/resources</resources.dir>
+        <ispnserver.project.dir>${basedir}/../../server/runtime</ispnserver.project.dir>
+        <server.build.dist>${ispnserver.project.dir}/target/${infinispan.brand.prefix}-server-${infinispan.brand.version}</server.build.dist>
+        <ispnserver.dist>${basedir}/target/infinispan-server</ispnserver.dist>
+        <ispn.config.file>${basedir}/server-integration-commons/target/test-classes/infinispan-custom.xml</ispn.config.file>
+    </properties>
+
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>pom</packaging>
+
+    <artifactId>infinispan-server-integration</artifactId>
+    <name>Server Integration</name>
+    <description>Server Integration</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-server-runtime</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skipTests>true</skipTests>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <server.jvm.args>${server.jvm.args}</server.jvm.args>
+                    </systemPropertyVariables>
+                    <!-- Force use of JUnit, since TestNG+Arquillian break in wonderful ways -->
+                    <testNGArtifactName>none:none</testNGArtifactName>
+                    <disableXmlReport>false</disableXmlReport>
+                    <properties>
+                        <usedefaultlisteners>false</usedefaultlisteners>
+                        <listener>${junitListener}</listener>
+                    </properties>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <configuration>
+                            <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit47</artifactId>
+                        <version>${version.maven.surefire}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate-distros-and-configs</id>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <skip>${skipTests}</skip>
+                            <target>
+                                <ant antfile="${ispnserver.project.dir}/src/main/ant/infinispan-server.xml" target="create-distro">
+                                    <property name="server.build.dist" value="${server.build.dist}" />
+                                    <property name="server.dist" value="${ispnserver.dist}" />
+                                    <property name="ispn.config.file" value="${ispn.config.file}" />
+                                </ant>
+                            </target>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>infinispan-server-startup</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skipTests}</skip>
+                            <target>
+                                <ant antfile="${ispnserver.project.dir}/src/main/ant/infinispan-server.xml" target="kill-server">
+                                    <property name="hotrod.port" value="11222" />
+                                </ant>
+                                <ant antfile="${ispnserver.project.dir}/src/main/ant/infinispan-server.xml" target="start-server">
+                                    <property name="server.dist" value="${ispnserver.dist}" />
+                                    <property name="port.offset" value="0" />
+                                    <property name="hotrod.port" value="11222" />
+                                    <property name="jboss.node.name" value="ispn-server" />
+                                    <property name="jboss.config.file" value="infinispan-custom.xml" />
+                                </ant>
+                            </target>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>infinispan-server-shutdown</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skipTests}</skip>
+                            <target>
+                                <ant antfile="${ispnserver.project.dir}/src/main/ant/infinispan-server.xml" target="kill-server">
+                                    <property name="hotrod.port" value="11222" />
+                                </ant>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/integrationtests/server-integration/server-integration-commons/pom.xml
+++ b/integrationtests/server-integration/server-integration-commons/pom.xml
@@ -1,0 +1,145 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.infinispan</groupId>
+        <artifactId>infinispan-server-integration</artifactId>
+        <version>15.0.4-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>infinispan-server-integrationtests-commons</artifactId>
+    <name>Infinispan Integration Tests Server Commons</name>
+    <description>Infinispan Integration Tests Server Commons</description>
+
+    <properties>
+        <ispnserver.project.dir>${basedir}/../../../server/runtime</ispnserver.project.dir>
+        <ispn.config.file>${basedir}/../server-integration-commons/target/test-classes/infinispan-custom.xml</ispn.config.file>
+    </properties>
+
+    <dependencies>
+        <!-- the following dependency must be provided because each server ( WF, WF with modules or Tomcat )
+        knows ( use as module or add a jar into war ) what should be done.
+        -->
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <version>${versionx.javax.inject.javax.inject}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.cache</groupId>
+            <artifactId>cache-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-cdi-embedded</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan.protostream</groupId>
+            <artifactId>protostream-processor</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-commons-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-client-hotrod</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-remote-query-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-query</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-query-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-cachestore-jdbc</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-cachestore-rocksdb</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.spy</groupId>
+            <artifactId>spymemcached</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-depchain</artifactId>
+            <type>pom</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <testResources>
+            <testResource>
+                <directory>${project.basedir}/src/test/resources</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration combine.self="override">
+                    <skipTests>true</skipTests>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration combine.self="override">
+                    <skipTests>true</skipTests>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/GenericDeploymentHelper.java
+++ b/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/GenericDeploymentHelper.java
@@ -1,0 +1,26 @@
+package org.infinispan.test.integration;
+
+import java.io.File;
+
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.jboss.shrinkwrap.resolver.api.maven.MavenResolverSystem;
+
+public class GenericDeploymentHelper {
+
+   private static final MavenResolverSystem MAVEN_RESOLVER = Maven.configureResolver().fromFile("../../../maven-settings.xml");
+
+   public static void addLibrary(WebArchive war, String canonicalForm) {
+      addLibrary(war, MAVEN_RESOLVER
+            .loadPomFromFile("pom.xml")
+            .resolve(canonicalForm)
+            .withTransitivity().as(File.class));
+   }
+
+   private static void addLibrary(WebArchive war, File[]... libGroup) {
+      for (File[] group : libGroup) {
+         war.addAsLibraries(group);
+      }
+   }
+
+}

--- a/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/cdi/AbstractDuplicatedDomainsCdiIT.java
+++ b/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/cdi/AbstractDuplicatedDomainsCdiIT.java
@@ -1,0 +1,38 @@
+package org.infinispan.test.integration.cdi;
+
+import static org.junit.Assert.assertNotEquals;
+
+import jakarta.inject.Inject;
+
+import org.infinispan.AdvancedCache;
+import org.infinispan.manager.DefaultCacheManager;
+import org.junit.Test;
+
+/**
+ * Tests whether {@link DefaultCacheManager} sets custom Cache name to avoid JMX
+ * name collision.
+ *
+ * @author Sebastian Laskawiec
+ */
+public abstract class AbstractDuplicatedDomainsCdiIT {
+
+   @Inject
+   private AdvancedCache<Object, Object> greetingCache;
+
+   /**
+    * Creates new {@link DefaultCacheManager}.
+    * This test will fail if CDI Extension registers and won't set Cache Manager's name.
+    */
+   @Test
+   public void testIfCreatingDefaultCacheManagerSucceeds() {
+      greetingCache.put("test-key", "test-value");
+
+      String cdiName = greetingCache.getCacheManager().getCacheManagerInfo().getName();
+
+      DefaultCacheManager cacheManager = new DefaultCacheManager();
+      String defaultName = cacheManager.getName();
+      cacheManager.stop();
+
+      assertNotEquals(defaultName, cdiName);
+   }
+}

--- a/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/cdi/CdiConfig.java
+++ b/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/cdi/CdiConfig.java
@@ -1,0 +1,64 @@
+package org.infinispan.test.integration.cdi;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Disposes;
+import jakarta.enterprise.inject.Produces;
+
+import org.infinispan.cdi.embedded.ConfigureCache;
+import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.cache.StorageType;
+import org.infinispan.manager.DefaultCacheManager;
+
+/**
+ * This is the configuration class.
+ *
+ * @author Kevin Pollet &lt;pollet.kevin@gmail.com&gt; (C) 2011
+ * @author Galder Zamarreño
+ */
+public class CdiConfig {
+
+   /**
+    * <p>This producer defines the greeting cache configuration.</p>
+    *
+    * <p>This cache will have:
+    * <ul>
+    *    <li>a maximum of 4 entries</li>
+    *    <li>use the strategy LRU for eviction</li>
+    * </ul>
+    * </p>
+    *
+    * @return the greeting cache configuration.
+    */
+   @GreetingCache
+   @ConfigureCache("greeting-cache")
+   @Produces
+   public Configuration greetingCache() {
+      return new ConfigurationBuilder()
+            .memory().storageType(StorageType.OBJECT).size(128)
+            .build();
+   }
+
+   /**
+    * <p>This producer overrides the default cache configuration used by the default cache manager.</p>
+    *
+    * <p>The default cache configuration defines that a cache entry will have a lifespan of 60000 ms.</p>
+    */
+   @Produces
+   public Configuration defaultCacheConfiguration() {
+      return new ConfigurationBuilder()
+            .expiration().lifespan(60000L)
+            .build();
+   }
+
+   @Produces
+   @ApplicationScoped
+   public org.infinispan.manager.EmbeddedCacheManager defaultEmbeddedCacheManager() {
+      return new DefaultCacheManager();
+   }
+
+   public void killCacheManager(@Disposes org.infinispan.manager.EmbeddedCacheManager cacheManager) {
+      cacheManager.stop();
+   }
+
+}

--- a/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/cdi/GreetingCache.java
+++ b/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/cdi/GreetingCache.java
@@ -1,0 +1,23 @@
+package org.infinispan.test.integration.cdi;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.inject.Qualifier;
+
+/**
+ * <p>The greeting cache qualifier.</p>
+ *
+ * <p>This qualifier will be associated to the greeting cache in the {@link CdiConfig} class.</p>
+ *
+ * @author Kevin Pollet &lt;pollet.kevin@gmail.com&gt; (C) 2011
+ */
+@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Qualifier
+@Documented
+public @interface GreetingCache {
+}

--- a/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/data/Book.java
+++ b/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/data/Book.java
@@ -1,0 +1,30 @@
+package org.infinispan.test.integration.data;
+
+import org.infinispan.api.annotations.indexing.Indexed;
+import org.infinispan.api.annotations.indexing.Text;
+import org.infinispan.protostream.annotations.ProtoFactory;
+import org.infinispan.protostream.annotations.ProtoField;
+
+@Indexed
+public class Book {
+
+   @ProtoField(1)
+   @Text
+   final String title;
+
+   @ProtoField(2)
+   @Text
+   final String author;
+
+   @ProtoField(number = 3, defaultValue = "0")
+   @Text
+   final int publicationYear;
+
+
+   @ProtoFactory
+   public Book(String title, String author, int publicationYear) {
+      this.title = title;
+      this.author = author;
+      this.publicationYear = publicationYear;
+   }
+}

--- a/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/data/KeyValueEntity.java
+++ b/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/data/KeyValueEntity.java
@@ -1,0 +1,84 @@
+package org.infinispan.test.integration.data;
+
+import java.io.Serializable;
+
+import org.infinispan.protostream.annotations.ProtoField;
+
+import jakarta.persistence.Basic;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+/**
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ * @since 7.0
+ */
+@Entity
+public class KeyValueEntity implements Serializable {
+   @Id
+   private String k; // key is reserved word in SQL
+
+   @Basic
+   private String value;
+
+   public KeyValueEntity() {
+   }
+
+   public KeyValueEntity(String key, String value) {
+      this.k = key;
+      this.value = value;
+   }
+
+   @ProtoField(1)
+   public String getK() {
+      return k;
+   }
+
+   public void setK(String k) {
+      this.k = k;
+   }
+
+   @ProtoField(2)
+   public String getValue() {
+      return value;
+   }
+
+   public void setValue(String value) {
+      this.value = value;
+   }
+
+   @Override
+   public int hashCode() {
+      final int prime = 31;
+      int result = 1;
+      result = prime * result + ((k == null) ? 0 : k.hashCode());
+      result = prime * result + ((value == null) ? 0 : value.hashCode());
+      return result;
+   }
+
+   @Override
+   public boolean equals(Object obj) {
+      if (this == obj)
+         return true;
+      if (obj == null)
+         return false;
+      if (getClass() != obj.getClass())
+         return false;
+      KeyValueEntity other = (KeyValueEntity) obj;
+      if (k == null) {
+         if (other.k != null)
+            return false;
+      } else if (!k.equals(other.k))
+         return false;
+      if (value == null) {
+         if (other.value != null)
+            return false;
+      } else if (!value.equals(other.value))
+         return false;
+      return true;
+   }
+
+   @Override
+   public String toString() {
+      return String.format("{key=%s, value=%s}", k, value);
+   }
+}

--- a/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/data/Person.java
+++ b/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/data/Person.java
@@ -1,0 +1,32 @@
+package org.infinispan.test.integration.data;
+
+import org.infinispan.protostream.annotations.ProtoField;
+
+public class Person {
+
+   @ProtoField(1)
+   public String name;
+
+   @ProtoField(2)
+   public Integer id;
+
+   public Person() {
+   }
+
+   public Person(String name) {
+      this.name = name;
+   }
+
+   public Person(String name, Integer id) {
+      this.name = name;
+      this.id = id;
+   }
+
+   public String getName() {
+      return name;
+   }
+
+   public Integer getId() {
+      return id;
+   }
+}

--- a/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/embedded/AbstractInfinispanCoreIT.java
+++ b/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/embedded/AbstractInfinispanCoreIT.java
@@ -1,0 +1,39 @@
+package org.infinispan.test.integration.embedded;
+
+import static org.junit.Assert.assertEquals;
+
+import org.infinispan.Cache;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.manager.DefaultCacheManager;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * Test the Infinispan AS module integration
+ *
+ * @author Tristan Tarrant
+ * @since 5.2
+ */
+public abstract class AbstractInfinispanCoreIT {
+
+   private EmbeddedCacheManager cm;
+
+   @After
+   public void cleanUp() {
+      if (cm != null)
+         cm.stop();
+   }
+
+   @Test
+   public void testCacheManager() {
+      GlobalConfigurationBuilder gcb = new GlobalConfigurationBuilder();
+      gcb.defaultCacheName("default");
+
+      cm = new DefaultCacheManager(gcb.build(), new ConfigurationBuilder().build());
+      Cache<String, String> cache = cm.getCache();
+      cache.put("a", "a");
+      assertEquals("a", cache.get("a"));
+   }
+}

--- a/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/persistence/jdbc/stringbased/PooledConnectionIT.java
+++ b/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/persistence/jdbc/stringbased/PooledConnectionIT.java
@@ -1,0 +1,81 @@
+package org.infinispan.test.integration.persistence.jdbc.stringbased;
+
+import static org.infinispan.test.integration.persistence.jdbc.util.JdbcConfigurationUtil.CACHE_NAME;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.infinispan.Cache;
+import org.infinispan.context.Flag;
+import org.infinispan.factories.ComponentRegistry;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.persistence.jdbc.stringbased.JdbcStringBasedStore;
+import org.infinispan.persistence.manager.PersistenceManager;
+import org.infinispan.test.integration.persistence.jdbc.util.JdbcConfigurationUtil;
+import org.infinispan.test.integration.persistence.jdbc.util.TableManipulation;
+import org.junit.After;
+import org.junit.Test;
+
+public class PooledConnectionIT {
+
+    private EmbeddedCacheManager cm;
+
+    @After
+    public void cleanUp() {
+        if (cm != null)
+            cm.stop();
+    }
+
+    @Test
+    public void testPutGetRemove() throws Exception {
+        JdbcConfigurationUtil jdbcUtil = new JdbcConfigurationUtil(true, true);
+        cm = jdbcUtil.getCacheManager();
+        Cache<String, String> cache = cm.getCache(CACHE_NAME);
+        PersistenceManager persistenceManager = ComponentRegistry.componentOf(cache, PersistenceManager.class);
+        JdbcStringBasedStore jdbcStringBasedStore = persistenceManager.getStores(JdbcStringBasedStore.class).iterator().next();
+        try (TableManipulation table = new TableManipulation(jdbcStringBasedStore.getTableManager(), jdbcUtil.getPersistenceConfiguration())) {
+            cache.put("k1", "v1");
+            cache.put("k2", "v2");
+
+            //not yet in store (eviction.max-entries=2, LRU)
+            assertNull(table.getValueByKey("k1"));
+            assertNull(table.getValueByKey("k2"));
+            cache.put("k3", "v3");
+            //now some key is evicted and stored in store
+            assertEquals(2, getNumberOfEntriesInMemory(cache));
+            // TODO: need to fix this later, for some reason this fails on Oracle but passes on other DBs
+//            assertEquals(1, table.countAllRows());
+
+            cache.stop();
+            cache.start();
+
+            assertEquals(3, cache.size());
+            assertEquals("v1", cache.get("k1"));
+            assertCleanCacheAndStore(cache);
+        }
+    }
+
+    @Test
+    public void testWithoutPreload() {
+        JdbcConfigurationUtil jdbcUtil = new JdbcConfigurationUtil(true, false);
+        cm = jdbcUtil.getCacheManager();
+        Cache<String, String> cache = cm.getCache(CACHE_NAME);
+        cache.put("k1", "v1");
+        cache.put("k2", "v2");
+
+        cache.stop();
+        cache.start();
+
+        assertEquals(0, getNumberOfEntriesInMemory(cache));
+        assertCleanCacheAndStore(cache);
+    }
+
+    private void assertCleanCacheAndStore(Cache cache) {
+        cache.clear();
+        assertEquals(0, cache.size());
+    }
+
+    private int getNumberOfEntriesInMemory(Cache<?, ?> cache) {
+        return cache.getAdvancedCache().withFlags(Flag.SKIP_CACHE_LOAD).size();
+    }
+
+}

--- a/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/persistence/jdbc/util/JdbcConfigurationUtil.java
+++ b/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/persistence/jdbc/util/JdbcConfigurationUtil.java
@@ -1,0 +1,70 @@
+package org.infinispan.test.integration.persistence.jdbc.util;
+
+import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.manager.DefaultCacheManager;
+import org.infinispan.persistence.jdbc.common.configuration.PooledConnectionFactoryConfigurationBuilder;
+import org.infinispan.persistence.jdbc.configuration.JdbcStringBasedStoreConfigurationBuilder;
+
+import java.io.IOException;
+import java.util.Properties;
+
+public class JdbcConfigurationUtil {
+
+    private PooledConnectionFactoryConfigurationBuilder persistenceConfiguration;
+    private final ConfigurationBuilder configurationBuilder;
+    public static final String CACHE_NAME = "jdbc";
+    public String driverClass;
+
+    public JdbcConfigurationUtil(boolean passivation, boolean preload) {
+        configurationBuilder = new ConfigurationBuilder();
+        createPersistenceConfiguration(passivation, preload);
+    }
+
+    private JdbcConfigurationUtil createPersistenceConfiguration(boolean passivation, boolean preload) {
+        Properties props = loadDBProperties();
+        driverClass = props.getProperty("driver.class");
+        configurationBuilder.memory().maxCount(2);
+        persistenceConfiguration = configurationBuilder
+                .persistence()
+                .passivation(passivation)
+                .addStore(JdbcStringBasedStoreConfigurationBuilder.class)
+                .segmented(false)
+                .preload(preload)
+                .table()
+                .createOnStart(true)
+                .tableNamePrefix("tbl")
+                .idColumnName("ID_COLUMN").idColumnType(props.getProperty("id.column.type"))
+                .dataColumnName("DATA_COLUMN").dataColumnType(props.getProperty("data.column.type"))
+                .timestampColumnName("TIMESTAMP_COLUMN").timestampColumnType(props.getProperty("timestamp.column.type"))
+                .connectionPool()
+                .driverClass(driverClass)
+                .connectionUrl(props.getProperty("connection.url"))
+                .username(props.getProperty("db.username"))
+                .password(props.getProperty("db.password"));
+        persistenceConfiguration.addProperty("infinispan.jdbc.upsert.disabled", props.getProperty("database.upsert.disabled"));
+        return this;
+    }
+
+    public PooledConnectionFactoryConfigurationBuilder getPersistenceConfiguration() {
+        return this.persistenceConfiguration;
+    }
+
+    public DefaultCacheManager getCacheManager() {
+        Configuration configuration = configurationBuilder.build();
+        GlobalConfigurationBuilder configurationBuilder = new GlobalConfigurationBuilder().nonClusteredDefault().defaultCacheName(CACHE_NAME);
+        return new DefaultCacheManager(configurationBuilder.build(), configuration);
+    }
+
+    private static Properties loadDBProperties() {
+        Properties props = new Properties();
+        try {
+            props.load(JdbcConfigurationUtil.class.getResourceAsStream("/connection.properties"));
+        } catch (IOException ioe) {
+            throw new RuntimeException("Unable to read DB properties");
+        }
+        return props;
+    }
+
+}

--- a/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/persistence/jdbc/util/TableManipulation.java
+++ b/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/persistence/jdbc/util/TableManipulation.java
@@ -1,0 +1,98 @@
+package org.infinispan.test.integration.persistence.jdbc.util;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Enumeration;
+
+import org.infinispan.commons.marshall.ProtoStreamMarshaller;
+import org.infinispan.commons.marshall.WrappedByteArray;
+import org.infinispan.persistence.jdbc.common.JdbcUtil;
+import org.infinispan.persistence.jdbc.common.configuration.PooledConnectionFactoryConfiguration;
+import org.infinispan.persistence.jdbc.common.configuration.PooledConnectionFactoryConfigurationBuilder;
+import org.infinispan.persistence.jdbc.common.connectionfactory.ConnectionFactory;
+import org.infinispan.persistence.jdbc.common.impl.connectionfactory.PooledConnectionFactory;
+import org.infinispan.persistence.jdbc.impl.table.TableManager;
+import org.infinispan.persistence.keymappers.DefaultTwoWayKey2StringMapper;
+
+public class TableManipulation implements AutoCloseable {
+
+   private ConnectionFactory connectionFactory;
+   private Connection connection;
+   public final PooledConnectionFactoryConfigurationBuilder persistenceConfiguration;
+   private final String countRowsSql;
+   private final String selectIdRowSqlWithLike;
+   private static final String ID_COLUMN_NAME = "ID_COLUMN";
+
+   public TableManipulation(TableManager tableManager, PooledConnectionFactoryConfigurationBuilder persistenceConfiguration) {
+      this.persistenceConfiguration = persistenceConfiguration;
+      String tableName = tableManager.getDataTableName().toString();
+      this.countRowsSql = "SELECT COUNT(*) FROM " + tableName;
+      this.selectIdRowSqlWithLike = String.format("SELECT %s FROM %s WHERE %s LIKE ?", ID_COLUMN_NAME, tableName, ID_COLUMN_NAME);
+   }
+
+   private ConnectionFactory getConnectionFactory() {
+      PooledConnectionFactoryConfiguration pooledConnectionFactoryConfiguration = persistenceConfiguration.create();
+      connectionFactory = ConnectionFactory.getConnectionFactory(PooledConnectionFactory.class);
+      connectionFactory.start(pooledConnectionFactoryConfiguration, connectionFactory.getClass().getClassLoader());
+      return connectionFactory;
+   }
+
+   private Connection getConnection() {
+      if(connection == null) {
+         connection = getConnectionFactory().getConnection();
+      }
+      return connection;
+   }
+
+   public String getValueByKey(String key) throws Exception {
+      Connection connection = getConnection();
+      PreparedStatement ps = null;
+      ResultSet rs = null;
+      try {
+         ps = connection.prepareStatement(selectIdRowSqlWithLike);
+         ps.setString(1, "%" + getEncodedKey(key) + "%");
+         rs = ps.executeQuery();
+         if(rs.next()) {
+            return rs.getString("ID");
+         }
+         return null;
+      } finally {
+         JdbcUtil.safeClose(ps);
+         JdbcUtil.safeClose(rs);
+      }
+   }
+
+   public String getEncodedKey(String key) throws Exception {
+      ProtoStreamMarshaller protoStreamMarshaller = new ProtoStreamMarshaller();
+      byte[] marshalled = protoStreamMarshaller.objectToByteBuffer(key);
+      DefaultTwoWayKey2StringMapper mapper = new DefaultTwoWayKey2StringMapper();
+      return mapper.getStringMapping(new WrappedByteArray(marshalled));
+   }
+
+   private void deregisterDrivers() {
+      Enumeration<Driver> drivers = DriverManager.getDrivers();
+      Driver driver;
+      while (drivers.hasMoreElements()) {
+         try {
+            driver = drivers.nextElement();
+            DriverManager.deregisterDriver(driver);
+         } catch (SQLException ex) {
+            ex.printStackTrace();
+         }
+      }
+   }
+
+   @Override
+   public void close() {
+      if(connection != null) {
+         JdbcUtil.safeClose(connection);
+         connectionFactory.stop();
+         connectionFactory.releaseConnection(connection);
+      }
+      deregisterDrivers();
+   }
+}

--- a/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/remote/AbstractHotRodClientIT.java
+++ b/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/remote/AbstractHotRodClientIT.java
@@ -1,0 +1,59 @@
+package org.infinispan.test.integration.remote;
+
+import static org.junit.Assert.assertEquals;
+
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.client.hotrod.configuration.Configuration;
+import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
+import org.infinispan.client.hotrod.marshall.MarshallerUtil;
+import org.infinispan.commons.marshall.ProtoStreamMarshaller;
+import org.infinispan.protostream.SerializationContext;
+import org.infinispan.test.integration.data.Person;
+import org.infinispan.test.integration.remote.proto.PersonSchema;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test the Infinispan AS remote client module integration
+ *
+ * @author Pedro Ruivo
+ * @author Richard Achmatowicz
+ * @author Martin Gencur
+ * @author Jozef Vilkolak
+ * @since 7.0
+ */
+public abstract class AbstractHotRodClientIT {
+
+   private RemoteCache<String, Person> remoteCache;
+
+   @Before
+   public void initialize() {
+      remoteCache = createRemoteCache();
+   }
+
+   @Test
+   public void testPutGetCustomObject() {
+      SerializationContext serializationContext = MarshallerUtil.getSerializationContext(remoteCache.getRemoteCacheManager());
+      PersonSchema.INSTANCE.registerMarshallers(serializationContext);
+      PersonSchema.INSTANCE.registerSchema(serializationContext);
+
+      final Person p = new Person("Martin");
+      remoteCache.put("k1", p);
+      assertEquals(p.getName(), remoteCache.get("k1").getName());
+   }
+
+   private static RemoteCache<String, Person> createRemoteCache() {
+      RemoteCacheManager remoteCacheManager = new RemoteCacheManager(createConfiguration(), true);
+      RemoteCache<String, Person> remoteCache = remoteCacheManager.getCache();
+      remoteCache.clear();
+      return remoteCache;
+   }
+
+   private static Configuration createConfiguration() {
+      ConfigurationBuilder config = new ConfigurationBuilder();
+      config.addServer().host("127.0.0.1");
+      config.marshaller(new ProtoStreamMarshaller());
+      return config.build();
+   }
+}

--- a/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/remote/AbstractHotRodQueryIT.java
+++ b/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/remote/AbstractHotRodQueryIT.java
@@ -1,0 +1,137 @@
+package org.infinispan.test.integration.remote;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.client.hotrod.Search;
+import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
+import org.infinispan.client.hotrod.marshall.MarshallerUtil;
+import org.infinispan.commons.configuration.StringConfiguration;
+import org.infinispan.commons.marshall.ProtoStreamMarshaller;
+import org.infinispan.protostream.SerializationContext;
+import org.infinispan.query.dsl.Query;
+import org.infinispan.query.dsl.QueryFactory;
+import org.infinispan.query.remote.client.ProtobufMetadataManagerConstants;
+import org.infinispan.test.integration.data.Book;
+import org.infinispan.test.integration.data.Person;
+import org.infinispan.test.integration.remote.proto.BookQuerySchema;
+import org.infinispan.test.integration.remote.proto.PersonSchema;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @since 9.0
+ */
+public abstract class AbstractHotRodQueryIT {
+
+   private static final String HOST = "127.0.0.1";
+
+   @Test
+   public void testIndexed() {
+      BookQuerySchema schema = BookQuerySchema.INSTANCE;
+      ConfigurationBuilder config = localServerConfiguration();
+      config.addContextInitializer(schema);
+      try (RemoteCacheManager remoteCacheManager = new RemoteCacheManager(config.build())) {
+
+         // register schema
+         registerSchema(remoteCacheManager, schema.getProtoFileName(), schema.getProtoFile());
+
+         String xmlConfig = """
+               <distributed-cache name="books">
+                 <indexing path="${java.io.tmpdir}/index">
+                   <indexed-entities>
+                     <indexed-entity>book_sample.Book</indexed-entity>
+                   </indexed-entities>
+                 </indexing>
+               </distributed-cache>""";
+         RemoteCache<Object, Object> remoteCache =
+               remoteCacheManager.administration().getOrCreateCache("books", new StringConfiguration(xmlConfig));
+
+         // Add some Books
+         Book book1 = new Book("Infinispan in Action", "Learn Infinispan with using it", 2015);
+         Book book2 = new Book("Cloud-Native Applications with Java and Quarkus", "Build robust and reliable cloud applications", 2019);
+
+         remoteCache.put(1, book1);
+         remoteCache.put(2, book2);
+
+         QueryFactory queryFactory = Search.getQueryFactory(remoteCache);
+         Query<Book> query = queryFactory.create("FROM book_sample.Book WHERE title:'java'");
+         List<Book> list = query.execute().list();
+         assertEquals(1, list.size());
+      }
+   }
+
+   @Test
+   public void testRemoteQuery() {
+      ConfigurationBuilder config = localServerConfiguration();
+      config.marshaller(new ProtoStreamMarshaller());
+      try (RemoteCacheManager rcm = new RemoteCacheManager(config.build())) {
+         // register schema
+         SerializationContext serializationContext = MarshallerUtil.getSerializationContext(rcm);
+         PersonSchema.INSTANCE.registerMarshallers(serializationContext);
+         PersonSchema.INSTANCE.registerSchema(serializationContext);
+         registerSchema(rcm, PersonSchema.INSTANCE.getProtoFileName(), PersonSchema.INSTANCE.getProtoFile());
+
+         RemoteCache<String, Person> cache = rcm.getCache();
+         cache.clear();
+         cache.put("Adrian", new Person("Adrian"));
+
+         assertTrue(cache.containsKey("Adrian"));
+
+         QueryFactory qf = Search.getQueryFactory(cache);
+         Query<Person> query = qf.from(Person.class)
+               .having("name").eq("Adrian")
+               .build();
+         List<Person> list = query.execute().list();
+         assertNotNull(list);
+         assertEquals(1, list.size());
+         assertEquals(Person.class, list.get(0).getClass());
+         assertEquals("Adrian", list.get(0).name);
+      }
+   }
+
+   /**
+    * Sorting on a field that does not contain DocValues so Hibernate Search is forced to uninvert it.
+    *
+    * @see <a href="https://issues.jboss.org/browse/ISPN-5729">https://issues.jboss.org/browse/ISPN-5729</a>
+    */
+   @Test
+   public void testUninverting() {
+      ConfigurationBuilder config = localServerConfiguration();
+      config.marshaller(new ProtoStreamMarshaller());
+      try (RemoteCacheManager rcm = new RemoteCacheManager(config.build())) {
+         SerializationContext serializationContext = MarshallerUtil.getSerializationContext(rcm);
+         PersonSchema.INSTANCE.registerMarshallers(serializationContext);
+         PersonSchema.INSTANCE.registerSchema(serializationContext);
+         registerSchema(rcm, PersonSchema.INSTANCE.getProtoFileName(), PersonSchema.INSTANCE.getProtoFile());
+
+         RemoteCache<String, Person> cache = rcm.getCache();
+         cache.clear();
+
+         QueryFactory qf = Search.getQueryFactory(cache);
+         Query<Person> query = qf.from(Person.class)
+               .having("name").eq("John")
+               .orderBy("id")
+               .build();
+         Assert.assertEquals(0, query.execute().list().size());
+      }
+   }
+
+   private ConfigurationBuilder localServerConfiguration() {
+      ConfigurationBuilder config = new ConfigurationBuilder();
+      config.addServer().host(HOST);
+      return config;
+   }
+
+   private void registerSchema(RemoteCacheManager rcm, String key, String protoFile) {
+      RemoteCache<String, String> metadataCache = rcm.getCache(ProtobufMetadataManagerConstants.PROTOBUF_METADATA_CACHE_NAME);
+      metadataCache.put(key, protoFile);
+      assertFalse(metadataCache.containsKey(ProtobufMetadataManagerConstants.ERRORS_KEY_SUFFIX));
+   }
+}

--- a/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/remote/proto/BookQuerySchema.java
+++ b/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/remote/proto/BookQuerySchema.java
@@ -1,0 +1,15 @@
+package org.infinispan.test.integration.remote.proto;
+
+import org.infinispan.protostream.GeneratedSchema;
+import org.infinispan.protostream.annotations.ProtoSchema;
+import org.infinispan.test.integration.data.Book;
+
+@ProtoSchema(
+      includeClasses = Book.class,
+      schemaFileName = "book.proto",
+      schemaFilePath = "proto/",
+      schemaPackageName = "book_sample"
+)
+public interface BookQuerySchema extends GeneratedSchema {
+   BookQuerySchema INSTANCE = new BookQuerySchemaImpl();
+}

--- a/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/remote/proto/PersonSchema.java
+++ b/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/remote/proto/PersonSchema.java
@@ -1,0 +1,15 @@
+package org.infinispan.test.integration.remote.proto;
+
+import org.infinispan.protostream.GeneratedSchema;
+import org.infinispan.protostream.annotations.ProtoSchema;
+import org.infinispan.test.integration.data.Person;
+
+@ProtoSchema(
+      includeClasses = Person.class,
+      schemaFileName = "person.proto",
+      schemaFilePath = "proto/",
+      schemaPackageName = "person_sample"
+)
+public interface PersonSchema extends GeneratedSchema {
+   PersonSchema INSTANCE = new PersonSchemaImpl();
+}

--- a/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/store/AbstractInfinispanStoreJdbcIT.java
+++ b/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/store/AbstractInfinispanStoreJdbcIT.java
@@ -1,0 +1,65 @@
+package org.infinispan.test.integration.store;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+
+import org.infinispan.Cache;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.manager.DefaultCacheManager;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.persistence.jdbc.configuration.JdbcStringBasedStoreConfigurationBuilder;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * Test the Infinispan JDBC CacheStore AS module integration
+ *
+ * @author Tristan Tarrant
+ * @since 5.2
+ */
+public abstract class AbstractInfinispanStoreJdbcIT {
+
+   private EmbeddedCacheManager cm;
+
+   @After
+   public void cleanUp() {
+      if (cm != null)
+         cm.stop();
+   }
+
+   @Test
+   public void testCacheManager() {
+      GlobalConfigurationBuilder gcb = new GlobalConfigurationBuilder();
+      gcb.defaultCacheName("default");
+      ConfigurationBuilder builder = new ConfigurationBuilder();
+      builder.persistence().addStore(JdbcStringBasedStoreConfigurationBuilder.class)
+            .table()
+            .tableNamePrefix("ISPN")
+            .idColumnName("K")
+            .idColumnType("VARCHAR(255)")
+            .dataColumnName("V")
+            .dataColumnType("BLOB")
+            .timestampColumnName("T")
+            .timestampColumnType("BIGINT")
+            .segmentColumnName("S")
+            .segmentColumnType("BIGINT")
+            .dataSource().jndiUrl(System.getProperty("infinispan.server.integration.data-source"));
+
+      cm = new DefaultCacheManager(gcb.build(), builder.build());
+
+      Cache<String, String> cache = cm.getCache();
+      cache.put("a", "a");
+      assertEquals("a", cache.get("a"));
+   }
+
+   @Test
+   public void testXmlConfig() throws IOException {
+      cm = new DefaultCacheManager("jdbc-config.xml");
+      Cache<String, String> cache = cm.getCache("anotherCache");
+      cache.put("a", "a");
+      assertEquals("a", cache.get("a"));
+   }
+
+}

--- a/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/store/AbstractInfinispanStoreRocksDBIT.java
+++ b/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/store/AbstractInfinispanStoreRocksDBIT.java
@@ -1,0 +1,86 @@
+package org.infinispan.test.integration.store;
+
+import static java.io.File.separator;
+import static org.junit.Assert.assertEquals;
+
+import org.infinispan.Cache;
+import org.infinispan.commons.test.CommonsTestingUtil;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.manager.DefaultCacheManager;
+import org.infinispan.persistence.rocksdb.configuration.RocksDBStoreConfigurationBuilder;
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.Test;
+
+/**
+ * Test the Infinispan RocksDB CacheStore AS module integration
+ *
+ * @author Tristan Tarrant
+ * @since 7.0
+ */
+public abstract class AbstractInfinispanStoreRocksDBIT {
+
+   @ArquillianResource
+   private Deployer deployer;
+
+   @Test
+   @InSequence(1)
+   public void deployDep1() {
+      deployer.deploy("dep1");
+   }
+
+   @Test
+   @OperateOnDeployment("dep1")
+   @InSequence(2)
+   public void testRunningInDep1() {
+      DefaultCacheManager cm = createCacheManager(1);
+      Cache<String, String> cache = cm.getCache();
+      cache.put("dep1", "dep1");
+   }
+
+   @Test
+   @InSequence(3)
+   public void deployDep2() {
+      deployer.deploy("dep2");
+   }
+
+   @Test
+   @OperateOnDeployment("dep2")
+   @InSequence(4)
+   public void testRunningInDep2() {
+      DefaultCacheManager cm = createCacheManager(2);
+      Cache<String, String> cache = cm.getCache();
+      assertEquals("dep1", cache.get("dep1"));
+   }
+
+   @Test
+   @InSequence(5)
+   public void undeploy() {
+      deployer.undeploy("dep1");
+      deployer.undeploy("dep2");
+   }
+
+   protected DefaultCacheManager createCacheManager(int index) {
+      String baseDir = CommonsTestingUtil.tmpDirectory(this.getClass().getSimpleName(), "server-" + index);
+      String dataDir = baseDir + separator + "data";
+      String expiredDir = baseDir + separator + "expired";
+
+      GlobalConfigurationBuilder global = new GlobalConfigurationBuilder();
+      global.transport()
+            .defaultTransport()
+            .clusterName(AbstractInfinispanStoreRocksDBIT.class.getSimpleName());
+      global.globalState().persistentLocation(baseDir);
+      global.defaultCacheName("default");
+      ConfigurationBuilder builder = new ConfigurationBuilder();
+      builder.clustering().cacheMode(CacheMode.REPL_SYNC);
+      builder.persistence()
+            .addStore(RocksDBStoreConfigurationBuilder.class)
+            .location(dataDir)
+            .expiredLocation(expiredDir);
+      return new DefaultCacheManager(global.build(), builder.build());
+   }
+}

--- a/integrationtests/server-integration/server-integration-commons/src/test/resources/META-INF/ispn-persistence.xml
+++ b/integrationtests/server-integration/server-integration-commons/src/test/resources/META-INF/ispn-persistence.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence xmlns="http://java.sun.com/xml/ns/persistence"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd"
+   version="2.0">
+   <persistence-unit name="org.infinispan.persistence.jpa">
+     <!-- This class is required to allow store metadata -->
+     <class>org.infinispan.persistence.jpa.impl.MetadataEntity</class>
+     <class>org.infinispan.test.integration.data.KeyValueEntity</class>
+     <properties>
+       <property name="hibernate.connection.datasource" value="${infinispan.server.integration.data-source}"/>
+       <!-- <property name="hibernate.dialect" value="${hibernate.dialect}" /> --> <!-- dialect is automatically determined by hibernate, uncomment to force the dialect -->
+       <property name="hibernate.jdbc.batch_size" value="20" />
+       <property name="hibernate.jdbc.fetch_size" value="20" />
+       <property name="hibernate.hbm2ddl.auto" value="update"/> <!--  use create-drop for testing -->
+       <property name="hibernate.show_sql" value="false" /> <!-- set to true if you'd like to see what's going on -->
+       <property name="hibernate.connection.autocommit" value="false" />  
+     </properties>
+   </persistence-unit>   
+</persistence>
+

--- a/integrationtests/server-integration/server-integration-commons/src/test/resources/beans.xml
+++ b/integrationtests/server-integration/server-integration-commons/src/test/resources/beans.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       version="1.2" bean-discovery-mode="all"/>

--- a/integrationtests/server-integration/server-integration-commons/src/test/resources/infinispan-custom.xml
+++ b/integrationtests/server-integration/server-integration-commons/src/test/resources/infinispan-custom.xml
@@ -1,0 +1,43 @@
+<infinispan
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="urn:infinispan:config:${infinispan.core.schema.version} https://infinispan.org/schemas/infinispan-config-${infinispan.core.schema.version}.xsd
+                            urn:infinispan:server:${infinispan.core.schema.version} https://infinispan.org/schemas/infinispan-server-${infinispan.core.schema.version}.xsd
+                            urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.2.xsd"
+      xmlns="urn:infinispan:config:${infinispan.core.schema.version}"
+      xmlns:ispn="urn:infinispan:config:${infinispan.core.schema.version}"
+      xmlns:server="urn:infinispan:server:${infinispan.core.schema.version}">
+
+   <jgroups>
+      <stack name="test-tcp" extends="tcp">
+         <LOCAL_PING ispn:stack.combine="REPLACE" ispn:stack.position="MPING" xmlns="urn:org:jgroups"/>
+      </stack>
+   </jgroups>
+
+   <cache-container default-cache="default" statistics="true">
+      <transport cluster="${infinispan.cluster.name:wildfly-modules-it}" stack="test-tcp"/>
+      <global-state unclean-shutdown-action="IGNORE" />
+      <metrics accurate-size="true"/>
+      <local-cache name="default"/>
+   </cache-container>
+
+   <server xmlns="urn:infinispan:server:${infinispan.core.schema.version}">
+      <interfaces>
+         <interface name="public">
+            <inet-address value="${infinispan.bind.address:127.0.0.1}"/>
+         </interface>
+      </interfaces>
+
+      <socket-bindings default-interface="public" port-offset="${infinispan.socket.binding.port-offset:0}">
+         <socket-binding name="default" port="${infinispan.bind.port:11222}"/>
+         <socket-binding name="memcached" port="11221"/>
+      </socket-bindings>
+
+      <endpoints>
+         <endpoint socket-binding="default">
+            <hotrod-connector name="hotrod"/>
+            <rest-connector name="rest"/>
+            <memcached-connector name="memcached" socket-binding="memcached"/>
+         </endpoint>
+      </endpoints>
+   </server>
+</infinispan>

--- a/integrationtests/server-integration/server-integration-commons/src/test/resources/jdbc-config.xml
+++ b/integrationtests/server-integration/server-integration-commons/src/test/resources/jdbc-config.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<infinispan
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="urn:infinispan:config:${infinispan.core.schema.version} https://infinispan.org/schemas/infinispan-config-${infinispan.core.schema.version}.xsd
+   urn:infinispan:config:store:jdbc:${infinispan.core.schema.version} https://infinispan.org/schemas/infinispan-cachestore-jdbc-config-${infinispan.core.schema.version}.xsd"
+   xmlns="urn:infinispan:config:${infinispan.core.schema.version}"
+   xmlns:jdbc="urn:infinispan:config:store:jdbc:${infinispan.core.schema.version}">
+
+  <cache-container default-cache="default">
+    <local-cache name="default">
+      <locking isolation="REPEATABLE_READ"
+               acquire-timeout="20000" concurrency-level="500" striping="false" />
+    </local-cache>
+    <local-cache name="anotherCache">
+      <persistence passivation="false">
+        <jdbc:string-keyed-jdbc-store segmented="false">
+          <jdbc:string-keyed-table prefix="ISPN">
+            <jdbc:id-column name="K" type="VARCHAR(255)"/>
+            <jdbc:data-column name="V" type="BLOB"/>
+            <jdbc:timestamp-column name="T" type="BIGINT"/>
+            <jdbc:segment-column name="S" type="BIGINT"/>
+          </jdbc:string-keyed-table>
+          <jdbc:data-source jndi-url="${infinispan.server.integration.data-source}"/>
+        </jdbc:string-keyed-jdbc-store>
+      </persistence>
+    </local-cache>
+  </cache-container>
+
+</infinispan>

--- a/integrationtests/server-integration/third-party-server/pom.xml
+++ b/integrationtests/server-integration/third-party-server/pom.xml
@@ -1,0 +1,387 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.infinispan</groupId>
+        <artifactId>infinispan-server-integration</artifactId>
+        <version>15.0.4-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>infinispan-third-party-integrationtests</artifactId>
+    <name>Integration tests - Third Party Integration Tests</name>
+    <description>Integration tests - Third Party Integration Tests</description>
+
+    <properties>
+        <version.wildfly>${appserver.version}</version.wildfly>
+        <version.arquillian-tomcat-managed>1.2.1.Final</version.arquillian-tomcat-managed>
+        <ispnserver.project.dir>${basedir}/../../../server/runtime</ispnserver.project.dir>
+        <ispn.config.file>${basedir}/../server-integration-commons/target/test-classes/infinispan-custom.xml</ispn.config.file>
+        <driver.jar>h2.jar</driver.jar>
+        <driver.dir>${project.basedir}/db-libs</driver.dir>
+        <driver.class>org.h2.Driver</driver.class>
+        <connection.url>jdbc:h2:mem:test;DATABASE_TO_UPPER=false</connection.url>
+        <db.username>sa</db.username>
+        <db.password>sa</db.password>
+        <database>h2</database>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.threads</groupId>
+            <artifactId>jboss-threads</artifactId>
+            <version>2.4.0.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan.protostream</groupId>
+            <artifactId>protostream-processor</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-commons-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-client-hotrod</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.spy</groupId>
+            <artifactId>spymemcached</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-server-integrationtests-commons</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-depchain</artifactId>
+            <type>pom</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.descriptors</groupId>
+            <artifactId>shrinkwrap-descriptors-impl-javaee</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <arquillian.launch>${infinispan.server.integration.launch}</arquillian.launch>
+                        <catalinaHome1>${catalinaHome1}</catalinaHome1>
+                        <catalinaHome2>${catalinaHome2}</catalinaHome2>
+                        <catalinaBindHttpPort1>${catalinaBindHttpPort1}</catalinaBindHttpPort1>
+                        <catalinaBindHttpPort2>${catalinaBindHttpPort2}</catalinaBindHttpPort2>
+                        <catalinaJmxPort1>${catalinaJmxPort1}</catalinaJmxPort1>
+                        <catalinaJmxPort2>${catalinaJmxPort2}</catalinaJmxPort2>
+                        <jbossHome1>${jbossHome1}</jbossHome1>
+                        <jbossHome2>${jbossHome2}</jbossHome2>
+                        <server.jvm>${server.jvm}</server.jvm>
+                        <infinispan.server.integration.data-source>${infinispan.server.integration.data-source}</infinispan.server.integration.data-source>
+                        <driver.path>${driver.dir}/${driver.jar}</driver.path>
+                    </systemPropertyVariables>
+                    <additionalClasspathElements>
+                        <additionalClasspathElement>${driver.dir}/${driver.jar}</additionalClasspathElement>
+                    </additionalClasspathElements>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>configs</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>src/test/resources</directory>
+                                    <filtering>true</filtering>
+                                    <includes>
+                                        <include>**/*.xml</include>
+                                        <include>**/*.properties</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                            <filters>
+                                <filter>src/test/resources/${database}.properties</filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>smoke</id>
+            <properties>
+                <skipTests>true</skipTests>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <skipITs>${skipTests}</skipITs>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>third-party-tomcat</id>
+            <activation>
+                <property>
+                    <name>infinispan.server.integration.launch</name>
+                    <value>tomcat</value>
+                </property>
+            </activation>
+            <properties>
+                <infinispan.server.integration.launch>tomcat</infinispan.server.integration.launch>
+                <catalinaHome>${project.build.directory}/tomcat</catalinaHome>
+                <catalinaHome1>${project.build.directory}/tomcat1</catalinaHome1>
+                <catalinaHome2>${project.build.directory}/tomcat2</catalinaHome2>
+                <catalinaBindHttpPort1>8080</catalinaBindHttpPort1>
+                <catalinaBindHttpPort2>8081</catalinaBindHttpPort2>
+                <catalinaJmxPort1>8089</catalinaJmxPort1>
+                <catalinaJmxPort2>8090</catalinaJmxPort2>
+                <catalinaUnzipExpression>apache-tomcat-*</catalinaUnzipExpression>
+                <infinispan.server.integration.data-source>java:comp/env/datasources/ExampleDS</infinispan.server.integration.data-source>
+            </properties>
+            <dependencies>
+                <!-- there is no arquillian-tomcat-managed-9. we are using arquillian-tomcat-managed-8 -->
+                <dependency>
+                    <groupId>org.jboss.arquillian.container</groupId>
+                    <artifactId>arquillian-tomcat-managed-10</artifactId>
+                    <version>${version.arquillian-tomcat-managed}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.weld.servlet</groupId>
+                    <artifactId>weld-servlet-shaded</artifactId>
+                    <version>${version.weld-servlet}</version>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <configuration>
+                            <skip>${skipTests}</skip>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>tomcat-prepare</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <echo message="Copying tomcat server" />
+                                        <delete dir="${catalinaHome1}" />
+                                        <delete dir="${catalinaHome2}" />
+                                        <copy todir="${catalinaHome1}">
+                                            <fileset dir="${catalinaHome}"/>
+                                        </copy>
+                                        <copy todir="${catalinaHome2}">
+                                            <fileset dir="${catalinaHome}"/>
+                                        </copy>
+
+                                        <echo message="Copying configurations" />
+                                        <copy file="${basedir}/src/test/resources/tomcat/tomcat-users.xml" todir="${catalinaHome1}/conf" overwrite="true" />
+                                        <copy file="${basedir}/src/test/resources/tomcat/context.xml" todir="${catalinaHome1}/conf" overwrite="true" />
+                                        <copy file="${basedir}/src/test/resources/tomcat/tomcat-users.xml" todir="${catalinaHome2}/conf" overwrite="true" />
+                                        <copy file="${basedir}/src/test/resources/tomcat/context.xml" todir="${catalinaHome2}/conf" overwrite="true" />
+
+                                        <echo message="Replace configurations" />
+                                        <replaceregexp file="${catalinaHome1}/conf/server.xml" match="port=&quot;8080&quot;" replace="port=&quot;${catalinaBindHttpPort1}&quot;" byline="true"/>
+                                        <replaceregexp file="${catalinaHome1}/conf/server.xml" match="port=&quot;8005&quot;" replace="port=&quot;8005&quot;" byline="true"/>
+                                        <replaceregexp file="${catalinaHome2}/conf/server.xml" match="port=&quot;8080&quot;" replace="port=&quot;${catalinaBindHttpPort2}&quot;" byline="true"/>
+                                        <replaceregexp file="${catalinaHome2}/conf/server.xml" match="port=&quot;8005&quot;" replace="port=&quot;8006&quot;" byline="true"/>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>third-party-wildfly</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>infinispan.server.integration.launch</name>
+                    <value>wildfly</value>
+                </property>
+            </activation>
+            <properties>
+                <infinispan.server.integration.launch>wildfly</infinispan.server.integration.launch>
+                <jbossHome1>${project.build.directory}/node1</jbossHome1>
+                <jbossHome2>${project.build.directory}/node2</jbossHome2>
+                <infinispan.server.integration.data-source>java:jboss/datasources/ExampleDS</infinispan.server.integration.data-source>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.wildfly.arquillian</groupId>
+                    <artifactId>wildfly-arquillian-container-managed</artifactId>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jboss.galleon</groupId>
+                        <artifactId>galleon-maven-plugin</artifactId>
+                        <configuration>
+                            <skip>${skipTests}</skip>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>server-provisioning-node1</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>prepare-package</phase>
+                                <configuration>
+                                    <install-dir>${project.build.directory}/node1</install-dir>
+                                    <record-state>false</record-state>
+                                    <!-- true: uses local m2 cache only -->
+                                    <offline>false</offline>
+                                    <feature-packs>
+                                        <!-- full server -->
+                                        <feature-pack>
+                                            <groupId>${appserver.groupId}</groupId>
+                                            <artifactId>wildfly-galleon-pack</artifactId>
+                                            <version>${appserver.version}</version>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <configurations>
+                                        <config>
+                                            <model>standalone</model>
+                                            <name>standalone.xml</name>
+                                        </config>
+                                    </configurations>
+                                    <plugin-options>
+                                        <!--
+                                        when true, the module.xml files only contains the maven coordinates of the jars to download when the server starts
+                                        when false, the plugin downloads the jars at build time
+                                         -->
+                                        <jboss-maven-dist>false</jboss-maven-dist>
+                                    </plugin-options>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>server-provisioning-node2</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>prepare-package</phase>
+                                <configuration>
+                                    <install-dir>${project.build.directory}/node2</install-dir>
+                                    <record-state>false</record-state>
+                                    <!-- true: uses local m2 cache only -->
+                                    <offline>false</offline>
+                                    <feature-packs>
+                                        <!-- full server -->
+                                        <feature-pack>
+                                            <groupId>${appserver.groupId}</groupId>
+                                            <artifactId>wildfly-galleon-pack</artifactId>
+                                            <version>${appserver.version}</version>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <configurations>
+                                        <config>
+                                            <model>standalone</model>
+                                            <name>standalone.xml</name>
+                                        </config>
+                                    </configurations>
+                                    <plugin-options>
+                                        <!--
+                                        when true, the module.xml files only contains the maven coordinates of the jars to download when the server starts
+                                        when false, the plugin downloads the jars at build time
+                                         -->
+                                        <jboss-maven-dist>false</jboss-maven-dist>
+                                    </plugin-options>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <configuration>
+                            <skip>${skipTests}</skip>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>wildfly-prepare</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <echo message="Copying WildFly configuration" />
+                                        <copy file="${project.build.directory}/test-classes/wildfly/standalone-test.xml" todir="${project.build.directory}/node1/standalone/configuration" overwrite="true" />
+                                        <copy file="${project.build.directory}/test-classes/wildfly/standalone-test.xml" todir="${project.build.directory}/node2/standalone/configuration" overwrite="true" />
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/integrationtests/server-integration/third-party-server/src/test/java/org/infinispan/test/integration/thirdparty/DeploymentHelper.java
+++ b/integrationtests/server-integration/third-party-server/src/test/java/org/infinispan/test/integration/thirdparty/DeploymentHelper.java
@@ -1,0 +1,45 @@
+package org.infinispan.test.integration.thirdparty;
+
+import static org.infinispan.test.integration.GenericDeploymentHelper.addLibrary;
+
+import java.io.File;
+
+import org.infinispan.test.integration.remote.AbstractHotRodQueryIT;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.FileAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+public class DeploymentHelper {
+
+   private static final String ARQUILLIAN_LAUNCH = System.getProperty("arquillian.launch");
+
+   public static WebArchive createDeployment() {
+      WebArchive war = ShrinkWrap.create(WebArchive.class, "infinispan-server-integration.war");
+      if (isTomcat()) {
+         tomcat(war);
+      } else if (isWildfly()) {
+         wildfly(war);
+      } else {
+         throw new IllegalStateException(String.format("'%s' not supported", ARQUILLIAN_LAUNCH));
+      }
+      return war;
+   }
+
+   public static boolean isTomcat() {
+      return "tomcat".equals(ARQUILLIAN_LAUNCH);
+   }
+
+   public static boolean isWildfly() {
+      return "wildfly".equals(ARQUILLIAN_LAUNCH);
+   }
+
+   private static void wildfly(WebArchive war) {
+      File file = new File(AbstractHotRodQueryIT.class.getClassLoader().getResource("wildfly/jboss-deployment-structure.xml").getFile());
+      war.add(new FileAsset(file), "WEB-INF/jboss-deployment-structure.xml");
+   }
+
+   private static void tomcat(WebArchive war) {
+      // required for cdi
+      addLibrary(war, "org.jboss.weld.servlet:weld-servlet-shaded");
+   }
+}

--- a/integrationtests/server-integration/third-party-server/src/test/java/org/infinispan/test/integration/thirdparty/cdi/DuplicatedDomainsCdiIT.java
+++ b/integrationtests/server-integration/third-party-server/src/test/java/org/infinispan/test/integration/thirdparty/cdi/DuplicatedDomainsCdiIT.java
@@ -1,0 +1,31 @@
+package org.infinispan.test.integration.thirdparty.cdi;
+
+import org.infinispan.manager.DefaultCacheManager;
+import org.infinispan.test.integration.GenericDeploymentHelper;
+import org.infinispan.test.integration.cdi.AbstractDuplicatedDomainsCdiIT;
+import org.infinispan.test.integration.thirdparty.DeploymentHelper;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests whether {@link DefaultCacheManager} sets custom Cache name to avoid JMX
+ * name collision.
+ *
+ * @author Sebastian Laskawiec
+ */
+@RunWith(Arquillian.class)
+public class DuplicatedDomainsCdiIT extends AbstractDuplicatedDomainsCdiIT {
+
+   @Deployment
+   @TargetsContainer("server-1")
+   public static Archive<?> deployment() {
+      WebArchive war = DeploymentHelper.createDeployment();
+      war.addClass(AbstractDuplicatedDomainsCdiIT.class);
+      GenericDeploymentHelper.addLibrary(war, "org.infinispan:infinispan-cdi-embedded");
+      return war;
+   }
+}

--- a/integrationtests/server-integration/third-party-server/src/test/java/org/infinispan/test/integration/thirdparty/embedded/InfinispanCoreIT.java
+++ b/integrationtests/server-integration/third-party-server/src/test/java/org/infinispan/test/integration/thirdparty/embedded/InfinispanCoreIT.java
@@ -1,0 +1,30 @@
+package org.infinispan.test.integration.thirdparty.embedded;
+
+import org.infinispan.test.integration.GenericDeploymentHelper;
+import org.infinispan.test.integration.thirdparty.DeploymentHelper;
+import org.infinispan.test.integration.embedded.AbstractInfinispanCoreIT;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.runner.RunWith;
+
+/**
+ * Test the Infinispan AS module integration
+ *
+ * @author Tristan Tarrant
+ * @since 5.2
+ */
+@RunWith(Arquillian.class)
+public class InfinispanCoreIT extends AbstractInfinispanCoreIT {
+
+   @Deployment
+   @TargetsContainer("server-1")
+   public static Archive<?> deployment() {
+      WebArchive war = DeploymentHelper.createDeployment();
+      war.addClass(AbstractInfinispanCoreIT.class);
+      GenericDeploymentHelper.addLibrary(war, "org.infinispan:infinispan-core");
+      return war;
+   }
+}

--- a/integrationtests/server-integration/third-party-server/src/test/java/org/infinispan/test/integration/thirdparty/persistence/jdbc/stringbased/PooledConnectionDeployIT.java
+++ b/integrationtests/server-integration/third-party-server/src/test/java/org/infinispan/test/integration/thirdparty/persistence/jdbc/stringbased/PooledConnectionDeployIT.java
@@ -1,0 +1,30 @@
+package org.infinispan.test.integration.thirdparty.persistence.jdbc.stringbased;
+
+import org.infinispan.test.integration.persistence.jdbc.stringbased.PooledConnectionIT;
+import org.infinispan.test.integration.persistence.jdbc.util.JdbcConfigurationUtil;
+import org.infinispan.test.integration.persistence.jdbc.util.TableManipulation;
+import org.infinispan.test.integration.thirdparty.DeploymentHelper;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.runner.RunWith;
+
+import static org.infinispan.test.integration.thirdparty.persistence.jdbc.util.BaseJdbcDeploy.addJdbcLibraries;
+
+@RunWith(Arquillian.class)
+public class PooledConnectionDeployIT extends PooledConnectionIT {
+
+    @Deployment
+    @TargetsContainer("server-1")
+    public static Archive<?> deployment() {
+        WebArchive war = DeploymentHelper.createDeployment();
+        war.addClass(PooledConnectionIT.class);
+        war.addClass(TableManipulation.class);
+        war.addClass(JdbcConfigurationUtil.class);
+        addJdbcLibraries(war);
+        return war;
+    }
+
+}

--- a/integrationtests/server-integration/third-party-server/src/test/java/org/infinispan/test/integration/thirdparty/persistence/jdbc/util/BaseJdbcDeploy.java
+++ b/integrationtests/server-integration/third-party-server/src/test/java/org/infinispan/test/integration/thirdparty/persistence/jdbc/util/BaseJdbcDeploy.java
@@ -1,0 +1,25 @@
+package org.infinispan.test.integration.thirdparty.persistence.jdbc.util;
+
+import static org.infinispan.test.integration.GenericDeploymentHelper.addLibrary;
+
+import java.io.File;
+
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+public class BaseJdbcDeploy {
+
+    public static void addJdbcLibraries(WebArchive war) {
+        addLibrary(war, "org.infinispan:infinispan-cachestore-jdbc");
+        addLibrary(war, "org.infinispan:infinispan-core");
+        addLibrary(war, "com.h2database:h2");
+        addLibrary(war, "org.jgroups:jgroups");
+        war.addAsResource("connection.properties");
+        String driverPath = System.getProperty("driver.path");
+        if (driverPath != null) {
+            File driverFile = new File(driverPath);
+            if (driverFile.exists()) {
+                war.addAsLibrary(driverFile);
+            }
+        }
+    }
+}

--- a/integrationtests/server-integration/third-party-server/src/test/java/org/infinispan/test/integration/thirdparty/remote/HotRodClientIT.java
+++ b/integrationtests/server-integration/third-party-server/src/test/java/org/infinispan/test/integration/thirdparty/remote/HotRodClientIT.java
@@ -1,0 +1,36 @@
+package org.infinispan.test.integration.thirdparty.remote;
+
+import static org.infinispan.test.integration.GenericDeploymentHelper.addLibrary;
+
+import org.infinispan.test.integration.data.Person;
+import org.infinispan.test.integration.remote.AbstractHotRodClientIT;
+import org.infinispan.test.integration.remote.proto.PersonSchema;
+import org.infinispan.test.integration.thirdparty.DeploymentHelper;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.runner.RunWith;
+
+/**
+ * Test the Infinispan AS remote client module integration
+ *
+ * @author Pedro Ruivo
+ * @since 7.0
+ */
+@RunWith(Arquillian.class)
+public class HotRodClientIT extends AbstractHotRodClientIT {
+
+   @Deployment
+   @TargetsContainer("server-1")
+   public static Archive<?> deployment() {
+      WebArchive war = DeploymentHelper.createDeployment();
+      war.addClass(AbstractHotRodClientIT.class);
+      war.addClass(Person.class);
+      war.addPackage(PersonSchema.class.getPackage().getName());
+      war.addAsResource("proto/person.proto");
+      addLibrary(war, "org.infinispan:infinispan-client-hotrod");
+      return war;
+   }
+}

--- a/integrationtests/server-integration/third-party-server/src/test/java/org/infinispan/test/integration/thirdparty/remote/HotRodQueryIT.java
+++ b/integrationtests/server-integration/third-party-server/src/test/java/org/infinispan/test/integration/thirdparty/remote/HotRodQueryIT.java
@@ -1,0 +1,45 @@
+package org.infinispan.test.integration.thirdparty.remote;
+
+import static org.infinispan.test.integration.GenericDeploymentHelper.addLibrary;
+import static org.infinispan.test.integration.thirdparty.DeploymentHelper.createDeployment;
+
+import java.io.IOException;
+
+import org.infinispan.test.integration.data.Book;
+import org.infinispan.test.integration.data.Person;
+import org.infinispan.test.integration.remote.AbstractHotRodQueryIT;
+import org.infinispan.test.integration.remote.proto.BookQuerySchema;
+import org.infinispan.test.integration.remote.proto.PersonSchema;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.runner.RunWith;
+
+/**
+ * Test remote query.
+ *
+ * @author anistor@redhat.com
+ * @since 8.2
+ */
+@RunWith(Arquillian.class)
+public class HotRodQueryIT extends AbstractHotRodQueryIT {
+
+   @Deployment
+   @TargetsContainer("server-1")
+   public static Archive<?> deployment() throws IOException {
+      WebArchive war = createDeployment();
+      war.addClass(AbstractHotRodQueryIT.class);
+      war.addClass(Person.class);
+      war.addPackage(PersonSchema.class.getPackage().getName());
+      war.addClass(Book.class);
+      war.addPackage(BookQuerySchema.class.getPackage().getName());
+      war.addAsResource("proto/book.proto");
+      war.addAsResource("proto/person.proto");
+      addLibrary(war, "org.infinispan:infinispan-query-dsl");
+      addLibrary(war, "org.infinispan:infinispan-remote-query-client");
+      addLibrary(war, "org.infinispan:infinispan-client-hotrod");
+      return war;
+   }
+}

--- a/integrationtests/server-integration/third-party-server/src/test/java/org/infinispan/test/integration/thirdparty/store/InfinispanStoreJdbcIT.java
+++ b/integrationtests/server-integration/third-party-server/src/test/java/org/infinispan/test/integration/thirdparty/store/InfinispanStoreJdbcIT.java
@@ -1,0 +1,38 @@
+package org.infinispan.test.integration.thirdparty.store;
+
+import static org.infinispan.test.integration.GenericDeploymentHelper.addLibrary;
+import static org.infinispan.test.integration.thirdparty.DeploymentHelper.isTomcat;
+
+import org.infinispan.test.integration.thirdparty.DeploymentHelper;
+import org.infinispan.test.integration.store.AbstractInfinispanStoreJdbcIT;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.runner.RunWith;
+
+/**
+ * Test the Infinispan JDBC CacheStore AS module integration
+ *
+ * @author Tristan Tarrant
+ * @since 5.2
+ */
+@RunWith(Arquillian.class)
+public class InfinispanStoreJdbcIT extends AbstractInfinispanStoreJdbcIT {
+
+   @Deployment
+   @TargetsContainer("server-1")
+   public static Archive<?> deployment() {
+      WebArchive war = DeploymentHelper.createDeployment();
+      war.addClass(AbstractInfinispanStoreJdbcIT.class);
+      war.addAsResource("jdbc-config.xml");
+      addLibrary(war, "org.infinispan:infinispan-core");
+      addLibrary(war, "org.infinispan:infinispan-cachestore-jdbc");
+      if (isTomcat()) {
+         addLibrary(war, "com.h2database:h2");
+      }
+      return war;
+   }
+
+}

--- a/integrationtests/server-integration/third-party-server/src/test/java/org/infinispan/test/integration/thirdparty/store/InfinispanStoreRocksDBIT.java
+++ b/integrationtests/server-integration/third-party-server/src/test/java/org/infinispan/test/integration/thirdparty/store/InfinispanStoreRocksDBIT.java
@@ -1,0 +1,45 @@
+package org.infinispan.test.integration.thirdparty.store;
+
+import static org.infinispan.test.integration.GenericDeploymentHelper.addLibrary;
+
+import org.infinispan.test.integration.store.AbstractInfinispanStoreRocksDBIT;
+import org.infinispan.test.integration.thirdparty.DeploymentHelper;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.runner.RunWith;
+
+/**
+ * Test the Infinispan RocksDB CacheStore AS module integration
+ *
+ * @author Tristan Tarrant
+ * @since 7.0
+ */
+@RunWith(Arquillian.class)
+public class InfinispanStoreRocksDBIT extends AbstractInfinispanStoreRocksDBIT {
+
+   @Deployment(name = "dep1", managed = false)
+   @TargetsContainer("server-1")
+   public static Archive<?> deployment1() {
+      return archive();
+   }
+
+   @Deployment(name = "dep2", managed = false)
+   @TargetsContainer("server-2")
+   public static Archive<?> deployment2() {
+      return archive();
+   }
+
+   private static Archive<?> archive() {
+      WebArchive war = DeploymentHelper.createDeployment();
+      war.addClass(AbstractInfinispanStoreRocksDBIT.class);
+      war.addClass(InfinispanStoreRocksDBIT.class);
+      addLibrary(war, "org.jgroups:jgroups");
+      addLibrary(war, "org.infinispan:infinispan-core");
+      addLibrary(war, "org.infinispan:infinispan-cachestore-rocksdb");
+      addLibrary(war, "org.infinispan:infinispan-commons-test");
+      return war;
+   }
+}

--- a/integrationtests/server-integration/third-party-server/src/test/resources/arquillian.xml
+++ b/integrationtests/server-integration/third-party-server/src/test/resources/arquillian.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://jboss.org/schema/arquillian"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <group qualifier="tomcat">
+        <!-- if you need find what are the supported properties, debug TomcatManagedContainer -->
+        <container qualifier="server-1">
+            <configuration>
+                <property name="catalinaHome">${catalinaHome1}</property>
+                <property name="user">admin</property>
+                <property name="pass">admin-pwd</property>
+                <property name="bindHttpPort">${catalinaBindHttpPort1}</property>
+                <property name="jmxPort">${catalinaJmxPort1}</property>
+                <!--
+                <property name="javaVmArguments">
+                    -agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=y,timeout=600000
+                </property>
+                -->
+                <property name="javaVmArguments">
+                    --add-opens=java.base/java.util=ALL-UNNAMED
+                    --add-opens=java.base/java.lang=ALL-UNNAMED
+                    -Dinfinispan.server.integration.data-source=${infinispan.server.integration.data-source}
+                    -Djava.net.preferIPv4Stack=true
+                    -Djgroups.bind.address=localhost
+                </property>
+            </configuration>
+        </container>
+        <container qualifier="server-2">
+            <configuration>
+                <property name="catalinaHome">${catalinaHome2}</property>
+                <property name="user">admin</property>
+                <property name="pass">admin-pwd</property>
+                <property name="bindHttpPort">${catalinaBindHttpPort2}</property>
+                <property name="jmxPort">${catalinaJmxPort2}</property>
+                <!--
+                <property name="javaVmArguments">
+                    -agentlib:jdwp=transport=dt_socket,address=9787,server=y,suspend=y,timeout=600000
+                </property>
+                -->
+                <property name="javaVmArguments">
+                    --add-opens=java.base/java.util=ALL-UNNAMED
+                    --add-opens=java.base/java.lang=ALL-UNNAMED
+                    -Dinfinispan.server.integration.data-source=${infinispan.server.integration.data-source}
+                    -Djava.net.preferIPv4Stack=true
+                    -Djgroups.bind.address=localhost
+                </property>
+            </configuration>
+        </container>
+    </group>
+    <group qualifier="wildfly">
+        <container qualifier="server-1">
+            <configuration>
+                <property name="jbossHome">${jbossHome1}</property>
+                <property name="javaHome">${server.jvm}</property>
+                <!-- org.wildfly.clustering.marshalling.protostream.util.EnumMapMarshaller uses setAccessible -->
+                <!-- org.infinispan.protostream.annotations.impl.MarshallerByteCodeGenerator uses setAccessible via javassist -->
+                <property name="javaVmArguments">
+                    --add-opens=java.base/java.util=ALL-UNNAMED
+                   --add-opens=java.base/java.lang=ALL-UNNAMED
+                    -Dinfinispan.server.integration.data-source=${infinispan.server.integration.data-source}
+                    -Djava.net.preferIPv4Stack=true
+                </property>
+                <property name="serverConfig">standalone-test.xml</property>
+            </configuration>
+        </container>
+        <container qualifier="server-2">
+            <configuration>
+                <property name="jbossHome">${jbossHome2}</property>
+                <property name="javaHome">${server.jvm}</property>
+                <!-- org.wildfly.clustering.marshalling.protostream.util.EnumMapMarshaller uses setAccessible -->
+                <!-- org.infinispan.protostream.annotations.impl.MarshallerByteCodeGenerator uses setAccessible via javassist -->
+                <property name="javaVmArguments">
+                   --add-opens=java.base/java.util=ALL-UNNAMED
+                   --add-opens=java.base/java.lang=ALL-UNNAMED
+                    -Dinfinispan.server.integration.data-source=${infinispan.server.integration.data-source}
+                    -Djava.net.preferIPv4Stack=true
+                    -Djboss.socket.binding.port-offset=100
+                </property>
+                <property name="managementPort">10090</property>
+                <property name="serverConfig">standalone-test.xml</property>
+            </configuration>
+        </container>
+    </group>
+</arquillian>

--- a/integrationtests/server-integration/third-party-server/src/test/resources/connection.properties
+++ b/integrationtests/server-integration/third-party-server/src/test/resources/connection.properties
@@ -1,0 +1,11 @@
+connection.url=${connection.url}
+db.schema=${db.schema}
+db.username=${db.username}
+db.password=${db.password}
+driver.class=${driver.class}
+id.column.type=${id.column.type}
+data.column.type=${data.column.type}
+timestamp.column.type=${timestamp.column.type}
+database.type=${database.type}
+datasource.jndi.location=${datasource.jndi.location}
+database.upsert.disabled=${database.upsert.disabled}

--- a/integrationtests/server-integration/third-party-server/src/test/resources/db2.properties
+++ b/integrationtests/server-integration/third-party-server/src/test/resources/db2.properties
@@ -1,0 +1,5 @@
+id.column.type=VARCHAR(255)
+data.column.type=BLOB(1000)
+timestamp.column.type=BIGINT
+database.type=DB2
+database.upsert.disabled=false

--- a/integrationtests/server-integration/third-party-server/src/test/resources/h2.properties
+++ b/integrationtests/server-integration/third-party-server/src/test/resources/h2.properties
@@ -1,0 +1,6 @@
+#specific for DB
+id.column.type=VARCHAR
+data.column.type=BINARY VARYING
+timestamp.column.type=BIGINT
+database.type=H2
+database.upsert.disabled=false

--- a/integrationtests/server-integration/third-party-server/src/test/resources/mariadb.properties
+++ b/integrationtests/server-integration/third-party-server/src/test/resources/mariadb.properties
@@ -1,0 +1,5 @@
+id.column.type=VARCHAR(255)
+data.column.type=VARBINARY(1000)
+timestamp.column.type=BIGINT
+database.type=MYSQL
+database.upsert.disabled=false

--- a/integrationtests/server-integration/third-party-server/src/test/resources/mssql.properties
+++ b/integrationtests/server-integration/third-party-server/src/test/resources/mssql.properties
@@ -1,0 +1,5 @@
+id.column.type=VARCHAR(255)
+data.column.type=VARBINARY(1000)
+timestamp.column.type=BIGINT
+database.type=SQL_SERVER
+database.upsert.disabled=false

--- a/integrationtests/server-integration/third-party-server/src/test/resources/mysql.properties
+++ b/integrationtests/server-integration/third-party-server/src/test/resources/mysql.properties
@@ -1,0 +1,5 @@
+id.column.type=VARCHAR(255)
+data.column.type=VARBINARY(1000)
+timestamp.column.type=BIGINT
+database.type=MYSQL
+database.upsert.disabled=false

--- a/integrationtests/server-integration/third-party-server/src/test/resources/oracle.properties
+++ b/integrationtests/server-integration/third-party-server/src/test/resources/oracle.properties
@@ -1,0 +1,5 @@
+id.column.type=VARCHAR2(255)
+data.column.type=RAW(1000)
+timestamp.column.type=NUMBER
+database.type=ORACLE
+database.upsert.disabled=false

--- a/integrationtests/server-integration/third-party-server/src/test/resources/postgresplus.properties
+++ b/integrationtests/server-integration/third-party-server/src/test/resources/postgresplus.properties
@@ -1,0 +1,5 @@
+id.column.type=VARCHAR(255)
+data.column.type=BYTEA
+timestamp.column.type=BIGINT
+database.type=POSTGRES
+database.upsert.disabled=false

--- a/integrationtests/server-integration/third-party-server/src/test/resources/postgresql.properties
+++ b/integrationtests/server-integration/third-party-server/src/test/resources/postgresql.properties
@@ -1,0 +1,6 @@
+#specific for DB
+id.column.type=VARCHAR(255)
+data.column.type=BYTEA
+timestamp.column.type=BIGINT
+database.type=POSTGRES
+database.upsert.disabled=false

--- a/integrationtests/server-integration/third-party-server/src/test/resources/sybase.properties
+++ b/integrationtests/server-integration/third-party-server/src/test/resources/sybase.properties
@@ -1,0 +1,5 @@
+id.column.type=VARCHAR(255)
+data.column.type=IMAGE
+timestamp.column.type=BIGINT
+database.type=SYBASE
+database.upsert.disabled=true

--- a/integrationtests/server-integration/third-party-server/src/test/resources/tomcat/context.xml
+++ b/integrationtests/server-integration/third-party-server/src/test/resources/tomcat/context.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- The contents of this file will be loaded for each web application -->
+<Context>
+
+    <!-- Default set of monitored resources. If one of these changes, the    -->
+    <!-- web application will be reloaded.                                   -->
+    <WatchedResource>WEB-INF/web.xml</WatchedResource>
+    <WatchedResource>WEB-INF/tomcat-web.xml</WatchedResource>
+    <WatchedResource>${catalina.base}/conf/web.xml</WatchedResource>
+
+    <!-- Uncomment this to disable session persistence across Tomcat restarts -->
+    <!--
+    <Manager pathname="" />
+    -->
+    <Resource name="datasources/ExampleDS" auth="Container" type="javax.sql.DataSource"
+              username="sa" password="sa" driverClassName="org.h2.Driver"
+              url="jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE"/>
+</Context>

--- a/integrationtests/server-integration/third-party-server/src/test/resources/tomcat/tomcat-users.xml
+++ b/integrationtests/server-integration/third-party-server/src/test/resources/tomcat/tomcat-users.xml
@@ -1,0 +1,7 @@
+<tomcat-users>
+    <role rolename="manager-gui"/>
+    <role rolename="manager-jmx"/>
+    <role rolename="manager-script"/>
+    <user username="tomcat" password="tomcat" roles="manager-script, manager-jmx, manager-gui"/>
+    <user username="admin" password="admin-pwd" roles="manager-script"/>
+</tomcat-users>

--- a/integrationtests/server-integration/third-party-server/src/test/resources/wildfly/jboss-deployment-structure.xml
+++ b/integrationtests/server-integration/third-party-server/src/test/resources/wildfly/jboss-deployment-structure.xml
@@ -1,0 +1,7 @@
+<jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.2">
+    <deployment>
+        <dependencies>
+            <module name="jdk.unsupported"/>
+        </dependencies>
+    </deployment>
+</jboss-deployment-structure>

--- a/integrationtests/server-integration/third-party-server/src/test/resources/wildfly/standalone-test.xml
+++ b/integrationtests/server-integration/third-party-server/src/test/resources/wildfly/standalone-test.xml
@@ -1,0 +1,569 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<server xmlns="urn:jboss:domain:20.0">
+    <extensions>
+        <extension module="org.jboss.as.clustering.infinispan"/>
+        <extension module="org.jboss.as.connector"/>
+        <extension module="org.jboss.as.deployment-scanner"/>
+        <extension module="org.jboss.as.ee"/>
+        <extension module="org.jboss.as.ejb3"/>
+        <extension module="org.jboss.as.jaxrs"/>
+        <extension module="org.jboss.as.jdr"/>
+        <extension module="org.jboss.as.jmx"/>
+        <extension module="org.jboss.as.jpa"/>
+        <extension module="org.jboss.as.jsf"/>
+        <extension module="org.jboss.as.logging"/>
+        <extension module="org.jboss.as.mail"/>
+        <extension module="org.jboss.as.naming"/>
+        <extension module="org.jboss.as.pojo"/>
+        <extension module="org.jboss.as.remoting"/>
+        <extension module="org.jboss.as.sar"/>
+        <extension module="org.jboss.as.transactions"/>
+        <extension module="org.jboss.as.webservices"/>
+        <extension module="org.jboss.as.weld"/>
+        <extension module="org.wildfly.extension.batch.jberet"/>
+        <extension module="org.wildfly.extension.bean-validation"/>
+        <extension module="org.wildfly.extension.clustering.ejb"/>
+        <extension module="org.wildfly.extension.clustering.web"/>
+        <extension module="org.wildfly.extension.core-management"/>
+        <extension module="org.wildfly.extension.discovery"/>
+        <extension module="org.wildfly.extension.ee-security"/>
+        <extension module="org.wildfly.extension.elytron"/>
+        <extension module="org.wildfly.extension.elytron-oidc-client"/>
+        <extension module="org.wildfly.extension.health"/>
+        <extension module="org.wildfly.extension.io"/>
+        <extension module="org.wildfly.extension.messaging-activemq"/>
+        <extension module="org.wildfly.extension.metrics"/>
+        <extension module="org.wildfly.extension.microprofile.config-smallrye"/>
+        <extension module="org.wildfly.extension.microprofile.jwt-smallrye"/>
+        <extension module="org.wildfly.extension.request-controller"/>
+        <extension module="org.wildfly.extension.security.manager"/>
+        <extension module="org.wildfly.extension.undertow"/>
+        <extension module="org.wildfly.iiop-openjdk"/>
+    </extensions>
+    <management>
+        <audit-log>
+            <formatters>
+                <json-formatter name="json-formatter"/>
+            </formatters>
+            <handlers>
+                <file-handler name="file" formatter="json-formatter" path="audit-log.log" relative-to="jboss.server.data.dir"/>
+            </handlers>
+            <logger log-boot="true" log-read-only="false" enabled="false">
+                <handlers>
+                    <handler name="file"/>
+                </handlers>
+            </logger>
+        </audit-log>
+        <management-interfaces>
+            <http-interface http-authentication-factory="management-http-authentication">
+                <http-upgrade enabled="true" sasl-authentication-factory="management-sasl-authentication"/>
+                <socket-binding http="management-http"/>
+            </http-interface>
+        </management-interfaces>
+        <access-control provider="simple">
+            <role-mapping>
+                <role name="SuperUser">
+                    <include>
+                        <user name="$local"/>
+                    </include>
+                </role>
+            </role-mapping>
+        </access-control>
+    </management>
+    <profile>
+        <subsystem xmlns="urn:jboss:domain:logging:8.0">
+            <console-handler name="CONSOLE">
+                <level name="INFO"/>
+                <formatter>
+                    <named-formatter name="COLOR-PATTERN"/>
+                </formatter>
+            </console-handler>
+            <periodic-rotating-file-handler name="FILE" autoflush="true">
+                <formatter>
+                    <named-formatter name="PATTERN"/>
+                </formatter>
+                <file relative-to="jboss.server.log.dir" path="server.log"/>
+                <suffix value=".yyyy-MM-dd"/>
+                <append value="true"/>
+            </periodic-rotating-file-handler>
+            <logger category="com.arjuna">
+                <level name="WARN"/>
+            </logger>
+            <logger category="com.networknt.schema">
+                <level name="WARN"/>
+            </logger>
+            <logger category="io.jaegertracing.Configuration">
+                <level name="WARN"/>
+            </logger>
+            <logger category="org.jboss.as.config">
+                <level name="DEBUG"/>
+            </logger>
+            <logger category="sun.rmi">
+                <level name="WARN"/>
+            </logger>
+            <root-logger>
+                <level name="INFO"/>
+                <handlers>
+                    <handler name="CONSOLE"/>
+                    <handler name="FILE"/>
+                </handlers>
+            </root-logger>
+            <formatter name="PATTERN">
+                <pattern-formatter pattern="%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
+            </formatter>
+            <formatter name="COLOR-PATTERN">
+                <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
+            </formatter>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:batch-jberet:3.0">
+            <default-job-repository name="in-memory"/>
+            <default-thread-pool name="batch"/>
+            <security-domain name="ApplicationDomain"/>
+            <job-repository name="in-memory">
+                <in-memory/>
+            </job-repository>
+            <thread-pool name="batch">
+                <max-threads count="10"/>
+                <keepalive-time time="30" unit="seconds"/>
+            </thread-pool>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:bean-validation:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:core-management:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:datasources:7.1">
+            <datasources>
+                <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true" statistics-enabled="${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}">
+                    <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=${wildfly.h2.compatibility.mode:REGULAR}</connection-url>
+                    <driver>h2</driver>
+                    <security user-name="sa" password="sa"/>
+                </datasource>
+                <drivers>
+                    <driver name="h2" module="com.h2database.h2">
+                        <xa-datasource-class>org.h2.jdbcx.JdbcDataSource</xa-datasource-class>
+                    </driver>
+                </drivers>
+            </datasources>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:deployment-scanner:2.0">
+            <deployment-scanner path="deployments" relative-to="jboss.server.base.dir" scan-interval="5000" runtime-failure-causes-rollback="${jboss.deployment.scanner.rollback.on.failure:false}"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:discovery:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:distributable-ejb:1.0" default-bean-management="default">
+            <infinispan-bean-management name="default" max-active-beans="10000" cache-container="ejb" cache="passivation"/>
+            <local-client-mappings-registry/>
+            <infinispan-timer-management name="persistent" cache-container="ejb" cache="persistent" max-active-timers="10000"/>
+            <infinispan-timer-management name="transient" cache-container="ejb" cache="transient" max-active-timers="10000"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:distributable-web:4.0" default-session-management="default" default-single-sign-on-management="default">
+            <infinispan-session-management name="default" cache-container="web" granularity="SESSION">
+                <local-affinity/>
+            </infinispan-session-management>
+            <infinispan-single-sign-on-management name="default" cache-container="web" cache="sso"/>
+            <local-routing/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:ee:6.0">
+            <spec-descriptor-property-replacement>false</spec-descriptor-property-replacement>
+            <concurrent>
+                <context-services>
+                    <context-service name="default" jndi-name="java:jboss/ee/concurrency/context/default"/>
+                </context-services>
+                <managed-thread-factories>
+                    <managed-thread-factory name="default" jndi-name="java:jboss/ee/concurrency/factory/default" context-service="default"/>
+                </managed-thread-factories>
+                <managed-executor-services>
+                    <managed-executor-service name="default" jndi-name="java:jboss/ee/concurrency/executor/default" context-service="default" hung-task-termination-period="0" hung-task-threshold="60000" keepalive-time="5000"/>
+                </managed-executor-services>
+                <managed-scheduled-executor-services>
+                    <managed-scheduled-executor-service name="default" jndi-name="java:jboss/ee/concurrency/scheduler/default" context-service="default" hung-task-termination-period="0" hung-task-threshold="60000" keepalive-time="3000"/>
+                </managed-scheduled-executor-services>
+            </concurrent>
+            <default-bindings context-service="java:jboss/ee/concurrency/context/default" datasource="java:jboss/datasources/ExampleDS" jms-connection-factory="java:jboss/DefaultJMSConnectionFactory" managed-executor-service="java:jboss/ee/concurrency/executor/default" managed-scheduled-executor-service="java:jboss/ee/concurrency/scheduler/default" managed-thread-factory="java:jboss/ee/concurrency/factory/default"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:ee-security:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:ejb3:10.0">
+            <session-bean>
+                <stateless>
+                    <bean-instance-pool-ref pool-name="slsb-strict-max-pool"/>
+                </stateless>
+                <stateful default-access-timeout="5000" cache-ref="simple" passivation-disabled-cache-ref="simple"/>
+                <singleton default-access-timeout="5000"/>
+            </session-bean>
+            <mdb>
+                <resource-adapter-ref resource-adapter-name="${ejb.resource-adapter-name:activemq-ra.rar}"/>
+                <bean-instance-pool-ref pool-name="mdb-strict-max-pool"/>
+            </mdb>
+            <pools>
+                <bean-instance-pools>
+                    <strict-max-pool name="slsb-strict-max-pool" derive-size="from-worker-pools" instance-acquisition-timeout="5" instance-acquisition-timeout-unit="MINUTES"/>
+                    <strict-max-pool name="mdb-strict-max-pool" derive-size="from-cpu-count" instance-acquisition-timeout="5" instance-acquisition-timeout-unit="MINUTES"/>
+                </bean-instance-pools>
+            </pools>
+            <caches>
+                <simple-cache name="simple"/>
+                <distributable-cache name="distributable"/>
+            </caches>
+            <async thread-pool-name="default"/>
+            <timer-service thread-pool-name="default" default-data-store="default-file-store">
+                <data-stores>
+                    <file-data-store name="default-file-store" path="timer-service-data" relative-to="jboss.server.data.dir"/>
+                </data-stores>
+            </timer-service>
+            <remote cluster="ejb" connectors="http-remoting-connector" thread-pool-name="default">
+                <channel-creation-options>
+                    <option name="MAX_OUTBOUND_MESSAGES" value="1234" type="remoting"/>
+                </channel-creation-options>
+            </remote>
+            <thread-pools>
+                <thread-pool name="default">
+                    <max-threads count="10"/>
+                    <keepalive-time time="60" unit="seconds"/>
+                </thread-pool>
+            </thread-pools>
+            <iiop enable-by-default="false" use-qualified-name="false"/>
+            <default-security-domain value="other"/>
+            <application-security-domains>
+                <application-security-domain name="other" security-domain="ApplicationDomain"/>
+            </application-security-domains>
+            <default-missing-method-permissions-deny-access value="true"/>
+            <statistics enabled="${wildfly.ejb3.statistics-enabled:${wildfly.statistics-enabled:false}}"/>
+            <log-system-exceptions value="true"/>
+        </subsystem>
+        <subsystem xmlns="urn:wildfly:elytron:community:18.0" final-providers="combined-providers" disallowed-providers="OracleUcrypto">
+            <providers>
+                <aggregate-providers name="combined-providers">
+                    <providers name="elytron"/>
+                    <providers name="openssl"/>
+                </aggregate-providers>
+                <provider-loader name="elytron" module="org.wildfly.security.elytron"/>
+                <provider-loader name="openssl" module="org.wildfly.openssl"/>
+            </providers>
+            <audit-logging>
+                <file-audit-log name="local-audit" path="audit.log" relative-to="jboss.server.log.dir" format="JSON"/>
+            </audit-logging>
+            <security-domains>
+                <security-domain name="ApplicationDomain" default-realm="ApplicationRealm" permission-mapper="default-permission-mapper">
+                    <realm name="ApplicationRealm" role-decoder="groups-to-roles"/>
+                    <realm name="local"/>
+                </security-domain>
+                <security-domain name="ManagementDomain" default-realm="ManagementRealm" permission-mapper="default-permission-mapper">
+                    <realm name="ManagementRealm" role-decoder="groups-to-roles"/>
+                    <realm name="local" role-mapper="super-user-mapper"/>
+                </security-domain>
+            </security-domains>
+            <security-realms>
+                <identity-realm name="local" identity="$local"/>
+                <properties-realm name="ApplicationRealm">
+                    <users-properties path="application-users.properties" relative-to="jboss.server.config.dir" digest-realm-name="ApplicationRealm"/>
+                    <groups-properties path="application-roles.properties" relative-to="jboss.server.config.dir"/>
+                </properties-realm>
+                <properties-realm name="ManagementRealm">
+                    <users-properties path="mgmt-users.properties" relative-to="jboss.server.config.dir" digest-realm-name="ManagementRealm"/>
+                    <groups-properties path="mgmt-groups.properties" relative-to="jboss.server.config.dir"/>
+                </properties-realm>
+            </security-realms>
+            <mappers>
+                <simple-permission-mapper name="default-permission-mapper" mapping-mode="first">
+                    <permission-mapping>
+                        <principal name="anonymous"/>
+                        <permission-set name="default-permissions"/>
+                    </permission-mapping>
+                    <permission-mapping match-all="true">
+                        <permission-set name="login-permission"/>
+                        <permission-set name="default-permissions"/>
+                    </permission-mapping>
+                </simple-permission-mapper>
+                <constant-realm-mapper name="local" realm-name="local"/>
+                <simple-role-decoder name="groups-to-roles" attribute="groups"/>
+                <constant-role-mapper name="super-user-mapper">
+                    <role name="SuperUser"/>
+                </constant-role-mapper>
+            </mappers>
+            <permission-sets>
+                <permission-set name="login-permission">
+                    <permission class-name="org.wildfly.security.auth.permission.LoginPermission"/>
+                </permission-set>
+                <permission-set name="default-permissions">
+                    <permission class-name="org.wildfly.transaction.client.RemoteTransactionPermission" module="org.wildfly.transaction.client"/>
+                    <permission class-name="org.jboss.ejb.client.RemoteEJBPermission" module="org.jboss.ejb-client"/>
+                    <permission class-name="org.wildfly.extension.batch.jberet.deployment.BatchPermission" module="org.wildfly.extension.batch.jberet" target-name="*"/>
+                </permission-set>
+            </permission-sets>
+            <http>
+                <http-authentication-factory name="application-http-authentication" security-domain="ApplicationDomain" http-server-mechanism-factory="global">
+                    <mechanism-configuration>
+                        <mechanism mechanism-name="BASIC">
+                            <mechanism-realm realm-name="ApplicationRealm"/>
+                        </mechanism>
+                    </mechanism-configuration>
+                </http-authentication-factory>
+                <http-authentication-factory name="management-http-authentication" security-domain="ManagementDomain" http-server-mechanism-factory="global">
+                    <mechanism-configuration>
+                        <mechanism mechanism-name="DIGEST">
+                            <mechanism-realm realm-name="ManagementRealm"/>
+                        </mechanism>
+                    </mechanism-configuration>
+                </http-authentication-factory>
+                <provider-http-server-mechanism-factory name="global"/>
+            </http>
+            <sasl>
+                <sasl-authentication-factory name="application-sasl-authentication" sasl-server-factory="configured" security-domain="ApplicationDomain">
+                    <mechanism-configuration>
+                        <mechanism mechanism-name="JBOSS-LOCAL-USER" realm-mapper="local"/>
+                        <mechanism mechanism-name="DIGEST-MD5">
+                            <mechanism-realm realm-name="ApplicationRealm"/>
+                        </mechanism>
+                    </mechanism-configuration>
+                </sasl-authentication-factory>
+                <sasl-authentication-factory name="management-sasl-authentication" sasl-server-factory="configured" security-domain="ManagementDomain">
+                    <mechanism-configuration>
+                        <mechanism mechanism-name="JBOSS-LOCAL-USER" realm-mapper="local"/>
+                        <mechanism mechanism-name="DIGEST-MD5">
+                            <mechanism-realm realm-name="ManagementRealm"/>
+                        </mechanism>
+                    </mechanism-configuration>
+                </sasl-authentication-factory>
+                <configurable-sasl-server-factory name="configured" sasl-server-factory="elytron">
+                    <properties>
+                        <property name="wildfly.sasl.local-user.default-user" value="$local"/>
+                        <property name="wildfly.sasl.local-user.challenge-path" value="${jboss.server.temp.dir}/auth"/>
+                    </properties>
+                </configurable-sasl-server-factory>
+                <mechanism-provider-filtering-sasl-server-factory name="elytron" sasl-server-factory="global">
+                    <filters>
+                        <filter provider-name="WildFlyElytron"/>
+                    </filters>
+                </mechanism-provider-filtering-sasl-server-factory>
+                <provider-sasl-server-factory name="global"/>
+            </sasl>
+            <tls>
+                <key-stores>
+                    <key-store name="applicationKS">
+                        <credential-reference clear-text="password"/>
+                        <implementation type="JKS"/>
+                        <file path="application.keystore" relative-to="jboss.server.config.dir"/>
+                    </key-store>
+                </key-stores>
+                <key-managers>
+                    <key-manager name="applicationKM" key-store="applicationKS" generate-self-signed-certificate-host="localhost">
+                        <credential-reference clear-text="password"/>
+                    </key-manager>
+                </key-managers>
+                <server-ssl-contexts>
+                    <server-ssl-context name="applicationSSC" key-manager="applicationKM"/>
+                </server-ssl-contexts>
+            </tls>
+            <policy name="jacc">
+                <jacc-policy/>
+            </policy>
+        </subsystem>
+        <subsystem xmlns="urn:wildfly:elytron-oidc-client:2.0"/>
+        <subsystem xmlns="urn:wildfly:health:1.0" security-enabled="false"/>
+        <subsystem xmlns="urn:jboss:domain:iiop-openjdk:3.0">
+            <orb socket-binding="iiop"/>
+            <initializers security="elytron" transactions="spec"/>
+            <security server-requires-ssl="false" client-requires-ssl="false"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:infinispan:14.0">
+            <cache-container name="hibernate" marshaller="JBOSS" modules="org.infinispan.hibernate-cache">
+                <local-cache name="entity">
+                    <heap-memory size="10000"/>
+                    <expiration max-idle="100000"/>
+                </local-cache>
+                <local-cache name="local-query">
+                    <heap-memory size="10000"/>
+                    <expiration max-idle="100000"/>
+                </local-cache>
+                <local-cache name="timestamps">
+                    <expiration interval="0"/>
+                </local-cache>
+                <local-cache name="pending-puts">
+                    <expiration max-idle="60000"/>
+                </local-cache>
+            </cache-container>
+            <cache-container name="ejb" default-cache="passivation" marshaller="PROTOSTREAM" aliases="sfsb" modules="org.wildfly.clustering.ejb.infinispan">
+                <local-cache name="passivation">
+                    <expiration interval="0"/>
+                    <file-store passivation="true"/>
+                </local-cache>
+                <local-cache name="persistent">
+                    <locking isolation="REPEATABLE_READ"/>
+                    <transaction mode="BATCH"/>
+                    <expiration interval="0"/>
+                    <file-store preload="true"/>
+                </local-cache>
+                <local-cache name="transient">
+                    <locking isolation="REPEATABLE_READ"/>
+                    <transaction mode="BATCH"/>
+                    <expiration interval="0"/>
+                    <file-store passivation="true" purge="true"/>
+                </local-cache>
+            </cache-container>
+            <cache-container name="web" default-cache="passivation" marshaller="PROTOSTREAM" modules="org.wildfly.clustering.web.infinispan">
+                <local-cache name="passivation">
+                    <expiration interval="0"/>
+                    <file-store passivation="true"/>
+                </local-cache>
+                <local-cache name="sso">
+                    <expiration interval="0"/>
+                </local-cache>
+            </cache-container>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:io:4.0" default-worker="default">
+            <worker name="default"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:jaxrs:3.0"/>
+        <subsystem xmlns="urn:jboss:domain:jca:6.0">
+            <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
+            <bean-validation enabled="true"/>
+            <default-workmanager>
+                <short-running-threads>
+                    <core-threads count="50"/>
+                    <queue-length count="50"/>
+                    <max-threads count="50"/>
+                    <keepalive-time time="10" unit="seconds"/>
+                </short-running-threads>
+                <long-running-threads>
+                    <core-threads count="50"/>
+                    <queue-length count="50"/>
+                    <max-threads count="50"/>
+                    <keepalive-time time="10" unit="seconds"/>
+                </long-running-threads>
+            </default-workmanager>
+            <cached-connection-manager/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:jdr:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:jmx:1.3">
+            <expose-resolved-model/>
+            <expose-expression-model/>
+            <remoting-connector/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:jpa:1.1">
+            <jpa default-extended-persistence-inheritance="DEEP"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:jsf:1.1"/>
+        <subsystem xmlns="urn:jboss:domain:mail:4.0">
+            <mail-session name="default" jndi-name="java:jboss/mail/Default">
+                <smtp-server outbound-socket-binding-ref="mail-smtp"/>
+            </mail-session>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:messaging-activemq:16.0">
+            <server name="default">
+                <security elytron-domain="ApplicationDomain"/>
+                <statistics enabled="${wildfly.messaging-activemq.statistics-enabled:${wildfly.statistics-enabled:false}}"/>
+                <security-setting name="#">
+                    <role name="guest" send="true" consume="true" create-non-durable-queue="true" delete-non-durable-queue="true"/>
+                </security-setting>
+                <address-setting name="#" dead-letter-address="jms.queue.DLQ" expiry-address="jms.queue.ExpiryQueue" max-size-bytes="10485760" page-size-bytes="2097152" message-counter-history-day-limit="10"/>
+                <http-connector name="http-connector" socket-binding="http" endpoint="http-acceptor"/>
+                <http-connector name="http-connector-throughput" socket-binding="http" endpoint="http-acceptor-throughput">
+                    <param name="batch-delay" value="50"/>
+                </http-connector>
+                <in-vm-connector name="in-vm" server-id="0">
+                    <param name="buffer-pooling" value="false"/>
+                </in-vm-connector>
+                <http-acceptor name="http-acceptor" http-listener="default"/>
+                <http-acceptor name="http-acceptor-throughput" http-listener="default">
+                    <param name="batch-delay" value="50"/>
+                    <param name="direct-deliver" value="false"/>
+                </http-acceptor>
+                <in-vm-acceptor name="in-vm" server-id="0">
+                    <param name="buffer-pooling" value="false"/>
+                </in-vm-acceptor>
+                <jms-queue name="ExpiryQueue" entries="java:/jms/queue/ExpiryQueue"/>
+                <jms-queue name="DLQ" entries="java:/jms/queue/DLQ"/>
+                <connection-factory name="InVmConnectionFactory" entries="java:/ConnectionFactory" connectors="in-vm"/>
+                <connection-factory name="RemoteConnectionFactory" entries="java:jboss/exported/jms/RemoteConnectionFactory" connectors="http-connector"/>
+                <pooled-connection-factory name="activemq-ra" entries="java:/JmsXA java:jboss/DefaultJMSConnectionFactory" connectors="in-vm" transaction="xa"/>
+            </server>
+        </subsystem>
+        <subsystem xmlns="urn:wildfly:metrics:1.0" security-enabled="false" exposed-subsystems="*" prefix="${wildfly.metrics.prefix:wildfly}"/>
+        <subsystem xmlns="urn:wildfly:microprofile-config-smallrye:2.0"/>
+        <subsystem xmlns="urn:wildfly:microprofile-jwt-smallrye:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:naming:2.0">
+            <remote-naming/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:pojo:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:remoting:7.0">
+            <endpoint worker="default"/>
+            <http-connector name="http-remoting-connector" connector-ref="default" sasl-authentication-factory="application-sasl-authentication"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:request-controller:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:resource-adapters:7.1"/>
+        <subsystem xmlns="urn:jboss:domain:sar:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:security-manager:1.0">
+            <deployment-permissions>
+                <maximum-set>
+                    <permission class="java.security.AllPermission"/>
+                </maximum-set>
+            </deployment-permissions>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:transactions:6.0">
+            <core-environment node-identifier="${jboss.tx.node.id:1}">
+                <process-id>
+                    <uuid/>
+                </process-id>
+            </core-environment>
+            <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
+            <coordinator-environment statistics-enabled="${wildfly.transactions.statistics-enabled:${wildfly.statistics-enabled:false}}"/>
+            <object-store path="tx-object-store" relative-to="jboss.server.data.dir"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:undertow:14.0" default-virtual-host="default-host" default-servlet-container="default" default-server="default-server" statistics-enabled="${wildfly.undertow.statistics-enabled:${wildfly.statistics-enabled:false}}" default-security-domain="other">
+            <byte-buffer-pool name="default"/>
+            <buffer-cache name="default"/>
+            <server name="default-server">
+                <http-listener name="default" socket-binding="http" redirect-socket="https" enable-http2="true"/>
+                <https-listener name="https" socket-binding="https" ssl-context="applicationSSC" enable-http2="true"/>
+                <host name="default-host" alias="localhost">
+                    <location name="/" handler="welcome-content"/>
+                    <http-invoker http-authentication-factory="application-http-authentication"/>
+                </host>
+            </server>
+            <servlet-container name="default">
+                <jsp-config/>
+                <websockets/>
+            </servlet-container>
+            <handlers>
+                <file name="welcome-content" path="${jboss.home.dir}/welcome-content"/>
+            </handlers>
+            <application-security-domains>
+                <application-security-domain name="other" security-domain="ApplicationDomain"/>
+            </application-security-domains>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:webservices:2.0" statistics-enabled="${wildfly.webservices.statistics-enabled:${wildfly.statistics-enabled:false}}">
+            <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>
+            <endpoint-config name="Standard-Endpoint-Config"/>
+            <endpoint-config name="Recording-Endpoint-Config">
+                <pre-handler-chain name="recording-handlers" protocol-bindings="##SOAP11_HTTP ##SOAP11_HTTP_MTOM ##SOAP12_HTTP ##SOAP12_HTTP_MTOM">
+                    <handler name="RecordingHandler" class="org.jboss.ws.common.invocation.RecordingServerHandler"/>
+                </pre-handler-chain>
+            </endpoint-config>
+            <client-config name="Standard-Client-Config"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:weld:5.0"/>
+    </profile>
+    <interfaces>
+        <interface name="management">
+            <inet-address value="${jboss.bind.address.management:127.0.0.1}"/>
+        </interface>
+        <interface name="public">
+            <inet-address value="${jboss.bind.address:127.0.0.1}"/>
+        </interface>
+        <interface name="unsecure">
+            <inet-address value="${jboss.bind.address.unsecure:127.0.0.1}"/>
+        </interface>
+    </interfaces>
+    <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
+        <socket-binding name="ajp" port="${jboss.ajp.port:8009}"/>
+        <socket-binding name="http" port="${jboss.http.port:8080}"/>
+        <socket-binding name="https" port="${jboss.https.port:8443}"/>
+        <socket-binding name="iiop" interface="unsecure" port="3528"/>
+        <socket-binding name="iiop-ssl" interface="unsecure" port="3529"/>
+        <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
+        <socket-binding name="txn-recovery-environment" port="4712"/>
+        <socket-binding name="txn-status-manager" port="4713"/>
+        <outbound-socket-binding name="mail-smtp">
+            <remote-destination host="${jboss.mail.server.host:localhost}" port="${jboss.mail.server.port:25}"/>
+        </outbound-socket-binding>
+    </socket-binding-group>
+</server>

--- a/maven-settings.xml
+++ b/maven-settings.xml
@@ -24,7 +24,7 @@
                 <repository>
                     <id>jboss-public-repository-group</id>
                     <name>JBoss Public Maven Repository Group</name>
-                    <url>https://repository.jboss.org/nexus/content/groups/public-jboss</url>
+                    <url>https://repository.jboss.org/nexus/content/groups/public</url>
                     <layout>default</layout>
                     <releases>
                         <enabled>true</enabled>
@@ -64,7 +64,7 @@
                 <pluginRepository>
                     <id>jboss-public-repository-group</id>
                     <name>JBoss Public Maven Repository Group</name>
-                    <url>https://repository.jboss.org/nexus/content/groups/public-jboss</url>
+                    <url>https://repository.jboss.org/nexus/content/groups/public</url>
                     <layout>default</layout>
                     <releases>
                         <enabled>true</enabled>

--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,9 @@
       <module>integrationtests/endpoints-interop-it</module>
       <module>integrationtests/jboss-marshalling-it</module>
       <module>integrationtests/cdi-weld-se-it</module>
+      <module>integrationtests/server-integration</module>
+      <module>integrationtests/server-integration/server-integration-commons</module>
+      <module>integrationtests/server-integration/third-party-server</module>
       <module>hibernate</module>
       <module>anchored-keys</module>
       <module>test-support/proto-sample-domain-implementation</module>
@@ -247,6 +250,7 @@
       <versionx.javax.activation.activation>1.1.1</versionx.javax.activation.activation>
       <versionx.javax.annotation.javax.annotation-api>1.3.2</versionx.javax.annotation.javax.annotation-api>
       <versionx.javax.inject.javax.inject>1</versionx.javax.inject.javax.inject>
+      <versionx.net.spy.spymemcached>2.12.3</versionx.net.spy.spymemcached>
       <versionx.org.antlr.antlr-runtime>3.5.3</versionx.org.antlr.antlr-runtime>
       <versionx.org.apache.avro.avro>1.11.3</versionx.org.apache.avro.avro>
       <versionx.org.apache.commons.commons-lang3>3.14.0</versionx.org.apache.commons.commons-lang3>
@@ -760,6 +764,11 @@
             <groupId>net.jcip</groupId>
             <artifactId>jcip-annotations</artifactId>
             <version>${version.jcip-annotations}</version>
+         </dependency>
+         <dependency>
+            <groupId>net.spy</groupId>
+            <artifactId>spymemcached</artifactId>
+            <version>${versionx.net.spy.spymemcached}</version>
          </dependency>
          <dependency>
             <groupId>org.infinispan</groupId>
@@ -1398,6 +1407,17 @@
             <version>${version.jboss.shrinkwrap}</version>
          </dependency>
          <dependency>
+            <groupId>org.jboss.shrinkwrap.descriptors</groupId>
+            <artifactId>shrinkwrap-descriptors-impl-javaee</artifactId>
+            <version>${version.jboss.shrinkwrap.descriptors}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-depchain</artifactId>
+            <version>${version.jboss.shrinkwrap.resolver}</version>
+            <type>pom</type>
+         </dependency>
+         <dependency>
             <groupId>org.jboss.spec</groupId>
             <artifactId>jboss-jakartaee-8.0</artifactId>
             <version>${versionx.org.jboss.spec.jboss-jakartaee-8.0}</version>
@@ -1686,6 +1706,12 @@
             <artifactId>mojo-executor</artifactId>
             <version>${versionx.org.twdata.maven.mojo-executor}</version>
          </dependency>
+         <dependency>
+            <groupId>org.wildfly.arquillian</groupId>
+            <artifactId>wildfly-arquillian-container-managed</artifactId>
+            <version>${version.org.wildfly.arquillian}</version>
+            <scope>test</scope>
+         </dependency>
          <!-- transitive dependency! force this version everywhere -->
          <dependency>
             <groupId>org.wildfly.common</groupId>
@@ -1894,6 +1920,23 @@
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-plugin-plugin</artifactId>
                <version>${version.maven-plugin-plugin}</version>
+            </plugin>
+            <plugin>
+               <groupId>org.wildfly.galleon-plugins</groupId>
+               <artifactId>wildfly-galleon-maven-plugin</artifactId>
+               <version>${version.org.wildfly.galleon-plugins}</version>
+            </plugin>
+            <plugin>
+               <groupId>org.jboss.galleon</groupId>
+               <artifactId>galleon-maven-plugin</artifactId>
+               <version>${version.org.jboss.galleon}</version>
+               <dependencies>
+                  <dependency>
+                     <groupId>xom</groupId>
+                     <artifactId>xom</artifactId>
+                     <version>${version.xom}</version>
+                  </dependency>
+               </dependencies>
             </plugin>
             <plugin>
                <groupId>org.antlr</groupId>


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-16057

Wildfly version bumped to 32.0

Tomcat tested with 10.1.23. Unfortunately we need to rely on a SNAPSHOT release of `arquillian-tomcat-managed-10` as this has [not yet been released](https://github.com/arquillian/arquillian-container-tomcat/pull/148), however I'm chasing our good friend @rhusar to see if we can get this released ASAP. This won't affect upstream CI as we don't execute the Tomcat tests here anyway.

@tristantarrant I dropped `MemcachedClientIT` as it relies upon the `SimpleMemcachedClient` that AFAICT is no longer compatible with the changes on our server and I didn't think was worth the time investment of debugging/fixing.