### PR TITLE
[15.0.x] [#14802] Recovering caches marked as ready

### DIFF
--- a/core/src/main/java/org/infinispan/manager/CacheManagerInfo.java
+++ b/core/src/main/java/org/infinispan/manager/CacheManagerInfo.java
@@ -227,8 +227,11 @@ public class CacheManagerInfo implements JsonSerialization {
          }
 
          // Verify if the component registry isn't in shutdown state.
-         if (!cr.getStatus().allowInvocations())
-            return false;
+         if (!cr.getStatus().allowInvocations()) {
+            // If the cache is recovering from a graceful shutdown we allow it to proceed.
+            LocalTopologyManager ltm = gcr.getLocalTopologyManager();
+            return ltm != null && ltm.isCacheRecoveringShutdown(cacheName);
+         }
 
          // Non-clustered caches accepting invocations will be ready.
          if (!cr.getConfiguration().clustering().cacheMode().isClustered())

--- a/core/src/main/java/org/infinispan/topology/LocalTopologyManager.java
+++ b/core/src/main/java/org/infinispan/topology/LocalTopologyManager.java
@@ -143,4 +143,8 @@ public interface LocalTopologyManager {
     */
    default void assertTopologyStable(String cacheName) { }
 
+   default boolean isCacheRecoveringShutdown(String cacheName) {
+      return false;
+   }
+
 }

--- a/core/src/main/java/org/infinispan/topology/LocalTopologyManagerImpl.java
+++ b/core/src/main/java/org/infinispan/topology/LocalTopologyManagerImpl.java
@@ -873,6 +873,12 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager, GlobalSta
       }
    }
 
+   @Override
+   public boolean isCacheRecoveringShutdown(String cacheName) {
+      LocalCacheStatus cacheStatus = runningCaches.get(cacheName);
+      return cacheStatus != null && cacheStatus.needRecovery() && !cacheStatus.isTopologyRestored();
+   }
+
    private void writeCHState(String cacheName) {
       ScopedPersistentState cacheState = new ScopedPersistentStateImpl(cacheName);
       cacheState.setProperty(GlobalStateManagerImpl.VERSION, Version.getVersion());

--- a/server/tests/src/test/java/org/infinispan/server/resilience/GracefulShutdownRestartIT.java
+++ b/server/tests/src/test/java/org/infinispan/server/resilience/GracefulShutdownRestartIT.java
@@ -55,6 +55,37 @@ public class GracefulShutdownRestartIT {
    }
 
    @Test
+   public void testClusterReadyDuringRecovery() {
+      ConfigurationBuilder builder = new ConfigurationBuilder();
+      builder.clustering().cacheMode(CacheMode.DIST_SYNC).persistence().addSingleFileStore().segmented(false);
+      RemoteCache<Object, Object> hotRod = SERVER.hotrod().withServerConfiguration(builder).create();
+
+      populateCache(hotRod);
+
+      RestClientConfigurationBuilder restClientBuilder = new RestClientConfigurationBuilder()
+            .socketTimeout(RestClientConfigurationProperties.DEFAULT_SO_TIMEOUT * 60)
+            .connectionTimeout(RestClientConfigurationProperties.DEFAULT_CONNECT_TIMEOUT * 60);
+      RestClient rest = SERVER.rest().withClientConfiguration(restClientBuilder).get();
+
+      sync(rest.cluster().stop(), 5, TimeUnit.MINUTES).close();
+      ContainerInfinispanServerDriver serverDriver = (ContainerInfinispanServerDriver) SERVER.getServerDriver();
+      Eventually.eventually(
+            "Cluster did not shutdown within timeout",
+            () -> (!serverDriver.isRunning(0) && !serverDriver.isRunning(1)),
+            serverDriver.getTimeout(), 1, TimeUnit.SECONDS);
+
+      for (int i = 0; i < 2; i++) {
+         serverDriver.restart(i);
+
+         try (RestResponse res = sync(rest.server().ready())) {
+            assertThat(res.status()).isEqualTo(200);
+         }
+      }
+
+      assertCacheData(hotRod);
+   }
+
+   @Test
    public void testRebalanceAndRestart() {
       ConfigurationBuilder builder = new ConfigurationBuilder();
       builder.clustering().cacheMode(CacheMode.DIST_SYNC).persistence().addSoftIndexFileStore();


### PR DESCRIPTION
**Backport:** https://github.com/infinispan/infinispan/pull/14869

* The ready endpoint allow caches waiting for the cluster shutdown procedure to complete as ready.
* The probe must return 200 to continue to the next pod.

