### PR TITLE
[15.1.x] [#13834] Install client topology only after a channel is fully connected

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/HeaderDecoder.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/HeaderDecoder.java
@@ -369,8 +369,12 @@ public class HeaderDecoder extends HintedReplayingDecoder<HeaderDecoder.State> {
          segmentOwners = null;
       }
 
-      dispatcher.updateTopology(cacheName, operation, newTopologyId,
-            addresses, segmentOwners, hashFunctionVersion);
+      // Only update the topology if this channel is fully connected and authenticated
+      OperationChannel operationChannel = channel.attr(OperationChannel.OPERATION_CHANNEL_ATTRIBUTE_KEY).get();
+      if (operationChannel != null && operationChannel.isAcceptingRequests()) {
+         dispatcher.updateTopology(cacheName, operation, newTopologyId,
+               addresses, segmentOwners, hashFunctionVersion);
+      }
    }
 
    private InetSocketAddress[] readTopology(ByteBuf buf) {

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/PingOnStartupTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/PingOnStartupTest.java
@@ -41,6 +41,8 @@ public class PingOnStartupTest extends MultiHotRodServersTest {
             new InternalRemoteCacheManager(clientBuilder.build())) {
          @Override
          public void call() {
+            // The topology isn't installed until the first operation now
+            assertEquals(0, rcm.getCache().size());
             OperationDispatcher dispatcher = rcm.getOperationDispatcher();
             eventuallyEquals(2, () -> dispatcher.getServers().size());
          }


### PR DESCRIPTION
**Backport:** https://github.com/infinispan/infinispan/pull/13838

Fixes #13834

This probably also fixes #13793, but would need to be confirmed.