### PR TITLE
[#15991] Not listing non-initialized caches in REST

### DIFF
--- a/server/rest/src/main/java/org/infinispan/rest/cachemanager/RestCacheManager.java
+++ b/server/rest/src/main/java/org/infinispan/rest/cachemanager/RestCacheManager.java
@@ -145,11 +145,15 @@ public class RestCacheManager<V> {
    }
 
    public Collection<String> getCacheNames() {
-      return instance.getCacheNames();
+      return instance.getCacheNames().stream()
+            .filter(instance::cacheExists)
+            .toList();
    }
 
    public Collection<String> getAccessibleCacheNames() {
-      return instance.getAccessibleCacheNames();
+      return instance.getAccessibleCacheNames().stream()
+            .filter(instance::cacheExists)
+            .toList();
    }
 
    public CompletionStage<CacheEntry<Object, V>> getInternalEntry(String cacheName, Object key, MediaType keyContentType, MediaType mediaType, RestRequest request) {

--- a/server/rest/src/main/java/org/infinispan/rest/resources/CacheResourceV2.java
+++ b/server/rest/src/main/java/org/infinispan/rest/resources/CacheResourceV2.java
@@ -293,6 +293,7 @@ public class CacheResourceV2 extends BaseCacheResource implements ResourceHandle
       // Remove internal caches
       Set<String> cacheNames = new HashSet<>(subjectCacheManager.getAccessibleCacheNames());
       cacheNames.removeAll(internalCacheRegistry.getInternalCacheNames());
+      cacheNames.removeIf(n -> !cacheManager.cacheExists(n));
 
 
       Set<String> ignoredCaches = serverStateManager.getIgnoredCaches();


### PR DESCRIPTION
The REST endpoint only returns a cache if it was created.
Closes #15991.