### PR TITLE
Add group-only-mapping to Client certificate authorization configuration example

### DIFF
--- a/documentation/src/main/asciidoc/topics/xml/server_client_certificate_authz.xml
+++ b/documentation/src/main/asciidoc/topics/xml/server_client_certificate_authz.xml
@@ -1,7 +1,7 @@
 <infinispan>
   <cache-container name="certificate-authentication" statistics="true">
     <security>
-      <authorization>
+      <authorization group-only-mapping="false">
         <!-- Declare a role mapper that associates the common name (CN) field in client certificate trust stores with authorization roles. -->
         <common-name-role-mapper/>
         <!-- In this example, if a client certificate contains `CN=Client1` then clients with matching certificates get ALL permissions. -->


### PR DESCRIPTION
The proposed configuration doesn't work unless you add the `group-only-mapping` attribute: `<authorization group-only-mapping="false">`

You can try and reproduce the issue with the following procedure; just remov the `group-only-mapping` attribute to trigger the issue itself:

# Generate necessary keystores

```bash
# certificate authority
keytool -validity 36500 -keyalg RSA -keysize 2048 -noprompt -storepass 123PIPPOBAUDO -storetype pkcs12 -genkeypair -alias ca -keystore ca-keystore.p12 -ext bc:c -dname 'CN=CA,OU=Infinispan,O=JBoss,L=Red Hat'
keytool -validity 36500 -keyalg RSA -keysize 2048 -noprompt -storepass 123PIPPOBAUDO -storetype pkcs12 -exportcert -alias ca -keystore ca-keystore.p12 -file ca.cer

# infinispan keystore
keytool -validity 36500 -keyalg RSA -keysize 2048 -noprompt -storepass 123PIPPOBAUDO -storetype pkcs12 -genkeypair -alias infinispan -dname 'CN=Infinispan,OU=Infinispan,O=JBoss,L=Red Hat' -keystore infinispan-keystore.p12
keytool -validity 36500 -keyalg RSA -keysize 2048 -noprompt -storepass 123PIPPOBAUDO -storetype pkcs12 -certreq -alias infinispan -dname 'CN=Infinispan,OU=Infinispan,O=JBoss,L=Red Hat' -keystore infinispan-keystore.p12 -file infinispan.csr
keytool -validity 36500 -keyalg RSA -keysize 2048 -noprompt -storepass 123PIPPOBAUDO -storetype pkcs12 -gencert -alias ca -keystore ca-keystore.p12 -infile infinispan.csr -outfile infinispan.cer -ext "san=dns:localhost"
keytool -validity 36500 -keyalg RSA -keysize 2048 -noprompt -storepass 123PIPPOBAUDO -storetype pkcs12 -importcert -alias ca -keystore infinispan-keystore.p12 -file ca.cer
keytool -validity 36500 -keyalg RSA -keysize 2048 -noprompt -storepass 123PIPPOBAUDO -storetype pkcs12 -importcert -alias infinispan -keystore infinispan-keystore.p12 -file infinispan.cer

# wildfly keystore
keytool -validity 36500 -keyalg RSA -keysize 2048 -noprompt -storepass 123PIPPOBAUDO -storetype pkcs12 -genkeypair -alias wildfly -dname 'CN=wildfly,OU=EAPQE,DC=Red Hat' -keystore wildfly-keystore.p12
keytool -validity 36500 -keyalg RSA -keysize 2048 -noprompt -storepass 123PIPPOBAUDO -storetype pkcs12 -certreq -alias wildfly -dname 'CN=wildfly,OU=EAPQE,DC=Red Hat' -keystore wildfly-keystore.p12 -file wildfly.csr
keytool -validity 36500 -keyalg RSA -keysize 2048 -noprompt -storepass 123PIPPOBAUDO -storetype pkcs12 -gencert -alias ca -keystore ca-keystore.p12 -infile wildfly.csr -outfile wildfly.cer -ext "san=dns:localhost"
keytool -validity 36500 -keyalg RSA -keysize 2048 -noprompt -storepass 123PIPPOBAUDO -storetype pkcs12 -importcert -alias ca -keystore wildfly-keystore.p12 -file ca.cer
keytool -validity 36500 -keyalg RSA -keysize 2048 -noprompt -storepass 123PIPPOBAUDO -storetype pkcs12 -importcert -alias wildfly -keystore wildfly-keystore.p12 -file wildfly.cer

# infinispan truststore
keytool -validity 36500 -keyalg RSA -keysize 2048 -noprompt -storepass 123PIPPOBAUDO -storetype pkcs12 -importcert -alias ca -keystore infinispan-truststore.p12 -file ca.cer
keytool -validity 36500 -keyalg RSA -keysize 2048 -noprompt -storepass 123PIPPOBAUDO -storetype pkcs12 -importcert -alias wildfly -keystore infinispan-truststore.p12 -file wildfly.cer

# wildfly truststore
keytool -validity 36500 -keyalg RSA -keysize 2048 -noprompt -storepass 123PIPPOBAUDO -storetype pkcs12 -importcert -alias ca -keystore wildfly-truststore.p12 -file ca.cer
keytool -validity 36500 -keyalg RSA -keysize 2048 -noprompt -storepass 123PIPPOBAUDO -storetype pkcs12 -importcert -alias infinispan -keystore wildfly-truststore.p12 -file infinispan.cer
```

# Infinispan

## Copy Keystores to Infinispan

```bash
export INFINISPAN_HOME=/.../infinispan-server-15.0.10.Final
cp infinispan-keystore.p12 $INFINISPAN_HOME/server/conf/
cp infinispan-truststore.p12 $INFINISPAN_HOME/server/conf/
```

