### PR TITLE
[#14370] Fix EXEC buffer allocation on jgroups thread in clustered mode

### DIFF
--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/tx/EXEC.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/tx/EXEC.java
@@ -109,11 +109,12 @@ public class EXEC extends RespCommand implements Resp3Command, TransactionResp3C
             cmd -> {
                writer.arrayNext();
                return cmd.perform(handler, ctx)
-                     .exceptionally(t -> {
-                        handler.writer().error(t);
+                     .<Void>handleAsync((r, t) -> {
+                        if (t != null) {
+                           handler.writer().error(t);
+                        }
                         return null;
-                     })
-                     .thenApply(CompletableFutures.toNullFunction());
+                     }, ctx.executor());
             });
    }
 }


### PR DESCRIPTION
Closes #14370