### PR TITLE
[15.1.x] [#13739] Enable server database tests execution against DB2

### DIFF
--- a/.github/workflows/on_build_do_test.yml
+++ b/.github/workflows/on_build_do_test.yml
@@ -181,6 +181,7 @@ jobs:
         dbs:
           - mssql
           - oracle
+          - db2
     steps:
       - name: set-commit-status-pending
         uses: myrotvorets/set-commit-status-action@v2.0.1

--- a/.github/workflows/on_test_publish_surefire_report.yml
+++ b/.github/workflows/on_test_publish_surefire_report.yml
@@ -70,3 +70,41 @@ jobs:
                 description: Fail. ${{ steps.test-number.outputs.test_count }} test ran, minimum required is ${{ steps.test-number.outputs.test_min }}
                 targetUrl: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
+   db:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        dbs:
+          - mssql
+          - oracle
+          - db2
+    steps:
+    - name: Set run_id based on event type
+      id: run_id
+      run: |
+         echo "runid=${{ github.event.workflow_run.id }}" >> $GITHUB_OUTPUT
+
+    - name: Download a Build Artifact
+      uses: actions/download-artifact@v4.1.8
+      with:
+        name: surefire-test-report-${{ matrix.dbs }}
+        github-token: ${{ github.token }}
+        run-id: ${{ steps.run_id.outputs.runid }}
+
+    - name: Get github sha
+      id: github_sha
+      uses: juliangruber/read-file-action@v1
+      with:
+        path: ./github-sha.txt
+
+    - name: Publish Test Report
+      if: success() || failure()
+      uses: ScaCap/action-surefire-report@v1.9.0
+      with:
+        check_name: Test Report Result ${{ matrix.dbs }}
+        commit: ${{ steps.github_sha.outputs.content }}
+        ignore_flaky_tests: true
+        report_paths: |
+          **/*-reports*/**/TEST-*.xml

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/api/HotRodTestClientDriver.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/api/HotRodTestClientDriver.java
@@ -10,6 +10,8 @@ import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.server.test.core.TestClient;
 import org.infinispan.server.test.core.TestServer;
 
+import java.util.Properties;
+
 /**
  *  Hot Rod operations for the testing framework
  *
@@ -56,6 +58,11 @@ public class HotRodTestClientDriver extends BaseTestClientDriver<HotRodTestClien
     */
    public HotRodTestClientDriver withClientConfiguration(ClientIntelligence clientIntelligence) {
       clientConfiguration.clientIntelligence(clientIntelligence);
+      return this;
+   }
+
+   public HotRodTestClientDriver withClientConfiguration(Properties properties) {
+      clientConfiguration.withProperties(properties);
       return this;
    }
 
@@ -120,13 +127,16 @@ public class HotRodTestClientDriver extends BaseTestClientDriver<HotRodTestClien
          remoteCacheManager = createRemoteCacheManager();
       }
       String name = testClient.getMethodName(qualifiers);
+      RemoteCache<K, V> remoteCache;
       if (serverConfiguration != null) {
-         return remoteCacheManager.administration().withFlags(flags).getOrCreateCache(name, serverConfiguration);
+         remoteCache = remoteCacheManager.administration().withFlags(flags).getOrCreateCache(name, serverConfiguration);
       } else if (mode != null) {
-         return remoteCacheManager.administration().withFlags(flags).getOrCreateCache(name, forCacheMode(mode));
+         remoteCache = remoteCacheManager.administration().withFlags(flags).getOrCreateCache(name, forCacheMode(mode));
       } else {
-         return remoteCacheManager.administration().withFlags(flags).getOrCreateCache(name, forCacheMode(CacheMode.DIST_SYNC));
+         remoteCache = remoteCacheManager.administration().withFlags(flags).getOrCreateCache(name, forCacheMode(CacheMode.DIST_SYNC));
       }
