### PR TITLE
[#16182] Default Hibernate 2LC configuration references obsolete JGroups resource location.

### DIFF
--- a/hibernate/cache-commons/src/main/resources/org/infinispan/hibernate/cache/commons/builder/infinispan-configs.xml
+++ b/hibernate/cache-commons/src/main/resources/org/infinispan/hibernate/cache/commons/builder/infinispan-configs.xml
@@ -5,7 +5,7 @@
         xmlns="urn:infinispan:config:${infinispan.core.schema.version}">
 
    <jgroups>
-      <stack-file name="hibernate-jgroups" path="${hibernate.cache.infinispan.jgroups_cfg:default-configs/default-jgroups-tcp.xml}"/>
+      <stack-file name="hibernate-jgroups" path="${hibernate.cache.infinispan.jgroups_cfg:org/infinispan/configuration/default-jgroups-tcp.xml}"/>
    </jgroups>
 
    <cache-container name="SampleCacheManager" statistics="false" default-cache="the-default-cache" shutdown-hook="DEFAULT">


### PR DESCRIPTION
Fixes #16182

Still references old (15.2.x) location.