### PR TITLE
[#16152] RESP ARRPOP, fix error handling on on array

### DIFF
--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/json/JSONARRPOP.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/json/JSONARRPOP.java
@@ -48,8 +48,13 @@ public class JSONARRPOP extends RespCommand implements Resp3Command {
                 return;
             }
             if (!c.isEmpty()) {
-                writer.string(c.get(c.size() - 1));
-                return;
+                // Find and write the last non-null element
+                for (int i = c.size() - 1; i >= 0; i--) {
+                    if (c.get(i) != null) {
+                        writer.string(c.get(i));
+                        return;
+                    }
+                }
             }
             writer.error("-ERR Path '" + RespUtil.utf8(path) + "' does not exist or not an array");
         };

--- a/server/resp/src/test/java/org/infinispan/server/resp/JsonCommandsTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/JsonCommandsTest.java
@@ -1356,6 +1356,19 @@ public class JsonCommandsTest extends SingleNodeRespBaseTest {
       assertThat(result.toString()).isEqualTo("[4]");
       result = redis.jsonArrpop(key, jp , 0);
       assertThat(result.toString()).isEqualTo("[1]");
+
+      // Test pop on non-array element (JSONPath - should return array with null)
+      redis.jsonSet(key, jpRoot, jv);
+      JsonPath jpNonArray = new JsonPath("$.foo");
+      result = redis.jsonArrpop(key, jpNonArray, 0);
+      assertThat(result).hasSize(1);
+      assertThat(result.toString()).isEqualTo("[null]");
+
+      // Test pop on non-array element (legacy path - should also throw exception)
+      JsonPath jpLegacyNonArray = new JsonPath(".foo");
+      assertThatThrownBy(() -> redis.jsonArrpop(key, jpLegacyNonArray, 0))
+            .isInstanceOf(RedisCommandExecutionException.class)
+            .hasMessage("ERR Path '$.foo' does not exist or not an array");
    }
 
    @Test


### PR DESCRIPTION
Fixes #16152 

If legacy path is used, return error instead of null if arrpop is not executed against array