### PR TITLE
[#14917] Terminate completes pending cache start exceptionally

### DIFF
--- a/core/src/main/java/org/infinispan/CoreModule.java
+++ b/core/src/main/java/org/infinispan/CoreModule.java
@@ -4,6 +4,7 @@ import org.infinispan.commons.api.Lifecycle;
 import org.infinispan.factories.GlobalComponentRegistry;
 import org.infinispan.factories.annotations.InfinispanModule;
 import org.infinispan.globalstate.GlobalConfigurationManager;
+import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.lifecycle.ModuleLifecycle;
 import org.infinispan.security.PrincipalRoleMapper;
 import org.infinispan.security.RolePermissionMapper;
@@ -26,6 +27,11 @@ public class CoreModule implements ModuleLifecycle {
 
    public static void startLifecycleComponent(GlobalComponentRegistry gcr, Class<?>... klasses) {
       for (Class<?> klass : klasses) {
+         // Cache manager was stopped before all components were started.
+         // Check the manager status because it stops before the global component registry.
+         ComponentStatus status = gcr.getCacheManager().getStatus();
+         if (status.isStopping() || status.isTerminated()) break;
+
          if (gcr.getComponent(klass) instanceof Lifecycle l) {
             l.start();
          }

--- a/core/src/main/java/org/infinispan/factories/GlobalComponentRegistry.java
+++ b/core/src/main/java/org/infinispan/factories/GlobalComponentRegistry.java
@@ -291,7 +291,7 @@ public class GlobalComponentRegistry extends AbstractComponentRegistry {
 
    private void modulesManagerStarted() {
       for (ModuleLifecycle l : moduleLifecycles) {
-         if (state != ComponentStatus.RUNNING) {
+         if (state != ComponentStatus.RUNNING || cacheManager.getStatus().isStopping()) {
             log.tracef("Registry was shut down while performing postStart, ignoring remainder of moduleLifecycle instances.");
             break;
          }

--- a/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
@@ -870,6 +870,12 @@ public class DefaultCacheManager extends InternalCacheManager {
    private void terminate(String cacheName) {
       CompletableFuture<Cache<?, ?>> cacheFuture = this.caches.get(cacheName);
       if (cacheFuture != null) {
+         if (!cacheFuture.isDone()) {
+            ComponentRegistry cr = globalComponentRegistry.getNamedComponentRegistry(cacheName);
+            if (cr != null) cr.stop();
+            cacheFuture.completeExceptionally(log.cacheManagerIsStopping());
+            return;
+         }
          Cache<?, ?> cache = cacheFuture.join();
          if (cache.getStatus().isTerminated()) {
             log.tracef("Ignoring cache %s, it is already terminated.", cacheName);

--- a/core/src/test/java/org/infinispan/manager/CacheManagerTest.java
+++ b/core/src/test/java/org/infinispan/manager/CacheManagerTest.java
@@ -306,8 +306,9 @@ public class CacheManagerTest extends AbstractInfinispanTest {
          Future<?> cacheStartFuture = fork(() -> manager.createCache(CACHE_NAME, new ConfigurationBuilder().build()));
          cacheStartBlocked.get(10, SECONDS);
 
-         Future<?> managerStopFuture = fork(() -> manager.stop());
-         Exceptions.expectException(TimeoutException.class, () -> managerStopBlocked.get(1, SECONDS));
+         // After we call stop in the manager, it should not block.
+         Future<?> managerStopFuture = fork(manager::stop);
+         managerStopBlocked.get(1, SECONDS);
 
          Future<?> cacheStartFuture2 = fork(() -> manager.getCache(CACHE_NAME));
          Exceptions.expectExecutionException(IllegalLifecycleStateException.class, cacheStartFuture2);
@@ -315,7 +316,6 @@ public class CacheManagerTest extends AbstractInfinispanTest {
          cacheStartResumed.complete(null);
          cacheStartFuture.get(10, SECONDS);
 
-         managerStopBlocked.get(10, SECONDS);
          managerStopResumed.complete(null);
          managerStopFuture.get(10, SECONDS);
       } finally {


### PR DESCRIPTION
* Terminate might hang until a cache has started.
* Terminate verifies if the cache has started, and completes exceptionally.

Closes #14917 