### PR TITLE
ISPN-16515 remove bad chars from testname for jira

### DIFF
--- a/bin/jira/track_flaky_tests.sh
+++ b/bin/jira/track_flaky_tests.sh
@@ -24,7 +24,7 @@ for TEST in "${TESTS[@]}"; do
     TEST_NAME=${TEST_NAME% (Flaky Test)}
     # Removing square brakets with execution counter i.e. flakyTest[1]
     TEST_NAME=${TEST_NAME%%[*}
-    TEST_NAME_NO_PARAMS=${TEST_NAME%%\\*}
+    TEST_NAME_NO_PARAMS=${TEST_NAME%%\(*}
     STACK_TRACE=$(xmlstarlet sel --template --value-of '/testsuite/testcase/failure['$i']' ${TEST})
 
     # Create Issue for Test Class+TestName


### PR DESCRIPTION
track_flaky_tests.sh fails to remove bad chars before querying jira
[ISPN-16515](https://issues.redhat.com/browse/ISPN-16515)