### PR TITLE
14257 single response collector

### DIFF
--- a/core/src/main/java/org/infinispan/remoting/transport/impl/SingleTargetRequest.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/impl/SingleTargetRequest.java
@@ -68,6 +68,8 @@ public class SingleTargetRequest<T> extends AbstractRequest<T> {
          if (tmp == null || members.contains(tmp.destination())) {
             return false;
          }
+         tmp.onComplete();
+         requestTracker = null;
          boolean skipSync = responseCollector instanceof SingleResponseCollector;
          if (skipSync) {
             result=addResponse(tmp.destination(), CacheNotFoundResponse.INSTANCE);

--- a/core/src/main/java/org/infinispan/remoting/transport/impl/SingleTargetRequest.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/impl/SingleTargetRequest.java
@@ -48,10 +48,9 @@ public class SingleTargetRequest<T> extends AbstractRequest<T> {
          boolean skipSync = responseCollector instanceof SingleResponseCollector;
          if (skipSync) {
             result = addResponse(sender, response);
-         }
-         else {
+         } else {
             synchronized(responseCollector) {
-               result=addResponse(sender, response);
+               result = addResponse(sender, response);
             }
          }
          complete(result);
@@ -72,11 +71,10 @@ public class SingleTargetRequest<T> extends AbstractRequest<T> {
          requestTracker = null;
          boolean skipSync = responseCollector instanceof SingleResponseCollector;
          if (skipSync) {
-            result=addResponse(tmp.destination(), CacheNotFoundResponse.INSTANCE);
-         }
-         else {
+            result = addResponse(tmp.destination(), CacheNotFoundResponse.INSTANCE);
+         } else {
             synchronized(responseCollector) {
-               result=addResponse(tmp.destination(), CacheNotFoundResponse.INSTANCE);
+               result = addResponse(tmp.destination(), CacheNotFoundResponse.INSTANCE);
             }
          }
          complete(result);
@@ -86,7 +84,6 @@ public class SingleTargetRequest<T> extends AbstractRequest<T> {
       return true;
    }
 
-   @GuardedBy("responseCollector")
    private T addResponse(Address sender, Response response) {
       T result = responseCollector.addResponse(sender, response);
       if (result == null) {


### PR DESCRIPTION
Synchronization in SingleTargetRequest is not needed (a) around `requestTracker` (already synchronized) and (2) is the response collector is `SingleResponseCollector` (used a lot for GET and ACK responses

 (https://github.com/infinispan/infinispan/issues/14257)