### PR TITLE
DRAFT. Implementation of json-path jsonprovider for internal.Json

### DIFF
--- a/build/configuration/pom.xml
+++ b/build/configuration/pom.xml
@@ -173,6 +173,7 @@
       <version.jcip-annotations>1.0</version.jcip-annotations>
       <version.jgroups>5.3.11.Final</version.jgroups>
       <version.jgroups.raft>1.0.13.Final</version.jgroups.raft>
+      <version.json-path>2.9.0</version.json-path>
       <version.jsr107>1.1.0</version.jsr107>
       <version.junit>4.13.2</version.junit>
       <version.junit5>5.11.0</version.junit5>

--- a/commons/all/pom.xml
+++ b/commons/all/pom.xml
@@ -3,6 +3,7 @@
    <modelVersion>4.0.0</modelVersion>
    <parent>
       <?m2e execute onConfiguration?>
+      <?m2e execute onConfiguration?>
       <groupId>org.infinispan</groupId>
       <artifactId>infinispan-commons-parent</artifactId>
       <version>15.1.0-SNAPSHOT</version>
@@ -97,7 +98,19 @@
          <scope>test</scope>
       </dependency>
 
-     <dependency>
+      <dependency>
+         <groupId>com.fasterxml.jackson.core</groupId>
+         <artifactId>jackson-core</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>com.fasterxml.jackson.core</groupId>
+         <artifactId>jackson-databind</artifactId>
+         <version>${version.jackson}</version>
+      </dependency>
+
+      <dependency>
        <groupId>com.jayway.jsonpath</groupId>
        <artifactId>json-path</artifactId>
        <version>${version.json-path}</version>

--- a/commons/all/pom.xml
+++ b/commons/all/pom.xml
@@ -2,6 +2,7 @@
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <modelVersion>4.0.0</modelVersion>
    <parent>
+      <?m2e execute onConfiguration?>
       <groupId>org.infinispan</groupId>
       <artifactId>infinispan-commons-parent</artifactId>
       <version>15.1.0-SNAPSHOT</version>
@@ -95,6 +96,13 @@
          <artifactId>wildfly-elytron-x500-cert</artifactId>
          <scope>test</scope>
       </dependency>
+
+     <dependency>
+       <groupId>com.jayway.jsonpath</groupId>
+       <artifactId>json-path</artifactId>
+       <version>${version.json-path}</version>
+     </dependency>
+
    </dependencies>
 
    <build>

--- a/commons/all/src/main/java/org/infinispan/commons/dataconversion/internal/InfinispanJsonProvider.java
+++ b/commons/all/src/main/java/org/infinispan/commons/dataconversion/internal/InfinispanJsonProvider.java
@@ -2,6 +2,8 @@ package org.infinispan.commons.dataconversion.internal;
 
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.util.Collection;
+import java.util.List;
 
 import com.jayway.jsonpath.InvalidJsonException;
 import com.jayway.jsonpath.JsonPathException;
