### PR TITLE
ISPN-14457 - Support nested queries with Ickle - indexed implementation

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/nested/ParentJoinNestedRemoteTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/nested/ParentJoinNestedRemoteTest.java
@@ -1,0 +1,113 @@
+package org.infinispan.client.hotrod.query.nested;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.infinispan.configuration.cache.IndexStorage.LOCAL_HEAP;
+
+import java.util.List;
+
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.test.SingleHotRodServerTest;
+import org.infinispan.commons.api.query.Query;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.protostream.SerializationContextInitializer;
+import org.infinispan.query.Search;
+import org.infinispan.query.core.stats.QueryStatistics;
+import org.infinispan.query.model.Player;
+import org.infinispan.query.model.Team;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+@Test(groups = "functional", testName = "org.infinispan.client.hotrod.query.nested.ParentJoinNestedRemoteTest")
+public class ParentJoinNestedRemoteTest extends SingleHotRodServerTest {
+
+   private QueryStatistics queryStatistics;
+
+   @Override
+   protected EmbeddedCacheManager createCacheManager() throws Exception {
+      ConfigurationBuilder indexed = new ConfigurationBuilder();
+      indexed.statistics().enable();
+      indexed.indexing().enable()
+            .storage(LOCAL_HEAP)
+            .addIndexedEntity("model.Team");
+      return TestCacheManagerFactory.createServerModeCacheManager(indexed);
+   }
+
+   @Override
+   protected SerializationContextInitializer contextInitializer() {
+      return Team.TeamSchema.INSTANCE;
+   }
+
+   @BeforeMethod
+   public void beforeClass() {
+      if (queryStatistics == null) {
+         queryStatistics = Search.getSearchStatistics(cache).getQueryStatistics();
+      }
+      queryStatistics.clear();
+
+      if (!cache.isEmpty()) {
+         return;
+      }
+      RemoteCache<String, Team> remoteCache = remoteCacheManager.getCache();
+      List<Player> playersA = List.of(new Player("Michael", "red", 7), new Player("Jonas", "blue", 3));
+      List<Player> playersB = List.of(new Player("Ulrich", "red", 3), new Player("Martha", "blue", 7));
+      remoteCache.put("1", new Team("New Team", playersA, playersA));
+      remoteCache.put("2", new Team("Old Team", playersB, playersB));
+   }
+
+   @Test
+   public void nested_usingJoin() {
+      RemoteCache<String, Team> remoteCache = remoteCacheManager.getCache();
+      Query<Object[]> query = remoteCache.query("select t.name from model.Team t " +
+            "join t.firstTeam p where p.color ='red' AND p.number=7");
+      List<Object[]> result = query.list();
+      // the structure is nested, so the match searches for a player that has at the same time the color red and number 7
+      assertThat(result).extracting(array -> array[0]).containsExactly("New Team");
+      assertThat(queryStatistics.getLocalIndexedQueryCount()).isEqualTo(1);
+   }
+
+   @Test
+   public void flattened_usingJoin() {
+      RemoteCache<String, Team> remoteCache = remoteCacheManager.getCache();
+      Query<Object[]> query = remoteCache.query("select t.name from model.Team t " +
+            "join t.replacements p where p.color ='red' AND p.number=7");
+      List<Object[]> result = query.list();
+      // the structure is flattened, so the match searches a player that has the color red and possibly another player having number 7
+      assertThat(result).extracting(array -> array[0]).containsExactly("New Team", "Old Team");
+      assertThat(queryStatistics.getLocalIndexedQueryCount()).isEqualTo(1);
+   }
+
+   @Test
+   public void nested_usingEquals() {
+      RemoteCache<String, Team> remoteCache = remoteCacheManager.getCache();
+      Query<Object[]> query = remoteCache.query("select t.name from model.Team t " +
+            "where t.firstTeam.color ='red' AND t.firstTeam.number=7");
+      List<Object[]> result = query.list();
+      // we don't use the join operator, so the match searches a player that has the color red and possibly another player having number 7
+      assertThat(result).extracting(array -> array[0]).containsExactly("New Team", "Old Team");
+      assertThat(queryStatistics.getLocalIndexedQueryCount()).isEqualTo(1);
+   }
+
+   @Test
+   public void flattened_usingEquals() {
+      RemoteCache<String, Team> remoteCache = remoteCacheManager.getCache();
+      Query<Object[]> query = remoteCache.query("select t.name from model.Team t " +
+            "where t.replacements.color ='red' AND t.replacements.number=7");
+      List<Object[]> result = query.list();
+      // we don't use the join operator, so the match searches a player that has the color red and possibly another player having number 7
+      assertThat(result).extracting(array -> array[0]).containsExactly("New Team", "Old Team");
+      assertThat(queryStatistics.getLocalIndexedQueryCount()).isEqualTo(1);
+   }
+
+   @Test
+   public void flattened_entityProj_usingEquals() {
+      RemoteCache<String, Team> remoteCache = remoteCacheManager.getCache();
+      Query<Team> query = remoteCache.query("from model.Team t " +
+            "where t.replacements.color ='red' AND t.replacements.number=7");
+      List<Team> result = query.list();
+      // we don't use the join operator, so the match searches a player that has the color red and possibly another player having number 7
+      assertThat(result).extracting(Team::name).containsExactly("New Team", "Old Team");
+      assertThat(queryStatistics.getLocalIndexedQueryCount()).isEqualTo(1);
+   }
+}

