### PR TITLE
[#13740] ProtobufMetadataManagerImpl should utilise SecurityActions to retrieve the cache manager configuration

### DIFF
--- a/client/hotrod-client-legacy/src/test/java/org/infinispan/client/hotrod/tracing/TracingSecurityTest.java
+++ b/client/hotrod-client-legacy/src/test/java/org/infinispan/client/hotrod/tracing/TracingSecurityTest.java
@@ -89,7 +89,7 @@ public class TracingSecurityTest extends SingleHotRodServerTest {
       eventually(() -> telemetryClient.finishedSpanItems().toString(),
             () -> {
                List<SpanData> spanItems = telemetryClient.finishedSpanItems();
-               if (spanItems.size() < 5) {
+               if (spanItems.size() < 4) {
                   return false;
                }
 
@@ -97,12 +97,12 @@ public class TracingSecurityTest extends SingleHotRodServerTest {
                if (spansByName.get("DENY").isEmpty()) {
                   return false;
                }
-               return spansByName.get("ALLOW").size() >= 4;
+               return spansByName.get("ALLOW").size() >= 3;
             }, 10, TimeUnit.SECONDS);
       List<SpanData> spanItems = telemetryClient.finishedSpanItems();
 
       Map<String, List<SpanData>> spansByName = InMemoryTelemetryClient.aggregateByName(spanItems);
       assertThat(spansByName.get("DENY")).hasSize(1);
-      assertThat(spansByName.get("ALLOW")).hasSize(4);
+      assertThat(spansByName.get("ALLOW")).hasSize(3);
    }
 }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/tracing/TracingSecurityTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/tracing/TracingSecurityTest.java
@@ -89,7 +89,7 @@ public class TracingSecurityTest extends SingleHotRodServerTest {
       eventually(() -> telemetryClient.finishedSpanItems().toString(),
             () -> {
                List<SpanData> spanItems = telemetryClient.finishedSpanItems();
-               if (spanItems.size() < 5) {
+               if (spanItems.size() < 4) {
                   return false;
                }
 
@@ -97,12 +97,12 @@ public class TracingSecurityTest extends SingleHotRodServerTest {
                if (spansByName.get("DENY").isEmpty()) {
                   return false;
                }
-               return spansByName.get("ALLOW").size() >= 4;
+               return spansByName.get("ALLOW").size() >= 3;
             }, 10, TimeUnit.SECONDS);
       List<SpanData> spanItems = telemetryClient.finishedSpanItems();
 
       Map<String, List<SpanData>> spansByName = InMemoryTelemetryClient.aggregateByName(spanItems);
       assertThat(spansByName.get("DENY")).hasSize(1);
-      assertThat(spansByName.get("ALLOW")).hasSize(4);
+      assertThat(spansByName.get("ALLOW")).hasSize(3);
    }
 }

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/ProtobufMetadataManagerImpl.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/ProtobufMetadataManagerImpl.java
@@ -93,7 +93,7 @@ public final class ProtobufMetadataManagerImpl implements ProtobufMetadataManage
 
    @Start
    void start() {
-      GlobalConfiguration globalConfiguration = cacheManager.getCacheManagerConfiguration();
+      GlobalConfiguration globalConfiguration = SecurityActions.getCacheManagerConfiguration(cacheManager);
 
       Configuration.Builder configuration = Configuration.builder();
       configuration.schemaValidation(globalConfiguration.serialization().schemaCompatibilityValidation())


### PR DESCRIPTION
Closes #13740