### PR TITLE
ISPN-16329 RESP3 response serialization compliance

### DIFF
--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/sortedset/ZSCAN.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/sortedset/ZSCAN.java
@@ -1,15 +1,5 @@
 package org.infinispan.server.resp.commands.sortedset;
 
-import org.infinispan.container.entries.CacheEntry;
-import org.infinispan.multimap.impl.EmbeddedMultimapSortedSetCache;
-import org.infinispan.multimap.impl.ScoredValue;
-import org.infinispan.server.iteration.IterationInitializationContext;
-import org.infinispan.server.iteration.IterationManager;
-import org.infinispan.server.iteration.list.ListIterationInitializationContext;
-import org.infinispan.server.resp.Resp3Handler;
-import org.infinispan.server.resp.commands.generic.SCAN;
-import org.infinispan.server.resp.commands.iteration.BaseIterationCommand;
-
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -17,6 +7,17 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletionStage;
+
+import org.infinispan.container.entries.CacheEntry;
+import org.infinispan.multimap.impl.EmbeddedMultimapSortedSetCache;
+import org.infinispan.multimap.impl.ScoredValue;
+import org.infinispan.server.iteration.IterationInitializationContext;
+import org.infinispan.server.iteration.IterationManager;
+import org.infinispan.server.iteration.list.ListIterationInitializationContext;
+import org.infinispan.server.resp.Resp3Handler;
+import org.infinispan.server.resp.commands.ArgumentUtils;
+import org.infinispan.server.resp.commands.generic.SCAN;
+import org.infinispan.server.resp.commands.iteration.BaseIterationCommand;
 
 /**
  * See {@link SCAN} for {@link ZSCAN} documentation.
@@ -50,8 +51,7 @@ public class ZSCAN extends BaseIterationCommand {
       Iterator<ScoredValue<byte[]>> ite = scoredValues.iterator();
       while (ite.hasNext()) {
         ScoredValue<byte[]> item = ite.next();
-         Map.Entry<Object, Object> entry = Map.entry(item.getValue(),
-               Double.toString(item.score()).getBytes(StandardCharsets.US_ASCII));
+         Map.Entry<Object, Object> entry = Map.entry(item.getValue(), ArgumentUtils.toByteArray(item.score()));
          elements.add(entry);
       }
       return elements;

--- a/server/resp/src/main/java/org/infinispan/server/resp/serialization/DoubleSerializer.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/serialization/DoubleSerializer.java
@@ -1,7 +1,8 @@
 package org.infinispan.server.resp.serialization;
 
+import java.nio.charset.StandardCharsets;
+
 import org.infinispan.server.resp.ByteBufPool;
-import org.infinispan.server.resp.commands.ArgumentUtils;
 
 import io.netty.buffer.ByteBuf;
 
@@ -65,7 +66,7 @@ final class DoubleSerializer implements ResponseSerializer<Double> {
    }
 
    private byte[] serializeDouble(double value) {
-      return ArgumentUtils.toByteArray(value);
+      return Double.toString(value).getBytes(StandardCharsets.US_ASCII);
    }
 
    @Override

--- a/server/resp/src/test/java/org/infinispan/server/resp/SortedSetCommandsTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/SortedSetCommandsTest.java
@@ -1,5 +1,24 @@
 package org.infinispan.server.resp;
 
+import static io.lettuce.core.Range.Boundary.excluding;
+import static io.lettuce.core.Range.Boundary.including;
+import static io.lettuce.core.Range.Boundary.unbounded;
+import static io.lettuce.core.Range.create;
+import static io.lettuce.core.Range.from;
+import static io.lettuce.core.ScoredValue.just;
+import static io.lettuce.core.ZAggregateArgs.Builder.max;
+import static io.lettuce.core.ZAggregateArgs.Builder.min;
+import static io.lettuce.core.ZAggregateArgs.Builder.sum;
+import static io.lettuce.core.ZAggregateArgs.Builder.weights;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.infinispan.server.resp.test.RespTestingUtil.assertWrongType;
+
+import java.util.List;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
 import io.lettuce.core.KeyValue;
 import io.lettuce.core.Limit;
 import io.lettuce.core.Range;
@@ -17,25 +36,6 @@ import io.lettuce.core.output.IntegerOutput;
 import io.lettuce.core.protocol.CommandArgs;
 import io.lettuce.core.protocol.CommandType;
 
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
-
-import java.util.List;
-
-import static io.lettuce.core.Range.Boundary.excluding;
-import static io.lettuce.core.Range.Boundary.including;
-import static io.lettuce.core.Range.Boundary.unbounded;
-import static io.lettuce.core.Range.create;
-import static io.lettuce.core.Range.from;
-import static io.lettuce.core.ScoredValue.just;
-import static io.lettuce.core.ZAggregateArgs.Builder.max;
-import static io.lettuce.core.ZAggregateArgs.Builder.min;
-import static io.lettuce.core.ZAggregateArgs.Builder.sum;
-import static io.lettuce.core.ZAggregateArgs.Builder.weights;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.infinispan.server.resp.test.RespTestingUtil.assertWrongType;
-
 /**
  * RESP Sorted set commands testing
  *
@@ -51,6 +51,14 @@ public class SortedSetCommandsTest extends SingleNodeRespBaseTest {
    @BeforeMethod
    public void initConnection() {
       redis = redisConnection.sync();
+   }
+
+   public void testDoubleLimit() {
+      double d = 179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368.00000000000000000;
+      redis.zadd("blmax", d, "huge");
+      double actual = redis.zscore("blmax", "huge");
+
+      assertThat(actual).isEqualTo(d);
    }
 
    public void testZADD() {


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-16329

* Pop in sorted set returns a list of lists when count is present;
* Fix DoubleSerializer conversion to byte array;
* Fix double parsing for ZSCAN;