### PR TITLE
[15.0.x] [#14725] Add port_range back to the default stacks

### DIFF
--- a/core/src/main/resources/default-configs/default-jgroups-azure.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-azure.xml
@@ -8,6 +8,7 @@
    <!-- jgroups.tcp.address is deprecated and will be removed, see ISPN-11867 -->
    <TCP bind_addr="${jgroups.bind.address,jgroups.tcp.address:SITE_LOCAL}"
         bind_port="${jgroups.bind.port,jgroups.tcp.port:7800}"
+        port_range="${jgroups.port_range:10}"
 
         diag.enabled="${jgroups.diag.enabled:false}"
         diag.enable_tcp="${jgroups.diag.enable_tcp:true}"

--- a/core/src/main/resources/default-configs/default-jgroups-ec2.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-ec2.xml
@@ -8,6 +8,7 @@
    <!-- jgroups.tcp.address is deprecated and will be removed, see ISPN-11867 -->
    <TCP bind_addr="${jgroups.bind.address,jgroups.tcp.address:SITE_LOCAL}"
         bind_port="${jgroups.bind.port,jgroups.tcp.port:7800}"
+        port_range="${jgroups.port_range:10}"
 
         diag.enabled="${jgroups.diag.enabled:false}"
         diag.enable_tcp="${jgroups.diag.enable_tcp:true}"

--- a/core/src/main/resources/default-configs/default-jgroups-google.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-google.xml
@@ -9,6 +9,7 @@
    <!-- jgroups.tcp.address is deprecated and will be removed, see ISPN-11867 -->
    <TCP bind_addr="${jgroups.bind.address,jgroups.tcp.address:SITE_LOCAL}"
         bind_port="${jgroups.bind.port,jgroups.tcp.port:7800}"
+        port_range="${jgroups.port_range:10}"
 
         diag.enabled="${jgroups.diag.enabled:false}"
         diag.enable_tcp="${jgroups.diag.enable_tcp:true}"

--- a/core/src/main/resources/default-configs/default-jgroups-kubernetes.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-kubernetes.xml
@@ -9,6 +9,7 @@
    <!-- jgroups.tcp.address is deprecated and will be removed, see ISPN-11867 -->
    <TCP bind_addr="${jgroups.bind.address,jgroups.tcp.address:SITE_LOCAL}"
         bind_port="${jgroups.bind.port,jgroups.tcp.port:7800}"
+        port_range="${jgroups.port_range:0}"
 
         diag.enabled="${jgroups.diag.enabled:false}"
         diag.enable_tcp="${jgroups.diag.enable_tcp:true}"

--- a/core/src/main/resources/default-configs/default-jgroups-tcp.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-tcp.xml
@@ -4,6 +4,7 @@
    <!-- jgroups.tcp.address is deprecated and will be removed, see ISPN-11867 -->
    <TCP bind_addr="${jgroups.bind.address,jgroups.tcp.address:SITE_LOCAL}"
         bind_port="${jgroups.bind.port,jgroups.tcp.port:7800}"
+        port_range="${jgroups.port_range:10}"
 
         diag.enabled="${jgroups.diag.enabled:false}"
         diag.enable_tcp="${jgroups.diag.enable_tcp:true}"

--- a/core/src/main/resources/default-configs/default-jgroups-tunnel.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-tunnel.xml
@@ -3,6 +3,7 @@
         xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.3.xsd">
    <TUNNEL bind_addr="${jgroups.tunnel.address,jgroups.bind.address:SITE_LOCAL}"
            bind_port="${jgroups.tunnel.port,jgroups.bind.port:0}"
+           port_range="${jgroups.port_range:0}"
 
            diag.enabled="${jgroups.diag.enabled:false}"
            diag.enable_tcp="${jgroups.diag.enable_tcp:true}"

--- a/core/src/main/resources/default-configs/default-jgroups-udp.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-udp.xml
@@ -6,6 +6,7 @@
         bind_port="${jgroups.bind.port,jgroups.udp.port:7800}"
         mcast_addr="${jgroups.mcast_addr:239.6.7.8}"
         mcast_port="${jgroups.mcast_port:46655}"
+        port_range="${jgroups.port_range:10}"
         tos="0"
         ucast_send_buf_size="1m"
         mcast_send_buf_size="1m"


### PR DESCRIPTION
**Backport:** https://github.com/infinispan/infinispan/pull/14726

Closes #14725 