### PR TITLE
[#14630] Break cycle between local and cluster topology manager

### DIFF
--- a/core/src/main/java/org/infinispan/commands/topology/CacheStatusRequestCommand.java
+++ b/core/src/main/java/org/infinispan/commands/topology/CacheStatusRequestCommand.java
@@ -1,7 +1,5 @@
 package org.infinispan.commands.topology;
 
-import java.util.Collections;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import org.infinispan.commons.marshall.ProtoStreamTypeIds;
@@ -9,7 +7,6 @@ import org.infinispan.factories.GlobalComponentRegistry;
 import org.infinispan.protostream.annotations.ProtoFactory;
 import org.infinispan.protostream.annotations.ProtoField;
 import org.infinispan.protostream.annotations.ProtoTypeId;
-import org.infinispan.topology.ManagerStatusResponse;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -34,11 +31,6 @@ public class CacheStatusRequestCommand extends AbstractCacheControlCommand {
 
    @Override
    public CompletionStage<?> invokeAsync(GlobalComponentRegistry gcr) throws Throwable {
-      if (!gcr.isLocalTopologyManagerRunning()) {
-         log.debug("Reply with empty status request because topology manager not running");
-         return CompletableFuture.completedFuture(new ManagerStatusResponse(Collections.emptyMap(), true));
-      }
-
       return gcr.getLocalTopologyManager()
             .handleStatusRequest(viewId);
    }

--- a/core/src/main/java/org/infinispan/commands/topology/TopologyUpdateCommand.java
+++ b/core/src/main/java/org/infinispan/commands/topology/TopologyUpdateCommand.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.concurrent.CompletionStage;
 
 import org.infinispan.commons.marshall.ProtoStreamTypeIds;
-import org.infinispan.commons.util.concurrent.CompletableFutures;
 import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.factories.GlobalComponentRegistry;
 import org.infinispan.marshall.protostream.impl.WrappedMessages;
@@ -96,11 +95,6 @@ public class TopologyUpdateCommand extends AbstractCacheControlCommand {
 
    @Override
    public CompletionStage<?> invokeAsync(GlobalComponentRegistry gcr) throws Throwable {
-      if (!gcr.isLocalTopologyManagerRunning()) {
-         log.debugf("Discard topology update because topology manager not running %s", this);
-         return CompletableFutures.completedNull();
-      }
-
       CacheTopology topology = new CacheTopology(topologyId, rebalanceId, getCurrentCH(), getPendingCH(), phase,
             (List<Address>)(List<?>) actualMembers, persistentUUIDs);
       return gcr.getLocalTopologyManager()

--- a/core/src/main/java/org/infinispan/factories/GlobalComponentRegistry.java
+++ b/core/src/main/java/org/infinispan/factories/GlobalComponentRegistry.java
@@ -4,6 +4,7 @@ import static org.infinispan.util.logging.Log.CONTAINER;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
@@ -151,6 +152,7 @@ public class GlobalComponentRegistry extends AbstractComponentRegistry {
    }
 
    private void cacheComponents() {
+      // ALWAYS keep this order. Local topology must start before cluster topology.
       localTopologyManager = basicComponentRegistry.getComponent(LocalTopologyManager.class);
       clusterTopologyManager = basicComponentRegistry.getComponent(ClusterTopologyManager.class);
    }
@@ -384,10 +386,6 @@ public class GlobalComponentRegistry extends AbstractComponentRegistry {
       return localTopologyManager.running();
    }
 
-   public boolean isLocalTopologyManagerRunning() {
-      return localTopologyManager != null && localTopologyManager.isRunning();
-   }
-
    public XSiteCacheMapper getXSiteCacheMapper() {
       return basicComponentRegistry.getComponent(XSiteCacheMapper.class).running();
    }
@@ -400,4 +398,22 @@ public class GlobalComponentRegistry extends AbstractComponentRegistry {
       return of(cacheManager).getComponent(type);
    }
 
+   /**
+    * Ensures the given component is in a running state.
+    *
+    * <p>
+    * This will guarantee that the requested component has all dependencies injected and have run all methods annotated
+    * with {@link Start}.
+    * </p>
+    *
+    * @param type The class of the component to verify.
+    * @param <T> The component type.
+    * @throws IllegalStateException If the component does not enter into a running state.
+    */
+   public <T> void ensureComponentRunning(Class<T> type) {
+      ComponentRef<T> ref = Objects.requireNonNull(basicComponentRegistry.getComponent(type));
+      T t = ref.running();
+      if (t == null || !ref.isRunning())
+         throw new IllegalStateException(String.format("Component '%s' expected to be running", ref.getName()));
+   }
 }

--- a/core/src/main/java/org/infinispan/topology/ClusterTopologyManagerImpl.java
+++ b/core/src/main/java/org/infinispan/topology/ClusterTopologyManagerImpl.java
@@ -183,6 +183,7 @@ public class ClusterTopologyManagerImpl implements ClusterTopologyManager, Globa
       }
       ReplicableCommand command = new RebalanceStatusRequestCommand();
       Address coordinator = transport.getCoordinator();
+      gcr.ensureComponentRunning(LocalTopologyManager.class);
       return helper.executeOnCoordinator(transport, command, getGlobalTimeout() / INITIAL_CONNECTION_ATTEMPTS)
                    .handle((rebalancingStatus, throwable) -> {
                       if (throwable == null)

--- a/core/src/test/java/org/infinispan/topology/AbstractStatefulCluster.java
+++ b/core/src/test/java/org/infinispan/topology/AbstractStatefulCluster.java
@@ -56,6 +56,9 @@ public abstract class AbstractStatefulCluster extends MultipleCacheManagersTest 
 
    protected final void assertClusterStateFiles(String cacheName) throws IOException {
       for (int i = 0; i < clusterSize; i++) {
+         if (i >= cacheManagers.size())
+            break;
+
          assertClusterStateFiles(manager(i), cacheName);
       }
    }


### PR DESCRIPTION
* Remove dependency from LocalTopologyManagerImpl.
* Cached components ensure correct initialization order.

Closes #14630
Closes #13346 
Closes #13356
Closes #13397 
Closes #13362 

I am not sure if there is something else at play for these:
Closes #13353
Closes #13574 
Closes #13685
Closes #14605