### PR TITLE
ISPN-16674 Flaky test: org.infinispan.client.hotrod.retry.TopologyUpd…

### DIFF
--- a/client/hotrod-client-new/src/main/java/org/infinispan/client/hotrod/impl/operations/DelegatingHotRodOperation.java
+++ b/client/hotrod-client-new/src/main/java/org/infinispan/client/hotrod/impl/operations/DelegatingHotRodOperation.java
@@ -100,4 +100,11 @@ public abstract class DelegatingHotRodOperation<T> extends HotRodOperation<T> {
    void handleStatsCompletion(ClientStatistics statistics, long startTime, short status, T responseValue) {
       delegate.handleStatsCompletion(statistics, startTime, status, responseValue);
    }
+
+   @Override
+   public String toString() {
+      return "getClass().getSimpleName(){" +
+            "delegate=" + delegate +
+            '}';
+   }
 }

--- a/client/hotrod-client-new/src/main/java/org/infinispan/client/hotrod/impl/operations/HotRodOperation.java
+++ b/client/hotrod-client-new/src/main/java/org/infinispan/client/hotrod/impl/operations/HotRodOperation.java
@@ -58,7 +58,7 @@ public abstract class HotRodOperation<T> extends CompletableFuture<T> implements
       // Default is operation does nothing
    }
 
-                              @Override
+   @Override
    public String toString() {
       String cn = getCacheName() == null || getCacheName().length() == 0 ? "(default)" : getCacheName();
       StringBuilder sb = new StringBuilder(64);

--- a/client/hotrod-client-new/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/OperationChannel.java
+++ b/client/hotrod-client-new/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/OperationChannel.java
@@ -111,6 +111,11 @@ public class OperationChannel implements MessagePassingQueue.Consumer<HotRodOper
       this.codec = codec;
    }
 
+   public boolean isAcceptingRequests() {
+      var f = attemptedConnect.get();
+      return f != null && f.isDone();
+   }
+
    public void markAcceptingRequests() {
       channel.eventLoop().submit(() -> {
          // We can't mark it as complete until we are authenticated

--- a/client/hotrod-client-new/src/test/java/org/infinispan/client/hotrod/retry/TopologyUpdateRetryTest.java
+++ b/client/hotrod-client-new/src/test/java/org/infinispan/client/hotrod/retry/TopologyUpdateRetryTest.java
@@ -35,6 +35,9 @@ public class TopologyUpdateRetryTest extends AbstractRetryTest {
 
       CountDownLatch latch = new CountDownLatch(1);
 
+      // Don't block the event loop until it can accept requests
+      eventually(opChannel::isAcceptingRequests);
+
       // Block the event loop which will prevent the operations from being processed
       opChannel.getChannel().eventLoop().submit(() -> latch.await(10, TimeUnit.SECONDS));
 


### PR DESCRIPTION
…ateRetryTest#testTopologyChangeWithQueuedOperations

* Wait until channel is fully configured before blocking event loop

https://issues.redhat.com/browse/ISPN-16674