### PR TITLE
[#15128] Rolling upgrades with persistence enabled

### DIFF
--- a/server/rollingupgradetests/pom.xml
+++ b/server/rollingupgradetests/pom.xml
@@ -28,6 +28,7 @@
       <test.driverArgs>
          -Dorg.infinispan.test.server.dir=${org.infinispan.test.server.dir}
          -Dorg.infinispan.test.server.container.ulimit=${org.infinispan.test.server.container.ulimit}
+         -Dorg.infinispan.test.database.jdbc.drivers.file="../tests/target/test-classes/database/jdbc-drivers.txt"
       </test.driverArgs>
    </properties>
 
@@ -209,6 +210,7 @@
                <properties>
                   <usedefaultlisteners>false</usedefaultlisteners>
                   <listener>${junitListener},org.infinispan.server.test.junit4.InfinispanServerTestListener</listener>
+                  <org.infinispan.test.database.jdbc.drivers.file>../tests/target/test-classes/database/jdbc-drivers.txt</org.infinispan.test.database.jdbc.drivers.file>
                </properties>
                <argLine>${forkJvmArgs} ${testjvm.jdkSpecificArgs} ${test.driverArgs} -Djdk.attach.allowAttachSelf=true -Ddir.jacoco=${dir.jacoco}</argLine>
             </configuration>

--- a/server/rollingupgradetests/src/test/java/org/infinispan/server/rollingupgrade/PersistenceRollingUpgradeIT.java
+++ b/server/rollingupgradetests/src/test/java/org/infinispan/server/rollingupgrade/PersistenceRollingUpgradeIT.java
@@ -1,0 +1,26 @@
+package org.infinispan.server.rollingupgrade;
+
+import org.infinispan.server.persistence.AsyncJdbcStringBasedCacheStore;
+import org.infinispan.server.persistence.BaseJdbcStringBasedCacheStoreIT;
+import org.infinispan.server.persistence.BasePooledConnectionOperations;
+import org.infinispan.server.persistence.ManagedConnectionOperations;
+import org.infinispan.server.persistence.PersistenceIT;
+import org.infinispan.server.test.junit5.InfinispanSuite;
+import org.infinispan.server.test.junit5.RollingUpgradeHandlerExtension;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+
+@Suite(failIfNoTests = false)
+@SelectClasses({
+      BasePooledConnectionOperations.class,
+      ManagedConnectionOperations.class,
+      BaseJdbcStringBasedCacheStoreIT.class,
+      AsyncJdbcStringBasedCacheStore.class
+})
+public class PersistenceRollingUpgradeIT extends InfinispanSuite {
+
+   @RegisterExtension
+   public static RollingUpgradeHandlerExtension SERVERS =
+         RollingUpgradeHandlerExtension.from(PersistenceIT.EXTENSION_BUILDER, "15.2.0.Final", "15.2.1.Final");
+}

--- a/server/rollingupgradetests/src/test/java/org/infinispan/server/rollingupgrade/RollingUpgradePersistenceTest.java
+++ b/server/rollingupgradetests/src/test/java/org/infinispan/server/rollingupgrade/RollingUpgradePersistenceTest.java
@@ -1,0 +1,116 @@
+package org.infinispan.server.rollingupgrade;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.infinispan.server.test.core.TestSystemPropertyNames.INFINISPAN_TEST_SERVER_CONTAINER_VOLUME_REQUIRED;
+
+import java.util.function.Consumer;
+
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.commons.configuration.BasicConfiguration;
+import org.infinispan.commons.configuration.StringConfiguration;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.server.persistence.JdbcConfigurationUtil;
+import org.infinispan.server.persistence.PersistenceIT;
+import org.infinispan.server.persistence.TableManipulation;
+import org.infinispan.server.test.core.persistence.Database;
+import org.infinispan.server.test.core.persistence.DatabaseServerListener;
+import org.infinispan.server.test.core.rollingupgrade.RollingUpgradeConfigurationBuilder;
+import org.infinispan.server.test.core.rollingupgrade.RollingUpgradeHandler;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+public class RollingUpgradePersistenceTest {
+
+   private static final int NUM_ENTRIES = 100;
+
+   @Test
+   public void testRollingUpgradeWithSIFS() throws Throwable {
+      String cacheName = "rolling-upgrade";
+      int nodeCount = 3;
+      String xml = """
+            <distributed-cache name="%s">
+              <persistence passivation="false">
+                <file-store shared="false" />
+              </persistence>
+            </distributed-cache>
+            """.formatted(cacheName);
+
+      RollingUpgradeConfigurationBuilder builder = new RollingUpgradeConfigurationBuilder("15.2.0.Final", "15.2.1.Final")
+            .nodeCount(nodeCount);
+      builder.handlers(
+            uh -> handleInitializer(uh, cacheName, new StringConfiguration(xml)),
+            uh -> assertDataIsCorrect(uh, cacheName)
+            );
+
+      RollingUpgradeHandler.performUpgrade(builder.build());
+   }
+
+   @ParameterizedTest
+   @org.infinispan.server.test.core.tags.Database
+   @ArgumentsSource(PersistenceIT.DefaultDatabaseTypes.class)
+   public void testRollingUpgradeWithJdbcString(String databaseType) throws Throwable {
+      String cacheName = "rolling_upgrade_jdbc";
+      int nodeCount = 2;
+      DatabaseServerListener listener = new DatabaseServerListener(databaseType);
+      RollingUpgradeConfigurationBuilder builder = new RollingUpgradeConfigurationBuilder("15.2.0.Final", "15.2.1.Final")
+            .nodeCount(nodeCount)
+            .addArtifacts(PersistenceIT.getJavaArchive())
+            .addMavenArtifacts(PersistenceIT.getJdbcDrivers())
+            .addProperty(INFINISPAN_TEST_SERVER_CONTAINER_VOLUME_REQUIRED, "true")
+            .addListener(listener);
+
+      Consumer<TableManipulation> validateTable = table -> {
+         try (table) {
+            assertThat(table.countAllRows()).isEqualTo(NUM_ENTRIES);
+            for (int i = 0; i < NUM_ENTRIES; i++) {
+               try {
+                  assertThat(table.getValueByKey("key-" + i)).isNotNull();
+               } catch (Exception e) {
+                  throw new AssertionError(e);
+               }
+            }
+         }
+      };
+
+      builder.handlers(ruh -> {
+         Database database = listener.getDatabase(databaseType);
+         JdbcConfigurationUtil jdbcUtil = new JdbcConfigurationUtil(CacheMode.REPL_SYNC, database, false, true)
+               .setLockingConfigurations();
+         handleInitializer(ruh, cacheName, jdbcUtil.getConfigurationBuilder().build());
+         validateTable.accept(new TableManipulation(cacheName, jdbcUtil.getPersistenceConfiguration()));
+      }, ruh -> {
+         Database database = listener.getDatabase(databaseType);
+         JdbcConfigurationUtil jdbcUtil = new JdbcConfigurationUtil(CacheMode.REPL_SYNC, database, false, true)
+               .setLockingConfigurations();
+         assertDataIsCorrect(ruh, cacheName);
+         validateTable.accept(new TableManipulation(cacheName, jdbcUtil.getPersistenceConfiguration()));
+         return true;
+      });
+
+      RollingUpgradeHandler.performUpgrade(builder.build());
+   }
+
+   private void handleInitializer(RollingUpgradeHandler uh, String cacheName, BasicConfiguration configuration) {
+      RemoteCache<String, String> cache = uh.getRemoteCacheManager()
+            .administration()
+            .getOrCreateCache(cacheName, configuration);
+
+      for (int i = 0; i < NUM_ENTRIES; i++) {
+         cache.put("key-" + i, "value-" + i);
+      }
+
+      assertThat(cache.size()).isEqualTo(NUM_ENTRIES);
+   }
+
+   private boolean assertDataIsCorrect(RollingUpgradeHandler ruh, String cacheName) {
+      RemoteCache<String, String> cache = ruh.getRemoteCacheManager().getCache(cacheName);
+      assertThat(cache.size()).isEqualTo(NUM_ENTRIES);
+
+      for (int i = 0; i < NUM_ENTRIES; i++) {
+         assertThat(cache.get("key-" + i)).isEqualTo("value-" + i);
+      }
+
+      return true;
+   }
+}

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/api/AbstractTestClientDriver.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/api/AbstractTestClientDriver.java
@@ -81,10 +81,7 @@ abstract class AbstractTestClientDriver<S extends AbstractTestClientDriver<S>> i
       return self();
    }
 
