### PR TITLE
[#13648] Retry operations submitted to closing channel

### DIFF
--- a/client/hotrod-client-legacy/src/main/java/org/infinispan/client/hotrod/impl/operations/RetryOnFailureOperation.java
+++ b/client/hotrod-client-legacy/src/main/java/org/infinispan/client/hotrod/impl/operations/RetryOnFailureOperation.java
@@ -77,7 +77,11 @@ public abstract class RetryOnFailureOperation<T> extends HotRodOperation<T> impl
          }
          executeOperation(channel);
       } catch (Throwable t) {
-         completeExceptionally(t);
+         SocketAddress address = ChannelRecord.of(channel).getUnresolvedAddress();
+         Throwable cause = handleException(t, channel, address);
+         if (cause != null) {
+            completeExceptionally(cause);
+         }
       } finally {
          releaseChannel(channel);
       }

--- a/client/hotrod-client-legacy/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/ChannelFactory.java
+++ b/client/hotrod-client-legacy/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/ChannelFactory.java
@@ -878,12 +878,12 @@ public class ChannelFactory {
    }
 
    public int getNumActive(SocketAddress address) {
-      ChannelPool pool = channelPoolMap.get(address);
+      ChannelPool pool = getPool(address);
       return pool == null ? 0 : pool.getActive();
    }
 
    public int getNumIdle(SocketAddress address) {
-      ChannelPool pool = channelPoolMap.get(address);
+      ChannelPool pool = getPool(address);
       return pool == null ? 0 : pool.getIdle();
    }
 
