### PR TITLE
[#15897] Client can cause disconnect with getCache called in a tight …

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/HeaderDecoder.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/HeaderDecoder.java
@@ -478,6 +478,10 @@ public class HeaderDecoder extends HintedReplayingDecoder<HeaderDecoder.State> {
       super.checkpoint();
    }
 
+   /**
+    * This method must only be invoked in the event loop that controls this decoder
+    * @return
+    */
    public Map<Long, HotRodOperation<?>> registeredOperationsById() {
       var map = new HashMap<Long, HotRodOperation<?>>();
       operations.forEach((opTimeout, id) -> {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/logging/Log.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/logging/Log.java
@@ -437,4 +437,7 @@ public interface Log extends BasicLogger {
    @Message(value = "Counter '%s' is not defined.", id = 4120)
    CounterException undefinedCounter(String name);
 
+   @LogMessage(level = WARN)
+   @Message(value = "Exception encountered while closing server connection %s", id = 4121)
+   void exceptionWhileClosingChannel(Channel channel, @Cause Throwable t);
 }


### PR DESCRIPTION
…loop

Fixes #15897

This reworks submission a bit so that before submitting an operation we optimistically "acquire" the read lock. Then after task submission if the "acquire" didn't work we double check the channel we submitted to to see if it still is the same or not. If not we have to resubmit the task so it can be ran on a new channel.

Also on a channel disconnect we can only close a ChannelHandler if the existing one matches the same one. Otherwise it could close a ChannelHandler tied to a different socket.