### PR TITLE
ISPN-16279 Non blocking methods for Query API

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/OperationsFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/OperationsFactory.java
@@ -242,8 +242,8 @@ public class OperationsFactory implements HotRodConstants {
             getCodec(), channelFactory, cacheNameBytes, clientTopologyRef, flags(), cfg);
    }
 
-   public QueryOperation newQueryOperation(RemoteQuery<?> remoteQuery, DataFormat dataFormat, boolean withHitCount) {
-      return new QueryOperation(getCodec(), channelFactory, cacheNameBytes, clientTopologyRef, flags(), cfg,
+   public <T> QueryOperation<T> newQueryOperation(RemoteQuery<T> remoteQuery, DataFormat dataFormat, boolean withHitCount) {
+      return new QueryOperation<>(getCodec(), channelFactory, cacheNameBytes, clientTopologyRef, flags(), cfg,
             remoteQuery, dataFormat, withHitCount);
    }
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/QueryOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/QueryOperation.java
@@ -17,6 +17,7 @@ import org.infinispan.client.hotrod.impl.transport.netty.ChannelFactory;
 import org.infinispan.client.hotrod.impl.transport.netty.HeaderDecoder;
 import org.infinispan.protostream.EnumMarshaller;
 import org.infinispan.protostream.SerializationContext;
+import org.infinispan.query.remote.client.impl.BaseQueryResponse;
 import org.infinispan.query.remote.client.impl.QueryRequest;
 
 import io.netty.buffer.ByteBuf;
@@ -27,14 +28,14 @@ import io.netty.channel.Channel;
  * @author anistor@redhat.com
  * @since 6.0
  */
-public final class QueryOperation extends RetryOnFailureOperation<Object> {
+public final class QueryOperation<T> extends RetryOnFailureOperation<BaseQueryResponse<T>> {
 
-   private final RemoteQuery<?> remoteQuery;
+   private final RemoteQuery<T> remoteQuery;
    private final QuerySerializer querySerializer;
    private final boolean withHitCount;
 
    public QueryOperation(Codec codec, ChannelFactory channelFactory, byte[] cacheName, AtomicReference<ClientTopology> clientTopology,
-                         int flags, Configuration cfg, RemoteQuery<?> remoteQuery, DataFormat dataFormat, boolean withHitCount) {
+                         int flags, Configuration cfg, RemoteQuery<T> remoteQuery, DataFormat dataFormat, boolean withHitCount) {
       super(QUERY_REQUEST, QUERY_RESPONSE, codec, channelFactory, cacheName, clientTopology, flags, cfg, dataFormat, null);
       this.remoteQuery = remoteQuery;
       this.querySerializer = QuerySerializer.findByMediaType(dataFormat.getValueType());
@@ -110,6 +111,6 @@ public final class QueryOperation extends RetryOnFailureOperation<Object> {
    @Override
    public void acceptResponse(ByteBuf buf, short status, HeaderDecoder decoder) {
       byte[] responseBytes = ByteBufUtil.readArray(buf);
-      complete(querySerializer.readQueryResponse(channelFactory.getMarshaller(), remoteQuery, responseBytes));
+      complete((BaseQueryResponse<T>) querySerializer.readQueryResponse(channelFactory.getMarshaller(), remoteQuery, responseBytes));
    }
 }


### PR DESCRIPTION
Add non blocking methods that can be used easily by the RemoteCache Query API

https://issues.redhat.com/browse/ISPN-16279

- [x] JavaDoc for the new methods.