### PR TITLE
ISPN-16535 Remove jira tracking for flaky test on Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -202,11 +202,6 @@ pipeline {
                 pmdParser(pattern: '**/target/pmd.xml'),
                 cpd(pattern: '**/target/cpd.xml')
             ]
-
-            script {
-               env.TARGET_BRANCH = env.BRANCH_NAME.startsWith('PR-') ? env.CHANGE_TARGET : env.BRANCH_NAME
-               sh 'FLAKY_TEST_GLOB="**/target/*-reports*/**/TEST-*FLAKY.xml" PROJECT_KEY=ISPN TYPE=Bug JENKINS_JOB_URL=$BUILD_URL TARGET_BRANCH=${TARGET_BRANCH} ./bin/jira/track_flaky_tests.sh'
-            }
         }
 
         // Send notification email when a build fails, has test failures, or is the first successful build


### PR DESCRIPTION
Jira traking for flaky test is now implemented in github workflow:
infinispan/.github/workflows/on_run_create_jira_flaky_test.yml