### PR TITLE
[15.0.x] [#15070] Do not install outdated JGroups views

### DIFF
--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
@@ -762,48 +762,59 @@ public class JGroupsTransport implements Transport, ChannelListener, AddressGene
             log.tracef("Local address %s, uuid %s", jgroupsAddress, uuid);
          }
       }
-      if (installIfFirst && clusterView.getViewId() != ClusterView.INITIAL_VIEW_ID) {
-         return;
-      }
+
+      ClusterView newClusterView;
+      ClusterView oldClusterView;
       List<List<Address>> subGroups;
-      if (newView instanceof MergeView) {
-         if (!(channel instanceof ForkChannel)) {
-            CLUSTER.receivedMergedView(channel.clusterName(), newView);
-         }
-         subGroups = new ArrayList<>();
-         List<View> jgroupsSubGroups = ((MergeView) newView).getSubgroups();
-         for (View group : jgroupsSubGroups) {
-            subGroups.add(fromJGroupsAddressList(group.getMembers()));
-         }
-      } else {
-         if (!(channel instanceof ForkChannel)) {
-            CLUSTER.receivedClusterView(channel.clusterName(), newView);
-         }
-         subGroups = Collections.emptyList();
-      }
-      long viewId = newView.getViewId().getId();
-      List<Address> members = fromJGroupsAddressList(newView.getMembers());
-      if (members.isEmpty()) {
-         return;
-      }
-
-      ClusterView oldView = this.clusterView;
-
-      // Update every view-related field while holding the lock so that waitForView only returns
-      // after everything was updated.
       CompletableFuture<Void> oldFuture = null;
+      int viewId = (int) newView.getViewId().getId();
+
       viewUpdateLock.lock();
       try {
+         oldClusterView = this.clusterView;
+         if (installIfFirst && oldClusterView.getViewId() != ClusterView.INITIAL_VIEW_ID) {
+            log.debugf("Rejected because installIfFirst is set to true and the current view id is %s", oldClusterView.getViewId());
+            return;
+         }
+
+         if (oldClusterView.getViewId() >= viewId) {
+            log.rejectOutdatedView(oldClusterView.getViewId(), String.valueOf(newView));
+            return;
+         }
+
+         newClusterView = new ClusterView(viewId, fromJGroupsAddressList(newView.getMembers()), address);
+         if (newView instanceof MergeView) {
+            if (!(channel instanceof ForkChannel)) {
+               CLUSTER.receivedMergedView(channel.clusterName(), newView);
+            }
+            subGroups = new ArrayList<>();
+            List<View> jgroupsSubGroups = ((MergeView) newView).getSubgroups();
+            for (View group : jgroupsSubGroups) {
+               subGroups.add(fromJGroupsAddressList(group.getMembers()));
+            }
+         } else {
+            if (!(channel instanceof ForkChannel)) {
+               CLUSTER.receivedClusterView(channel.clusterName(), newView);
+            }
+            subGroups = Collections.emptyList();
+         }
+
+         if (newView.getMembers().isEmpty()) {
+            return;
+         }
+
+         // Update every view-related field while holding the lock so that waitForView only returns
+         // after everything was updated.
          // Delta view debug log for large cluster
-         if (log.isDebugEnabled() && oldView.getMembers() != null) {
-            List<Address> joined = new ArrayList<>(members);
-            joined.removeAll(oldView.getMembers());
-            List<Address> left = new ArrayList<>(oldView.getMembers());
-            left.removeAll(members);
+         if (log.isDebugEnabled() && oldClusterView.getMembers() != null) {
+            List<Address> joined = new ArrayList<>(newClusterView.getMembers());
+            joined.removeAll(oldClusterView.getMembers());
+            List<Address> left = new ArrayList<>(oldClusterView.getMembers());
+            left.removeAll(newClusterView.getMembers());
             log.debugf("Joined: %s, Left: %s", joined, left);
          }
 
-         this.clusterView = new ClusterView((int) viewId, members, address);
+         this.clusterView = newClusterView;
 
          // Create a completable future for the new view
          oldFuture = nextViewFuture;
@@ -827,9 +838,9 @@ public class JGroupsTransport implements Transport, ChannelListener, AddressGene
       if (hasNotifier) {
          if (!subGroups.isEmpty()) {
             final Address address1 = getAddress();
-            CompletionStages.join(notifier.notifyMerge(members, oldView.getMembers(), address1, (int) viewId, subGroups));
+            CompletionStages.join(notifier.notifyMerge(newClusterView.getMembers(), oldClusterView.getMembers(), address1, viewId, subGroups));
          } else {
-            CompletionStages.join(notifier.notifyViewChange(members, oldView.getMembers(), getAddress(), (int) viewId));
+            CompletionStages.join(notifier.notifyViewChange(newClusterView.getMembers(), oldClusterView.getMembers(), getAddress(), viewId));
          }
       }
 

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -2405,4 +2405,8 @@ public interface Log extends BasicLogger {
    @LogMessage(level = ERROR)
    @Message(value = "Failed to initialize global registry", id = 710)
    void failedToInitializeGlobalRegistry(@Cause Throwable t);
+
+   @LogMessage(level = WARN)
+   @Message(value = "View event rejected. The installed view id '%s' is newer than the received view: %s", id = 711)
+   void rejectOutdatedView(int viewId, String newView);
 }


### PR DESCRIPTION
**Backport:** https://github.com/infinispan/infinispan/pull/15096

Fixes #15070 