### PR TITLE
[#14537] Update to Netty 4.2

### DIFF
--- a/build/configuration/pom.xml
+++ b/build/configuration/pom.xml
@@ -151,7 +151,6 @@
       <version.mockito_dep.objenesis>3.3</version.mockito_dep.objenesis>
       <version.nashorn>15.6</version.nashorn>
       <version.netty>4.2.0.Final</version.netty>
-      <version.netty.incubator.iouring>0.0.26.Final</version.netty.incubator.iouring>
       <version.openjdk.jmh>1.37</version.openjdk.jmh>
       <version.org.wildfly.arquillian>5.0.1.Final</version.org.wildfly.arquillian>
       <version.org.wildfly.elytron>2.6.2.Final</version.org.wildfly.elytron>

--- a/build/configuration/pom.xml
+++ b/build/configuration/pom.xml
@@ -150,7 +150,7 @@
       <version.mockito_dep.bytebuddy>1.15.3</version.mockito_dep.bytebuddy>
       <version.mockito_dep.objenesis>3.3</version.mockito_dep.objenesis>
       <version.nashorn>15.6</version.nashorn>
-      <version.netty>4.1.119.Final</version.netty>
+      <version.netty>4.2.0.Final</version.netty>
       <version.netty.incubator.iouring>0.0.26.Final</version.netty.incubator.iouring>
       <version.openjdk.jmh>1.37</version.openjdk.jmh>
       <version.org.wildfly.arquillian>5.0.1.Final</version.org.wildfly.arquillian>

--- a/client/hotrod-client-legacy/pom.xml
+++ b/client/hotrod-client-legacy/pom.xml
@@ -97,21 +97,21 @@
       </dependency>
 
       <dependency>
-         <groupId>io.netty.incubator</groupId>
-         <artifactId>netty-incubator-transport-native-io_uring</artifactId>
+         <groupId>io.netty</groupId>
+         <artifactId>netty-transport-native-io_uring</artifactId>
          <optional>true</optional>
       </dependency>
 
       <dependency>
-         <groupId>io.netty.incubator</groupId>
-         <artifactId>netty-incubator-transport-native-io_uring</artifactId>
+         <groupId>io.netty</groupId>
+         <artifactId>netty-transport-native-io_uring</artifactId>
          <classifier>linux-x86_64</classifier>
          <optional>true</optional>
       </dependency>
 
       <dependency>
-         <groupId>io.netty.incubator</groupId>
-         <artifactId>netty-incubator-transport-native-io_uring</artifactId>
+         <groupId>io.netty</groupId>
+         <artifactId>netty-transport-native-io_uring</artifactId>
          <classifier>linux-aarch_64</classifier>
          <optional>true</optional>
       </dependency>

--- a/client/hotrod-client-legacy/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/IoURingNativeTransport.java
+++ b/client/hotrod-client-legacy/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/IoURingNativeTransport.java
@@ -3,11 +3,12 @@ package org.infinispan.client.hotrod.impl.transport.netty;
 import java.util.concurrent.ExecutorService;
 
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.SocketChannel;
-import io.netty.incubator.channel.uring.IOUringDatagramChannel;
-import io.netty.incubator.channel.uring.IOUringEventLoopGroup;
-import io.netty.incubator.channel.uring.IOUringSocketChannel;
+import io.netty.channel.uring.IoUringDatagramChannel;
+import io.netty.channel.uring.IoUringIoHandler;
+import io.netty.channel.uring.IoUringSocketChannel;
 
 /**
  * @since 14.0
@@ -15,14 +16,14 @@ import io.netty.incubator.channel.uring.IOUringSocketChannel;
 public class IOURingNativeTransport {
 
    public static Class<? extends SocketChannel> socketChannelClass() {
-      return IOUringSocketChannel.class;
+      return IoUringSocketChannel.class;
    }
 
    public static EventLoopGroup createEventLoopGroup(int maxExecutors, ExecutorService executorService) {
-      return new IOUringEventLoopGroup(maxExecutors, executorService);
+      return new MultiThreadIoEventLoopGroup(maxExecutors, executorService, IoUringIoHandler.newFactory(maxExecutors));
    }
 
    public static Class<? extends DatagramChannel> datagramChannelClass() {
-      return IOUringDatagramChannel.class;
+      return IoUringDatagramChannel.class;
    }
 }

--- a/client/hotrod-client-legacy/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/IoURingNativeTransport.java
+++ b/client/hotrod-client-legacy/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/IoURingNativeTransport.java
@@ -13,7 +13,7 @@ import io.netty.channel.uring.IoUringSocketChannel;
 /**
  * @since 14.0
  **/
-public class IOURingNativeTransport {
+public class IoURingNativeTransport {
 
    public static Class<? extends SocketChannel> socketChannelClass() {
       return IoUringSocketChannel.class;

--- a/client/hotrod-client/pom.xml
+++ b/client/hotrod-client/pom.xml
@@ -106,21 +106,21 @@
       </dependency>
 
       <dependency>
-         <groupId>io.netty.incubator</groupId>
-         <artifactId>netty-incubator-transport-native-io_uring</artifactId>
+         <groupId>io.netty</groupId>
+         <artifactId>netty-transport-native-io_uring</artifactId>
          <optional>true</optional>
       </dependency>
 
       <dependency>
-         <groupId>io.netty.incubator</groupId>
-         <artifactId>netty-incubator-transport-native-io_uring</artifactId>
+         <groupId>io.netty</groupId>
+         <artifactId>netty-transport-native-io_uring</artifactId>
          <classifier>linux-x86_64</classifier>
          <optional>true</optional>
       </dependency>
 
       <dependency>
-         <groupId>io.netty.incubator</groupId>
-         <artifactId>netty-incubator-transport-native-io_uring</artifactId>
+         <groupId>io.netty</groupId>
+         <artifactId>netty-transport-native-io_uring</artifactId>
          <classifier>linux-aarch_64</classifier>
          <optional>true</optional>
       </dependency>

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/IoURingNativeTransport.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/IoURingNativeTransport.java
@@ -3,26 +3,27 @@ package org.infinispan.client.hotrod.impl.transport.netty;
 import java.util.concurrent.ExecutorService;
 
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.SocketChannel;
-import io.netty.incubator.channel.uring.IOUringDatagramChannel;
-import io.netty.incubator.channel.uring.IOUringEventLoopGroup;
-import io.netty.incubator.channel.uring.IOUringSocketChannel;
+import io.netty.channel.uring.IoUringDatagramChannel;
+import io.netty.channel.uring.IoUringIoHandler;
+import io.netty.channel.uring.IoUringSocketChannel;
 
 /**
  * @since 14.0
  **/
-public class IOURingNativeTransport {
+public class IoURingNativeTransport {
 
    public static Class<? extends SocketChannel> socketChannelClass() {
-      return IOUringSocketChannel.class;
+      return IoUringSocketChannel.class;
    }
 
    public static EventLoopGroup createEventLoopGroup(int maxExecutors, ExecutorService executorService) {
-      return new IOUringEventLoopGroup(maxExecutors, executorService);
+      return new MultiThreadIoEventLoopGroup(maxExecutors, executorService, IoUringIoHandler.newFactory(maxExecutors));
    }
 
    public static Class<? extends DatagramChannel> datagramChannelClass() {
-      return IOUringDatagramChannel.class;
+      return IoUringDatagramChannel.class;
    }
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/NativeTransport.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/NativeTransport.java
@@ -2,14 +2,16 @@ package org.infinispan.client.hotrod.impl.transport.netty;
 
 import static org.infinispan.client.hotrod.logging.Log.HOTROD;
 
+import java.nio.channels.spi.SelectorProvider;
 import java.util.concurrent.ExecutorService;
 
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.epoll.Epoll;
 import io.netty.channel.epoll.EpollDatagramChannel;
-import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.epoll.EpollIoHandler;
 import io.netty.channel.epoll.EpollSocketChannel;
-import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.nio.NioIoHandler;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioDatagramChannel;
@@ -86,11 +88,11 @@ public final class NativeTransport {
 
    public static EventLoopGroup createEventLoopGroup(int maxExecutors, ExecutorService executorService) {
       if (USE_NATIVE_EPOLL) {
-         return new EpollEventLoopGroup(maxExecutors, executorService);
+         return new MultiThreadIoEventLoopGroup(maxExecutors, executorService, EpollIoHandler.newFactory());
       } else if (USE_NATIVE_IOURING) {
          return IoURingNativeTransport.createEventLoopGroup(maxExecutors, executorService);
       } else {
-         return new NioEventLoopGroup(maxExecutors, executorService);
+         return new MultiThreadIoEventLoopGroup(maxExecutors, executorService, NioIoHandler.newFactory(SelectorProvider.provider()));
       }
    }
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/NativeTransport.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/NativeTransport.java
@@ -49,11 +49,11 @@ public final class NativeTransport {
    private static boolean useNativeIOUring() {
       try {
          Class.forName("io.netty.incubator.channel.uring.IOUring", true, NativeTransport.class.getClassLoader());
-         if (io.netty.incubator.channel.uring.IOUring.isAvailable()) {
+         if (io.netty.channel.uring.IoUring.isAvailable()) {
             return !IOURING_DISABLED && IS_LINUX;
          } else {
             if (IS_LINUX) {
-               HOTROD.ioUringNotAvailable(io.netty.incubator.channel.uring.IOUring.unavailabilityCause().toString());
+               HOTROD.ioUringNotAvailable(io.netty.channel.uring.IoUring.unavailabilityCause().toString());
             }
          }
       } catch (ClassNotFoundException e) {
@@ -68,7 +68,7 @@ public final class NativeTransport {
       if (USE_NATIVE_EPOLL) {
          return EpollSocketChannel.class;
       } else if (USE_NATIVE_IOURING) {
-         return IOURingNativeTransport.socketChannelClass();
+         return IoURingNativeTransport.socketChannelClass();
       } else {
          return NioSocketChannel.class;
       }
@@ -78,7 +78,7 @@ public final class NativeTransport {
       if (USE_NATIVE_EPOLL) {
          return EpollDatagramChannel.class;
       } else if (USE_NATIVE_IOURING) {
-         return IOURingNativeTransport.datagramChannelClass();
+         return IoURingNativeTransport.datagramChannelClass();
       } else {
          return NioDatagramChannel.class;
       }
@@ -88,7 +88,7 @@ public final class NativeTransport {
       if (USE_NATIVE_EPOLL) {
          return new EpollEventLoopGroup(maxExecutors, executorService);
       } else if (USE_NATIVE_IOURING) {
-         return IOURingNativeTransport.createEventLoopGroup(maxExecutors, executorService);
+         return IoURingNativeTransport.createEventLoopGroup(maxExecutors, executorService);
       } else {
          return new NioEventLoopGroup(maxExecutors, executorService);
       }

--- a/javadoc/pom.xml
+++ b/javadoc/pom.xml
@@ -220,8 +220,8 @@
       </dependency>
 
       <dependency>
-         <groupId>io.netty.incubator</groupId>
-         <artifactId>netty-incubator-transport-native-io_uring</artifactId>
+         <groupId>io.netty</groupId>
+         <artifactId>netty-transport-native-io_uring</artifactId>
       </dependency>
    </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -590,20 +590,20 @@
             <version>${version.netty}</version>
          </dependency>
          <dependency>
-            <groupId>io.netty.incubator</groupId>
-            <artifactId>netty-incubator-transport-native-io_uring</artifactId>
-            <version>${version.netty.incubator.iouring}</version>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-io_uring</artifactId>
+            <version>${version.netty}</version>
          </dependency>
          <dependency>
-            <groupId>io.netty.incubator</groupId>
-            <artifactId>netty-incubator-transport-native-io_uring</artifactId>
-            <version>${version.netty.incubator.iouring}</version>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-io_uring</artifactId>
+            <version>${version.netty}</version>
             <classifier>linux-x86_64</classifier>
          </dependency>
          <dependency>
-            <groupId>io.netty.incubator</groupId>
-            <artifactId>netty-incubator-transport-native-io_uring</artifactId>
-            <version>${version.netty.incubator.iouring}</version>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-io_uring</artifactId>
+            <version>${version.netty}</version>
             <classifier>linux-aarch_64</classifier>
          </dependency>
          <dependency>

--- a/server/core/pom.xml
+++ b/server/core/pom.xml
@@ -33,19 +33,19 @@
          <classifier>linux-aarch_64</classifier>
       </dependency>
       <dependency>
-         <groupId>io.netty.incubator</groupId>
-         <artifactId>netty-incubator-transport-native-io_uring</artifactId>
+         <groupId>io.netty</groupId>
+         <artifactId>netty-transport-native-io_uring</artifactId>
          <optional>true</optional>
       </dependency>
       <dependency>
-         <groupId>io.netty.incubator</groupId>
-         <artifactId>netty-incubator-transport-native-io_uring</artifactId>
+         <groupId>io.netty</groupId>
+         <artifactId>netty-transport-native-io_uring</artifactId>
          <classifier>linux-x86_64</classifier>
          <optional>true</optional>
       </dependency>
       <dependency>
-         <groupId>io.netty.incubator</groupId>
-         <artifactId>netty-incubator-transport-native-io_uring</artifactId>
+         <groupId>io.netty</groupId>
+         <artifactId>netty-transport-native-io_uring</artifactId>
          <classifier>linux-aarch_64</classifier>
          <optional>true</optional>
       </dependency>

--- a/server/core/src/main/java/org/infinispan/server/core/transport/IoURingNativeTransport.java
+++ b/server/core/src/main/java/org/infinispan/server/core/transport/IoURingNativeTransport.java
@@ -2,21 +2,22 @@ package org.infinispan.server.core.transport;
 
 import java.util.concurrent.ThreadFactory;
 
+import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.MultithreadEventLoopGroup;
 import io.netty.channel.socket.ServerSocketChannel;
-import io.netty.incubator.channel.uring.IOUringEventLoopGroup;
-import io.netty.incubator.channel.uring.IOUringServerSocketChannel;
+import io.netty.channel.uring.IoUringIoHandler;
+import io.netty.channel.uring.IoUringServerSocketChannel;
 
 /**
  * @since 14.0
  **/
-public class IOURingNativeTransport {
+public class IoURingNativeTransport {
 
    public static Class<? extends ServerSocketChannel> serverSocketChannelClass() {
-      return IOUringServerSocketChannel.class;
+      return IoUringServerSocketChannel.class;
    }
 
    public static MultithreadEventLoopGroup createEventLoopGroup(int maxExecutors, ThreadFactory threadFactory) {
-      return new IOUringEventLoopGroup(maxExecutors, threadFactory);
+      return new MultiThreadIoEventLoopGroup(maxExecutors, threadFactory, IoUringIoHandler.newFactory(maxExecutors));
    }
 }

--- a/server/core/src/main/java/org/infinispan/server/core/transport/NativeTransport.java
+++ b/server/core/src/main/java/org/infinispan/server/core/transport/NativeTransport.java
@@ -46,11 +46,11 @@ public final class NativeTransport {
    private static boolean useNativeIOUring() {
       try {
          Class.forName("io.netty.incubator.channel.uring.IOUring", true, NativeTransport.class.getClassLoader());
-         if (io.netty.incubator.channel.uring.IOUring.isAvailable()) {
+         if (io.netty.channel.uring.IoUring.isAvailable()) {
             return !IOURING_DISABLED && IS_LINUX;
          } else {
             if (IS_LINUX) {
-               SERVER.ioUringNotAvailable(io.netty.incubator.channel.uring.IOUring.unavailabilityCause().toString());
+               SERVER.ioUringNotAvailable(io.netty.channel.uring.IoUring.unavailabilityCause().toString());
             }
          }
       } catch (ClassNotFoundException e) {
@@ -67,7 +67,7 @@ public final class NativeTransport {
          return EpollServerSocketChannel.class;
       } else if (USE_NATIVE_IOURING) {
          SERVER.usingTransport("IOUring");
-         return IOURingNativeTransport.serverSocketChannelClass();
+         return IoURingNativeTransport.serverSocketChannelClass();
       } else {
          SERVER.usingTransport("NIO");
          return NioServerSocketChannel.class;
@@ -78,7 +78,7 @@ public final class NativeTransport {
       if (USE_NATIVE_EPOLL) {
          return new EpollEventLoopGroup(maxExecutors, threadFactory);
       } else if (USE_NATIVE_IOURING) {
-         return IOURingNativeTransport.createEventLoopGroup(maxExecutors, threadFactory);
+         return IoURingNativeTransport.createEventLoopGroup(maxExecutors, threadFactory);
       } else {
          return new NioEventLoopGroup(maxExecutors, threadFactory);
       }

--- a/server/core/src/main/java/org/infinispan/server/core/transport/NativeTransport.java
+++ b/server/core/src/main/java/org/infinispan/server/core/transport/NativeTransport.java
@@ -2,13 +2,15 @@ package org.infinispan.server.core.transport;
 
 import static org.infinispan.server.core.logging.Log.SERVER;
 
+import java.nio.channels.spi.SelectorProvider;
 import java.util.concurrent.ThreadFactory;
 
+import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.MultithreadEventLoopGroup;
 import io.netty.channel.epoll.Epoll;
-import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.epoll.EpollIoHandler;
 import io.netty.channel.epoll.EpollServerSocketChannel;
-import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.nio.NioIoHandler;
 import io.netty.channel.socket.ServerSocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 
@@ -76,11 +78,11 @@ public final class NativeTransport {
 
    public static MultithreadEventLoopGroup createEventLoopGroup(int maxExecutors, ThreadFactory threadFactory) {
       if (USE_NATIVE_EPOLL) {
-         return new EpollEventLoopGroup(maxExecutors, threadFactory);
+         return new MultiThreadIoEventLoopGroup(maxExecutors, threadFactory, EpollIoHandler.newFactory());
       } else if (USE_NATIVE_IOURING) {
          return IoURingNativeTransport.createEventLoopGroup(maxExecutors, threadFactory);
       } else {
-         return new NioEventLoopGroup(maxExecutors, threadFactory);
+         return new MultiThreadIoEventLoopGroup(maxExecutors, threadFactory, NioIoHandler.newFactory(SelectorProvider.provider()));
       }
    }
 }

--- a/server/core/src/main/java/org/infinispan/server/core/utils/DelegatingEventLoopGroup.java
+++ b/server/core/src/main/java/org/infinispan/server/core/utils/DelegatingEventLoopGroup.java
@@ -41,11 +41,13 @@ public abstract class DelegatingEventLoopGroup implements EventLoopGroup {
    }
 
    @Override
+   @Deprecated
    public void shutdown() {
       delegate().shutdown();
    }
 
    @Override
+   @Deprecated
    public List<Runnable> shutdownNow() {
       return delegate().shutdownNow();
    }
@@ -141,6 +143,7 @@ public abstract class DelegatingEventLoopGroup implements EventLoopGroup {
    }
 
    @Override
+   @Deprecated
    public ChannelFuture register(Channel channel, ChannelPromise promise) {
       return delegate().register(channel, promise);
    }

--- a/server/runtime/build.xml
+++ b/server/runtime/build.xml
@@ -18,7 +18,7 @@
             <!-- hack to rewrite the netty os-arch classifier -->
             <compositemapper>
                <regexpmapper from="netty-transport-native-epoll-(.*)-linux-(.*)\.jar" to="netty-transport-native-epoll-linux-\2-\1.jar"/>
-               <regexpmapper from="netty-incubator-transport-native-io_uring-(.*)-linux-(.*)\.jar" to="netty-incubator-transport-native-io_uring-linux-\2-\1.jar"/>
+               <regexpmapper from="netty-transport-native-io_uring-(.*)-linux-(.*)\.jar" to="netty-transport-native-io_uring-linux-\2-\1.jar"/>
                <regexpmapper from="^(?!.*x86_64[.]jar$$).*$$" to="\0"/>
             </compositemapper>
          </chainedmapper>

--- a/server/runtime/pom.xml
+++ b/server/runtime/pom.xml
@@ -566,19 +566,19 @@
          </activation>
          <dependencies>
             <dependency>
-               <groupId>io.netty.incubator</groupId>
-               <artifactId>netty-incubator-transport-native-io_uring</artifactId>
+               <groupId>io.netty</groupId>
+               <artifactId>netty-transport-native-io_uring</artifactId>
             </dependency>
 
             <dependency>
-               <groupId>io.netty.incubator</groupId>
-               <artifactId>netty-incubator-transport-native-io_uring</artifactId>
+               <groupId>io.netty</groupId>
+               <artifactId>netty-transport-native-io_uring</artifactId>
                <classifier>linux-x86_64</classifier>
             </dependency>
 
             <dependency>
-               <groupId>io.netty.incubator</groupId>
-               <artifactId>netty-incubator-transport-native-io_uring</artifactId>
+               <groupId>io.netty</groupId>
+               <artifactId>netty-transport-native-io_uring</artifactId>
                <classifier>linux-aarch_64</classifier>
             </dependency>
          </dependencies>


### PR DESCRIPTION
* Update to version 4.2.0.Final.
* Remove usage of incubator io_uring and use the graduated version.
* Utilize the new recommended approach to create the event loop groups.
* Remove deprecated code in HTTP2.

I've added these as individual commits for review. I've utilized `-Dmaven.compiler.showDeprecation` to track the deprecated code. For context: https://netty.io/wiki/netty-4.2-migration-guide.html
Closes #14537.