### PR TITLE
[14.0.x] [#13829] Don't include protocol stack in transport exceptions

### DIFF
--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
@@ -762,7 +762,7 @@ public class JGroupsTransport implements Transport, ChannelListener, AddressGene
       try {
          channel = configurator.createChannel(configuration.transport().clusterName());
       } catch (Exception e) {
-         throw CLUSTER.errorCreatingChannelFromConfigurator(configurator.getProtocolStackString(), e);
+         throw CLUSTER.errorCreatingChannelFromConfigurator(configurator.getName(), e);
       }
    }
 


### PR DESCRIPTION
**Backport:** https://github.com/infinispan/infinispan/pull/13830

Closes #13829