### PR TITLE
[#15080] Refactor InfinispanServerExtension to be injectable for tests

### DIFF
--- a/graalvm/client-hotrod/src/test/resources/reflect-config.json
+++ b/graalvm/client-hotrod/src/test/resources/reflect-config.json
@@ -10,5 +10,13 @@
   {
     "name": "org.infinispan.server.functional.extensions.entities.Entities$Person",
     "allDeclaredFields": true
+  },
+  {
+    "name": "org.infinispan.server.test.junit5.CustomInfinispanExtension",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "org.infinispan.server.test.junit5.InfinispanServerExtension",
+    "allPublicMethods": true
   }
 ]

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/api/AbstractTestClientDriver.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/api/AbstractTestClientDriver.java
@@ -16,12 +16,24 @@ import org.infinispan.configuration.cache.CacheMode;
  * @param <S>
  * @author Tristan Tarrant
  */
-abstract class BaseTestClientDriver<S extends BaseTestClientDriver<S>> implements Self<S> {
+abstract class AbstractTestClientDriver<S extends AbstractTestClientDriver<S>> implements Self<S>, CommonTestClientDriver<S> {
    protected BasicConfiguration serverConfiguration = null;
    protected EnumSet<CacheContainerAdmin.AdminFlag> flags = EnumSet.noneOf(CacheContainerAdmin.AdminFlag.class);
    protected CacheMode mode = null;
    protected Object[] qualifiers;
 
+   static StringConfiguration forCacheMode(CacheMode mode) {
+      return switch (mode) {
+         case LOCAL -> DefaultTemplate.LOCAL.getConfiguration();
+         case DIST_ASYNC -> DefaultTemplate.DIST_ASYNC.getConfiguration();
+         case DIST_SYNC -> DefaultTemplate.DIST_SYNC.getConfiguration();
+         case REPL_ASYNC -> DefaultTemplate.REPL_ASYNC.getConfiguration();
+         case REPL_SYNC -> DefaultTemplate.REPL_SYNC.getConfiguration();
+         default -> throw new IllegalArgumentException(mode.toString());
+      };
+   }
+
+   @Override
    public S withServerConfiguration(org.infinispan.configuration.cache.ConfigurationBuilder serverConfiguration) {
       if (mode != null) {
          throw new IllegalStateException("Cannot set server configuration and cache mode");
@@ -30,6 +42,7 @@ abstract class BaseTestClientDriver<S extends BaseTestClientDriver<S>> implement
       return self();
    }
 
+   @Override
    public S withServerConfiguration(StringConfiguration configuration) {
       if (mode != null) {
          throw new IllegalStateException("Cannot set server configuration and cache mode");
@@ -38,6 +51,7 @@ abstract class BaseTestClientDriver<S extends BaseTestClientDriver<S>> implement
       return self();
    }
 
+   @Override
    public S withCacheMode(CacheMode mode) {
       if (serverConfiguration != null) {
          throw new IllegalStateException("Cannot set server configuration and cache mode");
@@ -60,14 +74,4 @@ abstract class BaseTestClientDriver<S extends BaseTestClientDriver<S>> implement
       return self();
    }
 
-   static StringConfiguration forCacheMode(CacheMode mode) {
-      return switch (mode) {
-         case LOCAL -> DefaultTemplate.LOCAL.getConfiguration();
-         case DIST_ASYNC -> DefaultTemplate.DIST_ASYNC.getConfiguration();
-         case DIST_SYNC -> DefaultTemplate.DIST_SYNC.getConfiguration();
-         case REPL_ASYNC -> DefaultTemplate.REPL_ASYNC.getConfiguration();
-         case REPL_SYNC -> DefaultTemplate.REPL_SYNC.getConfiguration();
-         default -> throw new IllegalArgumentException(mode.toString());
-      };
-   }
 }

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/api/CommonTestClientDriver.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/api/CommonTestClientDriver.java
@@ -1,0 +1,12 @@
+package org.infinispan.server.test.api;
+
+import org.infinispan.commons.configuration.StringConfiguration;
+import org.infinispan.configuration.cache.CacheMode;
+
+public interface CommonTestClientDriver<T extends CommonTestClientDriver<T>> {
+   T withServerConfiguration(org.infinispan.configuration.cache.ConfigurationBuilder serverConfiguration);
+
+   T withServerConfiguration(StringConfiguration configuration);
+
+   T withCacheMode(CacheMode mode);
+}

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/api/HotRodClientDriver.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/api/HotRodClientDriver.java
@@ -1,0 +1,27 @@
+package org.infinispan.server.test.api;
+
+import java.util.Properties;
+
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.client.hotrod.configuration.ClientIntelligence;
+import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
+import org.infinispan.commons.marshall.Marshaller;
+
+public interface HotRodClientDriver<T extends HotRodClientDriver<T>> extends CommonTestClientDriver<T> {
+   T withClientConfiguration(ConfigurationBuilder clientConfiguration);
+
+   T withClientConfiguration(ClientIntelligence clientIntelligence);
+
+   T withClientConfiguration(Properties properties);
+
+   T withMarshaller(Class<? extends Marshaller> marshallerClass);
+
+   <K, V> RemoteCache<K, V> create();
+
+   <K, V> RemoteCache<K, V> create(int index);
+
+   RemoteCacheManager createRemoteCacheManager();
+
+   RemoteCacheManager createRemoteCacheManager(int index);
+}

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/api/HotRodTestClientDriver.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/api/HotRodTestClientDriver.java
@@ -1,5 +1,7 @@
 package org.infinispan.server.test.api;
 
+import java.util.Properties;
+
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.configuration.ClientIntelligence;
@@ -10,15 +12,13 @@ import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.server.test.core.TestClient;
 import org.infinispan.server.test.core.TestServer;
 
-import java.util.Properties;
-
 /**
  *  Hot Rod operations for the testing framework
  *
  * @author Tristan Tarrant
  * @since 10
  */
-public class HotRodTestClientDriver extends BaseTestClientDriver<HotRodTestClientDriver> {
+public class HotRodTestClientDriver extends AbstractTestClientDriver<HotRodTestClientDriver> implements HotRodClientDriver<HotRodTestClientDriver> {
    private final TestServer testServer;
    private final TestClient testClient;
    private ConfigurationBuilder clientConfiguration;
@@ -45,6 +45,7 @@ public class HotRodTestClientDriver extends BaseTestClientDriver<HotRodTestClien
     * @param clientConfiguration
     * @return the current {@link HotRodTestClientDriver} instance with the client configuration override
     */
+   @Override
    public HotRodTestClientDriver withClientConfiguration(ConfigurationBuilder clientConfiguration) {
       this.clientConfiguration = applyDefaultConfiguration(clientConfiguration);
       return this;
@@ -56,11 +57,13 @@ public class HotRodTestClientDriver extends BaseTestClientDriver<HotRodTestClien
     * @param clientIntelligence
     * @return the current {@link HotRodTestClientDriver} instance with the client intelligence override
     */
+   @Override
    public HotRodTestClientDriver withClientConfiguration(ClientIntelligence clientIntelligence) {
       clientConfiguration.clientIntelligence(clientIntelligence);
       return this;
    }
 
+   @Override
    public HotRodTestClientDriver withClientConfiguration(Properties properties) {
       clientConfiguration.withProperties(properties);
       return this;
@@ -72,6 +75,7 @@ public class HotRodTestClientDriver extends BaseTestClientDriver<HotRodTestClien
     * @param marshallerClass
     * @return the current {@link HotRodTestClientDriver} instance with the Marshaller configuration override
     */
+   @Override
    public HotRodTestClientDriver withMarshaller(Class<? extends Marshaller> marshallerClass) {
       this.clientConfiguration.marshaller(marshallerClass);
       return this;
@@ -110,6 +114,7 @@ public class HotRodTestClientDriver extends BaseTestClientDriver<HotRodTestClien
     *
     * @return {@link RemoteCache}, the cache
     */
+   @Override
    public <K, V> RemoteCache<K, V> create() {
       return create(-1);
    }
@@ -119,6 +124,7 @@ public class HotRodTestClientDriver extends BaseTestClientDriver<HotRodTestClien
     * @param index the server index, -1 for all
     * @return {@link RemoteCache}, the cache
     */
+   @Override
    public <K, V> RemoteCache<K, V> create(int index) {
       RemoteCacheManager remoteCacheManager;
       if (index >= 0) {
@@ -139,10 +145,12 @@ public class HotRodTestClientDriver extends BaseTestClientDriver<HotRodTestClien
       return remoteCache;
    }
 
+   @Override
    public RemoteCacheManager createRemoteCacheManager() {
       return testClient.registerResource(testServer.newHotRodClient(clientConfiguration, port));
    }
 
+   @Override
    public RemoteCacheManager createRemoteCacheManager(int index) {
       return testClient.registerResource(testServer.newHotRodClient(clientConfiguration, port, index));
    }

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/api/MemcachedTestClientDriver.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/api/MemcachedTestClientDriver.java
@@ -14,7 +14,7 @@ import net.spy.memcached.auth.AuthDescriptor;
  * @author Tristan Tarrant
  * @since 15
  */
-public class MemcachedTestClientDriver extends BaseTestClientDriver<MemcachedTestClientDriver> {
+public class MemcachedTestClientDriver extends AbstractTestClientDriver<MemcachedTestClientDriver> {
    private final TestServer testServer;
    private final TestClient testClient;
    private ConnectionFactoryBuilder builder;

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/api/RespTestClientDriver.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/api/RespTestClientDriver.java
@@ -11,7 +11,7 @@ import io.vertx.redis.client.Redis;
 import io.vertx.redis.client.RedisConnection;
 import io.vertx.redis.client.RedisOptions;
 
-public class RespTestClientDriver extends BaseTestClientDriver<RespTestClientDriver> {
+public class RespTestClientDriver extends AbstractTestClientDriver<RespTestClientDriver> {
 
    private final TestServer testServer;
    private final TestClient testClient;

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/api/RestTestClientDriver.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/api/RestTestClientDriver.java
@@ -20,7 +20,7 @@ import org.infinispan.server.test.core.TestServer;
  * @author Tristan Tarrant
  * @since 10
  */
-public class RestTestClientDriver extends BaseTestClientDriver<RestTestClientDriver> {
+public class RestTestClientDriver extends AbstractTestClientDriver<RestTestClientDriver> {
    public static final int TIMEOUT = Integer.getInteger("org.infinispan.test.server.http.timeout", 10);
 
    private RestClientConfigurationBuilder clientConfiguration = new RestClientConfigurationBuilder();
@@ -80,7 +80,6 @@ public class RestTestClientDriver extends BaseTestClientDriver<RestTestClientDri
       RestEntity configEntity;
       if (serverConfiguration != null) {
          configEntity = RestEntity.create(MediaType.APPLICATION_XML, serverConfiguration.toStringConfiguration(name));
-
       } else {
          configEntity = RestEntity.create(MediaType.APPLICATION_JSON, forCacheMode(mode != null ? mode : CacheMode.DIST_SYNC).toStringConfiguration(name));
       }

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/api/TestClientDriver.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/api/TestClientDriver.java
@@ -1,5 +1,6 @@
 package org.infinispan.server.test.api;
 
+import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.counter.api.CounterManager;
 
 /**
@@ -11,11 +12,26 @@ import org.infinispan.counter.api.CounterManager;
 public interface TestClientDriver {
 
    /**
+    * Adds a script to the remote server
+    * @param remoteCacheManager the manager to install the script on
+    * @param script the script to install
+    * @return the named script
+    */
+   String addScript(RemoteCacheManager remoteCacheManager, String script);
+
+   /**
+    * If the driver is being ran with a container that is running the server as opposed to in a separate process or
+    * in memory.
+    * @return Whether this driver is currently being used in a container
+    */
+   boolean isContainerized();
+
+   /**
     * Get the HotRod instance for hotrod api operations
     *
     * @return {@link HotRodTestClientDriver} instance
     */
-   HotRodTestClientDriver hotrod();
+   HotRodClientDriver<?> hotrod();
 
    /**
     * Get the REST instance

--- a/server/testdriver/junit4/src/main/java/org/infinispan/server/test/junit4/InfinispanServerTestMethodRule.java
+++ b/server/testdriver/junit4/src/main/java/org/infinispan/server/test/junit4/InfinispanServerTestMethodRule.java
@@ -91,6 +91,11 @@ public class InfinispanServerTestMethodRule implements TestRule, TestClientDrive
       return testClient.addScript(remoteCacheManager, script);
    }
 
+   @Override
+   public boolean isContainerized() {
+      return false;
+   }
+
    public RestClient newRestClient(RestClientConfigurationBuilder restClientConfigurationBuilder) {
       return testClient.newRestClient(restClientConfigurationBuilder);
    }

--- a/server/testdriver/junit5/src/main/java/org/infinispan/server/test/junit5/AbstractServerExtension.java
+++ b/server/testdriver/junit5/src/main/java/org/infinispan/server/test/junit5/AbstractServerExtension.java
@@ -1,20 +1,27 @@
 package org.infinispan.server.test.junit5;
 
+import static org.junit.platform.commons.support.AnnotationSupport.findAnnotatedFields;
+
 import java.io.File;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 import org.infinispan.server.test.core.TestClient;
 import org.infinispan.server.test.core.TestServer;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.commons.support.ModifierSupport;
 import org.junit.platform.suite.api.SelectClasses;
 import org.junit.platform.suite.api.Suite;
 
-public abstract class AbstractServerExtension {
+public abstract class AbstractServerExtension implements BeforeAllCallback, AfterAllCallback {
 
    protected final List<Consumer<File>> configurationEnhancers = new ArrayList<>();
    protected final Set<Class<?>> suiteTestClasses = new HashSet<>();
@@ -73,4 +80,53 @@ public abstract class AbstractServerExtension {
       String testName = testName(extensionContext);
       testServer.stopServerDriver(testName);
    }
+
+   private void injectFields(Class<?> testClass, Object testInstance,
+                             Object value, Predicate<Field> predicate) {
+      findAnnotatedFields(testClass, InfinispanServer.class, predicate)
+            .forEach(field -> {
+               try {
+                  field.setAccessible(true);
+                  field.set(testInstance, value);
+               }
+               catch (Exception ex) {
+                  throw new RuntimeException(ex);
+               }
+            });
+   }
+
+   private void injectExtension(Class<?> testClass, Object value) {
+      injectFields(testClass, null, value, ModifierSupport::isStatic);
+   }
+
+   @Override
+   public final void beforeAll(ExtensionContext context) throws Exception {
+      initSuiteClasses(context);
+
+      // Inject all classes that are using a static @InfinispanServer(ClusteredIT.class) field.
+      Class<?> testClass = context.getRequiredTestClass();
+
+      injectExtension(testClass, this);
+
+      SelectClasses selectClasses = testClass.getAnnotation(SelectClasses.class);
+      if (selectClasses != null) {
+         for (Class<?> selectClass : selectClasses.value()) {
+            injectExtension(selectClass, this);
+         }
+      }
+      onTestsStart(context);
+   }
+
+   protected abstract void onTestsStart(ExtensionContext extensionContext) throws Exception;
+
+   @Override
+   public final void afterAll(ExtensionContext context) {
+      cleanupSuiteClasses(context);
+      // Only stop the extension resources when all tests in a Suite have been completed
+      if (suiteTestClasses.isEmpty()) {
+         onTestsComplete(context);
+      }
+   }
+
+   protected abstract void onTestsComplete(ExtensionContext extensionContext);
 }

--- a/server/testdriver/junit5/src/main/java/org/infinispan/server/test/junit5/CustomInfinispanExtension.java
+++ b/server/testdriver/junit5/src/main/java/org/infinispan/server/test/junit5/CustomInfinispanExtension.java
@@ -1,0 +1,110 @@
+package org.infinispan.server.test.junit5;
+
+import static org.junit.platform.commons.support.AnnotationSupport.findAnnotatedFields;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.platform.commons.support.ModifierSupport;
+import org.junit.platform.commons.support.ReflectionSupport;
+
+public class CustomInfinispanExtension implements BeforeAllCallback, BeforeEachCallback, AfterEachCallback, AfterAllCallback {
+
+   public static final String EXTENSION_OVERRIDE = "org.infinispan.server.test.junit5.extension";
+
+   private static void invokeMethodIfPresent(ExtensionContext context, String methodName) {
+      invokeMethodIfPresent(findAnnotatedFields(context.getRequiredTestClass(), InfinispanServer.class,
+            ModifierSupport::isStatic), context, methodName);
+   }
+
+   private static void invokeMethodIfPresent(List<Field> fields, ExtensionContext context, String methodName) {
+      fields.forEach(f -> {
+         try {
+            Object is = f.get(null);
+            if (is != null) {
+               ReflectionSupport.findMethod(is.getClass(), methodName, ExtensionContext.class)
+                     .ifPresent(m -> ReflectionSupport.invokeMethod(m, is, context));
+            }
+         }
+         catch (Exception ex) {
+            throw new RuntimeException(ex);
+         }
+      });
+   }
+
+   @Override
+   public void afterAll(ExtensionContext extensionContext) {
+      invokeMethodIfPresent(extensionContext, "afterAll");
+   }
+
+   @Override
+   public void afterEach(ExtensionContext extensionContext) {
+      invokeMethodIfPresent(extensionContext, "afterEach");
+   }
+
+   @Override
+   public void beforeAll(ExtensionContext extensionContext) {
+      Class<?> testClass = extensionContext.getRequiredTestClass();
+      List<Field> fields = findAnnotatedFields(testClass, InfinispanServer.class,
+            ModifierSupport::isStatic);
+
+      fields.forEach(f -> {
+         try {
+            Object is = f.get(null);
+            // Means the suite didn't define an extension to use - so inject the default
+            if (is == null) {
+               Class<? extends InfinispanSuite> suiteClass;
+               String override = System.getProperty(EXTENSION_OVERRIDE);
+               if (override != null) {
+                  try {
+                     Class<?> possibleClass = Class.forName(override);
+                     if (!InfinispanSuite.class.isAssignableFrom(possibleClass)) {
+                        throw new IllegalArgumentException("System property defined class name: " + override + " does not extend " +
+                              InfinispanSuite.class.getName());
+                     }
+                     suiteClass = (Class<? extends InfinispanSuite>) possibleClass;
+                  } catch (ClassNotFoundException e) {
+                     throw new IllegalArgumentException("System property defined class name: " + override + " for extension override is not found!", e);
+                  }
+               } else {
+                  InfinispanServer ann = f.getAnnotation(InfinispanServer.class);
+                  suiteClass = ann.value();
+               }
+
+               List<Field> extensionFields = findAnnotatedFields(suiteClass, RegisterExtension.class,
+                     possibleField -> {
+                        try {
+                           return ModifierSupport.isStatic(possibleField) && possibleField.get(null) instanceof AbstractServerExtension;
+                        } catch (IllegalAccessException e) {
+                           return false;
+                        }
+                     });
+               if (extensionFields.size() != 1) {
+                  throw new IllegalStateException("Test " + testClass + " was ran without an explicit Suite explicit RegisterExtension and" +
+                        " its default suite class " + suiteClass + " doesn't have a single static" +
+                        " @RegisterExtension field that extends AbstractServerExtension, had " + extensionFields);
+               }
+               is = extensionFields.get(0).get(null);
+               f.set(null, is);
+            }
+            Object finalIs = is;
+            ReflectionSupport.findMethod(is.getClass(), "beforeAll", ExtensionContext.class)
+                  .ifPresent(m -> ReflectionSupport.invokeMethod(m, finalIs, extensionContext));
+         }
+         catch (Exception ex) {
+            throw new RuntimeException(ex);
+         }
+      });
+   }
+
+   @Override
+   public void beforeEach(ExtensionContext extensionContext) {
+      invokeMethodIfPresent(extensionContext, "beforeEach");
+   }
+}

--- a/server/testdriver/junit5/src/main/java/org/infinispan/server/test/junit5/InfinispanServer.java
+++ b/server/testdriver/junit5/src/main/java/org/infinispan/server/test/junit5/InfinispanServer.java
@@ -1,0 +1,23 @@
+package org.infinispan.server.test.junit5;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Target({ ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(CustomInfinispanExtension.class)
+public @interface InfinispanServer {
+   /**
+    * Defines the default suite to use if one is not defined. InfinispanServer will pick up any extension defined by
+    * a suite, but if the test is ran isolated it will use the Suite defined here along with its extensions.
+    * <p>
+    * Can be overridden by using the system property: `org.infinispan.test.server.junit5.extension` with a value
+    * that maps to a class that extends {@link InfinispanSuite}.
+    * @return suite class that has an extension
+    */
+   Class<? extends InfinispanSuite> value();
+}

--- a/server/testdriver/junit5/src/main/java/org/infinispan/server/test/junit5/InfinispanXSiteServerExtension.java
+++ b/server/testdriver/junit5/src/main/java/org/infinispan/server/test/junit5/InfinispanXSiteServerExtension.java
@@ -12,9 +12,7 @@ import org.infinispan.server.test.api.RestTestClientDriver;
 import org.infinispan.server.test.api.TestClientXSiteDriver;
 import org.infinispan.server.test.core.TestClient;
 import org.infinispan.server.test.core.TestServer;
-import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
@@ -40,10 +38,8 @@ import org.junit.jupiter.api.extension.ExtensionContext;
  */
 public class InfinispanXSiteServerExtension extends AbstractServerExtension implements
       TestClientXSiteDriver,
-      BeforeAllCallback,
       BeforeEachCallback,
-      AfterEachCallback,
-      AfterAllCallback {
+      AfterEachCallback {
 
    private final List<TestServer> testServers;
    private final Map<String, TestClient> testClients = new HashMap<>();
@@ -53,8 +49,7 @@ public class InfinispanXSiteServerExtension extends AbstractServerExtension impl
    }
 
    @Override
-   public void beforeAll(ExtensionContext extensionContext) {
-      initSuiteClasses(extensionContext);
+   protected void onTestsStart(ExtensionContext extensionContext) {
       testServers.forEach((it) -> startTestServer(extensionContext, it));
    }
 
@@ -73,16 +68,14 @@ public class InfinispanXSiteServerExtension extends AbstractServerExtension impl
    }
 
    @Override
-   public void afterAll(ExtensionContext extensionContext) {
-      if (suiteTestClasses.isEmpty()) {
-         testServers.stream()
-               .filter(TestServer::isDriverInitialized)
-               .forEach(server -> {
-                  if (server.isDriverInitialized())
-                     stopTestServer(extensionContext, server);
-                  server.afterListeners();
-               });
-      }
+   protected void onTestsComplete(ExtensionContext extensionContext) {
+      testServers.stream()
+            .filter(TestServer::isDriverInitialized)
+            .forEach(server -> {
+               if (server.isDriverInitialized())
+                  stopTestServer(extensionContext, server);
+               server.afterListeners();
+            });
    }
 
    @Override

--- a/server/tests/src/test/java/org/infinispan/server/functional/extensions/PojoMarshalling.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/extensions/PojoMarshalling.java
@@ -8,9 +8,9 @@ import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.commons.marshall.JavaSerializationMarshaller;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.server.functional.ClusteredIT;
-import org.infinispan.server.test.junit5.InfinispanServerExtension;
+import org.infinispan.server.test.api.TestClientDriver;
+import org.infinispan.server.test.junit5.InfinispanServer;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * @author Tristan Tarrant &lt;tristan@infinispan.org&gt;
@@ -18,8 +18,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
  **/
 public class PojoMarshalling {
 
-   @RegisterExtension
-   public static final InfinispanServerExtension SERVERS = ClusteredIT.SERVERS;
+   @InfinispanServer(ClusteredIT.class)
+   public static TestClientDriver SERVERS;
 
    @Test
    public void testPojoMarshalling() {

--- a/server/tests/src/test/java/org/infinispan/server/functional/extensions/ScriptingTasks.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/extensions/ScriptingTasks.java
@@ -15,9 +15,9 @@ import org.infinispan.commons.marshall.JavaSerializationMarshaller;
 import org.infinispan.commons.marshall.ProtoStreamMarshaller;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.server.functional.ClusteredIT;
-import org.infinispan.server.test.junit5.InfinispanServerExtension;
+import org.infinispan.server.test.api.TestClientDriver;
+import org.infinispan.server.test.junit5.InfinispanServer;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * @author Tristan Tarrant &lt;tristan@infinispan.org&gt;
@@ -25,8 +25,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
  **/
 public class ScriptingTasks {
 
-   @RegisterExtension
-   public static final InfinispanServerExtension SERVERS = ClusteredIT.SERVERS;
+   @InfinispanServer(ClusteredIT.class)
+   public static TestClientDriver SERVERS;
 
    @Test
    public void testSimpleScript() {

--- a/server/tests/src/test/java/org/infinispan/server/functional/extensions/ServerTasks.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/extensions/ServerTasks.java
@@ -11,9 +11,9 @@ import java.util.List;
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.jboss.marshalling.commons.GenericJBossMarshaller;
 import org.infinispan.server.functional.ClusteredIT;
-import org.infinispan.server.test.junit5.InfinispanServerExtension;
+import org.infinispan.server.test.api.TestClientDriver;
+import org.infinispan.server.test.junit5.InfinispanServer;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * @author Tristan Tarrant &lt;tristan@infinispan.org&gt;
@@ -21,8 +21,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
  **/
 public class ServerTasks {
 
-   @RegisterExtension
-   public static final InfinispanServerExtension SERVERS = ClusteredIT.SERVERS;
+   @InfinispanServer(ClusteredIT.class)
+   public static TestClientDriver SERVERS;
 
    @Test
    public void testServerTaskNoParameters() {

--- a/server/tests/src/test/java/org/infinispan/server/functional/hotrod/HotRodAdmin.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/hotrod/HotRodAdmin.java
@@ -11,9 +11,9 @@ import org.infinispan.client.hotrod.exceptions.HotRodClientException;
 import org.infinispan.commons.configuration.StringConfiguration;
 import org.infinispan.commons.test.Exceptions;
 import org.infinispan.server.functional.ClusteredIT;
-import org.infinispan.server.test.junit5.InfinispanServerExtension;
+import org.infinispan.server.test.api.TestClientDriver;
+import org.infinispan.server.test.junit5.InfinispanServer;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * @author Ryan Emerson
@@ -21,8 +21,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
  */
 public class HotRodAdmin {
 
-   @RegisterExtension
-   public static InfinispanServerExtension SERVERS = ClusteredIT.SERVERS;
+   @InfinispanServer(ClusteredIT.class)
+   public static TestClientDriver SERVERS;
 
    @Test
    public void testCreateDeleteCache() {

--- a/server/tests/src/test/java/org/infinispan/server/functional/hotrod/HotRodCacheContinuousQueries.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/hotrod/HotRodCacheContinuousQueries.java
@@ -17,8 +17,8 @@ import org.infinispan.commons.api.query.ContinuousQueryListener;
 import org.infinispan.commons.api.query.Query;
 import org.infinispan.protostream.sampledomain.User;
 import org.infinispan.server.functional.ClusteredIT;
-import org.infinispan.server.test.junit5.InfinispanServerExtension;
-import org.junit.jupiter.api.extension.RegisterExtension;
+import org.infinispan.server.test.api.TestClientDriver;
+import org.infinispan.server.test.junit5.InfinispanServer;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -28,8 +28,8 @@ import org.junit.jupiter.params.provider.ValueSource;
  **/
 public class HotRodCacheContinuousQueries {
 
-   @RegisterExtension
-   public static InfinispanServerExtension SERVERS = ClusteredIT.SERVERS;
+   @InfinispanServer(ClusteredIT.class)
+   public static TestClientDriver SERVERS;
 
    @ParameterizedTest
    @ValueSource(booleans = {true, false})

--- a/server/tests/src/test/java/org/infinispan/server/functional/hotrod/HotRodCacheEvents.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/hotrod/HotRodCacheEvents.java
@@ -28,10 +28,10 @@ import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.server.functional.ClusteredIT;
 import org.infinispan.server.functional.extensions.entities.Entities;
+import org.infinispan.server.test.api.TestClientDriver;
 import org.infinispan.server.test.core.Common;
-import org.infinispan.server.test.junit5.InfinispanServerExtension;
+import org.infinispan.server.test.junit5.InfinispanServer;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
@@ -43,8 +43,8 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
  **/
 public class HotRodCacheEvents {
 
-   @RegisterExtension
-   public static InfinispanServerExtension SERVERS = ClusteredIT.SERVERS;
+   @InfinispanServer(ClusteredIT.class)
+   public static TestClientDriver SERVERS;
 
    static class ArgsProvider implements ArgumentsProvider {
       @Override

--- a/server/tests/src/test/java/org/infinispan/server/functional/hotrod/HotRodCacheOperations.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/hotrod/HotRodCacheOperations.java
@@ -29,9 +29,9 @@ import org.infinispan.client.hotrod.exceptions.TransportException;
 import org.infinispan.commons.test.Exceptions;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.server.functional.ClusteredIT;
-import org.infinispan.server.test.junit5.InfinispanServerExtension;
+import org.infinispan.server.test.api.TestClientDriver;
+import org.infinispan.server.test.junit5.InfinispanServer;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
@@ -45,8 +45,8 @@ public class HotRodCacheOperations<K, V> {
 
    private static final String TEST_OUTPUT = "{0}-{1}";
 
-   @RegisterExtension
-   public static InfinispanServerExtension SERVERS = ClusteredIT.SERVERS;
+   @InfinispanServer(ClusteredIT.class)
+   public static TestClientDriver SERVERS;
    static class ArgsProvider implements ArgumentsProvider {
       @Override
       public Stream<? extends Arguments> provideArguments(ExtensionContext context) {

--- a/server/tests/src/test/java/org/infinispan/server/functional/hotrod/HotRodCacheQueries.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/hotrod/HotRodCacheQueries.java
@@ -1,5 +1,25 @@
 package org.infinispan.server.functional.hotrod;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.infinispan.query.remote.client.ProtobufMetadataManagerConstants.PROTOBUF_METADATA_CACHE_NAME;
+import static org.infinispan.server.test.core.Common.createQueryableCache;
+import static org.infinispan.server.test.core.Common.sync;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import org.assertj.core.api.Assertions;
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.Search;
@@ -20,31 +40,11 @@ import org.infinispan.protostream.sampledomain.User;
 import org.infinispan.query.dsl.QueryFactory;
 import org.infinispan.server.functional.ClusteredIT;
 import org.infinispan.server.functional.extensions.entities.Entities;
-import org.infinispan.server.test.junit5.InfinispanServerExtension;
+import org.infinispan.server.test.api.TestClientDriver;
+import org.infinispan.server.test.junit5.InfinispanServer;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.infinispan.query.remote.client.ProtobufMetadataManagerConstants.PROTOBUF_METADATA_CACHE_NAME;
-import static org.infinispan.server.test.core.Common.createQueryableCache;
-import static org.infinispan.server.test.core.Common.sync;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Tristan Tarrant &lt;tristan@infinispan.org&gt;
@@ -55,8 +55,8 @@ public class HotRodCacheQueries {
    public static final String BANK_PROTO_FILE = "/proto/generated/test.protostream.sampledomain.proto";
    public static final String ENTITY_USER = "sample_bank_account.User";
 
-   @RegisterExtension
-   public static InfinispanServerExtension SERVERS = ClusteredIT.SERVERS;
+   @InfinispanServer(ClusteredIT.class)
+   public static TestClientDriver SERVERS;
 
    @ParameterizedTest
    @ValueSource(booleans = {true, false})

--- a/server/tests/src/test/java/org/infinispan/server/functional/hotrod/HotRodClientMetrics.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/hotrod/HotRodClientMetrics.java
@@ -12,8 +12,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import io.micrometer.prometheusmetrics.PrometheusConfig;
-import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
 import org.infinispan.client.hotrod.configuration.NearCacheMode;
@@ -21,17 +19,19 @@ import org.infinispan.client.hotrod.metrics.micrometer.MicrometerRemoteCacheMana
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.server.functional.ClusteredIT;
 import org.infinispan.server.functional.rest.RestMetricsResourceIT;
-import org.infinispan.server.test.junit5.InfinispanServerExtension;
+import org.infinispan.server.test.api.TestClientDriver;
+import org.infinispan.server.test.junit5.InfinispanServer;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.prometheusmetrics.PrometheusConfig;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 
 public class HotRodClientMetrics {
 
@@ -95,8 +95,8 @@ public class HotRodClientMetrics {
       }
    }
 
-   @RegisterExtension
-   public static InfinispanServerExtension SERVERS = ClusteredIT.SERVERS;
+   @InfinispanServer(ClusteredIT.class)
+   public static TestClientDriver SERVERS;
 
    @ParameterizedTest(name = "testConnectionPoolMetrics[{0},{1}]")
    @ArgumentsSource(ConnectionPoolArgsProvider.class)

--- a/server/tests/src/test/java/org/infinispan/server/functional/hotrod/HotRodCounterOperations.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/hotrod/HotRodCounterOperations.java
@@ -8,9 +8,9 @@ import org.infinispan.counter.api.CounterType;
 import org.infinispan.counter.api.SyncStrongCounter;
 import org.infinispan.counter.api.SyncWeakCounter;
 import org.infinispan.server.functional.ClusteredIT;
-import org.infinispan.server.test.junit5.InfinispanServerExtension;
+import org.infinispan.server.test.api.TestClientDriver;
+import org.infinispan.server.test.junit5.InfinispanServer;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * @author Tristan Tarrant &lt;tristan@infinispan.org&gt;
@@ -18,8 +18,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
  **/
 public class HotRodCounterOperations {
 
-   @RegisterExtension
-   public static InfinispanServerExtension SERVERS = ClusteredIT.SERVERS;
+   @InfinispanServer(ClusteredIT.class)
+   public static TestClientDriver SERVERS;
 
    @Test
    public void testCounters() {

--- a/server/tests/src/test/java/org/infinispan/server/functional/hotrod/HotRodListenerWithDslFilter.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/hotrod/HotRodListenerWithDslFilter.java
@@ -35,11 +35,11 @@ import org.infinispan.query.dsl.Query;
 import org.infinispan.query.dsl.QueryFactory;
 import org.infinispan.query.remote.client.FilterResult;
 import org.infinispan.server.functional.ClusteredIT;
-import org.infinispan.server.test.junit5.InfinispanServerExtension;
+import org.infinispan.server.test.api.TestClientDriver;
+import org.infinispan.server.test.junit5.InfinispanServer;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Basic test for query DSL based remote event filters.
@@ -48,8 +48,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
  * @since 8.1
  */
 public class HotRodListenerWithDslFilter {
-   @RegisterExtension
-   public static InfinispanServerExtension SERVERS = ClusteredIT.SERVERS;
+   @InfinispanServer(ClusteredIT.class)
+   public static TestClientDriver SERVERS;
 
    @Test
    public void testEventFilter() {

--- a/server/tests/src/test/java/org/infinispan/server/functional/hotrod/HotRodMultiMapOperations.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/hotrod/HotRodMultiMapOperations.java
@@ -13,9 +13,9 @@ import org.infinispan.client.hotrod.multimap.MultimapCacheManager;
 import org.infinispan.client.hotrod.multimap.RemoteMultimapCache;
 import org.infinispan.client.hotrod.multimap.RemoteMultimapCacheManagerFactory;
 import org.infinispan.server.functional.ClusteredIT;
-import org.infinispan.server.test.junit5.InfinispanServerExtension;
+import org.infinispan.server.test.api.TestClientDriver;
+import org.infinispan.server.test.junit5.InfinispanServer;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * @author Tristan Tarrant &lt;tristan@infinispan.org&gt;
@@ -23,8 +23,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
  **/
 public class HotRodMultiMapOperations {
 
-   @RegisterExtension
-   public static InfinispanServerExtension SERVERS = ClusteredIT.SERVERS;
+   @InfinispanServer(ClusteredIT.class)
+   public static TestClientDriver SERVERS;
 
    @Test
    public void testMultiMap() {

--- a/server/tests/src/test/java/org/infinispan/server/functional/hotrod/HotRodTransactionalCacheOperations.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/hotrod/HotRodTransactionalCacheOperations.java
@@ -10,8 +10,8 @@ import org.infinispan.client.hotrod.transaction.lookup.RemoteTransactionManagerL
 import org.infinispan.commons.configuration.StringConfiguration;
 import org.infinispan.configuration.parsing.Parser;
 import org.infinispan.server.functional.ClusteredIT;
-import org.infinispan.server.test.junit5.InfinispanServerExtension;
-import org.junit.jupiter.api.extension.RegisterExtension;
+import org.infinispan.server.test.api.TestClientDriver;
+import org.infinispan.server.test.junit5.InfinispanServer;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
@@ -31,8 +31,8 @@ public class HotRodTransactionalCacheOperations {
                "  </distributed-cache-configuration>" +
                "</cache-container></infinispan>";
 
-   @RegisterExtension
-   public static InfinispanServerExtension SERVERS = ClusteredIT.SERVERS;
+   @InfinispanServer(ClusteredIT.class)
+   public static TestClientDriver SERVERS;
 
    @ParameterizedTest(name = "{0}")
    @EnumSource(value = Parser.TransactionMode.class, names = {"NON_XA", "NON_DURABLE_XA", "FULL_XA"})

--- a/server/tests/src/test/java/org/infinispan/server/functional/hotrod/IgnoreCaches.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/hotrod/IgnoreCaches.java
@@ -15,17 +15,17 @@ import org.infinispan.client.rest.configuration.RestClientConfigurationBuilder;
 import org.infinispan.commons.dataconversion.internal.Json;
 import org.infinispan.rest.helper.RestResponses;
 import org.infinispan.server.functional.ClusteredIT;
-import org.infinispan.server.test.junit5.InfinispanServerExtension;
+import org.infinispan.server.test.api.TestClientDriver;
+import org.infinispan.server.test.junit5.InfinispanServer;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * @since 10.0
  */
 public class IgnoreCaches {
 
-   @RegisterExtension
-   public static InfinispanServerExtension SERVERS = ClusteredIT.SERVERS;
+   @InfinispanServer(ClusteredIT.class)
+   public static TestClientDriver SERVERS;
 
    @Test
    public void testIgnoreCaches() {

--- a/server/tests/src/test/java/org/infinispan/server/functional/memcached/MemcachedOperations.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/memcached/MemcachedOperations.java
@@ -13,8 +13,8 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.infinispan.server.functional.ClusteredIT;
-import org.infinispan.server.test.junit5.InfinispanServerExtension;
-import org.junit.jupiter.api.extension.RegisterExtension;
+import org.infinispan.server.test.api.TestClientDriver;
+import org.infinispan.server.test.junit5.InfinispanServer;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
@@ -29,8 +29,8 @@ import net.spy.memcached.internal.GetFuture;
  **/
 public class MemcachedOperations {
 
-   @RegisterExtension
-   public static InfinispanServerExtension SERVERS = ClusteredIT.SERVERS;
+   @InfinispanServer(ClusteredIT.class)
+   public static TestClientDriver SERVERS;
 
    private static final AtomicInteger KCOUNTER = new AtomicInteger(0);
 

--- a/server/tests/src/test/java/org/infinispan/server/functional/rest/RestLoggingResource.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/rest/RestLoggingResource.java
@@ -13,17 +13,17 @@ import org.infinispan.client.rest.RestClient;
 import org.infinispan.client.rest.RestResponse;
 import org.infinispan.commons.dataconversion.internal.Json;
 import org.infinispan.server.functional.ClusteredIT;
-import org.infinispan.server.test.junit5.InfinispanServerExtension;
+import org.infinispan.server.test.api.TestClientDriver;
+import org.infinispan.server.test.junit5.InfinispanServer;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * @since 11.0
  */
 public class RestLoggingResource {
 
-   @RegisterExtension
-   public static InfinispanServerExtension SERVERS = ClusteredIT.SERVERS;
+   @InfinispanServer(ClusteredIT.class)
+   public static TestClientDriver SERVERS;
 
    @Test
    public void testListLoggers() {

--- a/server/tests/src/test/java/org/infinispan/server/functional/rest/RestOperations.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/rest/RestOperations.java
@@ -31,8 +31,8 @@ import org.infinispan.counter.configuration.ConvertUtil;
 import org.infinispan.rest.resources.AbstractRestResourceTest;
 import org.infinispan.rest.resources.WeakSSEListener;
 import org.infinispan.server.functional.ClusteredIT;
-import org.infinispan.server.test.junit5.InfinispanServerExtension;
-import org.junit.jupiter.api.extension.RegisterExtension;
+import org.infinispan.server.test.api.TestClientDriver;
+import org.infinispan.server.test.junit5.InfinispanServer;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
@@ -42,8 +42,8 @@ import org.junit.jupiter.params.provider.EnumSource;
  **/
 public class RestOperations {
 
-   @RegisterExtension
-   public static InfinispanServerExtension SERVERS = ClusteredIT.SERVERS;
+   @InfinispanServer(ClusteredIT.class)
+   public static TestClientDriver SERVERS;
 
    @ParameterizedTest
    @EnumSource(Protocol.class)

--- a/server/tests/src/test/java/org/infinispan/server/functional/rest/RestRouter.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/rest/RestRouter.java
@@ -10,17 +10,17 @@ import java.util.function.Function;
 import org.infinispan.client.rest.RestClient;
 import org.infinispan.client.rest.configuration.RestClientConfigurationBuilder;
 import org.infinispan.server.functional.ClusteredIT;
-import org.infinispan.server.test.junit5.InfinispanServerExtension;
+import org.infinispan.server.test.api.TestClientDriver;
+import org.infinispan.server.test.junit5.InfinispanServer;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * @since 10.0
  */
 public class RestRouter {
 
-   @RegisterExtension
-   public static InfinispanServerExtension SERVERS = ClusteredIT.SERVERS;
+   @InfinispanServer(ClusteredIT.class)
+   public static TestClientDriver SERVERS;
 
    @Test
    public void testRestRouting() throws Exception {

--- a/server/tests/src/test/java/org/infinispan/server/functional/rest/RestServerResource.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/rest/RestServerResource.java
@@ -14,10 +14,9 @@ import org.infinispan.client.rest.RestClient;
 import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.commons.dataconversion.internal.Json;
 import org.infinispan.server.functional.ClusteredIT;
-import org.infinispan.server.test.core.ContainerInfinispanServerDriver;
-import org.infinispan.server.test.junit5.InfinispanServerExtension;
+import org.infinispan.server.test.api.TestClientDriver;
+import org.infinispan.server.test.junit5.InfinispanServer;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.shaded.com.google.common.collect.Sets;
 
 /**
@@ -25,8 +24,8 @@ import org.testcontainers.shaded.com.google.common.collect.Sets;
  */
 public class RestServerResource {
 
-   @RegisterExtension
-   public static InfinispanServerExtension SERVERS = ClusteredIT.SERVERS;
+   @InfinispanServer(ClusteredIT.class)
+   public static TestClientDriver SERVERS;
 
    @Test
    public void testConfig() {
@@ -39,7 +38,7 @@ public class RestServerResource {
       Json endpoints = server.at("endpoints");
       Json endpoint = endpoints.at("endpoint");
 
-      String inetAddress = SERVERS.getServerDriver() instanceof ContainerInfinispanServerDriver ? "SITE_LOCAL" : "127.0.0.1";
+      String inetAddress = SERVERS.isContainerized() ? "SITE_LOCAL" : "127.0.0.1";
       assertEquals(inetAddress, interfaces.at(0).at("inet-address").at("value").asString());
       assertEquals("default", security.at("security-realms").at(0).at("name").asString());
       assertEquals("hotrod", endpoint.at("hotrod-connector").at("name").asString());

--- a/server/tests/src/test/java/org/infinispan/server/test/core/Common.java
+++ b/server/tests/src/test/java/org/infinispan/server/test/core/Common.java
@@ -53,8 +53,8 @@ import org.infinispan.protostream.SerializationContext;
 import org.infinispan.protostream.sampledomain.TestDomainSCI;
 import org.infinispan.query.remote.client.ProtobufMetadataManagerConstants;
 import org.infinispan.server.persistence.PersistenceIT;
-import org.infinispan.server.test.api.HotRodTestClientDriver;
-import org.infinispan.server.test.junit5.InfinispanServerExtension;
+import org.infinispan.server.test.api.HotRodClientDriver;
+import org.infinispan.server.test.api.TestClientDriver;
 import org.infinispan.test.TestingUtil;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.provider.Arguments;
@@ -248,12 +248,12 @@ public class Common {
    }
 
 
-   public static <K, V> RemoteCache<K, V> createQueryableCache(InfinispanServerExtension server, boolean indexed, String protoFile, String entityName) {
+   public static <K, V> RemoteCache<K, V> createQueryableCache(TestClientDriver server, boolean indexed, String protoFile, String entityName) {
 
       ConfigurationBuilder config = new ConfigurationBuilder();
       config.marshaller(new ProtoStreamMarshaller());
 
-      HotRodTestClientDriver hotRodTestClientDriver = server.hotrod().withClientConfiguration(config);
+      HotRodClientDriver<?> hotRodTestClientDriver = server.hotrod().withClientConfiguration(config);
       RemoteCacheManager remoteCacheManager = hotRodTestClientDriver.createRemoteCacheManager();
 
       if (protoFile != null) {


### PR DESCRIPTION
Fixes #15080 

This PR sets it up to allow for JUnit 5 extensions to be injected between IT tests. That is a test only need to use @InfinispanServer instead of @RegisterExtension and specify a default IT to be used if one is not injected. Then the test can be ran with any IT that has a defined @RegisterExtension that implements AbstractInfinispanExtension automatically.

If the test is ran individually it will use the annotation class defined IT and automatically inject the AbstractInfinispanExtension if there is only one. Then you can also override this by using the System property to define your own IT (e.g. `-Dorg.infinispan.server.test.junit5.extension=org.infinispan.server.functional.ClusteredRollingUpgradeIT`).