### PR TITLE
[15.0.x] ISPN-16765: Incorrect note about GC pause in performance documentation

### DIFF
--- a/documentation/src/main/asciidoc/topics/con_performance_partition_handling.adoc
+++ b/documentation/src/main/asciidoc/topics/con_performance_partition_handling.adoc
@@ -9,7 +9,7 @@ When this happens, {brandname} caches in minority partitions enter **DEGRADED** 
 Garbage collection (GC) pauses are the most common cause of network partitions.
 When GC pauses result in nodes becoming unresponsive, {brandname} clusters can start operating in a split brain network.
 
-Rather then dealing with network partitions, try to avoid GC pauses by controlling JVM heap usage and by monitoring and tuning the GC. The default G1GC is appropriate for most use cases but needs tuning according to the usage pattern. A different GC implementation, such as Shenandoah, could be beneficial but might not work well if there are many short living objects. For information about the Shenandoah GC, see link:https://docs.redhat.com/en/documentation/red_hat_build_of_openjdk/21/html-single/using_shenandoah_garbage_collector_with_red_hat_build_of_openjdk_21/index#shenandoah-gc-overview[Shenandoah garbage collector]. 
+Rather than dealing with network partitions, try to avoid GC pauses by controlling JVM heap usage and by monitoring and tuning the GC. The default G1GC is appropriate for most use cases but needs tuning according to the usage pattern. A different GC implementation, such as Shenandoah, could be beneficial but might not work well if there are many short living objects. For information about the Shenandoah GC, see link:https://docs.redhat.com/en/documentation/red_hat_build_of_openjdk/21/html-single/using_shenandoah_garbage_collector_with_red_hat_build_of_openjdk_21/index#shenandoah-gc-overview[Shenandoah garbage collector]. 
 ====
 
 .CAP theorem and partition handling strategies

--- a/documentation/src/main/asciidoc/topics/con_performance_partition_handling.adoc
+++ b/documentation/src/main/asciidoc/topics/con_performance_partition_handling.adoc
@@ -9,7 +9,7 @@ When this happens, {brandname} caches in minority partitions enter **DEGRADED** 
 Garbage collection (GC) pauses are the most common cause of network partitions.
 When GC pauses result in nodes becoming unresponsive, {brandname} clusters can start operating in a split brain network.
 
-Rather than dealing with network partitions, try to avoid GC pauses by controlling JVM heap usage and by using a modern, low-pause GC implementation such as Shenandoah with OpenJDK.
+Rather then dealing with network partitions, try to avoid GC pauses by controlling JVM heap usage and by monitoring and tuning the GC. The default G1GC is appropriate for most use cases but needs tuning according to the usage pattern. A different GC implementation, such as Shenandoah, could be beneficial but might not work well if there are many short living objects. For information about the Shenandoah GC, see link:https://docs.redhat.com/en/documentation/red_hat_build_of_openjdk/21/html-single/using_shenandoah_garbage_collector_with_red_hat_build_of_openjdk_21/index#shenandoah-gc-overview[Shenandoah garbage collector]. 
 ====
 
 .CAP theorem and partition handling strategies


### PR DESCRIPTION
**Backport:** https://github.com/infinispan/infinispan/pull/13062

https://issues.redhat.com/browse/ISPN-16765