### PR TITLE
[#15271] Disable JGroups suspect events

### DIFF
--- a/core/src/test/resources/configs/xsite/bridge.xml
+++ b/core/src/test/resources/configs/xsite/bridge.xml
@@ -14,8 +14,6 @@
          thread_pool.keep_alive_time="5s"
 
          use_vthreads="${jgroups.thread.virtual,org.infinispan.threads.virtual:true}"
-
-         enable_suspect_events="true"
     />
     <RED/>
 

--- a/core/src/test/resources/stacks/tcp.xml
+++ b/core/src/test/resources/stacks/tcp.xml
@@ -18,8 +18,6 @@
          thread_pool.keep_alive_time="1m"
 
          use_vthreads="${jgroups.thread.virtual,org.infinispan.threads.virtual:true}"
-
-         enable_suspect_events="true"
          />
    <RED/>
 


### PR DESCRIPTION
fixes #15271 


failure detection should be disable for bridge and tcp, otherwise nodes get suspected, removed and xsite tests fail for timeout.

thanks @jabolina for the analysis!