## Configure Infinispan

```bash
# optional
$INFINISPAN_HOME/bin/cli.sh user create admin -p pass.1234 --groups=admin 

sed -i '/./{H;$!d} ; x ; s#<[^>]*server-identities>.*</server-identities[^>]*>#<server-identities>\n<ssl>\n<keystore path="infinispan-keystore.p12" keystore-password="123PIPPOBAUDO" alias="infinispan" relative-to="infinispan.server.config.path"/>\n<truststore path="infinispan-truststore.p12" password="123PIPPOBAUDO" relative-to="infinispan.server.config.path"/>\n</ssl>\n</server-identities>\n<truststore-realm/>#' $INFINISPAN_HOME/server/conf/infinispan.xml
sed -i 's#<authorization/>#<authorization group-only-mapping="false">\n<common-name-role-mapper/>\n<role name="wildfly" permissions="ALL"/>\n</authorization>#' $INFINISPAN_HOME/server/conf/infinispan.xml
```   

## Start Infinispan

```
$INFINISPAN_HOME/bin/server.sh --server-config=infinispan.xml
```

# Wildfly

## Copy Keystores to Wildfly

```bash
export WILDFLY_HOME=/.../wildfly-34.0.0.Beta1
cp wildfly-keystore.p12 $WILDFLY_HOME/
cp wildfly-truststore.p12 $WILDFLY_HOME/
```

## Configure Wildfly

### Option 1: use elytron

```
$WILDFLY_HOME/bin/jboss-cli.sh
        embed-server --server-config=standalone-ha.xml
        /socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=remote-jdg-server1:add(host=localhost, port=11222)

        # keystore
	/subsystem=elytron/key-store=WildFly-Keystore:add(path=wildfly-keystore.p12, relative-to=jboss.home.dir, credential-reference={clear-text=123PIPPOBAUDO}, type=PKCS12)
	/subsystem=elytron/key-manager=WildFly-KeyManager:add(key-store=WildFly-Keystore, algorithm="SunX509", credential-reference={clear-text=123PIPPOBAUDO})

	# truststore
	/subsystem=elytron/key-store=WildFly-Truststore:add(path=wildfly-truststore.p12, relative-to=jboss.home.dir, credential-reference={clear-text=123PIPPOBAUDO}, type=PKCS12)
	/subsystem=elytron/trust-manager=WildFly-TrustManager:add(key-store=WildFly-Truststore, algorithm="SunX509")

	# ssl client
	/subsystem=elytron/client-ssl-context=CLIENT_SSL_CONTEXT:add(key-manager=WildFly-KeyManager, trust-manager=WildFly-TrustManager, protocols=["TLSv1.2"])

	batch
	/subsystem=infinispan/remote-cache-container=web-sessions:add(default-remote-cluster=jdg-server-cluster, statistics-enabled=true, properties={infinispan.client.hotrod.sasl_mechanism=EXTERNAL})
	/subsystem=infinispan/remote-cache-container=web-sessions/remote-cluster=jdg-server-cluster:add(socket-bindings=[remote-jdg-server1])
	run-batch
	/subsystem=infinispan/remote-cache-container=web-sessions/component=security:write-attribute(name=ssl-context,value=CLIENT_SSL_CONTEXT)
```

### Option 2: use hotrod properties

```
$WILDFLY_HOME/bin/jboss-cli.sh
        embed-server --server-config=standalone-ha.xml
        /socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=remote-jdg-server1:add(host=localhost, port=11222)
        batch
        /subsystem=infinispan/remote-cache-container=web-sessions:add(default-remote-cluster=jdg-server-cluster, statistics-enabled=true, properties={infinispan.client.hotrod.trust_store_file_name=/.../wildfly-truststore.p12, infinispan.client.hotrod.trust_store_password=123PIPPOBAUDO,infinispan.client.hotrod.key_store_file_name=/.../wildfly-keystore.p12,infinispan.client.hotrod.key_store_password=123PIPPOBAUDO,infinispan.client.hotrod.sasl_mechanism=EXTERNAL})
        /subsystem=infinispan/remote-cache-container=web-sessions/remote-cluster=jdg-server-cluster:add(socket-bindings=[remote-jdg-server1])
        run-batch
        /subsystem=infinispan/remote-cache-container=web-sessions:write-attribute(name=marshaller,value=PROTOSTREAM)
        /subsystem=infinispan/cache-container=web/invalidation-cache=offload:add()
        /subsystem=infinispan/cache-container=web/invalidation-cache=offload/store=hotrod:add(remote-cache-container=web-sessions, fetch-state=false, preload=false, passivation=false, purge=false, shared=true)
        /subsystem=infinispan/cache-container=web/invalidation-cache=offload/component=transaction:add(mode=BATCH)
        /subsystem=infinispan/cache-container=web:write-attribute(name=default-cache, value=offload)     
```

## Start Wildfly

```bash
$WILDFLY_HOME/bin/standalone.sh --server-config=standalone-ha.xml
```

## Deploy a ditributed application to Wildfly

Deploy clusterbech to Wildfly;

# troubleshooting

If you get:

```
11:43:29,487 WARN  [org.infinispan.HOTROD] (ASYNC-0) ISPN004005: Error received from the server: org.infinispan.commons.CacheException: ISPN000287: Unauthorized access: subject 'Subject with principal(s): [CN=admin, OU=Infinispan, O=JBoss, L=Red Hat, InetAddressPrincipal [address=127.0.0.1/127.0.0.1]]' lacks 'CREATE' permission
```

you might be missing attribute `group-only-mapping` on `<authorization>`: it should be `<authorization group-only-mapping="false">`;