### PR TITLE
[15.0.x] [#14924] GLOBAL components should not start caches in their start method

### DIFF
--- a/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cachemanager/external/Config.java
+++ b/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/cachemanager/external/Config.java
@@ -43,7 +43,7 @@ public class Config {
    @ApplicationScoped
    @SuppressWarnings("unused")
    public EmbeddedCacheManager defaultCacheManager() {
-      EmbeddedCacheManager externalCacheContainerManager = TestCacheManagerFactory.createCacheManager(false);
+      EmbeddedCacheManager externalCacheContainerManager = TestCacheManagerFactory.createCacheManager(true);
 
       // define large configuration
       externalCacheContainerManager.defineConfiguration("large", new ConfigurationBuilder()

--- a/core/src/main/java/org/infinispan/CoreModule.java
+++ b/core/src/main/java/org/infinispan/CoreModule.java
@@ -1,11 +1,43 @@
 package org.infinispan;
 
+import org.infinispan.commons.api.Lifecycle;
+import org.infinispan.factories.GlobalComponentRegistry;
 import org.infinispan.factories.annotations.InfinispanModule;
+import org.infinispan.globalstate.GlobalConfigurationManager;
 import org.infinispan.lifecycle.ModuleLifecycle;
+import org.infinispan.security.PrincipalRoleMapper;
+import org.infinispan.security.RolePermissionMapper;
 
 /**
  * @api.private
  */
 @InfinispanModule(name = "core")
 public class CoreModule implements ModuleLifecycle {
+   @Override
+   public void cacheManagerStarted(GlobalComponentRegistry gcr) {
+      gcr.getComponent(GlobalConfigurationManager.class).postStart();
+      startLifecycleComponent(gcr, RolePermissionMapper.class, PrincipalRoleMapper.class);
+   }
+
+   @Override
+   public void cacheManagerStopping(GlobalComponentRegistry gcr) {
+      stopLifecycleComponent(gcr, RolePermissionMapper.class, PrincipalRoleMapper.class);
+   }
+
+   public static void startLifecycleComponent(GlobalComponentRegistry gcr, Class<?>... klasses) {
+      for (Class<?> klass : klasses) {
+         if (gcr.getComponent(klass) instanceof Lifecycle l) {
+            l.start();
+         }
+      }
+   }
+
+   public static void stopLifecycleComponent(GlobalComponentRegistry gcr, Class<?>... klasses) {
+      for (Class<?> klass : klasses) {
+         if (gcr.getComponent(klass) instanceof Lifecycle l) {
+            l.stop();
+         }
+      }
+   }
+
 }

--- a/core/src/main/java/org/infinispan/cache/impl/CacheImpl.java
+++ b/core/src/main/java/org/infinispan/cache/impl/CacheImpl.java
@@ -1035,6 +1035,7 @@ public class CacheImpl<K, V> implements AdvancedCache<K, V>, InternalCache<K, V>
    )
    public void start() {
       componentRegistry.start();
+      componentRegistry.postStart();
       queryProducer = componentRegistry.getComponent(QueryProducer.class);
 
       if (stateTransferManager != null) {

--- a/core/src/main/java/org/infinispan/cache/impl/SimpleCacheImpl.java
+++ b/core/src/main/java/org/infinispan/cache/impl/SimpleCacheImpl.java
@@ -149,6 +149,7 @@ public class SimpleCacheImpl<K, V> implements AdvancedCache<K, V>, InternalCache
             .lifespan(configuration.expiration().lifespan())
             .maxIdle(configuration.expiration().maxIdle()).build();
       componentRegistry.start();
+      componentRegistry.postStart();
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/factories/ComponentRegistry.java
+++ b/core/src/main/java/org/infinispan/factories/ComponentRegistry.java
@@ -258,7 +258,7 @@ public class ComponentRegistry extends AbstractComponentRegistry {
    }
 
    @Override
-   protected void postStart() {
+   public void postStart() {
       CompletionStages.join(cacheManagerNotifier.notifyCacheStarted(cacheName));
    }
 

--- a/core/src/main/java/org/infinispan/factories/GlobalComponentRegistry.java
+++ b/core/src/main/java/org/infinispan/factories/GlobalComponentRegistry.java
@@ -308,6 +308,7 @@ public class GlobalComponentRegistry extends AbstractComponentRegistry {
       basicComponentRegistry.getComponent(XSiteEventsManager.class).running();
    }
 
+   @Override
    public void postStart() {
       modulesManagerStarted();
    }
@@ -328,6 +329,10 @@ public class GlobalComponentRegistry extends AbstractComponentRegistry {
 
    private void modulesManagerStarted() {
       for (ModuleLifecycle l : moduleLifecycles) {
+         if (state != ComponentStatus.RUNNING) {
+            log.tracef("Registry was shut down while performing postStart, ignoring remainder of moduleLifecycle instances.");
+            break;
+         }
          if (log.isTraceEnabled()) {
             log.tracef("Invoking %s.cacheManagerStarted()", l);
          }

--- a/core/src/main/java/org/infinispan/globalstate/impl/GlobalConfigurationManagerImpl.java
+++ b/core/src/main/java/org/infinispan/globalstate/impl/GlobalConfigurationManagerImpl.java
@@ -25,7 +25,6 @@ import org.infinispan.configuration.parsing.CacheParser;
 import org.infinispan.configuration.parsing.ConfigurationBuilderHolder;
 import org.infinispan.configuration.parsing.ParserRegistry;
 import org.infinispan.factories.annotations.Inject;
-import org.infinispan.factories.annotations.Start;
 import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
 import org.infinispan.globalstate.GlobalConfigurationManager;
@@ -82,8 +81,8 @@ public class GlobalConfigurationManagerImpl implements GlobalConfigurationManage
       return CACHE_SCOPE.equals(scope) || TEMPLATE_SCOPE.equals(scope);
    }
 
-   @Start
-   void start() {
+   @Override
+   public void postStart() {
       switch (configurationManager.getGlobalConfiguration().globalState().configurationStorage()) {
          case IMMUTABLE:
             this.localConfigurationManager = new ImmutableLocalConfigurationStorage();

--- a/core/src/main/java/org/infinispan/security/actions/SecurityActions.java
+++ b/core/src/main/java/org/infinispan/security/actions/SecurityActions.java
@@ -174,4 +174,15 @@ public class SecurityActions {
          return null;
       });
    }
+
+   public static void startManager(EmbeddedCacheManager cacheManager) {
+      doPrivileged(() -> {
+         cacheManager.start();
+         return null;
+      });
+   }
+
+   public static RaftManager getRaftManager(EmbeddedCacheManager ecm) {
+      return doPrivileged(new GetRaftManagerAction(ecm));
+   }
 }

--- a/core/src/main/java/org/infinispan/security/mappers/ClusterPermissionMapper.java
+++ b/core/src/main/java/org/infinispan/security/mappers/ClusterPermissionMapper.java
@@ -8,12 +8,12 @@ import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
 
 import org.infinispan.Cache;
+import org.infinispan.commons.api.Lifecycle;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.context.Flag;
 import org.infinispan.factories.annotations.Inject;
-import org.infinispan.factories.annotations.Start;
 import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -30,7 +30,7 @@ import org.infinispan.security.actions.SecurityActions;
  * @since 14.0
  */
 @Scope(Scopes.GLOBAL)
-public class ClusterPermissionMapper implements MutableRolePermissionMapper {
+public class ClusterPermissionMapper implements MutableRolePermissionMapper, Lifecycle {
    public static final String CLUSTER_PERMISSION_MAPPER_CACHE = "org.infinispan.PERMISSIONS";
    @Inject
    EmbeddedCacheManager cacheManager;
@@ -39,12 +39,15 @@ public class ClusterPermissionMapper implements MutableRolePermissionMapper {
    private Cache<String, Role> clusterPermissionMap;
    private Cache<String, Role> clusterPermissionReadMap;
 
-   @Start
-   void start() {
+   @Override
+   public void start() {
       initializeInternalCache();
       clusterPermissionMap = cacheManager.getCache(CLUSTER_PERMISSION_MAPPER_CACHE);
       clusterPermissionReadMap = clusterPermissionMap.getAdvancedCache().withFlags(Flag.SKIP_CACHE_LOAD, Flag.CACHE_MODE_LOCAL);
    }
+
+   @Override
+   public void stop() { }
 
    private void initializeInternalCache() {
       GlobalConfiguration globalConfiguration = SecurityActions.getCacheManagerConfiguration(cacheManager);

--- a/core/src/main/java/org/infinispan/security/mappers/ClusterRoleMapper.java
+++ b/core/src/main/java/org/infinispan/security/mappers/ClusterRoleMapper.java
@@ -1,13 +1,13 @@
 package org.infinispan.security.mappers;
 
 import org.infinispan.Cache;
+import org.infinispan.commons.api.Lifecycle;
 import org.infinispan.commons.marshall.ProtoStreamTypeIds;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.context.Flag;
 import org.infinispan.factories.annotations.Inject;
-import org.infinispan.factories.annotations.Start;
 import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -35,7 +35,7 @@ import java.util.stream.Collectors;
  * @since 7.0
  */
 @Scope(Scopes.GLOBAL)
-public class ClusterRoleMapper implements MutablePrincipalRoleMapper {
+public class ClusterRoleMapper implements MutablePrincipalRoleMapper, Lifecycle {
    @Inject
    EmbeddedCacheManager cacheManager;
    @Inject
@@ -45,12 +45,15 @@ public class ClusterRoleMapper implements MutablePrincipalRoleMapper {
    private Cache<String, RoleSet> clusterRoleReadMap;
    private NameRewriter nameRewriter = NameRewriter.IDENTITY_REWRITER;
 
-   @Start
-   void start() {
+   @Override
+   public void start() {
       initializeInternalCache();
       clusterRoleMap = cacheManager.getCache(CLUSTER_ROLE_MAPPER_CACHE);
       clusterRoleReadMap = clusterRoleMap.getAdvancedCache().withFlags(Flag.SKIP_CACHE_LOAD, Flag.CACHE_MODE_LOCAL);
    }
+
+   @Override
+   public void stop() { }
 
    @Override
    public Set<String> principalToRoles(Principal principal) {

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -2398,4 +2398,11 @@ public interface Log extends BasicLogger {
    @LogMessage(level = ERROR)
    @Message(value = "Failed to initialize cache: '%s'", id = 708)
    void failedToInitializeCache(String cacheName, @Cause Throwable t);
+
+   @Message(value = "Failed to backup cache `%s` to one or more remote sites: %s", id = 709)
+   String failedToBackupData(String cacheName, String siteMessages);
+
+   @LogMessage(level = ERROR)
+   @Message(value = "Failed to initialize global registry", id = 710)
+   void failedToInitializeGlobalRegistry(@Cause Throwable t);
 }

--- a/core/src/test/java/org/infinispan/api/APINonTxTest.java
+++ b/core/src/test/java/org/infinispan/api/APINonTxTest.java
@@ -78,7 +78,7 @@ public class APINonTxTest extends SingleCacheManagerTest {
       // start a single cache instance
       ConfigurationBuilder c = getDefaultStandaloneCacheConfig(false);
       configure(c);
-      EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(false, TestDataSCI.INSTANCE);
+      EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(true, TestDataSCI.INSTANCE);
       cm.defineConfiguration("test", c.build());
       cache = cm.getCache("test");
       return cm;

--- a/core/src/test/java/org/infinispan/api/AsyncAPITest.java
+++ b/core/src/test/java/org/infinispan/api/AsyncAPITest.java
@@ -21,6 +21,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.infinispan.Cache;
+import org.infinispan.commons.time.ControlledTimeService;
 import org.infinispan.commons.time.TimeService;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.container.entries.InternalCacheEntry;
@@ -31,7 +32,6 @@ import org.infinispan.metadata.Metadata;
 import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
-import org.infinispan.commons.time.ControlledTimeService;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -51,6 +51,7 @@ public class AsyncAPITest extends SingleCacheManagerTest {
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(false);
       TestingUtil.replaceComponent(cm, TimeService.class, timeService, true);
+      cm.start();
       c = cm.getCache();
       return cm;
    }

--- a/core/src/test/java/org/infinispan/api/CacheAPITest.java
+++ b/core/src/test/java/org/infinispan/api/CacheAPITest.java
@@ -44,7 +44,7 @@ public abstract class CacheAPITest extends APINonTxTest {
       cb.locking().isolationLevel(getIsolationLevel());
       addEviction(cb);
       amend(cb);
-      EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(false);
+      EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(true);
       cm.defineConfiguration("test", cb.build());
       cache = cm.getCache("test");
       return cm;

--- a/core/src/test/java/org/infinispan/api/MetadataAPITest.java
+++ b/core/src/test/java/org/infinispan/api/MetadataAPITest.java
@@ -39,7 +39,7 @@ public class MetadataAPITest extends SingleCacheManagerTest {
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
-      EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(false);
+      EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(true);
       advCache = cm.<Integer, String>getCache().getAdvancedCache();
       return cm;
    }

--- a/core/src/test/java/org/infinispan/api/SkipLockingTest.java
+++ b/core/src/test/java/org/infinispan/api/SkipLockingTest.java
@@ -20,7 +20,7 @@ public class SkipLockingTest extends SingleCacheManagerTest {
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
-      return TestCacheManagerFactory.createCacheManager(false);
+      return TestCacheManagerFactory.createCacheManager(true);
    }
 
    public void testSkipLockingAfterPutWithoutTm(Method m) {

--- a/core/src/test/java/org/infinispan/api/TerminatedCacheTest.java
+++ b/core/src/test/java/org/infinispan/api/TerminatedCacheTest.java
@@ -20,7 +20,7 @@ public class TerminatedCacheTest extends SingleCacheManagerTest {
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
-      return TestCacheManagerFactory.createCacheManager(false);
+      return TestCacheManagerFactory.createCacheManager(true);
    }
 
    @Test(expectedExceptions = IllegalLifecycleStateException.class)

--- a/core/src/test/java/org/infinispan/api/batch/AbstractBatchTest.java
+++ b/core/src/test/java/org/infinispan/api/batch/AbstractBatchTest.java
@@ -20,7 +20,7 @@ public abstract class AbstractBatchTest extends SingleCacheManagerTest {
 
    @Override
    public EmbeddedCacheManager createCacheManager() {
-      return TestCacheManagerFactory.createCacheManager(false);
+      return TestCacheManagerFactory.createCacheManager(true);
    }
 
    public void testClearInBatch(Method method) {

--- a/core/src/test/java/org/infinispan/api/lazy/LazyCacheAPITest.java
+++ b/core/src/test/java/org/infinispan/api/lazy/LazyCacheAPITest.java
@@ -25,7 +25,7 @@ public class LazyCacheAPITest extends SingleCacheManagerTest {
       // start a single cache instance
       ConfigurationBuilder c = getDefaultStandaloneCacheConfig(true);
       c.memory().storageType(StorageType.BINARY);
-      EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(false, TestDataSCI.INSTANCE);
+      EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(true, TestDataSCI.INSTANCE);
       cm.defineConfiguration("lazy-cache-test", c.build());
       cache = cm.getCache("lazy-cache-test");
       return cm;

--- a/core/src/test/java/org/infinispan/configuration/XSiteInlineConfigFileParsingTest.java
+++ b/core/src/test/java/org/infinispan/configuration/XSiteInlineConfigFileParsingTest.java
@@ -28,7 +28,7 @@ public class XSiteInlineConfigFileParsingTest extends SingleCacheManagerTest {
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       ConfigurationBuilderHolder holder = TestCacheManagerFactory.parseFile(FILE_NAME, false);
       TransportFlags flags = new TransportFlags().withPreserveConfig(true);
-      return TestCacheManagerFactory.createClusteredCacheManager(false, holder, flags);
+      return TestCacheManagerFactory.createClusteredCacheManager(true, holder, flags);
    }
 
    public void testInlineConfiguration() {

--- a/core/src/test/java/org/infinispan/distribution/rehash/NonTxBackupOwnerBecomingPrimaryOwnerTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/NonTxBackupOwnerBecomingPrimaryOwnerTest.java
@@ -141,6 +141,7 @@ public class NonTxBackupOwnerBecomingPrimaryOwnerTest extends MultipleCacheManag
       EmbeddedCacheManager cm = createClusteredCacheManager(false, globalBuilder, c, new TransportFlags());
       registerCacheManager(cm);
       addBlockingLocalTopologyManager(manager(2), checkPoint, joinTopologyId, stateReceivedTopologyId);
+      cm.start();
 
 
       log.tracef("Starting the cache on the joiner");

--- a/core/src/test/java/org/infinispan/expiration/impl/ExpirationFileStoreDistListenerFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/expiration/impl/ExpirationFileStoreDistListenerFunctionalTest.java
@@ -116,6 +116,7 @@ public class ExpirationFileStoreDistListenerFunctionalTest extends ExpirationSto
       extraManager = createClusteredCacheManager(false, globalBuilder, builder, new TransportFlags());
       // Inject our time service into the new CacheManager as well
       TestingUtil.replaceComponent(extraManager, TimeService.class, timeService, true);
+      extraManager.start();
       extraCache = extraManager.getCache();
 
       globalBuilder = GlobalConfigurationBuilder.defaultClusteredBuilder();
@@ -128,6 +129,7 @@ public class ExpirationFileStoreDistListenerFunctionalTest extends ExpirationSto
       // Unfortunately we can't reinject timeservice once a cache has been started, thus we have to inject
       // here as well, since we need the cache to verify the cluster was formed
       TestingUtil.replaceComponent(returned, TimeService.class, timeService, true);
+      returned.start();
       Cache<Object, Object> checkCache = returned.getCache();
       TestingUtil.blockUntilViewReceived(checkCache, 2, TimeUnit.SECONDS.toMillis(10));
       return returned;

--- a/core/src/test/java/org/infinispan/expiration/impl/ExpirationFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/expiration/impl/ExpirationFunctionalTest.java
@@ -66,6 +66,7 @@ public class ExpirationFunctionalTest extends SingleCacheManagerTest {
       // Create the cache manager, but don't start it until we replace the time service
       EmbeddedCacheManager cm = createCacheManager(builder);
       TestingUtil.replaceComponent(cm, TimeService.class, timeService, true);
+      cm.start();
       cache = cm.getCache();
       expirationManager = cache.getAdvancedCache().getExpirationManager();
       afterCacheCreated(cm);

--- a/core/src/test/java/org/infinispan/expiry/ExpiryTest.java
+++ b/core/src/test/java/org/infinispan/expiry/ExpiryTest.java
@@ -43,7 +43,7 @@ public class ExpiryTest extends AbstractInfinispanTest {
 
    @BeforeMethod
    public void setUp() {
-      cm = TestCacheManagerFactory.createCacheManager(false);
+      cm = TestCacheManagerFactory.createCacheManager(true);
       timeService = new ControlledTimeService();
       TestingUtil.replaceComponent(cm, TimeService.class, timeService, true);
    }

--- a/core/src/test/java/org/infinispan/functional/distribution/rehash/FunctionalTxTest.java
+++ b/core/src/test/java/org/infinispan/functional/distribution/rehash/FunctionalTxTest.java
@@ -116,6 +116,7 @@ public class FunctionalTxTest extends MultipleCacheManagersTest {
                                                             cb, new TransportFlags());
       registerCacheManager(cm);
       Future<?> future = fork(() -> {
+         cm.start();
          cache(3);
       });
 
@@ -150,6 +151,7 @@ public class FunctionalTxTest extends MultipleCacheManagersTest {
                                                             cb, new TransportFlags());
       registerCacheManager(cm);
       Future<?> future = fork(() -> {
+         cm.start();
          cache(3);
       });
 

--- a/core/src/test/java/org/infinispan/globalstate/GlobalStateTest.java
+++ b/core/src/test/java/org/infinispan/globalstate/GlobalStateTest.java
@@ -54,8 +54,8 @@ public class GlobalStateTest extends AbstractInfinispanTest {
       GlobalConfigurationBuilder global1 = statefulGlobalBuilder(state1, true);
       String state2 = tmpDirectory(this.getClass().getSimpleName(), m.getName() + "2");
       GlobalConfigurationBuilder global2 = statefulGlobalBuilder(state2, true);
-      EmbeddedCacheManager cm1 = TestCacheManagerFactory.createClusteredCacheManager(false, global1, null, new TransportFlags());
-      EmbeddedCacheManager cm2 = TestCacheManagerFactory.createClusteredCacheManager(false, global2, null, new TransportFlags());
+      EmbeddedCacheManager cm1 = TestCacheManagerFactory.createClusteredCacheManager(true, global1, null, new TransportFlags());
+      EmbeddedCacheManager cm2 = TestCacheManagerFactory.createClusteredCacheManager(true, global2, null, new TransportFlags());
       try {
          Configuration cacheConfig = new ConfigurationBuilder().build();
          Configuration template = new ConfigurationBuilder().template(true).build();
@@ -77,7 +77,7 @@ public class GlobalStateTest extends AbstractInfinispanTest {
          cm2.stop();
 
          global1 = statefulGlobalBuilder(state1, false);
-         EmbeddedCacheManager newCm1 = TestCacheManagerFactory.createClusteredCacheManager(false, global1, new ConfigurationBuilder(), new TransportFlags());
+         EmbeddedCacheManager newCm1 = TestCacheManagerFactory.createClusteredCacheManager(true, global1, new ConfigurationBuilder(), new TransportFlags());
          assertNotNull(newCm1.getCache("replicated-cache"));
          assertNotNull(newCm1.getCacheConfiguration("replicated-template"));
       } finally {
@@ -131,8 +131,8 @@ public class GlobalStateTest extends AbstractInfinispanTest {
       GlobalConfigurationBuilder global1 = statefulGlobalBuilder(state1, true);
       String state2 = tmpDirectory(this.getClass().getSimpleName(), m.getName() + "2");
       GlobalConfigurationBuilder global2 = statefulGlobalBuilder(state2, true);
-      EmbeddedCacheManager cm1 = TestCacheManagerFactory.createClusteredCacheManager(false, global1, new ConfigurationBuilder(), new TransportFlags());
-      EmbeddedCacheManager cm2 = TestCacheManagerFactory.createClusteredCacheManager(false, global2, new ConfigurationBuilder(), new TransportFlags());
+      EmbeddedCacheManager cm1 = TestCacheManagerFactory.createClusteredCacheManager(true, global1, new ConfigurationBuilder(), new TransportFlags());
+      EmbeddedCacheManager cm2 = TestCacheManagerFactory.createClusteredCacheManager(true, global2, new ConfigurationBuilder(), new TransportFlags());
       try {
          cm1.start();
          cm2.start();
@@ -249,7 +249,7 @@ public class GlobalStateTest extends AbstractInfinispanTest {
       // Test the PURGE action by creating a dangling lock file
       global.globalState().uncleanShutdownAction(UncleanShutdownAction.PURGE);
       runHoldingFileLock(state, () -> {
-         EmbeddedCacheManager cmPurge = TestCacheManagerFactory.createClusteredCacheManager(false, global, null, new TransportFlags());
+         EmbeddedCacheManager cmPurge = TestCacheManagerFactory.createClusteredCacheManager(true, global, null, new TransportFlags());
          try {
             cmPurge.start();
          } finally {
@@ -266,7 +266,7 @@ public class GlobalStateTest extends AbstractInfinispanTest {
       // Test the IGNORE action
       global.globalState().uncleanShutdownAction(UncleanShutdownAction.IGNORE);
       runHoldingFileLock(state, () -> {
-         EmbeddedCacheManager cmIgnore = TestCacheManagerFactory.createClusteredCacheManager(false, global, null, new TransportFlags());
+         EmbeddedCacheManager cmIgnore = TestCacheManagerFactory.createClusteredCacheManager(true, global, null, new TransportFlags());
          try {
             cmIgnore.start();
          } finally {
@@ -298,8 +298,8 @@ public class GlobalStateTest extends AbstractInfinispanTest {
       GlobalConfigurationBuilder global1 = statefulGlobalBuilder(state1, true);
       String state2 = tmpDirectory(this.getClass().getSimpleName(), m.getName() + "2");
       GlobalConfigurationBuilder global2 = statefulGlobalBuilder(state2, true);
-      EmbeddedCacheManager cm1 = TestCacheManagerFactory.createClusteredCacheManager(false, global1, null, new TransportFlags());
-      EmbeddedCacheManager cm2 = TestCacheManagerFactory.createClusteredCacheManager(false, global2, null, new TransportFlags());
+      EmbeddedCacheManager cm1 = TestCacheManagerFactory.createClusteredCacheManager(true, global1, null, new TransportFlags());
+      EmbeddedCacheManager cm2 = TestCacheManagerFactory.createClusteredCacheManager(true, global2, null, new TransportFlags());
       try {
          Configuration cacheConfig = new ConfigurationBuilder().build();
          Configuration template = new ConfigurationBuilder().template(true).build();
@@ -327,7 +327,7 @@ public class GlobalStateTest extends AbstractInfinispanTest {
       final String exceptionMessage = String.format("ISPN000663: Name must be less than 256 bytes, current name '%s' exceeds the size.", cacheName);
       String state1 = tmpDirectory(this.getClass().getSimpleName(), m.getName());
       GlobalConfigurationBuilder gcb = statefulGlobalBuilder(state1, true);
-      EmbeddedCacheManager cm = TestCacheManagerFactory.createClusteredCacheManager(false, gcb, null, new TransportFlags());
+      EmbeddedCacheManager cm = TestCacheManagerFactory.createClusteredCacheManager(true, gcb, null, new TransportFlags());
       final Configuration configuration = new ConfigurationBuilder().build();
 
       try {

--- a/core/src/test/java/org/infinispan/lock/APITest.java
+++ b/core/src/test/java/org/infinispan/lock/APITest.java
@@ -197,7 +197,7 @@ public class APITest extends MultipleCacheManagersTest {
    @Test(expectedExceptions = UnsupportedOperationException.class)
    public void testLockOnNonTransactionalCache() {
       withCacheManager(new CacheManagerCallable(
-            TestCacheManagerFactory.createCacheManager(false)) {
+            TestCacheManagerFactory.createCacheManager(true)) {
          @Override
          public void call() {
             cm.getCache().getAdvancedCache().lock("k");

--- a/core/src/test/java/org/infinispan/manager/CacheManagerTest.java
+++ b/core/src/test/java/org/infinispan/manager/CacheManagerTest.java
@@ -89,7 +89,7 @@ public class CacheManagerTest extends AbstractInfinispanTest {
    private static final java.lang.String CACHE_NAME = "name";
 
    public void testDefaultCache() {
-      EmbeddedCacheManager cm = createCacheManager(false);
+      EmbeddedCacheManager cm = createCacheManager(true);
 
       try {
          assertEquals(ComponentStatus.RUNNING, cm.getCache().getStatus());
@@ -125,9 +125,7 @@ public class CacheManagerTest extends AbstractInfinispanTest {
          public void call() {
             assertEquals(ComponentStatus.INSTANTIATED, cm.getStatus());
             assertFalse(cm.getStatus().allowInvocations());
-            Cache<Object, Object> cache = cm.getCache();
-            cache.put("k", "v");
-            assertEquals(cache.get("k"), "v");
+            Exceptions.expectException(IllegalLifecycleStateException.class, cm::getCache);
          }
       });
    }
@@ -160,7 +158,7 @@ public class CacheManagerTest extends AbstractInfinispanTest {
    }
 
    public void testStartAndStop() {
-      EmbeddedCacheManager cm = createCacheManager(false);
+      EmbeddedCacheManager cm = createCacheManager(true);
       try {
          cm.defineConfiguration("cache1", new ConfigurationBuilder().build());
          cm.defineConfiguration("cache2", new ConfigurationBuilder().build());
@@ -225,7 +223,7 @@ public class CacheManagerTest extends AbstractInfinispanTest {
    }
 
    public void testGetCacheNames() {
-      EmbeddedCacheManager cm = createCacheManager(false);
+      EmbeddedCacheManager cm = createCacheManager(true);
       try {
          cm.defineConfiguration("one", new ConfigurationBuilder().build());
          cm.defineConfiguration("two", new ConfigurationBuilder().build());
@@ -242,7 +240,7 @@ public class CacheManagerTest extends AbstractInfinispanTest {
    }
 
    public void testCacheStopTwice() {
-      EmbeddedCacheManager localCacheManager = createCacheManager(false);
+      EmbeddedCacheManager localCacheManager = createCacheManager(true);
       try {
          Cache<String, String> cache = localCacheManager.getCache();
          cache.put("k", "v");
@@ -254,7 +252,7 @@ public class CacheManagerTest extends AbstractInfinispanTest {
    }
 
    public void testCacheManagerStopTwice() {
-      EmbeddedCacheManager localCacheManager = createCacheManager(false);
+      EmbeddedCacheManager localCacheManager = createCacheManager(true);
       try {
          Cache<String, String> cache = localCacheManager.getCache();
          cache.put("k", "v");

--- a/core/src/test/java/org/infinispan/notifications/AsyncNotificationTest.java
+++ b/core/src/test/java/org/infinispan/notifications/AsyncNotificationTest.java
@@ -25,7 +25,7 @@ public class AsyncNotificationTest extends AbstractInfinispanTest {
 
    @BeforeMethod
    public void setUp() {
-      cm = TestCacheManagerFactory.createCacheManager(false);
+      cm = TestCacheManagerFactory.createCacheManager(true);
       c = cm.getCache();
    }
 

--- a/core/src/test/java/org/infinispan/notifications/CacheListenerCacheLoaderTest.java
+++ b/core/src/test/java/org/infinispan/notifications/CacheListenerCacheLoaderTest.java
@@ -27,7 +27,7 @@ public class CacheListenerCacheLoaderTest extends AbstractInfinispanTest {
 
    @BeforeMethod
    public void setUp() {
-      cm = TestCacheManagerFactory.createCacheManager(false);
+      cm = TestCacheManagerFactory.createCacheManager(true);
       ConfigurationBuilder c = new ConfigurationBuilder();
       c.persistence().addStore(DummyInMemoryStoreConfigurationBuilder.class)
          .storeName("no_passivation");

--- a/core/src/test/java/org/infinispan/notifications/CacheListenerRemovalTest.java
+++ b/core/src/test/java/org/infinispan/notifications/CacheListenerRemovalTest.java
@@ -26,7 +26,7 @@ public class CacheListenerRemovalTest extends AbstractInfinispanTest {
 
    @BeforeMethod
    public void setUp() {
-      cm = TestCacheManagerFactory.createCacheManager(false);
+      cm = TestCacheManagerFactory.createCacheManager(true);
       cache = cm.getCache();
    }
 

--- a/core/src/test/java/org/infinispan/notifications/ConcurrentNotificationTest.java
+++ b/core/src/test/java/org/infinispan/notifications/ConcurrentNotificationTest.java
@@ -30,7 +30,7 @@ public class ConcurrentNotificationTest extends AbstractInfinispanTest {
 
    @BeforeMethod
    public void setUp() {
-      cm = TestCacheManagerFactory.createCacheManager(false);
+      cm = TestCacheManagerFactory.createCacheManager(true);
       cache = cm.getCache();
       listener = new CacheListener();
       cache.addListener(listener);

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/CacheListenerVisibilityTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/CacheListenerVisibilityTest.java
@@ -43,7 +43,7 @@ public class CacheListenerVisibilityTest extends SingleCacheManagerTest {
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
-      return TestCacheManagerFactory.createCacheManager(false);
+      return TestCacheManagerFactory.createCacheManager(true);
    }
 
    public void testSizeVisibility() throws Exception {

--- a/core/src/test/java/org/infinispan/notifications/cachemanagerlistener/CacheManagerNotifierTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachemanagerlistener/CacheManagerNotifierTest.java
@@ -43,7 +43,7 @@ public class CacheManagerNotifierTest extends AbstractInfinispanTest {
       ConfigurationBuilderHolder holder = new ConfigurationBuilderHolder();
       holder.getGlobalConfigurationBuilder().clusteredDefault().defaultCacheName("default");
       holder.newConfigurationBuilder("default").clustering().cacheMode(CacheMode.DIST_SYNC);
-      EmbeddedCacheManager cmA = TestCacheManagerFactory.createClusteredCacheManager(false, holder);
+      EmbeddedCacheManager cmA = TestCacheManagerFactory.createClusteredCacheManager(true, holder);
       EmbeddedCacheManager cmB = null;
 
       try {

--- a/core/src/test/java/org/infinispan/persistence/BaseStoreFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/persistence/BaseStoreFunctionalTest.java
@@ -107,11 +107,15 @@ public abstract class BaseStoreFunctionalTest extends SingleCacheManagerTest {
       global.globalState().persistentLocation(CommonsTestingUtil.tmpDirectory(this.getClass()));
       global.serialization().addContextInitializer(getSerializationContextInitializer());
       global.cacheContainer().security().authorization().enable();
-      return createCacheManager(false, global, new ConfigurationBuilder());
+      return createCacheManager(true, global, new ConfigurationBuilder());
    }
 
    protected EmbeddedCacheManager createCacheManager(boolean start, GlobalConfigurationBuilder global, ConfigurationBuilder cb) {
-      return TestCacheManagerFactory.newDefaultCacheManager(start, global, cb);
+      EmbeddedCacheManager embeddedCacheManager = TestCacheManagerFactory.newDefaultCacheManager(false, global, cb);
+      if (start) {
+         TestingUtil.startCacheManager(embeddedCacheManager);
+      }
+      return embeddedCacheManager;
    }
 
    protected SerializationContextInitializer getSerializationContextInitializer() {

--- a/core/src/test/java/org/infinispan/persistence/sifs/SoftIndexFileStoreLockingTest.java
+++ b/core/src/test/java/org/infinispan/persistence/sifs/SoftIndexFileStoreLockingTest.java
@@ -14,7 +14,6 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.PersistenceConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
-import org.infinispan.manager.EmbeddedCacheManagerStartupException;
 import org.infinispan.persistence.spi.PersistenceException;
 import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.TestingUtil;
@@ -45,8 +44,7 @@ public class SoftIndexFileStoreLockingTest extends SingleCacheManagerTest {
       tmpDirectory = CommonsTestingUtil.tmpDirectory(getClass());
       GlobalConfigurationBuilder global = new GlobalConfigurationBuilder();
       global.globalState().persistentLocation(CommonsTestingUtil.tmpDirectory(this.getClass()));
-      global.cacheContainer().security().authorization().enable();
-      EmbeddedCacheManager ecm = TestCacheManagerFactory.newDefaultCacheManager(false, global, new ConfigurationBuilder());
+      EmbeddedCacheManager ecm = TestCacheManagerFactory.newDefaultCacheManager(true, global, new ConfigurationBuilder());
       TestingUtil.defineConfiguration(ecm, CACHE_NAME, createCacheConfiguration().build());
       return ecm;
    }
@@ -81,7 +79,7 @@ public class SoftIndexFileStoreLockingTest extends SingleCacheManagerTest {
 
       // It is not possible to retrieve the running cache.
       Exceptions.expectException("ISPN029025: Failed acquiring lock .*", () -> ecm.getCache(CACHE_NAME),
-            EmbeddedCacheManagerStartupException.class, PersistenceException.class);
+            PersistenceException.class);
       TestingUtil.killCacheManagers(ecm);
 
       // The original cache still works properly.

--- a/core/src/test/java/org/infinispan/statetransfer/ConcurrentStartForkChannelTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/ConcurrentStartForkChannelTest.java
@@ -80,9 +80,15 @@ public class ConcurrentStartForkChannelTest extends MultipleCacheManagersTest {
          // When the coordinator starts first, it's ok to just start the caches in sequence.
          // When the coordinator starts last, however, the other node is not able to start before the
          // coordinator has the ClusterTopologyManager running.
-         Future<Cache<String, String>> c1rFuture = fork(() -> manager(eagerManager).getCache(CACHE_NAME));
+         Future<Cache<String, String>> c1rFuture = fork(() -> {
+            EmbeddedCacheManager m = manager(eagerManager);
+            m.start();
+            return m.getCache(CACHE_NAME);
+         });
          Thread.sleep(1000);
-         Cache<String, String> c2r = manager(lazyManager).getCache(CACHE_NAME);
+         EmbeddedCacheManager m = manager(lazyManager);
+         m.start();
+         Cache<String, String> c2r = m.getCache(CACHE_NAME);
          Cache<String, String> c1r = c1rFuture.get(10, TimeUnit.SECONDS);
 
          blockUntilViewsReceived(10000, cm1, cm2);

--- a/core/src/test/java/org/infinispan/statetransfer/ConcurrentStartTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/ConcurrentStartTest.java
@@ -60,9 +60,9 @@ public class ConcurrentStartTest extends MultipleCacheManagersTest {
       EmbeddedCacheManager cm2 = createCacheManager();
 
       // Install the blocking invocation handlers
-      assertEquals(ComponentStatus.INSTANTIATED, extractGlobalComponentRegistry(cm1).getStatus());
+      assertEquals(ComponentStatus.RUNNING, extractGlobalComponentRegistry(cm1).getStatus());
       replaceInboundInvocationHandler(cm1, checkPoint, 0);
-      assertEquals(ComponentStatus.INSTANTIATED, extractGlobalComponentRegistry(cm2).getStatus());
+      assertEquals(ComponentStatus.RUNNING, extractGlobalComponentRegistry(cm2).getStatus());
       replaceInboundInvocationHandler(cm2, checkPoint, 1);
 
       log.debugf("Cache managers created. Starting the caches");
@@ -106,7 +106,7 @@ public class ConcurrentStartTest extends MultipleCacheManagersTest {
       gcb.transport().defaultTransport();
       TestCacheManagerFactory.amendGlobalConfiguration(gcb, new TransportFlags());
       ConfigurationBuilder defaultCacheConfig = new ConfigurationBuilder();
-      EmbeddedCacheManager cm = TestCacheManagerFactory.newDefaultCacheManager(false, gcb, defaultCacheConfig);
+      EmbeddedCacheManager cm = TestCacheManagerFactory.newDefaultCacheManager(true, gcb, defaultCacheConfig);
       registerCacheManager(cm);
 
       Configuration replCfg = new ConfigurationBuilder().clustering().cacheMode(CacheMode.REPL_SYNC).build();

--- a/core/src/test/java/org/infinispan/statetransfer/ForkChannelRestartTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/ForkChannelRestartTest.java
@@ -114,7 +114,7 @@ public class ForkChannelRestartTest extends MultipleCacheManagersTest {
       gcb.transport().transport(new JGroupsTransport(fch));
       gcb.transport().distributedSyncTimeout(40, TimeUnit.SECONDS);
 
-      EmbeddedCacheManager cm = TestCacheManagerFactory.newDefaultCacheManager(false, gcb, cacheCfg);
+      EmbeddedCacheManager cm = TestCacheManagerFactory.newDefaultCacheManager(true, gcb, cacheCfg);
       registerCacheManager(cm);
       return cm;
    }

--- a/core/src/test/java/org/infinispan/test/TestingUtil.java
+++ b/core/src/test/java/org/infinispan/test/TestingUtil.java
@@ -2013,6 +2013,10 @@ public class TestingUtil {
       SecurityActions.defineConfiguration(cacheManager, cacheName, configuration);
    }
 
+   public static void startCacheManager(EmbeddedCacheManager cacheManager) {
+      SecurityActions.startManager(cacheManager);
+   }
+
    public static Set<Object> getListeners(Cache<?, ?> cache) {
       CacheNotifierImpl<?, ?> notifier = (CacheNotifierImpl<?, ?>) extractComponent(cache, CacheNotifier.class);
       return notifier.getListeners();

--- a/core/src/test/java/org/infinispan/tx/DummyTxTest.java
+++ b/core/src/test/java/org/infinispan/tx/DummyTxTest.java
@@ -32,7 +32,7 @@ public class DummyTxTest extends SingleCacheManagerTest {
    protected static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
 
    protected EmbeddedCacheManager createCacheManager() throws Exception {
-      EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(false);  // also try this test with 'true' so you can tell the difference between DummyTransactionManager and JBoss TM
+      EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(true);  // also try this test with 'true' so you can tell the difference between DummyTransactionManager and JBoss TM
 
       ConfigurationBuilder cb = new ConfigurationBuilder();
       cb.transaction().transactionMode(TransactionMode.TRANSACTIONAL) //default to write-skew

--- a/core/src/test/java/org/infinispan/tx/EntryWrappingInterceptorDoesNotBlockTest.java
+++ b/core/src/test/java/org/infinispan/tx/EntryWrappingInterceptorDoesNotBlockTest.java
@@ -136,7 +136,10 @@ public class EntryWrappingInterceptorDoesNotBlockTest extends MultipleCacheManag
       EmbeddedCacheManager cm = createClusteredCacheManager(false, GlobalConfigurationBuilder.defaultClusteredBuilder(),
                                                             cb, new TransportFlags());
       registerCacheManager(cm);
-      Future<?> newNode = fork(() -> cache(3));
+      Future<?> newNode = fork(() -> {
+         cm.start();
+         return cache(3);
+      });
 
       // block sending segment 0 to node 2
       crm2.expectCommand(StateTransferGetTransactionsCommand.class).send().receiveAll();

--- a/counter/src/main/java/org/infinispan/counter/impl/CounterModuleLifecycle.java
+++ b/counter/src/main/java/org/infinispan/counter/impl/CounterModuleLifecycle.java
@@ -4,9 +4,7 @@ import static java.util.EnumSet.of;
 import static org.infinispan.registry.InternalCacheRegistry.Flag.EXCLUSIVE;
 import static org.infinispan.registry.InternalCacheRegistry.Flag.PERSISTENT;
 
-import java.util.Map;
-
-import org.infinispan.commons.marshall.AdvancedExternalizer;
+import org.infinispan.CoreModule;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
@@ -26,6 +24,7 @@ import org.infinispan.counter.impl.function.RemoveFunction;
 import org.infinispan.counter.impl.function.ResetFunction;
 import org.infinispan.counter.impl.function.SetFunction;
 import org.infinispan.counter.impl.interceptor.CounterInterceptor;
+import org.infinispan.counter.impl.manager.CounterConfigurationManager;
 import org.infinispan.counter.impl.manager.EmbeddedCounterManager;
 import org.infinispan.counter.impl.persistence.PersistenceContextInitializerImpl;
 import org.infinispan.counter.logging.Log;
@@ -160,5 +159,16 @@ public class CounterModuleLifecycle implements ModuleLifecycle {
          bcr.getComponent(AsyncInterceptorChain.class).wired()
                .addInterceptorAfter(counterInterceptor, EntryWrappingInterceptor.class);
       }
+   }
+
+   @Override
+   public void cacheManagerStarted(GlobalComponentRegistry gcr) {
+      // We cannot initialize the cache during the start of the manager otherwise it creates a cyclic dependency
+      CoreModule.startLifecycleComponent(gcr, CounterConfigurationManager.class);
+   }
+
+   @Override
+   public void cacheManagerStopping(GlobalComponentRegistry gcr) {
+      CoreModule.stopLifecycleComponent(gcr, CounterConfigurationManager.class);
    }
 }

--- a/jcache/embedded/src/test/java/org/infinispan/jcache/JCacheConfigurationTest.java
+++ b/jcache/embedded/src/test/java/org/infinispan/jcache/JCacheConfigurationTest.java
@@ -44,7 +44,7 @@ import org.testng.annotations.Test;
 public class JCacheConfigurationTest extends AbstractInfinispanTest {
 
    public void testNamedCacheConfiguration() {
-      withCacheManager(TestCacheManagerFactory.createCacheManager(false), cm -> {
+      withCacheManager(TestCacheManagerFactory.createCacheManager(true), cm -> {
          cm.defineConfiguration("oneCache", new ConfigurationBuilder().build());
          JCacheManager jCacheManager = new JCacheManager(URI.create("oneCacheManager"), cm, null);
          assertNotNull(jCacheManager.getCache("oneCache"));

--- a/jcache/embedded/src/test/java/org/infinispan/jcache/JCacheLoaderTest.java
+++ b/jcache/embedded/src/test/java/org/infinispan/jcache/JCacheLoaderTest.java
@@ -49,7 +49,7 @@ public class JCacheLoaderTest extends AbstractInfinispanTest {
 //      GlobalConfigurationBuilder globalBuilder = new GlobalConfigurationBuilder();
 //      globalBuilder.asyncTransportExecutor().addProperty("maxThreads", "1");
       withCacheManager(new CacheManagerCallable(
-            TestCacheManagerFactory.createCacheManager(false)) {
+            TestCacheManagerFactory.createCacheManager(true)) {
          @Override
          public void call() {
             JCacheManager jCacheManager = createJCacheManager(cm, this);
@@ -75,7 +75,7 @@ public class JCacheLoaderTest extends AbstractInfinispanTest {
 
    public void testLoadAllWithInfinispanCacheLoader() {
       withCacheManager(new CacheManagerCallable(
-            TestCacheManagerFactory.createCacheManager(false)) {
+            TestCacheManagerFactory.createCacheManager(true)) {
          @Override
          public void call() {
             ConfigurationBuilder builder = new ConfigurationBuilder();
@@ -115,7 +115,7 @@ public class JCacheLoaderTest extends AbstractInfinispanTest {
    public void testLoadEntryWithExpiration(Method m) {
       final String cacheName = m.getName();
       withCacheManager(new CacheManagerCallable(
-         TestCacheManagerFactory.createCacheManager(false)) {
+         TestCacheManagerFactory.createCacheManager(true)) {
          @Override
          public void call() {
             ControlledTimeService timeService = new ControlledTimeService();
@@ -166,7 +166,7 @@ public class JCacheLoaderTest extends AbstractInfinispanTest {
       NonMarshallablePojo v2 = new NonMarshallablePojo("v2");
 
       withCacheManager(new CacheManagerCallable(
-            TestCacheManagerFactory.createCacheManager(false)) {
+            TestCacheManagerFactory.createCacheManager(true)) {
          @Override
          public void call() {
             JCacheManager jCacheManager = createJCacheManager(cm, this);

--- a/jcache/embedded/src/test/java/org/infinispan/jcache/UnwrapTest.java
+++ b/jcache/embedded/src/test/java/org/infinispan/jcache/UnwrapTest.java
@@ -22,7 +22,7 @@ public class UnwrapTest extends AbstractInfinispanTest {
 
    public void testUnwrap() {
       withCacheManager(new CacheManagerCallable(
-            TestCacheManagerFactory.createCacheManager(false)) {
+            TestCacheManagerFactory.createCacheManager(true)) {
          @Override
          public void call() {
             cm.defineConfiguration("UnwrapCache", new ConfigurationBuilder().build());

--- a/lock/src/main/java/org/infinispan/lock/impl/ClusteredLockModuleLifecycle.java
+++ b/lock/src/main/java/org/infinispan/lock/impl/ClusteredLockModuleLifecycle.java
@@ -3,6 +3,7 @@ package org.infinispan.lock.impl;
 import java.util.EnumSet;
 import java.util.Map;
 
+import org.infinispan.CoreModule;
 import org.infinispan.commons.logging.LogFactory;
 import org.infinispan.commons.marshall.AdvancedExternalizer;
 import org.infinispan.configuration.cache.CacheMode;
@@ -42,6 +43,16 @@ public class ClusteredLockModuleLifecycle implements ModuleLifecycle {
    private static final Log log = LogFactory.getLog(ClusteredLockModuleLifecycle.class, Log.class);
 
    public static final String CLUSTERED_LOCK_CACHE_NAME = "org.infinispan.LOCKS";
+
+   @Override
+   public void cacheManagerStarted(GlobalComponentRegistry gcr) {
+      CoreModule.startLifecycleComponent(gcr, ClusteredLockManager.class);
+   }
+
+   @Override
+   public void cacheManagerStopping(GlobalComponentRegistry gcr) {
+      CoreModule.stopLifecycleComponent(gcr, ClusteredLockManager.class);
+   }
 
    @Override
    public void cacheManagerStarting(GlobalComponentRegistry gcr, GlobalConfiguration globalConfiguration) {

--- a/lock/src/main/java/org/infinispan/lock/impl/manager/EmbeddedClusteredLockManager.java
+++ b/lock/src/main/java/org/infinispan/lock/impl/manager/EmbeddedClusteredLockManager.java
@@ -6,13 +6,12 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 
 import org.infinispan.AdvancedCache;
+import org.infinispan.commons.api.Lifecycle;
 import org.infinispan.commons.logging.LogFactory;
 import org.infinispan.context.Flag;
 import org.infinispan.factories.KnownComponentNames;
 import org.infinispan.factories.annotations.ComponentName;
 import org.infinispan.factories.annotations.Inject;
-import org.infinispan.factories.annotations.Start;
-import org.infinispan.factories.annotations.Stop;
 import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
 import org.infinispan.jmx.annotations.MBean;
@@ -39,7 +38,7 @@ import org.infinispan.util.ByteString;
  */
 @Scope(Scopes.GLOBAL)
 @MBean(objectName = EmbeddedClusteredLockManager.OBJECT_NAME, description = "Component to manage clustered locks")
-public class EmbeddedClusteredLockManager implements ClusteredLockManager {
+public class EmbeddedClusteredLockManager implements ClusteredLockManager, Lifecycle {
    public static final String OBJECT_NAME = "ClusteredLockManager";
    private static final Log log = LogFactory.getLog(EmbeddedClusteredLockManager.class, Log.class);
    public static final String FORCE_RELEASE = "forceRelease";
@@ -63,7 +62,7 @@ public class EmbeddedClusteredLockManager implements ClusteredLockManager {
       this.config = config;
    }
 
-   @Start
+   @Override
    public void start() {
       if (log.isTraceEnabled())
          log.trace("Starting EmbeddedClusteredLockManager");
@@ -74,7 +73,7 @@ public class EmbeddedClusteredLockManager implements ClusteredLockManager {
       started = true;
    }
 
-   @Stop
+   @Override
    public void stop() {
       if (log.isTraceEnabled())
          log.trace("Stopping EmbeddedClusteredLockManager");

--- a/lock/src/test/java/org/infinispan/lock/ClusteredLockWithoutClusterTest.java
+++ b/lock/src/test/java/org/infinispan/lock/ClusteredLockWithoutClusterTest.java
@@ -14,7 +14,7 @@ public class ClusteredLockWithoutClusterTest extends SingleCacheManagerTest {
    @Override
    protected EmbeddedCacheManager createCacheManager() {
       ConfigurationBuilder c = getDefaultStandaloneCacheConfig(false);
-      EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(false);
+      EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(true);
       cm.defineConfiguration("test", c.build());
       cache = cm.getCache("test");
       return cm;

--- a/multimap/src/test/java/org/infinispan/multimap/impl/TxEmbeddedMultimapCacheTest.java
+++ b/multimap/src/test/java/org/infinispan/multimap/impl/TxEmbeddedMultimapCacheTest.java
@@ -40,7 +40,7 @@ public class TxEmbeddedMultimapCacheTest extends EmbeddedMultimapCacheTest {
       // start a single multimapCache instance
       ConfigurationBuilder c = getDefaultStandaloneCacheConfig(true);
       c.locking().isolationLevel(IsolationLevel.READ_COMMITTED);
-      EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(false);
+      EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(true);
       MultimapCacheManager multimapCacheManager = EmbeddedMultimapCacheManagerFactory.from(cm);
       multimapCacheManager.defineConfiguration("test", c.build());
       multimapCache = multimapCacheManager.get("test");

--- a/persistence/jdbc/src/test/java/org/infinispan/persistence/jdbc/stringbased/JdbcStringBasedStoreTxFunctionalTest.java
+++ b/persistence/jdbc/src/test/java/org/infinispan/persistence/jdbc/stringbased/JdbcStringBasedStoreTxFunctionalTest.java
@@ -89,7 +89,11 @@ public class JdbcStringBasedStoreTxFunctionalTest extends JdbcStringBasedStoreFu
             holder.newConfigurationBuilder(defaultName).read(cb.build(), Combine.DEFAULT);
          }
          global.transport().defaultTransport();
-         return TestCacheManagerFactory.createClusteredCacheManager(start, holder);
+         EmbeddedCacheManager ecm = TestCacheManagerFactory.createClusteredCacheManager(false, holder);
+         if (start) {
+            TestingUtil.startCacheManager(ecm);
+         }
+         return ecm;
       } else {
          return super.createCacheManager(start, global, cb);
       }

--- a/persistence/jdbc/src/test/java/org/infinispan/persistence/jdbc/stringbased/JdbcStringBasedStoreVamTest.java
+++ b/persistence/jdbc/src/test/java/org/infinispan/persistence/jdbc/stringbased/JdbcStringBasedStoreVamTest.java
@@ -33,7 +33,7 @@ public class JdbcStringBasedStoreVamTest extends JdbcStringBasedStoreTest {
 
    @BeforeClass
    public void setUpClass() {
-      cm = TestCacheManagerFactory.createCacheManager(false);
+      cm = TestCacheManagerFactory.createCacheManager(true);
       marshaller = extractPersistenceMarshaller(cm.getCache().getCacheManager());
    }
 

--- a/query-core/src/test/java/org/infinispan/query/core/tests/QueryCoreTest.java
+++ b/query-core/src/test/java/org/infinispan/query/core/tests/QueryCoreTest.java
@@ -57,7 +57,7 @@ public class QueryCoreTest extends SingleCacheManagerTest {
       ConfigurationBuilder c = getDefaultStandaloneCacheConfig(false);
       ConfigurationBuilder stat = getDefaultStandaloneCacheConfig(false);
       stat.statistics().enable();
-      EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(false);
+      EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(true);
       cm.defineConfiguration("test", c.build());
       cm.defineConfiguration("stat", stat.build());
       cache = cm.getCache("test");


### PR DESCRIPTION
**Backport:** https://github.com/infinispan/infinispan/pull/14925

Fixes #14924

Also prevent starting/retrieving caches from the CacheManger until it is started since it requires the global registry to be running.