### PR TITLE
[#16001] Show unknown auth mechanism name instead of 'null'

### DIFF
--- a/server/runtime/src/main/java/org/infinispan/server/security/ElytronHTTPAuthenticator.java
+++ b/server/runtime/src/main/java/org/infinispan/server/security/ElytronHTTPAuthenticator.java
@@ -133,10 +133,11 @@ public class ElytronHTTPAuthenticator implements RestAuthenticator {
                   extractSubject(request, mechanism);
                }
             } else {
-               String mechName = challengePrefixMechanisms.get(authorizationHeader.substring(0, authorizationHeader.indexOf(' ')).toUpperCase());
+               String headerMechName = authorizationHeader.substring(0, authorizationHeader.indexOf(' ')).toUpperCase();
+               String mechName = challengePrefixMechanisms.get(headerMechName);
                HttpServerAuthenticationMechanism mechanism = factory.createMechanism(mechName);
                if (mechanism == null) {
-                  throw Server.log.unsupportedMechanism(mechName);
+                  throw Server.log.unsupportedMechanism(headerMechName);
                }
                mechanism.evaluateRequest(requestAdapter);
                extractSubject(request, mechanism);


### PR DESCRIPTION
If using the REST API authorization mechanism that isn't enabled in the Infinispan server, the error message was an unhelpful: "ISPN080052: The request authentication mechanism 'null' is not supported"

This is because it was using the mechanism name retrieved from the challengePrefixMechanisms map, and if a mechanism isn't enabled, that map will return null. This fixes the problem by printing the mechanism name sent by the client instead.

Closes #16001