### PR TITLE
[15.2.x] [#14777] Intermittent Indexing incorrectly states Hibernate Search qu…

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/pressure/LargePutAllPressureTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/pressure/LargePutAllPressureTest.java
@@ -47,8 +47,8 @@ public class LargePutAllPressureTest extends SingleHotRodServerTest {
             .storage(LOCAL_HEAP)
                .addIndexedEntity("Sale")
             .writer()
-               .queueCount(1)
-               .queueSize(200);
+               .queueCount(10)
+               .queueSize(100);
 
       return TestCacheManagerFactory.createServerModeCacheManager(contextInitializer(), config);
    }

--- a/query/src/test/java/org/infinispan/query/api/PutAllTest.java
+++ b/query/src/test/java/org/infinispan/query/api/PutAllTest.java
@@ -54,7 +54,7 @@ public class PutAllTest extends SingleCacheManagerTest {
             .storage(LOCAL_HEAP)
             .addIndexedEntity(TestEntity.class)
             .addIndexedEntity(AnotherTestEntity.class)
-            .writer().queueSize(5).queueCount(100);
+            .writer().queueSize(10).queueCount(100);
       cfg.memory()
             .storageType(storageType);
       return TestCacheManagerFactory.createCacheManager(QueryTestSCI.INSTANCE, cfg);

--- a/query/src/test/java/org/infinispan/query/indexing/IndexingOperationOffloadingTest.java
+++ b/query/src/test/java/org/infinispan/query/indexing/IndexingOperationOffloadingTest.java
@@ -40,7 +40,7 @@ public class IndexingOperationOffloadingTest extends SingleCacheManagerTest {
             .indexing()
             .enable()
             .storage(IndexStorage.LOCAL_HEAP)
-            .writer().queueCount(5).queueSize(100) // Use a very small single queue
+            .writer().queueCount(10).queueSize(100)
             .addIndexedEntity(TypeA.class)
             .addIndexedEntity(TypeB.class)
             .addIndexedEntity(TypeC.class);

--- a/query/src/test/java/org/infinispan/query/reindex/ReindexPressureTest.java
+++ b/query/src/test/java/org/infinispan/query/reindex/ReindexPressureTest.java
@@ -32,7 +32,7 @@ public class ReindexPressureTest extends SingleCacheManagerTest {
       config.statistics().enable();
       // While testing this fails around with queueCount=2 & queueSize=50 so making it more for CI to pass (2.5x2 more)
       config.indexing().writer()
-            .queueCount(5)
+            .queueCount(10)
             .queueSize(100);
       config.indexing().enable()
             .storage(LOCAL_HEAP)


### PR DESCRIPTION
**Backport:** https://github.com/infinispan/infinispan/pull/15054

…eue is not able to keep up

* Increase queue sizes so tests don't fail when running severely limited

Also updated mass indexer test so it better relays why it failed.