### PR TITLE
[#14351] Invoke shutdownNow() on rest client close

### DIFF
--- a/client/rest-client/src/main/java/org/infinispan/client/rest/impl/jdk/RestRawClientJDK.java
+++ b/client/rest-client/src/main/java/org/infinispan/client/rest/impl/jdk/RestRawClientJDK.java
@@ -266,7 +266,8 @@ public class RestRawClientJDK implements RestRawClient, AutoCloseable {
    @Override
    public void close() throws Exception {
       if (Runtime.version().feature() >= 21) {
-         ((AutoCloseable) httpClient).close(); // close() was only introduced in JDK 21
+         // HttpClient.close() can hang for 1 day
+         HttpClient.class.getMethod("shutdownNow").invoke(httpClient);
       }
       if (managedExecutorService) {
          executorService.shutdownNow();


### PR DESCRIPTION
Closes #14351

I could not really work out where it's hanging (although the most likely culprit is the `listen()` method which uses subscription). However the rest client is mostly for internal use and I'd rather have less CI hangs