### PR TITLE
[15.0.x] [#14322] Document Vector Search as a not supported feature

### DIFF
--- a/documentation/src/main/asciidoc/topics/con_indexing_annotations.adoc
+++ b/documentation/src/main/asciidoc/topics/con_indexing_annotations.adoc
@@ -47,7 +47,10 @@ Each of the annotations supports a set of attributes that you can use to further
 | searchable, sortable, projectable, aggregable, indexNullAs, normalizer, norms
 
 | @Text
-| searchable, projectable, norms, analyzer, searchAnalyzer, termVector
+| searchable, projectable, norms, analyzer, searchAnalyzer
+ifdef::community[]
+, termVector
+endif::[]
 
 ifdef::community[]
 | @Vector


### PR DESCRIPTION
**Backport:** https://github.com/infinispan/infinispan/pull/14531

