### PR TITLE
[#15381] Fixed the specific modules to work properly with jacoco arg …

### DIFF
--- a/jcache/tck-runner-embedded/pom.xml
+++ b/jcache/tck-runner-embedded/pom.xml
@@ -24,6 +24,7 @@
       <embedded.CacheInvocationContextImpl>org.infinispan.jcache.annotation.CacheKeyInvocationContextImpl</embedded.CacheInvocationContextImpl>
 
       <jvm.x64.args />
+      <jacoco.agent.argLine/>
    </properties>
 
    <dependencies>
@@ -128,7 +129,7 @@
                   <infinispan.module-suffix>${infinispan.module-suffix}</infinispan.module-suffix>
                   <ansi.strip>${ansi.strip}</ansi.strip>
                </systemPropertyVariables>
-               <argLine>${forkJvmArgs} ${testjvm.jdkSpecificArgs} ${jacoco.agent.argLine}</argLine>
+               <argLine>${forkJvmArgs} ${testjvm.jdkSpecificArgs} @{jacoco.agent.argLine}</argLine>
                <properties>
                   <listener>${junitListener}</listener>
                </properties>

--- a/jcache/tck-runner-remote/pom.xml
+++ b/jcache/tck-runner-remote/pom.xml
@@ -39,6 +39,7 @@
       <!-- infinispan.xml ignores the infinispan.cluster.stack system property and uses the test-tcp stack -->
       <transport.stack/>
       <jvm.x64.args />
+      <jacoco.agent.argLine/>
    </properties>
 
    <dependencies>
@@ -245,7 +246,7 @@
                   <infinispan.module-suffix>${infinispan.module-suffix}</infinispan.module-suffix>
                   <ansi.strip>${ansi.strip}</ansi.strip>
                </systemPropertyVariables>
-               <argLine>${forkJvmArgs} ${testjvm.jdkSpecificArgs} ${jacoco.agent.argLine}</argLine>
+               <argLine>${forkJvmArgs} ${testjvm.jdkSpecificArgs} @{jacoco.agent.argLine}</argLine>
                <properties>
                   <listener>${junitListener}</listener>
                </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -2772,7 +2772,7 @@
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-surefire-plugin</artifactId>
                   <configuration>
-                     <argLine combine.self="override">${forkJvmArgs} ${jacoco.agent.argLine}</argLine>
+                     <argLine combine.self="override">${forkJvmArgs} ${testjvm.jdkSpecificArgs} -Djdk.attach.allowAttachSelf=true ${jacoco.agent.argLine}</argLine>
                   </configuration>
                </plugin>
 

--- a/query/pom.xml
+++ b/query/pom.xml
@@ -14,6 +14,7 @@
 
    <properties>
       <infinispan.test.parallel.threads>5</infinispan.test.parallel.threads>
+      <jacoco.agent.argLine/>
    </properties>
 
    <dependencies>
@@ -265,7 +266,7 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
                <reportsDirectory>${project.build.directory}/ignored-surefire-reports</reportsDirectory>
-               <argLine>${forkJvmArgs} ${testjvm.jdkSpecificArgs} -Djdk.attach.allowAttachSelf=true ${jacoco.agent.argLine}</argLine>
+               <argLine>${forkJvmArgs} ${testjvm.jdkSpecificArgs} -Djdk.attach.allowAttachSelf=true @{jacoco.agent.argLine}</argLine>
             </configuration>
          </plugin>
          <plugin>

--- a/server/router/pom.xml
+++ b/server/router/pom.xml
@@ -12,6 +12,10 @@
     <name>Infinispan Multi Tenant Router</name>
     <description>Infinispan Multi Tenant Router</description>
 
+    <properties>
+        <jacoco.agent.argLine/>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.infinispan</groupId>
@@ -136,7 +140,7 @@
                         <usedefaultlisteners>false</usedefaultlisteners>
                         <listener>${junitListener}</listener>
                     </properties>
-                    <argLine>${forkJvmArgs} ${testjvm.jdkSpecificArgs} ${jacoco.agent.argLine}</argLine>
+                    <argLine>${forkJvmArgs} ${testjvm.jdkSpecificArgs} @{jacoco.agent.argLine}</argLine>
                 </configuration>
                 <dependencies>
                     <dependency>


### PR DESCRIPTION
…line.

The modules where the surefire plugin is overriden, the jacoco coverage report was not generated while coverage profile enabled. I have updated the argLine in my prev. PR, but this way the mvn command started to hang when the coverage profile was NOT activated. 

So now, I have added the empty jacoco arg property in that modules so that when the property is not set, i.e. the coverage profile is not activated, the maven command doesn't hang. In case the profile is activated, then the property will be filled with proper value (using maven late property evaluation feature). 

I have tested the changes locally both coverage profile enabled / disabled. 