### PR TITLE
[15.0.x] [#13609] Reduce virtual thread pinned events

### DIFF
--- a/commons/all/src/main/java/org/infinispan/commons/jdkspecific/ThreadCreator.java
+++ b/commons/all/src/main/java/org/infinispan/commons/jdkspecific/ThreadCreator.java
@@ -30,6 +30,9 @@ public class ThreadCreator {
       return new ThreadCreatorImpl();
    }
 
+   public static boolean isVirtual(Thread thread) {
+      return INSTANCE.isVirtual(thread);
+   }
 
    public static Thread createThread(ThreadGroup threadGroup, Runnable target, boolean useVirtualThread) {
       return INSTANCE.createThread(threadGroup, target, useVirtualThread);
@@ -49,6 +52,11 @@ public class ThreadCreator {
       @Override
       public Optional<ExecutorService> newVirtualThreadPerTaskExecutor() {
          return Optional.empty();
+      }
+
+      @Override
+      public boolean isVirtual(Thread thread) {
+         return false;
       }
    }
 }

--- a/commons/all/src/main/java/org/infinispan/commons/tx/TransactionImpl.java
+++ b/commons/all/src/main/java/org/infinispan/commons/tx/TransactionImpl.java
@@ -10,6 +10,8 @@ import static org.infinispan.commons.util.concurrent.CompletableFutures.extractE
 import static org.infinispan.commons.util.concurrent.CompletableFutures.identity;
 import static org.infinispan.commons.util.concurrent.CompletableFutures.rethrowExceptionIfPresent;
 
+import javax.transaction.xa.XAException;
+import javax.transaction.xa.XAResource;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -19,8 +21,12 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
-import java.util.stream.Collectors;
+
+import org.infinispan.commons.logging.Log;
+import org.infinispan.commons.logging.LogFactory;
 
 import jakarta.transaction.HeuristicMixedException;
 import jakarta.transaction.HeuristicRollbackException;
@@ -29,11 +35,6 @@ import jakarta.transaction.Status;
 import jakarta.transaction.Synchronization;
 import jakarta.transaction.SystemException;
 import jakarta.transaction.Transaction;
-import javax.transaction.xa.XAException;
-import javax.transaction.xa.XAResource;
-
-import org.infinispan.commons.logging.Log;
-import org.infinispan.commons.logging.LogFactory;
 
 
 /**
@@ -61,7 +62,7 @@ public class TransactionImpl implements Transaction {
    private static final String FORCE_ROLLBACK_MESSAGE = "Force rollback invoked. (debug mode)";
    private final List<Synchronization> syncs;
    private final List<XaResourceData> resources;
-   private final Object xidLock = new Object();
+   private final Lock xidLock;
    private volatile XidImpl xid;
    private volatile int status;
    private RollbackException firstRollbackException;
@@ -70,6 +71,7 @@ public class TransactionImpl implements Transaction {
       status = Status.STATUS_ACTIVE;
       syncs = new ArrayList<>(2);
       resources = new ArrayList<>(2);
+      xidLock = new ReentrantLock();
    }
 
    private static boolean isRollbackCode(XAException ex) {
@@ -265,8 +267,11 @@ public class TransactionImpl implements Transaction {
          }
       }
 
-      synchronized (xidLock) {
+      xidLock.lock();
+      try {
          resources.add(new XaResourceData(resource));
+      } finally {
+         xidLock.unlock();
       }
 
       try {
@@ -319,13 +324,16 @@ public class TransactionImpl implements Transaction {
       if (log.isTraceEnabled()) {
          log.tracef("Registering synchronization handler %s", sync);
       }
-      synchronized (xidLock) {
+      xidLock.lock();
+      try {
          syncs.add(sync);
+      } finally {
+         xidLock.unlock();
       }
    }
 
    public Collection<XAResource> getEnlistedResources() {
-      return resources.stream().map(xaResourceData -> xaResourceData.xaResource).collect(Collectors.toUnmodifiableList());
+      return resources.stream().map(XaResourceData::getXaResource).toList();
    }
 
    public boolean runPrepare() {
@@ -362,8 +370,9 @@ public class TransactionImpl implements Transaction {
     *
     * @param forceRollback force the transaction to rollback.
     */
-   public synchronized void runCommit(boolean forceRollback) //synchronized because of client transactions
+   public void runCommit(boolean forceRollback)
          throws HeuristicMixedException, HeuristicRollbackException, RollbackException {
+      xidLock.lock(); //locked because of client transactions
       try {
          runCommitAsync(forceRollback, DefaultResourceConverter.INSTANCE).toCompletableFuture().get();
       } catch (InterruptedException e) {
@@ -371,6 +380,8 @@ public class TransactionImpl implements Transaction {
       } catch (ExecutionException e) {
          Throwable cause = throwChecked(e.getCause());
          throwRuntimeException(cause);
+      } finally {
+         xidLock.unlock();
       }
    }
 
@@ -414,10 +425,13 @@ public class TransactionImpl implements Transaction {
    }
 
    public void setXid(XidImpl xid) {
-      synchronized (xidLock) {
+      xidLock.lock();
+      try {
          if (syncs.isEmpty() && resources.isEmpty()) {
             this.xid = xid;
          }
+      } finally {
+         xidLock.unlock();
       }
    }
 
@@ -438,19 +452,24 @@ public class TransactionImpl implements Transaction {
       return this == obj;
    }
 
-   public synchronized void transactionFailed(Throwable throwable) {
-      if (isDone()) {
-         throw new IllegalStateException("Transaction is done. Cannot change status");
-      }
-      if (status == Status.STATUS_MARKED_ROLLBACK) {
-         return;
-      }
-      status = Status.STATUS_MARKED_ROLLBACK;
-      if (firstRollbackException == null) {
-         firstRollbackException = new RollbackException("Exception caught while running transaction");
-         firstRollbackException.addSuppressed(throwable);
-      } else if (!(throwable instanceof RollbackException)) {
-         firstRollbackException.addSuppressed(throwable);
+   public void transactionFailed(Throwable throwable) {
+      xidLock.lock();
+      try {
+         if (isDone()) {
+            throw new IllegalStateException("Transaction is done. Cannot change status");
+         }
+         if (status == Status.STATUS_MARKED_ROLLBACK) {
+            return;
+         }
+         status = Status.STATUS_MARKED_ROLLBACK;
+         if (firstRollbackException == null) {
+            firstRollbackException = new RollbackException("Exception caught while running transaction");
+            firstRollbackException.addSuppressed(throwable);
+         } else if (!(throwable instanceof RollbackException)) {
+            firstRollbackException.addSuppressed(throwable);
+         }
+      } finally {
+         xidLock.unlock();
       }
    }
 
@@ -710,8 +729,12 @@ public class TransactionImpl implements Transaction {
       final XAResource xaResource;
       volatile int status;
 
-      private XaResourceData(XAResource xaResource) {
+      XaResourceData(XAResource xaResource) {
          this.xaResource = Objects.requireNonNull(xaResource);
+      }
+
+      XAResource getXaResource() {
+         return xaResource;
       }
    }
 
@@ -749,8 +772,7 @@ public class TransactionImpl implements Transaction {
          throwable = extractException(throwable);
          log.errorCommittingTx(throwable);
          exceptions.add(throwable);
-         if (throwable instanceof XAException) {
-            XAException e = (XAException) throwable;
+         if (throwable instanceof XAException e) {
             switch (e.errorCode) {
                case XAException.XA_HEURCOM:
                case XAException.XA_HEURRB:

--- a/commons/jdk21/src/main/java/org/infinispan/commons/jdk21/ThreadCreatorImpl.java
+++ b/commons/jdk21/src/main/java/org/infinispan/commons/jdk21/ThreadCreatorImpl.java
@@ -23,4 +23,9 @@ public class ThreadCreatorImpl implements org.infinispan.commons.spi.ThreadCreat
       return Optional.of(Executors.newVirtualThreadPerTaskExecutor());
    }
 
+   @Override
+   public boolean isVirtual(Thread thread) {
+      return thread.isVirtual();
+   }
+
 }

--- a/commons/spi/src/main/java/org/infinispan/commons/spi/ThreadCreator.java
+++ b/commons/spi/src/main/java/org/infinispan/commons/spi/ThreadCreator.java
@@ -10,4 +10,6 @@ public interface ThreadCreator {
    Thread createThread(ThreadGroup threadGroup, Runnable target, boolean lightweight);
 
    Optional<ExecutorService> newVirtualThreadPerTaskExecutor();
+
+   boolean isVirtual(Thread thread);
 }

--- a/core/src/main/java/org/infinispan/factories/NamedExecutorsFactory.java
+++ b/core/src/main/java/org/infinispan/factories/NamedExecutorsFactory.java
@@ -94,6 +94,10 @@ public class NamedExecutorsFactory extends AbstractComponentFactory implements A
          executorFactory = createThreadPoolFactoryWithDefaults(componentName, type);
       }
 
+      if (type == ExecutorServiceType.NON_BLOCKING && threadFactory instanceof DefaultThreadFactory dtf) {
+         dtf.useVirtualThread(false);
+      }
+
       switch (type) {
          case SCHEDULED:
             return (T) new LazyInitializingScheduledExecutorService(executorFactory, threadFactory);

--- a/core/src/main/java/org/infinispan/factories/threads/NonBlockingThreadPoolExecutorFactory.java
+++ b/core/src/main/java/org/infinispan/factories/threads/NonBlockingThreadPoolExecutorFactory.java
@@ -64,7 +64,7 @@ public class NonBlockingThreadPoolExecutorFactory extends AbstractThreadPoolExec
 
    @Override
    public String toString() {
-      return "BlockingThreadPoolExecutorFactory{" +
+      return "NonBlockingThreadPoolExecutorFactory{" +
             "maxThreads=" + maxThreads +
             ", coreThreads=" + coreThreads +
             ", queueLength=" + queueLength +

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/cluster/ClusterListenerReplicateCallable.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/cluster/ClusterListenerReplicateCallable.java
@@ -98,6 +98,7 @@ public class ClusterListenerReplicateCallable<K, V> implements Function<Embedded
          if (cacheManager.getMembers().contains(origin)) {
             // Prevent multiple invocations to get in here at once, which should prevent concurrent registration of
             // the same id.  Note we can't use a static CHM due to running more than 1 node in same JVM
+            // TODO virtual thread pinning, waiting on CF while inside the synchronized block
             synchronized (cacheNotifier) {
                boolean alreadyInstalled = false;
                // First make sure the listener is not already installed, if it is we don't do anything.

--- a/core/src/test/java/org/infinispan/expiration/impl/ExpirationThreadCountTest.java
+++ b/core/src/test/java/org/infinispan/expiration/impl/ExpirationThreadCountTest.java
@@ -25,8 +25,10 @@ public class ExpirationThreadCountTest extends SingleCacheManagerTest {
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
+      var tf = new DefaultThreadFactory(null, 1, EXPIRATION_THREAD_NAME_PREFIX, null, null);
+      tf.useVirtualThread(false);
       GlobalConfigurationBuilder globalCfg = new GlobalConfigurationBuilder();
-      globalCfg.expirationThreadPool().threadFactory(new DefaultThreadFactory(null, 1, EXPIRATION_THREAD_NAME_PREFIX, null, null));
+      globalCfg.expirationThreadPool().threadFactory(tf);
       return TestCacheManagerFactory.createCacheManager(globalCfg, new ConfigurationBuilder());
    }
 

--- a/core/src/test/java/org/infinispan/test/fwk/JGroupsConfigBuilder.java
+++ b/core/src/test/java/org/infinispan/test/fwk/JGroupsConfigBuilder.java
@@ -88,6 +88,8 @@ public class JGroupsConfigBuilder {
 
       if (!flags.withFD())
          removeFailureDetection(jgroupsCfg);
+      // sockets won't be unexpectedly closed.
+      removeFD_SOCK(jgroupsCfg);
 
       if (!flags.isRelayRequired()) {
          removeRelay2(jgroupsCfg);
@@ -150,6 +152,10 @@ public class JGroupsConfigBuilder {
       jgroupsCfg.removeProtocol(FD).removeProtocol(FD_SOCK).removeProtocol(FD_SOCK2)
                 .removeProtocol(FD_ALL).removeProtocol(FD_ALL2).removeProtocol(FD_ALL3)
                 .removeProtocol(VERIFY_SUSPECT).removeProtocol(VERIFY_SUSPECT2);
+   }
+
+   private static void removeFD_SOCK(JGroupsProtocolCfg jgroupsCfg) {
+      jgroupsCfg.removeProtocol(FD_SOCK).removeProtocol(FD_SOCK2);
    }
 
    private static void removeRelay2(JGroupsProtocolCfg jgroupsCfg) {

--- a/core/src/test/resources/configs/xsite/bridge.xml
+++ b/core/src/test/resources/configs/xsite/bridge.xml
@@ -31,7 +31,7 @@
            <!--break_on_coord_rsp="true"/>-->
     <MERGE3 max_interval="5000"
             min_interval="3000"/>
-    <FD_SOCK2 connect_timeout="3000"/>
+    <!--FD_SOCK2 connect_timeout="3000"/-->
     <!-- Suspect node `timeout` to `timeout + timeout_check_interval` millis after the last heartbeat -->
     <FD_ALL3 timeout="3000"
              interval="1000"

--- a/core/src/test/resources/stacks/tcp.xml
+++ b/core/src/test/resources/stacks/tcp.xml
@@ -38,7 +38,7 @@
 
    <MERGE3 min_interval="1000" max_interval="5000"/>
 
-   <FD_SOCK2 connect_timeout="3000"/>
+   <!--FD_SOCK2 connect_timeout="3000"/-->
    <!-- Suspect node `timeout` to `timeout + timeout_check_interval` millis after the last heartbeat -->
    <FD_ALL3 timeout="3000"
             interval="1000"

--- a/core/src/test/resources/stacks/udp.xml
+++ b/core/src/test/resources/stacks/udp.xml
@@ -31,7 +31,7 @@
    <LOCAL_PING/>
 
    <MERGE3 min_interval="1000" max_interval="5000"/>
-   <FD_SOCK2 connect_timeout="3000"/>
+   <!--FD_SOCK2 connect_timeout="3000"/-->
    <!-- Suspect node `timeout` to `timeout + timeout_check_interval` millis after the last heartbeat -->
    <FD_ALL3 timeout="3000"
            interval="1000"


### PR DESCRIPTION
**Backport:** https://github.com/infinispan/infinispan/pull/13610

* Replace synchronized block with lock
* Remove FD_SOCK2 - not required for our test suite
* Use platform threads in non-blocking thread pool

Closes #13609 