### PR TITLE
Fix examples in the encoding section

### DIFF
--- a/documentation/src/main/asciidoc/topics/ref_protostream_types.adoc
+++ b/documentation/src/main/asciidoc/topics/ref_protostream_types.adoc
@@ -43,7 +43,7 @@ public interface LibraryInitalizer extends SerializationContextInitializer {
 
 [source,java,options="nowrap",subs=attributes+]
 ----
-@ProtoSchema(includeClasses = { Author.class, Book.class, UUIDAdapter.class, java.math.BigInteger }, schemaFileName = "library.proto", schemaFilePath = "proto", schemaPackageName = "library")
+@ProtoSchema(includeClasses = { Author.class, Book.class, UUIDAdapter.class, org.infinispan.protostream.types.java.math.BigIntegerAdapter.class }, schemaFileName = "library.proto", schemaFilePath = "proto", schemaPackageName = "library")
 public interface LibraryInitalizer extends SerializationContextInitializer {
 
 }

--- a/documentation/src/main/asciidoc/topics/ref_protostream_types.adoc
+++ b/documentation/src/main/asciidoc/topics/ref_protostream_types.adoc
@@ -34,7 +34,7 @@ However, if you want to use adapter classes as marshallable fields in ProtoStrea
 
 [source,java,options="nowrap",subs=attributes+]
 ----
-@ProtoSchema(dependsOn = {org.infinispan.protostream.types.java.CommonTypes, org.infinispan.protostream.types.java.CommonContainerTypes}, schemaFileName = "library.proto", schemaFilePath = "proto", schemaPackageName = "example")
+@ProtoSchema(dependsOn = {org.infinispan.protostream.types.java.CommonTypes.class, org.infinispan.protostream.types.java.CommonContainerTypes.class}, schemaFileName = "library.proto", schemaFilePath = "proto", schemaPackageName = "example")
 public interface LibraryInitalizer extends SerializationContextInitializer {
 }
 ----


### PR DESCRIPTION
This fixes two examples in the [encoding section](https://infinispan.org/docs/stable/titles/encoding/encoding.html#protostream-types_marshalling) of the Infinispan documentation.