### PR TITLE
[#14324] Client can be inudated with large stack traces

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/iteration/RemoteInnerPublisherHandler.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/iteration/RemoteInnerPublisherHandler.java
@@ -120,7 +120,8 @@ class RemoteInnerPublisherHandler<K, E> extends AbstractAsyncPublisherHandler<Ma
 
    @Override
    protected void handleThrowableInResponse(Throwable t, Map.Entry<SocketAddress, IntSet> target) {
-      if (t instanceof TransportException || t instanceof RemoteIllegalLifecycleStateException || t instanceof ConnectException) {
+      if ((t instanceof TransportException || t instanceof RemoteIllegalLifecycleStateException || t instanceof ConnectException)
+            && target.getKey() != null) {
          log.throwableDuringPublisher(t);
          if (log.isTraceEnabled()) {
             IntSet targetSegments = target.getValue();


### PR DESCRIPTION
* Don't retry publisher operation if server key is null

Fixes #14324 