### PR TITLE
[#16034] Virtual threads cause extra allocations for netty responses

### DIFF
--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/VersionedEncoder.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/VersionedEncoder.java
@@ -3,10 +3,9 @@ package org.infinispan.server.hotrod;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletionStage;
 
-import org.infinispan.CacheSet;
 import org.infinispan.commons.tx.XidImpl;
-import org.infinispan.commons.util.CloseableIterator;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.counter.api.CounterConfiguration;
 import org.infinispan.server.core.iteration.IterableIterationResult;
@@ -16,6 +15,7 @@ import org.infinispan.server.hotrod.counter.listener.ClientCounterEvent;
 import org.infinispan.server.hotrod.streaming.GetStreamResponse;
 import org.infinispan.stats.ClusterCacheStats;
 import org.infinispan.stats.Stats;
+import org.reactivestreams.Publisher;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
@@ -44,7 +44,7 @@ public interface VersionedEncoder {
 
    ByteBuf errorResponse(HotRodHeader header, HotRodServer server, Channel channel, String message, OperationStatus status);
 
-   ByteBuf bulkGetResponse(HotRodHeader header, HotRodServer server, Channel channel, int size, CacheSet<Map.Entry<byte[], byte[]>> entries);
+   CompletionStage<ByteBuf> bulkGetResponse(HotRodHeader header, HotRodServer server, Channel channel, int size, Publisher<CacheEntry<byte[], byte[]>> publisher);
 
    ByteBuf emptyResponse(HotRodHeader header, HotRodServer server, Channel channel, OperationStatus status);
 
@@ -71,7 +71,7 @@ public interface VersionedEncoder {
 
    ByteBuf getAllResponse(HotRodHeader header, HotRodServer server, Channel channel, Map<byte[], byte[]> map);
 
-   ByteBuf bulkGetKeysResponse(HotRodHeader header, HotRodServer server, Channel channel, CloseableIterator<byte[]> iterator);
+   CompletionStage<ByteBuf> bulkGetKeysResponse(HotRodHeader header, HotRodServer server, Channel channel, Publisher<byte[]> publisher);
 
    ByteBuf iterationStartResponse(HotRodHeader header, HotRodServer server, Channel channel, String iterationId);
 


### PR DESCRIPTION
Fixes #16034 

I started down the rabbit hole of fixing every place. But that requires a lot more work as the transaction processor response handling is intertwined in the actual processing logic. And the stats method is directly tied as well, so I stopped with what I had here.

For the benchmark [put isolated](https://github.com/infinispan/infinispan-benchmarks/blob/b8f395013e83c0ec7f5e1153336168b8410afd5c/getputremovetest/src/main/java/org/infinispan/JMHBenchmarks.java#L28) I got just under a 2% increase in throughput due to the reduction in allocations, despite being thread local only.

NEW: 11050.22867 vs MAIN: 10836.26933 average throughput