### PR TITLE
Utilise Keycloak 24 in IT tests

### DIFF
--- a/server/tests/src/test/java/org/infinispan/server/test/core/KeyCloakServerExtension.java
+++ b/server/tests/src/test/java/org/infinispan/server/test/core/KeyCloakServerExtension.java
@@ -36,7 +36,7 @@ import org.testcontainers.utility.MountableFile;
  * @since 10.0
  **/
 public class KeyCloakServerExtension implements AfterAllCallback, BeforeAllCallback {
-   public static final String KEYCLOAK_IMAGE = System.getProperty(TestSystemPropertyNames.KEYCLOAK_IMAGE, "quay.io/keycloak/keycloak:latest");
+   public static final String KEYCLOAK_IMAGE = System.getProperty(TestSystemPropertyNames.KEYCLOAK_IMAGE, "quay.io/keycloak/keycloak:24.0");
    private final String realmJsonFile;
 
    private FixedHostPortGenericContainer<?> container;


### PR DESCRIPTION
@tristantarrant To fix CI ASAP I've just pinned the Keycloak version to 24.0.

With 25.0 we're getting authentication failures when trying to authenticate using the `access_token` returned by the Keycloak server. I've created [ISPN-16183](https://issues.redhat.com/browse/ISPN-16183) to track the work  and I'll continue to investigate.