-   public S withQualifier(String qualifier) {
-      return withQualifiers(qualifier);
-   }
-
+   @Override
    public S withQualifiers(Object... qualifiers) {
       this.qualifiers = qualifiers;
       return self();

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/api/CommonTestClientDriver.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/api/CommonTestClientDriver.java
@@ -14,4 +14,10 @@ public interface CommonTestClientDriver<T extends CommonTestClientDriver<T>> {
    T withUser(TestUser testUser);
 
    T withUser(AuthorizationPermission permission);
+
+   T withQualifiers(Object... qualifiers);
+
+   default T withQualifier(String qualifier) {
+      return withQualifiers(qualifier);
+   }
 }

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/api/TestClientDriver.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/api/TestClientDriver.java
@@ -1,5 +1,7 @@
 package org.infinispan.server.test.api;
 
+import java.net.InetAddress;
+
 import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.counter.api.CounterManager;
 
@@ -74,4 +76,12 @@ public interface TestClientDriver {
     * @return the {@link CounterManager} instance
     */
    CounterManager getCounterManager();
+
+   /**
+    * Get the address of a specific node in the cluster.
+    *
+    * @param offset The offset to access the node, starting at 0.
+    * @return The address the node is bind to.
+    */
+   InetAddress getServerAddress(int offset);
 }

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/core/InfinispanServerDriver.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/core/InfinispanServerDriver.java
@@ -146,6 +146,27 @@ public interface InfinispanServerDriver {
    void restartCluster();
 
    /**
+    * Stop all nodes in the cluster.
+    */
+   default void stopCluster() {
+      for (int i = 0; i < getConfiguration().numServers(); i++) {
+         stop(i);
+      }
+   }
+
+   /**
+    * Forcefully stops all nodes in the cluster.
+    * <p>
+    * Equivalent of submitting a -SIGKILL to all processes in order.
+    * </p>
+    */
+   default void killCluster() {
+      for (int i = 0; i < getConfiguration().numServers(); i++) {
+         kill(i);
+      }
+   }
+
+   /**
     * Returns a {@link MBeanServerConnection} to the specified server
     *
     * @param server the index of the server

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/core/persistence/DatabaseServerListener.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/core/persistence/DatabaseServerListener.java
@@ -1,8 +1,12 @@
 package org.infinispan.server.test.core.persistence;
 
+import static org.infinispan.server.test.core.TestSystemPropertyNames.INFINISPAN_TEST_CONTAINER_DATABASE_PROPERTIES;
+import static org.infinispan.server.test.core.TestSystemPropertyNames.INFINISPAN_TEST_CONTAINER_DATABASE_TYPES;
+
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -10,9 +14,6 @@ import java.util.Properties;
 import org.infinispan.server.test.core.InfinispanServerDriver;
 import org.infinispan.server.test.core.InfinispanServerListener;
 import org.jboss.logging.Logger;
-
-import static org.infinispan.server.test.core.TestSystemPropertyNames.INFINISPAN_TEST_CONTAINER_DATABASE_PROPERTIES;
-import static org.infinispan.server.test.core.TestSystemPropertyNames.INFINISPAN_TEST_CONTAINER_DATABASE_TYPES;
 
 /**
  * @author Gustavo Lira &lt;glira@redhat.com&gt;
@@ -22,28 +23,31 @@ public class DatabaseServerListener implements InfinispanServerListener {
    private static final Logger log = Logger.getLogger(DatabaseServerListener.class);
    private static final String DATABASE_PROPERTIES = "org.infinispan.server.test.database.%s.%s";
    private final String[] databaseTypes;
-   public Map<String, Database> databases;
+   public final Map<String, Database> databases;
 
    public DatabaseServerListener(String... databaseTypes) {
       String property = System.getProperty(INFINISPAN_TEST_CONTAINER_DATABASE_TYPES);
       if (property != null) {
          this.databaseTypes = property.split(",");
-         log.infof("Overriding databases: %s", this.databaseTypes);
+         log.infof("Overriding databases: %s", Arrays.toString(this.databaseTypes));
       } else {
          this.databaseTypes = databaseTypes;
       }
+      this.databases = new LinkedHashMap<>(databaseTypes.length);
    }
 
    @Override
    public void before(InfinispanServerDriver driver) {
-      databases = new LinkedHashMap<>(databaseTypes.length);
       for (String dbType : databaseTypes) {
-         Database database = initDatabase(dbType);
-         log.infof("Starting database: %s", database.getType());
-         database.start();
-         log.infof("Started database: %s", database.getType());
-         if (databases.putIfAbsent(dbType, database) != null) {
-            throw new RuntimeException("Duplicate database type " + dbType);
+         Database database = databases.get(dbType);
+         if (database == null) {
+            database = initDatabase(dbType);
+            log.infof("Starting database: %s", database.getType());
+            database.start();
+            log.infof("Started database: %s", database.getType());
+            if (databases.putIfAbsent(dbType, database) != null) {
+               throw new RuntimeException("Duplicate database type " + dbType);
+            }
          }
          addDbProperty(driver, database,"jdbcUrl", database.jdbcUrl());
          addDbProperty(driver, database,"username", database.username());
@@ -56,6 +60,7 @@ public class DatabaseServerListener implements InfinispanServerListener {
    public void after(InfinispanServerDriver driver) {
       log.info("Stopping databases");
       databases.values().forEach(Database::stop);
+      databases.clear();
       log.info("Stopped databases");
    }
 

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/core/rollingupgrade/CombinedInfinispanServerDriver.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/core/rollingupgrade/CombinedInfinispanServerDriver.java
@@ -147,6 +147,16 @@ public class CombinedInfinispanServerDriver implements InfinispanServerDriver {
    }
 
    @Override
+   public void stopCluster() {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   public void killCluster() {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
    public String syncFilesFromServer(int server, String dir) {
       throw new UnsupportedOperationException();
    }

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/core/rollingupgrade/RollingUpgradeConfiguration.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/core/rollingupgrade/RollingUpgradeConfiguration.java
@@ -1,5 +1,6 @@
 package org.infinispan.server.test.core.rollingupgrade;
 
+import java.util.List;
 import java.util.Properties;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -7,12 +8,14 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
+import org.infinispan.server.test.core.InfinispanServerListener;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 
 public record RollingUpgradeConfiguration(int nodeCount, String fromVersion, String toVersion, boolean xSite,
                                           String jgroupsProtocol, int serverCheckTimeSecs, boolean useSharedDataMount,
                                           String serverConfigurationFile, boolean defaultServerConfigurationFile,
                                           Properties properties, JavaArchive[] customArtifacts, String[] mavenArtifacts,
+                                          List<InfinispanServerListener> listeners,
                                           BiConsumer<Throwable, RollingUpgradeHandler> exceptionHandler,
                                           Consumer<RollingUpgradeHandler> initialHandler,
                                           Predicate<RollingUpgradeHandler> isValidServerState,

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/core/rollingupgrade/RollingUpgradeConfigurationBuilder.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/core/rollingupgrade/RollingUpgradeConfigurationBuilder.java
@@ -16,6 +16,7 @@ import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
 import org.infinispan.commons.configuration.StringConfiguration;
+import org.infinispan.server.test.core.InfinispanServerListener;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 
 public class RollingUpgradeConfigurationBuilder {
@@ -29,6 +30,7 @@ public class RollingUpgradeConfigurationBuilder {
    private final Properties properties = new Properties();
    private final List<JavaArchive> customArtifacts = new ArrayList<>();
    private final List<String> mavenArtifacts = new ArrayList<>();
+   private final List<InfinispanServerListener> listeners = new ArrayList<>();
    private String jgroupsProtocol = "tcp";
    private int serverCheckTimeSecs = 30;
    private boolean useSharedDataMount = true;
@@ -143,6 +145,11 @@ public class RollingUpgradeConfigurationBuilder {
       return this;
    }
 
+   public RollingUpgradeConfigurationBuilder addListener(InfinispanServerListener listener) {
+      this.listeners.add(listener);
+      return this;
+   }
+
    public RollingUpgradeConfigurationBuilder handlers(Consumer<RollingUpgradeHandler> initialHandler,
                                                       Predicate<RollingUpgradeHandler> isValidServerState) {
       this.initialHandler = Objects.requireNonNull(initialHandler);
@@ -158,7 +165,7 @@ public class RollingUpgradeConfigurationBuilder {
    public RollingUpgradeConfiguration build() {
       return new RollingUpgradeConfiguration(nodeCount, fromVersion, toVersion, xSite, jgroupsProtocol, serverCheckTimeSecs,
             useSharedDataMount, serverConfigurationFile, defaultServerConfigurationFile, properties,
-            customArtifacts.toArray(new JavaArchive[0]), mavenArtifacts.toArray(new String[0]),
+            customArtifacts.toArray(new JavaArchive[0]), mavenArtifacts.toArray(new String[0]), listeners,
             exceptionHandler, initialHandler, isValidServerState, configurationHandler);
    }
 }

--- a/server/testdriver/junit4/src/main/java/org/infinispan/server/test/junit4/InfinispanServerTestMethodRule.java
+++ b/server/testdriver/junit4/src/main/java/org/infinispan/server/test/junit4/InfinispanServerTestMethodRule.java
@@ -1,5 +1,6 @@
 package org.infinispan.server.test.junit4;
 
+import java.net.InetAddress;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -69,6 +70,11 @@ public class InfinispanServerTestMethodRule implements TestRule, TestClientDrive
    @Override
    public CounterManager getCounterManager() {
       return testClient.getCounterManager();
+   }
+
+   @Override
+   public InetAddress getServerAddress(int offset) {
+      return testClient.getServerDriver().getServerAddress(offset);
    }
 
    @Override

--- a/server/testdriver/junit5/src/main/java/org/infinispan/server/test/junit5/InfinispanServerExtension.java
+++ b/server/testdriver/junit5/src/main/java/org/infinispan/server/test/junit5/InfinispanServerExtension.java
@@ -1,5 +1,7 @@
 package org.infinispan.server.test.junit5;
 
+import java.net.InetAddress;
+
 import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.counter.api.CounterManager;
 import org.infinispan.server.test.api.HotRodTestClientDriver;
@@ -115,6 +117,11 @@ public class InfinispanServerExtension extends AbstractServerExtension implement
    @Override
    public CounterManager getCounterManager() {
       return testClient.getCounterManager();
+   }
+
+   @Override
+   public InetAddress getServerAddress(int offset) {
+      return getServerDriver().getServerAddress(offset);
    }
 
    public TestServer getTestServer() {

--- a/server/tests/src/test/java/org/infinispan/server/functional/hotrod/HotRodCacheOperations.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/hotrod/HotRodCacheOperations.java
@@ -26,8 +26,8 @@ import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.VersionedValue;
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
 import org.infinispan.client.hotrod.exceptions.TransportException;
+import org.infinispan.commons.configuration.StringConfiguration;
 import org.infinispan.commons.test.Exceptions;
-import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.server.functional.ClusteredIT;
 import org.infinispan.server.test.api.TestClientDriver;
 import org.infinispan.server.test.junit5.InfinispanServer;
@@ -44,6 +44,14 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 public class HotRodCacheOperations<K, V> {
 
    private static final String TEST_OUTPUT = "{0}-{1}";
+
+   private static final String CACHE_CONFIGURATION = """
+         <distributed-cache name="%s">
+           <persistence passivation="false">
+             <file-store shared="false"/>
+           </persistence>
+         </distributed-cache>
+         """;
 
    @InfinispanServer(ClusteredIT.class)
    public static TestClientDriver SERVERS;
@@ -64,7 +72,11 @@ public class HotRodCacheOperations<K, V> {
    private RemoteCache<K, V> remoteCache(ProtocolVersion protocolVersion, boolean frv) {
       ConfigurationBuilder builder = new ConfigurationBuilder();
       builder.version(protocolVersion).forceReturnValues(frv);
-      return SERVERS.hotrod().withClientConfiguration(builder).withCacheMode(CacheMode.DIST_SYNC).create();
+      String xml = CACHE_CONFIGURATION.formatted(SERVERS.getMethodName());
+      return SERVERS.hotrod()
+            .withServerConfiguration(new StringConfiguration(xml))
+            .withClientConfiguration(builder)
+            .create();
    }
 
    private RemoteCache<K, V> remoteCache(ProtocolVersion protocolVersion) {

--- a/server/tests/src/test/java/org/infinispan/server/persistence/AsyncJdbcStringBasedCacheStore.java
+++ b/server/tests/src/test/java/org/infinispan/server/persistence/AsyncJdbcStringBasedCacheStore.java
@@ -5,18 +5,18 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.server.test.api.TestClientDriver;
 import org.infinispan.server.test.core.Common;
 import org.infinispan.server.test.core.persistence.Database;
-import org.infinispan.server.test.junit5.InfinispanServerExtension;
-import org.junit.jupiter.api.extension.RegisterExtension;
+import org.infinispan.server.test.junit5.InfinispanServer;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
 @org.infinispan.server.test.core.tags.Database
 public class AsyncJdbcStringBasedCacheStore {
 
-    @RegisterExtension
-    public static InfinispanServerExtension SERVERS = PersistenceIT.SERVERS;
+    @InfinispanServer(PersistenceIT.class)
+    public static TestClientDriver SERVERS;
 
     @ParameterizedTest
     @ArgumentsSource(Common.DatabaseProvider.class)

--- a/server/tests/src/test/java/org/infinispan/server/persistence/BaseJdbcStringBasedCacheStoreIT.java
+++ b/server/tests/src/test/java/org/infinispan/server/persistence/BaseJdbcStringBasedCacheStoreIT.java
@@ -1,0 +1,67 @@
+package org.infinispan.server.persistence;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.commons.test.Eventually;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.server.test.api.TestClientDriver;
+import org.infinispan.server.test.core.Common;
+import org.infinispan.server.test.core.persistence.Database;
+import org.infinispan.server.test.junit5.InfinispanServer;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+@org.infinispan.server.test.core.tags.Database
+public class BaseJdbcStringBasedCacheStoreIT {
+
+   @InfinispanServer(PersistenceIT.class)
+   public static TestClientDriver SERVERS;
+
+   /*
+    * This should verify that DefaultTwoWayKey2StringMapper on server side can work with ByteArrayKey which
+    * is always produced by HotRod client regardless of type of key being stored in a cache.
+    */
+   @ParameterizedTest
+   @ArgumentsSource(Common.DatabaseProvider.class)
+   public void testDefaultTwoWayKey2StringMapper(Database database) {
+      JdbcConfigurationUtil jdbcUtil = new JdbcConfigurationUtil(CacheMode.REPL_SYNC, database, false, true)
+            .setLockingConfigurations();
+      RemoteCache<Object, Object> cache = SERVERS.hotrod()
+            .withClientConfiguration(database.getHotrodClientProperties())
+            .withServerConfiguration(jdbcUtil.getConfigurationBuilder()).create();
+      try(TableManipulation table = new TableManipulation(cache.getName(), jdbcUtil.getPersistenceConfiguration())) {
+         Double doubleKey = 10.0;
+         Double doubleValue = 20.0;
+         assertEquals(0, cache.size());
+         assertEquals(0, table.countAllRows());
+         cache.put(doubleKey, doubleValue);
+         // test passivation==false, database should contain all entries which are in the cache
+         assertEquals(1, table.countAllRows());
+         assertEquals(doubleValue, cache.get(doubleKey));
+      }
+   }
+
+   @ParameterizedTest
+   @ArgumentsSource(Common.DatabaseProvider.class)
+   public void testExpiration(Database database) {
+      var jdbcUtil = new JdbcConfigurationUtil(CacheMode.LOCAL, database, false, false);
+      var configBuilder = jdbcUtil.getConfigurationBuilder();
+      configBuilder.expiration()
+            .lifespan(1)
+            .wakeUpInterval("10ms");
+      RemoteCache<String, String> cache = SERVERS.hotrod()
+            .withClientConfiguration(database.getHotrodClientProperties())
+            .withServerConfiguration(configBuilder).create();
+      cache.put("Key", "Value");
+      Eventually.eventually(cache::isEmpty);
+      try(TableManipulation table = new TableManipulation(cache.getName(), jdbcUtil.getPersistenceConfiguration())) {
+         table.countAllRows();
+         Eventually.eventually(() -> {
+            var rows = table.countAllRows();
+            System.out.println(rows);
+            return rows == 0;
+         });
+      }
+   }
+}

--- a/server/tests/src/test/java/org/infinispan/server/persistence/BasePooledConnectionOperations.java
+++ b/server/tests/src/test/java/org/infinispan/server/persistence/BasePooledConnectionOperations.java
@@ -1,0 +1,72 @@
+package org.infinispan.server.persistence;
+
+import static org.infinispan.server.persistence.PooledConnectionOperations.assertCleanCacheAndStore;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.server.test.api.TestClientDriver;
+import org.infinispan.server.test.core.Common;
+import org.infinispan.server.test.core.persistence.Database;
+import org.infinispan.server.test.junit5.InfinispanServer;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+@org.infinispan.server.test.core.tags.Database
+public class BasePooledConnectionOperations {
+
+   @InfinispanServer(PersistenceIT.class)
+   public static TestClientDriver SERVERS;
+
+   @ParameterizedTest
+   @ArgumentsSource(Common.DatabaseProvider.class)
+   public void testTwoCachesSameCacheStore(Database database) {
+      JdbcConfigurationUtil jdbcUtil = new JdbcConfigurationUtil(CacheMode.DIST_SYNC, database, false, false);
+      RemoteCache<String, String> cache1 = SERVERS.hotrod()
+            .withClientConfiguration(database.getHotrodClientProperties())
+            .withServerConfiguration(jdbcUtil.getConfigurationBuilder()).withQualifier("1").create();
+      RemoteCache<String, String> cache2 = SERVERS.hotrod()
+            .withClientConfiguration(database.getHotrodClientProperties())
+            .withServerConfiguration(jdbcUtil.getConfigurationBuilder()).withQualifier("2").create();
+
+      cache1.put("k1", "v1");
+      String firstK1 = cache1.get("k1");
+      assertEquals("v1", firstK1);
+      assertNull(cache2.get("k1"));
+
+      cache2.put("k2", "v2");
+      assertEquals("v2", cache2.get("k2"));
+      assertNull(cache1.get("k2"));
+
+      assertCleanCacheAndStore(cache1);
+      assertCleanCacheAndStore(cache2);
+   }
+
+   @ParameterizedTest
+   @ArgumentsSource(Common.DatabaseProvider.class)
+   public void testPutGetRemove(Database database) {
+      JdbcConfigurationUtil jdbcUtil = new JdbcConfigurationUtil(CacheMode.DIST_SYNC, database, false, false);
+      RemoteCache<String, String> cache = SERVERS.hotrod()
+            .withClientConfiguration(database.getHotrodClientProperties())
+            .withServerConfiguration(jdbcUtil.getConfigurationBuilder()).create();
+
+      cache.put("k1", "v1");
+      cache.put("k2", "v2");
+
+      assertNotNull(cache.get("k1"));
+      assertNotNull(cache.get("k2"));
+
+      cache.stop();
+      cache.start();
+
+      assertNotNull(cache.get("k1"));
+      assertNotNull(cache.get("k2"));
+      assertEquals("v1", cache.get("k1"));
+      assertEquals("v2", cache.get("k2"));
+      cache.remove("k1");
+      assertNull(cache.get("k1"));
+      assertCleanCacheAndStore(cache);
+   }
+}

--- a/server/tests/src/test/java/org/infinispan/server/persistence/ManagedConnectionOperations.java
+++ b/server/tests/src/test/java/org/infinispan/server/persistence/ManagedConnectionOperations.java
@@ -11,19 +11,19 @@ import org.infinispan.cli.impl.AeshDelegatingShell;
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.persistence.jdbc.configuration.JdbcStringBasedStoreConfigurationBuilder;
+import org.infinispan.server.test.api.TestClientDriver;
 import org.infinispan.server.test.core.AeshTestConnection;
 import org.infinispan.server.test.core.Common;
 import org.infinispan.server.test.core.persistence.Database;
-import org.infinispan.server.test.junit5.InfinispanServerExtension;
-import org.junit.jupiter.api.extension.RegisterExtension;
+import org.infinispan.server.test.junit5.InfinispanServer;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
 @org.infinispan.server.test.core.tags.Database
 public class ManagedConnectionOperations {
 
-   @RegisterExtension
-   public static InfinispanServerExtension SERVERS = PersistenceIT.SERVERS;
+   @InfinispanServer(PersistenceIT.class)
+   public static TestClientDriver SERVERS;
 
    private org.infinispan.configuration.cache.ConfigurationBuilder createConfigurationBuilder(Database database) {
       org.infinispan.configuration.cache.ConfigurationBuilder builder = new org.infinispan.configuration.cache.ConfigurationBuilder();
@@ -94,7 +94,7 @@ public class ManagedConnectionOperations {
    public void testDataSourceCLI(Database database) {
       try (AeshTestConnection terminal = new AeshTestConnection()) {
          CLI.main(new AeshDelegatingShell(terminal), new String[]{}, new Properties());
-         terminal.send("connect " + SERVERS.getServerDriver().getServerAddress(0).getHostAddress() + ":11222");
+         terminal.send("connect " + SERVERS.getServerAddress(0).getHostAddress() + ":11222");
          terminal.assertContains("//containers/default]>");
          terminal.clear();
          terminal.send("server datasource ls");

--- a/server/tests/src/test/java/org/infinispan/server/persistence/PersistenceIT.java
+++ b/server/tests/src/test/java/org/infinispan/server/persistence/PersistenceIT.java
@@ -1,5 +1,6 @@
 package org.infinispan.server.persistence;
 
+import static org.infinispan.server.test.core.TestSystemPropertyNames.INFINISPAN_TEST_CONTAINER_DATABASE_TYPES;
 import static org.infinispan.server.test.core.TestSystemPropertyNames.INFINISPAN_TEST_SERVER_CONTAINER_VOLUME_REQUIRED;
 
 import java.io.File;
@@ -11,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.infinispan.commons.test.Exceptions;
 import org.infinispan.server.test.core.ServerRunMode;
@@ -21,7 +23,11 @@ import org.infinispan.server.test.junit5.InfinispanServerExtensionBuilder;
 import org.infinispan.server.test.junit5.InfinispanSuite;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 import org.junit.platform.suite.api.SelectClasses;
 import org.junit.platform.suite.api.Suite;
 
@@ -31,8 +37,10 @@ import org.junit.platform.suite.api.Suite;
  **/
 @Suite(failIfNoTests = false)
 @SelectClasses({
+      BasePooledConnectionOperations.class,
       PooledConnectionOperations.class,
       ManagedConnectionOperations.class,
+      BaseJdbcStringBasedCacheStoreIT.class,
       JdbcStringBasedCacheStoreIT.class,
       AsyncJdbcStringBasedCacheStore.class
 })
@@ -42,20 +50,21 @@ public class PersistenceIT extends InfinispanSuite {
    static final String EXTERNAL_JDBC_DRIVER = System.getProperty(TestSystemPropertyNames.INFINISPAN_TEST_CONTAINER_DATABASE_EXTERNAL_DRIVERS);
    static final String JDBC_DRIVER_FROM_FILE = System.getProperty(TestSystemPropertyNames.INFINISPAN_TEST_CONTAINER_DATABASE_DRIVERS_FILE, "target/test-classes/database/jdbc-drivers.txt");
 
-   public static String[] DEFAULT_DATABASES = new String[]{"h2", "mysql", "postgres"};
+   public static final String[] DEFAULT_DATABASES = new String[]{"h2", "mysql", "postgres"};
 
    public static final DatabaseServerListener DATABASE_LISTENER = new DatabaseServerListener(DEFAULT_DATABASES);
 
-   @RegisterExtension
-   public static InfinispanServerExtension SERVERS =
+   public static final InfinispanServerExtensionBuilder EXTENSION_BUILDER =
          InfinispanServerExtensionBuilder.config(System.getProperty(PersistenceIT.class.getName(), "configuration/PersistenceTest.xml"))
-                                    .numServers(1)
-                                    .runMode(ServerRunMode.CONTAINER)
-                                    .mavenArtifacts(getJdbcDrivers())
-                                    .artifacts(getJavaArchive())
-                                    .addListener(DATABASE_LISTENER)
-                                    .property(INFINISPAN_TEST_SERVER_CONTAINER_VOLUME_REQUIRED, "true")
-                                    .build();
+               .numServers(2)
+               .runMode(ServerRunMode.CONTAINER)
+               .mavenArtifacts(getJdbcDrivers())
+               .artifacts(getJavaArchive())
+               .addListener(DATABASE_LISTENER)
+               .property(INFINISPAN_TEST_SERVER_CONTAINER_VOLUME_REQUIRED, "true");
+
+   @RegisterExtension
+   public static InfinispanServerExtension SERVERS = EXTENSION_BUILDER.build();
 
    public static String[] getJdbcDrivers() {
       Map<String, String> jdbcDrivers = Exceptions.unchecked(() -> Files.lines(Paths.get(JDBC_DRIVER_FROM_FILE))
@@ -85,5 +94,17 @@ public class PersistenceIT extends InfinispanSuite {
       }
 
       return externalJdbcDriver.toArray(new JavaArchive[0]);
+   }
+
+   public static final class DefaultDatabaseTypes implements ArgumentsProvider {
+      @Override
+      public Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters, ExtensionContext context) throws Exception {
+         String[] databaseTypes = DEFAULT_DATABASES;
+         String property = System.getProperty(INFINISPAN_TEST_CONTAINER_DATABASE_TYPES);
+         if (property != null) {
+            databaseTypes = property.split(",");
+         }
+         return Arrays.stream(databaseTypes).map(Arguments::of);
+      }
    }
 }

--- a/server/tests/src/test/resources/database/mssql.properties
+++ b/server/tests/src/test/resources/database/mssql.properties
@@ -15,3 +15,4 @@ data.column.type=VARBINARY(1000)
 timestamp.column.type=BIGINT
 segment.column.type=BIGINT
 database.mode=CONTAINER
+infinispan.client.hotrod.socket_timeout=10000

--- a/server/tests/src/test/resources/database/mysql.properties
+++ b/server/tests/src/test/resources/database/mysql.properties
@@ -16,3 +16,4 @@ database.jdbc.url=jdbc:mysql://${container.address}:${org.infinispan.server.test
 database.jdbc.username=test
 database.jdbc.password=test
 database.test.query=SELECT 1
+infinispan.client.hotrod.socket_timeout=10000

--- a/server/tests/src/test/resources/database/oracle.properties
+++ b/server/tests/src/test/resources/database/oracle.properties
@@ -15,3 +15,4 @@ database.jdbc.username=SYSTEM
 database.jdbc.password=test
 database.test.query=SELECT 1 FROM DUAL
 org.infinispan.test.database.container.log.regex=.*DATABASE IS READY TO USE!.*
+infinispan.client.hotrod.socket_timeout=10000

--- a/server/tests/src/test/resources/database/postgres.properties
+++ b/server/tests/src/test/resources/database/postgres.properties
@@ -15,3 +15,4 @@ database.jdbc.url=jdbc:postgresql://${container.address}:${org.infinispan.server
 database.jdbc.username=test
 database.jdbc.password=test
 database.test.query=SELECT 1
+infinispan.client.hotrod.socket_timeout=10000


### PR DESCRIPTION
* HotRod operations now use SIFS.
* Add listener support to rolling upgrade handler.
* Split PersistenceIT tests that don't change the driver lifecycle.
* Create extra tests for rolling upgrades with persistence configured.

Closes #15128.