### PR TITLE
ISPN-16314 Map embedded non-root-indexed types

### DIFF
--- a/query/src/test/java/org/infinispan/query/model/Player.java
+++ b/query/src/test/java/org/infinispan/query/model/Player.java
@@ -1,11 +1,9 @@
 package org.infinispan.query.model;
 
 import org.infinispan.api.annotations.indexing.Basic;
-import org.infinispan.api.annotations.indexing.Indexed;
 import org.infinispan.protostream.annotations.Proto;
 
 @Proto
-@Indexed // @Indexed: Workaround for https://issues.redhat.com/browse/ISPN-16314
 public record Player(@Basic String name, @Basic String color, @Basic Integer number) {
 
 }

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/indexing/IndexingMetadata.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/indexing/IndexingMetadata.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import org.infinispan.protostream.descriptors.AnnotationElement;
 import org.infinispan.protostream.descriptors.Descriptor;
+import org.infinispan.protostream.descriptors.FieldDescriptor;
 
 /**
  * @author anistor@redhat.com
@@ -155,6 +156,10 @@ public final class IndexingMetadata {
    }
 
    public static <T> T findProcessedAnnotation(Descriptor descriptor, String name) {
+      return descriptor.getProcessedAnnotation(name);
+   }
+
+   public static <T> T findProcessedAnnotation(FieldDescriptor descriptor, String name) {
       return descriptor.getProcessedAnnotation(name);
    }
 

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/indexing/infinispan/IndexingMetadataHolder.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/indexing/infinispan/IndexingMetadataHolder.java
@@ -1,0 +1,16 @@
+package org.infinispan.query.remote.impl.indexing.infinispan;
+
+import org.infinispan.query.remote.impl.indexing.IndexingMetadata;
+
+public class IndexingMetadataHolder {
+
+   private IndexingMetadata indexingMetadata;
+
+   public IndexingMetadata getIndexingMetadata() {
+      return indexingMetadata;
+   }
+
+   public void setIndexingMetadata(IndexingMetadata indexingMetadata) {
+      this.indexingMetadata = indexingMetadata;
+   }
+}

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/indexing/infinispan/IndexingMetadataHolderFactory.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/indexing/infinispan/IndexingMetadataHolderFactory.java
@@ -1,0 +1,13 @@
+package org.infinispan.query.remote.impl.indexing.infinispan;
+
+import org.infinispan.protostream.AnnotationMetadataCreator;
+import org.infinispan.protostream.descriptors.AnnotationElement;
+import org.infinispan.protostream.descriptors.FieldDescriptor;
+
+public class IndexingMetadataHolderFactory implements AnnotationMetadataCreator<IndexingMetadataHolder, FieldDescriptor> {
+
+   @Override
+   public IndexingMetadataHolder create(FieldDescriptor annotatedDescriptor, AnnotationElement.Annotation annotation) {
+      return new IndexingMetadataHolder();
+   }
+}

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/indexing/infinispan/InfinispanAnnotations.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/indexing/infinispan/InfinispanAnnotations.java
@@ -152,6 +152,7 @@ public class InfinispanAnnotations {
                   .packageName(ANNOTATIONS_OPTIONS_PACKAGE)
                   .allowedValues(structureAllowedValues())
                   .defaultValue(Structure.NESTED.name())
+               .metadataCreator(new IndexingMetadataHolderFactory())
             .annotation(VECTOR_ANNOTATION, AnnotationElement.AnnotationTarget.FIELD)
                .attribute(NAME_ATTRIBUTE)
                   .type(AnnotationElement.AttributeType.STRING)

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/indexing/search5/Search5MetadataCreator.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/indexing/search5/Search5MetadataCreator.java
@@ -28,7 +28,7 @@ import org.infinispan.search.mapper.mapping.impl.DefaultAnalysisConfigurer;
  * @author anistor@redhat.com
  * @since 7.0
  */
-final class Search5MetadataCreator implements AnnotationMetadataCreator<IndexingMetadata, Descriptor> {
+public final class Search5MetadataCreator implements AnnotationMetadataCreator<IndexingMetadata, Descriptor> {
 
    private static final Log log = LogFactory.getLog(Search5MetadataCreator.class, Log.class);
 
@@ -50,22 +50,7 @@ final class Search5MetadataCreator implements AnnotationMetadataCreator<Indexing
          }
       }
 
