### PR TITLE
[#16671] Retrieve cache configuration by alias

### DIFF
--- a/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
@@ -966,6 +966,7 @@ public class DefaultCacheManager extends InternalCacheManager {
    @Override
    public Configuration getCacheConfiguration(String name) {
       authorizer.checkPermission(getSubject(), AuthorizationPermission.ADMIN);
+      name = configurationManager.selectCache(name);
       Configuration configuration = configurationManager.getConfiguration(name, true);
       if (configuration == null && cacheExists(name)) {
          return getDefaultCacheConfiguration();

--- a/core/src/main/java/org/infinispan/manager/EmbeddedCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/EmbeddedCacheManager.java
@@ -131,6 +131,7 @@ public interface EmbeddedCacheManager extends CacheContainer, Listenable, Closea
    /**
     * Returns the configuration for the given cache.
     *
+    * @param name The cache name or alias.
     * @return the configuration for the given cache or null if no such cache is defined
     */
    Configuration getCacheConfiguration(String name);

--- a/core/src/test/java/org/infinispan/manager/CacheManagerAdminTest.java
+++ b/core/src/test/java/org/infinispan/manager/CacheManagerAdminTest.java
@@ -1,9 +1,12 @@
 package org.infinispan.manager;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertTrue;
+
+import java.lang.reflect.Method;
 
 import org.infinispan.Cache;
 import org.infinispan.commons.CacheConfigurationException;
@@ -63,6 +66,21 @@ public class CacheManagerAdminTest extends MultipleCacheManagersTest {
 
       addClusterEnabledCacheManager();
       checkCacheExistenceAcrossCluster("a", false);
+   }
+
+   public void testGetCacheConfiguration(Method m) {
+      EmbeddedCacheManager ecm = manager(0);
+
+      ConfigurationBuilder builder = new ConfigurationBuilder();
+      builder.clustering().cacheMode(CacheMode.DIST_SYNC);
+
+      String alias = "alias-" + this.hashCode();
+      builder.aliases(alias);
+      ecm.defineConfiguration(m.getName(), builder.build());
+
+      assertThat(ecm.getCacheConfiguration(m.getName())).isNotNull();
+      assertThat(ecm.getCacheConfiguration(alias)).isNotNull();
+      assertThat(ecm.getCacheConfiguration("something-that-doesnt-exist")).isNull();
    }
 
    protected void checkCacheExistenceAcrossCluster(String cacheName, boolean exists) {


### PR DESCRIPTION
* Retrieving the cache configuration requires the cache name, while other methods (cacheConfigurationExists, isRunning), accept the alias.
* Utilizing an alias also allows for configuring a connector with the cache alias.

Close #16671.