### PR TITLE
[16.0.x] [#16326] Fix JSON.RESP command result

### DIFF
--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/json/JSONRESP.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/json/JSONRESP.java
@@ -81,12 +81,16 @@ public class JSONRESP extends RespCommand implements Resp3Command {
             writer.doubles(d);
             return;
          }
+         if (object instanceof Character c) {
+            writer.simpleString(c.toString());
+            return;
+         }
          if (object instanceof String s) {
             writer.string(s);
             return;
          }
          if (object instanceof Boolean b) {
-            writer.booleans(b);
+            writer.simpleString(b ? RespConstants.TRUE : RespConstants.FALSE);
             return;
          }
          if (object instanceof List<?> list) {

--- a/server/resp/src/main/java/org/infinispan/server/resp/json/JsonRespFunction.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/json/JsonRespFunction.java
@@ -54,7 +54,7 @@ public class JsonRespFunction implements SerializableFunction<ReadWriteEntryView
     private Object resp(JsonNode jsonNode) {
         if (jsonNode.isArray()) {
             ArrayList<Object> arr = new ArrayList<>();
-            arr.add("[");
+            arr.add('[');
             for (JsonNode jsonNode2 : ((ArrayNode) jsonNode)) {
                 arr.add(resp(jsonNode2));
             }
@@ -62,7 +62,7 @@ public class JsonRespFunction implements SerializableFunction<ReadWriteEntryView
         }
         if (jsonNode.isObject()) {
             ArrayList<Object> obj = new ArrayList<>();
-            obj.add("{");
+            obj.add('{');
             jsonNode.fields().forEachRemaining(entry -> {
                 obj.add(entry.getKey());
                 obj.add(resp(entry.getValue()));

--- a/server/resp/src/main/java/org/infinispan/server/resp/serialization/RespConstants.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/serialization/RespConstants.java
@@ -18,4 +18,6 @@ public interface RespConstants {
    byte[] CRLF = CRLF_STRING.getBytes(StandardCharsets.US_ASCII);
    String OK = "OK";
    String QUEUED_REPLY = "QUEUED";
+   String TRUE = "true";
+   String FALSE = "false";
 }

--- a/server/resp/src/test/java/org/infinispan/server/resp/JsonCommandsTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/JsonCommandsTest.java
@@ -2098,7 +2098,7 @@ public class JsonCommandsTest extends SingleNodeRespBaseTest {
       list = resp(key, "$.colors");
       assertThat((List)list.get(0)).containsExactly("[", "black", "white");
       list = resp(key, "$.connection.*");
-      assertThat(list).containsExactly(true, null, "Bluetooth");
+      assertThat(list).containsExactly("true", null, "Bluetooth");
       assertThat(resp(key, "$.non-existent")).isEmpty();
       assertThatThrownBy(() -> resp(key, ".non-existent")).isInstanceOf(RedisCommandExecutionException.class)
             .hasMessage("ERR Path '$.non-existent' does not exist");


### PR DESCRIPTION
**Backport:** https://github.com/infinispan/infinispan/pull/16336

Fixes #16326

plus fixed json.resp command must return booleans as simple strings instead of resp3 booleans value.


