### PR TITLE
[#13836] Fix concurrency group for push

### DIFF
--- a/.github/workflows/on_propen_push_do_build.yml
+++ b/.github/workflows/on_propen_push_do_build.yml
@@ -5,15 +5,15 @@ on:
     branches:
       - feature/*
       - main
-      - 15.[0-9]+.x
+      - 15.*.x
       - 14.0.x
 
 concurrency:
   # Cancel jobs same head_branch same repo, works
   # both for pull_request and push
   group: >
-      ${{ github.workflow }}-${{ github.event.repository.full_name }}-
-      ${{ github.event.pull_request.head.ref || github.event.push.ref }}
+      ${{ github.workflow }}-${{ github.repository }}-
+      ${{ github.event.pull_request.head.ref || github.event.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/operator_upgrade.yaml
+++ b/.github/workflows/operator_upgrade.yaml
@@ -14,8 +14,8 @@ concurrency:
   # Cancel jobs same head_branch same repo, works
   # both for pull_request and push
   group: >
-      ${{ github.workflow }}-${{ github.event.repository.full_name }}-
-      ${{ github.event.pull_request.head.ref || github.event.push.ref }}
+      ${{ github.workflow }}-${{ github.repository }}-
+      ${{ github.event.pull_request.head.ref || github.event.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/pull_request_native_cli.yml
+++ b/.github/workflows/pull_request_native_cli.yml
@@ -16,8 +16,8 @@ concurrency:
   # Cancel jobs same head_branch same repo, works
   # both for pull_request and push
   group: >
-      ${{ github.workflow }}-${{ github.event.repository.full_name }}-
-      ${{ github.event.pull_request.head.ref || github.event.push.ref }}
+      ${{ github.workflow }}-${{ github.repository }}-
+      ${{ github.event.pull_request.head.ref || github.event.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/supported_jdks.yaml
+++ b/.github/workflows/supported_jdks.yaml
@@ -15,8 +15,8 @@ concurrency:
   # Cancel jobs same head_branch same repo, works
   # both for pull_request and push
   group: >
-      ${{ github.workflow }}-${{ github.event.repository.full_name }}-
-      ${{ github.event.pull_request.head.ref || github.event.push.ref }}
+      ${{ github.workflow }}-${{ github.repository }}-
+      ${{ github.event.pull_request.head.ref || github.event.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:


### PR DESCRIPTION
replaced:
- `github.event.push.ref` with `github.event.ref`
-  `github.event.repository.full_name` with `github.repository` 
to attach git `repository` and `ref` correctly to concurrency group on push event.
