### PR TITLE
Fix LicenseTest.testLicense. Fixes #13217

### DIFF
--- a/server/runtime/pom.xml
+++ b/server/runtime/pom.xml
@@ -330,7 +330,7 @@
             <executions>
                <execution>
                   <id>console</id>
-                  <phase>prepare-package</phase>
+                  <phase>generate-test-resources</phase>
                   <goals>
                      <goal>unpack</goal>
                   </goals>
@@ -422,7 +422,7 @@
                </execution>
                <execution>
                   <id>build-server</id>
-                  <phase>package</phase>
+                  <phase>process-test-resources</phase>
                   <goals>
                      <goal>run</goal>
                   </goals>
@@ -496,7 +496,7 @@
                   <goals>
                      <goal>transform</goal>
                   </goals>
-                  <phase>package</phase>
+                  <phase>generate-test-resources</phase>
                   <configuration>
                      <transformationSets>
                         <transformationSet>


### PR DESCRIPTION
change execution order to have all the files ready for testing.
Fixes #13217 