### PR TITLE
ISPN-16495 Flaky test: org.infinispan.client.hotrod.impl.transport.ne…

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/transport/netty/ChannelCloseAndInactiveTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/transport/netty/ChannelCloseAndInactiveTest.java
@@ -58,8 +58,9 @@ public class ChannelCloseAndInactiveTest extends AbstractRetryTest {
       eventually(() -> firstChannelRef.get() != null);
       Channel firstChannel = firstChannelRef.get();
 
+      // Eventually the Noop operation is registered.
       HeaderDecoder firstDecoder = ((HeaderDecoder) firstChannel.pipeline().get(HeaderDecoder.NAME));
-      assertThat(firstDecoder.registeredOperations()).isOne();
+      eventually(() -> firstDecoder.registeredOperations() == 1);
 
       // The first channel does not return to the pool. We submit the second operation to create a new channel.
       CrashMidOperationTest.NoopRetryingOperation secondOperation = new CrashMidOperationTest.NoopRetryingOperation(1, channelFactory, remoteCacheManager.getConfiguration(),


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-16495

…tty.ChannelCloseAndInactiveTest#testKillAndInactiveDifferentChannelsConcurrently

We set the AtomicReference for the channel and LATER registered it. It is possible to have a gap between acquiring the channel and asserting the registered operations.