### PR TITLE
[#16204] REST security resource blocking operations

### DIFF
--- a/server/rest/src/main/java/org/infinispan/rest/framework/impl/RestDispatcherImpl.java
+++ b/server/rest/src/main/java/org/infinispan/rest/framework/impl/RestDispatcherImpl.java
@@ -87,12 +87,12 @@ public class RestDispatcherImpl implements RestDispatcher {
 
       try {
          if (invocation.permission() != null) {
-               authorizer.checkPermission(restRequest.getSubject(), invocation.permission(), invocation.getName(), invocation.auditContext());
-            }
-            if (restRequest.getSubject() != null) {
-               if (invocation.requireCacheManagerStart() && !started)
-                  return UNAVAILABLE;
-               return Security.doAs(restRequest.getSubject(), invocation.handler(), restRequest);
+            authorizer.checkPermission(restRequest.getSubject(), invocation.permission(), invocation.getName(), invocation.auditContext());
+         }
+         if (restRequest.getSubject() != null) {
+            if (invocation.requireCacheManagerStart() && !started)
+               return UNAVAILABLE;
+            return Security.doAs(restRequest.getSubject(), invocation.handler(), restRequest);
          } else {
             if (invocation.requireCacheManagerStart() && !started)
                return UNAVAILABLE;


### PR DESCRIPTION
* Cluster role mapper has some blocking methods.
* Update REST security resource to offload blocking operations to blocking manager.

Close #16204