### PR TITLE
[#15887] ThreadLeak detection in tests uses too much memory with virt…

### DIFF
--- a/commons-test/src/main/java/org/infinispan/commons/test/ThreadLeakChecker.java
+++ b/commons-test/src/main/java/org/infinispan/commons/test/ThreadLeakChecker.java
@@ -122,7 +122,21 @@ public class ThreadLeakChecker {
    private static class ThreadInfoLocal extends InheritableThreadLocal<LeakException> {
       @Override
       protected LeakException childValue(LeakException parentValue) {
+         Thread thread = Thread.currentThread();
+         if (isVirtualThread(thread)) {
+            // Just use parentValue for virtual threads
+            return parentValue;
+         }
          return new LeakException(Thread.currentThread().getName(), parentValue);
+      }
+   }
+
+   private static boolean isVirtualThread(Thread thread) {
+      try {
+         Method isVirtualMethod = Thread.class.getMethod("isVirtual");
+         return (boolean) isVirtualMethod.invoke(thread);
+      } catch (Exception e) {
+         return false;
       }
    }
 


### PR DESCRIPTION
…ual threads

Fixes #15887 

With this in place I never saw more than 500-600 MB at the same time when I saw near 2 GB.