### PR TITLE
[#13761] Ensure cluster is ok for script cache. Also [#14248]

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ExecTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ExecTest.java
@@ -54,6 +54,8 @@ public class ExecTest extends MultiHotRodServersTest {
       createHotRodServers(NUM_SERVERS, new ConfigurationBuilder());
       defineInAll(REPL_CACHE, CacheMode.REPL_SYNC);
       defineInAll(DIST_CACHE, CacheMode.DIST_SYNC);
+      waitForClusterToForm();
+      waitForClusterToForm(SCRIPT_CACHE_NAME);
    }
 
    @Override

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ExecTypedTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ExecTypedTest.java
@@ -39,6 +39,8 @@ public class ExecTypedTest extends MultiHotRodServersTest {
       ConfigurationBuilder builder = hotRodCacheConfiguration(
             getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, false));
       defineInAll(NAME, builder);
+      waitForClusterToForm();
+      waitForClusterToForm(SCRIPT_CACHE_NAME);
       execClient = createExecClient();
       clients.add(execClient);
       addScriptClient = createAddScriptClient();

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/JsonScriptTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/JsonScriptTest.java
@@ -31,6 +31,7 @@ public class JsonScriptTest extends MultiHotRodServersTest {
       ConfigurationBuilder cfgBuilder = hotRodCacheConfiguration(MediaType.APPLICATION_JSON);
       createHotRodServers(CLUSTER_SIZE, cfgBuilder);
       waitForClusterToForm();
+      waitForClusterToForm(SCRIPT_CACHE_NAME);
    }
 
    @Override

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ProtobufJsonScriptTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ProtobufJsonScriptTest.java
@@ -37,6 +37,7 @@ public class ProtobufJsonScriptTest extends MultiHotRodServersTest {
       cfgBuilder.encoding().value().mediaType(APPLICATION_PROTOSTREAM_TYPE);
       createHotRodServers(CLUSTER_SIZE, cfgBuilder);
       waitForClusterToForm();
+      waitForClusterToForm(SCRIPT_CACHE_NAME);
    }
 
    @Override


### PR DESCRIPTION
fixes #13761
fixes #14248

Explicitly check that cluster is formed for script cache, we have something similar for counter tests, see [here](https://github.com/infinispan/infinispan/blob/2ed68ecefda4d9ef2815202e0b4ee2a5148f9bbf/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/counter/StrongCounterHitsAwareTest.java)