### PR TITLE
[#16762] Buffer SIFS Index updates to prevent multiple overlapping wr…

### DIFF
--- a/core/src/main/java/org/infinispan/persistence/sifs/IndexNode.java
+++ b/core/src/main/java/org/infinispan/persistence/sifs/IndexNode.java
@@ -221,12 +221,11 @@ class IndexNode {
       }
       assert buffer.position() == buffer.limit() : "Buffer position: " + buffer.position() + " limit: " + buffer.limit();
       buffer.flip();
-      try (FileProvider.Handle handle = segment.getIndexFile()) {
-         handle.write(buffer, offset);
-      }
+
+      segment.bufferIndexWrite(offset, buffer, occupiedSpace);
 
       if (log.isTraceEnabled()) {
-         log.tracef("Persisted %08x (length %d, %d %s) to %d:%d", System.identityHashCode(this), length(),
+         log.tracef("Buffered %08x (length %d, %d %s) to %d:%d", System.identityHashCode(this), length(),
             innerNodes != null ? innerNodes.length : leafNodes.length,
             innerNodes != null ? "children" : "leaves", offset, occupiedSpace);
       }

--- a/core/src/main/java/org/infinispan/persistence/sifs/NonBlockingSoftIndexFileStore.java
+++ b/core/src/main/java/org/infinispan/persistence/sifs/NonBlockingSoftIndexFileStore.java
@@ -671,10 +671,8 @@ public class NonBlockingSoftIndexFileStore<K, V> implements NonBlockingStore<K, 
                      log.tracef("Entry for key=%s found in temporary table on %d:%d but it is a tombstone", key, entry.file, entry.offset);
                      return null;
                   }
-                  MarshallableEntry<K, V> marshallableEntry = readValueFromFileOffset(key, entry);
-                  if (marshallableEntry != null) {
-                     return marshallableEntry;
-                  }
+                  // TODO: I don't know if this is okay or not... it should be as a tombstone should be null
+                  return readValueFromFileOffset(key, entry);
                } else {
                   EntryRecord record = index.getRecord(key, segmentUsed, marshaller.objectToBuffer(key));
                   if (record == null) {

--- a/core/src/test/java/org/infinispan/persistence/sifs/SoftIndexFileStoreTest.java
+++ b/core/src/test/java/org/infinispan/persistence/sifs/SoftIndexFileStoreTest.java
@@ -238,7 +238,9 @@ public class SoftIndexFileStoreTest extends BaseNonBlockingStoreTest {
       // We don't care about the actual expiration sub info
       Compactor.CompactionExpirationSubscriber sub = new Compactor.CompactionExpirationSubscriber() {
          @Override
-         public void onEntryPosition(EntryPosition entryPosition) { }
+         public void onEntryPosition(EntryPosition entryPosition) {
+            expired.incrementAndGet();
+         }
          @Override
          public void onEntryEntryRecord(EntryRecord entryRecord) {
             expired.incrementAndGet();


### PR DESCRIPTION
…ites

Fixes #16762 

Changed IndexNode.store() to buffer writes instead of writing directly to disk. The Segment maintains a Map of pending writes and a list of pending temporary table operations.

Writes are flushed when:
- A non-UPDATE request is processed
- After 50 UPDATE requests have accumulated
- During segment shutdown

If index space is freed any pending write for that offset is dropped, avoiding unnecessary disk I/O when writes would be immediately overwritten.