### PR TITLE
ISPN-16215 - fix Locking problems during StringBaseJdbcStore#purgeExpired

### DIFF
--- a/persistence/jdbc-common/src/main/java/org/infinispan/persistence/jdbc/common/logging/Log.java
+++ b/persistence/jdbc-common/src/main/java/org/infinispan/persistence/jdbc/common/logging/Log.java
@@ -37,7 +37,7 @@ public interface Log extends BasicLogger {
 
    @LogMessage(level = ERROR)
    @Message(value = "Failed clearing cache store", id = 8001)
-   void failedClearingJdbcCacheStore(@Cause Exception e);
+   void failedClearingJdbcCacheStore(@Cause Throwable t);
 
 //   @LogMessage(level = ERROR)
 //   @Message(value = "I/O failure while integrating state into store", id = 8002)

--- a/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/stringbased/JdbcStringBasedStore.java
+++ b/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/stringbased/JdbcStringBasedStore.java
@@ -345,9 +345,9 @@ public class JdbcStringBasedStore<K, V> extends BaseJdbcStore<K, V, JdbcStringBa
             log.infof("Successfully purged %d rows of table %s.", purgedAmount, getTableManager().getDataTableName());
          }
          unicastProcessor.onComplete();
-      } catch (SQLException e) {
-         log.failedClearingJdbcCacheStore(e);
-         unicastProcessor.onError(e);
+      } catch (Throwable t) {
+         log.failedClearingJdbcCacheStore(t);
+         unicastProcessor.onError(t);
       }
    }
 


### PR DESCRIPTION
As described in the Jira Task and demonstrated in a separate project, purgeExpired may lead to locking problems.

We fixed the problem in our keycloak installation by subclassing the StringBasedJdbcStore. But we would like the fix to be integrated into the standard. Therefore this pullrequest

I thought about integrating the reproduction scenario into the integration tests but was not able to completely understand their working.

Nevertheless the presented solution avoids several problems I see with the current implementation of purgeExpired:

1. concurrent read and delete on the same indices
2. unlimited transaction size
3. concurrent deletions on different connections in the same thread