### PR TITLE
ISPN-16285 Memory size for more resp types

### DIFF
--- a/build/configuration/pom.xml
+++ b/build/configuration/pom.xml
@@ -97,6 +97,7 @@
       <version.caffeine>3.2.0</version.caffeine>
       <version.commons.compress>1.27.1</version.commons.compress>
       <version.console>15.2.0.Final</version.console>
+      <version.ehcache.sizeof>0.3.0</version.ehcache.sizeof>
       <version.fabric8.kubernetes-client>6.13.5</version.fabric8.kubernetes-client>
       <version.glassfish.jaxb>4.0.5</version.glassfish.jaxb>
       <version.graalvm>24.0.0</version.graalvm>

--- a/pom.xml
+++ b/pom.xml
@@ -1437,6 +1437,11 @@
             <version>${version.io.prometheus.server}</version>
          </dependency>
          <dependency>
+            <groupId>org.ehcache</groupId>
+            <artifactId>sizeof</artifactId>
+            <version>${version.ehcache.sizeof}</version>
+         </dependency>
+         <dependency>
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
             <version>${versionx.org.mariadb.jdbc}</version>

--- a/server/resp/pom.xml
+++ b/server/resp/pom.xml
@@ -15,6 +15,10 @@
 
    <dependencies>
       <dependency>
+         <groupId>org.ehcache</groupId>
+         <artifactId>sizeof</artifactId>
+      </dependency>
+      <dependency>
          <groupId>org.infinispan</groupId>
          <artifactId>infinispan-component-processor</artifactId>
       </dependency>
@@ -34,7 +38,7 @@
          <groupId>com.jayway.jsonpath</groupId>
          <artifactId>json-path</artifactId>
          <version>${version.json-path}</version>
-     </dependency>
+      </dependency>
       <dependency>
          <groupId>org.kohsuke.metainf-services</groupId>
          <artifactId>metainf-services</artifactId>

--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/connection/MemoryEntrySizeUtils.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/connection/MemoryEntrySizeUtils.java
@@ -1,0 +1,26 @@
+package org.infinispan.server.resp.commands.connection;
+
+import org.ehcache.sizeof.SizeOf;
+import org.infinispan.container.entries.CacheEntrySizeCalculator;
+import org.infinispan.container.entries.InternalCacheEntry;
+import org.infinispan.container.entries.PrimitiveEntrySizeCalculator;
+
+public class MemoryEntrySizeUtils {
+   private static PrimitiveEntrySizeCalculator pesc = new PrimitiveEntrySizeCalculator();
+   private static CacheEntrySizeCalculator<byte[], Object> cesc = new CacheEntrySizeCalculator<byte[], Object>(
+         MemoryEntrySizeUtils::internalCalculateSize);
+   private static SizeOf sizeof = SizeOf.newInstance();
+
+   public static long calculateSize(byte[] key, InternalCacheEntry<byte[], Object> ice) {
+      return cesc.calculateSize(key, ice);
+   }
+
+   static long internalCalculateSize(byte[] key, Object value) {
+      try {
+         return sizeof.deepSizeOf(key) + sizeof.deepSizeOf(value);
+      } catch (Exception ex) {
+         // Try an old style computation
+         return pesc.calculateSize(key, value);
+      }
+   }
+}

--- a/server/resp/src/test/java/org/infinispan/server/resp/RespSingleNodeTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/RespSingleNodeTest.java
@@ -60,6 +60,9 @@ import io.lettuce.core.ZAddArgs;
 import io.lettuce.core.api.sync.RedisCommands;
 import io.lettuce.core.codec.RedisCodec;
 import io.lettuce.core.codec.StringCodec;
+import io.lettuce.core.json.DefaultJsonParser;
+import io.lettuce.core.json.JsonPath;
+import io.lettuce.core.json.JsonValue;
 import io.lettuce.core.output.ArrayOutput;
 import io.lettuce.core.output.StatusOutput;
 import io.lettuce.core.protocol.CommandArgs;
@@ -848,10 +851,43 @@ public class RespSingleNodeTest extends SingleNodeRespBaseTest {
    @Test
    public void testMemoryUsage() {
       RedisCommands<String, String> redis = redisConnection.sync();
+      // String test
       redis.set(k(), "1");
-      assertThat(redis.memoryUsage(k())).isEqualTo(16);
+      // Memory usage for this entry is:
+      // key: 16(header)+4(length)+4(padding) = 24
+      // value: 16(header)+1(length)+7(padding) = 24
+      // entry overhead: 24
+      assertThat(redis.memoryUsage(k())).isEqualTo(72);
       redis.set(k(1), "a".repeat(1001));
-      assertThat(redis.memoryUsage(k(1))).isEqualTo(1032);
+      // Memory usage for this entry is:
+      // key: 16(header)+18(length)+6(padding) = 40
+      // value: 16(header)+1001(length)+7(padding) = 1024
+      // entry overhead: 24
+      assertThat(redis.memoryUsage(k(1))).isEqualTo(1088);
+
+      // Check that memory usage doesn't fail for implemented data types
+      // HashMap
+      Map<String, String> map = Map.of("key1", "value1", "key2", "value2", "key3", "value3");
+      redis.hmset(k(2), map);
+      assertThat(redis.memoryUsage(k(2))).isPositive();
+      // HyperLogLog
+      redis.pfadd(k(3), "el1", "el2", "el3");
+      assertThat(redis.memoryUsage(k(3))).isPositive();
+      // List
+      redis.rpush(k(4), "william", "jose", "pedro");
+      assertThat(redis.memoryUsage(k(4))).isPositive();
+      // Set
+      redis.sadd(k(5), "1", "2", "3");
+      assertThat(redis.memoryUsage(k(5))).isPositive();
+      // SortedSet
+      redis.zadd(k(6), 10.4, "william");
+      assertThat(redis.memoryUsage(k(6))).isPositive();
+
+      JsonPath jp = new JsonPath("$");
+      DefaultJsonParser defaultJsonParser = new DefaultJsonParser();
+      JsonValue jv = defaultJsonParser.createJsonValue("{\"key\":\"value\"}");
+      redis.jsonSet(k(7), jp, jv);
+      assertThat(redis.memoryUsage(k(7))).isPositive();
    }
 
    @Test


### PR DESCRIPTION
~~Implemented using [jol library](https://github.com/openjdk/jol)~~
changed to use ehcache.sizeof which uses Unsafe to compute the size. it gives the same results as jol anyway.