### PR TITLE
[#14879] Cluster-wide cache shutdown

### DIFF
--- a/commons/all/src/main/java/org/infinispan/commons/api/BasicCacheContainer.java
+++ b/commons/all/src/main/java/org/infinispan/commons/api/BasicCacheContainer.java
@@ -31,6 +31,17 @@ public interface BasicCacheContainer extends Lifecycle {
    <K, V> BasicCache<K, V> getCache(String cacheName);
 
    /**
+    * Forcefully stops a cache with the given name.
+    *
+    * <p>
+    * This method will force a stop of the cache, even if it is not completely initialized.
+    * </p>
+    *
+    * @param cacheName name of the cache to stop
+    */
+   void stopCache(String cacheName);
+
+   /**
     * This method returns a collection of all cache names.
         * The configurations may have been defined via XML, in the programmatic configuration,
     * or at runtime.

--- a/core/src/main/java/org/infinispan/factories/AbstractComponentRegistry.java
+++ b/core/src/main/java/org/infinispan/factories/AbstractComponentRegistry.java
@@ -359,6 +359,10 @@ public abstract class AbstractComponentRegistry implements Lifecycle {
       // Start all the components. The order doesn't matter, as starting one component starts its dependencies as well
       Collection<ComponentRef<?>> components = basicComponentRegistry.getRegisteredComponents();
       for (ComponentRef<?> component : components) {
+         if (state.isStopping() || state.isTerminated()) {
+            getLog().tracef("Component %s not started because the registry was stopped or terminated", getName());
+            break;
+         }
          component.running();
       }
 

--- a/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
@@ -928,6 +928,11 @@ public class DefaultCacheManager extends InternalCacheManager {
       internalStop();
    }
 
+   @Override
+   public void stopCache(String cacheName) {
+      terminate(cacheName);
+   }
+
    private void internalStop() {
       lifecycleLock.lock();
       String identifierString = identifierString();
@@ -986,7 +991,7 @@ public class DefaultCacheManager extends InternalCacheManager {
 
       for (String cacheName : cachesToStop) {
          try {
-            terminate(cacheName);
+            stopCache(cacheName);
          } catch (Throwable t) {
             CONTAINER.componentFailedToStop(t);
          }

--- a/core/src/main/java/org/infinispan/manager/impl/AbstractDelegatingEmbeddedCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/impl/AbstractDelegatingEmbeddedCacheManager.java
@@ -178,6 +178,11 @@ public class AbstractDelegatingEmbeddedCacheManager extends InternalCacheManager
    }
 
    @Override
+   public void stopCache(String cacheName) {
+      cm.stopCache(cacheName);
+   }
+
+   @Override
    public EmbeddedCacheManager startCaches(String... cacheNames) {
       return cm.startCaches(cacheNames);
    }

--- a/core/src/main/java/org/infinispan/partitionhandling/AvailabilityMode.java
+++ b/core/src/main/java/org/infinispan/partitionhandling/AvailabilityMode.java
@@ -21,7 +21,12 @@ public enum AvailabilityMode {
    /**
     * Data can not be safely accessed because of a network split or successive nodes leaving.
     */
-   DEGRADED_MODE;
+   DEGRADED_MODE,
+
+   /**
+    * Data is not available because the cache is performing graceful shutdown.
+    */
+   STOPPED;
 
    public AvailabilityMode min(AvailabilityMode other) {
       if (this == DEGRADED_MODE || other == DEGRADED_MODE)

--- a/core/src/main/java/org/infinispan/partitionhandling/impl/PartitionHandlingManagerImpl.java
+++ b/core/src/main/java/org/infinispan/partitionhandling/impl/PartitionHandlingManagerImpl.java
@@ -255,6 +255,10 @@ public class PartitionHandlingManagerImpl implements PartitionHandlingManager {
       if (availabilityMode == AvailabilityMode.AVAILABLE)
          return;
 
+      if (availabilityMode == AvailabilityMode.STOPPED) {
+         throw CONTAINER.cacheIsTerminated(cacheName, "AvailabilityMode.STOPPED");
+      }
+
       LocalizedCacheTopology cacheTopology = distributionManager.getCacheTopology();
       if (isKeyOperationAllowed(isWrite, flagBitSet, cacheTopology, key)) {
          if (log.isTraceEnabled()) log.tracef("Key %s is available.", key);

--- a/core/src/main/java/org/infinispan/topology/ClusterTopologyManagerImpl.java
+++ b/core/src/main/java/org/infinispan/topology/ClusterTopologyManagerImpl.java
@@ -311,6 +311,13 @@ public class ClusterTopologyManagerImpl implements ClusterTopologyManager, Globa
                     leaver, cacheName);
          return CompletableFutures.completedNull();
       }
+
+      if (cacheStatus.isGracefulStopped()) {
+         log.tracef("Ignoring leave request from %s for cache %s because it is graceful stopped",
+                    leaver, cacheName);
+         return CompletableFutures.completedNull();
+      }
+
       return cacheStatus.doLeave(leaver);
    }
 

--- a/core/src/test/java/org/infinispan/globalstate/GracefulShutdownTest.java
+++ b/core/src/test/java/org/infinispan/globalstate/GracefulShutdownTest.java
@@ -1,0 +1,100 @@
+package org.infinispan.globalstate;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.infinispan.commons.test.CommonsTestingUtil.tmpDirectory;
+import static org.infinispan.lifecycle.ComponentStatus.TERMINATED;
+
+import org.infinispan.Cache;
+import org.infinispan.commons.IllegalLifecycleStateException;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.fwk.CleanupAfterMethod;
+import org.testng.annotations.Test;
+
+@CleanupAfterMethod
+@Test(groups = "functional", testName = "globalstate.GracefulShutdownTest")
+public class GracefulShutdownTest extends MultipleCacheManagersTest {
+
+   private static final String CACHE_NAME = "testCache";
+   private static final int NUM_NODES = 5;
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      for (int i = 0; i < NUM_NODES; i++) {
+         addCacheManager(i);
+      }
+   }
+
+   private void addCacheManager(int index) {
+      String stateDirectory = tmpDirectory(this.getClass().getSimpleName(), Character.toString('A' + index));
+
+      GlobalConfigurationBuilder global = GlobalConfigurationBuilder.defaultClusteredBuilder();
+      global.globalState().enable().persistentLocation(stateDirectory);
+
+      ConfigurationBuilder cb = new ConfigurationBuilder();
+      cb.clustering().cacheMode(CacheMode.DIST_SYNC);
+      EmbeddedCacheManager ecm = addClusterEnabledCacheManager(global, null);
+      ecm.defineConfiguration(CACHE_NAME, cb.build());
+   }
+
+   public void testShutdownStopAllCoordinator() throws Throwable {
+      testShutdownStopAll(true);
+   }
+
+   public void testShutdownStopAllNonCoordinator() throws Throwable {
+      testShutdownStopAll(false);
+   }
+
+   public void testJoinAfterShutdown() {
+      final int stoppingNode = findNodeIndex(true);
+
+      waitForClusterToForm(CACHE_NAME);
+      populateCache();
+      cache(stoppingNode, CACHE_NAME).shutdown();
+
+      addCacheManager(NUM_NODES);
+
+      // The cache was shutdown with the previous members.
+      // The new node is able to retrieve the cache instance, but it will not accept any operations.
+      // The instance will return in an already terminated state.
+      Cache<String, String> newCache = cache(NUM_NODES, CACHE_NAME);
+      assertThat(newCache.getStatus()).isEqualTo(TERMINATED);
+      assertThatThrownBy(() -> newCache.get("1"))
+            .hasMessageContaining("ISPN000323: Cache '" + CACHE_NAME + "' is in 'TERMINATED'")
+            .isInstanceOf(IllegalLifecycleStateException.class);
+   }
+
+   private void testShutdownStopAll(boolean fromCoordinator) throws Throwable {
+      final int stoppingNode = findNodeIndex(fromCoordinator);
+
+      waitForClusterToForm(CACHE_NAME);
+      populateCache();
+      cache(stoppingNode, CACHE_NAME).shutdown();
+
+      // No operations are allowed on the cache after shutdown.
+      for (int i = 0; i < NUM_NODES; i++) {
+         final Cache<?, ?> cache = cache(i, CACHE_NAME);
+         assertThatThrownBy(() -> cache.get("1"))
+               .hasMessageContaining("ISPN000323: Cache '" + CACHE_NAME + "' is in 'TERMINATED'")
+               .isInstanceOf(IllegalLifecycleStateException.class);
+      }
+   }
+
+   private int findNodeIndex(boolean coordinator) {
+      for (int i = 0; i < NUM_NODES; i++) {
+         EmbeddedCacheManager ecm = manager(i);
+         if (ecm.isCoordinator() == coordinator) return i;
+      }
+      throw new AssertionError("Matching node not found in the cluster");
+   }
+
+   private void populateCache() {
+      for (int i = 0; i < 100; i++) {
+         cache(0, CACHE_NAME).put(String.valueOf(i), String.valueOf(i));
+      }
+   }
+}

--- a/core/src/test/java/org/infinispan/globalstate/TransactionalGracefulShutdownTest.java
+++ b/core/src/test/java/org/infinispan/globalstate/TransactionalGracefulShutdownTest.java
@@ -1,0 +1,126 @@
+package org.infinispan.globalstate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.infinispan.commons.test.CommonsTestingUtil.tmpDirectory;
+
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.transaction.TransactionManager;
+
+import org.infinispan.Cache;
+import org.infinispan.commands.topology.CacheShutdownCommand;
+import org.infinispan.commands.tx.PrepareCommand;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.distribution.MagicKey;
+import org.infinispan.factories.ComponentRegistry;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.test.Mocks;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.TestDataSCI;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.CheckPoint;
+import org.infinispan.test.fwk.CleanupAfterMethod;
+import org.infinispan.transaction.LockingMode;
+import org.infinispan.transaction.TransactionMode;
+import org.testng.annotations.Test;
+
+@CleanupAfterMethod
+@Test(groups = "functional", testName = "globalstate.TransactionalGracefulShutdownTest")
+public class TransactionalGracefulShutdownTest extends MultipleCacheManagersTest {
+
+   private static final String CACHE_NAME = "testCache";
+   private static final int NUM_NODES = 2;
+
+   @Override
+   protected void createCacheManagers() {
+      for (int i = 0; i < NUM_NODES; i++) {
+         addCacheManager(i);
+      }
+   }
+
+   private void addCacheManager(int index) {
+      String stateDirectory = tmpDirectory(this.getClass().getSimpleName(), Character.toString('A' + index));
+
+      GlobalConfigurationBuilder global = GlobalConfigurationBuilder.defaultClusteredBuilder();
+      global.globalState().enable().persistentLocation(stateDirectory);
+      global.serialization().addContextInitializer(TestDataSCI.INSTANCE);
+
+      ConfigurationBuilder cb = new ConfigurationBuilder();
+      cb.clustering().cacheMode(CacheMode.DIST_SYNC);
+      cb.transaction().transactionMode(TransactionMode.TRANSACTIONAL).lockingMode(LockingMode.PESSIMISTIC);
+      cb.persistence().addSoftIndexFileStore();
+      EmbeddedCacheManager ecm = addClusterEnabledCacheManager(global, null);
+      ecm.defineConfiguration(CACHE_NAME, cb.build());
+   }
+
+   public void testShutdownRollbackOperations() throws Throwable {
+      Cache<MagicKey, String> c0 = testCache(0);
+      Cache<MagicKey, String> c1 = testCache(1);
+
+      MagicKey key = new MagicKey("remote-key", c1);
+
+      assertThat(c1.put(key, "value")).isNull();
+      assertThat(c0.get(key)).isEqualTo("value");
+
+      CheckPoint commitCheckpoint = new CheckPoint();
+      commitCheckpoint.triggerForever(Mocks.AFTER_RELEASE);
+
+      CheckPoint shutdownCheckpoint = new CheckPoint();
+
+      // One checkpoint will block after the commit operation is submitted and the other during the graceful shutdown.
+      Mocks.blockInboundCacheRpcCommand(c1, commitCheckpoint, crc -> crc instanceof PrepareCommand);
+      Mocks.blockInboundGlobalCommand(manager(1), shutdownCheckpoint, rc -> rc instanceof CacheShutdownCommand);
+
+      Future<Void> tx = fork(() -> {
+         TransactionManager tm = TestingUtil.getTransactionManager(c0);
+         tm.begin();
+         c0.put(key, "updated");
+         tm.commit();
+      });
+
+      // After C1 receives the prepare command, it initiates the shutdown command BEFORE handling the command.
+      commitCheckpoint.awaitStrict(Mocks.BEFORE_INVOCATION, 10, TimeUnit.SECONDS);
+      Future<?> shutdown = fork(c1::shutdown);
+      shutdownCheckpoint.awaitStrict(Mocks.BEFORE_INVOCATION, 10, TimeUnit.SECONDS);
+
+      // Shutdown happens cluster-wide, and the TX table has a "degradation" period before giving up.
+      assertThat(shutdown.isDone()).isFalse();
+
+      // Release the shutdown of C1, it will stop all running components and reply CacheNotFound for commit command.
+      shutdownCheckpoint.trigger(Mocks.BEFORE_RELEASE, 1);
+      shutdownCheckpoint.awaitStrict(Mocks.AFTER_INVOCATION, 10, TimeUnit.SECONDS);
+      commitCheckpoint.trigger(Mocks.BEFORE_RELEASE, 1);
+
+      // Even though the shutdown future hasn't completed because it is cluster-wide, C1 is already shutdown.
+      assertThat(ComponentRegistry.of(c1).getStatus().isTerminated()).isTrue();
+      shutdownCheckpoint.triggerForever(Mocks.AFTER_RELEASE);
+
+      // After some time, the shutdown will finally complete.
+      // C0 will wait a period before giving up transactions, this makes the shutdown procedure to take a while.
+      shutdown.get(30, TimeUnit.SECONDS);
+      assertThat(tx.isDone()).isTrue();
+
+      // We restart the cluster again. Since persistence is enabled, the data should be present and still the same.
+      recreateCluster();
+
+      assertThat(testCache(0).get(key)).isEqualTo("value");
+      assertThat(testCache(1).get(key)).isEqualTo("value");
+   }
+
+   private void recreateCluster() {
+      for (EmbeddedCacheManager ecm : cacheManagers) {
+         ecm.stop();
+      }
+
+      cacheManagers.clear();
+      createCacheManagers();
+      waitForClusterToForm(CACHE_NAME);
+   }
+
+   private Cache<MagicKey, String> testCache(int index) {
+      return cache(index, CACHE_NAME);
+   }
+}


### PR DESCRIPTION
We use the shutdown message that the coordinator broadcasts to stop the component registry. To handle the joiners after shutdown, I've added a new entry in the `AvailabilityMode` to `STOPPED`, and that value is returned in the join response.

I've included a `stopCache(String)` in the `BasicCacheContainer` API because we need a way to stop the cache when the join response is in the `STOPPED` state. We can't use `EmbeddedCacheManager#getCache(String).stop()` because that would block until the cache is completely initialized. With the new API to stop, we are sure that the caller of `getCache(String)`, which initiated the join, will receive an instance already stopped and won't be able to submit operations.

I'll add documentation next, but the main changes are ready. The backport would include only the stop after the coordinator message.

Closes #14879.
