### PR TITLE
16729-Add-JSON_DEBUG-command-16.0.x: Added the link redis link for js…

### DIFF
--- a/documentation/src/main/asciidoc/topics/ref_redis_commands.adoc
+++ b/documentation/src/main/asciidoc/topics/ref_redis_commands.adoc
@@ -154,6 +154,8 @@ NOTE: This implementation attempts to return all attributes that a real Redis se
 
 * link:https://redis.io/commands/json.arrpop[JSON.ARRPOP]
 
+* link:https://redis.io/commands/json.debug-memory[JSON.DEBUG MEMORY]
+
 * link:https://redis.io/commands/json.del[JSON.DEL]
 
 * link:https://redis.io/commands/json.forget[JSON.FORGET]


### PR DESCRIPTION
JSON.DEBUG MEMORY key [path]
https://redis.io/docs/latest/commands/json.debug-memory/