### PR TITLE
[15.2.x] [#15897] Client can cause disconnect with getCache called in a tight …

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/HeaderDecoder.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/HeaderDecoder.java
@@ -478,6 +478,10 @@ public class HeaderDecoder extends HintedReplayingDecoder<HeaderDecoder.State> {
       super.checkpoint();
    }
 
+   /**
+    * This method must only be invoked in the event loop that controls this decoder
+    * @return
+    */
    public Map<Long, HotRodOperation<?>> registeredOperationsById() {
       var map = new HashMap<Long, HotRodOperation<?>>();
       operations.forEach((opTimeout, id) -> {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/OperationChannel.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/OperationChannel.java
@@ -18,6 +18,7 @@ import org.infinispan.client.hotrod.impl.operations.HotRodOperation;
 import org.infinispan.client.hotrod.impl.protocol.Codec;
 import org.infinispan.client.hotrod.logging.Log;
 import org.infinispan.client.hotrod.logging.LogFactory;
+import org.reactivestreams.Subscriber;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
@@ -26,6 +27,9 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.AttributeKey;
 import io.netty.util.internal.shaded.org.jctools.queues.MessagePassingQueue;
 import io.netty.util.internal.shaded.org.jctools.queues.MpscUnboundedArrayQueue;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.processors.FlowableProcessor;
+import io.reactivex.rxjava3.processors.UnicastProcessor;
 
 public class OperationChannel implements MessagePassingQueue.Consumer<HotRodOperation<?>> {
    private static final Log log = LogFactory.getLog(OperationChannel.class);
@@ -254,6 +258,15 @@ public class OperationChannel implements MessagePassingQueue.Consumer<HotRodOper
       return queue;
    }
 
+   /**
+    * Drains the pending queue of operations passing them to the provided Consumer. Note these operations will thus
+    * be never submitted to the underlying Channel and the invoker must process these operations somehow.
+    * @param consumer callback for each non submitted operation
+    */
+   public void drainQueue(MessagePassingQueue.Consumer<HotRodOperation<?>> consumer) {
+      queue.drain(consumer, Integer.MAX_VALUE);
+   }
+
    public List<HotRodOperation<?>> close() {
       acceptingRequests = false;
       CompletableFuture<Void> future = attemptedConnect.getAndSet(null);
@@ -283,5 +296,35 @@ public class OperationChannel implements MessagePassingQueue.Consumer<HotRodOper
             ", channel=" + channel +
             ", acceptingRequests=" + acceptingRequests +
             '}';
+   }
+
+   /**
+    * Provides a flowable that will return all operations that have either not been submitted or have that are waiting
+    * for results to complete. If the channel is connected the {@link Subscriber#onNext(Object)}
+    * and {@link Subscriber#onComplete()} methods will be invoked in the event loop for the given channel ensuring they
+    * are not concurrently processed.
+    * @return Flowable that can be subscribed to provide the operations for the operation channel
+    */
+   public Flowable<HotRodOperation<?>> pendingOperationFlowable() {
+      return Flowable.defer(() -> {
+         Channel channel = this.channel;
+         if (channel == null) {
+            return Flowable.fromIterable(pendingChannelOperations());
+         } else {
+            FlowableProcessor<HotRodOperation<?>> processor = UnicastProcessor.create();
+            channel.eventLoop().execute(() -> {
+               try {
+                  pendingChannelOperations().forEach(processor::onNext);
+                  HeaderDecoder decoder = channel.pipeline().get(HeaderDecoder.class);
+                  decoder.registeredOperationsById()
+                        .forEach((k, v) -> processor.onNext(v));
+                  processor.onComplete();
+               } catch (Throwable t) {
+                  processor.onError(t);
+               }
+            });
+            return processor;
+         }
+      });
    }
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/OperationDispatcher.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/OperationDispatcher.java
@@ -12,7 +12,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -54,6 +53,7 @@ import org.infinispan.client.hotrod.impl.topology.CacheInfo;
 import org.infinispan.client.hotrod.impl.topology.ClusterInfo;
 import org.infinispan.client.hotrod.logging.Log;
 import org.infinispan.client.hotrod.logging.LogFactory;
+import org.infinispan.commons.reactive.RxJavaInterop;
 import org.infinispan.commons.stat.CounterTracker;
 import org.infinispan.commons.time.TimeService;
 import org.infinispan.commons.util.concurrent.CompletionStages;
@@ -64,6 +64,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.DecoderException;
 import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.internal.functions.Functions;
 import net.jcip.annotations.GuardedBy;
 
 /**
@@ -100,7 +101,7 @@ public class OperationDispatcher {
    @GuardedBy("lock")
    private Set<HotRodOperation<?>> priorAgeOperations = null;
 
-   @GuardedBy("lock")
+   // This can only be written to when holding the writeLock for lock
    private final Set<SocketAddress> connectionFailedServers;
    private final ChannelHandler channelHandler;
    private final ExecutorService executorService;
@@ -306,11 +307,51 @@ public class OperationDispatcher {
          socketAddress = getBalancer(operation.getCacheName()).nextServer(connectionFailedServers);
       }
       log.tracef("Dispatching %s to %s", operation, socketAddress);
-      return channelHandler.submitOperation(operation, Objects.requireNonNull(socketAddress));
+      long stamp = lock.tryOptimisticRead();
+      OperationChannel operationChannel = channelHandler.getOrCreateChannelForAddress(socketAddress);
+      operationChannel.sendOperation(operation);
+      // If the lock stamp changed - that means a channel may have been modified, verify if it was ours
+      if (!lock.validate(stamp)) {
+         // Note we don't need to acquire the read lock as channelHandler#getChannelForAddress is thread safe. The
+         // callers would would acquire the write lock will try to shut down operations, so all we have to do is
+         // check our own operation only if it is present or not in the queue.
+         handleChannelChangePossibility(operation, socketAddress, operationChannel);
+      }
+      return operation.asCompletableFuture();
+   }
+
+   private void handleChannelChangePossibility(HotRodOperation<?> operation, SocketAddress socketAddress,
+                                                   OperationChannel operationChannel) {
+      log.tracef("Concurrent topology update while sending operation %s", operation);
+      OperationChannel otherChannel = channelHandler.getChannelForAddress(socketAddress);
+      // If the channel no longer matches then we have to see if our operation needs to be resubmitted or not
+      if (otherChannel != operationChannel) {
+         // We only worry about the queue, as any submitted operation will be handled by the close/gracefulClose methods
+         if (operationChannel.pendingChannelOperations().remove(operation)) {
+            log.tracef("Our channel no longer exists so resubmitting operation %s", operation);
+            // Note this can't use the single arg execute method as we may have received a AddClientListener
+            // operation. And if we did it already registered itself so we don't call executeAddListener.
+            execute(operation, Set.of());
+         } else {
+            log.tracef("Operation %s already sent to prior channel, so allowing it to complete", operation);
+         }
+      } else {
+         log.tracef("Our channel did not change, so operation %s can continue unchanged", operation);
+      }
    }
 
    public FailoverRequestBalancingStrategy getBalancer(String cacheName) {
-      return topologyInfo.getOrCreateCacheInfo(cacheName).getBalancer();
+      long stamp = lock.tryOptimisticRead();
+      FailoverRequestBalancingStrategy balancer = topologyInfo.getOrCreateCacheInfo(cacheName).getBalancer();
+      if (!lock.validate(stamp)) {
+         stamp = lock.readLock();
+         try {
+            balancer = topologyInfo.getOrCreateCacheInfo(cacheName).getBalancer();
+         } finally {
+            lock.unlockRead(stamp);
+         }
+      }
+      return balancer;
    }
 
    public ClientIntelligence getClientIntelligence() {
@@ -426,7 +467,7 @@ public class OperationDispatcher {
       for (SocketAddress server : removedServers) {
          HOTROD.removingServer(server);
          connectionFailedServers.remove(server);
-         closeChannel(server);
+         gracefulCloseChannel(server);
       }
    }
 
@@ -554,14 +595,44 @@ public class OperationDispatcher {
          HOTROD.switchedBackToMainCluster();
    }
 
+   // This method can only be invoked while holding the writeLock - this prevents additional channels being changed
+   private void gracefulCloseChannel(SocketAddress server) {
+      OperationChannel operationChannel = channelHandler.removeChannel(server);
+      if (operationChannel != null) {
+         // We have to use the overloaded execute method as we could have a ClientListener operation which
+         // would have already been registered so we don't have to use the executeAddListener method
+         // We have to submit on the executor as execute acquires the read lock
+         operationChannel.drainQueue(hro -> executorService.submit(() -> execute(hro, Set.of())));
+
+         // Any left over pending operations are waited on before closing the channel forcibly. If an operation is
+         // submitted to the queue (can't be processed as flowable is processed in the event loop) that operation
+         // is submitted afterwards on a new channel as above
+         operationChannel.pendingOperationFlowable()
+               .flatMap(hro -> RxJavaInterop.voidCompletionStageToFlowable(hro.asCompletableFuture()))
+               .ignoreElements().doFinally(() -> {
+                  log.tracef("Closing channel for %s as previous operations were complete", server);
+                  handleRemainingOperations(operationChannel.close(), server, false);
+               })
+               .subscribe(Functions.EMPTY_ACTION, t -> log.exceptionWhileClosingChannel(operationChannel.getChannel(), t));
+      }
+   }
+
    private void closeChannel(SocketAddress server) {
       List<HotRodOperation<?>> ops = channelHandler.closeChannel(server);
+      handleRemainingOperations(ops, server, true);
+   }
+
+   private void handleRemainingOperations(List<HotRodOperation<?>> ops, SocketAddress server, boolean force) {
       if (!ops.isEmpty()) {
          // Need to submit on executor as we are currently holding the write lock
          executorService.submit(() -> {
-            TransportException transportException = log.connectionClosed(server, server);
-            for (HotRodOperation<?> op : ops) {
-               handleResponse(op, -1, server, null, transportException);
+            if (force) {
+               TransportException transportException = log.connectionClosed(server, server);
+               for (HotRodOperation<?> op : ops) {
+                  handleResponse(op, -1, server, null, transportException);
+               }
+            } else {
+               ops.forEach(op -> execute(op, Set.of()));
             }
          });
       }
@@ -866,7 +937,10 @@ public class OperationDispatcher {
       assert channel.eventLoop().inEventLoop();
       SocketAddress unresolved = ChannelRecord.of(channel);
       OperationChannel operationChannel = channelHandler.getChannelForAddress(unresolved);
-      if (operationChannel != null) {
+      // If you have multiple requests that create new connections and remove them (when default hostname doesn't
+      // match server hostname) then it will close the original channel. In this case we could have multiple channels
+      // for the same default hostname so only treat the failure if it matches
+      if (operationChannel != null && operationChannel.getChannel() == channel) {
          handleChannelFailure(operationChannel, t);
       }
    }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/logging/Log.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/logging/Log.java
@@ -437,4 +437,7 @@ public interface Log extends BasicLogger {
    @Message(value = "Counter '%s' is not defined.", id = 4120)
    CounterException undefinedCounter(String name);
 
+   @LogMessage(level = WARN)
+   @Message(value = "Exception encountered while closing server connection %s", id = 4121)
+   void exceptionWhileClosingChannel(Channel channel, @Cause Throwable t);
 }


### PR DESCRIPTION
**Backport:** https://github.com/infinispan/infinispan/pull/15920

…loop

Fixes #15897

This reworks submission a bit so that before submitting an operation we optimistically "acquire" the read lock. Then after task submission if the "acquire" didn't work we double check the channel we submitted to to see if it still is the same or not. If not we have to resubmit the task so it can be ran on a new channel.

Also on a channel disconnect we can only close a ChannelHandler if the existing one matches the same one. Otherwise it could close a ChannelHandler tied to a different socket.