### PR TITLE
[#16266] Per-version test configuration files

### DIFF
--- a/build/configuration/pom.xml
+++ b/build/configuration/pom.xml
@@ -48,7 +48,7 @@
       <infinispan.olm.name>infinispan</infinispan.olm.name>
       <infinispan.gpg.key>9E31AB27445478DB</infinispan.gpg.key>
       <!-- This should be updated to a stable version from the previous release -->
-      <infinispan.old.version>16.0.2</infinispan.old.version>
+      <infinispan.old.version>16.0.3</infinispan.old.version>
 
       <wildfly.brand.name>WildFly</wildfly.brand.name>
       <wildfly.brand.prefix>wildfly</wildfly.brand.prefix>

--- a/server/rollingupgradetests/pom.xml
+++ b/server/rollingupgradetests/pom.xml
@@ -211,6 +211,7 @@
                <disableXmlReport>false</disableXmlReport>
                <useFile>false</useFile>
                <systemPropertyVariables>
+                  <infinispan.old.version>${infinispan.old.version}</infinispan.old.version>
                   <infinispan.cluster.stack>${infinispan.cluster.stack}</infinispan.cluster.stack>
                   <jgroups.bind_addr>127.0.0.1</jgroups.bind_addr>
                   <jgroups.join_timeout>2000</jgroups.join_timeout>

--- a/server/rollingupgradetests/src/test/java/org/infinispan/server/rollingupgrade/RollingUpgradeTestUtil.java
+++ b/server/rollingupgradetests/src/test/java/org/infinispan/server/rollingupgrade/RollingUpgradeTestUtil.java
@@ -7,20 +7,27 @@ import static org.infinispan.server.test.core.TestSystemPropertyNames.INFINISPAN
 import java.nio.file.Path;
 import java.util.Objects;
 
+import org.infinispan.commons.util.Version;
+import org.infinispan.server.test.core.rollingupgrade.RollingUpgradeVersion;
+
 public class RollingUpgradeTestUtil {
-   public static String getFromVersion() {
-      return System.getProperty(INFINISPAN_ROLLING_UPGRADE_FROM_VERSION, "latest");
+   private static final String INFINISPAN_OLD_VERSION = "infinispan.old.version";
+
+   public static RollingUpgradeVersion getFromVersion() {
+      String label = System.getProperty(INFINISPAN_ROLLING_UPGRADE_FROM_VERSION, "latest");
+      String version = System.getProperty(INFINISPAN_OLD_VERSION, "16.0.3");
+      return new RollingUpgradeVersion(label, version);
    }
 
-   public static String getToVersion() {
+   public static RollingUpgradeVersion getToVersion() {
       String toVersion = System.getProperty(INFINISPAN_ROLLING_UPGRADE_TO_VERSION);
       if (toVersion != null) {
-         return toVersion;
+         return new RollingUpgradeVersion(toVersion, toVersion);
       }
       // This variable by default is set to the SNAPSHOT test directory in the pom.xml, but can be overridden if needed
       String testServerDir = System.getProperty(INFINISPAN_TEST_SERVER_DIR);
       Objects.requireNonNull(testServerDir, INFINISPAN_TEST_SERVER_DIR + " or " +
             INFINISPAN_ROLLING_UPGRADE_TO_VERSION + " must be defined in the system properties.");
-      return "file://" + Path.of(testServerDir).normalize();
+      return new RollingUpgradeVersion("file://" + Path.of(testServerDir).normalize(), Version.getVersion());
    }
 }

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/core/rollingupgrade/RollingUpgradeConfiguration.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/core/rollingupgrade/RollingUpgradeConfiguration.java
@@ -11,7 +11,7 @@ import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
 import org.infinispan.server.test.core.InfinispanServerListener;
 import org.jboss.shrinkwrap.api.Archive;
 
-public record RollingUpgradeConfiguration(int nodeCount, String fromVersion, String toVersion, String name,
+public record RollingUpgradeConfiguration(int nodeCount, RollingUpgradeVersion fromVersion, RollingUpgradeVersion toVersion, String name,
                                           String jgroupsProtocol, int serverCheckTimeSecs, boolean useSharedDataMount,
                                           String serverConfigurationFile, boolean defaultServerConfigurationFile,
                                           Properties properties, Archive<?>[] customArtifacts, String[] mavenArtifacts,

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/core/rollingupgrade/RollingUpgradeConfigurationBuilder.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/core/rollingupgrade/RollingUpgradeConfigurationBuilder.java
@@ -21,8 +21,8 @@ import org.infinispan.server.test.core.InfinispanServerListener;
 import org.jboss.shrinkwrap.api.Archive;
 
 public class RollingUpgradeConfigurationBuilder {
-   private final String fromVersion;
-   private final String toVersion;
+   private final RollingUpgradeVersion fromVersion;
+   private final RollingUpgradeVersion toVersion;
    private final String name;
 
    private int nodeCount = 3;
@@ -78,7 +78,7 @@ public class RollingUpgradeConfigurationBuilder {
       };
    }
 
-   public RollingUpgradeConfigurationBuilder(String name, String fromVersion, String toVersion) {
+   public RollingUpgradeConfigurationBuilder(String name, RollingUpgradeVersion fromVersion, RollingUpgradeVersion toVersion) {
       this.fromVersion = Objects.requireNonNull(fromVersion);
       this.toVersion = Objects.requireNonNull(toVersion);
       this.name = name;

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/core/rollingupgrade/RollingUpgradeHandler.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/core/rollingupgrade/RollingUpgradeHandler.java
@@ -1,17 +1,16 @@
 package org.infinispan.server.test.core.rollingupgrade;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.lang.invoke.MethodHandles;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -21,8 +20,6 @@ import org.infinispan.client.hotrod.configuration.ClientIntelligence;
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
 import org.infinispan.client.rest.RestClient;
 import org.infinispan.client.rest.configuration.RestClientConfigurationBuilder;
-import org.infinispan.commons.maven.MavenArtifact;
-import org.infinispan.commons.test.CommonsTestingUtil;
 import org.infinispan.commons.util.OS;
 import org.infinispan.commons.util.Util;
 import org.infinispan.server.Server;
@@ -34,12 +31,9 @@ import org.infinispan.server.test.core.InfinispanServerTestConfiguration;
 import org.infinispan.server.test.core.ServerConfigBuilder;
 import org.infinispan.server.test.core.ServerRunMode;
 import org.infinispan.server.test.core.TestSystemPropertyNames;
-import org.infinispan.server.test.core.Unzip;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.cluster.RedisClusterClient;
@@ -51,7 +45,7 @@ public class RollingUpgradeHandler {
                                  ContainerInfinispanServerDriver containerInfinispanServerDriver) {
    }
 
-   private static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
+   static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
 
    private final RollingUpgradeConfiguration configuration;
 
@@ -61,8 +55,8 @@ public class RollingUpgradeHandler {
    // Holds a value of how many nodes are left to upgrade
    private int nodeLeft;
 
-   private final String versionFrom;
-   private final String versionTo;
+   private final RollingUpgradeVersion versionFrom;
+   private final RollingUpgradeVersion versionTo;
 
    private String toImageCreated;
    private String fromImageCreated;
@@ -239,29 +233,20 @@ public class RollingUpgradeHandler {
       try {
          log.debugf("Starting %d nodes to version %s in cluster %s", handler.nodeCount, handler.versionFrom, handler.clusterName);
          final Archive<?>[] artifacts;
-         try {
-            if (configuration.customArtifacts().length > 0) {
-               // If possible, use the "fromVersion" artifacts
-               MavenArtifact mavenArtifacts = new MavenArtifact("org.infinispan", "infinispan-server-tests", configuration.fromVersion(), "artifacts");
-               Path artifactsZip = mavenArtifacts.resolveArtifact("zip");
-               if (artifactsZip == null) {
-                  artifacts = configuration.customArtifacts();
-                  log.warnf("Could not download custom artifacts for version %s using %s. Failures may happen", configuration.fromVersion(), mavenArtifacts);
-               } else {
-                  artifacts = Unzip.unzip(artifactsZip, Paths.get(CommonsTestingUtil.tmpDirectory(), configuration.fromVersion()))
-                        .stream().map(p -> ShrinkWrap.createFromZipFile(JavaArchive.class, p.toFile()))
-                        .toArray(i -> new Archive<?>[i]);
-                  log.infof("Custom artifacts for version %s using %s", configuration.fromVersion(), mavenArtifacts);
-               }
-            } else {
-               artifacts = configuration.customArtifacts();
-            }
-         } catch (IOException e) {
-            throw new UncheckedIOException(e);
+         if (configuration.customArtifacts().length > 0) {
+            // If possible, use the "fromVersion" artifacts
+            artifacts = Optional.ofNullable(VersionInterop.loadVersionedArtifacts(handler.versionFrom.version()))
+                  .orElseGet(configuration::customArtifacts);
+         } else {
+            artifacts = configuration.customArtifacts();
          }
 
+         String serverConfiguration = Optional.ofNullable(VersionInterop.loadVersionedConfigurations(handler.versionFrom.version()))
+               .map(p -> p.toAbsolutePath().toString())
+               .orElse("");
+
          handler.fromDriver = handler.startNode(VersionType.FROM, configuration.nodeCount(), configuration.nodeCount(),
-               configuration.jgroupsProtocol(), null, configuration.serverConfigurationFile(),
+               configuration.jgroupsProtocol(), null, String.format("%s/%s", serverConfiguration, configuration.serverConfigurationFile()),
                configuration.defaultServerConfigurationFile(), artifacts,
                configuration.mavenArtifacts(), configuration.properties(), configuration.listeners());
          handler.currentState = STATE.OLD_RUNNING;
@@ -366,11 +351,11 @@ public class RollingUpgradeHandler {
 
    public void close() {
       if (fromDriver != null) {
-         fromDriver.containerInfinispanServerDriver.stop(configuration.fromVersion());
+         fromDriver.containerInfinispanServerDriver.stop(configuration.fromVersion().imageLabel());
          fromDriver = null;
       }
       if (toDriver != null) {
-         toDriver.containerInfinispanServerDriver.stop(configuration.toVersion());
+         toDriver.containerInfinispanServerDriver.stop(configuration.toVersion().imageLabel());
          toDriver = null;
       }
 
@@ -450,7 +435,9 @@ public class RollingUpgradeHandler {
          builder.property(TestSystemPropertyNames.INFINISPAN_TEST_SERVER_CONTAINER_VOLUME_REQUIRED, "true");
       }
 
-      String versionToUse = versionType == VersionType.TO ? configuration.toVersion() : configuration.fromVersion();
+      String versionToUse = versionType == VersionType.TO
+            ? configuration.toVersion().imageLabel()
+            : configuration.fromVersion().imageLabel();
       String name = (siteName != null ? siteName : "") + clusterName + "-";
 
       if (versionToUse.startsWith("image://")) {

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/core/rollingupgrade/RollingUpgradeVersion.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/core/rollingupgrade/RollingUpgradeVersion.java
@@ -1,0 +1,3 @@
+package org.infinispan.server.test.core.rollingupgrade;
+
+public record RollingUpgradeVersion(String imageLabel, String version) { }

--- a/server/testdriver/core/src/main/java/org/infinispan/server/test/core/rollingupgrade/VersionInterop.java
+++ b/server/testdriver/core/src/main/java/org/infinispan/server/test/core/rollingupgrade/VersionInterop.java
@@ -1,0 +1,57 @@
+package org.infinispan.server.test.core.rollingupgrade;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.infinispan.commons.maven.MavenArtifact;
+import org.infinispan.commons.test.CommonsTestingUtil;
+import org.infinispan.server.test.core.Unzip;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+
+final class VersionInterop {
+
+   private static final String GROUP_ID = "org.infinispan";
+   private static final String ARTIFACT_ID = "infinispan-server-tests";
+   private static final String ARTIFACT_CLASSIFIER = "artifacts";
+   private static final String CONFIGURATIONS_CLASSIFIER = "configurations";
+
+   public static Archive<?>[] loadVersionedArtifacts(String version) {
+      try {
+         MavenArtifact mavenArtifacts = new MavenArtifact(GROUP_ID, ARTIFACT_ID, version, ARTIFACT_CLASSIFIER);
+         Path artifactsZip = mavenArtifacts.resolveArtifact("zip");
+         if (artifactsZip == null) {
+            RollingUpgradeHandler.log.warnf("Could not download custom artifacts for version %s using %s. Failures may happen", version, mavenArtifacts);
+            return null;
+         }
+
+         RollingUpgradeHandler.log.infof("Custom artifacts for version %s using %s", version, mavenArtifacts);
+         return Unzip.unzip(artifactsZip, Paths.get(CommonsTestingUtil.tmpDirectory(), version))
+               .stream().map(p -> ShrinkWrap.createFromZipFile(JavaArchive.class, p.toFile()))
+               .toArray(i -> new Archive<?>[i]);
+      } catch (IOException e) {
+         throw new UncheckedIOException(e);
+      }
+   }
+
+   public static Path loadVersionedConfigurations(String version) {
+      try {
+         MavenArtifact mavenArtifacts =  new MavenArtifact(GROUP_ID, ARTIFACT_ID, version, CONFIGURATIONS_CLASSIFIER);
+         Path configurationsZip = mavenArtifacts.resolveArtifact("zip");
+         if (configurationsZip == null) {
+            RollingUpgradeHandler.log.warnf("Could not download custom configurations for version %s using %s. Failures may happen", version, mavenArtifacts);
+            return null;
+         }
+
+         RollingUpgradeHandler.log.infof("Configurations for version %s using %s", version, mavenArtifacts);
+         Path target = Paths.get(CommonsTestingUtil.tmpDirectory(), version);
+         Unzip.unzip(configurationsZip, target);
+         return target;
+      } catch (IOException e) {
+         throw new UncheckedIOException(e);
+      }
+   }
+}

--- a/server/testdriver/junit5/src/main/java/org/infinispan/server/test/junit5/RollingUpgradeHandlerExtension.java
+++ b/server/testdriver/junit5/src/main/java/org/infinispan/server/test/junit5/RollingUpgradeHandlerExtension.java
@@ -16,6 +16,7 @@ import org.infinispan.server.test.core.TestServer;
 import org.infinispan.server.test.core.rollingupgrade.CombinedInfinispanServerDriver;
 import org.infinispan.server.test.core.rollingupgrade.RollingUpgradeConfigurationBuilder;
 import org.infinispan.server.test.core.rollingupgrade.RollingUpgradeHandler;
+import org.infinispan.server.test.core.rollingupgrade.RollingUpgradeVersion;
 import org.jboss.shrinkwrap.api.Archive;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
@@ -32,15 +33,15 @@ public class RollingUpgradeHandlerExtension extends AbstractServerExtension impl
       this.configurationBuilder = configurationBuilder;
    }
 
-   public static RollingUpgradeHandlerExtension from(Class<?> caller, InfinispanServerExtensionBuilder iseb, String fromVersion, String toVersion) {
+   public static RollingUpgradeHandlerExtension from(Class<?> caller, InfinispanServerExtensionBuilder iseb, RollingUpgradeVersion fromVersion, RollingUpgradeVersion toVersion) {
       return new RollingUpgradeHandlerExtension(convertBuilder(caller, iseb, fromVersion, toVersion));
    }
 
-   public static RollingUpgradeConfigurationBuilder convertBuilder(Class<?> caller, InfinispanServerExtensionBuilder iseb, String fromVersion, String toVersion) {
+   public static RollingUpgradeConfigurationBuilder convertBuilder(Class<?> caller, InfinispanServerExtensionBuilder iseb, RollingUpgradeVersion fromVersion, RollingUpgradeVersion toVersion) {
       return convertBuilder(caller.getName(), iseb, fromVersion, toVersion);
    }
 
-   public static RollingUpgradeConfigurationBuilder convertBuilder(String name, InfinispanServerExtensionBuilder iseb, String fromVersion, String toVersion) {
+   public static RollingUpgradeConfigurationBuilder convertBuilder(String name, InfinispanServerExtensionBuilder iseb, RollingUpgradeVersion fromVersion, RollingUpgradeVersion toVersion) {
       RollingUpgradeConfigurationBuilder builder = new RollingUpgradeConfigurationBuilder(name, fromVersion, toVersion);
       InfinispanServerTestConfiguration configuration = iseb.createServerTestConfiguration();
 

--- a/server/testdriver/junit5/src/main/java/org/infinispan/server/test/junit5/RollingUpgradeHandlerXSiteExtension.java
+++ b/server/testdriver/junit5/src/main/java/org/infinispan/server/test/junit5/RollingUpgradeHandlerXSiteExtension.java
@@ -10,6 +10,7 @@ import org.infinispan.server.test.core.rollingupgrade.CombinedInfinispanServerDr
 import org.infinispan.server.test.core.rollingupgrade.RollingUpgradeConfiguration;
 import org.infinispan.server.test.core.rollingupgrade.RollingUpgradeConfigurationBuilder;
 import org.infinispan.server.test.core.rollingupgrade.RollingUpgradeHandler;
+import org.infinispan.server.test.core.rollingupgrade.RollingUpgradeVersion;
 import org.infinispan.server.test.core.rollingupgrade.RollingUpgradeXSiteHandler;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
@@ -18,7 +19,8 @@ public class RollingUpgradeHandlerXSiteExtension extends InfinispanXSiteServerEx
    private RollingUpgradeXSiteHandler handler;
 
    private RollingUpgradeHandlerXSiteExtension(Class<?> caller, Map<String, InfinispanServerExtensionBuilder> sites,
-                                              String fromVersion, String toVersion, Consumer<RollingUpgradeConfigurationBuilder> decorator) {
+                                               RollingUpgradeVersion fromVersion, RollingUpgradeVersion toVersion,
+                                               Consumer<RollingUpgradeConfigurationBuilder> decorator) {
       super(new ArrayList<>());
       this.sites = sites.entrySet().stream()
             .collect(Collectors.toMap(
@@ -31,12 +33,13 @@ public class RollingUpgradeHandlerXSiteExtension extends InfinispanXSiteServerEx
    }
 
    public static RollingUpgradeHandlerXSiteExtension from(Class<?> caller, InfinispanXSiteServerExtensionBuilder builder,
-                                                          String fromVersion, String toVersion) {
+                                                          RollingUpgradeVersion fromVersion, RollingUpgradeVersion toVersion) {
       return from(caller, builder, fromVersion, toVersion, ignore -> {});
    }
 
    public static RollingUpgradeHandlerXSiteExtension from(Class<?> caller, InfinispanXSiteServerExtensionBuilder builder,
-                                                          String fromVersion, String toVersion, Consumer<RollingUpgradeConfigurationBuilder> decorator) {
+                                                          RollingUpgradeVersion fromVersion, RollingUpgradeVersion toVersion,
+                                                          Consumer<RollingUpgradeConfigurationBuilder> decorator) {
       return new RollingUpgradeHandlerXSiteExtension(caller, builder.siteConfigurations(), fromVersion, toVersion, decorator);
    }
 

--- a/server/tests/pom.xml
+++ b/server/tests/pom.xml
@@ -270,6 +270,7 @@
                   <configuration>
                      <descriptors>
                         <descriptor>src/assemblies/artifacts.xml</descriptor>
+                        <descriptor>src/assemblies/configurations.xml</descriptor>
                      </descriptors>
                      <attach>true</attach>
                   </configuration>

--- a/server/tests/src/assemblies/configurations.xml
+++ b/server/tests/src/assemblies/configurations.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+    <id>configurations</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+
+    <includeBaseDirectory>false</includeBaseDirectory>
+
+    <fileSets>
+        <fileSet>
+            <directory>${project.build.directory}/test-classes/configuration</directory>
+            <outputDirectory>configuration</outputDirectory>
+            <includes>
+                <include>**/*.*</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+</assembly>


### PR DESCRIPTION
* Assembly all the configuration files utilized by tests.
* Publish zip with `configurations` classifier.
* Rolling-upgrades download the files with the correct from version.
* Version identifier represents maven and image label.

Closes #16266.