### PR TITLE
[15.1.x] [#13487] Native Mac CLI release incorrectly states amd64 when it shou…

### DIFF
--- a/.github/workflows/pull_request_native_cli.yml
+++ b/.github/workflows/pull_request_native_cli.yml
@@ -32,7 +32,7 @@ jobs:
             asset_name: linux-amd64
             gu_binary: gu
           - os: macos-latest
-            asset_name: darwin-amd64
+            asset_name: darwin-arm64
             gu_binary: gu
           - os: windows-2022
             asset_name: windows-amd64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
             asset_name: linux-amd64
             gu_binary: gu
           - os: macos-latest
-            asset_name: darwin-amd64
+            asset_name: darwin-arm64
             gu_binary: gu
           - os: windows-2022
             asset_name: windows-amd64


### PR DESCRIPTION
**Backport:** https://github.com/infinispan/infinispan/pull/13488

Closes #13487