### PR TITLE
[#14804] Long running tasks progress tracker

### DIFF
--- a/commons/all/src/main/java/org/infinispan/commons/internal/CommonsBlockHoundIntegration.java
+++ b/commons/all/src/main/java/org/infinispan/commons/internal/CommonsBlockHoundIntegration.java
@@ -12,6 +12,7 @@ import java.util.concurrent.locks.StampedLock;
 import org.apache.logging.log4j.spi.AbstractLogger;
 import org.infinispan.commons.dataconversion.MediaTypeResolver;
 import org.infinispan.commons.executors.NonBlockingResource;
+import org.infinispan.commons.util.ProgressTracker;
 import org.infinispan.commons.util.ServiceFinder;
 import org.infinispan.commons.util.SslContextFactory;
 import org.infinispan.commons.util.concurrent.NonBlockingRejectedExecutionHandler;
@@ -48,6 +49,11 @@ public class CommonsBlockHoundIntegration implements BlockHoundIntegration {
       // ReferenceQueue in JVM can cause blocking in some cases - we are assuming users of this are responsible and the
       // lock should be short lived even if contested
       builder.allowBlockingCallsInside(ReferenceQueue.class.getName(), "poll");
+
+      // Allow blocking calls for progress tracking.
+      builder.allowBlockingCallsInside(ProgressTracker.class.getName(), "addTasks");
+      builder.allowBlockingCallsInside(ProgressTracker.class.getName(), "removeTasks");
+      builder.allowBlockingCallsInside(ProgressTracker.class.getName(), "finishedAllTasks");
 
       handleJREClasses(builder);
 

--- a/commons/all/src/main/java/org/infinispan/commons/logging/Log.java
+++ b/commons/all/src/main/java/org/infinispan/commons/logging/Log.java
@@ -294,7 +294,7 @@ public interface Log extends BasicLogger {
    CacheConfigurationException attributeMustBeAnInteger(Number value, Enum<?> attribute);
 
    @LogMessage(level = INFO)
-   @Message(value = "Task '%s', pending (%d) tasks, last check had (%d), task status is %s", id = 972)
+   @Message(value = "Task '%s', pending (%d), last check had (%d) pending, status is %s", id = 972)
    void taskProgression(String name, long pending, long lastCheck, String status);
 
    @LogMessage(level = INFO)

--- a/commons/all/src/main/java/org/infinispan/commons/logging/Log.java
+++ b/commons/all/src/main/java/org/infinispan/commons/logging/Log.java
@@ -5,6 +5,7 @@ import static org.jboss.logging.Logger.Level.INFO;
 import static org.jboss.logging.Logger.Level.WARN;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.EnumSet;
 
 import org.infinispan.commons.CacheConfigurationException;
@@ -291,6 +292,14 @@ public interface Log extends BasicLogger {
 
    @Message(value = "Invalid value %s for attribute %s: must be a number less than " + Integer.MAX_VALUE, id = 971)
    CacheConfigurationException attributeMustBeAnInteger(Number value, Enum<?> attribute);
+
+   @LogMessage(level = INFO)
+   @Message(value = "Task '%s', pending (%d) tasks, last check had (%d), task status is %s", id = 972)
+   void taskProgression(String name, long pending, long lastCheck, String status);
+
+   @LogMessage(level = INFO)
+   @Message(value = "Task '%s' started at %s and done %s", id = 973)
+   void taskDone(String name, Instant started, Instant completed);
 
    @Message(value = "Cannot instantiate class '%s'", id = 29523)
    CacheConfigurationException cannotInstantiateClass(String classname, @Suppressed Throwable t);

--- a/commons/all/src/main/java/org/infinispan/commons/logging/LogFactory.java
+++ b/commons/all/src/main/java/org/infinispan/commons/logging/LogFactory.java
@@ -1,5 +1,7 @@
 package org.infinispan.commons.logging;
 
+import java.lang.invoke.MethodHandles;
+
 import org.jboss.logging.Logger;
 
 /**
@@ -16,5 +18,9 @@ public class LogFactory {
 
    public static <T> T getLog(Class<?> clazz, Class<T> logClass) {
       return Logger.getMessageLogger(logClass, clazz.getName());
+   }
+
+   public static Log getLog(String category) {
+      return Logger.getMessageLogger(MethodHandles.lookup(), Log.class, Log.LOG_ROOT + category);
    }
 }

--- a/commons/all/src/main/java/org/infinispan/commons/util/ProgressTracker.java
+++ b/commons/all/src/main/java/org/infinispan/commons/util/ProgressTracker.java
@@ -1,0 +1,171 @@
+package org.infinispan.commons.util;
+
+import java.time.Instant;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.infinispan.commons.logging.Log;
+import org.infinispan.commons.logging.LogFactory;
+import org.infinispan.commons.time.TimeService;
+
+import net.jcip.annotations.GuardedBy;
+import net.jcip.annotations.ThreadSafe;
+
+@ThreadSafe
+public final class ProgressTracker {
+
+   private static final Log log = LogFactory.getLog("LIFECYCLE");
+
+   private final String name;
+   private final ScheduledExecutorService executor;
+   private final TimeService timeService;
+   private final long delay;
+   private final TimeUnit unit;
+   private final State state;
+
+   public ProgressTracker(String name, ScheduledExecutorService executor, TimeService timeService, long delay, TimeUnit unit) {
+      this.name = name;
+      this.executor = executor;
+      this.timeService = timeService;
+      this.state = new State();
+      this.delay = delay;
+      this.unit = unit;
+   }
+
+   public void addTasks(long value) {
+      state.addTasks(value);
+   }
+
+   public void removeTasks(long value) {
+      state.addTasks(-value);
+   }
+
+   public void finishedAllTasks() {
+      state.completed();
+   }
+
+   public long pendingTasks() {
+      return state.pending();
+   }
+
+   public Progression currentTaskStatus() {
+      return state.status();
+   }
+
+   /**
+    * Holds the internal state of the task progress.
+    *
+    * <p>
+    * This runnable tracks how many operations are pending to verify if it has stall or is progressing. These operations
+    * mutate many variables simultaneously. These operations should happen atomically. To guarantee the correct update,
+    * we utilize a reentrant lock to perform read and write operations.
+    * </p>
+    */
+   @ThreadSafe
+   private final class State implements Runnable {
+      private final Lock lock = new ReentrantLock();
+      private long pending;
+      private long lastCheck;
+      private Progression status = Progression.IDLE;
+      private Instant startedAt = null;
+      private ScheduledFuture<?> progression;
+
+      public long pending() {
+         lock.lock();
+         try {
+            return pending;
+         } finally {
+            lock.unlock();
+         }
+      }
+
+      public Progression status() {
+         lock.lock();
+         try {
+            return status;
+         } finally {
+            lock.unlock();
+         }
+      }
+
+      public void addTasks(long value) {
+         lock.lock();
+         try {
+            if (value < 0) {
+               if (startedAt == null)
+                  throw new IllegalStateException("Removing tasks from a completed tracker: " + name);
+
+               status = Progression.PROGRESSING;
+            }
+
+            // If the tracker is initializing or restarting, we need to track the time the operations started.
+            if (status == Progression.IDLE || status == Progression.DONE) {
+               startedAt = timeService.instant();
+
+               // The status goes back to idle the first time it reinitialize.
+               status = Progression.IDLE;
+            }
+
+            pending += value;
+
+            if (progression == null)
+               progression = executor.scheduleAtFixedRate(state, delay, delay, unit);
+         } finally {
+            lock.unlock();
+         }
+      }
+
+      public void completed() {
+         lock.lock();
+         try {
+            status = Progression.DONE;
+
+            if (startedAt != null)
+               log.taskDone(name, startedAt, timeService.instant());
+
+            reset();
+         } finally {
+            lock.unlock();
+         }
+      }
+
+      @GuardedBy("lock")
+      private void reset() {
+         pending = 0;
+         lastCheck = -1;
+         startedAt = null;
+
+         if (progression != null) {
+            progression.cancel(true);
+            progression = null;
+         }
+      }
+
+      @Override
+      public void run() {
+         lock.lock();
+         try {
+            if (status == Progression.DONE)
+               return;
+
+            if (lastCheck == pending)
+               status = Progression.HANG;
+
+            log.taskProgression(name, pending, lastCheck, status.name());
+            lastCheck = pending;
+         } finally {
+            lock.unlock();
+         }
+      }
+   }
+
+   public enum Progression {
+      IDLE,
+      PROGRESSING,
+      HANG,
+      DONE,
+   }
+}

--- a/commons/all/src/test/java/org/infinispan/commons/util/ProgressTrackerTest.java
+++ b/commons/all/src/test/java/org/infinispan/commons/util/ProgressTrackerTest.java
@@ -1,0 +1,85 @@
+package org.infinispan.commons.util;
+
+import static org.infinispan.commons.test.Eventually.eventually;
+import static org.junit.Assert.assertEquals;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.infinispan.commons.time.ControlledTimeService;
+import org.junit.AfterClass;
+import org.junit.Test;
+
+public class ProgressTrackerTest {
+
+   private static final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+
+   @AfterClass
+   public static void stopExecutor() {
+      executor.shutdown();
+   }
+
+   @Test
+   public void testStartingAndCompletingTracker() {
+      ProgressTracker tracker = new ProgressTracker("name", executor, new ControlledTimeService(), 10, TimeUnit.MINUTES);
+
+      tracker.addTasks(5);
+      assertEquals(5, tracker.pendingTasks());
+
+      tracker.removeTasks(3);
+      assertEquals(2, tracker.pendingTasks());
+
+      tracker.finishedAllTasks();
+      assertEquals(0, tracker.pendingTasks());
+   }
+
+   @Test
+   public void testStartAndComplete() {
+      ProgressTracker tracker = new ProgressTracker("name", executor, new ControlledTimeService(), 10, TimeUnit.MINUTES);
+
+      tracker.addTasks(5);
+      assertEquals(5, tracker.pendingTasks());
+
+      tracker.removeTasks(5);
+      assertEquals(0, tracker.pendingTasks());
+
+      assertEquals(ProgressTracker.Progression.PROGRESSING, tracker.currentTaskStatus());
+
+      tracker.finishedAllTasks();
+      assertEquals(0, tracker.pendingTasks());
+      assertEquals(ProgressTracker.Progression.DONE, tracker.currentTaskStatus());
+   }
+
+   @Test
+   public void testTaskMovesToHang() {
+      ProgressTracker tracker = new ProgressTracker("name", executor, new ControlledTimeService(), 500, TimeUnit.MILLISECONDS);
+
+      tracker.addTasks(5);
+      assertEquals(ProgressTracker.Progression.IDLE, tracker.currentTaskStatus());
+
+      tracker.addTasks(-2);
+      assertEquals(ProgressTracker.Progression.PROGRESSING, tracker.currentTaskStatus());
+
+      eventually(() -> tracker.currentTaskStatus() == ProgressTracker.Progression.HANG, 2, TimeUnit.SECONDS);
+
+      tracker.finishedAllTasks();
+      assertEquals(ProgressTracker.Progression.DONE, tracker.currentTaskStatus());
+   }
+
+   @Test
+   public void testTrackerIsReUtilized() {
+      ProgressTracker tracker = new ProgressTracker("name", executor, new ControlledTimeService(), 10, TimeUnit.MINUTES);
+
+      for (int i = 0; i < 3; i++) {
+         tracker.addTasks(5);
+         assertEquals(ProgressTracker.Progression.IDLE, tracker.currentTaskStatus());
+
+         tracker.addTasks(-2);
+         assertEquals(ProgressTracker.Progression.PROGRESSING, tracker.currentTaskStatus());
+
+         tracker.finishedAllTasks();
+         assertEquals(ProgressTracker.Progression.DONE, tracker.currentTaskStatus());
+      }
+   }
+}

--- a/core/src/main/java/org/infinispan/persistence/sifs/Compactor.java
+++ b/core/src/main/java/org/infinispan/persistence/sifs/Compactor.java
@@ -204,7 +204,7 @@ class Compactor {
       // We have to copy the file ids into its own collection because it can pickup the compactor files sometimes
       // causing extra unneeded churn in some cases
       Set<Integer> currentFiles = new HashSet<>();
-      try (CloseableIterator<Integer> iter = fileProvider.getFileIterator()) {
+      try (CloseableIterator<Integer> iter = fileProvider.getFileIterator(null)) {
          while (iter.hasNext()) {
             currentFiles.add(iter.next());
          }

--- a/core/src/main/java/org/infinispan/persistence/sifs/FileProvider.java
+++ b/core/src/main/java/org/infinispan/persistence/sifs/FileProvider.java
@@ -25,6 +25,7 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.infinispan.commons.util.CloseableIterator;
+import org.infinispan.commons.util.ProgressTracker;
 import org.infinispan.persistence.sifs.pmem.PmemUtilWrapper;
 import org.infinispan.util.logging.LogFactory;
 
@@ -274,7 +275,7 @@ public class FileProvider {
       }
    }
 
-   public CloseableIterator<Integer> getFileIterator() {
+   public CloseableIterator<Integer> getFileIterator(ProgressTracker tracker) {
       String regex = String.format(REGEX_FORMAT, prefix);
       lock.readLock().lock();
       try {
@@ -284,6 +285,7 @@ public class FileProvider {
                set.add(Integer.parseInt(file.substring(prefix.length())));
             }
          }
+         if (tracker != null && !set.isEmpty()) tracker.addTasks(set.size());
          FileIterator iterator = new FileIterator(set.iterator());
          iterators.add(iterator);
          return iterator;

--- a/core/src/main/java/org/infinispan/persistence/sifs/NonBlockingSoftIndexFileStore.java
+++ b/core/src/main/java/org/infinispan/persistence/sifs/NonBlockingSoftIndexFileStore.java
@@ -1,5 +1,6 @@
 package org.infinispan.persistence.sifs;
 
+import static org.infinispan.factories.KnownComponentNames.TIMEOUT_SCHEDULE_EXECUTOR;
 import static org.infinispan.persistence.PersistenceUtil.getQualifiedLocation;
 import static org.infinispan.util.logging.Log.PERSISTENCE;
 
@@ -14,6 +15,8 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
@@ -31,6 +34,7 @@ import org.infinispan.commons.util.ByRef;
 import org.infinispan.commons.util.CloseableIterator;
 import org.infinispan.commons.util.IntSet;
 import org.infinispan.commons.util.IntSets;
+import org.infinispan.commons.util.ProgressTracker;
 import org.infinispan.commons.util.Util;
 import org.infinispan.commons.util.concurrent.CompletableFutures;
 import org.infinispan.commons.util.concurrent.CompletionStages;
@@ -38,6 +42,7 @@ import org.infinispan.commons.util.concurrent.FileSystemLock;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.container.entries.ExpiryHelper;
 import org.infinispan.distribution.ch.KeyPartitioner;
+import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.metadata.Metadata;
 import org.infinispan.metadata.impl.PrivateMetadata;
 import org.infinispan.persistence.sifs.configuration.SoftIndexFileStoreConfiguration;
@@ -154,6 +159,7 @@ public class NonBlockingSoftIndexFileStore<K, V> implements NonBlockingStore<K, 
    private ActionSequencer sizeAndClearSequencer;
    private KeyPartitioner keyPartitioner;
    private InitializationContext ctx;
+   private ProgressTracker progressTracker;
 
    @Override
    public Set<Characteristic> characteristics() {
@@ -225,6 +231,11 @@ public class NonBlockingSoftIndexFileStore<K, V> implements NonBlockingStore<K, 
       logAppender.start(blockingManager.asExecutor("sifs-log-processor"));
       startIndex();
       final AtomicLong maxSeqId = new AtomicLong(0);
+      TimeService ts = ComponentRegistry.componentOf(ctx.getCache(), TimeService.class);
+      ScheduledExecutorService timeoutExecutor = ComponentRegistry.componentOf(ctx.getCache(), ScheduledExecutorService.class, TIMEOUT_SCHEDULE_EXECUTOR);
+      Configuration cfg = ComponentRegistry.of(ctx.getCache()).getConfiguration();
+      long timeout = cfg.clustering().remoteTimeout();
+      progressTracker = new ProgressTracker("sifs-task", timeoutExecutor, ts, timeout, TimeUnit.MILLISECONDS);
 
       return blockingManager.runBlocking(() -> {
          boolean migrateData = false;
@@ -332,7 +343,7 @@ public class NonBlockingSoftIndexFileStore<K, V> implements NonBlockingStore<K, 
       }
       // Only update the key/value/meta bytes if the default marshaller is configured
       boolean transformationRequired = ctx.getGlobalConfiguration().serialization().marshaller() == null;
-      try(CloseableIterator<Integer> it = oldFileProvider.getFileIterator()) {
+      try(CloseableIterator<Integer> it = oldFileProvider.getFileIterator(null)) {
          while (it.hasNext()) {
             int fileId = it.next();
             try (FileProvider.Handle handle = oldFileProvider.getFile(fileId)) {
@@ -421,7 +432,10 @@ public class NonBlockingSoftIndexFileStore<K, V> implements NonBlockingStore<K, 
                      index.handleRequest(IndexRequest.update(segment, key, ByteBufferImpl.create(serializedKey), file, offset, size));
                   }
                   return null;
-               }).doOnComplete(() -> compactor.completeFile(outerFile, -1, nextExpirationTime.get(), false));
+               }).doOnComplete(() -> {
+                  progressTracker.removeTasks(1);
+                  compactor.completeFile(outerFile, -1, nextExpirationTime.get(), false);
+               });
       }).ignoreElements().toCompletionStage(null);
       CompletionStages.join(stage);
    }
@@ -489,6 +503,7 @@ public class NonBlockingSoftIndexFileStore<K, V> implements NonBlockingStore<K, 
             fileProvider.stop();
             fileProvider = null;
             temporaryTable = null;
+            progressTracker.finishedAllTasks();
          } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw log.interruptedWhileStopping(e);
@@ -732,10 +747,13 @@ public class NonBlockingSoftIndexFileStore<K, V> implements NonBlockingStore<K, 
    }
 
    private Flowable<Integer> filePublisher() {
-      return Flowable.using(fileProvider::getFileIterator, it -> Flowable.fromIterable(() -> it),
-            // This close happens after the lasst file iterator is returned, but before processing it.
+      return Flowable.using(() -> fileProvider.getFileIterator(progressTracker), it -> Flowable.fromIterable(() -> it),
+            // This close happens after the last file iterator is returned, but before processing it.
             // TODO: Is this okay or can compaction etc affect this?
-            CloseableIterator::close);
+            it -> {
+         progressTracker.finishedAllTasks();
+         it.close();
+      });
    }
 
    private <R> Flowable<R> handleFilePublisher(int file, boolean fetchValue, boolean fetchMetadata,

--- a/query/src/main/java/org/infinispan/query/impl/ComponentRegistryUtils.java
+++ b/query/src/main/java/org/infinispan/query/impl/ComponentRegistryUtils.java
@@ -1,5 +1,9 @@
 package org.infinispan.query.impl;
 
+import static org.infinispan.factories.KnownComponentNames.TIMEOUT_SCHEDULE_EXECUTOR;
+
+import java.util.concurrent.ScheduledExecutorService;
+
 import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
 import org.infinispan.commons.time.TimeService;
@@ -27,9 +31,9 @@ public final class ComponentRegistryUtils {
    private ComponentRegistryUtils() {
    }
 
-   private static <T> T getRequiredComponent(Cache<?, ?> cache, Class<T> clazz) {
+   private static <T> T getRequiredComponent(Cache<?, ?> cache, Class<T> clazz, String name) {
       ComponentRegistry componentRegistry = SecurityActions.getCacheComponentRegistry(cache.getAdvancedCache());
-      T component = componentRegistry.getComponent(clazz, clazz.getName());
+      T component = componentRegistry.getComponent(clazz, name == null ? clazz.getName() : name);
       if (component == null) {
          throw new IllegalStateException(clazz.getName() + " not found in component registry");
       }
@@ -49,12 +53,12 @@ public final class ComponentRegistryUtils {
    }
 
    public static KeyPartitioner getKeyPartitioner(Cache<?, ?> cache) {
-      return getRequiredComponent(cache, KeyPartitioner.class);
+      return getRequiredComponent(cache, KeyPartitioner.class, null);
    }
 
    public static QueryInterceptor getQueryInterceptor(Cache<?, ?> cache) {
       ensureIndexed(cache);
-      return getRequiredComponent(cache, QueryInterceptor.class);
+      return getRequiredComponent(cache, QueryInterceptor.class, null);
    }
 
    public static LocalQueryStatistics getLocalQueryStatistics(Cache<?, ?> cache) {
@@ -67,15 +71,19 @@ public final class ComponentRegistryUtils {
 
    public static KeyTransformationHandler getKeyTransformationHandler(Cache<?, ?> cache) {
       ensureIndexed(cache);
-      return getRequiredComponent(cache, KeyTransformationHandler.class);
+      return getRequiredComponent(cache, KeyTransformationHandler.class, null);
    }
 
    public static QueryEngine<Class<?>> getEmbeddedQueryEngine(Cache<?, ?> cache) {
-      return getRequiredComponent(cache, QueryEngine.class);
+      return getRequiredComponent(cache, QueryEngine.class, null);
    }
 
    public static TimeService getTimeService(Cache<?, ?> cache) {
-      return getRequiredComponent(cache, TimeService.class);
+      return getRequiredComponent(cache, TimeService.class, null);
+   }
+
+   public static ScheduledExecutorService getTimeoutScheduledExecutor(Cache<?, ?> cache) {
+      return getRequiredComponent(cache, ScheduledExecutorService.class, TIMEOUT_SCHEDULE_EXECUTOR);
    }
 
    /**
@@ -87,10 +95,10 @@ public final class ComponentRegistryUtils {
 
    public static Indexer getIndexer(AdvancedCache<?, ?> cache) {
       ensureIndexed(cache);
-      return getRequiredComponent(cache, Indexer.class);
+      return getRequiredComponent(cache, Indexer.class, null);
    }
 
    public static InfinispanQueryStatisticsInfo getQueryStatistics(AdvancedCache<?, ?> cache) {
-      return getRequiredComponent(cache, InfinispanQueryStatisticsInfo.class);
+      return getRequiredComponent(cache, InfinispanQueryStatisticsInfo.class, null);
    }
 }

--- a/query/src/main/java/org/infinispan/query/impl/massindex/IndexWorker.java
+++ b/query/src/main/java/org/infinispan/query/impl/massindex/IndexWorker.java
@@ -7,15 +7,19 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
 import org.infinispan.AdvancedCache;
 import org.infinispan.commons.marshall.ProtoStreamTypeIds;
 import org.infinispan.commons.time.TimeService;
+import org.infinispan.commons.util.ProgressTracker;
 import org.infinispan.commons.util.concurrent.AggregateCompletionStage;
 import org.infinispan.commons.util.concurrent.CompletableFutures;
 import org.infinispan.commons.util.concurrent.CompletionStages;
+import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.context.Flag;
 import org.infinispan.distribution.ch.KeyPartitioner;
@@ -84,20 +88,24 @@ public final class IndexWorker implements Function<EmbeddedCacheManager, Void> {
       DataConversion valueDataConversion = cache.getValueDataConversion();
 
       AdvancedCache<Object, Object> reindexCache = cache.withStorageMediaType();
-      boolean javaEmbeddedEntities = SecurityActions.getCacheConfiguration(reindexCache).indexing().useJavaEmbeddedEntities();
+      Configuration cfg = SecurityActions.getCacheConfiguration(reindexCache);
+      boolean javaEmbeddedEntities = cfg.indexing().useJavaEmbeddedEntities();
 
       SearchMapping searchMapping = ComponentRegistryUtils.getSearchMapping(cache);
       TimeService timeService = ComponentRegistryUtils.getTimeService(cache);
+      ScheduledExecutorService timeoutExecutor = ComponentRegistryUtils.getTimeoutScheduledExecutor(cache);
 
       MassIndexerProgressNotifier notifier = new MassIndexerProgressNotifier(searchMapping, timeService);
+      ProgressTracker progressTracker = new ProgressTracker("query-indexer", timeoutExecutor, timeService, cfg.clustering().remoteTimeout(), TimeUnit.MILLISECONDS);
       IndexUpdater indexUpdater = new IndexUpdater(searchMapping);
       KeyPartitioner keyPartitioner = ComponentRegistryUtils.getKeyPartitioner(cache);
 
       if (keys == null || keys.isEmpty()) {
          preIndex(cache, indexUpdater, notifier);
-         MassIndexerProgressState progressState = new MassIndexerProgressState(notifier);
+         MassIndexerProgressState progressState = new MassIndexerProgressState(notifier, progressTracker);
 
          if (!skipIndex) {
+            progressTracker.addTasks(reindexCache.withFlags(Flag.CACHE_MODE_LOCAL).size());
             try (Stream<CacheEntry<Object, Object>> stream = reindexCache.getAdvancedCache().withFlags(Flag.CACHE_MODE_LOCAL)
                   .cacheEntrySet().stream()) {
                Iterator<UpdateRecord> records = stream.map(entry -> {
@@ -125,6 +133,8 @@ public final class IndexWorker implements Function<EmbeddedCacheManager, Void> {
          Set<Class<?>> classSet = new HashSet<>(keys.size());
          AggregateCompletionStage<Void> updates = CompletionStages.aggregateCompletionStage();
 
+         progressTracker.addTasks(keys.size());
+
          for (Object key : keys) {
             Object storedKey = keyDataConversion.toStorage(key);
             Object unwrappedKey = keyDataConversion.extractIndexable(storedKey, javaEmbeddedEntities);
@@ -141,6 +151,7 @@ public final class IndexWorker implements Function<EmbeddedCacheManager, Void> {
             indexUpdater.refresh(classSet);
          }
       }
+      progressTracker.finishedAllTasks();
       return null;
    }
 

--- a/query/src/main/java/org/infinispan/query/impl/massindex/MassIndexerProgressState.java
+++ b/query/src/main/java/org/infinispan/query/impl/massindex/MassIndexerProgressState.java
@@ -3,19 +3,22 @@ package org.infinispan.query.impl.massindex;
 import java.util.concurrent.CompletableFuture;
 
 import org.hibernate.search.util.common.impl.Futures;
+import org.infinispan.commons.util.ProgressTracker;
 import org.infinispan.query.core.impl.Log;
 import org.infinispan.util.logging.LogFactory;
 
-public class MassIndexerProgressState {
+class MassIndexerProgressState {
 
    private static final Log LOG = LogFactory.getLog(IndexUpdater.class, Log.class);
 
    private final MassIndexerProgressNotifier notifier;
+   private final ProgressTracker progressTracker;
 
    private CompletableFuture<?> lastFuture = CompletableFuture.completedFuture( null );
 
-   public MassIndexerProgressState(MassIndexerProgressNotifier notifier) {
+   public MassIndexerProgressState(MassIndexerProgressNotifier notifier, ProgressTracker progressTracker) {
       this.notifier = notifier;
+      this.progressTracker = progressTracker;
    }
 
    public void addItem(Object key, Object value, CompletableFuture<?> future) {
@@ -26,6 +29,7 @@ public class MassIndexerProgressState {
          } else {
             notifier.notifyDocumentsAdded(1);
          }
+         progressTracker.removeTasks(1);
       }).thenCombine(lastFuture, (ignored1, ignored2) -> null);
    }
 

--- a/tools/src/main/java/org/infinispan/tools/store/migrator/file/SoftIndexFileStoreIterator.java
+++ b/tools/src/main/java/org/infinispan/tools/store/migrator/file/SoftIndexFileStoreIterator.java
@@ -67,7 +67,7 @@ public class SoftIndexFileStoreIterator implements StoreIterator {
             this.fileProvider = new FileProvider(location, 1000, prefix, 1024 * 1024);
             this.reader = EntryRecord::readEntryHeader;
          }
-         this.iterator = fileProvider.getFileIterator();
+         this.iterator = fileProvider.getFileIterator(null);
       }
 
       @Override


### PR DESCRIPTION
The tracker will receive the expected number of operations still pending to perform and will gradually reach zero. The timeout executor will output how many tasks are still pending and whether it has progressed since the last check.

Currently, I am wrapping:

* State transfer: keep track of outstanding requests for segments. This is the same metric we expose.
* SIFS: the index rebuild, we track the number of files pending.
* Query indexer: tracks the number of keys still pending. This does a `.size()` operation with a LOCAL flag :(

Closes #14804 
