### PR TITLE
[16.0.x] [#15405] PersistenceIT tests timing out

### DIFF
--- a/server/rollingupgradetests/src/test/java/org/infinispan/server/rollingupgrade/PersistenceRollingUpgradeIT.java
+++ b/server/rollingupgradetests/src/test/java/org/infinispan/server/rollingupgrade/PersistenceRollingUpgradeIT.java
@@ -22,6 +22,11 @@ public class PersistenceRollingUpgradeIT extends InfinispanSuite {
 
    @RegisterExtension
    public static RollingUpgradeHandlerExtension SERVERS =
-         RollingUpgradeHandlerExtension.from(PersistenceRollingUpgradeIT.class, PersistenceIT.EXTENSION_BUILDER,
-               RollingUpgradeTestUtil.getFromVersion(), RollingUpgradeTestUtil.getToVersion());
+         new RollingUpgradeHandlerExtension(
+               RollingUpgradeHandlerExtension.convertBuilder(
+                     PersistenceRollingUpgradeIT.class,
+                     PersistenceIT.EXTENSION_BUILDER,
+                     RollingUpgradeTestUtil.getFromVersion(),
+                     RollingUpgradeTestUtil.getToVersion()
+               ).nodeCount(2));
 }

--- a/server/tests/src/test/java/org/infinispan/server/persistence/PersistenceIT.java
+++ b/server/tests/src/test/java/org/infinispan/server/persistence/PersistenceIT.java
@@ -57,7 +57,7 @@ public class PersistenceIT extends InfinispanSuite {
 
    public static final InfinispanServerExtensionBuilder EXTENSION_BUILDER =
          InfinispanServerExtensionBuilder.config(System.getProperty(PersistenceIT.class.getName(), "configuration/PersistenceTest.xml"))
-               .numServers(2)
+               .numServers(1)
                .runMode(ServerRunMode.CONTAINER)
                .mavenArtifacts(getJdbcDrivers())
                .artifacts(getJavaArchive())


### PR DESCRIPTION
**Backport:** https://github.com/infinispan/infinispan/pull/16667

* The tests failes because the `getOrCreateCache` operation, submitted in Hot Rod are timing out.
* The cache creation is taking a long time when running in a cluster of multiple servers.

This PR is mostly to get CI happy downstream. To find the actual problem, I've opened #16666.

Closes #15405.