### PR TITLE
[#15862] CLI command for persistent state

### DIFF
--- a/cli/src/main/java/org/infinispan/cli/commands/troubleshoot/PersistentStateParse.java
+++ b/cli/src/main/java/org/infinispan/cli/commands/troubleshoot/PersistentStateParse.java
@@ -1,0 +1,154 @@
+package org.infinispan.cli.commands.troubleshoot;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.CommandException;
+import org.aesh.command.CommandResult;
+import org.aesh.command.impl.completer.FileOptionCompleter;
+import org.aesh.command.option.Argument;
+import org.aesh.command.option.Option;
+import org.infinispan.cli.commands.CliCommand;
+import org.infinispan.cli.completers.PersistentScopeCompleter;
+import org.infinispan.cli.impl.ContextAwareCommandInvocation;
+import org.infinispan.commons.time.DefaultTimeService;
+import org.infinispan.commons.util.concurrent.FileSystemLock;
+import org.infinispan.globalstate.GlobalStateManager;
+import org.infinispan.globalstate.ScopedPersistentState;
+import org.infinispan.globalstate.impl.GlobalStateHandler;
+
+/**
+ * Visualize and manipulate the persistent state.
+ *
+ * <p>
+ * <b>DISCLAIMER:</b> This command is dangerous and should be utilized only for investigation. Deleting a scope is harmful.
+ * </p>
+ *
+ * <p>
+ * This command allows to list, read, and delete a scope in the global state. A scope is written during the graceful
+ * shutdown procedure and is utilized during start-up to reconstruct the previous cluster and avoid unnecessary state
+ * transfer.
+ * </p>
+ *
+ * <p>
+ * The operations are:
+ * <ul>
+ *    <li>Default: This command list all existing scopes in the file system. Usually, there is a scope per cache.</li>
+ *    <li><b>show [name]</b>: Shows the data stored in the given scope.</li>
+ *    <li><b>delete [name]</b>: Deletes the data stored in the given scope. This operation is dangerous.</li>
+ * </ul>
+ *
+ * All commands accept the path to directory utilized in the server's global-state configuration.
+ * </p>
+ *
+ * @author José Bolina
+ * @since 16.0
+ */
+@CommandDefinition(name = "persistent-state", description = "Inspect the persistent state")
+public class PersistentStateParse extends CliCommand implements PersistentScopeCompleter.PersistentScopeAwareCommand {
+
+   @Option(name = "show", completer = PersistentScopeCompleter.class, description = "Show the persistent state of a single scope")
+   String show;
+
+   @Option(name = "delete", completer = PersistentScopeCompleter.class, description = "Delete the persistent state of a single scope")
+   String delete;
+
+   @Argument(completer = FileOptionCompleter.class, description = "Path to the persistent state directory")
+   String path;
+
+   @Option(shortName = 'h', hasValue = false, overrideRequired = true)
+   protected boolean help;
+
+   @Override
+   protected boolean isHelp() {
+      return help || path == null;
+   }
+
+   @Override
+   protected CommandResult exec(ContextAwareCommandInvocation invocation) throws CommandException {
+      if (path == null) return CommandResult.FAILURE;
+
+      Path p = Path.of(path);
+      if (Files.notExists(p) || !Files.isDirectory(p)) {
+         invocation.getShellError().println("The path " + path + " does not exist or is not a directory");
+         return CommandResult.FAILURE;
+      }
+
+      if (show != null) {
+         showScope(invocation, show);
+         return CommandResult.SUCCESS;
+      }
+
+      if (delete != null) {
+         FileSystemLock lock = new FileSystemLock(p, ScopedPersistentState.GLOBAL_SCOPE);
+         try {
+            if (!lock.tryLock() && !lock.isAcquired()) {
+               invocation.getShellError().printf("Global file lock is held by server at %s. Can not manipulate scoped data%n", path);
+               return CommandResult.FAILURE;
+            }
+            return modifyScope(invocation);
+         } catch (IOException e) {
+            throw new RuntimeException(e);
+         } finally {
+            if (lock.isAcquired()) {
+               lock.unlock();
+            }
+         }
+      }
+
+      listAllScopes(invocation);
+      return CommandResult.SUCCESS;
+   }
+
+   private CommandResult modifyScope(ContextAwareCommandInvocation invocation) {
+      if (delete != null) {
+         showScope(invocation, delete);
+         deleteScope(invocation, delete);
+      }
+
+      return CommandResult.SUCCESS;
+   }
+
+   @Override
+   public Collection<String> getPersistentScopes() {
+      try (Stream<Path> paths = Files.walk(Path.of(path))) {
+         return paths.filter(Files::isRegularFile)
+               .filter(p -> p.getFileName().toString().endsWith(".state"))
+               .map(p -> p.getFileName().toString().replace(".state", ""))
+               .filter(s -> !Objects.equals(s, ScopedPersistentState.GLOBAL_SCOPE))
+               .toList();
+      } catch (IOException e) {
+         throw new RuntimeException(e);
+      }
+   }
+
+   private void showScope(ContextAwareCommandInvocation invocation, String scope) {
+      GlobalStateManager handler = new GlobalStateHandler(path, DefaultTimeService.INSTANCE);
+      Optional<ScopedPersistentState> optional = handler.readScopedState(scope);
+      if (optional.isEmpty()) {
+         invocation.getShellError().println("The scope " + scope + " does not exist in " + path);
+         return;
+      }
+
+      ScopedPersistentState state = optional.get();
+      invocation.getShell().writeln(String.format("Scope=%s; Checksum=%d", scope, state.getChecksum()));
+      state.forEach((k, v) -> invocation.getShell().writeln(String.format("key=%s; value=%s", k, v)));
+   }
+
+   private void deleteScope(ContextAwareCommandInvocation invocation, String scope) {
+      GlobalStateManager handler = new GlobalStateHandler(path, DefaultTimeService.INSTANCE);
+      handler.deleteScopedState(scope);
+      invocation.getShellOutput().printf("Deleted scope %s in %s.%n", scope, path);
+   }
+
+   private void listAllScopes(ContextAwareCommandInvocation invocation) {
+      invocation.getShellOutput().printf("List all states in: %s%n", path);
+      getPersistentScopes().forEach(invocation.getShell()::writeln);
+   }
+}

--- a/cli/src/main/java/org/infinispan/cli/commands/troubleshoot/Troubleshoot.java
+++ b/cli/src/main/java/org/infinispan/cli/commands/troubleshoot/Troubleshoot.java
@@ -22,7 +22,7 @@ import org.kohsuke.MetaInfServices;
  * @since 15.0
  */
 @MetaInfServices(Command.class)
-@GroupCommandDefinition(name = "troubleshoot", description = "Execute troubleshooting commands", groupCommands = { AccessLogParse.class })
+@GroupCommandDefinition(name = "troubleshoot", description = "Execute troubleshooting commands", groupCommands = { AccessLogParse.class, PersistentStateParse.class })
 public class Troubleshoot extends CliCommand {
 
    @Option(shortName = 'h', hasValue = false, overrideRequired = true)

--- a/cli/src/main/java/org/infinispan/cli/completers/PersistentScopeCompleter.java
+++ b/cli/src/main/java/org/infinispan/cli/completers/PersistentScopeCompleter.java
@@ -1,0 +1,27 @@
+package org.infinispan.cli.completers;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import org.aesh.command.Command;
+import org.infinispan.cli.Context;
+
+public class PersistentScopeCompleter extends ListCompleter {
+   @Override
+   Collection<String> getAvailableItems(Context context) throws IOException {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   protected Collection<String> getAvailableItems(ContextAwareCompleterInvocation invocation) throws IOException {
+      Command<?> command = invocation.getCommand();
+      if (command instanceof PersistentScopeAwareCommand psac) {
+         return psac.getPersistentScopes();
+      }
+      return super.getAvailableItems(invocation);
+   }
+
+   public interface PersistentScopeAwareCommand {
+      Collection<String> getPersistentScopes();
+   }
+}

--- a/cli/src/main/resources/help/troubleshoot.adoc
+++ b/cli/src/main/resources/help/troubleshoot.adoc
@@ -57,3 +57,30 @@ Generates statistics grouped by clients from the local files `access.log` and `a
 operations, and only accept operations at or after the given. Note the date *must* be quoted.
 
 
+SYNOPSIS
+--------
+*troubleshoot persistent-state* ['OPTIONS'] `PERSISTENT_STATE_DIRECTORY`
+
+
+PERSISTENT STATE OPTIONS
+------------------------
+*--show*='NAME'::
+Inspect the persistent state of a single cache.
+
+*--delete*='NAME'::
+Deletes the persistent state of a single cache.
+This operation only succeeds when the server is *not* running. It will acquire exclusive access to the file through
+the duration of the operation.
+
+
+EXAMPLES
+--------
+`troubleshoot persistent-state server/data` +
+List all existing persistent states in the directory.
+
+`troubleshoot persistent-state server/data --show org.infinispan.CONFIG` +
+Shows the current persistent state for the cache.
+
+`troubleshoot persistent-state server/data --delete org.infinispan.CONFIG` +
+Shows and deletes the persistent state associated with the cache.
+

--- a/cli/src/test/java/org/infinispan/cli/commands/troubleshoot/PersistentStateParseTest.java
+++ b/cli/src/test/java/org/infinispan/cli/commands/troubleshoot/PersistentStateParseTest.java
@@ -1,0 +1,126 @@
+package org.infinispan.cli.commands.troubleshoot;
+
+import static org.infinispan.commons.test.CommonsTestingUtil.tmpDirectory;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Properties;
+import java.util.UUID;
+
+import org.infinispan.cli.AeshTestShell;
+import org.infinispan.cli.CliPipeTest;
+import org.infinispan.cli.commands.CLI;
+import org.infinispan.commons.test.CommonsTestingUtil;
+import org.infinispan.commons.util.Util;
+import org.infinispan.commons.util.concurrent.FileSystemLock;
+import org.infinispan.globalstate.ScopedPersistentState;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+public class PersistentStateParseTest {
+
+   private static final String SAMPLE_STATE_CONTENT = "key=content";
+
+   @Rule
+   public TestName name = new TestName();
+
+   @Test
+   public void testListAllStates() throws IOException {
+      File workingDir = new File(CommonsTestingUtil.tmpDirectory(CliPipeTest.class));
+      Util.recursiveFileRemove(workingDir);
+      workingDir.mkdirs();
+      Properties properties = new Properties(System.getProperties());
+      properties.put("cli.dir", workingDir.getAbsolutePath());
+      String persistentStateName = UUID.randomUUID().toString();
+      Path p = createPersistentState(name.getMethodName(), persistentStateName);
+
+      AeshTestShell shell = new AeshTestShell();
+      int exit = CLI.main(shell, new String[] {"troubleshoot", "persistent-state", p.toAbsolutePath().getParent().toString()}, properties);
+      assertEquals(0, exit);
+      shell.assertContains(persistentStateName);
+   }
+
+   @Test
+   public void showStateContents() throws IOException {
+      File workingDir = new File(CommonsTestingUtil.tmpDirectory(CliPipeTest.class));
+      Util.recursiveFileRemove(workingDir);
+      workingDir.mkdirs();
+      Properties properties = new Properties(System.getProperties());
+      properties.put("cli.dir", workingDir.getAbsolutePath());
+      String persistentStateName = UUID.randomUUID().toString();
+      Path p = createPersistentState(name.getMethodName(), persistentStateName);
+
+      AeshTestShell shell = new AeshTestShell();
+      int exit = CLI.main(shell, new String[] {"troubleshoot", "persistent-state", p.toAbsolutePath().getParent().toString(), "--show", persistentStateName}, properties);
+      assertEquals(0, exit);
+      shell.assertContains("key=key; value=content");
+   }
+
+   @Test
+   public void testSuccessfulDeleteScope() throws IOException {
+      File workingDir = new File(CommonsTestingUtil.tmpDirectory(CliPipeTest.class));
+      Util.recursiveFileRemove(workingDir);
+      workingDir.mkdirs();
+      Properties properties = new Properties(System.getProperties());
+      properties.put("cli.dir", workingDir.getAbsolutePath());
+      String persistentStateName = UUID.randomUUID().toString();
+      Path p = createPersistentState(name.getMethodName(), persistentStateName);
+
+      // Assert the file exists before submitting command.
+      assertTrue(p.toFile().exists());
+
+      AeshTestShell shell = new AeshTestShell();
+      int exit = CLI.main(shell, new String[] {"troubleshoot", "persistent-state", p.toAbsolutePath().getParent().toString(), "--delete", persistentStateName}, properties);
+      assertEquals(0, exit);
+      shell.assertContains("key=key; value=content");
+
+      // Assert the file was deleted.
+      assertFalse(p.toFile().exists());
+   }
+
+   @Test
+   public void testFailedDeleteOnGlobalLock() throws IOException {
+      File workingDir = new File(CommonsTestingUtil.tmpDirectory(CliPipeTest.class));
+      Util.recursiveFileRemove(workingDir);
+      workingDir.mkdirs();
+      Properties properties = new Properties(System.getProperties());
+      properties.put("cli.dir", workingDir.getAbsolutePath());
+      String persistentStateName = UUID.randomUUID().toString();
+      Path p = createPersistentState(name.getMethodName(), persistentStateName);
+
+      // Assert the file exists before submitting command.
+      assertTrue(p.toFile().exists());
+
+      FileSystemLock lock = new FileSystemLock(p.toAbsolutePath().getParent(), ScopedPersistentState.GLOBAL_SCOPE);
+      assertTrue(lock.tryLock());
+      try {
+         AeshTestShell shell = new AeshTestShell();
+         int exit = CLI.main(shell, new String[] {"troubleshoot", "persistent-state", p.toAbsolutePath().getParent().toString(), "--delete", persistentStateName}, properties);
+         assertEquals(0, exit);
+      } finally {
+         lock.unlock();
+      }
+
+      // Assert the file is still present.
+      assertTrue(p.toFile().exists());
+   }
+
+   private Path createPersistentState(String parent, String name) throws IOException {
+      String p = tmpDirectory(PersistentStateParseTest.class.getName(), parent);
+      Util.recursiveFileRemove(p);
+      Path state = Path.of(p, name + ".state");
+      state.toFile().getParentFile().mkdirs();
+      state.toFile().createNewFile();
+      try (BufferedWriter writer = new BufferedWriter(new FileWriter(state.toFile()))) {
+         writer.write(SAMPLE_STATE_CONTENT);
+      }
+      return state;
+   }
+}

--- a/commons/all/src/main/java/org/infinispan/commons/util/concurrent/FileSystemLock.java
+++ b/commons/all/src/main/java/org/infinispan/commons/util/concurrent/FileSystemLock.java
@@ -126,7 +126,7 @@ public class FileSystemLock {
 
       try {
          globalLock = globalLockFile.getChannel().tryLock();
-         return globalLock.isValid();
+         return globalLock != null && globalLock.isValid();
       } catch (OverlappingFileLockException ignore) {
          return false;
       }

--- a/core/src/main/java/org/infinispan/globalstate/impl/GlobalStateHandler.java
+++ b/core/src/main/java/org/infinispan/globalstate/impl/GlobalStateHandler.java
@@ -1,0 +1,145 @@
+package org.infinispan.globalstate.impl;
+
+import static org.infinispan.globalstate.ScopedPersistentState.GLOBAL_SCOPE;
+import static org.infinispan.globalstate.impl.GlobalStateManagerImpl.TIMESTAMP;
+import static org.infinispan.globalstate.impl.GlobalStateManagerImpl.VERSION;
+import static org.infinispan.globalstate.impl.GlobalStateManagerImpl.VERSION_MAJOR;
+import static org.infinispan.util.logging.Log.CONTAINER;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.infinispan.commons.time.TimeService;
+import org.infinispan.commons.util.Util;
+import org.infinispan.commons.util.Version;
+import org.infinispan.globalstate.GlobalStateManager;
+import org.infinispan.globalstate.GlobalStateProvider;
+import org.infinispan.globalstate.ScopedPersistentState;
+
+public final class GlobalStateHandler implements GlobalStateManager {
+
+   private final List<GlobalStateProvider> providers = new CopyOnWriteArrayList<>();
+
+   private String root;
+   private TimeService timeService;
+
+   public GlobalStateHandler(String root, TimeService timeService) {
+      this.root = root;
+      this.timeService = timeService;
+   }
+
+   GlobalStateHandler() { }
+
+   void setRoot(String root) {
+      this.root = root;
+   }
+
+   void setTimeService(TimeService timeService) {
+      this.timeService = timeService;
+   }
+
+   // Utilized only by the GlobalStateManagerImpl
+   ScopedPersistentState startStateHandler() {
+      File stateFile = getStateFile(GLOBAL_SCOPE);
+      ScopedPersistentState globalState = readScopedState(GLOBAL_SCOPE).orElse(null);
+      if (globalState != null) {
+         // We proceed only if we can write to the file
+         if (!stateFile.canWrite()) {
+            throw CONTAINER.nonWritableStateFile(stateFile);
+         }
+         // Validate the state before proceeding
+         if (!globalState.containsProperty(VERSION) || !globalState.containsProperty(VERSION_MAJOR) || !globalState.containsProperty(TIMESTAMP)) {
+            throw CONTAINER.invalidPersistentState(GLOBAL_SCOPE);
+         }
+         CONTAINER.globalStateLoad(globalState.getProperty(VERSION), globalState.getProperty(TIMESTAMP));
+         providers.forEach(provider -> provider.prepareForRestore(globalState));
+      } else {
+         // Clean slate. Create the persistent location if necessary and acquire a lock
+         stateFile.getParentFile().mkdirs();
+      }
+      return globalState;
+   }
+
+   @Override
+   public void registerStateProvider(GlobalStateProvider provider) {
+      providers.add(provider);
+   }
+
+   @Override
+   public Optional<ScopedPersistentState> readScopedState(String scope) {
+      File stateFile = getStateFile(scope);
+      if (!stateFile.exists())
+         return Optional.empty();
+
+      try (BufferedReader r = new BufferedReader(new FileReader(stateFile))) {
+         ScopedPersistentState state = new ScopedPersistentStateImpl(scope);
+         for (String line = r.readLine(); line != null; line = r.readLine()) {
+            if (!line.startsWith("#")) { // Skip comment lines
+               int eq = line.indexOf('=');
+               while (eq > 0 && line.charAt(eq - 1) == '\\') {
+                  eq = line.indexOf('=', eq + 1);
+               }
+               if (eq > 0) {
+                  state.setProperty(Util.unicodeUnescapeString(line.substring(0, eq).trim()),
+                        Util.unicodeUnescapeString(line.substring(eq + 1).trim()));
+               }
+            }
+         }
+         return Optional.of(state);
+      } catch (IOException e) {
+         throw CONTAINER.failedReadingPersistentState(e, stateFile);
+      }
+   }
+
+   @Override
+   public void writeScopedState(ScopedPersistentState state) {
+      File stateFile = getStateFile(state.getScope());
+      try (PrintWriter w = new PrintWriter(stateFile)) {
+         state.forEach((key, value) -> {
+            w.printf("%s=%s%n", Util.unicodeEscapeString(key), Util.unicodeEscapeString(value));
+         });
+      } catch (IOException e) {
+         throw CONTAINER.failedWritingGlobalState(e, stateFile);
+      }
+   }
+
+   @Override
+   public void deleteScopedState(String scope) {
+      File stateFile = getStateFile(scope);
+      try {
+         Files.deleteIfExists(stateFile.toPath());
+      } catch (IOException e) {
+         throw CONTAINER.failedWritingGlobalState(e, stateFile);
+      }
+   }
+
+   @Override
+   public void writeGlobalState() {
+      if (providers.isEmpty()) {
+         // If no state providers were registered, we cannot persist
+         CONTAINER.incompleteGlobalState();
+      } else {
+         ScopedPersistentState state = new ScopedPersistentStateImpl(GLOBAL_SCOPE);
+         state.setProperty(VERSION, Version.getVersion());
+         state.setProperty(VERSION_MAJOR, Version.getMajor());
+         state.setProperty(TIMESTAMP, timeService.instant().toString());
+         // ask any state providers to contribute to the global state
+         for (GlobalStateProvider provider : providers) {
+            provider.prepareForPersist(state);
+         }
+         writeScopedState(state);
+         CONTAINER.globalStateWrite(state.getProperty(VERSION), state.getProperty(TIMESTAMP));
+      }
+   }
+
+   private File getStateFile(String scope) {
+      return new File(root, scope + ".state");
+   }
+}


### PR DESCRIPTION
Honestly, I am not 100% happy about how this command. It basically wraps the operations to ls the directory, rm and cat the file. I don't want to make it possible to "remove" the persistent state in the server during runtime. That would be quite a lot of work and would leave many moving pieces. Therefore, this command tries to acquire the global lock to perform the delete operation, so it only works in offline mode during deletion. The command to list and inspect the state work fine while the server runs.

I am not happy because this command is only useful running in bare metal. If a server is running in OCP, and is crashing because of a problem in the persistent state, the user would need to keep the pod in the crash loop to inspect/delete the persistent state. I hope to work in this aspect next in another PR (caches failing to initializate do not crash the server).

Let me know what you think. If you think this is not worth it, I am fine if we close the PR without merging.
Closes #15862.