### PR TITLE
[#15305] Rolling Upgrade tests versions are overridden by INFINISPAN_TEST_SERVER_DIR env var

### DIFF
--- a/server/rollingupgradetests/src/test/java/org/infinispan/server/rollingupgrade/ClusteredRollingUpgradeIT.java
+++ b/server/rollingupgradetests/src/test/java/org/infinispan/server/rollingupgrade/ClusteredRollingUpgradeIT.java
@@ -76,7 +76,8 @@ import org.junit.platform.suite.api.Suite;
 public class ClusteredRollingUpgradeIT extends InfinispanSuite {
 
    static {
-      RollingUpgradeConfigurationBuilder builder = new RollingUpgradeConfigurationBuilder(ClusteredRollingUpgradeIT.class.getName(), "15.2.0.Final", "15.2.1.Final")
+      RollingUpgradeConfigurationBuilder builder = new RollingUpgradeConfigurationBuilder(ClusteredRollingUpgradeIT.class.getName(),
+            RollingUpgradeTestUtil.getFromVersion(), RollingUpgradeTestUtil.getToVersion())
             // ClusterIT only currently passes with just 2 nodes.. some tests aren't testing serialization and other things
             .nodeCount(2)
             .useCustomServerConfiguration("configuration/ClusteredServerTest.xml")

--- a/server/rollingupgradetests/src/test/java/org/infinispan/server/rollingupgrade/DefaultRollingUpgradeTest.java
+++ b/server/rollingupgradetests/src/test/java/org/infinispan/server/rollingupgrade/DefaultRollingUpgradeTest.java
@@ -31,7 +31,8 @@ import net.spy.memcached.auth.AuthDescriptor;
 public class DefaultRollingUpgradeTest {
    @Test
    public void testDefaultSetting() throws InterruptedException {
-      RollingUpgradeConfigurationBuilder builder = new RollingUpgradeConfigurationBuilder(DefaultRollingUpgradeTest.class.getName(), "15.2.0.Final", "15.2.1.Final");
+      RollingUpgradeConfigurationBuilder builder = new RollingUpgradeConfigurationBuilder(DefaultRollingUpgradeTest.class.getName(),
+            RollingUpgradeTestUtil.getFromVersion(), RollingUpgradeTestUtil.getToVersion());
       RollingUpgradeHandler.performUpgrade(builder.build());
    }
 
@@ -40,7 +41,8 @@ public class DefaultRollingUpgradeTest {
       String cacheName = "rolling-upgrade";
       TestUser user = TestUser.ADMIN;
       int nodeCount = 3;
-      RollingUpgradeConfigurationBuilder builder = new RollingUpgradeConfigurationBuilder(DefaultRollingUpgradeTest.class.getName(),"15.2.0.Final", "15.2.1.Final")
+      RollingUpgradeConfigurationBuilder builder = new RollingUpgradeConfigurationBuilder(DefaultRollingUpgradeTest.class.getName(),
+            RollingUpgradeTestUtil.getFromVersion(), RollingUpgradeTestUtil.getToVersion())
             .nodeCount(nodeCount);
       RestClientConfigurationBuilder restBuilder = new RestClientConfigurationBuilder();
       restBuilder.security().authentication().enable().username(user.getUser()).password(user.getPassword());
@@ -88,7 +90,8 @@ public class DefaultRollingUpgradeTest {
       TestUser user = TestUser.ADMIN;
       int nodeCount = 3;
       ByRef.Integer interactions = new ByRef.Integer(0);
-      RollingUpgradeConfigurationBuilder builder = new RollingUpgradeConfigurationBuilder(DefaultRollingUpgradeTest.class.getName(),"15.2.0.Final", "15.2.1.Final")
+      RollingUpgradeConfigurationBuilder builder = new RollingUpgradeConfigurationBuilder(DefaultRollingUpgradeTest.class.getName(),
+            RollingUpgradeTestUtil.getFromVersion(), RollingUpgradeTestUtil.getToVersion())
             .nodeCount(nodeCount);
 
       RedisURI.Builder respBuilder = RedisURI.builder()
@@ -137,7 +140,8 @@ public class DefaultRollingUpgradeTest {
             .setOpTimeout(TimeUnit.SECONDS.toMillis(30))
             .setAuthDescriptor(AuthDescriptor.typical(user.getUser(), user.getPassword()));
 
-      RollingUpgradeConfigurationBuilder builder = new RollingUpgradeConfigurationBuilder(DefaultRollingUpgradeTest.class.getName(),"15.2.0.Final", "15.2.1.Final")
+      RollingUpgradeConfigurationBuilder builder = new RollingUpgradeConfigurationBuilder(DefaultRollingUpgradeTest.class.getName(),
+            RollingUpgradeTestUtil.getFromVersion(), RollingUpgradeTestUtil.getToVersion())
             .nodeCount(nodeCount);
       builder.handlers(
             uh -> {

--- a/server/rollingupgradetests/src/test/java/org/infinispan/server/rollingupgrade/PersistenceRollingUpgradeIT.java
+++ b/server/rollingupgradetests/src/test/java/org/infinispan/server/rollingupgrade/PersistenceRollingUpgradeIT.java
@@ -22,5 +22,6 @@ public class PersistenceRollingUpgradeIT extends InfinispanSuite {
 
    @RegisterExtension
    public static RollingUpgradeHandlerExtension SERVERS =
-         RollingUpgradeHandlerExtension.from(PersistenceRollingUpgradeIT.class, PersistenceIT.EXTENSION_BUILDER, "15.2.0.Final", "15.2.1.Final");
+         RollingUpgradeHandlerExtension.from(PersistenceRollingUpgradeIT.class, PersistenceIT.EXTENSION_BUILDER,
+               RollingUpgradeTestUtil.getFromVersion(), RollingUpgradeTestUtil.getToVersion());
 }

--- a/server/rollingupgradetests/src/test/java/org/infinispan/server/rollingupgrade/RollingUpgradeAuthenticationIT.java
+++ b/server/rollingupgradetests/src/test/java/org/infinispan/server/rollingupgrade/RollingUpgradeAuthenticationIT.java
@@ -23,7 +23,8 @@ import org.junit.platform.suite.api.Suite;
 public class RollingUpgradeAuthenticationIT extends InfinispanSuite {
 
    static {
-      RollingUpgradeConfigurationBuilder builder = new RollingUpgradeConfigurationBuilder(RollingUpgradeAuthenticationIT.class.getName(), "15.2.0.Final", "15.2.1.Final")
+      RollingUpgradeConfigurationBuilder builder = new RollingUpgradeConfigurationBuilder(RollingUpgradeAuthenticationIT.class.getName(),
+            RollingUpgradeTestUtil.getFromVersion(), RollingUpgradeTestUtil.getToVersion())
             .nodeCount(3)
             .configurationUpdater(cb -> {
                cb.security().authentication()

--- a/server/rollingupgradetests/src/test/java/org/infinispan/server/rollingupgrade/RollingUpgradePersistenceTest.java
+++ b/server/rollingupgradetests/src/test/java/org/infinispan/server/rollingupgrade/RollingUpgradePersistenceTest.java
@@ -36,7 +36,8 @@ public class RollingUpgradePersistenceTest {
             </distributed-cache>
             """.formatted(cacheName);
 
-      RollingUpgradeConfigurationBuilder builder = new RollingUpgradeConfigurationBuilder(RollingUpgradePersistenceTest.class.getName(), "15.2.0.Final", "15.2.1.Final")
+      RollingUpgradeConfigurationBuilder builder = new RollingUpgradeConfigurationBuilder(RollingUpgradePersistenceTest.class.getName(),
+            RollingUpgradeTestUtil.getFromVersion(), RollingUpgradeTestUtil.getToVersion())
             .nodeCount(nodeCount);
       builder.handlers(
             uh -> handleInitializer(uh, cacheName, new StringConfiguration(xml)),
@@ -53,7 +54,8 @@ public class RollingUpgradePersistenceTest {
       String cacheName = "rolling_upgrade_jdbc";
       int nodeCount = 2;
       DatabaseServerListener listener = new DatabaseServerListener(databaseType);
-      RollingUpgradeConfigurationBuilder builder = new RollingUpgradeConfigurationBuilder(RollingUpgradePersistenceTest.class.getName(), "15.2.0.Final", "15.2.1.Final")
+      RollingUpgradeConfigurationBuilder builder = new RollingUpgradeConfigurationBuilder(RollingUpgradePersistenceTest.class.getName(),
+            RollingUpgradeTestUtil.getFromVersion(), RollingUpgradeTestUtil.getToVersion())
             .nodeCount(nodeCount)
             .addArchives(PersistenceIT.getJavaArchive())
             .addMavenArtifacts(PersistenceIT.getJdbcDrivers())

--- a/server/rollingupgradetests/src/test/java/org/infinispan/server/rollingupgrade/RollingUpgradeTaskTest.java
+++ b/server/rollingupgradetests/src/test/java/org/infinispan/server/rollingupgrade/RollingUpgradeTaskTest.java
@@ -14,7 +14,8 @@ public class RollingUpgradeTaskTest {
 
    @Test
    public void testHelloWorldTask() throws Throwable {
-      RollingUpgradeConfigurationBuilder builder = new RollingUpgradeConfigurationBuilder(RollingUpgradeTaskTest.class.getName(), "15.2.0.Final", "15.2.1.Final")
+      RollingUpgradeConfigurationBuilder builder = new RollingUpgradeConfigurationBuilder(RollingUpgradeTaskTest.class.getName(),
+            RollingUpgradeTestUtil.getFromVersion(), RollingUpgradeTestUtil.getToVersion())
             .useCustomServerConfiguration("configuration/ClusteredServerTest.xml")
             .addArchives(ClusteredIT.artifacts())
             .addMavenArtifacts(ClusteredIT.mavenArtifacts())

--- a/server/rollingupgradetests/src/test/java/org/infinispan/server/rollingupgrade/RollingUpgradeTestUtil.java
+++ b/server/rollingupgradetests/src/test/java/org/infinispan/server/rollingupgrade/RollingUpgradeTestUtil.java
@@ -1,0 +1,26 @@
+package org.infinispan.server.rollingupgrade;
+
+import static org.infinispan.server.test.core.TestSystemPropertyNames.INFINISPAN_ROLLING_UPGRADE_FROM_VERSION;
+import static org.infinispan.server.test.core.TestSystemPropertyNames.INFINISPAN_ROLLING_UPGRADE_TO_VERSION;
+import static org.infinispan.server.test.core.TestSystemPropertyNames.INFINISPAN_TEST_SERVER_DIR;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+public class RollingUpgradeTestUtil {
+   public static String getFromVersion() {
+      return System.getProperty(INFINISPAN_ROLLING_UPGRADE_FROM_VERSION, "16.0.0.Dev02");
+   }
+
+   public static String getToVersion() {
+      String toVersion = System.getProperty(INFINISPAN_ROLLING_UPGRADE_TO_VERSION);
+      if (toVersion != null) {
+         return toVersion;
+      }
+      // This variable by default is set to the SNAPSHOT test directory in the pom.xml, but can be overridden if needed
+      String testServerDir = System.getProperty(INFINISPAN_TEST_SERVER_DIR);
+      Objects.requireNonNull(testServerDir, INFINISPAN_TEST_SERVER_DIR + " or " +
+            INFINISPAN_ROLLING_UPGRADE_TO_VERSION + " must be defined in the system properties.");
+      return "file://" + Path.of(testServerDir).normalize();
+   }
+}

--- a/server/rollingupgradetests/src/test/java/org/infinispan/server/rollingupgrade/RollingUpgradeXSiteIT.java
+++ b/server/rollingupgradetests/src/test/java/org/infinispan/server/rollingupgrade/RollingUpgradeXSiteIT.java
@@ -28,6 +28,7 @@ public class RollingUpgradeXSiteIT extends InfinispanSuite {
 
    @RegisterExtension
    public static final RollingUpgradeHandlerXSiteExtension SERVERS = RollingUpgradeHandlerXSiteExtension.from(
-         RollingUpgradeXSiteIT.class, XSiteIT.EXTENSION_BUILDER, "15.2.0.Final", "15.2.1.Final");
+         RollingUpgradeXSiteIT.class, XSiteIT.EXTENSION_BUILDER,
+         RollingUpgradeTestUtil.getFromVersion(), RollingUpgradeTestUtil.getToVersion());
 
 }

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/core/AbstractServerConfigBuilder.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/core/AbstractServerConfigBuilder.java
@@ -98,6 +98,16 @@ public abstract class AbstractServerConfigBuilder<T extends AbstractServerConfig
       return (T) this;
    }
 
+   /**
+    * Removes a property that was either previously defined or imported from the current running system properties
+    * @param name the name of the property to remove
+    * @return this to allow chain invocation
+    */
+   public T removeProperty(String name) {
+      this.properties.remove(name);
+      return (T) this;
+   }
+
    public T enableJMX() {
       this.jmx = true;
       return (T) this;

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/core/ContainerInfinispanServerDriver.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/core/ContainerInfinispanServerDriver.java
@@ -429,6 +429,8 @@ public class ContainerInfinispanServerDriver extends AbstractInfinispanServerDri
       if (Boolean.parseBoolean(isCoverageEnabled)) {
          javaOpts = javaOpts == null ? "-javaagent:/opt/infinispan/server/lib/org.jacoco.agent-0.8.12-runtime.jar=output=file,destfile=" + JACOCO_COVERAGE_CONTAINER_PATH + ",append=true"
                  : javaOpts + " " + "-javaagent:/opt/infinispan/server/lib/org.jacoco.agent-0.8.12-runtime.jar=output=file,destfile=" + JACOCO_COVERAGE_CONTAINER_PATH + ",append=true";
+         // Code coverage requires more metaspace when the base image only has 96MB by default
+         container.withEnv("JAVA_GC_MAX_METASPACE_SIZE", "512M");
       }
 
       if (javaOpts != null) {

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/core/ContainerInfinispanServerDriver.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/core/ContainerInfinispanServerDriver.java
@@ -432,12 +432,10 @@ public class ContainerInfinispanServerDriver extends AbstractInfinispanServerDri
       }
 
       if (javaOpts != null) {
-         String baseImage = configuration.properties().getProperty(TestSystemPropertyNames.INFINISPAN_TEST_SERVER_BASE_IMAGE_NAME);
-         if (baseImage == null) {
-            container.withEnv("JAVA_OPTS", javaOpts);
-         } else {
-            container.withEnv("JAVA_OPTIONS", javaOpts);
-         }
+         // We set both environment variables as an image from infinispan-images uses JAVA_OPTIONS
+         // and an image from a directory would use JAVA_OPTS. And a custom image could be either.
+         container.withEnv("JAVA_OPTS", javaOpts);
+         container.withEnv("JAVA_OPTIONS", javaOpts);
       }
 
       // Process any enhancers

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/core/rollingupgrade/RollingUpgradeConfigurationBuilder.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/core/rollingupgrade/RollingUpgradeConfigurationBuilder.java
@@ -1,8 +1,5 @@
 package org.infinispan.server.test.core.rollingupgrade;
 
-import static org.infinispan.server.test.core.TestSystemPropertyNames.INFINISPAN_ROLLING_UPGRADE_FROM_VERSION;
-import static org.infinispan.server.test.core.TestSystemPropertyNames.INFINISPAN_ROLLING_UPGRADE_TO_VERSION;
-
 import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.List;
@@ -81,8 +78,8 @@ public class RollingUpgradeConfigurationBuilder {
    }
 
    public RollingUpgradeConfigurationBuilder(String name, String fromVersion, String toVersion) {
-      this.fromVersion = System.getProperty(INFINISPAN_ROLLING_UPGRADE_FROM_VERSION, fromVersion);
-      this.toVersion = System.getProperty(INFINISPAN_ROLLING_UPGRADE_TO_VERSION, toVersion);
+      this.fromVersion = Objects.requireNonNull(fromVersion);
+      this.toVersion = Objects.requireNonNull(toVersion);
       this.name = name;
    }
 


### PR DESCRIPTION
Fixes #15305
Fixes #15341

This PR also fixes some issues with a container running off of a base image. That is that it uses JAVA_OPTIONS instead of JAVA_OPTS and also that we need to increase the max metaspace when using code coverage as 96MB was not enough.