### PR TITLE
[16.0.x] [#16679] RESP cache only use alias 0 if available

### DIFF
--- a/server/resp/src/main/java/org/infinispan/server/resp/RespServer.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/RespServer.java
@@ -120,7 +120,10 @@ public class RespServer extends AbstractProtocolServer<RespServerConfiguration> 
             builder.encoding().key().mediaType(RESP_KEY_MEDIA_TYPE);
             builder.encoding().value().mediaType(configuredValueType);
          }
-         builder.statistics().enable().aliases("0");
+         builder.statistics().enable();
+         if (!cacheManager.cacheConfigurationExists(RespServerConfiguration.DEFAULT_RESP_CACHE_ALIAS))
+            builder.aliases(RespServerConfiguration.DEFAULT_RESP_CACHE_ALIAS);
+
          explicitConfiguration = builder.build();
          SecurityActions.defineConfiguration(cacheManager, cacheName, explicitConfiguration);
       } else {

--- a/server/resp/src/main/java/org/infinispan/server/resp/configuration/RespServerConfiguration.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/configuration/RespServerConfiguration.java
@@ -21,6 +21,7 @@ public class RespServerConfiguration extends ProtocolServerConfiguration<RespSer
 
    public static final int DEFAULT_RESP_PORT = 6379;
    public static final String DEFAULT_RESP_CACHE = "respCache";
+   public static final String DEFAULT_RESP_CACHE_ALIAS = "0";
 
    public static AttributeSet attributeDefinitionSet() {
       return new AttributeSet(RespServerConfiguration.class, ProtocolServerConfiguration.attributeDefinitionSet());

--- a/server/resp/src/test/java/org/infinispan/server/resp/AbstractRespTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/AbstractRespTest.java
@@ -14,14 +14,12 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.infinispan.Cache;
-import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.commons.test.TestResourceTracker;
 import org.infinispan.commons.time.ControlledTimeService;
 import org.infinispan.commons.time.TimeService;
 import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
-import org.infinispan.distribution.ch.impl.RESPHashFunctionPartitioner;
 import org.infinispan.globalstate.ConfigurationStorage;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.security.Security;
@@ -151,10 +149,7 @@ public abstract class AbstractRespTest extends MultipleCacheManagersTest {
    }
 
    protected final ConfigurationBuilder defaultRespConfiguration() {
-      ConfigurationBuilder builder = new ConfigurationBuilder();
-      builder.encoding().key().mediaType(MediaType.APPLICATION_OCTET_STREAM);
-      builder.clustering().hash().keyPartitioner(new RESPHashFunctionPartitioner()).numSegments(256);
-      return builder;
+      return RespTestingUtil.defaultRespConfiguration();
    }
 
    protected final boolean isAuthorizationEnabled() {

--- a/server/resp/src/test/java/org/infinispan/server/resp/configuration/RespAliasTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/configuration/RespAliasTest.java
@@ -1,0 +1,59 @@
+package org.infinispan.server.resp.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.infinispan.commons.test.CommonsTestingUtil.tmpDirectory;
+
+import org.infinispan.commons.util.Util;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.globalstate.ConfigurationStorage;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.server.resp.RespServer;
+import org.infinispan.server.resp.test.RespTestingUtil;
+import org.infinispan.test.SingleCacheManagerTest;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.Test;
+
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.sync.RedisCommands;
+
+@Test(groups = "functional", testName = "resp.configuration.RespAliasTest")
+public class RespAliasTest extends SingleCacheManagerTest {
+   @Override
+   protected EmbeddedCacheManager createCacheManager() {
+      String stateDir = tmpDirectory(this.getClass().getSimpleName());
+      Util.recursiveFileRemove(stateDir);
+
+      GlobalConfigurationBuilder gcb = GlobalConfigurationBuilder.defaultClusteredBuilder();
+      gcb.globalState().enable()
+            .persistentLocation(stateDir)
+            .configurationStorage(ConfigurationStorage.OVERLAY)
+            .sharedPersistentLocation(stateDir);
+
+      EmbeddedCacheManager ecm = TestCacheManagerFactory.createClusteredCacheManager(gcb, null);
+
+      ConfigurationBuilder cb = new ConfigurationBuilder();
+      cb.clustering().cacheMode(CacheMode.DIST_SYNC);
+      cb.aliases("0");
+      ecm.defineConfiguration("other-cache", cb.build());
+
+      return ecm;
+   }
+
+   public void testRespCache() {
+      RespServer server = RespTestingUtil.startServer(cacheManager);
+
+      RedisClient c = RespTestingUtil.createClient(10_000, server.getPort());
+      try (StatefulRedisConnection<String, String> conn = c.connect()) {
+         RedisCommands<String, String> redis = conn.sync();
+
+         redis.set("key", "value");
+         assertThat(redis.get("key")).isEqualTo("value");
+      }
+
+      RespTestingUtil.killClient(c);
+      RespTestingUtil.killServer(server);
+   }
+}

--- a/server/resp/src/test/java/org/infinispan/server/resp/test/RespTestingUtil.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/test/RespTestingUtil.java
@@ -6,6 +6,8 @@ import io.lettuce.core.RedisCommandExecutionException;
 import io.lettuce.core.RedisURI;
 import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.commons.test.TestResourceTracker;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.distribution.ch.impl.RESPHashFunctionPartitioner;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.security.AuthorizationPermission;
 import org.infinispan.server.core.logging.Log;
@@ -42,6 +44,13 @@ public class RespTestingUtil {
    static {
       Map<AuthorizationPermission, Subject> subjects = TestingUtil.makeAllSubjects();
       ADMIN = subjects.get(AuthorizationPermission.ALL);
+   }
+
+   public static ConfigurationBuilder defaultRespConfiguration() {
+      ConfigurationBuilder builder = new ConfigurationBuilder();
+      builder.encoding().key().mediaType(MediaType.APPLICATION_OCTET_STREAM);
+      builder.clustering().hash().keyPartitioner(new RESPHashFunctionPartitioner()).numSegments(256);
+      return builder;
    }
 
    public static RedisClient createClient(long timeout, int port) {


### PR DESCRIPTION
**Backport:** https://github.com/infinispan/infinispan/pull/16686

* The alias is a 1:1 mapping to a cache configuration.
* Instead of always utilizing alias 0, we verify if it is already in use by some other configuration.

Close #16679.