### PR TITLE
[DOC] ISPN-16092 Documenting RESP cache

### DIFF
--- a/documentation/src/main/asciidoc/stories/assembly_resp_endpoint.adoc
+++ b/documentation/src/main/asciidoc/stories/assembly_resp_endpoint.adoc
@@ -1,14 +1,7 @@
 [id='resp-endpoint']
 :context: resp-endpoint
-= Using the RESP endpoint
 
-{brandname} Server includes a module that implements the link:https://github.com/redis/redis-specifications/blob/master/protocol/RESP3.md[RESP3 protocol].
-The RESP endpoint allows Redis clients to connect to one or several {brandname}-backed RESP servers and perform cache operations.
-
-The RESP endpoint is enabled by default on the single-port endpoint. Redis client connections will automatically be detected and routed to the internal connector.
-
-
-include::{topics}/proc_server_enabling_resp.adoc[leveloffset=+1]
+include::{topics}/proc_server_configuring_resp.adoc[leveloffset=+1]
 include::{topics}/proc_server_resp_databases.adoc[leveloffset=+1]
 include::{topics}/ref_redis_commands.adoc[leveloffset=+1]
 

--- a/documentation/src/main/asciidoc/titles/resp/resp-endpoint.asciidoc
+++ b/documentation/src/main/asciidoc/titles/resp/resp-endpoint.asciidoc
@@ -16,9 +16,9 @@ include::../{topics}/attributes/community-attributes.adoc[]
 :context: resp
 
 //Title
-= Using the RESP protocol endpoint with Infinispan
+= Using the RESP protocol with {brandname}
 
-Infinispan Server includes an endpoint that implements the RESP3 protocol and allows you to interact with remote caches using Redis clients.
+{brandname} Server includes an endpoint that implements the link:https://github.com/redis/redis-specifications/blob/master/protocol/RESP3.md[RESP3 protocol] and allows you to interact with remote caches using Redis clients.
 
 //User stories
 include::stories.adoc[]

--- a/documentation/src/main/asciidoc/topics/proc_server_configuring_resp.adoc
+++ b/documentation/src/main/asciidoc/topics/proc_server_configuring_resp.adoc
@@ -1,6 +1,7 @@
 [id='enabling-resp-endpoint_{context}']
-= Using the RESP endpoint
+= {brandname} RESP endpoint
 
+The RESP endpoint is enabled by default on the single-port endpoint. Redis client connections will automatically be detected and routed to the internal connector.
 The RESP endpoint works with:
 
 * Standalone {brandname} Server deployments, exactly like standalone Redis, where each server instance runs independently of each other.


### PR DESCRIPTION
Docu has an unresolved ref that breaks part of the RESP docu, [see](https://infinispan.org/docs/15.0.x/titles/resp/resp-endpoint.html)
This is a fix.
Also some lines were replicated, I cleaned up a bit and made it similar to the REST docu structure.

fixes https://issues.redhat.com/browse/ISPN-16092