### PR TITLE
[15.0.x] Bump io.lettuce:lettuce-core from 6.3.2.RELEASE to 6.5.2.RELEASE

### DIFF
--- a/build/configuration/pom.xml
+++ b/build/configuration/pom.xml
@@ -149,7 +149,7 @@
       <version.infinispan.maven-plugins>1.0.8.Final</version.infinispan.maven-plugins>
       <version.insights>2.0.4</version.insights>
       <version.io.agroal>2.4</version.io.agroal>
-      <version.io.lettuce>6.3.2.RELEASE</version.io.lettuce>
+      <version.io.lettuce>6.5.2.RELEASE</version.io.lettuce>
       <version.vertx>4.5.12</version.vertx>
       <version.io.mashona>1.1.0</version.io.mashona>
       <version.jackson>2.16.2</version.jackson>

--- a/server/resp/src/test/java/org/infinispan/server/resp/RespSingleNodeTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/RespSingleNodeTest.java
@@ -421,11 +421,6 @@ public class RespSingleNodeTest extends SingleNodeRespBaseTest {
       public byte[] getBytes() {
          return name.getBytes(StandardCharsets.UTF_8);
       }
-
-      @Override
-      public String name() {
-         return name;
-      }
    }
 
    @Test


### PR DESCRIPTION
Fixes https://github.com/netty/netty/security/advisories/GHSA-xq3w-v528-46rv
Medium severity. 

We use Lettuce primarily on our tests. This warning comes from the CLI using Lettuce to submit get/set operations for the benchmark command.