### PR TITLE
Fix REST client parsing for gzip content

### DIFF
--- a/client/rest-client/src/main/java/org/infinispan/client/rest/impl/jdk/RestRawClientJDK.java
+++ b/client/rest-client/src/main/java/org/infinispan/client/rest/impl/jdk/RestRawClientJDK.java
@@ -230,6 +230,7 @@ public class RestRawClientJDK implements RestRawClient, AutoCloseable {
          return switch (mediaType.getTypeSubtype()) {
             case MediaType.APPLICATION_OCTET_STREAM_TYPE, MediaType.APPLICATION_PROTOSTREAM_TYPE,
                  MediaType.APPLICATION_SERIALIZED_OBJECT_TYPE -> HttpResponse.BodyHandlers::ofByteArray;
+            case MediaType.APPLICATION_GZIP_TYPE -> HttpResponse.BodyHandlers::ofInputStream;
             default -> HttpResponse.BodyHandlers::ofString;
          };
       }

--- a/client/rest-client/src/main/java/org/infinispan/client/rest/impl/jdk/RestServerClientJDK.java
+++ b/client/rest-client/src/main/java/org/infinispan/client/rest/impl/jdk/RestServerClientJDK.java
@@ -1,6 +1,10 @@
 package org.infinispan.client.rest.impl.jdk;
 
+import static org.infinispan.client.rest.RestHeaders.ACCEPT;
+import static org.infinispan.client.rest.RestHeaders.ACCEPT_ENCODING;
+
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletionStage;
 
 import org.infinispan.client.rest.IpFilterRule;