--- a/object-filter/src/main/java/org/infinispan/objectfilter/impl/predicateindex/be/BETreeMaker.java
+++ b/object-filter/src/main/java/org/infinispan/objectfilter/impl/predicateindex/be/BETreeMaker.java
@@ -18,6 +18,7 @@ import org.infinispan.objectfilter.impl.syntax.ConstantBooleanExpr;
 import org.infinispan.objectfilter.impl.syntax.ConstantValueExpr;
 import org.infinispan.objectfilter.impl.syntax.IsNullExpr;
 import org.infinispan.objectfilter.impl.syntax.LikeExpr;
+import org.infinispan.objectfilter.impl.syntax.NestedExpr;
 import org.infinispan.objectfilter.impl.syntax.NotExpr;
 import org.infinispan.objectfilter.impl.syntax.OrExpr;
 import org.infinispan.objectfilter.impl.syntax.PrimaryPredicateExpr;
@@ -71,6 +72,8 @@ public final class BETreeMaker<AttributeId extends Comparable<AttributeId>> {
          makeBooleanOperatorNode((OrExpr) child, nodes, treeCounters, new OrNode(parent), namedParameters);
       } else if (child instanceof AndExpr) {
          makeBooleanOperatorNode((AndExpr) child, nodes, treeCounters, new AndNode(parent), namedParameters);
+      } else if (child instanceof NestedExpr) {
+         throw new UnsupportedOperationException("Nested expression is currently only supported in indexed queries!");
       } else {
          throw new IllegalStateException("Unexpected *Expr node type: " + child);
       }

--- a/object-filter/src/main/java/org/infinispan/objectfilter/impl/syntax/BooleShannonExpansion.java
+++ b/object-filter/src/main/java/org/infinispan/objectfilter/impl/syntax/BooleShannonExpansion.java
@@ -113,6 +113,14 @@ public final class BooleShannonExpansion {
       }
 
       @Override
+      public BooleanExpr visit(NestedExpr nestedExpr) {
+         for (BooleanExpr c : nestedExpr.getChildren()) {
+            c.acceptVisitor(this);
+         }
+         return nestedExpr;
+      }
+
+      @Override
       public BooleanExpr visit(ConstantBooleanExpr constantBooleanExpr) {
          return constantBooleanExpr;
       }

--- a/object-filter/src/main/java/org/infinispan/objectfilter/impl/syntax/ExprVisitor.java
+++ b/object-filter/src/main/java/org/infinispan/objectfilter/impl/syntax/ExprVisitor.java
@@ -93,4 +93,9 @@ public class ExprVisitor implements Visitor<BooleanExpr, ValueExpr> {
    public ValueExpr visit(AggregationExpr aggregationExpr) {
       return aggregationExpr;
    }
+
+   @Override
+   public BooleanExpr visit(NestedExpr nestedExpr) {
+      return nestedExpr;
+   }
 }