-      Map<String, FieldMapping> fields = new HashMap<>(descriptor.getFields().size());
-      for (FieldDescriptor fd : descriptor.getFields()) {
-         Map<String, AnnotationElement.Annotation> annotations = fd.getAnnotations();
-
-         FieldMapping fieldMapping = InfinispanMetadataCreator.fieldMapping(fd, annotations);
-         if (fieldMapping != null) {
-            fields.put(fd.getName(), fieldMapping);
-            continue;
-         }
-
-         fieldMapping = search5FieldMapping(fd, annotations);
-         if (fieldMapping != null) {
-            fields.put(fd.getName(), fieldMapping);
-         }
-      }
-
+      Map<String, FieldMapping> fields = fieldsMapping(descriptor);
       String keyEntity = (String) annotation.getAttributeValue(InfinispanAnnotations.KEY_ENTITY_ATTRIBUTE).getValue();
       IndexingKeyMetadata indexingKeyMetadata = null;
       if (!keyEntity.isEmpty()) {
@@ -83,6 +68,34 @@ final class Search5MetadataCreator implements AnnotationMetadataCreator<Indexing
          log.debugf("Descriptor name=%s indexingMetadata=%s", descriptor.getFullName(), indexingMetadata);
       }
       return indexingMetadata;
+   }
+
+   public static IndexingMetadata createForEmbeddedType(Descriptor descriptor) {
+      Map<String, FieldMapping> fields = fieldsMapping(descriptor);
+      IndexingMetadata indexingMetadata = new IndexingMetadata(false, null, null, fields, null);
+      if (log.isDebugEnabled()) {
+         log.debugf("Descriptor name=%s indexingMetadata=%s", descriptor.getFullName(), indexingMetadata);
+      }
+      return indexingMetadata;
+   }
+
+   private static Map<String, FieldMapping> fieldsMapping(Descriptor descriptor) {
+      Map<String, FieldMapping> fields = new HashMap<>(descriptor.getFields().size());
+      for (FieldDescriptor fd : descriptor.getFields()) {
+         Map<String, AnnotationElement.Annotation> annotations = fd.getAnnotations();
+
+         FieldMapping fieldMapping = InfinispanMetadataCreator.fieldMapping(fd, annotations);
+         if (fieldMapping != null) {
+            fields.put(fd.getName(), fieldMapping);
+            continue;
+         }
+
+         fieldMapping = search5FieldMapping(fd, annotations);
+         if (fieldMapping != null) {
+            fields.put(fd.getName(), fieldMapping);
+         }
+      }
+      return fields;
    }
 
    private static FieldMapping search5FieldMapping(FieldDescriptor fd, Map<String, AnnotationElement.Annotation> annotations) {

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/mapping/reference/GlobalReferenceHolder.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/mapping/reference/GlobalReferenceHolder.java
@@ -86,7 +86,9 @@ public class GlobalReferenceHolder {
          IndexingMetadata indexingMetadata = Search5MetadataCreator.createForEmbeddedType(descriptor);
          return new MessageReferenceProvider(descriptor, indexingMetadata);
       });
-      return messageReferenceProviders.get(typeFullName);
+      MessageReferenceProvider provider = messageReferenceProviders.get(typeFullName);
+      embedded.indexingMetadata(provider.indexingMetadata());
+      return provider;
    }
 
    public static class RootMessageInfo {

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/mapping/typebridge/ProtobufMessageBinder.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/mapping/typebridge/ProtobufMessageBinder.java
@@ -72,12 +72,8 @@ public class ProtobufMessageBinder implements TypeBinder {
                   currentState.path + "." + embedded.getFieldName();
 
             maxDepth = embedded.getIncludeDepth();
-
-            String typeName = embedded.getTypeFullName();
-            MessageReferenceProvider messageReferenceProvider = globalReferenceHolder.getMessageReferenceProviders().get(typeName);
-            if (messageReferenceProvider == null) {
-               throw log.unknownType(typeName);
-            }
+            MessageReferenceProvider messageReferenceProvider = globalReferenceHolder
+                  .messageProviderForEmbeddedType(embedded);
 
             ObjectStructure structure = embedded.getStructure();
             if (structure == null) {


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-16314

The implementation is a bit convoluted since with the current version of ProtoStream when we process the embedded annotations the embedded type descriptor is not filled. So my idea was to produce a wrapper and fill it later, when we discover that the type is actually used as embedded indexed.
