### PR TITLE
[#13429] RESP json.forget command

### DIFF
--- a/documentation/src/main/asciidoc/topics/ref_redis_commands.adoc
+++ b/documentation/src/main/asciidoc/topics/ref_redis_commands.adoc
@@ -131,6 +131,8 @@ NOTE: This implementation attempts to return all attributes that a real Redis se
 
 * link:https://redis.io/commands/json.del[JSON.DEL]
 
+* link:https://redis.io/commands/json.forget[JSON.FORGET]
+
 * link:https://redis.io/commands/json.get[JSON.GET]
 
 * link:https://redis.io/commands/json.objkeys[JSON.OBJKEYS]

--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/Commands.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/Commands.java
@@ -62,6 +62,7 @@ import org.infinispan.server.resp.commands.hll.PFADD;
 import org.infinispan.server.resp.commands.json.JSONARRAPPEND;
 import org.infinispan.server.resp.commands.json.JSONARRLEN;
 import org.infinispan.server.resp.commands.json.JSONDEL;
+import org.infinispan.server.resp.commands.json.JSONFORGET;
 import org.infinispan.server.resp.commands.json.JSONGET;
 import org.infinispan.server.resp.commands.json.JSONOBJKEYS;
 import org.infinispan.server.resp.commands.json.JSONOBJLEN;
@@ -197,7 +198,7 @@ public final class Commands {
       ALL_COMMANDS[6] = new RespCommand[]{new GET(), new GETDEL(), new GETEX(), new GETRANGE(), new GETSET()};
       ALL_COMMANDS[7] = new RespCommand[]{new HELLO(), new HGET(), new HSET(), new HLEN(), new HEXISTS(), new HDEL(), new HMGET(), new HSETNX(), new HKEYS(), new HVALS(), new HSCAN(), new HGETALL(), new HMSET(), new HINCRBY(), new HINCRBYFLOAT(), new HRANDFIELD(), new HSTRLEN()};
       ALL_COMMANDS[8] = new RespCommand[]{new INCR(), new INCRBY(), new INCRBYFLOAT(), new INFO()};
-      ALL_COMMANDS[9] = new RespCommand[]{new JSONGET(), new JSONSET(), new JSONARRLEN(), new JSONOBJLEN(), new JSONSTRLEN(), new JSONTYPE(), new JSONDEL(), new JSONSTRAPPEND(), new JSONARRAPPEND(), new JSONTOGGLE(), new JSONOBJKEYS()};
+      ALL_COMMANDS[9] = new RespCommand[]{new JSONGET(), new JSONSET(), new JSONARRLEN(), new JSONOBJLEN(), new JSONSTRLEN(), new JSONTYPE(), new JSONDEL(), new JSONSTRAPPEND(), new JSONARRAPPEND(), new JSONTOGGLE(), new JSONOBJKEYS(), new JSONFORGET()};
       ALL_COMMANDS[10] = new RespCommand[]{new KEYS()};
       ALL_COMMANDS[11] = new RespCommand[]{new LINDEX(), new LINSERT(), new LPUSH(), new LPUSHX(), new LPOP(), new LRANGE(), new LLEN(), new LPOS(), new LREM(), new LSET(), new LTRIM(), new LMOVE(), new LMPOP(), new LCS()};
       ALL_COMMANDS[12] = new RespCommand[]{new MGET(), new MSET(), new MSETNX(), new MULTI(), new MODULE(), new MEMORY()};

--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/json/JSONDEL.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/json/JSONDEL.java
@@ -27,6 +27,10 @@ public class JSONDEL extends RespCommand implements Resp3Command {
       super("JSON.DEL", -2, 1, 1, 1);
    }
 
+   protected JSONDEL(String name, int arity, int firstKeyPos, int lastKeyPos, int steps) {
+      super(name, arity, firstKeyPos, lastKeyPos, steps);
+   }
+
    @Override
    public long aclMask() {
       return 0;

--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/json/JSONFORGET.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/json/JSONFORGET.java
@@ -1,0 +1,15 @@
+package org.infinispan.server.resp.commands.json;
+
+/**
+ * JSON.FORGET
+ *
+ * @see <a href="https://redis.io/commands/json.forget/">JSON.FORGET</a>
+ *
+ * @since 15.2
+ */
+public class JSONFORGET extends JSONDEL {
+    // This command is an alias of JSON.DEL
+   public JSONFORGET() {
+      super("JSON.FORGET", -2, 1, 1, 1);
+   }
+}

--- a/server/resp/src/test/java/org/infinispan/server/resp/CustomStringCommands.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/CustomStringCommands.java
@@ -48,6 +48,9 @@ public interface CustomStringCommands extends Commands {
    @Command("JSON.GET :key :path1 :path2 :path3")
    String jsonGet(@Param("key") String key, @Param("path1") String path1, @Param("path2") String path2, @Param("path3") String path3);
 
+   @Command("JSON.FORGET :key :path")
+   Long jsonForget(@Param("key") String key, @Param("path") String path);
+
    // Lettuce arrAppend command has a bug, it doesn't support root path, so we need to use a custom command
    @Command("JSON.ARRAPPEND :key :path :v1 :v2 :v3")
    Long jsonArrappend(@Param("key") String key, @Param("path") String path, @Param("v1") String v1, @Param("v2") String v2, @Param("v2") String v3);

--- a/server/resp/src/test/java/org/infinispan/server/resp/JsonCommandsTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/JsonCommandsTest.java
@@ -791,6 +791,32 @@ public class JsonCommandsTest extends SingleNodeRespBaseTest {
    }
 
    @Test
+   public void testJSONFORGET() {
+      // JSON.FORGET is an alias for JSON.DEL. Check if alias is in place
+      String key = k();
+      String jsonStr = """
+               {
+                  "name": "Alice",
+                  "age": 30,
+                  "isStudent": false,
+                  "grades": [85, 90, 78],
+                  "address": {
+                    "verified": true,
+                    "city": "New York",
+                    "zip": "10001"
+                  },
+                  "phone": null
+                }
+            """;
+      JsonValue jv = defaultJsonParser.createJsonValue(jsonStr);
+      redis.jsonSet(key, new JsonPath("$"), jv);
+      CustomStringCommands command = CustomStringCommands.instance(redisConnection);
+      // Deleting whole object
+      assertThat(command.jsonForget(key, "$")).isEqualTo(1);
+      // Not using json.get since lettuce json.get fails with RESP3 null
+      assertThat(redis.get(key)).isNull();
+   }
+   @Test
    public void testJSONSTRAPPEND() {
       JsonPath jp = new JsonPath("$");
       JsonValue jv = defaultJsonParser.createJsonValue("\"string\"");


### PR DESCRIPTION
RESP JSON.FORGET implementation. (alias of json.del)
Fixed #13429 