### PR TITLE
[#15874] Log outside synchronized block

### DIFF
--- a/core/src/main/java/org/infinispan/topology/LocalTopologyManagerImpl.java
+++ b/core/src/main/java/org/infinispan/topology/LocalTopologyManagerImpl.java
@@ -563,10 +563,11 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager, GlobalSta
          if (!validateCommandViewId(cacheTopology, viewId, sender, cacheName))
             return false;
 
-         log.debugf("Updating local topology for cache %s: %s", cacheName, cacheTopology);
          cacheStatus.setCurrentTopology(cacheTopology);
-         return true;
       }
+      // logging is outside of the synchronized block to avoid deadlocks when running in virtual threads
+      log.debugf("Updated local topology for cache %s: %s", cacheName, cacheTopology);
+      return true;
    }
 
    /**


### PR DESCRIPTION
This will help when running in a virtual threads environment and debug logging is active.

Fixes #15874