@@ -62,12 +66,12 @@ public class RestServerClientJDK implements RestServerClient {
 
    @Override
    public CompletionStage<RestResponse> report() {
-      return client.get(path + "/report");
+      return client.get(path + "/report", Map.of(ACCEPT, MediaType.APPLICATION_GZIP_TYPE, ACCEPT_ENCODING, "gzip"));
    }
 
    @Override
    public CompletionStage<RestResponse> report(String node) {
-      return client.get(path + "/report/" + node);
+      return client.get(path + "/report/" + node, Map.of(ACCEPT, MediaType.APPLICATION_GZIP_TYPE, ACCEPT_ENCODING, "gzip"));
    }
 
    @Override

--- a/commons/all/src/main/java/org/infinispan/commons/dataconversion/MediaType.java
+++ b/commons/all/src/main/java/org/infinispan/commons/dataconversion/MediaType.java
@@ -73,6 +73,7 @@ public final class MediaType {
    public static final String APPLICATION_XML_TYPE = "application/xml";
    public static final String APPLICATION_YAML_TYPE = "application/yaml";
    public static final String APPLICATION_ZIP_TYPE = "application/zip";
+   public static final String APPLICATION_GZIP_TYPE = "application/gzip";
    public static final String APPLICATION_JBOSS_MARSHALLING_TYPE = "application/x-jboss-marshalling";
    public static final String APPLICATION_PROTOSTREAM_TYPE = "application/x-protostream";
    /**
@@ -136,6 +137,7 @@ public final class MediaType {
    public static final MediaType APPLICATION_PDF = fromString(APPLICATION_PDF_TYPE);
    public static final MediaType APPLICATION_RTF = fromString(APPLICATION_RTF_TYPE);
    public static final MediaType APPLICATION_ZIP = fromString(APPLICATION_ZIP_TYPE);
+   public static final MediaType APPLICATION_GZIP = fromString(APPLICATION_GZIP_TYPE);
    /**
     * @deprecated Since 11.0, will be removed with ISPN-9622
     */

--- a/server/rest/src/main/java/org/infinispan/rest/resources/ServerResource.java
+++ b/server/rest/src/main/java/org/infinispan/rest/resources/ServerResource.java
@@ -443,7 +443,7 @@ public class ServerResource implements ResourceHandler {
 
    private RestResponse createReportResponse(RestRequest request, Object report, String filename) {
       return invocationHelper.newResponse(request)
-            .contentType(MediaType.fromString("application/gzip"))
+            .contentType(MediaType.APPLICATION_GZIP_TYPE)
             .header("Content-Disposition",
                   String.format("attachment; filename=\"%s-%s-%3$tY%3$tm%3$td%3$tH%3$tM%3$tS-report.tar.gz\"",
                         Version.getBrandName().toLowerCase().replaceAll("\\s", "-"),

--- a/server/runtime/src/main/server/bin/report.sh
+++ b/server/runtime/src/main/server/bin/report.sh
@@ -3,7 +3,7 @@
 PROGNAME=$(basename "$0")
 DIRNAME=$(dirname "$0")
 
-count() { echo $#; }
+count() { echo "$@" | wc -l; }
 
 # Get the PID
 if [ "$1" = "" ]; then

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/core/ContainerInfinispanServerDriver.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/core/ContainerInfinispanServerDriver.java
@@ -5,6 +5,7 @@ import static org.infinispan.server.Server.DEFAULT_SERVER_CONFIG;
 import static org.infinispan.server.test.core.Containers.DOCKER_CLIENT;
 import static org.infinispan.server.test.core.Containers.getDockerBridgeAddress;
 import static org.infinispan.server.test.core.Containers.imageArchitecture;
+import static org.infinispan.server.test.core.TestSystemPropertyNames.INFINISPAN_TEST_SERVER_CONTAINER_ULIMIT;
 import static org.infinispan.server.test.core.TestSystemPropertyNames.INFINISPAN_TEST_SERVER_CONTAINER_VOLUME_REQUIRED;
 import static org.infinispan.server.test.core.TestSystemPropertyNames.INFINISPAN_TEST_SERVER_LOG_FILE;
 
@@ -69,6 +70,7 @@ import com.github.dockerjava.api.command.InspectImageResponse;
 import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.api.model.Mount;
 import com.github.dockerjava.api.model.MountType;
+import com.github.dockerjava.api.model.Ulimit;
 
 /**
  * @author Tristan Tarrant &lt;tristan@infinispan.org&gt;
@@ -84,6 +86,14 @@ public class ContainerInfinispanServerDriver extends AbstractInfinispanServerDri
    private static final Long IMAGE_MEMORY_SWAP = Long.getLong(TestSystemPropertyNames.INFINISPAN_TEST_SERVER_CONTAINER_MEMORY_SWAP, null);
    public static final String INFINISPAN_SERVER_HOME = "/opt/infinispan";
    public static final String JDK_BASE_IMAGE_NAME = "registry.access.redhat.com/ubi9/openjdk-21-runtime";
+   private static final String[] IMAGE_DEPENDENCIES = {
+         "file",
+         "gzip",
+         "iproute",
+         "lsof",
+         "tar",
+         "vim-minimal"
+   };
    public static final String IMAGE_USER = "185";
    public static final Integer[] EXPOSED_PORTS = {
          11222, // Protocol endpoint
@@ -304,6 +314,15 @@ public class ContainerInfinispanServerDriver extends AbstractInfinispanServerDri
                }
                if (IMAGE_MEMORY_SWAP != null) {
                   cmd.getHostConfig().withMemorySwap(IMAGE_MEMORY_SWAP);
+               }
+
+               String ulimit = configuration.properties().getProperty(INFINISPAN_TEST_SERVER_CONTAINER_ULIMIT);
+               if (ulimit != null) {
+                  String[] softHard = ulimit.split(",");
+                  assert softHard.length == 2 : "Ulimit property must have format '<soft>,<hard>'";
+                  long soft = Long.parseLong(softHard[0]);
+                  long hard = Long.parseLong(softHard[1]);
+                  cmd.getHostConfig().withUlimits(new Ulimit[] { new Ulimit("nofile", soft, hard) });
                }
             });
       if (configuration.numServers() == 1 && (OS.getCurrentOs().equals(OS.MAC_OS) || OS.getCurrentOs().equals(OS.WINDOWS))) {
@@ -590,7 +609,7 @@ public class ContainerInfinispanServerDriver extends AbstractInfinispanServerDri
                      .label("architecture", imageArchitecture())
                      .withStatement(new RawStatement("COPY", "--chown=" + IMAGE_USER + ":" + IMAGE_USER + " build " + INFINISPAN_SERVER_HOME))
                      .user("root")
-                     .run("microdnf install -y tar")
+                     .run(String.format("microdnf install -y %s", String.join(" ", IMAGE_DEPENDENCIES)))
                      .user(IMAGE_USER));
          log.infof("Building server snapshot image from %s", serverOutputPath);
          image.get();

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/core/TestSystemPropertyNames.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/core/TestSystemPropertyNames.java
@@ -86,6 +86,13 @@ public class TestSystemPropertyNames {
     * Specifies whether a docker volume should be created and mounted to the container
     */
    public static final String INFINISPAN_TEST_SERVER_CONTAINER_VOLUME_REQUIRED= PREFIX + "container.volume";
+
+   /**
+    * Specifies the soft and hard ulimit to use in the container.
+    * Follows the format: `<code>soft,hard</code>`
+    */
+   public static final String INFINISPAN_TEST_SERVER_CONTAINER_ULIMIT = PREFIX + "container.ulimit";
+
    /**
     * Specifies the name of the keycloak base image
     */

--- a/server/tests/pom.xml
+++ b/server/tests/pom.xml
@@ -20,9 +20,15 @@
       <defaultExcludedTestGroup/>
       <org.infinispan.test.server.dir>${project.basedir}/../runtime/target/${infinispan.brand.prefix}-server-${infinispan.brand.version}</org.infinispan.test.server.dir>
       <org.infinispan.test.server.lib.dir>${project.build.directory}/testlibs</org.infinispan.test.server.lib.dir>
+      <org.infinispan.test.server.container.ulimit>4096,65539</org.infinispan.test.server.container.ulimit>
       <infinispan.cluster.stack>test-tcp</infinispan.cluster.stack>
       <log4j.configurationFile>${project.build.testOutputDirectory}/configuration/log4j2.xml</log4j.configurationFile>
       <infinispan.server.log.path>${project.build.directory}</infinispan.server.log.path>
+
+      <test.driverArgs>
+         -Dorg.infinispan.test.server.dir=${org.infinispan.test.server.dir}
+         -Dorg.infinispan.test.server.container.ulimit=${org.infinispan.test.server.container.ulimit}
+      </test.driverArgs>
    </properties>
 
    <dependencies>
@@ -100,6 +106,13 @@
       <dependency>
          <groupId>io.vertx</groupId>
          <artifactId>vertx-junit5</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.apache.commons</groupId>
+         <artifactId>commons-compress</artifactId>
+         <version>${version.commons.compress}</version>
          <scope>test</scope>
       </dependency>
 
@@ -202,7 +215,7 @@
                   <usedefaultlisteners>false</usedefaultlisteners>
                   <listener>${junitListener},org.infinispan.server.test.junit4.InfinispanServerTestListener</listener>
                </properties>
-               <argLine>${forkJvmArgs} ${testjvm.jdkSpecificArgs} -Dorg.infinispan.test.server.dir=${org.infinispan.test.server.dir} -Djdk.attach.allowAttachSelf=true</argLine>
+               <argLine>${forkJvmArgs} ${testjvm.jdkSpecificArgs} ${test.driverArgs} -Djdk.attach.allowAttachSelf=true</argLine>
             </configuration>
             <executions>
                <execution>
@@ -229,7 +242,7 @@
             <activeByDefault>false</activeByDefault>
          </activation>
          <properties>
-            <container.argLine>${forkJvmArgs} ${testjvm.jdkSpecificArgs} -Dorg.infinispan.test.server.dir=${org.infinispan.test.server.dir}
+            <container.argLine>${forkJvmArgs} ${testjvm.jdkSpecificArgs} ${test.driverArgs}
                -Djdk.attach.allowAttachSelf=true -Dorg.infinispan.test.server.driver=CONTAINER
             </container.argLine>
          </properties>

--- a/server/tests/src/test/java/org/infinispan/server/security/authorization/RESTAuthorizationTest.java
+++ b/server/tests/src/test/java/org/infinispan/server/security/authorization/RESTAuthorizationTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.server.security.authorization;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.infinispan.client.rest.RestHeaders.CONTENT_DISPOSITION;
 import static org.infinispan.client.rest.RestResponse.ACCEPTED;
 import static org.infinispan.client.rest.RestResponse.CREATED;
@@ -40,7 +41,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.zip.GZIPInputStream;
 
+import org.apache.commons.compress.archivers.ArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.infinispan.client.rest.RestCacheClient;
 import org.infinispan.client.rest.RestClient;
 import org.infinispan.client.rest.RestClusterClient;
@@ -416,7 +421,7 @@ abstract class RESTAuthorizationTest {
    }
 
    @Test
-   public void testRestServerNodeReport() {
+   public void testRestServerNodeReport() throws Exception {
       ext.assumeContainerMode();
 
       RestClusterClient restClient = ext.rest().withClientConfiguration(restBuilders.get(TestUser.ADMIN)).get().cluster();
@@ -428,10 +433,12 @@ abstract class RESTAuthorizationTest {
 
       RestServerClient client = ext.rest().withClientConfiguration(restBuilders.get(TestUser.ADMIN)).get().server();
       for (String name : nodes) {
-         RestResponse response = CompletionStages.join(client.report(name));
-         assertEquals(OK, response.status());
-         assertEquals("application/gzip", response.header("content-type"));
-         assertTrue(response.header("Content-Disposition").startsWith("attachment;"));
+         try (RestResponse response = CompletionStages.join(client.report(name))) {
+            assertEquals(OK, response.status());
+            assertEquals(MediaType.APPLICATION_GZIP_TYPE, response.header("content-type"));
+            assertTrue(response.header("Content-Disposition").startsWith("attachment;"));
+            assertValidTar(response.bodyAsStream());
+         }
       }
 
       RestResponse response = CompletionStages.join(client.report("not-a-node-name"));
@@ -441,6 +448,39 @@ abstract class RESTAuthorizationTest {
          RestServerClient otherClient = ext.rest().withClientConfiguration(restBuilders.get(user)).get().server();
          assertStatus(FORBIDDEN, otherClient.report(ext.getMethodName()));
       }
+   }
+
+   @Test
+   public void testRestServerGeneralReport() throws Exception {
+      ext.assumeContainerMode();
+
+      RestServerClient client = ext.rest().withClientConfiguration(restBuilders.get(TestUser.ADMIN)).get().server();
+
+      try (RestResponse response = CompletionStages.join(client.report())) {
+         assertEquals(OK, response.status());
+         assertEquals(MediaType.APPLICATION_GZIP_TYPE, response.header("content-type"));
+         assertTrue(response.header("Content-Disposition").startsWith("attachment;"));
+         assertValidTar(response.bodyAsStream());
+      }
+
+      for (TestUser user : EnumSet.complementOf(EnumSet.of(TestUser.ANONYMOUS, TestUser.ADMIN))) {
+         RestServerClient otherClient = ext.rest().withClientConfiguration(restBuilders.get(user)).get().server();
+         assertStatus(FORBIDDEN, otherClient.report());
+      }
+   }
+
+   private void assertValidTar(InputStream is) throws Exception {
+      long contentSize = 0;
+      try (GZIPInputStream gis = new GZIPInputStream(is);
+           TarArchiveInputStream tar = new TarArchiveInputStream(new GzipCompressorInputStream(gis))) {
+         ArchiveEntry entry;
+         while ((entry = tar.getNextEntry()) != null) {
+            if (entry.isDirectory()) continue;
+            contentSize += entry.getSize();
+         }
+      }
+
+      assertThat(contentSize).isPositive();
    }
 
    @Test


### PR DESCRIPTION
* Set the header and the correct handler to parse the body;
* Handle the stream as gzip in the CLI client;
* Updates the test to generate the report and validate the contents;

Closes #13210.