### PR TITLE
[#13405] - nested queries improvements - proper handling of OR predicates

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/nested/ParentJoinNestedRemoteTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/nested/ParentJoinNestedRemoteTest.java
@@ -110,4 +110,37 @@ public class ParentJoinNestedRemoteTest extends SingleHotRodServerTest {
       assertThat(result).extracting(Team::name).containsExactly("New Team", "Old Team");
       assertThat(queryStatistics.getLocalIndexedQueryCount()).isEqualTo(1);
    }
+
+   @Test
+   public void nested_usingJoinWithOr() {
+      RemoteCache<String, Team> remoteCache = remoteCacheManager.getCache();
+      Query<Object[]> query = remoteCache.query("select t.name from model.Team t " +
+            "join t.firstTeam p " +
+            "where (p.color ='red' AND p.number=7) or (p.color='blue' AND p.number=7)");
+      List<Object[]> result = query.list();
+      assertThat(result).extracting(array -> array[0]).containsExactly("New Team", "Old Team");
+      assertThat(queryStatistics.getLocalIndexedQueryCount()).isEqualTo(1);
+   }
+
+   @Test
+   public void nested_usingJoinWithNegation() {
+      RemoteCache<String, Team> remoteCache = remoteCacheManager.getCache();
+      Query<Object[]> query = remoteCache.query("select t.name from model.Team t " +
+            "join t.firstTeam p " +
+            "where (p.color ='red' AND p.number!=7)");
+      List<Object[]> result = query.list();
+      assertThat(result).extracting(array -> array[0]).containsExactly("New Team");
+      assertThat(queryStatistics.getLocalIndexedQueryCount()).isEqualTo(1);
+   }
+
+   @Test
+   public void nested_usingJoinWithIn() {
+      RemoteCache<String, Team> remoteCache = remoteCacheManager.getCache();
+      Query<Object[]> query = remoteCache.query("select t.name from model.Team t " +
+            "join t.firstTeam p " +
+            "where (p.color ='red' AND p.number IN (7,3))");
+      List<Object[]> result = query.list();
+      assertThat(result).extracting(array -> array[0]).containsExactly("New Team", "Old Team");
+      assertThat(queryStatistics.getLocalIndexedQueryCount()).isEqualTo(1);
+   }
 }

--- a/object-filter/src/main/java/org/infinispan/objectfilter/impl/syntax/parser/ExpressionBuilder.java
+++ b/object-filter/src/main/java/org/infinispan/objectfilter/impl/syntax/parser/ExpressionBuilder.java
@@ -106,6 +106,8 @@ final class ExpressionBuilder<TypeMetadata> {
       if (!nestedExprMap.containsKey(joinAlias)) {
          nestedExprMap.put(joinAlias, new NestedExpr(getNestedPath(propertyPath)));
          push(nestedExprMap.get(joinAlias));
+      }else if(stack.peek() instanceof LazyNegationExpr && !nestedExprMap.isEmpty()){
+         push(nestedExprMap.get(joinAlias));
       }
       nestedExprMap.get(joinAlias).add(comparisonExpr);
    }
@@ -204,6 +206,9 @@ final class ExpressionBuilder<TypeMetadata> {
 
    public void pop() {
       stack.pop();
+      if(!nestedExprMap.isEmpty() && stack.peek() instanceof LazyOrExpr){
+         nestedExprMap.clear();
+      }
    }
 
    public BooleanExpr build() {

--- a/object-filter/src/main/java/org/infinispan/objectfilter/impl/syntax/parser/ExpressionBuilder.java
+++ b/object-filter/src/main/java/org/infinispan/objectfilter/impl/syntax/parser/ExpressionBuilder.java
@@ -106,7 +106,7 @@ final class ExpressionBuilder<TypeMetadata> {
       if (!nestedExprMap.containsKey(joinAlias)) {
          nestedExprMap.put(joinAlias, new NestedExpr(getNestedPath(propertyPath)));
          push(nestedExprMap.get(joinAlias));
-      }else if(stack.peek() instanceof LazyNegationExpr && !nestedExprMap.isEmpty()){
+      } else if (stack.peek() instanceof LazyNegationExpr) {
          push(nestedExprMap.get(joinAlias));
       }
       nestedExprMap.get(joinAlias).add(comparisonExpr);

--- a/query/src/test/java/org/infinispan/query/nested/ParentJoinNestedTest.java
+++ b/query/src/test/java/org/infinispan/query/nested/ParentJoinNestedTest.java
@@ -97,4 +97,34 @@ public class ParentJoinNestedTest extends SingleCacheManagerTest {
       assertThat(result).extracting(Team::name).containsExactly("New Team", "Old Team");
       assertThat(queryStatistics.getLocalIndexedQueryCount()).isEqualTo(1);
    }
+
+   @Test
+   public void nested_usingJoinWithOr() {
+      Query<Object[]> query = cache.query("select t.name from org.infinispan.query.model.Team t " +
+            "join t.firstTeam p " +
+            "where (p.color ='red' AND p.number=7) or (p.color='blue' AND p.number=7)");
+      List<Object[]> result = query.list();
+      assertThat(result).extracting(array -> array[0]).containsExactly("New Team", "Old Team");
+      assertThat(queryStatistics.getLocalIndexedQueryCount()).isEqualTo(1);
+   }
+
+   @Test
+   public void nested_usingJoinWithNegation() {
+      Query<Object[]> query = cache.query("select t.name from org.infinispan.query.model.Team t " +
+            "join t.firstTeam p " +
+            "where (p.color ='red' AND p.number!=7)");
+      List<Object[]> result = query.list();
+      assertThat(result).extracting(array -> array[0]).containsExactly("New Team");
+      assertThat(queryStatistics.getLocalIndexedQueryCount()).isEqualTo(1);
+   }
+
+   @Test
+   public void nested_usingJoinWithIn() {
+      Query<Object[]> query = cache.query("select t.name from org.infinispan.query.model.Team t " +
+            "join t.firstTeam p " +
+            "where (p.color ='red' AND p.number IN (7,3))");
+      List<Object[]> result = query.list();
+      assertThat(result).extracting(array -> array[0]).containsExactly("New Team", "Old Team");
+      assertThat(queryStatistics.getLocalIndexedQueryCount()).isEqualTo(1);
+   }
 }


### PR DESCRIPTION
Fixes #13405

Implemented proper handling of OR predicates when using it with nested objects in an ickle query. 

Problematic query example:
```
select t.name from org.infinispan.query.model.Team t 
join t.firstTeam p
where (p.color ='red' AND p.number=7) or (p.color='blue' AND p.number=7)
```
After the fix this returns correct results instead of an error