### PR TITLE
ISPN-16789 Mark topology of replicated caches without force

### DIFF
--- a/core/src/main/java/org/infinispan/topology/ClusterCacheStatus.java
+++ b/core/src/main/java/org/infinispan/topology/ClusterCacheStatus.java
@@ -822,12 +822,12 @@ public class ClusterCacheStatus implements AvailabilityStrategyContext {
                .fromPersistentState(persistentState.get());
          int missing = pastConsistentHash.getMembers().size() - members.size();
          int owners = joinInfo.getNumOwners();
-         if (!force && missing >= owners) {
+         boolean isReplicated = gcr.getCacheManager().getCacheConfiguration(cacheName).clustering().cacheMode().isReplicated();
+         if (!isReplicated && !force && missing >= owners) {
             throw log.missingTooManyMembers(cacheName, owners, missing, pastConsistentHash.getMembers().size());
          }
 
          boolean safelyRecovered = missing < owners;
-         boolean isReplicated = gcr.getCacheManager().getCacheConfiguration(cacheName).clustering().cacheMode().isReplicated();
          ConsistentHash ch;
          if (safelyRecovered && !isReplicated) {
             // We reuse the previous topology, only changing it to reflect the current members.


### PR DESCRIPTION
https://issues.redhat.com/browse/ISPN-16789

I've only changed the verification to verify if it is replicated. This means it can install the topology for replicated caches without requiring the force flag. The behavior is the same as if the flag was provided.