### PR TITLE
[15.0] Blockhound 1.0.13

### DIFF
--- a/build/configuration/pom.xml
+++ b/build/configuration/pom.xml
@@ -93,7 +93,7 @@
       <version.ant-contrib>1.0b3</version.ant-contrib>
       <version.antlr3>3.5.3</version.antlr3>
       <version.arquillian>1.8.1.Final</version.arquillian>
-      <version.blockhound>1.0.10.RELEASE</version.blockhound>
+      <version.blockhound>1.0.13.RELEASE</version.blockhound>
       <version.bouncycastle>1.70</version.bouncycastle>
       <version.byteman>4.0.24</version.byteman>
       <version.caffeine>3.1.8</version.caffeine>


### PR DESCRIPTION
Fixes builds with JDK 25