### PR TITLE
ISPN-16638 Don't fail the pipeline if flaky jira fails

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -202,10 +202,11 @@ pipeline {
                 pmdParser(pattern: '**/target/pmd.xml'),
                 cpd(pattern: '**/target/cpd.xml')
             ]
-
-            script {
-               env.TARGET_BRANCH = env.BRANCH_NAME.startsWith('PR-') ? env.CHANGE_TARGET : env.BRANCH_NAME
-               sh 'FLAKY_TEST_GLOB="**/target/*-reports*/**/TEST-*FLAKY.xml" PROJECT_KEY=ISPN TYPE=Bug JENKINS_JOB_URL=$BUILD_URL TARGET_BRANCH=${TARGET_BRANCH} ./bin/jira/track_flaky_tests.sh'
+            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+               script {
+                  env.TARGET_BRANCH = env.BRANCH_NAME.startsWith('PR-') ? env.CHANGE_TARGET : env.BRANCH_NAME
+                  sh 'FLAKY_TEST_GLOB="**/target/*-reports*/**/TEST-*FLAKY.xml" PROJECT_KEY=ISPN TYPE=Bug JENKINS_JOB_URL=$BUILD_URL TARGET_BRANCH=${TARGET_BRANCH} ./bin/jira/track_flaky_tests.sh'
+               }
             }
         }
 

--- a/bin/jira/track_flaky_tests.sh
+++ b/bin/jira/track_flaky_tests.sh
@@ -22,8 +22,11 @@ for TEST in "${TESTS[@]}"; do
     TEST_NAME=$(xmlstarlet sel --template --value-of '/testsuite/testcase['$i']/@name' ${TEST})
     # Removing (Flaky Test) text
     TEST_NAME=${TEST_NAME% (Flaky Test)}
-    # Removing square brakets with execution counter i.e. flakyTest[1]
+    # Some tests have arguments with backslash, ie testReplace\[NO_TX, P_TX\]. Removing
+    TEST_NAME=${TEST_NAME%%\[*}
+    # Some tests have it without backslash or have fail counter, ie testContainsAll[1]. Removing
     TEST_NAME=${TEST_NAME%%[*}
+    # Some tests end with \(. Removing
     TEST_NAME_NO_PARAMS=${TEST_NAME%%\(*}
     STACK_TRACE=$(xmlstarlet sel --template --value-of '/testsuite/testcase/failure['$i']' ${TEST})
 


### PR DESCRIPTION
Only fail the post build stage  instead of the whole pipeline
also fixed test name extraction (some test with arguments contains `\[`)
