### PR TITLE
[RESP] Added dependency for json/regex filter and fixed pattern syntax

### DIFF
--- a/build/configuration/pom.xml
+++ b/build/configuration/pom.xml
@@ -117,6 +117,7 @@
       <version.jgroups>5.5.1.Final</version.jgroups>
       <version.jgroups.raft>1.1.3.Final</version.jgroups.raft>
       <version.json-path>2.10.0</version.json-path>
+      <version.json-smart>2.6.0</version.json-smart>
       <version.jsr107>1.1.0</version.jsr107>
       <version.junit>4.13.2</version.junit>
       <version.junit5>5.14.1</version.junit5>

--- a/documentation/src/main/asciidoc/topics/ref_redis_commands.adoc
+++ b/documentation/src/main/asciidoc/topics/ref_redis_commands.adoc
@@ -159,6 +159,16 @@ NOTE: This implementation attempts to return all attributes that a real Redis se
 * link:https://redis.io/commands/json.forget[JSON.FORGET]
 
 * link:https://redis.io/commands/json.get[JSON.GET]
++
+[NOTE]
+=====
+ JSON filter with RegEx differencies from Redis implementation:
+
+1. Pattern could be expressed in Redis style "(i)pattern" or Java style "/.*pattern.*/i)".
+2. Dynamic filter with regex is not supported. i.e. `$.store.book[?(@.name =~ $.pattern)]` doesn't work.
+3. Filtering an array returns all matching elements and all nested arrays containing matching elements.
+
+=====
 
 * link:https://redis.io/commands/json.mset[JSON.MSET]
 +

--- a/server/resp/pom.xml
+++ b/server/resp/pom.xml
@@ -40,6 +40,11 @@
          <version>${version.json-path}</version>
       </dependency>
       <dependency>
+         <groupId>net.minidev</groupId>
+         <artifactId>json-smart</artifactId>
+         <version>${version.json-smart}</version>
+      </dependency>
+      <dependency>
          <groupId>org.infinispan</groupId>
          <artifactId>infinispan-scripting</artifactId>
       </dependency>

