### PR TITLE
[#16123] Handle server failures during post-start

### DIFF
--- a/server/core/src/test/java/org/infinispan/server/core/AbstractProtocolServerTest.java
+++ b/server/core/src/test/java/org/infinispan/server/core/AbstractProtocolServerTest.java
@@ -1,8 +1,11 @@
 package org.infinispan.server.core;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.server.core.configuration.MockServerConfiguration;
 import org.infinispan.server.core.configuration.MockServerConfigurationBuilder;
+import org.infinispan.server.core.test.Stoppable;
 import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.testng.Assert;
@@ -51,11 +54,8 @@ public class AbstractProtocolServerTest extends AbstractInfinispanTest {
 
    private void expectIllegalArgument(MockServerConfigurationBuilder builder, MockProtocolServer server) {
       try {
-//         Stoppable.useCacheManager(TestCacheManagerFactory.createCacheManager()) { cm =>
-//            server.start(builder.build(), cm)
-//         }
-      } catch (IllegalArgumentException e) {
-//         case i: IllegalArgumentException => // expected
+         assertThatThrownBy(() -> Stoppable.useCacheManager(TestCacheManagerFactory.createCacheManager(), cm -> server.start(builder.build(), cm)))
+               .isInstanceOf(IllegalArgumentException.class);
       } finally {
          server.stop();
       }

--- a/server/resp/src/main/java/org/infinispan/server/resp/logging/Log.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/logging/Log.java
@@ -77,4 +77,8 @@ public interface Log extends BasicLogger {
    @LogMessage(level = WARN)
    @Message(value = "Multi-Exec operations without transactions have a relaxed isolation level. Consider enabling transaction.", id = 13011)
    void enableTransactionForMultiExec();
+
+   @LogMessage(level = WARN)
+   @Message(value = "Failed to load script engine. Script features disabled for RESP")
+   void failedToLoadScriptEngine(@Cause Throwable cause);
 }

--- a/server/resp/src/main/java/org/infinispan/server/resp/logging/Messages.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/logging/Messages.java
@@ -15,4 +15,6 @@ public interface Messages {
    @Message(value = "NOAUTH HELLO must be called with the client already authenticated, otherwise the HELLO <proto> AUTH <user> <pass> option can be used to authenticate the client and select the RESP protocol version at the same time")
    String noAuthHello();
 
+   @Message(value = "Lua engine is not active")
+   String scriptEngineDisabled();
 }

--- a/server/runtime/pom.xml
+++ b/server/runtime/pom.xml
@@ -279,6 +279,11 @@
          <artifactId>shrinkwrap-impl-base</artifactId>
          <scope>test</scope>
       </dependency>
+       <dependency>
+           <groupId>org.mockito</groupId>
+           <artifactId>mockito-core</artifactId>
+           <scope>test</scope>
+       </dependency>
    </dependencies>
 
    <build>

--- a/server/runtime/src/main/java/org/infinispan/server/Server.java
+++ b/server/runtime/src/main/java/org/infinispan/server/Server.java
@@ -45,7 +45,6 @@ import org.infinispan.commons.marshall.ProtoStreamTypeIds;
 import org.infinispan.commons.util.OS;
 import org.infinispan.commons.util.Util;
 import org.infinispan.commons.util.Version;
-import org.infinispan.commons.util.concurrent.CompletableFutures;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.configuration.global.ShutdownHookBehavior;
@@ -513,24 +512,23 @@ public class Server extends BaseServerManagement implements AutoCloseable {
                return;
             }
 
-            serverStateManager.start();
-
             try {
+               serverStateManager.start();
                backupManager.init();
-            } catch (IOException e) {
-               throw CompletableFutures.asCompletionException(e);
-            }
 
-            // Change status
-            SecurityActions.postStartProtocolServer(protocolServers.values());
-            log.serverStarted(Version.getBrandName(), Version.getBrandVersion(), uptime());
-            this.status = ComponentStatus.RUNNING;
-            if (Boolean.getBoolean("infinispan.shutdown.immediately")) {
-               r.complete(ExitStatus.SERVER_SHUTDOWN);
+               // Change status
+               SecurityActions.postStartProtocolServer(protocolServers.values());
+               log.serverStarted(Version.getBrandName(), Version.getBrandVersion(), uptime());
+               this.status = ComponentStatus.RUNNING;
+               if (Boolean.getBoolean("infinispan.shutdown.immediately")) {
+                  r.complete(ExitStatus.SERVER_SHUTDOWN);
+               }
+            } catch (Throwable t2) {
+               r.completeExceptionally(t2);
             }
          });
-      } catch (Exception e) {
-         r.completeExceptionally(e);
+      } catch (Throwable t) {
+         r.completeExceptionally(t);
       }
       return exit;
    }

