### PR TITLE
Ensure shutdown completed

### DIFF
--- a/server/memcached/src/main/java/org/infinispan/server/memcached/MemcachedServer.java
+++ b/server/memcached/src/main/java/org/infinispan/server/memcached/MemcachedServer.java
@@ -2,6 +2,7 @@ package org.infinispan.server.memcached;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import org.infinispan.Cache;
 import org.infinispan.commons.dataconversion.MediaType;
@@ -144,6 +145,12 @@ public class MemcachedServer extends AbstractProtocolServer<MemcachedServerConfi
    public void stop() {
       super.stop();
       scheduler.shutdown();
+      try {
+         // Wait some time for actual shutdown
+         scheduler.awaitTermination(30, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+         throw new RuntimeException(e);
+      }
    }
 
    /**


### PR DESCRIPTION
Fixes #13278

suspecting an interaction between tests MemcachedBinaryEncryptionTest and MemcachedBinaryAuthenticationTest. Server for the latter test is not actually off before the former starts.
