### PR TITLE
[15.0.x] ISPN-16748 [RESP] WATCH within a MULTI should not fail

### DIFF
--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/tx/WATCH.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/tx/WATCH.java
@@ -78,7 +78,6 @@ public class WATCH extends RespCommand implements Resp3Command, TransactionResp3
    @Override
    public CompletionStage<RespRequestHandler> perform(RespTransactionHandler handler, ChannelHandlerContext ctx, List<byte[]> arguments) {
       RespErrorUtil.customError("WATCH inside MULTI is not allowed", handler.allocator());
-      handler.errorInTransactionContext();
       return handler.myStage();
    }
 

--- a/server/resp/src/test/java/org/infinispan/server/resp/TransactionOperationsTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/TransactionOperationsTest.java
@@ -3,6 +3,8 @@ package org.infinispan.server.resp;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.infinispan.server.resp.test.RespTestingUtil.OK;
+import static org.infinispan.test.TestingUtil.k;
+import static org.infinispan.test.TestingUtil.v;
 
 import java.util.concurrent.TimeUnit;
 
@@ -102,20 +104,30 @@ public class TransactionOperationsTest extends SingleNodeRespBaseTest {
       multi.closeAsync().get(10, TimeUnit.SECONDS);
    }
 
-   @Test
-   public void testTransactionAbortWithError() {
+   @Test(enabled = false, description = "redis/lettuce#3009")
+   public void testWatchInMultiNotAbort() {
       RedisCommands<String, String> redis = redisConnection.sync();
 
       assertThat(redis.multi()).isEqualTo(OK);
       assertThat(redisConnection.isMulti()).isTrue();
 
+      redis.set(k(), v());
+      redis.set(k(1), v(1));
+
       // This returns an -ERR, but lettuce just returns null when in TX context.
       assertThat(redis.watch("something")).isNull();
 
+      redis.set(k(2), v(2));
 
-      assertThatThrownBy(redis::exec)
-            .isInstanceOf(RedisCommandExecutionException.class)
-            .hasMessage("EXECABORT Transaction discarded because of previous errors.");
+      TransactionResult result = redis.exec();
+      assertThat(result.wasDiscarded()).isFalse();
+      assertThat(result)
+            .hasSize(3)
+            .allMatch(OK::equals);
+
+      for (int i = 0; i < 3; i++) {
+         assertThat(redis.get(k(i))).isEqualTo(v(i));
+      }
    }
 
    @Test


### PR DESCRIPTION
**Backport:** https://github.com/infinispan/infinispan/pull/13027

https://issues.redhat.com/browse/ISPN-16748

The test is disabled because Lettuce can't properly parse the EXEC response in this case.