### PR TITLE
[16.0.x] [#15973] RESP configuration defined at start

### DIFF
--- a/server/core/src/test/java/org/infinispan/server/core/AbstractAuthAccessLoggingTest.java
+++ b/server/core/src/test/java/org/infinispan/server/core/AbstractAuthAccessLoggingTest.java
@@ -47,7 +47,12 @@ public abstract class AbstractAuthAccessLoggingTest extends SingleCacheManagerTe
       globalBuilder.defaultCacheName("default");
       ConfigurationBuilder builder = new ConfigurationBuilder();
       builder.security().authorization().enable();
+      customCacheConfiguration(builder);
       return Security.doAs(ADMIN, () -> TestCacheManagerFactory.createCacheManager(globalBuilder, builder));
+   }
+
+   protected void customCacheConfiguration(ConfigurationBuilder builder) {
+      // Overridden by other classes.
    }
 
    @Override

--- a/server/resp/src/test/java/org/infinispan/server/resp/logging/RespAuthAccessLoggingTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/logging/RespAuthAccessLoggingTest.java
@@ -10,6 +10,8 @@ import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
 
+import org.infinispan.commons.dataconversion.MediaType;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.security.Security;
 import org.infinispan.server.core.AbstractAuthAccessLoggingTest;
 import org.infinispan.server.resp.RespServer;
@@ -43,6 +45,11 @@ public class RespAuthAccessLoggingTest extends AbstractAuthAccessLoggingTest {
       builder.host(HOST).port(RespTestingUtil.port()).defaultCacheName("default")
             .authentication().enable().authenticator(authenticator);
       server = Security.doAs(ADMIN, () -> RespTestingUtil.startServer(cacheManager, builder.build()));
+   }
+
+   @Override
+   protected void customCacheConfiguration(ConfigurationBuilder builder) {
+      builder.encoding().mediaType(MediaType.APPLICATION_OCTET_STREAM);
    }
 
    @Override

--- a/server/tests/src/test/java/org/infinispan/server/resilience/ResilienceStartupIT.java
+++ b/server/tests/src/test/java/org/infinispan/server/resilience/ResilienceStartupIT.java
@@ -1,7 +1,6 @@
 package org.infinispan.server.resilience;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.infinispan.client.rest.RestResponseInfo.BAD_REQUEST;
 import static org.infinispan.client.rest.RestResponseInfo.OK;
 import static org.infinispan.commons.dataconversion.MediaType.APPLICATION_XML;
@@ -17,15 +16,11 @@ import org.infinispan.client.rest.RestResponse;
 import org.infinispan.client.rest.configuration.RestClientConfigurationBuilder;
 import org.infinispan.client.rest.configuration.RestClientConfigurationProperties;
 import org.infinispan.commons.dataconversion.internal.Json;
-import org.infinispan.server.resp.configuration.RespServerConfiguration;
 import org.infinispan.server.test.core.ServerRunMode;
 import org.infinispan.server.test.junit5.InfinispanServerExtension;
 import org.infinispan.server.test.junit5.InfinispanServerExtensionBuilder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-
-import io.lettuce.core.RedisClient;
-import io.lettuce.core.RedisConnectionException;
 
 public class ResilienceStartupIT {
 
@@ -74,55 +69,6 @@ public class ResilienceStartupIT {
 
       // Assert that the cache manager and server are running.
       // Also validate that the cache still exists in a FAILED state.
-      assertCacheIsFailed(rest, invalidCacheName);
-   }
-
-   @Test
-   public void testInvalidConnectorCache() {
-      RestClientConfigurationBuilder restClientBuilder = new RestClientConfigurationBuilder()
-            .socketTimeout(RestClientConfigurationProperties.DEFAULT_SO_TIMEOUT * 60)
-            .connectionTimeout(RestClientConfigurationProperties.DEFAULT_CONNECT_TIMEOUT * 60);
-      RestClient rest = SERVER.rest().withClientConfiguration(restClientBuilder).get();
-
-      // Define an invalid configuration for the RESP cache.
-      String invalidCacheName = RespServerConfiguration.DEFAULT_RESP_CACHE;
-      String invalidConfig = """
-            <infinispan>
-              <cache-container>
-                <distributed-cache name="respCache">
-                  <encoding media-type="application/x-java-object"/>
-                  <indexing>
-                   <indexed-entities>
-                     <indexed-entity>Dummy</indexed-entity>
-                    </indexed-entities>
-                 </indexing>
-                </distributed-cache>
-              </cache-container>
-            </infinispan>
-            """;
-      // Store the configuration for the RESP cache.
-      // Once a connection is established using the RESP protocol, it will fail to create the cache.
-      try (RestResponse response = sync(rest.cache(invalidCacheName).createWithConfiguration(RestEntity.create(APPLICATION_XML, invalidConfig)))) {
-         assertThat(response.status()).isEqualTo(BAD_REQUEST);
-      }
-
-      assertCacheIsFailed(rest, invalidCacheName);
-      try (RedisClient client = RedisClient.create(SERVER.resp().connectionString(0))) {
-         assertThatThrownBy(client::connect)
-               .isInstanceOf(RedisConnectionException.class);
-      }
-
-      // Restart the driver and re-create the RESP connector.
-      SERVER.getServerDriver().stopCluster();
-      SERVER.getServerDriver().restartCluster();
-
-      // Assert it still fails to create the RESP cache.
-      try (RedisClient client = RedisClient.create(SERVER.resp().connectionString(0))) {
-         assertThatThrownBy(client::connect)
-               .isInstanceOf(RedisConnectionException.class);
-      }
-
-      // Assert the RESP cache is failed, and that the server and cache manager are running.
       assertCacheIsFailed(rest, invalidCacheName);
    }
 


### PR DESCRIPTION
* Defines the RESP configuration at start to avoid any overrides from users.
* Backport: https://github.com/infinispan/infinispan/pull/15997

Closes #15973