### PR TITLE
[15.0.x] Forgotten Database tag on AsyncJdbcStringBasedCacheStore

### DIFF
--- a/server/tests/src/test/java/org/infinispan/server/persistence/AsyncJdbcStringBasedCacheStore.java
+++ b/server/tests/src/test/java/org/infinispan/server/persistence/AsyncJdbcStringBasedCacheStore.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
+@org.infinispan.server.test.core.tags.Database
 public class AsyncJdbcStringBasedCacheStore {
 
     @RegisterExtension


### PR DESCRIPTION
**Backport:** https://github.com/infinispan/infinispan/pull/13146

Additional fix for https://issues.redhat.com/browse/ISPN-16587