### PR TITLE
[16.1.x] [#15973] RESP configuration defined at start

### DIFF
--- a/server/core/src/test/java/org/infinispan/server/core/AbstractAuthAccessLoggingTest.java
+++ b/server/core/src/test/java/org/infinispan/server/core/AbstractAuthAccessLoggingTest.java
@@ -47,7 +47,12 @@ public abstract class AbstractAuthAccessLoggingTest extends SingleCacheManagerTe
       globalBuilder.defaultCacheName("default");
       ConfigurationBuilder builder = new ConfigurationBuilder();
       builder.security().authorization().enable();
+      customCacheConfiguration(builder);
       return Security.doAs(ADMIN, () -> TestCacheManagerFactory.createCacheManager(globalBuilder, builder));
+   }
+
+   protected void customCacheConfiguration(ConfigurationBuilder builder) {
+      // Overridden by other classes.
    }
 
    @Override

--- a/server/resp/src/main/java/org/infinispan/server/resp/RespServer.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/RespServer.java
@@ -2,8 +2,8 @@ package org.infinispan.server.resp;
 
 import static org.infinispan.commons.logging.Log.CONFIG;
 
+import java.util.Objects;
 import java.util.Random;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import org.infinispan.AdvancedCache;
@@ -54,6 +54,7 @@ public class RespServer extends AbstractProtocolServer<RespServerConfiguration> 
    private static final Log log = Log.getLog(RespServer.class);
    public static final String RESP_SERVER_FEATURE = "resp-server";
    public static final MediaType RESP_KEY_MEDIA_TYPE = MediaType.APPLICATION_OCTET_STREAM;
+   private Configuration defaultCacheConfiguration;
    private MetadataRepository metadataRepository;
    private MediaType configuredValueType = MediaType.APPLICATION_OCTET_STREAM;
    private DefaultIterationManager iterationManager;
@@ -79,15 +80,15 @@ public class RespServer extends AbstractProtocolServer<RespServerConfiguration> 
       dataStructureIterationManager.addKeyValueFilterConverterFactory(GlobMatchFilterConverterFactory.class.getName(), new GlobMatchFilterConverterFactory(true));
       metadataRepository = new MetadataRepository();
       initializeLuaTaskEngine(gcr);
+      defineCacheConfiguration();
 
       super.internalPostStart();
    }
 
