### PR TITLE
[16.0.x] [#16334] Deprecate metrics.names-as-tags attribute

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/global/GlobalMetricsConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/global/GlobalMetricsConfiguration.java
@@ -16,7 +16,7 @@ public class GlobalMetricsConfiguration {
    @Deprecated(forRemoval = true, since = "16.0")
    public static final AttributeDefinition<String> PREFIX = AttributeDefinition.builder(org.infinispan.configuration.parsing.Attribute.PREFIX, "").immutable().build();
    @Deprecated(forRemoval = true, since = "16.0")
-   public static final AttributeDefinition<Boolean> NAMES_AS_TAGS = AttributeDefinition.builder(org.infinispan.configuration.parsing.Attribute.NAMES_AS_TAGS, false).immutable().build();
+   public static final AttributeDefinition<Boolean> NAMES_AS_TAGS = AttributeDefinition.builder(org.infinispan.configuration.parsing.Attribute.NAMES_AS_TAGS, true).immutable().build();
    public static final AttributeDefinition<Boolean> ACCURATE_SIZE = AttributeDefinition.builder(org.infinispan.configuration.parsing.Attribute.ACCURATE_SIZE, false).build();
    @Deprecated(forRemoval = true, since = "16.0")
    public static final AttributeDefinition<Boolean> JVM = AttributeDefinition.builder(org.infinispan.configuration.parsing.Attribute.JVM, false).build();

--- a/documentation/src/main/asciidoc/topics/changes.adoc
+++ b/documentation/src/main/asciidoc/topics/changes.adoc
@@ -1,4 +1,4 @@
-== Upgrading from 16.0 to 16.1
+== Upgrading to 16.0.4
 
 === Metrics
 


### PR DESCRIPTION
**Backport:** https://github.com/infinispan/infinispan/pull/16364

Closes #16334 