### PR TITLE
[#14390] Moved polarion reports in different folder

### DIFF
--- a/.github/actions/comment-pr-flaky-test/action.yml
+++ b/.github/actions/comment-pr-flaky-test/action.yml
@@ -26,13 +26,21 @@ runs:
           TESTS=(${FLAKY_TEST_GLOB})
           for TEST in "${TESTS[@]}"
           do
-            FULL_TEST_NAME=$(xmlstarlet sel -T -t -m "/testsuite/testcase" -o '   - '\
-             -v "concat(@classname,'#',@name)" -n ${TEST} \
-             | sed 's/(Flaky Test)//' | sed 's/\[[0-9]\]//')
-            FLAKES_PR_COMMENT="$FLAKES_PR_COMMENT$FULL_TEST_NAME\n"
+            # Sometimes flaky plugin writes two root elements in the same file
+            # producing invalid xml. https://github.com/camunda/flaky-test-extractor-maven-plugin/issues/106
+            # We need to split them into separate files
+            cat $TEST | grep -v '^<?xml ' | csplit -z -f csplit-flaky-xml- - '/^<testsuite /' '{*}'
+            for FILE in csplit-flaky-xml-*
+            do
+              FULL_TEST_NAME=$(xmlstarlet sel -T -t -m "/testsuite/testcase" -o '   - '\
+              -v "concat(@classname,'#',@name)" -n ${FILE} \
+              | sed 's/(Flaky Test)//')
+              FLAKES_PR_COMMENT="$FLAKES_PR_COMMENT$FULL_TEST_NAME\n"
+            done
+            rm csplit-flaky-xml-*
           done
           if [ "$FLAKES_PR_COMMENT" != "" ]; then
             pr_url=https://github.com/${{ github.repository }}/pull/$PR
-            printf "__FLAKY TESTS__\n%b" "$FLAKES_PR_COMMENT" | gh pr comment $pr_url -F -
+            printf "__FLAKY TESTS__\n%b" "$FLAKES_PR_COMMENT" | gh pr comment --repo $GITHUB_REPOSITORY $pr_url -F -
           fi
         fi

--- a/.github/workflows/on_build_do_test.yml
+++ b/.github/workflows/on_build_do_test.yml
@@ -158,7 +158,6 @@ jobs:
           path: |
             test_dir/infinispan/**/target/*-reports*/**/TEST-*.xml
             !test_dir/infinispan/**/*-reports*/**/TEST-*FLAKY.xml
-            !test_dir/infinispan/**/*-reports*/TEST-*RocksDB*.xml
             test_dir/infinispan/**/*.dump*
             test_dir/infinispan/**/hs_err_*
             test_dir/infinispan/jacoco/

--- a/.github/workflows/on_test_publish_surefire_report.yml
+++ b/.github/workflows/on_test_publish_surefire_report.yml
@@ -72,7 +72,7 @@ jobs:
             MIN_TEST_NUM: 35000
             GH_TOKEN: ${{ github.token }}
           run: |
-            COUNT=$(find . -name "TEST-*.xml" | while read f; do xmlstarlet sel -t -c  "count(//testcase)" -n "$f"; done | awk '{s+=$1} END {print s}')
+            COUNT=$(find . -name "TEST-*.xml" | grep -v polarion | while read f; do xmlstarlet sel -t -c  "count(//testcase)" -n "$f"; done | awk '{s+=$1} END {print s}')
             echo "test_count=$COUNT" >> $GITHUB_OUTPUT
             echo "test_min=$MIN_TEST_NUM" >> $GITHUB_OUTPUT
 

--- a/bin/gh/track_flaky_tests.sh
+++ b/bin/gh/track_flaky_tests.sh
@@ -9,57 +9,66 @@ requiredEnv GH_JOB_URL FLAKY_TEST_GLOB TARGET_BRANCH GITHUB_REPOSITORY
 
 shopt -s nullglob globstar
 TESTS=(${FLAKY_TEST_GLOB})
-API_LIMIT_TIME=0
-for TEST in "${TESTS[@]}"; do
-  TEST_CLASS_NAMES=$(xmlstarlet sel -t --value-of '/testsuite/testcase/@classname'  ${TEST})
-  declare -i i
-  for TEST_CLASS in $TEST_CLASS_NAMES; do
-    # just get the first one for now
-    i=1
-    TEST_NAME=$(xmlstarlet sel --template --value-of '/testsuite/testcase['$i']/@name' ${TEST})
-    # Removing (Flaky Test) text
-    TEST_NAME=${TEST_NAME% (Flaky Test)}
-    # Some tests have arguments with backslash, ie testReplace\[NO_TX, P_TX\]. Removing
-    TEST_NAME=${TEST_NAME%%\[*}
-    # Some tests have it without backslash or have fail counter, ie testContainsAll[1]. Removing
-    TEST_NAME=${TEST_NAME%%[*}
-    # Some tests end with \(. Removing
-    TEST_NAME_NO_PARAMS=${TEST_NAME%%\(*}
-    STACK_TRACE=$(xmlstarlet sel --template --value-of '/testsuite/testcase/failure['$i']' ${TEST})
+for TEST_FILE in "${TESTS[@]}"; do
+  # Sometimes flaky plugin writes two root elements in the same file
+  # producing invalid xml. https://github.com/camunda/flaky-test-extractor-maven-plugin/issues/106
+  # We need to split them into separate files
+  cat ${TEST_FILE} | grep -v '^<?xml ' | csplit -z -f csplit-flaky-xml- - '/^<testsuite /' '{*}'
+  for TEST in csplit-flaky-xml-*; do
+    API_LIMIT_TIME=0
+    TEST_CLASS_NAMES=$(xmlstarlet sel -t --value-of '/testsuite/testcase/@classname'  ${TEST})
+    declare -i i
+    for TEST_CLASS in $TEST_CLASS_NAMES; do
+      # just get the first one for now
+      i=1
+      TEST_NAME=$(xmlstarlet sel --template --value-of '/testsuite/testcase['$i']/@name' ${TEST})
+      # Removing (Flaky Test) text
+      TEST_NAME=${TEST_NAME% (Flaky Test)}
+      # Some tests have arguments with backslash, ie testReplace\[NO_TX, P_TX\]. Removing
+      TEST_NAME_NO_PARAMS=${TEST_NAME%%\\\[*}
+      # Some tests have it without backslash or have fail counter, ie testContainsAll[1]. Removing
+      TEST_NAME_NO_PARAMS=${TEST_NAME_NO_PARAMS%%[*}
+      # Some tests end with \(. Removing
+      TEST_NAME_NO_PARAMS=${TEST_NAME_NO_PARAMS%%\\\(*}
+      # Some tests end with (. Removing
+      TEST_NAME_NO_PARAMS=${TEST_NAME_NO_PARAMS%%(*}
+      STACK_TRACE=$(xmlstarlet sel --template --value-of '/testsuite/testcase/failure['$i']' ${TEST})
 
-    # Create Issue for Test Class+TestName
-    SUMMARY="Flaky test: ${TEST_CLASS}#${TEST_NAME_NO_PARAMS}"
-    echo ${SUMMARY}
+      # Create Issue for Test Class+TestName
+      SUMMARY="Flaky test: ${TEST_CLASS}#${TEST_NAME_NO_PARAMS}"
+      echo "${SUMMARY}"
 
-    # Search issues for existing github issue
-    # Wait some time for subsequent request to respect API rate limit
-    sleep $API_LIMIT_TIME
-    ISSUES="$(gh search issues \"${SUMMARY}\" in:title --json number --repo $GITHUB_REPOSITORY || true)"
-    API_LIMIT_TIME=120
-    if [[ "${ISSUES}" == "" ]]; then
-      echo Error with gh search. Maybe rate limits reached? Wait 120 sec and retry...
-      gh api rate_limit
+      # Search issues for existing github issue
+      # Wait some time for subsequent request to respect API rate limit
       sleep $API_LIMIT_TIME
-      ISSUES="$(gh search issues \"${SUMMARY}\" in:title --json number --repo $GITHUB_REPOSITORY|| true)"
-      continue
-    fi
-    TOTAL_ISSUES=$(echo "${ISSUES}" | jq length)
-    if [ ${TOTAL_ISSUES} -gt 1 ]; then
-      echo "Multiple issues for same flaky test: ${SUMMARY}"
-      exit 1
-    fi
-
-      BODY=$(printf "### Target Branch: %s\n### Github Job:%s\n%s" "${TARGET_BRANCH}" "${GH_JOB_URL}" "${STACK_TRACE}")
-    if [ ${TOTAL_ISSUES} == 0 ]; then
-      echo "Existing issue not found, creating a new one"
-      gh issue create --title "${SUMMARY}" --body "${BODY}" --label "kind/flaky test"
-    else
-      export ISSUE_KEY=$(echo "${ISSUES}" | jq  '.[0].number')
-      # Re-open the issue if it was previously resolved
-      if [ "$(gh issue view ${ISSUE_KEY} --json state | jq .state)" == '"CLOSED"' ]; then
-        gh issue reopen ${ISSUE_KEY}
+      ISSUES="$(gh search issues --json number --repo $GITHUB_REPOSITORY -- "$(printf '%s' "$SUMMARY")" in:title || true)"
+      API_LIMIT_TIME=120
+      if [[ "${ISSUES}" == "" ]]; then
+        echo Error with gh search. Maybe rate limits reached? Wait 120 sec and retry...
+        gh api rate_limit
+        sleep $API_LIMIT_TIME
+        ISSUES="$(gh search issues --json number --repo $GITHUB_REPOSITORY -- "$(printf '%s' "$SUMMARY")" in:title || true)"
+        continue
       fi
-      gh issue comment ${ISSUE_KEY} --body "${BODY}"
-    fi
+      TOTAL_ISSUES=$(echo "${ISSUES}" | jq length)
+      if [ ${TOTAL_ISSUES} -gt 1 ]; then
+        echo "Multiple issues for same flaky test: $(printf '%s' "$SUMMARY")"
+        exit 1
+      fi
+
+        BODY=$(printf "### Target Branch: %s\n### Github Job:%s\n### Test method:%s\n%s" "${TARGET_BRANCH}" "${GH_JOB_URL}" "$TEST_NAME" "${STACK_TRACE}")
+      if [ ${TOTAL_ISSUES} == 0 ]; then
+        echo "Existing issue not found, creating a new one"
+        gh issue create --title "${SUMMARY}" --body "${BODY}" --label "kind/flaky test" --repo $GITHUB_REPOSITORY
+      else
+        export ISSUE_KEY=$(echo "${ISSUES}" | jq  '.[0].number')
+        # Re-open the issue if it was previously resolved
+        if [ "$(gh issue view ${ISSUE_KEY} --json state | jq .state)" == '"CLOSED"' ]; then
+          gh issue reopen ${ISSUE_KEY}  --repo $GITHUB_REPOSITORY
+        fi
+        gh issue comment ${ISSUE_KEY} --body "${BODY}" --repo $GITHUB_REPOSITORY
+      fi
+    done
   done
+  rm -f split-flaky-xml-*
 done

--- a/commons-test/src/main/java/org/infinispan/commons/test/PolarionJUnitXMLReporter.java
+++ b/commons-test/src/main/java/org/infinispan/commons/test/PolarionJUnitXMLReporter.java
@@ -146,7 +146,7 @@ public class PolarionJUnitXMLReporter implements IResultListener2, ISuiteListene
          long elapsedTime = m_allTests.values().stream().mapToLong(PolarionJUnitTest::elapsedTime).sum();
          long testCount = m_allTests.values().size();
 
-         String outputDir = String.format("%s/surefire-reports", System.getProperty("build.directory"));
+         String outputDir = String.format("%s/polarion", System.getProperty("build.directory"));
          Map<String, List<PolarionJUnitTest>> testsByClass = m_allTests.values().stream().collect(Collectors.groupingBy(p -> p.clazz));
          for (Map.Entry<String, List<PolarionJUnitTest>> entry : testsByClass.entrySet()) {
             File outputFile = new File(outputDir, String.format("TEST-%s.xml", entry.getKey()));

--- a/commons-test/src/main/java/org/infinispan/commons/test/PolarionJUnitXMLReporter.java
+++ b/commons-test/src/main/java/org/infinispan/commons/test/PolarionJUnitXMLReporter.java
@@ -146,7 +146,7 @@ public class PolarionJUnitXMLReporter implements IResultListener2, ISuiteListene
          long elapsedTime = m_allTests.values().stream().mapToLong(PolarionJUnitTest::elapsedTime).sum();
          long testCount = m_allTests.values().size();
 
-         String outputDir = String.format("%s/polarion", System.getProperty("build.directory"));
+         String outputDir = String.format("%s/surefire-reports", System.getProperty("build.directory"));
          Map<String, List<PolarionJUnitTest>> testsByClass = m_allTests.values().stream().collect(Collectors.groupingBy(p -> p.clazz));
          for (Map.Entry<String, List<PolarionJUnitTest>> entry : testsByClass.entrySet()) {
             File outputFile = new File(outputDir, String.format("TEST-%s.xml", entry.getKey()));

--- a/multimap/src/test/java/org/infinispan/multimap/impl/DistributedMultimapCacheTest.java
+++ b/multimap/src/test/java/org/infinispan/multimap/impl/DistributedMultimapCacheTest.java
@@ -255,6 +255,11 @@ public class DistributedMultimapCacheTest extends BaseDistFunctionalTest<String,
       }));
    }
 
+   static int i = 0;
+   public void testINot0() {
+      assertTrue(i++ > 0);
+   }
+
    public void testGetEmpty() {
       MultimapCache<String, Person> multimapCache = getMultimapCacheMember();
 

--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
       <packaging>jar</packaging>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
       <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-      <testNGListeners>org.infinispan.commons.test.TestNGTestListener,org.infinispan.commons.test.PolarionJUnitXMLReporter</testNGListeners>
+      <testNGListeners>org.infinispan.commons.test.PolarionJUnitXMLReporter</testNGListeners>
       <log4j.configurationFile>${infinispan.root}/etc/log4j2.xml</log4j.configurationFile>
       <uberjar.deps.optional>true</uberjar.deps.optional>
 
@@ -2448,6 +2448,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
+               <reportsDirectory>${project.build.directory}/unused-reports</reportsDirectory>
                <properties>
                   <configurationParameters>
                      testng.excludedGroups = ${defaultExcludedTestNGGroups}


### PR DESCRIPTION
closes #14390
~disabling surefire report to avoid conflicts and keeping al the rest as is (i.e. flaky test)~

~a better solution would be to remove polarion and use surefire report, but this needs more planning~

- moved polarion test from `surefire-reports` to `polarion`
- workaround for [flaky-test-extractor-maven-plugin](https://github.com/camunda/flaky-test-extractor-maven-plugin/issues/106)
- cleaned up issue title from extra chars