### PR TITLE
[#13272] Collect remote cache configuration to concurrent map

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/ConfigurationBuilder.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/ConfigurationBuilder.java
@@ -635,8 +635,9 @@ public class ConfigurationBuilder implements ConfigurationChildBuilder, Builder<
             throw new IllegalArgumentException("Both marshaller and marshallerClass attributes are present, but marshaller is not an instance of marshallerClass");
       }
 
-      Map<String, RemoteCacheConfiguration> remoteCaches = remoteCacheBuilders.entrySet().stream().collect(Collectors.toMap(
-            Map.Entry::getKey, e -> e.getValue().create()));
+      // Collect to a concurrent map to handle concurrent access for read/writes.
+      Map<String, RemoteCacheConfiguration> remoteCaches = remoteCacheBuilders.entrySet().stream()
+            .collect(Collectors.toConcurrentMap(Map.Entry::getKey, e -> e.getValue().create()));
 
       return new Configuration(asyncExecutorFactory.create(), balancingStrategyFactory, classLoader == null ? null : classLoader.get(),
             clientIntelligence, connectionPool.create(), connectionTimeout, consistentHashImpl,


### PR DESCRIPTION
* Collect the configurations to a concurrent map;
* Uniform usage of synchronized block to access remote caches.

Closes #13272.
