### PR TITLE
Revert "[#14712] Disable op upgrade test on main"

### DIFF
--- a/.github/workflows/operator_upgrade.yaml
+++ b/.github/workflows/operator_upgrade.yaml
@@ -3,9 +3,11 @@ name: Operator Upgrade Tests
 on:
   push:
     branches:
+      - main
       - '*.0.x'
   pull_request:
     branches:
+      - main
       - '*.0.x'
 
 concurrency:


### PR DESCRIPTION
This reverts commit b3568ce60504fb5c41ee7b8fabcf4eb7f5ebcace.
