### PR TITLE
[#14575] Close stale 'kind/flaky test' issue

### DIFF
--- a/.github/workflows/cron-close-stale-issues.yaml
+++ b/.github/workflows/cron-close-stale-issues.yaml
@@ -1,0 +1,24 @@
+name: Close Stale Issues
+
+on:
+  schedule:
+    - cron: '23 1 * * *'  # Every day at 1:23 AM UTC
+  workflow_dispatch:      # Optional: allows manual triggering
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+
+    steps:
+      - name: Close stale issues
+        uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 14
+          days-before-close: 0
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          only-issue-labels: 'kind/flaky test'   # only affects issues with this label
+          operations-per-run: 100

--- a/bin/gh/track_flaky_tests.sh
+++ b/bin/gh/track_flaky_tests.sh
@@ -57,6 +57,7 @@ for TEST in "${TESTS[@]}"; do
       export ISSUE_KEY=$(echo "${ISSUES}" | jq  '.[0].number')
       # Re-open the issue if it was previously resolved
       if [ "$(gh issue view ${ISSUE_KEY} --json state | jq .state)" == '"CLOSED"' ]; then
+        gh issue edit {ISSUE_KEY} --remove-label Stale || true
         gh issue reopen ${ISSUE_KEY}
       fi
       gh issue comment ${ISSUE_KEY} --body "${BODY}"


### PR DESCRIPTION
closes #14575 

Before the first run, old flaky tests must be closed manually since action/stale has bug in handling cache between runs, if number of operations per run exceeds `operations-per-run` [see](https://github.com/actions/stale/issues/1131)