### PR TITLE
[15.0.x] [#14905] Don't override JVM args for surefire in integrationtests

### DIFF
--- a/integrationtests/pom.xml
+++ b/integrationtests/pom.xml
@@ -14,10 +14,6 @@
     <description>Infinispan Integration Tests Parent</description>
     <packaging>pom</packaging>
 
-    <properties>
-        <forkJvmArgs>-Xmx500m ${testjvm.commonArgs}</forkJvmArgs>
-    </properties>
-
     <profiles>
         <profile>
             <id>distribution</id>
@@ -38,20 +34,5 @@
             </properties>
         </profile>
     </profiles>
-
-    <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <configuration>
-                        <trimStackTrace>false</trimStackTrace>
-                        <argLine>${forkJvmArgs} ${testjvm.jdkSpecificArgs}</argLine>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-    </build>
 </project>
 


### PR DESCRIPTION
**Backport:** https://github.com/infinispan/infinispan/pull/14906

Closes #14905
