### PR TITLE
[#14537] Prepare for Netty 4.2

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/IOURingNativeTransport.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/IOURingNativeTransport.java
@@ -5,9 +5,7 @@ import java.util.concurrent.ExecutorService;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.SocketChannel;
-import io.netty.incubator.channel.uring.IOUringDatagramChannel;
 import io.netty.incubator.channel.uring.IOUringEventLoopGroup;
-import io.netty.incubator.channel.uring.IOUringSocketChannel;
 
 /**
  * @since 14.0
@@ -15,14 +13,27 @@ import io.netty.incubator.channel.uring.IOUringSocketChannel;
 public class IOURingNativeTransport {
 
    public static Class<? extends SocketChannel> socketChannelClass() {
-      return IOUringSocketChannel.class;
+      // return io.netty.channel.uring.IoUringSocketChannel.class;
+      return io.netty.incubator.channel.uring.IOUringSocketChannel.class;
    }
 
    public static EventLoopGroup createEventLoopGroup(int maxExecutors, ExecutorService executorService) {
+      // new MultiThreadIoEventLoopGroup(maxExecutors, executorService, IoUringIoHandler.newFactory(maxExecutors));
       return new IOUringEventLoopGroup(maxExecutors, executorService);
    }
 
    public static Class<? extends DatagramChannel> datagramChannelClass() {
-      return IOUringDatagramChannel.class;
+      // return io.netty.channel.uring.IoUringDatagramChannel.class;
+      return io.netty.incubator.channel.uring.IOUringDatagramChannel.class;
+   }
+
+   public static boolean isAvailable() {
+      // io.netty.channel.uring.IoUring.isAvailable();
+      return io.netty.incubator.channel.uring.IOUring.isAvailable();
+   }
+
+   public static String unavailableCause() {
+      // io.netty.channel.uring.IoUring.unavailabilityCause().toString()
+      return io.netty.incubator.channel.uring.IOUring.unavailabilityCause().toString();
    }
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/NativeTransport.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/NativeTransport.java
@@ -49,11 +49,11 @@ public final class NativeTransport {
    private static boolean useNativeIOUring() {
       try {
          Class.forName("io.netty.incubator.channel.uring.IOUring", true, NativeTransport.class.getClassLoader());
-         if (io.netty.incubator.channel.uring.IOUring.isAvailable()) {
+         if (IOURingNativeTransport.isAvailable()) {
             return !IOURING_DISABLED && IS_LINUX;
          } else {
             if (IS_LINUX) {
-               HOTROD.ioUringNotAvailable(io.netty.incubator.channel.uring.IOUring.unavailabilityCause().toString());
+               HOTROD.ioUringNotAvailable(IOURingNativeTransport.unavailableCause());
             }
          }
       } catch (ClassNotFoundException e) {
@@ -86,10 +86,12 @@ public final class NativeTransport {
 
    public static EventLoopGroup createEventLoopGroup(int maxExecutors, ExecutorService executorService) {
       if (USE_NATIVE_EPOLL) {
+         // new MultiThreadIoEventLoopGroup(maxExecutors, executorService, EpollIoHandler.newFactory());
          return new EpollEventLoopGroup(maxExecutors, executorService);
       } else if (USE_NATIVE_IOURING) {
          return IOURingNativeTransport.createEventLoopGroup(maxExecutors, executorService);
       } else {
+         // new MultiThreadIoEventLoopGroup(maxExecutors, executorService, NioIoHandler.newFactory(SelectorProvider.provider()));
          return new NioEventLoopGroup(maxExecutors, executorService);
       }
    }

--- a/server/core/src/main/java/org/infinispan/server/core/transport/IOURingNativeTransport.java
+++ b/server/core/src/main/java/org/infinispan/server/core/transport/IOURingNativeTransport.java
@@ -5,7 +5,6 @@ import java.util.concurrent.ThreadFactory;
 import io.netty.channel.MultithreadEventLoopGroup;
 import io.netty.channel.socket.ServerSocketChannel;
 import io.netty.incubator.channel.uring.IOUringEventLoopGroup;
-import io.netty.incubator.channel.uring.IOUringServerSocketChannel;
 
 /**
  * @since 14.0
@@ -13,10 +12,22 @@ import io.netty.incubator.channel.uring.IOUringServerSocketChannel;
 public class IOURingNativeTransport {
 
    public static Class<? extends ServerSocketChannel> serverSocketChannelClass() {
-      return IOUringServerSocketChannel.class;
+      // return io.netty.channel.uring.IoUringServerSocketChannel.class;
+      return io.netty.incubator.channel.uring.IOUringServerSocketChannel.class;
    }
 
    public static MultithreadEventLoopGroup createEventLoopGroup(int maxExecutors, ThreadFactory threadFactory) {
+      // new MultiThreadIoEventLoopGroup(maxExecutors, threadFactory, IoUringIoHandler.newFactory(maxExecutors));
       return new IOUringEventLoopGroup(maxExecutors, threadFactory);
+   }
+
+   public static boolean isAvailable() {
+      // io.netty.channel.uring.IoUring.isAvailable();
+      return io.netty.incubator.channel.uring.IOUring.isAvailable();
+   }
+
+   public static String unavailableCause() {
+      // io.netty.channel.uring.IoUring.unavailabilityCause().toString()
+      return io.netty.incubator.channel.uring.IOUring.unavailabilityCause().toString();
    }
 }

--- a/server/core/src/main/java/org/infinispan/server/core/transport/NativeTransport.java
+++ b/server/core/src/main/java/org/infinispan/server/core/transport/NativeTransport.java
@@ -46,11 +46,11 @@ public final class NativeTransport {
    private static boolean useNativeIOUring() {
       try {
          Class.forName("io.netty.incubator.channel.uring.IOUring", true, NativeTransport.class.getClassLoader());
-         if (io.netty.incubator.channel.uring.IOUring.isAvailable()) {
+         if (IOURingNativeTransport.isAvailable()) {
             return !IOURING_DISABLED && IS_LINUX;
          } else {
             if (IS_LINUX) {
-               SERVER.ioUringNotAvailable(io.netty.incubator.channel.uring.IOUring.unavailabilityCause().toString());
+               SERVER.ioUringNotAvailable(IOURingNativeTransport.unavailableCause());
             }
          }
       } catch (ClassNotFoundException e) {
@@ -76,10 +76,12 @@ public final class NativeTransport {
 
    public static MultithreadEventLoopGroup createEventLoopGroup(int maxExecutors, ThreadFactory threadFactory) {
       if (USE_NATIVE_EPOLL) {
+         // new MultiThreadIoEventLoopGroup(maxExecutors, executorService, EpollIoHandler.newFactory());
          return new EpollEventLoopGroup(maxExecutors, threadFactory);
       } else if (USE_NATIVE_IOURING) {
          return IOURingNativeTransport.createEventLoopGroup(maxExecutors, threadFactory);
       } else {
+         // new MultiThreadIoEventLoopGroup(maxExecutors, executorService, NioIoHandler.newFactory(SelectorProvider.provider()));
          return new NioEventLoopGroup(maxExecutors, threadFactory);
       }
    }


### PR DESCRIPTION
* Remove deprecated code for HTTP/2.
* Move some of the IoUring verification code to a single class.
* Still not using only reflection because the new recommended approach to create the event loop.

Related to #14537, but not fully updating yet.