### PR TITLE
[#14351] Close and open the HTTP client at every test method

### DIFF
--- a/client/rest-client/src/main/java/org/infinispan/client/rest/impl/jdk/RestRawClientJDK.java
+++ b/client/rest-client/src/main/java/org/infinispan/client/rest/impl/jdk/RestRawClientJDK.java
@@ -266,7 +266,8 @@ public class RestRawClientJDK implements RestRawClient, AutoCloseable {
    @Override
    public void close() throws Exception {
       if (Runtime.version().feature() >= 21) {
-         ((AutoCloseable) httpClient).close(); // close() was only introduced in JDK 21
+         // HttpClient.close() can hang for 1 day
+         HttpClient.class.getMethod("shutdownNow").invoke(httpClient);
       }
       if (managedExecutorService) {
          executorService.shutdownNow();

--- a/client/rest-client/src/main/java/org/infinispan/client/rest/impl/jdk/sse/EventSubscriber.java
+++ b/client/rest-client/src/main/java/org/infinispan/client/rest/impl/jdk/sse/EventSubscriber.java
@@ -37,9 +37,9 @@ public class EventSubscriber implements Flow.Subscriber<String>, Closeable {
    public void onNext(String line) {
       if (line.isEmpty()) {
          Map<String, String> map = lines.stream()
-               .map(l -> l.split(":", 2))
-               .filter(pair -> !pair[0].isEmpty())
-               .collect(toMap(pair -> pair[0], pair -> pair[1].trim(), String::concat));
+            .map(l -> l.split(":", 2))
+            .filter(pair -> !pair[0].isEmpty())
+            .collect(toMap(pair -> pair[0], pair -> pair[1].trim(), String::concat));
          listener.onMessage(map.get("id"), map.get("event"), map.get("data"));
          lines.clear();
       } else {
@@ -50,32 +50,27 @@ public class EventSubscriber implements Flow.Subscriber<String>, Closeable {
 
    @Override
    public void onError(Throwable throwable) {
-      if (subscription != null) {
-         listener.onError(throwable, responseInfo);
-      }
+      listener.onError(throwable, responseInfo);
    }
 
    @Override
    public void onComplete() {
-      subscription = null;
       listener.close();
    }
 
    @Override
    public void close() {
-      var sub = subscription;
-      subscription = null;
+      subscription.cancel();
       listener.close();
-      if (sub != null) sub.cancel();
    }
 
    public HttpResponse.BodyHandler<Void> bodyHandler() {
       return (responseInfo) -> {
          this.responseInfo = new RestResponseInfoJDK(responseInfo);
          return HttpResponse.BodySubscribers.fromLineSubscriber(this,
-               s -> null,
-               charsetFrom(responseInfo.headers()),
-               null);
+            s -> null,
+            charsetFrom(responseInfo.headers()),
+            null);
       };
    }
 

--- a/server/rest/src/test/java/org/infinispan/rest/resources/AbstractRestResourceTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/resources/AbstractRestResourceTest.java
@@ -58,6 +58,7 @@ import org.infinispan.test.fwk.TransportFlags;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import io.netty.buffer.ByteBufUtil;
@@ -158,9 +159,6 @@ public class AbstractRestResourceTest extends MultipleCacheManagersTest {
             restServers.add(restServerHelper);
          }
       });
-
-      adminClient = RestClient.forConfiguration(getClientConfig("admin", "admin").build());
-      client = RestClient.forConfiguration(getClientConfig("user", "user").build());
    }
 
    protected RestServerHelper configureServer(RestServerHelper helper) {
@@ -195,13 +193,19 @@ public class AbstractRestResourceTest extends MultipleCacheManagersTest {
    @AfterClass
    public void afterClass() {
       Security.doAs(ADMIN, () -> restServers.forEach(RestServerHelper::stop));
-      Util.close(client);
-      Util.close(adminClient);
       restServers.clear();
+   }
+
+   @BeforeMethod
+   public void beforeMethod() {
+      adminClient = RestClient.forConfiguration(getClientConfig("admin", "admin").build());
+      client = RestClient.forConfiguration(getClientConfig("user", "user").build());
    }
 
    @AfterMethod
    public void afterMethod() {
+      Util.close(client);
+      Util.close(adminClient);
       Security.doAs(ADMIN, () -> restServers.forEach(RestServerHelper::clear));
    }
 

--- a/server/rest/src/test/java/org/infinispan/rest/resources/ContainerResourceTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/resources/ContainerResourceTest.java
@@ -32,7 +32,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import org.assertj.core.api.Assertions;
-import org.infinispan.client.rest.RestContainerClient;
 import org.infinispan.client.rest.RestEntity;
 import org.infinispan.client.rest.RestResponse;
 import org.infinispan.commons.CacheConfigurationException;
@@ -72,7 +71,6 @@ public class ContainerResourceTest extends AbstractRestResourceTest {
 
    private Configuration cache2Config;
    private Configuration templateConfig;
-   private RestContainerClient restContainerClient, adminRestContainerClient;
    private ControlledTimeService timeService;
 
    @Override
@@ -103,8 +101,6 @@ public class ContainerResourceTest extends AbstractRestResourceTest {
    protected void createCacheManagers() throws Exception {
       Util.recursiveFileRemove(PERSISTENT_LOCATION);
       super.createCacheManagers();
-      restContainerClient = client.container();
-      adminRestContainerClient = adminClient.container();
       timeService = new ControlledTimeService();
       cacheManagers.forEach(cm -> TestingUtil.replaceComponent(cm, TimeService.class, timeService, true));
    }
@@ -145,7 +141,7 @@ public class ContainerResourceTest extends AbstractRestResourceTest {
 
    @Test
    public void testHealth() {
-      RestResponse response = join(restContainerClient.health());
+      RestResponse response = join(client.container().health());
       ResponseAssertion.assertThat(response).isOk();
       Json jsonNode = Json.read(response.body());
       Json clusterHealth = jsonNode.at("cluster_health");
@@ -158,7 +154,7 @@ public class ContainerResourceTest extends AbstractRestResourceTest {
       assertTrue(cacheNames.contains(CACHE_1));
       assertTrue(cacheNames.contains(CACHE_2));
 
-      response = join(restContainerClient.health(true));
+      response = join(client.container().health(true));
       ResponseAssertion.assertThat(response).isOk();
       ResponseAssertion.assertThat(response).hasNoContent();
    }
@@ -175,7 +171,7 @@ public class ContainerResourceTest extends AbstractRestResourceTest {
          } catch (CacheConfigurationException ignored) {
          }
       });
-      RestResponse response = join(restContainerClient.health());
+      RestResponse response = join(client.container().health());
       ResponseAssertion.assertThat(response).isOk();
 
       Json jsonNode = Json.read(response.body());
@@ -187,7 +183,7 @@ public class ContainerResourceTest extends AbstractRestResourceTest {
    public void testCacheConfigs() {
       String accept = "text/plain; q=0.9, application/json; q=0.6";
 
-      RestResponse response = join(restContainerClient.cacheConfigurations(accept));
+      RestResponse response = join(client.container().cacheConfigurations(accept));
 
       ResponseAssertion.assertThat(response).isOk();
 
@@ -203,7 +199,7 @@ public class ContainerResourceTest extends AbstractRestResourceTest {
    public void testCacheConfigsTemplates() {
       String accept = "text/plain; q=0.9, application/json; q=0.6";
 
-      RestResponse response = join(restContainerClient.templates(accept));
+      RestResponse response = join(client.container().templates(accept));
 
       ResponseAssertion.assertThat(response).isOk();
 
@@ -222,7 +218,7 @@ public class ContainerResourceTest extends AbstractRestResourceTest {
 
    @Test
    public void testGetGlobalConfig() {
-      RestResponse response = join(adminRestContainerClient.globalConfiguration());
+      RestResponse response = join(adminClient.container().globalConfiguration());
 
       ResponseAssertion.assertThat(response).isOk();
 
@@ -238,7 +234,7 @@ public class ContainerResourceTest extends AbstractRestResourceTest {
 
    @Test
    public void testGetGlobalConfigXML() {
-      RestResponse response = join(adminRestContainerClient.globalConfiguration(APPLICATION_XML_TYPE));
+      RestResponse response = join(adminClient.container().globalConfiguration(APPLICATION_XML_TYPE));
 
       ResponseAssertion.assertThat(response).isOk();
 
@@ -252,7 +248,7 @@ public class ContainerResourceTest extends AbstractRestResourceTest {
 
    @Test
    public void testInfo() {
-      RestResponse response = join(restContainerClient.info());
+      RestResponse response = join(client.container().info());
 
       ResponseAssertion.assertThat(response).isOk();
 
@@ -273,7 +269,7 @@ public class ContainerResourceTest extends AbstractRestResourceTest {
 
    @Test
    public void testStats() {
-      RestResponse response = join(adminRestContainerClient.stats());
+      RestResponse response = join(adminClient.container().stats());
 
       ResponseAssertion.assertThat(response).isOk();
 
@@ -329,12 +325,12 @@ public class ContainerResourceTest extends AbstractRestResourceTest {
    public void testRebalancingActions() {
       assertRebalancingStatus(true);
 
-      try (RestResponse response = join(adminRestContainerClient.disableRebalancing())) {
+      try (RestResponse response = join(adminClient.container().disableRebalancing())) {
          ResponseAssertion.assertThat(response).isOk();
          assertRebalancingStatus(false);
       }
 
-      try (RestResponse response = join(adminRestContainerClient.enableRebalancing())) {
+      try (RestResponse response = join(adminClient.container().enableRebalancing())) {
          ResponseAssertion.assertThat(response).isOk();
          assertRebalancingStatus(true);
       }

--- a/server/rest/src/test/java/org/infinispan/rest/resources/HealthCheckResourceTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/resources/HealthCheckResourceTest.java
@@ -25,6 +25,7 @@ import org.infinispan.security.Security;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 @CleanupAfterMethod
@@ -73,6 +74,12 @@ public class HealthCheckResourceTest extends AbstractRestResourceTest {
    protected void createCacheManagers() throws Exception {
       Util.recursiveFileRemove(PERSISTENT_LOCATION);
       super.createCacheManagers();
+   }
+
+   @BeforeMethod(alwaysRun = true)
+   @Override
+   public void beforeMethod() {
+      super.beforeMethod();
       restServerClient = client.server();
    }
 


### PR DESCRIPTION
Closes #14351

This PR is used to investigate the cause of the HttpClient hang.
Instead of opening/closing clients before/after the class, I've moved it to before/after each method.