### PR TITLE
[#14490] Server new cache startup should not block

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/topology/CacheInfo.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/topology/CacheInfo.java
@@ -150,4 +150,18 @@ public class CacheInfo {
    public void updateClientTopologyRef() {
       clientTopologyRef.set(clientTopology);
    }
+
+   @Override
+   public String toString() {
+      return "CacheInfo{" +
+            "cacheName='" + cacheName + '\'' +
+            ", balancer=" + balancer +
+            ", numSegments=" + numSegments +
+            ", servers=" + servers +
+            ", primarySegments=" + primarySegments +
+            ", consistentHash=" + consistentHash +
+            ", clientTopologyRef=" + clientTopologyRef +
+            ", clientTopology=" + clientTopology +
+            '}';
+   }
 }

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/ServerHotRodBlockHoundIntegration.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/ServerHotRodBlockHoundIntegration.java
@@ -18,7 +18,6 @@ public class ServerHotRodBlockHoundIntegration implements BlockHoundIntegration 
    }
 
    private static void questionableBlockingMethod(BlockHound.Builder builder) {
-      builder.allowBlockingCallsInside(HotRodServer.class.getName(), "obtainAnonymizedCache");
       builder.allowBlockingCallsInside(Encoder2x.class.getName(), "getCounterCacheTopology");
 
       // Stream method is blocking

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodAsymmetricClusterTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodAsymmetricClusterTest.java
@@ -12,6 +12,7 @@ import java.lang.reflect.Method;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.server.hotrod.test.HotRodClient;
 import org.infinispan.server.hotrod.test.TestResponse;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.testng.annotations.Test;
@@ -32,8 +33,12 @@ public class HotRodAsymmetricClusterTest extends HotRodMultiNodeTest {
            getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, false));
   }
 
+   @Override
+   protected boolean pingOnConnect() {
+      return false;
+   }
 
