### PR TITLE
[#14257] SingleResponseCollector excessive locking

### DIFF
--- a/core/src/main/java/org/infinispan/remoting/transport/ResponseCollector.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/ResponseCollector.java
@@ -7,8 +7,9 @@ import org.infinispan.remoting.responses.Response;
  * A representation of a request's responses.
  *
  * <p>Thread-safety: The request will invoke {@link #addResponse(Address, Response)} and
- * {@link #finish()} while holding the collector's monitor, so
- * implementations don't normally need explicit synchronization.</p>
+ * {@link #finish()} in a mutually exclusive way. If {@link #addResponse(Address, Response)} is invoked
+ * more than once it may be on different threads, but never concurrently and only with a happens-before operation
+ * ensuring proper visibility, allowing implementations to use non concurrent structures.</p>
  *
  * @author Dan Berindei
  * @since 9.1

--- a/core/src/main/java/org/infinispan/remoting/transport/impl/ExclusiveTargetRequest.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/impl/ExclusiveTargetRequest.java
@@ -1,0 +1,138 @@
+package org.infinispan.remoting.transport.impl;
+
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.Set;
+
+import org.infinispan.remoting.responses.Response;
+import org.infinispan.remoting.transport.AbstractRequest;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.remoting.transport.ResponseCollector;
+
+import net.jcip.annotations.GuardedBy;
+
+/**
+ * Request implementation that waits for responses from multiple target nodes.
+ * <p>
+ * This Request handles concurrent calls to {@link #onResponse(Address, Response)},
+ * {@link #onNewView(Set)} and {@link #onTimeout()} by using a very small synchronized block to guarantee only a single
+ * thread is performing any these actual operations at a time. This is done by updating the instance variable {@link #handling}
+ * to <b>true</b> for the first caller to enter one of these methods. The thread that updates it to true will perform their
+ * operation immediately. However, if another concurrent call enters any of these methods and {@link #handling} is already
+ * <b>true</b> this thread will instead initialize the {@link #queue} if necessary and add its operation as a Runnable to it.
+ * The caller that updated {@link #handling} to <b>true</b> will after performing its operation check under lock if the
+ * {@link #queue} has been updated and if so run any of those operations, thus guaranteeing thread safety.
+ * <p>
+ * Note that {@link #onNewView(Set)} return value is only valid if invoked before submitting this request. This is due
+ * to the update being possibly enqueued, and thus we cannot guarantee its correctness.
+ * @author William Burns
+ */
+public abstract class ExclusiveTargetRequest<T> extends AbstractRequest<T> {
+   @GuardedBy("this")
+   private Queue<Runnable> queue;
+   @GuardedBy("this")
+   private boolean handling;
+
+   public ExclusiveTargetRequest(ResponseCollector<T> responseCollector, long requestId, RequestRepository repository) {
+      super(requestId, responseCollector, repository);
+   }
+
+   @Override
+   public final void onResponse(Address sender, Response response) {
+      if (isDone()) {
+         return;
+      }
+      synchronized (this) {
+         if (isDone()) {
+            return;
+         }
+         if (handling) {
+            enqueueOperation(() -> actualOnResponse(sender, response));
+            return;
+         }
+         handling = true;
+      }
+      actualOnResponse(sender, response);
+      handleLoop();
+   }
+
+   @Override
+   public final boolean onNewView(Set<Address> members) {
+      if (isDone()) {
+         return false;
+      }
+      boolean response;
+      synchronized (this) {
+         if (isDone()) {
+            return false;
+         }
+         if (handling) {
+            enqueueOperation(() -> actualOnView(members));
+            return false;
+         }
+         handling = true;
+      }
+      response = actualOnView(members);
+      handleLoop();
+      return response;
+   }
+
+   @Override
+   protected final void onTimeout() {
+      if (isDone()) {
+         return;
+      }
+      synchronized (this) {
+         if (isDone()) {
+            return;
+         }
+         if (handling) {
+            enqueueOperation(this::actualOnTimeout);
+            return;
+         }
+         handling = true;
+      }
+      actualOnTimeout();
+      handleLoop();
+   }
+
+   @GuardedBy("this")
+   private void enqueueOperation(Runnable runnable) {
+      Queue<Runnable> queue = this.queue;
+      if (queue == null) {
+         queue = new ArrayDeque<>(2);
+         this.queue = queue;
+      }
+      queue.add(runnable);
+   }
+
+   /**
+    * This method can only be invoked after updating {@link #handling} from <b>false</b> to <b>true</b> while under
+    * the monitor for <b>this</b>.
+    */
+   private void handleLoop() {
+      //noinspection FieldAccessNotGuarded
+      assert handling;
+      // Note each loop will use the synchronized block to pull the queue to a local reference and set the
+      // instance variable back to null allowing for additional concurrent updates to create/insert into a new
+      // queue to be processed on a subsequent loop
+      while (!isDone()) {
+         Queue<Runnable> queue;
+         synchronized (this) {
+            queue = this.queue;
+            if (queue == null) {
+               handling = false;
+               return;
+            }
+            this.queue = null;
+         }
+         queue.forEach(Runnable::run);
+      }
+   }
+
+   protected abstract void actualOnResponse(Address sender, Response response);
+
+   protected abstract boolean actualOnView(Set<Address> members);
+
+   protected abstract void actualOnTimeout();
+}

--- a/core/src/main/java/org/infinispan/remoting/transport/impl/Request.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/impl/Request.java
@@ -28,7 +28,8 @@ public interface Request<T> extends CompletionStage<T> {
    /**
     * Called when the node received a new cluster view.
     *
-    * @return {@code true} if any of the request targets is not in the view.
+    * @return {@code true} if any of the request targets is not in the view. This value should only be used
+    * before the request was actually submitted.
     */
    boolean onNewView(Set<Address> members);
 


### PR DESCRIPTION
Fixes #14257 

I have updated all of the Requests to no longer use any locking on the actual Collectors. Instead it now uses exclusive access so that the collector can only be invoked on a single thread at a time without locking for a given instance of a Request. Note that if a collector is shared between requests this is no longer protected and honestly shouldn't be happening unless the collector was immutable already before.