### PR TITLE
[#14313] Metrics with manually created JGroups channel

### DIFF
--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/AbstractJGroupsChannelConfigurator.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/AbstractJGroupsChannelConfigurator.java
@@ -1,12 +1,7 @@
 package org.infinispan.remoting.transport.jgroups;
 
-
-import java.util.ArrayList;
-import java.util.List;
-
 import javax.sql.DataSource;
 
-import org.jgroups.ChannelListener;
 import org.jgroups.JChannel;
 import org.jgroups.stack.Protocol;
 import org.jgroups.util.SocketFactory;
@@ -18,7 +13,6 @@ import org.jgroups.util.SocketFactory;
 public abstract class AbstractJGroupsChannelConfigurator implements JGroupsChannelConfigurator {
    private SocketFactory socketFactory;
    protected DataSource dataSource;
-   protected List<ChannelListener> channelListeners = new ArrayList<>(2);
 
    @Override
    public void setSocketFactory(SocketFactory socketFactory) {
@@ -39,13 +33,6 @@ public abstract class AbstractJGroupsChannelConfigurator implements JGroupsChann
          Protocol protocol = channel.getProtocolStack().getTopProtocol();
          protocol.setSocketFactory(socketFactory);
       }
-      for(ChannelListener listener : channelListeners) {
-         channel.addChannelListener(listener);
-      }
       return channel;
-   }
-
-   public void addChannelListener(ChannelListener channelListener) {
-      channelListeners.add(channelListener);
    }
 }

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/EmbeddedJGroupsChannelConfigurator.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/EmbeddedJGroupsChannelConfigurator.java
@@ -10,7 +10,6 @@ import java.util.Map;
 
 import org.infinispan.configuration.global.JGroupsConfiguration;
 import org.infinispan.xsite.XSiteNamedCache;
-import org.jgroups.ChannelListener;
 import org.jgroups.JChannel;
 import org.jgroups.conf.ProtocolConfiguration;
 import org.jgroups.conf.ProtocolStackConfigurator;
@@ -124,9 +123,6 @@ public class EmbeddedJGroupsChannelConfigurator extends AbstractJGroupsChannelCo
             socketFactory = new NamedSocketFactory((NamedSocketFactory) socketFactory, remoteCluster);
          }
          configurator.setSocketFactory(socketFactory);
-         for(ChannelListener listener : channelListeners) {
-            configurator.addChannelListener(listener);
-         }
          RelayConfig.SiteConfig siteConfig = new RelayConfig.SiteConfig(remoteSite.getKey());
          siteConfig.addBridge(new RelayConfig.BridgeConfig(remoteCluster) {
             @Override

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsChannelConfigurator.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsChannelConfigurator.java
@@ -2,7 +2,6 @@ package org.infinispan.remoting.transport.jgroups;
 
 import javax.sql.DataSource;
 
-import org.jgroups.ChannelListener;
 import org.jgroups.JChannel;
 import org.jgroups.conf.ProtocolStackConfigurator;
 import org.jgroups.util.SocketFactory;
@@ -19,6 +18,4 @@ public interface JGroupsChannelConfigurator extends ProtocolStackConfigurator {
    void setSocketFactory(SocketFactory socketFactory);
 
    void setDataSource(DataSource dataSource);
-
-   void addChannelListener(ChannelListener listener);
 }


### PR DESCRIPTION
Currently if a JGroups channel is created manually then no metrics will be registered for it since the metrics channel listener is not added. This change makes it so that the channel listener is added when the channel is initialized regardless of how it is created (it also contains some minor cleanup and fix for warnings).
Closes #14313