### PR TITLE
[#15264] Configurable version by system properties

### DIFF
--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/core/TestSystemPropertyNames.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/core/TestSystemPropertyNames.java
@@ -110,6 +110,18 @@ public class TestSystemPropertyNames {
     */
    public static final String INFINISPAN_TEST_SERVER_CONTAINER_ULIMIT = PREFIX + "container.ulimit";
 
+   private static final String INFINISPAN_ROLLING_UPGRADE_TEST = PREFIX + "rolling.upgrade.";
+
+   /**
+    * Specifies the version to start the containers during the rolling upgrade procedure.
+    */
+   public static final String INFINISPAN_ROLLING_UPGRADE_FROM_VERSION = INFINISPAN_ROLLING_UPGRADE_TEST + "from";
+
+   /**
+    * Specifies the target version to perform the rolling upgrades.
+    */
+   public static final String INFINISPAN_ROLLING_UPGRADE_TO_VERSION = INFINISPAN_ROLLING_UPGRADE_TEST + "to";
+
    /**
     * Specifies the name of the keycloak base image
     */

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/core/rollingupgrade/RollingUpgradeConfigurationBuilder.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/core/rollingupgrade/RollingUpgradeConfigurationBuilder.java
@@ -1,5 +1,8 @@
 package org.infinispan.server.test.core.rollingupgrade;
 
+import static org.infinispan.server.test.core.TestSystemPropertyNames.INFINISPAN_ROLLING_UPGRADE_FROM_VERSION;
+import static org.infinispan.server.test.core.TestSystemPropertyNames.INFINISPAN_ROLLING_UPGRADE_TO_VERSION;
+
 import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.List;
@@ -79,8 +82,8 @@ public class RollingUpgradeConfigurationBuilder {
    }
 
    public RollingUpgradeConfigurationBuilder(String name, String fromVersion, String toVersion) {
-      this.fromVersion = fromVersion;
-      this.toVersion = toVersion;
+      this.fromVersion = System.getProperty(INFINISPAN_ROLLING_UPGRADE_FROM_VERSION, fromVersion);
+      this.toVersion = System.getProperty(INFINISPAN_ROLLING_UPGRADE_TO_VERSION, toVersion);
       this.name = name;
    }
 


### PR DESCRIPTION
* When creating the builder, it automatically verifies the system properties.

When using maven, we pass the properties:

```
-Dorg.infinispan.test.server.rolling.upgrade.from="image://quay.io/infinispan/server:15.2.0.Final" \
-Dorg.infinispan.test.server.rolling.upgrade.to="image://quay.io/infinispan/server:15.2.4.Final-1"
```

Closes #15264.