### PR TITLE
[15.2.x] [#14820] Size method with a local cache and store is not optimized

### DIFF
--- a/core/src/main/java/org/infinispan/persistence/sifs/Index.java
+++ b/core/src/main/java/org/infinispan/persistence/sifs/Index.java
@@ -240,6 +240,18 @@ class Index {
     * @return True if the index was loaded from well persisted state
     */
    public boolean load() {
+      boolean loaded = attemptLoad();
+
+      // If we failed to load any of the index we have to make sure the sizer per segment is cleared
+      if (!loaded) {
+         for (int i = 0; i < sizePerSegment.length(); ++i) {
+            sizePerSegment.set(i, 0);
+         }
+      }
+      return loaded;
+   }
+
+   private boolean attemptLoad() {
       if (!checkForExistingIndexSizeFile()) {
          return false;
       }

--- a/core/src/test/java/org/infinispan/expiration/impl/ExpirationFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/expiration/impl/ExpirationFunctionalTest.java
@@ -16,6 +16,7 @@ import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.StorageType;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.context.Flag;
 import org.infinispan.expiration.ExpirationManager;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.protostream.annotations.ProtoFactory;
@@ -116,7 +117,7 @@ public class ExpirationFunctionalTest extends SingleCacheManagerTest {
          cache.put("key-" + i, "value-" + i, 1, TimeUnit.MILLISECONDS);
       }
       timeService.advance(2);
-      assertEquals(0, cache.size());
+      assertEquals(0, cache.getAdvancedCache().withFlags(Flag.SKIP_SIZE_OPTIMIZATION).size());
    }
 
    protected int maxInMemory() {

--- a/core/src/test/java/org/infinispan/persistence/dummy/DummyInMemoryStore.java
+++ b/core/src/test/java/org/infinispan/persistence/dummy/DummyInMemoryStore.java
@@ -468,6 +468,10 @@ public class DummyInMemoryStore<K, V> implements WaitNonBlockingStore<K, V> {
    private long actualSize(IntSet segments) {
       record("size");
 
+      if (!configuration.segmented()) {
+         segments = IntSets.immutableSet(0);
+      }
+
       AtomicLong size = new AtomicLong();
       long now = timeService.wallClockTime();
       for (PrimitiveIterator.OfInt iter = segments.iterator(); iter.hasNext(); ) {


### PR DESCRIPTION
**Backport:** https://github.com/infinispan/infinispan/pull/14823

Fixes #14820