### PR TITLE
 ISPN-16144 Support Micrometer 1.13

### DIFF
--- a/build/configuration/pom.xml
+++ b/build/configuration/pom.xml
@@ -136,7 +136,6 @@
       <version.console>15.1.3.Final</version.console>
       <version.fabric8.kubernetes-client>6.11.0</version.fabric8.kubernetes-client>
       <version.glassfish.jaxb>4.0.5</version.glassfish.jaxb>
-      <version.graalvm>24.0.0</version.graalvm>
       <version.groovy>2.4.21</version.groovy>
       <version.hamcrest>2.2</version.hamcrest>
       <version.hibernate.core>6.4.10.Final</version.hibernate.core>
@@ -177,12 +176,12 @@
       <version.log4j>2.23.1</version.log4j>
       <version.lucene>9.9.2</version.lucene>
       <version.metainf-services>1.11</version.metainf-services>
-      <version.micrometer>1.12.11</version.micrometer>
+      <version.micrometer>1.13.7</version.micrometer>
       <version.mockito>5.14.2</version.mockito>
       <version.mockito_dep.bytebuddy>1.15.3</version.mockito_dep.bytebuddy>
       <version.mockito_dep.objenesis>3.3</version.mockito_dep.objenesis>
       <version.nashorn>15.4</version.nashorn>
-      <version.netty>4.1.109.Final</version.netty>
+      <version.netty>4.1.111.Final</version.netty>
       <version.netty.incubator.iouring>0.0.25.Final</version.netty.incubator.iouring>
       <version.openjdk.jmh>1.37</version.openjdk.jmh>
       <version.org.wildfly.arquillian>5.0.1.Final</version.org.wildfly.arquillian>
@@ -198,11 +197,10 @@
       <version.testng.engine>1.0.5</version.testng.engine>
 
       <!-- these versions must be kept in sync with ${version.micrometer}: -->
-      <version.io.prometheus>0.15.0</version.io.prometheus>
-      <version.hdrhistogram>2.1.12</version.hdrhistogram>
+      <version.hdrhistogram>2.2.2</version.hdrhistogram>
       <version.latencyutils>2.0.3</version.latencyutils>
 
-      <version.quarkus>3.8.6</version.quarkus>
+      <version.quarkus>3.15.1</version.quarkus>
       <version.graalvm>23.1.5</version.graalvm>
       <version.jandex>3.2.3</version.jandex>
 

--- a/core/src/main/java/org/infinispan/metrics/config/MicrometerMeterRegisterConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/metrics/config/MicrometerMeterRegisterConfigurationBuilder.java
@@ -8,7 +8,7 @@ import org.infinispan.commons.configuration.attributes.AttributeSet;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 
 /**
  * Builder to inject an instance of {@link MeterRegistry}.

--- a/core/src/main/java/org/infinispan/metrics/impl/MetricsRegistryImpl.java
+++ b/core/src/main/java/org/infinispan/metrics/impl/MetricsRegistryImpl.java
@@ -42,8 +42,8 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.TimeGauge;
 import io.micrometer.core.instrument.Timer;
-import io.micrometer.prometheus.PrometheusConfig;
-import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.micrometer.prometheusmetrics.PrometheusConfig;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 
 /**
  * Concrete implementation of {@link MetricsRegistry}.

--- a/server/tests/src/test/java/org/infinispan/server/functional/hotrod/HotRodClientMetrics.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/hotrod/HotRodClientMetrics.java
@@ -30,8 +30,8 @@ import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.prometheus.PrometheusConfig;
-import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.micrometer.prometheusmetrics.PrometheusConfig;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 
 public class HotRodClientMetrics {
 

--- a/server/tests/src/test/java/org/infinispan/server/functional/rest/RestMetricsResourceIT.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/rest/RestMetricsResourceIT.java
@@ -41,8 +41,6 @@ import org.infinispan.util.logging.LogFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.prometheus.client.exporter.common.TextFormat;
-
 /**
  * Tests the Micrometer metrics exporter.
  *
@@ -53,6 +51,8 @@ public class RestMetricsResourceIT {
 
    // copied from regex101.com
    private static final Pattern PROMETHEUS_PATTERN = Pattern.compile("^(?<metric>[a-zA-Z_:][a-zA-Z0-9_:]*]*)(?<tags>\\{.*})?[\\t ]*(?<value>-?[0-9E.\\-]*)[\\t ]*(?<timestamp>[0-9]+)?$");
+   private static final String CONTENT_TYPE_004 = "text/plain; version=0.0.4; charset=utf-8";
+   private static final String CONTENT_TYPE_OPENMETRICS_100 = "application/openmetrics-text; version=1.0.0; charset=utf-8";
    private static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
    private static final int NUM_SERVERS = 3;
    private static final String[] OWNERSHIP = new String[]{
@@ -296,14 +296,14 @@ public class RestMetricsResourceIT {
    }
 
    public static void checkIsPrometheus(MediaType contentType) {
-      String[] expectedContentType = TextFormat.CONTENT_TYPE_004.split(";");
+      String[] expectedContentType = CONTENT_TYPE_004.split(";");
       String[] actualContentType = contentType.toString().split(";");
 
       assertThat(actualContentType).containsExactlyInAnyOrder(expectedContentType);
    }
 
    public static void checkIsOpenmetrics(MediaType contentType) {
-      String[] expectedContentType = TextFormat.CONTENT_TYPE_OPENMETRICS_100.split(";");
+      String[] expectedContentType = CONTENT_TYPE_OPENMETRICS_100.split(";");
       String[] actualContentType = contentType.toString().split(";");
 
       assertThat(actualContentType).containsExactlyInAnyOrder(expectedContentType);

--- a/spring/spring-boot-3/pom.xml
+++ b/spring/spring-boot-3/pom.xml
@@ -21,7 +21,7 @@
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.release>17</maven.compiler.release>
         <infinispan.cluster.stack>tcp</infinispan.cluster.stack>
-        <version.micrometer>1.10.3</version.micrometer>
+        <version.micrometer>1.13.7</version.micrometer>
     </properties>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
This change moves to support Micrometer >=1.13 instead of Micrometer <=1.12 (Micrometer 1.13 moves the prometheus package from io.micrometer.prometheus to io.micrometer.prometheusmetrics).
Please consider this for 15.1!