### PR TITLE
[#14802] Recovering caches marked as ready

### DIFF
--- a/core/src/main/java/org/infinispan/manager/CacheManagerInfo.java
+++ b/core/src/main/java/org/infinispan/manager/CacheManagerInfo.java
@@ -233,8 +233,11 @@ public class CacheManagerInfo implements JsonSerialization {
          }
 
          // Verify if the component registry isn't in shutdown state.
-         if (!cr.getStatus().allowInvocations())
-            return false;
+         if (!cr.getStatus().allowInvocations()) {
+            // If the cache is recovering from a graceful shutdown we allow it to proceed.
+            LocalTopologyManager ltm = gcr.getLocalTopologyManager();
+            return ltm != null && ltm.isCacheRecoveringShutdown(cacheName);
+         }
 
          // Non-clustered caches accepting invocations will be ready.
          if (!cr.getConfiguration().clustering().cacheMode().isClustered())

--- a/core/src/main/java/org/infinispan/topology/LocalTopologyManager.java
+++ b/core/src/main/java/org/infinispan/topology/LocalTopologyManager.java
@@ -143,4 +143,8 @@ public interface LocalTopologyManager {
     */
    default void assertTopologyStable(String cacheName) { }
 
+   default boolean isCacheRecoveringShutdown(String cacheName) {
+      return false;
+   }
+
 }

--- a/core/src/main/java/org/infinispan/topology/LocalTopologyManagerImpl.java
+++ b/core/src/main/java/org/infinispan/topology/LocalTopologyManagerImpl.java
@@ -879,6 +879,12 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager, GlobalSta
       }
    }
 
+   @Override
+   public boolean isCacheRecoveringShutdown(String cacheName) {
+      LocalCacheStatus cacheStatus = runningCaches.get(cacheName);
+      return cacheStatus != null && cacheStatus.needRecovery() && !cacheStatus.isTopologyRestored();
+   }
+
    private void writeCHState(String cacheName) {
       ScopedPersistentState cacheState = new ScopedPersistentStateImpl(cacheName);
       cacheState.setProperty(GlobalStateManagerImpl.VERSION, Version.getVersion());


### PR DESCRIPTION
* The ready endpoint allow caches waiting for the cluster shutdown procedure to complete as ready.
* The probe must return 200 to continue to the next pod.

