### PR TITLE
[#16788] Fix shared deadline in waitForSites causing flaky xsite tests

### DIFF
--- a/core/src/test/java/org/infinispan/xsite/AbstractXSiteTest.java
+++ b/core/src/test/java/org/infinispan/xsite/AbstractXSiteTest.java
@@ -151,7 +151,7 @@ public abstract class AbstractXSiteTest extends AbstractCacheTest {
     * Wait for all the site masters to see a specific list of sites.
     */
    public void waitForSites(long timeout, TimeUnit unit, String... siteNames) {
-      long deadlineNanos = System.nanoTime() + unit.toNanos(timeout);
+      long timeoutNanos = unit.toNanos(timeout);
       Set<String> expectedSites = new HashSet<>(Arrays.asList(siteNames));
       sites.forEach(site -> {
          site.cacheManagers.forEach(manager -> {
@@ -159,6 +159,7 @@ public abstract class AbstractXSiteTest extends AbstractCacheTest {
             RELAY2 relay2 = transport.getChannel().getProtocolStack().findProtocol(RELAY2.class);
             if (!relay2.isSiteMaster())
                return;
+            long deadlineNanos = System.nanoTime() + timeoutNanos;
             while (System.nanoTime() - deadlineNanos < 0) {
                if (expectedSites.equals(transport.getSitesView()))
                   break;


### PR DESCRIPTION
## Summary
- Fixes flaky `DistSyncOnePhaseWriteSkewTxStateTransferTest` that times out waiting for bridge view convergence
- The deadline in `AbstractXSiteTest.waitForSites()` was computed once and shared across all site masters; if the first consumed most of the timeout, later ones failed immediately
- Moved deadline computation inside the per-site-master loop so each gets its own full timeout window

Closes #16788