### PR TITLE
[15.0.x] ISPN-16840 [RESP] LPUSH + DEL + SET fails with unable to aquire a lock

### DIFF
--- a/core/src/main/java/org/infinispan/cache/impl/DecoratedCache.java
+++ b/core/src/main/java/org/infinispan/cache/impl/DecoratedCache.java
@@ -89,8 +89,12 @@ public class DecoratedCache<K, V> extends AbstractDelegatingAdvancedCache<K, V> 
          //we already have all specified flags
          return this;
       } else {
-         return new DecoratedCache<>(this.cacheImplementation, lockOwner, EnumUtil.mergeBitSets(this.flags, newFlags));
+         return newInstance(this.cacheImplementation, lockOwner, EnumUtil.mergeBitSets(this.flags, newFlags));
       }
+   }
+
+   protected DecoratedCache<K, V> newInstance(CacheImpl<K, V> impl, Object lockOwner, long newFlags) {
+      return new DecoratedCache<>(this.cacheImplementation, lockOwner, newFlags);
    }
 
    @Override
@@ -98,7 +102,7 @@ public class DecoratedCache<K, V> extends AbstractDelegatingAdvancedCache<K, V> 
       if (lockOwner == null) {
          return this.cacheImplementation;
       } else {
-         return new DecoratedCache<>(this.cacheImplementation, lockOwner, 0L);
+         return newInstance(this.cacheImplementation, lockOwner, 0L);
       }
    }
 
@@ -129,7 +133,7 @@ public class DecoratedCache<K, V> extends AbstractDelegatingAdvancedCache<K, V> 
    public AdvancedCache<K, V> lockAs(Object lockOwner) {
       Objects.requireNonNull(lockOwner);
       if (lockOwner != this.lockOwner) {
-         return new DecoratedCache<>(cacheImplementation, lockOwner, flags);
+         return newInstance(cacheImplementation, lockOwner, flags);
       }
       return this;
    }

--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/tx/TransactionDecorator.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/tx/TransactionDecorator.java
@@ -149,6 +149,16 @@ final class TransactionDecorator {
          this.ctx = ctx;
       }
 
+      private RespExecDecoratedCache(InvocationContext ctx, CacheImpl<byte[], byte[]> delegate, Object lockOwner, long flags) {
+         super(delegate, lockOwner, flags);
+         this.ctx = ctx;
+      }
+
+      @Override
+      protected DecoratedCache<byte[], byte[]> newInstance(CacheImpl<byte[], byte[]> impl, Object lockOwner, long newFlags) {
+         return new RespExecDecoratedCache(ctx, impl, lockOwner, newFlags);
+      }
+
       @Override
       protected InvocationContext readContext(int size) {
          return ctx;

--- a/server/resp/src/test/java/org/infinispan/server/resp/dist/TransactionClusteredTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/dist/TransactionClusteredTest.java
@@ -3,18 +3,10 @@ package org.infinispan.server.resp.dist;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.infinispan.server.resp.test.RespTestingUtil.OK;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.Map;
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.function.Predicate;
-import java.util.stream.IntStream;
 
-import org.infinispan.Cache;
-import org.infinispan.commons.marshall.WrappedByteArray;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
-import org.infinispan.distribution.LocalizedCacheTopology;
 import org.infinispan.server.resp.TransactionOperationsTest;
 import org.infinispan.server.resp.test.TestSetup;
 import org.testng.annotations.Test;
@@ -26,40 +18,32 @@ import io.lettuce.core.api.sync.RedisCommands;
 public class TransactionClusteredTest extends TransactionOperationsTest {
 
    private CacheMode mode;
+   private boolean fromOwner;
 
    private TransactionClusteredTest withCacheMode(CacheMode mode) {
       this.mode = mode;
       return this;
    }
 
+   private TransactionClusteredTest fromOwner(boolean value) {
+      this.fromOwner = value;
+      return this;
+   }
+
    @Override
    public Object[] factory() {
       return new Object[] {
-            new TransactionClusteredTest().withCacheMode(CacheMode.DIST_SYNC),
+            new TransactionClusteredTest().withCacheMode(CacheMode.DIST_SYNC).fromOwner(false),
+            new TransactionClusteredTest().withCacheMode(CacheMode.DIST_SYNC).fromOwner(true),
             new TransactionClusteredTest().withCacheMode(CacheMode.REPL_SYNC),
       };
    }
 
-   private String getStringKeyForCache(String prefix, Cache<?, ?> primary, Cache<?, ?> ... secondary) {
-      LocalizedCacheTopology topology = primary.getAdvancedCache().getDistributionManager().getCacheTopology();
-      Predicate<String> isBackupOwner = key -> Arrays.stream(secondary)
-            .allMatch(c -> {
-               LocalizedCacheTopology t = c.getAdvancedCache().getDistributionManager().getCacheTopology();
-               int segment = t.getSegment(new WrappedByteArray(key.getBytes(StandardCharsets.US_ASCII)));
-               return t.isSegmentReadOwner(segment);
-            });
-      return IntStream.generate(ThreadLocalRandom.current()::nextInt).mapToObj(i -> prefix + i)
-            .filter(key -> topology.getDistribution(new WrappedByteArray(key.getBytes(StandardCharsets.US_ASCII))).isPrimary())
-            .filter(isBackupOwner).findAny().orElseThrow();
-   }
-
-   private String getRemoteKey() {
-      return getStringKeyForCache("key", cache(1), cache(2));
-   }
-
    @Override
-   public void testBlockingPopWithTx() throws Throwable {
-      testBlockingPopWithTx(this::getRemoteKey);
+   protected String getOperationKey(int i) {
+      return fromOwner
+            ? getStringKeyForCache("key-" + i, cache(0))
+            : getStringKeyForCache("key-" + i, cache(1));
    }
 
    public void testFunctionalTxWithRemote() {
@@ -68,13 +52,13 @@ public class TransactionClusteredTest extends TransactionOperationsTest {
       assertThat(redis.multi()).isEqualTo("OK");
       assertThat(redisConnection.isMulti()).isTrue();
 
-      String k1 = getRemoteKey();
+      String k1 = getOperationKey(0);
       redis.lpush(k1, "v1", "v2", "v3");
 
-      String k2 = getRemoteKey();
+      String k2 = getOperationKey(1);
       redis.hset(k2, Map.of("f1", "v1", "f2", "v2"));
 
-      String k3 = getRemoteKey();
+      String k3 = getOperationKey(2);
       redis.set(k3, "value");
 
       TransactionResult result = redis.exec();
@@ -90,12 +74,13 @@ public class TransactionClusteredTest extends TransactionOperationsTest {
 
    @Override
    protected String parameters() {
-      return "[mode=" + mode + "]";
+      return "[mode=" + mode + ", fromOwner=" + fromOwner + "]";
    }
 
    @Override
    protected void amendConfiguration(ConfigurationBuilder configurationBuilder) {
       super.amendConfiguration(configurationBuilder);
+      configurationBuilder.clustering().hash().numOwners(1);
       configurationBuilder.clustering().cacheMode(mode);
    }
 


### PR DESCRIPTION
**Backport:** https://github.com/infinispan/infinispan/pull/13178

https://issues.redhat.com/browse/ISPN-16840


The `withFlags` was creating a new instance of the `DecoratedCache` instead of the instance holding the TX context for RESP. That would create a new transaction for the set operation.

I took the chance to increase coverage in the TX tests in RESP by operating over local and remote keys.