### PR TITLE
ISPN-16730 Handle transactional context with many operations

### DIFF
--- a/core/src/main/java/org/infinispan/cache/impl/DecoratedCache.java
+++ b/core/src/main/java/org/infinispan/cache/impl/DecoratedCache.java
@@ -54,7 +54,21 @@ public class DecoratedCache<K, V> extends AbstractDelegatingAdvancedCache<K, V> 
    private final ContextBuilder contextBuilder = this::writeContext;
 
    public DecoratedCache(CacheImpl<K, V> delegate, long flagsBitSet) {
-      this(delegate, null, flagsBitSet);
+      this(delegate, (Object) null, flagsBitSet);
+   }
+
+   public DecoratedCache(AdvancedCache<K, V> delegate, CacheImpl<K, V> impl) {
+      super(delegate);
+      this.flags = 0;
+      this.lockOwner = null;
+      this.cacheImplementation = impl;
+   }
+
+   public DecoratedCache(AdvancedCache<K, V> delegate, CacheImpl<K, V> impl, long flags) {
+      super(delegate);
+      this.flags = flags;
+      this.lockOwner = null;
+      this.cacheImplementation = impl;
    }
 
    public DecoratedCache(CacheImpl<K, V> delegate, Object lockOwner, long newFlags) {
@@ -84,7 +98,7 @@ public class DecoratedCache<K, V> extends AbstractDelegatingAdvancedCache<K, V> 
       return withFlags(EnumUtil.bitSetOf(flag));
    }
 
