### PR TITLE
[15.0.x] ISPN-16771 [RESP] Fix sinterstore with missing keys

### DIFF
--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/set/SINTERSTORE.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/set/SINTERSTORE.java
@@ -41,7 +41,7 @@ public class SINTERSTORE extends RespCommand implements Resp3Command {
       var keys = arguments.subList(1, arguments.size());
 
       var uniqueKeys = SINTER.getUniqueKeys(handler, keys);
-      var allEntries= esc.getAll(uniqueKeys);
+      var allEntries= esc.getAll(uniqueKeys).thenApply( sets -> SINTER.checkTypeOrEmpty(sets,uniqueKeys.size()));
       return handler.stageToReturn(
             allEntries.thenCompose(sets -> handler.getEmbeddedSetCache().set(destination, SINTER.intersect(sets.values(), 0))),
             ctx,


### PR DESCRIPTION
**Backport:** https://github.com/infinispan/infinispan/pull/13072

Missing keys should be treated as empty set.
Fixes [ISPN-16771](https://issues.redhat.com/browse/ISPN-16771)