--- a/server/runtime/src/test/java/org/infinispan/server/ProtocolInitializationTest.java
+++ b/server/runtime/src/test/java/org/infinispan/server/ProtocolInitializationTest.java
@@ -1,0 +1,114 @@
+package org.infinispan.server;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.infinispan.test.TestingUtil.withCacheManager;
+import static org.junit.Assume.assumeThat;
+import static org.mockito.ArgumentMatchers.eq;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.hamcrest.Matchers;
+import org.infinispan.commons.CacheConfigurationException;
+import org.infinispan.commons.test.junit.JUnitThreadTrackerRule;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.server.core.ProtocolServer;
+import org.infinispan.server.core.configuration.ProtocolServerConfiguration;
+import org.infinispan.server.hotrod.HotRodServer;
+import org.infinispan.server.hotrod.configuration.HotRodServerConfiguration;
+import org.infinispan.server.hotrod.configuration.HotRodServerConfigurationBuilder;
+import org.infinispan.server.resp.RespServer;
+import org.infinispan.server.resp.configuration.RespServerConfigurationBuilder;
+import org.infinispan.test.CacheManagerCallable;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import com.badlogic.gdx.utils.SharedLibraryLoadRuntimeException;
+
+import party.iroiro.luajava.lua51.Lua51;
+import party.iroiro.luajava.lua51.Lua51Natives;
+import party.iroiro.luajava.util.GlobalLibraryLoader;
+
+public class ProtocolInitializationTest {
+
+   @ClassRule
+   public static final JUnitThreadTrackerRule tracker = new JUnitThreadTrackerRule();
+
+   @Test
+   public void testRespServerStartWithLua() {
+      RespServer respServer = new RespServer();
+      withCacheManager(new CacheManagerCallable(TestCacheManagerFactory.createClusteredCacheManager()) {
+         @Override
+         public void call() {
+            RespServerConfigurationBuilder builder = new RespServerConfigurationBuilder();
+            executeLifecycle(respServer, builder.build(), cm);
+         }
+      });
+   }
+
+   @Test
+   public void testRespServerStartWithoutLua() {
+      try (MockedStatic<GlobalLibraryLoader> mockedStatic = Mockito.mockStatic(GlobalLibraryLoader.class)) {
+         mockedStatic.when(() -> GlobalLibraryLoader.load(eq("lua51")))
+               .thenThrow(new SharedLibraryLoadRuntimeException("Unable to locate the library path"));
+
+         RespServer respServer = new RespServer();
+         withCacheManager(new CacheManagerCallable(TestCacheManagerFactory.createClusteredCacheManager()) {
+            @Override
+            public void call() {
+               RespServerConfigurationBuilder builder = new RespServerConfigurationBuilder();
+               forceLuaNativeUnload(Lua51.class, "natives");
+               forceLuaNativeUnload(Lua51Natives.class, "loaded");
+               executeLifecycle(respServer, builder.build(), cm);
+            }
+         });
+      }
+   }
+
+   @Test
+   public void testTopologyCacheDefined() {
+      HotRodServer hotRodServer = new HotRodServer();
+      withCacheManager(new CacheManagerCallable(TestCacheManagerFactory.createClusteredCacheManager()) {
+         @Override
+         public void call() {
+            cm.defineConfiguration(HotRodServerConfiguration.TOPOLOGY_CACHE_NAME_PREFIX + "_hotrod", new ConfigurationBuilder().clustering().cacheMode(CacheMode.DIST_SYNC).build());
+            HotRodServerConfigurationBuilder builder = new HotRodServerConfigurationBuilder();
+            assertThatThrownBy(() -> executeLifecycle(hotRodServer, builder.build(), cm))
+                  .isInstanceOf(CacheConfigurationException.class);
+         }
+      });
+   }
+
+   @SuppressWarnings("rawtypes")
+   private <C extends ProtocolServerConfiguration> void executeLifecycle(ProtocolServer<C> server, C config, EmbeddedCacheManager cm) {
+      try {
+         server.start(config, cm);
+         server.postStart();
+      } finally {
+         server.stop();
+      }
+   }
+
+   private void forceLuaNativeUnload(Class<?> clazz, String fieldName) {
+      Exception exception = null;
+      try {
+         Field nativesField = clazz.getDeclaredField(fieldName);
+         nativesField.setAccessible(true);
+         AtomicReference<?> reference = (AtomicReference<?>) nativesField.get(null);
+         if (reference != null) {
+            reference.set(null);
+         } else {
+            exception = new NullPointerException("Native method reference is null");
+         }
+      } catch (Exception e) {
+         exception = e;
+      }
+
+      assumeThat(String.format("Failed unloading: %s#%s", clazz, fieldName), exception, Matchers.equalTo(null));
+   }
+}

