### PR TITLE
[#15295] Change server status after post start

### DIFF
--- a/server/runtime/src/main/java/org/infinispan/server/Server.java
+++ b/server/runtime/src/main/java/org/infinispan/server/Server.java
@@ -528,9 +528,9 @@ public class Server extends BaseServerManagement implements AutoCloseable {
             }
 
             // Change status
-            this.status = ComponentStatus.RUNNING;
             SecurityActions.postStartProtocolServer(protocolServers.values());
             log.serverStarted(Version.getBrandName(), Version.getBrandVersion(), timeService.timeDuration(startTime, TimeUnit.MILLISECONDS));
+            this.status = ComponentStatus.RUNNING;
          });
       } catch (Exception e) {
          r.completeExceptionally(e);


### PR DESCRIPTION
* Change server to running only after post start.
* Embedded driver wait until server is ready (or failed).

Closes #15295.