### PR TITLE
ISPN-16500 Fix IRAC backoff flaky tests

### DIFF
--- a/core/src/main/java/org/infinispan/xsite/irac/IracManagerKeyChangedState.java
+++ b/core/src/main/java/org/infinispan/xsite/irac/IracManagerKeyChangedState.java
@@ -149,7 +149,8 @@ class IracManagerKeyChangedState implements IracManagerKeyState {
       return result;
    }
 
-   private enum Status {
+   // Package-private for testing purposes.
+   enum Status {
       READY,
       SENDING,
       DONE

--- a/core/src/test/java/org/infinispan/xsite/irac/ControlledExponentialBackOff.java
+++ b/core/src/test/java/org/infinispan/xsite/irac/ControlledExponentialBackOff.java
@@ -43,8 +43,9 @@ public class ControlledExponentialBackOff implements ExponentialBackOff {
    }
 
    void release() {
-      backOff.complete(null);
-      this.backOff = new CompletableFuture<>();
+      CompletableFuture<Void> cs = backOff;
+      backOff = new CompletableFuture<>();
+      cs.complete(null);
    }
 
    void cleanupEvents() {


### PR DESCRIPTION
This includes a few issues:

https://issues.redhat.com/browse/ISPN-16429
https://issues.redhat.com/browse/ISPN-16371
https://issues.redhat.com/browse/ISPN-16431
https://issues.redhat.com/browse/ISPN-16466
https://issues.redhat.com/browse/ISPN-16500

There were a couple of concurrency issues on the test side. After releasing the backoff CF, it could sometimes re-run, fail with an exception, and not see the new CF instance. Another issue is after seeing the BACKOFF event on the queue, we would release it for a retry, but the key didn't change the state to retry on time. Therefore, the key state was never sent.