### PR TITLE
ISPN-16286 RESP `KEYS *` hangs with persistence enabled

### DIFF
--- a/server/core/src/main/java/org/infinispan/server/iteration/IterationManager.java
+++ b/server/core/src/main/java/org/infinispan/server/iteration/IterationManager.java
@@ -17,6 +17,17 @@ public interface IterationManager {
                         List<byte[]> filterConverterParams, MediaType valueMediaType, int batch, boolean metadata,
                         DeliveryGuarantee guarantee, IterationInitializationContext ctx);
 
+   /**
+    * Reds the next batch from the iterator associated with {@param iterationId}.
+    *
+    * <p>
+    * <b>Warning:</b> This method can block.
+    * </p>
+    *
+    * @param iterationId: The iterator identifier.
+    * @param batch: The maximum number of entries to include in the batch.
+    * @return An {@link IterableIterationResult} object with the current data and metadata about the iterator.
+    */
    IterableIterationResult next(String iterationId, int batch);
 
    IterationState close(String iterationId);

--- a/server/resp/src/test/java/org/infinispan/server/resp/AbstractRespTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/AbstractRespTest.java
@@ -106,12 +106,16 @@ public abstract class AbstractRespTest extends MultipleCacheManagersTest {
    @AfterClass(alwaysRun = true)
    @Override
    protected void destroy() {
-      for (AbstractRedisClient client : clients) {
-         killClient(client);
+      if (clients != null) {
+         for (AbstractRedisClient client : clients) {
+            killClient(client);
+         }
       }
 
-      for (RespServer server : servers) {
-         killServer(server);
+      if (servers != null) {
+         for (RespServer server : servers) {
+            killServer(server);
+         }
       }
 
       super.destroy();

--- a/server/resp/src/test/java/org/infinispan/server/resp/persistent/ClusteredPersistentStringCommandTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/persistent/ClusteredPersistentStringCommandTest.java
@@ -1,0 +1,65 @@
+package org.infinispan.server.resp.persistent;
+
+import org.infinispan.commons.util.Util;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.server.resp.test.TestSetup;
+import org.infinispan.test.fwk.CleanupAfterMethod;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+@CleanupAfterMethod
+@Test(groups = "functional", testName = "server.resp.persistent.DistributedPersistentCommandTest")
+public class ClusteredPersistentStringCommandTest extends PersistentStringCommandTest {
+
+   private CacheMode mode;
+
+   @Override
+   public Object[] factory() {
+      return new Object[] {
+            new ClusteredPersistentStringCommandTest().withCacheMode(CacheMode.DIST_SYNC),
+            new ClusteredPersistentStringCommandTest().withCacheMode(CacheMode.REPL_SYNC),
+      };
+   };
+
+   protected ClusteredPersistentStringCommandTest withCacheMode(CacheMode mode) {
+      this.mode = mode;
+      return this;
+   }
+
+   @Override
+   @AfterClass(alwaysRun = true)
+   protected void removeData() {
+      Util.recursiveFileRemove(baseFolderName());
+   }
+
+   @BeforeMethod(alwaysRun = true)
+   @Override
+   public void createBeforeMethod() throws Throwable {
+      Util.recursiveFileRemove(baseFolderName());
+      destroy();
+      super.createBeforeMethod();
+   }
+
+   @Override
+   protected String parameters() {
+      return "[mode=" + mode + "]";
+   }
+
+   @Override
+   protected void amendConfiguration(ConfigurationBuilder builder) {
+      super.amendConfiguration(builder);
+      builder.clustering().cacheMode(mode);
+   }
+
+   @Override
+   protected TestSetup setup() {
+      return TestSetup.clusteredTestSetup(3);
+   }
+
+   @Override
+   protected String nodeId() {
+      return super.nodeId() + cacheManagers.size();
+   }
+}

--- a/server/resp/src/test/java/org/infinispan/server/resp/persistent/PersistentStringCommandTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/persistent/PersistentStringCommandTest.java
@@ -1,0 +1,98 @@
+package org.infinispan.server.resp.persistent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.infinispan.server.resp.test.RespTestingUtil.OK;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.infinispan.commons.test.CommonsTestingUtil;
+import org.infinispan.commons.util.Util;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.server.resp.SingleNodeRespBaseTest;
+import org.infinispan.test.fwk.CleanupAfterMethod;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import io.lettuce.core.KeyScanCursor;
+import io.lettuce.core.ScanArgs;
+import io.lettuce.core.api.sync.RedisCommands;
+
+@CleanupAfterMethod
+@Test(groups = "functional", testName = "server.resp.persistent.PersistentStringCommandTest")
+public class PersistentStringCommandTest extends SingleNodeRespBaseTest {
+
+   @AfterClass(alwaysRun = true)
+   protected void removeData() {
+      Util.recursiveFileRemove(baseFolderName());
+   }
+
+   @BeforeMethod(alwaysRun = true)
+   @Override
+   public void createBeforeMethod() throws Throwable {
+      Util.recursiveFileRemove(baseFolderName());
+      destroy();
+      super.createBeforeMethod();
+   }
+
+   @Override
+   protected void amendConfiguration(ConfigurationBuilder builder) {
+      String dir = CommonsTestingUtil.tmpDirectory(baseFolderName() + "/" + nodeId());
+      builder.persistence()
+            .addSoftIndexFileStore()
+            .dataLocation(dir + "/data")
+            .indexLocation(dir + "/index");
+   }
+
+   public void testSetGetPersistent() {
+      RedisCommands<String, String> redis = redisConnection.sync();
+
+      assertThat(redis.set("key", "value")).isEqualTo(OK);
+      assertThat(redis.get("key")).isEqualTo("value");
+   }
+
+   public void testIteration() {
+      RedisCommands<String, String> redis = redisConnection.sync();
+
+      assertThat(redis.keys("*")).isEmpty();
+
+      assertThat(redis.set("test-key", "value")).isEqualTo(OK);
+      assertThat(redis.keys("*")).hasSize(1).containsExactly("test-key");
+      assertThat(redis.keys("test-*")).hasSize(1).containsExactly("test-key");
+      assertThat(redis.keys("other-*")).isEmpty();
+   }
+
+   public void testBatchingScan() {
+      RedisCommands<String, String> redis = redisConnection.sync();
+
+      Set<String> expected = new HashSet<>();
+      for (int i = 0; i < 100; i++) {
+         String k = "prefix-" + i;
+         expected.add(k);
+         assertThat(redis.set(k, "value")).isEqualTo(OK);
+      }
+
+      Set<String> actual = new HashSet<>();
+      ScanArgs args = ScanArgs.Builder
+            .limit(10)
+            .match("prefix-*");
+      for (KeyScanCursor<String> cursor = redis.scan(args);; cursor = redis.scan(cursor, args)) {
+         actual.addAll(cursor.getKeys());
+         if (cursor.isFinished())
+            break;
+      }
+
+      assertThat(actual)
+            .hasSize(expected.size())
+            .isEqualTo(expected);
+   }
+
+   protected String baseFolderName() {
+      return getClass().getSimpleName();
+   }
+
+   protected String nodeId() {
+      return "";
+   }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-16286

* Added single node and distributed tests with SIFS. The test executes the KEYS and SCAN commands;
* Updated the iteration to read the next batch on the BlockingManager and handed it to Netty's event loop to write the response.