### PR TITLE
Patch supporting remote cache names with wildcard when setting up near cache

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
@@ -311,7 +311,7 @@ public class RemoteCacheManager implements RemoteCacheContainer, Closeable, Remo
    }
 
    private <K, V> InternalRemoteCache<K, V> getInternalCache(String cacheName) {
-      return createRemoteCache(cacheName, configuration.forceReturnValues(), null, null);
+      return moteCache(cacheName, configuration.forceReturnValues(), null, null);
    }
 
    public CompletableFuture<Void> startAsync() {
@@ -625,7 +625,7 @@ public class RemoteCacheManager implements RemoteCacheContainer, Closeable, Remo
    }
 
    private <K, V> InternalRemoteCache<K, V> createRemoteCache(String cacheName, Function<InternalRemoteCache<K, V>, CacheOperationsFactory> factoryFunction) {
-      RemoteCacheConfiguration remoteCacheConfiguration = configuration.remoteCaches().get(cacheName);
+      RemoteCacheConfiguration cacheConfiguration = findConfiguration(cacheName);
       NearCacheConfiguration nearCache;
       if (remoteCacheConfiguration != null) {
          nearCache = new NearCacheConfiguration(remoteCacheConfiguration.nearCacheMode(), remoteCacheConfiguration.nearCacheMaxEntries(),

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
@@ -311,7 +311,7 @@ public class RemoteCacheManager implements RemoteCacheContainer, Closeable, Remo
    }
 
    private <K, V> InternalRemoteCache<K, V> getInternalCache(String cacheName) {
-      return moteCache(cacheName, configuration.forceReturnValues(), null, null);
+      return createRemoteCache(cacheName, configuration.forceReturnValues(), null, null);
    }
 
    public CompletableFuture<Void> startAsync() {


### PR DESCRIPTION
When a wildcard is used in remote cache configuration, the near cache configuration is not applied to actual caches.

This is the non-working configuration:

configurationBuilder
.remoteCache("myapp-*)
.nearCacheMode(NearCacheMode.INVALIDATED)
.nearCacheMaxEntries(100);

One can check that, when using a remote cache named "myapp-cache", the correct near cache config is not applied.

This patch fixes that issue.