--- a/object-filter/src/main/java/org/infinispan/objectfilter/impl/syntax/FullTextVisitor.java
+++ b/object-filter/src/main/java/org/infinispan/objectfilter/impl/syntax/FullTextVisitor.java
@@ -104,4 +104,14 @@ public final class FullTextVisitor implements Visitor<Boolean, Boolean> {
    public Boolean visit(AggregationExpr aggregationExpr) {
       return Boolean.FALSE;
    }
+
+   @Override
+   public Boolean visit(NestedExpr nestedExpr) {
+      for (BooleanExpr c : nestedExpr.getNestedChildren()) {
+         if (c.acceptVisitor(this)) {
+            return Boolean.TRUE;
+         }
+      }
+      return Boolean.FALSE;
+   }
 }

--- a/object-filter/src/main/java/org/infinispan/objectfilter/impl/syntax/NestedExpr.java
+++ b/object-filter/src/main/java/org/infinispan/objectfilter/impl/syntax/NestedExpr.java
@@ -1,0 +1,63 @@
+package org.infinispan.objectfilter.impl.syntax;
+
+import java.util.Collections;
+import java.util.List;
+
+public class NestedExpr extends BooleanOperatorExpr {
+
+   private String nestedPath;
+
+   @Override
+   public void appendQueryString(StringBuilder sb) {
+      sb.append("NESTED ( ");
+      for (int i = 0; i < children.size(); i++) {
+         if (i != 0) {
+            sb.append(" AND ");
+         }
+         sb.append('(');
+         children.get(i).appendQueryString(sb);
+         sb.append(')');
+      }
+      sb.append(" ) ");
+   }
+
+   @Override
+   public String toString() {
+      StringBuilder sb = new StringBuilder();
+      sb.append("NESTED(");
+      boolean isFirst = true;
+      for (BooleanExpr c : children) {
+         if (isFirst) {
+            isFirst = false;
+         } else {
+            sb.append(", ");
+         }
+         sb.append(c);
+      }
+      sb.append(')');
+      return sb.toString();
+   }
+
+   @Override
+   public <T> T acceptVisitor(Visitor<?, ?> visitor) {
+      return (T) visitor.visit(this);
+   }
+
+   public NestedExpr(String nestedPath, BooleanExpr... nestedChildExpressions) {
+      this.nestedPath= nestedPath;
+      Collections.addAll(this.children, nestedChildExpressions);
+   }
+
+   public List<BooleanExpr> getNestedChildren() {
+      return children;
+   }
+
+   public String getNestedPath() {
+      return nestedPath;
+   }
+
+   public void add(BooleanExpr expr) {
+      children.add(expr);
+
+   }
+}

--- a/object-filter/src/main/java/org/infinispan/objectfilter/impl/syntax/Visitor.java
+++ b/object-filter/src/main/java/org/infinispan/objectfilter/impl/syntax/Visitor.java
@@ -44,4 +44,7 @@ public interface Visitor<BE, VE> {
    VE visit(PropertyValueExpr propertyValueExpr);
 
    VE visit(AggregationExpr aggregationExpr);
+
+   BE visit(NestedExpr nestedExpr);
+
 }

--- a/object-filter/src/main/java/org/infinispan/objectfilter/impl/syntax/parser/ObjectPropertyHelper.java
+++ b/object-filter/src/main/java/org/infinispan/objectfilter/impl/syntax/parser/ObjectPropertyHelper.java
@@ -154,6 +154,10 @@ public abstract class ObjectPropertyHelper<TypeMetadata> {
       return null; // non-indexed
    }
 
+   public boolean isNestedIndexStructure(TypeMetadata entityType, String[] propertyPath) {
+      return false;
+   }
+
    public abstract boolean hasProperty(TypeMetadata entityType, String[] propertyPath);
 
    public abstract boolean hasEmbeddedProperty(TypeMetadata entityType, String[] propertyPath);

