### PR TITLE
[#15369] Generate Jacoco report for rolling-upgrades

### DIFF
--- a/.github/scripts/merge-jacoco-files.sh
+++ b/.github/scripts/merge-jacoco-files.sh
@@ -7,7 +7,11 @@ sourceDirs="$2"
 copy_files() {
     source_dir="$1"
     db="${source_dir##*-}"
-    for file in "$source_dir"/*; do
+    for file in "$source_dir"/tests/target/*; do
+        if [[ -d $file ]]; then
+            echo "Skipping directory: $file"
+            continue
+        fi
         # Get the file name and extension
         filename=$(basename "$file")
         extension="${filename##*.}"
@@ -15,6 +19,7 @@ copy_files() {
 
         #Forming new filename based on DB name
         filename="$filename_without_extension-$db.$extension"
+        echo "Copying file $filename to $destination/server/tests/target/$filename"
 
         # Copy the file to the destination
         cp "$file" "$destination/server/tests/target/$filename"
@@ -22,6 +27,10 @@ copy_files() {
 }
 
 for i in $sourceDirs; do
+    if [[ "$i" == *-rolling-upgrades ]]; then
+        echo "Skipping $i as it matches the ignore pattern."
+        continue # 'continue' skips to the next item in the loop
+    fi
     echo "Copying $i"
     db="${i##*-}"
     if [[ "$db" = "main" ]]; then

--- a/.github/workflows/on_build_do_test.yml
+++ b/.github/workflows/on_build_do_test.yml
@@ -255,7 +255,7 @@ jobs:
   targets-test:
     needs: get-info
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    name: ${{ matrix.targets == 'tomcat' && 'tomcat' || format('db ({0})', matrix.targets) }}
+    name: ${{ matrix.targets == 'tomcat' && 'tomcat' || matrix.targets == 'rolling-upgrades' && 'rolling-upgrades' || format('db ({0})', matrix.targets) }}
     runs-on: ubuntu-latest
     env:
       TOMCAT_VERSION: 11.0.10
@@ -267,6 +267,7 @@ jobs:
           - oracle
           - db2
           - tomcat
+          - rolling-upgrades
     steps:
       - uses: actions/checkout@v5
 
@@ -345,13 +346,23 @@ jobs:
 
 
       - name: Test
-        if: ${{ matrix.targets != 'tomcat' }}
+        if: ${{ matrix.targets != 'tomcat' && matrix.targets != 'rolling-upgrades' }}
         run: |
           cd test_dir/infinispan && \
           ./mvnw verify -B -e -pl server/tests -Dmaven.test.failure.ignore=true \
             -Dansi.strip=true \
             -DdefaultTestGroup=database \
             -Dorg.infinispan.test.database.types=${{ matrix.targets }} \
+            -Dorg.infinispan.test.server.dir=/tmp/infinispan-server-${{ steps.dis.outputs.server-version }} \
+            -Pcoverage
+
+      - name: Run rolling upgrades
+        if: ${{ matrix.targets == 'rolling-upgrades' }}
+        run: |
+          cd test_dir/infinispan && \
+          ./mvnw verify -B -e -pl server/rollingupgradetests -Dmaven.test.failure.ignore=true \
+            -Dansi.strip=true \
+            -DskipRollingUpgradeTests=false \
             -Dorg.infinispan.test.server.dir=/tmp/infinispan-server-${{ steps.dis.outputs.server-version }} \
             -Pcoverage
 
@@ -409,6 +420,7 @@ jobs:
           name: jacoco-files-${{ matrix.targets }}
           path: |
             test_dir/infinispan/server/tests/target/*.exec
+            test_dir/infinispan/server/rollingupgradetests/target/*.exec
 
   coverage:
     needs: [get-info, ci-build-test-pr, targets-test]
@@ -449,6 +461,7 @@ jobs:
           mkdir test_dir && cd test_dir
           unzip ${GITHUB_WORKSPACE}/infinispan-${{ steps.dis.outputs.server-version }}-src.zip
           mv infinispan-${{ steps.dis.outputs.server-version }}-src infinispan
+          cp -r infinispan infinispan-rolling-upgrade
 
       - uses: actions/download-artifact@v5
         with:
@@ -504,3 +517,35 @@ jobs:
           name: jacocoReport
           path: |
             ${{ github.workspace }}/jacocoReport/
+
+      - name: Report for rolling upgrades
+        shell: bash
+        # language=bash
+        run: |
+          cd test_dir/infinispan-rolling-upgrade
+          mvn clean install -DskipTests=true -pl server/rollingupgradetests -am
+          cp ${{ github.workspace }}/jacoco-files-rolling-upgrades/rollingupgradetests/target/*.exec server/rollingupgradetests/target/
+          mvn validate -P jacocoReport
+          mkdir ${{ github.workspace }}/jacocoReport-rolling-upgrade
+          cp -R jacoco-report/ ${{ github.workspace }}/jacocoReport-rolling-upgrade
+
+      - name: Add rolling upgrade coverage to PR
+        id: jacoco-rolling-upgrade
+        uses: madrapps/jacoco-report@v1.7.2
+        with:
+          paths: |
+            ${{ github.workspace }}/test_dir/infinispan-rolling-upgrade/jacoco-report/jacoco.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: 25
+          min-coverage-changed-files: 25
+          pr-number: ${{ env.PR_NUMBER }}
+          title: Coverage for rolling-upgrade tests
+          debug-mode: true
+
+      - name: Upload jacoco report for rolling upgrade
+        if: (success() || failure())
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacocoReport-rolling-upgrade
+          path: |
+            ${{ github.workspace }}/jacocoReport-rolling-upgrade/

--- a/.github/workflows/on_test_publish_surefire_report.yml
+++ b/.github/workflows/on_test_publish_surefire_report.yml
@@ -19,7 +19,7 @@ jobs:
         - name: Download Surefire Report Artifact
           uses: actions/download-artifact@v5
           with:
-            name: surefire-test-report
+            pattern: surefire-test-report*
             github-token: ${{ github.token }}
             run-id: ${{ steps.run_id.outputs.runid }}
 
@@ -28,7 +28,7 @@ jobs:
           id: github_sha
           uses: juliangruber/read-file-action@v1
           with:
-            path: ./github-sha.txt
+            path: ./surefire-test-report/github-sha.txt
 
         # Get GitHub App token to use in API calls
         - uses: actions/create-github-app-token@v2
@@ -140,6 +140,7 @@ jobs:
           - oracle
           - db2
           - tomcat
+          - rolling-upgrades
     steps:
     - name: Set run_id based on event type
       id: run_id
@@ -172,10 +173,14 @@ jobs:
       id: job-status
       run: |
         if [ "${{ matrix.targets }}" = "tomcat" ]; then
-          JOB_STATUS=$(gh api https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ steps.run_id.outputs.runid }}/jobs --jq '.jobs[] | select(.name=="tomcat") | .conclusion')
+          JOB_NAME="tomcat"
+        elif [ "${{ matrix.targets }}" = "rolling-upgrades" ]; then
+          JOB_NAME="rolling-upgrades"
         else
-          JOB_STATUS=$(gh api https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ steps.run_id.outputs.runid }}/jobs --jq '.jobs[] | select(.name=="db (${{ matrix.targets }})") | .conclusion')
+          JOB_NAME="db (${{ matrix.targets }})"
         fi
+
+        JOB_STATUS=$(gh api "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ steps.run_id.outputs.runid }}/jobs" --jq ".jobs[] | select(.name==\"$JOB_NAME\") | .conclusion")
         echo "job_status=$JOB_STATUS" >> $GITHUB_OUTPUT
 
     - name: Publish Test Report

--- a/server/rollingupgradetests/pom.xml
+++ b/server/rollingupgradetests/pom.xml
@@ -16,6 +16,7 @@
 
    <properties>
       <module.skipMavenRemoteResource>true</module.skipMavenRemoteResource>
+      <skipRollingUpgradeTests>true</skipRollingUpgradeTests>
       <defaultTestGroup/>
       <defaultExcludedTestGroup/>
       <org.infinispan.test.server.dir>${project.basedir}/../runtime/target/${infinispan.brand.prefix}-server-${infinispan.brand.version}</org.infinispan.test.server.dir>
@@ -28,7 +29,6 @@
       <test.driverArgs>
          -Dorg.infinispan.test.server.dir=${org.infinispan.test.server.dir}
          -Dorg.infinispan.test.server.container.ulimit=${org.infinispan.test.server.container.ulimit}
-         -Dorg.infinispan.test.database.jdbc.drivers.file="../tests/target/test-classes/database/jdbc-drivers.txt"
       </test.driverArgs>
    </properties>
 
@@ -168,8 +168,29 @@
    </dependencies>
 
    <build>
+      <testResources>
+         <testResource>
+            <directory>${project.basedir}/src/test/resources</directory>
+            <filtering>false</filtering>
+         </testResource>
 
-   <plugins>
+         <testResource>
+            <directory>${project.basedir}/../tests/src/test/resources</directory>
+            <filtering>false</filtering>
+            <excludes>
+               <exclude>**/*.txt</exclude>
+            </excludes>
+         </testResource>
+         <testResource>
+            <directory>${project.basedir}/../tests/src/test/resources</directory>
+            <filtering>true</filtering>
+            <includes>
+               <include>**/*.txt</include>
+            </includes>
+         </testResource>
+      </testResources>
+
+      <plugins>
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-checkstyle-plugin</artifactId>
@@ -180,6 +201,7 @@
          <plugin>
             <artifactId>maven-failsafe-plugin</artifactId>
             <configuration>
+               <skip>${skipRollingUpgradeTests}</skip>
                <groups combine.self="override">${defaultTestGroup}</groups>
                <excludedGroups combine.self="override">${defaultExcludedJUnitGroups}</excludedGroups>
                <parallel>none</parallel>
@@ -210,7 +232,6 @@
                <properties>
                   <usedefaultlisteners>false</usedefaultlisteners>
                   <listener>${junitListener},org.infinispan.server.test.junit4.InfinispanServerTestListener</listener>
-                  <org.infinispan.test.database.jdbc.drivers.file>../tests/target/test-classes/database/jdbc-drivers.txt</org.infinispan.test.database.jdbc.drivers.file>
                </properties>
                <argLine>${forkJvmArgs} ${testjvm.jdkSpecificArgs} ${test.driverArgs} -Djdk.attach.allowAttachSelf=true</argLine>
             </configuration>

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/core/AbstractInfinispanServerDriver.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/core/AbstractInfinispanServerDriver.java
@@ -589,9 +589,11 @@ public abstract class AbstractInfinispanServerDriver implements InfinispanServer
    }
 
    public static String abbreviate(String name) {
-      String[] split = name.split("\\.");
+      String[] split = name.split("[./-]");
       StringBuilder sb = new StringBuilder();
       for (int i = 0; i < split.length - 1; i++) {
+         if (split[i].isBlank())
+            continue;
          sb.append(split[i].charAt(0));
          sb.append('.');
       }

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/core/ContainerInfinispanServerDriver.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/core/ContainerInfinispanServerDriver.java
@@ -113,6 +113,7 @@ public class ContainerInfinispanServerDriver extends AbstractInfinispanServerDri
    private final List<InfinispanGenericContainer> containers;
    private final String[] volumes;
    private String name;
+   private String fullName;
    ImageFromDockerfile image;
    private static final List<String> sites = new ArrayList<>();
    private final NettyLeakDetectionLoggingConsumer leakDetectionLoggingConsumer = new NettyLeakDetectionLoggingConsumer();
@@ -185,6 +186,7 @@ public class ContainerInfinispanServerDriver extends AbstractInfinispanServerDri
 
    private void configureImage(String fqcn, File rootDir) {
       this.name = abbreviate(fqcn);
+      this.fullName = fqcn;
       // If properties define the cluster stack let that take priority over the system property
       String jGroupsStack = !configuration.properties().containsKey(Server.INFINISPAN_CLUSTER_STACK) ?
             System.getProperty(Server.INFINISPAN_CLUSTER_STACK) : null;
@@ -543,7 +545,7 @@ public class ContainerInfinispanServerDriver extends AbstractInfinispanServerDri
          container.stop();
          if (isCoverage() && !container.isKilled()) {
             //Getting Jacoco Coverage Report after stopping the container
-            container.uploadCoverageInfoToHost(JACOCO_COVERAGE_CONTAINER_PATH, JACOCO_COVERAGE_HOST_PATH + this.name + "-" + server + ".exec");
+            container.uploadCoverageInfoToHost(JACOCO_COVERAGE_CONTAINER_PATH, JACOCO_COVERAGE_HOST_PATH + this.fullName + "-" + server + ".exec");
          }
          eventually("Container wasn't stopped.", () -> !isRunning(server));
          log.infof("Stopped container %s", containerAndSite);

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/core/rollingupgrade/RollingUpgradeHandler.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/core/rollingupgrade/RollingUpgradeHandler.java
@@ -27,6 +27,7 @@ import org.infinispan.commons.util.OS;
 import org.infinispan.commons.util.Util;
 import org.infinispan.server.Server;
 import org.infinispan.server.test.api.TestUser;
+import org.infinispan.server.test.core.AbstractInfinispanServerDriver;
 import org.infinispan.server.test.core.ContainerInfinispanServerDriver;
 import org.infinispan.server.test.core.InfinispanServerListener;
 import org.infinispan.server.test.core.InfinispanServerTestConfiguration;
@@ -449,16 +450,15 @@ public class RollingUpgradeHandler {
       }
 
       String versionToUse = versionType == VersionType.TO ? configuration.toVersion() : configuration.fromVersion();
-      String name = (siteName != null ? siteName : "") + clusterName + "-" + versionToUse;
+      String name = (siteName != null ? siteName : "") + clusterName + "-";
 
       if (versionToUse.startsWith("image://")) {
          builder.property(TestSystemPropertyNames.INFINISPAN_TEST_SERVER_BASE_IMAGE_NAME, versionToUse.substring("image://".length()));
+         name += "image-" + AbstractInfinispanServerDriver.abbreviate(versionToUse);
       } else if (versionToUse.startsWith("file://")) {
          // Need to strip the file: as testcontainers strips all `file:` occurrences which seems like a bug
-         {
-            versionToUse = versionToUse.substring("file://".length());
-            name = (siteName != null ? siteName : "") + clusterName + "-" + versionToUse;
-         }
+         versionToUse = versionToUse.substring("file://".length());
+         name += "file-" + AbstractInfinispanServerDriver.abbreviate(versionToUse);
          builder.property(TestSystemPropertyNames.INFINISPAN_TEST_SERVER_DIR, versionToUse);
          // For simplicity trim down to the directory name for the rest of the test
          versionToUse = Path.of(versionToUse).getFileName().toString();
@@ -473,6 +473,7 @@ public class RollingUpgradeHandler {
          }
          builder.property(TestSystemPropertyNames.INFINISPAN_TEST_SERVER_SNAPSHOT_IMAGE_NAME, imageName);
       } else {
+         name += versionToUse;
          builder.property(TestSystemPropertyNames.INFINISPAN_TEST_SERVER_VERSION, versionToUse);
       }
       InfinispanServerTestConfiguration config = builder.createServerTestConfiguration();


### PR DESCRIPTION
We can now run generate the coverage report for rolling upgrade. The basic idea is:

* Run clean.
* Build only server/rollingupgrades with -am, and run tests with coverage profile and passing the jacoco library.
* Run validate in jacocoReport profile from project root.
* Customize report output folder with dir.jacoco.report property (optional).

This generates the coverage with only the dependencies of rollingupgrade. If you run clean and the build everything, it will generate the coverage in relation to the whole code.


Closes #15369.