### PR TITLE
ISPN-16080 Use ProtoStream's ProtoLock

### DIFF
--- a/client/hotrod/pom.xml
+++ b/client/hotrod/pom.xml
@@ -170,7 +170,7 @@
       <plugins>
          <plugin>
             <groupId>org.infinispan.maven-plugins</groupId>
-            <artifactId>protocol-parser-generator</artifactId>
+            <artifactId>protocol-parser-generator-maven-plugin</artifactId>
             <configuration>
                <files>
                   <file>${basedir}/src/main/resources/hotrod.gr</file>

--- a/server/hotrod/pom.xml
+++ b/server/hotrod/pom.xml
@@ -88,7 +88,7 @@
       <plugins>
          <plugin>
             <groupId>org.infinispan.maven-plugins</groupId>
-            <artifactId>protocol-parser-generator</artifactId>
+            <artifactId>protocol-parser-generator-maven-plugin</artifactId>
             <configuration>
                <files>
                   <file>${basedir}/src/main/resources/hotrod.gr</file>

--- a/server/memcached/pom.xml
+++ b/server/memcached/pom.xml
@@ -66,7 +66,7 @@
       <plugins>
          <plugin>
             <groupId>org.infinispan.maven-plugins</groupId>
-            <artifactId>protocol-parser-generator</artifactId>
+            <artifactId>protocol-parser-generator-maven-plugin</artifactId>
             <configuration>
                <files>
                   <file>${basedir}/src/main/resources/memcache-binary-auth.gr</file>

--- a/server/resp/pom.xml
+++ b/server/resp/pom.xml
@@ -77,7 +77,7 @@
       <plugins>
          <plugin>
             <groupId>org.infinispan.maven-plugins</groupId>
-            <artifactId>protocol-parser-generator</artifactId>
+            <artifactId>protocol-parser-generator-maven-plugin</artifactId>
             <configuration>
                <files>
                   <file>${basedir}/src/main/resources/resp.gr</file>


### PR DESCRIPTION
* fix maven plugin name

Fixes

```
[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.infinispan:infinispan-server-memcached:jar:15.0.4-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.infinispan.maven-plugins:protocol-parser-generator is missing. @ line 67, column 18
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.infinispan:infinispan-server-hotrod:jar:15.0.4-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.infinispan.maven-plugins:protocol-parser-generator is missing. @ line 89, column 18
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.infinispan:infinispan-server-resp:jar:15.0.4-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.infinispan.maven-plugins:protocol-parser-generator is missing. @ line 78, column 18
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.infinispan:infinispan-hotrod:jar:15.0.4-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.infinispan.maven-plugins:protocol-parser-generator is missing. @ line 171, column 18
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```