### PR TITLE
[#16231] Custom Module archetype doesn't work

### DIFF
--- a/archetypes/custom-module/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/custom-module/src/main/resources/archetype-resources/pom.xml
@@ -5,8 +5,8 @@
     <artifactId>\${artifactId}</artifactId>
     <packaging>jar</packaging>
     <version>\${version}</version>
-    <name>Server Task</name>
-    <description>Archetype project for building Server Task for use within Infinispan</description>
+    <name>Custom Module</name>
+    <description>Archetype project for building Custom Module for use within Infinispan</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -37,11 +37,6 @@
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-component-processor</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.kohsuke.metainf-services</groupId>
-            <artifactId>metainf-services</artifactId>
-            <version>${versionx.org.kohsuke.metainf-services.metainf-services}</version>
         </dependency>
     </dependencies>
 
@@ -81,6 +76,12 @@
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>
                     <encoding>UTF-8</encoding>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.infinispan</groupId>
+                            <artifactId>infinispan-component-processor</artifactId>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
         </plugins>

--- a/archetypes/custom-module/src/main/resources/archetype-resources/src/main/java/CustomListener.java
+++ b/archetypes/custom-module/src/main/resources/archetype-resources/src/main/java/CustomListener.java
@@ -1,0 +1,27 @@
+package ${package};
+
+import org.infinispan.notifications.Listener;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryCreated;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryModified;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryRemoved;
+import org.infinispan.notifications.cachelistener.event.CacheEntryCreatedEvent;
+import org.infinispan.notifications.cachelistener.event.CacheEntryModifiedEvent;
+import org.infinispan.notifications.cachelistener.event.CacheEntryRemovedEvent;
+
+@Listener(clustered = true, observation = Listener.Observation.POST)
+public class CustomListener {
+   @CacheEntryCreated
+   public void entryCreated(CacheEntryCreatedEvent<Object, Object> event) {
+      System.out.println("entryCreated " + event);
+   }
+
+   @CacheEntryModified
+   public void entryModified(CacheEntryModifiedEvent<String, String> event) {
+      System.out.println("entryModified: " + event);
+   }
+
+   @CacheEntryRemoved
+   public void entryRemoved(CacheEntryRemovedEvent<String, String> event) {
+      System.out.println("entryRemoved " + event);
+   }
+}

--- a/archetypes/custom-module/src/main/resources/archetype-resources/src/main/java/CustomModule.java
+++ b/archetypes/custom-module/src/main/resources/archetype-resources/src/main/java/CustomModule.java
@@ -1,6 +1,8 @@
 package ${package};
 
+import org.infinispan.Cache;
 import org.infinispan.configuration.global.GlobalConfiguration;
+import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.factories.GlobalComponentRegistry;
 import org.infinispan.factories.annotations.InfinispanModule;
 import org.infinispan.lifecycle.ModuleLifecycle;
@@ -16,6 +18,14 @@ public class CustomModule implements ModuleLifecycle {
          // Print out welcome message from CustomModuleConfiguration. If the message attribute hasn't been overridden in
          // the config, then the default message is printed
          System.out.println("Custom Module Message: " + config.message());
+      } else {
+         System.out.println("Custom Module namespace was not configured");
       }
+   }
+
+   @Override
+   public void cacheStarted(ComponentRegistry cr, String cacheName) {
+      System.out.println("Cache " + cacheName + " started!");
+      cr.getComponent(Cache.class).addListener(new CustomListener());
    }
 }

--- a/archetypes/store/src/main/resources/archetype-resources/src/main/java/CustomStoreConfiguration.java
+++ b/archetypes/store/src/main/resources/archetype-resources/src/main/java/CustomStoreConfiguration.java
@@ -19,7 +19,7 @@ public class CustomStoreConfiguration extends AbstractStoreConfiguration {
    }
 
    public CustomStoreConfiguration(AttributeSet attributes, AsyncStoreConfiguration async) {
-      super(attributes, async);
+      super(Element.CUSTOM_STORE, attributes, async);
       // TODO Auto-generated constructor stub
    }
 }

--- a/archetypes/store/src/main/resources/archetype-resources/src/main/java/Element.java
+++ b/archetypes/store/src/main/resources/archetype-resources/src/main/java/Element.java
@@ -1,0 +1,53 @@
+package ${package};
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * An enumeration of all the recognized XML element local names for the DummyInMemory cache store
+ */
+public enum Element {
+   // must be first
+   UNKNOWN(null),
+
+   CUSTOM_STORE("custom-store");
+
+   private final String name;
+
+   Element(final String name) {
+      this.name = name;
+   }
+
+   /**
+    * Get the local name of this element.
+    *
+    * @return the local name
+    */
+   public String getLocalName() {
+      return name;
+   }
+
+   private static final Map<String, Element> MAP;
+
+   static {
+      final Map<String, Element> map = new HashMap<String, Element>(8);
+      for (Element element : values()) {
+         final String name = element.getLocalName();
+         if (name != null) {
+            map.put(name, element);
+         }
+      }
+      MAP = map;
+   }
+
+   public static Element forName(final String localName) {
+      final Element element = MAP.get(localName);
+      return element == null ? UNKNOWN : element;
+   }
+
+   @Override
+   public String toString() {
+      return name;
+   }
+
+}


### PR DESCRIPTION
Fixes #16231

Added a custom listener that prints every entry modification for all caches as well as an example.
Also fixed issue with custom store that didn't compile with new store configuration.