### PR TITLE
[#16429] Use base ref for labeller

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+         ref: ${{ github.base_ref }}
       - name: Add release labels on merge
         run: |
           .github/scripts/pr-label-issues.sh "${{ github.event.pull_request.number }}" "$GITHUB_REPOSITORY" "$GITHUB_BASE_REF" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
base ref now need to be explicitly passed to checkout.

Fixes: #16429 