### PR TITLE
[#16568] We should make sure all the server modules use JDK 25

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -12,6 +12,12 @@
    <name>Infinispan Server Parent</name>
    <packaging>pom</packaging>
 
+   <properties>
+      <maven.compiler.source>25</maven.compiler.source>
+      <maven.compiler.target>25</maven.compiler.target>
+      <maven.compiler.release>25</maven.compiler.release>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.infinispan</groupId>

--- a/server/rollingupgradetests/pom.xml
+++ b/server/rollingupgradetests/pom.xml
@@ -15,6 +15,9 @@
    <description>Infinispan Server Rolling Upgrade Integration Tests</description>
 
    <properties>
+      <maven.compiler.source>17</maven.compiler.source>
+      <maven.compiler.target>17</maven.compiler.target>
+      <maven.compiler.release>17</maven.compiler.release>
       <module.skipMavenRemoteResource>true</module.skipMavenRemoteResource>
       <skipRollingUpgradeTests>true</skipRollingUpgradeTests>
       <defaultTestGroup/>

--- a/server/runtime/pom.xml
+++ b/server/runtime/pom.xml
@@ -15,9 +15,6 @@
    <description>Infinispan Server</description>
 
    <properties>
-      <maven.compiler.source>25</maven.compiler.source>
-      <maven.compiler.target>25</maven.compiler.target>
-      <maven.compiler.release>25</maven.compiler.release>
       <module.skipMavenRemoteResource>true</module.skipMavenRemoteResource>
       <version.lucene>${version.lucene10}</version.lucene>
       <defaultTestGroup/>

--- a/server/testdriver/pom.xml
+++ b/server/testdriver/pom.xml
@@ -12,6 +12,12 @@
    <name>Infinispan parent pom for the test driver</name>
    <packaging>pom</packaging>
 
+   <properties>
+      <maven.compiler.source>17</maven.compiler.source>
+      <maven.compiler.target>17</maven.compiler.target>
+      <maven.compiler.release>17</maven.compiler.release>
+   </properties>
+
    <modules>
       <module>core</module>
       <module>junit5</module>

--- a/server/tests/pom.xml
+++ b/server/tests/pom.xml
@@ -15,6 +15,9 @@
    <description>Infinispan Server Integration Tests</description>
 
    <properties>
+      <maven.compiler.source>17</maven.compiler.source>
+      <maven.compiler.target>17</maven.compiler.target>
+      <maven.compiler.release>17</maven.compiler.release>
       <module.skipMavenRemoteResource>true</module.skipMavenRemoteResource>
       <defaultTestGroup/>
       <defaultExcludedTestGroup/>


### PR DESCRIPTION
Fixes #16568

Move the JDK 25 compiler properties to the server parent pom instead of runtime.