### PR TITLE
[16.1.x] [#16647] Server tests often fail because of not-stopped containers

### DIFF
--- a/server/rollingupgradetests/src/test/java/org/infinispan/server/rollingupgrade/PersistenceRollingUpgradeIT.java
+++ b/server/rollingupgradetests/src/test/java/org/infinispan/server/rollingupgrade/PersistenceRollingUpgradeIT.java
@@ -1,7 +1,7 @@
 package org.infinispan.server.rollingupgrade;
 
 import org.infinispan.server.persistence.AsyncJdbcStringBasedCacheStore;
-import org.infinispan.server.persistence.BaseJdbcStringBasedCacheStoreIT;
+import org.infinispan.server.persistence.BaseJdbcStringBasedCacheStore;
 import org.infinispan.server.persistence.BasePooledConnectionOperations;
 import org.infinispan.server.persistence.ManagedConnectionOperations;
 import org.infinispan.server.persistence.PersistenceIT;
@@ -15,7 +15,7 @@ import org.junit.platform.suite.api.Suite;
 @SelectClasses({
       BasePooledConnectionOperations.class,
       ManagedConnectionOperations.class,
-      BaseJdbcStringBasedCacheStoreIT.class,
+      BaseJdbcStringBasedCacheStore.class,
       AsyncJdbcStringBasedCacheStore.class
 })
 public class PersistenceRollingUpgradeIT extends InfinispanSuite {

--- a/server/tests/src/test/java/org/infinispan/server/persistence/BaseJdbcStringBasedCacheStore.java
+++ b/server/tests/src/test/java/org/infinispan/server/persistence/BaseJdbcStringBasedCacheStore.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
 @org.infinispan.server.test.core.tags.Database
-public class BaseJdbcStringBasedCacheStoreIT {
+public class BaseJdbcStringBasedCacheStore {
 
    @InfinispanServer(PersistenceIT.class)
    public static TestClientDriver SERVERS;

--- a/server/tests/src/test/java/org/infinispan/server/persistence/JdbcStringBasedCacheStore.java
+++ b/server/tests/src/test/java/org/infinispan/server/persistence/JdbcStringBasedCacheStore.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
  *
  */
 @org.infinispan.server.test.core.tags.Database
-public class JdbcStringBasedCacheStoreIT {
+public class JdbcStringBasedCacheStore {
 
     @RegisterExtension
     public static InfinispanServerExtension SERVERS = PersistenceIT.SERVERS;

--- a/server/tests/src/test/java/org/infinispan/server/persistence/PersistenceIT.java
+++ b/server/tests/src/test/java/org/infinispan/server/persistence/PersistenceIT.java
@@ -41,8 +41,8 @@ import org.junit.platform.suite.api.Suite;
       BasePooledConnectionOperations.class,
       PooledConnectionOperations.class,
       ManagedConnectionOperations.class,
-      BaseJdbcStringBasedCacheStoreIT.class,
-      JdbcStringBasedCacheStoreIT.class,
+      BaseJdbcStringBasedCacheStore.class,
+      JdbcStringBasedCacheStore.class,
       AsyncJdbcStringBasedCacheStore.class
 })
 public class PersistenceIT extends InfinispanSuite {


### PR DESCRIPTION
**Backport:** https://github.com/infinispan/infinispan/pull/16648

Closes #16647 

The issue were the names of the tests BaseJdbcStringBasedCacheStoreIT and JdbcStringBasedCacheStoreIT which were included in the PersistenceIT Suite. 
The issue was that those tests were run as in the Suite as well as separately (because of the test name ) and because of that the created containers were not stopped properly. 