### PR TITLE
[#13399] RESP batch of flaky fixes

### DIFF
--- a/server/resp/src/test/java/org/infinispan/server/resp/RespBxPOPTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/RespBxPOPTest.java
@@ -544,10 +544,13 @@ public class RespBxPOPTest extends SingleNodeRespBaseTest {
          RedisFuture<KeyValue<String, List<String>>> rf = blmpop(0, 3, key);
 
          redis.lpush(key, "v1");
+
+         // Must wait for BLMPOP.
+         // Otherwise, remaining pushes might happen concurrently with poll and remove more than one element.
+         KeyValue<String, List<String>> response = rf.get(10, TimeUnit.SECONDS);
+
          redis.lpush(key, "v2");
          redis.lpush(key, "v3", "v4", "v5");
-
-         KeyValue<String, List<String>> response = rf.get(10, TimeUnit.SECONDS);
 
          assertThat(response.getKey()).isEqualTo(key);
          assertThat(response.getValue()).containsExactly("v1");


### PR DESCRIPTION
The only code change is for #13395. All the other fixes are changes in the test.

Basically, concurrency issues around the order of operation. In the tests, we needed to wait for push operations to complete before doing a range check.

Closes #13399.
Closes #13660.
Closes #13382.
Closes #13395.