### PR TITLE
[#13284] shared storage index startup

### DIFF
--- a/documentation/src/main/asciidoc/stories/assembly_upgrading.adoc
+++ b/documentation/src/main/asciidoc/stories/assembly_upgrading.adoc
@@ -3,7 +3,7 @@
 = {brandname} Version Details
 Learn about changes in {brandname} versions before you upgrade.
 
-include::{topics}/upgrading.adoc
+include::{topics}/upgrading.adoc[leveloffset=+0]
 
 // Restore the parent context.
 ifdef::parent-context[:context: {parent-context}]

--- a/documentation/src/main/asciidoc/topics/ref_indexing_configuration.adoc
+++ b/documentation/src/main/asciidoc/topics/ref_indexing_configuration.adoc
@@ -39,6 +39,7 @@ When setting a custom value, ensure that there are no conflicts between caches u
 ====
 
 [discrete]
+[id='indexing-configuration_startup-mode']
 == Index startup mode
 
 When {brandname} starts caches it can perform operations to ensure the index is consistent with data in the cache.

--- a/documentation/src/main/asciidoc/topics/ref_indexing_configuration.adoc
+++ b/documentation/src/main/asciidoc/topics/ref_indexing_configuration.adoc
@@ -83,6 +83,27 @@ a warning message will be logged when the cache is startede starts
 include::xml/indexing_startup_reindex.xml[]
 ----
 
+=== Automatic strategy and shared cache stores
+
+In case of:
+
+1. A shared storage is configured
+2. The indexes are persistent on file system
+
+The `AUTO` startup mode will apply the `REINDEX` strategy.
+This is done in order to not miss potential updates in case of crash and recovery of an indexed node.
+
+Thus `AUTO` in this case may penalize the average user using a shared cache store that does not do any eviction,
+since more reindex than necessary will be triggered.
+For this reason if:
+
+1. A shared storage is configured
+2. The indexes are persistent on file system
+3. Automatic evictions are not possible: cache memory `max-size` and `max-count` are not used
+4. Manual eviction using the embedded API `cache.eviction()` is not used
+
+to use `NONE` in place of `AUTO` as the index startup strategy.
+
 [discrete]
 == Indexing mode
 

--- a/documentation/src/main/asciidoc/topics/upgrading.adoc
+++ b/documentation/src/main/asciidoc/topics/upgrading.adoc
@@ -5,6 +5,13 @@ The native server and its associated `quay.io/infinispan/server-native` images a
 use the JVM based server instead as it provides significant performance issues over its native counterpart, without 
 compromising on features, and is fully supported.
 
+=== Default Index startup mode is now AUTO
+
+The default used to be `NONE`, meaning that no actions at cache startup time are taken in case
+potential index data inconsistencies are detected from the cache configuration.
+With `AUTO`, for instance, a purge is automatically triggered if the cache is not persistent while the indexes are.
+For complete detail see link:{query_docs}#indexing-configuration_startup-mode[Index startup mode].
+
 == Upgrading from 15.0 to 15.1
 
 === Java HotRod Client Changes

--- a/query/src/main/java/org/infinispan/query/impl/IndexStartupRunner.java
+++ b/query/src/main/java/org/infinispan/query/impl/IndexStartupRunner.java
@@ -1,5 +1,7 @@
 package org.infinispan.query.impl;
 
+import java.util.List;
+
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.IndexStartupMode;
 import org.infinispan.configuration.cache.IndexStorage;
@@ -28,10 +30,10 @@ public final class IndexStartupRunner {
 
    private static IndexStartupMode computeFinalMode(Configuration configuration) {
       IndexStartupMode startupMode = configuration.indexing().startupMode();
-      boolean dataIsVolatile = configuration.persistence().stores().stream()
-            .allMatch(StoreConfiguration::purgeOnStartup);
+      DataKind dataKind = computeDataKind(configuration);
       boolean indexesAreVolatile = IndexStorage.LOCAL_HEAP.equals(configuration.indexing().storage());
-      if (dataIsVolatile && !indexesAreVolatile) {
+
+      if (DataKind.VOLATILE.equals(dataKind) && !indexesAreVolatile) {
          switch (startupMode) {
             case AUTO, PURGE,
                  // reindex is equivalent to purge, since there is no data in the caches
@@ -44,7 +46,8 @@ public final class IndexStartupRunner {
             }
          }
       }
-      if (!dataIsVolatile && indexesAreVolatile) {
+
+      if (DataKind.PERSISTENT.equals(dataKind) && indexesAreVolatile) {
          switch (startupMode) {
             case AUTO, REINDEX -> {
                return IndexStartupMode.REINDEX;
@@ -55,6 +58,48 @@ public final class IndexStartupRunner {
             }
          }
       }
+
+      if (DataKind.SHARED_STORE.equals(dataKind) && !indexesAreVolatile &&
+            IndexStartupMode.AUTO.equals(startupMode)) {
+         // @fax4ever: I'm against this. In my opinion run always a reindex, even if
+         // configuration.memory().isEvictionEnabled() is false, is wrong.
+         // This may penalize the average user using a shared cache store that does not do any eviction!
+         // But since the others of the team want this at all cost, I give up in the spirit of collaboration.
+         return IndexStartupMode.REINDEX;
+      }
+
       return (IndexStartupMode.AUTO.equals(startupMode)) ? IndexStartupMode.NONE : startupMode;
+   }
+
+   private enum DataKind {
+      VOLATILE, PERSISTENT, SHARED_STORE
+   }
+
+   private static DataKind computeDataKind(Configuration configuration) {
+      List<StoreConfiguration> cacheStores = configuration.persistence().stores();
+      if (cacheStores.isEmpty()) {
+         return DataKind.VOLATILE;
+      }
+
+      boolean sharedStore = false;
+      for (StoreConfiguration cacheStore : cacheStores) {
+         if (cacheStore.purgeOnStartup()) {
+            continue;
+         }
+         if (cacheStore.shared()) {
+            // @fax4ever: I'm against this. In my opinion run always a reindex, even if
+            // configuration.memory().isEvictionEnabled() is false, is wrong.
+            // This may penalize the average user using a shared cache store that does not do any eviction!
+            // But since the others of the team want this at all cost, I give up in the spirit of collaboration.
+            sharedStore = true;
+         } else {
+            return DataKind.PERSISTENT;
+         }
+      }
+
+      if (sharedStore) {
+         return DataKind.SHARED_STORE;
+      }
+      return DataKind.VOLATILE;
    }
 }

--- a/query/src/test/java/org/infinispan/query/distributed/IndexWithSharedStoreTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/IndexWithSharedStoreTest.java
@@ -1,0 +1,108 @@
+package org.infinispan.query.distributed;
+
+import static org.infinispan.commons.test.CommonsTestingUtil.tmpDirectory;
+
+import java.io.File;
+
+import org.infinispan.Cache;
+import org.infinispan.commons.util.Util;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.cache.IndexStartupMode;
+import org.infinispan.configuration.cache.IndexStorage;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.globalstate.ConfigurationStorage;
+import org.infinispan.persistence.dummy.DummyInMemoryStoreConfigurationBuilder;
+import org.infinispan.query.queries.faceting.Car;
+import org.infinispan.query.test.QueryTestSCI;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.testng.AssertJUnit;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+@Test(groups = "functional", testName = "query.distributed")
+public class IndexWithSharedStoreTest extends MultipleCacheManagersTest {
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      createCacheManager("1");
+      createCacheManager("2");
+   }
+
+   private void createCacheManager(String globalStateDirectory) {
+      var persistentLocation = tmpDirectory(getClass().getSimpleName(), globalStateDirectory);
+      //noinspection ResultOfMethodCallIgnored
+      new File(persistentLocation).mkdirs();
+      var global = GlobalConfigurationBuilder.defaultClusteredBuilder();
+      global.globalState().enable().persistentLocation(persistentLocation).configurationStorage(ConfigurationStorage.OVERLAY);
+      global.serialization().addContextInitializer(QueryTestSCI.INSTANCE);
+
+      addClusterEnabledCacheManager(global, null);
+   }
+
+   @AfterClass(alwaysRun = true)
+   protected void destroy() {
+      try {
+         super.destroy();
+      } finally {
+         Util.recursiveFileRemove(tmpDirectory(getClass().getSimpleName()));
+      }
+   }
+
+   private static ConfigurationBuilder cacheConfiguration() {
+      var builder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC);
+      builder.indexing().enable()
+            .addIndexedEntities(Car.class)
+            .storage(IndexStorage.FILESYSTEM)
+            .startupMode(IndexStartupMode.AUTO);
+      builder.persistence()
+            .addStore(DummyInMemoryStoreConfigurationBuilder.class)
+            .shared(true)
+            .storeName(IndexWithSharedStoreTest.class.getSimpleName());
+      builder.memory().maxCount(1);
+      return builder;
+   }
+
+   private static Car createCar(String carMake) {
+      return new Car(carMake, "black", 1000);
+   }
+
+   private static String query(String carMake) {
+      return String.format("FROM %s where make:'%s'", Car.class.getName(), carMake);
+   }
+
+   private static void queryAndAssert(Cache<String, Car> cache, Car expectedCar) {
+      var cars = cache.<Car>query(query(expectedCar.getMake())).execute().list();
+      AssertJUnit.assertNotNull(cars);
+      AssertJUnit.assertEquals(1, cars.size());
+      AssertJUnit.assertEquals(expectedCar.getMake(), cars.get(0).getMake());
+   }
+
+   public void testIndexesAfterRestart() {
+      var cacheName = "test-indexes-after-restart";
+      manager(0).defineConfiguration(cacheName, cacheConfiguration().build());
+      manager(1).defineConfiguration(cacheName, cacheConfiguration().build());
+      var cache0 = manager(0).<String, Car>getCache(cacheName);
+      var cache1 = manager(1).<String, Car>getCache(cacheName);
+      waitForClusterToForm(cacheName);
+
+      var carA = createCar("A");
+      cache0.put("car1", carA);
+
+      queryAndAssert(cache0, carA);
+      queryAndAssert(cache1, carA);
+
+      killMember(1, cacheName, true);
+
+      var carB = createCar("B");
+      cache0.put("car1", carB);
+      cache0.put("car2", createCar("C"));
+
+      createCacheManager("2");
+      manager(1).defineConfiguration(cacheName, cacheConfiguration().build());
+      cache1 = manager(1).getCache(cacheName);
+      waitForClusterToForm(cacheName);
+
+      queryAndAssert(cache0, carB);
+      queryAndAssert(cache1, carB);
+   }
+}

--- a/query/src/test/java/org/infinispan/query/distributed/IndexWithSharedStoreTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/IndexWithSharedStoreTest.java
@@ -20,7 +20,7 @@ import org.testng.AssertJUnit;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
-@Test(groups = "functional", testName = "query.distributed")
+@Test(groups = "functional", testName = "query.distributed.IndexWithSharedStoreTest")
 public class IndexWithSharedStoreTest extends MultipleCacheManagersTest {
    @Override
    protected void createCacheManagers() throws Throwable {


### PR DESCRIPTION
Closes #13284

Thanks again @pruivo for the reproducer. It will be a nice template for possible similar tests in the future.
It is very cool IMO since with it we simulate the classic node crash / recovery scenario, in this case used to
verify the index consistency when a node recovers.

The fix I'm proposing is quite simple. Since we always have the data and the indexes and the data is always the
source of truth, we can realign the indexes.
Other suggestions are more than welcome.