-   @Override
-   public CompletionStage<Void> initializeDefaultCache() {
+   private void defineCacheConfiguration() {
       GlobalConfiguration globalConfiguration = SecurityActions.getCacheManagerConfiguration(cacheManager);
       if (!globalConfiguration.features().isAvailable(RESP_SERVER_FEATURE)) {
-         return CompletableFuture.failedFuture(CONFIG.featureDisabled(RESP_SERVER_FEATURE));
+         throw CONFIG.featureDisabled(RESP_SERVER_FEATURE);
       }
       String cacheName = configuration.defaultCacheName();
       Configuration explicitConfiguration = SecurityActions.getCacheConfiguration(cacheManager, cacheName);
@@ -99,14 +100,14 @@ public class RespServer extends AbstractProtocolServer<RespServerConfiguration> 
             configuredValueType = builder.encoding().value().mediaType();
             if (globalConfiguration.isClustered() &&
                   !(builder.clustering().hash().keyPartitioner() instanceof RESPHashFunctionPartitioner)) {
-               return CompletableFuture.failedFuture(CONFIG.respCacheUseDefineConsistentHash(cacheName, builder.clustering().hash().keyPartitioner().getClass().getName()));
+               throw CONFIG.respCacheUseDefineConsistentHash(cacheName, builder.clustering().hash().keyPartitioner().getClass().getName());
             }
             MediaType keyMediaType = builder.encoding().key().mediaType();
             if (keyMediaType == null) {
                log.debugf("Setting RESP cache key media type storage to OCTET stream to avoid key encodings");
                builder.encoding().key().mediaType(RESP_KEY_MEDIA_TYPE);
             } else if (!keyMediaType.equals(RESP_KEY_MEDIA_TYPE)) {
-               return CompletableFuture.failedFuture(CONFIG.respCacheKeyMediaTypeSupplied(cacheName, keyMediaType));
+               throw CONFIG.respCacheKeyMediaTypeSupplied(cacheName, keyMediaType);
             }
 
             if (builder.transaction().transactionMode().isTransactional()
@@ -125,19 +126,29 @@ public class RespServer extends AbstractProtocolServer<RespServerConfiguration> 
          }
          builder.statistics().enable().aliases("0");
          explicitConfiguration = builder.build();
+         SecurityActions.defineConfiguration(cacheManager, cacheName, explicitConfiguration);
       } else {
          if (!RESP_KEY_MEDIA_TYPE.equals(explicitConfiguration.encoding().keyDataType().mediaType()))
-            return CompletableFuture.failedFuture(CONFIG.respCacheKeyMediaTypeSupplied(cacheName, explicitConfiguration.encoding().keyDataType().mediaType()));
+            throw CONFIG.respCacheKeyMediaTypeSupplied(cacheName, explicitConfiguration.encoding().keyDataType().mediaType());
 
          if (globalConfiguration.isClustered() &&
                !(explicitConfiguration.clustering().hash().keyPartitioner() instanceof RESPHashFunctionPartitioner)) {
-            return CompletableFuture.failedFuture(CONFIG.respCacheUseDefineConsistentHash(cacheName, explicitConfiguration.clustering().hash().keyPartitioner().getClass().getName()));
+            throw CONFIG.respCacheUseDefineConsistentHash(cacheName, explicitConfiguration.clustering().hash().keyPartitioner().getClass().getName());
          }
       }
-      segmentSlots = new SegmentSlotRelation(explicitConfiguration.clustering().hash().numSegments());
-      Configuration c = explicitConfiguration;
+
+      defaultCacheConfiguration = explicitConfiguration;
+   }
+
+   @Override
+   public CompletionStage<Void> initializeDefaultCache() {
+      Objects.requireNonNull(defaultCacheConfiguration, "Cache configuration not initialized");
+      String cacheName = configuration.defaultCacheName();
+      segmentSlots = new SegmentSlotRelation(defaultCacheConfiguration.clustering().hash().numSegments());
       return getBlockingManager()
-            .runBlocking(() -> SecurityActions.getOrCreateCache(cacheManager, cacheName, c), "create-resp-cache");
+            // Ensure it invokes `.getOrCreateCache` because it starts the cache in all nodes in the cluster.
+            // Otherwise, the node would start only at the node the connection was established.
+            .runBlocking(() -> SecurityActions.getOrCreateCache(cacheManager, cacheName, defaultCacheConfiguration), "create-resp-cache");
    }
 
    @Override

--- a/server/resp/src/test/java/org/infinispan/server/resp/RespServerTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/RespServerTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.server.resp;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.infinispan.functional.FunctionalTestUtils.await;
 import static org.infinispan.testing.Testing.tmpDirectory;
 import static org.testng.AssertJUnit.assertEquals;
@@ -12,6 +13,7 @@ import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.distribution.ch.impl.HashFunctionPartitioner;
 import org.infinispan.globalstate.ConfigurationStorage;
 import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -93,5 +95,23 @@ public class RespServerTest extends AbstractInfinispanTest {
                await(ms.initializeDefaultCache());
                assertEquals(CacheMode.DIST_SYNC, ms.getCache().getCacheConfiguration().clustering().cacheMode());
             }));
