### PR TITLE
[#14390] Avoid file clash in surefire-reports

### DIFF
--- a/.github/workflows/on_build_do_test.yml
+++ b/.github/workflows/on_build_do_test.yml
@@ -165,7 +165,7 @@ jobs:
           path: |
             test_dir/infinispan/**/target/*-reports*/**/TEST-*.xml
             !test_dir/infinispan/**/*-reports*/**/TEST-*FLAKY.xml
-            !test_dir/infinispan/**/*-reports*/TEST-*RocksDB*.xml
+            !test_dir/infinispan/**/ignored*reports*
             test_dir/infinispan/**/*.dump*
             test_dir/infinispan/**/hs_err_*
             test_dir/infinispan/jacoco/
@@ -336,6 +336,7 @@ jobs:
           path: |
             test_dir/infinispan/**/target/*-reports*/**/TEST-*.xml
             !test_dir/infinispan/**/target/*-reports*/**/TEST-*FLAKY.xml
+            !test_dir/infinispan/**/ignored*reports*
             test_dir/infinispan/**/*.dump*
             test_dir/infinispan/**/hs_err_*
             test_dir/infinispan/**/failsafe-summary.xml

--- a/anchored-keys/pom.xml
+++ b/anchored-keys/pom.xml
@@ -31,6 +31,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <reportsDirectory>${project.build.directory}/ignored-surefire-reports</reportsDirectory>
                     <dependenciesToScan>
                         <!-- TestNGSuiteChecksTest -->
                         <dependency>org.infinispan:infinispan-commons-test</dependency>

--- a/cdi/embedded/pom.xml
+++ b/cdi/embedded/pom.xml
@@ -88,6 +88,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <reportsDirectory>${project.build.directory}/ignored-surefire-reports</reportsDirectory>
                     <reuseForks>true</reuseForks>
                     <forkCount>1</forkCount>
                     <parallel>none</parallel>

--- a/cdi/remote/pom.xml
+++ b/cdi/remote/pom.xml
@@ -108,6 +108,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <reportsDirectory>${project.build.directory}/ignored-surefire-reports</reportsDirectory>
                     <reuseForks>true</reuseForks>
                     <forkCount>1</forkCount>
                     <parallel>none</parallel>

--- a/client/hotrod-client/pom.xml
+++ b/client/hotrod-client/pom.xml
@@ -303,6 +303,7 @@
                      <goal>test</goal>
                   </goals>
                   <configuration>
+                     <reportsDirectory>${project.build.directory}/ignored-surefire-reports</reportsDirectory>
                      <properties>
                         <configurationParameters>
                            testng.excludedGroups = ${defaultExcludedTestNGGroups}
@@ -323,6 +324,7 @@
                </execution>
             </executions>
             <configuration>
+               <reportsDirectory>${project.build.directory}/ignored-surefire-reports</reportsDirectory>
                <systemPropertyVariables combine.self="append">
                   <infinispan.server.hotrod.workerThreads>3</infinispan.server.hotrod.workerThreads>
                </systemPropertyVariables>
@@ -344,6 +346,7 @@
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-surefire-plugin</artifactId>
                   <configuration>
+                     <reportsDirectory>${project.build.directory}/ignored-surefire-reports</reportsDirectory>
                      <excludes>
                         <exclude>**/*QueryDslConditions*.java</exclude>
                         <exclude>**/*QueryString*.java</exclude>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -252,6 +252,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
+               <reportsDirectory>${project.build.directory}/ignored-surefire-reports</reportsDirectory>
                <dependenciesToScan>
                   <!-- TestNGSuiteChecksTest -->
                   <dependency>org.infinispan:infinispan-commons-test</dependency>
@@ -281,6 +282,7 @@
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-surefire-plugin</artifactId>
                   <configuration>
+                     <reportsDirectory>${project.build.directory}/ignored-surefire-reports</reportsDirectory>
                      <excludes>
                         <!-- explicitly exclude some tests because of TestNG issue which ignores
                              restricted groups in subclasses -->

--- a/counter/pom.xml
+++ b/counter/pom.xml
@@ -47,6 +47,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <reportsDirectory>${project.build.directory}/ignored-surefire-reports</reportsDirectory>
                     <dependenciesToScan>
                         <!-- TestNGSuiteChecksTest -->
                         <dependency>org.infinispan:infinispan-commons-test</dependency>

--- a/gridfs/pom.xml
+++ b/gridfs/pom.xml
@@ -31,6 +31,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <reportsDirectory>${project.build.directory}/ignored-surefire-reports</reportsDirectory>
                     <dependenciesToScan>
                         <!-- TestNGSuiteChecksTest -->
                         <dependency>org.infinispan:infinispan-commons-test</dependency>

--- a/integrationtests/cdi-weld-se-it/pom.xml
+++ b/integrationtests/cdi-weld-se-it/pom.xml
@@ -69,6 +69,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
+               <reportsDirectory>${project.build.directory}/ignored-surefire-reports</reportsDirectory>
                <dependenciesToScan>
                   <!-- TestNGSuiteChecksTest -->
                   <dependency>org.infinispan:infinispan-commons-test</dependency>

--- a/integrationtests/endpoints-interop-it/pom.xml
+++ b/integrationtests/endpoints-interop-it/pom.xml
@@ -133,6 +133,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
+               <reportsDirectory>${project.build.directory}/ignored-surefire-reports</reportsDirectory>
                <dependenciesToScan>
                   <!-- TestNGSuiteChecksTest -->
                   <dependency>org.infinispan:infinispan-commons-test</dependency>

--- a/integrationtests/jboss-marshalling-it/pom.xml
+++ b/integrationtests/jboss-marshalling-it/pom.xml
@@ -123,6 +123,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
+               <reportsDirectory>${project.build.directory}/ignored-surefire-reports</reportsDirectory>
                <dependenciesToScan>
                   <!-- TestNGSuiteChecksTest -->
                   <dependency>org.infinispan:infinispan-commons-test</dependency>

--- a/jcache/embedded/pom.xml
+++ b/jcache/embedded/pom.xml
@@ -107,6 +107,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
+               <reportsDirectory>${project.build.directory}/ignored-surefire-reports</reportsDirectory>
                <parallel>none</parallel>
                <groups>${defaultTestGroup}</groups>
                <dependenciesToScan>

--- a/jcache/remote/pom.xml
+++ b/jcache/remote/pom.xml
@@ -130,6 +130,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
+               <reportsDirectory>${project.build.directory}/ignored-surefire-reports</reportsDirectory>
                <parallel>none</parallel>
                <systemPropertyVariables>
                   <infinispan.jcache.mgmt.lookup.skip>true</infinispan.jcache.mgmt.lookup.skip>

--- a/lock/pom.xml
+++ b/lock/pom.xml
@@ -38,6 +38,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
+               <reportsDirectory>${project.build.directory}/ignored-surefire-reports</reportsDirectory>
                <dependenciesToScan>
                   <!-- TestNGSuiteChecksTest -->
                   <dependency>org.infinispan:infinispan-commons-test</dependency>

--- a/multimap/pom.xml
+++ b/multimap/pom.xml
@@ -97,6 +97,7 @@
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-surefire-plugin</artifactId>
               <configuration>
+                 <reportsDirectory>${project.build.directory}/ignored-surefire-reports</reportsDirectory>
                  <dependenciesToScan>
                     <!-- TestNGSuiteChecksTest -->
                     <dependency>org.infinispan:infinispan-commons-test</dependency>

--- a/persistence/remote/pom.xml
+++ b/persistence/remote/pom.xml
@@ -167,6 +167,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
+               <reportsDirectory>${project.build.directory}/ignored-surefire-reports</reportsDirectory>
                <dependenciesToScan>
                   <!-- TestNGSuiteChecksTest -->
                   <dependency>org.infinispan:infinispan-commons-test</dependency>

--- a/persistence/rocksdb/pom.xml
+++ b/persistence/rocksdb/pom.xml
@@ -106,6 +106,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
+               <reportsDirectory>${project.build.directory}/ignored-surefire-reports</reportsDirectory>
                <dependenciesToScan>
                   <!-- TestNGSuiteChecksTest -->
                   <dependency>org.infinispan:infinispan-commons-test</dependency>

--- a/query-core/pom.xml
+++ b/query-core/pom.xml
@@ -112,6 +112,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <reportsDirectory>${project.build.directory}/ignored-surefire-reports</reportsDirectory>
                     <dependenciesToScan>
                         <!-- TestNGSuiteChecksTest -->
                         <dependency>org.infinispan:infinispan-commons-test</dependency>

--- a/query/pom.xml
+++ b/query/pom.xml
@@ -221,6 +221,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
+               <reportsDirectory>${project.build.directory}/ignored-surefire-reports</reportsDirectory>
                <argLine>${forkJvmArgs} ${testjvm.jdkSpecificArgs} -Djdk.attach.allowAttachSelf=true</argLine>
             </configuration>
          </plugin>
@@ -247,6 +248,7 @@
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-surefire-plugin</artifactId>
                   <configuration>
+                     <reportsDirectory>${project.build.directory}/ignored-surefire-reports</reportsDirectory>
                      <!-- explicitly exclude some tests because of TestNG issue which ignores
                           restricted groups in subclasses -->
                      <includes>

--- a/remote-query/remote-query-server/pom.xml
+++ b/remote-query/remote-query-server/pom.xml
@@ -123,6 +123,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
+               <reportsDirectory>${project.build.directory}/ignored-surefire-reports</reportsDirectory>
                <dependenciesToScan>
                   <!-- TestNGSuiteChecksTest -->
                   <dependency>org.infinispan:infinispan-commons-test</dependency>

--- a/server/core/pom.xml
+++ b/server/core/pom.xml
@@ -189,6 +189,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
+               <reportsDirectory>${project.build.directory}/ignored-surefire-reports</reportsDirectory>
                <dependenciesToScan>
                   <!-- TestNGSuiteChecksTest -->
                   <dependency>org.infinispan:infinispan-commons-test</dependency>

--- a/server/hotrod/pom.xml
+++ b/server/hotrod/pom.xml
@@ -102,6 +102,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
+               <reportsDirectory>${project.build.directory}/ignored-surefire-reports</reportsDirectory>
                <dependenciesToScan>
                   <!-- TestNGSuiteChecksTest -->
                   <dependency>org.infinispan:infinispan-commons-test</dependency>

--- a/server/memcached/pom.xml
+++ b/server/memcached/pom.xml
@@ -91,6 +91,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
+               <reportsDirectory>${project.build.directory}/ignored-surefire-reports</reportsDirectory>
                <dependenciesToScan>
                   <!-- TestNGSuiteChecksTest -->
                   <dependency>org.infinispan:infinispan-commons-test</dependency>

--- a/server/resp/pom.xml
+++ b/server/resp/pom.xml
@@ -126,6 +126,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
+               <reportsDirectory>${project.build.directory}/ignored-surefire-reports</reportsDirectory>
                <dependenciesToScan>
                   <!-- TestNGSuiteChecksTest -->
                   <dependency>org.infinispan:infinispan-commons-test</dependency>

--- a/server/rest/pom.xml
+++ b/server/rest/pom.xml
@@ -212,6 +212,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
+               <reportsDirectory>${project.build.directory}/ignored-surefire-reports</reportsDirectory>
                <dependenciesToScan>
                   <!-- TestNGSuiteChecksTest -->
                   <dependency>org.infinispan:infinispan-commons-test</dependency>
@@ -225,6 +226,7 @@
                      <goal>test</goal>
                   </goals>
                   <configuration>
+                     <reportsDirectory>${project.build.directory}/ignored-surefire-reports</reportsDirectory>
                      <properties>
                         <configurationParameters>
                            testng.excludedGroups = ${defaultExcludedTestNGGroups}

--- a/spring/spring6/spring6-embedded/pom.xml
+++ b/spring/spring6/spring6-embedded/pom.xml
@@ -164,6 +164,7 @@
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-surefire-plugin</artifactId>
               <configuration>
+                 <reportsDirectory>${project.build.directory}/ignored-surefire-reports</reportsDirectory>
                  <dependenciesToScan>
                     <!-- TestNGSuiteChecksTest -->
                     <dependency>org.infinispan:infinispan-commons-test</dependency>
@@ -193,6 +194,7 @@
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-surefire-plugin</artifactId>
                   <configuration>
+        <reportsDirectory>${project.build.directory}/ignored-surefire-reports</reportsDirectory>
                      <skipTests>true</skipTests>
                   </configuration>
                </plugin>

--- a/spring/spring6/spring6-remote/pom.xml
+++ b/spring/spring6/spring6-remote/pom.xml
@@ -161,6 +161,7 @@
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-surefire-plugin</artifactId>
               <configuration>
+                 <reportsDirectory>${project.build.directory}/ignored-surefire-reports</reportsDirectory>
                  <dependenciesToScan>
                     <!-- TestNGSuiteChecksTest -->
                     <dependency>org.infinispan:infinispan-commons-test</dependency>
@@ -182,6 +183,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
+                            <reportsDirectory>${project.build.directory}/ignored-surefire-reports</reportsDirectory>
                             <skipTests>true</skipTests>
                         </configuration>
                     </plugin>

--- a/tasks/manager/pom.xml
+++ b/tasks/manager/pom.xml
@@ -84,6 +84,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
+               <reportsDirectory>${project.build.directory}/ignored-surefire-reports</reportsDirectory>
                <dependenciesToScan>
                   <!-- TestNGSuiteChecksTest -->
                   <dependency>org.infinispan:infinispan-commons-test</dependency>

--- a/tasks/scripting/pom.xml
+++ b/tasks/scripting/pom.xml
@@ -89,6 +89,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
+               <reportsDirectory>${project.build.directory}/ignored-surefire-reports</reportsDirectory>
                <dependenciesToScan>
                   <!-- TestNGSuiteChecksTest -->
                   <dependency>org.infinispan:infinispan-commons-test</dependency>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -147,6 +147,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
+               <reportsDirectory>${project.build.directory}/ignored-surefire-reports</reportsDirectory>
                <dependenciesToScan>
                   <!-- TestNGSuiteChecksTest -->
                   <dependency>org.infinispan:infinispan-commons-test</dependency>


### PR DESCRIPTION
Closes #14390 and replaces #14391.
Move default surefire report in an ignored folder so to avoid conflicts in modules with testng engine that generates polarion reports.

Needs to be merged to have effect