### PR TITLE
[#15253] Update readiness probe

### DIFF
--- a/server/rest/src/main/java/org/infinispan/rest/resources/HealthCheckResource.java
+++ b/server/rest/src/main/java/org/infinispan/rest/resources/HealthCheckResource.java
@@ -48,9 +48,10 @@ public class HealthCheckResource implements ResourceHandler {
       DefaultCacheManager dcm = helper.getServer().getCacheManager();
       HttpResponseStatus status = HttpResponseStatus.SERVICE_UNAVAILABLE;
       if (dcm.getStatus().allowInvocations() && helper.getProtocolServer().isStarted()) {
+         status = HttpResponseStatus.OK;
          CacheManagerInfo cmi = dcm.getCacheManagerInfo();
-         if (cmi.allCachesReady())
-            status = HttpResponseStatus.OK;
+         if (cmi.allCachesStopped())
+            status = HttpResponseStatus.SERVICE_UNAVAILABLE;
       }
 
       return CompletableFuture.completedFuture(builder.status(status).build());

--- a/server/rest/src/test/java/org/infinispan/rest/RestServerLifecycleTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/RestServerLifecycleTest.java
@@ -1,12 +1,19 @@
 package org.infinispan.rest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.infinispan.commons.internal.InternalCacheNames.CONFIG_STATE_CACHE_NAME;
 import static org.infinispan.test.TestingUtil.join;
 import static org.infinispan.test.fwk.TestCacheManagerFactory.createClusteredCacheManager;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.BiConsumer;
 
@@ -15,8 +22,12 @@ import org.infinispan.client.rest.RestResponse;
 import org.infinispan.client.rest.configuration.RestClientConfigurationBuilder;
 import org.infinispan.commons.dataconversion.internal.Json;
 import org.infinispan.commons.test.TestResourceTracker;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.configuration.internal.PrivateGlobalConfigurationBuilder;
+import org.infinispan.factories.GlobalComponentRegistry;
 import org.infinispan.factories.impl.BasicComponentRegistry;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.rest.assertion.ResponseAssertion;
@@ -28,7 +39,10 @@ import org.infinispan.server.core.MockProtocolServer;
 import org.infinispan.server.core.ProtocolServer;
 import org.infinispan.server.core.ServerStateManager;
 import org.infinispan.test.AbstractInfinispanTest;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.CheckPoint;
 import org.infinispan.test.fwk.TransportFlags;
+import org.infinispan.topology.LocalTopologyManager;
 import org.junit.jupiter.api.Assertions;
 import org.testng.annotations.Test;
 
@@ -63,6 +77,77 @@ public class RestServerLifecycleTest extends AbstractInfinispanTest {
 
          ResponseAssertion.assertThat(client.server().ready()).isOk();
       });
+   }
+
+   public void testCacheCreationDoesNotChanceReadiness() throws Throwable {
+      EmbeddedCacheManager ecm = null;
+      RestServer server = null;
+      RestClient client = null;
+
+      try {
+         ecm = createCacheManager();
+         server = createRestServer(ecm, TestResourceTracker.getCurrentTestShortName());
+         client = createRestClient(server);
+
+         LocalTopologyManager original = GlobalComponentRegistry.componentOf(ecm, LocalTopologyManager.class);
+         LocalTopologyManager spy = spy(original);
+         TestingUtil.replaceComponent(ecm, LocalTopologyManager.class, spy, true);
+
+         // We block the cache manager initialization by blocking the start of the config cache.
+         CheckPoint checkPoint = new CheckPoint();
+         doAnswer(invocation -> {
+            checkPoint.trigger("local-topology-enter");
+            checkPoint.awaitStrict("local-topology-wait", 10, TimeUnit.SECONDS);
+            return invocation.callRealMethod();
+         }).when(spy).join(eq(CONFIG_STATE_CACHE_NAME), any(), any(), any());
+
+         Future<?> start = fork(ecm::start);
+
+         checkPoint.awaitStrict("local-topology-enter", 10, TimeUnit.SECONDS);
+
+         // We haven't started the server and the cache manager is still initializing.
+         ResponseAssertion.assertThat(client.server().live()).isOk();
+         ResponseAssertion.assertThat(client.server().ready()).isServiceUnavailable();
+
+         // The server is initiated but the cache manager is still starting, continue unavailable.
+         server.postStart();
+         ResponseAssertion.assertThat(client.server().live()).isOk();
+         ResponseAssertion.assertThat(client.server().ready()).isServiceUnavailable();
+
+         // Releases the cache manager start. After this point the probe is always available.
+         checkPoint.trigger("local-topology-wait");
+         start.get(10, TimeUnit.SECONDS);
+
+         ResponseAssertion.assertThat(client.server().live()).isOk();
+         ResponseAssertion.assertThat(client.server().ready()).isOk();
+
+         // We create a new cache at runtime and delay its start.
+         // The probe should still continue to reply as available.
+         final EmbeddedCacheManager finalCacheManager = ecm;
+         Configuration configuration = new ConfigurationBuilder()
+               .clustering().cacheMode(CacheMode.DIST_SYNC).build();
+         doAnswer(invocation -> {
+            checkPoint.trigger("local-topology-enter");
+            checkPoint.awaitStrict("local-topology-wait", 10, TimeUnit.SECONDS);
+            return invocation.callRealMethod();
+         }).when(spy).join(eq("second-cache"), any(), any(), any());
+         Future<?> cache = fork(() -> finalCacheManager.createCache("second-cache", configuration));
+
+         checkPoint.awaitStrict("local-topology-enter", 10, TimeUnit.SECONDS);
+
+         ResponseAssertion.assertThat(client.server().live()).isOk();
+         ResponseAssertion.assertThat(client.server().ready()).isOk();
+
+         checkPoint.trigger("local-topology-wait");
+         cache.get(10, TimeUnit.SECONDS);
+
+         ResponseAssertion.assertThat(client.server().live()).isOk();
+         ResponseAssertion.assertThat(client.server().ready()).isOk();
+      } finally {
+         if (ecm != null) ecm.stop();
+         if (server != null) server.stop();
+         if (client != null) client.close();
+      }
    }
 
    private void runTest(BiConsumer<Status, RestClient> test) throws Throwable {

--- a/server/rest/src/test/java/org/infinispan/rest/resources/HealthCheckResourceTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/resources/HealthCheckResourceTest.java
@@ -14,6 +14,7 @@ import org.infinispan.client.rest.RestResponse;
 import org.infinispan.client.rest.RestServerClient;
 import org.infinispan.client.rest.configuration.Protocol;
 import org.infinispan.commons.util.Util;
+import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.globalstate.ConfigurationStorage;
@@ -62,6 +63,10 @@ public class HealthCheckResourceTest extends AbstractRestResourceTest {
       ConfigurationBuilder builder = new ConfigurationBuilder();
       builder.statistics().enable().clustering().cacheMode(DIST_SYNC).partitionHandling().whenSplit(DENY_READ_WRITES).aliases("alias");
       cm.defineConfiguration(TEST_CACHE_NAME, builder.build());
+
+      ConfigurationBuilder cb = new ConfigurationBuilder();
+      cb.simpleCache(true).clustering().cacheMode(CacheMode.LOCAL);
+      cm.defineConfiguration("local-cache", cb.build());
    }
 
    @Override
@@ -91,6 +96,7 @@ public class HealthCheckResourceTest extends AbstractRestResourceTest {
 
    public void testReplyDuringShutdown() {
       manager(0).getCache(TEST_CACHE_NAME).put("key", "value");
+      manager(0).getCache("local-cache").put("key", "value");
 
       try (RestResponse res = join(restServerClient.ready())) {
          assertThat(res.status()).isEqualTo(OK);


### PR DESCRIPTION
* Readiness will always be available if server and cache manager have started.
* Readiness will become unavailable if all caches are shutdown. This handle graceful shutdown.

Closes #15253.