### PR TITLE
ISPN-12828 Post start from security action

### DIFF
--- a/server/runtime/src/main/java/org/infinispan/server/SecurityActions.java
+++ b/server/runtime/src/main/java/org/infinispan/server/SecurityActions.java
@@ -3,6 +3,7 @@ package org.infinispan.server;
 import static org.infinispan.security.Security.doPrivileged;
 
 import java.security.Provider;
+import java.util.Collection;
 import java.util.function.Supplier;
 
 import javax.naming.NamingException;
@@ -59,6 +60,12 @@ final class SecurityActions {
       doPrivileged(() -> {
          server.start(configuration, cacheManager);
          return null;
+      });
+   }
+
+   static void postStartProtocolServer(Collection<ProtocolServer> servers) {
+      doPrivileged(() -> {
+         servers.forEach(ProtocolServer::postStart);
       });
    }
 

--- a/server/runtime/src/main/java/org/infinispan/server/Server.java
+++ b/server/runtime/src/main/java/org/infinispan/server/Server.java
@@ -515,7 +515,7 @@ public class Server extends BaseServerManagement implements AutoCloseable {
          serverStateManager.start();
          // Change status
          this.status = ComponentStatus.RUNNING;
-         protocolServers.forEach((ignore, s) -> s.postStart());
+         SecurityActions.postStartProtocolServer(protocolServers.values());
          log.serverStarted(Version.getBrandName(), Version.getBrandVersion(), timeService.timeDuration(startTime, TimeUnit.MILLISECONDS));
       } catch (Exception e) {
          r.completeExceptionally(e);


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-12828

Fix for #12912. It should call postStart with a context to have permission to create the cache.