### PR TITLE
Updated missed wildfly-galleon-pack dependency.

### DIFF
--- a/integrationtests/server-integration/third-party-server/pom.xml
+++ b/integrationtests/server-integration/third-party-server/pom.xml
@@ -336,7 +336,7 @@
                                         <!-- full server -->
                                         <feature-pack>
                                             <groupId>${appserver.groupId}</groupId>
-                                            <artifactId>wildfly-galleon-pack</artifactId>
+                                            <artifactId>wildfly-ee-galleon-pack</artifactId>
                                             <version>${appserver.version}</version>
                                         </feature-pack>
                                     </feature-packs>


### PR DESCRIPTION
Related to PR #12447 . Missed second dependency of wildfly-galleon-pack.