### PR TITLE
[15.0.x] [#14815] RESP documentation page fix

### DIFF
--- a/documentation/src/main/asciidoc/stories/assembly_resp_endpoint.adoc
+++ b/documentation/src/main/asciidoc/stories/assembly_resp_endpoint.adoc
@@ -1,8 +1,8 @@
 [id='resp-endpoint']
 :context: resp-endpoint
 
-include::{topics}/proc_server_configuring_resp.adoc
-include::{topics}/proc_server_resp_databases.adoc[leveloffset=+2]
+include::{topics}/proc_server_configuring_resp.adoc[leveloffset=+1]
+include::{topics}/proc_server_resp_databases.adoc[leveloffset=+1]
 include::{topics}/proc_server_resp_differences.adoc[leveloffset=+1]
 include::{topics}/ref_redis_commands.adoc[leveloffset=+1]
 


### PR DESCRIPTION
**Backport:** https://github.com/infinispan/infinispan/pull/14816

Closes #14815.