### PR TITLE
Bump Log4j and Vertx to non-vulnerable versions

### DIFF
--- a/build/configuration/pom.xml
+++ b/build/configuration/pom.xml
@@ -93,7 +93,7 @@
       <version.insights>2.0.4</version.insights>
       <version.io.agroal>2.8</version.io.agroal>
       <version.io.lettuce>6.8.1.RELEASE</version.io.lettuce>
-      <version.vertx>4.5.21</version.vertx>
+      <version.vertx>4.5.24</version.vertx>
       <version.io.mashona>1.1.0</version.io.mashona>
       <version.jackson>2.19.2</version.jackson>
       <version.jackson.databind>2.16.0</version.jackson.databind>
@@ -122,7 +122,7 @@
       <version.junit>4.13.2</version.junit>
       <version.junit5>5.14.1</version.junit5>
       <version.junit6>6.0.0</version.junit6>
-      <version.log4j>2.25.2</version.log4j>
+      <version.log4j>2.25.3</version.log4j>
       <!-- version.lucene is defined in the lucene profiles below -->
       <version.metainf-services>1.11</version.metainf-services>
       <version.micrometer>1.16.0</version.micrometer>


### PR DESCRIPTION
* `org.apache.logging.log4j:log4j-core:2.25.2` is affected by [CVE-2025-68161](https://ossindex.sonatype.org/vulnerability/CVE-2025-68161?component-type=maven&component-name=org.apache.logging.log4j%2Flog4j-core)
* `io.vertx:vertx-core:4.5.21` is affected by [CVE-2026-1002](https://ossindex.sonatype.org/vulnerability/CVE-2026-1002?component-type=maven&component-name=io.vertx%2Fvertx-core)