### PR TITLE
[#14133] Change consistent hash factories to be singletons

### DIFF
--- a/core/src/main/java/org/infinispan/distribution/ch/impl/DefaultConsistentHashFactory.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/impl/DefaultConsistentHashFactory.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import org.infinispan.commons.marshall.ProtoStreamTypeIds;
 import org.infinispan.distribution.ch.ConsistentHashFactory;
 import org.infinispan.globalstate.ScopedPersistentState;
+import org.infinispan.protostream.annotations.ProtoFactory;
 import org.infinispan.protostream.annotations.ProtoTypeId;
 import org.infinispan.remoting.transport.Address;
 
@@ -27,6 +28,14 @@ import org.infinispan.remoting.transport.Address;
  */
 @ProtoTypeId(ProtoStreamTypeIds.DEFAULT_CONSISTENT_HASH_FACTORY)
 public class DefaultConsistentHashFactory extends AbstractConsistentHashFactory<DefaultConsistentHash> {
+   private static final DefaultConsistentHashFactory INSTANCE = new DefaultConsistentHashFactory();
+
+   protected DefaultConsistentHashFactory() { }
+
+   @ProtoFactory
+   public static DefaultConsistentHashFactory getInstance() {
+      return INSTANCE;
+   }
 
    @Override
    public DefaultConsistentHash create(int numOwners, int numSegments,

--- a/core/src/main/java/org/infinispan/distribution/ch/impl/ReplicatedConsistentHashFactory.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/impl/ReplicatedConsistentHashFactory.java
@@ -12,6 +12,7 @@ import java.util.Queue;
 import org.infinispan.commons.marshall.ProtoStreamTypeIds;
 import org.infinispan.distribution.ch.ConsistentHashFactory;
 import org.infinispan.globalstate.ScopedPersistentState;
+import org.infinispan.protostream.annotations.ProtoFactory;
 import org.infinispan.protostream.annotations.ProtoTypeId;
 import org.infinispan.remoting.transport.Address;
 
@@ -24,6 +25,14 @@ import org.infinispan.remoting.transport.Address;
  */
 @ProtoTypeId(ProtoStreamTypeIds.REPLICATED_CONSISTENT_HASH_FACTORY)
 public class ReplicatedConsistentHashFactory implements ConsistentHashFactory<ReplicatedConsistentHash> {
+   private static final ReplicatedConsistentHashFactory INSTANCE = new ReplicatedConsistentHashFactory();
+
+   protected ReplicatedConsistentHashFactory() { }
+
+   @ProtoFactory
+   public static ReplicatedConsistentHashFactory getInstance() {
+      return INSTANCE;
+   }
 
    @Override
    public ReplicatedConsistentHash create(int numOwners, int numSegments, List<Address> members,

--- a/core/src/main/java/org/infinispan/distribution/ch/impl/SyncConsistentHashFactory.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/impl/SyncConsistentHashFactory.java
@@ -15,6 +15,7 @@ import org.infinispan.commons.hash.MurmurHash3;
 import org.infinispan.commons.marshall.ProtoStreamTypeIds;
 import org.infinispan.distribution.ch.ConsistentHashFactory;
 import org.infinispan.globalstate.ScopedPersistentState;
+import org.infinispan.protostream.annotations.ProtoFactory;
 import org.infinispan.protostream.annotations.ProtoTypeId;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.remoting.transport.jgroups.JGroupsAddress;
@@ -40,6 +41,14 @@ import org.jgroups.util.UUID;
  */
 @ProtoTypeId(ProtoStreamTypeIds.SYNC_CONSISTENT_HASH)
 public class SyncConsistentHashFactory implements ConsistentHashFactory<DefaultConsistentHash> {
+   private static final SyncConsistentHashFactory INSTANCE = new SyncConsistentHashFactory();
+
+   protected SyncConsistentHashFactory() { }
+
+   @ProtoFactory
+   public static SyncConsistentHashFactory getInstance() {
+      return INSTANCE;
+   }
 
    @Override
    public DefaultConsistentHash create(int numOwners, int numSegments, List<Address> members,
@@ -134,16 +143,6 @@ public class SyncConsistentHashFactory implements ConsistentHashFactory<DefaultC
    @Override
    public DefaultConsistentHash union(DefaultConsistentHash ch1, DefaultConsistentHash ch2) {
       return ch1.union(ch2);
-   }
-
-   @Override
-   public boolean equals(Object other) {
-      return other != null && other.getClass() == getClass();
-   }
-
-   @Override
-   public int hashCode() {
-      return -10007;
    }
 
    static class Builder {

--- a/core/src/main/java/org/infinispan/distribution/ch/impl/SyncReplicatedConsistentHashFactory.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/impl/SyncReplicatedConsistentHashFactory.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import org.infinispan.commons.marshall.ProtoStreamTypeIds;
 import org.infinispan.distribution.ch.ConsistentHashFactory;
 import org.infinispan.globalstate.ScopedPersistentState;
+import org.infinispan.protostream.annotations.ProtoFactory;
 import org.infinispan.protostream.annotations.ProtoTypeId;
 import org.infinispan.remoting.transport.Address;
 
@@ -22,8 +23,16 @@ import org.infinispan.remoting.transport.Address;
  */
 @ProtoTypeId(ProtoStreamTypeIds.SYNC_REPLICATED_CONSISTENT_HASH)
 public class SyncReplicatedConsistentHashFactory implements ConsistentHashFactory<ReplicatedConsistentHash> {
+   private static final SyncReplicatedConsistentHashFactory INSTANCE = new SyncReplicatedConsistentHashFactory();
 
-   private static final SyncConsistentHashFactory syncCHF = new SyncConsistentHashFactory();
+   protected SyncReplicatedConsistentHashFactory() { }
+
+   @ProtoFactory
+   public static SyncReplicatedConsistentHashFactory getInstance() {
+      return INSTANCE;
+   }
+
+   private static final SyncConsistentHashFactory syncCHF = SyncConsistentHashFactory.getInstance();
 
    @Override
    public ReplicatedConsistentHash create(int numOwners, int numSegments,

--- a/core/src/main/java/org/infinispan/distribution/ch/impl/TopologyAwareSyncConsistentHashFactory.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/impl/TopologyAwareSyncConsistentHashFactory.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import org.infinispan.commons.marshall.ProtoStreamTypeIds;
 import org.infinispan.distribution.topologyaware.TopologyInfo;
 import org.infinispan.distribution.topologyaware.TopologyLevel;
+import org.infinispan.protostream.annotations.ProtoFactory;
 import org.infinispan.protostream.annotations.ProtoTypeId;
 import org.infinispan.remoting.transport.Address;
 
@@ -24,6 +25,15 @@ import org.infinispan.remoting.transport.Address;
  */
 @ProtoTypeId(ProtoStreamTypeIds.TOPOLOGY_AWARE_SYNC_CONSISTENT_HASH)
 public class TopologyAwareSyncConsistentHashFactory extends SyncConsistentHashFactory {
+   private static final TopologyAwareSyncConsistentHashFactory INSTANCE = new TopologyAwareSyncConsistentHashFactory();
+
+   protected TopologyAwareSyncConsistentHashFactory() { }
+
+   @ProtoFactory
+   public static TopologyAwareSyncConsistentHashFactory getInstance() {
+      return INSTANCE;
+   }
+
    @Override
    protected Builder createBuilder(int numOwners, int numSegments, List<Address> members, Map<Address, Float> capacityFactors) {
       return new Builder(numOwners, numSegments, members, capacityFactors);

--- a/core/src/main/java/org/infinispan/statetransfer/StateTransferManagerImpl.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateTransferManagerImpl.java
@@ -135,12 +135,12 @@ public class StateTransferManagerImpl implements StateTransferManager {
          if (cacheMode.isClustered()) {
             if (cacheMode.isDistributed()) {
                if (globalConfiguration.transport().hasTopologyInfo()) {
-                  factory = new TopologyAwareSyncConsistentHashFactory();
+                  factory = TopologyAwareSyncConsistentHashFactory.getInstance();
                } else {
-                  factory = new SyncConsistentHashFactory();
+                  factory = SyncConsistentHashFactory.getInstance();
                }
             } else if (cacheMode.isReplicated() || cacheMode.isInvalidation()) {
-               factory = new SyncReplicatedConsistentHashFactory();
+               factory = SyncReplicatedConsistentHashFactory.getInstance();
             } else {
                throw new CacheException("Unexpected cache mode: " + cacheMode);
             }

--- a/core/src/test/java/org/infinispan/configuration/HashConfigurationBuilderTest.java
+++ b/core/src/test/java/org/infinispan/configuration/HashConfigurationBuilderTest.java
@@ -47,7 +47,7 @@ public class HashConfigurationBuilderTest extends AbstractInfinispanTest {
       Configuration c = cb.build();
       Assert.assertNull(c.clustering().hash().consistentHashFactory());
 
-      SyncConsistentHashFactory consistentHashFactory = new SyncConsistentHashFactory();
+      SyncConsistentHashFactory consistentHashFactory = SyncConsistentHashFactory.getInstance();
       cb.clustering().hash().consistentHashFactory(consistentHashFactory);
       c = cb.build();
       Assert.assertSame(c.clustering().hash().consistentHashFactory(), consistentHashFactory);

--- a/core/src/test/java/org/infinispan/conflict/impl/StateReceiverTest.java
+++ b/core/src/test/java/org/infinispan/conflict/impl/StateReceiverTest.java
@@ -182,7 +182,7 @@ public class StateReceiverTest extends AbstractInfinispanTest {
          persistentUUIDManager.addPersistentAddressMapping(address, PersistentUUID.randomUUID());
       }
 
-      DefaultConsistentHashFactory chf = new DefaultConsistentHashFactory();
+      DefaultConsistentHashFactory chf = DefaultConsistentHashFactory.getInstance();
       return chf.create(2, 40, addresses, null);
    }
 

--- a/core/src/test/java/org/infinispan/distribution/ConsistentHashPerfTest.java
+++ b/core/src/test/java/org/infinispan/distribution/ConsistentHashPerfTest.java
@@ -43,7 +43,7 @@ public class ConsistentHashPerfTest extends AbstractInfinispanTest {
    private ConsistentHash createNewConsistentHash(List<Address> servers) {
       try {
          // TODO Revisit after we have replaced the CH with the CHFactory in the configuration
-         return new DefaultConsistentHashFactory().create(2, 10,
+         return DefaultConsistentHashFactory.getInstance().create(2, 10,
                servers, null);
       } catch (RuntimeException re) {
          throw re;

--- a/core/src/test/java/org/infinispan/distribution/ZeroCapacityNodeTest.java
+++ b/core/src/test/java/org/infinispan/distribution/ZeroCapacityNodeTest.java
@@ -78,10 +78,10 @@ public class ZeroCapacityNodeTest extends MultipleCacheManagersTest {
    @DataProvider(name = "cm_chf")
    protected Object[][] consistentHashFactory() {
       return new Object[][]{
-            {CacheMode.DIST_SYNC, new DefaultConsistentHashFactory()},
-            {CacheMode.DIST_SYNC, new SyncConsistentHashFactory()},
-            {CacheMode.REPL_SYNC, new ReplicatedConsistentHashFactory()},
-            {CacheMode.REPL_SYNC, new SyncReplicatedConsistentHashFactory()},
+            {CacheMode.DIST_SYNC, DefaultConsistentHashFactory.getInstance()},
+            {CacheMode.DIST_SYNC, SyncConsistentHashFactory.getInstance()},
+            {CacheMode.REPL_SYNC, ReplicatedConsistentHashFactory.getInstance()},
+            {CacheMode.REPL_SYNC, SyncReplicatedConsistentHashFactory.getInstance()},
             };
    }
 

--- a/core/src/test/java/org/infinispan/distribution/ch/DefaultConsistentHashPersistenceTest.java
+++ b/core/src/test/java/org/infinispan/distribution/ch/DefaultConsistentHashPersistenceTest.java
@@ -15,7 +15,7 @@ public class DefaultConsistentHashPersistenceTest extends BaseCHPersistenceTest 
 
    @Override
    protected ConsistentHashFactory<?> createConsistentHashFactory() {
-      return new DefaultConsistentHashFactory();
+      return DefaultConsistentHashFactory.getInstance();
    }
 
    @Override
@@ -28,7 +28,7 @@ public class DefaultConsistentHashPersistenceTest extends BaseCHPersistenceTest 
       for (Address member : members) {
          capacityFactors.put(member, 1.0f);
       }
-      DefaultConsistentHashFactory hashFactory = new DefaultConsistentHashFactory();
+      DefaultConsistentHashFactory hashFactory = DefaultConsistentHashFactory.getInstance();
       return hashFactory.create(2, 100, members, capacityFactors);
    }
 

--- a/core/src/test/java/org/infinispan/distribution/ch/ReplicatedConsistentHashFactoryTest.java
+++ b/core/src/test/java/org/infinispan/distribution/ch/ReplicatedConsistentHashFactoryTest.java
@@ -24,7 +24,7 @@ public class ReplicatedConsistentHashFactoryTest {
    public void test1() {
       int[] testSegments = { 1, 2, 4, 8, 16, 31, 32, 33, 67, 128};
 
-      ReplicatedConsistentHashFactory factory = new ReplicatedConsistentHashFactory();
+      ReplicatedConsistentHashFactory factory = ReplicatedConsistentHashFactory.getInstance();
       Address A = new TestAddress(0, "A");
       Address B = new TestAddress(1, "B");
       Address C = new TestAddress(2, "C");

--- a/core/src/test/java/org/infinispan/distribution/ch/ReplicatedConsistentHashPersistenceTest.java
+++ b/core/src/test/java/org/infinispan/distribution/ch/ReplicatedConsistentHashPersistenceTest.java
@@ -15,7 +15,7 @@ public class ReplicatedConsistentHashPersistenceTest extends BaseCHPersistenceTe
 
    @Override
    protected ConsistentHashFactory<?> createConsistentHashFactory() {
-      return new ReplicatedConsistentHashFactory();
+      return ReplicatedConsistentHashFactory.getInstance();
    }
 
    @Override
@@ -28,7 +28,7 @@ public class ReplicatedConsistentHashPersistenceTest extends BaseCHPersistenceTe
       for (Address member : members) {
          capacityFactors.put(member, 1.0f);
       }
-      ReplicatedConsistentHashFactory hashFactory = new ReplicatedConsistentHashFactory();
+      ReplicatedConsistentHashFactory hashFactory = ReplicatedConsistentHashFactory.getInstance();
       return hashFactory.create(2, 100, members, capacityFactors);
    }
 

--- a/core/src/test/java/org/infinispan/distribution/ch/SyncConsistentHashFactoryKeyDistributionTest.java
+++ b/core/src/test/java/org/infinispan/distribution/ch/SyncConsistentHashFactoryKeyDistributionTest.java
@@ -58,7 +58,7 @@ public class SyncConsistentHashFactoryKeyDistributionTest extends AbstractInfini
    public static final double[] PERCENTILES = { .999 };
 
    protected ConsistentHashFactory<DefaultConsistentHash> createFactory() {
-      return new SyncConsistentHashFactory();
+      return SyncConsistentHashFactory.getInstance();
    }
 
    protected List<Address> createAddresses(int numNodes) {

--- a/core/src/test/java/org/infinispan/distribution/ch/SyncConsistentHashPersistenceTest.java
+++ b/core/src/test/java/org/infinispan/distribution/ch/SyncConsistentHashPersistenceTest.java
@@ -15,7 +15,7 @@ public class SyncConsistentHashPersistenceTest extends BaseCHPersistenceTest {
 
    @Override
    protected ConsistentHashFactory<?> createConsistentHashFactory() {
-      return new SyncConsistentHashFactory();
+      return SyncConsistentHashFactory.getInstance();
    }
 
    @Override
@@ -28,7 +28,7 @@ public class SyncConsistentHashPersistenceTest extends BaseCHPersistenceTest {
       for (Address member : members) {
          capacityFactors.put(member, 1.0f);
       }
-      SyncConsistentHashFactory hashFactory = new SyncConsistentHashFactory();
+      SyncConsistentHashFactory hashFactory = SyncConsistentHashFactory.getInstance();
       return hashFactory.create(2, 100, members, capacityFactors);
    }
 

--- a/core/src/test/java/org/infinispan/distribution/ch/TopologyAwareSyncConsistentHashFactoryKeyDistributionTest.java
+++ b/core/src/test/java/org/infinispan/distribution/ch/TopologyAwareSyncConsistentHashFactoryKeyDistributionTest.java
@@ -38,7 +38,7 @@ public class TopologyAwareSyncConsistentHashFactoryKeyDistributionTest extends S
 
    @Override
    protected ConsistentHashFactory<DefaultConsistentHash> createFactory() {
-      return new TopologyAwareSyncConsistentHashFactory();
+      return TopologyAwareSyncConsistentHashFactory.getInstance();
    }
 
    @Override

--- a/core/src/test/java/org/infinispan/distribution/rehash/WorkDuringJoinTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/WorkDuringJoinTest.java
@@ -61,7 +61,7 @@ public class WorkDuringJoinTest extends BaseDistFunctionalTest<Object, String> {
       Address joinerAddress = startNewMember();
       List<Address> newMembers = new ArrayList<>(chOld.getMembers());
       newMembers.add(joinerAddress);
-      DefaultConsistentHashFactory chf = new DefaultConsistentHashFactory();
+      DefaultConsistentHashFactory chf = DefaultConsistentHashFactory.getInstance();
       ConsistentHash chNew = chf.rebalance(chf.updateMembers((DefaultConsistentHash) chOld, newMembers, null));
       // which key should me mapped to the joiner?
       MagicKey keyToTest = null;

--- a/core/src/test/java/org/infinispan/distribution/topologyaware/TopologyAwareSyncConsistentHashFactoryTest.java
+++ b/core/src/test/java/org/infinispan/distribution/topologyaware/TopologyAwareSyncConsistentHashFactoryTest.java
@@ -24,7 +24,7 @@ public class TopologyAwareSyncConsistentHashFactoryTest extends TopologyAwareCon
 
    @Override
    protected ConsistentHashFactory<DefaultConsistentHash> createConsistentHashFactory() {
-      return new TopologyAwareSyncConsistentHashFactory();
+      return TopologyAwareSyncConsistentHashFactory.getInstance();
    }
 
    @Override

--- a/core/src/test/java/org/infinispan/partitionhandling/impl/PreferAvailabilityStrategyTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/impl/PreferAvailabilityStrategyTest.java
@@ -62,10 +62,10 @@ public class PreferAvailabilityStrategyTest extends AbstractInfinispanTest {
    }
 
    private static final CacheJoinInfo DIST_INFO =
-         new CacheJoinInfo(new DefaultConsistentHashFactory(), 8, 2, 1000, CacheMode.DIST_SYNC, 1.0f, null,
+         new CacheJoinInfo(DefaultConsistentHashFactory.getInstance(), 8, 2, 1000, CacheMode.DIST_SYNC, 1.0f, null,
                            Optional.empty());
    private static final CacheJoinInfo REPL_INFO =
-         new CacheJoinInfo(new DefaultConsistentHashFactory(), 8, 2, 1000, CacheMode.REPL_SYNC, 1.0f, null,
+         new CacheJoinInfo(DefaultConsistentHashFactory.getInstance(), 8, 2, 1000, CacheMode.REPL_SYNC, 1.0f, null,
                            Optional.empty());
    private static final Address A = new TestAddress(1, "A");
    private static final Address B = new TestAddress(2, "B");

--- a/core/src/test/java/org/infinispan/remoting/rpc/RpcManagerTest.java
+++ b/core/src/test/java/org/infinispan/remoting/rpc/RpcManagerTest.java
@@ -141,7 +141,7 @@ public class RpcManagerTest extends MultipleCacheManagersTest {
          // Add a node to the cache topology, but not to the JGroups cluster view
          List<Address> newMembers = new ArrayList<>(initialTopology.getMembers());
          newMembers.add(SUSPECT);
-         ConsistentHash newCH = new ReplicatedConsistentHashFactory().create(1, 1,
+         ConsistentHash newCH = ReplicatedConsistentHashFactory.getInstance().create(1, 1,
                                                                              newMembers, null);
          CacheTopology suspectTopology =
             new CacheTopology(initialTopology.getTopologyId(), initialTopology.getRebalanceId(), newCH, null, null,

--- a/core/src/test/java/org/infinispan/statetransfer/StateConsumerTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateConsumerTest.java
@@ -314,7 +314,7 @@ public class StateConsumerTest extends AbstractInfinispanTest {
       List<Address> members2 = Arrays.asList(addresses[0], addresses[1], addresses[2]);
 
       // create CHes
-      DefaultConsistentHashFactory chf = new DefaultConsistentHashFactory();
+      DefaultConsistentHashFactory chf = DefaultConsistentHashFactory.getInstance();
       DefaultConsistentHash ch1 = chf.create(2, 40, members1, null);
       final DefaultConsistentHash ch2 = chf.updateMembers(ch1, members2, null);
       DefaultConsistentHash ch3 = chf.rebalance(ch2);
@@ -372,7 +372,7 @@ public class StateConsumerTest extends AbstractInfinispanTest {
       List<Address> members2 = Arrays.asList(addresses[1], addresses[2]);
 
       // create CHes
-      DefaultConsistentHashFactory chf = new DefaultConsistentHashFactory();
+      DefaultConsistentHashFactory chf = DefaultConsistentHashFactory.getInstance();
       DefaultConsistentHash ch1 = chf.create(2, 40, members1, null);
       final DefaultConsistentHash ch2 = chf.updateMembers(ch1, members2, null);
       DefaultConsistentHash ch3 = chf.rebalance(ch2);

--- a/core/src/test/java/org/infinispan/statetransfer/StateProviderTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateProviderTest.java
@@ -144,7 +144,7 @@ public class StateProviderTest {
 
       // create CHes
       KeyPartitioner keyPartitioner = new HashFunctionPartitioner(StateProviderTest.NUM_SEGMENTS);
-      DefaultConsistentHashFactory chf = new DefaultConsistentHashFactory();
+      DefaultConsistentHashFactory chf = DefaultConsistentHashFactory.getInstance();
       DefaultConsistentHash ch1 = chf.create(2, StateProviderTest.NUM_SEGMENTS, members1, null);
       DefaultConsistentHash ch2 = chf.updateMembers(ch1, members2, null);
 
@@ -234,7 +234,7 @@ public class StateProviderTest {
 
       // create CHes
       KeyPartitioner keyPartitioner = new HashFunctionPartitioner(StateProviderTest.NUM_SEGMENTS);
-      DefaultConsistentHashFactory chf = new DefaultConsistentHashFactory();
+      DefaultConsistentHashFactory chf = DefaultConsistentHashFactory.getInstance();
       DefaultConsistentHash ch1 = chf.create(2, NUM_SEGMENTS, members1, null);
       //todo [anistor] it seems that address 6 is not used for un-owned segments
       DefaultConsistentHash ch2 = chf.updateMembers(ch1, members2, null);

--- a/core/src/test/java/org/infinispan/stress/LargeCluster2StressTest.java
+++ b/core/src/test/java/org/infinispan/stress/LargeCluster2StressTest.java
@@ -77,8 +77,8 @@ public class LargeCluster2StressTest extends MultipleCacheManagersTest {
       final Configuration distConfig = new ConfigurationBuilder()
             .clustering().cacheMode(CacheMode.DIST_SYNC)
             .clustering().stateTransfer().awaitInitialTransfer(false)
-//            .hash().consistentHashFactory(new TopologyAwareSyncConsistentHashFactory()).numSegments(NUM_SEGMENTS)
-            .hash().consistentHashFactory(new SyncConsistentHashFactory()).numSegments(NUM_SEGMENTS)
+//            .hash().consistentHashFactory(TopologyAwareSyncConsistentHashFactory.getInstance()).numSegments(NUM_SEGMENTS)
+            .hash().consistentHashFactory(SyncConsistentHashFactory.getInstance()).numSegments(NUM_SEGMENTS)
             .build();
       final Configuration replConfig = new ConfigurationBuilder()
             .clustering().cacheMode(CacheMode.REPL_SYNC)

--- a/core/src/test/java/org/infinispan/topology/ClusterCacheStatusTest.java
+++ b/core/src/test/java/org/infinispan/topology/ClusterCacheStatusTest.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
 public class ClusterCacheStatusTest extends AbstractInfinispanTest {
    private static final String CACHE_NAME = "test";
    private static final CacheJoinInfo JOIN_INFO =
-      new CacheJoinInfo(new DefaultConsistentHashFactory(), 8, 2, 1000,
+      new CacheJoinInfo(DefaultConsistentHashFactory.getInstance(), 8, 2, 1000,
             CacheMode.DIST_SYNC, 1.0f, null, Optional.empty());
    private static final Address A = new TestAddress(1, "A");
    private static final Address B = new TestAddress(2, "B");

--- a/core/src/test/java/org/infinispan/topology/ClusterTopologyManagerImplTest.java
+++ b/core/src/test/java/org/infinispan/topology/ClusterTopologyManagerImplTest.java
@@ -55,7 +55,7 @@ public class ClusterTopologyManagerImplTest extends AbstractInfinispanTest {
 
    private static final Address A = new TestAddress(0, "A");
    private static final Address B = new TestAddress(1, "B");
-   private final ConsistentHashFactory<?> replicatedChf = new ReplicatedConsistentHashFactory();
+   private final ConsistentHashFactory<?> replicatedChf = ReplicatedConsistentHashFactory.getInstance();
    // The persistent UUIDs are different, the rest of the join info is the same
    private final CacheJoinInfo joinInfoA = makeJoinInfo();
    private final CacheJoinInfo joinInfoB = makeJoinInfo();


### PR DESCRIPTION
CacheJoinInfo instances are not reused properly due to every ConsistentHashFactory being a separate instance that didn't implement equals. This changes it so these are singletons as they have no state and allows CacheJoinInfo to work properly with equals which means they are reused in the ManagerStatusResponse in ClusterTopologyManagerImpl