### PR TITLE
[#13603] Flaky test: org.infinispan.persistence.sifs.SoftIndexFileSto…

### DIFF
--- a/core/src/main/java/org/infinispan/persistence/sifs/LogAppender.java
+++ b/core/src/main/java/org/infinispan/persistence/sifs/LogAppender.java
@@ -91,8 +91,6 @@ public class LogAppender implements Consumer<LogAppender.WriteOperation> {
       writeProcessor = UnicastProcessor.create();
       writeProcessor.observeOn(Schedulers.from(executor))
             .subscribe(this, e -> log.warn("Exception encountered while performing write log request ", e), () -> {
-               completionProcessor.onComplete();
-               completionProcessor = null;
                if (logFile != null) {
                   Util.close(logFile);
                   // add the current appended file - note this method will fail if it is already present, which will
@@ -100,6 +98,8 @@ public class LogAppender implements Consumer<LogAppender.WriteOperation> {
                   compactor.addLogFileOnShutdown(logFile.fileId, nextExpirationTime);
                   logFile = null;
                }
+               completionProcessor.onComplete();
+               completionProcessor = null;
             });
 
       completionProcessor = UnicastProcessor.create();


### PR DESCRIPTION
…reRestartTest#testStatsUponRestart

Fixes #13603

The flakiness was due to the `addLogFileOnShutdown` call sometimes having the log file persisted into the file stats. Changing it so the processor is completed after the call makes sure it always is written.

When the issue happens the stats file is incorrect, which can cause the compactor to not operate as it should.