### PR TITLE
ISPN-16278 [RESP] Fix msetnx behavior with same key

### DIFF
--- a/server/resp/src/test/java/org/infinispan/server/resp/CustomStringCommands.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/CustomStringCommands.java
@@ -14,6 +14,11 @@ public interface CustomStringCommands extends Commands {
    @Command("LCS :k1 :k2 LEN")
    Long lcsLen(@Param("k1") byte[] k1, @Param("k2") byte[] k2);
 
+   @Command("MSETNX :k1 :v1 :k1 :v2 :k1 :v3 :k1 :v4")
+   Long msetnxSameKey(@Param("k1") byte[] k1, @Param("v1") byte[] v1,
+                             @Param("v2") byte[] v2, @Param("v3") byte[] v3,
+                             @Param("v4") byte[] v4);
+
    static CustomStringCommands instance(StatefulConnection<String, String> conn) {
       RedisCommandFactory factory = new RedisCommandFactory(conn);
       return factory.getCommands(CustomStringCommands.class);

--- a/server/resp/src/test/java/org/infinispan/server/resp/StringCommandsTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/StringCommandsTest.java
@@ -562,6 +562,16 @@ public class StringCommandsTest extends SingleNodeRespBaseTest {
    }
 
    @Test
+   public void testMsetnxSameKey() {
+      // Needs custom command to allow byte[] args
+      CustomStringCommands commands = CustomStringCommands.instance(redisConnection);
+      Long l = commands.msetnxSameKey(new byte[]{'k','1'}, new byte[]{'v','1'}, new byte[]{'v','2'}, new byte[]{'v','3'}, new byte[]{'v','4'});
+      assertThat(l).isEqualTo(1);
+      String actual = redisConnection.sync().get("k1");
+      assertThat(actual).isEqualTo("v4");
+   }
+
+   @Test
    public void testSetex() {
       RedisCommands<String, String> redis = redisConnection.sync();
 


### PR DESCRIPTION
fixes https://issues.redhat.com/browse/ISPN-16278

change map of bytes to map of wrappedbytearray so equals works and prevent entries with same key