### PR TITLE
ISPN-16787 [RESP] Cache with authorization enabled fails to connect

### DIFF
--- a/server/resp/src/main/java/org/infinispan/server/resp/CacheRespRequestHandler.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/CacheRespRequestHandler.java
@@ -6,10 +6,9 @@ import org.infinispan.commons.dataconversion.MediaType;
 public class CacheRespRequestHandler extends RespRequestHandler {
    protected AdvancedCache<byte[], byte[]> cache;
 
-   protected CacheRespRequestHandler(RespServer respServer) {
+   protected CacheRespRequestHandler(RespServer respServer, AdvancedCache<byte[], byte[]> cache) {
       super(respServer);
-      setCache(respServer.getCache()
-            .withMediaType(MediaType.APPLICATION_OCTET_STREAM, MediaType.APPLICATION_OCTET_STREAM));
+      setCache(cache.withMediaType(MediaType.APPLICATION_OCTET_STREAM, MediaType.APPLICATION_OCTET_STREAM));
    }
 
    public AdvancedCache<byte[], byte[]> cache() {

--- a/server/resp/src/main/java/org/infinispan/server/resp/Resp3AuthHandler.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/Resp3AuthHandler.java
@@ -7,6 +7,7 @@ import java.util.concurrent.CompletionStage;
 import javax.security.auth.Subject;
 import javax.security.sasl.SaslException;
 
+import org.infinispan.AdvancedCache;
 import org.infinispan.commons.util.concurrent.CompletableFutures;
 import org.infinispan.server.core.transport.ConnectionMetadata;
 import org.infinispan.server.resp.authentication.RespAuthenticator;
@@ -17,7 +18,11 @@ import io.netty.channel.ChannelHandlerContext;
 public class Resp3AuthHandler extends CacheRespRequestHandler {
 
    public Resp3AuthHandler(RespServer server) {
-      super(server);
+      this(server, server.getCache());
+   }
+
+   protected Resp3AuthHandler(RespServer server, AdvancedCache<byte[], byte[]> cache) {
+      super(server, cache);
    }
 
    @Override

--- a/server/resp/src/main/java/org/infinispan/server/resp/Resp3Handler.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/Resp3Handler.java
@@ -36,8 +36,8 @@ public class Resp3Handler extends Resp3AuthHandler {
 
    private final MediaType valueMediaType;
 
-   Resp3Handler(RespServer respServer, MediaType valueMediaType) {
-      super(respServer);
+   Resp3Handler(RespServer respServer, MediaType valueMediaType, AdvancedCache<byte[], byte[]> cache) {
+      super(respServer, cache);
       this.valueMediaType = valueMediaType;
 
       GlobalComponentRegistry gcr = SecurityActions.getGlobalComponentRegistry(cache.getCacheManager());

--- a/server/resp/src/main/java/org/infinispan/server/resp/RespChannelInitializer.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/RespChannelInitializer.java
@@ -33,7 +33,7 @@ public class RespChannelInitializer implements NettyInitializer {
       if (respServer.getConfiguration().authentication().enabled()) {
          initialHandler = new Resp3AuthHandler(respServer);
       } else {
-         initialHandler = respServer.newHandler();
+         initialHandler = respServer.newHandler(respServer.getCache());
       }
 
       RespDecoder decoder = new RespDecoder();

--- a/server/resp/src/main/java/org/infinispan/server/resp/RespServer.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/RespServer.java
@@ -144,8 +144,8 @@ public class RespServer extends AbstractProtocolServer<RespServerConfiguration> 
       return cacheManager.<byte[], byte[]>getCache(configuration.defaultCacheName()).getAdvancedCache();
    }
 
-   public Resp3Handler newHandler() {
-      return new Resp3Handler(this, configuredValueType);
+   public Resp3Handler newHandler(AdvancedCache<byte[], byte[]> cache) {
+      return new Resp3Handler(this, configuredValueType, cache);
    }
 
    @Override

--- a/server/resp/src/main/java/org/infinispan/server/resp/SubscriberHandler.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/SubscriberHandler.java
@@ -41,7 +41,7 @@ public class SubscriberHandler extends CacheRespRequestHandler {
    private final Resp3Handler resp3Handler;
 
    public SubscriberHandler(RespServer respServer, Resp3Handler prevHandler) {
-      super(respServer);
+      super(respServer, prevHandler.cache());
       this.resp3Handler = prevHandler;
    }
 

--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/connection/HELLO.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/connection/HELLO.java
@@ -68,10 +68,13 @@ public class HELLO extends RespCommand implements AuthResp3Command {
 
       if (successStage != null) {
          return handler.stageToReturn(successStage, ctx, success -> {
+            RespRequestHandler next = AUTH.silentCreateAfterAuthentication(success, handler);
+            if (next == null)
+               return handler;
+
             if (success) helloResponse(handler, ctx);
             else RespErrorUtil.unauthorized(handler.allocator());
-
-            return AUTH.silentCreateAfterAuthentication(success, handler);
+            return next;
          });
       }
 

--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/connection/QUIT.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/connection/QUIT.java
@@ -42,6 +42,7 @@ public class QUIT extends RespCommand implements AuthResp3Command, PubSubResp3Co
    @Override
    public CompletionStage<RespRequestHandler> perform(RespTransactionHandler handler, ChannelHandlerContext ctx, List<byte[]> arguments) {
       return handler.dropTransaction(ctx)
-            .thenCompose(ignore -> handler.respServer().newHandler().handleRequest(ctx, this, arguments));
+            .thenCompose(ignore -> handler.respServer().newHandler(handler.cache())
+                  .handleRequest(ctx, this, arguments));
    }
 }

--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/tx/DISCARD.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/tx/DISCARD.java
@@ -38,7 +38,7 @@ public class DISCARD extends RespCommand implements Resp3Command, TransactionRes
 
    @Override
    public CompletionStage<RespRequestHandler> perform(RespTransactionHandler handler, ChannelHandlerContext ctx, List<byte[]> arguments) {
-      Resp3Handler next = handler.respServer().newHandler();
+      Resp3Handler next = handler.respServer().newHandler(handler.cache());
       return handler.stageToReturn(handler.dropTransaction(ctx), ctx, ignore -> {
          Resp3Response.ok(handler.allocator());
          return next;

--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/tx/EXEC.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/tx/EXEC.java
@@ -51,7 +51,7 @@ public class EXEC extends RespCommand implements Resp3Command, TransactionResp3C
 
    @Override
    public CompletionStage<RespRequestHandler> perform(RespTransactionHandler handler, ChannelHandlerContext ctx, List<byte[]> arguments) {
-      Resp3Handler next = handler.respServer().newHandler();
+      Resp3Handler next = handler.respServer().newHandler(handler.cache());
       CompletionStage<?> cs = handler.performingOperations(ctx)
             .thenCompose(commands -> perform(commands, handler, next, ctx));
       return next.stageToReturn(cs, ctx, ignore -> next);

--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/tx/MULTI.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/tx/MULTI.java
@@ -47,7 +47,7 @@ public class MULTI extends RespCommand implements Resp3Command, TransactionResp3
    @Override
    public CompletionStage<RespRequestHandler> perform(Resp3Handler handler, ChannelHandlerContext ctx, List<byte[]> arguments) {
       Resp3Response.ok(handler.allocator());
-      return CompletableFuture.completedFuture(new RespTransactionHandler(handler.respServer()));
+      return CompletableFuture.completedFuture(new RespTransactionHandler(handler.respServer(), handler.cache()));
    }
 
    @Override

--- a/server/resp/src/main/java/org/infinispan/server/resp/tx/RespTransactionHandler.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/tx/RespTransactionHandler.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 
+import org.infinispan.AdvancedCache;
 import org.infinispan.server.resp.CacheRespRequestHandler;
 import org.infinispan.server.resp.RespCommand;
 import org.infinispan.server.resp.RespErrorUtil;
@@ -43,8 +44,8 @@ public class RespTransactionHandler extends CacheRespRequestHandler {
    private final List<TransactionCommand> queued;
    private boolean failed;
 
-   public RespTransactionHandler(RespServer respServer) {
-      super(respServer);
+   public RespTransactionHandler(RespServer respServer, AdvancedCache<byte[], byte[]> cache) {
+      super(respServer, cache);
       this.queued = new ArrayList<>();
    }
 
@@ -55,7 +56,7 @@ public class RespTransactionHandler extends CacheRespRequestHandler {
       // Doing specific checks here instead of implementing on the commands, so we can update this later, if necessary.
       if (command instanceof SUBSCRIBE || command instanceof PSUBSCRIBE) {
          CompletionStage<?> drop = dropTransaction(ctx);
-         SubscriberHandler subscriberHandler = new SubscriberHandler(respServer(), respServer().newHandler());
+         SubscriberHandler subscriberHandler = new SubscriberHandler(respServer(), respServer().newHandler(cache));
          return subscriberHandler.handleRequest(ctx, command, arguments).thenCombine(drop, (handler, ignore) -> handler);
       }
 

--- a/server/tests/src/test/resources/configuration/cache-container/clustered-authz-common-name.xml
+++ b/server/tests/src/test/resources/configuration/cache-container/clustered-authz-common-name.xml
@@ -24,4 +24,11 @@
          <backup site="NYC"/>
       </backups>
    </distributed-cache>
+
+   <replicated-cache name="respCache" key-partitioner="org.infinispan.distribution.ch.impl.RESPHashFunctionPartitioner">
+      <encoding media-type="application/octet-stream"/>
+      <security>
+         <authorization/>
+      </security>
+   </replicated-cache>
 </cache-container>

--- a/server/tests/src/test/resources/configuration/cache-container/clustered-authz.xml
+++ b/server/tests/src/test/resources/configuration/cache-container/clustered-authz.xml
@@ -24,4 +24,11 @@
          <backup site="NYC"/>
       </backups>
    </distributed-cache>
+
+   <replicated-cache name="respCache" key-partitioner="org.infinispan.distribution.ch.impl.RESPHashFunctionPartitioner">
+      <encoding media-type="application/octet-stream"/>
+      <security>
+         <authorization/>
+      </security>
+   </replicated-cache>
 </cache-container>


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-16787

We authenticate and create the SecureCache with the correct subject. However, once we create a new handler, we invoke the cache manager to get the cache again instead of re-utilizing the SecureCache with the subject.