### PR TITLE
[#15386] Rolling upgrade tests accept JGroups stack

### DIFF
--- a/server/rollingupgradetests/src/test/java/org/infinispan/server/rollingupgrade/DefaultRollingUpgradeTestIT.java
+++ b/server/rollingupgradetests/src/test/java/org/infinispan/server/rollingupgrade/DefaultRollingUpgradeTestIT.java
@@ -33,6 +33,7 @@ public class DefaultRollingUpgradeTestIT {
    public void testDefaultSetting() throws InterruptedException {
       RollingUpgradeConfigurationBuilder builder = new RollingUpgradeConfigurationBuilder(DefaultRollingUpgradeTestIT.class.getName(),
             RollingUpgradeTestUtil.getFromVersion(), RollingUpgradeTestUtil.getToVersion());
+      builder.jgroupsProtocol("tcp");
       RollingUpgradeHandler.performUpgrade(builder.build());
    }
 
@@ -43,6 +44,7 @@ public class DefaultRollingUpgradeTestIT {
       int nodeCount = 3;
       RollingUpgradeConfigurationBuilder builder = new RollingUpgradeConfigurationBuilder(DefaultRollingUpgradeTestIT.class.getName(),
             RollingUpgradeTestUtil.getFromVersion(), RollingUpgradeTestUtil.getToVersion())
+            .jgroupsProtocol("tcp")
             .nodeCount(nodeCount);
       RestClientConfigurationBuilder restBuilder = new RestClientConfigurationBuilder();
       restBuilder.security().authentication().enable().username(user.getUser()).password(user.getPassword());
@@ -92,6 +94,7 @@ public class DefaultRollingUpgradeTestIT {
       ByRef.Integer interactions = new ByRef.Integer(0);
       RollingUpgradeConfigurationBuilder builder = new RollingUpgradeConfigurationBuilder(DefaultRollingUpgradeTestIT.class.getName(),
             RollingUpgradeTestUtil.getFromVersion(), RollingUpgradeTestUtil.getToVersion())
+            .jgroupsProtocol("tcp")
             .nodeCount(nodeCount);
 
       RedisURI.Builder respBuilder = RedisURI.builder()
@@ -142,6 +145,7 @@ public class DefaultRollingUpgradeTestIT {
 
       RollingUpgradeConfigurationBuilder builder = new RollingUpgradeConfigurationBuilder(DefaultRollingUpgradeTestIT.class.getName(),
             RollingUpgradeTestUtil.getFromVersion(), RollingUpgradeTestUtil.getToVersion())
+            .jgroupsProtocol("tcp")
             .nodeCount(nodeCount);
       builder.handlers(
             uh -> {

--- a/server/rollingupgradetests/src/test/java/org/infinispan/server/rollingupgrade/RollingUpgradePersistenceTestIT.java
+++ b/server/rollingupgradetests/src/test/java/org/infinispan/server/rollingupgrade/RollingUpgradePersistenceTestIT.java
@@ -38,6 +38,7 @@ public class RollingUpgradePersistenceTestIT {
 
       RollingUpgradeConfigurationBuilder builder = new RollingUpgradeConfigurationBuilder(RollingUpgradePersistenceTestIT.class.getName(),
             RollingUpgradeTestUtil.getFromVersion(), RollingUpgradeTestUtil.getToVersion())
+            .jgroupsProtocol("tcp")
             .nodeCount(nodeCount);
       builder.handlers(
             uh -> handleInitializer(uh, cacheName, new StringConfiguration(xml)),
@@ -60,6 +61,7 @@ public class RollingUpgradePersistenceTestIT {
             .addArchives(PersistenceIT.getJavaArchive())
             .addMavenArtifacts(PersistenceIT.getJdbcDrivers())
             .addProperty(INFINISPAN_TEST_SERVER_CONTAINER_VOLUME_REQUIRED, "true")
+            .jgroupsProtocol("tcp")
             .addListener(listener);
 
       Consumer<TableManipulation> validateTable = table -> {

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/core/rollingupgrade/RollingUpgradeConfigurationBuilder.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/core/rollingupgrade/RollingUpgradeConfigurationBuilder.java
@@ -16,6 +16,7 @@ import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
 import org.infinispan.commons.configuration.StringConfiguration;
+import org.infinispan.server.Server;
 import org.infinispan.server.test.core.InfinispanServerListener;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 
@@ -31,7 +32,7 @@ public class RollingUpgradeConfigurationBuilder {
    private final List<JavaArchive> customArchives = new ArrayList<>();
    private final List<String> mavenArtifacts = new ArrayList<>();
    private final List<InfinispanServerListener> listeners = new ArrayList<>();
-   private String jgroupsProtocol = "tcp";
+   private String jgroupsProtocol = System.getProperty(Server.INFINISPAN_CLUSTER_STACK, "tcp");
    private int serverCheckTimeSecs = 30;
    private boolean useSharedDataMount = true;
    private BiConsumer<Throwable, RollingUpgradeHandler> exceptionHandler = (t, uh) -> {


### PR DESCRIPTION
* Give preference to the environment variable.
* Fallback to the programmatic configuration (tcp).

Now, we can run with something like:

```
./mvnw clean verify -Dinfinispan.cluster.stack=test-udp -pl server/rollingupgradetests -Dit.test=ClusteredRollingUpgradeIT
```

And it picks up the correct configuration:

```
[o.i.s.r.C.0.0.Dev02#1]STDOUT: 12:26:23,295 INFO  [o.i.CLUSTER] ISPN000078: Starting JGroups channel `org.infinispan.server.rollingupgrade.ClusteredRollingUpgradeIT` with stack `test-udp`
```

Closes #15386.
