### PR TITLE
[15.1.x] [#13734] Client topology installed during authentication can cause

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/HeaderDecoder.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/HeaderDecoder.java
@@ -129,7 +129,7 @@ public class HeaderDecoder extends HintedReplayingDecoder<HeaderDecoder.State> {
    }
 
    public long registerOperation(HotRodOperation<?> operation) {
-      log.tracef("Decoder is %s Channel is %s", this, channel);
+      log.tracef("Decoder is %s Channel is %s for operation %s", this, channel, operation);
       assert channel.eventLoop().inEventLoop();
 
       long messageId = messageOffset++;


### PR DESCRIPTION
**Backport:** https://github.com/infinispan/infinispan/pull/13735

client to hang

Fixes #13734 