### PR TITLE
[#15958] Use better JVM options for containers

### DIFF
--- a/server/image/src/main/docker/Dockerfile
+++ b/server/image/src/main/docker/Dockerfile
@@ -85,7 +85,10 @@ RUN rm -rf \
 ADD src/main/docker/install-server.sh /tmp/
 RUN /tmp/install-server.sh ${NEWROOT} ${WORKDIR}
 ADD src/main/docker/launch.sh ${NEWROOT}${WORKDIR}/bin/
+# Build the AOT cache using a fixed memory configuration
 ENV JAVA_HOME=${NEWROOT}/usr/lib/jvm/default-java
+ENV JAVA_OPTS="-XX:+ExitOnOutOfMemoryError -Djava.awt.headless=true -Djava.net.preferIPv4Stack=true -Xms64m -Xmx512m"
+# Temporarily disabled
 #RUN ${NEWROOT}/${WORKDIR}/bin/server.sh --aot || true
 RUN chown -R 65532:65532 ${NEWROOT}/${WORKDIR}
 

--- a/server/runtime/src/main/server/bin/server.conf
+++ b/server/runtime/src/main/server/bin/server.conf
@@ -17,25 +17,18 @@
 #MAX_FD="maximum"
 
 #
-# Specify the profiler configuration file to load.
-#
-# Default is to not load profiler configuration file.
-#
-#PROFILER=""
-
-#
 # Specify the location of the Java home directory.  If set then $JAVA will
 # be defined to $JAVA_HOME/bin/java, else $JAVA will be "java".
 #
 #JAVA_HOME="/opt/java/jdk"
 
-# tell linux glibc how many memory pools can be created that are used by malloc
-# MALLOC_ARENA_MAX="5"
-
 #
 # Specify the exact Java VM executable to use.
 #
 #JAVA=""
+
+# tell linux glibc how many memory pools can be created that are used by malloc
+# MALLOC_ARENA_MAX="5"
 
 # Uncomment the following line to prevent manipulation of JVM options
 # by shell scripts.
@@ -46,8 +39,12 @@
 # Specify options to pass to the Java VM.
 #
 if [ "x$JAVA_OPTS" = "x" ]; then
-   JAVA_OPTS="-Xms64m -Xmx512m -XX:MetaspaceSize=64M -Djava.net.preferIPv4Stack=true"
-   JAVA_OPTS="$JAVA_OPTS -Djava.awt.headless=true"
+   JAVA_OPTS="-XX:+ExitOnOutOfMemoryError -Djava.awt.headless=true -Djava.net.preferIPv4Stack=true"
+   if [ -f "/.dockerenv" ] || [ -f "/run/.containerenv" ] || [ "$RUN_IN_CONTAINER" = "true" ]; then
+     JAVA_OPTS="$JAVA_OPTS -XX:InitialRAMPercentage=50 -XX:MinRAMPercentage=70 -XX:MaxRAMPercentage=70 -XX:+UseCompressedOops"
+   else
+     JAVA_OPTS="$JAVA_OPTS -Xms64m -Xmx512m"
+   fi
 else
    echo "JAVA_OPTS already set in environment; overriding default settings with values: $JAVA_OPTS"
 fi


### PR DESCRIPTION
A little explanation:
* when running in container we use `-XX:InitialRAMPercentage=50 -XX:MinRAMPercentage=70 -XX:MaxRAMPercentage=70`
* we also set `-XX:+UseCompressedOops` to ensure the generated AOT works with heaps < and > 32GB

Closes #15958