### PR TITLE
[15.2.x] [#14965] SoftIndexFileStore on restart will report the index is dirty…

### DIFF
--- a/core/src/main/java/org/infinispan/persistence/sifs/Index.java
+++ b/core/src/main/java/org/infinispan/persistence/sifs/Index.java
@@ -737,9 +737,11 @@ class Index {
                indexFileSize = freeBlocksOffset;
                loaded = true;
             } else {
+               // If the file was empty and we had no entries in our sizePerSegment we can treat this as loaded
+               // as this means we didn't own the segment before
+               loaded = handle.getFileSize() == 0 && index.sizePerSegment.get(id) == 0;
                handle.truncate(0);
                root = IndexNode.emptyWithLeaves(this);
-               loaded = false;
                // reserve space for shutdown
                indexFileSize = INDEX_FILE_HEADER_SIZE;
             }


### PR DESCRIPTION
**Backport:** https://github.com/infinispan/infinispan/pull/14966

… if it didn't own all segments on shutdown

Fixes #14965