### PR TITLE
ISPN-16597 Client iteration can miss segments due to invalid iteration response during shutdown

### DIFF
--- a/client/hotrod-client-new/src/main/java/org/infinispan/client/hotrod/impl/iteration/RemotePublisher.java
+++ b/client/hotrod-client-new/src/main/java/org/infinispan/client/hotrod/impl/iteration/RemotePublisher.java
@@ -79,7 +79,7 @@ public class RemotePublisher<K, E> implements Publisher<Map.Entry<K, E>> {
       if (segments == null) {
          AtomicBoolean shouldRetry = new AtomicBoolean(true);
 
-         RemoteInnerPublisherHandler<K, E> innerHandler = new RemoteInnerPublisherHandler<K, E>(this,
+         RemoteInnerPublisherHandler<K, E> innerHandler = new RemoteInnerPublisherHandler<>(this,
                batchSize, () -> {
             // Note that this publisher will continue to return empty entries until it has completed a given
             // target without encountering a Throwable

--- a/client/hotrod-client-new/src/main/java/org/infinispan/client/hotrod/impl/operations/IterationNextOperation.java
+++ b/client/hotrod-client-new/src/main/java/org/infinispan/client/hotrod/impl/operations/IterationNextOperation.java
@@ -118,7 +118,7 @@ public class IterationNextOperation<K, E> extends AbstractCacheOperation<Iterati
       if (HotRodConstants.isInvalidIteration(status)) {
          throw HOTROD.errorRetrievingNext(new String(iterationId, HOTROD_STRING_CHARSET));
       }
-      return new IterationNextResponse<>(status, entries, finishedSegmentSet, entriesSize > 0);
+      return new IterationNextResponse<>(status, entries, finishedSegmentSet, true);
    }
 
    @Override

--- a/client/hotrod-client-new/src/test/java/org/infinispan/client/hotrod/impl/iteration/BaseIterationFailOverTest.java
+++ b/client/hotrod-client-new/src/test/java/org/infinispan/client/hotrod/impl/iteration/BaseIterationFailOverTest.java
@@ -70,8 +70,6 @@ public abstract class BaseIterationFailOverTest extends MultiHotRodServersTest {
 
       }
 
-      assertEquals(cacheSize, entries.size());
-
       Set<Integer> keys = extractKeys(entries);
       assertEquals(rangeAsSet(0, cacheSize), keys);
    }

--- a/client/hotrod-client-new/src/test/java/org/infinispan/client/hotrod/impl/iteration/Util.java
+++ b/client/hotrod-client-new/src/test/java/org/infinispan/client/hotrod/impl/iteration/Util.java
@@ -30,7 +30,7 @@ class Util {
    }
 
    static <T> void populateCache(int numElements, Function<Integer, T> supplier, RemoteCache<Integer, T> remoteCache) {
-      IntStream.range(0, numElements).parallel().forEach(i -> remoteCache.put(i, supplier.apply(i)));
+      IntStream.range(0, numElements).forEach(i -> remoteCache.put(i, supplier.apply(i)));
    }
 
    static <T> void assertForAll(Collection<T> elements, Predicate<? super T> condition) {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/iteration/RemoteInnerPublisherHandler.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/iteration/RemoteInnerPublisherHandler.java
@@ -13,6 +13,7 @@ import org.infinispan.client.hotrod.exceptions.RemoteIllegalLifecycleStateExcept
 import org.infinispan.client.hotrod.exceptions.TransportException;
 import org.infinispan.client.hotrod.impl.operations.IterationNextResponse;
 import org.infinispan.client.hotrod.impl.operations.IterationStartResponse;
+import org.infinispan.client.hotrod.impl.protocol.HotRodConstants;
 import org.infinispan.client.hotrod.logging.Log;
 import org.infinispan.client.hotrod.logging.LogFactory;
 import org.infinispan.commons.reactive.AbstractAsyncPublisherHandler;
@@ -91,7 +92,13 @@ class RemoteInnerPublisherHandler<K, E> extends AbstractAsyncPublisherHandler<Ma
       if (!nextResponse.hasMore()) {
          // server doesn't clean up when complete
          sendCancel(target);
-         publisher.completeSegments(target.getValue());
+         // Don't complete the segments if it was an invalid iteration
+         if (nextResponse.getStatus() != HotRodConstants.INVALID_ITERATION) {
+            log.tracef("No more entries retrieved, so completing segments %s from %s", target.getValue(), target.getKey());
+            publisher.completeSegments(target.getValue());
+         } else {
+            log.tracef("Invalid iteration response, so must retry segments %s", target.getValue());
+         }
          targetComplete();
       }
       IntSet completedSegments = nextResponse.getCompletedSegments();
@@ -100,6 +107,8 @@ class RemoteInnerPublisherHandler<K, E> extends AbstractAsyncPublisherHandler<Ma
          if (targetSegments != null) {
             targetSegments.removeAll(completedSegments);
          }
+         log.tracef("Completed segments: %s still have %s left for %s", completedSegments, targetSegments,
+               target.getKey());
       }
       publisher.completeSegments(completedSegments);
       List<Map.Entry<K, E>> entries = nextResponse.getEntries();

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/iteration/RemotePublisher.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/iteration/RemotePublisher.java
@@ -79,7 +79,7 @@ public class RemotePublisher<K, E> implements Publisher<Map.Entry<K, E>> {
       if (segments == null) {
          AtomicBoolean shouldRetry = new AtomicBoolean(true);
 
-         RemoteInnerPublisherHandler<K, E> innerHandler = new RemoteInnerPublisherHandler<K, E>(this,
+         RemoteInnerPublisherHandler<K, E> innerHandler = new RemoteInnerPublisherHandler<>(this,
                batchSize, () -> {
             // Note that this publisher will continue to return empty entries until it has completed a given
             // target without encountering a Throwable

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/IterationNextOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/IterationNextOperation.java
@@ -130,7 +130,7 @@ public class IterationNextOperation<K, E> extends HotRodOperation<IterationNextR
       if (HotRodConstants.isInvalidIteration(status)) {
          throw HOTROD.errorRetrievingNext(new String(iterationId, HOTROD_STRING_CHARSET));
       }
-      complete(new IterationNextResponse<>(status, entries, finishedSegmentSet, entriesSize > 0));
+      complete(new IterationNextResponse<>(status, entries, finishedSegmentSet, true));
    }
 
    private <M> M unmarshallValue(byte[] bytes) {

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/BaseIterationFailOverTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/BaseIterationFailOverTest.java
@@ -70,8 +70,6 @@ public abstract class BaseIterationFailOverTest extends MultiHotRodServersTest {
 
       }
 
-      assertEquals(cacheSize, entries.size());
-
       Set<Integer> keys = extractKeys(entries);
       assertEquals(rangeAsSet(0, cacheSize), keys);
    }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/Util.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/Util.java
@@ -30,7 +30,7 @@ class Util {
    }
 
    static <T> void populateCache(int numElements, Function<Integer, T> supplier, RemoteCache<Integer, T> remoteCache) {
-      IntStream.range(0, numElements).parallel().forEach(i -> remoteCache.put(i, supplier.apply(i)));
+      IntStream.range(0, numElements).forEach(i -> remoteCache.put(i, supplier.apply(i)));
    }
 
    static <T> void assertForAll(Collection<T> elements, Predicate<? super T> condition) {


### PR DESCRIPTION
* Fix issue where an invalid iteration request would complete segments

https://issues.redhat.com/browse/ISPN-16597