+      testClient.registerHotRodCache(name, remoteCacheManager);
+      return remoteCache;
    }
 
    public RemoteCacheManager createRemoteCacheManager() {

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/api/RestTestClientDriver.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/api/RestTestClientDriver.java
@@ -97,6 +97,7 @@ public class RestTestClientDriver extends BaseTestClientDriver<RestTestClientDri
                   throw new RuntimeException("Could not obtain rest client = " + response.status());
             }
          } else {
+            testClient.registerRestCache(name, restClient);
             // If the request succeeded without authn but we were expecting to authenticate, it's an error
             if (restClient.getConfiguration().security().authentication().enabled() && !response.usedAuthentication()) {
                throw new SecurityException("Authentication expected but anonymous access succeeded");

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/core/persistence/Database.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/core/persistence/Database.java
@@ -60,6 +60,15 @@ public abstract class Database {
       return properties.getProperty("database.test.sql-file");
    }
 
+   public Properties getHotrodClientProperties() {
+      Properties clientProperties = new Properties();
+      properties.forEach((k,v) -> {
+         if (k.toString().startsWith("infinispan.client.hotrod"))
+            clientProperties.put(k, v);
+      });
+      return clientProperties;
+   }
+
    public static Database fromProperties(String type, Properties properties) {
       String mode = properties.getProperty("database.mode");
       switch (mode) {

--- a/server/tests/pom.xml
+++ b/server/tests/pom.xml
@@ -148,6 +148,11 @@
          <scope>test</scope>
       </dependency>
       <dependency>
+         <groupId>com.ibm.db2</groupId>
+         <artifactId>jcc</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
          <groupId>org.assertj</groupId>
          <artifactId>assertj-core</artifactId>
          <scope>test</scope>

--- a/server/tests/src/test/java/org/infinispan/server/persistence/AsyncJdbcStringBasedCacheStore.java
+++ b/server/tests/src/test/java/org/infinispan/server/persistence/AsyncJdbcStringBasedCacheStore.java
@@ -27,7 +27,9 @@ public class AsyncJdbcStringBasedCacheStore {
 
         JdbcConfigurationUtil jdbcUtil = new JdbcConfigurationUtil(CacheMode.REPL_SYNC, database, false, true)
                 .setLockingConfigurations();
-        RemoteCache<String, String> cache = SERVERS.hotrod().withServerConfiguration(jdbcUtil.getConfigurationBuilder()).create();
+        RemoteCache<String, String> cache = SERVERS.hotrod()
+                .withClientConfiguration(database.getHotrodClientProperties())
+                .withServerConfiguration(jdbcUtil.getConfigurationBuilder()).create();
         try(TableManipulation table = new TableManipulation(cache.getName(), jdbcUtil.getPersistenceConfiguration())) {
             // test PUT operation
             for (int i = 0; i < numEntries; i++) {

--- a/server/tests/src/test/java/org/infinispan/server/persistence/JGroupsJdbcPing2IT.java
+++ b/server/tests/src/test/java/org/infinispan/server/persistence/JGroupsJdbcPing2IT.java
@@ -45,6 +45,7 @@ import org.jgroups.protocols.pbcast.NAKACK2;
 import org.jgroups.protocols.pbcast.STABLE;
 import org.jgroups.stack.Protocol;
 import org.jgroups.stack.ProtocolStack;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -103,6 +104,11 @@ public class JGroupsJdbcPing2IT {
 
    private ContainerDatabase initDatabase(String databaseType) {
       var props = properties(databaseType);
+
+      // The test assumes TestContainer driven deployment and a volume mount
+      Assumptions.assumeTrue("CONTAINER".equals(props.get("database.mode")));
+      Assumptions.assumeTrue(props.get("database.container.volumeMount") != null);
+
       // Ensure that a volume is created so that tables and their content survive container recreation
       props.put(ContainerDatabase.DB_PREFIX + "volume", "true");
       return new ContainerDatabase(databaseType, props);

--- a/server/tests/src/test/java/org/infinispan/server/persistence/JdbcStringBasedCacheStoreIT.java
+++ b/server/tests/src/test/java/org/infinispan/server/persistence/JdbcStringBasedCacheStoreIT.java
@@ -39,7 +39,9 @@ public class JdbcStringBasedCacheStoreIT {
     public void testFailover(Database database) throws Exception {
         JdbcConfigurationUtil jdbcUtil = new JdbcConfigurationUtil(CacheMode.REPL_SYNC, database, false, true)
                 .setLockingConfigurations();
-        RemoteCache<String, String> cache = SERVERS.hotrod().withServerConfiguration(jdbcUtil.getConfigurationBuilder()).create();
+        RemoteCache<String, String> cache = SERVERS.hotrod()
+                .withClientConfiguration(database.getHotrodClientProperties())
+                .withServerConfiguration(jdbcUtil.getConfigurationBuilder()).create();
         try(TableManipulation table = new TableManipulation(cache.getName(), jdbcUtil.getPersistenceConfiguration())) {
             cache.put("k1", "v1");
             cache.put("k2", "v2");
@@ -68,7 +70,9 @@ public class JdbcStringBasedCacheStoreIT {
     public void testPreload(Database database) throws Exception {
         JdbcConfigurationUtil jdbcUtil = new JdbcConfigurationUtil(CacheMode.REPL_SYNC, database, false, true)
                 .setLockingConfigurations();
-        RemoteCache<String, String> cache = SERVERS.hotrod().withServerConfiguration(jdbcUtil.getConfigurationBuilder()).create();
+        RemoteCache<String, String> cache = SERVERS.hotrod()
+                .withClientConfiguration(database.getHotrodClientProperties())
+                .withServerConfiguration(jdbcUtil.getConfigurationBuilder()).create();
         try(TableManipulation table = new TableManipulation(cache.getName(), jdbcUtil.getPersistenceConfiguration())) {
             cache.clear();
             cache.put("k1", "v1");
@@ -96,7 +100,9 @@ public class JdbcStringBasedCacheStoreIT {
     public void testDefaultTwoWayKey2StringMapper(Database database) {
         JdbcConfigurationUtil jdbcUtil = new JdbcConfigurationUtil(CacheMode.REPL_SYNC, database, false, true)
                 .setLockingConfigurations();
-        RemoteCache<Object, Object> cache = SERVERS.hotrod().withServerConfiguration(jdbcUtil.getConfigurationBuilder()).create();
+        RemoteCache<Object, Object> cache = SERVERS.hotrod()
+                .withClientConfiguration(database.getHotrodClientProperties())
+                .withServerConfiguration(jdbcUtil.getConfigurationBuilder()).create();
         try(TableManipulation table = new TableManipulation(cache.getName(), jdbcUtil.getPersistenceConfiguration())) {
             Double doubleKey = 10.0;
             Double doubleValue = 20.0;
@@ -115,7 +121,9 @@ public class JdbcStringBasedCacheStoreIT {
         JdbcConfigurationUtil jdbcUtil = new JdbcConfigurationUtil(CacheMode.REPL_SYNC, database, true, false)
               .setEviction()
               .setLockingConfigurations();
-        RemoteCache<String, String> cache = SERVERS.hotrod().withServerConfiguration(jdbcUtil.getConfigurationBuilder()).create();
+        RemoteCache<String, String> cache = SERVERS.hotrod()
+                .withClientConfiguration(database.getHotrodClientProperties())
+                .withServerConfiguration(jdbcUtil.getConfigurationBuilder()).create();
         try(TableManipulation table = new TableManipulation(cache.getName(), jdbcUtil.getPersistenceConfiguration())) {
             cache.put("k1", "v1");
             cache.put("k2", "v2");
@@ -150,7 +158,10 @@ public class JdbcStringBasedCacheStoreIT {
         JdbcConfigurationUtil jdbcUtil = new JdbcConfigurationUtil(CacheMode.REPL_SYNC, database, true, false)
               .setEviction()
               .setLockingConfigurations();
-        RemoteCache<String, String> cache = SERVERS.hotrod().withServerConfiguration(jdbcUtil.getConfigurationBuilder()).create();
+
+        RemoteCache<String, String> cache = SERVERS.hotrod()
+                .withClientConfiguration(database.getHotrodClientProperties())
+                .withServerConfiguration(jdbcUtil.getConfigurationBuilder()).create();
         try(TableManipulation table = new TableManipulation(cache.getName(), jdbcUtil.getPersistenceConfiguration())) {
             cache.put("k1", "v1");
             cache.put("k2", "v2");
@@ -181,7 +192,9 @@ public class JdbcStringBasedCacheStoreIT {
         configBuilder.expiration()
               .lifespan(1)
               .wakeUpInterval("10ms");
-        RemoteCache<String, String> cache = SERVERS.hotrod().withServerConfiguration(configBuilder).create();
+        RemoteCache<String, String> cache = SERVERS.hotrod()
+                .withClientConfiguration(database.getHotrodClientProperties())
+                .withServerConfiguration(configBuilder).create();
         cache.put("Key", "Value");
         Eventually.eventually(cache::isEmpty);
         try(TableManipulation table = new TableManipulation(cache.getName(), jdbcUtil.getPersistenceConfiguration())) {

--- a/server/tests/src/test/java/org/infinispan/server/persistence/ManagedConnectionOperations.java
+++ b/server/tests/src/test/java/org/infinispan/server/persistence/ManagedConnectionOperations.java
@@ -43,8 +43,12 @@ public class ManagedConnectionOperations {
    @ParameterizedTest
    @ArgumentsSource(Common.DatabaseProvider.class)
    public void testTwoCachesSameCacheStore(Database database) {
-      RemoteCache<String, String> cache1 = SERVERS.hotrod().withServerConfiguration(createConfigurationBuilder(database)).withQualifier("1").create();
-      RemoteCache<String, String> cache2 = SERVERS.hotrod().withServerConfiguration(createConfigurationBuilder(database)).withQualifier("2").create();
+      RemoteCache<String, String> cache1 = SERVERS.hotrod()
+              .withClientConfiguration(database.getHotrodClientProperties())
+              .withServerConfiguration(createConfigurationBuilder(database)).withQualifier("1").create();
+      RemoteCache<String, String> cache2 = SERVERS.hotrod()
+              .withClientConfiguration(database.getHotrodClientProperties())
+              .withServerConfiguration(createConfigurationBuilder(database)).withQualifier("2").create();
       cache1.put("k1", "v1");
       String firstK1 = cache1.get("k1");
       assertEquals("v1", firstK1);
@@ -60,7 +64,9 @@ public class ManagedConnectionOperations {
    @ParameterizedTest
    @ArgumentsSource(Common.DatabaseProvider.class)
    public void testPutGetRemove(Database database) {
-      RemoteCache<String, String> cache = SERVERS.hotrod().withServerConfiguration(createConfigurationBuilder(database)).create();
+      RemoteCache<String, String> cache = SERVERS.hotrod()
+              .withClientConfiguration(database.getHotrodClientProperties())
+              .withServerConfiguration(createConfigurationBuilder(database)).create();
       cache.put("k1", "v1");
       cache.put("k2", "v2");
 

--- a/server/tests/src/test/java/org/infinispan/server/persistence/PooledConnectionOperations.java
+++ b/server/tests/src/test/java/org/infinispan/server/persistence/PooledConnectionOperations.java
@@ -28,8 +28,12 @@ public class PooledConnectionOperations {
    @ArgumentsSource(Common.DatabaseProvider.class)
    public void testTwoCachesSameCacheStore(Database database) {
       JdbcConfigurationUtil jdbcUtil = new JdbcConfigurationUtil(CacheMode.DIST_SYNC, database, false, false);
-      RemoteCache<String, String> cache1 = SERVERS.hotrod().withServerConfiguration(jdbcUtil.getConfigurationBuilder()).withQualifier("1").create();
-      RemoteCache<String, String> cache2 = SERVERS.hotrod().withServerConfiguration(jdbcUtil.getConfigurationBuilder()).withQualifier("2").create();
+      RemoteCache<String, String> cache1 = SERVERS.hotrod()
+              .withClientConfiguration(database.getHotrodClientProperties())
+              .withServerConfiguration(jdbcUtil.getConfigurationBuilder()).withQualifier("1").create();
+      RemoteCache<String, String> cache2 = SERVERS.hotrod()
+              .withClientConfiguration(database.getHotrodClientProperties())
+              .withServerConfiguration(jdbcUtil.getConfigurationBuilder()).withQualifier("2").create();
 
       cache1.put("k1", "v1");
       String firstK1 = cache1.get("k1");
@@ -48,7 +52,9 @@ public class PooledConnectionOperations {
    @ArgumentsSource(Common.DatabaseProvider.class)
    public void testPutGetRemove(Database database) {
       JdbcConfigurationUtil jdbcUtil = new JdbcConfigurationUtil(CacheMode.DIST_SYNC, database, false, false);
-      RemoteCache<String, String> cache = SERVERS.hotrod().withServerConfiguration(jdbcUtil.getConfigurationBuilder()).create();
+      RemoteCache<String, String> cache = SERVERS.hotrod()
+              .withClientConfiguration(database.getHotrodClientProperties())
+              .withServerConfiguration(jdbcUtil.getConfigurationBuilder()).create();
 
       cache.put("k1", "v1");
       cache.put("k2", "v2");
@@ -73,7 +79,9 @@ public class PooledConnectionOperations {
    public void testPreload(Database database) throws Exception {
       JdbcConfigurationUtil jdbcUtil = new JdbcConfigurationUtil(CacheMode.REPL_SYNC, database, false, true)
               .setLockingConfigurations();
-      RemoteCache<String, String> cache = SERVERS.hotrod().withServerConfiguration(jdbcUtil.getConfigurationBuilder()).create();
+      RemoteCache<String, String> cache = SERVERS.hotrod()
+              .withClientConfiguration(database.getHotrodClientProperties())
+              .withServerConfiguration(jdbcUtil.getConfigurationBuilder()).create();
       cache.put("k1", "v1");
       cache.put("k2", "v2");
 
@@ -93,7 +101,9 @@ public class PooledConnectionOperations {
       JdbcConfigurationUtil jdbcUtil = new JdbcConfigurationUtil(CacheMode.REPL_SYNC, database, true, false)
               .setEviction()
               .setLockingConfigurations();
-      RemoteCache<String, String> cache = SERVERS.hotrod().withServerConfiguration(jdbcUtil.getConfigurationBuilder()).create();
+      RemoteCache<String, String> cache = SERVERS.hotrod()
+              .withClientConfiguration(database.getHotrodClientProperties())
+              .withServerConfiguration(jdbcUtil.getConfigurationBuilder()).create();
       cache.put("k1", "v1");
       cache.put("k2", "v2");
       cache.put("k3", "v3");

--- a/server/tests/src/test/resources/configuration/datasources/default.xml
+++ b/server/tests/src/test/resources/configuration/datasources/default.xml
@@ -49,4 +49,12 @@
                           new-connection-sql="SELECT 1" />
       <connection-pool max-size="10" background-validation="1000" idle-removal="1" initial-size="1" leak-detection="10000"/>
    </data-source>
+   <data-source name="db2" jndi-name="jdbc/db2" statistics="true">
+      <connection-factory driver="${org.infinispan.server.test.database.db2.driver:com.ibm.db2.jcc.DB2Driver}"
+                          username="${org.infinispan.server.test.database.db2.username}"
+                          password="${org.infinispan.server.test.database.db2.password}"
+                          url="${org.infinispan.server.test.database.db2.jdbcUrl}"
+                          new-connection-sql="VALUES 1" />
+      <connection-pool max-size="10" background-validation="1000" idle-removal="1" initial-size="1" leak-detection="10000"/>
+   </data-source>
 </data-sources>

--- a/server/tests/src/test/resources/database/db2.properties
+++ b/server/tests/src/test/resources/database/db2.properties
@@ -1,0 +1,21 @@
+id.column.type=VARCHAR(255)
+data.column.type=BLOB(1000)
+timestamp.column.type=BIGINT
+segment.column.type=BIGINT
+database.jdbc.driver=com.ibm.db2.jcc.DB2Driver
+database.jdbc.password=test
+database.jdbc.username=db2inst1
+
+database.mode=CONTAINER
+database.container.name=icr.io/db2_community/db2
+database.container.tag=11.5.9.0
+database.container.env.LICENSE=accept
+database.container.env.DB2INST1_PASSWORD=test
+database.container.env.DBNAME=testdb
+database.container.port=50000
+database.container.volumeMount=/database
+database.jdbc.url=jdbc:db2://${container.address}:50000/testdb
+database.test.query=VALUES 1
+org.infinispan.test.database.container.log.regex=.*Setup has completed.*
+
+infinispan.client.hotrod.socket_timeout=10000

--- a/server/tests/src/test/resources/database/jdbc-drivers.txt
+++ b/server/tests/src/test/resources/database/jdbc-drivers.txt
@@ -4,3 +4,4 @@ org.postgresql:postgresql:${versionx.com.postgresqldatabase.postgresql}
 org.mariadb.jdbc:mariadb-java-client:${versionx.org.mariadb.jdbc}
 com.microsoft.sqlserver:mssql-jdbc:${versionx.com.microsoft.sqlserver}
 com.oracle.ojdbc:ojdbc8:${versionx.com.oracle.ojdbc.ojdbc8}
+com.ibm.db2:jcc:11.5.9.0


### PR DESCRIPTION
**Backport:** https://github.com/infinispan/infinispan/pull/13792

Enables '@database' test execution against DB2 and adds it to the matrix alongside MSSQL and OracleDB

Closes #13739 