### PR TITLE
[#16454] Run rolling upgrade suite with multiple versions

### DIFF
--- a/.github/scripts/merge-jacoco-files.sh
+++ b/.github/scripts/merge-jacoco-files.sh
@@ -7,7 +7,7 @@ sourceDirs="$2"
 copy_files() {
     source_dir="$1"
     db="${source_dir##*-}"
-    for file in "$source_dir"/tests/target/*; do
+    for file in "$source_dir"/*; do
         if [[ -d $file ]]; then
             echo "Skipping directory: $file"
             continue
@@ -27,7 +27,7 @@ copy_files() {
 }
 
 for i in $sourceDirs; do
-    if [[ "$i" == *-rolling-upgrades ]]; then
+    if [[ "$i" == *-rolling-upgrades-* ]]; then
         echo "Skipping $i as it matches the ignore pattern."
         continue # 'continue' skips to the next item in the loop
     fi

--- a/.github/workflows/on_build_do_test.yml
+++ b/.github/workflows/on_build_do_test.yml
@@ -263,7 +263,7 @@ jobs:
   targets-test:
     needs: get-info
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    name: ${{ matrix.targets == 'tomcat' && 'tomcat' || matrix.targets == 'rolling-upgrades' && 'rolling-upgrades' || format('db ({0})', matrix.targets) }}
+    name: ${{ matrix.targets == 'tomcat' && 'tomcat' || format('db ({0})', matrix.targets) }}
     runs-on: ubuntu-latest
     env:
       TOMCAT_VERSION: 11.0.12
@@ -275,7 +275,6 @@ jobs:
           - oracle
           - db2
           - tomcat
-          - rolling-upgrades
     steps:
       - uses: actions/checkout@v6
 
@@ -359,25 +358,14 @@ jobs:
           integrationtests/server-integration/third-party-server/ \
           -DcatalinaHome="${CATALINA_HOME}" -Dinfinispan.server.integration.launch=tomcat
 
-
       - name: Test
-        if: ${{ matrix.targets != 'tomcat' && matrix.targets != 'rolling-upgrades' }}
+        if: ${{ matrix.targets != 'tomcat' }}
         run: |
           cd test_dir/infinispan && \
           ./mvnw verify -B -e -pl server/tests -Dmaven.test.failure.ignore=true \
             -Dansi.strip=true \
             -DdefaultTestGroup=database \
             -Dorg.infinispan.test.database.types=${{ matrix.targets }} \
-            -Dorg.infinispan.test.server.dir=/tmp/infinispan-server-${{ steps.dis.outputs.server-version }} \
-            -Pcoverage
-
-      - name: Run rolling upgrades
-        if: ${{ matrix.targets == 'rolling-upgrades' }}
-        run: |
-          cd test_dir/infinispan && \
-          ./mvnw verify -B -e -pl server/rollingupgradetests -Dmaven.test.failure.ignore=true \
-            -Dansi.strip=true \
-            -DskipRollingUpgradeTests=false \
             -Dorg.infinispan.test.server.dir=/tmp/infinispan-server-${{ steps.dis.outputs.server-version }} \
             -Pcoverage
 
@@ -435,15 +423,39 @@ jobs:
           name: jacoco-files-${{ matrix.targets }}
           path: |
             test_dir/infinispan/server/tests/target/*.exec
-            test_dir/infinispan/server/rollingupgradetests/target/*.exec
+
+
+  rolling-upgrades-matrix:
+    needs: get-info
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    name: "Rolling Upgrades (${{ matrix.targets.name }})"
+    strategy:
+      fail-fast: false
+      matrix:
+        targets:
+          # The name here should match the reporting side in the on_test_publish_surefire_report workflow
+          - name: 'latest'
+            args: '-Dorg.infinispan.test.server.rolling.upgrade.from=latest'
+          - name: 'first-version'
+            args: '-Dorg.infinispan.test.server.rolling.upgrade.from=16.0.1'
+    uses: ./.github/workflows/rolling-upgrade-test.yml
+    with:
+      name: ${{ matrix.targets.name }}
+      maven-args: ${{ matrix.targets.args }}
+      run-id: ${{ github.event.workflow_run.id }}
+      source-head-sha: ${{ needs.get-info.outputs.source-head-sha }}
+    secrets:
+      GH_APP_ISPN_ID: ${{ secrets.GH_APP_ISPN_ID }}
+      GH_APP_ISPN_KEY: ${{ secrets.GH_APP_ISPN_KEY }}
 
   coverage:
-    needs: [get-info, ci-build-test-pr, targets-test]
+    needs: [get-info, ci-build-test-pr, targets-test, rolling-upgrades-matrix]
     if: ${{ github.event.workflow_run.conclusion == 'success' && needs.get-info.outputs.source-event == 'pull_request' }}
     name: Publish Coverage Report
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}
+      ROLLING_UPGRADE_COVERAGE: 'latest'
     steps:
       - uses: actions/checkout@v6
 
@@ -539,7 +551,10 @@ jobs:
         run: |
           cd test_dir/infinispan-rolling-upgrade
           mvn clean install -DskipTests=true -pl server/rollingupgradetests -am
-          cp ${{ github.workspace }}/jacoco-files-rolling-upgrades/rollingupgradetests/target/*.exec server/rollingupgradetests/target/
+          
+          # COPY only the artifact for the primary variant
+          cp ${{ github.workspace }}/jacoco-files-rolling-upgrades-${{ env.ROLLING_UPGRADE_COVERAGE }}/*.exec server/rollingupgradetests/target/
+          
           mvn validate -P jacocoReport
           mkdir ${{ github.workspace }}/jacocoReport-rolling-upgrade
           cp -R jacoco-report/ ${{ github.workspace }}/jacocoReport-rolling-upgrade

--- a/.github/workflows/on_test_publish_surefire_report.yml
+++ b/.github/workflows/on_test_publish_surefire_report.yml
@@ -147,7 +147,6 @@ jobs:
           - oracle
           - db2
           - tomcat
-          - rolling-upgrades
     steps:
     - name: Set run_id based on event type
       id: run_id
@@ -181,8 +180,6 @@ jobs:
       run: |
         if [ "${{ matrix.targets }}" = "tomcat" ]; then
           JOB_NAME="tomcat"
-        elif [ "${{ matrix.targets }}" = "rolling-upgrades" ]; then
-          JOB_NAME="rolling-upgrades"
         else
           JOB_NAME="db (${{ matrix.targets }})"
         fi
@@ -235,3 +232,92 @@ jobs:
           -f "output[summary]=Result from workflow run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
           -f "output[title]=Run Failed" \
           --method PATCH
+
+   rolling-upgrades-report:
+      runs-on: ubuntu-latest
+      strategy:
+        fail-fast: false
+        matrix:
+          name:
+            # The name here should match the names in on_build_do_test workflow file.
+            - latest
+            - first-version
+      steps:
+      - name: Set run_id based on event type
+        id: run_id
+        run: |
+           echo "runid=${{ github.event.workflow_run.id }}" >> $GITHUB_OUTPUT
+
+      - name: Download Rolling Upgrade Artifact
+        uses: actions/download-artifact@v7.0.0
+        with:
+          name: surefire-test-report-rolling-upgrades-${{ matrix.name }}
+          github-token: ${{ github.token }}
+          run-id: ${{ steps.run_id.outputs.runid }}
+
+      - name: Get github sha
+        id: github_sha
+        uses: juliangruber/read-file-action@v1
+        with:
+          path: ./github-sha.txt
+
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.GH_APP_ISPN_ID }}
+          private-key: ${{ secrets.GH_APP_ISPN_KEY }}
+
+      - name: Get job status
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        id: job-status
+        run: |
+          # Match the specific job name defined inside the rolling-upgrade-test.yml workflow
+          JOB_SUFFIX="Rolling Upgrades (${{ matrix.name }})"
+          
+          # Use 'endswith' to ignore the variable prefix (caller job name + arguments)
+          JOB_STATUS=$(gh api "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ steps.run_id.outputs.runid }}/jobs" \
+          --jq ".jobs[] | select(.name | endswith(\"$JOB_SUFFIX\")) | .conclusion")
+          
+          echo "Found status: $JOB_STATUS"
+          echo "job_status=$JOB_STATUS" >> $GITHUB_OUTPUT
+
+      - name: Publish Test Report
+        if: (success() || failure()) && steps.job-status.outputs.job_status == 'success'
+        uses: rigazilla/action-surefire-report@summary
+        with:
+          github_token: ${{ steps.app-token.outputs.token }}
+          check_name: Test Report Rolling Upgrades (${{ matrix.name }})
+          commit: ${{ steps.github_sha.outputs.content }}
+          ignore_flaky_tests: true
+          summary: "Result from workflow run: https://github.com/${{ github.repository }}/actions/runs/${{ steps.run_id.outputs.runid }}"
+          report_paths: |
+            **/*-reports*/**/TEST-*.xml
+
+      - name: Download Check Run ID
+        if: failure()
+        uses: actions/download-artifact@v7.0.0
+        with:
+          name: check-run-id-rolling-upgrades-${{ matrix.name }}
+          github-token: ${{ github.token }}
+          run-id: ${{ steps.run_id.outputs.runid }}
+
+      - name: Read Check Run ID
+        if: failure()
+        id: read_check_id
+        run: |
+          CHECK_RUN_ID=$(cat check-run-id.txt)
+          echo "CHECK_RUN_ID=$CHECK_RUN_ID" >> $GITHUB_ENV
+
+      - name: Set failure check if Publish Test Report step failed
+        if: failure()
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh api repos/${{ github.repository }}/check-runs/${CHECK_RUN_ID} \
+            -H "Accept: application/vnd.github+json" \
+            -f status="completed" \
+            -f conclusion="failure" \
+            -f "output[summary]=Result from workflow run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            -f "output[title]=Run Failed" \
+            --method PATCH

--- a/.github/workflows/rolling-upgrade-test.yml
+++ b/.github/workflows/rolling-upgrade-test.yml
@@ -1,0 +1,133 @@
+name: Rolling Upgrade Test Module
+
+on:
+  workflow_call:
+    inputs:
+      # The identifier for this matrix entry (e.g., 'standard', 'special-config')
+      name:
+        required: true
+        type: string
+      # The extra arguments to pass to the test (e.g., '-DcustomProperty=true')
+      maven-args:
+        required: false
+        type: string
+        default: ''
+      # Context inputs
+      run-id:
+        required: true
+        type: string
+      source-head-sha:
+        required: true
+        type: string
+    secrets:
+      GH_APP_ISPN_ID:
+        required: true
+      GH_APP_ISPN_KEY:
+        required: true
+
+jobs:
+  test:
+    name: Rolling Upgrades (${{ inputs.name }})
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Java
+        uses: ./.github/actions/setup-java
+
+      - name: Extract Maven Artifacts
+        uses: ./.github/actions/extract-maven-artifacts
+        with:
+          run-id: ${{ inputs.run-id }}
+
+      - name: Download Infinispan Server
+        id: dis
+        uses: ./.github/actions/download-infinispan
+        with:
+          run-id: ${{ inputs.run-id }}
+          github-token: ${{ github.token }}
+
+      - name: Extract Infinispan Server
+        working-directory: /tmp
+        run: unzip -q "${GITHUB_WORKSPACE}/infinispan-server-${{ steps.dis.outputs.server-version }}.zip"
+
+      - name: Extract Infinispan Source
+        run: |
+          mkdir test_dir && cd test_dir
+          unzip -q "${GITHUB_WORKSPACE}/infinispan-${{ steps.dis.outputs.server-version }}-src.zip"
+          mv infinispan-${{ steps.dis.outputs.server-version }}-src infinispan
+
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.GH_APP_ISPN_ID }}
+          private-key: ${{ secrets.GH_APP_ISPN_KEY }}
+
+      # Create a unique Check Run for this specific matrix entry
+      - name: Create Check Run
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        id: create_check
+        run: |
+          CHECK_RUN=$(gh api repos/${{ github.repository }}/check-runs \
+            -H "Accept: application/vnd.github+json" \
+            -f name="Test Report Rolling Upgrades (${{ inputs.name }})" \
+            -f head_sha="${{ inputs.source-head-sha }}" \
+            -f status="in_progress" \
+            -f "output[summary]=Result from workflow run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            -f "output[title]=Waiting for report result..." \
+            --method POST \
+            --jq '.id')
+          echo "id=$CHECK_RUN" >> "$GITHUB_OUTPUT"
+
+      - name: Run Rolling Upgrade Tests
+        working-directory: test_dir/infinispan
+        run: |
+          ./mvnw verify -B -e -pl server/rollingupgradetests \
+            -Dmaven.test.failure.ignore=true \
+            -Dansi.strip=true \
+            -DskipRollingUpgradeTests=false \
+            -Dorg.infinispan.test.server.dir=/tmp/infinispan-server-${{ steps.dis.outputs.server-version }} \
+            -Pcoverage ${{ inputs.maven-args }}
+
+      # Update Check Run Status
+      - name: Update Check Run (Failure)
+        if: failure()
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh api repos/${{ github.repository }}/check-runs/${{ steps.create_check.outputs.id }} \
+            -H "Accept: application/vnd.github+json" \
+            -f status="completed" \
+            -f conclusion="failure" \
+            -f "output[title]=Run Failed" \
+            -f "output[summary]=Tests failed. See logs: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --method PATCH
+
+      - name: Archive commit sha PR
+        if: >
+          (success() || failure())
+        run: |
+          echo -n ${{ inputs.source-head-sha }} > github-sha.txt
+
+      # Upload Artifacts with a UNIQUE name based on the input name
+      # This allows the main workflow to distinguish between matrix runs
+      - name: Upload jacoco exec files
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: jacoco-files-rolling-upgrades-${{ inputs.name }}
+          path: |
+            test_dir/infinispan/server/rollingupgradetests/target/*.exec
+
+      - name: Upload surefire test report
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: surefire-test-report-rolling-upgrades-${{ inputs.name }}
+          path: |
+            test_dir/infinispan/**/target/*-reports*/**/TEST-*.xml
+            !test_dir/infinispan/**/target/*-reports*/**/TEST-*FLAKY.xml
+            test_dir/infinispan/**/*.dump*
+            test_dir/infinispan/**/hs_err_*
+            github-sha.txt


### PR DESCRIPTION
* Execute the rolling upgrade test suite to run against different versions.
* Run against the oldest compatible and the newest compatible.

Here is an example run: https://github.com/jabolina/infinispan/pull/10
You can see it has a `Test Report Rolling Upgrades (standard) ` and `Test Report Rolling Upgrades (first-version)`

Closes #16454.