+   }
+
+   public void testInvalidConfiguration(Method m) {
+      GlobalConfigurationBuilder global = GlobalConfigurationBuilder.defaultClusteredBuilder();
+      Stoppable.useCacheManager(new DefaultCacheManager(addGlobalState(global, m).build()), cm -> {
+         ConfigurationBuilder config = new ConfigurationBuilder();
+         config.clustering().cacheMode(CacheMode.DIST_SYNC);
+         config.encoding().key().mediaType(MediaType.TEXT_PLAIN);
+         config.clustering().hash().keyPartitioner(new HashFunctionPartitioner());
+         cm.defineConfiguration("respCache", config.build());
+
+         Stoppable.useServer(new RespServer(), ms -> {
+            ms.start(new RespServerConfigurationBuilder().port(0).build(), cm);
+            assertThatThrownBy(ms::postStart)
+                  .isInstanceOf(IllegalArgumentException.class)
+                  .hasMessageContaining("key media type must be configured");
+         });
+      });
    }
 }

--- a/server/resp/src/test/java/org/infinispan/server/resp/logging/RespAuthAccessLoggingTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/logging/RespAuthAccessLoggingTest.java
@@ -10,6 +10,8 @@ import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
 
+import org.infinispan.commons.dataconversion.MediaType;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.security.Security;
 import org.infinispan.server.core.AbstractAuthAccessLoggingTest;
 import org.infinispan.server.resp.RespServer;
@@ -43,6 +45,11 @@ public class RespAuthAccessLoggingTest extends AbstractAuthAccessLoggingTest {
       builder.host(HOST).port(RespTestingUtil.port()).defaultCacheName("default")
             .authentication().enable().authenticator(authenticator);
       server = Security.doAs(ADMIN, () -> RespTestingUtil.startServer(cacheManager, builder.build()));
+   }
+
+   @Override
+   protected void customCacheConfiguration(ConfigurationBuilder builder) {
+      builder.encoding().mediaType(MediaType.APPLICATION_OCTET_STREAM);
    }
 
    @Override

--- a/server/runtime/src/test/java/org/infinispan/server/ProtocolInitializationTest.java
+++ b/server/runtime/src/test/java/org/infinispan/server/ProtocolInitializationTest.java
@@ -10,8 +10,10 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.hamcrest.Matchers;
 import org.infinispan.commons.CacheConfigurationException;
+import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.distribution.ch.impl.RESPHashFunctionPartitioner;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.server.core.ProtocolServer;
 import org.infinispan.server.core.configuration.ProtocolServerConfiguration;
