### PR TITLE
[#15272] Add RollingUpgrade support for XSite integration tests

### DIFF
--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/EmbeddedJGroupsChannelConfigurator.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/EmbeddedJGroupsChannelConfigurator.java
@@ -133,6 +133,7 @@ public class EmbeddedJGroupsChannelConfigurator extends AbstractJGroupsChannelCo
          });
          relay2.addSite(remoteSite.getKey(), siteConfig);
       }
+      relay2.enableAddressTagging(true);
    }
 
    private static List<ProtocolConfiguration> combineStack(JGroupsChannelConfigurator baseStack, List<ProtocolConfiguration> stack) {

--- a/server/rollingupgradetests/src/test/java/org/infinispan/server/rollingupgrade/ClusteredRollingUpgradeIT.java
+++ b/server/rollingupgradetests/src/test/java/org/infinispan/server/rollingupgrade/ClusteredRollingUpgradeIT.java
@@ -81,7 +81,7 @@ public class ClusteredRollingUpgradeIT extends InfinispanSuite {
             .nodeCount(2)
             .useCustomServerConfiguration("configuration/ClusteredServerTest.xml")
             .addMavenArtifacts(ClusteredIT.mavenArtifacts())
-            .addArtifacts(ClusteredIT.artifacts())
+            .addArchives(ClusteredIT.artifacts())
             .addProperty("infinispan.query.lucene.max-boolean-clauses", "1025");
       SERVERS = new RollingUpgradeHandlerExtension(builder);
    }

--- a/server/rollingupgradetests/src/test/java/org/infinispan/server/rollingupgrade/RollingUpgradePersistenceTest.java
+++ b/server/rollingupgradetests/src/test/java/org/infinispan/server/rollingupgrade/RollingUpgradePersistenceTest.java
@@ -55,7 +55,7 @@ public class RollingUpgradePersistenceTest {
       DatabaseServerListener listener = new DatabaseServerListener(databaseType);
       RollingUpgradeConfigurationBuilder builder = new RollingUpgradeConfigurationBuilder(RollingUpgradePersistenceTest.class.getName(), "15.2.0.Final", "15.2.1.Final")
             .nodeCount(nodeCount)
-            .addArtifacts(PersistenceIT.getJavaArchive())
+            .addArchives(PersistenceIT.getJavaArchive())
             .addMavenArtifacts(PersistenceIT.getJdbcDrivers())
             .addProperty(INFINISPAN_TEST_SERVER_CONTAINER_VOLUME_REQUIRED, "true")
             .addListener(listener);

--- a/server/rollingupgradetests/src/test/java/org/infinispan/server/rollingupgrade/RollingUpgradeTaskTest.java
+++ b/server/rollingupgradetests/src/test/java/org/infinispan/server/rollingupgrade/RollingUpgradeTaskTest.java
@@ -16,7 +16,7 @@ public class RollingUpgradeTaskTest {
    public void testHelloWorldTask() throws Throwable {
       RollingUpgradeConfigurationBuilder builder = new RollingUpgradeConfigurationBuilder(RollingUpgradeTaskTest.class.getName(), "15.2.0.Final", "15.2.1.Final")
             .useCustomServerConfiguration("configuration/ClusteredServerTest.xml")
-            .addArtifacts(ClusteredIT.artifacts())
+            .addArchives(ClusteredIT.artifacts())
             .addMavenArtifacts(ClusteredIT.mavenArtifacts())
             .nodeCount(3);
 

--- a/server/rollingupgradetests/src/test/java/org/infinispan/server/rollingupgrade/RollingUpgradeXSiteIT.java
+++ b/server/rollingupgradetests/src/test/java/org/infinispan/server/rollingupgrade/RollingUpgradeXSiteIT.java
@@ -1,0 +1,33 @@
+package org.infinispan.server.rollingupgrade;
+
+import org.infinispan.server.cli.XSiteCliOperations;
+import org.infinispan.server.functional.XSiteIT;
+import org.infinispan.server.functional.hotrod.XSiteHotRodCacheOperations;
+import org.infinispan.server.functional.rest.XSiteRestCacheOperations;
+import org.infinispan.server.functional.rest.XSiteRestMetricsOperations;
+import org.infinispan.server.test.junit5.InfinispanSuite;
+import org.infinispan.server.test.junit5.RollingUpgradeHandlerXSiteExtension;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+
+/**
+ * Cross-Site suite for rolling upgrade tests
+ *
+ * @author William Burns
+ * @since 16.0
+ */
+@Suite(failIfNoTests = false)
+@SelectClasses({
+      XSiteRestMetricsOperations.class,
+      XSiteHotRodCacheOperations.class,
+      XSiteRestCacheOperations.class,
+      XSiteCliOperations.class
+})
+public class RollingUpgradeXSiteIT extends InfinispanSuite {
+
+   @RegisterExtension
+   public static final RollingUpgradeHandlerXSiteExtension SERVERS = RollingUpgradeHandlerXSiteExtension.from(
+         RollingUpgradeXSiteIT.class, XSiteIT.EXTENSION_BUILDER, "15.2.0.Final", "15.2.1.Final");
+
+}

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/api/TestClientXSiteDriver.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/api/TestClientXSiteDriver.java
@@ -35,6 +35,13 @@ public interface TestClientXSiteDriver {
    String getMethodName();
 
    /**
+    * Returns
+    * @param siteName
+    * @return
+    */
+   String hostAndPort(String siteName);
+
+   /**
     * Access to the {@link CounterManager} to perform counters operations on tests
     *
     * @return the {@link CounterManager} instance

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/core/AbstractServerConfigBuilder.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/core/AbstractServerConfigBuilder.java
@@ -127,6 +127,10 @@ public abstract class AbstractServerConfigBuilder<T extends AbstractServerConfig
       return (T) this;
    }
 
+   public String site() {
+      return this.siteName;
+   }
+
    public T portOffset(int port) {
       this.portOffset = port;
       return (T) this;

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/core/rollingupgrade/RollingUpgradeConfiguration.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/core/rollingupgrade/RollingUpgradeConfiguration.java
@@ -11,7 +11,7 @@ import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
 import org.infinispan.server.test.core.InfinispanServerListener;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 
-public record RollingUpgradeConfiguration(int nodeCount, String fromVersion, String toVersion, String name, boolean xSite,
+public record RollingUpgradeConfiguration(int nodeCount, String fromVersion, String toVersion, String name,
                                           String jgroupsProtocol, int serverCheckTimeSecs, boolean useSharedDataMount,
                                           String serverConfigurationFile, boolean defaultServerConfigurationFile,
                                           Properties properties, JavaArchive[] customArtifacts, String[] mavenArtifacts,

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/core/rollingupgrade/RollingUpgradeConfigurationBuilder.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/core/rollingupgrade/RollingUpgradeConfigurationBuilder.java
@@ -28,14 +28,13 @@ public class RollingUpgradeConfigurationBuilder {
    private final String name;
 
    private int nodeCount = 3;
-   private boolean xSite;
    private String serverConfigurationFile = "infinispan.xml";
    private boolean defaultServerConfigurationFile = true;
    private final Properties properties = new Properties();
-   private final List<JavaArchive> customArtifacts = new ArrayList<>();
+   private final List<JavaArchive> customArchives = new ArrayList<>();
    private final List<String> mavenArtifacts = new ArrayList<>();
    private final List<InfinispanServerListener> listeners = new ArrayList<>();
-   private String jgroupsProtocol = "tcp";
+   private String jgroupsProtocol = "test-tcp";
    private int serverCheckTimeSecs = 30;
    private boolean useSharedDataMount = true;
    private BiConsumer<Throwable, RollingUpgradeHandler> exceptionHandler = (t, uh) -> {
@@ -95,11 +94,6 @@ public class RollingUpgradeConfigurationBuilder {
       return this;
    }
 
-   public RollingUpgradeConfigurationBuilder xSite(boolean xSite) {
-      this.xSite = xSite;
-      return this;
-   }
-
    public RollingUpgradeConfigurationBuilder jgroupsProtocol(String jgroupsProtocol) {
       this.jgroupsProtocol = Objects.requireNonNull(jgroupsProtocol);
       return this;
@@ -140,8 +134,8 @@ public class RollingUpgradeConfigurationBuilder {
       return this;
    }
 
-   public RollingUpgradeConfigurationBuilder addArtifacts(JavaArchive ... mavenArtifact) {
-      customArtifacts.addAll(List.of(mavenArtifact));
+   public RollingUpgradeConfigurationBuilder addArchives(JavaArchive ... javaArchives) {
+      customArchives.addAll(List.of(javaArchives));
       return this;
    }
 
@@ -170,9 +164,9 @@ public class RollingUpgradeConfigurationBuilder {
    }
 
    public RollingUpgradeConfiguration build() {
-      return new RollingUpgradeConfiguration(nodeCount, fromVersion, toVersion, name, xSite, jgroupsProtocol, serverCheckTimeSecs,
+      return new RollingUpgradeConfiguration(nodeCount, fromVersion, toVersion, name, jgroupsProtocol, serverCheckTimeSecs,
             useSharedDataMount, serverConfigurationFile, defaultServerConfigurationFile, properties,
-            customArtifacts.toArray(new JavaArchive[0]), mavenArtifacts.toArray(new String[0]), listeners,
+            customArchives.toArray(new JavaArchive[0]), mavenArtifacts.toArray(new String[0]), listeners,
             exceptionHandler, initialHandler, isValidServerState, configurationHandler);
    }
 }

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/core/rollingupgrade/RollingUpgradeXSiteHandler.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/core/rollingupgrade/RollingUpgradeXSiteHandler.java
@@ -1,0 +1,66 @@
+package org.infinispan.server.test.core.rollingupgrade;
+
+import java.lang.invoke.MethodHandles;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.infinispan.commons.util.Util;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
+public class RollingUpgradeXSiteHandler {
+   private static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
+   private final Map<String, RollingUpgradeHandler> sites;
+
+   private RollingUpgradeXSiteHandler(Map<String, RollingUpgradeHandler> sites) {
+      this.sites = sites;
+   }
+
+   public static RollingUpgradeXSiteHandler startOldClusters(Map<String, RollingUpgradeConfiguration> sites) {
+      Map<String, RollingUpgradeHandler> siteHandlers = new HashMap<>(sites.size());
+      for (Map.Entry<String, RollingUpgradeConfiguration> site : sites.entrySet()) {
+         siteHandlers.put(site.getKey(), RollingUpgradeHandler.startOldCluster(site.getValue(), site.getKey()));
+      }
+
+      return new RollingUpgradeXSiteHandler(siteHandlers);
+   }
+
+   public RollingUpgradeHandler handlerForSite(String siteName) {
+      return sites.get(siteName);
+   }
+
+   public void completeUpgrade(boolean shouldClose) {
+      Throwable throwableEncountered = null;
+      try {
+         for (Map.Entry<String, RollingUpgradeHandler> entry : sites.entrySet()) {
+            String siteName = entry.getKey();
+            RollingUpgradeHandler ruh = entry.getValue();
+            try {
+               ruh.completeUpgrade(false);
+            } catch (Throwable t) {
+               log.errorf(t, "Exception encountered with site %s", siteName);
+               ruh.exceptionEncountered(t);
+               // Propagate the first exception as it may cause the later ones
+               if (throwableEncountered == null) {
+                  throwableEncountered = t;
+               }
+            }
+         }
+         if (throwableEncountered != null) {
+            throw Util.unchecked(throwableEncountered);
+         }
+      } finally {
+         if (shouldClose) {
+            close();
+         }
+      }
+   }
+
+   public void close() {
+      sites.forEach((siteName, ruh) -> ruh.close());
+   }
+
+   public void exceptionEncountered(Throwable throwable) {
+      sites.forEach((siteName, ruh) -> ruh.exceptionEncountered(throwable));
+   }
+}

--- a/server/testdriver/junit4/src/main/java/org/infinispan/server/test/junit4/InfinispanXSiteServerTestMethodRule.java
+++ b/server/testdriver/junit4/src/main/java/org/infinispan/server/test/junit4/InfinispanXSiteServerTestMethodRule.java
@@ -33,6 +33,11 @@ public class InfinispanXSiteServerTestMethodRule implements TestRule, TestClient
    }
 
    @Override
+   public String hostAndPort(String siteName) {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
    public HotRodTestClientDriver hotrod(String siteName) {
       return testClients.get(siteName).hotrod();
    }

--- a/server/testdriver/junit5/src/main/java/org/infinispan/server/test/junit5/CustomInfinispanExtension.java
+++ b/server/testdriver/junit5/src/main/java/org/infinispan/server/test/junit5/CustomInfinispanExtension.java
@@ -57,6 +57,7 @@ public class CustomInfinispanExtension implements BeforeAllCallback, BeforeEachC
       fields.forEach(f -> {
          try {
             Object is = f.get(null);
+            Class<?> fieldType = f.getType();
             // Means the suite didn't define an extension to use - so inject the default
             if (is == null) {
                Class<? extends InfinispanSuite> suiteClass;
@@ -80,7 +81,7 @@ public class CustomInfinispanExtension implements BeforeAllCallback, BeforeEachC
                List<Field> extensionFields = findAnnotatedFields(suiteClass, RegisterExtension.class,
                      possibleField -> {
                         try {
-                           return ModifierSupport.isStatic(possibleField) && possibleField.get(null) instanceof AbstractServerExtension;
+                           return ModifierSupport.isStatic(possibleField) && fieldType.isAssignableFrom(possibleField.get(null).getClass());
                         } catch (IllegalAccessException e) {
                            return false;
                         }
@@ -88,7 +89,7 @@ public class CustomInfinispanExtension implements BeforeAllCallback, BeforeEachC
                if (extensionFields.size() != 1) {
                   throw new IllegalStateException("Test " + testClass + " was ran without an explicit Suite explicit RegisterExtension and" +
                         " its default suite class " + suiteClass + " doesn't have a single static" +
-                        " @RegisterExtension field that extends AbstractServerExtension, had " + extensionFields);
+                        " @RegisterExtension field that is assignable to type: " + fieldType + ", had " + extensionFields);
                }
                is = extensionFields.get(0).get(null);
                f.set(null, is);

--- a/server/testdriver/junit5/src/main/java/org/infinispan/server/test/junit5/InfinispanXSiteServerExtension.java
+++ b/server/testdriver/junit5/src/main/java/org/infinispan/server/test/junit5/InfinispanXSiteServerExtension.java
@@ -41,15 +41,15 @@ public class InfinispanXSiteServerExtension extends AbstractServerExtension impl
       BeforeEachCallback,
       AfterEachCallback {
 
-   private final List<TestServer> testServers;
-   private final Map<String, TestClient> testClients = new HashMap<>();
+   protected final List<TestServer> testServers;
+   protected final Map<String, TestClient> testClients = new HashMap<>();
 
    public InfinispanXSiteServerExtension(List<TestServer> testServers) {
       this.testServers = testServers;
    }
 
    @Override
-   protected void onTestsStart(ExtensionContext extensionContext) {
+   protected void onTestsStart(ExtensionContext extensionContext) throws Exception {
       testServers.forEach((it) -> startTestServer(extensionContext, it));
    }
 
@@ -97,6 +97,18 @@ public class InfinispanXSiteServerExtension extends AbstractServerExtension impl
    //All of methodName will be the same
    public String getMethodName() {
       return testClients.values().iterator().next().getMethodName();
+   }
+
+   @Override
+   public String hostAndPort(String siteName) {
+      for (TestServer server : testServers) {
+         if (siteName.equals(server.getSiteName())) {
+            String host = server.getDriver().getServerAddress(0).getHostAddress();
+            int port = server.getDriver().getServerSocket(0, 11222).getPort();
+            return host + ":" + port;
+         }
+      }
+      throw new IllegalStateException("Site " + siteName + " not found.");
    }
 
    @Override

--- a/server/testdriver/junit5/src/main/java/org/infinispan/server/test/junit5/InfinispanXSiteServerExtensionBuilder.java
+++ b/server/testdriver/junit5/src/main/java/org/infinispan/server/test/junit5/InfinispanXSiteServerExtensionBuilder.java
@@ -3,7 +3,9 @@ package org.infinispan.server.test.junit5;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.infinispan.server.test.core.TestServer;
@@ -22,6 +24,11 @@ public class InfinispanXSiteServerExtensionBuilder {
       siteBuilder.site(siteName);
       sites.add(siteBuilder);
       return this;
+   }
+
+   public Map<String, InfinispanServerExtensionBuilder> siteConfigurations() {
+      return sites.stream().collect(Collectors.toMap(
+            InfinispanServerExtensionBuilder::site, Function.identity()));
    }
 
    public InfinispanXSiteServerExtension build() {

--- a/server/testdriver/junit5/src/main/java/org/infinispan/server/test/junit5/RollingUpgradeHandlerXSiteExtension.java
+++ b/server/testdriver/junit5/src/main/java/org/infinispan/server/test/junit5/RollingUpgradeHandlerXSiteExtension.java
@@ -1,0 +1,59 @@
+package org.infinispan.server.test.junit5;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.infinispan.server.test.core.TestServer;
+import org.infinispan.server.test.core.rollingupgrade.CombinedInfinispanServerDriver;
+import org.infinispan.server.test.core.rollingupgrade.RollingUpgradeConfiguration;
+import org.infinispan.server.test.core.rollingupgrade.RollingUpgradeHandler;
+import org.infinispan.server.test.core.rollingupgrade.RollingUpgradeXSiteHandler;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class RollingUpgradeHandlerXSiteExtension extends InfinispanXSiteServerExtension {
+   private final Map<String, RollingUpgradeConfiguration> sites;
+   private RollingUpgradeXSiteHandler handler;
+
+   private RollingUpgradeHandlerXSiteExtension(Class<?> caller, Map<String, InfinispanServerExtensionBuilder> sites,
+                                              String fromVersion, String toVersion) {
+      super(new ArrayList<>());
+      this.sites = sites.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e ->
+         RollingUpgradeHandlerExtension.convertBuilder(caller.getName() + "-" + e.getKey(), e.getValue(), fromVersion, toVersion).build()));
+   }
+
+   public static RollingUpgradeHandlerXSiteExtension from(Class<?> caller, InfinispanXSiteServerExtensionBuilder builder,
+                                                          String fromVersion, String toVersion) {
+      return new RollingUpgradeHandlerXSiteExtension(caller, builder.siteConfigurations(), fromVersion, toVersion);
+   }
+
+   @Override
+   protected void onTestsStart(ExtensionContext extensionContext) throws InterruptedException {
+      if (handler == null) {
+         handler = RollingUpgradeXSiteHandler.startOldClusters(sites);
+         for (String siteName : sites.keySet()) {
+            RollingUpgradeHandler handler = this.handler.handlerForSite(siteName);
+            // We take a more extreme approach that every site has a mixed cluster with one node being upgraded
+            handler.upgradeNewNode();
+            testServers.add(new TestServer(handler.getFromConfig(), new CombinedInfinispanServerDriver(
+                  handler.getFromDriver(), handler.getToDriver())));
+         }
+      }
+   }
+
+   @Override
+   protected void onTestsComplete(ExtensionContext extensionContext) {
+      if (handler != null) {
+         testServers.forEach(TestServer::afterListeners);
+         try {
+            if (extensionContext.getExecutionException().isPresent()) {
+               handler.exceptionEncountered(extensionContext.getExecutionException().get());
+            } else {
+               handler.completeUpgrade(false);
+            }
+         } finally {
+            handler.close();
+         }
+      }
+   }
+}

--- a/server/tests/src/test/java/org/infinispan/server/functional/XSiteIT.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/XSiteIT.java
@@ -32,7 +32,7 @@ import org.junit.platform.suite.api.Suite;
 })
 public class XSiteIT extends InfinispanSuite {
 
-   public static final int NUM_SERVERS = 1;
+   public static final int NUM_SERVERS = 2;
 
    public static final String LON_CACHE_CONFIG =
          "<replicated-cache name=\"%s\">" +
@@ -89,9 +89,10 @@ public class XSiteIT extends InfinispanSuite {
          .runMode(ServerRunMode.CONTAINER)
          .numServers(NUM_SERVERS);
 
+   public static final InfinispanXSiteServerExtensionBuilder EXTENSION_BUILDER = new InfinispanXSiteServerExtensionBuilder()
+         .addSite(LON, lonServerRule)
+         .addSite(NYC, nycServerRule);
+
    @RegisterExtension
-   public static final InfinispanXSiteServerExtension SERVERS = new InfinispanXSiteServerExtensionBuilder()
-            .addSite(LON, lonServerRule)
-            .addSite(NYC, nycServerRule)
-            .build();
+   public static final InfinispanXSiteServerExtension SERVERS = EXTENSION_BUILDER.build();
 }

--- a/server/tests/src/test/java/org/infinispan/server/functional/hotrod/XSiteHotRodCacheOperations.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/hotrod/XSiteHotRodCacheOperations.java
@@ -41,11 +41,11 @@ import org.infinispan.configuration.cache.BackupFailurePolicy;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.server.functional.XSiteIT;
-import org.infinispan.server.test.junit5.InfinispanXSiteServerExtension;
+import org.infinispan.server.test.api.TestClientXSiteDriver;
+import org.infinispan.server.test.junit5.InfinispanServer;
 import org.infinispan.transaction.LockingMode;
 import org.infinispan.transaction.TransactionMode;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * @author Pedro Ruivo
@@ -54,8 +54,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
  **/
 public class XSiteHotRodCacheOperations {
 
-   @RegisterExtension
-   public static final InfinispanXSiteServerExtension SERVERS = XSiteIT.SERVERS;
+   @InfinispanServer(XSiteIT.class)
+   public static TestClientXSiteDriver SERVERS;
 
    @Test
    public void testHotRodOperations() {

--- a/server/tests/src/test/java/org/infinispan/server/functional/rest/XSiteRestCacheOperations.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/rest/XSiteRestCacheOperations.java
@@ -28,9 +28,9 @@ import org.infinispan.client.rest.RestResponse;
 import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.commons.dataconversion.internal.Json;
 import org.infinispan.server.functional.XSiteIT;
-import org.infinispan.server.test.junit5.InfinispanXSiteServerExtension;
+import org.infinispan.server.test.api.TestClientXSiteDriver;
+import org.infinispan.server.test.junit5.InfinispanServer;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * @author Pedro Ruivo
@@ -39,8 +39,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
  **/
 public class XSiteRestCacheOperations {
 
-   @RegisterExtension
-   public static final InfinispanXSiteServerExtension SERVERS = XSiteIT.SERVERS;
+   @InfinispanServer(XSiteIT.class)
+   public static TestClientXSiteDriver SERVERS;
 
    @Test
    public void testRestOperationsLonToNycBackup() {

--- a/server/tests/src/test/java/org/infinispan/server/functional/rest/XSiteRestMetricsOperations.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/rest/XSiteRestMetricsOperations.java
@@ -18,9 +18,9 @@ import org.infinispan.client.rest.RestMetricsClient;
 import org.infinispan.client.rest.RestResponse;
 import org.infinispan.commons.configuration.StringConfiguration;
 import org.infinispan.server.functional.XSiteIT;
-import org.infinispan.server.test.junit5.InfinispanXSiteServerExtension;
+import org.infinispan.server.test.api.TestClientXSiteDriver;
+import org.infinispan.server.test.junit5.InfinispanServer;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Test site status metrics
@@ -47,8 +47,8 @@ public class XSiteRestMetricsOperations {
                "  </replicated-cache>" +
                "</cache-container></infinispan>";
 
-   @RegisterExtension
-   public static final InfinispanXSiteServerExtension SERVERS = XSiteIT.SERVERS;
+   @InfinispanServer(XSiteIT.class)
+   public static TestClientXSiteDriver SERVERS;
 
 
    private static final String[] TAGGED_METRICS = {


### PR DESCRIPTION
Fixes #15272
Fixes #15340

The extension currently starts up the nodes in each configured site and migrates one server on each site. While this is not how a user would normally do this, I figured it was more strict having a "mixed" cluster for each site to catch various issues.