--- a/server/tests/src/test/java/org/infinispan/server/resilience/NativeMissingResilienceIT.java
+++ b/server/tests/src/test/java/org/infinispan/server/resilience/NativeMissingResilienceIT.java
@@ -1,0 +1,164 @@
+package org.infinispan.server.resilience;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.infinispan.commons.util.Util.recursiveFileRemove;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
+import org.infinispan.commons.util.Util;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.server.resp.logging.Messages;
+import org.infinispan.server.test.core.ServerRunMode;
+import org.infinispan.server.test.core.TestSystemPropertyNames;
+import org.infinispan.server.test.core.tags.Resilience;
+import org.infinispan.server.test.junit5.InfinispanServerExtension;
+import org.infinispan.server.test.junit5.InfinispanServerExtensionBuilder;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ArchivePath;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.importer.ZipImporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.RedisCommandExecutionException;
+import io.lettuce.core.ScriptOutputType;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.sync.RedisCommands;
+
+@Resilience
+public class NativeMissingResilienceIT {
+
+   private static final String OTHER_SERVER_PATH;
+   static {
+      String directory = System.getProperty(TestSystemPropertyNames.INFINISPAN_TEST_SERVER_DIR);
+      Path source = Paths.get(directory);
+      Path target = source.resolve("..").resolve("infinispan-server-copied");
+      try {
+         target.toFile().mkdir();
+         Util.recursiveDirectoryCopy(source, target);
+      } catch (IOException e) {
+         throw new AssertionError("Could not copy directories", e);
+      }
+
+      OTHER_SERVER_PATH = target.toAbsolutePath().toString();
+   }
+
+   @RegisterExtension
+   public static InfinispanServerExtension EXTENSION = InfinispanServerExtensionBuilder.config("configuration/ClusteredServerTest.xml")
+         .numServers(1)
+         .runMode(ServerRunMode.CONTAINER)
+         .artifacts(NativeMissingResilienceIT.createMangledLuaJar())
+         .property(TestSystemPropertyNames.INFINISPAN_TEST_SERVER_PRESERVE_IMAGE, "false")
+         .property(TestSystemPropertyNames.INFINISPAN_TEST_SERVER_SNAPSHOT_IMAGE_NAME, "localhost/infinispan/server-invalid-lua-native-image")
+         .property(TestSystemPropertyNames.INFINISPAN_TEST_SERVER_DIR, OTHER_SERVER_PATH)
+         .build();
+
+   @Test
+   public void testUnresponsiveNode() {
+      try {
+         verifyCacheWorkingHotRod();
+         verifyCacheWorkingResp();
+         verifyCacheEvalHandleFailure();
+      } finally {
+         recursiveFileRemove(OTHER_SERVER_PATH);
+      }
+   }
+
+   private void verifyCacheWorkingHotRod() {
+      ConfigurationBuilder builder = new ConfigurationBuilder();
+      builder.socketTimeout(1000).connectionTimeout(1000).maxRetries(10).connectionPool().maxActive(1);
+      RemoteCache<String, String> cache = EXTENSION.hotrod().withClientConfiguration(builder).withCacheMode(CacheMode.REPL_SYNC).create();
+
+      cache.put("k1", "v1");
+      assertThat(cache.get("k1")).isEqualTo("v1");
+   }
+
+   private void verifyCacheWorkingResp() {
+      RedisClient client = RedisClient.create(EXTENSION.resp().connectionString(0));
+      try (StatefulRedisConnection<String, String> conn = client.connect()) {
+         RedisCommands<String, String> sync = conn.sync();
+         sync.set("k1", "v1");
+         assertThat(sync.get("k1")).isEqualTo("v1");
+      } finally {
+         client.shutdown();
+      }
+   }
+
+   private void verifyCacheEvalHandleFailure() {
+      RedisClient client = RedisClient.create(EXTENSION.resp().connectionString(0));
+      try (StatefulRedisConnection<String, String> conn = client.connect()) {
+         RedisCommands<String, String> redis = conn.sync();
+         assertThatThrownBy(() -> redis.eval("return redis.call('set', KEYS[1], ARGV[1])", ScriptOutputType.STATUS, new String[]{ "key", "value" }))
+               .isInstanceOf(RedisCommandExecutionException.class)
+               .hasMessageContaining(Messages.MESSAGES.scriptEngineDisabled());
+      }
+   }
+
+   private static Archive<?> createMangledLuaJar() {
+      // Create JAR from original server path.
+      String directory = System.getProperty(TestSystemPropertyNames.INFINISPAN_TEST_SERVER_DIR);
+      Path root = Paths.get(directory);
+      Path lib = root.resolve("lib");
+      try (Stream<Path> jars = Files.list(lib)) {
+         Optional<Path> jar = jars
+               .filter(Files::isRegularFile)
+               .filter(p -> p.getFileName().toString().startsWith("infinispan-lua51-platform-"))
+               .filter(p -> p.getFileName().toString().endsWith(".jar"))
+               .findFirst();
+         return jar.map(NativeMissingResilienceIT::createMangledLuaJar).orElse(null);
+      } catch (IOException e) {
+         throw new AssertionError("Could not create corrupted jar", e);
+      } finally {
+         // Remove the JAR from the copied server folder.
+         // The original must be kept.
+         destroyLuaJar();
+      }
+   }
+
+   private static void destroyLuaJar() {
+      Path lib = Path.of(OTHER_SERVER_PATH, "lib");
+      try (Stream<Path> jars = Files.list(lib)) {
+         Optional<Path> jar = jars
+               .filter(Files::isRegularFile)
+               .filter(p -> p.getFileName().toString().startsWith("infinispan-lua51-platform-"))
+               .filter(p -> p.getFileName().toString().endsWith(".jar"))
+               .findFirst();
+         if (jar.isEmpty())
+            return;
+
+         Path jarPath = jar.get();
+         if (!jarPath.toFile().delete()) {
+            System.out.println("Failed to delete jar: " + jarPath);
+         }
+      } catch (IOException e) {
+         throw new AssertionError("Could not destroy jar", e);
+      }
+   }
+
+   private static Archive<?> createMangledLuaJar(Path originalJar) {
+      Archive<?> archive = ShrinkWrap.create(ZipImporter.class, originalJar.getFileName().toString())
+            .importFrom(originalJar.toFile())
+            .as(JavaArchive.class);
+
+      List<ArchivePath> binaries = archive.getContent().keySet().stream()
+            .filter(p -> p.get().endsWith(".so") || p.get().endsWith(".dll"))
+            .toList();
+
+      for (ArchivePath binary : binaries) {
+         archive.delete(binary);
+      }
+
+      return archive;
+   }
+}


### PR DESCRIPTION
* Handle failures during post-start and disable the connector.
* Simulate failure with missing binaries.

Now the initialization also handles and logs any failures during the post-start phase.
Closes #16123.