-  @Override
+   @Override
   protected void createCacheManagers() {
      for (int i = 0; i < 2; i++) {
         EmbeddedCacheManager cm = TestCacheManagerFactory.createClusteredCacheManager(hotRodCacheConfiguration());
@@ -45,7 +50,9 @@ public class HotRodAsymmetricClusterTest extends HotRodMultiNodeTest {
   }
 
    public void testPutInCacheDefinedNode(Method m) {
-      TestResponse resp = clients().get(0).put(k(m) , 0, 0, v(m));
+      HotRodClient client0 = clients().get(0);
+      assertStatus(client0.ping(), Success);
+      TestResponse resp = client0.put(k(m) , 0, 0, v(m));
       assertStatus(resp, Success);
    }
 

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodDefaultCacheTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodDefaultCacheTest.java
@@ -31,7 +31,10 @@ public class HotRodDefaultCacheTest extends HotRodSingleNodeTest {
    }
 
    public void testPutOnDefaultCache(Method m) {
-      TestResponse resp = client().execute(0xA0, (byte) 0x01, "", k(m), 0, 0, v(m), 0, (byte) 1, 0);
+      String defaultName = "";
+      // Need to ping the cache first like a normal client, which ensures it is started
+      assertStatus(client().ping(defaultName), Success);
+      TestResponse resp = client().execute(0xA0, (byte) 0x01, defaultName, k(m), 0, 0, v(m), 0, (byte) 1, 0);
       assertStatus(resp, Success);
       assertHotRodEquals(cacheManager, ANOTHER_CACHE, k(m), v(m));
       assertFalse(cacheManager.getCache().containsKey(k(m)));

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodFunctionalTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodFunctionalTest.java
@@ -67,7 +67,10 @@ public class HotRodFunctionalTest extends HotRodSingleNodeTest {
    }
 
    public void testPutOnDefaultCache(Method m) {
-      TestResponse resp = client().execute(0xA0, (byte) 0x01, "", k(m), 0, 0, v(m), 0, (byte) 1, 0);
+      String defaultName = "";
+      // Need to ping the cache first like a normal client, which ensures it is started
+      assertStatus(client().ping(defaultName), Success);
+      TestResponse resp = client().execute(0xA0, (byte) 0x01, defaultName, k(m), 0, 0, v(m), 0, (byte) 1, 0);
       assertStatus(resp, Success);
       assertHotRodEquals(cacheManager, k(m), v(m));
    }

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodMultiNodeTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodMultiNodeTest.java
@@ -62,7 +62,7 @@ public abstract class HotRodMultiNodeTest extends MultipleCacheManagersTest {
          nextServerPort += 50;
       }
 
-      hotRodClients = createClients(cacheName());
+      hotRodClients = createClients(cacheName(), pingOnConnect());
    }
 
    protected OptionalInt findHighestPort() {
@@ -75,8 +75,18 @@ public abstract class HotRodMultiNodeTest extends MultipleCacheManagersTest {
                           .collect(Collectors.toList());
    }
 
+   List<HotRodClient> createClients(String cacheName, boolean pingOnConnect) {
+      return hotRodServers.stream()
+            .map(s -> createClient(s, cacheName, pingOnConnect))
+            .collect(Collectors.toList());
+   }
+
    protected HotRodClient createClient(HotRodServer server, String cacheName) {
       return createClient(server, cacheName, "127.0.0.1");
+   }
+
+   protected HotRodClient createClient(HotRodServer server, String cacheName, boolean pingOnConnect) {
+      return new HotRodClient("127.0.0.1", server.getPort(), cacheName, protocolVersion(), pingOnConnect);
    }
 
    protected HotRodClient createClient(HotRodServer server, String cacheName, String address) {
@@ -142,6 +152,10 @@ public abstract class HotRodMultiNodeTest extends MultipleCacheManagersTest {
 
    protected List<HotRodClient> clients() {
       return hotRodClients;
+   }
+
+   protected boolean pingOnConnect() {
+      return true;
    }
 
    protected abstract String cacheName();

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodSingleClusteredNonLoopbackTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodSingleClusteredNonLoopbackTest.java
@@ -2,6 +2,7 @@ package org.infinispan.server.hotrod;
 
 import static org.infinispan.server.core.test.ServerTestingUtil.killServer;
 import static org.infinispan.server.hotrod.OperationStatus.Success;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.assertStatus;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.findNetworkInterfaces;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.getDefaultHotRodConfiguration;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
@@ -76,6 +77,7 @@ public class HotRodSingleClusteredNonLoopbackTest extends MultipleCacheManagersT
                                                   hotRodCacheConfiguration().build(),
                                                   EnumSet.of(InternalCacheRegistry.Flag.USER,
                                                              InternalCacheRegistry.Flag.PROTECTED));
+      assertStatus(hotRodClient.ping("MyInternalCache"), Success);
       TestResponse resp = hotRodClient
             .execute(0xA0, (byte) 0x01, "MyInternalCache", k(m), 0, 0, v(m), 0, (byte) 1, 0);
       assertEquals(resp.status, Success, "Status should have been 'Success' but instead was: " + resp.status);

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodSingleClusteredTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodSingleClusteredTest.java
@@ -84,6 +84,7 @@ public class HotRodSingleClusteredTest extends MultipleCacheManagersTest {
                                                   hotRodCacheConfiguration().build(),
                                                   EnumSet.of(InternalCacheRegistry.Flag.USER,
                                                              InternalCacheRegistry.Flag.PROTECTED));
+      assertStatus(hotRodClient.ping("MyInternalCache"), Success);
       TestResponse resp = hotRodClient.execute(0xA0, (byte) 0x01, "MyInternalCache", k(m), 0, 0, v(m), 0, (byte) 1, 0);
       assertEquals(Success, resp.status);
    }

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodSniFunctionalTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodSniFunctionalTest.java
@@ -169,7 +169,7 @@ public class HotRodSniFunctionalTest extends HotRodSingleNodeTest {
 
       public HotRodClient build() {
          return new HotRodClient(hotRodServer.getHost(), hotRodServer.getPort(), cacheName,
-                                 HotRodClient.DEFAULT_TIMEOUT_SECONDS, (byte) 20, sslEngine);
+                                 HotRodClient.DEFAULT_TIMEOUT_SECONDS, (byte) 20, sslEngine, false);
       }
    }
 

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodStatsTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodStatsTest.java
@@ -54,8 +54,8 @@ public class HotRodStatsTest extends HotRodSingleNodeTest {
       assertEquals(s.get("removeHits"), "0");
       assertEquals(s.get("removeMisses"), "0");
       bytesRead = assertHigherBytes(bytesRead, s.get("totalBytesRead"));
-      // At time of request, no data had been written yet
-      assertEquals(s.get("totalBytesWritten"), "0");
+      // At time of request, we have only done ping
+      assertEquals(s.get("totalBytesWritten"), "6");
 
       client().assertPut(m);
       s = client().stats();

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/counter/CounterManagerOperationTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/counter/CounterManagerOperationTest.java
@@ -43,6 +43,11 @@ public class CounterManagerOperationTest extends HotRodMultiNodeTest implements 
       strategy = new CounterManagerImplTestStrategy(this::allTestCounterManagers, this::log, this::cacheManager);
    }
 
+   @Override
+   protected boolean pingOnConnect() {
+      return false;
+   }
+
    @BeforeClass(alwaysRun = true)
    @Override
    public void createBeforeClass() throws Throwable {

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/logging/HotRodAccessLoggingTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/logging/HotRodAccessLoggingTest.java
@@ -40,7 +40,7 @@ public class HotRodAccessLoggingTest extends HotRodSingleNodeTest {
 
       server().getTransport().stop();
 
-      String logline = logAppender.getLog(0);
+      String logline = logAppender.getLog(1);
       assertTrue(logline, logline.matches(
             "^127\\.0\\.0\\.1 - \\[\\d+/\\w+/\\d+:\\d+:\\d+:\\d+ [+-]?\\d*] \"PUT /" +
             getDefaultCacheName() + "/\\[B0x6B6579 HOTROD/2\\.1\" OK \\d+ \\d+ \\d+$"));


### PR DESCRIPTION
* PING and AUTH_MECH commands offload cache initialization
* Rely on cache always invoking above commands

Fixes #14490 