### PR TITLE
16656-Add-JSON_RESP-command: Added the link redis link for json.resp to Redis commands section.

### DIFF
--- a/documentation/src/main/asciidoc/topics/ref_redis_commands.adoc
+++ b/documentation/src/main/asciidoc/topics/ref_redis_commands.adoc
@@ -184,7 +184,7 @@ NOTE: This command is non atomic
 
 * link:https://redis.io/commands/json.objlen[JSON.OBJLEN]
 
-* link:https://redis.io/docs/latest/commands/json.resp/[JSON_RESP]
+* link:https://redis.io/docs/latest/commands/json.resp[JSON.RESP]
 
 * link:https://redis.io/commands/json.set[JSON.SET]
 


### PR DESCRIPTION
Done for #16656