### PR TITLE
[#14806] Add mapper to ConsistentHashFactory.fromPersistentState method

### DIFF
--- a/core/src/main/java/org/infinispan/distribution/ch/ConsistentHash.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/ConsistentHash.java
@@ -4,10 +4,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.function.UnaryOperator;
 
 import org.infinispan.globalstate.ScopedPersistentState;
 import org.infinispan.remoting.transport.Address;
+import org.infinispan.topology.PersistentUUID;
 
 /**
  * A consistent hash algorithm implementation. Implementations would typically be constructed via a
@@ -50,7 +50,7 @@ public interface ConsistentHash {
    /**
     * Should return the addresses of the nodes used to create this consistent hash.
     *
-    * @return set of node addresses.
+    * @return list of node addresses.
     */
    List<Address> getMembers();
 
@@ -112,31 +112,10 @@ public interface ConsistentHash {
     * Writes this {@link ConsistentHash} to the specified scoped persistent state.
     *
     * @param state         The state to which this {@link ConsistentHash} will be written.
-    * @param addressMapper The mapper {@link Function} to convert the {@link Address} to the unique string used to
-    *                      persist the address within the state.
+    * @param addressMapper The mapper {@link Function} to convert the {@link Address} to the {@link PersistentUUID} used
+    *                      to persist the address within the state.
     */
-   default void toScopedState(ScopedPersistentState state, Function<Address, String> addressMapper) {
-      throw new UnsupportedOperationException();
-   }
-
-   /**
-    * Returns a new ConsistentHash with the addresses remapped according to the provided {@link UnaryOperator}.
-    * If an address cannot me remapped (i.e. the remapper returns null) this method should return null.
-    *
-    * @param remapper the remapper which given an address replaces it with another one
-    * @return the remapped ConsistentHash or null if one of the remapped addresses is null
-    */
-   default ConsistentHash remapAddresses(UnaryOperator<Address> remapper) {
-      throw new UnsupportedOperationException();
-   }
-
-   /**
-    * Same as {@link #remapAddresses(UnaryOperator)} but skip missing members.
-    *
-    * @param remapper: the remapper which given an address replaces it with another one
-    * @return the remapped ConsistentHash
-    */
-   default ConsistentHash remapAddressRemoveMissing(UnaryOperator<Address> remapper) {
+   default void toScopedState(ScopedPersistentState state, Function<Address, PersistentUUID> addressMapper) {
       throw new UnsupportedOperationException();
    }
 

--- a/core/src/main/java/org/infinispan/distribution/ch/PersistedConsistentHash.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/PersistedConsistentHash.java
@@ -1,0 +1,49 @@
+package org.infinispan.distribution.ch;
+
+import java.util.Collection;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+
+import org.infinispan.globalstate.ScopedPersistentState;
+import org.infinispan.topology.PersistentUUID;
+
+/**
+ * A record containing the {@link ConsistentHash} restored from persistent state and any missing
+ * {@link PersistentUUID}s.
+ *
+ * @param consistentHash The {@link ConsistentHash} instance. Note that its ownership information might be incomplete if
+ *                       {@link #missingUuids()} is not empty.
+ * @param missingUuids   A collection of {@link PersistentUUID}s representing members that were present in the
+ *                       persistent state but are not currently online.
+ * @param <CH>           The specific implementation type of the {@link ConsistentHash}.
+ * @see ConsistentHashFactory#fromPersistentState(ScopedPersistentState, Function)
+ */
+public record PersistedConsistentHash<CH extends ConsistentHash>(CH consistentHash,
+                                                                 Collection<PersistentUUID> missingUuids) {
+
+   public PersistedConsistentHash(CH consistentHash, Collection<PersistentUUID> missingUuids) {
+      this.consistentHash = Objects.requireNonNull(consistentHash);
+      this.missingUuids = Set.copyOf(missingUuids);
+   }
+
+   /**
+    * Returns the total number of members that were present in the persistent state, including those currently marked as
+    * missing.
+    *
+    * @return The total number of members, including both online and missing members.
+    */
+   public int totalMembers() {
+      return consistentHash.getMembers().size() + missingUuids.size();
+   }
+
+   /**
+    * Indicates whether there are missing members that were part of the persistent state but are not currently online.
+    *
+    * @return {@code true} if the {@link #missingUuids()} collection is not empty, signifying potential incomplete
+    * ownership information in the associated {@link ConsistentHash}. Otherwise, returns {@code false}.
+    */
+   public boolean hasMissingMembers() {
+      return !missingUuids.isEmpty();
+   }
+}

--- a/core/src/main/java/org/infinispan/distribution/ch/impl/PersistedMembers.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/impl/PersistedMembers.java
@@ -1,0 +1,29 @@
+package org.infinispan.distribution.ch.impl;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.topology.PersistentUUID;
+
+/**
+ * A record containing the currently online members' {@link Address}es, their capacity factors, and the
+ * {@link PersistentUUID}s of any members that were part of a previous state but are not currently online.
+ *
+ * @param members         The list of {@link Address}es of the currently online members.
+ * @param capacityFactors A map of {@link Address} to their capacity factor. This may be {@code null} if all online
+ *                        members have a default capacity factor of 1.
+ * @param missingUuids    A collection of {@link PersistentUUID}s representing members that were present in a previous
+ *                        persistent state but are not currently online.
+ */
+record PersistedMembers(List<Address> members, Map<Address, Float> capacityFactors,
+                        Collection<PersistentUUID> missingUuids) {
+
+   public PersistedMembers(List<Address> members, Map<Address, Float> capacityFactors, Collection<PersistentUUID> missingUuids) {
+      this.members = List.copyOf(members);
+      this.capacityFactors = capacityFactors == null ? null : Map.copyOf(capacityFactors);
+      this.missingUuids = Set.copyOf(missingUuids);
+   }
+}

--- a/core/src/main/java/org/infinispan/distribution/ch/impl/ReplicatedConsistentHashFactory.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/impl/ReplicatedConsistentHashFactory.java
@@ -8,13 +8,16 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import java.util.function.Function;
 
 import org.infinispan.commons.marshall.ProtoStreamTypeIds;
 import org.infinispan.distribution.ch.ConsistentHashFactory;
+import org.infinispan.distribution.ch.PersistedConsistentHash;
 import org.infinispan.globalstate.ScopedPersistentState;
 import org.infinispan.protostream.annotations.ProtoFactory;
 import org.infinispan.protostream.annotations.ProtoTypeId;
 import org.infinispan.remoting.transport.Address;
+import org.infinispan.topology.PersistentUUID;
 
 /**
  * Factory for ReplicatedConsistentHash.
@@ -54,11 +57,11 @@ public class ReplicatedConsistentHashFactory implements ConsistentHashFactory<Re
    }
 
    @Override
-   public ReplicatedConsistentHash fromPersistentState(ScopedPersistentState state) {
+   public PersistedConsistentHash<ReplicatedConsistentHash> fromPersistentState(ScopedPersistentState state, Function<PersistentUUID, Address> addressMapper) {
       String consistentHashClass = state.getProperty("consistentHash");
       if (!ReplicatedConsistentHash.class.getName().equals(consistentHashClass))
          throw CONTAINER.persistentConsistentHashMismatch(this.getClass().getName(), consistentHashClass);
-      return new ReplicatedConsistentHash(state);
+      return ReplicatedConsistentHash.fromPersistentScope(state, addressMapper);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/distribution/ch/impl/SyncReplicatedConsistentHashFactory.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/impl/SyncReplicatedConsistentHashFactory.java
@@ -6,13 +6,16 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 import org.infinispan.commons.marshall.ProtoStreamTypeIds;
 import org.infinispan.distribution.ch.ConsistentHashFactory;
+import org.infinispan.distribution.ch.PersistedConsistentHash;
 import org.infinispan.globalstate.ScopedPersistentState;
 import org.infinispan.protostream.annotations.ProtoFactory;
 import org.infinispan.protostream.annotations.ProtoTypeId;
 import org.infinispan.remoting.transport.Address;
+import org.infinispan.topology.PersistentUUID;
 
 /**
  * {@link SyncConsistentHashFactory} adapted for replicated caches, so that the primary owner of a key
@@ -43,11 +46,11 @@ public class SyncReplicatedConsistentHashFactory implements ConsistentHashFactor
    }
 
    @Override
-   public ReplicatedConsistentHash fromPersistentState(ScopedPersistentState state) {
+   public PersistedConsistentHash<ReplicatedConsistentHash> fromPersistentState(ScopedPersistentState state, Function<PersistentUUID, Address> addressMapper) {
       String consistentHashClass = state.getProperty("consistentHash");
       if (!ReplicatedConsistentHash.class.getName().equals(consistentHashClass))
          throw CONTAINER.persistentConsistentHashMismatch(this.getClass().getName(), consistentHashClass);
-      return new ReplicatedConsistentHash(state);
+      return ReplicatedConsistentHash.fromPersistentScope(state, addressMapper);
    }
 
    private ReplicatedConsistentHash replicatedFromDefault(DefaultConsistentHash dch,
@@ -76,7 +79,7 @@ public class SyncReplicatedConsistentHashFactory implements ConsistentHashFactor
       for (int segment = 0; segment < numSegments; segment++) {
          baseSegmentOwners[segment] = Collections.singletonList(baseCH.locatePrimaryOwnerForSegment(segment));
       }
-      return new DefaultConsistentHash(1,
+      return DefaultConsistentHash.create(1,
             numSegments, baseCH.getMembers(), baseCH.getCapacityFactors(), baseSegmentOwners);
    }
 

--- a/core/src/main/java/org/infinispan/partitionhandling/impl/PreferConsistencyStrategy.java
+++ b/core/src/main/java/org/infinispan/partitionhandling/impl/PreferConsistencyStrategy.java
@@ -60,7 +60,7 @@ public class PreferConsistencyStrategy implements AvailabilityStrategy {
 
          // Not losing any data with the members. We utilize the persistent UUID to verify.
          if (!isDataLost(stableTopology.getCurrentCH(), membersUuid, persistentUUIDManager.addressToPersistentUUID())) {
-            List<Address> lost = new ArrayList<>(stableTopology.getMembers()).stream()
+            List<Address> lost = stableTopology.getMembers().stream()
                   .map(persistentUUIDManager::getPersistentUuid)
                   .filter(m -> !membersUuid.contains(m))
                   .collect(Collectors.toList());

--- a/core/src/main/java/org/infinispan/topology/PersistentUUIDManager.java
+++ b/core/src/main/java/org/infinispan/topology/PersistentUUIDManager.java
@@ -1,7 +1,7 @@
 package org.infinispan.topology;
 
 import java.util.List;
-import java.util.function.UnaryOperator;
+import java.util.function.Function;
 
 import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
@@ -58,10 +58,10 @@ public interface PersistentUUIDManager {
    /**
     * Provides a remapping operator which translates addresses to persistentuuids
     */
-   UnaryOperator<Address> addressToPersistentUUID();
+   Function<Address, PersistentUUID> addressToPersistentUUID();
 
    /**
     * Provides a remapping operator which translates persistentuuids to addresses
     */
-   UnaryOperator<Address> persistentUUIDToAddress();
+   Function<PersistentUUID, Address> persistentUUIDToAddress();
 }

--- a/core/src/main/java/org/infinispan/topology/PersistentUUIDManagerImpl.java
+++ b/core/src/main/java/org/infinispan/topology/PersistentUUIDManagerImpl.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.function.UnaryOperator;
+import java.util.function.Function;
 
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.util.logging.Log;
@@ -78,12 +78,12 @@ public class PersistentUUIDManagerImpl implements PersistentUUIDManager {
    }
 
    @Override
-   public UnaryOperator<Address> addressToPersistentUUID() {
-      return (address) -> address2uuid.get(address);
+   public Function<Address, PersistentUUID> addressToPersistentUUID() {
+      return address2uuid::get;
    }
 
    @Override
-   public UnaryOperator<Address> persistentUUIDToAddress() {
-      return (address) -> uuid2address.get(address);
+   public Function<PersistentUUID, Address> persistentUUIDToAddress() {
+      return uuid2address::get;
    }
 }

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/OnlyPrimaryOwnerTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/OnlyPrimaryOwnerTest.java
@@ -98,7 +98,7 @@ public class OnlyPrimaryOwnerTest {
       public LocalizedCacheTopology getCacheTopology() {
          List<Address> members = Arrays.asList(PRIMARY, BACKUP, NON_OWNER);
          List<Address>[] ownership = new List[]{Arrays.asList(PRIMARY, BACKUP)};
-         ConsistentHash ch = new DefaultConsistentHash(2, 1, members, null, ownership);
+         ConsistentHash ch = DefaultConsistentHash.create(2, 1, members, null, ownership);
          CacheTopology cacheTopology = new CacheTopology(0, 0, ch, null, CacheTopology.Phase.NO_REBALANCE, null, null);
          Address localAddress = isPrimaryOwner ? PRIMARY : (isOwner ? BACKUP : NON_OWNER);
          return new LocalizedCacheTopology(CacheMode.DIST_SYNC, cacheTopology, key -> 0, localAddress, true);

--- a/core/src/test/java/org/infinispan/util/BaseControlledConsistentHashFactory.java
+++ b/core/src/test/java/org/infinispan/util/BaseControlledConsistentHashFactory.java
@@ -119,7 +119,7 @@ public abstract class BaseControlledConsistentHashFactory<CH extends ConsistentH
       public DefaultConsistentHash create(int numOwners, int numSegments, List<Address> members,
                                           Map<Address, Float> capacityFactors, List<Address>[] segmentOwners,
                                           boolean rebalanced) {
-         return new DefaultConsistentHash(numOwners, numSegments, members, capacityFactors, segmentOwners);
+         return DefaultConsistentHash.create(numOwners, numSegments, members, capacityFactors, segmentOwners);
       }
 
       @Override


### PR DESCRIPTION
Closes #14806 

Not ready yet. I think this is the last place that forces `PersistentUUID` to implement `Address` :crossed_fingers: 