### PR TITLE
Revert "ISPN-13839 Remove invalidation templates from internal server…

### DIFF
--- a/server/runtime/src/main/resources/infinispan-defaults.xml
+++ b/server/runtime/src/main/resources/infinispan-defaults.xml
@@ -4,8 +4,8 @@
 <!-- This file supplies the internal configuration defaults per cache mode -->
 <infinispan
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:infinispan:config:15.1 https://infinispan.org/schemas/infinispan-config-15.1.xsd"
-        xmlns="urn:infinispan:config:15.1">
+        xsi:schemaLocation="urn:infinispan:config:15.0 https://infinispan.org/schemas/infinispan-config-15.0.xsd"
+        xmlns="urn:infinispan:config:15.0">
 
    <cache-container shutdown-hook="DONT_REGISTER">
       <global-state>
@@ -13,14 +13,28 @@
          <shared-persistent-location path="${infinispan.server.data.path}"/>
          <overlay-configuration-storage/>
       </global-state>
-      <local-cache-configuration name="org.infinispan.LOCAL" statistics="true"/>
-      <replicated-cache-configuration name="org.infinispan.REPL_SYNC" configuration="org.infinispan.LOCAL"/>
-      <replicated-cache-configuration name="org.infinispan.REPL_ASYNC" mode="ASYNC" configuration="org.infinispan.LOCAL"/>
-      <distributed-cache-configuration name="org.infinispan.DIST_SYNC" configuration="org.infinispan.LOCAL"/>
-      <distributed-cache-configuration name="org.infinispan.DIST_ASYNC" mode="ASYNC" configuration="org.infinispan.LOCAL"/>
-      <distributed-cache-configuration name="example.PROTOBUF_DIST" configuration="org.infinispan.LOCAL">
+      <local-cache-configuration name="org.infinispan.LOCAL" statistics="true">
+         <locking acquire-timeout="15000" striping="false" concurrency-level="1000"/>
+      </local-cache-configuration>
+      <replicated-cache-configuration name="org.infinispan.REPL_SYNC" remote-timeout="17500" configuration="org.infinispan.LOCAL">
+         <state-transfer timeout="60000"/>
+      </replicated-cache-configuration>
+      <replicated-cache-configuration name="org.infinispan.REPL_ASYNC" mode="ASYNC" configuration="org.infinispan.LOCAL">
+         <state-transfer timeout="60000"/>
+      </replicated-cache-configuration>
+      <distributed-cache-configuration name="org.infinispan.DIST_SYNC" remote-timeout="17500" configuration="org.infinispan.LOCAL">
+         <state-transfer timeout="60000"/>
+      </distributed-cache-configuration>
+      <distributed-cache-configuration name="example.PROTOBUF_DIST" remote-timeout="17500" configuration="org.infinispan.LOCAL">
          <!-- Template for a queryable cache. Warning: may be removed in future versions -->
          <encoding media-type="application/x-protostream"/>
+         <state-transfer timeout="60000"/>
       </distributed-cache-configuration>
+      <distributed-cache-configuration name="org.infinispan.DIST_ASYNC" mode="ASYNC" configuration="org.infinispan.LOCAL">
+         <state-transfer timeout="60000"/>
+      </distributed-cache-configuration>
+      <invalidation-cache-configuration name="org.infinispan.INVALIDATION_SYNC" remote-timeout="17500" configuration="org.infinispan.LOCAL"/>
+      <invalidation-cache-configuration name="org.infinispan.INVALIDATION_ASYNC" mode="ASYNC" configuration="org.infinispan.LOCAL"/>
    </cache-container>
+
 </infinispan>

--- a/server/tests/src/test/resources/data/templates.xml
+++ b/server/tests/src/test/resources/data/templates.xml
@@ -10,9 +10,15 @@
                 <locking concurrency-level="1000" acquire-timeout="15000" striping="false"/>
                 <state-transfer timeout="60000"/>
             </distributed-cache-configuration>
+            <invalidation-cache-configuration name="org.infinispan.INVALIDATION_ASYNC" mode="ASYNC" statistics="true">
+                <locking concurrency-level="1000" acquire-timeout="15000" striping="false"/>
+            </invalidation-cache-configuration>
             <local-cache-configuration name="org.infinispan.LOCAL" statistics="true">
                 <locking concurrency-level="1000" acquire-timeout="15000" striping="false"/>
             </local-cache-configuration>
+            <invalidation-cache-configuration name="org.infinispan.INVALIDATION_SYNC" mode="SYNC" remote-timeout="17500" statistics="true">
+                <locking concurrency-level="1000" acquire-timeout="15000" striping="false"/>
+            </invalidation-cache-configuration>
             <replicated-cache-configuration name="org.infinispan.REPL_SYNC" mode="SYNC" remote-timeout="17500" statistics="true">
                 <locking concurrency-level="1000" acquire-timeout="15000" striping="false"/>
                 <state-transfer timeout="60000"/>


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-13839

@tristantarrant This commit breaks the upgrade CI. Until we have a fix for the [underlying issue](https://infinispan.zulipchat.com/#narrow/stream/118645-infinispan/topic/Invalidation.20cache/near/442735960) we should revert it.