@@ -910,6 +910,10 @@ public class ChannelFactory {
    public void incrementRetryCount() {
       totalRetries.increment();
       totalRetriesMetric.increment();
+   }
+
+   ChannelPool getPool(SocketAddress address) {
+      return channelPoolMap.get(address);
    }
 
    public ClientIntelligence getClientIntelligence() {

--- a/client/hotrod-client-legacy/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/ChannelPool.java
+++ b/client/hotrod-client-legacy/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/ChannelPool.java
@@ -354,7 +354,7 @@ class ChannelPool {
     * @param removeBeforeInvoke: Whether to de-queue the callback before executing it.
     * @return <code>true</code> if executed the callback, <code>false</code>, otherwise.
     */
-   private boolean invokeCallback(Channel channel, ChannelOperation callback, boolean removeBeforeInvoke) {
+   boolean invokeCallback(Channel channel, ChannelOperation callback, boolean removeBeforeInvoke) {
       if (removeBeforeInvoke && !removeCallback(callback)) {
          log.debugf("Operation %s picked-up twice, returning channel to pool", callback);
          release(channel, ChannelRecord.of(channel));

--- a/client/hotrod-client-legacy/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/HeaderDecoder.java
+++ b/client/hotrod-client-legacy/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/HeaderDecoder.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.function.BiFunction;
 
 import org.infinispan.client.hotrod.configuration.Configuration;
@@ -72,7 +73,7 @@ public class HeaderDecoder extends HintedReplayingDecoder<HeaderDecoder.State> {
                operation, System.identityHashCode(operation), operation.header().messageId(), channel);
       }
       if (closing) {
-         throw HOTROD.noMoreOperationsAllowed();
+         throw new RejectedExecutionException(HOTROD.noMoreOperationsAllowed());
       }
       HotRodOperation<?> prev = incomplete.put(operation.header().messageId(), operation);
       assert prev == null || prev == operation : "Already registered: " + prev + ", new: " + operation;
@@ -288,6 +289,10 @@ public class HeaderDecoder extends HintedReplayingDecoder<HeaderDecoder.State> {
       if (log.isTraceEnabled()) {
          log.tracef("Decoder %08X removed? %s listener %s", hashCode(), Boolean.toString(removed), Util.printArray(listenerId));
       }
+   }
+
+   public boolean isClosing() {
+      return closing;
    }
 
    enum State {

--- a/client/hotrod-client-legacy/src/test/java/org/infinispan/client/hotrod/impl/transport/netty/CloseBeforeEnqueuingTest.java
+++ b/client/hotrod-client-legacy/src/test/java/org/infinispan/client/hotrod/impl/transport/netty/CloseBeforeEnqueuingTest.java
@@ -6,6 +6,7 @@ import static org.testng.AssertJUnit.assertTrue;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
@@ -13,20 +14,24 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import org.infinispan.client.hotrod.DataFormat;
 import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.configuration.Configuration;
 import org.infinispan.client.hotrod.impl.ClientTopology;
+import org.infinispan.client.hotrod.impl.consistenthash.ConsistentHash;
+import org.infinispan.client.hotrod.impl.operations.HotRodOperation;
 import org.infinispan.client.hotrod.impl.operations.RetryOnFailureOperation;
 import org.infinispan.client.hotrod.impl.protocol.CodecHolder;
+import org.infinispan.client.hotrod.metrics.RemoteCacheManagerMetricsRegistry;
 import org.infinispan.client.hotrod.retry.AbstractRetryTest;
 import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
 import org.infinispan.client.hotrod.test.InternalRemoteCacheManager;
-import org.infinispan.client.hotrod.metrics.RemoteCacheManagerMetricsRegistry;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.server.hotrod.test.HotRodTestingUtil;
 import org.infinispan.test.fwk.CheckPoint;
 import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.testng.annotations.Test;
@@ -62,6 +67,87 @@ public class CloseBeforeEnqueuingTest extends AbstractRetryTest {
       remoteCacheManager.start();
       return remoteCacheManager;
    }
+
+   public void testSubmittingOnClosedPool() {
+      ChannelFactory channelFactory = remoteCacheManager.getChannelFactory();
+      InetSocketAddress address = InetSocketAddress.createUnresolved(hotRodServer1.getHost(), hotRodServer1.getPort());
+
+      CountDownLatch operationLatch = new CountDownLatch(1);
+      AtomicReference<Channel> channelRef = new AtomicReference<>();
+
+      NoopRetryingOperation firstOperation = new NoopRetryingOperation(0, channelFactory, remoteCacheManager.getConfiguration(),
+            channelRef, operationLatch);
+      fork(() -> channelFactory.fetchChannelAndInvoke(address, firstOperation));
+
+      eventually(() -> channelRef.get() != null);
+      Channel channel = channelRef.get();
+
+      ChannelPool pool = channelFactory.getPool(address);
+      operationLatch.countDown();
+      ChannelRecord.of(channel).release(channel);
+      pool.close();
+
+      String key = getKeyForServer(address, channelFactory.getConsistentHash(RemoteCacheManager.cacheNameBytes()));
+      remoteCache.put(key, "something");
+   }
+
+   public void testClosingPoolDuringExecution() {
+      ChannelFactory channelFactory = remoteCacheManager.getChannelFactory();
+      assertTrue(channelFactory instanceof CustomChannelFactory);
+
+      HotRodOperation<Void> dummy = new HotRodOperation<>((short) 0, (short) 0, null, 0, null, null, null, channelFactory, null) {
+         private final CompletableFuture<Void> cf = new CompletableFuture<>();
+
+         @Override
+         public CompletableFuture<Void> execute() {
+            return cf;
+         }
+
+         @Override
+         public void acceptResponse(ByteBuf buf, short status, HeaderDecoder decoder) {
+            cf.complete(null);
+         }
+      };
+
+      AtomicBoolean once = new AtomicBoolean(true);
+      ((CustomChannelFactory) channelFactory).setBeforeInvoke(channel -> {
+         if (once.getAndSet(false)) {
+            HeaderDecoder decoder = channel.pipeline().get(HeaderDecoder.class);
+            // We need to register a dummy operation that never completes.
+            // If the channel closes, the pipeline is tear down by Netty, and the HeaderDecoder is removed.
+            decoder.registerOperation(channel, dummy);
+
+            ChannelPool pool = channelFactory.getPool(ChannelRecord.of(channel).getUnresolvedAddress());
+
+            // Add the channel in the queue to trigger the shutdown event.
+            ChannelRecord.of(channel).release(channel);
+            pool.close();
+
+            // The shutdown even is triggered asynchronously.
+            // The header decoder is marked as shutting down but the channel will remain open because of the dummy operation.
+            // This will guarantee the header decoder is still present.
+            eventually(decoder::isClosing);
+            assertThat(channel.pipeline().get(HeaderDecoder.NAME)).isNotNull();
+            assertThat(channel.isOpen()).isTrue();
+         }
+      });
+      // Operation should retry and succeed on another server.
+      remoteCache.put("something", "something");
+      dummy.acceptResponse(null, (short) 0, null);
+   }
+
+   private String getKeyForServer(SocketAddress address, ConsistentHash ch) {
+      int i = 0;
+      while (i++ < 100) {
+         String k = UUID.randomUUID().toString();
+         SocketAddress owner = ch.getServer(HotRodTestingUtil.marshall(k));
+         if (owner.equals(address))
+            return k;
+      }
+
+      throw new IllegalStateException("Unable to find key for: " + address);
+   }
+
 
    public void testClosingAndEnqueueing() throws Exception {
       ChannelFactory channelFactory = remoteCacheManager.getChannelFactory();
@@ -256,6 +342,7 @@ public class CloseBeforeEnqueuingTest extends AbstractRetryTest {
 
       private final Configuration configuration;
       private Supplier<Boolean> executeInstead;
+      private Consumer<Channel> beforeInvoke;
 
       public CustomChannelFactory(Configuration cfg) {
          super(cfg, new CodecHolder(cfg.version().getCodec()));
@@ -265,6 +352,10 @@ public class CloseBeforeEnqueuingTest extends AbstractRetryTest {
 
       public void setExecuteInstead(Supplier<Boolean> supplier) {
          this.executeInstead = supplier;
+      }
+
+      public void setBeforeInvoke(Consumer<Channel> beforeInvoke) {
+         this.beforeInvoke = beforeInvoke;
       }
 
       @Override
@@ -285,6 +376,13 @@ public class CloseBeforeEnqueuingTest extends AbstractRetryTest {
                   return false;
                }
                return super.executeDirectlyIfPossible(callback, checkCallback);
+            }
+
+            @Override
+            boolean invokeCallback(Channel channel, ChannelOperation callback, boolean removeBeforeInvoke) {
+               if (beforeInvoke != null)
+                  beforeInvoke.accept(channel);
+               return super.invokeCallback(channel, callback, removeBeforeInvoke);
             }
          };
       }


### PR DESCRIPTION
This happens in a very narrow case: the channel has received the `ChannelPoolCloseEvent`, it is still open and available on the pool, and the operation is already trying to write the bytes. In this case, the operation would hit the `HeaderDecoder` with the `closing` flag set and fail without retrying.

I'll open a backport manually.

Close #13648. 