### PR TITLE
[15.2.x] [#14630] Break cycle between local and cluster topology manager

### DIFF
--- a/core/src/main/java/org/infinispan/commands/topology/CacheStatusRequestCommand.java
+++ b/core/src/main/java/org/infinispan/commands/topology/CacheStatusRequestCommand.java
@@ -3,12 +3,9 @@ package org.infinispan.commands.topology;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
-import java.util.Collections;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import org.infinispan.factories.GlobalComponentRegistry;
-import org.infinispan.topology.ManagerStatusResponse;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -37,11 +34,6 @@ public class CacheStatusRequestCommand extends AbstractCacheControlCommand {
 
    @Override
    public CompletionStage<?> invokeAsync(GlobalComponentRegistry gcr) throws Throwable {
-      if (!gcr.isLocalTopologyManagerRunning()) {
-         log.debug("Reply with empty status request because topology manager not running");
-         return CompletableFuture.completedFuture(new ManagerStatusResponse(Collections.emptyMap(), true));
-      }
-
       return gcr.getLocalTopologyManager()
             .handleStatusRequest(viewId);
    }

--- a/core/src/main/java/org/infinispan/commands/topology/TopologyUpdateCommand.java
+++ b/core/src/main/java/org/infinispan/commands/topology/TopologyUpdateCommand.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.concurrent.CompletionStage;
 
 import org.infinispan.commons.marshall.MarshallUtil;
-import org.infinispan.commons.util.concurrent.CompletableFutures;
 import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.factories.GlobalComponentRegistry;
 import org.infinispan.partitionhandling.AvailabilityMode;
@@ -64,11 +63,6 @@ public class TopologyUpdateCommand extends AbstractCacheControlCommand {
 
    @Override
    public CompletionStage<?> invokeAsync(GlobalComponentRegistry gcr) throws Throwable {
-      if (!gcr.isLocalTopologyManagerRunning()) {
-         log.debugf("Discard topology update because topology manager not running %s", this);
-         return CompletableFutures.completedNull();
-      }
-
       CacheTopology topology = new CacheTopology(topologyId, rebalanceId, currentCH, pendingCH, phase, actualMembers, persistentUUIDs);
       return gcr.getLocalTopologyManager()
             .handleTopologyUpdate(cacheName, topology, availabilityMode, viewId, origin);

--- a/core/src/main/java/org/infinispan/commands/topology/TopologyUpdateStableCommand.java
+++ b/core/src/main/java/org/infinispan/commands/topology/TopologyUpdateStableCommand.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.concurrent.CompletionStage;
 
 import org.infinispan.commons.marshall.MarshallUtil;
-import org.infinispan.commons.util.concurrent.CompletableFutures;
 import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.factories.GlobalComponentRegistry;
 import org.infinispan.remoting.transport.Address;
@@ -58,11 +57,6 @@ public class TopologyUpdateStableCommand extends AbstractCacheControlCommand {
 
    @Override
    public CompletionStage<?> invokeAsync(GlobalComponentRegistry gcr) throws Throwable {
-      if (!gcr.isLocalTopologyManagerRunning()) {
-         log.debugf("Discard stable update because topology manager not running %s", this);
-         return CompletableFutures.completedNull();
-      }
-
       CacheTopology topology = new CacheTopology(topologyId, rebalanceId, topologyRestored, currentCH, pendingCH,
             CacheTopology.Phase.NO_REBALANCE, actualMembers, persistentUUIDs);
       return gcr.getLocalTopologyManager()

--- a/core/src/main/java/org/infinispan/topology/ClusterTopologyManagerImpl.java
+++ b/core/src/main/java/org/infinispan/topology/ClusterTopologyManagerImpl.java
@@ -183,6 +183,7 @@ public class ClusterTopologyManagerImpl implements ClusterTopologyManager, Globa
       }
       ReplicableCommand command = new RebalanceStatusRequestCommand();
       Address coordinator = transport.getCoordinator();
+      gcr.ensureComponentRunning(LocalTopologyManager.class);
       return helper.executeOnCoordinator(transport, command, getGlobalTimeout() / INITIAL_CONNECTION_ATTEMPTS)
                    .handle((rebalancingStatus, throwable) -> {
                       if (throwable == null)

--- a/core/src/main/java/org/infinispan/topology/LocalTopologyManagerImpl.java
+++ b/core/src/main/java/org/infinispan/topology/LocalTopologyManagerImpl.java
@@ -103,8 +103,6 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager, GlobalSta
    @Inject PersistentUUIDManager persistentUUIDManager;
    @Inject EventLogManager eventLogManager;
    @Inject CacheManagerNotifier cacheManagerNotifier;
-   // Not used directly, but we have to start the ClusterTopologyManager before sending the join request
-   @Inject ClusterTopologyManager clusterTopologyManager;
 
    private TopologyManagementHelper helper;
    private ActionSequencer actionSequencer;
@@ -239,6 +237,7 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager, GlobalSta
                                                                long endTime) {
       int viewId = transport.getViewId();
       ReplicableCommand command = new CacheJoinCommand(cacheName, transport.getAddress(), joinInfo, viewId);
+      gcr.ensureComponentRunning(ClusterTopologyManager.class);
       return handleAndCompose(helper.executeOnCoordinator(transport, command, timeout), (response, throwable) -> {
          int currentViewId = transport.getViewId();
          if (viewId != currentViewId) {
@@ -866,6 +865,7 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager, GlobalSta
       LocalCacheStatus cacheStatus = runningCaches.get(cacheName);
       if (cacheStatus != null && !cacheStatus.isTopologyRestored()) {
          List<Address> members;
+         ClusterTopologyManager clusterTopologyManager = gcr.getClusterTopologyManager();
          if ((members = clusterTopologyManager.currentJoiners(cacheName)) == null) {
             members = cacheStatus.knownMembers();
          }

--- a/core/src/test/java/org/infinispan/topology/AbstractStatefulCluster.java
+++ b/core/src/test/java/org/infinispan/topology/AbstractStatefulCluster.java
@@ -56,6 +56,9 @@ public abstract class AbstractStatefulCluster extends MultipleCacheManagersTest 
 
    protected final void assertClusterStateFiles(String cacheName) throws IOException {
       for (int i = 0; i < clusterSize; i++) {
+         if (i >= cacheManagers.size())
+            break;
+
          assertClusterStateFiles(manager(i), cacheName);
       }
    }


### PR DESCRIPTION
* Remove dependency from LocalTopologyManagerImpl.
* Cached components ensure correct initialization order.

Backport of #14631