### PR TITLE
[15.0.x] ISPN-16774 List, Sets, Sorted Sets, and Hashes working with transactions

### DIFF
--- a/multimap/src/main/java/org/infinispan/multimap/impl/EmbeddedMultimapCacheManager.java
+++ b/multimap/src/main/java/org/infinispan/multimap/impl/EmbeddedMultimapCacheManager.java
@@ -69,4 +69,12 @@ public class EmbeddedMultimapCacheManager<K, V> implements MultimapCacheManager<
       }
       return new EmbeddedMultimapPairCache<>(cache);
    }
+
+   public EmbeddedSetCache<K, V> getMultimapSet(String cacheName) {
+      Cache<K, SetBucket<V>> cache = cacheManager.getCache(cacheName);
+      if (cache == null) {
+         throw new IllegalStateException("Cache must exist: " + cacheName);
+      }
+      return new EmbeddedSetCache<>(cache);
+   }
 }

--- a/multimap/src/main/java/org/infinispan/multimap/impl/EmbeddedSetCache.java
+++ b/multimap/src/main/java/org/infinispan/multimap/impl/EmbeddedSetCache.java
@@ -2,7 +2,6 @@ package org.infinispan.multimap.impl;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -86,7 +85,7 @@ public class EmbeddedSetCache<K, V> {
    public CompletionStage<Long> add(K key, V value) {
       requireNonNull(key, ERR_KEY_CAN_T_BE_NULL);
       requireNonNull(value, ERR_VALUE_CAN_T_BE_NULL);
-      return readWriteMap.eval(key, new SAddFunction<>(Arrays.asList(value)));
+      return readWriteMap.eval(key, new SAddFunction<>(List.of(value)));
    }
 
    /**
@@ -112,7 +111,7 @@ public class EmbeddedSetCache<K, V> {
    public CompletionStage<Long> remove(K key, V value) {
       requireNonNull(key, ERR_KEY_CAN_T_BE_NULL);
       requireNonNull(value, ERR_VALUE_CAN_T_BE_NULL);
-      return readWriteMap.eval(key, new SRemoveFunction<>(Arrays.asList(value)));
+      return readWriteMap.eval(key, new SRemoveFunction<>(List.of(value)));
    }
 
    /**

--- a/multimap/src/main/java/org/infinispan/multimap/impl/function/hmap/HashMapPutFunction.java
+++ b/multimap/src/main/java/org/infinispan/multimap/impl/function/hmap/HashMapPutFunction.java
@@ -45,20 +45,17 @@ public class HashMapPutFunction<K, HK, HV> extends HashMapBucketBaseFunction<K, 
       Map<HK, HV> values = entries.stream().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
       Optional<HashMapBucket<HK, HV>> existing = view.peek();
 
-      int res;
-      HashMapBucket<HK, HV> bucket;
-      if (existing.isPresent()) {
-         bucket = existing.get();
-         res = putIfAbsent
-               ? bucket.putIfAbsent(values)
-               : bucket.putAll(values);
-      } else {
-         bucket = HashMapBucket.create(values);
-         res = values.size();
+      if (existing.isEmpty()) {
+         view.set(HashMapBucket.create(values));
+         return values.size();
       }
-      view.set(bucket);
+      HashMapBucket<HK, HV> bucket = existing.get();
+      HashMapBucket.HashMapBucketResponse<Integer, HK, HV> res = putIfAbsent
+            ? bucket.putIfAbsent(values)
+            : bucket.putAll(values);
+      view.set(res.bucket());
 
-      return res;
+      return res.response();
    }
 
    public static class Externalizer implements AdvancedExternalizer<HashMapPutFunction> {

--- a/multimap/src/main/java/org/infinispan/multimap/impl/function/hmap/HashMapRemoveFunction.java
+++ b/multimap/src/main/java/org/infinispan/multimap/impl/function/hmap/HashMapRemoveFunction.java
@@ -27,23 +27,21 @@ public class HashMapRemoveFunction<K, HK, HV> extends HashMapBucketBaseFunction<
 
    @Override
    public Integer apply(EntryView.ReadWriteEntryView<K, HashMapBucket<HK, HV>> view) {
-      int res = 0;
       Optional<HashMapBucket<HK, HV>> existing = view.peek();
+      if (existing.isEmpty()) return 0;
 
-      if (existing.isPresent()) {
-         HashMapBucket<HK, HV> bucket = existing.get();
-         res = bucket.removeAll(keys);
+      HashMapBucket<HK, HV> bucket = existing.get();
+      var res = bucket.removeAll(keys);
 
-         if (bucket.isEmpty()) {
-            view.remove();
-         } else {
-            view.set(bucket);
-         }
+      if (res.bucket().isEmpty()) {
+         view.remove();
+      } else {
+         view.set(res.bucket());
       }
-      return res;
+      return res.response();
    }
 
-   @SuppressWarnings({"rawtypes", "deprecation"})
+   @SuppressWarnings({"rawtypes"})
    private static class Externalizer implements AdvancedExternalizer<HashMapRemoveFunction> {
 
       @Override

--- a/multimap/src/main/java/org/infinispan/multimap/impl/function/hmap/HashMapReplaceFunction.java
+++ b/multimap/src/main/java/org/infinispan/multimap/impl/function/hmap/HashMapReplaceFunction.java
@@ -33,10 +33,11 @@ public class HashMapReplaceFunction<K, HK, HV> extends HashMapBucketBaseFunction
       Optional<HashMapBucket<HK, HV>> existing = view.peek();
       HashMapBucket<HK, HV> bucket = existing.orElse(HashMapBucket.create(Map.of()));
 
-      boolean replaced = bucket.replace(property, expected, replacement);
-      if (replaced) view.set(bucket);
+      // Replace returns null when there are no changes.
+      HashMapBucket<HK, HV> next = bucket.replace(property, expected, replacement);
+      if (next != null && next != bucket) view.set(next);
 
-      return replaced;
+      return next != null;
    }
 
    @SuppressWarnings({"unchecked", "rawtypes", "deprecation"})

--- a/multimap/src/main/java/org/infinispan/multimap/impl/function/list/PollFunction.java
+++ b/multimap/src/main/java/org/infinispan/multimap/impl/function/list/PollFunction.java
@@ -1,10 +1,5 @@
 package org.infinispan.multimap.impl.function.list;
 
-import org.infinispan.commons.marshall.AdvancedExternalizer;
-import org.infinispan.functional.EntryView;
-import org.infinispan.multimap.impl.ExternalizerIds;
-import org.infinispan.multimap.impl.ListBucket;
-
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
@@ -13,6 +8,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+
+import org.infinispan.commons.marshall.AdvancedExternalizer;
+import org.infinispan.functional.EntryView;
+import org.infinispan.multimap.impl.ExternalizerIds;
+import org.infinispan.multimap.impl.ListBucket;
 
 /**
  * Serializable function used by
@@ -43,13 +43,13 @@ public final class PollFunction<K, V> implements ListBucketBaseFunction<K, V, Co
             return List.of();
          }
 
-         ListBucket<V>.ListBucketResult result = existing.get().poll(first, count);
-         if (result.bucketValue().isEmpty()) {
+         ListBucket.ListBucketResult<Collection<V>, V> result = existing.get().poll(first, count);
+         if (result.bucket().isEmpty()) {
             entryView.remove();
          } else {
-            entryView.set(result.bucketValue());
+            entryView.set(result.bucket());
          }
-         return result.opResult();
+         return result.result();
       }
       // key does not exist
       return null;

--- a/multimap/src/main/java/org/infinispan/multimap/impl/function/list/RemoveCountFunction.java
+++ b/multimap/src/main/java/org/infinispan/multimap/impl/function/list/RemoveCountFunction.java
@@ -1,16 +1,16 @@
 package org.infinispan.multimap.impl.function.list;
 
-import org.infinispan.commons.marshall.AdvancedExternalizer;
-import org.infinispan.functional.EntryView;
-import org.infinispan.multimap.impl.ExternalizerIds;
-import org.infinispan.multimap.impl.ListBucket;
-
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
+
+import org.infinispan.commons.marshall.AdvancedExternalizer;
+import org.infinispan.functional.EntryView;
+import org.infinispan.multimap.impl.ExternalizerIds;
+import org.infinispan.multimap.impl.ListBucket;
 
 /**
  * Serializable function used by
@@ -36,12 +36,15 @@ public final class RemoveCountFunction<K, V> implements ListBucketBaseFunction<K
       Optional<ListBucket<V>> existing = entryView.peek();
       if (existing.isPresent()) {
          ListBucket<V> prevBucket = existing.get();
-         long removedCount = existing.get().remove(count, element);
-         if (prevBucket.isEmpty()) {
+         ListBucket.ListBucketResult<Long, V> result = prevBucket.remove(count, element);
+         if (result.bucket().isEmpty()) {
             // if the list is empty, remove
             entryView.remove();
+            return result.result();
          }
-         return removedCount;
+
+         entryView.set(result.bucket());
+         return result.result();
       }
       // key does not exist
       return 0L;

--- a/multimap/src/main/java/org/infinispan/multimap/impl/function/list/RotateFunction.java
+++ b/multimap/src/main/java/org/infinispan/multimap/impl/function/list/RotateFunction.java
@@ -1,16 +1,16 @@
 package org.infinispan.multimap.impl.function.list;
 
-import org.infinispan.commons.marshall.AdvancedExternalizer;
-import org.infinispan.functional.EntryView;
-import org.infinispan.multimap.impl.ExternalizerIds;
-import org.infinispan.multimap.impl.ListBucket;
-
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
+
+import org.infinispan.commons.marshall.AdvancedExternalizer;
+import org.infinispan.functional.EntryView;
+import org.infinispan.multimap.impl.ExternalizerIds;
+import org.infinispan.multimap.impl.ListBucket;
 
 /**
  * Serializable function used by
@@ -33,7 +33,9 @@ public final class RotateFunction<K, V> implements ListBucketBaseFunction<K, V, 
    public V apply(EntryView.ReadWriteEntryView<K, ListBucket<V>> entryView) {
       Optional<ListBucket<V>> existing = entryView.peek();
       if (existing.isPresent()) {
-         return existing.get().rotate(rotateRight);
+         ListBucket.ListBucketResult<V, V> result = existing.get().rotate(rotateRight);
+         entryView.set(result.bucket());
+         return result.result();
       }
       // key does not exist
       return null;

--- a/multimap/src/main/java/org/infinispan/multimap/impl/function/list/TrimFunction.java
+++ b/multimap/src/main/java/org/infinispan/multimap/impl/function/list/TrimFunction.java
@@ -35,10 +35,12 @@ public final class TrimFunction<K, V> implements ListBucketBaseFunction<K, V, Bo
    public Boolean apply(EntryView.ReadWriteEntryView<K, ListBucket<V>> entryView) {
       Optional<ListBucket<V>> existing = entryView.peek();
       if (existing.isPresent()) {
-         ListBucket bucket = existing.get();
-         bucket.trim(from, to);
-         if (bucket.isEmpty()) {
+         ListBucket<V> bucket = existing.get();
+         ListBucket<V> trimmed = bucket.trim(from, to);
+         if (trimmed.isEmpty()) {
             entryView.remove();
+         } else {
+            entryView.set(trimmed);
          }
          return true;
       }

--- a/multimap/src/main/java/org/infinispan/multimap/impl/function/set/SAddFunction.java
+++ b/multimap/src/main/java/org/infinispan/multimap/impl/function/set/SAddFunction.java
@@ -35,11 +35,13 @@ public final class SAddFunction<K, V> implements SetBucketBaseFunction<K, V, Lon
    @Override
    public Long apply(EntryView.ReadWriteEntryView<K, SetBucket<V>> entryView) {
       Optional<SetBucket<V>> existing = entryView.peek();
-      Long added = 0L;
-      var s = existing.isPresent() ? existing.get() : new SetBucket<V>();
+      long added = 0L;
+      var s = existing.orElseGet(SetBucket::new);
       var initSize = s.size();
-      if (s.addAll(values)) {
-         added = Long.valueOf(s.size() - initSize);
+      var res = s.addAll(values);
+      s = res.bucket();
+      if (res.result()) {
+         added = s.size() - initSize;
       }
       // don't change the cache if the value already exists. it avoids replicating a
       // no-op

--- a/multimap/src/main/java/org/infinispan/multimap/impl/function/set/SRemoveFunction.java
+++ b/multimap/src/main/java/org/infinispan/multimap/impl/function/set/SRemoveFunction.java
@@ -35,14 +35,16 @@ public final class SRemoveFunction<K, V> implements SetBucketBaseFunction<K, V, 
    @Override
    public Long apply(EntryView.ReadWriteEntryView<K, SetBucket<V>> entryView) {
       Optional<SetBucket<V>> existing = entryView.peek();
-      Long removed = 0L;
-      if (!existing.isPresent()) {
+      long removed = 0L;
+      if (existing.isEmpty()) {
          return 0L;
       }
-      var s = existing.get();
-      var initSize = s.size();
-      if (s.removeAll(values)) {
-         removed = Long.valueOf(initSize - s.size());
+      SetBucket<V> s = existing.get();
+      int initSize = s.size();
+      var res = s.removeAll(values);
+      s = res.bucket();
+      if (res.result()) {
+         removed = initSize - s.size();
       }
       // don't change the cache if the value already exists. it avoids replicating a
       // no-op

--- a/multimap/src/main/java/org/infinispan/multimap/impl/function/set/SSetFunction.java
+++ b/multimap/src/main/java/org/infinispan/multimap/impl/function/set/SSetFunction.java
@@ -39,7 +39,7 @@ public final class SSetFunction<K, V> implements SetBucketBaseFunction<K, V, Lon
          }
          return 0L;
       }
-      var set = new SetBucket<V>(new HashSet<>(values));
+      var set = SetBucket.create(values);
       entryView.set(set);
       return (long) set.size();
    }

--- a/multimap/src/main/java/org/infinispan/multimap/impl/function/sortedset/IncrFunction.java
+++ b/multimap/src/main/java/org/infinispan/multimap/impl/function/sortedset/IncrFunction.java
@@ -63,10 +63,11 @@ public final class IncrFunction<K, V> implements SortedSetBucketBaseFunction<K, 
       }
       Double result = null;
       if (bucket != null) {
-         result = bucket.incrScore(score, member, addOnly, updateOnly, updateLessScoresOnly, updateGreaterScoresOnly);
+         var res = bucket.incrScore(score, member, addOnly, updateOnly, updateLessScoresOnly, updateGreaterScoresOnly);
          //don't change if nothing was added or updated. it avoids replicating a no-op
-         if (result != null) {
-            entryView.set(bucket);
+         if (res != null) {
+            result = res.result();
+            entryView.set(res.bucket());
          }
       }
 

--- a/multimap/src/main/java/org/infinispan/multimap/impl/function/sortedset/PopFunction.java
+++ b/multimap/src/main/java/org/infinispan/multimap/impl/function/sortedset/PopFunction.java
@@ -37,11 +37,12 @@ public final class PopFunction<K, V> implements SortedSetBucketBaseFunction<K, V
       Optional<SortedSetBucket<V>> existing = entryView.peek();
       if (existing.isPresent()) {
          SortedSetBucket<V> sortedSetBucket = existing.get();
-         Collection<ScoredValue<V>> poppedValues = sortedSetBucket.pop(min, count);
-         if (sortedSetBucket.size() == 0) {
+         var result = sortedSetBucket.pop(min, count);
+         Collection<ScoredValue<V>> poppedValues = result.result();
+         if (result.bucket().size() == 0) {
             entryView.remove();
          } else {
-            entryView.set(sortedSetBucket);
+            entryView.set(result.bucket());
          }
          return poppedValues;
       }

--- a/multimap/src/main/java/org/infinispan/multimap/impl/internal/MultimapObjectWrapper.java
+++ b/multimap/src/main/java/org/infinispan/multimap/impl/internal/MultimapObjectWrapper.java
@@ -49,10 +49,11 @@ public class MultimapObjectWrapper<T> implements Comparable<MultimapObjectWrappe
       if (this == obj) return true;
       if (!(obj instanceof MultimapObjectWrapper<?> other)) return false;
 
-      if (object instanceof byte[] && other.object instanceof byte[])
-         return Arrays.equals((byte[]) object, (byte[]) other.object);
+      return wrappedEquals(this.object, other.object);
+   }
 
-      return Objects.equals(object, other.object);
+   public boolean wrappedEquals(Object obj) {
+      return MultimapObjectWrapper.wrappedEquals(this.object, obj);
    }
 
    public Double asDouble() {
@@ -99,5 +100,12 @@ public class MultimapObjectWrapper<T> implements Comparable<MultimapObjectWrappe
          return "MultimapObjectWrapper{" + "object=" + Util.hexDump((byte[])object) + '}';
       }
       return "MultimapObjectWrapper{" + "object=" + object + '}';
+   }
+
+   public static boolean wrappedEquals(Object thisWrapped, Object thatWrapped) {
+      if (thisWrapped instanceof byte[] left && thatWrapped instanceof byte[] right)
+         return Arrays.equals(left, right);
+
+      return Objects.equals(thisWrapped, thatWrapped);
    }
 }

--- a/multimap/src/test/java/org/infinispan/multimap/impl/BaseDistributedMultimapTest.java
+++ b/multimap/src/test/java/org/infinispan/multimap/impl/BaseDistributedMultimapTest.java
@@ -1,9 +1,13 @@
 package org.infinispan.multimap.impl;
 
+import static org.infinispan.functional.FunctionalTestUtils.await;
+
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletionStage;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
@@ -53,6 +57,12 @@ public abstract class BaseDistributedMultimapTest<T, V> extends BaseDistFunction
                   constructor.get().fromOwner(true).numOwners(1).cacheMode(CacheMode.DIST_SYNC).transactional(true).lockingMode(mode)
             ))
             .toArray();
+   }
+
+   protected void runAndRollback(Callable<CompletionStage<?>> method) throws Throwable {
+      tm(0, cacheName).begin();
+      await(method.call());
+      tm(0, cacheName).rollback();
    }
 
    protected final <O extends BaseDistributedMultimapTest<T, V>> O self() {

--- a/multimap/src/test/java/org/infinispan/multimap/impl/BaseDistributedMultimapTest.java
+++ b/multimap/src/test/java/org/infinispan/multimap/impl/BaseDistributedMultimapTest.java
@@ -1,0 +1,95 @@
+package org.infinispan.multimap.impl;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.distribution.BaseDistFunctionalTest;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.multimap.api.embedded.EmbeddedMultimapCacheManagerFactory;
+import org.infinispan.protostream.SerializationContextInitializer;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.transaction.LockingMode;
+
+public abstract class BaseDistributedMultimapTest<T, V> extends BaseDistFunctionalTest<String, V> {
+
+   protected Map<Address, T> cluster = new HashMap<>();
+   protected boolean fromOwner;
+
+   protected abstract T create(EmbeddedMultimapCacheManager<String, V> manager);
+
+   protected void createCacheManagers() throws Throwable {
+      super.createCacheManagers();
+
+      for (EmbeddedCacheManager cacheManager : cacheManagers) {
+         EmbeddedMultimapCacheManager<String, V> multimapCacheManager = (EmbeddedMultimapCacheManager<String, V>) EmbeddedMultimapCacheManagerFactory.from(cacheManager);
+         cluster.put(cacheManager.getAddress(), create(multimapCacheManager));
+      }
+   }
+
+   protected final Object[] factory(Supplier<BaseDistributedMultimapTest<T, V>> constructor) {
+      return Stream.of(Boolean.TRUE, Boolean.FALSE)
+            .flatMap(tx -> {
+               if (tx) {
+                  return Stream.of(transactionalFactory(constructor));
+               }
+
+               return Stream.of(
+                     constructor.get().fromOwner(false).numOwners(1).cacheMode(CacheMode.DIST_SYNC).transactional(false),
+                     constructor.get().fromOwner(true).numOwners(1).cacheMode(CacheMode.DIST_SYNC).transactional(false)
+               );
+            })
+            .toArray();
+   }
+
+   protected final Object[] transactionalFactory(Supplier<BaseDistributedMultimapTest<T, V>> constructor) {
+      return Arrays.stream(LockingMode.values())
+            .flatMap(mode -> Stream.of(
+                  constructor.get().fromOwner(false).numOwners(1).cacheMode(CacheMode.DIST_SYNC).transactional(true).lockingMode(mode),
+                  constructor.get().fromOwner(true).numOwners(1).cacheMode(CacheMode.DIST_SYNC).transactional(true).lockingMode(mode)
+            ))
+            .toArray();
+   }
+
+   protected final <O extends BaseDistributedMultimapTest<T, V>> O self() {
+      return (O) this;
+   }
+
+   protected <O extends BaseDistributedMultimapTest<T, V>> O fromOwner(boolean value) {
+      this.fromOwner = value;
+      return self();
+   }
+
+   @Override
+   protected String[] parameterNames() {
+      return concat(super.parameterNames(), "fromOwner");
+   }
+
+   @Override
+   protected Object[] parameterValues() {
+      return concat(super.parameterValues(), fromOwner);
+   }
+
+   @Override
+   protected SerializationContextInitializer getSerializationContext() {
+      return MultimapSCI.INSTANCE;
+   }
+
+   protected final String getEntryKey() {
+      return fromOwner
+            ? getStringKeyForCache(cache(0, cacheName))
+            : getStringKeyForCache(cache(cluster.size() - 1, cacheName));
+   }
+
+   protected final T getMultimapMember() {
+      return getMultimapMember(0);
+   }
+
+   protected final T getMultimapMember(int index) {
+      return Objects.requireNonNull(cluster.get(manager(index).getAddress()));
+   }
+}

--- a/multimap/src/test/java/org/infinispan/multimap/impl/DistributedMultimapSortedSetCacheTest.java
+++ b/multimap/src/test/java/org/infinispan/multimap/impl/DistributedMultimapSortedSetCacheTest.java
@@ -1,19 +1,5 @@
 package org.infinispan.multimap.impl;
 
-import org.infinispan.configuration.cache.CacheMode;
-import org.infinispan.distribution.BaseDistFunctionalTest;
-import org.infinispan.functional.FunctionalTestUtils;
-import org.infinispan.manager.EmbeddedCacheManager;
-import org.infinispan.multimap.api.embedded.EmbeddedMultimapCacheManagerFactory;
-import org.infinispan.protostream.SerializationContextInitializer;
-import org.infinispan.remoting.transport.Address;
-import org.infinispan.test.data.Person;
-import org.testng.annotations.Test;
-
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.util.Lists.list;
@@ -24,146 +10,108 @@ import static org.infinispan.multimap.impl.MultimapTestUtils.FELIX;
 import static org.infinispan.multimap.impl.MultimapTestUtils.IGOR;
 import static org.infinispan.multimap.impl.MultimapTestUtils.IZARO;
 import static org.infinispan.multimap.impl.MultimapTestUtils.JULIEN;
-import static org.infinispan.multimap.impl.MultimapTestUtils.NAMES_KEY;
 import static org.infinispan.multimap.impl.MultimapTestUtils.OIHANA;
 import static org.infinispan.multimap.impl.MultimapTestUtils.PEPE;
 import static org.infinispan.multimap.impl.MultimapTestUtils.RAMON;
 import static org.infinispan.multimap.impl.ScoredValue.of;
 import static org.infinispan.multimap.impl.SortedSetBucket.AggregateFunction.SUM;
-import static org.infinispan.multimap.impl.SortedSetSubsetArgs.create;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertTrue;
 
+import java.util.Map;
+
+import org.infinispan.functional.FunctionalTestUtils;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.test.data.Person;
+import org.testng.annotations.Test;
+
 @Test(groups = "functional", testName = "distribution.DistributedMultimapSortedSetCacheTest")
-public class DistributedMultimapSortedSetCacheTest extends BaseDistFunctionalTest<String, Collection<Person>> {
-
-   protected Map<Address, EmbeddedMultimapSortedSetCache<String, Person>> sortedSetCluster = new HashMap<>();
-   protected boolean fromOwner;
-
-   public DistributedMultimapSortedSetCacheTest fromOwner(boolean fromOwner) {
-      this.fromOwner = fromOwner;
-      return this;
-   }
+public class DistributedMultimapSortedSetCacheTest extends BaseDistributedMultimapTest<EmbeddedMultimapSortedSetCache<String, Person>, Person> {
 
    @Override
-   protected void createCacheManagers() throws Throwable {
-      super.createCacheManagers();
-
-      for (EmbeddedCacheManager cacheManager : cacheManagers) {
-         EmbeddedMultimapCacheManager multimapCacheManager = (EmbeddedMultimapCacheManager) EmbeddedMultimapCacheManagerFactory.from(cacheManager);
-         sortedSetCluster.put(cacheManager.getAddress(), multimapCacheManager.getMultimapSortedSet(cacheName));
-      }
-   }
-
-   @Override
-   protected SerializationContextInitializer getSerializationContext() {
-      return MultimapSCI.INSTANCE;
-   }
-
-   @Override
-   protected String[] parameterNames() {
-      return concat(super.parameterNames(), "fromOwner");
-   }
-
-   @Override
-   protected Object[] parameterValues() {
-      return concat(super.parameterValues(), fromOwner ? Boolean.TRUE : Boolean.FALSE);
+   protected EmbeddedMultimapSortedSetCache<String, Person> create(EmbeddedMultimapCacheManager<String, Person> manager) {
+      return manager.getMultimapSortedSet(cacheName);
    }
 
    @Override
    public Object[] factory() {
-      return new Object[]{
-            new DistributedMultimapSortedSetCacheTest().fromOwner(false).cacheMode(CacheMode.DIST_SYNC).transactional(false),
-            new DistributedMultimapSortedSetCacheTest().fromOwner(true).cacheMode(CacheMode.DIST_SYNC).transactional(false),
-      };
-   }
-
-   @Override
-   protected void initAndTest() {
-      for (EmbeddedMultimapSortedSetCache sortedSet : sortedSetCluster.values()) {
-         assertThat(await(sortedSet.size(NAMES_KEY))).isEqualTo(0L);
-      }
-   }
-
-   protected EmbeddedMultimapSortedSetCache<String, Person> getMultimapCacheMember() {
-      return sortedSetCluster.
-            values().stream().findFirst().orElseThrow(() -> new IllegalStateException("Cluster is empty"));
+      return super.factory(DistributedMultimapSortedSetCacheTest::new);
    }
 
    public void testAddMany() {
-      initAndTest();
-      EmbeddedMultimapSortedSetCache<String, Person> sortedSet = getMultimapCacheMember();
-      await(sortedSet.addMany(NAMES_KEY, list(of(1.1, OIHANA), of(9.1, ELAIA)),
+      String key = getEntryKey();
+      EmbeddedMultimapSortedSetCache<String, Person> sortedSet = getMultimapMember();
+      await(sortedSet.addMany(key, list(of(1.1, OIHANA), of(9.1, ELAIA)),
             SortedSetAddArgs.create().build()));
-      assertValuesAndOwnership(NAMES_KEY, of(1.1, OIHANA));
-      assertValuesAndOwnership(NAMES_KEY, of(9.1, ELAIA));
+      assertValuesAndOwnership(key, of(1.1, OIHANA));
+      assertValuesAndOwnership(key, of(9.1, ELAIA));
    }
 
    public void testCount() {
-      initAndTest();
-      EmbeddedMultimapSortedSetCache<String, Person> sortedSet = getMultimapCacheMember();
-      await(sortedSet.addMany(NAMES_KEY,
+      String key = getEntryKey();
+      EmbeddedMultimapSortedSetCache<String, Person> sortedSet = getMultimapMember();
+      await(sortedSet.addMany(key,
             list(of(1, OIHANA), of(1, ELAIA), of(2, FELIX),
                   of(2, RAMON), of(2, JULIEN), of(3, PEPE), of(3, IGOR),
                   of(3, IZARO)), SortedSetAddArgs.create().build()));
-      assertThat(await(sortedSet.size(NAMES_KEY))).isEqualTo(8);
-      assertThat(await(sortedSet.count(NAMES_KEY, 1, true, 3, true))).isEqualTo(8);
+      assertThat(await(sortedSet.size(key))).isEqualTo(8);
+      assertThat(await(sortedSet.count(key, 1, true, 3, true))).isEqualTo(8);
    }
 
    public void testCountByLex() {
-      initAndTest();
-      EmbeddedMultimapSortedSetCache<String, Person> sortedSet = getMultimapCacheMember();
-      await(sortedSet.addMany(NAMES_KEY,
+      String key = getEntryKey();
+      EmbeddedMultimapSortedSetCache<String, Person> sortedSet = getMultimapMember();
+      await(sortedSet.addMany(key,
             list(of(1, ELAIA), of(1, FELIX), of(1, OIHANA)), SortedSetAddArgs.create().build()));
-      assertThat(await(sortedSet.size(NAMES_KEY))).isEqualTo(3);
-      assertThat(await(sortedSet.count(NAMES_KEY, ELAIA, true, OIHANA, true))).isEqualTo(3);
+      assertThat(await(sortedSet.size(key))).isEqualTo(3);
+      assertThat(await(sortedSet.count(key, ELAIA, true, OIHANA, true))).isEqualTo(3);
    }
 
    public void testPop() {
-      initAndTest();
-      EmbeddedMultimapSortedSetCache<String, Person> sortedSet = getMultimapCacheMember();
-      await(sortedSet.addMany(NAMES_KEY,
+      String key = getEntryKey();
+      EmbeddedMultimapSortedSetCache<String, Person> sortedSet = getMultimapMember();
+      await(sortedSet.addMany(key,
             list(of(1, OIHANA), of(1, ELAIA), of(2, FELIX),
                   of(2, RAMON), of(2, JULIEN), of(3, PEPE), of(3, IGOR),
                   of(3, IZARO)), SortedSetAddArgs.create().build()));
-      assertThat(await(sortedSet.size(NAMES_KEY))).isEqualTo(8);
-      assertThat(await(sortedSet.pop(NAMES_KEY, false, 3)))
+      assertThat(await(sortedSet.size(key))).isEqualTo(8);
+      assertThat(await(sortedSet.pop(key, false, 3)))
             .containsExactly(of(3, PEPE), of(3, IZARO), of(3, IGOR));
    }
 
    public void testScore() {
-      initAndTest();
-      EmbeddedMultimapSortedSetCache<String, Person> sortedSet = getMultimapCacheMember();
-      await(sortedSet.addMany(NAMES_KEY,
+      String key = getEntryKey();
+      EmbeddedMultimapSortedSetCache<String, Person> sortedSet = getMultimapMember();
+      await(sortedSet.addMany(key,
             list(of(1.1, OIHANA), of(9.1, ELAIA)), SortedSetAddArgs.create().build()));
-      assertThat(await(sortedSet.score(NAMES_KEY, OIHANA))).isEqualTo(1.1);
-      assertThat(await(sortedSet.score(NAMES_KEY, ELAIA))).isEqualTo(9.1);
+      assertThat(await(sortedSet.score(key, OIHANA))).isEqualTo(1.1);
+      assertThat(await(sortedSet.score(key, ELAIA))).isEqualTo(9.1);
    }
 
    public void testSubset() {
-      initAndTest();
-      EmbeddedMultimapSortedSetCache<String, Person> sortedSet = getMultimapCacheMember();
-      await(sortedSet.addMany(NAMES_KEY,
+      String key = getEntryKey();
+      EmbeddedMultimapSortedSetCache<String, Person> sortedSet = getMultimapMember();
+      await(sortedSet.addMany(key,
             list(of(1, ELAIA), of(1, FELIX), of(1, IZARO), of(1, OIHANA)),
             SortedSetAddArgs.create().build()));
-      SortedSetSubsetArgs.Builder<Long> argsIndex = create();
-      assertThat(await(sortedSet.subsetByIndex(NAMES_KEY, argsIndex.start(0L).stop(-1L).isRev(false).build())))
+      SortedSetSubsetArgs.Builder<Long> argsIndex = SortedSetSubsetArgs.create();
+      assertThat(await(sortedSet.subsetByIndex(key, argsIndex.start(0L).stop(-1L).isRev(false).build())))
             .containsExactly(
                   of(1, ELAIA),
                   of(1, FELIX),
                   of(1, IZARO),
                   of(1, OIHANA));
 
-      SortedSetSubsetArgs.Builder<Double> argsScore = create();
-      assertThat(await(sortedSet.subsetByScore(NAMES_KEY, argsScore.start(0d).stop(2d).isRev(false).build())))
+      SortedSetSubsetArgs.Builder<Double> argsScore = SortedSetSubsetArgs.create();
+      assertThat(await(sortedSet.subsetByScore(key, argsScore.start(0d).stop(2d).isRev(false).build())))
             .containsExactly(
                   of(1, ELAIA),
                   of(1, FELIX),
                   of(1, IZARO),
                   of(1, OIHANA));
 
-      SortedSetSubsetArgs.Builder<Person> argsLex = create();
-      assertThat(await(sortedSet.subsetByLex(NAMES_KEY,
+      SortedSetSubsetArgs.Builder<Person> argsLex = SortedSetSubsetArgs.create();
+      assertThat(await(sortedSet.subsetByLex(key,
             argsLex.start(FELIX).includeStart(true).stop(OIHANA).includeStop(true).isRev(false).build())))
             .containsExactly(
                   of(1, FELIX),
@@ -172,79 +120,79 @@ public class DistributedMultimapSortedSetCacheTest extends BaseDistFunctionalTes
    }
 
    public void testIncrScore() {
-      initAndTest();
-      EmbeddedMultimapSortedSetCache<String, Person> sortedSet = getMultimapCacheMember();
+      String key = getEntryKey();
+      EmbeddedMultimapSortedSetCache<String, Person> sortedSet = getMultimapMember();
       SortedSetAddArgs args = SortedSetAddArgs.create().build();
-      await(sortedSet.addMany(NAMES_KEY,
+      await(sortedSet.addMany(key,
             list(of(1.1, OIHANA), of(9.1, ELAIA)), args));
-      assertThat(await(sortedSet.incrementScore(NAMES_KEY, 12, OIHANA, args))).isEqualTo(13.1);
-      assertThat(await(sortedSet.score(NAMES_KEY, ELAIA))).isEqualTo(9.1);
+      assertThat(await(sortedSet.incrementScore(key, 12, OIHANA, args))).isEqualTo(13.1);
+      assertThat(await(sortedSet.score(key, ELAIA))).isEqualTo(9.1);
    }
 
    public void testInter() {
-      initAndTest();
-      EmbeddedMultimapSortedSetCache<String, Person> sortedSet = getMultimapCacheMember();
+      String key = getEntryKey();
+      EmbeddedMultimapSortedSetCache<String, Person> sortedSet = getMultimapMember();
       SortedSetAddArgs args = SortedSetAddArgs.create().build();
-      await(sortedSet.addMany(NAMES_KEY,
+      await(sortedSet.addMany(key,
             list(of(1.1, OIHANA), of(9.1, ELAIA)), args));
-      assertThat(await(sortedSet.inter(NAMES_KEY, null, 1, SUM)))
+      assertThat(await(sortedSet.inter(key, null, 1, SUM)))
             .containsExactly(of(1.1, OIHANA), of(9.1, ELAIA));
-      assertThat(await(sortedSet.score(NAMES_KEY, ELAIA))).isEqualTo(9.1);
+      assertThat(await(sortedSet.score(key, ELAIA))).isEqualTo(9.1);
    }
 
    public void testUnion() {
-      initAndTest();
-      EmbeddedMultimapSortedSetCache<String, Person> sortedSet = getMultimapCacheMember();
+      String key = getEntryKey();
+      EmbeddedMultimapSortedSetCache<String, Person> sortedSet = getMultimapMember();
       SortedSetAddArgs args = SortedSetAddArgs.create().build();
-      await(sortedSet.addMany(NAMES_KEY,
+      await(sortedSet.addMany(key,
             list(of(1.1, OIHANA), of(9.1, ELAIA)), args));
-      assertThat(await(sortedSet.union(NAMES_KEY, null, 1, SUM)))
+      assertThat(await(sortedSet.union(key, null, 1, SUM)))
             .containsExactly(of(1.1, OIHANA), of(9.1, ELAIA));
-      assertThat(await(sortedSet.score(NAMES_KEY, ELAIA))).isEqualTo(9.1);
+      assertThat(await(sortedSet.score(key, ELAIA))).isEqualTo(9.1);
    }
 
    public void testRemoveAll() {
-      initAndTest();
-      EmbeddedMultimapSortedSetCache<String, Person> sortedSet = getMultimapCacheMember();
-      await(sortedSet.addMany(NAMES_KEY,
+      String key = getEntryKey();
+      EmbeddedMultimapSortedSetCache<String, Person> sortedSet = getMultimapMember();
+      await(sortedSet.addMany(key,
             list(of(1, OIHANA), of(1, ELAIA), of(2, FELIX),
                   of(2, RAMON), of(2, JULIEN), of(3, PEPE), of(3, IGOR),
                   of(3, IZARO)), SortedSetAddArgs.create().build()));
-      assertThat(await(sortedSet.size(NAMES_KEY))).isEqualTo(8);
-      assertThat(await(sortedSet.removeAll(NAMES_KEY, list(OIHANA, FELIX, CHARY)))).isEqualTo(2);
-      assertThat(await(sortedSet.size(NAMES_KEY))).isEqualTo(6);
+      assertThat(await(sortedSet.size(key))).isEqualTo(8);
+      assertThat(await(sortedSet.removeAll(key, list(OIHANA, FELIX, CHARY)))).isEqualTo(2);
+      assertThat(await(sortedSet.size(key))).isEqualTo(6);
    }
 
    public void testRemoveAllRange() {
-      initAndTest();
-      EmbeddedMultimapSortedSetCache<String, Person> sortedSet = getMultimapCacheMember();
-      await(sortedSet.addMany(NAMES_KEY,
+      String key = getEntryKey();
+      EmbeddedMultimapSortedSetCache<String, Person> sortedSet = getMultimapMember();
+      await(sortedSet.addMany(key,
             list(of(1, OIHANA), of(1, ELAIA), of(2, FELIX),
                   of(2, RAMON), of(2, JULIEN), of(3, IGOR),
                   of(3, IZARO), of(3, PEPE)), SortedSetAddArgs.create().build()));
-      assertThat(await(sortedSet.size(NAMES_KEY))).isEqualTo(8);
-      assertThat(await(sortedSet.removeAll(NAMES_KEY, 0L, 2L))).isEqualTo(3);
-      assertThat(await(sortedSet.removeAll(NAMES_KEY, 2d, true, 2d, true))).isEqualTo(2);
-      assertThat(await(sortedSet.removeAll(NAMES_KEY, IGOR, true, PEPE, true))).isEqualTo(3);
-      assertThat(await(sortedSet.size(NAMES_KEY))).isZero();
-      await(sortedSet.addMany(NAMES_KEY,
+      assertThat(await(sortedSet.size(key))).isEqualTo(8);
+      assertThat(await(sortedSet.removeAll(key, 0L, 2L))).isEqualTo(3);
+      assertThat(await(sortedSet.removeAll(key, 2d, true, 2d, true))).isEqualTo(2);
+      assertThat(await(sortedSet.removeAll(key, IGOR, true, PEPE, true))).isEqualTo(3);
+      assertThat(await(sortedSet.size(key))).isZero();
+      await(sortedSet.addMany(key,
             list(of(1, OIHANA), of(1, ELAIA), of(2, FELIX),
                   of(2, RAMON), of(2, JULIEN), of(3, IGOR),
                   of(3, IZARO), of(3, PEPE)), SortedSetAddArgs.create().build()));
-      assertThat(await(sortedSet.removeAll(NAMES_KEY, null, true, 3d, true))).isEqualTo(8);
-      await(sortedSet.addMany(NAMES_KEY,
+      assertThat(await(sortedSet.removeAll(key, null, true, 3d, true))).isEqualTo(8);
+      await(sortedSet.addMany(key,
             list(of(0, OIHANA), of(0, ELAIA), of(0, FELIX),
                   of(0, RAMON), of(0, JULIEN), of(0, IGOR),
                   of(0, IZARO), of(0, PEPE)), SortedSetAddArgs.create().build()));
-      assertThat(await(sortedSet.removeAll(NAMES_KEY, null, true, RAMON, true))).isEqualTo(8);
+      assertThat(await(sortedSet.removeAll(key, null, true, RAMON, true))).isEqualTo(8);
    }
 
    public void testRandomMembers() {
-      initAndTest();
-      EmbeddedMultimapSortedSetCache<String, Person> sortedSet = getMultimapCacheMember();
+      String key = getEntryKey();
+      EmbeddedMultimapSortedSetCache<String, Person> sortedSet = getMultimapMember();
       SortedSetAddArgs args = SortedSetAddArgs.create().build();
-      await(sortedSet.addMany(NAMES_KEY, list(of(1.1, OIHANA)), args));
-      assertThat(await(sortedSet.randomMembers(NAMES_KEY, 1))).containsExactly(of(1.1, OIHANA));
+      await(sortedSet.addMany(key, list(of(1.1, OIHANA)), args));
+      assertThat(await(sortedSet.randomMembers(key, 1))).containsExactly(of(1.1, OIHANA));
    }
 
    protected void assertValuesAndOwnership(String key, ScoredValue<Person> value) {
@@ -253,7 +201,7 @@ public class DistributedMultimapSortedSetCacheTest extends BaseDistFunctionalTes
    }
 
    protected void assertOnAllCaches(Object key, ScoredValue<Person> value) {
-      for (Map.Entry<Address, EmbeddedMultimapSortedSetCache<String, Person>> entry : sortedSetCluster.entrySet()) {
+      for (Map.Entry<Address, EmbeddedMultimapSortedSetCache<String, Person>> entry : cluster.entrySet()) {
          FunctionalTestUtils.await(entry.getValue().get((String) key).thenAccept(v -> {
                   assertNotNull(format("values on the key %s must be not null", key), v);
                   assertTrue(format("values on the key '%s' must contain '%s' on node '%s'", key, value, entry.getKey()),

--- a/multimap/src/test/java/org/infinispan/multimap/impl/DistributedSetTest.java
+++ b/multimap/src/test/java/org/infinispan/multimap/impl/DistributedSetTest.java
@@ -5,138 +5,95 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.infinispan.functional.FunctionalTestUtils.await;
 import static org.infinispan.multimap.impl.MultimapTestUtils.ELAIA;
 import static org.infinispan.multimap.impl.MultimapTestUtils.FELIX;
-import static org.infinispan.multimap.impl.MultimapTestUtils.RAMON;
-import static org.infinispan.multimap.impl.MultimapTestUtils.NAMES_KEY;
 import static org.infinispan.multimap.impl.MultimapTestUtils.OIHANA;
+import static org.infinispan.multimap.impl.MultimapTestUtils.RAMON;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertTrue;
 
-import java.util.Collection;
-import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.infinispan.configuration.cache.CacheMode;
-import org.infinispan.distribution.BaseDistFunctionalTest;
-import org.infinispan.manager.EmbeddedCacheManager;
-import org.infinispan.protostream.SerializationContextInitializer;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.test.data.Person;
 import org.testng.annotations.Test;
 
 @Test(groups = "functional", testName = "distribution.DistributedSetTest")
-public class DistributedSetTest extends BaseDistFunctionalTest<String, Collection<Person>> {
-
-   protected Map<Address, EmbeddedSetCache<String, Person>> listCluster = new HashMap<>();
-   protected boolean fromOwner;
-
-   public DistributedSetTest fromOwner(boolean fromOwner) {
-      this.fromOwner = fromOwner;
-      return this;
-   }
+public class DistributedSetTest extends BaseDistributedMultimapTest<EmbeddedSetCache<String, Person>, Person> {
 
    @Override
-   protected void createCacheManagers() throws Throwable {
-      super.createCacheManagers();
-
-      for (EmbeddedCacheManager cm : cacheManagers) {
-         listCluster.put(cm.getAddress(), new EmbeddedSetCache<String, Person>(cm.getCache(cacheName)));
-      }
-   }
-
-   @Override
-   protected SerializationContextInitializer getSerializationContext() {
-      return MultimapSCIImpl.INSTANCE;
-   }
-
-   @Override
-   protected String[] parameterNames() {
-      return concat(super.parameterNames(), "fromOwner");
-   }
-
-   @Override
-   protected Object[] parameterValues() {
-      return concat(super.parameterValues(), fromOwner ? Boolean.TRUE : Boolean.FALSE);
+   protected EmbeddedSetCache<String, Person> create(EmbeddedMultimapCacheManager<String, Person> manager) {
+      return manager.getMultimapSet(cacheName);
    }
 
    @Override
    public Object[] factory() {
-      return new Object[] {
-            new DistributedSetTest().fromOwner(false).cacheMode(CacheMode.DIST_SYNC).transactional(false),
-            new DistributedSetTest().fromOwner(true).cacheMode(CacheMode.DIST_SYNC).transactional(false),
-      };
-   }
-
-   @Override
-   protected void initAndTest() {
-      for (var set : listCluster.values()) {
-         assertThat(await(set.size(NAMES_KEY))).isEqualTo(0L);
-      }
-   }
-
-   protected EmbeddedSetCache<String, Person> getSetCacheMember() {
-      return listCluster.values().stream().findFirst().orElseThrow(() -> new IllegalStateException("Cluster is empty"));
+      return super.factory(DistributedSetTest::new);
    }
 
    @Test
    public void testAdd() {
-      initAndTest();
-      EmbeddedSetCache<String, Person> set = getSetCacheMember();
-      await(set.add(NAMES_KEY, OIHANA));
-      assertValuesAndOwnership(NAMES_KEY, OIHANA);
+      String key = getEntryKey();
+      EmbeddedSetCache<String, Person> set = getMultimapMember();
+      await(set.add(key, OIHANA));
+      assertValuesAndOwnership(key, OIHANA);
 
-      await(set.add(NAMES_KEY, ELAIA));
-      assertValuesAndOwnership(NAMES_KEY, ELAIA);
+      await(set.add(key, ELAIA));
+      assertValuesAndOwnership(key, ELAIA);
 
    }
 
    @Test
    public void testGet() {
-      testAdd();
-      EmbeddedSetCache<String, Person> set = getSetCacheMember();
-      set.get(NAMES_KEY).thenApply(v->v.toSet()).thenAccept(resultSet -> assertThat(resultSet).containsExactlyInAnyOrder(ELAIA, OIHANA));
+      String key = getEntryKey();
+      EmbeddedSetCache<String, Person> set = getMultimapMember();
+
+      await(set.add(key, List.of(OIHANA, ELAIA)));
+
+      Set<Person> actual = await(set.get(key)).toSet();
+      assertThat(actual).containsExactlyInAnyOrder(ELAIA, OIHANA);
    }
 
    @Test
    public void testSize() {
-      initAndTest();
-      EmbeddedSetCache<String, Person> set = getSetCacheMember();
+      String key = getEntryKey();
+      EmbeddedSetCache<String, Person> set = getMultimapMember();
       await(
-            set.add(NAMES_KEY, OIHANA)
-                  .thenCompose(r1 -> set.add(NAMES_KEY, ELAIA))
-                  .thenCompose(r1 -> set.add(NAMES_KEY, FELIX))
-                  .thenCompose(r1 -> set.add(NAMES_KEY, OIHANA))
-                  .thenCompose(r1 -> set.size(NAMES_KEY))
+            set.add(key, OIHANA)
+                  .thenCompose(r1 -> set.add(key, ELAIA))
+                  .thenCompose(r1 -> set.add(key, FELIX))
+                  .thenCompose(r1 -> set.add(key, OIHANA))
+                  .thenCompose(r1 -> set.size(key))
                   .thenAccept(size -> assertThat(size).isEqualTo(3))
       );
    }
 
    @Test
    public void testSet() {
-      initAndTest();
-      EmbeddedSetCache<String, Person> set = getSetCacheMember();
+      String key = getEntryKey();
+      EmbeddedSetCache<String, Person> set = getMultimapMember();
       Set<Person> pers = Set.of(OIHANA, ELAIA);
-      await(set.set(NAMES_KEY, pers));
+      await(set.set(key, pers));
 
-      assertValuesAndOwnership(NAMES_KEY, OIHANA);
-      assertValuesAndOwnership(NAMES_KEY, ELAIA);
+      assertValuesAndOwnership(key, OIHANA);
+      assertValuesAndOwnership(key, ELAIA);
    }
 
    @Test
    public void testPutAll() {
-      initAndTest();
+      String key = getEntryKey();
 
-      EmbeddedSetCache<String, Person> set = getSetCacheMember();
+      EmbeddedSetCache<String, Person> set = getMultimapMember();
       Set<Person> pers = Set.of(OIHANA, ELAIA);
-      await(set.set(NAMES_KEY, pers));
+      await(set.set(key, pers));
 
       String name_key2 = "names2";
       Set<Person> pers2 = Set.of(FELIX, RAMON);
-      await(set.set(NAMES_KEY, pers));
+      await(set.set(key, pers));
       await(set.set(name_key2, pers2));
 
-      assertValuesAndOwnership(NAMES_KEY, OIHANA);
-      assertValuesAndOwnership(NAMES_KEY, ELAIA);
+      assertValuesAndOwnership(key, OIHANA);
+      assertValuesAndOwnership(key, ELAIA);
 
       assertValuesAndOwnership(name_key2, FELIX);
       assertValuesAndOwnership(name_key2, RAMON);
@@ -148,7 +105,7 @@ public class DistributedSetTest extends BaseDistFunctionalTest<String, Collectio
    }
 
    protected void assertOnAllCaches(Object key, Person value) {
-      for (Map.Entry<Address, EmbeddedSetCache<String, Person>> entry : listCluster.entrySet()) {
+      for (Map.Entry<Address, EmbeddedSetCache<String, Person>> entry : cluster.entrySet()) {
          var set = await(entry.getValue().get((String) key));
          assertNotNull(format("values on the key %s must be not null", key), set);
          assertTrue(format("values on the key '%s' must contain '%s' on node '%s'", key, value, entry.getKey()),

--- a/multimap/src/test/java/org/infinispan/multimap/impl/TxDistributedMultimapCacheTest.java
+++ b/multimap/src/test/java/org/infinispan/multimap/impl/TxDistributedMultimapCacheTest.java
@@ -97,18 +97,22 @@ public class TxDistributedMultimapCacheTest extends DistributedMultimapCacheTest
       return asList(
             new TxDistributedMultimapCacheTest()
                   .fromOwner(false)
+                  .numOwners(1)
                   .lockingMode(lockingMode)
                   .isolationLevel(IsolationLevel.READ_COMMITTED),
             new TxDistributedMultimapCacheTest()
                   .fromOwner(true)
+                  .numOwners(1)
                   .lockingMode(lockingMode)
                   .isolationLevel(IsolationLevel.READ_COMMITTED),
             new TxDistributedMultimapCacheTest()
                   .fromOwner(false)
-                  .lockingMode(lockingMode).
-                  isolationLevel(IsolationLevel.REPEATABLE_READ),
+                  .numOwners(1)
+                  .lockingMode(lockingMode)
+                  .isolationLevel(IsolationLevel.REPEATABLE_READ),
             new TxDistributedMultimapCacheTest()
                   .fromOwner(true)
+                  .numOwners(1)
                   .lockingMode(lockingMode).
                   isolationLevel(IsolationLevel.REPEATABLE_READ)
       );

--- a/multimap/src/test/java/org/infinispan/multimap/impl/tx/TxDistributedMultimapListCacheTest.java
+++ b/multimap/src/test/java/org/infinispan/multimap/impl/tx/TxDistributedMultimapListCacheTest.java
@@ -1,0 +1,166 @@
+package org.infinispan.multimap.impl.tx;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.infinispan.functional.FunctionalTestUtils.await;
+import static org.infinispan.multimap.impl.MultimapTestUtils.ELAIA;
+import static org.infinispan.multimap.impl.MultimapTestUtils.FELIX;
+import static org.infinispan.multimap.impl.MultimapTestUtils.OIHANA;
+import static org.infinispan.multimap.impl.MultimapTestUtils.PEPE;
+
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
+import org.infinispan.multimap.impl.BaseDistributedMultimapTest;
+import org.infinispan.multimap.impl.EmbeddedMultimapCacheManager;
+import org.infinispan.multimap.impl.EmbeddedMultimapListCache;
+import org.infinispan.test.data.Person;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+@Test(groups = "functional", testName = "distribution.tx.TxDistributedMultimapPairCacheTest")
+public class TxDistributedMultimapListCacheTest extends BaseDistributedMultimapTest<EmbeddedMultimapListCache<String, Person>, Person> {
+
+   @Override
+   protected EmbeddedMultimapListCache<String, Person> create(EmbeddedMultimapCacheManager<String, Person> manager) {
+      return manager.getMultimapList(cacheName);
+   }
+
+   @Override
+   public Object[] factory() {
+      return transactionalFactory(TxDistributedMultimapListCacheTest::new);
+   }
+
+   @Test(dataProvider = "booleans")
+   public void testRollbackOfferOperation(boolean front) throws Throwable {
+      String key = getEntryKey();
+      EmbeddedMultimapListCache<String, Person> list = getMultimapMember();
+      await(list.offerFirst(key, OIHANA));
+
+      tm(0, cacheName).begin();
+      CompletionStage<Void> cs;
+      if (front) {
+         cs = list.offerFirst(key, ELAIA);
+      } else {
+         cs = list.offerLast(key, ELAIA);
+      }
+      await(cs);
+      tm(0, cacheName).rollback();
+
+      assertThat(await(list.get(key)))
+            .hasSize(1)
+            .containsOnlyOnce(OIHANA);
+   }
+
+   @Test(dataProvider = "booleans")
+   public void testRollbackPollOperation(boolean front) throws Throwable {
+      String key = getEntryKey();
+      EmbeddedMultimapListCache<String, Person> list = getMultimapMember();
+      await(list.offerFirst(key, List.of(OIHANA, ELAIA)));
+
+      tm(0, cacheName).begin();
+      CompletionStage<?> cs;
+      if (front) {
+         cs = list.pollFirst(key, 1);
+      } else {
+         cs = list.pollLast(key, 1);
+      }
+      await(cs);
+      tm(0, cacheName).rollback();
+
+      assertThat(await(list.get(key)))
+            .hasSize(2)
+            .containsOnlyOnce(OIHANA, ELAIA);
+   }
+
+   public void testRollbackSetOperation() throws Throwable {
+      String key = getEntryKey();
+      EmbeddedMultimapListCache<String, Person> list = getMultimapMember();
+      await(list.offerFirst(key, List.of(OIHANA, ELAIA)));
+
+      tm(0, cacheName).begin();
+      await(list.set(key, 1, FELIX));
+      tm(0, cacheName).rollback();
+
+      assertThat(await(list.get(key)))
+            .hasSize(2)
+            .containsOnlyOnce(OIHANA, ELAIA);
+   }
+
+   @Test(dataProvider = "booleans")
+   public void testRollbackInsertOperation(boolean front) throws Throwable {
+      String key = getEntryKey();
+      EmbeddedMultimapListCache<String, Person> list = getMultimapMember();
+      await(list.offerFirst(key, List.of(OIHANA, ELAIA)));
+
+      tm(0, cacheName).begin();
+      await(list.insert(key, front, ELAIA, FELIX));
+      tm(0, cacheName).rollback();
+
+      assertThat(await(list.get(key)))
+            .hasSize(2)
+            .containsOnlyOnce(OIHANA, ELAIA);
+   }
+
+   public void testRollbackRemoveOperation() throws Throwable {
+      String key = getEntryKey();
+      EmbeddedMultimapListCache<String, Person> list = getMultimapMember();
+      await(list.offerFirst(key, List.of(OIHANA, ELAIA)));
+
+      tm(0, cacheName).begin();
+      await(list.remove(key, 1, ELAIA));
+      tm(0, cacheName).rollback();
+
+      assertThat(await(list.get(key)))
+            .hasSize(2)
+            .containsOnlyOnce(OIHANA, ELAIA);
+   }
+
+   public void testRollbackTrimOperation() throws Throwable {
+      String key = getEntryKey();
+      EmbeddedMultimapListCache<String, Person> list = getMultimapMember();
+      await(list.offerFirst(key, List.of(OIHANA, ELAIA, FELIX)));
+
+      tm(0, cacheName).begin();
+      await(list.trim(key, 0, 1));
+      tm(0, cacheName).rollback();
+
+      assertThat(await(list.get(key)))
+            .hasSize(3)
+            .containsOnlyOnce(OIHANA, ELAIA, FELIX);
+   }
+
+   public void testRollbackReplaceOperation() throws Throwable {
+      String key = getEntryKey();
+      EmbeddedMultimapListCache<String, Person> list = getMultimapMember();
+      await(list.offerFirst(key, List.of(OIHANA, ELAIA)));
+
+      tm(0, cacheName).begin();
+      await(list.replace(key, List.of(FELIX, PEPE)));
+      tm(0, cacheName).rollback();
+
+      assertThat(await(list.get(key)))
+            .hasSize(2)
+            .containsOnlyOnce(OIHANA, ELAIA);
+   }
+
+   @Test(dataProvider = "booleans")
+   public void testRollbackRotateOperation(boolean front) throws Throwable {
+      String key = getEntryKey();
+      EmbeddedMultimapListCache<String, Person> list = getMultimapMember();
+      await(list.offerLast(key, List.of(OIHANA, ELAIA, FELIX)));
+
+      tm(0, cacheName).begin();
+      await(list.rotate(key, front));
+      tm(0, cacheName).rollback();
+
+      assertThat(await(list.get(key)))
+            .hasSize(3)
+            .containsExactly(OIHANA, ELAIA, FELIX);
+   }
+
+   @DataProvider(name = "booleans")
+   Object[][] booleans() {
+      return new Object[][]{
+            {Boolean.TRUE}, {Boolean.FALSE}};
+   }
+}

--- a/multimap/src/test/java/org/infinispan/multimap/impl/tx/TxDistributedMultimapPairCacheTest.java
+++ b/multimap/src/test/java/org/infinispan/multimap/impl/tx/TxDistributedMultimapPairCacheTest.java
@@ -1,0 +1,98 @@
+package org.infinispan.multimap.impl.tx;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.infinispan.functional.FunctionalTestUtils.await;
+import static org.infinispan.multimap.impl.MultimapTestUtils.ELAIA;
+import static org.infinispan.multimap.impl.MultimapTestUtils.FELIX;
+import static org.infinispan.multimap.impl.MultimapTestUtils.OIHANA;
+
+import java.util.Map;
+
+import org.infinispan.multimap.impl.BaseDistributedMultimapTest;
+import org.infinispan.multimap.impl.EmbeddedMultimapCacheManager;
+import org.infinispan.multimap.impl.EmbeddedMultimapPairCache;
+import org.infinispan.test.data.Person;
+import org.testng.annotations.Test;
+
+@Test(groups = "functional", testName = "distribution.tx.TxDistributedMultimapPairCacheTest")
+public class TxDistributedMultimapPairCacheTest extends BaseDistributedMultimapTest<EmbeddedMultimapPairCache<String, String, Person>, Map<String, Person>> {
+
+   @Override
+   protected EmbeddedMultimapPairCache<String, String, Person> create(EmbeddedMultimapCacheManager<String, Map<String, Person>> manager) {
+      return manager.getMultimapPair(cacheName);
+   }
+
+   @Override
+   public Object[] factory() {
+      return transactionalFactory(TxDistributedMultimapPairCacheTest::new);
+   }
+
+   public void testRollbackSetOperation() throws Throwable {
+      String key = getEntryKey();
+      EmbeddedMultimapPairCache<String, String, Person> multimap = getMultimapMember();
+      assertThat(await(multimap.set(key, Map.entry("oihana", OIHANA))))
+            .isEqualTo(1);
+
+      assertThat(await(multimap.size(key))).isOne();
+
+      tm(0, cacheName).begin();
+      await(multimap.set(key, Map.entry("felix", FELIX)));
+      tm(0, cacheName).rollback();
+
+      assertThat(await(multimap.size(key))).isOne();
+      assertThat(await(multimap.keySet(key))).containsOnlyOnce("oihana");
+   }
+
+   public void testRollbackRemoveOperation() throws Throwable {
+      String key = getEntryKey();
+      EmbeddedMultimapPairCache<String, String, Person> multimap = getMultimapMember();
+      assertThat(await(multimap.set(key, Map.entry("oihana", OIHANA), Map.entry("elaia", ELAIA))))
+            .isEqualTo(2);
+
+      assertThat(await(multimap.size(key))).isEqualTo(2);
+
+      tm(0, cacheName).begin();
+      await(multimap.remove(key, "oihana"));
+      tm(0, cacheName).rollback();
+
+      assertThat(await(multimap.size(key))).isEqualTo(2);
+      assertThat(await(multimap.keySet(key)))
+            .containsOnlyOnce("oihana", "elaia");
+   }
+
+   public void testRollbackComputeOperation() throws Throwable {
+      String key = getEntryKey();
+      EmbeddedMultimapPairCache<String, String, Person> multimap = getMultimapMember();
+      assertThat(await(multimap.set(key, Map.entry("oihana", OIHANA))))
+            .isEqualTo(1);
+
+      assertThat(await(multimap.size(key))).isOne();
+
+      tm(0, cacheName).begin();
+      await(multimap.compute(key, "oihana", (k, v) -> {
+         assertThat(k).isEqualTo("oihana");
+         assertThat((Object) v).isEqualTo(OIHANA);
+         return ELAIA;
+      }));
+      tm(0, cacheName).rollback();
+
+      assertThat(await(multimap.size(key))).isOne();
+      assertThat((Object) await(multimap.get(key, "oihana"))).isEqualTo(OIHANA);
+   }
+
+   public void testRollbackSetIfAbsentOperation() throws Throwable {
+      String key = getEntryKey();
+      EmbeddedMultimapPairCache<String, String, Person> multimap = getMultimapMember();
+      assertThat(await(multimap.set(key, Map.entry("oihana", OIHANA))))
+            .isEqualTo(1);
+
+      assertThat(await(multimap.size(key))).isOne();
+
+      tm(0, cacheName).begin();
+      await(multimap.setIfAbsent(key, "felix", FELIX));
+      tm(0, cacheName).rollback();
+
+      assertThat(await(multimap.size(key))).isOne();
+      assertThat(await(multimap.keySet(key))).containsOnlyOnce("oihana");
+   }
+}

--- a/multimap/src/test/java/org/infinispan/multimap/impl/tx/TxDistributedMultimapSetCacheTest.java
+++ b/multimap/src/test/java/org/infinispan/multimap/impl/tx/TxDistributedMultimapSetCacheTest.java
@@ -1,0 +1,98 @@
+package org.infinispan.multimap.impl.tx;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.infinispan.functional.FunctionalTestUtils.await;
+import static org.infinispan.multimap.impl.MultimapTestUtils.ELAIA;
+import static org.infinispan.multimap.impl.MultimapTestUtils.FELIX;
+import static org.infinispan.multimap.impl.MultimapTestUtils.OIHANA;
+import static org.infinispan.multimap.impl.MultimapTestUtils.PEPE;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.infinispan.multimap.impl.BaseDistributedMultimapTest;
+import org.infinispan.multimap.impl.EmbeddedMultimapCacheManager;
+import org.infinispan.multimap.impl.EmbeddedSetCache;
+import org.infinispan.test.data.Person;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+@Test(groups = "functional", testName = "distribution.tx.TxDistributedMultimapSetCacheTest")
+public class TxDistributedMultimapSetCacheTest extends BaseDistributedMultimapTest<EmbeddedSetCache<String, Person>, Person> {
+
+   @Override
+   protected EmbeddedSetCache<String, Person> create(EmbeddedMultimapCacheManager<String, Person> manager) {
+      return manager.getMultimapSet(cacheName);
+   }
+
+   @Override
+   public Object[] factory() {
+      return super.transactionalFactory(TxDistributedMultimapSetCacheTest::new);
+   }
+
+   public void testRollbackAddOperation() throws Throwable {
+      String key = getEntryKey();
+      EmbeddedSetCache<String, Person> set = getMultimapMember();
+
+      assertThat(await(set.add(key, OIHANA))).isOne();
+
+      runAndRollback(() -> set.add(key, List.of(ELAIA, FELIX)));
+
+      Collection<Person> actual = await(set.getAsSet(key));
+      assertThat(actual)
+            .hasSize(1)
+            .containsOnlyOnce(OIHANA);
+   }
+
+   public void testRollbackRemoveOperation() throws Throwable {
+      String key = getEntryKey();
+      EmbeddedSetCache<String, Person> set = getMultimapMember();
+
+      await(set.add(key, List.of(OIHANA, ELAIA, FELIX)));
+
+      runAndRollback(() -> set.remove(key, List.of(ELAIA, FELIX, PEPE)));
+
+      Collection<Person> actual = await(set.getAsSet(key));
+      assertThat(actual)
+            .hasSize(3)
+            .containsExactlyInAnyOrder(OIHANA, ELAIA, FELIX);
+   }
+
+   public void testRollbackSetOperation() throws Throwable {
+      String key = getEntryKey();
+      EmbeddedSetCache<String, Person> set = getMultimapMember();
+
+      await(set.add(key, List.of(OIHANA, ELAIA)));
+
+      runAndRollback(() -> set.set(key, List.of(FELIX, PEPE)));
+
+      Collection<Person> actual = await(set.getAsSet(key));
+      assertThat(actual)
+            .hasSize(2)
+            .containsExactlyInAnyOrder(OIHANA, ELAIA);
+   }
+
+   @Test(dataProvider = "pop-args")
+   public void testRollbackPopOperation(long count) throws Throwable {
+      String key = getEntryKey();
+      EmbeddedSetCache<String, Person> set = getMultimapMember();
+
+      await(set.add(key, List.of(OIHANA, ELAIA, PEPE)));
+
+      runAndRollback(() -> set.pop(key, count, true));
+
+      Collection<Person> actual = await(set.getAsSet(key));
+      assertThat(actual)
+            .hasSize(3)
+            .containsExactlyInAnyOrder(OIHANA, ELAIA, PEPE);
+   }
+
+   @DataProvider(name = "pop-args")
+   Object[][] popArgs() {
+      return new Object[][]{
+            {1L},
+            {2L},
+            {Long.MAX_VALUE},
+      };
+   }
+}

--- a/multimap/src/test/java/org/infinispan/multimap/impl/tx/TxDistributedMultimapSortedSetCacheTest.java
+++ b/multimap/src/test/java/org/infinispan/multimap/impl/tx/TxDistributedMultimapSortedSetCacheTest.java
@@ -1,0 +1,167 @@
+package org.infinispan.multimap.impl.tx;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.infinispan.functional.FunctionalTestUtils.await;
+import static org.infinispan.multimap.impl.MultimapTestUtils.ELAIA;
+import static org.infinispan.multimap.impl.MultimapTestUtils.FELIX;
+import static org.infinispan.multimap.impl.MultimapTestUtils.OIHANA;
+import static org.infinispan.multimap.impl.MultimapTestUtils.PEPE;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.infinispan.multimap.impl.BaseDistributedMultimapTest;
+import org.infinispan.multimap.impl.EmbeddedMultimapCacheManager;
+import org.infinispan.multimap.impl.EmbeddedMultimapSortedSetCache;
+import org.infinispan.multimap.impl.ScoredValue;
+import org.infinispan.multimap.impl.SortedSetAddArgs;
+import org.infinispan.test.data.Person;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+@Test(groups = "functional", testName = "distribution.tx.TxDistributedMultimapSortedSetCacheTest")
+public class TxDistributedMultimapSortedSetCacheTest extends BaseDistributedMultimapTest<EmbeddedMultimapSortedSetCache<String, Person>, Person> {
+
+   @Override
+   protected EmbeddedMultimapSortedSetCache<String, Person> create(EmbeddedMultimapCacheManager<String, Person> manager) {
+      return manager.getMultimapSortedSet(cacheName);
+   }
+
+   @Override
+   public Object[] factory() {
+      return super.transactionalFactory(TxDistributedMultimapSortedSetCacheTest::new);
+   }
+
+   @Test(dataProvider = "sorted-set-args")
+   public void testRollbackAddManyOperation(SortedSetAddArgs args) throws Throwable {
+      String key = getEntryKey();
+      EmbeddedMultimapSortedSetCache<String, Person> sortedSet = getMultimapMember();
+
+      List<ScoredValue<Person>> initial = List.of(ScoredValue.of(4, PEPE), ScoredValue.of(5, OIHANA));
+      await(sortedSet.addMany(key, initial, SortedSetAddArgs.create().build()));
+
+      List<ScoredValue<Person>> values = List.of(
+            // For smaller score only.
+            ScoredValue.of(3, ELAIA),
+
+            // For greater score only.
+            ScoredValue.of(9, FELIX),
+
+            // For update only.
+            ScoredValue.of(7, OIHANA),
+
+            // For update smaller.
+            ScoredValue.of(2, PEPE)
+      );
+      runAndRollback(() -> sortedSet.addMany(key, values, args));
+
+      Collection<ScoredValue<Person>> actual = await(sortedSet.get(key));
+      assertThat(actual)
+            .hasSize(2)
+            .containsExactly(initial.get(0), initial.get(1));
+   }
+
+   @Test(dataProvider = "sorted-set-args")
+   public void testRollbackIncrementScoreOperation(SortedSetAddArgs args) throws Throwable {
+      String key = getEntryKey();
+      EmbeddedMultimapSortedSetCache<String, Person> sortedSet = getMultimapMember();
+
+      List<ScoredValue<Person>> initial = List.of(ScoredValue.of(5, OIHANA));
+      await(sortedSet.addMany(key, initial, SortedSetAddArgs.create().build()));
+
+      tm(0, cacheName).begin();
+      await(sortedSet.incrementScore(key, 7d, OIHANA, args));
+      await(sortedSet.incrementScore(key, 3d, ELAIA, args));
+      tm(0, cacheName).rollback();
+
+      Collection<ScoredValue<Person>> actual = await(sortedSet.get(key));
+      assertThat(actual)
+            .hasSize(1)
+            .satisfiesExactly(entry -> {
+               assertThat((Object) entry.getValue()).isEqualTo(OIHANA);
+               assertThat(entry.score()).isIn(5d, 12d);
+            });
+   }
+
+   @Test(dataProvider = "pop-args")
+   public void testRollbackPopOperation(boolean min, int count) throws Throwable {
+      String key = getEntryKey();
+      EmbeddedMultimapSortedSetCache<String, Person> sortedSet = getMultimapMember();
+
+      List<ScoredValue<Person>> initial = List.of(ScoredValue.of(4, PEPE), ScoredValue.of(5, OIHANA), ScoredValue.of(6, ELAIA));
+      await(sortedSet.addMany(key, initial, SortedSetAddArgs.create().build()));
+
+      runAndRollback(() -> sortedSet.pop(key, min, count));
+
+      Collection<ScoredValue<Person>> actual = await(sortedSet.get(key));
+      assertThat(actual)
+            .hasSize(initial.size())
+            .containsExactlyElementsOf(initial);
+   }
+
+   @Test(dataProvider = "remove-all-args")
+   public void testRollbackRemoveAllByScoreOperation(boolean min, boolean max) throws Throwable {
+      String key = getEntryKey();
+      EmbeddedMultimapSortedSetCache<String, Person> sortedSet = getMultimapMember();
+
+      List<ScoredValue<Person>> initial = List.of(ScoredValue.of(4, PEPE), ScoredValue.of(5, OIHANA), ScoredValue.of(6, ELAIA));
+      await(sortedSet.addMany(key, initial, SortedSetAddArgs.create().build()));
+
+      runAndRollback(() -> sortedSet.removeAll(key, 4d, min, 6d, max));
+
+      Collection<ScoredValue<Person>> actual = await(sortedSet.get(key));
+      assertThat(actual)
+            .hasSize(initial.size())
+            .containsExactlyElementsOf(initial);
+   }
+
+   @Test(dataProvider = "remove-all-args")
+   public void testRollbackRemoveAllByLexOperation(boolean min, boolean max) throws Throwable {
+      String key = getEntryKey();
+      EmbeddedMultimapSortedSetCache<String, Person> sortedSet = getMultimapMember();
+
+      List<ScoredValue<Person>> initial = List.of(ScoredValue.of(1, ELAIA), ScoredValue.of(1, FELIX), ScoredValue.of(1, OIHANA));
+      await(sortedSet.addMany(key, initial, SortedSetAddArgs.create().build()));
+
+      runAndRollback(() -> sortedSet.removeAll(key, ELAIA, min, OIHANA, max));
+
+      Collection<ScoredValue<Person>> actual = await(sortedSet.get(key));
+      assertThat(actual)
+            .hasSize(initial.size())
+            .containsExactlyElementsOf(initial);
+   }
+
+   @DataProvider(name = "sorted-set-args")
+   Object[][] sortedSetArguments() {
+      return new Object[][]{
+            {SortedSetAddArgs.create().build()},
+            {SortedSetAddArgs.create().addOnly().build()},
+            {SortedSetAddArgs.create().updateOnly().build()},
+            {SortedSetAddArgs.create().updateLessScoresOnly().build()},
+            {SortedSetAddArgs.create().updateGreaterScoresOnly().build()},
+            {SortedSetAddArgs.create().returnChangedCount().build()}
+      };
+   }
+
+   @DataProvider(name = "pop-args")
+   Object[][] popArgs() {
+      return new Object[][]{
+            {Boolean.TRUE, 1},
+            {Boolean.TRUE, 2},
+            {Boolean.TRUE, Integer.MAX_VALUE},
+            {Boolean.FALSE, 1},
+            {Boolean.FALSE, 2},
+            {Boolean.FALSE, Integer.MAX_VALUE},
+      };
+   }
+
+   @DataProvider(name = "remove-all-args")
+   Object[][] removeAllArgs() {
+      return new Object[][] {
+            {Boolean.FALSE, Boolean.FALSE},
+            {Boolean.FALSE, Boolean.TRUE},
+            {Boolean.TRUE, Boolean.FALSE},
+            {Boolean.TRUE, Boolean.TRUE},
+      };
+   }
+}


### PR DESCRIPTION
**Backport:** https://github.com/infinispan/infinispan/pull/13166

https://issues.redhat.com/browse/ISPN-16774

I've added one commit for each data structure. The functional nature of the Functional Map requires an operation that changes the structure's state to return a new instance. The base multimap implementation already does that, I updated the newer classes we added.