--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/json/JSONCommandArgumentReader.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/json/JSONCommandArgumentReader.java
@@ -40,7 +40,7 @@ public final class JSONCommandArgumentReader {
     public static CommandArgs readCommandArgs(List<byte[]> arguments,  byte[] key , int pos) {
         byte[] path = arguments.size() > pos ? arguments.get(pos) : DEFAULT_COMMAND_PATH;
         final byte[] jsonPath = JSONUtil.toJsonPath(path);
-        boolean isLegacy = path != jsonPath;
+        boolean isLegacy = !JSONUtil.isJsonPath(path);
         boolean isRoot = path.length == 1 && (path[0] == JSON_ROOT[0] || path[0] == DEFAULT_COMMAND_PATH[0]);
         return new CommandArgs(key, path, jsonPath, isLegacy, isRoot);
     }

--- a/server/resp/src/main/java/org/infinispan/server/resp/json/JsonGetFunction.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/json/JsonGetFunction.java
@@ -81,7 +81,7 @@ public class JsonGetFunction
          // Convert to jsonpath and set legacy=false if any path is a jsonpath
          List<byte[]> jsonPaths = paths.stream().map((p) -> {
             var jp = JSONUtil.toJsonPath(p);
-            isLegacy &= (jp != p);
+            isLegacy = isLegacy && !JSONUtil.isJsonPath(p);
             return jp;
          }).toList();
 

--- a/server/resp/src/test/java/org/infinispan/server/resp/JsonFilterCommandsTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/JsonFilterCommandsTest.java
@@ -1,0 +1,233 @@
+package org.infinispan.server.resp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.infinispan.test.TestingUtil.k;
+
+import java.util.List;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import io.lettuce.core.api.sync.RedisCommands;
+import io.lettuce.core.json.DefaultJsonParser;
+import io.lettuce.core.json.JsonPath;
+import io.lettuce.core.json.JsonValue;
+
+@Test(groups = "functional", testName = "server.resp.JsonFilterCommandsTest")
+public class JsonFilterCommandsTest extends SingleNodeRespBaseTest {
+   /**
+    * RESP JSON filter commands testing
+    *
+    * @since 15.2
+    */
+   private RedisCommands<String, String> redis;
+   private DefaultJsonParser defaultJsonParser = new DefaultJsonParser();
+
+   @BeforeMethod
+   public void initConnection() {
+      redis = redisConnection.sync();
+   }
+
+   @Test
+   public void testJSONGETWithFilterExpression() {
+      // Test JSONPath filter expressions with regex matching
+      JsonPath jpRoot = new JsonPath("$");
+      String key = k();
+
+      // JSON.SET doc $ '{"arr":["foo","bar","foobar","bazfoo","baz"]}'
+      JsonValue jv = defaultJsonParser.createJsonValue("""
+            {"arr":["foo","bar","foobar","bazfoo","baz"]}
+            """);
+      assertThat(redis.jsonSet(key, jpRoot, jv)).isEqualTo("OK");
+
+      // JSON.GET doc '$.arr[?(@ =~ ".*foo")]'
+      // Should return elements matching the regex pattern ".*foo"
+      JsonPath filterPath = new JsonPath("$.arr[?(@ =~ \".*foo\")]");
+      List<JsonValue> result = redis.jsonGet(key, filterPath);
+      assertThat(result).hasSize(1);
+      assertThat(result.get(0).asJsonArray().size()).isEqualTo(3);
+      assertThat(result.get(0).asJsonArray().asList())
+            .map(JsonValue::asString)
+            .containsExactly("foo", "foobar", "bazfoo");
+
+      // Same test with Java regex syntax
+      JsonPath javaFilterPath = new JsonPath("$.arr[?(@ =~ /.*foo.*/)]");
+      result = redis.jsonGet(key, javaFilterPath);
+      assertThat(result).hasSize(1);
+      assertThat(result.get(0).asJsonArray().size()).isEqualTo(3);
+      assertThat(result.get(0).asJsonArray().asList())
+            .map(JsonValue::asString)
+            .containsExactly("foo", "foobar", "bazfoo");
+
+      // Test with different filter: exact match
+      // JSON.GET doc $.arr[?(@ == "bar")]
+      JsonPath exactMatchPath = new JsonPath("$.arr[?(@ == \"bar\")]");
+      result = redis.jsonGet(key, exactMatchPath);
+      assertThat(result).hasSize(1);
+      assertThat(result.get(0).asJsonArray().size()).isEqualTo(1);
+      assertThat(result.get(0).asJsonArray().getFirst().asString()).isEqualTo("bar");
+
+      // Test with numeric array and comparison filter
+      // JSON.SET doc2 $ '{"nums":[1,5,10,15,20,25]}'
+      String key2 = k(2);
+      JsonValue jv2 = defaultJsonParser.createJsonValue("""
+            {"nums":[1,5,10,15,20,25]}
+            """);
+      assertThat(redis.jsonSet(key2, jpRoot, jv2)).isEqualTo("OK");
+
+      // JSON.GET doc2 $.nums[?(@ > 10)]
+      JsonPath numFilterPath = new JsonPath("$.nums[?(@ > 10)]");
+      result = redis.jsonGet(key2, numFilterPath);
+      assertThat(result).hasSize(1);
+      assertThat(result.get(0).asJsonArray().size()).isEqualTo(3);
+      assertThat(result.get(0).asJsonArray().asList())
+            .map(JsonValue::asNumber)
+            .map(Number::intValue)
+            .containsExactly(15, 20, 25);
+
+      // Test with object array and nested property filter
+      // JSON.SET doc3 $ '{"items":[{"name":"foo","price":10},{"name":"bar","price":20},{"name":"foobar","price":15}]}'
+      String key3 = k(3);
+      JsonValue jv3 = defaultJsonParser.createJsonValue("""
+            {"items":[{"name":"foo","price":10},{"name":"bar","price":20},{"name":"foobar","price":15}]}
+            """);
+      assertThat(redis.jsonSet(key3, jpRoot, jv3)).isEqualTo("OK");
+
+      // JSON.GET doc3 $.items[?(@.price > 10)]
+      JsonPath objFilterPath = new JsonPath("$.items[?(@.price > 10)]");
+      result = redis.jsonGet(key3, objFilterPath);
+      assertThat(result).hasSize(1);
+      assertThat(result.get(0).asJsonArray().size()).isEqualTo(2);
+      // Should return the two items with price > 10
+      String resultStr = result.get(0).toString();
+      assertThat(resultStr).isEqualTo("[{\"name\":\"bar\",\"price\":20},{\"name\":\"foobar\",\"price\":15}]");
+
+      // Test with complex array and regex filter
+      // JSON.SET doc4 $ '{"arr": ["kaboom", "kafoosh", "four", "bar", 7.0, "foolish", ["FoO", "fight"]]}'
+      String key4 = k(4);
+      JsonValue jv4 = defaultJsonParser.createJsonValue("""
+            {"arr": ["kaboom", "kafoosh", "four", "bar", 7.0, "foolish", ["FoO", "fight"]]}
+            """);
+      assertThat(redis.jsonSet(key4, jpRoot, jv4)).isEqualTo("OK");
+
+      // JSON.GET doc4 '$.arr[?(@ =~ "foo")]' - should match "kafoosh", "foolish" (case-sensitive partial match)
+      JsonPath fooFilterPath = new JsonPath("$.arr[?(@ =~ \"foo\")]");
+      result = redis.jsonGet(key4, fooFilterPath);
+      assertThat(result).hasSize(1);
+      assertThat(result.get(0).asJsonArray().size()).isEqualTo(2);
+      assertThat(result.get(0).asJsonArray().asList())
+            .map(JsonValue::asString)
+            .containsExactly("kafoosh", "foolish");
+
+      // JSON.GET doc4 '$.arr[?(@ =~ "^ka")]' - should match "kaboom", "kafoosh" (starts with "ka")
+      JsonPath kaFilterPath = new JsonPath("$.arr[?(@ =~ \"^ka\")]");
+      result = redis.jsonGet(key4, kaFilterPath);
+      assertThat(result).hasSize(1);
+      assertThat(result.get(0).asJsonArray().size()).isEqualTo(2);
+      assertThat(result.get(0).asJsonArray().asList())
+            .map(JsonValue::asString)
+            .containsExactly("kaboom", "kafoosh");
+   }
+
+   @Test
+   public void testJSONGETWithDynamicFilter() {
+      // Test JSONPath filter expressions that compare document fields
+      JsonPath jpRoot = new JsonPath("$");
+      String key = k();
+
+      // Test comparing two numeric fields in the same object
+      // JSON.SET doc $ '{"products":[{"name":"laptop","price":1000,"discount":100},{"name":"mouse","price":50,"discount":60},{"name":"keyboard","price":80,"discount":20}]}'
+      JsonValue jv = defaultJsonParser.createJsonValue("""
+            {"products":[
+               {"name":"laptop","price":1000,"discount":100},
+               {"name":"mouse","price":50,"discount":60},
+               {"name":"keyboard","price":80,"discount":20}
+            ]}
+            """);
+      assertThat(redis.jsonSet(key, jpRoot, jv)).isEqualTo("OK");
+
+      // JSON.GET doc '$.products[?(@.price > @.discount)]' - should return items where price > discount
+      JsonPath filterPath = new JsonPath("$.products[?(@.price > @.discount)]");
+      List<JsonValue> result = redis.jsonGet(key, filterPath);
+      assertThat(result).hasSize(1);
+      assertThat(result.get(0).asJsonArray().size()).isEqualTo(2);
+      // Should return laptop and keyboard, but not mouse (50 < 60)
+      String resultStr = result.get(0).toString();
+      assertThat(resultStr).contains("laptop");
+      assertThat(resultStr).contains("keyboard");
+      assertThat(resultStr).doesNotContain("mouse");
+
+      // Test with equality comparison
+      // JSON.SET doc2 $ '{"users":[{"name":"alice","age":30,"minAge":25},{"name":"bob","age":20,"minAge":20},{"name":"charlie","age":35,"minAge":40}]}'
+      String key2 = k(2);
+      JsonValue jv2 = defaultJsonParser.createJsonValue("""
+            {"users":[
+               {"name":"alice","age":30,"minAge":25},
+               {"name":"bob","age":20,"minAge":20},
+               {"name":"charlie","age":35,"minAge":40}
+            ]}
+            """);
+      assertThat(redis.jsonSet(key2, jpRoot, jv2)).isEqualTo("OK");
+
+      // JSON.GET doc2 '$.users[?(@.age >= @.minAge)]' - should return users where age >= minAge
+      JsonPath ageFilterPath = new JsonPath("$.users[?(@.age >= @.minAge)]");
+      result = redis.jsonGet(key2, ageFilterPath);
+      assertThat(result).hasSize(1);
+      assertThat(result.get(0).asJsonArray().size()).isEqualTo(2);
+      resultStr = result.get(0).toString();
+      assertThat(resultStr).contains("alice");
+      assertThat(resultStr).contains("bob");
+      assertThat(resultStr).doesNotContain("charlie");
+
+      // Test with string field comparison
+      // JSON.SET doc3 $ '{"items":[{"id":"A","category":"electronics","targetCategory":"electronics"},{"id":"B","category":"books","targetCategory":"electronics"},{"id":"C","category":"toys","targetCategory":"toys"}]}'
+      String key3 = k(3);
+      JsonValue jv3 = defaultJsonParser.createJsonValue("""
+            {"items":[
+               {"id":"A","category":"electronics","targetCategory":"electronics"},
+               {"id":"B","category":"books","targetCategory":"electronics"},
+               {"id":"C","category":"toys","targetCategory":"toys"}
+            ]}
+            """);
+      assertThat(redis.jsonSet(key3, jpRoot, jv3)).isEqualTo("OK");
+
+      // JSON.GET doc3 '$.items[?(@.category == @.targetCategory)]' - should return items where category matches targetCategory
+      JsonPath categoryFilterPath = new JsonPath("$.items[?(@.category == @.targetCategory)]");
+      result = redis.jsonGet(key3, categoryFilterPath);
+      assertThat(result).hasSize(1);
+      assertThat(result.get(0).asJsonArray().size()).isEqualTo(2);
+      resultStr = result.get(0).toString();
+      assertThat(resultStr).contains("\"id\":\"A\"");
+      assertThat(resultStr).contains("\"id\":\"C\"");
+      assertThat(resultStr).doesNotContain("\"id\":\"B\"");
+
+      // Test with complex comparison combining field comparison and constant
+      // JSON.SET doc4 $ '{"scores":[{"player":"alice","score":100,"threshold":80,"bonus":10},{"player":"bob","score":70,"threshold":80,"bonus":5},{"player":"charlie","score":90,"threshold":85,"bonus":15}]}'
+      String key4 = k(4);
+      JsonValue jv4 = defaultJsonParser.createJsonValue("""
+            {"scores":[
+               {"player":"alice","score":100,"threshold":80,"bonus":10},
+               {"player":"bob","score":70,"threshold":80,"bonus":5},
+               {"player":"charlie","score":90,"threshold":85,"bonus":15}
+            ],
+            "pattern": "bob"}
+            """);
+      assertThat(redis.jsonSet(key4, jpRoot, jv4)).isEqualTo("OK");
+
+      // JSON.GET doc4 '$.scores[?(@.score > @.threshold && @.bonus > 10)]' - combined filter
+      JsonPath combinedFilterPath = new JsonPath("$.scores[?(@.score > @.threshold && @.bonus > 10)]");
+      result = redis.jsonGet(key4, combinedFilterPath);
+      assertThat(result).hasSize(1);
+      assertThat(result.get(0).asJsonArray().size()).isEqualTo(1);
+      resultStr = result.get(0).toString();
+      assertThat(resultStr).contains("charlie");
+      assertThat(resultStr).doesNotContain("alice");
+      assertThat(resultStr).doesNotContain("bob");
+
+      // Test with pattern not in the current node
+      JsonPath dynFilterPath = new JsonPath("$.scores[?(@.player == $.pattern)]");
+      result = redis.jsonGet(key4, dynFilterPath);
+      assertThat(result).hasSize(1);
+      assertThat(result.get(0).asJsonArray().size()).isEqualTo(1);
+   }
+}

--- a/server/tests/src/test/java/org/infinispan/server/footprint/FootprintIT.java
+++ b/server/tests/src/test/java/org/infinispan/server/footprint/FootprintIT.java
@@ -31,8 +31,8 @@ public class FootprintIT {
    private static final int LOADED_CLASS_COUNT_UPPER_BOUND = 11_900;
    private static final long HEAP_USAGE_LOWER_BOUND = 24_500_000L;
    private static final long HEAP_USAGE_UPPER_BOUND = 28_000_000L;
-   private static final long DISK_USAGE_LOWER_BOUND = 76_000_000L;
-   private static final long DISK_USAGE_UPPER_BOUND = 77_500_000L;
+   private static final long DISK_USAGE_LOWER_BOUND = 77_500_000L;
+   private static final long DISK_USAGE_UPPER_BOUND = 79_000_000L;
 
    private static final int JACOCO_CLASS_COUNT = 165;
    private static final long JACOCO_HEAP_USAGE = 2_350_000L;


### PR DESCRIPTION
Fixes #16144 

When filtering with regex an additional dependecy is needed (net.minidev.json-smart)
Added conversion to support Redis style regex pattern.
Documented Redis/infinispan diff

