### PR TITLE
[15.0.x] [#14151] Avoid thread pinning in RebalanceConfirmationCollector

### DIFF
--- a/core/src/main/java/org/infinispan/topology/RebalanceConfirmationCollector.java
+++ b/core/src/main/java/org/infinispan/topology/RebalanceConfirmationCollector.java
@@ -3,6 +3,7 @@ package org.infinispan.topology;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.util.logging.Log;
@@ -17,6 +18,7 @@ import org.infinispan.util.logging.LogFactory;
 class RebalanceConfirmationCollector {
    private final static Log log = LogFactory.getLog(RebalanceConfirmationCollector.class);
 
+   private final ReentrantLock lock = new ReentrantLock();
    private final String cacheName;
    private final int topologyId;
    private final Set<Address> confirmationsNeeded;
@@ -35,7 +37,8 @@ class RebalanceConfirmationCollector {
     * @return {@code true} if everyone has confirmed
     */
    public void confirmPhase(Address node, int receivedTopologyId) {
-      synchronized (this) {
+      acquireLock();
+      try {
          if (topologyId > receivedTopologyId) {
             log.tracef("Ignoring rebalance confirmation with old topology from %s " +
                   "for cache %s, expecting topology id %d but got %d", node, cacheName, topologyId, receivedTopologyId);
@@ -53,6 +56,8 @@ class RebalanceConfirmationCollector {
          if (confirmationsNeeded.isEmpty()) {
             whenCompleted.run();
          }
+      } finally {
+         releaseLock();
       }
    }
 
@@ -60,7 +65,8 @@ class RebalanceConfirmationCollector {
     * @return {@code true} if everyone has confirmed
     */
    public void updateMembers(Collection<Address> newMembers) {
-      synchronized (this) {
+      acquireLock();
+      try {
          // only return true the first time
          boolean modified = confirmationsNeeded.retainAll(newMembers);
          log.tracef("Rebalance confirmation collector %d@%s members list updated, remaining list is %s",
@@ -68,17 +74,33 @@ class RebalanceConfirmationCollector {
          if (modified && confirmationsNeeded.isEmpty()) {
             whenCompleted.run();
          }
+      } finally {
+         releaseLock();
       }
    }
 
    @Override
    public String toString() {
-      synchronized (this) {
+      acquireLock();
+      try {
          return "RebalanceConfirmationCollector{" +
                "cacheName=" + cacheName +
                ", topologyId=" + topologyId +
                ", confirmationsNeeded=" + confirmationsNeeded +
                '}';
+      } finally {
+         releaseLock();
       }
    }
+
+   // This method is here to augment with blockhound as we allow it to block, but don't want the calls
+   // inside the lock to block - Do not move or rename without updating the reference
+   private void acquireLock() {
+      lock.lock();
+   }
+
+   private void releaseLock() {
+      lock.unlock();
+   }
+
 }

--- a/core/src/main/java/org/infinispan/util/CoreBlockHoundIntegration.java
+++ b/core/src/main/java/org/infinispan/util/CoreBlockHoundIntegration.java
@@ -67,6 +67,8 @@ public class CoreBlockHoundIntegration implements BlockHoundIntegration {
          builder.allowBlockingCallsInside(ClusterCacheStatus.class.getName(), "acquireLock");
          builder.allowBlockingCallsInside(ClusterCacheStatus.class.getName() + "$ConflictResolution", "acquireLock");
 
+         builder.allowBlockingCallsInside("org.infinispan.topology.RebalanceConfirmationCollector", "acquireLock");
+
          builder.allowBlockingCallsInside(PersistenceManagerImpl.class.getName(), "acquireReadLock");
 
          builder.allowBlockingCallsInside(JGroupsTransport.class.getName(), "withView");


### PR DESCRIPTION
**Backport:** https://github.com/infinispan/infinispan/pull/14152

Closes #14151

I backported the change to ISPN 15.0.x and used it in KC 26.2.x and didn't see any additional information about pinned threads, so I assume this is now sufficient.