### PR TITLE
[#14618] DistSyncNonTxStateTransferTest can fail to complete

### DIFF
--- a/core/src/test/java/org/infinispan/xsite/statetransfer/BaseStateTransferTest.java
+++ b/core/src/test/java/org/infinispan/xsite/statetransfer/BaseStateTransferTest.java
@@ -78,7 +78,7 @@ public abstract class BaseStateTransferTest extends AbstractStateTransferTest {
       assertNoStateTransferInSendingSite();
    }
 
-   @Test(groups = "xsite")
+   @Test(groups = "xsite", enabled = false, description = "Disabled as part of https://github.com/infinispan/infinispan/issues/14618")
    public void testCancelStateTransfer(Method method) throws InterruptedException {
       takeSiteOffline();
       assertOffline();


### PR DESCRIPTION
* Disabling test until we can fix it

This does not resolve the issue, just disables the test until we can fix it properly. It can hang CI runs though when it happens so we are disabling for now.