### PR TITLE
Helper to await cache rebalance

### DIFF
--- a/core/src/main/java/org/infinispan/topology/ClusterTopologyManager.java
+++ b/core/src/main/java/org/infinispan/topology/ClusterTopologyManager.java
@@ -2,6 +2,7 @@ package org.infinispan.topology;
 
 import java.util.List;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
 
 import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
@@ -97,6 +98,8 @@ public interface ClusterTopologyManager {
     * Retrieves the rebalancing status of a cache
     */
    RebalancingStatus getRebalancingStatus(String cacheName);
+
+   void awaitRebalance(String cacheName, long timeout, TimeUnit unit) throws InterruptedException;
 
    CompletionStage<Void> forceRebalance(String cacheName);
 

--- a/core/src/main/java/org/infinispan/topology/ClusterTopologyManagerImpl.java
+++ b/core/src/main/java/org/infinispan/topology/ClusterTopologyManagerImpl.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
@@ -766,6 +767,14 @@ public class ClusterTopologyManagerImpl implements ClusterTopologyManager, Globa
          return cacheStatus.getRebalancingStatus();
       } else {
          return RebalancingStatus.PENDING;
+      }
+   }
+
+   @Override
+   public void awaitRebalance(String cacheName, long timeout, TimeUnit unit) throws InterruptedException {
+      ClusterCacheStatus cacheStatus = cacheStatusMap.get(cacheName);
+      if (cacheStatus != null) {
+         cacheStatus.awaitRebalance(timeout, unit);
       }
    }
 


### PR DESCRIPTION
_Not_ a proper fix for #16316 but a simple addition that would allowing working around it by e.g.:

```java
cache.stop();
var clusterTopologyManager = GlobalComponentRegistry.componentOf(cache.getCacheManager(), ClusterTopologyManager.class);
clusterTopologyManager.awaitRebalance(cache.getName(), 12345, TimeUnit.MILLISECONDS);
```

Feel free to close if a proper fix for #16316 should be done instead...