### PR TITLE
[#16130] Support Lucene 10

### DIFF
--- a/build/configuration/pom.xml
+++ b/build/configuration/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
@@ -120,7 +121,7 @@
       <version.junit>4.13.2</version.junit>
       <version.junit5>5.14.1</version.junit5>
       <version.log4j>2.25.2</version.log4j>
-      <version.lucene>9.12.1</version.lucene>
+      <!-- version.lucene is defined in the lucene profiles below -->
       <version.metainf-services>1.11</version.metainf-services>
       <version.micrometer>1.16.0</version.micrometer>
       <version.mockito>5.20.0</version.mockito>
@@ -256,4 +257,24 @@
          </plugin>
       </plugins>
    </build>
+
+   <profiles>
+      <profile>
+         <id>lucene9</id>
+         <activation>
+            <activeByDefault>true</activeByDefault>
+         </activation>
+         <properties>
+            <version.lucene>9.12.3</version.lucene>
+            <hibernate.search.backend.artifactId>hibernate-search-backend-lucene</hibernate.search.backend.artifactId>
+         </properties>
+      </profile>
+      <profile>
+         <id>lucene10</id>
+         <properties>
+            <version.lucene>10.2.2</version.lucene>
+            <hibernate.search.backend.artifactId>hibernate-search-backend-lucene-next</hibernate.search.backend.artifactId>
+         </properties>
+      </profile>
+   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -788,6 +788,11 @@
          </dependency>
          <dependency>
             <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-analysis-common</artifactId>
+            <version>${version.lucene}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-analyzers-common</artifactId>
             <version>${version.lucene}</version>
          </dependency>
@@ -804,6 +809,11 @@
          <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-grouping</artifactId>
+            <version>${version.lucene}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-highlighter</artifactId>
             <version>${version.lucene}</version>
          </dependency>
          <dependency>

--- a/query/pom.xml
+++ b/query/pom.xml
@@ -46,7 +46,7 @@
 
       <dependency>
          <groupId>org.hibernate.search</groupId>
-         <artifactId>hibernate-search-backend-lucene</artifactId>
+         <artifactId>${hibernate.search.backend.artifactId}</artifactId>
       </dependency>
 
       <dependency>

--- a/query/src/main/java/org/infinispan/query/core/impl/Log.java
+++ b/query/src/main/java/org/infinispan/query/core/impl/Log.java
@@ -253,6 +253,10 @@ public interface Log extends BasicLogger {
    @Message(value = "Hibernate Search updates are not keeping up. Look into increasing index writer queue and/or thread pool sizes.", id = 14067)
    CacheBackpressureFullException hibernateSearchBackpressure();
 
+   @LogMessage(level = INFO)
+   @Message(value = "Lucene version: %s", id = 14068)
+   void luceneBackendVersion(String version);
+
    @Message(id = 14501, value = "Exception while retrieving the type model for '%1$s'.")
    SearchException errorRetrievingTypeModel(@FormatWith(ClassFormatter.class) Class<?> clazz, @Cause Exception cause);
 

--- a/query/src/main/java/org/infinispan/query/impl/LifecycleManager.java
+++ b/query/src/main/java/org/infinispan/query/impl/LifecycleManager.java
@@ -20,8 +20,8 @@ import java.util.concurrent.ConcurrentMap;
 
 import javax.management.ObjectName;
 
-import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.util.Version;
 import org.hibernate.search.backend.lucene.work.spi.LuceneWorkExecutorProvider;
 import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
@@ -89,7 +89,7 @@ import org.infinispan.util.logging.Log;
 public class LifecycleManager implements ModuleLifecycle {
 
    /**
-    * Optional integer system property that sets value of {@link BooleanQuery#setMaxClauseCount}.
+    * Optional integer system property that sets value of {@link IndexSearcher#setMaxClauseCount}.
     */
    public static final String MAX_BOOLEAN_CLAUSES_SYS_PROP = "infinispan.query.lucene.max-boolean-clauses";
 
@@ -439,6 +439,7 @@ public class LifecycleManager implements ModuleLifecycle {
       ctxRegistry.addContextInitializer(PERSISTENCE, new PersistenceContextInitializerImpl());
       ctxRegistry.addContextInitializer(GLOBAL, new org.infinispan.query.core.impl.GlobalContextInitializerImpl());
       ctxRegistry.addContextInitializer(GLOBAL, new GlobalContextInitializerImpl());
+      CONTAINER.luceneBackendVersion(Version.LATEST.toString());
    }
 
    @Override


### PR DESCRIPTION
Closes #16130

By default this compiles and tests against Lucene 9.x as usual.
Enable the `lucene10` profile and it will use Lucene 10.x (which requires JDK 21). The `lucene10` profile can then be enabled by default when we bump the server JDK requirement (it can even be done now for the server image).