### PR TITLE
[#15974] Test start procedure resiliency

### DIFF
--- a/core/src/main/java/org/infinispan/topology/ClusterCacheStatus.java
+++ b/core/src/main/java/org/infinispan/topology/ClusterCacheStatus.java
@@ -816,7 +816,7 @@ public class ClusterCacheStatus implements AvailabilityStrategyContext {
       var persistedCH = joinInfo.getConsistentHashFactory().fromPersistentState(state, persistentUUIDManager.persistentUUIDToAddress());
       var ch = persistedCH.consistentHash();
       if (persistedCH.hasMissingMembers() || !getExpectedMembers().containsAll(ch.getMembers())) {
-         log.recoverFromStateMissingMembers(cacheName, expectedMembers, ch.getMembers().size());
+         log.recoverFromStateMissingMembers(cacheName, expectedMembers, persistedCH.totalMembers());
          return null;
       }
 

--- a/core/src/test/java/org/infinispan/manager/FailedCacheDefinitionTest.java
+++ b/core/src/test/java/org/infinispan/manager/FailedCacheDefinitionTest.java
@@ -1,0 +1,78 @@
+package org.infinispan.manager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.infinispan.commons.test.CommonsTestingUtil.tmpDirectory;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.CompletionException;
+
+import org.infinispan.Cache;
+import org.infinispan.commons.util.Util;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.globalstate.ConfigurationStorage;
+import org.infinispan.test.AbstractInfinispanTest;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.topology.CacheJoinException;
+import org.testng.annotations.Test;
+
+@Test(groups = "functional", testName = "manager.FailedCacheDefinitionTest")
+public class FailedCacheDefinitionTest extends AbstractInfinispanTest {
+
+   public void testJoinStatelessWithState(Method m) {
+      String state1 = tmpDirectory(this.getClass().getSimpleName(), m.getName(), "1");
+      String state2 = tmpDirectory(this.getClass().getSimpleName(), m.getName(), "2");
+
+      GlobalConfigurationBuilder gcb1 = statefulGlobalBuilder(state1, true);
+      GlobalConfigurationBuilder gcb2 = statefulGlobalBuilder(state2, true);
+
+      EmbeddedCacheManager cm1 = TestCacheManagerFactory.createClusteredCacheManager(gcb1, null);
+      EmbeddedCacheManager cm2 = TestCacheManagerFactory.createClusteredCacheManager(gcb2, null);
+      try {
+         Configuration cacheConfig = new ConfigurationBuilder().clustering().cacheMode(CacheMode.DIST_SYNC).build();
+
+         // Create cache and trigger shutdown
+         Cache<?, ?> c1 = cm1.administration().getOrCreateCache(m.getName(), cacheConfig);
+         Cache<?, ?> c2 = cm2.getCache(m.getName());
+         assertThat(c1.getStatus().allowInvocations()).isTrue();
+         assertThat(c2.getStatus().allowInvocations()).isTrue();
+         TestingUtil.waitForNoRebalance(c1, c2);
+         c1.shutdown();
+         c2.shutdown();
+
+         TestingUtil.killCacheManagers(cm1, cm2);
+
+         // Start with a fresh state in CM1, and join with CM2.
+         gcb1 = statefulGlobalBuilder(state1, true);
+         cm1 =  TestCacheManagerFactory.createClusteredCacheManager(gcb1, null);
+
+         // Since CM1 started fresh, it created the cache correctly.
+         c1 =  cm1.administration().getOrCreateCache(m.getName(), cacheConfig);
+         assertThat(c1.getStatus().allowInvocations()).isTrue();
+
+         // Because CM2 tried to join with persistent state, the cache is in FAILED state.
+         gcb2 = statefulGlobalBuilder(state2, false);
+         final EmbeddedCacheManager cm2Final =  TestCacheManagerFactory.createClusteredCacheManager(gcb2, null);
+         assertThatThrownBy(() -> cm2Final.getCache(m.getName()))
+               .cause()
+               .isInstanceOf(CompletionException.class)
+               .hasMessageStartingWith(CacheJoinException.class.getName());
+
+         // Ensure the manager is still running.
+         assertThat(cm2Final.getStatus().allowInvocations()).isTrue();
+      } finally {
+         TestingUtil.killCacheManagers(cm1, cm2);
+      }
+   }
+
+   private GlobalConfigurationBuilder statefulGlobalBuilder(String stateDirectory, boolean clear) {
+      if (clear) Util.recursiveFileRemove(stateDirectory);
+      GlobalConfigurationBuilder global = GlobalConfigurationBuilder.defaultClusteredBuilder();
+      global.globalState().enable().persistentLocation(stateDirectory).sharedPersistentLocation(stateDirectory).configurationStorage(ConfigurationStorage.OVERLAY);
+      return global;
+   }
+}

--- a/server/tests/src/test/java/org/infinispan/server/resilience/ResilienceStartupIT.java
+++ b/server/tests/src/test/java/org/infinispan/server/resilience/ResilienceStartupIT.java
@@ -1,0 +1,139 @@
+package org.infinispan.server.resilience;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.infinispan.client.rest.RestResponseInfo.BAD_REQUEST;
+import static org.infinispan.client.rest.RestResponseInfo.OK;
+import static org.infinispan.commons.dataconversion.MediaType.APPLICATION_XML;
+import static org.infinispan.server.test.core.Common.sync;
+import static org.infinispan.server.test.core.TestSystemPropertyNames.INFINISPAN_TEST_SERVER_CONTAINER_VOLUME_REQUIRED;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.infinispan.client.rest.RestClient;
+import org.infinispan.client.rest.RestEntity;
+import org.infinispan.client.rest.RestResponse;
+import org.infinispan.client.rest.configuration.RestClientConfigurationBuilder;
+import org.infinispan.client.rest.configuration.RestClientConfigurationProperties;
+import org.infinispan.commons.dataconversion.internal.Json;
+import org.infinispan.server.resp.configuration.RespServerConfiguration;
+import org.infinispan.server.test.core.ServerRunMode;
+import org.infinispan.server.test.junit5.InfinispanServerExtension;
+import org.infinispan.server.test.junit5.InfinispanServerExtensionBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.RedisConnectionException;
+
+public class ResilienceStartupIT {
+
+   @RegisterExtension
+   public static final InfinispanServerExtension SERVER =
+         InfinispanServerExtensionBuilder.config("configuration/ClusteredServerTest.xml")
+               .numServers(1)
+               .runMode(ServerRunMode.CONTAINER)
+               .property(INFINISPAN_TEST_SERVER_CONTAINER_VOLUME_REQUIRED, "true")
+               .build();
+
+   @Test
+   public void testRestartWithInvalidCache() {
+      RestClientConfigurationBuilder restClientBuilder = new RestClientConfigurationBuilder()
+            .socketTimeout(RestClientConfigurationProperties.DEFAULT_SO_TIMEOUT * 60)
+            .connectionTimeout(RestClientConfigurationProperties.DEFAULT_CONNECT_TIMEOUT * 60);
+      RestClient rest = SERVER.rest().withClientConfiguration(restClientBuilder).get();
+
+      // Create a cache with an invalid configuration that remains in the failed state.
+      String invalidCacheName = "books";
+      String invalidConfig = """
+            <infinispan>
+              <cache-container>
+                <replicated-cache name="books">
+                  <encoding media-type="application/x-java-object"/>
+                  <indexing>
+                    <indexed-entities>
+                      <indexed-entity>Dummy</indexed-entity>
+                    </indexed-entities>
+                  </indexing>
+                </replicated-cache>
+              </cache-container>
+            </infinispan>""";
+      try (RestResponse response = sync(rest.cache(invalidCacheName).createWithConfiguration(RestEntity.create(APPLICATION_XML, invalidConfig)))) {
+         assertThat(response.status()).isEqualTo(BAD_REQUEST);
+      }
+
+      // Invalid cache exists and is in failed state.
+      assertCacheIsFailed(rest, invalidCacheName);
+
+      // Restart the node again.
+      // This will load the invalid cache from caches.xml and fail to create again.
+      // The server and cache manager should NOT fail.
+      SERVER.getServerDriver().stopCluster();
+      SERVER.getServerDriver().restartCluster();
+
+      // Assert that the cache manager and server are running.
+      // Also validate that the cache still exists in a FAILED state.
+      assertCacheIsFailed(rest, invalidCacheName);
+   }
+
+   @Test
+   public void testInvalidConnectorCache() {
+      RestClientConfigurationBuilder restClientBuilder = new RestClientConfigurationBuilder()
+            .socketTimeout(RestClientConfigurationProperties.DEFAULT_SO_TIMEOUT * 60)
+            .connectionTimeout(RestClientConfigurationProperties.DEFAULT_CONNECT_TIMEOUT * 60);
+      RestClient rest = SERVER.rest().withClientConfiguration(restClientBuilder).get();
+
+      // Define an invalid configuration for the RESP cache.
+      String invalidCacheName = RespServerConfiguration.DEFAULT_RESP_CACHE;
+      String invalidConfig = """
+            <infinispan>
+              <cache-container>
+                <distributed-cache name="respCache">
+                  <encoding media-type="application/x-java-object"/>
+                  <indexing>
+                   <indexed-entities>
+                     <indexed-entity>Dummy</indexed-entity>
+                    </indexed-entities>
+                 </indexing>
+                </distributed-cache>
+              </cache-container>
+            </infinispan>
+            """;
+      // Store the configuration for the RESP cache.
+      // Once a connection is established using the RESP protocol, it will fail to create the cache.
+      try (RestResponse response = sync(rest.cache(invalidCacheName).createWithConfiguration(RestEntity.create(APPLICATION_XML, invalidConfig)))) {
+         assertThat(response.status()).isEqualTo(BAD_REQUEST);
+      }
+
+      assertCacheIsFailed(rest, invalidCacheName);
+      try (RedisClient client = RedisClient.create(SERVER.resp().connectionString(0))) {
+         assertThatThrownBy(client::connect)
+               .isInstanceOf(RedisConnectionException.class);
+      }
+
+      // Restart the driver and re-create the RESP connector.
+      SERVER.getServerDriver().stopCluster();
+      SERVER.getServerDriver().restartCluster();
+
+      // Assert it still fails to create the RESP cache.
+      try (RedisClient client = RedisClient.create(SERVER.resp().connectionString(0))) {
+         assertThatThrownBy(client::connect)
+               .isInstanceOf(RedisConnectionException.class);
+      }
+
+      // Assert the RESP cache is failed, and that the server and cache manager are running.
+      assertCacheIsFailed(rest, invalidCacheName);
+   }
+
+   private void assertCacheIsFailed(RestClient rest, String cacheName) {
+      try (RestResponse response = sync(rest.container().health())) {
+         assertThat(response.status()).isEqualTo(OK);
+         Json payload = Json.read(response.body());
+         List<Json> statuses = payload.at("cache_health").asJsonList();
+         Optional<Json> books = statuses.stream().filter(j -> j.at("cache_name").asString().equals(cacheName)).findFirst();
+         assertThat(books.isPresent()).isTrue();
+         assertThat(books.get().at("status").asString()).isEqualTo("FAILED");
+      }
+   }
+}


### PR DESCRIPTION
* Verify the cache manager does not fail to start with an invalid cache.
* Verify the server does not fail to start with an invalid cache.

Closes #15974.