### PR TITLE
[#14663] On 15.1.x docs go only to 15.1.x

### DIFF
--- a/.github/workflows/sync_docs.yml
+++ b/.github/workflows/sync_docs.yml
@@ -35,15 +35,9 @@ jobs:
         ref: master
         path: infinispan.github.io
 
-    - if: github.ref == 'refs/heads/main'
-      name: Copy docs to dev
+    - name: Copy docs to version
       run: |
-        cp -r documentation/target/generated/1*/html/* infinispan.github.io/docs/dev/
-
-    - if: github.ref == 'refs/heads/15.0.x'
-      name: Copy docs to stable
-      run: |
-        cp -r documentation/target/generated/1*/html/* infinispan.github.io/docs/stable/
+        cp -r documentation/target/generated/1*/html/* infinispan.github.io/docs/${{ github.ref_name }}
 
     - name: Commit files
       run: |


### PR DESCRIPTION
Documentation pushed to 15.1.x branch must go under 15.1.x folder
fix for #14663 