### PR TITLE
[16.1.x] 16656-Add-JSON_RESP-command-16.1.x: Added the link redis link for json.resp to Redis commands section.

### DIFF
--- a/documentation/src/main/asciidoc/topics/ref_redis_commands.adoc
+++ b/documentation/src/main/asciidoc/topics/ref_redis_commands.adoc
@@ -184,6 +184,8 @@ NOTE: This command is non atomic
 
 * link:https://redis.io/commands/json.objlen[JSON.OBJLEN]
 
+* link:https://redis.io/docs/latest/commands/json.resp[JSON.RESP]
+
 * link:https://redis.io/commands/json.set[JSON.SET]
 
 * link:https://redis.io/commands/json.strappend[JSON.STRAPPEND]


### PR DESCRIPTION
Done for https://github.com/infinispan/infinispan/issues/16656