### PR TITLE
[15.1.x] [#14600] Test can fail on shutdown due to netty thread blocking

### DIFF
--- a/server/core/src/main/java/org/infinispan/server/core/ServerCoreBlockHoundIntegration.java
+++ b/server/core/src/main/java/org/infinispan/server/core/ServerCoreBlockHoundIntegration.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import org.infinispan.server.core.utils.SslUtils;
 import org.kohsuke.MetaInfServices;
 
+import io.netty.util.concurrent.SingleThreadEventExecutor;
 import reactor.blockhound.BlockHound;
 import reactor.blockhound.BlockingOperationError;
 import reactor.blockhound.integration.BlockHoundIntegration;
@@ -22,6 +23,9 @@ public class ServerCoreBlockHoundIntegration implements BlockHoundIntegration {
 
       // Nashorn prints to stderr in its constructor
       builder.allowBlockingCallsInside("jdk.nashorn.api.scripting.NashornScriptEngineFactory", "getScriptEngine");
+
+      // Don't worry about blocking in netty event loop when shutting down
+      builder.allowBlockingCallsInside(SingleThreadEventExecutor.class.getName(), "confirmShutdown");
 
       questionableBlockingMethod(builder);
       methodsToBeRemoved(builder);


### PR DESCRIPTION
**Backport:** https://github.com/infinispan/infinispan/pull/14601

Fixes #14600