### PR TITLE
[#14663] On 15.2.x docs go to stable

### DIFF
--- a/.github/workflows/sync_docs.yml
+++ b/.github/workflows/sync_docs.yml
@@ -35,17 +35,12 @@ jobs:
         ref: master
         path: infinispan.github.io
 
-    - if: github.ref != 'refs/heads/main'
+    - if: github.ref != 'refs/heads/15.2.x'
       name: Copy docs to version
       run: |
         cp -r documentation/target/generated/1*/html/* infinispan.github.io/docs/${{ github.ref_name }}
 
-    - if: github.ref == 'refs/heads/main'
-      name: Copy docs to dev
-      run: |
-        cp -r documentation/target/generated/1*/html/* infinispan.github.io/docs/dev/
-
-    - if: github.ref == 'refs/heads/15.1.x'
+    - if: github.ref == 'refs/heads/15.2.x'
       name: Copy docs to stable
       run: |
         cp -r documentation/target/generated/1*/html/* infinispan.github.io/docs/stable/


### PR DESCRIPTION
Documentation pushed to 14.0.x branch must go under stable folder
fix for #14663 