### PR TITLE
ISPN-16323 Correct Logging Statement for Transaction Rollback in TransactionImpl Class

### DIFF
--- a/commons/all/src/main/java/org/infinispan/commons/tx/TransactionImpl.java
+++ b/commons/all/src/main/java/org/infinispan/commons/tx/TransactionImpl.java
@@ -198,7 +198,7 @@ public class TransactionImpl implements Transaction {
 
    public CompletionStage<Void> rollbackAsync(TransactionResourceConverter converter) {
       if (log.isTraceEnabled()) {
-         log.tracef("Transaction.commit() invoked in transaction with Xid=%s", xid);
+         log.tracef("Transaction.rollback() invoked in transaction with Xid=%s", xid);
       }
       if (isDone()) {
          return CompletableFuture.failedFuture(new IllegalStateException("Transaction is done. Cannot commit transaction."));

--- a/core/src/main/java/org/infinispan/xsite/events/XSiteEventsManagerImpl.java
+++ b/core/src/main/java/org/infinispan/xsite/events/XSiteEventsManagerImpl.java
@@ -243,7 +243,7 @@ public class XSiteEventsManagerImpl implements XSiteEventsManager {
       public Void apply(Throwable throwable) {
          var step = nextBackOffStep();
          if (step >= BACK_OFF_DELAYS.length) {
-            log.debugf(throwable, "Failed to send %s to %s", cmd, cmd);
+            log.debugf(throwable, "Failed to send %s to %s", cmd, backup);
             return null;
          }
          log.debugf(throwable, "Sending %s to %s with delay of %s milliseconds", cmd, backup, BACK_OFF_DELAYS[step]);


### PR DESCRIPTION
## Description:
https://issues.redhat.com/browse/ISPN-16323
This PR corrects a misleading logging statement in the TransactionImpl class. The existing log message incorrectly states that the transaction’s commit method is invoked, whereas the surrounding code is actually performing a rollback operation.

## Changes Made:

Updated the log statement from `Transaction.commit() invoked in transaction with Xid=%s` to `Transaction.rollback() invoked in transaction with Xid=%s.`

## Reason for Change:
The original log message could cause confusion during debugging or monitoring, as it suggests that a commit operation is being performed when, in fact, the transaction is being rolled back. This change ensures that the log accurately reflects the operation being performed, thereby improving clarity and maintainability of the code.

## Testing:
Verified that the log message appears correctly when a transaction rollback is triggered.
Ensured that no other parts of the code are affected by this change.
