### PR TITLE
Add GitHub Workflow for Running mvn pmd:pmd and Reporting Results #14184

### DIFF
--- a/.github/workflows/pmd-analysis.yml
+++ b/.github/workflows/pmd-analysis.yml
@@ -1,0 +1,53 @@
+name: PMD Static Analysis
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  pmd-analysis:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: PMD analysis
+        id: pmd
+        uses: pmd/pmd-github-action@v2
+        with:
+          version: '7.15.0'
+          rulesets: 'rulesets/java/quickstart.xml'
+          analyzeModifiedFilesOnly: true
+          createGitHubAnnotations: true
+          uploadSarifReport: true
+
+      - name: Fail build on new violations
+        if: >
+          steps.pmd.outputs.violations != '0' &&
+          !(
+            github.event_name == 'push' &&
+            (
+              contains(github.event.head_commit.message, '[skip-pmd]') ||
+              contains(github.event.head_commit.message, '[SKIP-PMD]') ||
+              contains(github.event.head_commit.message, 'skip pmd') ||
+              contains(github.event.head_commit.message, 'SKIP PMD')
+            )
+            ||
+            github.event_name == 'pull_request' &&
+            (
+              contains(github.event.pull_request.title, '[skip-pmd]') ||
+              contains(github.event.pull_request.title, '[SKIP-PMD]') ||
+              contains(github.event.pull_request.title, 'skip pmd') ||
+              contains(github.event.pull_request.title, 'SKIP PMD')
+            )
+          )
+        run: exit 1

--- a/pom.xml
+++ b/pom.xml
@@ -2106,6 +2106,13 @@
                      <excludeRoot>target/generated-sources</excludeRoot>
                   </excludeRoots>
                </configuration>
+               <executions>
+                  <execution>
+                     <goals>
+                        <goal>pmd</goal>
+                     </goals>
+                  </execution>
+               </executions>
             </plugin>
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Summary of change dones & usage

**What it does**: Runs PMD on every push/PR to main, using the built-in Quickstart ruleset, analyzing only changed files, annotating violations inline, and uploading a SARIF report.

**Fail-build guard**: The workflow will block the build if any new PMD violations are found.

**How to skip**: Simply include skip pmd or [skip-pmd] in your commit message (for pushes) or PR title, the workflow will still run and annotate but won’t fail the build.