### PR TITLE
Paginate gh get labels call. Fixes #13311

### DIFF
--- a/.github/workflows/pull_request_open.yml
+++ b/.github/workflows/pull_request_open.yml
@@ -60,7 +60,7 @@ jobs:
     steps:
       - name: Get Labels Action
         run: |
-         labels=$(gh api repos/${GH_REPO}/labels -q 'map(.name)')
+         labels=$(gh api repos/${GH_REPO}/labels -q 'map(.name)' --paginate)
          echo "LABELS=$labels" >> $GITHUB_ENV
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
use pagination when labels are more than 30.
Fixes #13311 