### PR TITLE
[15.0.x] [#14581] Missing BuiltBy annotation

### DIFF
--- a/core/src/main/java/org/infinispan/metrics/config/MicrometerMeterRegistryConfiguration.java
+++ b/core/src/main/java/org/infinispan/metrics/config/MicrometerMeterRegistryConfiguration.java
@@ -2,6 +2,7 @@ package org.infinispan.metrics.config;
 
 import java.util.Objects;
 
+import org.infinispan.commons.configuration.BuiltBy;
 import org.infinispan.configuration.serializing.SerializedWith;
 
 import io.micrometer.core.instrument.MeterRegistry;
@@ -11,6 +12,7 @@ import io.micrometer.core.instrument.MeterRegistry;
  *
  * @since 15.0
  */
+@BuiltBy(MicrometerMeterRegisterConfigurationBuilder.class)
 @SerializedWith(MicrometerMeterRegistryConfigurationSerializer.class)
 public class MicrometerMeterRegistryConfiguration {
 


### PR DESCRIPTION
**Backport:** https://github.com/infinispan/infinispan/pull/14612

The GlobalConfigurationBuilder read(GlobalConfiguration template) method requires that classes registered as modules be annotated with @BuiltBy at runtime.
Without the required annotation, a NullPointerException is observed.

Caused by: java.lang.NullPointerException: Cannot invoke "org.infinispan.commons.configuration.BuiltBy.value()" because "builtBy" is null

The simple fix here is to add the missing annotation. I tested this locally and observed that the configured metrics registry is used.