### PR TITLE
[#15962] Refresh documentation

### DIFF
--- a/documentation/src/main/asciidoc/stories/assembly_architecture_use_cases.adoc
+++ b/documentation/src/main/asciidoc/stories/assembly_architecture_use_cases.adoc
@@ -9,6 +9,7 @@ ifdef::context[:parent-context: {context}]
 * Ensure service availability and continuity.
 * Lower operational costs.
 
+include::{topics}/con_performance_metric_considerations.adoc[leveloffset=+1]
 include::{topics}/con_infinispan_deployment_models.adoc[leveloffset=+1]
 include::{topics}/con_platforms_automation_tooling.adoc[leveloffset=+2]
 include::{topics}/con_in_line_caching.adoc[leveloffset=+1]

--- a/documentation/src/main/asciidoc/stories/assembly_configuring_maven_repository.adoc
+++ b/documentation/src/main/asciidoc/stories/assembly_configuring_maven_repository.adoc
@@ -3,7 +3,7 @@ ifdef::context[:parent-context: {context}]
 :context: configuring-maven-repository
 = Adding {brandname} to your Maven repository
 
-{brandname} Java distributions are available from Maven.
+{brandname} Java distributions are available from Maven and requires at least JDK {jdkminversion}.
 
 //Community content
 ifdef::community[]

--- a/documentation/src/main/asciidoc/stories/assembly_deployment_planning.adoc
+++ b/documentation/src/main/asciidoc/stories/assembly_deployment_planning.adoc
@@ -9,7 +9,6 @@ To get the best performance for your {brandname} deployment, you should do the f
 * Determine what type of clustered cache mode best suits your use case and requirements.
 * Understand performance trade-offs and considerations for {brandname} capabilities that provide fault tolerance and consistency guarantees.
 
-include::{topics}/con_performance_metric_considerations.adoc[leveloffset=+1]    
 include::{topics}/con_calculate_size_data_set.adoc[leveloffset=+1]
 include::{topics}/con_memory_overhead.adoc[leveloffset=+2]
 include::{topics}/con_jvm_heap_memory_allocation.adoc[leveloffset=+2]

--- a/documentation/src/main/asciidoc/stories/assembly_setting_up_clusters.adoc
+++ b/documentation/src/main/asciidoc/stories/assembly_setting_up_clusters.adoc
@@ -43,6 +43,9 @@ include::assembly_encrypting_cluster_traffic.adoc[leveloffset=+1]
 
 include::{topics}/ref_jgroups_ports.adoc[leveloffset=+1]
 
+// Configuring virtual threads
+include::{topics}/proc_virtual_threads.adoc[leveloffset=+1]
+
 // Restore the parent context.
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/documentation/src/main/asciidoc/stories/assembly_streams.adoc
+++ b/documentation/src/main/asciidoc/stories/assembly_streams.adoc
@@ -4,7 +4,7 @@
 
 Efficiently process data stored in {brandname} caches using the `Streams` API.
 
-include::{topics}/streams.adoc[leveloffset=+0]
+include::{topics}/streams.adoc[leveloffset=+1]
 
 // Restore the parent context.
 ifdef::parent-context[:context: {parent-context}]

--- a/documentation/src/main/asciidoc/titles/embedding/stories.adoc
+++ b/documentation/src/main/asciidoc/titles/embedding/stories.adoc
@@ -2,7 +2,6 @@
 //Please review authoring guidelines in the Contributors Guide.
 
 include::{stories}/assembly_configuring_maven_repository.adoc[leveloffset=+1]
-include::{stories}/assembly_virtual_threads.adoc[leveloffset=+1]
 include::{stories}/assembly_creating_embedded_caches.adoc[leveloffset=+1]
 include::{stories}/assembly_authorization_embedded.adoc[leveloffset=+1]
 include::{stories}/assembly_configuring_statistics_jmx.adoc[leveloffset=+1]
@@ -18,7 +17,7 @@ include::{stories}/assembly_cdi.adoc[leveloffset=+1]
 include::{stories}/assembly_multimap_cache.adoc[leveloffset=+1]
 //Community content
 ifdef::community[]
-include::{stories}/assembly_custom_interceptors.adoc[leveloffset=+1]
+//include::{stories}/assembly_custom_interceptors.adoc[leveloffset=+1]
 include::{stories}/assembly_functional_map_api.adoc[leveloffset=+1]
 include::{stories}/assembly_anchored_keys.adoc[leveloffset=+1]
 include::{stories}/assembly_extending.adoc[leveloffset=+1]

--- a/documentation/src/main/asciidoc/topics/cache_api.adoc
+++ b/documentation/src/main/asciidoc/topics/cache_api.adoc
@@ -1,7 +1,7 @@
 [id='cache-modes_{context}']
 = Cache API
 
-{brandname} provides a link:../../apidocs/org/infinispan/Cache.html[Cache] interface that exposes simple methods for adding, retrieving and removing entries, including atomic mechanisms exposed by the JDK's ConcurrentMap interface.  Based on the cache mode used, invoking these methods will trigger a number of things to happen, potentially even including replicating an entry to a remote node or looking up an entry from a remote node, or potentially a cache store.
+{brandname} provides a link:../../apidocs/org/infinispan/Cache.html[Cache] interface that exposes simple methods for adding, retrieving and removing entries, including atomic mechanisms exposed by the JDK's ConcurrentMap interface.  Based on the cache mode used, invoking these methods will trigger a number of things, potentially replicating an entry to a remote node or looking up an entry from a remote node, or even a cache store.
 
 For simple usage, using the Cache API should be no different from using the JDK Map API, and hence migrating from simple in-memory caches based on a Map to {brandname}'s Cache should be trivial.
 
@@ -10,10 +10,10 @@ Certain methods exposed in Map have certain performance consequences when used w
 link:../../apidocs/org/infinispan/Cache.html#size()[size()] ,
 link:../../apidocs/org/infinispan/Cache.html#values()[values()] ,
 link:../../apidocs/org/infinispan/Cache.html#keySet()[keySet()] and
-link:../../apidocs/org/infinispan/Cache.html#entrySet()[entrySet()] .
+link:../../apidocs/org/infinispan/Cache.html#entrySet()[entrySet()].
 Specific methods on the `keySet`, `values` and `entrySet` are fine for use please see their Javadoc for further details.
 
-Attempting to perform these operations globally would have large performance impact as well as become a scalability bottleneck.  As such, these methods should only be used for informational or debugging purposes only.
+Attempting to perform these operations globally could have large performance impact as well as become a scalability bottleneck.  As such, these methods should be avoided in production code and only be used for informational or debugging purposes only.
 
 It should be noted that using certain flags with the link:../../apidocs/org/infinispan/AdvancedCache.html#withFlags(java.util.Collection)[withFlags()] method can mitigate some of these concerns, please check each method's documentation for more details.
 
@@ -34,7 +34,7 @@ To understand how to use this operation, let's look at basic example. Imagine a 
 include::code_examples/PersonId.java[]
 ----
 
-Note that link:../../apidocs/org/infinispan/Cache.html#putForExternalRead(K,V)[putForExternalRead] should never be used as a mechanism to update the cache with a new Person instance originating from application execution (i.e. from a transaction that modifies a Person's address). When updating cached values, please use the standard link:{jdkdocroot}/java/util/Map.html#put-K-V-[put] operation, otherwise the possibility of caching corrupt data is likely.
+Note that link:../../apidocs/org/infinispan/Cache.html#putForExternalRead(K,V)[putForExternalRead] should never be used as a mechanism to update the cache with a new Person instance originating from application execution (i.e. from a transaction that modifies a Person's address). When updating cached values, please use the standard link:{jdkdocroot}/java/util/Map.html#put-K-V-[put] operation, otherwise the possibility of caching inconsistent data is likely.
 
 == AdvancedCache API
 In addition to the simple Cache interface, {brandname} offers an link:../../apidocs/org/infinispan/AdvancedCache.html[AdvancedCache] interface, geared towards extension authors.  The AdvancedCache offers the ability to access certain internal components and to apply flags to alter the default behavior of certain cache methods.  The following code snippet depicts how an AdvancedCache can be obtained:
@@ -56,12 +56,12 @@ include::code_examples/AdvancedCacheWithFlags.java[]
 ==  Asynchronous API
 In addition to synchronous API methods like link:{jdkdocroot}/java/util/Map.html#put-K-V-[Cache.put()] , link:{jdkdocroot}/java/util/Map.html#remove-java.lang.Object-[Cache.remove()] , etc., {brandname} also has an asynchronous, non-blocking API where you can achieve the same results in a non-blocking fashion.
 
-These methods are named in a similar fashion to their blocking counterparts, with "Async" appended.  E.g., link:../../apidocs/org/infinispan/commons/api/AsyncCache.html#putAsync(K,V)[Cache.putAsync()] , link:../../apidocs/org/infinispan/commons/api/AsyncCache.html#removeAsync(java.lang.Object)[Cache.removeAsync()] , etc.  These asynchronous counterparts return a link:{jdkdocroot}/java/util/concurrent/CompletableFuture.html[CompletableFuture] that contains the actual result of the operation.
+These methods are named in a similar fashion to their blocking counterparts, with "Async" appended. E.g., link:../../apidocs/org/infinispan/commons/api/AsyncCache.html#putAsync(K,V)[Cache.putAsync()] , link:../../apidocs/org/infinispan/commons/api/AsyncCache.html#removeAsync(java.lang.Object)[Cache.removeAsync()] , etc. These asynchronous counterparts return a link:{jdkdocroot}/java/util/concurrent/CompletableFuture.html[CompletableFuture] that contains the actual result of the operation.
 
 For example, in a cache parameterized as `Cache<String, String>`, `Cache.put(String key, String value)` returns `String` while `Cache.putAsync(String key, String value)` returns `CompletableFuture<String>`.
 
 === Why use such an API?
-Non-blocking APIs are powerful in that they provide all of the guarantees of synchronous communications - with the ability to handle communication failures and exceptions - with the ease of not having to block until a call completes.  This allows you to better harness parallelism in your system.  For example:
+Non-blocking APIs are powerful in that they provide all of the guarantees of synchronous communications - with the ability to handle communication failures and exceptions - with the ease of not having to block until a call completes. This allows you to better harness parallelism in your system. For example:
 
 [source,java]
 ----
@@ -69,12 +69,12 @@ include::code_examples/NonBlocking.java[]
 ----
 
 === Which processes actually happen asynchronously?
-There are 4 things in {brandname} that can be considered to be on the critical path of a typical write operation.
-These are, in order of cost:
+There are four things in {brandname} that can be considered to be on the critical path of a typical write operation.
+These are, in descending order of cost:
 
-* network calls
-* marshalling
-* writing to a cache store (optional)
-* locking
+. network calls
+. marshalling
+. writing to a cache store (optional)
+. locking
 
-Using the async methods will take the network calls and marshalling off the critical path.  For various technical reasons, writing to a cache store and acquiring locks, however, still happens in the caller's thread.
+Using the async methods will take the network calls and marshalling off the critical path. For various technical reasons, writing to a cache store and acquiring locks, however, still happens in the caller's thread.

--- a/documentation/src/main/asciidoc/topics/code_examples/MultiMapCacheEmbedded.java
+++ b/documentation/src/main/asciidoc/topics/code_examples/MultiMapCacheEmbedded.java
@@ -1,11 +1,15 @@
-// create or obtain your EmbeddedCacheManager
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+
+// Create or obtain your EmbeddedCacheManager
 EmbeddedCacheManager cm = ... ;
+// Configure the multimap cache
+ConfigurationBuilder cb = ...;
 
 // create or obtain a MultimapCacheManager passing the EmbeddedCacheManager
 MultimapCacheManager multimapCacheManager = EmbeddedMultimapCacheManagerFactory.from(cm);
 
 // define the configuration for the multimap cache
-multimapCacheManager.defineConfiguration(multimapCacheName, c.build());
+multimapCacheManager.defineConfiguration(multimapCacheName, cb.build());
 
 // get the multimap cache
 multimapCache = multimapCacheManager.get(multimapCacheName);

--- a/documentation/src/main/asciidoc/topics/code_examples/PiAppx.java
+++ b/documentation/src/main/asciidoc/topics/code_examples/PiAppx.java
@@ -4,15 +4,24 @@ public class PiAppx {
       EmbeddedCacheManager cacheManager = ..
       boolean isCluster = ..
 
+      // The number of darts to shoot at the circle.
       int numPoints = 1_000_000_000;
       int numServers = isCluster ? cacheManager.getMembers().size() : 1;
       int numberPerWorker = numPoints / numServers;
 
       ClusterExecutor clusterExecutor = cacheManager.executor();
       long start = System.currentTimeMillis();
-      // We receive results concurrently - need to handle that
+      // We receive results concurrently from the executor.
+      // You must guarantee thread-safety when collecting the results.
+      // In this example, we utilize an AtomicLong to collect the results from the executor.
       AtomicLong countCircle = new AtomicLong();
+
+      // Submits the lambda utilizing the executor.
+      // The future completes once the computation finishes cluster-wide (exceptionally or not).
       CompletableFuture<Void> fut = clusterExecutor.submitConsumer(m -> {
+
+         // This is the lambda executed remotely across all nodes in the cluster.
+         // All the values and methods must be serializable to be transferred across the wire.
          int insideCircleCount = 0;
          for (int i = 0; i < numberPerWorker; i++) {
             double x = Math.random();
@@ -21,7 +30,11 @@ public class PiAppx {
                insideCircleCount++;
          }
          return insideCircleCount;
-      }, (address, count, throwable) -> {
+      },
+      // This lambda runs on the caller and does not need to be marshallable.
+      // It is invoked with the results of each remote call, possibly concurrently.
+      // Therefore, collecting the results must guarantee thread-safety.
+      (address, count, throwable) -> {
          if (throwable != null) {
             throwable.printStackTrace();
             System.out.println("Address: " + address + " encountered an error: " + throwable);
@@ -43,6 +56,7 @@ public class PiAppx {
       });
 
       // May have to sleep here to keep alive if no user threads left
+      fut.join();
    }
 
    private static boolean insideCircle(double x, double y) {

--- a/documentation/src/main/asciidoc/topics/code_examples/ReadOnlyMapCompleted.java
+++ b/documentation/src/main/asciidoc/topics/code_examples/ReadOnlyMapCompleted.java
@@ -1,7 +1,0 @@
-import org.infinispan.functional.EntryView.*;
-import org.infinispan.functional.FunctionalMap.*;
-import org.infinispan.functional.Param.*;
-
-ReadOnlyMap<String, String> readOnlyMap = ...
-ReadOnlyMap<String, String> readOnlyMapCompleted = readOnlyMap.withParams(FutureMode.COMPLETED);
-Optional<String> readFuture = readOnlyMapCompleted.eval("key1", ReadEntryView::find).get();

--- a/documentation/src/main/asciidoc/topics/code_examples/ReadWriteMapMarshallableFunctions.java
+++ b/documentation/src/main/asciidoc/topics/code_examples/ReadWriteMapMarshallableFunctions.java
@@ -4,6 +4,6 @@ import org.infinispan.commons.marshall.MarshallableFunctions;
 
 ReadWriteMap<String, String> readWriteMap = ...
 
-CompletableFuture<Boolean> future = readWriteMap.eval("key1,
+CompletableFuture<Boolean> future = readWriteMap.eval("key1",
    MarshallableFunctions.setValueIfAbsentReturnBoolean());
 future.thenAccept(stored -> System.out.printf("Value was put? %s%n", stored));

--- a/documentation/src/main/asciidoc/topics/code_examples/TemperatureMonitor.java
+++ b/documentation/src/main/asciidoc/topics/code_examples/TemperatureMonitor.java
@@ -6,8 +6,8 @@ public class TemperatureChangesListener {
       this.location = location;
    }
 
-   @ClientCacheEntryCreated
-   public void created(ClientCacheEntryCreatedEvent event) {
+   @ClientCacheEntryModified
+   public void updated(ClientCacheEntryModifiedEvent event) {
       if(event.getKey().equals(location)) {
          cache.getAsync(location)
                .whenComplete((temperature, ex) ->

--- a/documentation/src/main/asciidoc/topics/code_examples/WriteOnlyMapProtoStream.java
+++ b/documentation/src/main/asciidoc/topics/code_examples/WriteOnlyMapProtoStream.java
@@ -1,0 +1,26 @@
+import org.infinispan.functional.EntryView.*;
+import org.infinispan.functional.FunctionalMap.*;
+import org.infinispan.protostream.annotations.ProtoFactory;
+import org.infinispan.protostream.annotations.ProtoField;
+
+WriteOnlyMap<String, String> writeOnlyMap = ...
+
+// Force a function to be Serializable
+Consumer<WriteEntryView<String>> function = new SetStringConstant<>("value1");
+CompletableFuture<Void> writeFuture = writeOnlyMap.eval("key1", function);
+
+class SetStringConstant implements Consumer<WriteEntryView<String>> {
+
+   @ProtoField(1)
+   final String target;
+
+   @ProtoFactory
+   public SetStringConstant(String target) {
+      this.target = target;
+   }
+
+   @Override
+   public void accept(WriteEntryView<String> view) {
+      view.set(target);
+   }
+}

--- a/documentation/src/main/asciidoc/topics/con_cross_site_replication.adoc
+++ b/documentation/src/main/asciidoc/topics/con_cross_site_replication.adoc
@@ -16,3 +16,7 @@ endif::community[]
 ifdef::downstream[]
 image::cross-site-replication.png[Cross-site replication with a {brandname} deployment.]
 endif::downstream[]
+
+[role="_additional-resources"]
+.Additional resources
+* link:{xsite_docs}[Cross-site replication]

--- a/documentation/src/main/asciidoc/topics/con_infinispan_deployment_models.adoc
+++ b/documentation/src/main/asciidoc/topics/con_infinispan_deployment_models.adoc
@@ -4,7 +4,7 @@
 {brandname} has two deployment models for caches, remote and embedded.
 Both deployment models allow applications to access data with significantly lower latency for read operations and higher throughput for write operations in comparison with traditional database systems.
 
-Remote caches:: {brandname} Server nodes run in a dedicated Java Virtual Machine (JVM). Clients access remote caches using either Hot Rod, a binary TCP protocol, or REST over HTTP.
+Remote caches:: {brandname} Server nodes run in a dedicated Java Virtual Machine (JVM). Clients access remote caches using either Hot Rod, a binary TCP protocol, REST over HTTP, and RESP or Memcached with the appropriate client.
 
 Embedded caches:: {brandname} runs in the same JVM as your Java application, meaning that data is stored in the memory space where code is executed.
 

--- a/documentation/src/main/asciidoc/topics/con_performance_data_consistency.adoc
+++ b/documentation/src/main/asciidoc/topics/con_performance_data_consistency.adoc
@@ -30,6 +30,12 @@ For workloads with high rates of contention, pessimistic locking provides the be
 Transaction commits complete in a single phase because keys are already locked.
 Pessimistic locking with multiple key transactions results in {brandname} locking keys for longer periods of time, which can decrease write throughput.
 
+[WARNING]
+====
+Using locks inherently introduces the risk of deadlock and performance degradation.
+Always simulate your production workload to verify the system's behavior under load.
+====
+
 .Read isolation
 
 Isolation levels do not impact {brandname} performance considerations except for optimistic locking with `REPEATABLE_READ`.

--- a/documentation/src/main/asciidoc/topics/con_performance_partition_handling.adoc
+++ b/documentation/src/main/asciidoc/topics/con_performance_partition_handling.adoc
@@ -9,7 +9,10 @@ When this happens, {brandname} caches in minority partitions enter **DEGRADED** 
 Garbage collection (GC) pauses are the most common cause of network partitions.
 When GC pauses result in nodes becoming unresponsive, {brandname} clusters can start operating in a split brain network.
 
-Rather than dealing with network partitions, try to avoid GC pauses by controlling JVM heap usage and by monitoring and tuning the GC. The default G1GC is appropriate for most use cases but needs tuning according to the usage pattern. A different GC implementation, such as Shenandoah, could be beneficial but might not work well if there are many short living objects. For information about the Shenandoah GC, see link:https://docs.redhat.com/en/documentation/red_hat_build_of_openjdk/21/html-single/using_shenandoah_garbage_collector_with_red_hat_build_of_openjdk_21/index#shenandoah-gc-overview[Shenandoah garbage collector]. 
+Rather than dealing with network partitions, try to avoid GC pauses by controlling JVM heap usage and by monitoring and tuning the GC.
+The default G1GC is appropriate for most use cases but needs tuning according to the usage pattern.
+A low-pause collector like ZGC or Shenandoah GC may also be a good fit, provided it is tuned correctly.
+For more on ZGC, see the link:https://wiki.openjdk.org/display/zgc[ZGC wiki], or the link:https://docs.redhat.com/en/documentation/red_hat_build_of_openjdk/21/html-single/using_shenandoah_garbage_collector_with_red_hat_build_of_openjdk_21/index#shenandoah-gc-overview[Shenandoah garbage collector]. .
 ====
 
 .CAP theorem and partition handling strategies

--- a/documentation/src/main/asciidoc/topics/con_performance_persistence.adoc
+++ b/documentation/src/main/asciidoc/topics/con_performance_persistence.adoc
@@ -46,3 +46,7 @@ Additionally, if the cache has reached the size limit, then {brandname} performs
 Another aspect of persistent storage that can affect {brandname} cluster performance is pre-loading caches.
 This capability populates your caches with data when {brandname} clusters start so they are "warm" and can handle reads and writes straight away.
 Pre-loading caches can slow down {brandname} cluster start times and result in out of memory exceptions if the amount of data in persistent storage is greater than the amount of available RAM.
+
+[role="_additional-resources"]
+.Additional resources
+* link:{config_docs}#persistence[Configuring persistent storage]

--- a/documentation/src/main/asciidoc/topics/con_performance_security.adoc
+++ b/documentation/src/main/asciidoc/topics/con_performance_security.adoc
@@ -8,6 +8,10 @@ With this in mind you need a robust security strategy to authenticate users and 
 But what are the costs to the performance of your {brandname} deployment?
 How should you approach these considerations during planning?
 
+[role="_additional-resources"]
+.Additional resources
+* link:{server_docs}#creating-security-realms_security-realms[Creating security realms]
+
 [discrete]
 == Authentication
 

--- a/documentation/src/main/asciidoc/topics/execute_grid.adoc
+++ b/documentation/src/main/asciidoc/topics/execute_grid.adoc
@@ -1,4 +1,5 @@
 [id='executing-code-grid_{context}']
+:stem:
 = Cluster Executor
 
 Since you have a group of machines, it makes sense to leverage their combined
@@ -18,7 +19,7 @@ interface as an argument. Also since these arguments will be sent to other nodes
 used a nice trick to ensure our lambdas are immediately Serializable.  That is by having the arguments implement both
 Serializable and the real argument type (ie. Runnable or Function).  The JRE will pick the most specific class when
 determining which method to invoke, so in that case your lambdas will always be serializable.
-It is also possible to use ProtoStream marshalling to reduce message size further.
+It is also possible to use link:{encoding_docs}#protostream_marshalling[ProtoStream marshalling] to reduce message size further.
 
 The manager by default will submit a given command to all nodes in the cluster including the node
 where it was submitted from. You can control on which nodes the task is executed on
@@ -37,7 +38,7 @@ requests to at the scope of same or different machine, rack or site level.
 include::code_examples/SameRack.java[]
 ----
 
-To use this topology base filtering you must enable topology aware consistent hashing through Server Hinting.
+To use this topology base filtering you must enable topology aware consistent hashing through link:{config_docs}#server-hinting_clustered-caches[Server Hinting].
 
 You can also filter using a predicate based on the `Address` of the node. This can also
 be optionally combined with topology based filtering in the previous code snippet.
@@ -56,10 +57,10 @@ include::code_examples/Predicate.java[]
 == Timeout
 
 Cluster Executor allows for a timeout to be set per invocation. This defaults to the distributed sync timeout
-as configured on the Transport Configuration. This timeout works in both a clustered and non clustered
-Cache Manager. The executor may or may not interrupt the threads executing a task when the timeout expires. However
+as configured on the Transport Configuration. This timeout works in both a clustered and non-clustered
+Cache Manager. The executor may or may not interrupt the threads executing a task when the timeout expires. However,
 when the timeout occurs any `Consumer` or `Future` will be completed passing back a `TimeoutException`.
-This value can be overridden by ivoking the
+This value can be overridden by invoking the
 link:../../apidocs/org/infinispan/manager/ClusterExecutor.html#timeout-long-java.util.concurrent.TimeUnit-[timeout]
 method and supplying the desired duration.
 
@@ -82,8 +83,8 @@ include::code_examples/SingleNode.java[]
 When running in single node submission it may be desirable to also allow the Cluster Executor
 handle cases where an exception occurred during the processing of a given command by retrying
 the command again.
-When this occurs the Cluster Executor will choose a single node again to resubmit the command to
-up to the desired number of failover attempts. Note the chosen node could be any node that passes
+When this occurs, the Cluster Executor will choose a single node again to resubmit the command to
+up to the desired number of failover attempts. Note that, the chosen node could be any node that passes
 the topology or predicate check. Failover is enabled by invoking the overridden
 link:../../apidocs/org/infinispan/manager/ClusterExecutor.html#singleNodeSubmission-int-[singleNodeSubmission]
 method. The given command will be resubmitted again to a single node until either
@@ -94,16 +95,16 @@ failover count.
 This example shows how you can use the ClusterExecutor to estimate the value of PI.
 
 Pi approximation can greatly benefit from parallel distributed execution via
-Cluster Executor. Recall that area of the square is Sa = 4r2 and area of the
-circle is Ca=pi*r2. Substituting r2 from the second equation into the first
-one it turns out that pi = 4 * Ca/Sa. Now, image that we can shoot very large
+Cluster Executor. Recall that the area of the square is stem:[S_a = 4r^{2}] and the area of the
+circle is stem:[C_a=\pi r^2]. Substituting stem:[r^2] from the second equation into the first
+one it turns out that stem:[\pi = 4\frac{C_a}{S_a}]. Now, image that we can shoot very large
 number of darts into a square; if we take ratio of darts that land inside a
-circle over a total number of darts shot we will approximate Ca/Sa value. Since
-we know that pi = 4 * Ca/Sa we can easily derive approximate value of pi. The
-more darts we shoot the better approximation we get. In the example below we
-shoot 1 billion darts but instead of "shooting" them serially we parallelize
-work of dart shooting across the entire {brandname} cluster. Note this will
-work in a cluster of 1 was well, but will be slower.
+circle over a total number of darts shot, we will approximate the stem:[\frac{C_a}{S_a}] value. Since
+we know that stem:[\pi = 4\frac{C_a}{S_a}], we can approximate the value of stem:[\pi]. The
+more darts we shoot, the better approximation we get. In the example below, we
+shoot 1 billion darts, but instead of "shooting" them serially, we parallelize
+the work of dart shooting across the entire {brandname} cluster. Note that, this
+works in a cluster of one as well, but likely slower.
 
 [source,java]
 ----

--- a/documentation/src/main/asciidoc/topics/extending.adoc
+++ b/documentation/src/main/asciidoc/topics/extending.adoc
@@ -17,7 +17,7 @@ You do so by:
 . Implementing custom commands and interceptors to provide the desired functionality
 . Add ProtoStream annotations to commands to ensure they can be marshalled
 . Generate `.proto` schema files and marshaller code by creating an interface annotated with `@ProtoSchema`
-. Register the generated `SerilaizationContextInitializer` with the `GLOBAL` `SerializationContextRegistry`
+. Register the generated `SerializationContextInitializer` with the `GLOBAL` `SerializationContextRegistry`
 
 See the link:https://github.com/infinispan/infinispan/tree/main/query[infinispan-query] module as an example of a custom
 module that adds both custom commands and interceptors.

--- a/documentation/src/main/asciidoc/topics/functional_api.adoc
+++ b/documentation/src/main/asciidoc/topics/functional_api.adoc
@@ -127,7 +127,7 @@ include::code_examples/WriteOnlyMap.java[]
 ----
 
 Multiple key/value pairs can be stored in one go using
-../../apidocs/org/infinispan/functional/FunctionalMap.WriteOnlyMap.html#evalMany(java.util.Map,java.util.function.BiConsumer)[`evalMany`]
+link:../../apidocs/org/infinispan/functional/FunctionalMap.WriteOnlyMap.html#evalMany(java.util.Map,java.util.function.BiConsumer)[`evalMany`]
 API:
 
 [source,java]
@@ -174,8 +174,8 @@ parameters associated with this key.
 
 == Read-Write Map API
 
-The final type of operations we have are read­write operations, and within
-this category CAS-like (Compare­And­Swap) operations can be found.
+The final type of operations we have are read-write operations, and within
+this category CAS-like (Compare-And-Swap) operations can be found.
 This type of operations require previous value associated with the key
 to be read and for locks to be acquired before executing the function.
 The vast majority of operations within
@@ -186,10 +186,10 @@ APIs fall within this category, and they can easily be implemented using the
 link:../../apidocs/org/infinispan/functional/FunctionalMap.ReadWriteMap.html[read-write map API]
 . Moreover, with
 link:../../apidocs/org/infinispan/functional/FunctionalMap.ReadWriteMap.html[read-write map API]
-, you can make CAS­like comparisons not only based on value equality
+, you can make CAS-like comparisons not only based on value equality
 but based on metadata parameter equality such as version information,
 and you can send back previous value or boolean instances to signal
-whether the CAS­like comparison succeeded.
+whether the CAS-like comparison succeeded.
 
 Implementing a write operation that returns the previous value associated
 with the cache entry is easy to achieve with the read-write map API:
@@ -234,8 +234,8 @@ and link:#write_only_entry_view[write-only entry views].
 == Metadata Parameter Handling
 link:../../apidocs/org/infinispan/functional/MetaParam.html[Metadata parameters]
 provide extra information about the cache entry, such
-as version information, lifespan, last accessed/used time...etc. Some of
-these can be provided by the user, e.g. version, lifespan...etc, but some
+as version information, lifespan, last accessed/used time, etc. Some of
+these can be provided by the user, e.g. version, lifespan, etc., but some
 others are computed internally and can only be queried, e.g. last
 accessed/used time.
 
@@ -273,7 +273,7 @@ lost:
 include::code_examples/ReadOnlyMapMetaParam.java[]
 ----
 
-When generic information is important the user can define a static helper
+When generic information is important, the user can define a static helper
 method that coerces the static class retrieval to the type requested,
 and then use that helper method in the call to `findMetaParam`:
 
@@ -295,31 +295,14 @@ done using the
 link:../../apidocs/org/infinispan/functional/FunctionalMap.html#withParams(org.infinispan.functional.Param...)[`withParams(Param<?>...)`]
 method.
 
-link:../../apidocs/org/infinispan/functional/Param.FutureMode.html[`Param.FutureMode`]
-tweaks whether a method returning a
-link:{jdkdocroot}/java/util/concurrent/CompletableFuture.html[`CompletableFuture`]
-will span a thread to invoke the method, or instead will use the caller
-thread. By default, whenever a call is made to a method returning a
-link:{jdkdocroot}/java/util/concurrent/CompletableFuture.html[`CompletableFuture`]
-, a separate thread will be span to execute the method asynchronously.
-However, if the caller will immediately block waiting for the
-link:{jdkdocroot}/java/util/concurrent/CompletableFuture.html[`CompletableFuture`]
-to complete, spanning a different thread is wasteful, and hence
-link:../../apidocs/org/infinispan/functional/Param.FutureMode.html#COMPLETED[`Param.FutureMode.COMPLETED`]
-can be passed as per-invocation parameter to avoid creating that extra thread. Example:
-
-[source,java]
-----
-include::code_examples/ReadOnlyMapCompleted.java[]
-----
-
-Param.PersistenceMode controls whether a write operation will be propagated
+link:../../apidocs/org/infinispan/functional/Param.PersistenceMode.html[`Param.PersistenceMode`]
+controls whether a write operation will be propagated
 to a persistence store. The default behaviour is for all write-operations
 to be propagated to the persistence store if the cache is configured with
-a persistence store. By passing PersistenceMode.SKIP as parameter,
+a persistence store. By passing link:../../apidocs/org/infinispan/functional/Param.PersistenceMode.html#SKIP[`PersistenceMode.SKIP`] as parameter,
 the write operation skips the persistence store and its effects are only
-seen in the in-memory contents of the cache. PersistenceMode.SKIP can
-be used to implement an
+seen in the in-memory contents of the cache. link:../../apidocs/org/infinispan/functional/Param.PersistenceMode.html#SKIP[`PersistenceMode.SKIP`]
+can be used to implement an
 link:../../apidocs/org/infinispan/Cache.html#evict-K-[`Cache.evict()`]
 method which removes data from memory but leaves the persistence store
 untouched:
@@ -329,17 +312,15 @@ untouched:
 include::code_examples/WriteOnlyMapSkipPersistence.java[]
 ----
 
-Note that there's no need for another PersistenceMode option to skip
+Note that there's no need for another link:../../apidocs/org/infinispan/functional/Param.PersistenceMode.html[`Param.PersistenceMode`] option to skip
 reading from the persistence store, because a write operation can skip
 reading previous value from the store by calling a write-only operation
-via the WriteOnlyMap.
+via the link:../../apidocs/org/infinispan/functional/FunctionalMap.WriteOnlyMap.html[WriteOnlyMap].
 
-Finally, new Param implementations are normally provided by the functional
+Finally, new link:../../apidocs/org/infinispan/functional/Param.html[Param] implementations are normally provided by the functional
 map API since they tweak how the internal logic works. So, for the most part
 of users, they should limit themselves to using the Param instances exposed
-by the API. The exception to this rule would be advanced users who decide
-to add new interceptors to the internal stack. These users have the ability
-to query these parameters within the interceptors.
+by the API.
 
 [[functional_listeners]]
 == Functional Listeners
@@ -506,7 +487,7 @@ standard APIs if that's what suits your use case best.
 
 The target audience for this new API is either:
 
-* Distributed or persistent caching/in­memory­data­grid users that want
+* Distributed or persistent caching/in-memory-data-grid users that want
 to benefit from CompletableFuture and/or Traversable for async/lazy data
 grid or caching data manipulation. The clear advantage here is that threads
 do not need to be idle waiting for remote operations to complete, but
@@ -518,3 +499,5 @@ and
 link:https://github.com/jsr107/jsr107spec/blob/v1.0.0/src/main/java/javax/cache/Cache.java[`JCache`], for example, if you want to do a replace
 operation using metadata parameter equality instead of value equality, or
 if you want to retrieve metadata information from values and so on.
+* Implement more complex data-structures backed by the cache. The link:{library_docs}#multimap-cache[multimap] is an example of a data-structure backed by
+the functional map API.

--- a/documentation/src/main/asciidoc/topics/multimapcache.adoc
+++ b/documentation/src/main/asciidoc/topics/multimapcache.adoc
@@ -13,7 +13,7 @@ include::dependencies_maven/multimap.xml[]
 
 == MultimapCache API
 
-MultimapCache API exposes several methods to interact with the Multimap Cache.
+link:../../apidocs/org/infinispan/multimap/api/embedded/MultimapCache.html[MultimapCache API] exposes several methods to interact with the Multimap Cache.
 These methods are non-blocking in most cases; see
 link:#multimap_limitations[limitations] for more information.
 
@@ -66,13 +66,13 @@ Asynchronous that returns true if this multimap contains at least one key-value 
 Asynchronous that returns the number of key-value pairs in the multimap cache. It doesn't return the distinct number of keys.
 
 .boolean supportsDuplicates()
-Asynchronous that returns true if the multimap cache supports duplicates. This means that the content of the multimap can be
-'a' -> ['1', '1', '2']. For now this method will always return false, as duplicates are not yet supported.
+Returns true if the multimap cache supports duplicates. This means that the content of the multimap can be
+'a' -> ['1', '1', '2'].
 The existence of a given value is determined by 'equals' and `hashcode' method's contract.
 
 == Creating a Multimap Cache
 
-Currently the MultimapCache is configured as a regular cache. This can be done either by code or XML configuration.
+Currently, the MultimapCache is configured as a regular cache. This can be done either by code or XML configuration.
 See how to configure a regular cache in link:{config_docs}#cache-configuration[Configuring {brandname} caches].
 
 === Embedded mode
@@ -85,7 +85,7 @@ include::code_examples/MultiMapCacheEmbedded.java[]
 [[multimap_limitations]]
 == Limitations
 
-In almost every case the Multimap Cache will behave as a regular Cache, but some limitations exist in the current version, as follows:
+In almost every case, the Multimap Cache will behave as a regular Cache, but some limitations exist in the current version, as follows:
 
 === Support for duplicates
 A multimap can be configured to store duplicate values for a single key. A duplicate is determined by the value's `equals` method.
@@ -95,10 +95,10 @@ Invoking remove on the multimap will remove all duplicates if present.
 === Eviction
 
 For now, the eviction works per key, and not per key-value pair.
-This means that whenever a key is evicted, all the values associated with the key will be evicted too.
+This means that, whenever a key is evicted, all the values associated with the key will be evicted too.
 
 === Transactions
 
-Implicit transactions are supported through the auto-commit and all the methods are non blocking.
+Implicit transactions are supported through the auto-commit and all the methods are non-blocking.
 Explicit transactions work without blocking in most of the cases.
-Methods that will block are `size`, `containsEntry` and `remove(Predicate<? super V> p)`
+Methods that will block are `size`, `containsEntry` and `remove(Predicate<? super V> p)`.

--- a/documentation/src/main/asciidoc/topics/proc_adding_dependencies_wildfly_modules.adoc
+++ b/documentation/src/main/asciidoc/topics/proc_adding_dependencies_wildfly_modules.adoc
@@ -1,5 +1,5 @@
 [id='configure_ispn_modules']
-= Configuring applications to Use {brandname} modules
+= Configuring applications to use {brandname} modules
 
 To use {brandname} libraries provided by {wildflybrandname} in your applications, add {brandname} dependency in the application's pom.xml file. 
 
@@ -11,7 +11,7 @@ To use {brandname} libraries provided by {wildflybrandname} in your applications
 include::dependencies_maven/eap_bom_dependencies.xml[]
 ----
 +
-You must define the value for `${version.infinispan.bom}`in the `<properties>` section of the pom.xml file.
+You must define the value for `${version.infinispan.bom}` in the `<properties>` section of the pom.xml file.
 
 . Declare the required {brandname} dependencies as _provided_.
 +

--- a/documentation/src/main/asciidoc/topics/proc_cdi_injecting_embedded.adoc
+++ b/documentation/src/main/asciidoc/topics/proc_cdi_injecting_embedded.adoc
@@ -80,6 +80,7 @@ method or do not add any qualifier.
 ====
 . Add the `@GreetingCache` qualifier to your cache injection point.
 +
+[source,java]
 ----
 ...
 import jakarta.inject.Inject;

--- a/documentation/src/main/asciidoc/topics/proc_cdi_injecting_remote.adoc
+++ b/documentation/src/main/asciidoc/topics/proc_cdi_injecting_remote.adoc
@@ -17,8 +17,8 @@ public @interface RemoteGreetingCache { <2>
 }
 ----
 +
-<1> names the cache to inject.
-<2> creates a `@RemoteGreetingCache` qualifier.
+<1> Names the cache to inject.
+<2> Creates a `@RemoteGreetingCache` qualifier.
 +
 . Add the `@RemoteGreetingCache` qualifier to your cache injection point.
 +
@@ -72,5 +72,5 @@ public class Config {
 }
 ----
 +
-<1> creates the bean once for the application. Producers that create Cache Managers should always include the `@ApplicationScoped` annotation to avoid creating multiple Cache Managers, which are heavy weight objects.
-<2> creates a new `RemoteCacheManager` instance that is bound to the `@RemoteGreetingCache` qualifier.
+<1> Creates the bean once for the application. Producers that create Cache Managers should always include the `@ApplicationScoped` annotation to avoid creating multiple Cache Managers, which are heavy weight objects.
+<2> Creates a new `RemoteCacheManager` instance that is bound to the `@RemoteGreetingCache` qualifier.

--- a/documentation/src/main/asciidoc/topics/proc_configuring_acl_cache.adoc
+++ b/documentation/src/main/asciidoc/topics/proc_configuring_acl_cache.adoc
@@ -52,6 +52,8 @@ include::yaml/authorization_acl_cache.yaml[]
 == Flushing ACL caches
 
 It is possible to flush the ACL cache using the `GlobalSecurityManager` MBean, accessible over JMX.
+In this case, flush means the cache is empty and the information is loaded from the external source.
+Flushing the ACL caches does not synchronize it cluster-wide.
 
 [role="_additional-resources"]
 .Additional resources

--- a/documentation/src/main/asciidoc/topics/proc_configuring_jgroups_asym_encrypt.adoc
+++ b/documentation/src/main/asciidoc/topics/proc_configuring_jgroups_asym_encrypt.adoc
@@ -36,4 +36,4 @@ Otherwise the following message is written to {brandname} logs:
 [role="_additional-resources"]
 .Additional resources
 * link:{jgroups_docs}[JGroups 5 Manual]
-* link:{jgroups_schema}[JGroups 5.4 Schema]
+* link:{jgroups_schema}[JGroups 5.5 Schema]

--- a/documentation/src/main/asciidoc/topics/proc_configuring_jgroups_sym_encrypt.adoc
+++ b/documentation/src/main/asciidoc/topics/proc_configuring_jgroups_sym_encrypt.adoc
@@ -35,4 +35,4 @@ Otherwise the following message is written to {brandname} logs:
 [role="_additional-resources"]
 .Additional resources
 * link:{jgroups_docs}[JGroups 5 Manual]
-* link:{jgroups_schema}[JGroups 5.4 Schema]
+* link:{jgroups_schema}[JGroups 5.5 Schema]

--- a/documentation/src/main/asciidoc/topics/proc_creating_caches_embedded.adoc
+++ b/documentation/src/main/asciidoc/topics/proc_creating_caches_embedded.adoc
@@ -69,6 +69,12 @@ For the +PERMANENT+ flag to take effect, you must enable global state and set a 
 
 For more information about configuration storage providers, see link:../../apidocs/org/infinispan/configuration/global/GlobalStateConfigurationBuilder.html#configurationStorage(org.infinispan.globalstate.ConfigurationStorage)[GlobalStateConfigurationBuilder#configurationStorage()].
 
+[TIP]
+====
+Visit the code tutorials to try examples with embedded {brandname}.
+See the link:{code_tutorials_root}/infinispan-embedded[code tutorial with embedded caches].
+====
+
 [role="_additional-resources"]
 .Additional resources
 * link:../../apidocs/org/infinispan/manager/EmbeddedCacheManager.html[EmbeddedCacheManager]

--- a/documentation/src/main/asciidoc/topics/proc_quarkus_injecting_embedded.adoc
+++ b/documentation/src/main/asciidoc/topics/proc_quarkus_injecting_embedded.adoc
@@ -1,6 +1,6 @@
 [id='quarkus_inject_embedded']
 = Injecting Embedded Caches
-Inject a `EmbeddedCacheManager` instance into your Quarkus application to interact with {brandname} caches..
+Inject a `EmbeddedCacheManager` instance into your Quarkus application to interact with {brandname} caches.
 
 .Procedure
 

--- a/documentation/src/main/asciidoc/topics/proc_using-cahches-in-jboss-applications.adoc
+++ b/documentation/src/main/asciidoc/topics/proc_using-cahches-in-jboss-applications.adoc
@@ -10,7 +10,7 @@ You can access {brandname} caches in your applications through resource lookup.
 .Prerequisites
 
 * {wildflybrandname} is running.
-* You have created {brandname} cahches in {wildflybrandname}.
+* You have created {brandname} caches in {wildflybrandname}.
 
 .Procedure
 

--- a/documentation/src/main/asciidoc/topics/streams.adoc
+++ b/documentation/src/main/asciidoc/topics/streams.adoc
@@ -2,12 +2,12 @@
 = Streams
 
 You may want to process a subset or all data in the cache to produce a result.
-This may bring thoughts of Map Reduce. {brandname} allows the user to do something
+This may bring thoughts of MapReduce. {brandname} allows the user to do something
 very similar but utilizes the standard JRE APIs to do so.
-Java 8 introduced the concept of a link:{jdkdocroot}/java/util/stream/Stream.html[Stream]
+Java 8 introduced the concept of a link:{jdkdocroot}/java/util/stream/Stream.html[Stream],
 which allows functional-style operations on collections rather than having to procedurally
 iterate over the data yourself. Stream operations can be implemented in a fashion very
-similar to MapReduce.  Streams, just like MapReduce allow you to perform processing
+similar to MapReduce. Streams, just like MapReduce allow you to perform processing
 upon the entirety of your cache, possibly a very large data set, but in an efficient way.
 
 [NOTE]
@@ -15,7 +15,7 @@ upon the entirety of your cache, possibly a very large data set, but in an effic
 Streams are the preferred method when dealing with data that exists in the cache because streams automatically adjust to cluster topology changes.
 ====
 
-Also since we can control how the entries are iterated upon we can more efficiently perform the operations in a cache that is distributed if you want it to perform all of the operations across the cluster concurrently.
+Also, since we can control how the entries are iterated upon, we can more efficiently perform the operations in a cache that is distributed if you want it to perform all the operations across the cluster concurrently.
 
 A stream is retrieved from the link:../../apidocs/org/infinispan/Cache.html#entrySet--[entrySet],
 link:../../apidocs/org/infinispan/Cache.html#keySet--[keySet] or
@@ -37,11 +37,11 @@ method on the `CacheStream`.  This should always be used over a Predicate
 link:{jdkdocroot}/java/util/stream/Stream.html?is-external=true#filter-java.util.function.Predicate-[filter]
 and will be faster if the predicate was holding all keys.
 
-If you are familiar with the ``AdvancedCache`` interface you may be wondering why you even use
+If you are familiar with the ``AdvancedCache`` interface, you may be wondering why you even use
 link:../../apidocs/org/infinispan/AdvancedCache.html#getAll-java.util.Set-[getAll]
 over this keyFilter.  There are some small benefits (mostly smaller payloads) to using getAll
-if you need the entries as is and need them all in memory in the local node.  However if you
-need to do processing on these elements a stream is recommended since you will get both
+if you need the entries as is and need them all in memory in the local node.  However, if you
+need to do processing on these elements, a stream is recommended, since you will get both
 distributed and threaded parallelism for free.
 
 == Segment based filtering
@@ -61,9 +61,9 @@ method on the `CacheStream`.  This is applied after the key filter but before an
 == Local/Invalidation
 
 A stream used with a local or invalidation cache can be used just the same way you would use a stream on a
-regular collection. {brandname} handles all of the translations if necessary behind the scenes and works with all
-of the more interesting options (ie. storeAsBinary and a cache loader).  Only data local to
-the node where the stream operation is performed will be used, for example invalidation only uses local entries.
+regular collection. {brandname} handles all the translations, if necessary, behind the scenes and works with all
+the more interesting options (i.e. storeAsBinary and a cache loader).  Only data local to
+the node where the stream operation is performed will be used, for example, invalidation only uses local entries.
 
 == Example
 
@@ -74,9 +74,9 @@ The code below takes a cache and returns a map with all the cache entries whose 
 include::code_examples/Stream.java[]
 ----
 
-== Distribution/Replication/Scattered
+== Distribution/Replication
 
-This is where streams come into their stride.  When a stream operation is performed it will
+This is where streams come into their stride.  When a stream operation is performed, it will
 send the various intermediate and terminal operations to each node that has pertinent data.
 This allows processing the intermediate values on the nodes owning the data, and only sending
 the final results back to the originating nodes, improving performance.
@@ -84,8 +84,8 @@ the final results back to the originating nodes, improving performance.
 
 === Rehash Aware
 
-Internally the data is segmented and each node only performs the operations upon the data it owns as a primary owner.
-This allows for data to be processed evenly, assuming segments are granular enough to provide for equal amounts of
+Internally, the data is segmented and each node only performs the operations upon the data it owns as a primary owner.
+This allows for data to be processed evenly, assuming segments are granular enough to provide an equal amount of
 data on each node.
 
 When you are utilizing a distributed cache, the data can be reshuffled between nodes when a
@@ -95,7 +95,7 @@ Reshuffled entries may be processed a second time, and we keep track of the proc
 key level or at the segment level (depending on the terminal operation) to limit the amount of
 duplicate processing.
 
-It is possible but highly discouraged to disable rehash awareness on the stream.  This should only be considered if
+It is possible, but highly discouraged, to disable rehash awareness on the stream.  This should only be considered if
 your request can handle only seeing a subset of data if a rehash occurs.  This can be done by invoking
 link:../../apidocs/org/infinispan/CacheStream.html#disableRehashAware--[CacheStream.disableRehashAware()]
 The performance gain for most operations when a rehash doesn't occur is completely negligible.
@@ -106,19 +106,19 @@ WARNING: Please rethink disabling rehash awareness unless you really know what y
 
 === Serialization
 
-Since the operations are sent across to other nodes they must be serializable by {brandname} marshalling.  This allows the
+Since the operations are sent across to other nodes, they must be serializable by {brandname} marshalling.  This allows the
 operations to be sent to the other nodes.
 
 The simplest way is to use a CacheStream instance and use a lambda just as you would normally.
-{brandname} overrides all of the various Stream intermediate and terminal methods to take
-Serializable versions of the arguments (ie. SerializableFunction, SerializablePredicate...)
+{brandname} overrides all the various Stream intermediate and terminal methods to take
+Serializable versions of the arguments (i.e. SerializableFunction, SerializablePredicate, etc.)
 You can find these methods at
 link:../../apidocs/org/infinispan/CacheStream.html[CacheStream].
 This relies on the spec to pick the most specific method as defined link:https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.12.2.5[here].
 
-In our previous example we used a `Collector` to collect all the results into a `Map`.
-Unfortunately the link:{jdkdocroot}/java/util/stream/Collectors.html[Collectors]
-class doesn't produce Serializable instances.  Thus if you need to use these, there are two ways to do so:
+In our previous example, we used a `Collector` to collect all the results into a `Map`.
+Unfortunately, the link:{jdkdocroot}/java/util/stream/Collectors.html[Collectors]
+class doesn't produce Serializable instances.  Thus, if you need to use these, there are two ways to do so:
 
 One option would be to use the
 link:../../apidocs/org/infinispan/stream/CacheCollectors.html[CacheCollectors]
@@ -145,9 +145,9 @@ Map<Object, String> jbossValues = cache.entrySet().stream()
               .collect(() -> Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 ----
 
-If however you are not able to use the `Cache` and `CacheStream` interfaces you cannot utilize `Serializable`
-arguments and you must instead cast the lambdas to be `Serializable` manually by casting the lambda to multiple
-interfaces.  It is not a pretty sight but it gets the job done.
+However, you are not able to use the `Cache` and `CacheStream` interfaces you cannot utilize `Serializable`
+arguments, and you must instead cast the lambdas to be `Serializable` manually by casting the lambda to multiple
+interfaces.  It is not a pretty sight, but it gets the job done.
 
 [source,java]
 ----
@@ -157,7 +157,7 @@ Map<Object, String> jbossValues = map.entrySet().stream()
 ----
 
 The recommended and most performant way is to use ProtoStream as this provides the smallest payload.  Unfortunately
-this means you cannot use lamdbas as this requires defining the class beforehand.
+this means you cannot use lambdas, as it requires defining the class beforehand.
 
 You can use an ProtoStream as shown below:
 
@@ -212,40 +212,40 @@ Map<Object, String> map = (Map<Object, String>) cache.entrySet().stream()
 == Parallel Computation
 
 Distributed streams by default try to parallelize as much as possible.  It is possible for the end user to control this and
-actually they always have to control one of the options.  There are 2 ways these streams are parallelized.
+actually they always have to control one of the options.  There are two ways these streams are parallelized.
 
-*Local to each node*
-When a stream is created from the cache collection the end user can choose between invoking
+*Local to each node:*
+When a stream is created from the cache collection, the end user can choose between invoking
 link:{jdkdocroot}/java/util/Collection.html#stream--[stream] or
 link:{jdkdocroot}/java/util/Collection.html#parallelStream--[parallelStream]
 method.  Depending on if the parallel stream was picked will enable multiple threading for
-each node locally.  Note that some operations like a rehash aware iterator and forEach operations
+each node locally.  Note that, some operations like a rehash aware iterator and forEach operations
 will always use a sequential stream locally.  This could be enhanced at some point to allow for
 parallel streams locally.
 
 Users should be careful when using local parallelism as it requires having a large number of entries or operations
-that are computationally expensive to be faster. Also it should be noted that if a user uses a parallel
-stream with `forEach` that the action should not block as this would be executed on the common pool, which
+that are computationally expensive to be faster. Also, it should be noted that, if a user uses a parallel
+stream with `forEach`, the action should not block as this would be executed on the common pool, which
 is normally reserved for computation operations.
 
 
-*Remote requests*
-When there are multiple nodes it may be desirable to control whether the remote requests are all processed
-at the same time concurrently or one at a time.  By default all terminal operations except the iterator
+*Remote requests:*
+When there are multiple nodes, it may be desirable to control whether the remote requests are all processed
+at the same time concurrently or one at a time.  By default, all terminal operations, except the iterator,
 perform concurrent requests.  The iterator, method to reduce overall memory pressure on the local node,
 only performs sequential requests which actually performs slightly better.
 
-If a user wishes to change this default however they can do so by invoking the
+If a user wishes to change the default behavior, they can do so by invoking the
 link:../../apidocs/org/infinispan/CacheStream.html#sequentialDistribution--[sequentialDistribution]
 or link:../../apidocs/org/infinispan/CacheStream.html#parallelDistribution--[parallelDistribution]
 methods on the `CacheStream`.
 
-== Task timeout
+== Operation timeout
 
-It is possible to set a timeout value for the operation requests. This timeout is used only for remote requests timing out and
-it is on a per request basis. The former means the local execution will not timeout and the latter means if you have a failover
-scenario as described above the subsequent requests each have a new timeout.  If no timeout is specified it uses the
-replication timeout as a default timeout. You can set the timeout in your task by doing the following:
+It is possible to set a timeout value for the operation requests. This timeout is used only for remote requests timing out, and
+it is on a per-request basis. The former means the local execution will not timeout, and the latter means if you have a failover
+scenario, as described above, the subsequent requests each have a new timeout.  If no timeout is specified, it uses the
+replication timeout as a default timeout. You can set the timeout in your operation by doing the following:
 
 [source,java]
 ----
@@ -262,15 +262,15 @@ javadoc.
 The link:{jdkdocroot}/java/util/stream/Stream.html[Stream]
 has a terminal operation called
 link:{jdkdocroot}/java/util/stream/Stream.html#forEach-java.util.function.Consumer-[forEach]
-which allows for running some sort of side effect operation on the data.  In this case it may be desirable to get a reference to
+which allows for running some sort of side effect operation on the data.  In this case, it may be desirable to get a reference to
 the `Cache` that is backing this Stream.  If your `Consumer` implements the
 link:../../apidocs/org/infinispan/stream/CacheAware.html[CacheAware]
-interface the `injectCache` method be invoked before the accept method from the `Consumer` interface.
+interface, the `injectCache` method must be invoked before the accept method from the `Consumer` interface.
 
 == Distributed Stream execution
 
-Distributed streams execution works in a fashion very similar to map reduce.  Except in this case we are sending zero to many intermediate operations
-(map, filter etc.) and a single terminal operation to the various nodes.  The operation basically comes down to the following:
+Distributed streams execution works in a fashion very similar to MapReduce.  Except, in this case, we are sending zero to many intermediate operations
+(map, filter etc.) and a single terminal operation to the various nodes.  The operation comes down to the following:
 
 . The desired segments are grouped by which node is the primary owner of the given segment
 
@@ -284,33 +284,33 @@ Distributed streams execution works in a fashion very similar to map reduce.  Ex
 
 . Final reduced response is then returned to the user
 
-In most cases all operations are fully distributed, as in the operations are all fully applied on each remote node and usually only the last operation or something related may be
+In most cases, all operations are fully distributed, as in the operations are all fully applied on each remote node and usually only the last operation or something related may be
 reapplied to reduce the results from multiple nodes.  One important note is that intermediate values do not actually have to be serializable, it is the last value
 sent back that is the part desired (exceptions for various operations will be highlighted below).
 
-*Terminal operator distributed result reductions*
+*Terminal operator distributed result reductions:*
 The following paragraphs describe how the distributed reductions work for the various terminal operators.  Some of these are special in that an intermediate value may
 be required to be serializable instead of the final result.
 
 allMatch noneMatch anyMatch::
 The link:{jdkdocroot}/java/util/stream/Stream.html#allMatch-java.util.function.Predicate-[allMatch]
-operation is ran on each node and then all the results are logically anded together locally
+operation is run on each node and then all the results use a logical _and_ together locally
 to get the appropriate value.  The
 link:{jdkdocroot}/java/util/stream/Stream.html#noneMatch-java.util.function.Predicate-[noneMatch]
 and
 link:{jdkdocroot}/java/util/stream/Stream.html#anyMatch-java.util.function.Predicate-[anyMatch]
-operations use a logical or instead. These methods also have early termination support,
+operations use a logical _or_ instead. These methods also have early termination support,
 stopping remote and local operations once the final result is known.
 
 collect::
 The link:{jdkdocroot}/java/util/stream/Stream.html#collect-java.util.stream.Collector-[collect]
-method is interesting in that it can do a few extra steps.  The remote node performs
-everything as normal except it doesn't perform the final
+method is interesting, in that it can do a few extra steps.  The remote node performs
+everything as normal, except it doesn't perform the final
 link:{jdkdocroot}/java/util/stream/Collector.html#finisher--[finisher]
 upon the result and instead sends back the fully combined results.  The local thread
 then link:{jdkdocroot}/java/util/stream/Collector.html#combiner--[combines]
 the remote and local result into a value which is then finally finished.  The key
-here to remember is that the final value doesn't have to be serializable but rather
+here to remember is that the final value doesn't have to be serializable, but rather
 the values produced from the link:{jdkdocroot}/java/util/stream/Collector.html#supplier--[supplier]
 and link:{jdkdocroot}/java/util/stream/Collector.html#combiner--[combiner]
 methods.
@@ -323,20 +323,20 @@ findAny findFirst::
 The link:{jdkdocroot}/java/util/stream/Stream.html#findAny--[findAny]
 operation returns just the first value they find, whether it was from a remote node
 or locally.  Note this supports early termination in that once a value is found it
-will not process others.  Note the findFirst method is special since it requires a sorted
+will not process others.  Note that, the findFirst method is special since it requires a sorted
 intermediate operation, which is detailed in the
 link:{library_docs}#intermediate_operation_exceptions[exceptions] section.
 
 max min::
 The link:{jdkdocroot}/java/util/stream/Stream.html#max-java.util.Comparator-[max] and
-link:{jdkdocroot}/java/util/stream/Stream.html#min-java.util.Comparator-[min] methods find the respective min or max value on each node then a final
+link:{jdkdocroot}/java/util/stream/Stream.html#min-java.util.Comparator-[min] methods find the respective min or max value on each node, then a final
 reduction is performed locally to ensure only the min or max across all nodes is returned.
 
 reduce::
 The various reduce methods link:{jdkdocroot}/java/util/stream/Stream.html#reduce-java.util.function.BinaryOperator-[1] ,
 link:{jdkdocroot}/java/util/stream/Stream.html#reduce-T-java.util.function.BinaryOperator-[2] ,
 link:{jdkdocroot}/java/util/stream/Stream.html#reduce-U-java.util.function.BiFunction-java.util.function.BinaryOperator-[3] will end up serializing
-the result as much as the accumulator can do.  Then it will accumulate the local and remote results together locally, before combining if you have provided that.  Note this means
+the result as much as the accumulator can do.  Then it will accumulate the local and remote results together locally, before combining if you have provided that.  Note that, this means
 a value coming from the combiner doesn't have to be Serializable.
 
 == Key based rehash aware operators
@@ -345,11 +345,11 @@ The link:../../apidocs/org/infinispan/CacheStream.html#iterator--[iterator],
 link:../../apidocs/org/infinispan/CacheStream.html#spliterator--[spliterator]
 and link:../../apidocs/org/infinispan/CacheStream.html#forEach-java.util.function.Consumer-[forEach]
 are unlike the other terminal operators in that the rehash awareness has to keep
-track of what keys per segment have been processed instead of just segments.  This is
+track of what keys per segment have been processed instead of just segments.  This is needed
 to guarantee an exactly once (iterator & spliterator) or at least once behavior (forEach)
 even under cluster membership changes.
 
-The `iterator` and `spliterator` operators when invoked on a remote node will return back batches
+The `iterator` and `spliterator` operators, when invoked on a remote node will return back batches
 of entries, where the next batch is only sent back after the last has been fully consumed.  This
 batching is done to limit how many entries are in memory at a given time.  The user node will hold
 onto which keys it has processed and when a given segment is completed it will release those keys from
@@ -357,17 +357,17 @@ memory.  This is why sequential processing is preferred for the iterator method,
 keys are held in memory at once, instead of from all nodes.
 
 The `forEach()` method also returns batches, but it returns a batch of keys after it has finished processing
-at least a batch worth of keys.  This way the originating node can know what keys have been processed
-already to reduce chances of processing the same entry again.  Unfortunately this means it is possible
-to have an at least once behavior when a node goes down unexpectedly.  In this case that node could have
+at least a batch worth of keys.  This way, the originating node can know what keys have been processed
+already to reduce chances of processing the same entry again.  Unfortunately, this means it is possible
+to have an at least once behavior when a node goes down unexpectedly.  In this case, that node could have
 been processing a batch and not yet completed one and those entries that were processed but not
-in a completed batch will be ran again when the rehash failure operation occurs.  Note that adding a
+in a completed batch will be ran again when the rehash failure operation occurs.  Note that, adding a
 node will not cause this issue as the rehash failover doesn't occur until all responses are received.
 
-These operations batch sizes are both controlled by the same value which can be configured by invoking
+These operations' batch sizes are both controlled by the same value which can be configured by invoking
 link:../../apidocs/org/infinispan/CacheStream.html#distributedBatchSize-int-[distributedBatchSize]
 method on the `CacheStream`.  This value will default to the `chunkSize` configured in state transfer.
-Unfortunately this value is a tradeoff with memory usage vs performance vs at least once and your
+Unfortunately, this value is a tradeoff with memory usage vs. performance vs. at least once, and your
 mileage may vary.
 
 *Using `iterator` with replicated and distributed caches*
@@ -386,12 +386,12 @@ sorted link:{jdkdocroot}/java/util/stream/Stream.html#sorted-java.util.Comparato
 link:{jdkdocroot}/java/util/stream/Stream.html#sorted--[2].
 & link:{jdkdocroot}/java/util/stream/Stream.html#distinct--[distinct].
 All of these methods have some sort of artificial iterator implanted in the stream
-processing to guarantee correctness, they are documented as below.  Note this means
-these operations may cause possibly severe performance degradation.
+processing to guarantee correctness, they are documented as below.  Note that, this means
+these operations may cause severe performance degradation.
 
 Skip::
 An artificial iterator is implanted up to the intermediate skip operation.
-Then results are brought locally so it can skip the appropriate amount of elements.
+Then, results are brought locally so it can skip the appropriate amount of elements.
 Sorted::
 WARNING: This operation requires having all entries in memory on the local node.
 An artificial iterator is implanted up to the intermediate sorted operation.
@@ -400,7 +400,7 @@ returns batches of elements, but this is not yet implemented.
 Distinct::
 WARNING: This operation requires having all or nearly all entries in memory on the local node.
 Distinct is performed on each remote node and then an artificial iterator returns those distinct values.
-Then finally all of those results have a distinct operation performed upon them.
+Then, finally all of those results have a distinct operation performed upon them.
 
 The rest of the intermediate operations are fully distributed as one would expect.
 
@@ -409,7 +409,7 @@ The rest of the intermediate operations are fully distributed as one would expec
 *Word Count*
 
 Word count is a classic, if overused, example
-of map/reduce paradigm. Assume we have a mapping of key -> sentence stored on
+of MapReduce paradigm. Assume we have a mapping of key -> sentence stored on
 {brandname} nodes. Key is a String, each sentence is also a String, and we have
 to count occurrence of all words in all sentences available. The implementation
 of such a distributed task could be defined as follows:
@@ -455,11 +455,11 @@ public class WordCountExample {
 
 ----
 
-In this case it is pretty simple to do the word count from the previous example.
+In this case, it is pretty simple to do the word count from the previous example.
 
-However what if we want to find the most frequent word in the example?  If you take a second
-to think about this case you will realize you need to have all words counted  and available
-locally first. Thus we actually have a few options.
+However, what if we want to find the most frequent word in the example?  If you take a second
+to think about this case, you will realize you need to have all words counted  and available
+locally first. Thus, we actually have a few options.
 
 We could use a finisher on the collector, which is invoked on the user thread
 after all the results have been collected.
@@ -479,22 +479,21 @@ public class WordCountExample {
                wordCountMap -> {
                   String mostFrequent = null;
                   long maxCount = 0;
-                     for (Map.Entry<String, Long> e : wordCountMap.entrySet()) {
-                        int count = e.getValue().intValue();
-                        if (count > maxCount) {
-                           maxCount = count;
-                           mostFrequent = e.getKey();
-                        }
+                  for (Map.Entry<String, Long> e : wordCountMap.entrySet()) {
+                     int count = e.getValue().intValue();
+                     if (count > maxCount) {
+                        maxCount = count;
+                        mostFrequent = e.getKey();
                      }
-                     return mostFrequent;
+                  }
+                  return mostFrequent;
                }));
-
 }
 
 ----
 
-Unfortunately the last step is only going to be ran in a single thread, which if we have a lot of
-words could be quite slow.  Maybe there is another way to parallelize this with Streams.
+Unfortunately, the last step is only going to be ran in a single thread, which if we have a lot of
+words, could be quite slow.  Maybe there is another way to parallelize this with Streams.
 
 We mentioned before we are in the local node after processing, so we could actually use
 a stream on the map results.  We can therefore use a parallel stream on the results.
@@ -513,12 +512,12 @@ public class WordFrequencyExample {
               (e1, e2) -> e1.getValue() > e2.getValue() ? e1 : e2);
 ----
 
-This way you can still utilize all of the cores locally when calculating the most frequent element.
+This way you can still utilize all the cores locally when calculating the most frequent element.
 
 *Remove specific entries*
 
 Distributed streams can also be used as a way to modify data where it lives.
-For example you may want to remove all entries in your cache that contain
+For example, you may want to remove all entries in your cache that contain
 a specific word.
 
 [source,java]
@@ -535,17 +534,16 @@ public class RemoveBadWords {
 
 If we carefully note what is serialized and what is not, we notice that only the word along
 with the operations are serialized across to other nods as it is captured by the lambda.
-However the real saving piece is that the cache operation is performed on the primary
-owner thus reducing the amount of network traffic required to remove these values from the
-cache. The cache is not captured by the lambda as we provide a special BiConsumer method
-override that when invoked on each node passes the cache to the BiConsumer
+However, the real saving piece is that the cache operation is performed on the primary
+owner, thus reducing the amount of network traffic required to remove these values from the
+cache. The cache is not captured by the lambda, as we provide a special BiConsumer method
+override that when invoked on each node passes the cache to the BiConsumer.
 
 One thing to keep in mind using the `forEach` command in this manner is that the underlying
 stream obtains no locks. The cache remove operation will still obtain locks naturally, but
 the value could have changed from what the stream saw. That means that the entry could
 have been changed after the stream read it but the remove actually removed it.
-
-We have specifically added a new variant which is called `LockedStream`.
+We have specifically added a new variant which is called `LockedStream` to address this.
 
 *Plenty of other examples*
 


### PR DESCRIPTION
* Update embedded documentation
* Update planning guide

I have commented out the documentation about custom interceptors. It already says it is marked for removal. Once we change core, we can delete the docs, too.

Closes #15952.