### PR TITLE
ISPN-16848 Programmatic configuration of virtual threads

### DIFF
--- a/commons/all/src/main/java/org/infinispan/commons/jdkspecific/ThreadCreator.java
+++ b/commons/all/src/main/java/org/infinispan/commons/jdkspecific/ThreadCreator.java
@@ -11,15 +11,32 @@ import org.infinispan.commons.util.Util;
  * @since 11.0
  **/
 public class ThreadCreator {
-   private static final org.infinispan.commons.spi.ThreadCreator INSTANCE = getInstance();
 
-   public static boolean useVirtualThreads() {
-      return Boolean.getBoolean("org.infinispan.threads.virtual");
+   private static boolean useVirtualThreads = Boolean.getBoolean("org.infinispan.threads.virtual");
+   private static org.infinispan.commons.spi.ThreadCreator INSTANCE = getInstance(useVirtualThreads);
+
+   public static void useVirtualThreads(boolean useVirtualThreads) {
+      if (useVirtualThreads != ThreadCreator.useVirtualThreads) {
+         ThreadCreator.useVirtualThreads = useVirtualThreads;
+         INSTANCE = getInstance(useVirtualThreads);
+      }
    }
 
-   private static org.infinispan.commons.spi.ThreadCreator getInstance() {
+   public static boolean useVirtualThreads() {
+      return useVirtualThreads;
+   }
+
+   public static Thread createThread(ThreadGroup threadGroup, Runnable target, boolean useVirtualThread) {
+      return INSTANCE.createThread(threadGroup, target, useVirtualThread);
+   }
+
+   public static Optional<ExecutorService> createBlockingExecutorService() {
+      return INSTANCE.newVirtualThreadPerTaskExecutor();
+   }
+
+   private static org.infinispan.commons.spi.ThreadCreator getInstance(boolean useVirtualThreads) {
       try {
-         if (useVirtualThreads()) {
+         if (useVirtualThreads) {
             org.infinispan.commons.spi.ThreadCreator instance = Util.getInstance("org.infinispan.commons.jdk21.ThreadCreatorImpl", ThreadCreator.class.getClassLoader());
             Log.CONTAINER.infof("Virtual threads support enabled");
             return instance;
@@ -30,16 +47,7 @@ public class ThreadCreator {
       return new ThreadCreatorImpl();
    }
 
-
-   public static Thread createThread(ThreadGroup threadGroup, Runnable target, boolean useVirtualThread) {
-      return INSTANCE.createThread(threadGroup, target, useVirtualThread);
-   }
-
-   public static Optional<ExecutorService> createBlockingExecutorService() {
-      return INSTANCE.newVirtualThreadPerTaskExecutor();
-   }
-
-   static class ThreadCreatorImpl implements org.infinispan.commons.spi.ThreadCreator {
+   private static class ThreadCreatorImpl implements org.infinispan.commons.spi.ThreadCreator {
 
       @Override
       public Thread createThread(ThreadGroup threadGroup, Runnable target, boolean lightweight) {


### PR DESCRIPTION
Currently virtual threads can only be enabled by setting a system property. This change makes it possible to also configure programmatically.