### PR TITLE
[#16188] RestContainerListenerTest adapted for rolling upgrades

### DIFF
--- a/server/tests/src/test/java/org/infinispan/server/functional/rest/RestContainerListenerTest.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/rest/RestContainerListenerTest.java
@@ -19,10 +19,10 @@ import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.commons.dataconversion.internal.Json;
 import org.infinispan.rest.resources.WeakSSEListener;
 import org.infinispan.server.functional.ClusteredIT;
-import org.infinispan.server.test.junit5.InfinispanServerExtension;
+import org.infinispan.server.test.api.TestClientDriver;
+import org.infinispan.server.test.junit5.InfinispanServer;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
@@ -36,8 +36,8 @@ import org.testcontainers.shaded.org.yaml.snakeyaml.Yaml;
  */
 public class RestContainerListenerTest {
 
-   @RegisterExtension
-   public static InfinispanServerExtension SERVERS = ClusteredIT.SERVERS;
+   @InfinispanServer(ClusteredIT.class)
+   public static TestClientDriver SERVERS;
 
    static class ArgsProvider implements ArgumentsProvider {
       @Override


### PR DESCRIPTION
* Utilize the correct annotation.

The `RestContainerListenerTest` is the second-to-last test to run. Because of the incorrect annotation, it wouldn't register the proper coverage for the tests run before it.

Closes #16188.