### PR TITLE
[15.0.x] [#13272] Collect remote cache configuration to concurrent map

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/Configuration.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/Configuration.java
@@ -323,18 +323,15 @@ public class Configuration {
     * @throws IllegalArgumentException if a cache configuration with the same name already exists
     */
    public RemoteCacheConfiguration addRemoteCache(String name, Consumer<RemoteCacheConfigurationBuilder> builderConsumer) {
-      synchronized (remoteCaches) {
-         if (remoteCaches.containsKey(name)) {
+      return remoteCaches.compute(name, (ignore, existent) -> {
+         if (existent != null)
             throw Log.HOTROD.duplicateCacheConfiguration(name);
-         } else {
-            RemoteCacheConfigurationBuilder builder = new RemoteCacheConfigurationBuilder(null, name);
-            builderConsumer.accept(builder);
-            builder.validate();
-            RemoteCacheConfiguration configuration = builder.create();
-            remoteCaches.put(name, configuration);
-            return configuration;
-         }
-      }
+
+         RemoteCacheConfigurationBuilder builder = new RemoteCacheConfigurationBuilder(null, name);
+         builderConsumer.accept(builder);
+         builder.validate();
+         return builder.create();
+      });
    }
 
    /**

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/ConfigurationBuilder.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/ConfigurationBuilder.java
@@ -627,8 +627,9 @@ public class ConfigurationBuilder implements ConfigurationChildBuilder, Builder<
             throw new IllegalArgumentException("Both marshaller and marshallerClass attributes are present, but marshaller is not an instance of marshallerClass");
       }
 
-      Map<String, RemoteCacheConfiguration> remoteCaches = remoteCacheBuilders.entrySet().stream().collect(Collectors.toMap(
-            Map.Entry::getKey, e -> e.getValue().create()));
+      // Collect to a concurrent map to handle concurrent access for read/writes.
+      Map<String, RemoteCacheConfiguration> remoteCaches = remoteCacheBuilders.entrySet().stream()
+            .collect(Collectors.toConcurrentMap(Map.Entry::getKey, e -> e.getValue().create()));
 
       return new Configuration(asyncExecutorFactory.create(), balancingStrategyFactory, classLoader == null ? null : classLoader.get(),
             clientIntelligence, connectionPool.create(), connectionTimeout, consistentHashImpl,


### PR DESCRIPTION
**Backport:** https://github.com/infinispan/infinispan/pull/13375

* Collect the configurations to a concurrent map;
* Uniform usage of synchronized block to access remote caches.

Closes #13272.