--- a/object-filter/src/main/java/org/infinispan/objectfilter/impl/syntax/parser/QueryRendererDelegateImpl.java
+++ b/object-filter/src/main/java/org/infinispan/objectfilter/impl/syntax/parser/QueryRendererDelegateImpl.java
@@ -74,7 +74,10 @@ final class QueryRendererDelegateImpl<TypeMetadata> implements QueryRendererDele
     * Persister space: keep track of aliases and entity names.
     */
    private final Map<String, String> aliasToEntityType = new HashMap<>();
-
+   /**
+    * Map containing alias as a key and propertyPath as value
+    * Currently, only registerJoinAlias populates this, so it will only contain join aliases
+    */
    private final Map<String, PropertyPath<TypeDescriptor<TypeMetadata>>> aliasToPropertyPath = new HashMap<>();
 
    private String alias;
@@ -100,7 +103,7 @@ final class QueryRendererDelegateImpl<TypeMetadata> implements QueryRendererDele
    QueryRendererDelegateImpl(String queryString, ObjectPropertyHelper<TypeMetadata> propertyHelper) {
       this.queryString = queryString;
       this.propertyHelper = propertyHelper;
-      this.expressionBuilder = new VirtualExpressionBuilder<>(this, propertyHelper);
+      this.expressionBuilder = new VirtualExpressionBuilder<>(this, propertyHelper, aliasToPropertyPath);
    }
 
    /**
@@ -262,9 +265,10 @@ final class QueryRendererDelegateImpl<TypeMetadata> implements QueryRendererDele
       if (property.isEmpty()) {
          throw log.getPredicatesOnEntityAliasNotAllowedException(propertyPath.asStringPath());
       }
+      String rootAlias = propertyPath.getFirst().getPropertyName();
       Object comparisonValue = parameterValue(value);
       checkAnalyzed(property, false);
-      expressionBuilder.addComparison(property, comparisonType, comparisonValue);
+      expressionBuilder.addComparison(property, comparisonType, comparisonValue, rootAlias);
    }
 
    @Override

--- a/query/src/main/java/org/infinispan/query/dsl/embedded/impl/HibernateSearchPropertyHelper.java
+++ b/query/src/main/java/org/infinispan/query/dsl/embedded/impl/HibernateSearchPropertyHelper.java
@@ -1,6 +1,5 @@
 package org.infinispan.query.dsl.embedded.impl;
 
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.text.ParseException;
 import java.util.Date;
@@ -22,7 +21,6 @@ import org.infinispan.objectfilter.impl.syntax.parser.ReflectionPropertyHelper;
 import org.infinispan.objectfilter.impl.syntax.parser.projection.CacheValuePropertyPath;
 import org.infinispan.objectfilter.impl.syntax.parser.projection.ScorePropertyPath;
 import org.infinispan.objectfilter.impl.syntax.parser.projection.VersionPropertyPath;
-import org.infinispan.objectfilter.impl.util.ReflectionHelper;
 import org.infinispan.objectfilter.impl.util.StringHelper;
 import org.infinispan.search.mapper.mapping.SearchIndexedEntity;
 import org.infinispan.search.mapper.mapping.SearchMapping;

--- a/query/src/main/java/org/infinispan/query/dsl/embedded/impl/HibernateSearchPropertyHelper.java
+++ b/query/src/main/java/org/infinispan/query/dsl/embedded/impl/HibernateSearchPropertyHelper.java
@@ -9,6 +9,7 @@ import org.hibernate.search.engine.backend.metamodel.IndexDescriptor;
 import org.hibernate.search.engine.backend.metamodel.IndexFieldDescriptor;
 import org.hibernate.search.engine.backend.metamodel.IndexValueFieldDescriptor;
 import org.hibernate.search.engine.backend.metamodel.IndexValueFieldTypeDescriptor;
+import org.hibernate.search.engine.backend.types.IndexFieldTraits;
 import org.infinispan.container.versioning.EntryVersion;
 import org.infinispan.objectfilter.ParsingException;
 import org.infinispan.objectfilter.impl.syntax.IndexedFieldProvider;
@@ -88,6 +89,15 @@ public class HibernateSearchPropertyHelper extends ReflectionPropertyHelper {
    }
 
    @Override
+   public boolean isNestedIndexStructure(Class<?> entityType, String[] propertyPath) {
+      IndexFieldDescriptor fieldDescriptor = getFieldDescriptor(entityType, propertyPath);
+      if (fieldDescriptor == null || fieldDescriptor.type() == null) {
+         return false;
+      }
+      return fieldDescriptor.type().traits().contains(IndexFieldTraits.Predicates.NESTED);
+   }
+
+   @Override
    public boolean isRepeatedProperty(Class<?> entityType, String[] propertyPath) {
       IndexFieldDescriptor fieldDescriptor = getFieldDescriptor(entityType, propertyPath);
       if (fieldDescriptor == null) {
@@ -114,8 +124,8 @@ public class HibernateSearchPropertyHelper extends ReflectionPropertyHelper {
       }
 
       if (propertyPath.length == 1 && (propertyPath[0].equals(KEY) || propertyPath[0].equals(VALUE) ||
-            propertyPath[0].equals(VERSION) || propertyPath[0].equals(SCORE)) ) {
-            return true;
+            propertyPath[0].equals(VERSION) || propertyPath[0].equals(SCORE))) {
+         return true;
       }
 
       return super.hasProperty(entityType, propertyPath);

--- a/query/src/test/java/org/infinispan/query/config/EngineConfigTest.java
+++ b/query/src/test/java/org/infinispan/query/config/EngineConfigTest.java
@@ -61,7 +61,7 @@ public class EngineConfigTest extends AbstractInfinispanTest {
 
       // Storage
       assertEquals("local-filesystem", properties.get("hibernate.search.backend.directory.type"));
-      assertEquals(tempDir.toString() +  File.separator + "baseDir", properties.get("hibernate.search.backend.directory.root"));
+      assertEquals(tempDir.toString() + File.separator + "baseDir", properties.get("hibernate.search.backend.directory.root"));
 
       // reader
       assertEquals(5000L, properties.get("hibernate.search.backend.io.refresh_interval"));
@@ -94,7 +94,7 @@ public class EngineConfigTest extends AbstractInfinispanTest {
 
       Map<String, Object> properties = resolveIndexingProperties(gcb, builder);
 
-      assertEquals(tempDir.getPath() + "/defaultcache", properties.get("hibernate.search.backend.directory.root"));
+      assertEquals(tempDir.getPath() + File.separator + "defaultcache", properties.get("hibernate.search.backend.directory.root"));
    }
 
    @Test
@@ -103,7 +103,7 @@ public class EngineConfigTest extends AbstractInfinispanTest {
       builder.indexing().enable().addIndexedEntity(Person.class).enable();
 
       Map<String, Object> properties = resolveIndexingProperties(new GlobalConfigurationBuilder(), builder);
-      assertEquals(System.getProperty("user.dir")  + "/defaultcache", properties.get("hibernate.search.backend.directory.root"));
+      assertEquals(System.getProperty("user.dir") + File.separator + "defaultcache", properties.get("hibernate.search.backend.directory.root"));
 
    }
 

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/impl/model/Company.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/impl/model/Company.java
@@ -17,6 +17,8 @@ public class Company {
 
    private String name;
 
+   private String vatNumber;
+
    private Set<Employee> employees;
 
    private Address address;
@@ -24,6 +26,11 @@ public class Company {
    @Keyword(projectable = true)
    public String getName() {
       return name;
+   }
+
+   @Keyword(projectable = true)
+   public String getVatNumber() {
+      return vatNumber;
    }
 
    public Set<Employee> getEmployees() {

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/impl/model/Employee.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/impl/model/Employee.java
@@ -34,7 +34,11 @@ public class Employee {
 
    public Company author;
 
+   public Company nestedAuthor;
+
    public List<ContactDetails> contactDetails = new ArrayList<>();
+
+   public List<ContactDetails> nestedContactDetails = new ArrayList<>();
 
    public List<ContactDetails> alternativeContactDetails = new ArrayList<>();
 
@@ -89,6 +93,16 @@ public class Employee {
    @Embedded(structure = Structure.FLATTENED)
    public List<ContactDetails> getContactDetails() {
       return contactDetails;
+   }
+
+   @Embedded(structure = Structure.NESTED)
+   public Company getNestedAuthor() {
+      return nestedAuthor;
+   }
+
+   @Embedded(structure = Structure.NESTED)
+   public List<ContactDetails> getNestedContactDetails() {
+      return nestedContactDetails;
    }
 
    @Embedded(structure = Structure.FLATTENED)

--- a/query/src/test/java/org/infinispan/query/model/Player.java
+++ b/query/src/test/java/org/infinispan/query/model/Player.java
@@ -1,0 +1,9 @@
+package org.infinispan.query.model;
+
+import org.infinispan.api.annotations.indexing.Basic;
+import org.infinispan.protostream.annotations.Proto;
+
+@Proto
+public record Player(@Basic String name, @Basic String color, @Basic Integer number) {
+
+}

--- a/query/src/test/java/org/infinispan/query/model/Player.java
+++ b/query/src/test/java/org/infinispan/query/model/Player.java
@@ -1,9 +1,11 @@
 package org.infinispan.query.model;
 
 import org.infinispan.api.annotations.indexing.Basic;
+import org.infinispan.api.annotations.indexing.Indexed;
 import org.infinispan.protostream.annotations.Proto;
 
 @Proto
+@Indexed // @Indexed: Workaround for https://issues.redhat.com/browse/ISPN-16314
 public record Player(@Basic String name, @Basic String color, @Basic Integer number) {
 
 }

--- a/query/src/test/java/org/infinispan/query/model/Team.java
+++ b/query/src/test/java/org/infinispan/query/model/Team.java
@@ -1,0 +1,23 @@
+package org.infinispan.query.model;
+
+import java.util.List;
+
+import org.infinispan.api.annotations.indexing.Basic;
+import org.infinispan.api.annotations.indexing.Embedded;
+import org.infinispan.api.annotations.indexing.Indexed;
+import org.infinispan.api.annotations.indexing.option.Structure;
+import org.infinispan.protostream.GeneratedSchema;
+import org.infinispan.protostream.annotations.Proto;
+import org.infinispan.protostream.annotations.ProtoSchema;
+
+@Proto
+@Indexed
+public record Team(@Basic String name, @Embedded(structure = Structure.NESTED) List<Player> firstTeam,
+                   @Embedded(structure = Structure.FLATTENED)List<Player> replacements) {
+
+   @ProtoSchema(includeClasses = {Team.class, Player.class}, schemaPackageName = "model")
+   public interface TeamSchema extends GeneratedSchema {
+      TeamSchema INSTANCE = new TeamSchemaImpl();
+   }
+
+}

--- a/query/src/test/java/org/infinispan/query/nested/ParentJoinNestedTest.java
+++ b/query/src/test/java/org/infinispan/query/nested/ParentJoinNestedTest.java
@@ -1,0 +1,100 @@
+package org.infinispan.query.nested;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.infinispan.configuration.cache.IndexStorage.LOCAL_HEAP;
+
+import java.util.List;
+
+import org.infinispan.commons.api.query.Query;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.query.Search;
+import org.infinispan.query.core.stats.QueryStatistics;
+import org.infinispan.query.model.Player;
+import org.infinispan.query.model.Team;
+import org.infinispan.test.SingleCacheManagerTest;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+@Test(groups = "functional", testName = "query.nested.ParentJoinNestedTest")
+public class ParentJoinNestedTest extends SingleCacheManagerTest {
+
+   private QueryStatistics queryStatistics;
+
+   @Override
+   protected EmbeddedCacheManager createCacheManager() throws Exception {
+      ConfigurationBuilder indexed = new ConfigurationBuilder();
+      indexed.statistics().enable();
+      indexed.indexing().enable()
+            .storage(LOCAL_HEAP)
+            .addIndexedEntity(Team.class);
+      return TestCacheManagerFactory.createCacheManager(indexed);
+   }
+
+   @BeforeMethod
+   public void beforeClass() {
+      if (queryStatistics == null) {
+         queryStatistics = Search.getSearchStatistics(cache).getQueryStatistics();
+      }
+      queryStatistics.clear();
+
+      if (!cache.isEmpty()) {
+         return;
+      }
+      List<Player> playersA = List.of(new Player("Michael", "red", 7), new Player("Jonas", "blue", 3));
+      List<Player> playersB = List.of(new Player("Ulrich", "red", 3), new Player("Martha", "blue", 7));
+      cache.put("1", new Team("New Team", playersA, playersA));
+      cache.put("2", new Team("Old Team", playersB, playersB));
+   }
+
+   @Test
+   public void nested_usingJoin() {
+      Query<Object[]> query = cache.query("select t.name from org.infinispan.query.model.Team t " +
+            "join t.firstTeam p where p.color ='red' AND p.number=7");
+      List<Object[]> result = query.list();
+      // the structure is nested, so the match searches for a player that has at the same time the color red and number 7
+      assertThat(result).extracting(array -> array[0]).containsExactly("New Team");
+      assertThat(queryStatistics.getLocalIndexedQueryCount()).isEqualTo(1);
+   }
+
+   @Test
+   public void flattened_usingJoin() {
+      Query<Object[]> query = cache.query("select t.name from org.infinispan.query.model.Team t " +
+            "join t.replacements p where p.color ='red' AND p.number=7");
+      List<Object[]> result = query.list();
+      // the structure is flattened, so the match searches a player that has the color red and possibly another player having number 7
+      assertThat(result).extracting(array -> array[0]).containsExactly("New Team", "Old Team");
+      assertThat(queryStatistics.getLocalIndexedQueryCount()).isEqualTo(1);
+   }
+
+   @Test
+   public void nested_usingEquals() {
+      Query<Object[]> query = cache.query("select t.name from org.infinispan.query.model.Team t " +
+            "where t.firstTeam.color ='red' AND t.firstTeam.number=7");
+      List<Object[]> result = query.list();
+      // we don't use the join operator, so the match searches a player that has the color red and possibly another player having number 7
+      assertThat(result).extracting(array -> array[0]).containsExactly("New Team", "Old Team");
+      assertThat(queryStatistics.getLocalIndexedQueryCount()).isEqualTo(1);
+   }
+
+   @Test
+   public void flattened_usingEquals() {
+      Query<Object[]> query = cache.query("select t.name from org.infinispan.query.model.Team t " +
+            "where t.replacements.color ='red' AND t.replacements.number=7");
+      List<Object[]> result = query.list();
+      // we don't use the join operator, so the match searches a player that has the color red and possibly another player having number 7
+      assertThat(result).extracting(array -> array[0]).containsExactly("New Team", "Old Team");
+      assertThat(queryStatistics.getLocalIndexedQueryCount()).isEqualTo(1);
+   }
+
+   @Test
+   public void flattened_entityProj_usingEquals() {
+      Query<Team> query = cache.query("from org.infinispan.query.model.Team t " +
+            "where t.replacements.color ='red' AND t.replacements.number=7");
+      List<Team> result = query.list();
+      // we don't use the join operator, so the match searches a player that has the color red and possibly another player having number 7
+      assertThat(result).extracting(Team::name).containsExactly("New Team", "Old Team");
+      assertThat(queryStatistics.getLocalIndexedQueryCount()).isEqualTo(1);
+   }
+}


### PR DESCRIPTION
Initial implementation of Nested query support. Currently, only Indexed (EmbeddedLuceneQuery) queries are supported, Hybrid/Non-indexed queries will throw UnsupportedOperationException.

Introduced new NestedExpr visitable, which is similar to the AndExpr, that ensures that the correct nested predicate is created in HibernateSearch.

As this is only supported on fields that are embedded and in NESTED structure, in case of FLATTENED fields the original functionality is kept and a warning log will be shown.

