### PR TITLE
[15.2.x] [#14472] Fix ChannelCloseAndInactiveTest failure

### DIFF
--- a/client/hotrod-client-legacy/src/test/java/org/infinispan/client/hotrod/impl/transport/netty/ChannelCloseAndInactiveTest.java
+++ b/client/hotrod-client-legacy/src/test/java/org/infinispan/client/hotrod/impl/transport/netty/ChannelCloseAndInactiveTest.java
@@ -37,6 +37,8 @@ public class ChannelCloseAndInactiveTest extends AbstractRetryTest {
    @Override
    protected void amendRemoteCacheManagerConfiguration(org.infinispan.client.hotrod.configuration.ConfigurationBuilder builder) {
       builder.maxRetries(1);
+      // We manually stall operations, so let's define something that won't timeout.
+      builder.socketTimeout(60_000);
       builder.connectionPool().maxActive(2);
    }
 
@@ -79,7 +81,7 @@ public class ChannelCloseAndInactiveTest extends AbstractRetryTest {
       Channel spyChannel = spy(secondChannel);
       CountDownLatch closeSecondLatch = new CountDownLatch(1);
       doAnswer(ivk -> {
-         closeSecondLatch.await(10, TimeUnit.SECONDS);
+         assertThat(closeSecondLatch.await(10, TimeUnit.SECONDS)).isTrue();
          return ivk.callRealMethod();
       }).when(spyChannel).close();
 


### PR DESCRIPTION
* Increase operation timeout to avoid retries.

The failure happens because the timeout adds the operation to the queue again, and some of the validations don't expect that.
This is failing hard on 15.2.x. The test is only on the legacy HR client and doesn't exist in main.
Closes #14472