### PR TITLE
[#14963] SIFS may encounter negative size exception on restart

### DIFF
--- a/core/src/main/java/org/infinispan/persistence/sifs/Index.java
+++ b/core/src/main/java/org/infinispan/persistence/sifs/Index.java
@@ -242,8 +242,10 @@ class Index {
    public boolean load() {
       boolean loaded = attemptLoad();
 
-      // If we failed to load any of the index we have to make sure the sizer per segment is cleared
+      // If we failed to load any of the index we have to make sure to clear anything we may have loaded
       if (!loaded) {
+         maxSeqId = -1;
+         compactor.getFileStats().clear();
          for (int i = 0; i < sizePerSegment.length(); ++i) {
             sizePerSegment.set(i, 0);
          }
@@ -773,6 +775,7 @@ class Index {
 
             write(handle, buffer, 0);
          }
+         freeBlocks.clear();
       }
 
       @Override


### PR DESCRIPTION
Fixes #14963

Make sure that when an index is not able to be loaded that all tertiary loaded things are also properly cleared out.