@@ -22,6 +24,7 @@ import org.infinispan.server.resp.RespServer;
 import org.infinispan.server.resp.configuration.RespServerConfigurationBuilder;
 import org.infinispan.test.CacheManagerCallable;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.test.fwk.TransportFlags;
 import org.infinispan.testing.junit.JUnitThreadTrackerRule;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -42,7 +45,10 @@ public class ProtocolInitializationTest {
    @Test
    public void testRespServerStartWithLua() {
       RespServer respServer = new RespServer();
-      withCacheManager(new CacheManagerCallable(TestCacheManagerFactory.createClusteredCacheManager()) {
+      ConfigurationBuilder b = new ConfigurationBuilder();
+      b.clustering().hash().keyPartitioner(new RESPHashFunctionPartitioner());
+      b.encoding().mediaType(MediaType.APPLICATION_OCTET_STREAM);
+      withCacheManager(new CacheManagerCallable(TestCacheManagerFactory.createClusteredCacheManager(b, new TransportFlags())) {
          @Override
          public void call() {
             RespServerConfigurationBuilder builder = new RespServerConfigurationBuilder();
@@ -58,7 +64,10 @@ public class ProtocolInitializationTest {
                .thenThrow(new SharedLibraryLoadRuntimeException("Unable to locate the library path"));
 
          RespServer respServer = new RespServer();
-         withCacheManager(new CacheManagerCallable(TestCacheManagerFactory.createClusteredCacheManager()) {
+         ConfigurationBuilder b = new ConfigurationBuilder();
+         b.clustering().hash().keyPartitioner(new RESPHashFunctionPartitioner());
+         b.encoding().mediaType(MediaType.APPLICATION_OCTET_STREAM);
+         withCacheManager(new CacheManagerCallable(TestCacheManagerFactory.createClusteredCacheManager(b, new TransportFlags())) {
             @Override
             public void call() {
                RespServerConfigurationBuilder builder = new RespServerConfigurationBuilder();

--- a/server/tests/src/test/java/org/infinispan/server/resilience/ResilienceStartupIT.java
+++ b/server/tests/src/test/java/org/infinispan/server/resilience/ResilienceStartupIT.java
@@ -1,7 +1,6 @@
 package org.infinispan.server.resilience;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.infinispan.client.rest.RestResponseInfo.BAD_REQUEST;
 import static org.infinispan.client.rest.RestResponseInfo.OK;
 import static org.infinispan.commons.dataconversion.MediaType.APPLICATION_XML;
@@ -17,15 +16,11 @@ import org.infinispan.client.rest.RestResponse;
 import org.infinispan.client.rest.configuration.RestClientConfigurationBuilder;
 import org.infinispan.client.rest.configuration.RestClientConfigurationProperties;
 import org.infinispan.commons.dataconversion.internal.Json;
-import org.infinispan.server.test.core.ServerConstants;
 import org.infinispan.server.test.core.ServerRunMode;
 import org.infinispan.server.test.junit5.InfinispanServerExtension;
 import org.infinispan.server.test.junit5.InfinispanServerExtensionBuilder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-
-import io.lettuce.core.RedisClient;
-import io.lettuce.core.RedisConnectionException;
 
 public class ResilienceStartupIT {
 
@@ -74,55 +69,6 @@ public class ResilienceStartupIT {
 
       // Assert that the cache manager and server are running.
       // Also validate that the cache still exists in a FAILED state.
-      assertCacheIsFailed(rest, invalidCacheName);
-   }
-
-   @Test
-   public void testInvalidConnectorCache() {
-      RestClientConfigurationBuilder restClientBuilder = new RestClientConfigurationBuilder()
-            .socketTimeout(RestClientConfigurationProperties.DEFAULT_SO_TIMEOUT * 60)
-            .connectionTimeout(RestClientConfigurationProperties.DEFAULT_CONNECT_TIMEOUT * 60);
-      RestClient rest = SERVER.rest().withClientConfiguration(restClientBuilder).get();
-
-      // Define an invalid configuration for the RESP cache.
-      String invalidCacheName = ServerConstants.DEFAULT_RESP_CACHE;
-      String invalidConfig = """
-            <infinispan>
-              <cache-container>
-                <distributed-cache name="respCache">
-                  <encoding media-type="application/x-java-object"/>
-                  <indexing>
-                   <indexed-entities>
-                     <indexed-entity>Dummy</indexed-entity>
-                    </indexed-entities>
-                 </indexing>
-                </distributed-cache>
-              </cache-container>
-            </infinispan>
-            """;
-      // Store the configuration for the RESP cache.
-      // Once a connection is established using the RESP protocol, it will fail to create the cache.
-      try (RestResponse response = sync(rest.cache(invalidCacheName).createWithConfiguration(RestEntity.create(APPLICATION_XML, invalidConfig)))) {
-         assertThat(response.status()).isEqualTo(BAD_REQUEST);
-      }
-
-      assertCacheIsFailed(rest, invalidCacheName);
-      try (RedisClient client = RedisClient.create(SERVER.resp().connectionString(0))) {
-         assertThatThrownBy(client::connect)
-               .isInstanceOf(RedisConnectionException.class);
-      }
-
-      // Restart the driver and re-create the RESP connector.
-      SERVER.getServerDriver().stopCluster();
-      SERVER.getServerDriver().restartCluster();
-
-      // Assert it still fails to create the RESP cache.
-      try (RedisClient client = RedisClient.create(SERVER.resp().connectionString(0))) {
-         assertThatThrownBy(client::connect)
-               .isInstanceOf(RedisConnectionException.class);
-      }
-
-      // Assert the RESP cache is failed, and that the server and cache manager are running.
       assertCacheIsFailed(rest, invalidCacheName);
    }
 


### PR DESCRIPTION
**Backport:** https://github.com/infinispan/infinispan/pull/15997

* Defines the RESP configuration at start to avoid any overrides from users.
Closes #15973