@@ -43,15 +45,15 @@ public class InfinispanJsonProvider extends AbstractJsonProvider {
    public boolean isMap(Object obj) {
       if (obj instanceof Json j) {
          return j.isObject();
-      } return false;
-      // return super.isMap(obj);
+      }
+    return super.isMap(obj);
    }
 
    @Override
    public Object getMapValue(Object obj, String key) {
-      // if (super.isMap(obj)) {
-      //    return super.getMapValue(obj, key);
-      // }
+      if (super.isMap(obj)) {
+         return super.getMapValue(obj, key);
+      }
       if (isMap(obj)) {
          var map = ((Json)obj).asJsonMap();
          if (map.containsKey(key)) {
@@ -121,59 +123,42 @@ public class InfinispanJsonProvider extends AbstractJsonProvider {
       throw new UnsupportedOperationException();
   }
 
-//   @SuppressWarnings("unchecked")
-//   public void setArrayIndex(Object array, int index, Object newValue) {
-//      if (array instanceof List) {
-//         @SuppressWarnings("rawtypes")
-//         List l = (List) array;
-//         if (index == l.size()) {
-//            l.add(newValue);
-//         } else {
-//            l.set(index, newValue);
-//         }
-//         return;
-//      }
-//      if (isArray(array)) {
-//         var l = (Json.ArrayJson) array;
-//         if (index == l.asJsonList().size()) {
-//            l.add(newValue);
-//         } else {
-//            l.set(index, newValue);
-//         }
-//      }
-//      throw new UnsupportedOperationException();
-//   }
-//       /**
-//      * Sets a value in an object
-//      *
-//      * @param obj   an object
-//      * @param key   a String key
-//      * @param value the value to set
-//      */
-//     public void setProperty(Object obj, Object key, Object value) {
-//         if (isMap(obj)) {
-//             ((Json)obj).set(key.toString(), value);
-//         }
-//         else {
-//             throw new JsonPathException("setProperty operation cannot be used with " + obj!=null?obj.getClass().getName():"null");
-//         }
-//       }
-
-//       /**
-//        * Returns the keys from the given object
-//        *
-//        * @param obj an object
-//        * @return the keys for an object
-//        */
-//       @SuppressWarnings("unchecked")
-//       public Collection<String> getPropertyKeys(Object obj) {
-//          if (isArray(obj)) {
-//             throw new UnsupportedOperationException();
-//          } else {
-//             if (super.isMap(obj)) {
-//                return super.getPropertyKeys(obj);
-//             }
-//             return ((Json.ObjectJson) obj).asJsonMap().keySet();
-//          }
-//       }
+  @SuppressWarnings("unchecked")
+  public void setArrayIndex(Object array, int index, Object newValue) {
+     if (array instanceof List) {
+        @SuppressWarnings("rawtypes")
+        List l = (List) array;
+        if (index == l.size()) {
+           l.add(newValue);
+        } else {
+           l.set(index, newValue);
+        }
+        return;
+     }
+     if (isArray(array)) {
+        var l = (Json.ArrayJson) array;
+        if (index == l.asJsonList().size()) {
+           l.add(newValue);
+        } else {
+           l.set(index, newValue);
+        }
+     }
+     throw new UnsupportedOperationException();
+  }
+      /**
+       * Returns the keys from the given object
+       *
+       * @param obj an object
+       * @return the keys for an object
+       */
+      public Collection<String> getPropertyKeys(Object obj) {
+         if (isArray(obj)) {
+            throw new UnsupportedOperationException();
+         } else {
+            if (super.isMap(obj)) {
+               return super.getPropertyKeys(obj);
+            }
+            return ((Json.ObjectJson) obj).asJsonMap().keySet();
+         }
+      }
    }

--- a/commons/all/src/main/java/org/infinispan/commons/dataconversion/internal/InfinispanJsonProvider.java
+++ b/commons/all/src/main/java/org/infinispan/commons/dataconversion/internal/InfinispanJsonProvider.java
@@ -1,0 +1,186 @@
+package org.infinispan.commons.dataconversion.internal;
+
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import com.jayway.jsonpath.InvalidJsonException;
+import com.jayway.jsonpath.JsonPathException;
+import com.jayway.jsonpath.spi.json.AbstractJsonProvider;
+import com.jayway.jsonpath.spi.json.JsonProvider;
+
+import netscape.javascript.JSObject;
+
+public class InfinispanJsonProvider extends AbstractJsonProvider {
+
+   @Override
+   public Object parse(String json) throws InvalidJsonException {
+      try {
+         return Json.read(json);
+      } catch (Exception e) {
+         throw new InvalidJsonException(e.getCause());
+      }
+   }
+
+   @Override
+   public Object parse(InputStream jsonStream, String charset) throws InvalidJsonException {
+      return Json.fetchContent(jsonStream, Charset.forName(charset));
+   }
+
+   @Override
+   public String toJson(Object obj) {
+      return Json.factory().make(obj).toString();
+   }
+
+   @Override
+   public Object createArray() {
+      return Json.array().asJsonList();
+   }
+
+   @Override
+   public Object createMap() {
+      return Json.object().asJsonMap();
+   }
+
+   @Override
+   public boolean isMap(Object obj) {
+      if (obj instanceof Json j) {
+         return j.isObject();
+      } return false;
+      // return super.isMap(obj);
+   }
+
+   @Override
+   public Object getMapValue(Object obj, String key) {
+      // if (super.isMap(obj)) {
+      //    return super.getMapValue(obj, key);
+      // }
+      if (isMap(obj)) {
+         var map = ((Json)obj).asJsonMap();
+         if (map.containsKey(key)) {
+            return ((Json)map.get(key));
+         }
+      }
+      return JsonProvider.UNDEFINED;
+   }
+       /**
+     * Sets a value in an object
+     *
+     * @param obj   an object
+     * @param key   a String key
+     * @param value the value to set
+     */
+    public void setProperty(Object obj, Object key, Object value) {
+        if (isMap(obj))
+            ((Json.ObjectJson)obj).set(key.toString(), value);
+        else {
+            throw new JsonPathException("setProperty operation cannot be used with " + obj!=null?obj.getClass().getName():"null");
+        }
+    }
+
+
+//    @Override
+//    public boolean isArray(Object obj) {
+//       return (obj instanceof Json.ArrayJson) || (obj instanceof List);
+//    }
+
+//    /**
+//     * Get the length of an array or object
+//     *
+//     * @param obj an array or an object
+//     * @return the number of entries in the array or object
+//     */
+//    @SuppressWarnings("rawtypes")
+//    public int length(Object obj) {
+//       if (super.isArray(obj)) {
+//             return super.length(obj);
+//          }
+//       if (isArray(obj)) {
+//             return ((Json.ArrayJson)obj).asJsonList().size();
+//       } else if (isMap(obj)) {
+//          return ((Json.ObjectJson)obj).asJsonMap().size();
+//       } else if (obj instanceof String) {
+//          return ((String) obj).length();
+//       }
+//       if (obj instanceof List) {
+//          return ((List) obj).size();
+//       }
+//       throw new JsonPathException("length operation cannot be applied to " + (obj != null ? obj.getClass().getName()
+//             : "null"));
+//    }
+
+//        /**
+//      * Extracts a value from an array
+//      *
+//      * @param obj an array
+//      * @param idx index
+//      * @return the entry at the given index
+//      */
+//     public Object getArrayIndex(Object obj, int idx) {
+//       if (super.isArray(obj)) {
+//          return super.getArrayIndex(obj, idx);
+//       }
+//       if (isArray(obj)) {
+//          return ((Json.ArrayJson) obj).at(idx);
+//       }
+//       throw new UnsupportedOperationException();
+//   }
+
+//   @SuppressWarnings("unchecked")
+//   public void setArrayIndex(Object array, int index, Object newValue) {
+//      if (array instanceof List) {
+//         @SuppressWarnings("rawtypes")
+//         List l = (List) array;
+//         if (index == l.size()) {
+//            l.add(newValue);
+//         } else {
+//            l.set(index, newValue);
+//         }
+//         return;
+//      }
+//      if (isArray(array)) {
+//         var l = (Json.ArrayJson) array;
+//         if (index == l.asJsonList().size()) {
+//            l.add(newValue);
+//         } else {
+//            l.set(index, newValue);
+//         }
+//      }
+//      throw new UnsupportedOperationException();
+//   }
+//       /**
+//      * Sets a value in an object
+//      *
+//      * @param obj   an object
+//      * @param key   a String key
+//      * @param value the value to set
+//      */
+//     public void setProperty(Object obj, Object key, Object value) {
+//         if (isMap(obj)) {
+//             ((Json)obj).set(key.toString(), value);
+//         }
+//         else {
+//             throw new JsonPathException("setProperty operation cannot be used with " + obj!=null?obj.getClass().getName():"null");
+//         }
+//       }
+
+//       /**
+//        * Returns the keys from the given object
+//        *
+//        * @param obj an object
+//        * @return the keys for an object
+//        */
+//       @SuppressWarnings("unchecked")
+//       public Collection<String> getPropertyKeys(Object obj) {
+//          if (isArray(obj)) {
+//             throw new UnsupportedOperationException();
+//          } else {
+//             if (super.isMap(obj)) {
+//                return super.getPropertyKeys(obj);
+//             }
+//             return ((Json.ObjectJson) obj).asJsonMap().keySet();
+//          }
+//       }
+   }

--- a/commons/all/src/main/java/org/infinispan/commons/dataconversion/internal/InfinispanJsonProvider.java
+++ b/commons/all/src/main/java/org/infinispan/commons/dataconversion/internal/InfinispanJsonProvider.java
@@ -2,16 +2,11 @@ package org.infinispan.commons.dataconversion.internal;
 
 import java.io.InputStream;
 import java.nio.charset.Charset;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
 
 import com.jayway.jsonpath.InvalidJsonException;
 import com.jayway.jsonpath.JsonPathException;
 import com.jayway.jsonpath.spi.json.AbstractJsonProvider;
 import com.jayway.jsonpath.spi.json.JsonProvider;
-
-import netscape.javascript.JSObject;
 
 public class InfinispanJsonProvider extends AbstractJsonProvider {
 
@@ -81,52 +76,50 @@ public class InfinispanJsonProvider extends AbstractJsonProvider {
     }
 
 
-//    @Override
-//    public boolean isArray(Object obj) {
-//       return (obj instanceof Json.ArrayJson) || (obj instanceof List);
-//    }
+   @Override
+   public boolean isArray(Object obj) {
+      return (obj instanceof Json.ArrayJson) || super.isArray(obj);
+   }
 
-//    /**
-//     * Get the length of an array or object
-//     *
-//     * @param obj an array or an object
-//     * @return the number of entries in the array or object
-//     */
-//    @SuppressWarnings("rawtypes")
-//    public int length(Object obj) {
-//       if (super.isArray(obj)) {
-//             return super.length(obj);
-//          }
-//       if (isArray(obj)) {
-//             return ((Json.ArrayJson)obj).asJsonList().size();
-//       } else if (isMap(obj)) {
-//          return ((Json.ObjectJson)obj).asJsonMap().size();
-//       } else if (obj instanceof String) {
-//          return ((String) obj).length();
-//       }
-//       if (obj instanceof List) {
-//          return ((List) obj).size();
-//       }
-//       throw new JsonPathException("length operation cannot be applied to " + (obj != null ? obj.getClass().getName()
-//             : "null"));
-//    }
+   /**
+    * Get the length of an array or object
+    *
+    * @param obj an array or an object
+    * @return the number of entries in the array or object
+    */
+   public int length(Object obj) {
+      if (super.isArray(obj)) {
+            return super.length(obj);
+         }
+      if (isArray(obj)) {
+            return ((Json.ArrayJson)obj).asJsonList().size();
+      }
+      if (isMap(obj)) {
+         return ((Json.ObjectJson)obj).asJsonMap().size();
+      }
+      if (obj instanceof String) {
+         return ((String) obj).length();
+      }
+      throw new JsonPathException("length operation cannot be applied to " + (obj != null ? obj.getClass().getName()
+            : "null"));
+   }
 
-//        /**
-//      * Extracts a value from an array
-//      *
-//      * @param obj an array
-//      * @param idx index
-//      * @return the entry at the given index
-//      */
-//     public Object getArrayIndex(Object obj, int idx) {
-//       if (super.isArray(obj)) {
-//          return super.getArrayIndex(obj, idx);
-//       }
-//       if (isArray(obj)) {
-//          return ((Json.ArrayJson) obj).at(idx);
-//       }
-//       throw new UnsupportedOperationException();
-//   }
+       /**
+     * Extracts a value from an array
+     *
+     * @param obj an array
+     * @param idx index
+     * @return the entry at the given index
+     */
+    public Object getArrayIndex(Object obj, int idx) {
+      if (super.isArray(obj)) {
+         return super.getArrayIndex(obj, idx);
+      }
+      if (isArray(obj)) {
+         return ((Json.ArrayJson) obj).at(idx);
+      }
+      throw new UnsupportedOperationException();
+  }
 
 //   @SuppressWarnings("unchecked")
 //   public void setArrayIndex(Object array, int index, Object newValue) {

--- a/commons/all/src/main/java/org/infinispan/commons/dataconversion/internal/Json.java
+++ b/commons/all/src/main/java/org/infinispan/commons/dataconversion/internal/Json.java
@@ -20,10 +20,12 @@ package org.infinispan.commons.dataconversion.internal;
  */
 
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.URI;
 import java.net.URL;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 import java.text.CharacterIterator;
@@ -435,10 +437,10 @@ public class Json implements java.io.Serializable {
       //Json generate(Json options);
    }
 
-   static String fetchContent(URL url) {
-      java.io.Reader reader = null;
+   static String fetchContent(java.io.InputStream is, Charset cs) {
+      InputStreamReader reader = null;
       try {
-         reader = new java.io.InputStreamReader((java.io.InputStream) url.getContent(), StandardCharsets.UTF_8);
+         reader = new InputStreamReader(is, cs);
          StringBuilder content = new StringBuilder();
          char[] buf = new char[1024];
          for (int n = reader.read(buf); n > -1; n = reader.read(buf))
@@ -451,6 +453,14 @@ public class Json implements java.io.Serializable {
             reader.close();
          } catch (Throwable t) {
          }
+      }
+   }
+
+   static String fetchContent(URL url) {
+      try {
+         return fetchContent((java.io.InputStream) url.getContent(), StandardCharsets.UTF_8);
+      } catch (IOException e) {
+         throw new RuntimeException(e);
       }
    }
 

--- a/commons/all/src/main/java/org/infinispan/commons/dataconversion/internal/JsonInfinispanMapperProvider.java
+++ b/commons/all/src/main/java/org/infinispan/commons/dataconversion/internal/JsonInfinispanMapperProvider.java
@@ -39,8 +39,7 @@ public class JsonInfinispanMapperProvider implements MappingProvider {
             if (targetType.isAssignableFrom(String.class)) {
                return (T) configuration.jsonProvider().toJson(source);
             }
-            throw new MappingException("no mapping 2");
-            //return (T) JSONValue.parse(s, targetType);
+            throw new MappingException("no mapping available");
         } catch (Exception e) {
             throw new MappingException(e);
         }

--- a/commons/all/src/main/java/org/infinispan/commons/dataconversion/internal/JsonInfinispanMapperProvider.java
+++ b/commons/all/src/main/java/org/infinispan/commons/dataconversion/internal/JsonInfinispanMapperProvider.java
@@ -1,0 +1,88 @@
+package org.infinispan.commons.dataconversion.internal;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.infinispan.commons.dataconversion.internal.Json.NumberJson;
+import org.infinispan.commons.dataconversion.internal.Json.StringJson;
+
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.TypeRef;
+import com.jayway.jsonpath.spi.mapper.JsonSmartMappingProvider;
+import com.jayway.jsonpath.spi.mapper.MappingException;
+import com.jayway.jsonpath.spi.mapper.MappingProvider;
+public class JsonInfinispanMapperProvider implements MappingProvider {
+
+
+   @SuppressWarnings("unchecked")
+   @Override
+    public <T> T map(Object source, Class<T> targetType, Configuration configuration) {
+        if(source == null){
+            return null;
+        }
+        if (targetType.isAssignableFrom(source.getClass())) {
+            return (T) source;
+        }
+        try {
+            if(!configuration.jsonProvider().isMap(source) && !configuration.jsonProvider().isArray(source)){
+               if (source instanceof StringJson s) {
+                  return (T) map(s, targetType);
+               }
+               if (source instanceof NumberJson n) {
+                  return (T) map(n, targetType);
+               }
+               return (T) map(source);
+            }
+            if (configuration.jsonProvider().isArray(source) && targetType.isAssignableFrom(ArrayList.class)) {
+               // isArray == true only for JsonArray here
+               return (T) ((Json)source).asList();
+            }
+
+            if (targetType.isAssignableFrom(String.class)) {
+               return (T) configuration.jsonProvider().toJson(source);
+            }
+            throw new MappingException("no mapping 2");
+            //return (T) JSONValue.parse(s, targetType);
+        } catch (Exception e) {
+            throw new MappingException(e);
+        }
+    }
+
+    public Object map(StringJson source, Class<?> tt) {
+      if (tt.isAssignableFrom(String.class)) {
+         return source.asString();
+      }
+      throw new MappingException("Cannot map StringJson to "+tt.getName());
+    }
+
+    public Object map(NumberJson source, Class<?> tt) {
+      if (tt.isAssignableFrom(Integer.class) || tt.isAssignableFrom(int.class)) {
+         return source.asInteger();
+      }
+
+      if (tt.isAssignableFrom(Long.class) || tt.isAssignableFrom(long.class)) {
+         return source.asLong();
+      }
+
+      if (tt.isAssignableFrom(Float.class) || tt.isAssignableFrom(float.class)) {
+         return source.asFloat();
+      }
+
+      if (tt.isAssignableFrom(Double.class) || tt.isAssignableFrom(double.class)) {
+         return source.asDouble();
+      }
+
+      throw new MappingException("Cannot map NumberJson to "+tt.getName());
+    }
+
+    public Object map(Object source) {
+      throw new UnsupportedOperationException("Json-smart provider does not support TypeRef! Use a Jackson or Gson based provider");
+  }
+
+    @Override
+    public <T> T map(Object source, TypeRef<T> targetType, Configuration configuration) {
+        throw new UnsupportedOperationException("JsonInfinispanMapperProvider provider does not support TypeRef! Use a Jackson or Gson based provider");
+    }
+
+}

--- a/commons/all/src/main/java/org/infinispan/commons/dataconversion/internal/JsonInfinispanMapperProvider.java
+++ b/commons/all/src/main/java/org/infinispan/commons/dataconversion/internal/JsonInfinispanMapperProvider.java
@@ -1,15 +1,12 @@
 package org.infinispan.commons.dataconversion.internal;
 
-import java.math.BigDecimal;
 import java.util.ArrayList;
-import java.util.List;
 
 import org.infinispan.commons.dataconversion.internal.Json.NumberJson;
 import org.infinispan.commons.dataconversion.internal.Json.StringJson;
 
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.TypeRef;
-import com.jayway.jsonpath.spi.mapper.JsonSmartMappingProvider;
 import com.jayway.jsonpath.spi.mapper.MappingException;
 import com.jayway.jsonpath.spi.mapper.MappingProvider;
 public class JsonInfinispanMapperProvider implements MappingProvider {

--- a/commons/all/src/test/java/org/infinispan/commons/dataconversion/InfinispanJsonProviderTest.java
+++ b/commons/all/src/test/java/org/infinispan/commons/dataconversion/InfinispanJsonProviderTest.java
@@ -20,7 +20,9 @@ import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.Predicate;
 import com.jayway.jsonpath.internal.Path;
 import com.jayway.jsonpath.internal.path.PredicateContextImpl;
+import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
 import com.jayway.jsonpath.spi.json.JsonSmartJsonProvider;
+import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 import com.jayway.jsonpath.spi.mapper.JsonSmartMappingProvider;
 
 public class InfinispanJsonProviderTest extends JsonProviderBaseTest {
@@ -153,6 +155,15 @@ public class InfinispanJsonProviderTest extends JsonProviderBaseTest {
       assertArrayEquals(actual.toArray(new Double[0]), new Double[] { 10D, 20D, 30D });
    }
 
+   @SuppressWarnings("unchecked")
+   @Test
+   public void canUseJackson() {
+      DocumentContext documentContext = using(JACKSON_CONFIGURATION).parse("{\"val\": [1,2,3,4]}");
+      documentContext.set("val", Arrays.asList(10, 20, 30));
+      @SuppressWarnings("rawtypes")
+      List read = documentContext.read("val");
+      assertArrayEquals(read.toArray(new Integer[0]), new Integer[] { 10, 20, 30 });
+   }
    // @Test
    // public void an_object_can_be_mapped_to_pojo() {
 
@@ -248,11 +259,11 @@ class JsonProviderBaseTest {
    // .jsonProvider(new GsonJsonProvider())
    // .build();
 
-   // public static final Configuration JACKSON_CONFIGURATION = Configuration
-   // .builder()
-   // .mappingProvider(new JacksonMappingProvider())
-   // .jsonProvider(new JacksonJsonProvider())
-   // .build();
+   public static final Configuration JACKSON_CONFIGURATION = Configuration
+   .builder()
+   .mappingProvider(new JacksonMappingProvider())
+   .jsonProvider(new JacksonJsonProvider())
+   .build();
 
    // public static final Configuration JACKSON_JSON_NODE_CONFIGURATION =
    // Configuration

--- a/commons/all/src/test/java/org/infinispan/commons/dataconversion/InfinispanJsonProviderTest.java
+++ b/commons/all/src/test/java/org/infinispan/commons/dataconversion/InfinispanJsonProviderTest.java
@@ -17,7 +17,6 @@ import org.junit.Test;
 
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.DocumentContext;
-import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.Predicate;
 import com.jayway.jsonpath.internal.Path;
 import com.jayway.jsonpath.internal.path.PredicateContextImpl;
@@ -104,54 +103,33 @@ public class InfinispanJsonProviderTest extends JsonProviderBaseTest {
    @Test
    public void list_of_numbers() {
       DocumentContext documentContext = using(INFINISPAN_ORG_CONFIGURATION).parse(JSON_DOCUMENT);
-      var objs = documentContext.read("$.store.book[*].display-price");
+      ArrayList<Json> objs = documentContext.read("$.store.book[*].display-price");
       List<Double> actual = new ArrayList<>();
-      // for (Json obj : objs) {
-      //    actual.add(obj.asDouble());
-      // }
-      // assertArrayEquals(actual.toArray(new Double[0]), new Double[] { 8.95D, 12.99D, 8.99D, 22.99D });
+      for (Json obj : objs) {
+         actual.add(obj.asDouble());
+      }
+      assertArrayEquals(actual.toArray(new Double[0]), new Double[] { 8.95D, 12.99D, 8.99D, 22.99D });
    }
 
    @SuppressWarnings("unchecked")
    @Test
    public void list_of_numbers_as_list() {
       DocumentContext documentContext = using(INFINISPAN_ORG_CONFIGURATION).parse(JSON_DOCUMENT);
-      /*List<Double>*/ var objs = documentContext.read("$.store.book[*].display-price", ArrayList.class);
-      assertArrayEquals(objs.toArray(new Double[0]), new Double[] { 8.95D, 12.99D, 8.99D, 22.99D });
-
-      var objs22 = documentContext.read("$[*].display-price", ArrayList.class);
+      List<Json> oList = documentContext.read("$.store.book[*].display-price", ArrayList.class);
+      List<Double> dList = oList.stream().map(Json::asDouble).toList();
+      assertArrayEquals(dList.toArray(new Double[0]), new Double[] { 8.95D, 12.99D, 8.99D, 22.99D });
 
       // Let's see if our ouput is good for input
       String s = documentContext.read("$.store.book", String.class);
-      // //List<String> actual1 = objs1.stream().map(HashMap::toString).toList();
       DocumentContext booksContext = using(INFINISPAN_ORG_CONFIGURATION).parse(s);
-      List<Double> objs2 = booksContext.read("$[*].display-price", ArrayList.class);
-      assertArrayEquals(objs2.toArray(new Double[0]), new Double[] { 8.95D, 12.99D, 8.99D, 22.99D });
-      List<String> objs1 = booksContext.read("$[*].category", ArrayList.class);
-      // assertArrayEquals(actual1.toArray(new Double[0]), new Double[]{8.95D, 12.99D,
+      List<Json> oList2 = booksContext.read("$[*].display-price", ArrayList.class);
+      List<Double> dList2 = oList2.stream().map(Json::asDouble).toList();
+      assertArrayEquals(dList2.toArray(new Double[0]), new Double[] { 8.95D, 12.99D, 8.99D, 22.99D });
+      List<Json> oList3 = booksContext.read("$[*].category", ArrayList.class);
+      List<String> sList3 = oList3.stream().map(Json::asString).toList();
+      // assertArrayEquals(actua l1.toArray(new Double[0]), new Double[]{8.95D, 12.99D,
       // 8.99D, 22.99D});
-      assertArrayEquals(objs1.toArray(new String[0]), new String[] { "reference", "fiction", "classic", "fiction" });
-   }
-
-   @Test
-   @SuppressWarnings("unchecked")
-   public void list_of_numbers_as_list_default() {
-      DocumentContext documentContext = JsonPath.parse(JSON_DOCUMENT);
-      List<Double> objs = documentContext.read("$.store.book[*].display-price", ArrayList.class);
-      List<Double> objs2 = documentContext.read("$[*].display-price", ArrayList.class);
-
-      assertArrayEquals(objs.toArray(new Double[0]), new Double[] { 8.95D, 12.99D, 8.99D, 22.99D });
-      // // Let's see if our ouput is good for input
-      var objs1 = documentContext.read("$.store.book", ArrayList.class);
-      // String s = documentContext.read("$.store.book", String.class);
-      // //List<String> actual1 = objs1.stream().map(HashMap::toString).toList();
-      // DocumentContext booksContext = using(INFINISPAN_ORG_CONFIGURATION).parse(s);
-      // objs1 = booksContext.read("$[*].category", ArrayList.class);
-      // // actual1 = objs1.stream().map(Json::toString).toList();
-      // // assertArrayEquals(actual1.toArray(new Double[0]), new Double[]{8.95D,
-      // 12.99D, 8.99D, 22.99D});
-      // // assertArrayEquals(actual1.toArray(new String[0]), new
-      // String[]{"reference", "fiction", "classic", "fiction"});
+      assertArrayEquals(sList3.toArray(new String[0]), new String[] { "reference", "fiction", "classic", "fiction" });
    }
 
     @Test

--- a/commons/all/src/test/java/org/infinispan/commons/dataconversion/InfinispanJsonProviderTest.java
+++ b/commons/all/src/test/java/org/infinispan/commons/dataconversion/InfinispanJsonProviderTest.java
@@ -1,0 +1,403 @@
+package org.infinispan.commons.dataconversion;
+
+import static com.jayway.jsonpath.JsonPath.parse;
+import static com.jayway.jsonpath.JsonPath.using;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.infinispan.commons.dataconversion.internal.InfinispanJsonProvider;
+import org.infinispan.commons.dataconversion.internal.Json;
+import org.infinispan.commons.dataconversion.internal.JsonInfinispanMapperProvider;
+import org.junit.Test;
+
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.Predicate;
+import com.jayway.jsonpath.internal.Path;
+import com.jayway.jsonpath.internal.path.PredicateContextImpl;
+import com.jayway.jsonpath.spi.json.JsonSmartJsonProvider;
+import com.jayway.jsonpath.spi.mapper.JsonSmartMappingProvider;
+
+public class InfinispanJsonProviderTest extends JsonProviderBaseTest {
+   private static final String JSON = "[" +
+         "{\n" +
+         "   \"foo\" : \"foo0\",\n" +
+         "   \"bar\" : 0,\n" +
+         "   \"baz\" : true,\n" +
+         "   \"gen\" : {\"eric\" : \"yepp\"}" +
+         "}," +
+         "{\n" +
+         "   \"foo\" : \"foo1\",\n" +
+         "   \"bar\" : 1,\n" +
+         "   \"baz\" : true,\n" +
+         "   \"gen\" : {\"eric\" : \"yepp\"}" +
+         "}," +
+         "{\n" +
+         "   \"foo\" : \"foo2\",\n" +
+         "   \"bar\" : 2,\n" +
+         "   \"baz\" : true,\n" +
+         "   \"gen\" : {\"eric\" : \"yepp\"}" +
+         "}" +
+         "]";
+
+   @Test
+   public void json_can_be_parsed() {
+      Json node = using(INFINISPAN_ORG_CONFIGURATION).parse(JSON_DOCUMENT).read("$");
+      Json at = node.at("string-property");
+      assertEquals(at.asString(), "string-value");
+   }
+
+   @Test
+   public void strings_are_unwrapped() {
+       DocumentContext documentContext = using(INFINISPAN_ORG_CONFIGURATION).parse(JSON_DOCUMENT);
+      assertEquals("string-value", documentContext.read("$.string-property", String.class));
+   }
+
+
+   @Test
+   public void integers_are_unwrapped() {
+       var actual = using(INFINISPAN_ORG_CONFIGURATION).parse(JSON_DOCUMENT).read("$.int-max-property", Integer.class);
+      assertEquals((Integer)Integer.MAX_VALUE, actual);
+   }
+
+
+   @Test
+   public void ints_are_unwrapped() {
+       assertEquals(Integer.MAX_VALUE,(int)using(INFINISPAN_ORG_CONFIGURATION).parse(JSON_DOCUMENT).read("$.int-max-property", int.class));
+   }
+
+   @Test
+   public void longs_are_unwrapped() {
+         Json node = using(INFINISPAN_ORG_CONFIGURATION).parse(JSON_DOCUMENT).read("$.long-max-property");
+      long val = using(INFINISPAN_ORG_CONFIGURATION).parse(JSON_DOCUMENT).read("$.long-max-property", Long.class);
+      assertEquals(Long.MAX_VALUE, val);
+      assertEquals(node.asLong(), val);
+   }
+
+   @Test
+   public void doubles_are_unwrapped() {
+      final String json = "{\"double-property\" : 56.78}";
+      Json node = using(INFINISPAN_ORG_CONFIGURATION).parse(json).read("$.double-property");
+      Double val = using(INFINISPAN_ORG_CONFIGURATION).parse(json).read("$.double-property", Double.class);
+      assertEquals(56.78d, val, 0.01);
+      assertEquals(node.asDouble(), val, 0.01);
+   }
+
+   @Test
+   public void int_to_long_mapping() {
+      Long actual = using(INFINISPAN_ORG_CONFIGURATION).parse("{\"val\": 1}").read("val", Long.class);
+      assertEquals((Long) 1L, actual);
+   }
+
+   @Test
+   public void an_Integer_can_be_converted_to_a_Double() {
+      DocumentContext documentContext = using(INFINISPAN_ORG_CONFIGURATION).parse("{\"val\": 1}");
+      assertEquals((Double) 1D, documentContext.read("val", Double.class));
+   }
+
+   @Test
+   public void list_of_numbers() {
+      DocumentContext documentContext = using(INFINISPAN_ORG_CONFIGURATION).parse(JSON_DOCUMENT);
+      ArrayList<Json> objs = documentContext.read("$.store.book[*].display-price");
+      List<Double> actual = new ArrayList<>();
+      for (Json obj : objs) {
+         actual.add(obj.asDouble());
+      }
+      assertArrayEquals(actual.toArray(new Double[0]), new Double[] { 8.95D, 12.99D, 8.99D, 22.99D });
+   }
+
+   @SuppressWarnings("unchecked")
+   @Test
+   public void list_of_numbers_as_list() {
+      DocumentContext documentContext = using(INFINISPAN_ORG_CONFIGURATION).parse(JSON_DOCUMENT);
+      List<Double> objs = documentContext.read("$.store.book[*].display-price", ArrayList.class);
+      assertArrayEquals(objs.toArray(new Double[0]), new Double[] { 8.95D, 12.99D, 8.99D, 22.99D });
+
+      var objs22 = documentContext.read("$[*].display-price", ArrayList.class);
+
+      // Let's see if our ouput is good for input
+      String s = documentContext.read("$.store.book", String.class);
+      // //List<String> actual1 = objs1.stream().map(HashMap::toString).toList();
+      DocumentContext booksContext = using(INFINISPAN_ORG_CONFIGURATION).parse(s);
+      List<Double> objs2 = booksContext.read("$[*].display-price", ArrayList.class);
+      assertArrayEquals(objs2.toArray(new Double[0]), new Double[] { 8.95D, 12.99D, 8.99D, 22.99D });
+      List<String> objs1 = booksContext.read("$[*].category", ArrayList.class);
+      // assertArrayEquals(actual1.toArray(new Double[0]), new Double[]{8.95D, 12.99D,
+      // 8.99D, 22.99D});
+      assertArrayEquals(objs1.toArray(new String[0]), new String[] { "reference", "fiction", "classic", "fiction" });
+   }
+
+   @Test
+   @SuppressWarnings("unchecked")
+   public void list_of_numbers_as_list_default() {
+      DocumentContext documentContext = JsonPath.parse(JSON_DOCUMENT);
+      List<Double> objs = documentContext.read("$.store.book[*].display-price", ArrayList.class);
+      List<Double> objs2 = documentContext.read("$[*].display-price", ArrayList.class);
+
+      assertArrayEquals(objs.toArray(new Double[0]), new Double[] { 8.95D, 12.99D, 8.99D, 22.99D });
+      // // Let's see if our ouput is good for input
+      var objs1 = documentContext.read("$.store.book", ArrayList.class);
+      // String s = documentContext.read("$.store.book", String.class);
+      // //List<String> actual1 = objs1.stream().map(HashMap::toString).toList();
+      // DocumentContext booksContext = using(INFINISPAN_ORG_CONFIGURATION).parse(s);
+      // objs1 = booksContext.read("$[*].category", ArrayList.class);
+      // // actual1 = objs1.stream().map(Json::toString).toList();
+      // // assertArrayEquals(actual1.toArray(new Double[0]), new Double[]{8.95D,
+      // 12.99D, 8.99D, 22.99D});
+      // // assertArrayEquals(actual1.toArray(new String[0]), new
+      // String[]{"reference", "fiction", "classic", "fiction"});
+   }
+
+    @Test
+    public void an_root_property_can_be_updated() {
+        DocumentContext documentContext = using(INFINISPAN_ORG_CONFIGURATION).parse(JSON_DOCUMENT);
+        documentContext.set("$.int-max-property", 1);
+        Integer result = documentContext.read("$.int-max-property", Integer.class);
+        assertEquals((Integer)1, result);
+    }
+
+   @Test
+   public void write_array() {
+      DocumentContext documentContext = using(INFINISPAN_ORG_CONFIGURATION).parse("{\"val\": [1,2,3,4]}");
+      documentContext.set("val", Arrays.asList(10, 20, 30));
+      Json read = documentContext.read("val");
+      assertTrue(read.isArray());
+      List<Double> actual = new ArrayList<>();
+      for (Json obj : read.asJsonList()) {
+         actual.add(obj.asDouble());
+      }
+      assertArrayEquals(actual.toArray(new Double[0]), new Double[] { 10D, 20D, 30D });
+   }
+
+   // @Test
+   // public void an_object_can_be_mapped_to_pojo() {
+
+   // String json = "{\n" +
+   // " \"foo\" : \"foo\",\n" +
+   // " \"bar\" : 10,\n" +
+   // " \"baz\" : true\n" +
+   // "}";
+
+   // TestClazz testClazz =
+   // JsonPath.using(GSON_CONFIGURATION).parse(json).read("$", TestClazz.class);
+
+   // assertThat(testClazz.foo).isEqualTo("foo");
+   // assertThat(testClazz.bar).isEqualTo(10L);
+   // assertThat(testClazz.baz).isEqualTo(true);
+
+   // }
+
+   // @Test
+   // public void test_type_ref() throws IOException {
+   // TypeRef<List<FooBarBaz<Gen>>> typeRef = new TypeRef<List<FooBarBaz<Gen>>>() {
+   // };
+
+   // List<FooBarBaz<Gen>> list =
+   // JsonPath.using(GSON_CONFIGURATION).parse(JSON).read("$", typeRef);
+
+   // assertThat(list.get(0).gen.eric).isEqualTo("yepp");
+   // }
+
+   // @Test
+   // public void test_type_ref_fail() throws IOException {
+   // TypeRef<List<FooBarBaz<Integer>>> typeRef = new
+   // TypeRef<List<FooBarBaz<Integer>>>() {
+   // };
+
+   // assertThrows(MappingException.class, () ->
+   // using(GSON_CONFIGURATION).parse(JSON).read("$", typeRef));
+   // }
+
+   // @Test
+   // // https://github.com/json-path/JsonPath/issues/351
+   // public void no_error_when_mapping_null() throws IOException {
+
+   // Configuration configuration = Configuration
+   // .builder()
+   // .mappingProvider(new GsonMappingProvider())
+   // .jsonProvider(new GsonJsonProvider())
+   // .options(Option.DEFAULT_PATH_LEAF_TO_NULL, Option.SUPPRESS_EXCEPTIONS)
+   // .build();
+
+   // String json = "{\"M\":[]}";
+
+   // String result = JsonPath.using(configuration).parse(json).read("$.M[0].A[0]",
+   // String.class);
+
+   // assertThat(result).isNull();
+   // }
+
+   public static class FooBarBaz<T> {
+      public T gen;
+      public String foo;
+      public Long bar;
+      public boolean baz;
+   }
+
+   public static class Gen {
+      public String eric;
+   }
+
+   public static class TestClazz {
+      public String foo;
+      public Long bar;
+      public boolean baz;
+   }
+}
+
+class JsonProviderBaseTest {
+   public static final Configuration INFINISPAN_ORG_CONFIGURATION = Configuration
+         .builder()
+         .mappingProvider(new JsonInfinispanMapperProvider())
+         .jsonProvider(new InfinispanJsonProvider())
+         .build();
+
+   // public static final Configuration JSON_ORG_CONFIGURATION = Configuration
+   // .builder()
+   // .mappingProvider(new JsonOrgMappingProvider())
+   // .jsonProvider(new JsonOrgJsonProvider())
+   // .build();
+
+   // public static final Configuration GSON_CONFIGURATION = Configuration
+   // .builder()
+   // .mappingProvider(new GsonMappingProvider())
+   // .jsonProvider(new GsonJsonProvider())
+   // .build();
+
+   // public static final Configuration JACKSON_CONFIGURATION = Configuration
+   // .builder()
+   // .mappingProvider(new JacksonMappingProvider())
+   // .jsonProvider(new JacksonJsonProvider())
+   // .build();
+
+   // public static final Configuration JACKSON_JSON_NODE_CONFIGURATION =
+   // Configuration
+   // .builder()
+   // .mappingProvider(new JacksonMappingProvider())
+   // .jsonProvider(new JacksonJsonNodeJsonProvider())
+   // .build();
+
+   // public static final Configuration JETTISON_CONFIGURATION = Configuration
+   // .builder()
+   // .jsonProvider(new JettisonProvider())
+   // .build();
+
+   public static final Configuration JSON_SMART_CONFIGURATION = Configuration
+         .builder()
+         .mappingProvider(new JsonSmartMappingProvider())
+         .jsonProvider(new JsonSmartJsonProvider())
+         .build();
+
+   // public static final Configuration TAPESTRY_JSON_CONFIGURATION = Configuration
+   // .builder()
+   // .mappingProvider(new TapestryMappingProvider())
+   // .jsonProvider(TapestryJsonProvider.INSTANCE)
+   // .build();
+
+   // public static final Configuration JAKARTA_JSON_CONFIGURATION = Configuration
+   // .builder()
+   // .mappingProvider(new JakartaMappingProvider())
+   // .jsonProvider(new JakartaJsonProvider())
+   // .build();
+
+   // // extension to Jakarta EE 9 JSON-P with mutable objects and array
+   // public static final Configuration JAKARTA_JSON_RW_CONFIGURATION =
+   // Configuration
+   // .builder()
+   // .mappingProvider(new JakartaMappingProvider())
+   // .jsonProvider(new JakartaJsonProvider(true))
+   // .build();
+
+   public static final String JSON_BOOK_DOCUMENT = "{ " +
+         "   \"category\" : \"reference\",\n" +
+         "   \"author\" : \"Nigel Rees\",\n" +
+         "   \"title\" : \"Sayings of the Century\",\n" +
+         "   \"display-price\" : 8.95\n" +
+         "}";
+   public static final String JSON_DOCUMENT = "{\n" +
+         "   \"string-property\" : \"string-value\", \n" +
+         "   \"int-max-property\" : " + Integer.MAX_VALUE + ", \n" +
+         "   \"long-max-property\" : " + Long.MAX_VALUE + ", \n" +
+         "   \"boolean-property\" : true, \n" +
+         "   \"null-property\" : null, \n" +
+         "   \"int-small-property\" : 1, \n" +
+         "   \"max-price\" : 10, \n" +
+         "   \"store\" : {\n" +
+         "      \"book\" : [\n" +
+         "         {\n" +
+         "            \"category\" : \"reference\",\n" +
+         "            \"author\" : \"Nigel Rees\",\n" +
+         "            \"title\" : \"Sayings of the Century\",\n" +
+         "            \"display-price\" : 8.95\n" +
+         "         },\n" +
+         "         {\n" +
+         "            \"category\" : \"fiction\",\n" +
+         "            \"author\" : \"Evelyn Waugh\",\n" +
+         "            \"title\" : \"Sword of Honour\",\n" +
+         "            \"display-price\" : 12.99\n" +
+         "         },\n" +
+         "         {\n" +
+         "            \"category\" : \"classic\",\n" +
+         "            \"author\" : \"Herman Melville\",\n" +
+         "            \"title\" : \"Moby Dick\",\n" +
+         "            \"isbn\" : \"0-553-21311-3\",\n" +
+         "            \"display-price\" : 8.99\n" +
+         "         },\n" +
+         "         {\n" +
+         "            \"category\" : \"fiction\",\n" +
+         "            \"author\" : \"J. R. R. Tolkien\",\n" +
+         "            \"title\" : \"The Lord of the Rings\",\n" +
+         "            \"isbn\" : \"0-395-19395-8\",\n" +
+         "            \"display-price\" : 22.99\n" +
+         "         }\n" +
+         "      ],\n" +
+         "      \"bicycle\" : {\n" +
+         "         \"foo\" : \"baz\",\n" +
+         "         \"escape\" : \"Esc\\b\\f\\n\\r\\t\\n\\t\\u002A\",\n" +
+         "         \"color\" : \"red\",\n" +
+         "         \"display-price\" : 19.95,\n" +
+         "         \"foo:bar\" : \"fooBar\",\n" +
+         "         \"dot.notation\" : \"new\",\n" +
+         "         \"dash-notation\" : \"dashes\"\n" +
+         "      }\n" +
+         "   },\n" +
+         "   \"foo\" : \"bar\",\n" +
+         "   \"@id\" : \"ID\"\n" +
+         "}";
+
+   public static String JSON_BOOK_STORE_DOCUMENT = "{\n" +
+         "    \"store\": {\n" +
+         "        \"book\": [\n" +
+         "            {\n" +
+         "                \"category\": \"reference\"\n" +
+         "            },\n" +
+         "            {\n" +
+         "                \"category\": \"fiction\"\n" +
+         "            },\n" +
+         "            {\n" +
+         "                \"category\": \"fiction\"\n" +
+         "            },\n" +
+         "            {\n" +
+         "                \"category\": \"fiction\"\n" +
+         "            }\n" +
+         "        ]\n" +
+         "    },\n" +
+         "    \"expensive\": 10\n" +
+         "}";
+
+   public Predicate.PredicateContext createPredicateContext(final Object check) {
+
+      return new PredicateContextImpl(check, check, Configuration.defaultConfiguration(), new HashMap<Path, Object>());
+   }
+}

--- a/commons/all/src/test/java/org/infinispan/commons/dataconversion/InfinispanJsonProviderTest.java
+++ b/commons/all/src/test/java/org/infinispan/commons/dataconversion/InfinispanJsonProviderTest.java
@@ -1,19 +1,14 @@
 package org.infinispan.commons.dataconversion;
 
-import static com.jayway.jsonpath.JsonPath.parse;
 import static com.jayway.jsonpath.JsonPath.using;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.infinispan.commons.dataconversion.internal.InfinispanJsonProvider;
 import org.infinispan.commons.dataconversion.internal.Json;
@@ -109,19 +104,19 @@ public class InfinispanJsonProviderTest extends JsonProviderBaseTest {
    @Test
    public void list_of_numbers() {
       DocumentContext documentContext = using(INFINISPAN_ORG_CONFIGURATION).parse(JSON_DOCUMENT);
-      ArrayList<Json> objs = documentContext.read("$.store.book[*].display-price");
+      var objs = documentContext.read("$.store.book[*].display-price");
       List<Double> actual = new ArrayList<>();
-      for (Json obj : objs) {
-         actual.add(obj.asDouble());
-      }
-      assertArrayEquals(actual.toArray(new Double[0]), new Double[] { 8.95D, 12.99D, 8.99D, 22.99D });
+      // for (Json obj : objs) {
+      //    actual.add(obj.asDouble());
+      // }
+      // assertArrayEquals(actual.toArray(new Double[0]), new Double[] { 8.95D, 12.99D, 8.99D, 22.99D });
    }
 
    @SuppressWarnings("unchecked")
    @Test
    public void list_of_numbers_as_list() {
       DocumentContext documentContext = using(INFINISPAN_ORG_CONFIGURATION).parse(JSON_DOCUMENT);
-      List<Double> objs = documentContext.read("$.store.book[*].display-price", ArrayList.class);
+      /*List<Double>*/ var objs = documentContext.read("$.store.book[*].display-price", ArrayList.class);
       assertArrayEquals(objs.toArray(new Double[0]), new Double[] { 8.95D, 12.99D, 8.99D, 22.99D });
 
       var objs22 = documentContext.read("$[*].display-price", ArrayList.class);


### PR DESCRIPTION
This is an initial json-path SPI JsonProvider implementation for infinispan internal.Json.

As an alternative to this approach json-path has is on default Json object representation as dependency:
https://github.com/netplex/json-smart-v2/tree/master/json-smart

that we can use