### PR TITLE
[#16586] MurmurHash3 should use VarHandle for getblock method

### DIFF
--- a/commons/all/src/main/java/org/infinispan/commons/hash/MurmurHash3.java
+++ b/commons/all/src/main/java/org/infinispan/commons/hash/MurmurHash3.java
@@ -1,5 +1,9 @@
 package org.infinispan.commons.hash;
 
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.nio.ByteOrder;
+
 import org.infinispan.commons.marshall.WrappedBytes;
 
 import com.google.errorprone.annotations.Immutable;
@@ -43,16 +47,10 @@ public class MurmurHash3 implements Hash {
       long c2;
    }
 
+   private static final VarHandle VH_LE_LONG = MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.LITTLE_ENDIAN);
+
    static long getblock(byte[] key, int i) {
-      return
-            ((key[i + 0] & 0x00000000000000FFL))
-                  | ((key[i + 1] & 0x00000000000000FFL) << 8)
-                  | ((key[i + 2] & 0x00000000000000FFL) << 16)
-                  | ((key[i + 3] & 0x00000000000000FFL) << 24)
-                  | ((key[i + 4] & 0x00000000000000FFL) << 32)
-                  | ((key[i + 5] & 0x00000000000000FFL) << 40)
-                  | ((key[i + 6] & 0x00000000000000FFL) << 48)
-                  | ((key[i + 7] & 0x00000000000000FFL) << 56);
+      return (long) VH_LE_LONG.get(key, i);
    }
 
    static void bmix(State state) {


### PR DESCRIPTION
Fixes #16586 