-   private AdvancedCache<K, V> withFlags(long newFlags) {
+   protected AdvancedCache<K, V> withFlags(long newFlags) {
       if (EnumUtil.containsAll(this.flags, newFlags)) {
          //we already have all specified flags
          return this;

--- a/core/src/main/java/org/infinispan/cache/impl/InternalCache.java
+++ b/core/src/main/java/org/infinispan/cache/impl/InternalCache.java
@@ -1,5 +1,6 @@
 package org.infinispan.cache.impl;
 
+import org.infinispan.context.InvocationContext;
 import org.infinispan.factories.ComponentRegistry;
 
 /**
@@ -8,4 +9,37 @@ import org.infinispan.factories.ComponentRegistry;
  **/
 public interface InternalCache<K, V> {
    ComponentRegistry getComponentRegistry();
+
+   /**
+    * Whether to bypass the {@link org.infinispan.context.InvocationContextFactory} and utilize the
+    * {@link #readContext(DecoratedCache, int)} and {@link #writeContext(DecoratedCache, int)} to
+    * create the {@link InvocationContext} instance.
+    *
+    * @return <code>true</code> to bypass, <code>false</code>, otherwise.
+    */
+   default boolean bypassInvocationContextFactory() {
+      return false;
+   }
+
+   /**
+    * Creates an {@link InvocationContext} using the cache instance for a read operation.
+    *
+    * @param cache Decorated cache to create the context.
+    * @param size Number of keys.
+    * @return a {@link InvocationContext} to utilize for the command execution.
+    */
+   static InvocationContext readContext(DecoratedCache<?, ?> cache, int size) {
+      return cache.readContext(size);
+   }
+
+   /**
+    * Creates an {@link InvocationContext} using the cache instance for a write operation.
+    *
+    * @param cache Decorated cache to create the context.
+    * @param size Number of keys.
+    * @return a {@link InvocationContext} to utilize for the command execution.
+    */
+   static InvocationContext writeContext(DecoratedCache<?, ?> cache, int size) {
+      return cache.writeContext(size);
+   }
 }

--- a/core/src/main/java/org/infinispan/configuration/cache/TransactionConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/TransactionConfigurationBuilder.java
@@ -104,7 +104,7 @@ public class TransactionConfigurationBuilder extends AbstractConfigurationChildB
       return this;
    }
 
-   LockingMode lockingMode() {
+   public LockingMode lockingMode() {
       return attributes.attribute(LOCKING_MODE).get();
    }
 

--- a/core/src/main/java/org/infinispan/functional/impl/AbstractFunctionalMap.java
+++ b/core/src/main/java/org/infinispan/functional/impl/AbstractFunctionalMap.java
@@ -81,6 +81,10 @@ abstract class AbstractFunctionalMap<K, V> implements FunctionalMap<K, V> {
    }
 
    protected InvocationContext getInvocationContext(boolean isWrite, int keyCount) {
+      // Avoid creating a new context for the command. Useful during transactions that can change threads.
+      if (fmap.delegateContextCreation())
+         return fmap.createInvocationContext(isWrite, keyCount);
+
       InvocationContext invocationContext;
       boolean txInjected = false;
       if (transactional) {

--- a/core/src/main/java/org/infinispan/util/concurrent/BlockingManagerImpl.java
+++ b/core/src/main/java/org/infinispan/util/concurrent/BlockingManagerImpl.java
@@ -168,7 +168,7 @@ public class BlockingManagerImpl implements BlockingManager {
    @Override
    public <I, O> CompletionStage<O> handleBlocking(CompletionStage<? extends I> stage,
          BiFunction<? super I, Throwable, ? extends O> function, Object traceId) {
-      if (isCurrentThreadBlocking()) {
+      if (CompletionStages.isCompletedSuccessfully(stage) && isCurrentThreadBlocking()) {
          I value = null;
          Throwable throwable = null;
          try {

--- a/server/resp/src/main/java/org/infinispan/server/resp/Resp3Handler.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/Resp3Handler.java
@@ -1,7 +1,5 @@
 package org.infinispan.server.resp;
 
-import static org.infinispan.server.resp.serialization.RespConstants.CRLF_STRING;
-
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ScheduledExecutorService;
@@ -25,7 +23,7 @@ import org.infinispan.util.concurrent.BlockingManager;
 import io.netty.channel.ChannelHandlerContext;
 
 public class Resp3Handler extends Resp3AuthHandler {
-   private static final byte[] CRLF_BYTES = CRLF_STRING.getBytes();
+
    protected AdvancedCache<byte[], byte[]> ignorePreviousValueCache;
    protected EmbeddedMultimapListCache<byte[], byte[]> listMultimap;
    protected EmbeddedMultimapPairCache<byte[], byte[], byte[]> mapMultimap;

--- a/server/resp/src/main/java/org/infinispan/server/resp/RespServer.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/RespServer.java
@@ -24,6 +24,7 @@ import org.infinispan.server.resp.filter.ComposedFilterConverterFactory;
 import org.infinispan.server.resp.filter.GlobMatchFilterConverterFactory;
 import org.infinispan.server.resp.filter.RespTypeFilterConverterFactory;
 import org.infinispan.server.resp.meta.MetadataRepository;
+import org.infinispan.transaction.LockingMode;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelInboundHandler;
@@ -85,6 +86,12 @@ public class RespServer extends AbstractProtocolServer<RespServerConfiguration> 
             } else if (!keyMediaType.equals(RESP_KEY_MEDIA_TYPE)) {
                throw CONFIG.respCacheKeyMediaTypeSupplied(cacheName, keyMediaType);
             }
+
+            if (builder.transaction().transactionMode().isTransactional()
+                  && builder.transaction().lockingMode() != LockingMode.PESSIMISTIC) {
+               org.infinispan.server.resp.logging.Log.CONFIG.utilizePessimisticLocking(builder.transaction().lockingMode().name());
+            }
+
          } else {
             if (cacheManager.getCacheManagerConfiguration().isClustered()) { // We are running in clustered mode
                builder.clustering().cacheMode(CacheMode.DIST_SYNC);

--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/tx/TransactionDecorator.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/tx/TransactionDecorator.java
@@ -1,0 +1,183 @@
+package org.infinispan.server.resp.commands.tx;
+
+import java.util.concurrent.CompletionStage;
+
+import org.infinispan.AdvancedCache;
+import org.infinispan.Cache;
+import org.infinispan.cache.impl.AbstractDelegatingAdvancedCache;
+import org.infinispan.cache.impl.AbstractDelegatingCache;
+import org.infinispan.cache.impl.CacheImpl;
+import org.infinispan.cache.impl.DecoratedCache;
+import org.infinispan.commons.tx.DefaultResourceConverter;
+import org.infinispan.context.InvocationContext;
+import org.infinispan.context.impl.LocalTxInvocationContext;
+import org.infinispan.factories.ComponentRegistry;
+import org.infinispan.server.resp.Resp3Handler;
+import org.infinispan.transaction.impl.LocalTransaction;
+import org.infinispan.transaction.impl.TransactionTable;
+import org.infinispan.transaction.tm.EmbeddedTransaction;
+import org.infinispan.transaction.tm.EmbeddedTransactionManager;
+
+/**
+ * Decorates the cache to utilize a transactional context.
+ *
+ * <p>
+ * The {@link EXEC} command execute many queued commands. These commands might change threads during the execution.
+ * Before executing the commands, we decorate the cache to bypass the creation of the {@link InvocationContext}. This
+ * way, we guarantee that all commands execute within the same transaction. Otherwise, we could lose context due to thread
+ * changes.
+ * </p>
+ *
+ * <p>
+ * We extend the {@link DecoratedCache} to override the methods to utilize a transactional context. Additionally, we
+ * also need to guarantee it works properly with instances of the {@link org.infinispan.cache.impl.EncoderCache}.That is,
+ * it needs to transform the key and values, to later submit the command with the decorated instance. The extended
+ * {@link RespExecDecoratedCache} also wraps the caches in case of new instances with flags or media-types.
+ * </p>
+ *
+ * @since 15.0
+ * @author José Bolina
+ */
+final class TransactionDecorator {
+
+   private TransactionDecorator() { }
+
+   /**
+    * Begin a new transaction with the given gaven for the given handler.
+    *
+    * <p>
+    * A transaction is initiated and it will contain all submitted commands until
+    * {@link #completeTransaction(TransactionResume, boolean)} is invoked. After the transaction starts, the user's
+    * {@link Resp3Handler} should <b>not</b> be utilized for other commands that do not belong to the transaction.
+    * </p>
+    *
+    * @param handler The handler to enter into transactional context.
+    * @param cache The cache to utilize for operations.
+    * @return A new instance of {@link TransactionResume} to utilize to complete the transaction.
+    * @throws IllegalStateException If a {@link CacheImpl} is not found.
+    */
+   static TransactionResume beginTransaction(Resp3Handler handler, AdvancedCache<byte[], byte[]> cache) {
+      EmbeddedTransaction tx = new EmbeddedTransaction(EmbeddedTransactionManager.getInstance());
+      TransactionTable table = acquireTransactionTable(cache);
+      LocalTransaction localTx = table.getOrCreateLocalTransaction(tx, false);
+      LocalTxInvocationContext ic = new LocalTxInvocationContext(localTx);
+      table.enlistClientTransaction(tx, localTx);
+
+      CacheImpl<byte[], byte[]> ci = unwrap(cache);
+      AdvancedCache<byte[], byte[]> other = new RespExecDecoratedCache(ic, cache, ci);
+
+      handler.setCache(other);
+      return new TransactionResume(handler, cache, tx);
+   }
+
+   /**
+    * Completes the transaction and frees the handler and cache.
+    *
+    * <p>
+    * Commits/rollbacks the transaction and release the {@link Resp3Handler} and {@link AdvancedCache} provided to
+    * start the transaction.
+    * </p>
+    *
+    * @param resume The transaction context created to start the transaction.
+    * @param success <code>true</code> to commit the transaction, <code>false</code>, otherwise.
+    * @return A {@link CompletionStage} that completes after the transaction is commit/rollback.
+    */
+   static CompletionStage<Void> completeTransaction(TransactionResume resume, boolean success) {
+      resume.handler.setCache(resume.cache);
+      return resume.tx.runCommitAsync(!success, DefaultResourceConverter.INSTANCE);
+   }
+
+   private static TransactionTable acquireTransactionTable(AdvancedCache<?, ?> cache) {
+      return ComponentRegistry.componentOf(cache, TransactionTable.class);
+   }
+
+   private static  <K, V> CacheImpl<K, V> unwrap(Cache<K, V> cache) {
+      if (cache instanceof CacheImpl<K,V> ci)
+         return ci;
+
+      if (cache instanceof AbstractDelegatingCache<K,V> adc)
+         return unwrap(adc.getDelegate());
+
+      throw new IllegalStateException("Simple cache not found for: " + cache.getClass());
+   }
+
+   /**
+    * Transactional context to complete a transaction and release resources.
+    */
+   static final class TransactionResume {
+      private final Resp3Handler handler;
+      private final AdvancedCache<byte[], byte[]> cache;
+      private final EmbeddedTransaction tx;
+
+      TransactionResume(Resp3Handler handler, AdvancedCache<byte[], byte[]> cache, EmbeddedTransaction tx) {
+         this.handler = handler;
+         this.cache = cache;
+         this.tx = tx;
+      }
+   }
+
+   /**
+    * Decorates the cache to maintain the transactional context throughout many commands.
+    *
+    * <p>
+    * Re-wrapping or adding flags must ensure the order with the {@link org.infinispan.cache.impl.EncoderCache}. The
+    * encoding of keys and values must <b>always</b> happen before invoking the command with the decorated cache.
+    * </p>
+    */
+   private static class RespExecDecoratedCache extends DecoratedCache<byte[], byte[]> {
+      private final InvocationContext ctx;
+
+      private RespExecDecoratedCache(InvocationContext ctx, AdvancedCache<byte[], byte[]> cache, CacheImpl<byte[], byte[]> ci) {
+         super(cache, ci);
+         this.ctx = ctx;
+      }
+
+      private RespExecDecoratedCache(InvocationContext ctx, AdvancedCache<byte[], byte[]> cache, CacheImpl<byte[], byte[]> ci, long flags) {
+         super(cache, ci, flags);
+         this.ctx = ctx;
+      }
+
+      @Override
+      public AdvancedCache rewrap(AdvancedCache newDelegate) {
+         // Change order between delegate and this instance.
+         // The delegate should apply any decoration and then hand the execution to the DecoratedCache.
+         // For example, the EncoderCache should transform the values before delegating to the DecoratedCache.
+         if (newDelegate instanceof AbstractDelegatingAdvancedCache<?,?> adac)
+            return adac.rewrap(this);
+
+         return super.rewrap(newDelegate);
+      }
+
+      @Override
+      protected InvocationContext readContext(int size) {
+         return ctx;
+      }
+
+      @Override
+      protected InvocationContext writeContext(int size) {
+         return ctx;
+      }
+
+      @Override
+      public boolean bypassInvocationContextFactory() {
+         return true;
+      }
+
+      @Override
+      protected AdvancedCache<byte[], byte[]> withFlags(long newFlags) {
+         AdvancedCache<byte[], byte[]> flagged = new RespExecDecoratedCache(ctx, cache, unwrap(getDelegate()), newFlags);
+         if (cache instanceof AbstractDelegatingAdvancedCache<byte[],byte[]> adac)
+            return adac.rewrap(flagged);
+
+         return flagged;
+      }
+
+      @Override
+      public AdvancedCache<byte[], byte[]> noFlags() {
+         if (getFlagsBitSet() == 0L)
+            return this;
+
+         return withFlags(0);
+      }
+   }
+}

--- a/server/resp/src/main/java/org/infinispan/server/resp/logging/Log.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/logging/Log.java
@@ -49,10 +49,10 @@ public interface Log extends BasicLogger {
    @Once
    void lmoveConsistencyMessage();
 
-   @Once
-   @LogMessage(level = WARN)
-   @Message(value = "Multi-key operations without batching have a relaxed isolation level. Consider enabling batching.", id = 13007)
-   void multiKeyOperationUseBatching();
+   //@Once
+   //@LogMessage(level = WARN)
+   //@Message(value = "Multi-key operations without batching have a relaxed isolation level. Consider enabling batching.", id = 13007)
+   //void multiKeyOperationUseBatching();
 
    @LogMessage(level = WARN)
    @Message(value = "SMOVE command can't guarantee atomicity and consistency when the source list and the destination set are different", id = 13008)
@@ -64,4 +64,12 @@ public interface Log extends BasicLogger {
    @Once
    void msetnxConsistencyMessage();
 
+   @LogMessage(level = WARN)
+   @Message(value = "PESSIMISTIC locking is preferred instead of '%s'", id = 13010)
+   void utilizePessimisticLocking(String mode);
+
+   @Once
+   @LogMessage(level = WARN)
+   @Message(value = "Multi-Exec operations without transactions have a relaxed isolation level. Consider enabling transaction.", id = 13011)
+   void enableTransactionForMultiExec();
 }

--- a/server/resp/src/test/java/org/infinispan/server/resp/dist/TransactionClusteredTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/dist/TransactionClusteredTest.java
@@ -1,10 +1,26 @@
 package org.infinispan.server.resp.dist;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.infinispan.server.resp.test.RespTestingUtil.OK;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Predicate;
+import java.util.stream.IntStream;
+
+import org.infinispan.Cache;
+import org.infinispan.commons.marshall.WrappedByteArray;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.distribution.LocalizedCacheTopology;
 import org.infinispan.server.resp.TransactionOperationsTest;
 import org.infinispan.server.resp.test.TestSetup;
 import org.testng.annotations.Test;
+
+import io.lettuce.core.TransactionResult;
+import io.lettuce.core.api.sync.RedisCommands;
 
 @Test(groups = "functional", testName = "dist.server.resp.TransactionClusteredTest")
 public class TransactionClusteredTest extends TransactionOperationsTest {
@@ -22,6 +38,54 @@ public class TransactionClusteredTest extends TransactionOperationsTest {
             new TransactionClusteredTest().withCacheMode(CacheMode.DIST_SYNC),
             new TransactionClusteredTest().withCacheMode(CacheMode.REPL_SYNC),
       };
+   }
+
+   private String getStringKeyForCache(String prefix, Cache<?, ?> primary, Cache<?, ?> ... secondary) {
+      LocalizedCacheTopology topology = primary.getAdvancedCache().getDistributionManager().getCacheTopology();
+      Predicate<String> isBackupOwner = key -> Arrays.stream(secondary)
+            .allMatch(c -> {
+               LocalizedCacheTopology t = c.getAdvancedCache().getDistributionManager().getCacheTopology();
+               int segment = t.getSegment(new WrappedByteArray(key.getBytes(StandardCharsets.US_ASCII)));
+               return t.isSegmentReadOwner(segment);
+            });
+      return IntStream.generate(ThreadLocalRandom.current()::nextInt).mapToObj(i -> prefix + i)
+            .filter(key -> topology.getDistribution(new WrappedByteArray(key.getBytes(StandardCharsets.US_ASCII))).isPrimary())
+            .filter(isBackupOwner).findAny().orElseThrow();
+   }
+
+   private String getRemoteKey() {
+      return getStringKeyForCache("key", cache(1), cache(2));
+   }
+
+   @Override
+   public void testBlockingPopWithTx() throws Throwable {
+      testBlockingPopWithTx(this::getRemoteKey);
+   }
+
+   public void testFunctionalTxWithRemote() {
+      RedisCommands<String, String> redis = redisConnection.sync();
+
+      assertThat(redis.multi()).isEqualTo("OK");
+      assertThat(redisConnection.isMulti()).isTrue();
+
+      String k1 = getRemoteKey();
+      redis.lpush(k1, "v1", "v2", "v3");
+
+      String k2 = getRemoteKey();
+      redis.hset(k2, Map.of("f1", "v1", "f2", "v2"));
+
+      String k3 = getRemoteKey();
+      redis.set(k3, "value");
+
+      TransactionResult result = redis.exec();
+      assertThat(result.wasDiscarded()).isFalse();
+      assertThat((Object) result.get(0))
+            .isInstanceOfSatisfying(Long.class, v -> assertThat(v).isEqualTo(3L));
+
+      assertThat((Object) result.get(1))
+            .isInstanceOfSatisfying(Long.class, v -> assertThat(v).isEqualTo(2L));
+
+      assertThat((Object) result.get(2)).isEqualTo(OK);
    }
 
    @Override

--- a/server/resp/src/test/java/org/infinispan/server/resp/types/TransactionMediaTypeTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/types/TransactionMediaTypeTest.java
@@ -7,6 +7,7 @@ import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.server.resp.TransactionOperationsTest;
+import org.infinispan.transaction.LockingMode;
 import org.testng.annotations.Test;
 
 @Test(groups = "functional", testName = "server.resp.types.TransactionMediaTypeTest")
@@ -23,6 +24,7 @@ public class TransactionMediaTypeTest extends TransactionOperationsTest {
          configurationBuilder.clustering().cacheMode(cacheMode);
          configurationBuilder.invocationBatching().enable(true);
       }
+      configurationBuilder.transaction().lockingMode(LockingMode.PESSIMISTIC);
       configurationBuilder.encoding().value().mediaType(valueType.toString());
    }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-16730

The core class is the `TransactionDecorator` which creates a `DecoratedCache` to propagate the transactional context in all commands. It is really tricky because it needs to keep working the `EncoderCache` in any combination.

I also changed the functional map to utilize the methods in the DecoderCache to create the invocation context.