### PR TITLE
[16.0] [#16377] Do not serialize the scope id in multihostaddresses

### DIFF
--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/MultiHomedServerAddress.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/MultiHomedServerAddress.java
@@ -209,7 +209,9 @@ public class MultiHomedServerAddress implements ServerAddress {
       @ProtoFactory
       static InetAddressWithNetMask protoFactory(String hostAddress, short prefixLength) {
          try {
-            return new InetAddressWithNetMask(InetAddress.getByName(hostAddress), prefixLength);
+            // Remove the scope id if necessary
+            int scopeSeparator = hostAddress.lastIndexOf('%');
+            return new InetAddressWithNetMask(InetAddress.getByName(scopeSeparator < 0 ? hostAddress : hostAddress.substring(0, scopeSeparator)), prefixLength);
          } catch (UnknownHostException e) {
             throw new MarshallingException(String.format("Unable to resolve InetAddress by name '%s'", hostAddress), e);
          }


### PR DESCRIPTION
Closes #16377